### PR TITLE
Bug 2034823: Added RHEL 9 as pinned template

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -81,6 +81,9 @@ export const ROOT_DISK_INSTALL_NAME = 'install';
 
 export const TEMPLATE_PIN = 'kubevirt.templates.pins';
 export const TEMPLATE_PIN_PROMOTED = 'kubevirt.templates.pins.promoted';
+export const TEMPLATE_PIN_RHEL_7 = 'rhel7-server-small';
+export const TEMPLATE_PIN_RHEL_8 = 'rhel8-server-small';
+export const TEMPLATE_PIN_RHEL_9 = 'rhel9-server-small';
 export const TEMPLATE_WARN_SUPPORT = 'kubevirt.templates.warnSupport';
 export const TEMPLATE_CUSTOMIZE_SOURCE = 'kubevirt.templates.customizeSource';
 

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-pinned-templates.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-pinned-templates.ts
@@ -1,9 +1,15 @@
 import * as React from 'react';
-import { TEMPLATE_PIN, TEMPLATE_PIN_PROMOTED } from '../constants';
+import {
+  TEMPLATE_PIN,
+  TEMPLATE_PIN_PROMOTED,
+  TEMPLATE_PIN_RHEL_7,
+  TEMPLATE_PIN_RHEL_8,
+  TEMPLATE_PIN_RHEL_9,
+} from '../constants';
 import { TemplateItem } from '../types/template';
 import { useLocalStorage } from './use-local-storage';
 
-const PROMOTED_TEMPLATES = ['rhel7-server-small', 'rhel8-server-small'];
+const PROMOTED_TEMPLATES = [TEMPLATE_PIN_RHEL_7, TEMPLATE_PIN_RHEL_8, TEMPLATE_PIN_RHEL_9];
 
 const isPromoted = (templateItem: TemplateItem): boolean =>
   templateItem.isCommon && PROMOTED_TEMPLATES.includes(templateItem.metadata.name);


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2034823

**Analysis / Root cause**: 
New RHEL 9 wasn't part of auto-pinned templates

**Solution Description**: 
Added RHEL 9 as a pinned template