### PR TITLE
Automation enhance export app ux experience odc 6296

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/global.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/global.ts
@@ -31,6 +31,7 @@ export enum operators {
   WebTerminalOperator = 'Web Terminal',
   ApacheKafka = 'Red Hat Integration - AMQ Streams',
   RedHatCodereadyWorkspaces = 'Red Hat CodeReady Workspaces',
+  GitopsPrimer = 'gitops-primer',
 }
 
 export enum authenticationType {

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/operators-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/operators-po.ts
@@ -32,6 +32,7 @@ export const operatorsPO = {
     redHatSourceType: '[data-test-group-name="catalogSourceDisplayName"] [title="Red Hat"]',
     redHatCodeReadyWorkspacesCard:
       '[data-test^="codeready-workspaces-redhat-operators-openshift-marketplace"]',
+    gitopsPrimer: '[data-test="gitops-primer-community-operators-openshift-marketplace"]',
   },
   subscription: {
     logo: 'h1.co-clusterserviceversion-logo__name__clusterserviceversion',

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster.ts
@@ -1,3 +1,4 @@
+import { modal } from '@console/cypress-integration-tests/views/modal';
 import { pageTitle, operators, switchPerspective } from '../../constants';
 import { devNavigationMenuPO, operatorsPO } from '../../pageObjects';
 import { app, perspective, projectNameSpace, sidePane } from '../app';
@@ -9,6 +10,13 @@ export const installOperator = (operatorName: operators) => {
   operatorsPage.navigateToOperatorHubPage();
   operatorsPage.searchOperator(operatorName);
   operatorsPage.selectOperator(operatorName);
+  cy.get('body').then(($body) => {
+    if ($body.text().includes('Show community Operator')) {
+      cy.log('Installing community operator');
+      modal.submit();
+      modal.shouldBeClosed();
+    }
+  });
   operatorsPage.verifySidePane();
   cy.get(operatorsPO.alertDialog).then(($sidePane) => {
     if ($sidePane.find(operatorsPO.sidePane.install).length) {
@@ -110,4 +118,9 @@ export const verifyAndInstallPipelinesOperator = () => {
 export const verifyAndInstallKnativeOperator = () => {
   perspective.switchTo(switchPerspective.Administrator);
   verifyAndInstallOperator(operators.ServerlessOperator);
+};
+
+export const verifyAndInstallGitopsPrimerOperator = () => {
+  perspective.switchTo(switchPerspective.Administrator);
+  verifyAndInstallOperator(operators.GitopsPrimer);
 };

--- a/frontend/packages/dev-console/integration-tests/support/pages/operators-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/operators-page.ts
@@ -132,6 +132,11 @@ export const operatorsPage = {
         cy.get(operatorsPO.operatorHub.webTerminalOperatorCard).click();
         break;
       }
+      case 'gitops-primer':
+      case operators.GitopsPrimer: {
+        cy.get(operatorsPO.operatorHub.gitopsPrimer).click();
+        break;
+      }
       default: {
         throw new Error('operator is not available');
       }

--- a/frontend/packages/topology/integration-tests/features/export-application/export-of-applicaton.feature
+++ b/frontend/packages/topology/integration-tests/features/export-application/export-of-applicaton.feature
@@ -6,26 +6,31 @@ Feature: Export of application
 
     #The operator mentioned below needs to be installed beforehand due to the issue in its installation
         Background:
-            Given user has installed Gitops primer Operator
+            # Given user has installed Gitops primer Operator
               And user is at developer perspective
               And user has created or selected namespace "aut-export-application"
 
 
-        @smoke
+#marking below test as broken due to intermittent issue of not getting toast notification after export is complete
+        @smoke @broken-test
         Scenario: Export application button in topology: EA-02-TC01
             Given user has created a deployment workload "nodejs-ex-git-1"
              When user navigates to Topology page
               And user clicks on Export Application button
              Then user can see a toast message saying "Export of resources in aut-export-application has started."
+              And user can see a toast message saying "All the resources are exported successfully from aut-export-application. Click below to download it." and close it
               And user can see primer job created in topology
 
 
         @regression @odc-6296
         Scenario: Export Application modal when export application is in progress: EA-02-TC02
-            Given user is at Topology page
+            Given user has created a deployment workload "nodejs-ex-git-2"
+              And user is at Topology page
              When user clicks on Export Application button
               And user clicks on Export Application button again
              Then user can see "View logs" link, "Cancel Export", "Restart Export", and "Ok" button
+              # And user can see a toast message saying "All the resources are exported successfully from aut-export-application. Click below to download it." and close it
+#commented above line due to intermittent issue of not getting toast notification after export is complete
 
 
         @regression @manual @odc-6296
@@ -37,16 +42,17 @@ Feature: Export of application
              Then user can see page showing the Pod log tab
 
 
-        @regression
+        @regression @broken-test
         Scenario: Restart Export when export application is in progress: EA-02-TC04
             Given user is at Topology page
               And Export Application has already started
              When user clicks on Export Application button again
               And user clicks on Restart button
              Then user can see a toast message saying "Export of resources in aut-export-application has started."
+              And user can see a toast message saying "All the resources are exported successfully from aut-export-application. Click below to download it." and close it
 
 
-        @regression
+        @regression @broken-test
         Scenario: Cancel Export when export application is in progress: EA-02-TC05
             Given user is at Topology page
               And Export Application has already started

--- a/frontend/packages/topology/integration-tests/features/export-application/export-of-applicaton.feature
+++ b/frontend/packages/topology/integration-tests/features/export-application/export-of-applicaton.feature
@@ -1,16 +1,17 @@
+@topology
 Feature: Export of application
               As a user, I have an unmanaged application which I want to export. I'd like to be able to later add that code to git or some shared location so that I can share with others, or import into a new cluster or same cluster but different project, or be able to apply updates to an existing application.
 
 
 
-    #The operator mentioned below is not yet available on operator hub
+    #The operator mentioned below needs to be installed beforehand due to the issue in its installation
         Background:
             Given user has installed Gitops primer Operator
               And user is at developer perspective
               And user has created or selected namespace "aut-export-application"
 
 
-        @smoke @to-do
+        @smoke
         Scenario: Export application button in topology: EA-02-TC01
             Given user has created a deployment workload "nodejs-ex-git-1"
              When user navigates to Topology page
@@ -19,25 +20,34 @@ Feature: Export of application
               And user can see primer job created in topology
 
 
-        @regression @to-do
+        @regression @odc-6296
         Scenario: Export Application modal when export application is in progress: EA-02-TC02
             Given user is at Topology page
              When user clicks on Export Application button
               And user clicks on Export Application button again
-             Then user can see a "Cancel Export", "Restart Export", and "Ok" button
+             Then user can see "View logs" link, "Cancel Export", "Restart Export", and "Ok" button
 
 
-        @manual @to-do
-        Scenario: Restart Export when export application is in progress: EA-02-TC02
+        @regression @manual @odc-6296
+        Scenario: View logs when export application is in progress: EA-02-TC03
             Given user is at Topology page
               And Export Application has already started
-             When user clicks on Export Application button
+             When user clicks on Export Application button again
+              And user clicks on View logs link
+             Then user can see page showing the Pod log tab
+
+
+        @regression
+        Scenario: Restart Export when export application is in progress: EA-02-TC04
+            Given user is at Topology page
+              And Export Application has already started
+             When user clicks on Export Application button again
               And user clicks on Restart button
              Then user can see a toast message saying "Export of resources in aut-export-application has started."
 
 
-        @manual @to-do
-        Scenario: Cancel Export when export application is in progress: EA-02-TC02
+        @regression
+        Scenario: Cancel Export when export application is in progress: EA-02-TC05
             Given user is at Topology page
               And Export Application has already started
              When user clicks on Export Application button again
@@ -45,15 +55,15 @@ Feature: Export of application
              Then user can see primer job gets deleted in topology
 
 
-        @regression @to-do
-        Scenario: Export application button in empty topology view: EA-02-TC03
+        @regression
+        Scenario: Export application button in empty topology view: EA-02-TC06
             Given user has created or selected namespace "aut-export-applicatio-temp"
              When user navigates to Topology page
              Then user can see Export Application button disabled
 
 
         @regression @manual
-        Scenario: Export Application is created: EA-02-TC04
+        Scenario: Export Application is created: EA-02-TC07
             Given user is at Topology page
               And Export Application is completed
              Then user can see a toast message on export completion along with a link to download
@@ -61,7 +71,7 @@ Feature: Export of application
 
 
         @regression @manual
-        Scenario: Download the exported application: EA-02-TC05
+        Scenario: Download the exported application: EA-02-TC08
             Given user is at Topology page
               And Export Application is completed
               And user clicks on download button from the toast message

--- a/frontend/packages/topology/integration-tests/support/page-objects/export-applications-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/export-applications-po.ts
@@ -1,0 +1,30 @@
+export const exportApplication = {
+  exportApplicationButton: '[data-test="export-app-btn"]',
+  infoTip: '[aria-label="Info Alert"]',
+};
+
+export const buttonDisplayName = (buttonName: string) => {
+  switch (buttonName) {
+    // below statements to be uncommented after the story ODC-6401 is completed
+    //   case 'View logs': {
+    //     // to be updated after the story ODC-6401 is completed
+    //   }
+    case 'Cancel Export': {
+      return 'export-cancel-btn';
+    }
+    case 'Restart Export': {
+      return 'export-restart-btn';
+    }
+    case 'Ok': {
+      return 'export-close-btn';
+    }
+    default: {
+      throw new Error('Option is not available');
+    }
+  }
+};
+
+export function exportModalButton(element: string) {
+  const buttonName = buttonDisplayName(element);
+  return `[data-test~="${buttonName}"]`;
+}

--- a/frontend/packages/topology/integration-tests/support/pages/export-application/export-applications.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/export-application/export-applications.ts
@@ -1,71 +1,49 @@
 import { exportApplication, exportModalButton } from '../../page-objects/export-applications-po';
-import { topologyPO } from '../../page-objects/topology-po';
-import { topologyHelper } from '../topology';
+
+export function clickVisibleButton(flag: boolean = true) {
+  /* eslint-disable promise/catch-or-return */
+
+  cy.get('body').then(($body) => {
+    if (
+      $body
+        .find('.modal-body')
+        .text()
+        .includes(' is in progress')
+    ) {
+      cy.log('Close progress modal');
+      cy.get(exportModalButton('Ok'))
+        .should('be.visible')
+        .click();
+      cy.get(exportModalButton('Ok')).should('not.exist');
+      cy.get(exportApplication.exportApplicationButton)
+        .should('be.visible')
+        .click();
+      if (flag === true) {
+        cy.get(exportModalButton('Restart Export'))
+          .should('be.visible')
+          .click();
+        cy.get(exportModalButton('Restart Export')).should('not.exist');
+      }
+    }
+  });
+}
 
 export const exportOfApplication = {
   exportApplicationFresh: () => {
-    topologyHelper.search('primer');
     /* eslint-disable promise/catch-or-return */
+
+    cy.get(exportApplication.exportApplicationButton)
+      .should('be.visible')
+      .click();
     cy.get('body').then(($body) => {
-      if ($body.find(topologyPO.highlightNode).length !== 0) {
-        cy.get(exportApplication.exportApplicationButton)
+      if ($body.find('[data-test="export-cancel-btn"]').length) {
+        cy.log('Close export application modal');
+        cy.get(exportModalButton('Restart Export'))
           .should('be.visible')
           .click();
-        if ($body.find('[data-test="export-cancel-btn"]').length !== 0) {
-          cy.get(exportModalButton('Cancel Export'))
-            .should('be.visible')
-            .click();
-          cy.get(exportApplication.exportApplicationButton)
-            .should('be.visible')
-            .click();
-        } else if (
-          $body
-            .find('.modal-body')
-            .text()
-            .includes(' is in progress')
-        ) {
-          cy.get(exportModalButton('Ok'))
-            .should('be.visible')
-            .click();
-          cy.get(exportApplication.exportApplicationButton)
-            .should('be.visible')
-            .click();
-          cy.get(exportModalButton('Cancel Export'))
-            .should('be.visible')
-            .click();
-        } else if (
-          $body
-            .find(exportApplication.infoTip)
-            .text()
-            .includes(
-              'All the resources are exported successfully from aut-export-application. Click below to download it.',
-            )
-        ) {
-          cy.get('[aria-label="Close Info alert: alert: Export Application"]')
-            .should('be.visible')
-            .click();
-          cy.get(exportApplication.exportApplicationButton)
-            .should('be.visible')
-            .click();
-          cy.get(exportModalButton('Cancel Export'))
-            .should('be.visible')
-            .click();
-        } else {
-          cy.get(exportApplication.exportApplicationButton)
-            .should('be.visible')
-            .click();
-          cy.get(exportModalButton('Cancel Export'))
-            .should('be.visible')
-            .click();
-        }
-        cy.get(exportApplication.exportApplicationButton, { timeout: 10000 })
-          .should('be.visible')
-          .click();
-      } else {
-        cy.get(exportApplication.exportApplicationButton)
-          .should('be.visible')
-          .click();
+        cy.get(exportModalButton('Restart Export')).should('not.exist');
       }
     });
+    clickVisibleButton();
   },
 };

--- a/frontend/packages/topology/integration-tests/support/pages/export-application/export-applications.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/export-application/export-applications.ts
@@ -1,0 +1,71 @@
+import { exportApplication, exportModalButton } from '../../page-objects/export-applications-po';
+import { topologyPO } from '../../page-objects/topology-po';
+import { topologyHelper } from '../topology';
+
+export const exportOfApplication = {
+  exportApplicationFresh: () => {
+    topologyHelper.search('primer');
+    /* eslint-disable promise/catch-or-return */
+    cy.get('body').then(($body) => {
+      if ($body.find(topologyPO.highlightNode).length !== 0) {
+        cy.get(exportApplication.exportApplicationButton)
+          .should('be.visible')
+          .click();
+        if ($body.find('[data-test="export-cancel-btn"]').length !== 0) {
+          cy.get(exportModalButton('Cancel Export'))
+            .should('be.visible')
+            .click();
+          cy.get(exportApplication.exportApplicationButton)
+            .should('be.visible')
+            .click();
+        } else if (
+          $body
+            .find('.modal-body')
+            .text()
+            .includes(' is in progress')
+        ) {
+          cy.get(exportModalButton('Ok'))
+            .should('be.visible')
+            .click();
+          cy.get(exportApplication.exportApplicationButton)
+            .should('be.visible')
+            .click();
+          cy.get(exportModalButton('Cancel Export'))
+            .should('be.visible')
+            .click();
+        } else if (
+          $body
+            .find(exportApplication.infoTip)
+            .text()
+            .includes(
+              'All the resources are exported successfully from aut-export-application. Click below to download it.',
+            )
+        ) {
+          cy.get('[aria-label="Close Info alert: alert: Export Application"]')
+            .should('be.visible')
+            .click();
+          cy.get(exportApplication.exportApplicationButton)
+            .should('be.visible')
+            .click();
+          cy.get(exportModalButton('Cancel Export'))
+            .should('be.visible')
+            .click();
+        } else {
+          cy.get(exportApplication.exportApplicationButton)
+            .should('be.visible')
+            .click();
+          cy.get(exportModalButton('Cancel Export'))
+            .should('be.visible')
+            .click();
+        }
+        cy.get(exportApplication.exportApplicationButton, { timeout: 10000 })
+          .should('be.visible')
+          .click();
+      } else {
+        cy.get(exportApplication.exportApplicationButton)
+          .should('be.visible')
+          .click();
+      }
+    });
+  },
+};

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-helper-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-helper-page.ts
@@ -7,7 +7,7 @@ export const topologyHelper = {
       .get(topologyPO.search)
       .clear()
       .type(name),
-  verifyWorkloadInTopologyPage: (appName: string) => {
+  verifyWorkloadInTopologyPage: (appName: string, options?: { timeout: number }) => {
     topologyHelper.search(appName);
     // eslint-disable-next-line promise/catch-or-return
     cy.get('body').then(($body) => {
@@ -21,7 +21,7 @@ export const topologyHelper = {
       }
     });
     cy.get(topologyPO.graph.reset).click();
-    cy.get(topologyPO.highlightNode).should('be.visible');
+    cy.get(topologyPO.highlightNode, options).should('be.visible');
     app.waitForDocumentLoad();
   },
   verifyWorkloadDeleted: (workloadName: string) => {

--- a/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
@@ -16,7 +16,10 @@ import {
   navigateTo,
   createForm,
 } from '@console/dev-console/integration-tests/support/pages/app';
-import { verifyAndInstallKnativeOperator } from '@console/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster';
+import {
+  verifyAndInstallGitopsPrimerOperator,
+  verifyAndInstallKnativeOperator,
+} from '@console/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster';
 import { topologyPO } from '@console/topology/integration-tests/support/page-objects/topology-po';
 import { topologyPage } from '@console/topology/integration-tests/support/pages/topology/topology-page';
 import { topologySidePane } from '@console/topology/integration-tests/support/pages/topology/topology-side-pane-page';
@@ -193,4 +196,8 @@ When('user enters Application Name as {string}', (appName: string) => {
 
 When('user enters Name as {string}', (name: string) => {
   gitPage.enterWorkloadName(name);
+});
+
+Given('user has installed Gitops primer Operator', () => {
+  verifyAndInstallGitopsPrimerOperator();
 });

--- a/frontend/packages/topology/integration-tests/support/step-definitions/export-application/export-of-application.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/export-application/export-of-application.ts
@@ -1,0 +1,91 @@
+import { When, Then, Given } from 'cypress-cucumber-preprocessor/steps';
+import { devNavigationMenu } from '@console/dev-console/integration-tests/support/constants/global';
+import { createGitWorkload } from '@console/dev-console/integration-tests/support/pages';
+import {
+  app,
+  navigateTo,
+  projectNameSpace,
+} from '@console/dev-console/integration-tests/support/pages/app';
+import { exportApplication, exportModalButton } from '../../page-objects/export-applications-po';
+import { topologyPO } from '../../page-objects/topology-po';
+import { exportOfApplication } from '../../pages/export-application/export-applications';
+import { topologyHelper, topologyPage } from '../../pages/topology';
+
+Given('user has created a deployment workload {string}', (workloadName: string) => {
+  navigateTo(devNavigationMenu.Add);
+  createGitWorkload(
+    'https://github.com/sclorg/nodejs-ex.git',
+    workloadName,
+    'Deployment',
+    'nodejs-ex-git-app',
+  );
+});
+
+When('user navigates to Topology page', () => {
+  navigateTo(devNavigationMenu.Topology);
+});
+
+When('user clicks on Export Application button', () => {
+  exportOfApplication.exportApplicationFresh();
+});
+
+Then('user can see a toast message saying {string}', (message: string) => {
+  cy.get(exportApplication.infoTip).contains(message);
+});
+
+Then('user can see primer job created in topology', () => {
+  topologyHelper.verifyWorkloadInTopologyPage('primer', { timeout: 15000 });
+});
+
+Given('user is at Topology page', () => {
+  navigateTo(devNavigationMenu.Topology);
+});
+
+When('user clicks on Export Application button again', () => {
+  topologyPage.verifyWorkloadInTopologyPage('primer');
+  cy.get(exportApplication.exportApplicationButton)
+    .should('be.visible')
+    .click();
+});
+
+Then(
+  'user can see {string} link, {string}, {string}, and {string} button',
+  (el1, el2, el3, el4) => {
+    //   To be uncommented after completion of story ODC-6401
+    //   cy.get(exportModalButton(el1)).should('be.visible');
+    cy.get(exportModalButton(el2)).should('be.visible');
+    cy.get(exportModalButton(el3)).should('be.visible');
+    cy.get(exportModalButton(el4)).should('be.visible');
+    cy.get(exportModalButton('Ok')).click();
+  },
+);
+
+Given('user has created or selected namespace {string}', (componentName: string) => {
+  projectNameSpace.selectOrCreateProject(componentName);
+});
+
+Then('user can see Export Application button disabled', () => {
+  cy.get(exportApplication.exportApplicationButton).should('be.disabled');
+});
+
+Given('Export Application has already started', () => {
+  exportOfApplication.exportApplicationFresh();
+});
+
+When('user clicks on Restart button', () => {
+  cy.get(exportModalButton('Restart Export'))
+    .should('be.visible')
+    .click();
+});
+
+When('user clicks on Cancel button', () => {
+  cy.get(exportModalButton('Cancel Export'))
+    .should('be.visible')
+    .click();
+});
+
+Given('user can see primer job gets deleted in topology', () => {
+  topologyHelper.search('primer');
+  cy.get(topologyPO.highlightNode, { timeout: 10000 }).should('not.exist');
+  app.waitForDocumentLoad();
+});

--- a/frontend/packages/topology/integration-tests/support/step-definitions/export-application/export-of-application.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/export-application/export-of-application.ts
@@ -8,8 +8,11 @@ import {
 } from '@console/dev-console/integration-tests/support/pages/app';
 import { exportApplication, exportModalButton } from '../../page-objects/export-applications-po';
 import { topologyPO } from '../../page-objects/topology-po';
-import { exportOfApplication } from '../../pages/export-application/export-applications';
-import { topologyHelper, topologyPage } from '../../pages/topology';
+import {
+  clickVisibleButton,
+  exportOfApplication,
+} from '../../pages/export-application/export-applications';
+import { topologyHelper } from '../../pages/topology';
 
 Given('user has created a deployment workload {string}', (workloadName: string) => {
   navigateTo(devNavigationMenu.Add);
@@ -30,11 +33,20 @@ When('user clicks on Export Application button', () => {
 });
 
 Then('user can see a toast message saying {string}', (message: string) => {
-  cy.get(exportApplication.infoTip).contains(message);
+  cy.get(exportApplication.infoTip, { timeout: 10000 }).contains(message);
+  cy.get(exportApplication.infoTip, { timeout: 10000 }).should('not.exist');
+});
+
+Then('user can see a toast message saying {string} and close it', (message: string) => {
+  cy.get(exportApplication.infoTip).should('not.exist');
+  cy.get(exportApplication.infoTip, { timeout: 120000 }).contains(message);
+  cy.get('[aria-label="Close Info alert: alert: Export Application"]')
+    .should('be.visible')
+    .click();
 });
 
 Then('user can see primer job created in topology', () => {
-  topologyHelper.verifyWorkloadInTopologyPage('primer', { timeout: 15000 });
+  topologyHelper.verifyWorkloadInTopologyPage('primer', { timeout: 30000 });
 });
 
 Given('user is at Topology page', () => {
@@ -42,10 +54,11 @@ Given('user is at Topology page', () => {
 });
 
 When('user clicks on Export Application button again', () => {
-  topologyPage.verifyWorkloadInTopologyPage('primer');
+  topologyHelper.verifyWorkloadInTopologyPage('primer', { timeout: 30000 });
   cy.get(exportApplication.exportApplicationButton)
     .should('be.visible')
     .click();
+  clickVisibleButton(false);
 });
 
 Then(
@@ -57,6 +70,11 @@ Then(
     cy.get(exportModalButton(el3)).should('be.visible');
     cy.get(exportModalButton(el4)).should('be.visible');
     cy.get(exportModalButton('Ok')).click();
+    // Need to handle below deletion of namespace better with task ODC-6453
+    cy.exec(`oc delete namespace ${Cypress.env('NAMESPACE')}`, {
+      failOnNonZeroExit: false,
+      timeout: 180000,
+    });
   },
 );
 
@@ -86,6 +104,6 @@ When('user clicks on Cancel button', () => {
 
 Given('user can see primer job gets deleted in topology', () => {
   topologyHelper.search('primer');
-  cy.get(topologyPO.highlightNode, { timeout: 10000 }).should('not.exist');
+  cy.get(topologyPO.highlightNode, { timeout: 30000 }).should('not.exist');
   app.waitForDocumentLoad();
 });


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-6296
Story: https://issues.redhat.com/browse/ODC-6424

Acceptance criteria:

- When an export is in progress, provide a quick link to view the logs when it's initially kicked off (via the toast)
- When an export is in progress, provide access to view logs if that toast has disappeared (via the Export modal)


**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]

**Fix**: https://issues.redhat.com/browse/ODC-6435
            https://issues.redhat.com/browse/ODC-6425


**Test Setup**:

Cluster should be running on local with **gitops-primer installed** due to issue with the installation

Check the TAGS in frontend/packages/topology/integration-tests/cypress.json file be: ""(@pre-condition or @smoke or @regression) and not (@manual or @to-do or @un-verified or @broken-test)"",


Command to execute:

Run a cluster locally and execute the command `npm run test-cypress-topology` simultaneously

Execute the export-of-application.feature file

**Browser**
Chrome 90

**Test Execution Screenshot:**
![Screenshot from 2021-11-22 14-53-03](https://user-images.githubusercontent.com/10252230/142835602-a694124a-afee-4d22-8c35-5da5584c2506.png)

