### PR TITLE
Add encrypted RBD storage class during deployment

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/payloads.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/payloads.ts
@@ -61,9 +61,7 @@ export const createStorageCluster = async (state: WizardState) => {
   const payload = getOCSRequestData(
     storageClass,
     storage,
-    // MCG requires clusterwide encryption to be true for kms configuration to take into affect
-    // https://github.com/red-hat-storage/ocs-operator/blob/main/controllers/storagecluster/noobaa_system_reconciler.go#L182
-    isMCG ? encryption.advanced : encryption.clusterWide,
+    encryption,
     isMinimal,
     isFlexibleScaling,
     publicNetwork,

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard.tsx
@@ -73,7 +73,7 @@ const createCluster = async (
     const storageCluster: StorageClusterKind = getOCSRequestData(
       { name: storageClass?.metadata?.name, provisioner: storageClass?.provisioner },
       defaultRequestSize.BAREMETAL,
-      encryption.clusterWide,
+      encryption,
       enableMinimal,
       enableFlexibleScaling,
       publicNetwork,

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/internal-mode/install-wizard.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/internal-mode/install-wizard.tsx
@@ -44,7 +44,7 @@ const makeOCSRequest = (state: InternalClusterState): Promise<StorageClusterKind
   const storageCluster: StorageClusterKind = getOCSRequestData(
     { name: storageClass?.metadata?.name, provisioner: storageClass?.provisioner },
     capacity,
-    encryption.clusterWide,
+    encryption,
     enableMinimal,
     enableFlexibleScaling,
     publicNetwork,

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-request-data.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-request-data.ts
@@ -17,6 +17,7 @@ import {
   StorageClusterResource,
   DeviceSet,
   ResourceConstraints,
+  EncryptionType,
 } from '../../types';
 import { WizardState } from '../create-storage-system/reducer';
 
@@ -124,7 +125,7 @@ export const createDeviceSet = (
 export const getOCSRequestData = (
   storageClass: WizardState['storageClass'],
   storage: string,
-  encrypted: boolean,
+  encryption: EncryptionType,
   isMinimal: boolean,
   flexibleScaling = false,
   publicNetwork?: string,
@@ -209,9 +210,11 @@ export const getOCSRequestData = (
     };
   }
 
-  if (encrypted) {
+  if (encryption) {
     requestData.spec.encryption = {
-      enable: encrypted,
+      enable: encryption.clusterWide,
+      clusterWide: encryption.clusterWide,
+      storageClass: encryption.storageClass,
       kms: {
         enable: kmsEnable,
       },

--- a/frontend/packages/ceph-storage-plugin/src/constants/kms.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/kms.ts
@@ -4,6 +4,7 @@ export const KMSMaxFileUploadSize = 4000000;
 export const KMSConfigMapName = 'ocs-kms-connection-details';
 export const KMSConfigMapCSIName = 'csi-kms-connection-details';
 export const KMSVaultTokenSecretName = 'ocs-kms-token';
+export const KMSVaultCSISecretName = 'ceph-csi-kms-token';
 export const KMS_PROVIDER = 'KMS_PROVIDER';
 
 /**

--- a/frontend/packages/ceph-storage-plugin/src/types.ts
+++ b/frontend/packages/ceph-storage-plugin/src/types.ts
@@ -376,7 +376,10 @@ export type StorageClusterKind = K8sResourceCommon & {
       arbiterLocation: string;
     };
     encryption?: {
+      /** @deprecated - enable is deprecated from 4.10 */
       enable: boolean;
+      clusterWide: boolean;
+      storageClass: boolean;
       kms?: {
         enable: boolean;
       };


### PR DESCRIPTION
Creating encrypted storage class with help of ocs-operator when encryption is checked for storage class.
 
On top of:
   https://github.com/openshift/console/pull/10475
   https://github.com/openshift/console/pull/10559
      
Issue: https://issues.redhat.com/browse/RHSTOR-2269