### PR TITLE
Bug 2020498: Trim the strings before localCompare

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/metrics/MetricsQueryInput.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/metrics/MetricsQueryInput.tsx
@@ -65,8 +65,8 @@ const MetricsQueryInput: React.FC = () => {
   }, [dispatch, metric, query, namespace, changeKey, t]);
 
   React.useEffect(() => {
-    const q = queries?.query;
-    const text = queries?.text;
+    const q = queries?.query?.trim();
+    const text = queries?.text?.trim();
     if (text && text.localeCompare(q) !== 0) {
       setTitle(CUSTOM_QUERY);
       setIsPromQlDisabled(true);


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGSM-36853

**Analysis / Root cause:** Query string has a new line at the end. Due to which `localCompare` between query and text is not equal to zero. Which disabled the `Show PromQL` button.

**Solution Description:** Trim the query and text strings before the `localCompare`.

**GIF:**
![Kapture 2021-12-02 at 20 23 32](https://user-images.githubusercontent.com/2561818/144445931-fd4c977b-8138-4da3-b528-1078852fbbff.gif)
