### PR TITLE
Make the github API mocks runnable for all cypress test plugins

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
@@ -1,4 +1,4 @@
-import { gitImportRepos } from '../../../testData/git-import/repos';
+import { getResponseMocks, gitImportRepos } from '../../../testData/git-import/repos';
 import { gitAdvancedOptions, buildConfigOptions, builderImages, messages } from '../../constants';
 import { gitPO } from '../../pageObjects';
 import { app } from '../app';
@@ -26,31 +26,22 @@ export const gitPage = {
       const organization = urlSegments[urlSegments.length - 2];
       const name = urlSegments[urlSegments.length - 1];
       const apiBaseUrl = `https://api.github.com/repos/${organization}/${name}`;
+      const responses = getResponseMocks(repository);
 
-      cy.readFile(`testData/git-import/${repository.folder}/repo.json`).then((repoResponse) => {
-        cy.intercept('GET', apiBaseUrl, {
-          statusCode: 200,
-          body: repoResponse,
-        }).as('getRepo');
-      });
+      cy.intercept('GET', apiBaseUrl, {
+        statusCode: 200,
+        body: responses.repoResponse,
+      }).as('getRepo');
 
-      cy.readFile(`testData/git-import/${repository.folder}/contents.json`).then(
-        (contentsResponse) => {
-          cy.intercept('GET', `${apiBaseUrl}/contents/`, {
-            statusCode: 200,
-            body: contentsResponse,
-          }).as('getContents');
-        },
-      );
+      cy.intercept('GET', `${apiBaseUrl}/contents/`, {
+        statusCode: 200,
+        body: responses.contentsResponse,
+      }).as('getContents');
 
-      cy.task('readFileIfExists', `testData/git-import/${repository.folder}/package.json`).then(
-        (packageResponse) => {
-          cy.intercept('GET', `${apiBaseUrl}/contents//package.json`, {
-            statusCode: packageResponse ? 200 : 404,
-            body: packageResponse,
-          }).as('getPackage');
-        },
-      );
+      cy.intercept('GET', `${apiBaseUrl}/contents//package.json`, {
+        statusCode: responses.packageResponse ? 200 : 404,
+        body: responses.packageResponse,
+      }).as('getPackage');
     }
 
     cy.get(gitPO.gitRepoUrl)

--- a/frontend/packages/dev-console/integration-tests/testData/git-import/repos.ts
+++ b/frontend/packages/dev-console/integration-tests/testData/git-import/repos.ts
@@ -1,3 +1,5 @@
+/* eslint-disable global-require, import/no-dynamic-require, @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
+
 export const gitImportRepos: GithubRepo[] = [
   { url: 'https://github.com/sclorg/dancer-ex', folder: 'dancer-ex' },
   { url: 'https://github.com/sclorg/cakephp-ex', folder: 'cakephp-ex' },
@@ -11,4 +13,17 @@ export const gitImportRepos: GithubRepo[] = [
 interface GithubRepo {
   url: string;
   folder: string;
+}
+
+export function getResponseMocks(repo: GithubRepo) {
+  const repoJson = require(`./${repo.folder}/repo.json`);
+  const contentsJson = require(`./${repo.folder}/contents.json`);
+
+  let packageJson = null;
+  try {
+    packageJson = require(`./${repo.folder}/package.json`);
+  } catch (err) {
+    // nothing, the file does not exist
+  }
+  return { repoResponse: repoJson, contentsResponse: contentsJson, packageResponse: packageJson };
 }


### PR DESCRIPTION
There is an issue where the github API mocks fail to load when running cypress tests from a different plugin than dev-console. The fs root is set to the root of whatever integration-tests project is currently loaded, so other plugins can't see testData folder from dev-console.

It doesn't look pretty, but the only way I could find that works without copying the files is dynamic require.

**How to test**
 - run cypress tests of other plugin than dev-console (e.g. test-cypress.sh -p topology)
 - run a scenario that imports a nodejs-ex project from github
 - the test should not get stuck when the import from git step happens