### PR TITLE
Bug 2026209: Fix tektonhub task upgrading issue

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/pipeline-quicksearch-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/pipeline-quicksearch-utils.ts
@@ -100,15 +100,8 @@ export const updateTask = async (
         ...task.metadata.annotations,
         ...getInstalledFromAnnotation(),
       };
-      await k8sUpdate(
-        TaskModel,
-        _.merge({}, taskData.data, {
-          metadata: task.metadata,
-          spec: task.spec,
-        }),
-        namespace,
-        name,
-      );
+      task.metadata = _.merge({}, taskData.data.metadata, task.metadata);
+      return k8sUpdate(TaskModel, task, namespace, name);
     })
     .catch((err) => {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

https://issues.redhat.com/browse/OCPBUGSM-37519

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
While updating to a new version of a task, the `spec` contains older version's task spec properties due to the merge, which causes a backend validation error while updating the task with new version.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Task spec is no longer merged to older spec, instead use it directly for the updating the task.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/9964343/145803599-8e8ff65a-0ecb-4ce2-a34d-ab867c210fc9.mp4




**Unit test coverage report**: 
<!-- Attach test coverage report -->

![image](https://user-images.githubusercontent.com/9964343/145801000-6e67cd54-c635-48c9-b7f6-38470cdfba92.png)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Install OSP operator
2. In Pipeline builder, add a task `openshift-client` from tekton hub and choose 0.1 version
3. Add one more task, now try and update the `openshift-client` from 0.1 to  0.2 and hit `update and Add` button.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge