### PR TITLE
Bug 2006067: Handle blank usernames in error message

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -141,6 +141,7 @@
   "InstallPlans": "InstallPlans",
   "Missing sufficient privileges for manual InstallPlan approval": "Missing sufficient privileges for manual InstallPlan approval",
   "User \"{{user}}\" does not have permissions to patch resource InstallPlans in API group \"{{apiGroup}}\" in the namespace \"{{namespace}}.\"": "User \"{{user}}\" does not have permissions to patch resource InstallPlans in API group \"{{apiGroup}}\" in the namespace \"{{namespace}}.\"",
+  "User does not have permissions to patch resource InstallPlans in API group \"{{apiGroup}}\" in the namespace \"{{namespace}}.\"": "User does not have permissions to patch resource InstallPlans in API group \"{{apiGroup}}\" in the namespace \"{{namespace}}.\"",
   "Review manual InstallPlan": "Review manual InstallPlan",
   "Inspect the requirements for the components specified in this InstallPlan before approving.": "Inspect the requirements for the components specified in this InstallPlan before approving.",
   "Preview InstallPlan": "Preview InstallPlan",


### PR DESCRIPTION
It looks like the underlying infrastructure for getting the username changed, so we were getting a blank username. I updated us to the latest and the username is now showing up again.

We were also not properly handling blank usernames in the error message. I added a separate message for this case.

<img width="1096" alt="Screen Shot 2022-01-05 at 2 33 16 PM" src="https://user-images.githubusercontent.com/7014965/148277731-225b5ea4-f051-4116-a526-27c5d0cc5b9d.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2006067.