### PR TITLE
Bug 2029394: missing empty text for hardware devices at wizard review

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/VirtualMachineHardware.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/VirtualMachineHardware.tsx
@@ -14,7 +14,7 @@ const VirtualMachineHardware: React.FC<VirtualMachineHardwareProps> = ({
   title = 'Devices',
 }) => {
   const { t } = useTranslation();
-  if (!devicesNames) {
+  if (!devicesNames?.length) {
     return t('kubevirt-plugin~None');
   }
 


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2029394

**Screen shots / Gifs for design review**:
**Before**: 

![before-1](https://user-images.githubusercontent.com/67270715/144842814-656bea0e-2875-4f22-8e06-893e6266cf95.png)

**After**:
 
![after](https://user-images.githubusercontent.com/67270715/144843384-03d0c744-a16b-4fb7-97b2-48a6d8b1affa.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>