### PR TITLE
Bug 2025903: - RoleBindings tab doesn't show correct rolebindings

### DIFF
--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -108,10 +108,10 @@ export const tableFilters: FilterMap = {
   'role-binding-roleRef-kind': (kind, binding) => binding.roleRef.kind === kind.selected?.[0],
 
   // Filter role bindings by user name
-  'role-binding-user': (userName, { subject }) => subject.name === userName.selected?.[0],
+  'role-binding-user': (userName, { subject }) => subject.name === userName,
 
   // Filter role bindings by group name
-  'role-binding-group': (groupName, { subject }) => subject.name === groupName.selected?.[0],
+  'role-binding-group': (groupName, { subject }) => subject.name === groupName,
 
   labels: (values, obj) => {
     if (!values.all) {


### PR DESCRIPTION
It seems this issue occurred due to regression. The `userName` is `resource.metadata.name` and doesn't have `selected` property. 

This fix should address bug [No data return when checking existing rolebinding information on RoleBindinds page](https://bugzilla.redhat.com/show_bug.cgi?id=2022175) as well. 

### **Before**
<img width="1561" alt="Screen Shot 2021-11-30 at 1 38 43 PM" src="https://user-images.githubusercontent.com/15249132/144107762-1e42abaf-0c81-4dc5-aab0-32a904461aa4.png">

### After
<img width="1654" alt="Screen Shot 2021-11-30 at 1 39 05 PM" src="https://user-images.githubusercontent.com/15249132/144107814-40cf1e63-e9fa-4f2c-93b0-595b80d78e1b.png">
