### PR TITLE
Bug 2023560: "Network Attachment Definitions" has no project field on the top in the list view

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/console-extensions.json
+++ b/frontend/packages/network-attachment-definition-plugin/console-extensions.json
@@ -6,7 +6,7 @@
     }
   },
   {
-    "type": "console.navigation/resource-cluster",
+    "type": "console.navigation/resource-ns",
     "properties": {
       "id": "networkattachmentdefinitions",
       "section": "networking",


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2023560
https://issues.redhat.com/browse/OCPBUGSM-37218

**Analysis / Root cause**:
using type `console.navigation/resource-cluster` is causing to not receive the namespace.

**Solution Description**:
changing type to `console.navigation/resource-ns`

**Screen shots / Gifs for design review**:

**Before**:

![before](https://user-images.githubusercontent.com/67270715/146671757-83e6280b-48aa-4421-958e-b290d4837df0.png)

**After**:

![after](https://user-images.githubusercontent.com/67270715/146671763-bb856324-fe09-499c-a2e8-e6f54bf48d6f.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>