### PR TITLE
Bug 2027299: The status of checkbox component is not revealed correctly in code

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/capacity-and-nodes-step/capacity-and-nodes-step.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/capacity-and-nodes-step/capacity-and-nodes-step.tsx
@@ -56,6 +56,7 @@ const EnableTaintNodes: React.FC<EnableTaintNodesProps> = ({ dispatch, enableTai
       )}
       className="odf-capacity-and-nodes__taint-checkbox"
       id="taint-nodes"
+      data-checked-state={enableTaint}
       isChecked={enableTaint}
       onChange={() => dispatch({ type: 'capacityAndNodes/enableTaint', payload: !enableTaint })}
     />

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/capacity-and-nodes-step/stretch-cluster.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/capacity-and-nodes-step/stretch-cluster.tsx
@@ -61,6 +61,7 @@ export const StretchCluster: React.FC<StretchClusterProps> = ({
         aria-label={t('ceph-storage-plugin~Enable arbiter')}
         id="stretch-cluster"
         isChecked={enableArbiter}
+        data-checked-state={enableArbiter}
         label={<EnableArbiterLabel />}
         description={<HelperText enableArbiter={enableArbiter} />}
         onChange={(hasChecked: boolean) => {

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/security-and-network-step/encryption.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/security-and-network-step/encryption.tsx
@@ -58,6 +58,7 @@ const EncryptionLevel: React.FC<EncryptionLevelProps> = ({ encryption, dispatch 
         id="cluster-wide-encryption"
         className="odf-security-encryption"
         isChecked={encryption.clusterWide}
+        data-checked-state={encryption.clusterWide}
         label={<span>{t('ceph-storage-plugin~Cluster-wide encryption')}</span>}
         description={t('ceph-storage-plugin~Encryption for the entire cluster (block and file)')}
         onChange={handleClusterWideEncryption}
@@ -66,6 +67,7 @@ const EncryptionLevel: React.FC<EncryptionLevelProps> = ({ encryption, dispatch 
         id="storage-class-encryption"
         className="odf-security-encryption"
         isChecked={encryption.storageClass}
+        data-checked-state={encryption.storageClass}
         label={<EncryptionLabel label={t('ceph-storage-plugin~StorageClass encryption')} />}
         description={t(
           'ceph-storage-plugin~An encryption key will be generated for each persistent volume (block) created using an encryption enabled StorageClass.',
@@ -114,6 +116,7 @@ const KMSConnection: React.FC<EncryptionProps> = ({ encryption, kms, dispatch, i
       <Checkbox
         id="kms-connection"
         isChecked={encryption.advanced}
+        data-checked-state={encryption.advanced}
         label={t('ceph-storage-plugin~Connect to an external key management service')}
         onChange={handleOnChange}
         isDisabled={encryption.storageClass || !encryption.hasHandled}
@@ -203,6 +206,7 @@ export const Encryption: React.FC<EncryptionProps> = ({ encryption, kms, dispatc
           data-test="encryption-checkbox"
           id="configure-encryption"
           isChecked={isMCG || encryptionChecked}
+          data-checked-state={isMCG || encryptionChecked}
           isDisabled={isMCG}
           label={encryptionLabel}
           description={description}

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-wizard/capacity-and-nodes.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-wizard/capacity-and-nodes.tsx
@@ -109,6 +109,7 @@ export const EnableTaintNodes: React.FC<EnableTaintNodesProps> = ({
       className="ocs-enable-taint"
       id="taint-nodes"
       isChecked={enableTaint}
+      data-checked-state={enableTaint}
       onChange={setEnableTaint}
     />
   );
@@ -176,6 +177,7 @@ export const StretchClusterFormGroup: React.FC<StretchClusterFormGroupProps> = (
         aria-label={t('ceph-storage-plugin~Enable arbiter')}
         id="arbiter-cluster"
         isChecked={stretchClusterChecked}
+        data-checked-state={stretchClusterChecked}
         label={<EnableArbiterLabel />}
         description={t(
           'ceph-storage-plugin~To support high availability when two data centers can be used, enable arbiter to get the valid quorum between two data centers.',

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-wizard/configure.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-wizard/configure.tsx
@@ -131,6 +131,7 @@ export const EncryptionFormGroup: React.FC<EncryptionFormGroupProps> = ({
           data-test="encryption-checkbox"
           id="enable-encryption"
           isChecked={encryptionChecked}
+          data-checked-state={encryptionChecked}
           label={t('ceph-storage-plugin~Enable Encryption')}
           description={t(
             'ceph-storage-plugin~Data encryption for block and file storage. MultiCloud Object Gateway is always encrypted.',
@@ -150,6 +151,7 @@ export const EncryptionFormGroup: React.FC<EncryptionFormGroupProps> = ({
               <Checkbox
                 id="cluster-wide-encryption"
                 isChecked={encryption.clusterWide}
+                data-checked-state={encryption.clusterWide}
                 label={
                   <span className="ocs-install-encryption__pv-title--padding">
                     {t('ceph-storage-plugin~Cluster-wide encryption')}
@@ -165,6 +167,7 @@ export const EncryptionFormGroup: React.FC<EncryptionFormGroupProps> = ({
               <Checkbox
                 id="storage-class-encryption"
                 isChecked={encryption.storageClass}
+                data-checked-state={encryption.storageClass}
                 label={<StorageClassEncryptionLabel />}
                 aria-label={t('ceph-storage-plugin~StorageClass encryption')}
                 description={t(
@@ -184,6 +187,7 @@ export const EncryptionFormGroup: React.FC<EncryptionFormGroupProps> = ({
               <Checkbox
                 id="advanced-encryption"
                 isChecked={encryption.advanced}
+                data-checked-state={encryption.advanced}
                 label={t('ceph-storage-plugin~Connect to an external key management service')}
                 onChange={toggleAdvancedEncryption}
                 isDisabled={encryption.storageClass || !encryption.hasHandled}

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-storage-class-form/ocs-storage-class-form.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-storage-class-form/ocs-storage-class-form.tsx
@@ -285,6 +285,7 @@ export const StorageClassEncryption: React.FC<ProvisionerProps> = ({
             <Checkbox
               id="storage-class-encryption"
               isChecked={checked}
+              data-checked-state={checked}
               label={<StorageClassEncryptionLabel />}
               aria-label={t('ceph-storage-plugin~StorageClass encryption')}
               onChange={setChecked}

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-storage-class-form/ocs-thick-provisioner.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-storage-class-form/ocs-thick-provisioner.tsx
@@ -27,6 +27,7 @@ export const ThickProvision: React.FC<ProvisionerProps> = ({ parameterKey, onPar
           id="ocs-sc-thickprovision-checkbox"
           data-test="ocs-sc-thickprovision-checkbox"
           isChecked={checked}
+          data-checked-state={checked}
           label={t('ceph-storage-plugin~Enable Thick Provisioning')}
           onChange={setChecked}
         />

--- a/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
@@ -242,6 +242,7 @@ const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
                 label={t('public~Wrap lines')}
                 id="wrapLogLines"
                 isChecked={isWrapLines}
+                data-checked-state={isWrapLines}
                 onChange={(checked: boolean) => {
                   setWrapLines(checked);
                 }}

--- a/frontend/packages/console-app/src/components/user-preferences/UserPreferenceCheckboxField.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/UserPreferenceCheckboxField.tsx
@@ -41,6 +41,7 @@ const UserPreferenceCheckboxField: React.FC<UserPreferenceCheckboxFieldProps> = 
       id={id}
       label={label}
       isChecked={currentUserPreferenceValue === trueValue}
+      data-checked-state={currentUserPreferenceValue === trueValue}
       onChange={onChange}
       data-test={`checkbox ${id}`}
     />

--- a/frontend/packages/console-app/src/components/user-preferences/language/LanguageDropdown.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/language/LanguageDropdown.tsx
@@ -56,6 +56,7 @@ const LanguageDropdown: React.FC = () => {
         id="default-language-checkbox"
         label={checkboxLabel}
         isChecked={isUsingDefault}
+        data-checked-state={isUsingDefault}
         onChange={onUsingDefault}
         aria-label={checkboxLabel}
         data-test="checkbox console.preferredLanguage"

--- a/frontend/packages/console-shared/src/components/dynamic-form/widgets.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/widgets.tsx
@@ -75,6 +75,7 @@ export const CheckboxWidget: React.FC<WidgetProps> = ({ value = false, id, label
       id={id}
       key={id}
       isChecked={value}
+      data-checked-state={value}
       label={label}
       onChange={(checked) => onChange(checked)}
     />

--- a/frontend/packages/console-shared/src/components/formik-fields/CheckboxField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/CheckboxField.tsx
@@ -5,7 +5,9 @@ import { CheckboxFieldProps } from './field-types';
 import ToggleableFieldBase from './ToggleableFieldBase';
 
 const CheckboxField: React.FC<CheckboxFieldProps> = (baseProps) => (
-  <ToggleableFieldBase {...baseProps}>{(props) => <Checkbox {...props} />}</ToggleableFieldBase>
+  <ToggleableFieldBase {...baseProps}>
+    {(props) => <Checkbox {...props} data-checked-state={props.isChecked} />}
+  </ToggleableFieldBase>
 );
 
 export default CheckboxField;

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form-status.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form-status.tsx
@@ -172,6 +172,7 @@ const CDIInitErrorStatus: React.FC<CDIInitErrorStatus> = ({ onErrorClick, pvcNam
               <Checkbox
                 id="approve-checkbox"
                 isChecked={shouldKillDv}
+                data-checked-state={shouldKillDv}
                 aria-label="kill datavolume checkbox"
                 label={`Delete Data Volume: ${pvcName}`}
                 onChange={(v) => setShouldKillDv(v)}

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
@@ -331,6 +331,7 @@ export const UploadPVCForm: React.FC<UploadPVCFormProps> = ({
             className="kv--create-upload__golden-switch"
             label={t('kubevirt-plugin~Attach this data to a Virtual Machine operating system')}
             isChecked={isGolden}
+            data-checked-state={isGolden}
             onChange={handleGoldenCheckbox}
             isDisabled={isLoading}
           />
@@ -386,6 +387,7 @@ export const UploadPVCForm: React.FC<UploadPVCFormProps> = ({
                   id="golden-os-checkbox-pvc-size-template"
                   className="kv--create-upload__golden-switch"
                   isChecked={pvcSizeFromTemplate}
+                  data-checked-state={pvcSizeFromTemplate}
                   label={t('kubevirt-plugin~Use template size PVC')}
                   onChange={handlePvcSizeTemplate}
                 />
@@ -393,6 +395,7 @@ export const UploadPVCForm: React.FC<UploadPVCFormProps> = ({
                   id="golden-os-checkbox-pvc-size-template"
                   className="kv--create-upload__golden-switch"
                   isChecked={!!mountAsCDROM}
+                  data-checked-state={!!mountAsCDROM}
                   label={t('kubevirt-plugin~This is a CD-ROM boot source')}
                   onChange={handleCDROMChange}
                 />
@@ -480,6 +483,7 @@ export const UploadPVCForm: React.FC<UploadPVCFormProps> = ({
                     'kubevirt-plugin~Use optimized access mode & volume mode settings from StorageProfile resource.',
                   )}
                   isChecked={applySP}
+                  data-checked-state={applySP}
                   onChange={() => setApplySP(!applySP)}
                   isDisabled={!isSPSettingProvided}
                   label={t('kubevirt-plugin~Apply optimized StorageProfile settings')}

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form.tsx
@@ -145,6 +145,7 @@ const AdvancedSection: React.FC<AdvancedSectionProps> = ({
               'kubevirt-plugin~Use optimized access mode & volume mode settings from StorageProfile resource.',
             )}
             isChecked={applySP}
+            data-checked-state={applySP}
             onChange={() => setApplySP(!applySP)}
             isDisabled={!isSPSettingProvided}
             label={t('kubevirt-plugin~Apply optimized StorageProfile settings')}
@@ -365,6 +366,7 @@ export const BootSourceForm: React.FC<BootSourceFormProps> = ({
       <FormRow fieldId="form-ds-cdrom">
         <Checkbox
           isChecked={state.cdRom?.value}
+          data-checked-state={state.cdRom?.value}
           onChange={(payload) => dispatch({ type: BOOT_ACTION_TYPE.SET_CD_ROM, payload })}
           isDisabled={disabled}
           label={

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/create-vm-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/create-vm-form.tsx
@@ -334,6 +334,7 @@ export const CreateVMForm: React.FC<CreateVMFormProps> = ({
           <FormRow fieldId="start-vm">
             <Checkbox
               isChecked={startVM}
+              data-checked-state={startVM}
               onChange={(value) => dispatch({ type: FORM_ACTION_TYPE.START_VM, payload: value })}
               label={t('kubevirt-plugin~Start this virtual machine after creation')}
               id="start-vm"

--- a/frontend/packages/kubevirt-plugin/src/components/modals/clone-vm-modal/clone-vm-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/clone-vm-modal/clone-vm-modal.tsx
@@ -199,6 +199,7 @@ export const CloneVMModal = withHandlePromise<CloneVMModalProps>((props) => {
               label={t('kubevirt-plugin~Start virtual machine on clone')}
               id={asId('start')}
               isChecked={startVM}
+              data-checked-state={startVM}
               onChange={setStartVM}
               className="kubevirt-clone-vm-modal__start_vm_checkbox"
             />

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -621,6 +621,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
               )}
               isDisabled={!isVMRunning}
               isChecked={autoDetach}
+              data-checked-state={autoDetach}
               onChange={() => setAutoDetach(!autoDetach)}
             />
           </FormRow>
@@ -694,6 +695,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
                         'kubevirt-plugin~Use optimized access mode & volume mode settings from StorageProfile resource.',
                       )}
                       isChecked={applySP}
+                      data-checked-state={applySP}
                       onChange={() => setApplySP(!applySP)}
                       isDisabled={!isSPSettingProvided}
                       label={t('kubevirt-plugin~Apply optimized StorageProfile settings')}
@@ -752,6 +754,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
                   }
                   isDisabled={!source.requiresBlankDisk()}
                   isChecked={enablePreallocation}
+                  data-checked-state={enablePreallocation}
                   label={t('kubevirt-plugin~Enable preallocation')}
                   onChange={() => onTogglePreallocation()}
                 />

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/dedicated-resources-modal/dedicated-resources-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/dedicated-resources-modal/dedicated-resources-modal.tsx
@@ -79,6 +79,7 @@ export const DedicatedResourcesModal = withHandlePromise<DedicatedResourcesModal
               'kubevirt-plugin~Schedule this workload with dedicated resources (guaranteed policy)',
             )}
             isChecked={isPinned}
+            data-checked-state={isPinned}
             isDisabled={!isLoaded(nodes) || inProgress}
             onChange={(flag) => setIsPinned(flag)}
             id="dedicated-resources-checkbox"

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/eviction-strategy-modal/eviction-strategy-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/eviction-strategy-modal/eviction-strategy-modal.tsx
@@ -45,6 +45,7 @@ const EvictionStrategyModal = withHandlePromise<EvictionStrategyModalWithPromise
           id="eviction-strategy"
           className="kubevirt-scheduling__checkbox"
           isChecked={isCheckedEvictionStrategy}
+          data-checked-state={isCheckedEvictionStrategy}
           onChange={() => setIsCheckedEvictionStrategy((value) => !value)}
           label={t('kubevirt-plugin~LiveMigrate')}
         />

--- a/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-modal/SnapshotsModal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-modal/SnapshotsModal.tsx
@@ -144,6 +144,7 @@ const SnapshotsModal = withHandlePromise((props: SnapshotsModalProps) => {
               <Checkbox
                 id="approve-checkbox"
                 isChecked={approveUnsupported}
+                data-checked-state={approveUnsupported}
                 aria-label={t('kubevirt-plugin~unsupported approve checkbox')}
                 label={t('kubevirt-plugin~I am aware of this warning and wish to proceed')}
                 onChange={setApproveUnsupported}

--- a/frontend/packages/kubevirt-plugin/src/components/modals/support-modal/support-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/support-modal/support-modal.tsx
@@ -82,6 +82,7 @@ const SupportModal: React.FC<SupportModalProps> = ({
               label={t('kubevirt-plugin~Do not show this message again')}
               onChange={setDoNotShow}
               isChecked={doNotShow}
+              data-checked-state={doNotShow}
             />
           </StackItem>
         </Stack>

--- a/frontend/packages/kubevirt-plugin/src/components/modals/template-customization/CustomizeSourceModal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/template-customization/CustomizeSourceModal.tsx
@@ -52,6 +52,7 @@ const CustomizeSourceModal: React.FC<CustomizeSourceModalProps> = ({ close, onCo
               label={t('kubevirt-plugin~Do not show this message again')}
               onChange={setDoNotShow}
               isChecked={doNotShow}
+              data-checked-state={doNotShow}
             />
           </StackItem>
         </Stack>

--- a/frontend/packages/kubevirt-plugin/src/components/modals/template-customization/FinishCustomizationModal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/template-customization/FinishCustomizationModal.tsx
@@ -50,6 +50,7 @@ const FinishCustomizationModal: React.FC<FinishCustomizationModalProps> = ({
               )}
               onChange={setConfirmed}
               isChecked={confirmed}
+              data-checked-state={confirmed}
               className="kv-finish-modal__checkbox"
             />
             <ExternalLink href={SEAL_BOOT_SOURCE_URL}>

--- a/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHCreateService/SSHCreateService.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHCreateService/SSHCreateService.tsx
@@ -29,6 +29,7 @@ const SSHCreateService: React.FC<SSHCreateServiceProps> = ({
           className="kv-ssh-service-checkbox--main"
           label={<SSHCreateServicePopup vmName={vmName} hidePopup={hidePopup} />}
           isChecked={enableSSHService}
+          data-checked-state={enableSSHService}
           onChange={(checked) => {
             setEnableSSHService(checked);
           }}

--- a/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHForm/SSHFormSave/SSHFormSaveInNamespace.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHForm/SSHFormSave/SSHFormSaveInNamespace.tsx
@@ -25,6 +25,7 @@ const SSHFormSaveInNamespace: React.FC = () => {
           </>
         }
         isChecked={updateSSHKeyInGlobalNamespaceSecret}
+        data-checked-state={updateSSHKeyInGlobalNamespaceSecret}
         isDisabled={disableSaveInNamespaceCheckbox}
         onChange={(checked) => setUpdateSSHKeyInSecret(checked)}
       />

--- a/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHModal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHModal.tsx
@@ -48,6 +48,7 @@ const SSHModal: React.FC<SSHModalProps> = ({ vm, close }) => {
                 </Trans>
               }
               isChecked={isEnabled}
+              data-checked-state={isEnabled}
               onChange={setEnabled}
             />
           </StackItem>

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/customize-source/CustomizeSourceForm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/customize-source/CustomizeSourceForm.tsx
@@ -433,6 +433,7 @@ const CustomizeSourceForm: React.FC<RouteComponentProps> = ({ location }) => {
                   <Checkbox
                     label="Inject cloud-init"
                     isChecked={injectCloudInit}
+                    data-checked-state={injectCloudInit}
                     onChange={(payload) =>
                       formDispatch({
                         type: FORM_ACTION_TYPE.INJECT_CLOUD_INIT,

--- a/frontend/packages/metal3-plugin/src/components/modals/PowerOffHostModal.tsx
+++ b/frontend/packages/metal3-plugin/src/components/modals/PowerOffHostModal.tsx
@@ -148,6 +148,7 @@ const ForcePowerOffDialog: React.FC<ForcePowerOffDialogProps> = ({
           label={t('metal3-plugin~Power off immediately')}
           onChange={setForceOff}
           isChecked={forceOff}
+          data-checked-state={forceOff}
         />
         <div className="text-secondary">{helpText}</div>
       </StackItem>

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
@@ -231,6 +231,7 @@ const CheckboxUIComponent: React.FC<SpecCapabilityProps> = ({
           id={descriptor.path}
           style={{ marginLeft: '10px' }}
           isChecked={checked}
+          data-checked-state={checked}
           label={label}
           onChange={(val) => {
             setChecked(val);

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/DEPRECATED_operand-form.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/DEPRECATED_operand-form.tsx
@@ -859,6 +859,7 @@ export const DEPRECATED_CreateOperandForm: React.FC<OperandFormProps> = ({
           id={id}
           style={{ marginLeft: '10px' }}
           isChecked={(_.isNil(currentValue) ? false : currentValue) as boolean}
+          data-checked-state={(_.isNil(currentValue) ? false : currentValue) as boolean}
           label={displayName}
           required={required}
           onChange={(value) => handleFormDataUpdate(path, value)}

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-community-provider-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-community-provider-modal.tsx
@@ -52,6 +52,7 @@ export const OperatorHubCommunityProviderModal: React.FC<OperatorHubCommunityPro
               className="co-modal-ignore-warning__checkbox"
               onChange={setIgnoreWarnings}
               isChecked={ignoreWarnings}
+              data-checked-state={ignoreWarnings}
               id="do-not-show-warning"
               label={t('olm~Do not show this warning again')}
             />

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -546,6 +546,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
             label={t('olm~Enable Operator recommended cluster monitoring on this Namespace')}
             onChange={setEnableMonitoring}
             isChecked={enableMonitoring}
+            data-checked-state={enableMonitoring}
           />
           {props.packageManifest.data[0].metadata.labels['opsrc-provider'] !== 'redhat' && (
             <Alert

--- a/frontend/public/components/RBAC/edit-rule.jsx
+++ b/frontend/public/components/RBAC/edit-rule.jsx
@@ -58,6 +58,7 @@ const Checkbox = ({ value, checked, onChange }) => (
         type="checkbox"
         onChange={({ target: { checked: newChecked } }) => onChange(value, newChecked)}
         checked={!!checked}
+        data-checked-state={!!checked}
       />
       &nbsp;&nbsp;{value}
     </label>

--- a/frontend/public/components/checkbox.tsx
+++ b/frontend/public/components/checkbox.tsx
@@ -10,6 +10,7 @@ export const Checkbox: React.SFC<CheckboxProps> = ({ name, label, checked, onCha
           name={name}
           onChange={onChange}
           checked={checked}
+          data-checked-state={checked}
           type="checkbox"
         />
         {label}

--- a/frontend/public/components/container-selector.tsx
+++ b/frontend/public/components/container-selector.tsx
@@ -15,6 +15,7 @@ export const ContainerSelector: React.FC<ContainerSelectorProps> = ({
         label={`${container.name} from image ${container.image}`}
         id={container.name}
         isChecked={selected.includes(container.name)}
+        data-checked-state={selected.includes(container.name)}
         onChange={onChange}
       />
     ))}

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -870,6 +870,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
               <Checkbox
                 id="stacked"
                 isChecked={isStacked}
+                data-checked-state={isStacked}
                 label={t('public~Stacked')}
                 onChange={(v) => setIsStacked(v)}
               />

--- a/frontend/public/components/utils/resource-log.tsx
+++ b/frontend/public/components/utils/resource-log.tsx
@@ -232,6 +232,7 @@ export const LogControls: React.FC<LogControlsProps> = ({
           label={t('public~Wrap lines')}
           id="wrapLogLines"
           isChecked={isWrapLines}
+          data-checked-state={isWrapLines}
           onChange={(checked: boolean) => {
             toggleWrapLines(checked);
           }}


### PR DESCRIPTION
Addresses [Bug 2027299](https://bugzilla.redhat.com/show_bug.cgi?id=2027299)

Because browsers don't always update the "checked" attribute, testing for the checked state of a checkbox in automated tests can be difficult.

This PR adds a `data-checked-state` attribute that has the same value as the checked state.

This is a similar fix that was implemented in [Bug 2005554](https://bugzilla.redhat.com/show_bug.cgi?id=2005554) to a single checkbox, but this fix applied to all checkboxes.

**Note:** This does not impact the functionality of the application.  It only adds a harmless attribute in the HTML code that can be used during testing.