### PR TITLE
Read from tektonconfig to enable/disable the hub tasks in pipeline builder

### DIFF
--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -306,6 +306,8 @@
   "Pod not found": "Pod not found",
   "TaskRun log": "TaskRun log",
   "{{taskLabel}} details": "{{taskLabel}} details",
+  "TektonConfig": "TektonConfig",
+  "TektonConfigs": "TektonConfigs",
   "Pipeline {{status}}": "Pipeline {{status}}",
   "Pipeline status is {{status}}. View logs.": "Pipeline status is {{status}}. View logs.",
   "Pipeline not started. Start pipeline.": "Pipeline not started. Start pipeline.",

--- a/frontend/packages/pipelines-plugin/src/components/catalog/catalog-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/catalog-utils.ts
@@ -1,4 +1,8 @@
+import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { TektonConfigModel } from '../../models';
 import { TektonHubTask } from '../../types/tektonHub';
+import { TEKTON_HUB_INTEGRATION_KEY } from './const';
 
 export const getClusterPlatform = (): string =>
   `${window.SERVER_FLAGS.GOOS}/${window.SERVER_FLAGS.GOARCH}`;
@@ -6,4 +10,18 @@ export const getClusterPlatform = (): string =>
 export const filterBySupportedPlatforms = (task: TektonHubTask): boolean => {
   const supportedPlatforms = task?.platforms.map((p) => p.name) ?? [];
   return supportedPlatforms.includes(getClusterPlatform());
+};
+
+export const useTektonHubIntegration = () => {
+  const [config, configLoaded, configLoadErr] = useK8sGet<K8sResourceKind>(
+    TektonConfigModel,
+    'config',
+  );
+  if (config && configLoaded && !configLoadErr) {
+    const devconsoleIntegrationEnabled = config.spec?.hub?.params.find(
+      (p) => p.name === TEKTON_HUB_INTEGRATION_KEY,
+    );
+    return devconsoleIntegrationEnabled ? devconsoleIntegrationEnabled.value : true;
+  }
+  return true;
 };

--- a/frontend/packages/pipelines-plugin/src/components/catalog/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/const.ts
@@ -1,2 +1,3 @@
 export const TEKTON_HUB_API_ENDPOINT = 'https://api.hub.tekton.dev';
 export const TEKTON_HUB_ENDPOINT = `https://hub.tekton.dev`;
+export const TEKTON_HUB_INTEGRATION_KEY = 'enable-devconsole-integration';

--- a/frontend/packages/pipelines-plugin/src/components/catalog/providers/useTekonHubTasksProvider.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/providers/useTekonHubTasksProvider.tsx
@@ -8,7 +8,7 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { TaskModel } from '../../../models/pipelines';
 import { TektonHubTask } from '../../../types/tektonHub';
 import { TektonTaskProviders } from '../../pipelines/const';
-import { filterBySupportedPlatforms } from '../catalog-utils';
+import { filterBySupportedPlatforms, useTektonHubIntegration } from '../catalog-utils';
 import { TEKTON_HUB_API_ENDPOINT } from '../const';
 import useApiResponse from '../hooks/useApiResponse';
 
@@ -82,9 +82,11 @@ const useTektonHubTasksProvider: ExtensionHook<CatalogItem[]> = ({
     verb: 'update',
   });
 
+  const integrationEnabled = useTektonHubIntegration();
+
   const [tektonHubTasks, tasksLoaded, tasksError] = useApiResponse<TektonHubTask>(
     `${TEKTON_HUB_API_ENDPOINT}/resources`,
-    canCreateTask && canUpdateTask,
+    canCreateTask && canUpdateTask && integrationEnabled,
   );
 
   React.useMemo(

--- a/frontend/packages/pipelines-plugin/src/models/pipelines.ts
+++ b/frontend/packages/pipelines-plugin/src/models/pipelines.ts
@@ -220,3 +220,20 @@ export const RepositoryModel: K8sKind = {
   badge: BadgeType.DEV,
   color,
 };
+
+export const TektonConfigModel: K8sKind = {
+  apiGroup: 'operator.tekton.dev',
+  apiVersion: 'v1alpha1',
+  label: 'TektonConfig',
+  // t('pipelines-plugin~TektonConfig')
+  labelKey: 'pipelines-plugin~TektonConfig',
+  // t('pipelines-plugin~TektonConfigs')
+  labelPluralKey: 'pipelines-plugin~TektonConfigs',
+  plural: 'tektonconfigs',
+  abbr: 'TC',
+  namespaced: false,
+  kind: 'TektonConfig',
+  id: 'tektonconfig',
+  labelPlural: 'TektonConfigs',
+  crd: true,
+};

--- a/frontend/packages/pipelines-plugin/src/test-data/tekon-config-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/tekon-config-data.ts
@@ -1,0 +1,130 @@
+import { K8sResourceKind } from 'public/module/k8s';
+import { TEKTON_HUB_INTEGRATION_KEY } from '../components/catalog/const';
+
+export enum IntegrationTypes {
+  ENABLED = 'enabled',
+  DISABLED = 'disabled',
+  MISSING_INTEGRATION_KEY = 'missing-integration-key',
+}
+
+type TekonHubIntegrationConfigs = { [key in IntegrationTypes]?: K8sResourceKind };
+
+const sampleTektonConfig = {
+  apiVersion: 'operator.tekton.dev/v1alpha1',
+  kind: 'TektonConfig',
+  metadata: {
+    creationTimestamp: '2022-01-04T05:13:42Z',
+    finalizers: ['tektonconfigs.operator.tekton.dev'],
+    name: 'config',
+    resourceVersion: '97919',
+    uid: '3f5045e0-44b5-4a50-8ba8-1e55e9f953d0',
+  },
+  spec: {
+    addon: {
+      params: [
+        {
+          name: 'clusterTasks',
+          value: 'true',
+        },
+        {
+          name: 'pipelineTemplates',
+          value: 'true',
+        },
+      ],
+    },
+    pipeline: {
+      'running-in-environment-with-injected-sidecars': true,
+      'metrics.taskrun.duration-type': 'histogram',
+      'disable-home-env-overwrite': true,
+      'metrics.pipelinerun.duration-type': 'histogram',
+      params: [
+        {
+          name: 'enableMetrics',
+          value: 'true',
+        },
+      ],
+      'default-service-account': 'pipeline',
+      'disable-working-directory-overwrite': true,
+      'scope-when-expressions-to-task': false,
+      'require-git-ssh-secret-known-hosts': false,
+      'enable-tekton-oci-bundles': false,
+      'metrics.taskrun.level': 'task',
+      'metrics.pipelinerun.level': 'pipeline',
+      'enable-api-fields': 'stable',
+      'enable-custom-tasks': false,
+      'disable-creds-init': false,
+      'disable-affinity-assistant': true,
+    },
+    config: {},
+    params: [
+      {
+        name: 'createRbacResource',
+        value: 'true',
+      },
+    ],
+    pruner: {
+      keep: 100,
+      resources: ['pipelinerun'],
+      schedule: '0 8 * * *',
+    },
+    profile: 'all',
+    targetNamespace: 'openshift-pipelines',
+    dashboard: {
+      readonly: false,
+    },
+    trigger: {
+      'default-service-account': 'pipeline',
+      'enable-api-fields': 'stable',
+    },
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2022-01-04T05:15:04Z',
+        status: 'True',
+        type: 'ComponentsReady',
+      },
+      {
+        lastTransitionTime: '2022-01-04T05:15:54Z',
+        status: 'True',
+        type: 'PostInstall',
+      },
+      {
+        lastTransitionTime: '2022-01-04T05:13:54Z',
+        status: 'True',
+        type: 'PreInstall',
+      },
+      {
+        lastTransitionTime: '2022-01-04T05:15:54Z',
+        status: 'True',
+        type: 'Ready',
+      },
+    ],
+    tektonInstallerSets: {
+      'rhosp-rbac': 'rbac-resources',
+    },
+    version: 'v1.6.1',
+  },
+};
+
+export const tektonHubIntegrationConfigs: TekonHubIntegrationConfigs = {
+  [IntegrationTypes.MISSING_INTEGRATION_KEY]: sampleTektonConfig,
+  [IntegrationTypes.ENABLED]: {
+    ...sampleTektonConfig,
+    spec: {
+      ...sampleTektonConfig.spec,
+      hub: {
+        params: [{ name: TEKTON_HUB_INTEGRATION_KEY, value: true }],
+      },
+    },
+  },
+  [IntegrationTypes.DISABLED]: {
+    ...sampleTektonConfig,
+    spec: {
+      ...sampleTektonConfig.spec,
+      hub: {
+        params: [{ name: TEKTON_HUB_INTEGRATION_KEY, value: false }],
+      },
+    },
+  },
+};


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6433

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
As a Admin, you can opt out the tektonhub integration and have only ClusterTasks and Namespace Tasks in the pipeline builder.



**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Reading from the tektonConfig CR (config) to enable/disable the tekton hub tasks in the pipeline builde


**Unit test coverage report**: 
<!-- Attach test coverage report -->
![Screenshot 2022-01-04 at 4 38 52 PM](https://user-images.githubusercontent.com/9964343/148050403-39fc7298-f5ad-49b0-bc83-529a025a1422.png)


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

This **cannot be verified in the cluster** as we don't have the backend changes merged yet in the operator. 
In order to test this in the localhost we need to set window variables in the browser console

To see the hub tasks:

1. Goto Pipelines list page and open the browser console and set the following server fags
  ```
        window.SERVER_FLAGS.GOOS = "linux";
        window.SERVER_FLAGS.GOARCH = "amd64";
  ```
2. Click on create pipeline and in Add Task you should see the hub tasks enabled.

To hide the hub tasks:

1. Add the following code in the catalog-utils.ts, line number 21
```
config.spec.hub = {       params: [{ name: 'enable-devconsole-integration', value: false }],     };
```
2. Repeat the steps from previous scenario (To see the hub tasks).


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge