### PR TITLE
Bug 2032547: hardware devices table have filter when table is empty

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/FilteredTable/FilteredTable.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/FilteredTable/FilteredTable.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { Table, TableProps, TextFilter } from '@console/internal/components/factory';
 
 export type FilteredTableProps = TableProps & {
@@ -26,9 +27,11 @@ const FilteredTable: React.FC<FilteredTableProps> = ({
 
   return (
     <>
-      <div className="co-m-pane__filter-row">
-        <TextFilter value={textFilter} onChange={setTextFilter} />
-      </div>
+      {!_.isEmpty(data) && (
+        <div className="co-m-pane__filter-row">
+          <TextFilter value={textFilter} onChange={setTextFilter} />
+        </div>
+      )}
       <Table {...props} data={filteredData} />
     </>
   );


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2032547

**Analysis / Root cause**: 
missing condition to check if table data is empty

**Solution Description**: 
adding missing condition

**Screen shots / Gifs for design review**: 

**Before**:

![before](https://user-images.githubusercontent.com/67270715/146046195-8ac915d5-7f9e-4829-8f23-0f30f6bdf926.png)

**After**:

![after](https://user-images.githubusercontent.com/67270715/146046220-930698c3-ab8c-4d1d-bb05-fea403ee18a9.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>