### PR TITLE
Bug 1992414: Removed the check for windows machines

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/storage-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/storage-tab-state-update.ts
@@ -397,18 +397,9 @@ const initialStorageWindowsPVCUpdater = ({ id, prevState, dispatch, getState }: 
   }
 };
 
-const initialStorageWindowsImportUpdater = ({
-  id,
-  prevState,
-  dispatch,
-  getState,
-}: UpdateOptions) => {
+const initialStorageCdromImportUpdater = ({ id, prevState, dispatch, getState }: UpdateOptions) => {
   const state = getState();
-  const relevantOptions = iGetRelevantTemplateSelectors(state, id);
-  const iCommonTemplates = iGetLoadedCommonData(state, id, VMWizardProps.commonTemplates);
   const isCdRom = getInitialData(state, id)?.source?.cdRom;
-  const template =
-    iCommonTemplates && iGetRelevantTemplate(iCommonTemplates, relevantOptions).toJS();
 
   if (!hasStoragesChanged(prevState, state, id)) {
     return;
@@ -426,7 +417,7 @@ const initialStorageWindowsImportUpdater = ({
       disk?.name === ROOT_DISK_NAME,
   );
 
-  if (isWindowsTemplate(template) && rootCdRom && isCdRom) {
+  if (rootCdRom && isCdRom) {
     const disk = new DiskWrapper(rootCdRom?.disk).setName(ROOT_DISK_INSTALL_NAME).asResource();
     const volume = new VolumeWrapper(rootCdRom.volume).setName(ROOT_DISK_INSTALL_NAME).asResource();
     dispatch(
@@ -454,7 +445,7 @@ export const updateStorageTabState = (options: UpdateOptions) =>
     initialStorageClassUpdater,
     initialStorageDiskUpdater,
     initialStorageWindowsPVCUpdater,
-    initialStorageWindowsImportUpdater,
+    initialStorageCdromImportUpdater,
   ].forEach((updater) => {
     updater && updater(options);
   });


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1992414

**Analysis / Root cause**: 
Wrong naming of cdrom disk for machines that arent windows

**Solution Description**: 
Removed the check for windows machines, now it will fix all machines the this is a cdrom boot source is checked.

**Screen shots / Gifs for design review**: 
Before:
![image](https://user-images.githubusercontent.com/14824964/147555829-486fa82b-1b71-4933-b96d-0c50042fe7a2.png)

After:
![image](https://user-images.githubusercontent.com/14824964/147555869-e60c422b-890d-472b-9443-d996f736561b.png)
