### PR TITLE
Bug 1999903: Changed This is cdrom boot source checkbox id

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
@@ -392,7 +392,7 @@ export const UploadPVCForm: React.FC<UploadPVCFormProps> = ({
                   onChange={handlePvcSizeTemplate}
                 />
                 <Checkbox
-                  id="golden-os-checkbox-pvc-size-template"
+                  id="golden-os-checkbox-cdrom-boot-source-template"
                   className="kv--create-upload__golden-switch"
                   isChecked={!!mountAsCDROM}
                   data-checked-state={!!mountAsCDROM}


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1999903

**Analysis / Root cause**: 
Same id was used for the 2 checkboxes

**Solution Description**: 
Replaced the id of cdrom boot source

Before:
![cdrom-checkbox-before](https://user-images.githubusercontent.com/14824964/148203898-ce4987a1-63e6-4f8c-b2a0-fedd22f85723.gif)

After:
![cdrom-checkbox-after](https://user-images.githubusercontent.com/14824964/148203920-fbee9684-9a9d-4dcd-9af0-f7662c77c689.gif)
