### PR TITLE
Bug 2034248: GPU/Host device modal is too small

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/hardware-devices/HardwareDevicesModal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/hardware-devices/HardwareDevicesModal.tsx
@@ -116,7 +116,7 @@ export const HardwareDevicesModal: React.FC<HardwareDevicesModalProps> = ({
   };
 
   return (
-    <div className="modal-content">
+    <div className="modal-content modal-content--no-inner-scroll">
       <HWContext.Provider
         value={{
           isBlur,


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2034248

**Analysis / Root cause**:
modal scroll is cutting selectbox and causing it to have a scroll too

**Solution Description**:
disable modal inner scroll

**Screen shots / Gifs for design review**:
**Before**:

![before](https://user-images.githubusercontent.com/67270715/147455182-dfe19212-4d43-4244-9731-5063ad19a65d.png)

**After**:

![after](https://user-images.githubusercontent.com/67270715/147455201-67c9a446-f697-4659-bdaf-1a04024a2d6a.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>