### PR TITLE
Bug 2033215: Do not render an empty button if it has no content to fix a11y check

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/TopConsumerPopover.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/TopConsumerPopover.tsx
@@ -42,6 +42,9 @@ const ConsumerPopover: React.FC<ConsumerPopoverProps> = React.memo(
     const [isOpen, setOpen] = React.useState(false);
     const onShow = React.useCallback(() => setOpen(true), []);
     const onHide = React.useCallback(() => setOpen(false), []);
+    if (!current) {
+      return null;
+    }
     return (
       <Popover
         position={position}


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2033215

**Analysis / Root cause**: 
`crud/other-routes.spec.ts` fails sometimes with an cypress ace/a11y AssertionError: 1 accessibility violation was detected. See Bugzilla for the full log of this issue, but the test itself is unrelated to the problem.

The problem was that there is a race condition on the admin dashboard between the a11y check and the prometheus data. The test doesn't wait on them, and if they are not loaded the "Cluster utilization" table shows a button which has no children which results in an a11y error.

This button shows nothing until the data are loaded:

![button-must-have-discernible-text](https://user-images.githubusercontent.com/139310/146342572-c2494569-d994-462f-a551-0ec197c365cc.png)

When logging the `current` value in `ConsumerPopover`  you can notice it was called first with null.

![consumer-popover](https://user-images.githubusercontent.com/139310/146342819-4f656e53-fb91-45b1-a23c-dfeaa9d71103.png)

The null was set here:

* https://github.com/openshift/console/blob/master/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx#L223
* https://github.com/openshift/console/blob/master/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/utilization-item.tsx#L130

**Solution Description**: 
`ConsumerPopover` checks now if there is no content and skip rendering the `Popover` and `Button`.

Another option might be to set an aria-disabled or label "Loading..." but I didn't want change the UX for this.

**Screen shots / Gifs for design review**: 
Skipping this column doesn't change the rendering.

Rendering before Chrome:
![chrome-before](https://user-images.githubusercontent.com/139310/146346553-ed0403d6-d592-4b64-9684-0523ead23d3d.gif)

Rendering after Chrome:
![chrome-after](https://user-images.githubusercontent.com/139310/146346570-f9d3c4de-6b54-421d-9291-9f22d2b26bb8.gif)

Rendering before Firefox:
![firefox-before](https://user-images.githubusercontent.com/139310/146346583-0f126b81-3448-4f18-af33-9662b8973705.gif)

Rendering after Firefox:
![firefox-after](https://user-images.githubusercontent.com/139310/146346608-70ae63e5-f863-42fd-83ed-e752dda728b5.gif)

**Unit test coverage report**: 
Not changed

**Test setup:**
Running cypress test `crud/other-routes.spec.ts` locally or on CI.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
