### PR TITLE
Bug 2025295: Add new option for VIRTIOWIN ConfigMap name

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/constants/v2v.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/v2v.ts
@@ -5,10 +5,7 @@ export const V2VVMWARE_DEPLOYMENT_NAME = 'v2v-vmware';
 export const CONVERSION_BASE_NAME = 'kubevirt-v2v-conversion';
 export const CONVERSION_GENERATE_NAME = `${CONVERSION_BASE_NAME}-`;
 
-export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES = [
-  'v2v-vmware',
-  'virtio-win',
-];
+export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES = ['v2v-vmware', 'virtio-win'];
 // Different releases, different locations. Respect the order when resolving. Otherwise the configMap name/namespace is considered as well-known.
 export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES = [
   'openshift-cnv',

--- a/frontend/packages/kubevirt-plugin/src/constants/v2v.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/v2v.ts
@@ -5,7 +5,10 @@ export const V2VVMWARE_DEPLOYMENT_NAME = 'v2v-vmware';
 export const CONVERSION_BASE_NAME = 'kubevirt-v2v-conversion';
 export const CONVERSION_GENERATE_NAME = `${CONVERSION_BASE_NAME}-`;
 
-export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME = 'v2v-vmware';
+export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES = [
+  'v2v-vmware',
+  'virtio-win',
+];
 // Different releases, different locations. Respect the order when resolving. Otherwise the configMap name/namespace is considered as well-known.
 export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES = [
   'openshift-cnv',

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/v2vvmware-configmap-validator.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/v2vvmware-configmap-validator.ts
@@ -4,7 +4,7 @@ import { VMImportProvider } from '../../../components/create-vm-wizard/types';
 import {
   V2VConfigMapAttribute,
   V2VProviderErrorSpecialUIMessageRequest,
-  VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME,
+  VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES,
   VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES,
 } from '../../../constants/v2v';
 import {
@@ -17,8 +17,8 @@ import { K8sDetailError } from '../../enhancedK8sMethods/errors';
 export const validateV2VConfigMap = (configMap: ConfigMapKind, providerType: VMImportProvider) => {
   if (!configMap) {
     return new K8sDetailError({
-      title: `${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} ConfigMap missing`,
-      message: `${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} ConfigMap cannot be found in any of the following namespaces: ${joinGrammaticallyListOfItems(
+      title: `${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES} ConfigMap missing`,
+      message: `${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES} ConfigMap cannot be found in any of the following namespaces: ${joinGrammaticallyListOfItems(
         VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES,
         'or',
       )}. Please see ${
@@ -50,7 +50,7 @@ export const validateV2VConfigMap = (configMap: ConfigMapKind, providerType: VMI
   if (requiredImagesMissing.length > 0) {
     return new K8sDetailError({
       title: `Image configuration missing`,
-      message: `The following images are missing in a ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} ConfigMap: ${joinGrammaticallyListOfItems(
+      message: `The following images are missing in a ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES} ConfigMap: ${joinGrammaticallyListOfItems(
         requiredImagesMissing,
       )}. Please see ${
         V2VProviderErrorSpecialUIMessageRequest.supplyDoclink

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/v2vvmware-configmap.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/v2vvmware-configmap.ts
@@ -1,7 +1,7 @@
 import { ConfigMapModel } from '@console/internal/models';
 import { k8sGet } from '@console/internal/module/k8s';
 import {
-  VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME,
+  VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES,
   VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES,
 } from '../../../constants/v2v';
 
@@ -11,23 +11,25 @@ export const getVmwareConfigMap = async () => {
   let lastErr;
   // query namespaces sequentially to respect order
   for (const namespace of VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES) {
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      const configMap = await k8sGet(
-        ConfigMapModel,
-        VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME,
-        namespace,
-      );
+    for (const configMapName of VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const configMap = await k8sGet(
+          ConfigMapModel,
+          configMapName,
+          namespace,
+        );
 
-      if (configMap) {
-        return configMap;
+        if (configMap) {
+          return configMap;
+        }
+      } catch (e) {
+        lastErr = e;
+        info(
+          `The ${configMapName} can not be found in the ${namespace} namespace.  Another namespace will be queried, if any left. Error: `,
+          e,
+        );
       }
-    } catch (e) {
-      lastErr = e;
-      info(
-        `The ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} can not be found in the ${namespace} namespace.  Another namespace will be queried, if any left. Error: `,
-        e,
-      );
     }
   }
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/v2vvmware-configmap.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/v2vvmware-configmap.ts
@@ -14,11 +14,7 @@ export const getVmwareConfigMap = async () => {
     for (const configMapName of VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES) {
       try {
         // eslint-disable-next-line no-await-in-loop
-        const configMap = await k8sGet(
-          ConfigMapModel,
-          configMapName,
-          namespace,
-        );
+        const configMap = await k8sGet(ConfigMapModel, configMapName, namespace);
 
         if (configMap) {
           return configMap;


### PR DESCRIPTION
In OpenShift Virtualization 4.10.0, the VM-Import operator has been removed from the package, along with the  config map.
However, virtio-win image pullspec, which was included in that config map, is still required by the UI and has nothing to do with V2V.
We are re-introducing this ConfigMap, but with more accurate name - .
This PR adds one more option for that config map name, to support a smooth upgrade path, so it will work both with OCP 4.10 + CNV 4.9 and OCP 4.10 + CNV 4.10.

This PR is a complementary for https://github.com/kubevirt/hyperconverged-cluster-operator/pull/1647 made HCO.

Signed-off-by: orenc1 <ocohen@redhat.com>