### PR TITLE
Bug 2027238: (dashboard) Allow leading and trailing spaces in legendFormat

### DIFF
--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -452,8 +452,10 @@ const getPanelClassModifier = (panel: Panel): string => {
   }
 };
 
-// Matches Prometheus labels surrounded by {{ }} in the graph legend label templates
-const legendTemplateOptions = { interpolate: /{{([a-zA-Z_][a-zA-Z0-9_]*)}}/g };
+// Matches Prometheus labels surrounded by {{ }} in the graph legend label templates.
+// The regex pattern is inspired from https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+// with additional matchers to consider leading and trailing spaces.
+const legendTemplateOptions = { interpolate: /{{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}/g };
 
 const Card: React.FC<CardProps> = React.memo(({ panel }) => {
   const namespace = React.useContext(NamespaceContext);


### PR DESCRIPTION
## Root cause
Few dashboard definitions from upstream components[1] makes uses of leading and
trailing spaces in legendFormat panel field, this causes wrong
interpretation and the legend values are missing from the final dashboard rendering.

## Fix
Alter console legendFormat regex to honour leading and trailing space[3]

## Alternatives
1) Remove spaces from the upstream dashboard definitions[1] - Doesn't
   scale as the future dashboards can still have spaces as it works fine
   in Grafana
2) Adopt legendFormat regex pattern from Grafana implementation[2] - It
   doesn't match original Prometheus label regex spec[4].

[1] https://github.com/prometheus/node_exporter/blob/9bc184d236a79437f6195b03bd17af061c134881/docs/node-mixin/dashboards/use.libsonnet#L234
[2] https://github.com/grafana/grafana/blob/f454a5ce60e85e7391b69245166c9b3a32c5c574/pkg/tsdb/prometheus/prometheus.go#L25
[3] https://regex101.com/r/deyJdC/1
[4] https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2027238

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>