### PR TITLE
Bug 2031831: Scope toolbar for specific left alignment use on list pages and remove...

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -15,7 +15,7 @@ $co-affinity-row-margin: 15px;
 }
 
 .co-clusterserviceversion-details__field {
-  padding-bottom: 10px;
+  padding-bottom: var(--pf-global--spacer--lg);
 }
 
 .co-clusterserviceversion-details__field-description {

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -22,6 +22,11 @@ $catalog-tile-width: $co-m-catalog-tile-width;
   min-width: 515px; // in order to accommodate filters and tiles at mobile
 }
 
+// Prevents our tile text from inheriting the link color
+.co-catalog-tile {
+  color: var(--pf-global--Color--100);
+}
+
 .co-catalog-tile-view {
   display: flex;
   flex-wrap: wrap;
@@ -118,7 +123,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
 
   &__description {
     margin-top: -10px;
-    padding: 0 $pf-global-gutter 10px;
+    padding: 0 $pf-global-gutter $pf-global-gutter;
     @media (min-width: $pf-global--breakpoint--xl) {
       padding-left: $pf-global-gutter--md;
       padding-right: $pf-global-gutter--md;

--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -5,7 +5,7 @@ import * as Modal from 'react-modal';
 import { Router } from 'react-router-dom';
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
-import { ActionGroup, Button } from '@patternfly/react-core';
+import { ActionGroup, Button, TextContent } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';
 import CloseButton from '@console/shared/src/components/close-button';
@@ -90,7 +90,7 @@ export const ModalTitle: React.SFC<ModalTitleProps> = ({
 export const ModalBody: React.SFC<ModalBodyProps> = ({ children }) => (
   <div className="modal-body">
     <div className="modal-body-content">
-      <div className="modal-body-inner-shadow-covers">{children}</div>
+      <TextContent className="modal-body-inner-shadow-covers">{children}</TextContent>
     </div>
   </div>
 );

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -276,6 +276,7 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
 
   return (
     <Toolbar
+      className="pf-c-toolbar--align-left"
       data-test="filter-toolbar"
       id="filter-toolbar"
       clearAllFilters={clearAll}

--- a/frontend/public/components/markdown-view.tsx
+++ b/frontend/public/components/markdown-view.tsx
@@ -228,7 +228,7 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
     padding-top: 0;
   }
   </style>
-  <body class="pf-m-redhat-font"><div style="overflow-y: auto;">${markup}</div></body>`;
+  <body class="pf-m-redhat-font pf-c-content"><div style="overflow-y: auto;">${markup}</div></body>`;
   return (
     <>
       <iframe

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -1,5 +1,9 @@
 $tooltip-background-color: var(--pf-global--BackgroundColor--dark-100);
 
+.co-alert-manager {
+  margin-bottom: var(--pf-global--spacer--md);
+}
+
 .co-alert-manager-config__edit-alert-routing-btn {
   margin-bottom: 10px;
 }

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -589,9 +589,11 @@ const AlertMessage: React.FC<AlertMessageProps> = ({ alertText, labels, template
   });
 
   return (
-    <p>
-      <LinkifyExternal>{messageParts}</LinkifyExternal>
-    </p>
+    <div className="co-alert-manager">
+      <p>
+        <LinkifyExternal>{messageParts}</LinkifyExternal>
+      </p>
+    </div>
   );
 };
 

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -223,6 +223,7 @@ const SearchPage_: React.FC<SearchProps> = (props) => {
       </Helmet>
       <PageHeading detail={true} title={t('public~Search')}>
         <Toolbar
+          className="pf-c-toolbar--align-left"
           id="search-toolbar"
           clearAllFilters={clearAll}
           collapseListedFiltersBreakpoint="xl"

--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import { Breadcrumb, BreadcrumbItem, Button } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem, Button, TextContent } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -94,7 +94,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
     _.get(allDefinitions, [ref, 'format']) || _.get(allDefinitions, [ref, 'type']);
 
   return (
-    <>
+    <TextContent>
       {!_.isEmpty(breadcrumbs) && (
         <Breadcrumb className="pf-c-breadcrumb--no-padding-top co-break-word">
           {breadcrumbs.map((crumb, i) => {
@@ -126,7 +126,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
       {_.isEmpty(currentProperties) ? (
         <EmptyBox label={t('public~Properties')} />
       ) : (
-        <ul className="co-resource-sidebar-list">
+        <ul className="co-resource-sidebar-list pf-c-list">
           {_.map(currentProperties, (definition: SwaggerDefinition, name: string) => {
             const path = getDrilldownPath(name);
             const definitionType = definition.type || getTypeForRef(getRef(definition));
@@ -160,7 +160,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
           })}
         </ul>
       )}
-    </>
+    </TextContent>
   );
 };
 

--- a/frontend/public/components/user.tsx
+++ b/frontend/public/components/user.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link, match } from 'react-router-dom';
 import * as _ from 'lodash-es';
-import { Button } from '@patternfly/react-core';
+import { Button, TextContent } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 
 import { useCanEditIdentityProviders, useOAuthData } from '@console/shared/src/hooks/oauth';
@@ -84,7 +84,7 @@ const NoDataEmptyMsgDetail = () => {
   const canEditIdentityProviders = useCanEditIdentityProviders();
   const [oauth, oauthLoaded] = useOAuthData(canEditIdentityProviders);
   return (
-    <>
+    <TextContent>
       {canEditIdentityProviders && oauthLoaded ? (
         oauth?.spec?.identityProviders?.length > 0 ? (
           <p>
@@ -109,7 +109,7 @@ const NoDataEmptyMsgDetail = () => {
           <UsersHelpText />
         </p>
       )}
-    </>
+    </TextContent>
   );
 };
 

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -154,8 +154,7 @@ form.pf-c-form {
     flex-direction: column;
   }
 
-  // `.pf-c-page` specificity required
-  .pf-c-toolbar {
+  .pf-c-toolbar--align-left {
     --pf-c-toolbar--PaddingTop: 0;
     --pf-c-toolbar__content--PaddingLeft: 0;
     --pf-c-toolbar__content--PaddingRight: 0;

--- a/frontend/public/style/ancillary/_patternfly4.scss
+++ b/frontend/public/style/ancillary/_patternfly4.scss
@@ -10,59 +10,45 @@
   --pf-c-content--MarginBottom: var(--pf-global--spacer--md);
 }
 
-// These are written as nested rules in PF4 .pf-c-content *
-// node_modules/@patternfly/patternfly/components/Content/content.css
-dl:not(:last-child), ol:not(:last-child), ul:not(:last-child), blockquote:not(:last-child), small:not(:last-child), hr:not(:last-child), pre:not(:last-child) {
-  margin-bottom: var(--pf-c-content--MarginBottom);
-}
+  h1, h2, h3, h4, h5, h6 {
+    font-family: var(--pf-global--FontFamily--heading--sans-serif);
+    font-weight: var(--pf-global--FontWeight--normal);
+    line-height: var(--pf-global--LineHeight--md);
+    margin-bottom: var(--pf-global--spacer--sm);
+    word-break: break-word;
+  }
 
-// Prevents our tile text from inheriting the link color
-.co-catalog-tile {
-  color: var(--pf-global--Color--100);
-}
+  h1 {
+    font-size: var(--pf-global--FontSize--2xl);
+    line-height: var(--pf-global--LineHeight--sm);
+  }
 
-h1, h2, h3, h4, h5, h6 {
-  font-family: var(--pf-global--FontFamily--heading--sans-serif);
-  font-weight: var(--pf-global--FontWeight--normal);
-  line-height: var(--pf-global--LineHeight--md);
-  margin-bottom: var(--pf-global--spacer--sm);
-  word-break: break-word;
-}
+  h2 {
+    font-size: var(--pf-global--FontSize--xl);
+  }
 
-h1 {
-  font-size: var(--pf-global--FontSize--2xl);
-  line-height: var(--pf-global--LineHeight--sm);
-}
+  h3 {
+    font-size: var(--pf-global--FontSize--lg);
+  }
 
-h2 {
-  font-size: var(--pf-global--FontSize--xl);
-}
+  h4, h5, h6 {
+    font-size: var(--pf-global--FontSize--md);
+  }
 
-h3 {
-  font-size: var(--pf-global--FontSize--lg);
-}
+  // Override PF4 inheritance
+  button, input, optgroup, select, textarea,
+  .pf-c-badge {
+    font-family: var(--pf-global--FontFamily--sans-serif);
+  }
 
-h4, h5, h6 {
-  font-size: var(--pf-global--FontSize--md);
-}
+  pre {
+    background-color: var(--pf-c-code-block--BackgroundColor);
+    color: var(--pf-global--Color--100);
+    font-family: var(--pf-c-code-block__pre--FontFamily);
+    font-size: var(--pf-c-code-block__pre--FontSize);
+    overflow-wrap: break-word;
+    padding: var(--pf-global--spacer--md);
+    white-space: pre-wrap;
+    display: block;
+  }
 
-// Override PF4 inheritance
-button, input, optgroup, select, textarea,
-.pf-c-badge {
-  font-family: var(--pf-global--FontFamily--sans-serif);
-}
-
-p {
-  margin-bottom: var(--pf-c-content--MarginBottom);
-}
-
-pre {
-  background-color: var(--pf-c-code-block--BackgroundColor);
-  color: var(--pf-global--Color--100);
-  font-family: var(--pf-c-code-block__pre--FontFamily);
-  font-size: var(--pf-c-code-block__pre--FontSize);
-  overflow-wrap: break-word;
-  padding: var(--pf-global--spacer--md);
-  white-space: pre-wrap;
-  display: block;
-}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2031231

Switch to specific `toolbar` css class for use on existing list screens.
Remove generic element (`p` `ul` ...) css rules to prevent display inconsistencies with dynamic plugin screens.

PatternFly uses its parent `pf-c-content` to apply spacing to nested elements. 
A parent `pf-c-content` class is applied to the primary sections where generic `<p>` and `<ul>` are located. OperatorHub install descriptions, Create resource YAML sidebar, and Modals.

Some individual cases required specific css modifications

PatternFly css
`@patternfly/patternfly/components/Content/content.css`

cc @spadgett @jamestalton 
