### PR TITLE
Bug 2015472: Form and YAML view switch button should have distinguishable status

### DIFF
--- a/frontend/public/components/radio.tsx
+++ b/frontend/public/components/radio.tsx
@@ -15,7 +15,12 @@ export const RadioInput: React.SFC<RadioInputProps> = (props) => {
       <label
         className={classNames({ 'radio-inline': props.inline, 'co-disabled': props.disabled })}
       >
-        <input type="radio" {...inputProps} data-test={`${props.title}-radio-input`} />
+        <input
+          type="radio"
+          {...inputProps}
+          data-test={`${props.title}-radio-input`}
+          data-checked-state={props.checked}
+        />
         {props.title} {props.subTitle && <span className="co-no-bold">{props.subTitle}</span>}
       </label>
       {props.desc && <p className="co-m-radio-desc text-muted">{props.desc}</p>}


### PR DESCRIPTION

Fix for [Bug 2015472](https://bugzilla.redhat.com/show_bug.cgi?id=2015472)

Add a data attribute that that mirrors the checked state of the radio button because browser doesn't update its own `checked` attribute all the time, making it hard to test for checked state.

This is a similar fix that was implemented in Bugs [2005554](https://bugzilla.redhat.com/show_bug.cgi?id=2005554) and [2027299](https://bugzilla.redhat.com/show_bug.cgi?id=2027299) to checkboxes.