### PR TITLE
Add webhook resources in git import pipeline flow

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils-data.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils-data.ts
@@ -861,3 +861,82 @@ export const sampleDevfileFormData: GitImportFormData = {
     },
   },
 };
+
+export const sampleClusterTriggerBinding = {
+  apiVersion: 'triggers.tekton.dev/v1beta1',
+  kind: 'ClusterTriggerBinding',
+  metadata: {
+    annotations: {
+      'kubectl.kubernetes.io/last-applied-configuration':
+        '{"apiVersion":"triggers.tekton.dev/v1alpha1","kind":"ClusterTriggerBinding","metadata":{"name":"github-push","namespace":"openshift-pipelines","ownerReferences":[{"apiVersion":"operator.tekton.dev/v1alpha1","blockOwnerDeletion":true,"controller":true,"kind":"TektonInstallerSet","name":"addon-triggers-k74bh","uid":"fe29d5cd-2580-48fa-b6de-a236c518e2e8"}]},"spec":{"params":[{"name":"git-revision","value":"$(body.head_commit.id)"},{"name":"git-commit-message","value":"$(body.head_commit.message)"},{"name":"git-repo-url","value":"$(body.repository.url)"},{"name":"git-repo-name","value":"$(body.repository.name)"},{"name":"content-type","value":"$(header.Content-Type)"},{"name":"pusher-name","value":"$(body.pusher.name)"}]}}\n',
+    },
+    creationTimestamp: '2021-12-15T04:29:42Z',
+    generation: 1,
+    managedFields: [
+      {
+        apiVersion: 'triggers.tekton.dev/v1alpha1',
+        fieldsType: 'FieldsV1',
+        fieldsV1: {
+          'f:metadata': {
+            'f:annotations': {
+              '.': {},
+              'f:kubectl.kubernetes.io/last-applied-configuration': {},
+            },
+            'f:ownerReferences': {
+              '.': {},
+              'k:{"uid":"fe29d5cd-2580-48fa-b6de-a236c518e2e8"}': {},
+            },
+          },
+          'f:spec': {
+            '.': {},
+            'f:params': {},
+          },
+        },
+        manager: 'manifestival',
+        operation: 'Update',
+        time: '2021-12-15T04:29:46Z',
+      },
+    ],
+    name: 'github-push',
+    ownerReferences: [
+      {
+        apiVersion: 'operator.tekton.dev/v1alpha1',
+        blockOwnerDeletion: true,
+        controller: true,
+        kind: 'TektonInstallerSet',
+        name: 'addon-triggers-k74bh',
+        uid: 'fe29d5cd-2580-48fa-b6de-a236c518e2e8',
+      },
+    ],
+    resourceVersion: '165774',
+    uid: '5e13962b-097f-4966-b1e6-d6774e517adb',
+  },
+  spec: {
+    params: [
+      {
+        name: 'git-revision',
+        value: '$(body.head_commit.id)',
+      },
+      {
+        name: 'git-commit-message',
+        value: '$(body.head_commit.message)',
+      },
+      {
+        name: 'git-repo-url',
+        value: '$(body.repository.url)',
+      },
+      {
+        name: 'git-repo-name',
+        value: '$(body.repository.name)',
+      },
+      {
+        name: 'content-type',
+        value: '$(header.Content-Type)',
+      },
+      {
+        name: 'pusher-name',
+        value: '$(body.pusher.name)',
+      },
+    ],
+  },
+};

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineOverview.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineOverview.tsx
@@ -17,6 +17,7 @@ import PipelineOverviewAlert from './PipelineOverviewAlert';
 import PipelineRunItem from './PipelineRunItem';
 import PipelineStartButton from './PipelineStartButton';
 import TriggerLastRunButton from './TriggerLastRunButton';
+import TriggersOverview from './TriggersOverview';
 
 const MAX_VISIBLE = 3;
 
@@ -33,10 +34,10 @@ const PipelinesOverview: React.FC<PipelinesOverviewProps> = ({
     pipelineRuns,
   },
 }) => {
-  const { t } = useTranslation();
   const {
     metadata: { name, namespace },
   } = pipeline;
+  const { t } = useTranslation();
   const [showAlert, setShowAlert] = React.useState(isPipelineNotStarted(name, namespace));
 
   React.useEffect(() => {
@@ -90,6 +91,7 @@ const PipelinesOverview: React.FC<PipelinesOverviewProps> = ({
           <PipelineRunItem key={pr.metadata.uid} pipelineRun={pr} />
         ))}
       </ul>
+      <TriggersOverview pipeline={pipeline} />
     </>
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/TriggerResourceLinks.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/TriggerResourceLinks.scss
@@ -1,0 +1,3 @@
+.opp-trigger-template-link {
+  margin-top: var(--pf-global--spacer--xs);
+}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/TriggerResourceLinks.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/TriggerResourceLinks.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { ResourceLink, ExternalLinkWithCopy } from '@console/internal/components/utils';
+import { K8sKind, referenceForModel } from '@console/internal/module/k8s';
+import { RouteTemplate } from '../utils/triggers';
+
+import './TriggerResourceLinks.scss';
+
+type TriggerResourceLinksProps = {
+  namespace: string;
+  model: K8sKind;
+  links: RouteTemplate[];
+};
+const TriggerResourceLinks: React.FC<TriggerResourceLinksProps> = ({
+  links = [],
+  namespace,
+  model,
+}) => {
+  if (links.length === 0) {
+    return null;
+  }
+  return (
+    <div>
+      <dl>
+        {links.map(({ routeURL, triggerTemplateName }) => {
+          return (
+            <dd key={triggerTemplateName}>
+              <ResourceLink
+                kind={referenceForModel(model)}
+                name={triggerTemplateName}
+                namespace={namespace}
+                title={triggerTemplateName}
+                inline
+              />
+              {routeURL && (
+                <div className="opp-trigger-template-link">
+                  <ExternalLinkWithCopy
+                    key={routeURL}
+                    link={routeURL}
+                    text={routeURL}
+                    additionalClassName="co-external-link--block"
+                  />
+                </div>
+              )}
+            </dd>
+          );
+        })}
+      </dl>
+    </div>
+  );
+};
+
+export default TriggerResourceLinks;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/TriggersOverview.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/TriggersOverview.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { SidebarSectionHeading } from '@console/internal/components/utils';
+import { TriggerTemplateModel } from '../../../models';
+import { PipelineKind } from '../../../types';
+import { usePipelineTriggerTemplateNames } from '../utils/triggers';
+import TriggerResourceLinks from './TriggerResourceLinks';
+
+type TriggersOverviewProps = {
+  pipeline: PipelineKind;
+};
+
+const TriggersOverview: React.FC<TriggersOverviewProps> = ({ pipeline }) => {
+  const {
+    metadata: { name, namespace },
+  } = pipeline;
+  const { t } = useTranslation();
+  const templateNames = usePipelineTriggerTemplateNames(name, namespace) || [];
+
+  return templateNames.length > 0 ? (
+    <>
+      <SidebarSectionHeading data-test="triggers-heading" text={t('pipelines-plugin~Triggers')} />
+      <ul className="list-group" data-test="triggers-list">
+        <li className="list-group-item pipeline-overview" data-test="triggers-list-item">
+          <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+            <FlexItem>
+              <TriggerResourceLinks
+                namespace={namespace}
+                model={TriggerTemplateModel}
+                links={templateNames}
+              />
+            </FlexItem>
+          </Flex>
+        </li>
+      </ul>
+    </>
+  ) : null;
+};
+
+export default TriggersOverview;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/__tests__/TriggersOverview.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/__tests__/TriggersOverview.spec.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import { ExternalLinkWithCopy, ResourceLink } from '@console/internal/components/utils';
+import store from '@console/internal/redux';
+import * as triggerUtils from '../../utils/triggers';
+import TriggersOverview from '../TriggersOverview';
+
+const templateNames = jest.spyOn(triggerUtils, 'usePipelineTriggerTemplateNames');
+
+const sampleTemplateNames = [
+  {
+    routeURL: 'http://devcluster.openshift.com',
+    triggerTemplateName: 'trigger-template-nodejs-ex-jvb0f9',
+  },
+];
+describe('Pipeline sidebar overview', () => {
+  let props: React.ComponentProps<typeof TriggersOverview>;
+
+  beforeEach(() => {
+    props = {
+      pipeline: { metadata: { name: 'pipeline', namespace: 'test' }, spec: { tasks: [] } },
+    };
+    templateNames.mockReturnValue([]);
+  });
+  it('should not show trigger template and url when there are no templateNames', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <TriggersOverview {...props} />
+      </Provider>,
+    );
+
+    expect(wrapper.find('[data-test="triggers-heading"]')).toHaveLength(0);
+    expect(wrapper.find('[data-test="triggers-list"]')).toHaveLength(0);
+  });
+
+  it('should show trigger template and url', () => {
+    templateNames.mockReturnValue(sampleTemplateNames);
+    const wrapper = mount(
+      <Provider store={store}>
+        <TriggersOverview {...props} />
+      </Provider>,
+    );
+
+    expect(wrapper.find('[data-test="triggers-heading"]')).toHaveLength(1);
+    expect(wrapper.find('[data-test="triggers-list-item"]')).toHaveLength(1);
+    expect(wrapper.find(ResourceLink).props().title).toBe('trigger-template-nodejs-ex-jvb0f9');
+    expect(wrapper.find(ExternalLinkWithCopy).props().link).toBe('http://devcluster.openshift.com');
+  });
+});


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6394

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
As a user, while importing an application (git import flow), I want to have a default webhook setup generated and provide the instructions to configure the webhook url in the git provider.


**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
1. Added the webhook resources, if the user checks the Add pipeline option
2. ~Show toast message with webhook Url~ (removed after discussing with UX)
3. Show the Webhook resources and Url in the Sidepanel of the selected resources.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

Sidebar Entry for Triggers:
![image](https://user-images.githubusercontent.com/9964343/146968304-07f002f1-2d68-488e-9dfb-d5224d2efadd.png)


GIF:
https://user-images.githubusercontent.com/9964343/146979399-4bfd6fcd-a288-4a53-8a30-af81aff7b5d0.mov


**Unit test coverage report**: 
<!-- Attach test coverage report -->
```
 createPipelineResource tests
      ✓ should create pipeline resource with same name as application name (3ms)
      ✓ should suppress the error if the trigger creation fails with the error (1ms)
      
  Pipeline sidebar overview
    ✓ should not show trigger template and url when there are no templateNames (33ms)
    ✓ should show trigger template and url (30ms)   
```
**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Add deployment through git import flow
2. Check `Add Pipeline` option.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc:  @openshift/team-devconsole-ux  @beaumorley @serenamarie125 @siamaksade 