### PR TITLE
Bug 1987044: [OCPV48] Shutoff VM is being shown as "Starting" in WebUI when using spec.runStrategy Manual/RerunOnFailure

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -6,6 +6,7 @@ import {
   TEMPLATE_WORKLOAD_LABEL,
 } from '../../constants/vm';
 import { RunStrategy, StateChangeRequest } from '../../constants/vm/vm';
+import { VMStatus } from '../../constants/vm/vm-status';
 import { VMIPhase } from '../../constants/vmi/phase';
 import { NetworkWrapper } from '../../k8s/wrapper/vm/network-wrapper';
 import { VolumeWrapper } from '../../k8s/wrapper/vm/volume-wrapper';
@@ -135,7 +136,19 @@ export const isVMExpectedRunning = (vm: VMKind, vmi: VMIKind) => {
   return false;
 };
 
+export const isStoppedFromConsole = (vm: VMKind, vmi: VMIKind) => {
+  return (
+    vm &&
+    isVMCreated(vm) &&
+    getStatusPhase(vmi) === VMIPhase.Succeeded &&
+    vm.status.printableStatus === VMStatus.STOPPED.getSimpleLabel()
+  );
+};
+
 export const isVMRunningOrExpectedRunning = (vm: VMKind, vmi: VMIKind) => {
+  if (isStoppedFromConsole(vm, vmi)) {
+    return false;
+  }
   if (isVMExpectedRunning(vm, vmi)) {
     return true;
   }

--- a/frontend/packages/kubevirt-plugin/src/statuses/vm/vm-status.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/vm/vm-status.ts
@@ -16,7 +16,11 @@ import {
   getStatusPhase,
 } from '../../selectors/selectors';
 import { findConversionPod } from '../../selectors/vm/combined';
-import { isVMCreated, isVMExpectedRunning } from '../../selectors/vm/selectors';
+import {
+  isStoppedFromConsole,
+  isVMCreated,
+  isVMExpectedRunning,
+} from '../../selectors/vm/selectors';
 import {
   findVMIMigration,
   getMigrationStatusPhase,
@@ -32,6 +36,7 @@ import {
   IMPORTING_VMWARE_MESSAGE,
   STARTING_MESSAGE,
   VMI_WAITING_MESSAGE,
+  VM_SHUTDOWN_FROM_CONSOLE,
 } from '../../strings/vm/status';
 import { VMIKind, VMKind } from '../../types';
 import { V1alpha1DataVolume } from '../../types/api';
@@ -306,6 +311,13 @@ const isWaitingForVMI = (vm: VMKind, vmi: VMIKind): VMStatusBundle => {
   return null;
 };
 
+const isStoppedConsole = (vm: VMKind, vmi: VMIKind): VMStatusBundle => {
+  if (isStoppedFromConsole(vm, vmi)) {
+    return { status: VMStatus.STOPPED, message: VM_SHUTDOWN_FROM_CONSOLE };
+  }
+  return null;
+};
+
 export const getVMStatus = ({
   vm,
   vmi,
@@ -337,6 +349,7 @@ export const getVMStatus = ({
     isOff(vm, vmi) ||
     isError(vm, vmi, launcherPod) ||
     isRunning(vmi) ||
+    isStoppedConsole(vm, vmi) ||
     isStarting(vm, vmi, launcherPod) ||
     isWaitingForVMI(vm, vmi) ||
     ([VMIPhase.Scheduling, VMIPhase.Scheduled].includes(getStatusPhase<VMIPhase>(vmi)) && {

--- a/frontend/packages/kubevirt-plugin/src/strings/vm/status.ts
+++ b/frontend/packages/kubevirt-plugin/src/strings/vm/status.ts
@@ -12,3 +12,5 @@ export const IMPORT_CDI_PENDING_MESSAGE =
   'The importer pod is waiting for resources to become available.';
 export const PENDING_CHANGES_WARNING_MESSAGE =
   'The following areas have pending changes that will be applied when this virtual machine is restarted.';
+export const VM_SHUTDOWN_FROM_CONSOLE =
+  'The virtual machine has recieved a shutdown signal from the console. VMI is not deleted and can be deleted manually or by starting and stopping the VM from menu actions on top right corner.';


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=1987044

**Solution Description**:
adding a condition to check for a shutdown signal from console

**Screen shots / Gifs for design review**:

**After**:

https://user-images.githubusercontent.com/67270715/147772508-758f723a-d0fc-4a10-bdb3-23eccd385b20.mp4

![after](https://user-images.githubusercontent.com/67270715/147772523-be6365af-da8d-483f-a3f2-957956e436ed.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>