### PR TITLE
Bug 2029273: Fix all-projects-wizard link

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/constants/url-params.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/url-params.ts
@@ -12,7 +12,7 @@ export enum VMWizardURLParams {
   VIEW = 'view',
 }
 
-const baseURLBuilder = (namespace: string | undefined) =>
+const baseURLBuilder = (namespace = 'default') =>
   resourceListPathFromModel(getKubevirtAvailableModel(VirtualMachineModel), namespace).concat(
     '/~new',
   );


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2029273

**Analysis / Root cause**: 
Missing support for namespace undefined

**Solution Description**: 
Added default value for the namespace in case of undefined