### PR TITLE
Bug 2037801: disabled serverless specs as serverless operator is not available in the operatorhub

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -47,7 +47,8 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-dev-console-headless
   yarn run test-cypress-olm-headless
   yarn run test-cypress-helm-headless
-  yarn run test-cypress-knative-headless
+  # disabled serverless as serverless operator is not availavle in operatorhub
+  # yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
   exit;
 fi


### PR DESCRIPTION
**Fixes:**

https://bugzilla.redhat.com/show_bug.cgi?id=2037801