### PR TITLE
Bug 1992509: Could not customize boot source due to source PVC not found

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/customize-source/CustomizeSource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/customize-source/CustomizeSource.tsx
@@ -52,7 +52,7 @@ const CustomizeSource: React.FC<RouteComponentProps> = ({ location }) => {
   });
 
   return finish ? (
-    <CustomizeSourceFinish vm={vm} />
+    <CustomizeSourceFinish vm={vm} dataVolumes={dataVolumes} pvcs={pvcs} />
   ) : (
     <StatusBox loaded={loaded} loadError={loadError} data={vm}>
       {isVMIRunning(vmi) ? (


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1992509
https://issues.redhat.com/browse/OCPBUGSM-33213

**Analysis / Root cause**: 
when customizing a boot source for a template, we create a temporary VM
that creates a DV that his owner is the VM.
once we delete the temporary VM, the DV is also being deleted, and the source is not available.

**Solution Description**: 
changing owner reference of DV created by the VM to the created template,
and changing the DV size the size of PVC cloned from to get inline with: https://github.com/openshift/console/pull/10477

**Screen shots / Gifs for design review**: 

**Before**: **Please follow the attachment file of BZ link provided above**

**After**:

![after-1](https://user-images.githubusercontent.com/67270715/144838128-5e677053-49c3-47ef-8f4c-7edc7d891a6e.png)

![after-2](https://user-images.githubusercontent.com/67270715/144838135-f398743a-23a3-4052-b48b-95d2e5194d77.png)

![after-3](https://user-images.githubusercontent.com/67270715/144838147-b735026e-d9c2-4944-a50b-59b93cad3f4f.png)

![after-4](https://user-images.githubusercontent.com/67270715/144838149-b7e4f989-7c23-4931-ac11-124ddbec3f59.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>