### PR TITLE
[WIP] Fix protractor e2e project dashboard resource quota test

### DIFF
--- a/frontend/integration-tests/tests/dashboards/project-dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/dashboards/project-dashboard.scenario.ts
@@ -198,9 +198,13 @@ describe('Project Dashboard', () => {
 
     it('shows Resource Quotas', async () => {
       expect(projectDashboardView.resourceQuotasCard.isDisplayed()).toBe(true);
-      expect(projectDashboardView.resourceQuotasCard.$('.pf-c-card__body').getText()).toEqual(
-        'No ResourceQuotas\nNo AppliedClusterResourceQuotas',
+      await browser.wait(
+        until.visibilityOf(
+          projectDashboardView.resourceQuotasCard.$('.pf-c-card__body .text-secondary'),
+        ),
       );
+      const card = await projectDashboardView.resourceQuotasCard.$('.pf-c-card__body');
+      expect(card.getText()).toEqual('No ResourceQuotas\nNo AppliedClusterResourceQuotas');
       createResource(resourceQuota);
       addLeakableResource(leakedResources, resourceQuota);
 


### PR DESCRIPTION
Noticing a [daily flake with protractor project dashbard tests](https://search.ci.openshift.org/?search=Project+Dashboard.Resource+Quotas&maxAge=336h&context=2&type=build-log&name=pull-ci-openshift-console-master-e2e-gcp-console&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=none).

Of course this works locally for me:
`CHROME_VERSION=$(google-chrome --version) ./test-protractor.sh "dashboards"`

I see the appropriate "No ...Quotas" messages locally:
![image](https://user-images.githubusercontent.com/12733153/146798711-7b89c0c0-7254-4ed9-9d12-dd3ee545a0c3.png)

However, CI seems to be running slower and failed screenshot is showing the donut charts with 0%.  Notice that it's showing the "RQ example" test resource which was being created after the failed assertion(?) So maybe happening asychronously?
![image](https://user-images.githubusercontent.com/12733153/146799018-e2a45285-2f31-4e59-823d-21f74f6992e4.png)

Added a `waitFor` the secondary "No ...Quotas" text to be visible to see if that helps clear the flake in CI.



