### PR TITLE
Bug 2033044: Shift invalid devfile alert down

### DIFF
--- a/frontend/packages/dev-console/src/components/import/devfile/DevfileStrategySection.scss
+++ b/frontend/packages/dev-console/src/components/import/devfile/DevfileStrategySection.scss
@@ -1,0 +1,7 @@
+.odc-devfile-strategy-section {
+  &__error-alert {
+    // Extra margin to offset strategy selector button overlap
+    // at .odc-import-strategy-section__strategy-selector
+    margin: 3.2em 0;
+  }
+}

--- a/frontend/packages/dev-console/src/components/import/devfile/DevfileStrategySection.tsx
+++ b/frontend/packages/dev-console/src/components/import/devfile/DevfileStrategySection.tsx
@@ -8,6 +8,7 @@ import { safeYAMLToJS } from '@console/shared/src/utils/yaml';
 import FormSection from '../section/FormSection';
 import { useDevfileServer, useDevfileSource, useSelectedDevfileSample } from './devfileHooks';
 import DevfileInfo from './DevfileInfo';
+import './DevfileStrategySection.scss';
 
 const DevfileStrategySection: React.FC = () => {
   const { t } = useTranslation();
@@ -93,9 +94,16 @@ const DevfileStrategySection: React.FC = () => {
   return (
     <>
       {devfileParseError && (
-        <Alert isInline variant="danger" title={t('devconsole~Import is not possible.')}>
-          {devfileParseError}
-        </Alert>
+        <FormSection>
+          <Alert
+            isInline
+            className="odc-devfile-strategy-section__error-alert"
+            variant="danger"
+            title={t('devconsole~Import is not possible.')}
+          >
+            {devfileParseError}
+          </Alert>
+        </FormSection>
       )}
       {showEditImportStrategy && importType !== 'devfile' && (
         <FormSection>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-38513
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The "edit strategy" button is shifted upwards.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Shift invalid devfile alert down to offset the overlap.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![0](https://user-images.githubusercontent.com/20013884/146567528-2df724fd-7777-44b0-bab7-0d0815ea1103.png)

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Test setup:**
Use a repo with multiple an invalid devfile and multiple import strategies, eg. https://github.com/rottencandy/devfile-python-invalid
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug