### PR TITLE
Bug 1999796: Add support for fetching partial metadata and fix helm list page crash

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/k8s/actions/__tests__/k8s.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/k8s/actions/__tests__/k8s.spec.ts
@@ -117,4 +117,49 @@ describe(sdkK8sActions.ActionType.StartWatchK8sList, () => {
 
     sdkK8sActions.watchK8sList('another-redux-id', {}, model)(dispatch, getState);
   });
+
+  it('send partial metadata headers to k8sList when partialMetadata is true', (done) => {
+    const k8sList = spyOn(k8sResource, 'k8sList').and.callFake(
+      (k8sKind, params, raw, requestOptions) => {
+        expect(params.limit).toEqual(250);
+        expect(requestOptions.headers).toEqual(sdkK8sActions.partialObjectMetadataListHeader);
+
+        if (k8sList.calls.count() === 1 || k8sList.calls.count() === 11) {
+          expect(params.continue).toBeUndefined();
+        } else {
+          expect(params.continue).toEqual('toNextPage');
+        }
+        resourceList.metadata.resourceVersion = (
+          parseInt(resourceList.metadata.resourceVersion, 10) + 1
+        ).toString();
+        resourceList.metadata.continue =
+          parseInt(resourceList.metadata.resourceVersion, 10) < 10 ? 'toNextPage' : undefined;
+
+        return resourceList;
+      },
+    );
+
+    let returnedItems = 0;
+    const dispatch = jasmine.createSpy('dispatch').and.callFake((action) => {
+      if (action.type === sdkK8sActions.ActionType.BulkAddToList) {
+        const bulkAddToListCalls = dispatch.calls
+          .allArgs()
+          .filter((args) => args[0].type === sdkK8sActions.ActionType.BulkAddToList);
+
+        expect(action.payload.k8sObjects).toEqual(resourceList.items);
+        expect(bulkAddToListCalls.length).toEqual(k8sList.calls.count() - 1);
+
+        returnedItems += action.payload.k8sObjects.length;
+
+        if (bulkAddToListCalls.length === 9) {
+          expect(returnedItems).toEqual(resourceList.items.length * bulkAddToListCalls.length);
+          done();
+        }
+      } else if (action.type === sdkK8sActions.ActionType.Errored) {
+        fail(action.payload.k8sObjects);
+      }
+    });
+
+    sdkK8sActions.watchK8sList('one-more-redux-id', {}, model, null, true)(dispatch, getState);
+  });
 });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -157,6 +157,7 @@ export type WatchK8sResource = {
   limit?: number;
   fieldSelector?: string;
   optional?: boolean;
+  partialMetadata?: boolean;
 };
 
 export type ResourcesObject = { [key: string]: K8sResourceCommon | K8sResourceCommon[] };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/k8s-watcher.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/k8s-watcher.ts
@@ -73,7 +73,14 @@ export const getIDAndDispatch: GetIDAndDispatch<SDKStoreState> = (resource, k8sM
   );
   const id = makeReduxID(k8sModel, query);
   const dispatch = resource.isList
-    ? k8sActions.watchK8sList(id, query, k8sModel)
-    : k8sActions.watchK8sObject(id, resource.name, resource.namespace, query, k8sModel);
+    ? k8sActions.watchK8sList(id, query, k8sModel, null, resource.partialMetadata)
+    : k8sActions.watchK8sObject(
+        id,
+        resource.name,
+        resource.namespace,
+        query,
+        k8sModel,
+        resource.partialMetadata,
+      );
   return { id, dispatch };
 };

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
@@ -48,6 +48,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace }) => {
       namespaced: true,
       optional: true,
       selector: { matchLabels: { owner: 'helm' } },
+      partialMetadata: true,
     }),
     [namespace],
   );

--- a/frontend/packages/helm-plugin/src/topology/helmResources.ts
+++ b/frontend/packages/helm-plugin/src/topology/helmResources.ts
@@ -5,6 +5,7 @@ export const getHelmWatchedResources = (namespace: string) => {
       kind: 'Secret',
       namespace,
       optional: true,
+      partialMetadata: true,
     },
   };
 };


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/OCPBUGSM-34177
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Helm list page used to crash with too many helm charts because fetching more than 250 secrets all with the data would time out in the browser.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: The solution was to fetch only partial metadata because we do not need the secret data for rendering helm list page. Added support to fetch only partial metadata in `watchK8s` hooks.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: No UI change.


https://user-images.githubusercontent.com/6041994/147684913-dec2c85d-76f5-4ecb-a3fc-2323f77b5184.mov



**Unit test coverage report**: 
<!-- Attach test coverage report -->

<img width="786" alt="Screenshot 2021-12-29 at 10 14 16 PM" src="https://user-images.githubusercontent.com/6041994/147684846-1740c2aa-f2fa-41c5-b78a-b0ead78651f2.png">



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [] Firefox
- [ ] Safari
- [ ] Edge
