### PR TITLE
Bug 2033290: Use TypeScript 4 when building SDK packages

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/package.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "rm -rf dist generated",
     "build": "yarn clean && yarn validate && yarn compile && yarn generate",
-    "compile": "for ext in '' '-internal' '-host-app' '-internal-kubevirt' '-webpack' ; do yarn tsc -p tsconfig${ext}.json || exit $? ; done",
+    "compile": "for ext in '' '-internal' '-host-app' '-internal-kubevirt' '-webpack' ; do ./node_modules/.bin/tsc -p tsconfig${ext}.json || exit $? ; done",
     "generate": "yarn generate-schema && yarn generate-doc && yarn generate-pkg-assets",
     "generate-schema": "yarn ts-node scripts/generate-schema.ts",
     "generate-doc": "yarn ts-node scripts/generate-doc.ts",


### PR DESCRIPTION
Previously we were picking up the TypeScript version from frontend/node_modules/.bin, which was TypeScript 3.

Depends on #10679 to pick up the TypeScript 4 fixes.

/cc @vojtechszocs @glekner 