### PR TITLE
Automation of toast notification and route label for epic ODC-6266

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
@@ -11,7 +11,7 @@ Feature: Create Application from git form
         # @smoke
         # Marking this scenario as @manual, because due to git-rate limit issue, below scenarios are failing
         # TODO: Use Cypress HTTP mocking to solve the github rate limiting issue. See - https://docs.cypress.io/guides/guides/network-requests
-        @regression @manual
+        @regression @manual @odc-6266
         Scenario Outline: Add new git workload with new application for resoruce type "<resource_type>": A-06-TC01
             Given user is at Import from Git form
              When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
@@ -20,6 +20,7 @@ Feature: Create Application from git form
               And user selects resource type as "<resource_type>"
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user can see toast notification saying "Deployment created successfully"
               And user is able to see workload "<name>" in topology page
 
         Examples:
@@ -28,7 +29,7 @@ Feature: Create Application from git form
                   | import-git-1 | Deployment Config |
 
 
-        @regression
+        @regression @odc-6266
         Scenario: Add new git workload to the existing application: A-06-TC02
             Given user has created workload "exist-git" with resource type "Deployment"
               And user is at Add page
@@ -39,6 +40,7 @@ Feature: Create Application from git form
               And user selects resource type as "Deployment Config"
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user can see toast notification saying "Deployment created successfully"
               And user can see the created workload "dancer-ex-git-2" is linked to existing application "nodejs-ex-git-app"
 
 
@@ -62,18 +64,21 @@ Feature: Create Application from git form
               And public url is not created for node "name-no-route" in the workload sidebar
 
 
-        @regression
+        @regression @odc-6266
         Scenario: Create a git workload with advanced option "Routing": A-06-TC05
             Given user is at Import from Git form
              When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
               And user enters name as "git-route" in General section
-              And user clicks "Routing" link in Advanced Options section
+              And user clicks "Show advanced Routing options" link in Advanced Options section
+              And user enters "route=testRoute1" in Additional Route labels section
               And user enters Hostname as "home"
               And user enters Path as "/home"
               And user selects default Target Port
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user can see the toast notification containg the route value "home"
               And the route of application "git-route" contains "home" in the Routes section of the workload sidebar
+              And user is able to see label "route=testRoute1"  in Route details page for deployment "git-route"
 
 
         @regression
@@ -207,20 +212,20 @@ Feature: Create Application from git form
         @regression
         Scenario: Provide custom build environments for nodejs git import
             Given user is at Import from Git form
-            When user enters Git Repo URL as "https://github.com/sclorg/nodejs-ex"
-            And user enters run command for "NPM_RUN" as "build1"
-            And user enters Name as "nodejs-env"
-            And user clicks Create button on Add page
-            Then user will be redirected to Topology page
-            And user is able to navigate to Build "nodejs-env-1" for deployment "nodejs-env" and see environment variable "NPM_RUN" with value "build1" in Environment tab of details page
+             When user enters Git Repo URL as "https://github.com/sclorg/nodejs-ex"
+              And user enters run command for "NPM_RUN" as "build1"
+              And user enters Name as "nodejs-env"
+              And user clicks Create button on Add page
+             Then user will be redirected to Topology page
+              And user is able to navigate to Build "nodejs-env-1" for deployment "nodejs-env" and see environment variable "NPM_RUN" with value "build1" in Environment tab of details page
 
         @regression
         Scenario: Update custom build environment in nodejs application edit page
             Given user is at Topology page
-            When user edits the application "nodejs-env"
-            And user enters run command for "NPM_RUN" as "build2"
-            And user clicks Create button on Add page
-            And user clicks on workload "nodejs-env"
-            And user starts a new build
-            And user navigates to Topology page
-            Then user is able to navigate to Build "nodejs-env-2" for deployment "nodejs-env" and see environment variable "NPM_RUN" with value "build2" in Environment tab of details page
+             When user edits the application "nodejs-env"
+              And user enters run command for "NPM_RUN" as "build2"
+              And user clicks Create button on Add page
+              And user clicks on workload "nodejs-env"
+              And user starts a new build
+              And user navigates to Topology page
+             Then user is able to navigate to Build "nodejs-env-2" for deployment "nodejs-env" and see environment variable "NPM_RUN" with value "build2" in Environment tab of details page

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -58,6 +58,8 @@ export const gitPO = {
       secureRoute: 'input#form-checkbox-route-secure-field',
       tlsTermination: 'button#form-dropdown-route-tls-termination-field',
       insecureTraffic: 'button#form-dropdown-route-tls-insecureEdgeTerminationPolicy-field',
+      routeLabel: '', // defined when feature pr of story ODC-6433 gets merged
+      labelsRouteDetails: '[data-test="label-list"]',
     },
     buildConfig: {
       webHookBuildTrigger: 'input#form-checkbox-build-triggers-webhook-field',

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
@@ -349,4 +349,8 @@ export const gitPage = {
   enterScalingReplicaCount: (replicaCount: string) =>
     cy.get(gitPO.advancedOptions.scaling.replicaCount).type(replicaCount),
   enterLabels: (labelName: string) => cy.get(gitPO.advancedOptions.labels).type(labelName),
+  enterRouteLabels: (labelRouteName: string) =>
+    cy.get(gitPO.advancedOptions.routing.routeLabel).type(labelRouteName),
+  notificationVerify: (message: string) =>
+    cy.get(gitPO.pipeline.infoMessage).should('contain.text', message),
 };

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-git.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-git.ts
@@ -1,6 +1,13 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
-import { addOptions, buildConfigOptions, messages } from '../../constants';
-import { gitPage, addPage, topologyPage, addHealthChecksPage, topologySidePane } from '../../pages';
+import { addOptions, buildConfigOptions, messages, resources } from '../../constants';
+import {
+  gitPage,
+  addPage,
+  topologyPage,
+  addHealthChecksPage,
+  topologySidePane,
+  app,
+} from '../../pages';
 import { dockerfilePage } from '../../pages/add-flow/dockerfile-page';
 
 Given('user is at Import from Git form', () => {
@@ -32,6 +39,10 @@ Then('Name displays as {string}', (nodeName: string) => {
   gitPage.verifyNodeName(nodeName);
 });
 
+Then('user can see toast notification saying {string}', (message: string) => {
+  gitPage.notificationVerify(message);
+});
+
 When('user selects resource type as {string}', (resourceType: string) => {
   gitPage.selectResource(resourceType);
 });
@@ -41,6 +52,7 @@ Then(
   (workloadName: string, appName: string) => {
     topologyPage.verifyWorkloadInTopologyPage(workloadName);
     topologyPage.getAppNode(appName).click({ force: true });
+    cy.get('[role="dialog"]').should('contain', 'DeploymentConfig');
     topologySidePane.verifyResource(workloadName);
   },
 );
@@ -71,6 +83,12 @@ When('user enters Name as {string} in General section of Dockerfile page', (name
 
 When('user clicks {string} link in Advanced Options section', (linkName: string) => {
   cy.byButtonText(linkName).click();
+});
+
+When('user enters {string} in Additional Route labels section', (labelName: string) => {
+  // Below to be uncommeted after the epic is feature complete
+  // gitPage.enterRouteLabels(labelName);
+  cy.log(labelName); // to avoid lint issues
 });
 
 When('user enters Hostname as {string}', (hostName: string) => {
@@ -181,6 +199,10 @@ When('user enters label as {string}', (labelName: string) => {
   gitPage.enterLabels(labelName);
 });
 
+Then('user can see the toast notification containg the route value {string}', (message: string) => {
+  gitPage.notificationVerify(message);
+});
+
 Then('public url is not created for node {string} in the workload sidebar', (nodeName: string) => {
   topologyPage.verifyWorkloadInTopologyPage(nodeName);
   topologyPage.componentNode(nodeName).click({ force: true });
@@ -199,7 +221,8 @@ Then(
     topologyPage.componentNode(nodeName).click({ force: true });
     topologySidePane.selectTab('Resources');
     topologySidePane.verifySection('Routes');
-    cy.get('a.co-external-link.co-external-link--block').should('contain.text', routeName);
+    // cy.get('a.co-external-link.co-external-link--block').should('contain.text', routeName);
+    cy.byLegacyTestID('route-link').should('contain.text', routeName);
   },
 );
 
@@ -210,5 +233,16 @@ Then(
     topologySidePane.selectTab('Details');
     topologySidePane.verifyLabel(labelName);
     topologySidePane.close();
+  },
+);
+
+Then(
+  'user is able to see label {string}  in Route details page for deployment {string}',
+  (labelName: string, nodeName: string) => {
+    topologySidePane.selectTab('Resources');
+    topologySidePane.selectResource(resources.Routes, 'aut-addflow-git', nodeName);
+    app.waitForLoad();
+    // Below to be uncommeted after the epic is feature complete
+    // cy.get(gitPO.advancedOptions.routing.labelsRouteDetails).should('contain', labelName);
   },
 );

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -108,7 +108,14 @@ export const RouteLinkAndCopy: React.FC<RouteLinkAndCopyProps> = ({
   additionalClassName,
 }) => {
   const link = getRouteWebURL(route);
-  return <ExternalLinkWithCopy additionalClassName={additionalClassName} link={link} text={link} />;
+  return (
+    <ExternalLinkWithCopy
+      additionalClassName={additionalClassName}
+      link={link}
+      text={link}
+      dataTestID="route-link"
+    />
+  );
 };
 
 // Renders LinkAndCopy for non subdomains


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-6266
Story: https://issues.redhat.com/browse/ODC-6411

Acceptance criteria:

- Show a toast notification when an application is imported from Git or imported Container image.
- If Route option was selected the toast notification should also show the external Route URL 
- Add a new "Additional route labels" option, with a label input field to the "Advanced Routing options"

**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]

**Fix**: https://issues.redhat.com/browse/ODC-6412


**Test Setup**:

Cluster should be running on local

Check the TAGS in frontend/packages/topology/integration-tests/cypress.json file be: ""(@pre-condition or @smoke or @regression) and @[odc-6266](https://issues.redhat.com/browse/odc-6266) and not (@manual or @to-do or @un-verified or @broken-test)"",


Command to execute:

Run a cluster locally and execute the command `npm run test-cypress-dev-console` simultaneously

Execute the create-from-git.feature file

**Browser**
Chrome 90

**Test Execution Screenshot:**

