### PR TITLE
Bug 2034621: show context menu for application group

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/components/componentFactory.ts
+++ b/frontend/packages/topology/src/components/graph-view/components/componentFactory.ts
@@ -33,7 +33,7 @@ import {
 import { AggregateEdge, ConnectsTo, CreateConnector, TrafficConnector } from './edges';
 import GraphComponent from './GraphComponent';
 import { Application } from './groups';
-import { graphContextMenu } from './nodeContextMenu';
+import { graphContextMenu, groupContextMenu } from './nodeContextMenu';
 import { WorkloadNode } from './nodes';
 
 import './ContextMenu.scss';
@@ -42,7 +42,7 @@ export const componentFactory: ComponentFactory = (kind, type) => {
   switch (type) {
     case TYPE_APPLICATION_GROUP:
       return withDndDrop(applicationGroupDropTargetSpec)(
-        withSelection({ controlled: true })(withContextMenu(contextMenuActions)(Application)),
+        withSelection({ controlled: true })(withContextMenu(groupContextMenu)(Application)),
       );
     case TYPE_WORKLOAD:
       return withCreateConnector(


### PR DESCRIPTION
**Fixes:**

**Solution description:**
used `groupContextMenu` to show context menu actions for application group

**GIF:**
![contextmenu-app](https://user-images.githubusercontent.com/22490998/146940258-bac2b46c-bc9c-4778-9be6-cb8e9f2865be.gif)
