### PR TITLE
Gherkin for disabling tektonhub integration in pipeline builder

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
@@ -332,3 +332,19 @@ Feature: Create the pipeline from builder page
               And user clicks on Create button
               And user clicks on Logs tab in PipelineRun details page
              Then user will be able to see the output in sum and multiply task
+
+
+        @regression @manual @odc-6377
+        Scenario: Disable Tektonhub integration in the pipeline builder : P-02-TC22
+            Given user is at Search page
+              And user searches 'TektonConfig' in Resources dropdown
+              And user selects config with apiVersion operator.openshift.io/v1 option from Resources dropdown
+              And user clicks on "config" Name in TektonConfigs
+              And user switches to YAML tab
+              And user adds value of "spec.hub.params.value" as "false"
+              And user clicks on Save button
+              And user clicks on Pipeline tab in navigation menu
+              And user clicks Create Pipeline button
+              And user clicks on Add task
+              And user types 'git'
+             Then user will see Task, clusterTask only


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-6377
Story: https://issues.redhat.com/browse/ODC-6428

Acceptance criteria:

- Admins should be able to shut off integration with Tekton Hub


**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]

