### PR TITLE
Bug 2031040: Fix property reading property resource from undefined

### DIFF
--- a/frontend/packages/dev-console/src/actions/providers.ts
+++ b/frontend/packages/dev-console/src/actions/providers.ts
@@ -185,7 +185,7 @@ export const useTopologyApplicationActionProvider: TopologyActionProvider = ({
     }),
     [element, application],
   );
-  const primaryResource = appData.resources?.[0].resource || {};
+  const primaryResource = appData.resources?.[0]?.resource || {};
   const [kindObj, inFlight] = useK8sModel(referenceFor(primaryResource));
 
   return React.useMemo(() => {


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2031040

**Analysis / Root cause**: 
When a Serverless application (a Knative Service) could not be started successfully and opens the topology sidebar for it, the content area shows the "Oh no! Something went wrong." error page because of property access not a non loaded "appData" object.

```
TypeError
Cannot read properties of undefined (reading 'resource')
Call Stack
 useTopologyApplicationActionProvider
  actions-1f6645dd9ee466d3516a.js:372:96
 ActionsHookResolver
  main-70696d9d817228734c45.js:30870:38
```

**Solution Description**: 
Add a missing optional chain `?.` check

**Screen shots / Gifs for design review**: 
Error before:
![image](https://user-images.githubusercontent.com/139310/145567851-1ac23011-4c8f-4119-9f47-c451bd522994.png)

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Install OpenShift Serverless operator and create Knative Serving/Eventing resources
2. Navigate to developer perspective > Add page > Import from Git
3. Import an Node.js application via a Builder Image (build from source) and enter "broken" for the npm "Start Command"

   - for Example use https://github.com/jerolimov/nodeinfo
   - select Edit Import Strategy > Builder Image
   - select Builder Image version "14-ubi8"
   - enter "Start command" "broken"

4. Select the Service in the topology view to open the sidebar.
5. If the error doesn't appear now reload the current tab.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge