### PR TITLE
Show Create Service Binding modal on dnd of binding connector in topology

### DIFF
--- a/frontend/packages/console-app/src/actions/creators/deployment-factory.ts
+++ b/frontend/packages/console-app/src/actions/creators/deployment-factory.ts
@@ -100,7 +100,7 @@ export const DeploymentActionFactory: ResourceActionFactory = {
     cta: () =>
       serviceBindingModal({
         model: kind,
-        resource: obj,
+        source: obj,
       }),
     accessReview: asAccessReview(ServiceBindingModel, obj, 'create'),
   }),

--- a/frontend/packages/console-app/src/components/modals/service-binding/CreateServiceBindingForm.tsx
+++ b/frontend/packages/console-app/src/components/modals/service-binding/CreateServiceBindingForm.tsx
@@ -14,18 +14,19 @@ import { InputField } from '@console/shared';
 import BindableServices from './BindableServices';
 
 export type CreateServiceBindingFormProps = {
-  resource: K8sResourceKind;
+  source: K8sResourceKind;
+  target?: K8sResourceKind;
   cancel?: () => void;
 };
 
 const CreateServiceBindingForm: React.FC<FormikProps<FormikValues> &
   CreateServiceBindingFormProps> = ({
-  resource,
+  source,
+  target,
   handleSubmit,
   isSubmitting,
   cancel,
   status,
-  dirty,
   errors,
 }) => {
   const { t } = useTranslation();
@@ -43,12 +44,12 @@ const CreateServiceBindingForm: React.FC<FormikProps<FormikValues> &
             label={t('console-app~Name')}
             required
           />
-          <BindableServices resource={resource} />
+          {!target && <BindableServices resource={source} />}
         </FormSection>
       </ModalBody>
       <ModalSubmitFooter
         submitText={t('console-app~Create')}
-        submitDisabled={!dirty || isSubmitting || !_.isEmpty(errors)}
+        submitDisabled={isSubmitting || !_.isEmpty(errors)}
         cancel={cancel}
         inProgress={isSubmitting}
         errorMessage={status?.submitError}

--- a/frontend/packages/console-app/src/components/modals/service-binding/ServiceBindingModalLauncher.tsx
+++ b/frontend/packages/console-app/src/components/modals/service-binding/ServiceBindingModalLauncher.tsx
@@ -4,7 +4,13 @@ import { useTranslation } from 'react-i18next';
 import { Perspective, isPerspective } from '@console/dynamic-plugin-sdk';
 import { createModalLauncher } from '@console/internal/components/factory/modal';
 import { history, getQueryArgument } from '@console/internal/components/utils';
-import { K8sKind, k8sList, K8sResourceKind } from '@console/internal/module/k8s';
+import {
+  K8sKind,
+  k8sList,
+  K8sResourceKind,
+  referenceFor,
+  modelFor,
+} from '@console/internal/module/k8s';
 import { useExtensions } from '@console/plugin-sdk';
 import { ServiceBindingModel } from '@console/topology/src/models';
 import { createServiceBinding } from '@console/topology/src/operators/actions/serviceBindings';
@@ -17,7 +23,8 @@ import { serviceBindingValidationSchema } from './servicebinding-validation-util
 
 type CreateServiceBindingModalProps = CreateServiceBindingFormProps & {
   model: K8sKind;
-  resource: K8sResourceKind;
+  source: K8sResourceKind;
+  target?: K8sResourceKind;
   close?: () => void;
 };
 
@@ -37,29 +44,29 @@ const handleRedirect = async (
 };
 
 const CreateServiceBindingModal: React.FC<CreateServiceBindingModalProps> = (props) => {
-  const { resource, model } = props;
+  const { source, model } = props;
   const { t } = useTranslation();
   const [activePerspective] = useValuesForPerspectiveContext();
   const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
   const handleSubmit = async (values, actions) => {
     const bindings: K8sResourceKind[] = await k8sList(ServiceBindingModel, {
-      ns: resource.metadata.namespace,
+      ns: source.metadata.namespace,
     });
     let existingServiceBinding = {};
     if (bindings.length > 0) {
       existingServiceBinding = checkExistingServiceBinding(
         bindings,
-        resource,
+        source,
         values.bindableService,
         model,
       );
     }
     if (Object.keys(existingServiceBinding ?? {}).length === 0) {
       try {
-        await createServiceBinding(resource, values.bindableService, values.name);
+        await createServiceBinding(source, values.bindableService, values.name);
         props.close();
         getQueryArgument('view') === null &&
-          handleRedirect(resource.metadata.namespace, activePerspective, perspectiveExtensions);
+          handleRedirect(source.metadata.namespace, activePerspective, perspectiveExtensions);
       } catch (errorMessage) {
         actions.setStatus({ submitError: errorMessage.message });
       }
@@ -73,8 +80,12 @@ const CreateServiceBindingModal: React.FC<CreateServiceBindingModalProps> = (pro
   };
 
   const initialValues: CreateServiceBindingFormType = {
-    name: '',
-    bindableService: {},
+    name: props.target
+      ? `${source.metadata.name}-${model.abbr.toLowerCase()}-${
+          props.target.metadata.name
+        }-${modelFor(referenceFor(props.target)).abbr.toLowerCase()}`
+      : '',
+    bindableService: props.target ? props.target : {},
   };
   return (
     <Formik

--- a/frontend/packages/console-app/src/components/modals/service-binding/__tests__/CreateServiceBindingForm.spec.tsx
+++ b/frontend/packages/console-app/src/components/modals/service-binding/__tests__/CreateServiceBindingForm.spec.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { FormikProps, FormikValues } from 'formik';
+import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
+import CreateServiceBindingForm from '../CreateServiceBindingForm';
+
+type CreateServiceBindingFormProps = React.ComponentProps<typeof CreateServiceBindingForm>;
+
+jest.mock(
+  '@console/dev-console/src/components/topology/bindable-services/fetch-bindable-services-utils',
+  () => ({
+    fetchBindableServices: jest.fn(),
+  }),
+);
+
+describe('CreateServiceBindingForm', () => {
+  let CreateServiceBindingFormWrapper: ShallowWrapper<CreateServiceBindingFormProps>;
+
+  type Props = FormikProps<FormikValues> & CreateServiceBindingFormProps;
+  const formProps: Props = {
+    ...formikFormProps,
+    source: {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: 'xyz-deployment',
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            app: 'hello-openshift',
+          },
+        },
+        replicas: 1,
+        template: {
+          metadata: {
+            labels: {
+              app: 'hello-openshift',
+            },
+          },
+          spec: {
+            containers: [
+              {
+                name: 'hello-openshift',
+                image: 'openshift/hello-openshift',
+                ports: [
+                  {
+                    containerPort: 8080,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+    target: {
+      apiVersion: 'rhoas.redhat.com/v1alpha1',
+      kind: 'KafkaConnection',
+      metadata: {
+        labels: {
+          'app.kubernetes.io/component': 'external-service',
+          'app.kubernetes.io/managed-by': 'rhoas',
+        },
+        name: 'kc',
+        namespace: 'deb',
+        resourceVersion: '59277',
+        uid: '370cbb34-18b1-4d7f-980c-fa56f6f2cd90',
+      },
+      status: {},
+    },
+  };
+
+  it('should not have bindable services dropdown component if the drop target is present', () => {
+    CreateServiceBindingFormWrapper = shallow(<CreateServiceBindingForm {...formProps} />);
+    expect(CreateServiceBindingFormWrapper.find('BindableServices').exists()).toBe(false);
+  });
+
+  it('should have bindable services dropdown component if the drop target is not present', () => {
+    formProps.target = null;
+    CreateServiceBindingFormWrapper = shallow(<CreateServiceBindingForm {...formProps} />);
+    expect(CreateServiceBindingFormWrapper.find('BindableServices').exists()).toBe(true);
+  });
+});

--- a/frontend/packages/dev-console/src/components/topology/relationship-provider.ts
+++ b/frontend/packages/dev-console/src/components/topology/relationship-provider.ts
@@ -1,6 +1,7 @@
 import { Node } from '@patternfly/react-topology';
+import { serviceBindingModal } from '@console/app/src/components/modals/service-binding';
+import { modelFor, referenceFor } from '@console/internal/module/k8s';
 import { TYPE_WORKLOAD } from '@console/topology/src/const';
-import { createServiceBinding } from '@console/topology/src/operators/actions/serviceBindings';
 import { getResource } from '@console/topology/src/utils';
 
 export const providerProvidesServiceBinding = (source: Node, target: Node) => {
@@ -19,5 +20,9 @@ export const providerProvidesServiceBinding = (source: Node, target: Node) => {
 export const providerCreateServiceBinding = (source: Node, target: Node) => {
   const sourceResource = getResource(source);
   const targetResource = getResource(target);
-  return createServiceBinding(sourceResource, targetResource).then(() => null);
+  return serviceBindingModal({
+    model: modelFor(referenceFor(sourceResource)),
+    source: sourceResource,
+    target: targetResource,
+  });
 };

--- a/frontend/packages/knative-plugin/src/topology/relationship-provider.ts
+++ b/frontend/packages/knative-plugin/src/topology/relationship-provider.ts
@@ -1,5 +1,6 @@
 import { Node } from '@patternfly/react-topology';
-import { createServiceBinding } from '@console/topology/src/operators/actions/serviceBindings';
+import { serviceBindingModal } from '@console/app/src/components/modals/service-binding';
+import { modelFor, referenceFor } from '@console/internal/module/k8s';
 import { getResource } from '@console/topology/src/utils';
 import { TYPE_KNATIVE_SERVICE } from './const';
 
@@ -19,5 +20,9 @@ export const providerProvidesServiceBinding = (source: Node, target: Node) => {
 export const providerCreateServiceBinding = (source: Node, target: Node) => {
   const sourceResource = getResource(source);
   const targetResource = getResource(target);
-  return createServiceBinding(sourceResource, targetResource).then(() => null);
+  return serviceBindingModal({
+    model: modelFor(referenceFor(sourceResource)),
+    source: sourceResource,
+    target: targetResource,
+  });
 };

--- a/frontend/packages/topology/src/utils/connector-utils.ts
+++ b/frontend/packages/topology/src/utils/connector-utils.ts
@@ -1,5 +1,6 @@
 import i18next from 'i18next';
 import * as _ from 'lodash';
+import { serviceBindingModal } from '@console/app/src/components/modals/service-binding';
 import { DeploymentConfigModel, DeploymentModel } from '@console/internal/models';
 import {
   k8sGet,
@@ -10,7 +11,6 @@ import {
   referenceFor,
   referenceForModel,
 } from '@console/internal/module/k8s';
-import { createServiceBinding } from '../operators/actions/serviceBindings';
 
 export type ConnectsToData = { apiVersion: string; kind: string; name: string };
 
@@ -295,6 +295,10 @@ export const doContextualBinding = async (
   contextualSource: string,
 ): Promise<K8sResourceKind> => {
   const { source } = await getSourceAndTargetForBinding(target, contextualSource, true);
-  await createServiceBinding(source, target);
+  serviceBindingModal({
+    model: modelFor(referenceFor(source)),
+    source,
+    target,
+  });
   return target;
 };


### PR DESCRIPTION
**Jira ticket:**
https://issues.redhat.com/browse/ODC-6398

**Solution description:**
- On dropping binding connector on the target node, create service binding modal with the name field is shown.
- default name is shown in the above name field
- On dragging and dropping connector on the topology canvas and after selecting the operator backed service from the menu the user is redirected to the topology on the creation of the service and the create service binding modal is shown

**Tests:**
![Screenshot from 2021-12-08 17-02-14](https://user-images.githubusercontent.com/22490998/145201738-adcf185f-d48b-413f-9db1-1a7f22411e17.png)

**GIF:**
![sb-dnd](https://user-images.githubusercontent.com/22490998/145085227-ca5ed42e-39e8-4ea0-8f71-bc917bf93f1e.gif)
