### PR TITLE
Bug 2034170: add support for new labels for serverless function

### DIFF
--- a/frontend/packages/knative-plugin/src/const.ts
+++ b/frontend/packages/knative-plugin/src/const.ts
@@ -26,5 +26,6 @@ export const KNATIVE_MAXSCALE_ANNOTATION = `${KNATIVE_AUTOSCALING_APIGROUP}/maxS
 export const KNATIVE_CONCURRENCYTARGET_ANNOTATION = `${KNATIVE_AUTOSCALING_APIGROUP}/target`;
 export const KNATIVE_CONCURRENCYUTILIZATION_ANNOTATION = `${KNATIVE_AUTOSCALING_APIGROUP}/targetUtilizationPercentage`;
 export const KNATIVE_AUTOSCALEWINDOW_ANNOTATION = `${KNATIVE_AUTOSCALING_APIGROUP}/window`;
-export const SERVERLESS_FUNCTION_LABEL = 'boson.dev/function';
+export const SERVERLESS_FUNCTION_LABEL_DEPRECATED = 'boson.dev/function'; // TODO: remove deprecated label for serverless function
+export const SERVERLESS_FUNCTION_LABEL = 'function.knative.dev';
 export const GLOBAL_OPERATOR_NS = 'openshift-operators';

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -35,6 +35,7 @@ import {
   FLAG_KNATIVE_EVENTING,
   CAMEL_SOURCE_INTEGRATION,
   SERVERLESS_FUNCTION_LABEL,
+  SERVERLESS_FUNCTION_LABEL_DEPRECATED,
 } from '../const';
 import {
   EventingBrokerModel,
@@ -1299,5 +1300,7 @@ export const isServerlessFunction = (element: K8sResourceKind): boolean => {
   const {
     metadata: { labels },
   } = element;
-  return !!labels?.[SERVERLESS_FUNCTION_LABEL];
+
+  // TODO: remove check for the deprecated label for serverless function
+  return !!(labels?.[SERVERLESS_FUNCTION_LABEL] || labels?.[SERVERLESS_FUNCTION_LABEL_DEPRECATED]);
 };

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-topology-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-topology-utils.spec.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import * as k8s from '@console/internal/module/k8s';
-import { SERVERLESS_FUNCTION_LABEL } from '../../const';
+import { SERVERLESS_FUNCTION_LABEL, SERVERLESS_FUNCTION_LABEL_DEPRECATED } from '../../const';
 import { EventSourceCronJobModel, EventSourceKafkaModel } from '../../models';
 import {
   MockKnativeResources,
@@ -185,6 +185,13 @@ describe('knative topology utils', () => {
       metadata: { labels: { [SERVERLESS_FUNCTION_LABEL]: 'true' } },
     };
     expect(isServerlessFunction(sampleKnResource)).toBe(true);
+
+    // TODO: remove test case for deprecated label for serverless function
+    const sampleKnResourceDep: k8s.K8sResourceKind = {
+      ...MockKnativeResources.ksservices.data[0],
+      metadata: { labels: { [SERVERLESS_FUNCTION_LABEL_DEPRECATED]: 'true' } },
+    };
+    expect(isServerlessFunction(sampleKnResourceDep)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=2034170

Problem:
Currently Developer Console is using Kubernetes labels "boson.dev/function: true" to determine whether or not the deployed Knative Service is a Function.
We would like to change this label to: "function.knative.dev: true".

Solution:
Add support for the proposed label while also maintaining support for the existing one, until the old label is fully deprecated.

Screens:
![Screenshot from 2021-12-22 13-50-26](https://user-images.githubusercontent.com/38663217/147061543-d56bb606-c3f2-4bed-8d28-8e36e18d55e6.png)

Test coverage:
![Screenshot from 2021-12-22 13-56-05](https://user-images.githubusercontent.com/38663217/147061581-95c70110-347c-4947-905e-7061df6f78c6.png)

Browser conformance:
- [x] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge