### PR TITLE
Bug 2020904: Add edge items in kubevirt topology data model factory

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/topology/kubevirt-data-transformer.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/kubevirt-data-transformer.ts
@@ -8,6 +8,7 @@ import {
 } from '@console/internal/module/k8s';
 import { OverviewItem } from '@console/shared';
 import {
+  getTopologyEdgeItems,
   getTopologyGroupItems,
   getTopologyNodeItem,
   mergeGroup,
@@ -103,6 +104,7 @@ export const getKubevirtTopologyDataModel = (
       vmsDataModel.nodes.push(
         getTopologyNodeItem(resource, TYPE_VIRTUAL_MACHINE, data, WorkloadModelProps),
       );
+      vmsDataModel.edges.push(...getTopologyEdgeItems(resource, resources.virtualmachines.data));
       mergeGroup(getTopologyGroupItems(resource), vmsDataModel.nodes);
     });
   }

--- a/frontend/packages/topology/src/utils/__tests__/connector-utils.spec.ts
+++ b/frontend/packages/topology/src/utils/__tests__/connector-utils.spec.ts
@@ -1,4 +1,27 @@
-import { edgesFromAnnotations } from '../connector-utils';
+import { DeploymentModel } from '@console/internal/models';
+import {
+  k8sGet,
+  k8sPatch,
+  K8sResourceKind,
+  modelFor,
+  referenceFor,
+  referenceForModel,
+} from '@console/internal/module/k8s';
+import { edgesFromAnnotations, doConnectsToBinding } from '../connector-utils';
+
+jest.mock('@console/internal/module/k8s', () => ({
+  k8sGet: jest.fn(),
+  k8sPatch: jest.fn(),
+  modelFor: jest.fn(),
+  referenceFor: jest.fn(),
+  referenceForModel: jest.fn(),
+}));
+
+const k8sGetMock = k8sGet as jest.Mock;
+const k8sPatchMock = k8sPatch as jest.Mock;
+const modelForMock = modelFor as jest.Mock;
+const referenceForModelMock = referenceForModel as jest.Mock;
+const referenceForMock = referenceFor as jest.Mock;
 
 describe('connector-utils', () => {
   describe('edgeFromAnnotations utils', () => {
@@ -14,6 +37,49 @@ describe('connector-utils', () => {
       expect(
         edgesFromAnnotations({ 'app.openshift.io/connects-to': 'abcd, mock, value' }),
       ).toEqual(['abcd', 'mock', 'value']);
+    });
+  });
+
+  describe('doConnectsToBinding', () => {
+    afterAll(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should fail when there is no context source', async () => {
+      await expect(doConnectsToBinding([], '')).rejects.toBeInstanceOf(Error);
+    });
+
+    it('should patch annotation to target resource', async () => {
+      const target = {
+        metadata: {
+          name: 'test-deployment',
+          namespace: 'test',
+        },
+      } as K8sResourceKind;
+      const mockResource = { metadata: { name: 'test-resource' } };
+      referenceForMock.mockReturnValue('apps/v1');
+      referenceForModelMock.mockReturnValue('apps/v1');
+      k8sGetMock.mockReturnValue(mockResource);
+      modelForMock.mockReturnValue(DeploymentModel);
+
+      await expect(doConnectsToBinding([target], 'apps/Deployment')).resolves.toBeTruthy();
+      expect(k8sPatchMock).toHaveBeenCalledWith(DeploymentModel, mockResource, [
+        expect.objectContaining({ op: 'add', path: '/metadata/annotations' }),
+      ]);
+    });
+
+    it('should fail when context resource is not found', async () => {
+      const target = {
+        metadata: {
+          name: 'test-deployment',
+          namespace: 'test',
+        },
+      } as K8sResourceKind;
+      referenceForMock.mockReturnValue('apps/v1');
+      referenceForModelMock.mockReturnValue('apps/v1');
+      k8sGetMock.mockReturnValue({});
+
+      await expect(doConnectsToBinding([target], 'apps/Deployment')).rejects.toBeInstanceOf(Error);
     });
   });
 });

--- a/frontend/packages/topology/src/utils/connector-utils.ts
+++ b/frontend/packages/topology/src/utils/connector-utils.ts
@@ -2,13 +2,11 @@ import i18next from 'i18next';
 import * as _ from 'lodash';
 import { DeploymentConfigModel, DeploymentModel } from '@console/internal/models';
 import {
-  allModels,
   k8sGet,
-  K8sKind,
   k8sList,
   k8sPatch,
   K8sResourceKind,
-  kindForReference,
+  modelFor,
   referenceFor,
   referenceForModel,
 } from '@console/internal/module/k8s';
@@ -16,18 +14,10 @@ import { createServiceBinding } from '../operators/actions/serviceBindings';
 
 export type ConnectsToData = { apiVersion: string; kind: string; name: string };
 
-const getModel = (groupVersionKind: string): K8sKind => {
-  const m = allModels().get(groupVersionKind);
-  if (m) {
-    return m;
-  }
-  return allModels().get(kindForReference(groupVersionKind));
-};
-
 const fetchResource = async (source: string, namespace: string) => {
   const [groupVersionKind, resourceName] = source.split('/');
   const contextualResource: K8sResourceKind = await k8sGet(
-    getModel(groupVersionKind),
+    modelFor(groupVersionKind),
     resourceName,
     namespace,
   );
@@ -63,7 +53,7 @@ export const listInstanceResources = (
   const kinds = ['ReplicationController', 'Route', 'Service', 'ReplicaSet', 'BuildConfig', 'Build'];
   _.forEach(kinds, (kind) => {
     lists.push(
-      k8sList(getModel(kind), {
+      k8sList(modelFor(kind), {
         ns: namespace,
         labelSelector: instanceLabelSelector,
       }).then((values) => {
@@ -85,7 +75,7 @@ export const updateItemAppConnectTo = (
   connectValue: ConnectsToData,
   oldValueIndex: number,
 ) => {
-  const model = getModel(referenceFor(item) || item.kind);
+  const model = modelFor(referenceFor(item) || item.kind);
 
   if (!model) {
     return Promise.reject(


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2020904
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
- The kubevirt topology data model factory did not create edges for connected nodes.
- Connector callback is using `getModels` that does not have CRDs.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
- Add edges to topology data model factory.
- Use `modelFor` in the connector callback to create/update connections.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![0](https://user-images.githubusercontent.com/20013884/144052526-946df460-dfa8-4905-a8c8-45768981f4fb.png)

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Test setup:**
Create 2 VMs and create a connection between them in topology.
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug