### PR TITLE
Bug 2016296: Windows machine can be created with import URL

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
@@ -34,6 +34,7 @@ export enum VMWizardProps {
   storageClassConfigMap = 'storageClassConfigMap',
   nads = 'nads',
   initialData = 'initialData',
+  cdRom = 'cdRom',
 }
 
 // order important
@@ -235,6 +236,7 @@ export type ChangedCommonDataProp =
   | VMWizardProps.userTemplate
   | VMWizardProps.userTemplates
   | VMWizardProps.commonTemplates
+  | VMWizardProps.cdRom
   | VMWizardProps.openshiftCNVBaseImages
   | VMWizardProps.dataVolumes
   | VMWizardProps.storageClassConfigMap


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2016296

**Analysis / Root cause**: 
Mismatch storages

**Solution Description**: 
Fixed mismatch storage and disk bus
 
**Screen shots / Gifs for design review**: 
After:
![image](https://user-images.githubusercontent.com/14824964/145200145-024df000-9c6b-42e3-8e44-12b837852377.png)

Before:
![image](https://user-images.githubusercontent.com/14824964/145200299-d549c7fd-c019-4fab-aee1-bf673318dc22.png)
