### PR TITLE
Bug 2033587: Wait for the quota chart row to improve test stability

### DIFF
--- a/frontend/integration-tests/tests/dashboards/project-dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/dashboards/project-dashboard.scenario.ts
@@ -213,6 +213,9 @@ describe('Project Dashboard', () => {
           .$('a')
           .getText(),
       ).toEqual(resourceQuota.metadata.name);
+      await browser.wait(
+        until.presenceOf(projectDashboardView.resourceQuotasCard.$('.co-resource-quota-chart-row')),
+      );
       expect(
         projectDashboardView.resourceQuotasCard.$('.co-resource-quota-chart-row').isDisplayed(),
       ).toBe(true);


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2033587

**Analysis / Root cause**: 
CI job fails sometimes with an assertion error in project-dashboard.scenario.ts:

```
Resource Quotas Card
heavy_multiplication_x shows Resource Quotas (1 failure)Leaked 
{"name":"example","namespace":"test-vci","kind":"ResourceQuota"}
...
Project Dashboard Resource Quotas Card : shows Resource Quotas
Error: Failed expectation
```

For example https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console/10680/pull-ci-openshift-console-master-e2e-gcp-console/1471761846649229312

Screenshot: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_console/10680/pull-ci-openshift-console-master-e2e-gcp-console/1471744528548368384/artifacts/e2e-gcp-console/test/artifacts/gui_test_screenshots/fc0aac0733fba8da97637ef640a51781.png

In the last 7 days this affects 17% of failures match = 9% impact (460 runs, 56% failed :mindblowing:)

See also: https://search.ci.openshift.org/?search=%E2%9C%96+shows+Resource+Quotas&maxAge=168h&context=0&type=all&name=pull-ci-openshift-console-master-e2e-gcp-console&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

**Solution Description**: 
Add another protractor `browser.wait` check to hopefully increase the stability of this test.
