### PR TITLE
Bug 2024316: Display correct annotation in Template support modal

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/support-modal/support-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/support-modal/support-modal.tsx
@@ -9,7 +9,7 @@ import {
 } from '@console/internal/components/factory';
 import { ExternalLink } from '@console/internal/components/utils';
 import { BlueInfoCircleIcon } from '@console/shared';
-import { TEMPLATE_PROVIDER_ANNOTATION, TEMPLATE_SUPPORT_LEVEL } from '../../../constants';
+import { TEMPLATE_PROVIDER_URL, TEMPLATE_SUPPORT_LEVEL } from '../../../constants';
 import { SUPPORT_URL } from '../../../constants/vm-templates/constants';
 import { TemplateSupport } from '../../../constants/vm-templates/support';
 import { ModalFooter } from '../modal/modal-footer';
@@ -68,7 +68,7 @@ const SupportModal: React.FC<SupportModalProps> = ({
               </StackItem>
               <StackItem>
                 <Label className="kv-support-label">
-                  {TEMPLATE_PROVIDER_ANNOTATION}: Your company name
+                  {TEMPLATE_PROVIDER_URL}: Your company name
                 </Label>
                 <Label>
                   {TEMPLATE_SUPPORT_LEVEL}: {TemplateSupport.FULL_SUPPORT.getValue()}


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2024316

**Analysis / Root cause**:
Incorrect constant `TEMPLATE_PROVIDER_ANNOTATION` used for displaying the info about missing annotation, in the Template support modal dialog when creating a VM from a user-defined template which contains the label `template.kubevirt.io/provider`.

**Solution Description**:
Use the correct constant `TEMPLATE_PROVIDER_URL`.

**Screen shots / Gifs for design review**:
Before:
![before](https://user-images.githubusercontent.com/13417815/143879935-29082dac-f899-439e-9203-337e63e6e5c6.png)

After
![after](https://user-images.githubusercontent.com/13417815/143879952-d798eba0-43be-4d95-8f76-734a2177d3b2.png)
