### PR TITLE
Bug 2030305: Fix that primer export download toast was not shown

### DIFF
--- a/frontend/packages/topology/src/components/export-app/ExportApplication.tsx
+++ b/frontend/packages/topology/src/components/export-app/ExportApplication.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ToolbarItem, Button, AlertVariant } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation, Trans } from 'react-i18next';
+import { getGroupVersionKindForResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';
 import { useAccessReview } from '@console/internal/components/utils';
 import { dateTimeFormatter } from '@console/internal/components/utils/datetime';
 import {
@@ -52,13 +53,14 @@ const ExportApplication: React.FC<ExportApplicationProps> = ({ namespace, isDisa
   const createExportCR = async () => {
     try {
       const exportResp = await createExportResource(getExportAppData(namespace));
-      const key = `${namespace}-${exportResp.metadata.name}`;
+      const { uid, name } = exportResp;
+      const key = `${namespace}-${name}`;
       const exportAppToastConfig = {
         ...exportAppToast,
         [key]: {
-          uid: exportResp.metadata.uid,
-          name: exportResp.metadata.name,
-          kind: exportResp.kind,
+          groupVersionKind: getGroupVersionKindForResource(exportResp),
+          uid,
+          name,
           namespace,
         },
       };

--- a/frontend/packages/topology/src/components/export-app/ExportApplicationModal.tsx
+++ b/frontend/packages/topology/src/components/export-app/ExportApplicationModal.tsx
@@ -11,6 +11,7 @@ import {
 import ExportViewLogButton from './ExportViewLogButton';
 
 export type ExportApplicationModalProps = ModalComponentProps & {
+  name: string;
   namespace: string;
   startTime?: string;
   onCancelExport?: () => Promise<boolean>;
@@ -19,7 +20,7 @@ export type ExportApplicationModalProps = ModalComponentProps & {
 
 export const ExportApplicationModal: React.FC<ExportApplicationModalProps> = (props) => {
   const { t } = useTranslation();
-  const { cancel, namespace, startTime, onCancelExport, onRestartExport } = props;
+  const { cancel, name, namespace, startTime, onCancelExport, onRestartExport } = props;
   const [errMessage, setErrMessage] = React.useState<string>('');
 
   const onCancel = async () => {
@@ -83,7 +84,7 @@ export const ExportApplicationModal: React.FC<ExportApplicationModalProps> = (pr
             </FlexItem>
           )}
           <FlexItem>
-            <ExportViewLogButton namespace={namespace} onViewLog={cancel} />
+            <ExportViewLogButton name={name} namespace={namespace} onViewLog={cancel} />
           </FlexItem>
           <FlexItem>
             <Button type="button" variant="primary" data-test="export-close-btn" onClick={cancel}>

--- a/frontend/packages/topology/src/components/export-app/ExportViewLogButton.tsx
+++ b/frontend/packages/topology/src/components/export-app/ExportViewLogButton.tsx
@@ -6,18 +6,23 @@ import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watc
 import { JobModel, PodModel } from '@console/internal/models';
 import { PodKind, JobKind } from '@console/internal/module/k8s';
 import { isModifiedEvent } from '@console/shared';
-import { EXPORT_JOB_NAME } from '../../const';
+import { EXPORT_JOB_PREFIX } from '../../const';
 
 interface ExportViewLogButtonProps {
+  name: string;
   namespace: string;
   onViewLog?: () => void;
 }
 
-const ExportViewLogButton: React.FC<ExportViewLogButtonProps> = ({ namespace, onViewLog }) => {
+const ExportViewLogButton: React.FC<ExportViewLogButtonProps> = ({
+  name,
+  namespace,
+  onViewLog,
+}) => {
   const { t } = useTranslation();
   const [job, jobLoaded] = useK8sWatchResource<JobKind>({
     kind: JobModel.kind,
-    name: EXPORT_JOB_NAME,
+    name: EXPORT_JOB_PREFIX + name,
     namespace,
     isList: false,
   });

--- a/frontend/packages/topology/src/components/export-app/__tests__/ExportApplication.spec.tsx
+++ b/frontend/packages/topology/src/components/export-app/__tests__/ExportApplication.spec.tsx
@@ -4,7 +4,6 @@ import { act } from 'react-dom/test-utils';
 import * as utils from '@console/internal/components/utils';
 import * as k8s from '@console/internal/module/k8s';
 import * as shared from '@console/shared';
-import { EXPORT_CR_NAME } from '../../../const';
 import { ExportModel } from '../../../models';
 import ExportApplication from '../ExportApplication';
 import { mockExportData } from './export-data';
@@ -70,7 +69,7 @@ describe('ExportApplication', () => {
     });
 
     expect(spyk8sGet).toHaveBeenCalledTimes(1);
-    expect(spyk8sGet).toHaveBeenCalledWith(ExportModel, EXPORT_CR_NAME, 'my-app');
+    expect(spyk8sGet).toHaveBeenCalledWith(ExportModel, 'primer', 'my-app');
     expect(spyk8sKill).toHaveBeenCalledTimes(1);
     expect(spyk8sKill).toHaveBeenCalledWith(ExportModel, mockExportData);
     expect(spyk8sCreate).toHaveBeenCalledTimes(1);

--- a/frontend/packages/topology/src/components/export-app/__tests__/ExportApplicationModal.spec.tsx
+++ b/frontend/packages/topology/src/components/export-app/__tests__/ExportApplicationModal.spec.tsx
@@ -5,7 +5,7 @@ import ExportViewLogButton from '../ExportViewLogButton';
 
 describe('ExportApplicationModal', () => {
   it('should show only one button to close modal', () => {
-    const wrapper = shallow(<ExportApplicationModal namespace="my-app" />);
+    const wrapper = shallow(<ExportApplicationModal name="my-export" namespace="my-app" />);
     expect(wrapper.find('[data-test="export-close-btn"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="export-canel-btn"]').exists()).toBe(false);
     expect(wrapper.find('[data-test="export-restart-btn"]').exists()).toBe(false);
@@ -14,6 +14,7 @@ describe('ExportApplicationModal', () => {
   it('should show buttons to cancel and restart export', () => {
     const wrapper = shallow(
       <ExportApplicationModal
+        name="my-export"
         namespace="my-app"
         onCancelExport={jest.fn()}
         onRestartExport={jest.fn()}
@@ -28,6 +29,7 @@ describe('ExportApplicationModal', () => {
     const onCancelExport = jest.fn();
     const wrapper = shallow(
       <ExportApplicationModal
+        name="my-export"
         namespace="my-app"
         onCancelExport={onCancelExport}
         onRestartExport={jest.fn()}
@@ -41,6 +43,7 @@ describe('ExportApplicationModal', () => {
     const onRestartExport = jest.fn();
     const wrapper = shallow(
       <ExportApplicationModal
+        name="my-export"
         namespace="my-app"
         onCancelExport={jest.fn()}
         onRestartExport={onRestartExport}
@@ -53,6 +56,7 @@ describe('ExportApplicationModal', () => {
   it('should contain view log button and call onViewLog', () => {
     const wrapper = shallow(
       <ExportApplicationModal
+        name="my-export"
         namespace="my-app"
         onCancelExport={jest.fn()}
         onRestartExport={jest.fn()}

--- a/frontend/packages/topology/src/components/export-app/__tests__/ExportViewLogButton.spec.tsx
+++ b/frontend/packages/topology/src/components/export-app/__tests__/ExportViewLogButton.spec.tsx
@@ -50,7 +50,7 @@ describe('ExportViewLogButton', () => {
     // mount required for using provider
     const logButtonWrapper = mount(
       <Provider store={store}>
-        <ExportViewLogButton namespace="test" />
+        <ExportViewLogButton name="test" namespace="test" />
       </Provider>,
     );
     const logButton = logButtonWrapper.find('[data-test="export-view-log-btn"]').find(Button);
@@ -64,7 +64,7 @@ describe('ExportViewLogButton', () => {
     // mount required for using provider
     const logButtonWrapper = mount(
       <Provider store={store}>
-        <ExportViewLogButton namespace="test" onViewLog={viewLogCallback} />
+        <ExportViewLogButton name="test" namespace="test" onViewLog={viewLogCallback} />
       </Provider>,
     );
     const logButton = logButtonWrapper.find('[data-test="export-view-log-btn"]').find(Button);
@@ -76,7 +76,7 @@ describe('ExportViewLogButton', () => {
     // mount required for using provider
     const logButtonWrapper = mount(
       <Provider store={store}>
-        <ExportViewLogButton namespace="test" />
+        <ExportViewLogButton name="test" namespace="test" />
       </Provider>,
     );
     expect(
@@ -113,7 +113,7 @@ describe('ExportViewLogButton', () => {
     // mount required for using provider
     const logButtonWrapper = mount(
       <Provider store={store}>
-        <ExportViewLogButton namespace="test" />
+        <ExportViewLogButton name="test" namespace="test" />
       </Provider>,
     );
     const logButton = logButtonWrapper.find('[data-test="export-view-log-btn"]').find(Button);
@@ -146,7 +146,7 @@ describe('ExportViewLogButton', () => {
     // mount required for using provider
     const logButtonWrapper = mount(
       <Provider store={store}>
-        <ExportViewLogButton namespace="test" />
+        <ExportViewLogButton name="test" namespace="test" />
       </Provider>,
     );
     const logTooltip = logButtonWrapper.find(Tooltip);

--- a/frontend/packages/topology/src/components/export-app/types.ts
+++ b/frontend/packages/topology/src/components/export-app/types.ts
@@ -1,8 +1,10 @@
+import { K8sGroupVersionKind } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
+
 export type ExportAppUserSettings = {
   [key: string]: {
+    groupVersionKind: K8sGroupVersionKind;
     uid: string;
     name: string;
     namespace: string;
-    kind: string;
   };
 };

--- a/frontend/packages/topology/src/const.ts
+++ b/frontend/packages/topology/src/const.ts
@@ -35,7 +35,7 @@ export const UNASSIGNED_KEY = '#UNASSIGNED_APP#';
 
 export const ALLOW_EXPORT_APP = 'ALLOW_EXPORT_APP';
 export const EXPORT_CR_NAME = 'primer';
-export const EXPORT_JOB_NAME = 'primer-export-primer';
+export const EXPORT_JOB_PREFIX = 'primer-export-';
 
 export const ROUTE_URL_ANNOTATION = 'app.openshift.io/route-url';
 export const ROUTE_DISABLED_ANNOTATION = 'app.openshift.io/route-disabled';

--- a/frontend/packages/topology/src/models/gitops-primer.ts
+++ b/frontend/packages/topology/src/models/gitops-primer.ts
@@ -1,6 +1,6 @@
-import { K8sKind } from '@console/internal/module/k8s';
+import { K8sModel } from '@console/dynamic-plugin-sdk/src/api/common-types';
 
-export const ExportModel: K8sKind = {
+export const ExportModel: K8sModel = {
   id: 'export',
   kind: 'Export',
   plural: 'exports',

--- a/frontend/packages/topology/src/utils/__tests__/export-app-utils.spec.ts
+++ b/frontend/packages/topology/src/utils/__tests__/export-app-utils.spec.ts
@@ -1,6 +1,5 @@
 import * as k8s from '@console/internal/module/k8s';
 import { mockExportData } from '../../components/export-app/__tests__/export-data';
-import { EXPORT_CR_NAME } from '../../const';
 import { ExportModel } from '../../models/gitops-primer';
 import {
   createExportResource,
@@ -13,7 +12,7 @@ describe('export-app-utils', () => {
   it('should create export resource', async () => {
     const spyk8sCreate = jest.spyOn(k8s, 'k8sCreate');
     spyk8sCreate.mockReturnValueOnce(Promise.resolve(mockExportData));
-    const createResData = getExportAppData('my-app');
+    const createResData = getExportAppData('my-export', 'my-app');
     const exportRes = await createExportResource(createResData);
     expect(exportRes).toEqual(mockExportData);
     expect(spyk8sCreate).toHaveBeenCalledTimes(1);
@@ -23,10 +22,10 @@ describe('export-app-utils', () => {
   it('should get export resource', async () => {
     const spyk8sGet = jest.spyOn(k8s, 'k8sGet');
     spyk8sGet.mockReturnValueOnce(Promise.resolve(mockExportData));
-    const exportRes = await getExportResource('my-app');
+    const exportRes = await getExportResource('my-export', 'my-app');
     expect(exportRes).toEqual(mockExportData);
     expect(spyk8sGet).toHaveBeenCalledTimes(1);
-    expect(spyk8sGet).toHaveBeenCalledWith(ExportModel, EXPORT_CR_NAME, 'my-app');
+    expect(spyk8sGet).toHaveBeenCalledWith(ExportModel, 'my-export', 'my-app');
   });
 
   it('should kill export resource', async () => {

--- a/frontend/packages/topology/src/utils/export-app-utils.ts
+++ b/frontend/packages/topology/src/utils/export-app-utils.ts
@@ -1,13 +1,12 @@
 import { k8sCreate, k8sGet, k8sKill, K8sResourceKind } from '@console/internal/module/k8s';
-import { EXPORT_CR_NAME } from '../const';
 import { ExportModel } from '../models/gitops-primer';
 
-export const getExportAppData = (namespace: string) => {
+export const getExportAppData = (name: string, namespace: string) => {
   return {
     apiVersion: `${ExportModel.apiGroup}/${ExportModel.apiVersion}`,
     kind: ExportModel.kind,
     metadata: {
-      name: EXPORT_CR_NAME,
+      name,
       namespace,
     },
     spec: {
@@ -18,7 +17,7 @@ export const getExportAppData = (namespace: string) => {
 
 export const createExportResource = (res: K8sResourceKind) => k8sCreate(ExportModel, res);
 
-export const getExportResource = (namespace: string) =>
-  k8sGet(ExportModel, EXPORT_CR_NAME, namespace);
+export const getExportResource = (name: string, namespace: string) =>
+  k8sGet(ExportModel, name, namespace);
 
 export const killExportResource = (res: K8sResourceKind) => k8sKill(ExportModel, res);


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2030305

**Analysis / Root cause**: 
The Exports wasn't found in 4.10 anymore. I don't get the exact reason, while debugging I saw "Export module not found" earlier, but could not reproduce this error now. I believe its related to some dynamic plugin code extraction or load order.

When checking the variables `exportAppWatchResources` and `exportResources` in `export-app-context.ts` you can see the following difference between 4.9 and 4.10:

In 4.9 the watcher when there is a running `Export`:

```js
exportAppWatchResources = {
  "christoph-primer": {
    "kind": "Export",
    "name": "primer",
    "namespace": "christoph",
    "namespaced": true,
    "isList": false,
    "optional": true
  }
}
exportResources = {
  "christoph-primer": {
    "data": {
      "apiVersion": "primer.gitops.io/v1alpha1",
      "kind": "Export",
      "metadata": {
        "creationTimestamp": "2022-01-13T16:12:54Z",
        "generation": 1,
        "managedFields": [], // removed
        "name": "primer",
        "namespace": "christoph",
        "resourceVersion": "44278",
        "uid": "26cccd06-ba00-4cf8-a03d-46b97a75f2df"
      },
      "spec": {
        "method": "download",
        "user": "kubeadmin"
      }
    },
    "loaded": true,
    "loadError": ""
  }
}
```

4.10 doesn't find the `Export` anymore:

```js
exportAppWatchResources = {
  "christoph-primer": {
    "kind": "Export",
    "name": "primer",
    "namespace": "christoph",
    "namespaced": true,
    "isList": false,
    "optional": true
  }
}
exportResources = {
  "christoph-primer": {
    "data": {},
    "loaded": true,
    "loadError": {}
  }
}
```

**Solution Description**: 
The first commit changes the useK8sWatch code to use an exact groupVersionKind instead of just a Kind which needs a registered module. For this, we also need to save this data in the user settings "toast" object.

```js
exportAppWatchResources {
  "christoph-primer": {
    "groupVersionKind": {
      "group": "primer.gitops.io",
      "version": "v1alpha1",
      "kind": "Export"
    },
    "name": "primer",
    "namespace": "christoph",
    "namespaced": true,
    "isList": false,
    "optional": true
  }
}
export-app-context.ts:49 exportResources {
  "christoph-primer": {
    "data": {
      "apiVersion": "primer.gitops.io/v1alpha1",
      "kind": "Export",
      "metadata": {
        "creationTimestamp": "2022-01-13T16:32:55Z",
        "generation": 1,
        "managedFields": [], // removed
        "name": "primer",
        "namespace": "christoph",
        "resourceVersion": "92408",
        "uid": "9480a2b4-f8a1-49a1-88bb-5b6cb3b2f57c"
      },
      "spec": {
        "method": "download",
        "user": "kubeadmin"
      }
    },
    "loaded": true,
    "loadError": ""
  }
}
```

The second commit is not really required, but makes testing much easier. Instead of a fix job name, it calculates this based on the found resource and pass the name down to the ExportViewLogButton.

**Screen shots / Gifs for design review**: 
UI doesn't change

**Unit test coverage report**: 
Untouched

**Test setup:**
* Install Primer operator
* Trigger export and wait for the download
* Export it at least one more time

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
