### PR TITLE
NETOBSERV-32 Use new CNO configmap to get network features

### DIFF
--- a/frontend/packages/console-app/src/__tests__/network-policies/network-policy-form.spec.tsx
+++ b/frontend/packages/console-app/src/__tests__/network-policies/network-policy-form.spec.tsx
@@ -30,8 +30,8 @@ const emptyPolicy: NetworkPolicyKind = {
   },
 };
 
-describe('NetworkPolicyForm without permissions to fetch CNI type', () => {
-  (useK8sGet as jest.Mock).mockReturnValue([null, true, 'error fetching CNI']);
+describe('NetworkPolicyForm without the CNO config map', () => {
+  (useK8sGet as jest.Mock).mockReturnValue([null, true, 'error fetching CNO configmap']);
   const wrapper = mount(<NetworkPolicyForm formData={emptyPolicy} onChange={jest.fn()} />);
 
   it('should render a warning in case the customer is using Openshift SDN', () => {
@@ -54,9 +54,9 @@ describe('NetworkPolicyForm without permissions to fetch CNI type', () => {
   });
 });
 
-describe('NetworkPolicyForm with Unknown CNI type', () => {
-  const unknownSDNSpec = { spec: { networkType: 'Calico' } };
-  (useK8sGet as jest.Mock).mockReturnValue([unknownSDNSpec, true, null]);
+describe('NetworkPolicyForm with unknown network features', () => {
+  const cm = { data: {} };
+  (useK8sGet as jest.Mock).mockReturnValue([cm, true, null]);
   const wrapper = mount(<NetworkPolicyForm formData={emptyPolicy} onChange={jest.fn()} />);
 
   it('should render a warning in case the customer is using Openshift SDN', () => {
@@ -80,8 +80,9 @@ describe('NetworkPolicyForm with Unknown CNI type', () => {
 });
 
 describe('NetworkPolicyForm with Openshift SDN CNI type', () => {
-  const openShiftSDNSpec = { spec: { networkType: 'OpenShiftSDN' } };
-  (useK8sGet as jest.Mock).mockReturnValue([openShiftSDNSpec, true, null]);
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  const cm = { data: { policy_egress: 'false', policy_peer_ipblock_exceptions: 'false' } };
+  (useK8sGet as jest.Mock).mockReturnValue([cm, true, null]);
   const wrapper = mount(<NetworkPolicyForm formData={emptyPolicy} onChange={jest.fn()} />);
 
   it('should not render any warning', () => {
@@ -102,8 +103,9 @@ describe('NetworkPolicyForm with Openshift SDN CNI type', () => {
 });
 
 describe('NetworkPolicyForm with OVN Kubernetes CNI type', () => {
-  const ovnK8sSpec = { spec: { networkType: 'OVNKubernetes' } };
-  (useK8sGet as jest.Mock).mockReturnValue([ovnK8sSpec, true, null]);
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  const cm = { data: { policy_egress: 'true', policy_peer_ipblock_exceptions: 'true' } };
+  (useK8sGet as jest.Mock).mockReturnValue([cm, true, null]);
   const wrapper = mount(<NetworkPolicyForm formData={emptyPolicy} onChange={jest.fn()} />);
 
   it('should not render any warning', () => {

--- a/frontend/packages/console-app/src/__tests__/network-policies/network-policy-peer-ipblock.spec.tsx
+++ b/frontend/packages/console-app/src/__tests__/network-policies/network-policy-peer-ipblock.spec.tsx
@@ -19,8 +19,8 @@ const networkPolicyPeerIPBlock = (
   />
 );
 
-describe('NetworkPolicyPeerIPBlock without permissions to fetch CNI type', () => {
-  (useK8sGet as jest.Mock).mockReturnValue([null, true, 'error fetching CNI']);
+describe('NetworkPolicyPeerIPBlock without the CNO config map', () => {
+  (useK8sGet as jest.Mock).mockReturnValue([null, true, 'error fetching CNO configmap']);
   const wrapper = mount(networkPolicyPeerIPBlock);
 
   it('should render the exceptions section', () => {
@@ -40,9 +40,9 @@ describe('NetworkPolicyPeerIPBlock without permissions to fetch CNI type', () =>
   });
 });
 
-describe('NetworkPolicyPeerIPBlock with Unknown CNI type', () => {
-  const unknownSDNSpec = { spec: { networkType: 'Calico' } };
-  (useK8sGet as jest.Mock).mockReturnValue([unknownSDNSpec, true, null]);
+describe('NetworkPolicyPeerIPBlock with unknown network features', () => {
+  const cm = { data: {} };
+  (useK8sGet as jest.Mock).mockReturnValue([cm, true, null]);
   const wrapper = mount(networkPolicyPeerIPBlock);
 
   it('should render the exceptions section', () => {
@@ -63,7 +63,9 @@ describe('NetworkPolicyPeerIPBlock with Unknown CNI type', () => {
 });
 
 describe('NetworkPolicyPeerIPBlock with OpenShift SDN CNI type', () => {
-  (useK8sGet as jest.Mock).mockReturnValue([{ spec: { networkType: 'OpenShiftSDN' } }, true, null]);
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  const cm = { data: { policy_egress: 'false', policy_peer_ipblock_exceptions: 'false' } };
+  (useK8sGet as jest.Mock).mockReturnValue([cm, true, null]);
   const wrapper = mount(networkPolicyPeerIPBlock);
 
   it('should not render the exceptions section', () => {
@@ -83,11 +85,9 @@ describe('NetworkPolicyPeerIPBlock with OpenShift SDN CNI type', () => {
 });
 
 describe('NetworkPolicyPeerIPBlock with OVN Kubernetes CNI type', () => {
-  (useK8sGet as jest.Mock).mockReturnValue([
-    { spec: { networkType: 'OVNKubernetes' } },
-    true,
-    null,
-  ]);
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  const cm = { data: { policy_egress: 'true', policy_peer_ipblock_exceptions: 'true' } };
+  (useK8sGet as jest.Mock).mockReturnValue([cm, true, null]);
   const wrapper = mount(networkPolicyPeerIPBlock);
 
   it('should render the exceptions section', () => {

--- a/frontend/public/module/k8s/network.ts
+++ b/frontend/public/module/k8s/network.ts
@@ -1,20 +1,12 @@
 import * as React from 'react';
 import { useK8sGet } from '../../components/utils/k8s-get-hook';
 import { K8sResourceKind } from './types';
-import { NetworkOperatorConfigModel } from '../../models';
+import { ConfigMapModel } from '../../models';
 
-const clusterNetworkModel = NetworkOperatorConfigModel;
-const networkName = 'cluster';
-
-/**
- * CNI type, or Unknown if the type can't be fetched (e.g. because the logged user does not
- * have permissions to fetch it)
- */
-enum ClusterNetworkType {
-  OpenShiftSDN = 'OpenShiftSDN',
-  OVNKubernetes = 'OVNKubernetes',
-  Unknown = 'Unknown',
-}
+const networkConfigMapName = 'openshift-network-features';
+const networkConfigMapNamespace = 'openshift-config-managed';
+const policyEgressConfigKey = 'policy_egress';
+const policyPeerIPBlockExceptionsConfigKey = 'policy_peer_ipblock_exceptions';
 
 export enum ClusterNetworkFeature {
   PolicyEgress = 'PolicyEgress',
@@ -25,29 +17,15 @@ export type ClusterNetworkFeatures = {
   [key in ClusterNetworkFeature]?: boolean;
 };
 
-/**
- * Main document depicting all the features that are supported by each supported CNI type.
- * Undefined features would require to take an ambiguous action (e.g. allow the customer
- * to set the policy Egress rule in a form, but show a warning explaining that this field is
- * not available for the Openshift SDN type)
- */
-const featuresDocument: {
-  [k in ClusterNetworkType]: ClusterNetworkFeatures;
-} = {
-  OpenShiftSDN: {
-    PolicyEgress: false,
-    PolicyPeerIPBlockExceptions: false,
-  },
-  OVNKubernetes: {
-    PolicyEgress: true,
-    PolicyPeerIPBlockExceptions: true,
-  },
-  Unknown: {},
+const getFeatureState = (data: { [key: string]: string }, key: string): boolean | undefined => {
+  // Note: config map data comes as string, not bool
+  return data.hasOwnProperty(key) ? data[key] === 'true' : undefined;
 };
 
 /**
  *  Fetches and returns the features supported by the Cluster Network Type
- *  (Openshift SDN or Kubernetes OVN)
+ *  (Openshift SDN, Kubernetes OVN ...) using a config map provided by the
+ *  cluster network operator.
  *
  *  @async
  *  @returns [ClusterNetworkFeatures, boolean, any] - The asynchronously-loaded cluster network
@@ -55,18 +33,25 @@ const featuresDocument: {
  *  returned)
  */
 export const useClusterNetworkFeatures = (): [ClusterNetworkFeatures, boolean] => {
-  const [features, setFeatures] = React.useState<ClusterNetworkFeatures>(
-    featuresDocument[ClusterNetworkType.Unknown],
-  );
+  const [features, setFeatures] = React.useState<ClusterNetworkFeatures>({});
   const [featuresLoaded, setFeaturesLoaded] = React.useState(false);
-  const [network, networkLoaded] = useK8sGet<K8sResourceKind>(clusterNetworkModel, networkName);
+  const [config, configLoaded] = useK8sGet<K8sResourceKind>(
+    ConfigMapModel,
+    networkConfigMapName,
+    networkConfigMapNamespace,
+  );
   React.useEffect(() => {
-    if (networkLoaded) {
-      const cniType = ClusterNetworkType[network?.spec?.networkType];
-      setFeatures(featuresDocument[cniType ?? ClusterNetworkType.Unknown]);
+    if (configLoaded && config?.data) {
+      setFeatures({
+        PolicyEgress: getFeatureState(config.data, policyEgressConfigKey),
+        PolicyPeerIPBlockExceptions: getFeatureState(
+          config.data,
+          policyPeerIPBlockExceptionsConfigKey,
+        ),
+      });
       setFeaturesLoaded(true);
     }
-  }, [network, networkLoaded]);
+  }, [config, configLoaded]);
 
   return [features, featuresLoaded];
 };

--- a/frontend/public/module/k8s/network.ts
+++ b/frontend/public/module/k8s/network.ts
@@ -41,14 +41,16 @@ export const useClusterNetworkFeatures = (): [ClusterNetworkFeatures, boolean] =
     networkConfigMapNamespace,
   );
   React.useEffect(() => {
-    if (configLoaded && config?.data) {
-      setFeatures({
-        PolicyEgress: getFeatureState(config.data, policyEgressConfigKey),
-        PolicyPeerIPBlockExceptions: getFeatureState(
-          config.data,
-          policyPeerIPBlockExceptionsConfigKey,
-        ),
-      });
+    if (configLoaded) {
+      if (config?.data) {
+        setFeatures({
+          PolicyEgress: getFeatureState(config.data, policyEgressConfigKey),
+          PolicyPeerIPBlockExceptions: getFeatureState(
+            config.data,
+            policyPeerIPBlockExceptionsConfigKey,
+          ),
+        });
+      }
       setFeaturesLoaded(true);
     }
   }, [config, configLoaded]);


### PR DESCRIPTION
https://issues.redhat.com/browse/NETOBSERV-32

This new solution works for any authenticated users, not just admins.
Requires CNO and openshift 4.10 (if these requirements are not met, network
features will be unknown and an info alert will be displayed like in the
current situation)

EP: https://github.com/openshift/enhancements/blob/master/enhancements/console/expose-network-features.md