### PR TITLE
update VM deletion method to take VM name as optional arg 

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/views/vm.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/views/vm.ts
@@ -111,7 +111,7 @@ export const vm = {
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(15000);
   },
-  delete: () => {
+  delete: (vmData?: VirtualMachineData) => {
     cy.get('body').then(($body) => {
       if ($body.text().includes('Instance')) {
         action(VMI_ACTION.Delete);
@@ -119,7 +119,13 @@ export const vm = {
         action(VM_ACTION.Delete);
       }
     });
-    cy.byTestID('create-vm-empty').should('be.visible');
+    if (vmData) {
+      cy.get(row)
+        .contains(vmData.name)
+        .should('not.exist');
+    } else {
+      cy.byTestID('create-vm-empty').should('be.visible');
+    }
   },
   resume: () => {
     waitForStatus(VM_STATUS.Paused);


### PR DESCRIPTION
**Problem:** VM deletion method verifies deletion of a VM **by appearance of "Create Virtual Machine" button** instead of empty VM list. If there some VM left from previous test, this method will fail too, even if deletion was successful.

![image](https://user-images.githubusercontent.com/85610882/147558659-9490aafa-b11a-4a78-9d4f-407421293efe.png)

**Solution:** to use optional VM name to verify the deletion by  **the absence of VM in list**
