### PR TITLE
Bug 2034129: Fix guided-tour popover title

### DIFF
--- a/frontend/packages/console-shared/src/components/popover/Popover.tsx
+++ b/frontend/packages/console-shared/src/components/popover/Popover.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import { FocusTrap } from '@patternfly/react-core';
+import { FocusTrap, TitleSizes, Title } from '@patternfly/react-core';
 import { PopoverArrow } from '@patternfly/react-core/dist/js/components/Popover/PopoverArrow';
 import { PopoverBody } from '@patternfly/react-core/dist/js/components/Popover/PopoverBody';
 import { PopoverCloseButton } from '@patternfly/react-core/dist/js/components/Popover/PopoverCloseButton';
 import { PopoverContent } from '@patternfly/react-core/dist/js/components/Popover/PopoverContent';
 import { PopoverFooter } from '@patternfly/react-core/dist/js/components/Popover/PopoverFooter';
-import { PopoverHeader } from '@patternfly/react-core/dist/js/components/Popover/PopoverHeader';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Popover/popover';
 import { useTranslation } from 'react-i18next';
@@ -56,7 +55,9 @@ const Popover: React.FC<PopoverProps> = ({
             <PopoverContent>
               <PopoverCloseButton onClose={onClose} aria-label={t('console-shared~Close')} />
               {headerContent && (
-                <PopoverHeader id={`popover-${uniqueId}-header`}>{headerContent}</PopoverHeader>
+                <Title headingLevel="h6" size={TitleSizes.md} id={`popover-${uniqueId}-header`}>
+                  {headerContent}
+                </Title>
               )}
               <PopoverBody id={`popover-${uniqueId}-body`}>{children}</PopoverBody>
               {footerContent && (


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=2034129

**Root Cause:**
PF `PopoverHeader` component had an issue with rendering the heading which was later fixed in v4.181.0 of patternfly/react-core.

**Solution:**
We don't need to use `PopoverHeader` as it's just simply using `Title` component , so simply replaced it with `Title`.

**Screen-recording:**

https://user-images.githubusercontent.com/20724543/147484556-e4da7e4e-6be4-47a6-a1a4-396a303f0132.mov


/kind bug

