### PR TITLE
Bug 2034647: missing volumes list in snapshot modal

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-modal/SupportedSnapshotVolumesList.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-modal/SupportedSnapshotVolumesList.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 const SupportedSnapshotVolumesList = ({ supportedVolumes }: SupportedSnapshotVolumesListProps) => {
   const { t } = useTranslation();
-
+  const [isExpanded, setIsExpanded] = React.useState<boolean>(true);
   if (_.isEmpty(supportedVolumes)) {
     return null;
   }
@@ -13,6 +13,8 @@ const SupportedSnapshotVolumesList = ({ supportedVolumes }: SupportedSnapshotVol
   return (
     <StackItem>
       <ExpandableSection
+        isExpanded={isExpanded}
+        onClick={() => setIsExpanded((prev) => !prev)}
         toggleText={t('kubevirt-plugin~Disks included in this snapshot ({{count}})', {
           count: supportedVolumes?.length,
         })}


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2034647

**Solution Description**:
volume list that is included in snapshot will be expanded on default

**Screen shots / Gifs for design review**:

**Before**:

https://user-images.githubusercontent.com/67270715/147462051-44410ce2-8d13-4b39-80c9-dc97247b2e55.mp4

**After**:

https://user-images.githubusercontent.com/67270715/147462062-a279b34d-1c95-45f0-af0b-81514ea506eb.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>