### PR TITLE
Bug 2022880: Fix pipeline builder edge spacing to avoid improper edge shapes

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/const.ts
@@ -64,7 +64,7 @@ export enum AddNodeDirection {
 const DAGRE_SHARED_PROPS: dagre.GraphLabel = {
   nodesep: NODE_SEPARATION_VERTICAL,
   ranksep: NODE_SEPARATION_HORIZONTAL,
-  edgesep: 25,
+  edgesep: 50,
   ranker: 'longest-path',
   rankdir: 'LR',
   marginx: 20,


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGSM-37166

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

The gap between the horizontal edges are not sufficient to show the integral shapes incase of multiple horizontal branching.
 
**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Increased the horizontal edge spacing to accommodate the integral shape.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
**Before: (Without when expressions)**
![Screenshot 2021-12-07 at 6 34 14 PM](https://user-images.githubusercontent.com/9964343/145034891-a8987095-78de-488c-887b-5a0c9d4d2402.png)
**After: (Without when expressions)**
<img width="1449" alt="Screenshot 2021-12-07 at 6 34 31 PM" src="https://user-images.githubusercontent.com/9964343/145034897-2d4c367f-1293-4b86-a039-7544f47ebbb7.png">
**Before: (with when expressions)**
![Screenshot 2021-12-07 at 6 36 03 PM](https://user-images.githubusercontent.com/9964343/145034903-c4284f61-317b-4432-a6de-99399525cc65.png)
**After: (with when expressions)**
<img width="1435" alt="Screenshot 2021-12-07 at 6 36 18 PM" src="https://user-images.githubusercontent.com/9964343/145034906-eccaa9f0-7e04-426e-823d-36ffaba23592.png">
**Pipeline Builder**
<img width="1291" alt="Screenshot 2021-12-07 at 6 38 16 PM" src="https://user-images.githubusercontent.com/9964343/145034907-2559b53c-8480-46c5-bf23-e2be18cec2e7.png">



**Unit test coverage report**: 
<!-- Attach test coverage report -->
No Tests.  Modified Dagre Js Options

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Create a pipeline From this [pipeline yaml](https://github.com/gnunn-gitops/product-catalog/blob/pipelines-1.6/components/tekton/pipelines/server/base/server-pipeline.yaml)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge