### PR TITLE
Bug 2024537: Change text to refer to Win iso instead of cloud image

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -410,7 +410,7 @@
   "Error: {{ rawErrorMessage }}": "Error: {{ rawErrorMessage }}",
   "Example: {{container}}": "Example: {{container}}",
   "Example: For RHEL, visit the <2><0>RHEL download page</0></2> (requires login) and copy the download link URL of the KVM guest image (expires quickly)": "Example: For RHEL, visit the <2><0>RHEL download page</0></2> (requires login) and copy the download link URL of the KVM guest image (expires quickly)",
-  "Example: For Windows, visit the <2><0>Windows 10 cloud image</0></2> and copy the download link URL for the cloud base image": "Example: For Windows, visit the <2><0>Windows 10 cloud image</0></2> and copy the download link URL for the cloud base image",
+  "Example: For Windows, get a link to the <2><0>installation iso of Windows 10</0></2> and copy the download link URL": "Example: For Windows, get a link to the <2><0>installation iso of Windows 10</0></2> and copy the download link URL",
   "Example: For CentOS, visit the <2><0>CentOS cloud image list</0></2> and copy the download link URL for the cloud base image": "Example: For CentOS, visit the <2><0>CentOS cloud image list</0></2> and copy the download link URL for the cloud base image",
   "Example: For Fedora, visit the <2><0>Fedora cloud image list</0></2> and copy the download link URL for the cloud base image": "Example: For Fedora, visit the <2><0>Fedora cloud image list</0></2> and copy the download link URL for the cloud base image",
   "Selected {{name}} is not available": "Selected {{name}} is not available",

--- a/frontend/packages/kubevirt-plugin/src/components/form/helper/url-source-help.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/form/helper/url-source-help.tsx
@@ -26,13 +26,13 @@ export const URLSourceHelp: React.FC<URLSourceHelpProps> = ({ baseImageName }) =
     </Trans>
   ) : baseImageName?.includes('win') ? (
     <Trans t={t} ns="kubevirt-plugin">
-      Example: For Windows, visit the{' '}
+      Example: For Windows, get a link to the{' '}
       <strong>
         <a href={WINDOWS_IMAGE_LINK} rel="noopener noreferrer" target="_blank">
-          Windows 10 cloud image
+          installation iso of Windows 10
         </a>
       </strong>{' '}
-      and copy the download link URL for the cloud base image
+      and copy the download link URL
     </Trans>
   ) : baseImageName?.includes('centos') ? (
     <Trans t={t} ns="kubevirt-plugin">


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2024537

**Analysis / Root cause**:
Usually, the term **cloud image** refers to a hard disk image, which is able to boot and is usually configured via cloud-init. For Windows, this is provided by https://cloudbase.it/windows-cloud-images/, but this is not what usual Windows users use.
The expected way of using Windows in KubeVirt is to install from the Microsoft's public Windows **iso image** to a hard disk image, and use this hard disk image as template for multiple VMs.

**Solution Description**:
Change the text displayed after _Boot source type_ selection _Import via URL_, when creating Windows VM from template, to refer to the installation iso of Windows, and not cloud image.

**Screen shots / Gifs for design review**:
Before:
![before](https://user-images.githubusercontent.com/13417815/143616636-42583f1b-c9cb-446c-a7dc-269429e34444.png)

After:
![after](https://user-images.githubusercontent.com/13417815/143616648-4878668c-53b2-4a1a-b3b8-abbfb77b492e.png)
