### PR TITLE
Add ability to modify the URL of the URL decorator in Topology

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__mocks__/deployImage-validation-mock.ts
+++ b/frontend/packages/dev-console/src/components/import/__mocks__/deployImage-validation-mock.ts
@@ -155,6 +155,7 @@ export const mockImageStreamData = {
         name: 'latest',
         annotations: {
           'openshift.io/generated-by': 'OpenShiftWebConsole',
+          'app.openshift.io/route-disabled': 'false',
           'openshift.io/imported-from': 'myimage',
         },
         from: { kind: 'DockerImage', name: 'myimage' },

--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
@@ -384,6 +384,7 @@ describe('Import Submit Utils', () => {
               '[{"from":{"kind":"ImageStreamTag","name":"devfile-sample:latest","namespace":"gijohn"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"devfile-sample\\")].image","pause":"false"}]',
             isFromDevfile: 'true',
             'openshift.io/generated-by': 'OpenShiftWebConsole',
+            'app.openshift.io/route-disabled': 'false',
           },
           creationTimestamp: null,
           labels: {

--- a/frontend/packages/dev-console/src/utils/__tests__/__snapshots__/shared-submit-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/utils/__tests__/__snapshots__/shared-submit-utils.spec.ts.snap
@@ -6,6 +6,7 @@ Object {
   "kind": "Route",
   "metadata": Object {
     "defaultAnnotations": Object {
+      "app.openshift.io/route-disabled": "false",
       "openshift.io/generated-by": "OpenShiftWebConsole",
     },
     "labels": Object {
@@ -41,6 +42,7 @@ Object {
   "kind": "Route",
   "metadata": Object {
     "defaultAnnotations": Object {
+      "app.openshift.io/route-disabled": "false",
       "app.openshift.io/vcs-ref": "",
       "app.openshift.io/vcs-uri": "https://github.com/test/repo",
       "openshift.io/generated-by": "OpenShiftWebConsole",
@@ -78,6 +80,7 @@ Object {
   "kind": "Service",
   "metadata": Object {
     "annotations": Object {
+      "app.openshift.io/route-disabled": "false",
       "openshift.io/generated-by": "OpenShiftWebConsole",
     },
     "labels": Object {
@@ -107,6 +110,7 @@ Object {
   "kind": "Service",
   "metadata": Object {
     "annotations": Object {
+      "app.openshift.io/route-disabled": "false",
       "app.openshift.io/vcs-ref": "",
       "app.openshift.io/vcs-uri": "https://github.com/test/repo",
       "openshift.io/generated-by": "OpenShiftWebConsole",

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { TRIGGERS_ANNOTATION } from '@console/shared';
+import { ROUTE_DISABLED_ANNOTATION } from '@console/topology/src/const';
 
 export const getAppLabels = ({
   name,
@@ -53,6 +54,7 @@ export const getGitAnnotations = (gitURL: string, gitRef?: string) => {
 export const getCommonAnnotations = () => {
   return {
     'openshift.io/generated-by': 'OpenShiftWebConsole',
+    [ROUTE_DISABLED_ANNOTATION]: 'false',
   };
 };
 

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/UrlDecorator.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/UrlDecorator.tsx
@@ -3,6 +3,7 @@ import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Node } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
+import { ROUTE_URL_ANNOTATION, ROUTE_DISABLED_ANNOTATION } from '../../../../../const';
 import { useRoutesURL } from '../../../../../data-transforms/useRoutesURL';
 import { getResource } from '../../../../../utils';
 import Decorator from './Decorator';
@@ -18,14 +19,17 @@ const UrlDecorator: React.FC<DefaultDecoratorProps> = ({ element, radius, x, y }
   const { t } = useTranslation();
   const resourceObj = getResource(element);
   const url = useRoutesURL(resourceObj);
+  const routeURL = resourceObj?.metadata?.annotations?.[ROUTE_URL_ANNOTATION];
+  const disabledRoute = resourceObj?.metadata?.annotations?.[ROUTE_DISABLED_ANNOTATION];
+  const decoratorURL = routeURL || url;
 
-  if (!url) {
+  if (!url || disabledRoute === 'true') {
     return null;
   }
   const label = t('topology~Open URL');
   return (
     <Tooltip key="route" content={label} position={TooltipPosition.right}>
-      <Decorator x={x} y={y} radius={radius} href={url} external ariaLabel={label}>
+      <Decorator x={x} y={y} radius={radius} href={decoratorURL} external ariaLabel={label}>
         <g transform={`translate(-${radius / 2}, -${radius / 2})`}>
           <ExternalLinkAltIcon style={{ fontSize: radius }} title={label} />
         </g>

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/__tests__/URLDecorator.spec.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/__tests__/URLDecorator.spec.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { sampleDeployments } from '@console/shared/src/utils/__tests__/test-resource-data';
+import { ROUTE_URL_ANNOTATION, ROUTE_DISABLED_ANNOTATION } from '../../../../../../const';
+import { WorkloadModelProps } from '../../../../../../data-transforms/transform-utils';
+import { useRoutesURL } from '../../../../../../data-transforms/useRoutesURL';
+import { OdcBaseNode } from '../../../../../../elements';
+import Decorator from '../Decorator';
+import UrlDecorator from '../UrlDecorator';
+
+jest.mock('../../../../../../data-transforms/useRoutesURL', () => ({
+  useRoutesURL: jest.fn(),
+}));
+
+const mockUseRoutesURL = useRoutesURL as jest.Mock;
+
+const topologyNodeDataModel = {
+  id: 'e187afa2-53b1-406d-a619-cf9ff1468031',
+  type: 'workload',
+  label: 'hello-openshift',
+  resource: sampleDeployments.data[0],
+  data: {
+    data: {},
+    id: 'e187afa2-53b1-406d-a619-cf9ff1468031',
+    name: 'hello-openshift',
+    type: 'workload',
+    resources: {
+      buildConfigs: [],
+      obj: sampleDeployments.data[0],
+      routes: [],
+      services: [],
+    },
+  },
+  ...WorkloadModelProps,
+};
+
+describe('URLDecorator', () => {
+  let mockNode;
+  beforeEach(() => {
+    mockUseRoutesURL.mockReturnValue('https://example.com');
+    mockNode = new OdcBaseNode();
+  });
+
+  it('should not show decorator if annotation ROUTE_DISABLED_ANNOTATION is true', () => {
+    topologyNodeDataModel.resource.metadata.annotations[ROUTE_DISABLED_ANNOTATION] = 'true';
+    mockNode.setModel(topologyNodeDataModel);
+    const wrapper = shallow(<UrlDecorator element={mockNode} radius={10} x={0} y={0} />);
+    expect(wrapper.find(Decorator).exists()).toBe(false);
+  });
+
+  it('should show decorator if annotation ROUTE_DISABLED_ANNOTATION is false', () => {
+    topologyNodeDataModel.resource.metadata.annotations[ROUTE_DISABLED_ANNOTATION] = 'false';
+    mockNode.setModel(topologyNodeDataModel);
+    const wrapper = shallow(<UrlDecorator element={mockNode} radius={10} x={0} y={0} />);
+    expect(wrapper.find(Decorator).exists()).toBe(true);
+  });
+
+  it('decorator href value should be equal to annotation ROUTE_URL_ANNOTATION', () => {
+    const customURL = 'https://test.com';
+    topologyNodeDataModel.resource.metadata.annotations[ROUTE_DISABLED_ANNOTATION] = 'false';
+    topologyNodeDataModel.resource.metadata.annotations[ROUTE_URL_ANNOTATION] = customURL;
+    mockNode.setModel(topologyNodeDataModel);
+    const wrapper = shallow(<UrlDecorator element={mockNode} radius={10} x={0} y={0} />);
+    expect(wrapper.find(Decorator).prop('href')).toBe(customURL);
+  });
+
+  it('decorator href value should be equal to default route if annotation ROUTE_URL_ANNOTATION is not present', () => {
+    topologyNodeDataModel.resource.metadata.annotations[ROUTE_DISABLED_ANNOTATION] = 'false';
+    topologyNodeDataModel.resource.metadata.annotations[ROUTE_URL_ANNOTATION] = '';
+    mockNode.setModel(topologyNodeDataModel);
+    const wrapper = shallow(<UrlDecorator element={mockNode} radius={10} x={0} y={0} />);
+    expect(wrapper.find(Decorator).prop('href')).toBe('https://example.com');
+  });
+});

--- a/frontend/packages/topology/src/const.ts
+++ b/frontend/packages/topology/src/const.ts
@@ -36,3 +36,6 @@ export const UNASSIGNED_KEY = '#UNASSIGNED_APP#';
 export const ALLOW_EXPORT_APP = 'ALLOW_EXPORT_APP';
 export const EXPORT_CR_NAME = 'primer';
 export const EXPORT_JOB_NAME = 'primer-export-primer';
+
+export const ROUTE_URL_ANNOTATION = 'app.openshift.io/route-url';
+export const ROUTE_DISABLED_ANNOTATION = 'app.openshift.io/route-disabled';


### PR DESCRIPTION
**Story:** https://issues.redhat.com/browse/ODC-6448

**Descriptions:**
- Should be able to modify the decorator URL by modifying the value of annotation app.openshift.io/route-url.
- Should be able to hide the URL decorator by modifying the value of annotation app.openshift.io/route-disabled: true/false.

**GIF:**
![Kapture 2021-12-24 at 19 48 08](https://user-images.githubusercontent.com/2561818/147358687-47e1773f-2926-43e5-9173-834d617594c3.gif)

**Test coverage:**
![image](https://user-images.githubusercontent.com/2561818/147358746-a0229604-0397-44bd-bc48-c9e446c08279.png)

