### PR TITLE
Bug 2022861: Make Storage System tab text consistent across tabs.

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -511,7 +511,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       model: mockModels.StorageSystemMockModel,
       page: {
-        name: '%ceph-storage-plugin~Storage Systems%',
+        name: '%ceph-storage-plugin~Storage System%',
         href: 'systems',
       },
       loader: async () =>


### PR DESCRIPTION
Make the [ODF -> Storage System] text same as [Operators -> Installed
Operators -> ODF -> Storage System], i.e., singular case. This is
contrary to the linked BZ that expects pluralizing both tab contents
(from "Storage System" to "Storage Systems"), but after a discussion
with backend folks, it was made clear that:

  - The "DisplayName" field is generated from the API by Operator SDK, and
    is conventionally kept singular: https://github.com/rexagod/odf-operator/blob/a7a17d854c528752f63c7b23ef6149740d9cc631/config/manifests/bases/odf-operator.clusterserviceversion.yaml#L41
  - OCS Operator handles the "DisplayName" field in the same way, i.e.,
    singular: https://github.com/red-hat-storage/ocs-operator/blob/main/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml#L1145

Hence, in order to provide consistency across different tabs that show
"Storage System", it's better to keep them singular.
***
#### Earlier
![image](https://user-images.githubusercontent.com/33557095/143201669-8ec4fe74-eacd-4dc8-bd50-016a9ebbe22d.png)
***
#### Now
![image](https://user-images.githubusercontent.com/33557095/143071567-1eef8fad-271f-4d0c-b51b-5de861d20a46.png)
