### PR TITLE
Bug 2027512: Reenable a few e2e tests, update Cypress to catch '> Unauthorized' exceptions

### DIFF
--- a/frontend/packages/integration-tests-cypress/support/index.ts
+++ b/frontend/packages/integration-tests-cypress/support/index.ts
@@ -12,6 +12,14 @@ Cypress.Cookies.defaults({
   preserve: ['openshift-session-token', 'csrf-token'],
 });
 
+Cypress.on('uncaught:exception', (err) => {
+  if (err.message.includes('> Unauthorized')) {
+    console.error('Cypress caught "> Unauthorized exception", continuing tests', err);
+    return false; // test continues
+  }
+  return true; // test fails
+});
+
 Cypress.Commands.overwrite('log', (originalFn, message) => {
   cy.task('log', `      ${message}`, { log: false }); // log:false means do not log task in runner GUI
   originalFn(message); // calls original cy.log(message)

--- a/frontend/packages/integration-tests-cypress/support/login.ts
+++ b/frontend/packages/integration-tests-cypress/support/login.ts
@@ -19,7 +19,7 @@ const KUBEADMIN_IDP = 'kube:admin';
 // ex: cy.login('my-idp', 'my-user', 'my-password')
 Cypress.Commands.add('login', (provider: string, username: string, password: string) => {
   // Check if auth is disabled (for a local development environment).
-  cy.visit(''); // visits baseUrl which is set in plugins/index.js
+  cy.visit('/'); // visits baseUrl which is set in plugins/index.js
   cy.window().then((win: any) => {
     if (win.SERVER_FLAGS?.authDisabled) {
       cy.task('log', '  skipping login, console is running with auth disabled');
@@ -57,6 +57,5 @@ Cypress.Commands.add('logout', () => {
     cy.byTestID('user-dropdown').click();
     cy.byTestID('log-out').should('be.visible');
     cy.byTestID('log-out').click({ force: true });
-    cy.byLegacyTestID('login').should('be.visible');
   });
 });

--- a/frontend/packages/integration-tests-cypress/tests/crud/roles-rolebindings.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/roles-rolebindings.spec.ts
@@ -102,8 +102,7 @@ const deleteClusterExamples = () => {
   detailsPage.isLoaded();
 };
 
-// disabling until https://bugzilla.redhat.com/show_bug.cgi?id=2024932 is fixed
-xdescribe('Roles and RoleBindings', () => {
+describe('Roles and RoleBindings', () => {
   before(() => {
     cy.login();
     cy.createProject(testName);

--- a/frontend/packages/integration-tests-cypress/tests/crud/secrets.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/secrets.spec.ts
@@ -16,7 +16,7 @@ const populateSecretForm = (name: string, key: string, fileName: string) => {
   cy.byTestID('file-input').attachFile(fileName);
 };
 
-xdescribe('Create key/value secrets', () => {
+describe('Create key/value secrets', () => {
   const binarySecretName = `${testName}binarysecretname`;
   const asciiSecretName = `${testName}asciisecretname`;
   const unicodeSecretName = `${testName}unicodesecretname`;

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -17,7 +17,7 @@ const testOperand: TestOperandProps = {
   exampleName: `example-kieappk`,
 };
 
-xdescribe(`Installing "${testOperator.name}" operator in ${testOperator.installedNamespace}`, () => {
+describe(`Installing "${testOperator.name}" operator in ${testOperator.installedNamespace}`, () => {
   before(() => {
     cy.login();
     cy.visit('/');


### PR DESCRIPTION
Tried several workarounds, but `Cypress.on('uncaught:exception'...` seemed to work best to target the specific error we want to catch.

Also, reenabled 3 previously disabled cypress tests