### PR TITLE
Bug 2033403: Show provider information for devfiles in catalog

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/providers/useDevfile.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useDevfile.tsx
@@ -9,7 +9,7 @@ import { DevfileSample } from '../../import/devfile/devfile-types';
 
 const normalizeDevfile = (devfileSamples: DevfileSample[], t: TFunction): CatalogItem[] => {
   const normalizedDevfileSamples = devfileSamples?.map((sample) => {
-    const { name: uid, displayName, description, tags, git, icon } = sample;
+    const { name: uid, displayName, description, tags, git, icon, provider } = sample;
     const gitRepoUrl = Object.values(git.remotes)[0];
     const href = `/import?importType=devfile&devfileName=${uid}&gitRepo=${gitRepoUrl}`;
     const createLabel = t('devconsole~Create Application');
@@ -36,6 +36,7 @@ const normalizeDevfile = (devfileSamples: DevfileSample[], t: TFunction): Catalo
       name: displayName,
       description,
       tags,
+      provider,
       cta: {
         label: createLabel,
         href,

--- a/frontend/packages/dev-console/src/components/catalog/providers/useDevfileSamples.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useDevfileSamples.tsx
@@ -8,7 +8,7 @@ import { DevfileSample } from '../../import/devfile/devfile-types';
 
 const normalizeDevfileSamples = (devfileSamples: DevfileSample[], t: TFunction): CatalogItem[] => {
   const normalizedDevfileSamples = devfileSamples.map((sample) => {
-    const { name: uid, displayName, description, tags, git, icon } = sample;
+    const { name: uid, displayName, description, tags, git, icon, provider } = sample;
     const gitRepoUrl = Object.values(git.remotes)[0];
     const label = t('devconsole~Create Devfile Sample');
     const href = `/import?importType=devfile&formType=sample&devfileName=${uid}&gitRepo=${gitRepoUrl}`;
@@ -20,6 +20,7 @@ const normalizeDevfileSamples = (devfileSamples: DevfileSample[], t: TFunction):
       name: displayName,
       description,
       tags,
+      provider,
       cta: {
         label,
         href,

--- a/frontend/packages/dev-console/src/components/import/devfile/devfile-types.ts
+++ b/frontend/packages/dev-console/src/components/import/devfile/devfile-types.ts
@@ -12,4 +12,5 @@ export interface DevfileSample {
       [remote: string]: string;
     };
   };
+  provider?: string;
 }


### PR DESCRIPTION
**Fixes**: https://github.com/openshift/console/issues/10664
**Fixes**: https://issues.redhat.com/browse/OCPBUGSM-38566
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Devfile registry was sending the provider information but catalog was not using it.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Use provider information from API response to show it in the catalog.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/146420733-fad31957-9f5e-47cd-b8fe-103d1faa1ff4.mov



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
