### PR TITLE
Bug 2013996: Project detail page: Action "Delete Project" does nothing for the default project

### DIFF
--- a/frontend/public/components/utils/__tests__/kebab.spec.tsx
+++ b/frontend/public/components/utils/__tests__/kebab.spec.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { KebabItem, KebabItemAccessReview_ } from '../kebab';
+import { useAccessReview } from '../index';
+
+jest.mock('../index', () => ({
+  useAccessReview: jest.fn(),
+}));
+
+const mockOption = {
+  labelKey: 'public~Edit {{kind}}',
+  labelKind: { kind: 'Project' },
+  dataTest: 'Edit Project',
+  href: '/k8s/cluster/projects/yvakil/yaml',
+};
+
+describe('KebabItem', () => {
+  it('should disable option without callback / href (i.e. option does nothing)', () => {
+    const nothingOption = { ...mockOption, href: undefined };
+    const trackOnClick = jest.fn();
+    const renderItem = render(<KebabItem onClick={trackOnClick} option={nothingOption} />);
+    fireEvent.click(renderItem.getByRole('button'));
+    expect(trackOnClick).toHaveBeenCalledTimes(0);
+  });
+  it('should enable when option has href', () => {
+    const hrefOption = { ...mockOption };
+    const trackOnClick = jest.fn();
+    const renderItem = render(<KebabItem onClick={trackOnClick} option={hrefOption} />);
+    fireEvent.click(renderItem.getByRole('button'));
+    expect(trackOnClick).toHaveBeenCalledTimes(1);
+  });
+  it('should enable when option has a callback', () => {
+    const callbackOption = { ...mockOption, href: undefined, callback: () => {} };
+    const trackOnClick = jest.fn();
+    const renderItem = render(<KebabItem onClick={trackOnClick} option={callbackOption} />);
+    fireEvent.click(renderItem.getByRole('button'));
+    expect(trackOnClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('KebabItemAccessReview_', () => {
+  const useAccessReviewOption = { ...mockOption, accessReview: {} };
+  const mockImpersonate = {
+    kind: 'dummy',
+    name: 'dummy',
+    subprotocols: ['dummy'],
+  };
+  it('should disable option when option.accessReview present and not allowed', () => {
+    const useAccessReviewMock = useAccessReview as jest.Mock;
+    const trackOnClick = jest.fn();
+    useAccessReviewMock.mockReturnValue(false);
+    const renderItem = render(
+      <KebabItemAccessReview_
+        option={useAccessReviewOption}
+        onClick={trackOnClick}
+        impersonate={mockImpersonate}
+      />,
+    );
+    fireEvent.click(renderItem.getByRole('button'));
+    expect(trackOnClick).toHaveBeenCalledTimes(0);
+  });
+  it('should enable option when option.accessReview present and allowed', () => {
+    const useAccessReviewMock = useAccessReview as jest.Mock;
+    const trackOnClick = jest.fn();
+    useAccessReviewMock.mockReturnValue(true);
+    const renderItem = render(
+      <KebabItemAccessReview_
+        option={useAccessReviewOption}
+        onClick={trackOnClick}
+        impersonate={mockImpersonate}
+      />,
+    );
+    fireEvent.click(renderItem.getByRole('button'));
+    expect(trackOnClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -91,7 +91,7 @@ const KebabItem_: React.FC<KebabItemProps & { isAllowed: boolean }> = ({
       onEscape();
     }
   };
-  const disabled = !isAllowed || option.isDisabled;
+  const disabled = !isAllowed || option.isDisabled || (!option.href && !option.callback);
   const classes = classNames('pf-c-dropdown__menu-item', { 'pf-m-disabled': disabled });
   return (
     <button
@@ -107,7 +107,9 @@ const KebabItem_: React.FC<KebabItemProps & { isAllowed: boolean }> = ({
     </button>
   );
 };
-const KebabItemAccessReview_ = (props: KebabItemProps & { impersonate: ImpersonateKind }) => {
+export const KebabItemAccessReview_ = (
+  props: KebabItemProps & { impersonate: ImpersonateKind },
+) => {
   const { option, impersonate } = props;
   const isAllowed = useAccessReview(option.accessReview, impersonate);
   return <KebabItem_ {...props} isAllowed={isAllowed} />;


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://bugzilla.redhat.com/show_bug.cgi?id=2013996
https://issues.redhat.com/browse/OCPBUGSM-36171

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
An action either has a callback or else a redirect
But when these are not present, the action will do 'nothing'
https://github.com/openshift/console/blob/7044928d3a9f3ae3704659ce2c9dedf2e250cac9/frontend/public/components/utils/dropdown.jsx#L637-L649

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Disable any action which does 'nothing'

**Screen shots / Gifs for design review**: 

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
# default project ( disabled )
![Screenshot from 2021-12-01 10-43-56](https://user-images.githubusercontent.com/20089340/144175967-e82e01f8-d696-4bd4-a91f-f78bd778cbab.png)
# normal project ( enabled )
![Screenshot from 2021-12-01 10-45-01](https://user-images.githubusercontent.com/20089340/144176007-c805eb26-1247-44f0-a3f4-f42e446e75ee.png)

**Unit test coverage report**: 
<!-- Attach test coverage report -->
in `frontend` we can use the new file `yarn test ./public/components/utils/__tests__/kebab.spec.tsx`
![image](https://user-images.githubusercontent.com/20089340/144582871-c74e8220-eccb-42fd-b4b5-b9dd2327c304.png)


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Switch to developer perspective
2. Navigate to 'Project' and select 'Project default' from the project list or the project dropdown
3. Click Actions => 'Delete Project'

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge