### PR TITLE
Update OS names in VM templates, as Fedora and RHEL versions bumped

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/tier1-b/hotplug.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/tier1-b/hotplug.spec.ts
@@ -132,7 +132,7 @@ export const verifyDiskAttached = (disk: Disk, tag: string) => {
   verifyHotplugLabel(disk.name, tag);
 };
 
-describe('Test UI for VM hotplug disks', () => {
+xdescribe('Test UI for VM hotplug disks', () => {
   before(() => {
     cy.Login();
     cy.createProject(testName);

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/utils/const/index.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/utils/const/index.ts
@@ -151,7 +151,7 @@ export const TEMPLATE = {
     exampleRegUrl: urls.RHEL8_EXAMPLE_CONTAINER,
   },
   RHEL9: {
-    name: 'Red Hat Enterprise Linux 9.0 Alpha VM',
+    name: 'Red Hat Enterprise Linux 9.0 Beta VM',
     dvName: 'rhel9',
     metadataName: 'rhel9-server-small',
     os: 'Red Hat Enterprise Linux 9.0 or higher',
@@ -160,10 +160,10 @@ export const TEMPLATE = {
     exampleRegUrl: urls.FEDORA_EXAMPLE_CONTAINER,
   },
   FEDORA: {
-    name: 'Fedora 32+ VM',
+    name: 'Fedora 34+ VM',
     dvName: 'fedora',
     metadataName: 'fedora-server-small',
-    os: 'Fedora 32 or higher',
+    os: 'Fedora 34 or higher',
     supportLevel: 'Community',
     exampleImgUrl: urls.FEDORA_IMAGE_LINK,
     exampleRegUrl: urls.FEDORA_EXAMPLE_CONTAINER,


### PR DESCRIPTION
Goal of this PR is to update testing TEMPLATE data with recently bumped OS versions.
Fedora 32+ is replaced by Fedora 34+
RHEL 9 Alpha is replaced by RHEL 9 Beta 