### PR TITLE
Bug 2035772: AccessMode and VolumeMode is not reserved for customize wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/create-vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/create-vm.tsx
@@ -328,6 +328,8 @@ export const CreateVM: React.FC<RouteComponentProps<{ ns: string }>> = ({ match,
         name: state.name,
         startVM: state.startVM,
         storageClass: bootState?.storageClass?.value,
+        accessMode: bootState?.accessMode?.value,
+        volumeMode: bootState?.volumeMode?.value,
         bootSource: dataSource
           ? {
               size:

--- a/frontend/packages/kubevirt-plugin/src/types/url.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/url.ts
@@ -6,6 +6,8 @@ export type VMWizardInitialData = {
   userTemplateName?: string;
   userTemplateNs?: string;
   storageClass?: string;
+  accessMode?: string;
+  volumeMode?: string;
 };
 
 export type VMWizardBootSourceParams = {

--- a/frontend/packages/kubevirt-plugin/src/utils/url.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/url.ts
@@ -84,6 +84,8 @@ export const getVMWizardCreateLink = ({
   bootSource,
   startVM,
   storageClass,
+  accessMode,
+  volumeMode,
 }: {
   namespace?: string;
   wizardName: VMWizardName;
@@ -94,6 +96,8 @@ export const getVMWizardCreateLink = ({
   bootSource?: VMWizardBootSourceParams;
   startVM?: boolean;
   storageClass?: string;
+  accessMode?: string;
+  volumeMode?: string;
 }) => {
   const params = new URLSearchParams();
   const initialData: VMWizardInitialData = {};
@@ -154,6 +158,14 @@ export const getVMWizardCreateLink = ({
 
   if (storageClass) {
     initialData.storageClass = storageClass;
+  }
+
+  if (accessMode) {
+    initialData.accessMode = accessMode;
+  }
+
+  if (volumeMode) {
+    initialData.volumeMode = volumeMode;
   }
 
   if (mode === VMWizardMode.IMPORT && view === VMWizardView.ADVANCED) {


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2035772

**Analysis / Root cause**:
when switching to customize wizard, we initialize volumeMode and accessMode from configMap setting instead of getting the user input from the simple wizard

**Solution Description**:
adding volumeMode and accessMode under initialData

**Screen shots / Gifs for design review**:

**After**:

https://user-images.githubusercontent.com/67270715/147588367-e50edd8d-6ed7-4203-9555-26be3bd630f0.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>