### PR TITLE
Bug 2009189: fix annotations on updating deployment

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/topology-details.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/topology-details.ts
@@ -37,9 +37,7 @@ export type DetailsTabSection = ExtensionDeclaration<
      * @param renderNull should be used for section that defines Adapter to
      *  determine if adapter component renders null or not
      * */
-    section: CodeRef<
-      (element: GraphElement, renderNull?: () => null) => React.Component | undefined
-    >;
+    section: CodeRef<DetailsTabSectionCallback>;
     /** Insert this item before the item referenced here.
      * For arrays, the first one found in order is used.
      * */
@@ -169,3 +167,8 @@ export type PodsAdapterDataType<E = K8sResourceCommon> = {
 export type NetworkAdapterType = {
   resource: K8sResourceCommon;
 };
+
+export type DetailsTabSectionCallback = (
+  element: GraphElement,
+  renderNull?: () => null,
+) => React.Component | undefined;


### PR DESCRIPTION
Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=2009189
https://issues.redhat.com/browse/OCPBUGSM-35668

Problem:
Changing annotations value in workload sidebar do not reflect on sidebar automatically. The same can be also reproduced for labels and tolerations. (It should be reproducible for any editable property in the sidebar).
Also, if a deployment is open in console in multiple tabs, and it is edited in one tab, the changes does not reflect on the other tabs.

Solution:
update the deployment in sidebar to reflect changes made to it.

Screens:
https://user-images.githubusercontent.com/38663217/144112940-730ae40c-41a6-448f-8465-1d7c2585a334.mp4

Tests:
![Screenshot from 2021-12-01 00-43-30](https://user-images.githubusercontent.com/38663217/144113010-fc7e65f3-2990-4c44-b6ec-03d7584d26b9.png)

Browser conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Chrome