### PR TITLE
Bug 1911173: Monitoring dashboards: Improve series titles when a label is missing

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -223,12 +223,15 @@ const Tooltip_: React.FC<TooltipProps> = ({ activePoints, center, height, style,
     [(k) => -_.uniq(allSeries.map((s) => s.labels[k])).length, (k) => k.length],
   );
   const getSeriesName = (series: TooltipSeries): string => {
-    if (series.name) {
+    if (_.isString(series.name)) {
       return series.name;
     }
-    const name = series.labels?.__name__ ?? '';
+    if (_.isEmpty(series.labels)) {
+      return '{}';
+    }
+    const name = series.labels.__name__ ?? '';
     const otherLabels = _.intersection(allSeriesSorted, Object.keys(series.labels));
-    return `${name}{${_.map(otherLabels, (l) => `${l}=${series.labels[l]}`).join(',')}}`;
+    return `${name}{${otherLabels.map((l) => `${l}=${series.labels[l]}`).join(',')}}`;
   };
 
   return (


### PR DESCRIPTION
When a series title includes a label, but that label is missing,
  - Replace any other labels in the title, if they exist
  - Don't leave the `{{label}}` string in the series title (replace it
    with an empty string instead)