### PR TITLE
Bug 2014352: Could not filter out machine by using node name on machines page (temp fix)

### DIFF
--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -38,6 +38,7 @@ import { useK8sWatchResource } from './utils/k8s-watch-hook';
 import VirtualizedTable, { TableData } from './factory/Table/VirtualizedTable';
 import { sortResourceByValue } from './factory/Table/sort';
 import { useActiveColumns } from './factory/Table/active-columns-hook';
+import { tableFilters } from './factory/table-filters';
 
 const { common } = Kebab.factory;
 const menuActions = [...Kebab.getExtensionsActionsForKind(MachineModel), ...common];
@@ -281,7 +282,10 @@ export const MachinePage: React.FC<MachinePageProps> = ({
     namespace,
   });
 
-  const [data, filteredData, onFilterChange] = useListPageFilter(machines);
+  // FIXME - there isn't a type for a simple filter like this nor is there an easy way to add this type
+  const machineFilter = [{ type: 'name', filter: tableFilters.machine }];
+  //@ts-ignore
+  const [data, filteredData, onFilterChange] = useListPageFilter(machines, machineFilter);
 
   return (
     <>


### PR DESCRIPTION
his address [Bug 2014352](https://bugzilla.redhat.com/show_bug.cgi?id=2014352)

In version 4.8, on the machine list when using the "name" filter, the filter would accept matches from both the "name" and "node" columns of the table.  In version 4.9, this changed so only matches from the "name" column were considered.

This PR brings the 4.8 functionality back.

**Filtering machine by name**
<img width="500" alt="Screen Shot 2021-11-10 at 1 03 38 PM" src="https://user-images.githubusercontent.com/82059948/141491933-1771153d-7159-46a6-aff6-0fe29f354edd.png">


**Filtering machine by node**
<img width="500" alt="Screen Shot 2021-11-10 at 1 04 05 PM" src="https://user-images.githubusercontent.com/82059948/141177290-3a0651f0-9eb2-42b3-8cfe-ee61f28bc122.png">


**NOTE** This is a temporary fix to address the bug.  While investigating this bug, it was discovered that there are multiple type definitions.  Those definitions are not compatible with the addition of a simple type/filter required for this bug fix.  In order to move this bug forward, a `@ts-ignore` was added and Jira card [CONSOLE-3008](https://issues.redhat.com/browse/CONSOLE-3008) was created to clean up the typing and remove the `@ts-ignore` added to this PR.  See [PR 10281 ](https://github.com/openshift/console/pull/10281)for a history of this work.