### PR TITLE
Support custom builder image environment variables in edit flow

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/import-environments.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/import-environments.ts
@@ -1,6 +1,6 @@
 import { Extension, ExtensionDeclaration } from '../types';
 
-type ImageEnvironment = {
+export type ImageEnvironment = {
   /** Environment variable key */
   key: string;
   /** The input field's label */

--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
@@ -208,8 +208,19 @@ Feature: Create Application from git form
         Scenario: Provide custom build environments for nodejs git import
             Given user is at Import from Git form
             When user enters Git Repo URL as "https://github.com/sclorg/nodejs-ex"
-            And user enters run command for "NPM_RUN" as "build2"
+            And user enters run command for "NPM_RUN" as "build1"
             And user enters Name as "nodejs-env"
             And user clicks Create button on Add page
             Then user will be redirected to Topology page
-            And user is able to navigate to Build #1 for deployment "nodejs-env" and see environment variable "NPM_RUN" in Environment tab of details page
+            And user is able to navigate to Build "nodejs-env-1" for deployment "nodejs-env" and see environment variable "NPM_RUN" with value "build1" in Environment tab of details page
+
+        @regression
+        Scenario: Update custom build environment in nodejs application edit page
+            Given user is at Topology page
+            When user edits the application "nodejs-env"
+            And user enters run command for "NPM_RUN" as "build2"
+            And user clicks Create button on Add page
+            And user clicks on workload "nodejs-env"
+            And user starts a new build
+            And user navigates to Topology page
+            Then user is able to navigate to Build "nodejs-env-2" for deployment "nodejs-env" and see environment variable "NPM_RUN" with value "build2" in Environment tab of details page

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/common/addFlow.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/common/addFlow.ts
@@ -103,14 +103,15 @@ When('user enters run command for {string} as {string}', (envKey: string, value:
 });
 
 Then(
-  'user is able to navigate to Build #1 for deployment {string} and see environment variable {string} in Environment tab of details page',
-  (name: string, env: string) => {
+  'user is able to navigate to Build {string} for deployment {string} and see environment variable {string} with value {string} in Environment tab of details page',
+  (build: string, name: string, envKey: string, envVal: string) => {
     topologyPage.clickOnNode(name);
     topologySidePane.selectTab('Resources');
-    topologySidePane.selectResource(resources.Builds, 'aut-addflow-git', `${name}-1`);
+    topologySidePane.selectResource(resources.Builds, 'aut-addflow-git', build);
     app.waitForLoad();
     detailsPage.selectTab('Environment');
     app.waitForLoad();
-    cy.get(`input[data-test="pairs-list-name"][value="${env}"]`).should('exist');
+    cy.get(`input[data-test="pairs-list-name"][value="${envKey}"]`).should('have.length', 1);
+    cy.get(`input[data-test="pairs-list-value"][value="${envVal}"]`).should('have.length', 1);
   },
 );

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/common/topology.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/common/topology.ts
@@ -29,6 +29,7 @@ Then('user will be redirected to Topology page', () => {
 });
 
 When('user clicks on workload {string}', (workloadName: string) => {
+  topologyPage.waitForLoad();
   topologyPage.componentNode(workloadName).click({ force: true });
 });
 

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/monitoring/topology-sidebar-actions.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/monitoring/topology-sidebar-actions.ts
@@ -103,6 +103,13 @@ When(
   },
 );
 
+When('user edits the application {string}', (name: string) => {
+  topologyPage.rightClickOnNode(name);
+  cy.byTestActionID(`Edit ${name}`)
+    .should('be.visible')
+    .click();
+});
+
 When(
   'user right clicks on the Service {string} to open the Context Menu',
   (serviceName: string) => {
@@ -128,6 +135,10 @@ When('user clicks on Save button', () => {
 
 When('user right clicks on the {string} to open the Context Menu', (nodeName: string) => {
   topologyPage.rightClickOnNode(nodeName);
+});
+
+When('user starts a new build', () => {
+  topologyPage.startBuild();
 });
 
 Then('user will be taken to Dashboard tab on the Monitoring page', () => {

--- a/frontend/packages/dev-console/src/components/import/advanced/__tests__/BuildConfigSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/__tests__/BuildConfigSection.spec.tsx
@@ -23,8 +23,13 @@ jest.mock('formik', () => ({
         },
         strategy: 'Source',
       },
+      image: { selected: 'nodejs-ex', tag: 'latest' },
     },
   })),
+}));
+
+jest.mock('../../builder/builderImageHooks', () => ({
+  useBuilderImageEnvironments: () => [[], true],
 }));
 
 describe('BuildConfigSection', () => {
@@ -53,6 +58,7 @@ describe('BuildConfigSection', () => {
           triggers: {},
           strategy: 'Source',
         },
+        image: { selected: 'nodejs-ex', tag: 'latest' },
       },
     });
     const wrapper = shallow(<BuildConfigSection {...BuildConfigSectionProps} />);

--- a/frontend/packages/dev-console/src/components/import/builder/__tests__/BuilderImageEnvironments.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/builder/__tests__/BuilderImageEnvironments.spec.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { useFormikContext } from 'formik';
+import { useResolvedExtensions } from '@console/dynamic-plugin-sdk';
+import { InputField } from '@console/shared';
+import BuilderImageEnvironments from '../BuilderImageEnvironments';
+
+jest.mock('formik', () => ({
+  useFormikContext: jest.fn(() => ({
+    setFieldValue: jest.fn(),
+    values: {
+      build: { env: [{ name: 'TEST_KEY', value: 'TEST_VAL' }] },
+      image: {},
+    },
+  })),
+  useField: jest.fn(() => ['', { touched: false }]),
+}));
+
+jest.mock('@console/dynamic-plugin-sdk', () => ({
+  useResolvedExtensions: jest.fn(),
+}));
+
+// make jest synchronously run the useEffect inside shallow
+jest.spyOn(React, 'useEffect').mockImplementation((f) => f());
+
+const mockExtensionsHook = useResolvedExtensions as jest.Mock;
+const mockFormikContext = useFormikContext as jest.Mock;
+
+describe('BuilderImageEnvironments', () => {
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should not render anything when there are no extensions provided', () => {
+    mockExtensionsHook.mockReturnValue([[], true]);
+    const wrapper = shallow(
+      <BuilderImageEnvironments
+        name="image.imageEnv"
+        imageStreamName="nodejs-ex"
+        imageStreamTag="14-ubi8"
+      />,
+    );
+    expect(wrapper.children()).toHaveLength(0);
+  });
+
+  it('should not render anything when imagestream does not exist in intensions', () => {
+    mockExtensionsHook.mockReturnValue([
+      [{ properties: { imageStreamName: 'golang', imageStreamTags: ['latest'] } }],
+      true,
+    ]);
+    const wrapper = shallow(
+      <BuilderImageEnvironments
+        name="image.imageEnv"
+        imageStreamName="nodejs-ex"
+        imageStreamTag="latest"
+      />,
+    );
+    expect(wrapper.children()).toHaveLength(0);
+  });
+
+  it('should render field when matching imagestream is provided', () => {
+    mockExtensionsHook.mockReturnValue([
+      [
+        {
+          properties: {
+            imageStreamName: 'nodejs-ex',
+            imageStreamTags: ['latest'],
+            environments: [{ key: 'NPM_RUN' }],
+          },
+        },
+      ],
+      true,
+    ]);
+    const wrapper = shallow(
+      <BuilderImageEnvironments
+        name="image.imageEnv"
+        imageStreamName="nodejs-ex"
+        imageStreamTag="latest"
+      />,
+    );
+    expect(wrapper.find(InputField)).toHaveLength(1);
+    expect(wrapper.find(InputField).props().name).toEqual('image.imageEnv.NPM_RUN');
+  });
+
+  it('should initialize field when a matching builderImage value exists in edit flow', () => {
+    mockExtensionsHook.mockReturnValue([
+      [
+        {
+          properties: {
+            imageStreamName: 'nodejs-ex',
+            imageStreamTags: ['latest'],
+            environments: [{ key: 'TEST_KEY' }],
+          },
+        },
+      ],
+      true,
+    ]);
+    const setFieldValueMock = jest.fn();
+    mockFormikContext.mockReturnValue({
+      setFieldValue: setFieldValueMock,
+      values: {
+        build: { env: [{ name: 'TEST_KEY', value: 'TEST_VAL' }] },
+        image: {},
+        formType: 'edit',
+      },
+    });
+    shallow(
+      <BuilderImageEnvironments
+        name="image.imageEnv"
+        imageStreamName="nodejs-ex"
+        imageStreamTag="latest"
+      />,
+    );
+    expect(setFieldValueMock).toHaveBeenCalledTimes(1);
+    expect(setFieldValueMock).toHaveBeenCalledWith('image.imageEnv.TEST_KEY', 'TEST_VAL');
+  });
+});

--- a/frontend/packages/dev-console/src/components/import/builder/builderImageHooks.ts
+++ b/frontend/packages/dev-console/src/components/import/builder/builderImageHooks.ts
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import {
+  ImageEnvironment,
+  ImportEnvironment,
+  isImportEnvironment,
+  useResolvedExtensions,
+} from '@console/dynamic-plugin-sdk';
+
+export const useBuilderImageEnvironments = (
+  imageStreamName: string,
+  imageStreamTag: string,
+): [ImageEnvironment[], boolean] => {
+  const [environmentExtensions, resolved] = useResolvedExtensions<ImportEnvironment>(
+    isImportEnvironment,
+  );
+
+  const filteredExtensions = React.useMemo(
+    () =>
+      resolved
+        ? environmentExtensions
+            .filter(
+              (e) =>
+                e.properties.imageStreamName === imageStreamName &&
+                e.properties.imageStreamTags.includes(imageStreamTag),
+            )
+            .map((e) => e.properties.environments)
+            .flat()
+        : [],
+    [environmentExtensions, imageStreamName, imageStreamTag, resolved],
+  );
+
+  return [filteredExtensions, resolved];
+};

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -182,11 +182,11 @@ export const createOrUpdateBuildConfig = (
   let buildStrategyData;
 
   let desiredContextDir = contextDir;
-  const customBuildEnvs = imageEnv
-    ? Object.keys(imageEnv)
-        .filter((k) => !!imageEnv[k])
-        .map((k) => ({ name: k, value: imageEnv[k] }))
-    : [];
+  const imageEnvKeys = imageEnv ? Object.keys(imageEnv) : [];
+  const customEnvs = imageEnvKeys
+    .filter((k) => !!imageEnv[k])
+    .map((k) => ({ name: k, value: imageEnv[k] }));
+  const buildEnvs = env.filter((buildEnv) => !imageEnvKeys.includes(buildEnv.name));
 
   switch (buildStrategy) {
     case 'Devfile':
@@ -203,7 +203,7 @@ export const createOrUpdateBuildConfig = (
     default:
       buildStrategyData = {
         sourceStrategy: {
-          env: [...env, ...customBuildEnvs],
+          env: [...customEnvs, ...buildEnvs],
           from: {
             kind: 'ImageStreamTag',
             name: `${imageStreamName}:${selectedTag}`,

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -321,6 +321,11 @@ export const topologyPage = {
     cy.get(topologyPO.sidePane.applicationGroupingsTitle).should('be.visible');
     cy.get(topologyPO.sidePane.resourcesTabApplicationGroupings).should('be.visible');
   },
+  startBuild: () => {
+    cy.get('button[data-test-id="start-build-action"]')
+      .should('be.visible')
+      .click({ force: true });
+  },
 };
 
 export const addGitWorkload = (

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-side-pane-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-side-pane-page.ts
@@ -139,7 +139,7 @@ export const topologySidePane = {
       }
       case 'Builds':
       case resources.Builds: {
-        cy.get(`[href="/k8s/ns/${namespace}/builds/${name}]`).click();
+        cy.get(`[href="/k8s/ns/${namespace}/builds/${name}"]`).click();
         break;
       }
       case 'Services':

--- a/frontend/packages/topology/src/components/workload/BuildOverview.tsx
+++ b/frontend/packages/topology/src/components/workload/BuildOverview.tsx
@@ -145,7 +145,7 @@ const BuildOverviewList: React.FC<BuildOverviewListProps> = ({ buildConfig }) =>
           </div>
           {canStartBuild && (
             <div>
-              <Button variant="secondary" onClick={onClick}>
+              <Button variant="secondary" onClick={onClick} data-test-id="start-build-action">
                 {t('topology~Start Build')}
               </Button>
             </div>

--- a/frontend/public/components/overview/build-overview.tsx
+++ b/frontend/public/components/overview/build-overview.tsx
@@ -145,7 +145,7 @@ const BuildOverviewList: React.SFC<BuildOverviewListProps> = ({ buildConfig }) =
           </div>
           {canStartBuild && (
             <div>
-              <Button variant="secondary" onClick={onClick}>
+              <Button variant="secondary" onClick={onClick} data-test-id="start-build-action">
                 {t('public~Start Build')}
               </Button>
             </div>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6414
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Description**: 
This is a follow up of #10331. Adds support for setting builder image environments defined by the ImportEnvironment extension to be loaded and shown in edit application form.
<!-- Describe your code changes in detail and explain the solution -->

<!--**Screen shots / Gifs for design review**:
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
- Create a node-js application from git import flow and use the run command field.
- Open the edit form for the application.
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
