### PR TITLE
Bug 2031006: Application name input field is not autofocused when user selects "Create new application" 

### DIFF
--- a/frontend/packages/topology/src/components/dropdowns/ApplicationSelector.tsx
+++ b/frontend/packages/topology/src/components/dropdowns/ApplicationSelector.tsx
@@ -30,6 +30,7 @@ const ApplicationSelector: React.FC<ApplicationSelectorProps> = ({
   const [nameField] = useField(subPath ? `${subPath}.application.name` : 'application.name');
   const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
   const [applicationExists, setApplicationExists] = React.useState<boolean>(false);
+  const applicationNameInputRef = React.useRef<HTMLInputElement>();
   const fieldId = getFieldId('application-name', 'dropdown');
   const isValid = !(touched && error);
   const errorMessage = !isValid ? error : '';
@@ -77,6 +78,12 @@ const ApplicationSelector: React.FC<ApplicationSelectorProps> = ({
     ? t('topology~Warning: the Application grouping already exists.')
     : t('topology~A unique name given to the Application grouping to label your resources.');
 
+  React.useEffect(() => {
+    if (selectedKey.value === CREATE_APPLICATION_KEY) {
+      applicationNameInputRef.current?.focus();
+    }
+  }, [selectedKey.value]);
+
   return (
     <>
       {projectsAvailable && applicationsAvailable && (
@@ -108,6 +115,7 @@ const ApplicationSelector: React.FC<ApplicationSelectorProps> = ({
           type={TextInputTypes.text}
           required={selectedKey.value === CREATE_APPLICATION_KEY}
           name={nameField.name}
+          ref={applicationNameInputRef}
           label={t('topology~Application name')}
           data-test-id="application-form-app-input"
           helpText={inputHelpText}


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://bugzilla.redhat.com/show_bug.cgi?id=2031006

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
No `focus()` call when dropdown is `CREATE` 
=> we just set the `applicationName InputField` as empty string `""` 

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
- Added a `ref` to the `InputField`
- Added a hook to `ref.focus()` when dropdown is `CREATE` && `applicationName` is empty string `""` 

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/20089340/146358401-804fd8a1-7b15-436d-828e-aa2fe3f09c73.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->
No change

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Switch to developer perspective
2. Import a component (with an application name)
3. Import another component, the first application name is automatically selected
4. Select "Create new application" from the application name dropdown (Dropdown / Select field)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge