### PR TITLE
Bug 2034190: unable to add new VirtIO disks to VMs

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -35,7 +35,7 @@ import {
   getTemplateValidationsFromTemplate,
   getVMTemplateNamespacedName,
 } from '../../selectors/vm-template/selectors';
-import { isVMRunningOrExpectedRunning } from '../../selectors/vm/selectors';
+import { isVMIReady, isVMRunningOrExpectedRunning } from '../../selectors/vm/selectors';
 import { asVM } from '../../selectors/vm/vm';
 import { getVMStatus } from '../../statuses/vm/vm-status';
 import { VMIKind } from '../../types';
@@ -180,7 +180,8 @@ export const VMDisks: React.FC<VMDisksProps> = ({ obj: vmLikeEntity, vmi }) => {
   const [isLocked, setIsLocked] = useSafetyFirst(false);
   const withProgress = wrapWithProgress(setIsLocked);
   const templateValidations = getTemplateValidationsFromTemplate(vmTemplate);
-  const isVMRunning = isVM(vmLikeEntity) && isVMRunningOrExpectedRunning(asVM(vmLikeEntity), vmi);
+  const isVMRunning =
+    isVM(vmLikeEntity) && isVMRunningOrExpectedRunning(asVM(vmLikeEntity), vmi) && isVMIReady(vmi);
   const pendingChangesDisks: Set<string> =
     isVMRunning && vmi
       ? new Set(changedDisks(new VMWrapper(asVM(vmLikeEntity)), new VMIWrapper(vmi)))


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2034190

**Solution Description**:
`isVMRunning` is now also checking for VMI's `status.phase` to be 'Running'

**Screen shots / Gifs for design review**:

**Before**:

https://user-images.githubusercontent.com/67270715/147658790-ffa4f700-d897-466f-b13e-47d2dd9f2e68.mp4

**After**:

https://user-images.githubusercontent.com/67270715/147658799-5e00e43c-56c1-430a-9463-07922878f174.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>