### PR TITLE
Bug 2019646: Display permission error modal for view only user

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -757,6 +757,7 @@
   "Remove favorite": "Remove favorite",
   "Favorite template": "Favorite template",
   "View full details": "View full details",
+  "You do not have permissions to create Virtual Machine. Contact your system administrator for more information.": "You do not have permissions to create Virtual Machine. Contact your system administrator for more information.",
   "Template details": "Template details",
   "Create VM": "Create VM",
   "Boot source is ready for customization or currently being customized.": "Boot source is ready for customization or currently being customized.",

--- a/frontend/packages/kubevirt-plugin/src/components/modals/permissions-error-modal/permissions-error-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/permissions-error-modal/permissions-error-modal.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { Alert, Button } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import {
+  createModalLauncher,
+  ModalBody,
+  ModalComponentProps,
+  ModalFooter,
+  ModalTitle,
+} from '@console/internal/components/factory';
+
+type PermissionsErrorModalProps = {
+  title: string;
+  errorMsg: string;
+} & ModalComponentProps;
+
+const PermissionsErrorModal: React.FC<PermissionsErrorModalProps> = ({
+  title,
+  errorMsg,
+  close,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <div className="modal-content modal-content--no-inner-scroll">
+      <ModalTitle>{title}</ModalTitle>
+      <ModalBody>
+        <Alert variant="danger" isInline title={t('kubevirt-plugin~Permissions required')}>
+          {errorMsg}
+        </Alert>
+      </ModalBody>
+      <ModalFooter inProgress={false}>
+        <Button type="button" data-test-id="modal-close-action" onClick={close}>
+          {t('kubevirt-plugin~Close')}
+        </Button>
+      </ModalFooter>
+    </div>
+  );
+};
+
+export const permissionsErrorModal = createModalLauncher(PermissionsErrorModal);


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2019646

**Analysis / Root cause**:
No permissions check after clicking on _Create VM_ button, in the templates list page.

**Solution Description:**
Add permissions check and missing modal window to display the permissions error, similar to the modal displayed after clicking on _Add source_ button (in the same, templates list page), for view only user. 

**Screen shots / Gifs for design review:**
Before:
![before](https://user-images.githubusercontent.com/13417815/143271630-8d72537c-019a-478a-b2b4-e4c6f922bb41.png)

After
![after](https://user-images.githubusercontent.com/13417815/143271640-c4845710-971f-43a4-afd0-f6d389116388.png)
:
