### PR TITLE
Bug 2015420: Update SupportedExtension to include all dashboard extensions

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-resolver.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-resolver.spec.ts
@@ -308,6 +308,40 @@ describe('resolveExtension', () => {
     });
   });
 
+  it('logs a warning if the referenced object resolves to null or undefined', async () => {
+    const extensions: Extension[] = [
+      {
+        type: 'Foo',
+        properties: {
+          test: true,
+          qux: getExecutableCodeRefMock(null),
+        },
+      },
+      {
+        type: 'Bar',
+        properties: {
+          test: [1],
+          baz: { test: getExecutableCodeRefMock(undefined) },
+        },
+      },
+    ];
+
+    expect((await resolveExtension(extensions[0])).properties).toHaveProperty('qux', null);
+
+    expect(consoleMock).toHaveBeenLastCalledWith(
+      "Code reference property 'qux' resolved to null or undefined",
+    );
+
+    expect((await resolveExtension(extensions[1])).properties).toHaveProperty(
+      'baz.test',
+      undefined,
+    );
+
+    expect(consoleMock).toHaveBeenLastCalledWith(
+      "Code reference property 'test' resolved to null or undefined",
+    );
+  });
+
   it('returns the same extension instance', async () => {
     const extensions: Extension[] = [
       {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/coderef-resolver.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/coderef-resolver.ts
@@ -130,6 +130,10 @@ export const resolveExtension = async <
       ref()
         .then((resolvedValue) => {
           obj[key] = resolvedValue;
+
+          if (_.isNil(resolvedValue)) {
+            console.warn(`Code reference property '${key}' resolved to null or undefined`);
+          }
         })
         .catch((e) => {
           setCodeRefError(ref, e ?? true);

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/dashboards.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/dashboards.ts
@@ -167,7 +167,7 @@ export type DashboardsOverviewInventoryItemReplacement<
 >;
 
 /** Adds a resource tile to the project overview inventory card. */
-export type ProjectDashboardInventoryItem<
+export type DashboardsProjectOverviewInventoryItem<
   T extends K8sModel = K8sModel,
   R extends { [key: string]: K8sResourceCommon[] } = { [key: string]: K8sResourceCommon[] }
 > = ExtensionDeclaration<
@@ -264,7 +264,9 @@ export const isDashboardsOverviewInventoryItemReplacement = (
 ): e is DashboardsOverviewInventoryItemReplacement =>
   e.type === 'console.dashboards/overview/inventory/item/replacement';
 
-export const isProjectDashboardInventoryItem = (e: Extension): e is ProjectDashboardInventoryItem =>
+export const isDashboardsProjectOverviewInventoryItem = (
+  e: Extension,
+): e is DashboardsProjectOverviewInventoryItem =>
   e.type === 'console.dashboards/project/overview/item';
 
 export const isDashboardsOverviewResourceActivity = (

--- a/frontend/packages/console-dynamic-plugin-sdk/src/schema/console-extensions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/schema/console-extensions.ts
@@ -18,7 +18,10 @@ import {
   DashboardsOverviewHealthOperator,
   DashboardsInventoryItemGroup,
   DashboardsOverviewInventoryItem,
+  DashboardsOverviewInventoryItemReplacement,
+  DashboardsProjectOverviewInventoryItem,
   DashboardsOverviewResourceActivity,
+  DashboardsOverviewPrometheusActivity,
 } from '../extensions/dashboards';
 import { FeatureFlag, ModelFeatureFlag } from '../extensions/feature-flags';
 import { FileUpload } from '../extensions/file-upload';
@@ -97,7 +100,10 @@ export type SupportedExtension =
   | DashboardsOverviewHealthOperator
   | DashboardsInventoryItemGroup
   | DashboardsOverviewInventoryItem
+  | DashboardsOverviewInventoryItemReplacement
+  | DashboardsProjectOverviewInventoryItem
   | DashboardsOverviewResourceActivity
+  | DashboardsOverviewPrometheusActivity
   | TopologyComponentFactory
   | TopologyCreateConnector
   | TopologyDataModelFactory

--- a/frontend/public/components/dashboard/project-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/inventory-card.tsx
@@ -35,8 +35,8 @@ import {
 } from '@console/plugin-sdk';
 import {
   useResolvedExtensions,
-  ProjectDashboardInventoryItem as DynamicProjectDashboardInventoryItem,
-  isProjectDashboardInventoryItem as isDynamicProjectDashboardInventoryItem,
+  DashboardsProjectOverviewInventoryItem as DynamicProjectDashboardInventoryItem,
+  isDashboardsProjectOverviewInventoryItem as isDynamicProjectDashboardInventoryItem,
   K8sResourceCommon,
   WatchK8sResources,
 } from '@console/dynamic-plugin-sdk';


### PR DESCRIPTION
- rename `ProjectDashboardInventoryItem` :arrow_right: `DashboardsProjectOverviewInventoryItem` for consistency
- ensure that `SupportedExtension` type union includes all dashboard extensions
- update `InventoryCard` component
- update CodeRef resolver - warn if the referenced object resolves to `null` or `undefined`