### PR TITLE
Gherkin and automation for specifying a name for  service binding connector

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/global.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/global.ts
@@ -32,6 +32,7 @@ export enum operators {
   ApacheKafka = 'Red Hat Integration - AMQ Streams',
   RedHatCodereadyWorkspaces = 'Red Hat CodeReady Workspaces',
   GitopsPrimer = 'gitops-primer',
+  ServiceBinding = 'Service Binding Operator',
 }
 
 export enum authenticationType {

--- a/frontend/packages/dev-console/integration-tests/support/constants/topology.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/topology.ts
@@ -38,6 +38,7 @@ export enum nodeActions {
   DeleteRevision = 'Delete Revision',
   MakeServerless = 'Make Serverless',
   AddTrigger = 'Add Trigger',
+  CreateServiceBinding = 'Create Service Binding',
 }
 
 export enum applicationGroupingsActions {

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/operators-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/operators-po.ts
@@ -33,6 +33,8 @@ export const operatorsPO = {
     redHatCodeReadyWorkspacesCard:
       '[data-test^="codeready-workspaces-redhat-operators-openshift-marketplace"]',
     gitopsPrimer: '[data-test="gitops-primer-community-operators-openshift-marketplace"]',
+    serviceBinding:
+      '[data-test="rh-service-binding-operator-redhat-operators-openshift-marketplace"]',
   },
   subscription: {
     logo: 'h1.co-clusterserviceversion-logo__name__clusterserviceversion',

--- a/frontend/packages/dev-console/integration-tests/support/pages/operators-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/operators-page.ts
@@ -137,6 +137,11 @@ export const operatorsPage = {
         cy.get(operatorsPO.operatorHub.gitopsPrimer).click();
         break;
       }
+      case 'Service Binding':
+      case operators.ServiceBinding: {
+        cy.get(operatorsPO.operatorHub.serviceBinding).click();
+        break;
+      }
       default: {
         throw new Error('operator is not available');
       }

--- a/frontend/packages/topology/integration-tests/features/topology/topology-chart-area-visual.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-chart-area-visual.feature
@@ -315,3 +315,74 @@ Feature: Topology chart area
               And user opens the details page for "nodejs-2" by clicking on the title
               And user navigate back to Topology page
              Then user will see the the workload "nodejs-2" selected with sidebar open
+
+
+        @regression @odc-5947
+        Scenario: Create Service Binding option in nodes actions menu: T-06-TC27
+            Given user has installed Service Binding operator
+              And user is at developer perspective
+              And user is at Topology page chart view
+              And user has created a deployment workload "node-js1"
+             When user right clicks on workload "node-js1"
+              And user clicks on "Create Service Binding" option from context menu
+             Then user will see "Create Service Binding" modal
+              And user will see alert "No bindable services available"
+
+
+        @regression @manual @odc-5947
+        Scenario: Bindable services options in Create Service Binding modal: T-06-TC28
+            Given user has installed Service Binding operator
+              And user is at Topology page chart view
+              And user has created a deployment workload "node-js2"
+            #Please refer to test case KM-01-TC01 for creating kafka connection
+              And user has created external bindable resource Kafka Connection "kafka-instance-ex"
+              And user has created operator-backed service of postgresSQL "example-pg"
+              And user has applied '/testdata/bindableresource1.yaml' yaml
+             When user right clicks on workload "node-js2"
+              And user clicks on "Create Service Binding" option from context menu
+              And user clicks on Bindable service dropdown
+             Then user will see postgres and kafka connection services options
+              And user is able to see service binding connector with name "node-js2-d-kafka-example-pg-pc" after clicking on create with "example-pg" option selected in Create Service Binding modal
+
+
+        @regression @manual @odc-5947
+        Scenario: Drag and drop connector to existing bindable resource: T-06-TC29
+            Given user has installed Service Binding operator
+              And user is at Topology page chart view
+              And user has created a deployment workload "node-s"
+            #Please refer to test case KM-01-TC01 for creating kafka connection
+              And user has created external bindable resource Kafka Connection "kafka-instance-ex"
+             When user drag and drop the connector to Kafka Connection
+              And user clicks on Create with name "node-s-d-kafka-instance-ex-akc"
+              And user clicks on connector
+             Then user will see the name as "node-s-d-kafka-instance-ex-akc"
+              And user will see Secret section with secret present
+
+
+        @regression @manual @odc-5947
+        Scenario: Specify the name and the bindable object to connect to in Create Service Binding modal: T-06-TC30
+            Given user has installed Service Binding operator
+              And user is at Topology page chart view
+              And user has created a deployment workload "node-js"
+             When user drag and drop the connector to empty area
+              And user selects Operator backed option
+              And user selects Kafka Connection
+              And user clicks on Create
+              And user clicks on Create button on Create Kafka Connection form
+              And user replaced the name "node-js-d-kafka-instance-ex-akc" with "node-kc-connection-1" in Create Service Binding modal
+              And user clicks on Create
+             Then user will see the connection between node workload and Kafka Connection
+              And user will see the name "node-kc-connection-1" in connector sidebar
+
+
+        @regression @manual @odc-5947
+        Scenario: Create connection to already existing service binding connection: T-06-TC31
+            Given user has installed Service Binding operator
+              And user is at Topology page chart view
+            #Please refer to test case KM-01-TC01 for creating kafka connection
+              And user has created service binding connnector between deployment workload "node-j" and Kafka Connection "kafka-instance-ex1"
+             When user right clicks on workload "node-j"
+              And user clicks on "Create Service Binding" option from context menu
+              And user selects Bindable service as "kafka-instance-ex1"
+              And user clicks on Save
+             Then user will see error "Service binding already exists. Select a different service to connect to."

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-actions-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-actions-page.ts
@@ -122,6 +122,14 @@ export const topologyActions = {
         detailsPage.titleShouldContain(action);
         break;
       }
+      case 'Create Service Binding':
+      case nodeActions.CreateServiceBinding: {
+        cy.byTestActionID(action)
+          .scrollIntoView()
+          .should('be.visible')
+          .click();
+        break;
+      }
       case 'Delete Application':
       case applicationGroupingsActions.DeleteApplication: {
         cy.byTestActionID(action)

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/chart-view.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/chart-view.ts
@@ -1,13 +1,30 @@
 import { When, Then, Given } from 'cypress-cucumber-preprocessor/steps';
+import { guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
+import { modal } from '@console/cypress-integration-tests/views/modal';
+import { nav } from '@console/cypress-integration-tests/views/nav';
 import { pageTitle } from '@console/dev-console/integration-tests/support/constants';
 import {
   devNavigationMenu,
+  operators,
   resources,
+  switchPerspective,
 } from '@console/dev-console/integration-tests/support/constants/global';
-import { createGitWorkload } from '@console/dev-console/integration-tests/support/pages';
-import { app, navigateTo } from '@console/dev-console/integration-tests/support/pages/app';
+import {
+  createGitWorkload,
+  verifyAndInstallOperator,
+} from '@console/dev-console/integration-tests/support/pages';
+import {
+  app,
+  navigateTo,
+  perspective,
+} from '@console/dev-console/integration-tests/support/pages/app';
 import { topologyPO, typeOfWorkload } from '../../page-objects/topology-po';
-import { topologyHelper, topologyPage, topologySidePane } from '../../pages/topology';
+import {
+  topologyActions,
+  topologyHelper,
+  topologyPage,
+  topologySidePane,
+} from '../../pages/topology';
 
 When('user navigates to Topology page', () => {
   navigateTo(devNavigationMenu.Topology);
@@ -181,3 +198,37 @@ Then(
     cy.log(workloadName, 'sidebar is open'); // to avoid lint issues
   },
 );
+
+Given('user has installed Service Binding operator', () => {
+  verifyAndInstallOperator(operators.ServiceBinding);
+});
+
+Given('user is at developer perspective', () => {
+  perspective.switchTo(switchPerspective.Developer);
+  guidedTour.close();
+  nav.sidenav.switcher.shouldHaveText(switchPerspective.Developer);
+});
+
+When('user right clicks on workload {string}', (appName: string) => {
+  topologyPage.rightClickOnNode(appName);
+});
+
+When('user clicks on {string} option from context menu', (actionItem: string) => {
+  app.waitForLoad();
+  topologyActions.selectAction(actionItem);
+});
+
+Then('user will see {string} modal', (modalName: string) => {
+  app.waitForLoad();
+  cy.get('[aria-label="Modal"]')
+    .should('be.visible')
+    .should('contain', modalName);
+});
+
+Then('user will see alert {string}', (alertName: string) => {
+  app.waitForDocumentLoad();
+  cy.get('[aria-label="Default Alert"]')
+    .should('be.visible')
+    .should('contain', alertName);
+  modal.cancel();
+});

--- a/frontend/packages/topology/integration-tests/support/test-data/bindable-resource1.yaml
+++ b/frontend/packages/topology/integration-tests/support/test-data/bindable-resource1.yaml
@@ -1,0 +1,35 @@
+apiVersion: binding.operators.coreos.com/v1alpha1
+kind: BindableKinds
+metadata:
+  creationTimestamp: '2021-11-18T05:19:15Z'
+  generation: 6
+  managedFields:
+    - apiVersion: binding.operators.coreos.com/v1alpha1
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:status': {}
+      manager: manager
+      operation: Update
+      time: '2021-11-18T05:19:15Z'
+  name: bindable-kinds
+  resourceVersion: '29894'
+  uid: ae6df662-41a2-45da-9acf-1332d5c69adf
+status:
+  - group: rabbitmq.com
+    kind: RabbitmqCluster
+    version: v1beta1
+  - group: rhoas.redhat.com
+    kind: KafkaConnection
+    version: v1alpha1
+  - group: redis.redis.opstreelabs.in
+    kind: Redis
+    version: v1beta1
+  - group: postgres-operator.crunchydata.com
+    kind: PostgresCluster
+    version: v1beta1
+  - group: postgresql.k8s.enterprisedb.io
+    kind: Cluster
+    version: v1
+  - group: rhoas.redhat.com
+    kind: ServiceRegistryConnection
+    version: v1alpha1


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-5947
Story: https://issues.redhat.com/browse/ODC-6415

Acceptance criteria:

-  User is able to name the Service Binding connector when creating a Service Binding through the drag & drop action in the Topology view.
-  User can access a Create Service Binding CTA to create a Service Binding from all resources which currently support the drag & drop capability.
-  The Create Service Binding modal issued from the Create Service Binding CTA will allow the user to specify the name as well as the bindable object to connect to.
-  The name is used as the name of the underlying ServiceBindingCR that is created.
-  The name of the ServiceBinding directory in the "/bindings" mountpoint of the Pod matches the name of the ServiceBindingCR (this is the responsibility of the Service Binding Operator).
-  When clicking on the Service Binding Connector in Topology, the associated secret (which is part of the exposed bindable data and is projected into the application's container as files/env variables) should be displayed in the Resources tab of the Side panel

**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]

**Fix**: https://issues.redhat.com/browse/ODC-6423


**Test Setup**:


Check the TAGS in frontend/packagesmanual or @to-do or @un-verified or @broken-test)"",


Command to execute:

Run a cluster locally and execute the command `yarn run dev` and then `npm run test-cypress-topology` simultaneously

Execute the topology-chart-area-visual.feature/topology/integration-tests/cypress.json file be: ""(@pre-condition or @smoke or @regression) and @5947 and not (@manual or @to-do or @un-verified or @broken-test)"",


Command to execute:

Run a cluster locally and execute the command `yarn run dev` and then `npm run test-cypress-topology` simultaneously

Execute the topology-chart-area-visual.feature file

**Browser**
Chrome 90

**Test Execution Screenshot:**

![Screenshot from 2021-12-23 18-41-12](https://user-images.githubusercontent.com/10252230/147245299-6b447593-05f2-446d-a6eb-5dac0092f1cd.png)
