### PR TITLE
Bug 2018234: Fix that user settings ConfigMap is also created for users with restricted access

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useUserSettings.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettings.ts
@@ -39,7 +39,7 @@ export const useUserSettings = <T>(
   defaultValue?: T,
   sync: boolean = false,
 ): [T, React.Dispatch<React.SetStateAction<T>>, boolean] => {
-  const impersonate = useSelector((state: RootState) => !!getImpersonate(state));
+  const impersonate: boolean = useSelector((state: RootState) => !!getImpersonate(state));
   const keyRef = React.useRef<string>(key);
   const defaultValueRef = React.useRef<T>(defaultValue);
   const [isRequestPending, increaseRequest, decreaseRequest] = useCounterRef();
@@ -86,7 +86,15 @@ export const useUserSettings = <T>(
     if (isLocalStorage) {
       return;
     }
-    if (cfLoadError?.response?.status === 404 || (!cfData && cfLoaded)) {
+    if (
+      // Expected load error (404 Not found) for kubeadmin or other admins,
+      // who have access to the complete openshift-console-user-settings namespace.
+      cfLoadError?.response?.status === 404 ||
+      // Expected load error (403 Forbidden) for all other (restricted) users,
+      // which have no access to non-existing ConfigMaps in openshift-console-user-settings namespace.
+      cfLoadError?.response?.status === 403 ||
+      (!cfData && cfLoaded)
+    ) {
       (async () => {
         try {
           await createConfigMap();


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2018234

**Analysis / Root cause**: 
In #9153 we changed the implementation to save the user settings automatically to the browser localStorage instead of ConfigMap when the watcher returns a 404 Not Found. Previously this check was done after the `createConfigMap` call and checks for 403 Forbidden and 404 Not Found.

The fetch call and watcher returns only 404 Not Found for kubeadmins or other cluster users with access to the `openshift-console-user-settings` namespace. But for users with restricted access, these API calls return a 403 Forbidden instead.

Previously the `createConfigMap` endpoint (`POST /api/console/user-settings`) was never called:

![49-user](https://user-images.githubusercontent.com/139310/146913908-eff29de3-b08c-4bea-888e-d0efc6c770d8.png)

**Solution Description**: 
We need to call `createConfigMap` also if the API returns 403 Forbidden.

Open the console the first time as kubeadmin:

![patched-kubeadmin](https://user-images.githubusercontent.com/139310/146914025-41f40078-e3dc-4f8f-b910-b7b237d760a1.png)

Open the console the first time as restricted user:

![patch-user](https://user-images.githubusercontent.com/139310/146914044-c6c644a9-55b9-44d1-b070-f5c72eb61e5f.png)

**Screen shots / Gifs for design review**: 
No UI change

**Unit test coverage report**: 
Added / updated some tests

**Test setup:**
1. Open your browser network inspector and filter for "settings".
2. Open ODC with kubeadmin
3. Open ODC with the restricted user. :warning: The user must not see other projects, and esp. not the `openshift-console-user-settings` namespace.

User settings should be created when opening the console the first time and updated/saved after that in the ConfigMap.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
