### PR TITLE
Add support to show platform supported tektonhub tasks in pipeline builder

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/catalog/__tests__/catalog-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/__tests__/catalog-utils.spec.ts
@@ -1,0 +1,29 @@
+import { tekonHubPlatformTasks } from '../../../test-data/catalog-item-data';
+import { filterBySupportedPlatforms } from '../catalog-utils';
+
+describe('catalog-utils', () => {
+  const sampleTekonhubTasks = Object.values(tekonHubPlatformTasks);
+
+  describe('filterBySupportedPlatforms', () => {
+    afterEach(function() {
+      window.SERVER_FLAGS.GOOS = '';
+      window.SERVER_FLAGS.GOARCH = '';
+    });
+
+    it('should return empty if the GOOS and GOARCH is not set in the SERVER_FLAGS', () => {
+      expect(sampleTekonhubTasks.filter(filterBySupportedPlatforms)).toHaveLength(0);
+    });
+
+    it('should return on the tasks that are matching the cluster platform', () => {
+      window.SERVER_FLAGS.GOOS = 'linux';
+      window.SERVER_FLAGS.GOARCH = 'amd64';
+      expect(sampleTekonhubTasks.filter(filterBySupportedPlatforms)).toHaveLength(2);
+    });
+
+    it('should return on the tasks that are matching the IBM Z architecture', () => {
+      window.SERVER_FLAGS.GOOS = 'linux';
+      window.SERVER_FLAGS.GOARCH = 's390x';
+      expect(sampleTekonhubTasks.filter(filterBySupportedPlatforms)).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/components/catalog/catalog-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/catalog-utils.ts
@@ -1,0 +1,9 @@
+import { TektonHubTask } from '../../types/tektonHub';
+
+export const getClusterPlatform = (): string =>
+  `${window.SERVER_FLAGS.GOOS}/${window.SERVER_FLAGS.GOARCH}`;
+
+export const filterBySupportedPlatforms = (task: TektonHubTask): boolean => {
+  const supportedPlatforms = task?.platforms.map((p) => p.name) ?? [];
+  return supportedPlatforms.includes(getClusterPlatform());
+};

--- a/frontend/packages/pipelines-plugin/src/components/catalog/providers/useTekonHubTasksProvider.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/providers/useTekonHubTasksProvider.tsx
@@ -8,13 +8,14 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { TaskModel } from '../../../models/pipelines';
 import { TektonHubTask } from '../../../types/tektonHub';
 import { TektonTaskProviders } from '../../pipelines/const';
+import { filterBySupportedPlatforms } from '../catalog-utils';
 import { TEKTON_HUB_API_ENDPOINT } from '../const';
 import useApiResponse from '../hooks/useApiResponse';
 
 const normalizeTektonHubTasks = async (
   tektonHubTasks: TektonHubTask[],
 ): Promise<CatalogItem<TektonHubTask>[]> => {
-  const tasks = tektonHubTasks.reduce((acc, task) => {
+  const tasks = tektonHubTasks.filter(filterBySupportedPlatforms).reduce((acc, task) => {
     if (task.kind !== TaskModel.kind) {
       return acc;
     }

--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/__tests__/PipelineQuickSearchVersionDropdown.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/__tests__/PipelineQuickSearchVersionDropdown.spec.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { render, cleanup, waitFor, configure } from '@testing-library/react';
 import { omit } from 'lodash';
+import { sampleClusterTaskCatalogItem } from '../../../test-data/catalog-item-data';
 import PipelineQuickSearchVersionDropdown from '../PipelineQuickSearchVersionDropdown';
-import { sampleClusterTaskCatalogItem } from './pipeline-quicksearch-data';
 
 configure({ testIdAttribute: 'data-test' });
 

--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/__tests__/PipelineQuicksearchDetails.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/__tests__/PipelineQuicksearchDetails.spec.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { render, fireEvent, screen, cleanup, waitFor, configure } from '@testing-library/react';
 import { omit } from 'lodash';
-import PipelineQuickSearchDetails from '../PipelineQuickSearchDetails';
 import {
   sampleClusterTaskCatalogItem,
   sampleTektonHubCatalogItem,
-} from './pipeline-quicksearch-data';
+} from '../../../test-data/catalog-item-data';
+import PipelineQuickSearchDetails from '../PipelineQuickSearchDetails';
 
 configure({ testIdAttribute: 'data-test' });
 

--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/__tests__/pipeline-quicksearch-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/__tests__/pipeline-quicksearch-utils.spec.ts
@@ -3,6 +3,13 @@ import { omit } from 'lodash';
 import * as coFetch from '@console/internal/co-fetch';
 import * as k8s from '@console/internal/module/k8s';
 import { CatalogItem } from '../../../../../console-dynamic-plugin-sdk/src';
+import {
+  sampleTektonHubCatalogItem,
+  sampleClusterTaskCatalogItem,
+  sampleCatalogItems,
+  sampleTaskWithMultipleVersions,
+  sampleVersions,
+} from '../../../test-data/catalog-item-data';
 import { CTALabel } from '../const';
 import {
   findInstalledTask,
@@ -18,13 +25,6 @@ import {
   isTaskVersionInstalled,
   updateTask,
 } from '../pipeline-quicksearch-utils';
-import {
-  sampleTektonHubCatalogItem,
-  sampleClusterTaskCatalogItem,
-  sampleCatalogItems,
-  sampleTaskWithMultipleVersions,
-  sampleVersions,
-} from './pipeline-quicksearch-data';
 
 describe('pipeline-quicksearch-utils', () => {
   const sampleCatalogInstalledTask: CatalogItem = {

--- a/frontend/packages/pipelines-plugin/src/test-data/catalog-item-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/catalog-item-data.ts
@@ -1,33 +1,28 @@
-import { CatalogItem } from '../../../../../console-dynamic-plugin-sdk/src';
+import { CatalogItem } from '@console/dynamic-plugin-sdk/src';
+import { TaskKind } from '../types';
+import { TektonHubTask } from '../types/tektonHub';
+
+export enum CatalogItemTypes {
+  CLUSTER_TASK = 'clusterTask',
+  TEKTONHUB_TASK = 'TektonHubTask',
+}
 
 export enum sampleVersions {
   VERSION_01 = '0.1',
   VERSION_02 = '0.2',
 }
-export const sampleClusterTaskCatalogItem: CatalogItem = {
-  uid: '8a357c10-ea59-49a3-b4ea-26fd594afb10',
-  type: 'Red Hat',
-  name: 'ansible-tower-cli',
-  description:
-    'Ansible-tower-cli task simplifies starting jobs, workflow jobs, manage users, projects etc.\nAnsible Tower (formerly ‘AWX’) is a web-based solution that makes Ansible even more easy to use for IT teams of all kinds, It provides the tower-cli(Tower-CLI) command line tool that simplifies the tasks of starting jobs, workflow jobs, manage users, projects etc.',
-  provider: 'Red Hat',
-  tags: ['ansible', 'cli'],
-  creationTimestamp: '2021-08-12T07:02:14Z',
-  icon: {},
-  attributes: {
-    installed: '0.1',
-    versions: [
-      {
-        id: '0.1',
-        version: '0.1',
-      },
-    ],
-    categories: ['CLI'],
-  },
-  cta: {
-    label: 'Add',
-  },
-  data: {
+export enum PlatformTypes {
+  LINUX_AMD64 = 'linux/amd64',
+  LINUX_PPC64LE = 'linux/ppc64le',
+  LINUX_S390X = 'linux/s390x',
+  LINUX_ARM64 = 'linux/arm64',
+}
+
+type SampleTasks = { [key in CatalogItemTypes]?: TaskKind | TektonHubTask };
+type TektonHubPlatformTasks = { [key in PlatformTypes]?: TaskKind | TektonHubTask };
+
+export const sampleTasks: SampleTasks = {
+  [CatalogItemTypes.CLUSTER_TASK]: {
     kind: 'Task',
     apiVersion: 'tekton.dev/v1beta1',
     metadata: {
@@ -82,26 +77,7 @@ export const sampleClusterTaskCatalogItem: CatalogItem = {
             'echo -e "verify_ssl = $(params.SSLVERIFY)\\nverbose = true\\nhost = $(params.HOST)\\nusername = $USER\\npassword = $PASS" > ~/.tower_cli.cfg\nchmod 600 ~/.tower_cli.cfg\necho "Generated tower_cli.cfg file"\necho "-----------------------------"\nls -lah ~/ | grep tower_cli\necho "-----------------------------"',
           ],
           command: ['/bin/sh', '-c'],
-          env: [
-            {
-              name: 'USER',
-              valueFrom: {
-                secretKeyRef: {
-                  key: 'USER',
-                  name: '$(params.tower-secret)',
-                },
-              },
-            },
-            {
-              name: 'PASS',
-              valueFrom: {
-                secretKeyRef: {
-                  key: 'PASS',
-                  name: '$(params.tower-secret)',
-                },
-              },
-            },
-          ],
+          env: [],
           image:
             'quay.io/rcmendes/ansible-tower-cli@sha256:3a61778f410526db8d6e02e87715d58ee770c4a4faf57ac408cb5ec1a025ef2c',
           name: 'config',
@@ -118,6 +94,102 @@ export const sampleClusterTaskCatalogItem: CatalogItem = {
       ],
     },
   },
+  [CatalogItemTypes.TEKTONHUB_TASK]: {
+    id: 1,
+    name: 'ansible-runner',
+    catalog: {
+      id: 1,
+      name: 'tekton',
+      type: 'community',
+    },
+    categories: [
+      {
+        id: 11,
+        name: 'CLI',
+      },
+    ],
+    kind: 'Task',
+    latestVersion: {
+      id: 1,
+      version: '0.1',
+      displayName: 'Ansible Runner',
+      description: 'Task to run Ansible playbooks using Ansible Runner',
+      minPipelinesVersion: '0.12.1',
+      hubURL: 'tekton/task/curl/0.1',
+      rawURL:
+        'https://raw.githubusercontent.com/tektoncd/catalog/main/task/ansible-runner/0.1/ansible-runner.yaml',
+      webURL:
+        'https://github.com/tektoncd/catalog/tree/main/task/ansible-runner/0.1/ansible-runner.yaml',
+      updatedAt: '2021-07-26T12:15:08Z',
+      platforms: [
+        {
+          id: 1,
+          name: 'linux/amd64',
+        },
+      ],
+    },
+    tags: [
+      {
+        id: 78,
+        name: 'cli',
+      },
+    ],
+    platforms: [
+      {
+        id: 1,
+        name: 'linux/amd64',
+      },
+    ],
+    rating: 4.2,
+  },
+};
+
+export const tekonHubPlatformTasks: TektonHubPlatformTasks = {
+  [PlatformTypes.LINUX_AMD64]: {
+    ...sampleTasks[CatalogItemTypes.TEKTONHUB_TASK],
+    platforms: [{ id: 1, name: PlatformTypes.LINUX_AMD64 }],
+  },
+  [PlatformTypes.LINUX_PPC64LE]: {
+    ...sampleTasks[CatalogItemTypes.TEKTONHUB_TASK],
+    platforms: [
+      { id: 1, name: PlatformTypes.LINUX_AMD64 },
+      { id: 2, name: PlatformTypes.LINUX_PPC64LE },
+    ],
+  },
+  [PlatformTypes.LINUX_S390X]: {
+    ...sampleTasks[CatalogItemTypes.TEKTONHUB_TASK],
+    platforms: [{ id: 3, name: PlatformTypes.LINUX_S390X }],
+  },
+  [PlatformTypes.LINUX_ARM64]: {
+    ...sampleTasks[CatalogItemTypes.TEKTONHUB_TASK],
+    platforms: [{ id: 4, name: PlatformTypes.LINUX_ARM64 }],
+  },
+};
+
+export const sampleClusterTaskCatalogItem: CatalogItem = {
+  uid: '8a357c10-ea59-49a3-b4ea-26fd594afb10',
+  type: 'Red Hat',
+  name: 'ansible-tower-cli',
+  description:
+    'Ansible-tower-cli task simplifies starting jobs, workflow jobs, manage users, projects etc.\nAnsible Tower (formerly ‘AWX’) is a web-based solution that makes Ansible even more easy to use for IT teams of all kinds, It provides the tower-cli(Tower-CLI) command line tool that simplifies the tasks of starting jobs, workflow jobs, manage users, projects etc.',
+  provider: 'Red Hat',
+  tags: ['ansible', 'cli'],
+  creationTimestamp: '2021-08-12T07:02:14Z',
+  icon: {},
+  attributes: {
+    installed: '0.1',
+    versions: [
+      {
+        id: '0.1',
+        version: '0.1',
+      },
+    ],
+    categories: ['CLI'],
+  },
+  cta: {
+    label: 'Add',
+  },
+  data: sampleTasks[CatalogItemTypes.CLUSTER_TASK],
 };
 
 export const sampleTektonHubCatalogItem: CatalogItem = {
@@ -167,54 +239,9 @@ export const sampleTektonHubCatalogItem: CatalogItem = {
   cta: {
     label: 'Add',
   },
-  data: {
-    id: 1,
-    name: 'ansible-runner',
-    catalog: {
-      id: 1,
-      name: 'tekton',
-      type: 'community',
-    },
-    categories: [
-      {
-        id: 11,
-        name: 'CLI',
-      },
-    ],
-    kind: 'Task',
-    latestVersion: {
-      id: 1,
-      version: '0.1',
-      displayName: 'Ansible Runner',
-      description: 'Task to run Ansible playbooks using Ansible Runner',
-      minPipelinesVersion: '0.12.1',
-      rawURL:
-        'https://raw.githubusercontent.com/tektoncd/catalog/main/task/ansible-runner/0.1/ansible-runner.yaml',
-      webURL:
-        'https://github.com/tektoncd/catalog/tree/main/task/ansible-runner/0.1/ansible-runner.yaml',
-      updatedAt: '2021-07-26T12:15:08Z',
-      platforms: [
-        {
-          id: 1,
-          name: 'linux/amd64',
-        },
-      ],
-    },
-    tags: [
-      {
-        id: 78,
-        name: 'cli',
-      },
-    ],
-    platforms: [
-      {
-        id: 1,
-        name: 'linux/amd64',
-      },
-    ],
-    rating: 4.2,
-  },
+  data: sampleTasks[CatalogItemTypes.TEKTONHUB_TASK],
 };
+
 export const sampleTaskWithMultipleVersions = {
   [sampleVersions.VERSION_01]: `---
   apiVersion: tekton.dev/v1beta1
@@ -318,6 +345,7 @@ export const sampleTaskWithMultipleVersions = {
           
                   $(params.SCRIPT)`,
 };
+
 export const sampleCatalogItems: CatalogItem[] = [
   sampleClusterTaskCatalogItem,
   sampleTektonHubCatalogItem,

--- a/frontend/packages/pipelines-plugin/src/test-data/event-listener-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/event-listener-data.ts
@@ -17,7 +17,7 @@ export enum EventlistenerTypes {
 
 type TriggerTestData = { [key in TriggerTypes]?: EventListenerKindTrigger };
 type EventListenerTestData = { [key in EventlistenerTypes]?: EventListenerKind };
-export const TriggerTestData = {
+export const TriggerTestData: TriggerTestData = {
   [TriggerTypes.BINDING_TEMPLATE_REF]: {
     name: 'foo-trig',
     bindings: [

--- a/frontend/packages/pipelines-plugin/src/types/tektonHub.ts
+++ b/frontend/packages/pipelines-plugin/src/types/tektonHub.ts
@@ -1,3 +1,18 @@
+export type TektonHubItem = {
+  id: number;
+  name: string;
+};
+
+export type TektonHubCategory = TektonHubItem;
+
+export type TektonHubTag = TektonHubItem;
+
+export type TektonHubPlatform = TektonHubItem;
+
+export type TektonHubCatalog = TektonHubItem & {
+  type: string;
+};
+
 export type TektonHubLatestVersion = {
   id: number;
   version: string;
@@ -6,28 +21,17 @@ export type TektonHubLatestVersion = {
   minPipelinesVersion: string;
   rawURL: string;
   webURL: string;
+  hubURL: string;
+  platforms: TektonHubPlatform[];
   updatedAt: string;
-};
-
-export type TektonHubCategory = {
-  id: number;
-  name: string;
-};
-
-export type TektonHubTag = {
-  id: number;
-  name: string;
 };
 
 export type TektonHubTask = {
   id: number;
   name: string;
   categories: TektonHubCategory[];
-  catalog: {
-    id: number;
-    name: string;
-    type: string;
-  };
+  catalog: TektonHubCatalog;
+  platforms: TektonHubPlatform[];
   kind: string;
   latestVersion: TektonHubLatestVersion;
   tags: TektonHubTag[];


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6451

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

As a user, I want to filter out some of the tasks which are not supported by the cluster. There should be a way to exclude tasks shown in the tekton hub tasks in the pipeline builder.


**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Filter out the tasks based on the cluster platform global variables window.SERVER_FLAGS.GOOS and window.SERVER_FLAGS_GOARCH to form the cluster platform.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

For IBM Z architecture (linux/s390x), only the tektonhub tasks that supports this platform are listed out.

<img width="1472" alt="Screenshot 2021-12-23 at 3 17 34 PM" src="https://user-images.githubusercontent.com/9964343/147222160-0b49768e-07a5-4fd9-926c-ad8b22fba55c.png">


**Unit test coverage report**: 

<!-- Attach test coverage report -->
```
  catalog-utils
    filterBySupportedPlatforms
      ✓ should return empty if the GOOS and GOARCH is not set in the SERVER_FLAGS (1ms)
      ✓ should return on the tasks that are matching the cluster platform (1ms)
      ✓ should return on the tasks that are matching the IBM Z architecture

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        3.022s
```
**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

Note: window.SERVER_FLAGS.GOOS and window.SERVER_FLAGS.GOARCH will be only set on the cluster mode, for localhost is will be set to empty string.

To test in localhost, set these flags in the browser console and then visit pipeline builder page


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

