### PR TITLE
Bug 2021205: fix git url change validation

### DIFF
--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -230,17 +230,26 @@ const GitSection: React.FC<GitSectionProps> = ({
         return;
       }
       const detectedGitType = detectGitType(url);
-      const gitType = values.git.showGitType ? values.git.type : detectedGitType;
+      const isUnsureDetectedGitType = detectedGitType === GitTypes.unsure;
       const gitRepoName = formType !== 'sample' && detectGitRepoName(url);
 
       // Updated detectedType only
       if (detectedGitType !== values.git.detectedType) {
-        setFieldValue('git.detectedType', gitType);
+        setFieldValue('git.detectedType', detectedGitType);
       }
-      if (detectedGitType === GitTypes.unsure && !values.git.showGitType) {
+      if (isUnsureDetectedGitType && !values.git.showGitType) {
         setFieldValue('git.showGitType', true);
       }
+
+      if (!isUnsureDetectedGitType && values.git.showGitType) {
+        setFieldValue('git.showGitType', false);
+      }
+
+      const gitType =
+        isUnsureDetectedGitType && values.git.showGitType ? values.git.type : detectedGitType;
+
       if (gitType !== values.git.type) {
+        setFieldTouched('git.type', false, false);
         setFieldValue('git.type', gitType);
       }
 


### PR DESCRIPTION
# Addresses 
https://issues.redhat.com/browse/OCPBUGSM-36949
https://bugzilla.redhat.com/show_bug.cgi

# Issue
Reads `gitType` instead of `detectedGitType`

# Screenshots
![url-change-validation](https://user-images.githubusercontent.com/24852534/148368351-ff6754a0-f31e-48be-a9ae-fd971d49a2a9.gif)


# Tests
no change

# Browser conformance
Chrome / Firefox
