### PR TITLE
Bug 2033634: fix modal list style type

### DIFF
--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -5,7 +5,7 @@ import * as Modal from 'react-modal';
 import { Router } from 'react-router-dom';
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
-import { ActionGroup, Button, TextContent } from '@patternfly/react-core';
+import { ActionGroup, Button } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';
 import CloseButton from '@console/shared/src/components/close-button';
@@ -90,7 +90,7 @@ export const ModalTitle: React.SFC<ModalTitleProps> = ({
 export const ModalBody: React.SFC<ModalBodyProps> = ({ children }) => (
   <div className="modal-body">
     <div className="modal-body-content">
-      <TextContent className="modal-body-inner-shadow-covers">{children}</TextContent>
+      <div className="modal-body-inner-shadow-covers">{children}</div>
     </div>
   </div>
 );


### PR DESCRIPTION
# Addresses 
https://bugzilla.redhat.com/show_bug.cgi?id=2033634
https://issues.redhat.com/browse/OCPBUGSM-38602

# Issue
`list-style-type` was overrriden by `pf-c-content ul` which is rendered by `TextContent` 

# Screenshot
<img width="668" alt="Screenshot 2021-12-27 at 8 35 35 PM" src="https://user-images.githubusercontent.com/24852534/147560426-10b9aa85-cc40-4749-a8b1-65c6e8f56aa3.png">

# Browser conformance
Chrome
