### PR TITLE
Bug 2027311: Fix k8s watch hooks to work with core resources

### DIFF
--- a/dynamic-demo-plugin/src/components/ListPage.tsx
+++ b/dynamic-demo-plugin/src/components/ListPage.tsx
@@ -84,7 +84,10 @@ export const filters: RowFilter[] = [
 
 const ListPage = () => {
   const [pods, loaded, loadError] = useK8sWatchResource<K8sResourceCommon[]>({
-    kind: 'Pod',
+    groupVersionKind: {
+      version: 'v1',
+      kind: 'Pod',
+    },
     isList: true,
     namespaced: true,
   });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sModel.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sModel.ts
@@ -1,8 +1,24 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
-import { UseK8sModel } from '../../../extensions/console-types';
+import { K8sModel } from '../../../api/common-types';
+import {
+  UseK8sModel,
+  K8sResourceKindReference,
+  K8sGroupVersionKind,
+} from '../../../extensions/console-types';
 import { getGroupVersionKindForReference, transformGroupVersionKindToReference } from '../k8s-ref';
+
+export const getK8sModel = (
+  k8s,
+  k8sGroupVersionKind?: K8sResourceKindReference | K8sGroupVersionKind,
+): K8sModel => {
+  const kindReference = transformGroupVersionKindToReference(k8sGroupVersionKind);
+  return kindReference
+    ? k8s.getIn(['RESOURCES', 'models', kindReference]) ??
+        k8s.getIn(['RESOURCES', 'models', getGroupVersionKindForReference(kindReference).kind])
+    : undefined;
+};
 
 /**
  * Hook that retrieves the k8s model for provided K8sGroupVersionKind from redux.
@@ -16,15 +32,7 @@ import { getGroupVersionKindForReference, transformGroupVersionKindToReference }
  * }
  * ```
  */
-export const useK8sModel: UseK8sModel = (k8sGroupVersionKind) => {
-  const kindReference = transformGroupVersionKindToReference(k8sGroupVersionKind);
-  return [
-    useSelector(({ k8s }) =>
-      kindReference
-        ? k8s.getIn(['RESOURCES', 'models', kindReference]) ??
-          k8s.getIn(['RESOURCES', 'models', getGroupVersionKindForReference(kindReference).kind])
-        : undefined,
-    ),
-    useSelector(({ k8s }) => k8s.getIn(['RESOURCES', 'inFlight']) ?? false),
-  ];
-};
+export const useK8sModel: UseK8sModel = (k8sGroupVersionKind) => [
+  useSelector(({ k8s }) => getK8sModel(k8s, k8sGroupVersionKind)),
+  useSelector(({ k8s }) => k8s.getIn(['RESOURCES', 'inFlight']) ?? false),
+];

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource.ts
@@ -3,27 +3,20 @@ import { Map as ImmutableMap } from 'immutable';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector, useDispatch } from 'react-redux';
-import { K8sModel } from '../../../api/common-types';
 import * as k8sActions from '../../../app/k8s/actions/k8s';
 import { getReduxIdPayload } from '../../../app/k8s/reducers/k8sSelector';
 import { SDKStoreState } from '../../../app/redux-types';
 import { UseK8sWatchResource } from '../../../extensions/console-types';
-import { getReference } from '../k8s-ref';
 import { getIDAndDispatch, getReduxData, NoModelError } from './k8s-watcher';
 import { useDeepCompareMemoize } from './useDeepCompareMemoize';
+import { useK8sModel } from './useK8sModel';
 import { useModelsLoaded } from './useModelsLoaded';
 
 export const useK8sWatchResource: UseK8sWatchResource = (initResource) => {
   const resource = useDeepCompareMemoize(initResource, true);
   const modelsLoaded = useModelsLoaded();
 
-  const kindReference = resource?.groupVersionKind
-    ? getReference(resource.groupVersionKind)
-    : resource?.kind;
-
-  const k8sModel = useSelector<SDKStoreState, K8sModel>(({ k8s }) =>
-    kindReference ? k8s.getIn(['RESOURCES', 'models', kindReference]) : null,
-  );
+  const [k8sModel] = useK8sModel(resource?.groupVersionKind || resource?.kind);
 
   const reduxID = React.useMemo(() => getIDAndDispatch(resource, k8sModel), [k8sModel, resource]);
 


### PR DESCRIPTION
The core issue is that k8s model is not found in redux store because core models are stored as `kind`, not `group~version~kind`.