### PR TITLE
Bug 2034243: regular user cant load template list

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/hooks/use-vm-templates-resources.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/hooks/use-vm-templates-resources.tsx
@@ -23,7 +23,7 @@ export const useVmTemplatesResources = (namespace: string): useVmTemplatesResour
     },
     isList: true,
   });
-  const [dataSources, dataSourcesLoaded] = useK8sWatchResource<DataSourceKind[]>({
+  const [dataSources] = useK8sWatchResource<DataSourceKind[]>({
     kind: kubevirtReferenceForModel(DataSourceModel),
     isList: true,
   });
@@ -56,13 +56,7 @@ export const useVmTemplatesResources = (namespace: string): useVmTemplatesResour
   const [baseImages, baseLoaded, baseError, baseDVs, basePods] = useBaseImages(baseTemplates, true);
 
   const resourcesLoaded =
-    utLoaded &&
-    btLoaded &&
-    podsLoaded &&
-    dvsLoaded &&
-    pvcsLoaded &&
-    baseLoaded &&
-    dataSourcesLoaded;
+    utLoaded && btLoaded && podsLoaded && dvsLoaded && pvcsLoaded && baseLoaded;
   const resourcesLoadError = utError || btError || podsError || dvsError || pvcsError || baseError;
 
   return React.useMemo(() => {

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -100,6 +100,7 @@ const VirtualMachineTemplatesPage: React.FC<VirtualMachineTemplatesPageProps &
       kind: kubevirtReferenceForModel(DataSourceModel),
       isList: true,
       prop: 'dataSources',
+      optional: true,
     },
     {
       kind: PodModel.kind,


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2034243

**Analysis / Root cause**:
regular user don't have permissions to dataSource CR

**Solution Description**:
making dataSource as optional to not fail

**Screen shots / Gifs for design review**:

**Before**:

![before-select-template](https://user-images.githubusercontent.com/67270715/146782004-02e8ffd6-c3df-4799-921a-14906315c70f.png)

![before-templates-page](https://user-images.githubusercontent.com/67270715/146782009-202eb913-3cf4-4be4-8d70-ef9e3c00a03a.png)

**After**:

![after-select-template](https://user-images.githubusercontent.com/67270715/146782032-84899fb0-9708-40d3-acd3-c9b12e175342.png)

![after-templates-page](https://user-images.githubusercontent.com/67270715/146782037-372f3ef0-f75e-4278-81cc-eda7dbe671bc.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>