### PR TITLE
Bug 2035409: Change catsrc name as the older is no longer published

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
@@ -23,14 +23,13 @@ describe('Create namespace from install operators', () => {
   const nsName = `${testName}-ns`;
 
   it('creates namespace from operator install page', () => {
-    const operatorSelector = 'advanced-cluster-management-redhat-operators-openshift-marketplace';
+    const operatorSelector = 'businessautomation-operator-redhat-operators-openshift-marketplace';
     cy.log('test namespace creation from dropdown');
     cy.visit(`/operatorhub/ns/${testName}`);
     cy.byTestID(operatorSelector).click();
     cy.byLegacyTestID('operator-install-btn').click({ force: true });
 
     // configure operator install ("^=Create_"" will match "Create_Namespace" and "Create_Project")
-    cy.byTestID('Select a Namespace-radio-input').check();
     cy.byTestID('dropdown-selectbox')
       .click()
       .get('[data-test-dropdown-menu^="Create_"]')


### PR DESCRIPTION
Bandaid fix for a failing olm-e2e test by referencing a catalog image present in the Redhat catalog index as the older one is no longer published.

context: https://github.com/operator-framework/operator-marketplace/pull/456#issuecomment-1000565909