### PR TITLE
Enable Secure Route option by default in Deploy Image & Import from git flow

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -219,6 +219,13 @@
     }
   },
   {
+    "type": "console.user-preference/group",
+    "properties": {
+      "id": "applications",
+      "label": "%console-app~Applications%"
+    }
+  },
+  {
     "type": "console.user-preference/item",
     "properties": {
       "id": "console.preferredPerspective",

--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -4,6 +4,7 @@
   "General": "General",
   "Language": "Language",
   "Notifications": "Notifications",
+  "Applications": "Applications",
   "Perspective": "Perspective",
   "If a perspective is not selected, the console defaults to the last viewed.": "If a perspective is not selected, the console defaults to the last viewed.",
   "Project": "Project",

--- a/frontend/packages/console-shared/src/components/formik-fields/DroppableFileInputField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/DroppableFileInputField.tsx
@@ -12,6 +12,7 @@ const DroppableFileInputField: React.FC<FieldProps> = ({ name, label, helpText }
   return (
     <FormGroup fieldId={fieldId}>
       <DroppableFileInput
+        id={fieldId}
         label={label}
         onChange={(fileData: string) => setFieldValue(name, fileData)}
         inputFileData={field.value}

--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -591,5 +591,19 @@
       "submenu": true,
       "insertAfter": ["delete-application"]
     }
+  },
+  {
+    "type": "console.user-preference/item",
+    "properties": {
+      "id": "devconsole.routingOptions",
+      "label": "",
+      "groupId": "applications",
+      "description": "",
+      "field": {
+        "type": "custom",
+        "component": { "$codeRef": "userPreferences.SecureRouteFields" }
+      },
+      "insertAfter": "console.preferredCreateEditMethod"
+    }
   }
 ]

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -571,6 +571,8 @@
   "Select a Project to view the list of {{projectLabelPlural}} or <4>create a Project</4>.": "Select a Project to view the list of {{projectLabelPlural}} or <4>create a Project</4>.",
   "Select a Project to search inside or <2>create a Project</2>.": "Select a Project to search inside or <2>create a Project</2>.",
   "BindableKinds": "BindableKinds",
+  "The defaults below will only apply to the Import from Git and Deploy Image forms when creating Deployments or Deployment Configs.": "The defaults below will only apply to the Import from Git and Deploy Image forms when creating Deployments or Deployment Configs.",
+  "Secure route": "Secure route",
   "Image name from external registry": "Image name from external registry",
   "Image stream tag from internal registry": "Image stream tag from internal registry"
 }

--- a/frontend/packages/dev-console/package.json
+++ b/frontend/packages/dev-console/package.json
@@ -28,7 +28,8 @@
       "catalog": "src/components/catalog",
       "fileUpload": "src/components/jar-file-upload/index.ts",
       "topology": "src/components/topology",
-      "perspective": "src/utils/perspective.tsx"
+      "perspective": "src/utils/perspective.tsx",
+      "userPreferences": "src/components/user-preferences"
     }
   }
 }

--- a/frontend/packages/dev-console/src/components/import/route/SecureRoute.tsx
+++ b/frontend/packages/dev-console/src/components/import/route/SecureRoute.tsx
@@ -3,6 +3,7 @@ import { FormHelperText } from '@patternfly/react-core';
 import { useFormikContext, FormikValues } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { DropdownField, DroppableFileInputField, CheckboxField } from '@console/shared';
+import { usePreferredRoutingOptions } from '../../user-preferences/usePreferredRoutingOptions';
 import {
   TerminationTypes,
   PassthroughInsecureTrafficTypes,
@@ -11,11 +12,30 @@ import {
 
 const SecureRoute: React.FC = () => {
   const { t } = useTranslation();
+  const [preferredRoutingOptions, , preferredRoutingOptionsLoaded] = usePreferredRoutingOptions();
+  const { secure: secureRoute, tlsTermination, insecureTraffic } =
+    preferredRoutingOptionsLoaded && preferredRoutingOptions;
   const {
     values: {
+      formType,
       route: { secure, tls },
     },
+    setFieldValue,
   } = useFormikContext<FormikValues>();
+  React.useEffect(() => {
+    if (formType !== 'edit' && preferredRoutingOptionsLoaded) {
+      setFieldValue('route.secure', secureRoute, false);
+      setFieldValue('route.tls.termination', tlsTermination, false);
+      setFieldValue('route.tls.insecureEdgeTerminationPolicy', insecureTraffic, true);
+    }
+  }, [
+    formType,
+    insecureTraffic,
+    preferredRoutingOptionsLoaded,
+    secureRoute,
+    setFieldValue,
+    tlsTermination,
+  ]);
   return (
     <>
       <CheckboxField

--- a/frontend/packages/dev-console/src/components/user-preferences/SecureRouteFields.tsx
+++ b/frontend/packages/dev-console/src/components/user-preferences/SecureRouteFields.tsx
@@ -1,0 +1,164 @@
+import * as React from 'react';
+import { Checkbox, FormGroup, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import {
+  InsecureTrafficTypes,
+  PassthroughInsecureTrafficTypes,
+  TerminationTypes,
+} from '../import/import-types';
+import { usePreferredRoutingOptions } from './usePreferredRoutingOptions';
+
+const SecureRouteFields: React.FC = () => {
+  const { t } = useTranslation();
+  const [
+    preferredRoutingOptions,
+    setPreferredRoutingOptions,
+    preferredRoutingOptionsLoaded,
+  ] = usePreferredRoutingOptions();
+  const { secure, tlsTermination, insecureTraffic } =
+    preferredRoutingOptionsLoaded && preferredRoutingOptions;
+  const [isTLSTerminationOpen, setIsTLSTerminationOpen] = React.useState<boolean>(false);
+  const [isInsecureTrafficOpen, setIsInsecureTrafficOpen] = React.useState<boolean>(false);
+
+  const tlsTerminationSelectOptions: JSX.Element[] = React.useMemo(
+    () =>
+      Object.keys(TerminationTypes).map((tlsTerminationOption) => (
+        <SelectOption key={tlsTerminationOption} value={tlsTerminationOption}>
+          {TerminationTypes[tlsTerminationOption]}
+        </SelectOption>
+      )),
+    [],
+  );
+
+  const insecureTrafficSelectOptions: JSX.Element[] = React.useMemo(
+    () =>
+      Object.keys(InsecureTrafficTypes).map((insecureTrafficOption) => (
+        <SelectOption key={insecureTrafficOption} value={insecureTrafficOption}>
+          {InsecureTrafficTypes[insecureTrafficOption]}
+        </SelectOption>
+      )),
+    [],
+  );
+
+  const passthroughInsecureTrafficTypesSelectOptions: JSX.Element[] = React.useMemo(
+    () =>
+      Object.keys(PassthroughInsecureTrafficTypes).map((passthroughInsecureTraffic) => (
+        <SelectOption key={passthroughInsecureTraffic} value={passthroughInsecureTraffic}>
+          {PassthroughInsecureTrafficTypes[passthroughInsecureTraffic]}
+        </SelectOption>
+      )),
+    [],
+  );
+
+  const onSecureRouteChecked = React.useCallback(
+    (checked: boolean) => {
+      setPreferredRoutingOptions({
+        secure: checked,
+        tlsTermination,
+        insecureTraffic,
+      });
+    },
+    [insecureTraffic, setPreferredRoutingOptions, tlsTermination],
+  );
+
+  const onTLSTerminationToggle = React.useCallback(
+    (isOpen: boolean) => setIsTLSTerminationOpen(isOpen),
+    [],
+  );
+
+  const onInsecureTrafficToggle = React.useCallback(
+    (isOpen: boolean) => setIsInsecureTrafficOpen(isOpen),
+    [],
+  );
+
+  const onTLSTerminationSelect = React.useCallback(
+    (_, selection: string) => {
+      setPreferredRoutingOptions({
+        secure,
+        tlsTermination: selection,
+        insecureTraffic,
+      });
+      setIsTLSTerminationOpen(false);
+    },
+    [insecureTraffic, secure, setPreferredRoutingOptions],
+  );
+
+  const onInsecureTrafficSelect = React.useCallback(
+    (_, selection: string) => {
+      setPreferredRoutingOptions({
+        secure,
+        tlsTermination,
+        insecureTraffic: selection,
+      });
+      setIsInsecureTrafficOpen(false);
+    },
+    [secure, setPreferredRoutingOptions, tlsTermination],
+  );
+
+  return (
+    <div className="pf-c-form">
+      <span className="co-help-text">
+        {t(
+          'devconsole~The defaults below will only apply to the Import from Git and Deploy Image forms when creating Deployments or Deployment Configs.',
+        )}
+      </span>
+      <Checkbox
+        id="secure-route-checkbox"
+        data-test="secure-route-checkbox"
+        label={t('devconsole~Secure route')}
+        isChecked={secure}
+        data-checked-state={secure}
+        onChange={onSecureRouteChecked}
+        aria-label={t('devconsole~Secure route')}
+        description={t(
+          'devconsole~Routes can be secured using several TLS termination types for serving certificates.',
+        )}
+        isDisabled={!preferredRoutingOptionsLoaded}
+        className="odc-secure-route-fields__secure-route"
+      />
+
+      <FormGroup fieldId="tls-termination" label={t('devconsole~TLS termination')}>
+        <Select
+          id="tls-termination"
+          variant={SelectVariant.single}
+          isOpen={isTLSTerminationOpen}
+          selections={tlsTermination}
+          toggleId="tls-termination"
+          onToggle={onTLSTerminationToggle}
+          onSelect={onTLSTerminationSelect}
+          placeholderText={t('devconsole~Select termination type')}
+          isDisabled={!preferredRoutingOptionsLoaded}
+          aria-label={t('devconsole~Select termination type')}
+          maxHeight={300}
+        >
+          {tlsTerminationSelectOptions}
+        </Select>
+      </FormGroup>
+      <FormGroup
+        fieldId="insecure-traffic"
+        label={t('devconsole~Insecure traffic')}
+        helperText={t('devconsole~Policy for traffic on insecure schemes like HTTP.')}
+      >
+        <Select
+          id="insecure-traffic"
+          variant={SelectVariant.single}
+          isOpen={isInsecureTrafficOpen}
+          selections={insecureTraffic}
+          toggleId="insecure-traffic"
+          onToggle={onInsecureTrafficToggle}
+          onSelect={onInsecureTrafficSelect}
+          placeholderText={t('devconsole~Select insecure traffic type')}
+          isDisabled={!preferredRoutingOptionsLoaded}
+          aria-label={t('devconsole~Select insecure traffic type')}
+          maxHeight={300}
+        >
+          {tlsTermination === 'passthrough'
+            ? passthroughInsecureTrafficTypesSelectOptions
+            : insecureTrafficSelectOptions}
+        </Select>
+      </FormGroup>
+    </div>
+  );
+};
+
+export default SecureRouteFields;

--- a/frontend/packages/dev-console/src/components/user-preferences/__tests__/SecureRouteFields.spec.tsx
+++ b/frontend/packages/dev-console/src/components/user-preferences/__tests__/SecureRouteFields.spec.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { configure, fireEvent, render, screen } from '@testing-library/react';
+import SecureRouteFields from '../SecureRouteFields';
+import { usePreferredRoutingOptions } from '../usePreferredRoutingOptions';
+
+configure({ testIdAttribute: 'id' });
+
+jest.mock('../usePreferredRoutingOptions', () => ({
+  usePreferredRoutingOptions: jest.fn(),
+}));
+
+const mockUsePreferredRoutingOptions = usePreferredRoutingOptions as jest.Mock;
+
+describe('SecureRouteFields', () => {
+  it('should render Secure Route Fields component', () => {
+    mockUsePreferredRoutingOptions.mockReturnValue([{}, () => {}, true]);
+    render(<SecureRouteFields />);
+    expect(screen.queryByTestId('secure-route-checkbox')).not.toBeNull();
+    expect(screen.queryByTestId('insecure-traffic')).not.toBeNull();
+    expect(screen.queryByTestId('tls-termination')).not.toBeNull();
+  });
+
+  it('should render skelton if usePreferredRoutingOptions is not loaded', () => {
+    mockUsePreferredRoutingOptions.mockReturnValue([{}, () => {}, false]);
+    render(<SecureRouteFields />);
+    const secureRouteCheckbox = screen.queryByTestId('secure-route-checkbox');
+    const tlsTermination = screen.queryByTestId('tls-termination');
+    const inSecureTraffic = screen.queryByTestId('insecure-traffic');
+    expect(secureRouteCheckbox.hasAttribute('disabled')).toBeTruthy();
+    expect(tlsTermination.hasAttribute('disabled')).toBeTruthy();
+    expect(inSecureTraffic.hasAttribute('disabled')).toBeTruthy();
+  });
+
+  it('should not show Allow option in Insecure traffic dropdown if TLS termination is Passthrough', () => {
+    mockUsePreferredRoutingOptions.mockReturnValue([
+      {
+        secure: true,
+        tlsTermination: 'passthrough',
+        insecureTraffic: 'Redirect',
+      },
+      () => {},
+      true,
+    ]);
+    render(<SecureRouteFields />);
+    const inSecureTraffic = screen.queryByTestId('insecure-traffic');
+    fireEvent.click(inSecureTraffic);
+    expect(screen.queryByRole('option', { name: /Allow/i })).toBeNull();
+    expect(screen.queryByRole('option', { name: /None/i })).not.toBeNull();
+    expect(screen.queryByRole('option', { name: /Redirect/i })).not.toBeNull();
+  });
+
+  it('should show Allow, None and  Redirect options in Insecure traffic dropdown if TLS termination is not Passthrough', () => {
+    mockUsePreferredRoutingOptions.mockReturnValue([
+      {
+        secure: true,
+        tlsTermination: 'edge',
+        insecureTraffic: 'Redirect',
+      },
+      () => {},
+      true,
+    ]);
+    render(<SecureRouteFields />);
+    const inSecureTraffic = screen.queryByTestId('insecure-traffic');
+    fireEvent.click(inSecureTraffic);
+    expect(screen.queryByRole('option', { name: /Allow/i })).not.toBeNull();
+    expect(screen.queryByRole('option', { name: /None/i })).not.toBeNull();
+    expect(screen.queryByRole('option', { name: /Redirect/i })).not.toBeNull();
+  });
+});

--- a/frontend/packages/dev-console/src/components/user-preferences/index.ts
+++ b/frontend/packages/dev-console/src/components/user-preferences/index.ts
@@ -1,0 +1,1 @@
+export { default as SecureRouteFields } from './SecureRouteFields';

--- a/frontend/packages/dev-console/src/components/user-preferences/usePreferredRoutingOptions.tsx
+++ b/frontend/packages/dev-console/src/components/user-preferences/usePreferredRoutingOptions.tsx
@@ -1,0 +1,27 @@
+import { Dispatch, SetStateAction } from 'react';
+import { useUserSettings } from '@console/shared';
+
+const PREFERRED_SECURE_ROUTING_OPTIONS_USER_SETTING_KEY = 'devconsole.import.secureRoutingOptions';
+
+type RoutingOptions = {
+  secure: boolean;
+  tlsTermination?: string;
+  insecureTraffic?: string;
+};
+
+export const usePreferredRoutingOptions = (): [
+  RoutingOptions,
+  Dispatch<SetStateAction<RoutingOptions>>,
+  boolean,
+] => {
+  const [
+    preferredRoutingOptions,
+    setPreferredRoutingOptions,
+    preferredRoutingOptionsLoaded,
+  ] = useUserSettings<RoutingOptions>(PREFERRED_SECURE_ROUTING_OPTIONS_USER_SETTING_KEY, {
+    secure: true,
+    tlsTermination: 'edge',
+    insecureTraffic: 'Redirect',
+  });
+  return [preferredRoutingOptions, setPreferredRoutingOptions, preferredRoutingOptionsLoaded];
+};


### PR DESCRIPTION
**Story:** https://issues.redhat.com/browse/ODC-6447

**Descriptions:** Enable Secure Route option by default in Deploy Image & Import from git flow

**GIF:**
![image](https://user-images.githubusercontent.com/2561818/146418989-41e4a925-61a7-47f0-a006-a5c4ce164245.png)

![Kapture 2021-12-16 at 22 53 26](https://user-images.githubusercontent.com/2561818/146419359-b197c71e-4b70-496d-926d-5dee37090248.gif)

**Test coverage:**
![image](https://user-images.githubusercontent.com/2561818/146419584-4611e3ba-4e6b-4189-93ee-bd14be113e77.png)

