### PR TITLE
Bug 2031057: Topology sidebar for Knative services shows a small pod ring with "0 undefined" as tooltip 

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodStatus.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodStatus.tsx
@@ -52,7 +52,7 @@ const PodStatus: React.FC<PodStatusProps> = ({
   standalone = false,
   showTooltip = true,
   title,
-  subTitle,
+  subTitle = '',
   titleComponent,
   subTitleComponent,
   data,
@@ -93,7 +93,7 @@ const PodStatus: React.FC<PodStatusProps> = ({
   const chartDonut = React.useMemo(() => {
     return (
       <ChartDonut
-        ariaTitle={`${title} ${subTitle}`}
+        ariaTitle={`${title}${subTitle && ` ${subTitle}`}`}
         animate={{
           duration: ANIMATION_DURATION,
           onEnd: updateOnEnd ? forceUpdate : undefined,


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://bugzilla.redhat.com/show_bug.cgi?id=2031057

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Our subtitle is undefined, so we can show only Title in the ariaTitle 

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
If subtitle is undefined then return a emtpy string `''`  so instead of `0 undefined` tooltip is `0`

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Screenshot from 2021-12-22 11-04-57](https://user-images.githubusercontent.com/20089340/147041047-951ec653-4a6e-4124-9cd2-e510ca05e121.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->
No change

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Install OpenShift Serverless operator
2. Create/import a Serverless Service (add knative serving operator then import from git select serverless deployment)
3. Switch to topology, select the service to open the sidebar
4. Hover over the pod status ring to understand what this means

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge