### PR TITLE
Bug 2028949: Remove unutilized css causing bug

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -207,14 +207,6 @@ $dropdown-background--hover: $pf-color-black-200; // pf-c-dropdown__menu-item--h
   overflow-y: auto;
 }
 
-// TEMP fix until https://github.com/patternfly/patternfly-next/issues/1543 is fixed upstream
-.pf-c-app-launcher__menu-item {
-  &:focus,
-  &:hover {
-    --pf-c-app-launcher__menu-item--Color:: var(--pf-global--Color--dark-100);
-  }
-}
-
 .pf-c-dropdown .co-m-resource-icon {
   margin-left: 2px;
 }


### PR DESCRIPTION
Extra `::` was causing incorrect text color. But upon further inspection, the custom rule is no longer needed.
<img width="509" alt="Screen Shot 2021-12-06 at 3 21 43 PM" src="https://user-images.githubusercontent.com/1874151/144917978-7dd2ad99-12a3-458b-b64d-97d3c553d0d1.png">

