### PR TITLE
Bug 2035910: Show manual approval options

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
@@ -125,25 +125,24 @@ const InstallNeedsApprovalMessage: React.FC<InstallNeedsApprovalMessageProps> = 
       </h2>
       <ActionGroup className="pf-c-form pf-c-form__group--no-top-margin">
         <InstallPlanReview installPlan={installObj} />
-        {(installObjIsInstallPlan && canPatchInstallPlans) ||
-          (!installObjIsInstallPlan && (
-            <>
-              <Button variant="primary" onClick={approve}>
-                {t('olm~Approve')}
+        {((installObjIsInstallPlan && canPatchInstallPlans) || !installObjIsInstallPlan) && (
+          <>
+            <Button variant="primary" onClick={approve}>
+              {t('olm~Approve')}
+            </Button>
+            <Link
+              to={`${resourcePathFromModel(
+                SubscriptionModel,
+                subscriptionObj?.metadata?.name,
+                namespace,
+              )}?showDelete=true`}
+            >
+              <Button className="co-clusterserviceversion__button" variant="secondary">
+                {t('olm~Deny')}
               </Button>
-              <Link
-                to={`${resourcePathFromModel(
-                  SubscriptionModel,
-                  subscriptionObj?.metadata?.name,
-                  namespace,
-                )}?showDelete=true`}
-              >
-                <Button className="co-clusterserviceversion__button" variant="secondary">
-                  {t('olm~Deny')}
-                </Button>
-              </Link>
-            </>
-          ))}
+            </Link>
+          </>
+        )}
         {!canPatchInstallPlans && installObjIsInstallPlan && (
           <NeedInstallPlanPermissions installPlan={installObj as InstallPlanKind} />
         )}


### PR DESCRIPTION
It looks we had some parentheses in the wrong places. The buttons should appear now.

<img width="611" alt="Screen Shot 2022-01-05 at 12 04 55 PM" src="https://user-images.githubusercontent.com/7014965/148258592-afbdad2c-1074-4503-9f7c-db73b474125d.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2035910.