### PR TITLE
Bug 2032831: Fix an error to show Knative Services and Revisions also if the Service has no owner revision

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/__tests__/get-knative-resources.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/get-knative-resources.spec.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { FirehoseResource } from '@console/internal/components/utils';
 import { MockResources } from '@console/shared/src/utils/__tests__/test-resource-data';
 import {
@@ -31,8 +32,20 @@ describe('Get knative resources', () => {
       expect(knServingRevResource.revisions).toHaveLength(1);
     });
     it('expect getKnativeServingRevisions to return revision as undefined', () => {
-      const knServingResource = getKnativeServingRevisions(deploymentData, MockResources);
-      expect(knServingResource).toBeUndefined();
+      const knServingRevResource = getKnativeServingRevisions(deploymentData, MockResources);
+      expect(knServingRevResource).toBeUndefined();
+    });
+    it('expect getKnativeServingRevisions to return revision as undefined when deployment contains an empty owner reference', () => {
+      const deployment = _.cloneDeep(deploymentKnativeData);
+      deployment.metadata.ownerReferences = [];
+      const knServingRevResource = getKnativeServingRevisions(deployment, MockKnativeResources);
+      expect(knServingRevResource).toBeUndefined();
+    });
+    it('expect getKnativeServingRevisions to return revision as undefined when deployment contains no owner reference array', () => {
+      const deployment = _.cloneDeep(deploymentKnativeData);
+      delete deployment.metadata.ownerReferences;
+      const knServingRevResource = getKnativeServingRevisions(deployment, MockKnativeResources);
+      expect(knServingRevResource).toBeUndefined();
     });
     it('expect getKnativeServingConfigurations to return configuration data', () => {
       const knServingResource = getKnativeServingConfigurations(

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -48,8 +48,9 @@ const isKnativeDeployment = (dc: K8sResourceKind) => {
 const getKsResource = (dc: K8sResourceKind, { data }: K8sResourceKind): K8sResourceKind[] => {
   let ksResource = [];
   if (isKnativeDeployment(dc)) {
+    const name = dc.metadata.labels?.[KNATIVE_SERVING_LABEL];
     ksResource = _.filter(data, (config: K8sResourceKind) => {
-      return dc.metadata.labels[KNATIVE_SERVING_LABEL] === _.get(config, 'metadata.name');
+      return name === _.get(config, 'metadata.name');
     });
   }
   return ksResource;
@@ -58,8 +59,9 @@ const getKsResource = (dc: K8sResourceKind, { data }: K8sResourceKind): K8sResou
 const getRevisions = (dc: K8sResourceKind, { data }): K8sResourceKind[] => {
   let revisionResource = [];
   if (isKnativeDeployment(dc)) {
+    const ownerUid = dc.metadata.ownerReferences?.[0]?.uid;
     revisionResource = _.filter(data, (revision: K8sResourceKind) => {
-      return dc.metadata.ownerReferences[0].uid === revision.metadata.uid;
+      return ownerUid && ownerUid === revision.metadata.uid;
     });
   }
   return revisionResource;


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2032831

**Analysis / Root cause**: 
There is a browser error logged but the topology shows no error. Just the Knative services are shown just as deployments.

Knative "Deployments" without Knative Services and Revisions:

![knative-deployments-without-revisions](https://user-images.githubusercontent.com/139310/146167720-6643ad45-e6f8-44bc-afbe-65939f4925b6.png)

Browser error:

![browser-error-log](https://user-images.githubusercontent.com/139310/146167738-8e129f99-321b-40a9-9889-4e80ecc733e5.png)

```
  ModelContext.ts:179 Unable to add some resources to topology TypeError: Cannot read properties of undefined (reading '0')
    at get-knative-resources.ts:62
    at arrayFilter (_arrayFilter.js:18)
    at Module.filter (filter.js:49)
    at getRevisions (get-knative-resources.ts:61)
    at getKnativeServingRevisions (get-knative-resources.ts:88)
    at knative-topology-utils.ts:486
    at Array.reduce (<anonymous>)
    at getKnativeServiceData (knative-topology-utils.ts:485)
    at createKnativeDeploymentItems (knative-topology-utils.ts:530)
    at knative-topology-utils.ts:1043
```

**Solution Description**: 
And some optional checks to a utils function which crashs.

**Screen shots / Gifs for design review**: 

With this change:

![after](https://user-images.githubusercontent.com/139310/146167864-606add26-44e5-45ff-875c-b250a6ec7f77.png)

**Unit test coverage report**: 
Minimal change only. Added two small tests.

**Test setup:**
Always on my local cluster, but don't know yet how to reproduce this. Will check this later again.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
