### PR TITLE
Bug 2028141: Catch unhandled promises when running tests (to support Node.js 15 and 16)

### DIFF
--- a/frontend/__tests__/components/resource-pages.spec.tsx
+++ b/frontend/__tests__/components/resource-pages.spec.tsx
@@ -4,29 +4,38 @@ import {
 } from '../../public/components/resource-pages';
 import { isGroupVersionKind } from '../../public/module/k8s';
 
+const isComponent = (Component) =>
+  typeof Component === 'function' ||
+  // connected redux component
+  (typeof Component === 'object' && typeof Component.WrappedComponent === 'function');
+
+const assertComponent = (Component, name) => {
+  if (!isComponent(Component)) {
+    fail(`Resource detail page ${name} promise doesn't return a react component.`);
+  }
+};
+
 describe('resourceDetailsPages', () => {
-  it('contains a map of promises which resolve to every resource detail view component', (done) => {
+  it('contains a map of promises which resolve to every resource detail view component', () => {
     getResourceDetailsPages().forEach((promise, name) => {
       expect(name.length > 0).toBe(true);
       expect(isGroupVersionKind(name)).toBe(true);
 
-      promise().then((Component) => {
-        expect(typeof Component).toEqual('function');
-        done();
-      });
+      promise()
+        .then((Component) => assertComponent(Component, name))
+        .catch(fail);
     });
   });
 });
 
 describe('resourceListPages', () => {
-  it('contains map of promises which resolve to every resource list view component', (done) => {
+  it('contains map of promises which resolve to every resource list view component', () => {
     getResourceListPages().forEach((promise, name) => {
       expect(isGroupVersionKind(name) || name === 'ClusterServiceVersionResources').toBe(true);
 
-      promise().then((Component) => {
-        expect(typeof Component).toEqual('function');
-        done();
-      });
+      promise()
+        .then((Component) => assertComponent(Component, name))
+        .catch(fail);
     });
   });
 });

--- a/frontend/before-tests.js
+++ b/frontend/before-tests.js
@@ -7,3 +7,28 @@ import 'url-search-params-polyfill';
 
 // http://airbnb.io/enzyme/docs/installation/index.html#working-with-react-16
 configure({ adapter: new Adapter() });
+
+/**
+ * Since Node.js 15 all unhandled promise rejections triggers a `unhandledRejection`
+ * runtime event. If this event is not handled the process is automatically terminated.
+ * We ignore this event when running the jest watch mode,
+ * otherwise we'll log some infos and stop the tests with the same error code (1).
+ */
+if (process.argv.includes('--watch')) {
+  // jest loads this file again and again (in watch mode when chaning source code or tests),
+  // so that we need to drop our own listener here before adding a new one
+  process.listeners('unhandledRejection').forEach((listener) => {
+    if (listener.name === 'beforeTestsUnhandledRejectionHandler') {
+      process.removeListener('unhandledRejection', listener);
+    }
+  });
+
+  process.on('unhandledRejection', function beforeTestsUnhandledRejectionHandler(reason, promise) {
+    // eslint-disable-next-line no-console
+    console.error(
+      'Unhandled promise rejections in unit test. This test will fail when watch mode is not active anymore!',
+      reason,
+      promise,
+    );
+  });
+}

--- a/frontend/packages/console-app/src/components/detect-namespace/__tests__/checkNamespaceExists.spec.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/__tests__/checkNamespaceExists.spec.ts
@@ -23,9 +23,9 @@ describe('getValueForNamespace', () => {
   });
 
   it(`should return true if namespace is equal to ${ALL_NAMESPACES_KEY}`, async () => {
-    k8sGetMock.mockReturnValueOnce(Promise.reject());
     const exists = await checkNamespaceExists(ALL_NAMESPACES_KEY, true);
 
+    expect(k8sGetMock).toHaveBeenCalledTimes(0);
     expect(exists).toBeTruthy();
   });
 

--- a/frontend/packages/dev-console/src/components/import/serverless/useUpdateKnScalingDefaultValues.ts
+++ b/frontend/packages/dev-console/src/components/import/serverless/useUpdateKnScalingDefaultValues.ts
@@ -5,6 +5,7 @@ import { useGetAutoscalerConfig } from './useGetAutoscalerConfig';
 export const setKnScalingDefaultValue = (initialValues, knScalingConfig) => {
   const { autoscalewindow, autoscalewindowUnit, defaultAutoscalewindowUnit } =
     knScalingConfig && getAutoscaleWindow(knScalingConfig['stable-window'] ?? '');
+  // TODO: we should not mutate initial values at all.
   initialValues.serverless.scaling.concurrencytarget =
     knScalingConfig['container-concurrency-target-default'] || '';
   initialValues.serverless.scaling.concurrencyutilization =
@@ -19,6 +20,7 @@ export const setKnScalingDefaultValue = (initialValues, knScalingConfig) => {
 
 export const useUpdateKnScalingDefaultValues = (initialValues) => {
   const knScalingConfig = useGetAutoscalerConfig();
+  // TODO: We should not expect that overridding the formik initialValues in a hook works fine.
   const [initialValuesState, setInitialValuesState] = React.useState(initialValues);
   React.useEffect(() => {
     if (knScalingConfig) {

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.spec.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 import { ReactWrapper, mount } from 'enzyme';
 import * as _ from 'lodash';
+import { act } from 'react-dom/test-utils';
 import { ModalTitle, ModalSubmitFooter } from '@console/internal/components/factory/modal';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { useAccessReview } from '@console/internal/components/utils/rbac';
+import { useOperands } from '@console/shared/src/hooks/useOperands';
 import { testSubscription, dummyPackageManifest } from '../../../mocks';
 import { ClusterServiceVersionModel, SubscriptionModel } from '../../models';
 import { SubscriptionKind } from '../../types';
@@ -11,6 +14,14 @@ import Spy = jasmine.Spy;
 
 jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
   useK8sWatchResource: jest.fn(),
+}));
+
+jest.mock('@console/internal/components/utils/rbac', () => ({
+  useAccessReview: jest.fn(),
+}));
+
+jest.mock('@console/shared/src/hooks/useOperands', () => ({
+  useOperands: jest.fn(),
 }));
 
 jest.mock('react-i18next', () => {
@@ -47,6 +58,8 @@ describe(UninstallOperatorModal.name, () => {
     subscription = { ..._.cloneDeep(testSubscription), status: { installedCSV: 'testapp.v1.0.0' } };
 
     (useK8sWatchResource as jest.Mock).mockReturnValue([dummyPackageManifest, true, null]);
+    (useAccessReview as jest.Mock).mockReturnValue(false);
+    (useOperands as jest.Mock).mockReturnValue([[], true, '']);
 
     // React.useEffect is not supported by Enzyme's shallow rendering, switching to mount
     wrapper = mount(
@@ -71,85 +84,77 @@ describe(UninstallOperatorModal.name, () => {
     expect(wrapper.find(ModalSubmitFooter).props().submitText).toEqual('Uninstall');
   });
 
-  it('calls `props.k8sKill` to delete the subscription when form is submitted', (done) => {
-    spyAndExpect(close)(null)
-      .then(() => {
-        expect(k8sKill.calls.argsFor(0)[0]).toEqual(SubscriptionModel);
-        expect(k8sKill.calls.argsFor(0)[1]).toEqual(subscription);
-        expect(k8sKill.calls.argsFor(0)[2]).toEqual({});
-        expect(k8sKill.calls.argsFor(0)[3]).toEqual({
-          kind: 'DeleteOptions',
-          apiVersion: 'v1',
-          propagationPolicy: 'Foreground',
-        });
-        done();
-      })
-      .catch((err) => fail(err));
+  it('calls `props.k8sKill` to delete the subscription when form is submitted', async () => {
+    await act(async () => {
+      wrapper.find('form').simulate('submit', new Event('submit'));
+      await spyAndExpect(close)(null);
+    });
 
-    wrapper.find('form').simulate('submit', new Event('submit'));
+    expect(k8sKill).toHaveBeenCalledTimes(2);
+    expect(k8sKill.calls.argsFor(0)[0]).toEqual(SubscriptionModel);
+    expect(k8sKill.calls.argsFor(0)[1]).toEqual(subscription);
+    expect(k8sKill.calls.argsFor(0)[2]).toEqual({});
+    expect(k8sKill.calls.argsFor(0)[3]).toEqual({
+      kind: 'DeleteOptions',
+      apiVersion: 'v1',
+      propagationPolicy: 'Foreground',
+    });
   });
 
-  it('calls `props.k8sKill` to delete the `ClusterServiceVersion` from the subscription namespace when form is submitted', (done) => {
-    spyAndExpect(close)(null)
-      .then(() => {
-        expect(k8sKill.calls.argsFor(1)[0]).toEqual(ClusterServiceVersionModel);
-        expect(k8sKill.calls.argsFor(1)[1].metadata.namespace).toEqual(
-          testSubscription.metadata.namespace,
-        );
-        expect(k8sKill.calls.argsFor(1)[1].metadata.name).toEqual('testapp.v1.0.0');
-        expect(k8sKill.calls.argsFor(1)[2]).toEqual({});
-        expect(k8sKill.calls.argsFor(1)[3]).toEqual({
-          kind: 'DeleteOptions',
-          apiVersion: 'v1',
-          propagationPolicy: 'Foreground',
-        });
-        done();
-      })
-      .catch((err) => fail(err));
+  it('calls `props.k8sKill` to delete the `ClusterServiceVersion` from the subscription namespace when form is submitted', async () => {
+    await act(async () => {
+      wrapper.find('form').simulate('submit', new Event('submit'));
+      await spyAndExpect(close)(null);
+    });
 
-    wrapper.find('form').simulate('submit', new Event('submit'));
+    expect(k8sKill).toHaveBeenCalledTimes(2);
+    expect(k8sKill.calls.argsFor(1)[0]).toEqual(ClusterServiceVersionModel);
+    expect(k8sKill.calls.argsFor(1)[1].metadata.namespace).toEqual(
+      testSubscription.metadata.namespace,
+    );
+    expect(k8sKill.calls.argsFor(1)[1].metadata.name).toEqual('testapp.v1.0.0');
+    expect(k8sKill.calls.argsFor(1)[2]).toEqual({});
+    expect(k8sKill.calls.argsFor(1)[3]).toEqual({
+      kind: 'DeleteOptions',
+      apiVersion: 'v1',
+      propagationPolicy: 'Foreground',
+    });
   });
 
-  it('does not call `props.k8sKill` to delete `ClusterServiceVersion` if `status.installedCSV` field missing from subscription', (done) => {
+  it('does not call `props.k8sKill` to delete `ClusterServiceVersion` if `status.installedCSV` field missing from subscription', async () => {
     wrapper = wrapper.setProps({ subscription: testSubscription });
 
-    spyAndExpect(close)(null)
-      .then(() => {
-        expect(k8sKill.calls.count()).toEqual(1);
-        done();
-      })
-      .catch((err) => fail(err));
+    await act(async () => {
+      wrapper.find('form').simulate('submit', new Event('submit'));
+      await spyAndExpect(close)(null);
+    });
 
-    wrapper.find('form').simulate('submit', new Event('submit'));
+    expect(k8sKill).toHaveBeenCalledTimes(1);
   });
 
-  it('adds delete options with `propagationPolicy`', (done) => {
-    spyAndExpect(close)(null)
-      .then(() => {
-        expect(k8sKill.calls.argsFor(0)[3]).toEqual({
-          kind: 'DeleteOptions',
-          apiVersion: 'v1',
-          propagationPolicy: 'Foreground',
-        });
-        expect(k8sKill.calls.argsFor(1)[3]).toEqual({
-          kind: 'DeleteOptions',
-          apiVersion: 'v1',
-          propagationPolicy: 'Foreground',
-        });
-        done();
-      })
-      .catch((err) => fail(err));
+  it('adds delete options with `propagationPolicy`', async () => {
+    await act(async () => {
+      wrapper.find('form').simulate('submit', new Event('submit'));
+      spyAndExpect(close)(null);
+    });
 
-    wrapper.find('form').simulate('submit', new Event('submit'));
+    expect(k8sKill).toHaveBeenCalledTimes(2);
+    expect(k8sKill.calls.argsFor(0)[3]).toEqual({
+      kind: 'DeleteOptions',
+      apiVersion: 'v1',
+      propagationPolicy: 'Foreground',
+    });
+    expect(k8sKill.calls.argsFor(1)[3]).toEqual({
+      kind: 'DeleteOptions',
+      apiVersion: 'v1',
+      propagationPolicy: 'Foreground',
+    });
   });
 
-  it('calls `props.close` after successful submit', (done) => {
-    spyAndExpect(close)(null)
-      .then(() => {
-        done();
-      })
-      .catch((err) => fail(err));
-
-    wrapper.find('form').simulate('submit', new Event('submit'));
+  it('calls `props.close` after successful submit', async () => {
+    await act(async () => {
+      wrapper.find('form').simulate('submit', new Event('submit'));
+      spyAndExpect(close)(null);
+    });
   });
 });

--- a/frontend/packages/topology/src/components/export-app/ExportApplication.tsx
+++ b/frontend/packages/topology/src/components/export-app/ExportApplication.tsx
@@ -125,8 +125,11 @@ const ExportApplication: React.FC<ExportApplicationProps> = ({ namespace, isDisa
         setExportAppToast(exportAppToastConfig);
         await createExportCR();
       }
-    } catch {
-      await createExportCR();
+    } catch (error) {
+      createExportCR().catch((createError) =>
+        // eslint-disable-next-line no-console
+        console.warn('Could not createExportCR:', createError),
+      );
     }
   };
 


### PR DESCRIPTION
**Fixes**:
https://issues.redhat.com/browse/ODC-6194
https://bugzilla.redhat.com/show_bug.cgi?id=2028141 / https://issues.redhat.com/browse/OCPBUGSM-37720

**Analysis / Root cause**: 
Since Node.js 15 all kinds of applications crashes by default if they doesn't handle promise failures. Some components and esp. tests in our code doesn't handle the promise rejections. That was the reason why our tests doesn't run on Node.js 15 (and 16).

**Solution Description**: 
Catch unhandled promises in our tests and one time in our application code. See `ExportApplication.tsx`.

Also added a handler for unhandled promises to `before-tests.js` which is only active in watch mode.

**Screen shots / Gifs for design review**: 
Doesn't affect the UI.

**Test setup:**
Run build, dev-once and tests successfully on this Node.js versions:

* v14 = node 14.18.1, npm 6.14.15, yarn 1.22.15
* v15 = node 15.14.0, npm 7.7.6,   yarn 1.22.15
* v16 = node 16.11.1, npm 8.0.0,   yarn 1.22.15

For Node.js 16 I have installed the dependencies with the changes from #10605 (with the latest node-sass version) because the currently used version doesn't support Node.js 16.

1. Switch Node.js version (for example via nvm use 15)
2. Clean your node_modules, reinstall dependencies
3. And run the tests time yarn test

For example

```bash
nvm use 15

git clean -df && git clean -dfX

time yarn install
time yarn generate
time yarn build
time yarn dev-once
time yarn test
```

**Browser conformance**: 
Unrelated
