### PR TITLE
Bug 2025431: Provide specific windows source link

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/utils/const/index.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/utils/const/index.ts
@@ -192,7 +192,7 @@ export const TEMPLATE = {
     metadataName: 'windows10-desktop-medium',
     os: 'Microsoft Windows 10',
     supportLevel: 'Full',
-    exampleImgUrl: urls.WINDOWS_IMAGE_LINK,
+    exampleImgUrl: urls.WINDOWS_IMAGE_LINKS.win10,
     exampleRegUrl: '',
   },
   WIN2K12R2: {
@@ -201,7 +201,7 @@ export const TEMPLATE = {
     metadataName: 'windows2k12r2-server-medium',
     os: 'Microsoft Windows Server 2012 R2',
     supportLevel: 'Full',
-    exampleImgUrl: urls.WINDOWS_IMAGE_LINK,
+    exampleImgUrl: urls.WINDOWS_IMAGE_LINKS.win2k12r2,
     exampleRegUrl: '',
   },
   WIN2K16: {
@@ -210,7 +210,7 @@ export const TEMPLATE = {
     metadataName: 'windows2k16-server-medium',
     os: 'Microsoft Windows Server 2016',
     supportLevel: 'Full',
-    exampleImgUrl: urls.WINDOWS_IMAGE_LINK,
+    exampleImgUrl: urls.WINDOWS_IMAGE_LINKS.win2k16,
     exampleRegUrl: '',
   },
   WIN2K19: {
@@ -219,7 +219,7 @@ export const TEMPLATE = {
     metadataName: 'windows2k19-server-medium',
     os: 'Microsoft Windows Server 2019',
     supportLevel: 'Full',
-    exampleImgUrl: urls.WINDOWS_IMAGE_LINK,
+    exampleImgUrl: urls.WINDOWS_IMAGE_LINKS.win2k19,
     exampleRegUrl: '',
   },
   DEFAULT: {

--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -429,7 +429,7 @@
   "Error: {{ rawErrorMessage }}": "Error: {{ rawErrorMessage }}",
   "Example: {{container}}": "Example: {{container}}",
   "Example: For RHEL, visit the <2><0>RHEL download page</0></2> (requires login) and copy the download link URL of the KVM guest image (expires quickly)": "Example: For RHEL, visit the <2><0>RHEL download page</0></2> (requires login) and copy the download link URL of the KVM guest image (expires quickly)",
-  "Example: For Windows, get a link to the <2><0>installation iso of Windows 10</0></2> and copy the download link URL": "Example: For Windows, get a link to the <2><0>installation iso of Windows 10</0></2> and copy the download link URL",
+  "Example: For Windows, get a link to the <2><0>installation iso of {windowsTemplateName}</0></2> and copy the download link URL": "Example: For Windows, get a link to the <2><0>installation iso of {windowsTemplateName}</0></2> and copy the download link URL",
   "Example: For CentOS, visit the <2><0>CentOS cloud image list</0></2> and copy the download link URL for the cloud base image": "Example: For CentOS, visit the <2><0>CentOS cloud image list</0></2> and copy the download link URL for the cloud base image",
   "Example: For Fedora, visit the <2><0>Fedora cloud image list</0></2> and copy the download link URL for the cloud base image": "Example: For Fedora, visit the <2><0>Fedora cloud image list</0></2> and copy the download link URL for the cloud base image",
   "Selected {{name}} is not available": "Selected {{name}} is not available",

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form.tsx
@@ -208,6 +208,7 @@ const AdvancedSection: React.FC<AdvancedSectionProps> = ({
 type BootSourceFormProps = AdvancedSectionProps & {
   withUpload?: boolean;
   baseImageName?: string;
+  templateName?: string;
 };
 
 export const BootSourceForm: React.FC<BootSourceFormProps> = ({
@@ -220,6 +221,7 @@ export const BootSourceForm: React.FC<BootSourceFormProps> = ({
   storageClassesLoaded,
   scAllowed,
   scAllowedLoading,
+  templateName,
 }) => {
   const { t } = useTranslation();
 
@@ -288,7 +290,7 @@ export const BootSourceForm: React.FC<BootSourceFormProps> = ({
             isDisabled={disabled}
             id={getFieldId(VMSettingsField.IMAGE_URL)}
           />
-          <URLSourceHelp baseImageName={baseImageName} />
+          <URLSourceHelp baseImageName={baseImageName} templateName={templateName} />
         </FormRow>
       )}
       {state.dataSource?.value === ProvisionSource.CONTAINER.getValue() && (

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/boot-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/boot-source.tsx
@@ -66,6 +66,7 @@ export const BootSource: React.FC<BootSourceProps> = ({ template, state, dispatc
               scAllowed={scAllowed}
               scAllowedLoading={scAllowedLoading}
               baseImageName={baseImageName}
+              templateName={name}
             />
           </GridItem>
         </Grid>

--- a/frontend/packages/kubevirt-plugin/src/components/form/helper/url-source-help.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/form/helper/url-source-help.tsx
@@ -4,15 +4,17 @@ import {
   CENTOS_IMAGE_LINK,
   FEDORA_IMAGE_LINK,
   RHEL_IMAGE_LINK,
-  WINDOWS_IMAGE_LINK,
+  WINDOWS_IMAGE_LINKS,
 } from '../../../utils/strings';
 
 type URLSourceHelpProps = {
   baseImageName: string;
+  templateName?: string;
 };
 
-export const URLSourceHelp: React.FC<URLSourceHelpProps> = ({ baseImageName }) => {
+export const URLSourceHelp: React.FC<URLSourceHelpProps> = ({ baseImageName, templateName }) => {
   const { t } = useTranslation();
+  const windowsTemplateName = templateName?.replace(/ VM/g, '') || 'Microsoft Windows 10';
   // checking os is RHEL/Windows and adjust link images accordingly, Fedora is default for all other OS.
   const body = baseImageName?.includes('rhel') ? (
     <Trans t={t} ns="kubevirt-plugin">
@@ -28,8 +30,12 @@ export const URLSourceHelp: React.FC<URLSourceHelpProps> = ({ baseImageName }) =
     <Trans t={t} ns="kubevirt-plugin">
       Example: For Windows, get a link to the{' '}
       <strong>
-        <a href={WINDOWS_IMAGE_LINK} rel="noopener noreferrer" target="_blank">
-          installation iso of Windows 10
+        <a
+          href={WINDOWS_IMAGE_LINKS[baseImageName] || WINDOWS_IMAGE_LINKS.win10}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          installation iso of {windowsTemplateName}
         </a>
       </strong>{' '}
       and copy the download link URL

--- a/frontend/packages/kubevirt-plugin/src/utils/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/strings.ts
@@ -30,7 +30,6 @@ export const CENTOS7_EXAMPLE_CONTAINER = 'quay.io/kubevirt/centos7-container-dis
 export const CENTOS_IMAGE_LINK = 'https://cloud.centos.org/centos/';
 export const FEDORA_IMAGE_LINK = 'https://alt.fedoraproject.org/cloud/';
 export const RHEL_IMAGE_LINK = 'https://access.redhat.com/downloads/content/479/ver=/rhel---8/';
-export const WINDOWS_IMAGE_LINK = 'https://www.microsoft.com/en-us/software-download/windows10ISO';
 export const CLOUD_INIT_MISSING_USERNAME =
   'No username set, see operating system documentation for the default username.';
 export const CLOUD_INIT_DOC_LINK = 'https://cloudinit.readthedocs.io/en/latest/index.html';
@@ -45,3 +44,11 @@ export const NODE_PORTS_LINK =
 
 export const PREALLOCATION_DATA_VOLUME_LINK =
   'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/virtualization/virtual-machines#virt-using-preallocation-for-datavolumes';
+
+export const WINDOWS_IMAGE_LINKS = {
+  win10: 'https://www.microsoft.com/en-us/software-download/windows10ISO',
+  win2k16: 'https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2016?filetype=ISO',
+  win2k12r2:
+    'https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2012-r2?filetype=ISO',
+  win2k19: 'https://www.microsoft.com/en-US/evalcenter/evaluate-windows-server-2019?filetype=ISO',
+};


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2025431

**Solution Description**:
Provide a more specific link to the installation iso of Windows, for Windows 2012r2, 2016 and 2019 (not only for Windows 10 as before), in the "Example" of the _Boot source_ step of the Create VM wizard, with respect to the chosen VM template.

**Screen shots / Gifs for design review:**
Before:
![before](https://user-images.githubusercontent.com/13417815/148583495-89db6e7d-2d72-4b3f-8401-9263379d3fc3.png)

After:
![after](https://user-images.githubusercontent.com/13417815/148583512-c172d902-8868-4724-901a-bb14cd759a43.png)
