### PR TITLE
Re-enable test case which checks for "Import from Git" action

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/add-page.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/add-page.feature
@@ -33,12 +33,10 @@ Feature: Add page on Developer Console
               And user will see "Operator Backed" option
               And user will see "Helm Chart" option
 
-     # Git, Docker file, Devfile forms are converged as per the 4.9 Epic: ODC-5009
-     #    @regression @to-do
-     #    Scenario: Git Repository option to create an Application, Component or Service: A-11-TC04
-     #         Then user will see "From Git" option
-     #          And user will see "From Devfile" option
-     #          And user will see "From Dockerfile" option
+
+        @regression
+        Scenario: Git Repository option to create an Application, Component or Service: A-11-TC04
+             Then user will see "Import from Git" option
 
 
         @regression

--- a/frontend/packages/dev-console/integration-tests/support/constants/add.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/add.ts
@@ -1,6 +1,8 @@
 export enum addOptions {
+  // TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
   Git = 'From Git',
   ContainerImage = 'Container Image',
+  // TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
   DockerFile = 'From Dockerfile',
   YAML = 'YAML',
   DeveloperCatalog = 'From Catalog',
@@ -9,6 +11,7 @@ export enum addOptions {
   HelmChart = 'Helm Chart',
   Pipeline = 'Pipeline',
   EventSource = 'Event Source',
+  // TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
   DevFile = 'From Devfile',
   Channel = 'Channel',
   UploadJARFile = 'Upload JAR file',

--- a/frontend/packages/dev-console/integration-tests/support/constants/topology.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/topology.ts
@@ -50,9 +50,12 @@ export enum authenticationTypes {
 }
 
 export enum addToApplicationGroupings {
+  // TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
   FromGit = 'From Git',
   ContainerImage = 'Container Image',
+  // TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
   FromDockerfile = 'From Dockerfile',
+  // TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
   FromDevfile = 'From Devfile',
   UploadJarfile = 'Upload JAR file',
   EventSource = 'Event Source',

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
@@ -20,6 +20,7 @@ export const addPage = {
         cy.testA11y('Deploy Page');
         detailsPage.titleShouldContain(pageTitle.ContainerImage);
         break;
+      // TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
       case 'Import from Dockerfile':
       case addOptions.DockerFile:
         cy.byTestID('item import-from-git').click();
@@ -149,12 +150,18 @@ export const verifyAddPage = {
       case 'Event Source':
         cy.byTestID('item knative-event-source').should('be.visible');
         break;
+      case 'Import from Git':
+        cy.byTestID('item import-from-git').should('be.visible');
+        break;
+      // TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
       case 'From Git':
         cy.byTestID('item import-from-git').should('be.visible');
         break;
+      // TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
       case 'From Devfile':
         cy.byTestID('item import-from-git').should('be.visible');
         break;
+      // TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
       case 'From Dockerfile':
         cy.byTestID('item import-from-git').should('be.visible');
         break;

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-devfile.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-devfile.ts
@@ -3,6 +3,8 @@ import { addOptions } from '../../constants';
 import { gitPO, topologyPO } from '../../pageObjects';
 import { addPage, gitPage, topologyPage, devFilePage } from '../../pages';
 
+// TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
+// In this case we could also use the given string instead of mapping it.
 Given('user is at Import from Devfile page', () => {
   addPage.selectCardFromOptions(addOptions.DevFile);
 });

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/page-details.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/page-details.ts
@@ -87,7 +87,7 @@ Then(
 
 Then('user will see Import from Git card under Git Repository section', () => {
   verifyAddPage.verifyAddPageCard('Git Repository');
-  verifyAddPage.verifyAddPageCard('From Git');
+  verifyAddPage.verifyAddPageCard('Import from Git');
 });
 
 Then('user will see Import YAML, Upload JAR file under From Local Machine section', () => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/userPreferences/user-preferences-dev-perspective.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/userPreferences/user-preferences-dev-perspective.ts
@@ -214,6 +214,8 @@ When('user deselects the checkbox of user preference Secure Route', () => {
   // cy.get().uncheck();
 });
 
+// TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
+// In this case we could maybe also use the given string instead of mapping it, or?
 Given('user clicks on Import from Git card', () => {
   addPage.selectCardFromOptions(addOptions.Git);
 });

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-actions-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-actions-page.ts
@@ -146,6 +146,7 @@ export const topologyActions = {
 export const addToApplication = {
   selectAction: (action: addToApplicationGroupings | string) => {
     switch (action) {
+      // TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
       case addToApplicationGroupings.FromGit:
       case 'From Git': {
         cy.byTestActionID(action)
@@ -153,6 +154,7 @@ export const addToApplication = {
           .click();
         break;
       }
+      // TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
       case addToApplicationGroupings.FromDevfile:
       case 'From Devfile': {
         cy.byTestActionID(action)
@@ -160,6 +162,7 @@ export const addToApplication = {
           .click();
         break;
       }
+      // TODO (ODC-6455): Tests should use latest UI labels like "Import from Git" instead of mapping strings
       case addToApplicationGroupings.FromDockerfile:
       case 'From Dockerfile': {
         cy.byTestActionID(action)


### PR DESCRIPTION
**Fixes**: 
No ticket yet, but its related to 4.9 changes in https://issues.redhat.com/browse/ODC-5009

**Analysis / Root cause**: 
Checked for `ODC-` todos in our code. Found a todo for [ODC-5009](https://issues.redhat.com/browse/ODC-5009) was which part of 4.9

**Solution Description**: 
Simply re-enable a test case and added a case for the "Import from Git" lookup.

Test run successful locally:

![image](https://user-images.githubusercontent.com/139310/146944149-8ccea295-444d-4de2-8443-34b776a6abf8.png)

Added some todos, because I would suggest to update our e2e tests to match the latest UI code instead of mapping old strings like "From Git" to the new UI code.

**Screen shots / Gifs for design review**: 
No UI change.

**Unit test coverage report**: 
No unit test change.

**Test setup:**
Should just pass locally and on the CI server.

**Browser conformance**: 
Not relevant.
