### PR TITLE
Bug 2009754: Fix sticky footer in the import forms

### DIFF
--- a/frontend/packages/dev-console/src/components/NamespacedPage.scss
+++ b/frontend/packages/dev-console/src/components/NamespacedPage.scss
@@ -9,7 +9,6 @@
     flex: 1;
     flex-direction: column;
     background-color: var(--pf-global--Color--light-200);
-    overflow-y: auto;
     position: relative;
 
     &.is-light {


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGSM-35735

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Import forms are no longer sticky.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Overflow property in the namespaced page styles causes to useScrollContainer hook to find incorrect parentNode.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->



https://user-images.githubusercontent.com/9964343/148216532-870b4946-eb03-4510-a2d7-2468d59258cd.mov


https://user-images.githubusercontent.com/9964343/148216604-51c0456b-1dad-43aa-a802-4bd6a8a15668.mov


https://user-images.githubusercontent.com/9964343/148216692-1f5b20ff-607b-4e94-8495-1496eefd8256.mov



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc: @jerolimov 
/kind bug
