### PR TITLE
Bug 2035704: RoleBindings list page filter doesn't apply

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -332,7 +332,7 @@ export const RoleBindingsPage = ({
         type: 'role-binding-kind',
         reducer: bindingType,
         filter: (filter, binding) =>
-          filter.selected?.includes(bindingType(binding)) || !filter.selected?.size,
+          filter.selected?.includes(bindingType(binding)) || !filter.selected?.length,
         items: hasCRBindings
           ? [
               {

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -317,8 +317,7 @@ export const RoleBindingsPage = ({
 
   const data = React.useMemo(() => flatten(resources), [resources]);
 
-  // Show table if at least a RBAC loaded property is true
-  const loaded = Object.values(resources).some((r) => r.loaded);
+  const loaded = Object.values(resources).every((r) => r.loaded);
 
   const hasCRBindings =
     resources.ClusterRoleBinding.data?.length > 0 &&


### PR DESCRIPTION
Fixes [Bug 2035704](https://bugzilla.redhat.com/show_bug.cgi?id=2035704)

Fixes an issue where the filter was not applying when the filter was changed.  (First commit)

In addition, while working on this bug, I identified another bug where if a user selects "Cluster-wide RoleBindings" and then refreshes the page, this filter is not applied to the table.  The second commit fixes this issue.  The solution for this second issue may cause the filter bar to load slightly later than the data.