### PR TITLE
Migrate ResourceIcon to the SDK

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -71,13 +71,17 @@ export const useListPageFilter: UseListPageFilter = require('@console/internal/c
   .useListPageFilter;
 export const ResourceLink: React.FC<ResourceLinkProps> = require('@console/internal/components/utils/resource-link')
   .ResourceLink;
-export { default as ResourceStatus } from '../app/components/utils/resource-status';
-
 export {
   checkAccess,
   useAccessReview,
   useAccessReviewAllowed,
 } from '@console/dynamic-plugin-sdk/src/app/components/utils/rbac';
+
+export { default as ResourceStatus } from '@console/dynamic-plugin-sdk/src/app/components/utils/resource-status';
+export {
+  ResourceIcon,
+  ResourceIconProps,
+} from '@console/dynamic-plugin-sdk/src/app/components/utils/resource-icon';
 
 export {
   useK8sModel,
@@ -86,11 +90,7 @@ export {
   useK8sWatchResources,
 } from '../utils/k8s/hooks';
 
-export {
-  consoleFetch,
-  consoleFetchJSON,
-  consoleFetchText,
-} from '../utils/fetch';
+export { consoleFetch, consoleFetchJSON, consoleFetchText } from '../utils/fetch';
 
 // Expose K8s CRUD utilities as below
 export {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/index.ts
@@ -5,6 +5,7 @@ export { default as PopoverStatus } from './status/PopoverStatus';
 export { default as StatusComponent } from './status/Status';
 export { default as StatusIconAndText } from './status/StatusIconAndText';
 export { default as ResourceStatus } from './utils/resource-status';
+export { ResourceIcon, ResourceIconProps } from './utils/resource-icon';
 
 export * from './status/icons';
 export * from './status/statuses';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/utils/resource-icon.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/utils/resource-icon.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import * as _ from 'lodash';
+
+import { getReference, kindToAbbr } from '../../../utils/k8s';
+import { K8sGroupVersionKind, K8sResourceKindReference } from '../../../extensions/console-types';
+import { modelFor } from '../../module/k8s/k8s-models'; // ??! - TO DO -resolve this dependency
+
+export type ResourceIconProps = {
+  className?: string;
+  /** @deprecated Use groupVersionKind instead. The kind property will be removed in a future release. */
+  kind?: K8sResourceKindReference;
+  groupVersionKind?: K8sGroupVersionKind;
+};
+
+const MEMO = {};
+
+export const ResourceIcon: React.SFC<ResourceIconProps> = ({
+  className,
+  groupVersionKind,
+  kind,
+}) => {
+  // if no kind or groupVersionKind, return null so an empty icon isn't rendered
+  if (!kind && !groupVersionKind) {
+    return null;
+  }
+  const kindReference = kind || getReference(groupVersionKind);
+  const memoKey = className ? `${kindReference}/${className}` : kindReference;
+  if (MEMO[memoKey]) {
+    return MEMO[memoKey];
+  }
+  const kindObj = modelFor(kindReference);
+  const kindStr = kindObj?.kind ?? kindReference;
+  const backgroundColor = _.get(kindObj, 'color', undefined);
+  const klass = classNames(`co-m-resource-icon co-m-resource-${kindStr.toLowerCase()}`, className);
+  const iconLabel = (kindObj && kindObj.abbr) || kindToAbbr(kindStr);
+
+  const rendered = (
+    <>
+      <span className="sr-only">{kindStr}</span>
+      <span className={klass} title={kindStr} style={{ backgroundColor }}>
+        {iconLabel}
+      </span>
+    </>
+  );
+  if (kindObj) {
+    MEMO[memoKey] = rendered;
+  }
+
+  return rendered;
+};
+
+export default ResourceIcon;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/index.ts
@@ -1,3 +1,4 @@
+export * from './k8s-get-resource';
 export * from './k8s-resource';
 export * from './k8s-utils';
 export * from './k8s-ref';

--- a/frontend/public/components/utils/resource-icon.tsx
+++ b/frontend/public/components/utils/resource-icon.tsx
@@ -1,55 +1,9 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
+import { K8sResourceKindReference } from '../../module/k8s';
+import { ResourceIcon } from '@console/dynamic-plugin-sdk';
 
-import { getReference } from '@console/dynamic-plugin-sdk/src/utils/k8s';
-import { K8sGroupVersionKind, K8sResourceKindReference } from '../../module/k8s';
-import { modelFor } from '../../module/k8s/k8s-models';
-import { kindToAbbr } from '../../module/k8s/get-resources';
-
-const MEMO = {};
-
-export const ResourceIcon: React.SFC<ResourceIconProps> = ({
-  className,
-  groupVersionKind,
-  kind,
-}) => {
-  // if no kind or groupVersionKind, return null so an empty icon isn't rendered
-  if (!kind && !groupVersionKind) {
-    return null;
-  }
-  const kindReference = kind || getReference(groupVersionKind);
-  const memoKey = className ? `${kindReference}/${className}` : kindReference;
-  if (MEMO[memoKey]) {
-    return MEMO[memoKey];
-  }
-  const kindObj = modelFor(kindReference);
-  const kindStr = kindObj?.kind ?? kindReference;
-  const backgroundColor = _.get(kindObj, 'color', undefined);
-  const klass = classNames(`co-m-resource-icon co-m-resource-${kindStr.toLowerCase()}`, className);
-  const iconLabel = (kindObj && kindObj.abbr) || kindToAbbr(kindStr);
-
-  const rendered = (
-    <>
-      <span className="sr-only">{kindStr}</span>
-      <span className={klass} title={kindStr} style={{ backgroundColor }}>
-        {iconLabel}
-      </span>
-    </>
-  );
-  if (kindObj) {
-    MEMO[memoKey] = rendered;
-  }
-
-  return rendered;
-};
-
-export type ResourceIconProps = {
-  className?: string;
-  /** @deprecated Use groupVersionKind instead. The kind property will be removed in a future release. */
-  kind?: K8sResourceKindReference;
-  groupVersionKind?: K8sGroupVersionKind;
-};
+export { ResourceIcon, ResourceIconProps } from '@console/dynamic-plugin-sdk';
 
 export type ResourceNameProps = {
   kind: K8sResourceKindReference;


### PR DESCRIPTION
Migrate ResourceIcon component to the SDK as a part of ListPage migration effort
https://issues.redhat.com/browse/HAC-311

Waiting for `modelFor` dependency resolution
@florkbr 