### PR TITLE
Bug 2035602: [e2e][automation] add tests for Virtualization Overview cards

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/tier1-b/hotplug.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/tier1-b/hotplug.spec.ts
@@ -190,7 +190,7 @@ xdescribe('Test UI for VM hotplug disks', () => {
     persHotplugDiskClone,
     persHotplugDiskPVC,
   ].forEach((disk) => {
-    it(`${disk.description}`, () => {
+    xit(`${disk.description}`, () => {
       verifyDiskAttached(disk, 'PersistingHotplug');
       deleteRow(disk.name);
       cy.get(`[data-id="${disk.name}"]`).should('not.exist');
@@ -204,7 +204,7 @@ xdescribe('Test UI for VM hotplug disks', () => {
     autoHotplugDiskClone,
     autoHotplugDiskPVC,
   ].forEach((disk) => {
-    it(`${disk.description}`, () => {
+    xit(`${disk.description}`, () => {
       verifyDiskAttached(disk, 'AutoDetachHotplug');
       deleteRow(disk.name);
       cy.get(`[data-id="${disk.name}"]`).should('not.exist');

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/virtualization-overview/getting-started-card.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/virtualization-overview/getting-started-card.spec.ts
@@ -1,41 +1,37 @@
+import { adminOnlyDescribe } from '../../utils/const';
 import * as virtOverview from '../../views/virtualization-overview';
 
 const EXIST = 'exist';
 const NOT_EXIST = 'not.exist';
 
-describe('Test Getting started card of the Virtualization Overview page', () => {
+adminOnlyDescribe('Test Getting started card of the Virtualization Overview page', () => {
   before(() => {
     cy.Login();
     cy.visit('/virtualization/overview');
   });
 
-  it('Getting started card is displayed', () => {
+  it('ID(CNV-7940) Getting started card is displayed and can be toggled', () => {
     cy.get(virtOverview.gettingStartedCard).should(EXIST);
-  });
-
-  it('Getting started card can be hidden', () => {
     cy.get(virtOverview.hideGettingStartedCardKebab).click();
     cy.get(virtOverview.hideGettingStartedCardTooltip).should(EXIST);
     cy.get(virtOverview.hideGettingStartedCardTooltip).click();
 
     cy.get(virtOverview.gettingStartedCard).should(NOT_EXIST);
-  });
 
-  it('Getting started card can be restored', () => {
     cy.get(virtOverview.restoreGettingStartedBtn).should(EXIST);
     cy.get(virtOverview.restoreGettingStartedBtn).click();
     cy.get(virtOverview.gettingStartedCard).should(EXIST);
   });
 
-  it('Quick starts card is displayed', () => {
+  it('ID(CNV-7927) Quick starts card is displayed', () => {
     cy.get(virtOverview.quickStartCard).should(EXIST);
   });
 
-  it('Feature highlights card is displayed', () => {
+  it('ID(CNV-7924) Feature highlights card is displayed', () => {
     cy.get(virtOverview.featureHighlightsCard).should(EXIST);
   });
 
-  it('Recommended operators card is displayed', () => {
+  it('ID(CNV-7925) Recommended operators card is displayed', () => {
     cy.get(virtOverview.recommendedOperatorsCard).should(EXIST);
   });
 });

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/virtualization-overview/overview-cards.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/virtualization-overview/overview-cards.spec.ts
@@ -1,0 +1,134 @@
+import { adminOnlyDescribe, OS_IMAGES_NS } from '../../utils/const';
+import * as virtOverview from '../../views/virtualization-overview';
+
+adminOnlyDescribe('Test Virtualization Overview cards', () => {
+  before(() => {
+    cy.Login();
+    cy.visit('/virtualization/overview');
+  });
+
+  it('ID(CNV-7928) Details card w/articles is displayed', () => {
+    cy.get(virtOverview.detailsCard)
+      .should('exist')
+      .within(() => {
+        cy.get(virtOverview.cardTitle)
+          .contains('Details')
+          .should('exist');
+        ['Service name', 'Provider', 'OpenShift Virtualization version', 'Update Channel'].forEach(
+          (article) => {
+            cy.get(virtOverview.itemTitle)
+              .contains(article)
+              .should('exist');
+          },
+        );
+      });
+  });
+
+  it('ID(CNV-7929) Running VMs per template card is displayed', () => {
+    cy.get(virtOverview.perTemplateCard)
+      .should('exist')
+      .within(() => {
+        cy.get(virtOverview.cardTitle)
+          .contains('Running VMs per template')
+          .should('exist');
+      });
+  });
+
+  it('ID(CNV-7931) Status card with items is displayed', () => {
+    cy.get(virtOverview.statusCard)
+      .should('exist')
+      .within(() => {
+        cy.get(virtOverview.cardTitle)
+          .contains('Status')
+          .should('exist');
+        cy.get(virtOverview.cardActions).should('exist');
+        cy.get(virtOverview.virtHealthItem).should('exist');
+        cy.get(virtOverview.virtHealthIcon).should('exist');
+        cy.get(virtOverview.netHealthItem).should('exist');
+        cy.get(virtOverview.netHealthIcon).should('exist');
+        cy.get(virtOverview.alertsList).should('exist');
+      });
+  });
+
+  it('ID(CNV-7930) Inventory card with items is displayed', () => {
+    cy.get(virtOverview.inventoryCard)
+      .should('exist')
+      .within(() => {
+        cy.get(virtOverview.cardTitle)
+          .contains('Inventory')
+          .should('exist');
+        cy.get(virtOverview.vmsLink)
+          .contains('Virtual Machines')
+          .should('exist');
+        cy.get(virtOverview.templatesLink)
+          .contains('Templates')
+          .should('exist')
+          .and('have.attr', 'href', `/k8s/ns/${OS_IMAGES_NS}/virtualmachinetemplates`);
+        cy.get(virtOverview.nodesLink)
+          .contains('Nodes')
+          .should('exist');
+        cy.get(virtOverview.networksLink)
+          .contains('Networks')
+          .should('exist');
+      });
+  });
+
+  it('ID(CNV-7932) Activity card with items is displayed', () => {
+    cy.get(virtOverview.activityCard)
+      .should('exist')
+      .within(() => {
+        cy.get(virtOverview.cardTitle)
+          .contains('Activity')
+          .should('exist');
+        cy.get(virtOverview.cardActions).should('exist');
+        cy.get(virtOverview.ongoingTitle).should('exist');
+        cy.get(virtOverview.ongoingActivity).should('exist');
+        cy.get(virtOverview.recentActivity).should('exist');
+        cy.get(virtOverview.pauseButton)
+          .should('exist')
+          .should('have.text', 'Pause')
+          .click();
+        cy.get(virtOverview.pauseButton)
+          .should('exist')
+          .should('have.text', 'Resume')
+          .click();
+        cy.get(virtOverview.pauseButton)
+          .should('exist')
+          .should('have.text', 'Pause');
+      });
+  });
+
+  it('ID(CNV-7933) Permissions card with items is displayed', () => {
+    cy.get(virtOverview.permissionsCard)
+      .should('exist')
+      .within(() => {
+        cy.get(virtOverview.cardTitle)
+          .contains('Permissions')
+          .should('exist');
+        cy.get(virtOverview.successIcon).should('exist');
+        cy.get(virtOverview.accessPopupButton)
+          .should('exist')
+          .click();
+      });
+    cy.get(virtOverview.modalTitle)
+      .contains('Permissions')
+      .should('exist');
+    cy.get(virtOverview.taskItem).should('have.length', 6);
+    cy.get(virtOverview.taskIcon).should('have.length', 6);
+    cy.get(virtOverview.closeButton)
+      .should('exist')
+      .click();
+  });
+
+  it('ID(CNV-7934) Top consumers card with items is displayed', () => {
+    cy.get(virtOverview.topConsumersCard)
+      .should('exist')
+      .within(() => {
+        cy.get(virtOverview.cardTitle)
+          .contains('Top consumers')
+          .should('exist');
+        cy.get(virtOverview.cardActions).should('exist');
+        cy.get(virtOverview.amountButton).should('exist');
+      });
+  });
+});

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/utils/const/index.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/utils/const/index.ts
@@ -232,3 +232,5 @@ export const TEMPLATE = {
     exampleRegUrl: urls.FEDORA_EXAMPLE_CONTAINER,
   },
 };
+
+export const adminOnlyDescribe = Cypress.env('NON_PRIV') ? xdescribe : describe;

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/views/virtualization-overview.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/views/virtualization-overview.ts
@@ -1,9 +1,59 @@
 // Getting started card
 export const gettingStartedCard = '[data-test="getting-started"]';
+export const gettingStartedTitle = '[data-test="title"]';
 export const quickStartCard = '[data-test="card quick-start"]';
+// export const installOperatorButton = '[data-test="item explore-pipelines"]';
+// export const installOperatorSidebar = '[data-test="quickstart drawer"]';
+export const closeButton = '[aria-label^="Close"]';
+export const startButton = '[data-test="Start button"]';
+// export const quickStartLink = '[data-test="item all-quick-starts"]';
 export const featureHighlightsCard = '[data-test="card feature-highlights"]';
+// export const installVMLink = '[data-test="item item1"]';
+// export const highlightsLink = '[data-test="item item2"]';
+// export const blogLink = '[data-test="item openshift-virtualization-feature-highlights"]';
 export const recommendedOperatorsCard = '[data-test="card recommended-operators"]';
-
+// export const storageLink = '[data-test="item openshift-virtualization-ocs"]';
+// export const migrationLink = '[data-test="item openshift-virtualization-mtv"]';
+// export const learnLink = '[data-test="item openshift-virtualization-recommended-operators"]';
 export const hideGettingStartedCardKebab = 'button[data-test="actions"]';
 export const hideGettingStartedCardTooltip = 'button[data-test="hide"]';
 export const restoreGettingStartedBtn = '[data-test="restore-getting-started"]';
+// common elements
+export const cardTitle = '.pf-c-card__title';
+export const cardActions = '.co-overview-card__actions';
+export const itemTitle = '[data-test="detail-item-title"]';
+export const itemValue = '[data-test="detail-item-value"]';
+export const popUp = '.pf-c-popover';
+export const alertsList = '.co-status-card__alerts-body';
+export const successIcon = '[data-test="success-icon"]';
+export const modalTitle = '[data-test-id="modal-title"]';
+// Details card
+export const detailsCard = '[data-test-id="kubevirt-overview-dashboard--details-card"]';
+// Running VMs card
+export const perTemplateCard = '[data-test-id="kv-running-vms-per-template-card"]';
+// Status card
+export const statusCard = '[data-test-id="kv-overview-status-card"]';
+export const virtHealthItem = '[data-item-id="Virtualization-health-item"]';
+export const virtHealthIcon = '[data-test="Virtualization-health-item-icon"]';
+export const netHealthItem = '[data-item-id="Networking-health-item"]';
+export const netHealthIcon = '[data-test="Networking-health-item-icon"]';
+// Inventory card
+export const inventoryCard = '[data-test-id="kv-running-inventory-card"]';
+export const vmsLink = '[data-test="kv-inventory-card--vms"]';
+export const templatesLink = '[data-test="kv-inventory-card--vm-templates"]';
+export const nodesLink = '[data-test="kv-inventory-card--nodes"]';
+export const networksLink = '[data-test="kv-inventory-card--nads"]';
+// Activity card
+export const activityCard = '[data-test-id="kubevirt-activity-card"]';
+export const ongoingTitle = '[data-test="ongoing-title"]';
+export const ongoingActivity = '[data-test="activity"]';
+export const recentActivity = '[data-test="activity-recent-title"]';
+export const pauseButton = '[data-test="events-pause-button"]';
+// Permissions card
+export const permissionsCard = '[data-test-id="kv-overview-permissions-card"]';
+export const accessPopupButton = '#virtualization-overview-permissions-popover-btn';
+export const taskItem = '[data-test="kv-permissions-card-task"]';
+export const taskIcon = '[data-test="kv-permissions-card-icon"]';
+// Top consumers card
+export const topConsumersCard = '[data-test="kv-top-consumers-card"]';
+export const amountButton = '#kv-top-consumers-card-amount-select';


### PR DESCRIPTION
Cypress tests for Virtualization Overview page cards

Epic:  [CNV-8665 - Create a Virtualization overview with statistics and links](https://issues.redhat.com/browse/CNV-8665)
Story:  [CNV-14967 - [qe] Create a virtualization overview page](https://issues.redhat.com/browse/CNV-14967)
Automation bug: [2035602 - add tests for Virtualization Overview page cards ](https://bugzilla.redhat.com/show_bug.cgi?id=2035602)
Polarion doc: [UI Virtualization Overview](https://polarion.engineering.redhat.com/polarion/#/project/CNV/wiki/Management/_UI_Virtualization_Overview)