### PR TITLE
CONSOLE-2925: Add initial dynamic demo plugin tests

### DIFF
--- a/dynamic-demo-plugin/oc-manifest.yaml
+++ b/dynamic-demo-plugin/oc-manifest.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: console-demo-plugin
-          image: quay.io/vszocs/console-demo-plugin
+          image: quay.io/jcaianirh/console-demo-plugin
           ports:
             - containerPort: 9001
               protocol: TCP

--- a/dynamic-demo-plugin/src/components/ExtensionConsumer.tsx
+++ b/dynamic-demo-plugin/src/components/ExtensionConsumer.tsx
@@ -29,7 +29,7 @@ const ExtensionConsumer: React.FC = () => {
     <Page
       additionalGroupedContent={
         <PageSection variant="light">
-          <Title headingLevel="h1">
+          <Title headingLevel="h1" data-test="test-consumer-title">
             {t("Extensions of type Console.flag/Model")}
           </Title>
         </PageSection>

--- a/dynamic-demo-plugin/src/components/UtilityConsumer.tsx
+++ b/dynamic-demo-plugin/src/components/UtilityConsumer.tsx
@@ -16,7 +16,7 @@ const UtilityConsumer: React.FC = () => {
     <Page
       additionalGroupedContent={
         <PageSection variant="light">
-          <Title headingLevel="h1">
+          <Title headingLevel="h1" data-test="test-utilities-title">
             {t("Utilities from Dynamic Plugin SDK")}
           </Title>
         </PageSection>
@@ -24,8 +24,8 @@ const UtilityConsumer: React.FC = () => {
     >
       <PageSection>
         <Card>
-          <CardTitle>{t("Utility: consoleFetchJSON")}</CardTitle>
-          <CardBody>
+          <CardTitle data-test="test-utility-card">{t("Utility: consoleFetchJSON")}</CardTitle>
+          <CardBody data-test="test-utility-fetch">
             <ConsoleFetchConsumer />
           </CardBody>
         </Card>

--- a/dynamic-demo-plugin/src/components/k8sConsumer/K8sAPIConsumer.tsx
+++ b/dynamic-demo-plugin/src/components/k8sConsumer/K8sAPIConsumer.tsx
@@ -131,14 +131,14 @@ const K8sAPIConsumer: React.FC = () => {
     <Page
       additionalGroupedContent={
         <PageSection variant="light">
-          <Title headingLevel="h1">{t('K8s API from Dynamic Plugin SDK')}</Title>
+          <Title headingLevel="h1" data-test="test-k8sapi-title">{t('K8s API from Dynamic Plugin SDK')}</Title>
         </PageSection>
       }
     >
       <PageSection>
         {errData && (
           <AlertGroup>
-            <Alert title={errData} variant="warning" isInline />
+            <Alert data-test="test-k8api-error" title={errData} variant="warning" isInline />
           </AlertGroup>
         )}
         <Card>
@@ -146,7 +146,7 @@ const K8sAPIConsumer: React.FC = () => {
             <Button isBlock onClick={k8sCreateClick}>
               {t('k8sCreate')}
             </Button>
-            <ConsoleK8sAPIConsumer data={k8sCreateData} />
+            <ConsoleK8sAPIConsumer data-test="test-k8s-create" data={k8sCreateData} />
           </CardBody>
         </Card>
         <Card>
@@ -154,7 +154,7 @@ const K8sAPIConsumer: React.FC = () => {
             <Button isBlock onClick={k8sGetClick}>
               {t('k8sGet')}
             </Button>
-            <ConsoleK8sAPIConsumer data={k8sGetData} />
+            <ConsoleK8sAPIConsumer data-test="test-k8s-get" data={k8sGetData} />
           </CardBody>
         </Card>
         <Card>
@@ -162,7 +162,7 @@ const K8sAPIConsumer: React.FC = () => {
             <Button isBlock onClick={k8sPatchClick}>
               {t('k8sPatch')}
             </Button>
-            <ConsoleK8sAPIConsumer data={k8sPatchData} />
+            <ConsoleK8sAPIConsumer data-test="test-k8s-patch" data={k8sPatchData} />
           </CardBody>
         </Card>
         <Card>
@@ -170,7 +170,7 @@ const K8sAPIConsumer: React.FC = () => {
             <Button isBlock onClick={k8sUpdateClick}>
               {t('k8sUpdate')}
             </Button>
-            <ConsoleK8sAPIConsumer data={k8sUpdateData} />
+            <ConsoleK8sAPIConsumer data-test="test-k8s-update" data={k8sUpdateData} />
           </CardBody>
         </Card>
         <Card>
@@ -178,7 +178,7 @@ const K8sAPIConsumer: React.FC = () => {
             <Button isBlock onClick={k8sListClick}>
               {t('k8sList')}
             </Button>
-            <ConsoleK8sAPIConsumer data={k8sListData} />
+            <ConsoleK8sAPIConsumer data-test="test-k8s-list" data={k8sListData} />
           </CardBody>
         </Card>
         <Card>
@@ -186,7 +186,7 @@ const K8sAPIConsumer: React.FC = () => {
             <Button isBlock onClick={k8sDeleteClick}>
               {t('k8sDelete')}
             </Button>
-            <ConsoleK8sAPIConsumer data={k8sDeleteData} />
+            <ConsoleK8sAPIConsumer data-test="test-k8s-delete" data={k8sDeleteData} />
           </CardBody>
         </Card>
       </PageSection>

--- a/dynamic-demo-plugin/src/components/k8sConsumer/k8s-data.ts
+++ b/dynamic-demo-plugin/src/components/k8sConsumer/k8s-data.ts
@@ -28,7 +28,7 @@ export const mockDeploymetData = {
             image: 'image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest',
             ports: [
               {
-                protocol: 'tcp',
+                protocol: 'TCP',
                 containerPort: 8080,
               },
             ],

--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -81,8 +81,8 @@
 "@openshift-console/dynamic-plugin-sdk@file:../frontend/packages/console-dynamic-plugin-sdk/dist/core":
   version "0.0.0-fixed"
   dependencies:
-    "@patternfly/react-core" "4.198.19"
-    "@patternfly/react-table" "4.67.19"
+    "@patternfly/react-core" "4.202.16"
+    "@patternfly/react-table" "4.71.16"
     react "^17.0.1"
     react-helmet "^6.1.0"
     react-i18next "^11.7.3"
@@ -105,14 +105,14 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-core@4.198.19", "@patternfly/react-core@^4.198.19":
-  version "4.198.19"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.198.19.tgz#14444b7421417eec43fb8a0f6163c34aa37c1c2e"
-  integrity sha512-f46CIKwWCJ1UNL50TXnvarYUhr2KtxNFw/kGYtG6QwrQwKXscZiXMMtW//0Q08cyhLB0vfxHOLbCKxVaVJ3R3w==
+"@patternfly/react-core@4.202.16", "@patternfly/react-core@^4.202.16":
+  version "4.202.16"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.202.16.tgz#dc45712315beb84b29f34d5cc29ec4f443b37857"
+  integrity sha512-yWDf0x+YFFVxm72RC/BUaSOn2UsIirT77qif6DfAWdSODhdxTfaLCeBZ08uWgxJ1YZNCrankj60va+G5L+LVrg==
   dependencies:
-    "@patternfly/react-icons" "^4.49.19"
-    "@patternfly/react-styles" "^4.48.19"
-    "@patternfly/react-tokens" "^4.50.19"
+    "@patternfly/react-icons" "^4.53.16"
+    "@patternfly/react-styles" "^4.52.16"
+    "@patternfly/react-tokens" "^4.54.16"
     focus-trap "6.2.2"
     react-dropzone "9.0.0"
     tippy.js "5.1.2"
@@ -136,20 +136,20 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.19.8.tgz#376cfe136b3acef86fa28081c99e4e88bd13457c"
   integrity sha512-JBBcVntRLspe857JnGo8lFaZfy+WOR/IYe2E9W3Rknqm1T8WO6oXpeEnrr5r9bpYDFUa4ttcb/acuQXc1xypxg==
 
-"@patternfly/react-icons@^4.49.19":
-  version "4.49.19"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.49.19.tgz#66f426570378213f6f717d4a39fadcbf57635d1e"
-  integrity sha512-Pr6JDDKWOnWChkifXKWglKEPo3Q+1CgiUTUrvk4ZbnD7mhq5e/TFxxInB9CPzi278bvnc2YlPyTjpaAcCN0yGw==
+"@patternfly/react-icons@^4.53.16":
+  version "4.53.16"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.53.16.tgz#2ffb273d623d47952efefbf052fcb0e347a5bcb1"
+  integrity sha512-QQOZwl9MR71uNaKUPKJUm2qjvol28evN7GgyiqGn7fr0p4FnPopm9F5GsnKMsE/764/HGwGLjYHulUo3Eb06dQ==
 
 "@patternfly/react-styles@^4.12.4", "@patternfly/react-styles@^4.18.8":
   version "4.18.8"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.18.8.tgz#92b314c41a8df27cf4c531ab60fc9daf11da8150"
   integrity sha512-136N/Whs0qXDtPpsh5JeNJld5BeFPsbmmcgI5LlMQ+P9dioddh24rTqaaOIea67tHiXUB7orxaqKpBBILXqcPQ==
 
-"@patternfly/react-styles@^4.48.19":
-  version "4.48.19"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.48.19.tgz#23bb4521a586275ed14d89c2c60fe8765e45b3bb"
-  integrity sha512-8+t8wqYGWkmyhxLty/kQXCY44rnW0y60nUMG7QKNzF1bAFJIpR8jKuVnHArM1h+MI9D53e8OVjKORH83hUAzJw==
+"@patternfly/react-styles@^4.52.16":
+  version "4.52.16"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.52.16.tgz#7925013717eb5246529935d965d1ecdaf6240b60"
+  integrity sha512-i/xj+r0qVlhSoxrFOePxXoC8BudDPsEma0qwP+3Ry4hSZhN6XhSRSqjA5xmaLkgbfWCAiT/+mR9ilCaguxoLTA==
 
 "@patternfly/react-table@4.31.7":
   version "4.31.7"
@@ -163,15 +163,15 @@
     lodash "^4.17.19"
     tslib "^2.0.0"
 
-"@patternfly/react-table@4.67.19":
-  version "4.67.19"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.67.19.tgz#a98345c53c8da8ea0708ab944676ec477d1f0b9c"
-  integrity sha512-pAa0tpafLHtICCiM3TDQ89xqQTvkZtRuwJ6+KKSpN1UdEEHy+3j0JjDUcslN+6Lo7stgoLwgWzGmE7bsx4Ys5Q==
+"@patternfly/react-table@4.71.16":
+  version "4.71.16"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.71.16.tgz#c8669a495371cf6a310a7c6aa5d2d0f7d4cfcd8d"
+  integrity sha512-HF//Sk1nnF7phAOjglC8zndRfJ3/3oe8Bkxbufhp3lSFdAyzjed6WBdV2dNIrsNj1UeO8MRSlYCbbDEZZlrO2A==
   dependencies:
-    "@patternfly/react-core" "^4.198.19"
-    "@patternfly/react-icons" "^4.49.19"
-    "@patternfly/react-styles" "^4.48.19"
-    "@patternfly/react-tokens" "^4.50.19"
+    "@patternfly/react-core" "^4.202.16"
+    "@patternfly/react-icons" "^4.53.16"
+    "@patternfly/react-styles" "^4.52.16"
+    "@patternfly/react-tokens" "^4.54.16"
     lodash "^4.17.19"
     tslib "^2.0.0"
 
@@ -180,10 +180,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.20.8.tgz#8413af8516fdcdaea1da81912434eef4c9c7865a"
   integrity sha512-OFlgTknFBNAETWVYYoLdISJBjPMQ8e3tcLpWb3h/KgKk/Tn1NR+P7Pl1gQGvTL/9liBZfS/HKDD5+P8c70w+2Q==
 
-"@patternfly/react-tokens@^4.50.19":
-  version "4.50.19"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.50.19.tgz#7619830e7ad70853e54819b37e196c85ed604f21"
-  integrity sha512-wbUPb8welJ8p+OjXrc0X3UYDj5JjN9xnfpYkZdAySpcFtk0BAn5Py6UEZCjKtw7XHHfCQ1zwKXpXDShcu/5KVQ==
+"@patternfly/react-tokens@^4.54.16":
+  version "4.54.16"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.54.16.tgz#0be2f0361cd42f703c62b6b710e0e2ae579654cb"
+  integrity sha512-BBVg40L4gx0Gew2kDdGNxP+EtDwGeBuJwXewKrTjXlCa4uhOOj7TqJ5rxhS4GULfYiYbUGdYe7UMFVb+mKDVVg==
 
 "@types/eslint-scope@^3.7.0":
   version "3.7.1"

--- a/frontend/packages/console-shared/src/components/toast/ToastContext.tsx
+++ b/frontend/packages/console-shared/src/components/toast/ToastContext.tsx
@@ -22,6 +22,8 @@ export type ToastOptions = {
     dismiss?: boolean;
     // Sets the base component to render. defaults to button
     component?: React.ElementType<any> | React.ComponentType<any>;
+    // The data test id
+    dataTest?: string;
   }[];
   // If `true`, displays a close button.
   dismissible?: boolean;

--- a/frontend/packages/console-shared/src/components/toast/ToastProvider.tsx
+++ b/frontend/packages/console-shared/src/components/toast/ToastProvider.tsx
@@ -83,6 +83,7 @@ const ToastProvider: React.FC = ({ children }) => {
                           action.callback();
                         }}
                         component={action.component}
+                        data-test={action.dataTest || 'toast-action'}
                       >
                         {action.label}
                       </AlertActionLink>

--- a/frontend/packages/integration-tests-cypress/tests/app/demo-dynamic-plugin.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/demo-dynamic-plugin.spec.ts
@@ -1,0 +1,198 @@
+import { safeLoadAll } from 'js-yaml';
+import { checkErrors } from '../../support';
+import { isLocalDevEnvironment } from '../../views/common';
+import { detailsPage } from '../../views/details-page';
+import { infoMessage, hintMessage, warningMessage, warningToast } from '../../views/form';
+import { listPage } from '../../views/list-page';
+import { modal } from '../../views/modal';
+import { nav } from '../../views/nav';
+
+const PLUGIN_NAME = 'console-demo-plugin';
+const PLUGIN_PATH = '../../../dynamic-demo-plugin';
+const CHECK_UPDATE_WAIT = 30000;
+const PLUGIN_PULL_SPEC = Cypress.env('PLUGIN_PULL_SPEC');
+
+/*
+  These tests are meant to:
+    1. show how to test a dynamic plugin using demo as the plugin instance
+    2. run locally:
+      2a. build the plugin locally, and run the server
+      2b. using bridge running with the plugin argument that points to the local dynanmic plugin server
+      2c. will intercept the check update call to mock a toast notification that a plugin has been enabled
+      2d. will not use all workload definitions defined in the yaml (not using the env variable for pull spec)
+    3. run on ci:
+      3a. ci will build the dynamic plugin and provide the pullspec in the env var: CYPRESS_PLUGIN_PULL_SPEC
+      3b. that pull spec will be used to create the deployment on the cluster
+      3c. intercepting the check-updates call will not occur as the toast will appear when the plugin is enabled
+    4. the scaffolding should remain the same except modifying the constants above
+ */
+
+const enableDemoPlugin = (enable: boolean) => {
+  // find console demo plugin and enable it
+  cy.visit('k8s/cluster/operator.openshift.io~v1~Console/cluster/console-plugins');
+  cy.url().should(
+    'include',
+    'k8s/cluster/operator.openshift.io~v1~Console/cluster/console-plugins',
+  );
+  cy.get('.co-resource-item__resource-name')
+    .byLegacyTestID(PLUGIN_NAME)
+    .should('be.visible');
+  cy.byLegacyTestID(PLUGIN_NAME)
+    .parents('tr')
+    .within(() => {
+      cy.byTestID('edit-console-plugin').contains(enable ? 'Disabled' : 'Enabled');
+      cy.byTestID('edit-console-plugin').click();
+    });
+  modal.shouldBeOpened();
+  cy.contains('Cancel');
+  modal.modalTitleShouldContain('Console plugin enablement');
+  cy.byTestID(enable ? 'Enable-radio-input' : 'Disable-radio-input').click();
+  modal.submit();
+  modal.shouldBeClosed();
+  cy.byLegacyTestID(PLUGIN_NAME)
+    .parents('tr')
+    .within(() => {
+      cy.byTestID('edit-console-plugin').contains(enable ? 'Enabled' : 'Disabled');
+    });
+  if (isLocalDevEnvironment) {
+    // for local dev env just trigger any change in the return value to activate the toast
+    cy.intercept('/api/check-updates*', { plugins: [] }).as('checkUpdates');
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(CHECK_UPDATE_WAIT);
+    cy.wait('@checkUpdates');
+    cy.log('Running plugin test locally using bridge.');
+  } else {
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(CHECK_UPDATE_WAIT);
+    cy.log(`Running plugin test on ci using PLUGIN_PULL_SPEC: ${PLUGIN_PULL_SPEC}.`);
+  }
+  cy.get(warningToast)
+    .should('exist')
+    .then(() => {
+      cy.reload();
+      if (!enable) {
+        cy.byLegacyTestID(PLUGIN_NAME).click();
+        detailsPage.titleShouldContain(PLUGIN_NAME);
+        detailsPage.clickPageActionFromDropdown('Delete ConsolePlugin');
+        modal.shouldBeOpened();
+        modal.submit();
+      }
+    });
+};
+
+const dynamicNavTest = (navID: string) => {
+  nav.sidenav.clickNavLink(['Demo Plugin', `Dynamic Nav ${navID}`]);
+  cy.get('.pf-c-title.pf-m-2xl').should('contain', `Dynamic Page ${navID}`);
+  cy.get(infoMessage).should('contain', 'Example info alert');
+  cy.get(warningMessage).should('contain', 'Example warning alert');
+  cy.get(hintMessage).should('contain', 'Example hint');
+  cy.get('.pf-c-card').should('contain', 'Example card');
+};
+
+const k8sAPINavTest = (apiID: string) => {
+  cy.byButtonText(apiID).click();
+  cy.get('test-k8api-error').should('not.exist');
+  cy.get(`test-k8s-${apiID}`).should('not.be.empty');
+};
+
+describe('Demo dynamic plugin test', () => {
+  before(() => {
+    cy.login();
+    nav.sidenav.switcher.changePerspectiveTo('Administrator');
+    nav.sidenav.switcher.shouldHaveText('Administrator');
+    cy.createProject(PLUGIN_NAME);
+    cy.readFile(`${PLUGIN_PATH}/oc-manifest.yaml`).then((textManifest) => {
+      const yamlManifest = safeLoadAll(textManifest);
+      const deployment = yamlManifest.find(({ kind }) => kind === 'Deployment');
+
+      if (!isLocalDevEnvironment && PLUGIN_PULL_SPEC) {
+        console.log('this is not a local env, setting the pull spec for the deployment');
+        deployment.spec.template.spec.containers[0].image = PLUGIN_PULL_SPEC;
+      } else {
+        console.log('this IS A local env, not setting the pull spec for the deployment');
+      }
+      const service = yamlManifest.find(({ kind }) => kind === 'Service');
+      const consolePlugin = yamlManifest.find(({ kind }) => kind === 'ConsolePlugin');
+      cy.exec(` echo '${JSON.stringify(deployment)}' | oc create -f -`, {
+        failOnNonZeroExit: false,
+      })
+        .its('stdout')
+        .should('contain', 'created')
+        .then(() =>
+          cy
+            .exec(` echo '${JSON.stringify(service)}' | oc create -f -`, {
+              failOnNonZeroExit: false,
+            })
+            .then((result) => {
+              console.log('Error: ', result.stderr);
+              console.log('Success: ', result.stdout);
+            })
+            .its('stdout')
+            .should('contain', 'created'),
+        )
+        .then(() =>
+          cy
+            .exec(` echo '${JSON.stringify(consolePlugin)}' | oc create -f -`, {
+              failOnNonZeroExit: false,
+            })
+            .then((result) => {
+              console.log('Error: ', result.stderr);
+              console.log('Success: ', result.stdout);
+            })
+            .its('stdout')
+            .should('contain', 'created'),
+        )
+        .then(() => {
+          cy.visit(`/k8s/ns/${PLUGIN_NAME}/deployments`);
+          listPage.rows.shouldBeLoaded();
+          listPage.filter.byName(PLUGIN_NAME);
+          listPage.rows.shouldExist(PLUGIN_NAME);
+          enableDemoPlugin(true);
+        });
+    });
+  });
+
+  afterEach(() => {
+    checkErrors();
+  });
+
+  after(() => {
+    enableDemoPlugin(false);
+    cy.deleteProject(PLUGIN_NAME);
+    cy.logout();
+  });
+
+  it(`test Dynamic Nav items`, () => {
+    const dynamicNavIDs = ['1', '2'];
+    dynamicNavIDs.forEach((id) => dynamicNavTest(id));
+  });
+
+  it(`test Test Consumer nav item`, () => {
+    nav.sidenav.clickNavLink(['Demo Plugin', 'Test Consumer']);
+    cy.byTestID('test-consumer-title').should('contain', 'Extensions of type Console.flag/Model');
+    cy.get('.pf-c-card').should('have.length', 20);
+  });
+
+  it(`test Test Utilities nav item`, () => {
+    nav.sidenav.clickNavLink(['Demo Plugin', 'Test Utilities']);
+    cy.byTestID('test-utilities-title').should('contain', 'Utilities from Dynamic Plugin SDK');
+    cy.byTestID('test-utility-card').should('contain', 'Utility: consoleFetchJSON');
+    cy.byTestID('test-utility-fetch').should('not.be.empty');
+  });
+
+  it(`test List Page nav item`, () => {
+    const podName = 'openshift-state-metrics';
+    nav.sidenav.clickNavLink(['Demo Plugin', 'List Page']);
+    listPage.titleShouldHaveText('OpenShift Pods List Page');
+    listPage.rows.shouldBeLoaded();
+    listPage.filter.byName(podName);
+    listPage.rows.shouldExist(podName);
+  });
+
+  it(`test K8s API nav item`, () => {
+    const apiIDs = ['k8sCreate', 'k8sGet', 'k8sPatch', 'k8sUpdate', 'k8sList', 'k8sDelete'];
+    nav.sidenav.clickNavLink(['Demo Plugin', 'K8s API']);
+    cy.byTestID('test-k8sapi-title').should('contain', 'K8s API from Dynamic Plugin SDK');
+    apiIDs.forEach((id) => k8sAPINavTest(id));
+  });
+});

--- a/frontend/packages/integration-tests-cypress/views/common.ts
+++ b/frontend/packages/integration-tests-cypress/views/common.ts
@@ -29,3 +29,5 @@ export const projectDropdown = {
     cy.byLegacyTestID('namespace-bar-dropdown').should('not.contain', name),
   shouldNotExist: () => cy.byLegacyTestID('namespace-bar-dropdown').should('not.exist'),
 };
+
+export const isLocalDevEnvironment = Cypress.config('baseUrl').includes('localhost');

--- a/frontend/packages/integration-tests-cypress/views/form.ts
+++ b/frontend/packages/integration-tests-cypress/views/form.ts
@@ -1,4 +1,7 @@
 export const submitButton = 'button[type=submit]';
 export const errorMessage = '.pf-c-alert.pf-m-inline.pf-m-danger';
+export const hintMessage = '.pf-c-hint';
 export const infoMessage = '.pf-c-alert.pf-m-inline.pf-m-info';
 export const successMessage = '.pf-c-alert.pf-m-inline.pf-m-success';
+export const warningMessage = '.pf-c-alert.pf-m-inline.pf-m-warning';
+export const warningToast = '.pf-c-alert.pf-m-warning';


### PR DESCRIPTION
For: https://issues.redhat.com/browse/CONSOLE-2925

```
These tests are meant to:
    1. show how to test a dynamic plugin using demo as the plugin instance
    2. run locally:
      2a. build the plugin locally, and run the server
      2b. using bridge running with the plugin argument that points to the local dynanmic plugin server
      2c. will intercept the check update call to mock a toast notification that a plugin has been enabled
      2d. will not use all workload definitions defined in the yaml (not using the env variable for pull spec)
    3. run on ci:
      3a. ci will build the dynamic plugin and provide the pullspec in the env var: CYPRESS_PLUGIN_PULL_SPEC
      3b. that pull spec will be used to create the deployment on the cluster
      3c. intercepting the check-updates call will not occur as the toast will appear when the plugin is enabled
    4. the scaffolding should remain the same except modifying the constants above
```

Video of local run with bridge:
https://user-images.githubusercontent.com/35978579/145464086-5f3fba88-cbf6-4ec6-8c5e-5c7108611a1c.mp4

CI run results:
<img width="1721" alt="Screen Shot 2021-12-19 at 3 01 55 PM" src="https://user-images.githubusercontent.com/35978579/146689173-d1137ad7-c4e4-476e-a9de-b7d0cae726af.png">
