### PR TITLE
Bug 2032516: Add support for checking .devfile.yaml during strategy detection

### DIFF
--- a/frontend/packages/git-service/src/utils/import-strategy-detector.ts
+++ b/frontend/packages/git-service/src/utils/import-strategy-detector.ts
@@ -15,7 +15,7 @@ const ImportStrategyList: ImportStrategyType[] = [
   {
     name: 'Devfile',
     type: ImportStrategy.DEVFILE,
-    expectedRegexp: /^devfile.yaml$/,
+    expectedRegexp: /^\.?devfile\.yaml$/,
     priority: 2,
   },
   {


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/OCPBUGSM-38473
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: The import strategy detection only checked for `devfile.yaml`.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Add support for detecting `.devfile.yaml` in the strategy detection.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/146227321-796c19e6-f754-4c77-a3bc-0af2e9bbdb31.mov


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
