### PR TITLE
[WIP] Bug 2027613: use the correct Alertmanager tenancy proxy

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -163,7 +163,7 @@ func (s *Server) prometheusProxyEnabled() bool {
 }
 
 func (s *Server) alertManagerProxyEnabled() bool {
-	return s.AlertManagerProxyConfig != nil
+	return s.AlertManagerProxyConfig != nil && s.AlertManagerTenancyProxyConfig != nil
 }
 
 func (s *Server) meteringProxyEnabled() bool {
@@ -389,7 +389,7 @@ func (s *Server) HTTPHandler() http.Handler {
 			alertManagerTenancyProxyAPIPath = alertManagerTenancyProxyEndpoint + "/api/"
 
 			alertManagerProxy        = proxy.NewProxy(s.AlertManagerProxyConfig)
-			alertManagerTenancyProxy = proxy.NewProxy(s.AlertManagerProxyConfig)
+			alertManagerTenancyProxy = proxy.NewProxy(s.AlertManagerTenancyProxyConfig)
 		)
 
 		handle(alertManagerProxyAPIPath, http.StripPrefix(


### PR DESCRIPTION
The /api/alertmanager-tenancy/* proxy should forward requests to the
Alertmanager tenancy service instead of the privileged service.