### PR TITLE
Bug 2024262: Sample catalog is not displayed when one API call to the backend fails

### DIFF
--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -57,8 +57,19 @@ declare interface Window {
   Cypress?: {};
 }
 
-// TODO: Remove when upgrading to TypeScript 4.1.2+, which has a type for RelativeTimeFormat.
+// TODO: Remove when upgrading to TypeScript 4.1.2+, which has a type for ListFormat and RelativeTimeFormat.
 declare namespace Intl {
+  type ListFormatOptions = {
+    localeMatcher: string;
+    type: string;
+    style: string;
+  };
+
+  class ListFormat {
+    constructor(locales?: Locale | string | undefined, options?: Partial<ListFormatOptions>);
+    public format(list?: Iterable<string>): string;
+  }
+
   class RelativeTimeFormat {
     constructor(locale: string);
     format(n: number, unit: string);

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/catalog.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/catalog.ts
@@ -27,6 +27,8 @@ export type CatalogItemProvider = ExtensionDeclaration<
     catalogId: string | string[];
     /** Type ID for the catalog item type. */
     type: string;
+    /** Title for the catalog item provider */
+    title: string;
     /** Fetch items and normalize it for the catalog. Value is a react effect hook. */
     provider: CodeRef<ExtensionHook<CatalogItem[], CatalogExtensionHookOptions>>;
     /** Priority for this provider. Defaults to 0. Higher priority providers may override catalog

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/error/http-error.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/error/http-error.ts
@@ -64,10 +64,8 @@ export class TimeoutError extends CustomError {
 }
 
 export class IncompleteDataError extends CustomError {
-  public constructor(public successfulCalls: number, public totalCalls: number) {
-    super(
-      `Only ${successfulCalls} of ${totalCalls} resources loaded. Some data might not be displayed.`,
-    );
+  public constructor(public labels: string[]) {
+    super(`Could not fetch all data. This data are missing: ${labels.join(', ')}.`);
   }
 }
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/error/http-error.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/error/http-error.ts
@@ -63,4 +63,12 @@ export class TimeoutError extends CustomError {
   }
 }
 
+export class IncompleteDataError extends CustomError {
+  public constructor(public successfulCalls: number, public totalCalls: number) {
+    super(
+      `Only ${successfulCalls} of ${totalCalls} resources loaded. Some data might not be displayed.`,
+    );
+  }
+}
+
 export class RetryError extends CustomError {}

--- a/frontend/packages/console-shared/src/components/catalog/service/CatalogExtensionHookResolver.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/service/CatalogExtensionHookResolver.tsx
@@ -10,7 +10,7 @@ type CatalogExtensionHookResolverProps = {
   useValue: ExtensionHook<CatalogItem[]>;
   options: CatalogExtensionHookOptions;
   onValueResolved: (value: CatalogItem[], id: string) => void;
-  onValueError: (error: any) => void;
+  onValueError: (error: any, id: string) => void;
 };
 
 const CatalogExtensionHookResolver: React.FC<CatalogExtensionHookResolverProps> = ({
@@ -27,8 +27,8 @@ const CatalogExtensionHookResolver: React.FC<CatalogExtensionHookResolverProps> 
   }, [id, loaded, onValueResolved, value]);
 
   React.useEffect(() => {
-    if (loadError) onValueError(loadError);
-  }, [loadError, onValueError]);
+    if (loadError) onValueError(loadError, id);
+  }, [id, loadError, onValueError]);
 
   return null;
 };

--- a/frontend/packages/console-shared/src/components/catalog/service/CatalogServiceProvider.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/service/CatalogServiceProvider.tsx
@@ -86,7 +86,14 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
     return result;
   }, [catalogProviderExtensions, catalogItems]);
 
-  const successfulCalls = catalogProviderExtensions.filter(({ uid }) => extItemsMap[uid]).length;
+  const failedExtensions = [
+    ...new Set(
+      catalogProviderExtensions
+        .filter(({ uid }) => extItemsErrorMap[uid])
+        .map((e) => e.properties.title),
+    ),
+  ];
+
   const failedCalls = catalogProviderExtensions.filter(({ uid }) => extItemsErrorMap[uid]).length;
   const totalCalls = catalogProviderExtensions.length;
   const loadError =
@@ -94,7 +101,7 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
       ? null
       : failedCalls === totalCalls
       ? new Error('failed loading catalog data')
-      : new IncompleteDataError(successfulCalls, totalCalls);
+      : new IncompleteDataError(failedExtensions);
 
   const catalogService: CatalogService = {
     type: catalogType,

--- a/frontend/packages/console-shared/src/components/catalog/service/CatalogServiceProvider.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/service/CatalogServiceProvider.tsx
@@ -4,6 +4,7 @@ import {
   CatalogExtensionHookOptions,
   CatalogItem,
 } from '@console/dynamic-plugin-sdk/src/extensions';
+import { IncompleteDataError } from '@console/dynamic-plugin-sdk/src/utils/error/http-error';
 import useCatalogExtensions from '../hooks/useCatalogExtensions';
 import { CatalogService } from '../utils';
 import { keywordCompare } from '../utils/catalog-utils';
@@ -31,12 +32,12 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
   ] = useCatalogExtensions(catalogId, catalogType);
 
   const [extItemsMap, setExtItemsMap] = React.useState<{ [uid: string]: CatalogItem[] }>({});
-  const [loadError, setLoadError] = React.useState<any>();
+  const [extItemsErrorMap, setItemsErrorMap] = React.useState<{ [uid: string]: Error }>({});
 
   const loaded =
     extensionsResolved &&
     (catalogProviderExtensions.length === 0 ||
-      catalogProviderExtensions.every(({ uid }) => extItemsMap[uid]));
+      catalogProviderExtensions.every(({ uid }) => extItemsMap[uid] || extItemsErrorMap[uid]));
 
   const catalogItems = React.useMemo(() => {
     if (!loaded) {
@@ -50,6 +51,8 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
           .reduce((acc, ext) => acc.filter(ext.properties.filter), extItemsMap[e.uid]),
       ),
     ).reduce((acc, item) => {
+      if (!item) return acc;
+
       acc[item.uid] = item;
       return acc;
     }, {} as { [uid: string]: CatalogItem });
@@ -59,6 +62,10 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
 
   const onValueResolved = React.useCallback((items, uid) => {
     setExtItemsMap((prev) => ({ ...prev, [uid]: items }));
+  }, []);
+
+  const onValueError = React.useCallback((error, uid) => {
+    setItemsErrorMap((prev) => ({ ...prev, [uid]: error }));
   }, []);
 
   const searchCatalog = React.useCallback(
@@ -79,12 +86,22 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
     return result;
   }, [catalogProviderExtensions, catalogItems]);
 
+  const successfulCalls = catalogProviderExtensions.filter(({ uid }) => extItemsMap[uid]).length;
+  const failedCalls = catalogProviderExtensions.filter(({ uid }) => extItemsErrorMap[uid]).length;
+  const totalCalls = catalogProviderExtensions.length;
+  const loadError =
+    !loaded || failedCalls === 0
+      ? null
+      : failedCalls === totalCalls
+      ? new Error('failed loading catalog data')
+      : new IncompleteDataError(successfulCalls, totalCalls);
+
   const catalogService: CatalogService = {
     type: catalogType,
     items: catalogItems,
     itemsMap: catalogItemsMap,
     loaded,
-    loadError: loaded && catalogItems.length < 1 ? loadError : null,
+    loadError,
     searchCatalog,
     catalogExtensions: catalogTypeExtensions,
   };
@@ -99,7 +116,7 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
             useValue={extension.properties.provider}
             options={defaultOptions}
             onValueResolved={onValueResolved}
-            onValueError={setLoadError}
+            onValueError={onValueError}
           />
         ))}
       {children(catalogService)}

--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -218,6 +218,7 @@
     "properties": {
       "catalogId": "dev-catalog",
       "type": "BuilderImage",
+      "title": "%devconsole~Builder Images%",
       "provider": { "$codeRef": "catalog.builderImageProvider" }
     },
     "flags": {
@@ -241,6 +242,7 @@
     "properties": {
       "catalogId": "dev-catalog",
       "type": "Template",
+      "title": "%devconsole~Templates%",
       "provider": { "$codeRef": "catalog.templateProvider" }
     },
     "flags": {
@@ -264,6 +266,7 @@
     "properties": {
       "catalogId": "dev-catalog",
       "type": "Devfile",
+      "title": "%devconsole~Devfiles%",
       "provider": { "$codeRef": "catalog.devfileProvider" }
     },
     "flags": {
@@ -285,6 +288,7 @@
     "properties": {
       "catalogId": "samples-catalog",
       "type": "Sample",
+      "title": "%devconsole~Builder Images%",
       "provider": { "$codeRef": "catalog.builderImageSamplesProvider" }
     },
     "flags": {
@@ -296,6 +300,7 @@
     "properties": {
       "catalogId": "samples-catalog",
       "type": "Sample",
+      "title": "%devconsole~Devfiles%",
       "provider": { "$codeRef": "catalog.devfileSamplesProvider" }
     },
     "flags": {

--- a/frontend/packages/dev-console/src/components/catalog/providers/useDevfile.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useDevfile.tsx
@@ -54,7 +54,7 @@ const normalizeDevfile = (devfileSamples: DevfileSample[], t: TFunction): Catalo
 };
 
 const useDevfile: ExtensionHook<CatalogItem[]> = (): [CatalogItem[], boolean, any] => {
-  const [devfileSamples, setDevfileSamples] = React.useState<DevfileSample[]>([]);
+  const [devfileSamples, setDevfileSamples] = React.useState<DevfileSample[]>();
   const [loadedError, setLoadedError] = React.useState<APIError>();
   const { t } = useTranslation();
 
@@ -70,7 +70,7 @@ const useDevfile: ExtensionHook<CatalogItem[]> = (): [CatalogItem[], boolean, an
     return () => (mounted = false);
   }, []);
 
-  const normalizedDevfileSamples = React.useMemo(() => normalizeDevfile(devfileSamples, t), [
+  const normalizedDevfileSamples = React.useMemo(() => normalizeDevfile(devfileSamples || [], t), [
     devfileSamples,
     t,
   ]);

--- a/frontend/packages/helm-plugin/console-extensions.json
+++ b/frontend/packages/helm-plugin/console-extensions.json
@@ -125,6 +125,7 @@
     "properties": {
       "catalogId": "dev-catalog",
       "type": "HelmChart",
+      "title": "%helm-plugin~Helm Charts%",
       "provider": { "$codeRef": "helmCatalog.helmChartProvider" }
     },
     "flags": {

--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -485,6 +485,7 @@
     "properties": {
       "catalogId": "dev-catalog",
       "type": "EventSource",
+      "title": "%knative-plugin~Event Sources%",
       "provider": { "$codeRef": "catalog.eventSourceProvider" }
     },
     "flags": {
@@ -496,6 +497,7 @@
     "properties": {
       "catalogId": "dev-catalog",
       "type": "EventSource",
+      "title": "%knative-plugin~Event Sources%",
       "provider": { "$codeRef": "catalog.kameletsProvider" }
     },
     "flags": {

--- a/frontend/packages/kubevirt-plugin/console-extensions.json
+++ b/frontend/packages/kubevirt-plugin/console-extensions.json
@@ -284,6 +284,7 @@
     "properties": {
       "catalogId": "dev-catalog",
       "type": "VmTemplate",
+      "title": "%kubevirt-plugin~VM templates%",
       "provider": { "$codeRef": "createVM.catalogVMTemplateProvider" }
     },
     "flags": {

--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -8,6 +8,7 @@
   "Quickly create a virtual machine from a template.": "Quickly create a virtual machine from a template.",
   "**Virtual Machines** have templates for quickly creating a virtual machine.": "**Virtual Machines** have templates for quickly creating a virtual machine.",
   "Template Providers": "Template Providers",
+  "VM templates": "VM templates",
   "With Data upload form": "With Data upload form",
   "Hardware Devices": "Hardware Devices",
   "Add": "Add",

--- a/frontend/packages/operator-lifecycle-manager/console-extensions.json
+++ b/frontend/packages/operator-lifecycle-manager/console-extensions.json
@@ -22,6 +22,7 @@
     "properties": {
       "catalogId": "dev-catalog",
       "type": "OperatorBackedService",
+      "title": "%olm~Operator Backed Services%",
       "provider": { "$codeRef": "utils.catalogCSVProvider" }
     },
     "flags": {

--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -2,6 +2,7 @@
   "Operator Backed": "Operator Backed",
   "Browse for a variety of managed services that are installed by cluster administrators. Cluster administrators can customize the content made available in the catalog.": "Browse for a variety of managed services that are installed by cluster administrators. Cluster administrators can customize the content made available in the catalog.",
   "**Operator backed** includes a variety of services managed by Kubernetes controllers.": "**Operator backed** includes a variety of services managed by Kubernetes controllers.",
+  "Operator Backed Services": "Operator Backed Services",
   "OperatorHub": "OperatorHub",
   "Installed Operators": "Installed Operators",
   "Edit {{item}}": "Edit {{item}}",

--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -704,6 +704,7 @@
     "properties": {
       "catalogId": "pipelines-task-catalog",
       "type": "Red Hat",
+      "title": "%pipelines-plugin~Tasks%",
       "provider": { "$codeRef": "catalog.TektonTaskProvider" }
     },
     "flags": {
@@ -715,6 +716,7 @@
     "properties": {
       "catalogId": "pipelines-task-catalog",
       "type": "Community",
+      "title": "%pipelines-plugin~Tasks%",
       "provider": { "$codeRef": "catalog.TektonHubTaskProvider" }
     },
     "flags": {

--- a/frontend/packages/rhoas-plugin/console-extensions.json
+++ b/frontend/packages/rhoas-plugin/console-extensions.json
@@ -97,6 +97,7 @@
     "properties": {
       "catalogId": "dev-catalog",
       "type": "managedservices",
+      "title": "%rhoas-plugin~Application Services%",
       "provider": { "$codeRef": "catalog.rhoasProvider" }
     },
     "flags": {

--- a/frontend/packages/rhoas-plugin/locales/en/rhoas-plugin.json
+++ b/frontend/packages/rhoas-plugin/locales/en/rhoas-plugin.json
@@ -8,6 +8,7 @@
   "Managed Services": "Managed Services",
   "Discover managed services to simplify deployments and reduce operational overhead & complexities": "Discover managed services to simplify deployments and reduce operational overhead & complexities",
   "Browse managed services to connect applications and microservices to support services to create a full solution.": "Browse managed services to connect applications and microservices to support services to create a full solution.",
+  "Application Services": "Application Services",
   "Create a Kafka connector": "Create a Kafka connector",
   "Unlock with token": "Unlock with token",
   "Unlocked": "Unlocked",

--- a/frontend/public/components/utils/__tests__/status-box.spec.tsx
+++ b/frontend/public/components/utils/__tests__/status-box.spec.tsx
@@ -123,12 +123,18 @@ describe('StatusBox', () => {
 
   it('should render a patternfly alert together with its children when an IncompleteDataError occured', () => {
     const { getByText } = render(
-      <StatusBox loaded data={[{}]} loadError={new IncompleteDataError(1, 5)}>
+      <StatusBox
+        loaded
+        data={[{}]}
+        loadError={new IncompleteDataError(['Test', 'RedHat', 'Hello World'])}
+      >
         my-children
       </StatusBox>,
     );
 
-    getByText('Only 1 of 5 resources loaded. Some data might not be displayed.');
+    getByText(
+      'Test, RedHat, and Hello World content is not available in the catalog at this time due to loading failures.',
+    );
     getByText('my-children');
   });
 

--- a/frontend/public/components/utils/__tests__/status-box.spec.tsx
+++ b/frontend/public/components/utils/__tests__/status-box.spec.tsx
@@ -1,0 +1,160 @@
+import {
+  IncompleteDataError,
+  TimeoutError,
+} from '@console/dynamic-plugin-sdk/src/utils/error/http-error';
+import { configure, render } from '@testing-library/react';
+import * as React from 'react';
+import {
+  AccessDenied,
+  Box,
+  EmptyBox,
+  LoadError,
+  Loading,
+  LoadingBox,
+  LoadingInline,
+  MsgBox,
+  StatusBox,
+} from '../status-box';
+
+configure({ testIdAttribute: 'data-test' });
+
+describe('Box', () => {
+  it('should render its children', () => {
+    const { getByText } = render(<Box>my-children</Box>);
+
+    //assertion
+    getByText('my-children');
+  });
+});
+
+describe('LoadError', () => {
+  it('should render info with label and message', () => {
+    const { getByText } = render(<LoadError label="test-label" message="test-message" />);
+    getByText('Error Loading test-label: test-message');
+  });
+
+  it('should render info with label and without message', () => {
+    const { getByText } = render(<LoadError label="test-label" />);
+    getByText('Error Loading test-label');
+  });
+
+  it('should render with retry button', () => {
+    const { getByText } = render(<LoadError label="test-label" />);
+    getByText('try again');
+  });
+
+  it('should render without retry button', () => {
+    const { queryByText } = render(<LoadError label="test-label" canRetry={false} />);
+    expect(queryByText('try again')).toBeNull();
+  });
+});
+
+describe('Loading', () => {
+  it('should render skeleton', () => {
+    const { getByTestId } = render(<Loading />);
+    getByTestId('loading-indicator');
+  });
+});
+
+describe('LoadingInline', () => {
+  it('should render skeleton', () => {
+    const { getByTestId } = render(<LoadingInline />);
+    getByTestId('loading-indicator');
+  });
+});
+
+describe('LoadingBox', () => {
+  it('should render skeleton', () => {
+    const { getByTestId } = render(<LoadingBox />);
+    getByTestId('loading-indicator');
+  });
+
+  it('should render message', () => {
+    const { getByText } = render(<LoadingBox message="test-message" />);
+    getByText('test-message');
+  });
+});
+
+describe('EmptyBox', () => {
+  it('should render without label', () => {
+    const { getByText } = render(<EmptyBox />);
+    getByText('Not found');
+  });
+
+  it('should render with label', () => {
+    const { getByText } = render(<EmptyBox label="test-label" />);
+    getByText('No test-label found');
+  });
+});
+
+describe('MsgBox', () => {
+  it('should render title', () => {
+    const { getByText } = render(<MsgBox title="test-title" />);
+    getByText('test-title');
+  });
+
+  it('should render detail', () => {
+    const { getByText } = render(<MsgBox detail="test-detail" />);
+    getByText('test-detail');
+  });
+});
+
+describe('AccessDenied', () => {
+  it('should render message', () => {
+    const { getByText } = render(<AccessDenied message="test-message" />);
+    getByText('test-message');
+  });
+});
+
+describe('StatusBox', () => {
+  it('should render 404: Not Found if the loadError status is 404', () => {
+    const { getByText } = render(<StatusBox loadError={{ response: { status: 404 } }} />);
+    getByText('404: Not Found');
+  });
+
+  it('should render access denied info together with the error message', () => {
+    const { getByText } = render(
+      <StatusBox loadError={{ message: 'test-message', response: { status: 403 } }} />,
+    );
+
+    getByText("You don't have access to this section due to cluster policy.");
+    getByText('test-message');
+  });
+
+  it('should render a patternfly alert together with its children when an IncompleteDataError occured', () => {
+    const { getByText } = render(
+      <StatusBox loaded data={[{}]} loadError={new IncompleteDataError(1, 5)}>
+        my-children
+      </StatusBox>,
+    );
+
+    getByText('Only 1 of 5 resources loaded. Some data might not be displayed.');
+    getByText('my-children');
+  });
+
+  it('should render an info together with its children when loaded and a TimeOutError ocurred', () => {
+    const { getByText } = render(
+      <StatusBox loaded data={[{}]} loadError={new TimeoutError('url', 346)}>
+        my-children
+      </StatusBox>,
+    );
+
+    getByText('Timed out fetching new data. The data below is stale.');
+    getByText('my-children');
+  });
+
+  it("should render skeleton when not loaded and there's no error", () => {
+    const { getByTestId } = render(<StatusBox loaded={false} />);
+    getByTestId('loading-indicator');
+  });
+
+  it("should render its children when loaded and there's no error", () => {
+    const { getByText } = render(
+      <StatusBox loaded data={[{}]}>
+        my-children
+      </StatusBox>,
+    );
+
+    getByText('my-children');
+  });
+});

--- a/frontend/public/components/utils/status-box.tsx
+++ b/frontend/public/components/utils/status-box.tsx
@@ -8,6 +8,7 @@ import {
   TimeoutError,
 } from '@console/dynamic-plugin-sdk/src/utils/error/http-error';
 import * as restrictedSignImg from '../../imgs/restricted-sign.svg';
+import { getLastLanguage } from '@console/app/src/components/user-preferences/language/getLastLanguage';
 
 export const Box: React.FC<BoxProps> = ({ children, className }) => (
   <div className={classNames('cos-status-box', className)}>{children}</div>
@@ -176,8 +177,13 @@ export const StatusBox: React.FC<StatusBoxProps> = (props) => {
             variant="info"
             isInline
             title={t(
-              'public~Only {{successfulCalls}} of {{totalCalls}} resources loaded. Some data might not be displayed.',
-              { successfulCalls: loadError.successfulCalls, totalCalls: loadError.totalCalls },
+              'public~{{labels}} content is not available in the catalog at this time due to loading failures.',
+              {
+                labels: new Intl.ListFormat(getLastLanguage() || 'en', {
+                  style: 'long',
+                  type: 'conjunction',
+                }).format(loadError.labels),
+              },
             )}
           />
           {props.children}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1691,7 +1691,7 @@
   "You don't have access to this section due to cluster policy.": "You don't have access to this section due to cluster policy.",
   "Error details": "Error details",
   "404: Not Found": "404: Not Found",
-  "Only {{successfulCalls}} of {{totalCalls}} resources loaded. Some data might not be displayed.": "Only {{successfulCalls}} of {{totalCalls}} resources loaded. Some data might not be displayed.",
+  "{{labels}} content is not available in the catalog at this time due to loading failures.": "{{labels}} content is not available in the catalog at this time due to loading failures.",
   "Timed out fetching new data. The data below is stale.": "Timed out fetching new data. The data below is stale.",
   "No default StorageClass": "No default StorageClass",
   "Select StorageClass": "Select StorageClass",

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1691,6 +1691,7 @@
   "You don't have access to this section due to cluster policy.": "You don't have access to this section due to cluster policy.",
   "Error details": "Error details",
   "404: Not Found": "404: Not Found",
+  "Only {{successfulCalls}} of {{totalCalls}} resources loaded. Some data might not be displayed.": "Only {{successfulCalls}} of {{totalCalls}} resources loaded. Some data might not be displayed.",
   "Timed out fetching new data. The data below is stale.": "Timed out fetching new data. The data below is stale.",
   "No default StorageClass": "No default StorageClass",
   "Select StorageClass": "Select StorageClass",


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2024262
https://issues.redhat.com/browse/OCPBUGSM-37299

**Analysis / Root cause**: 
On the samples page when you try to add an application from a sample the catalog gets not rendered when one API Call fails but the catalog placeholder is rendered instead. I assume that there are multiple sources for those entries on the samples page.

## Before
<img width="1393" alt="Bildschirmfoto 2021-11-29 um 10 57 49" src="https://user-images.githubusercontent.com/33380107/143846733-97fec538-799f-448f-961d-340f5ef51df0.png">

## After

### partially loaded
<img width="2063" alt="Bildschirmfoto 2021-12-09 um 19 10 59" src="https://user-images.githubusercontent.com/33380107/145453286-f5b48d65-0c1e-47c0-b7a3-cfbde52aacbd.png">
<img width="2063" alt="Bildschirmfoto 2021-12-09 um 19 10 40" src="https://user-images.githubusercontent.com/33380107/145453297-b127eaf3-520a-4762-b660-a450afd1c1e0.png">

### not loaded at all
<img width="2063" alt="Bildschirmfoto 2021-12-09 um 19 10 49" src="https://user-images.githubusercontent.com/33380107/145453364-5fa0721a-2cb3-4a01-8100-4d16d9bba3c7.png">


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge