### PR TITLE
Bug 2038034: non-privileged user cannot see auto-update boot source

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/hooks/use-vm-templates-resources.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/hooks/use-vm-templates-resources.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
+import { isUpstream } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { PersistentVolumeClaimModel, PodModel, TemplateModel } from '@console/internal/models';
 import { PersistentVolumeClaimKind, PodKind, TemplateKind } from '@console/internal/module/k8s';
 import {
   CDI_APP_LABEL,
+  KUBEVIRT_OS_IMAGES_NS,
+  OPENSHIFT_OS_IMAGES_NS,
   TEMPLATE_TYPE_BASE,
   TEMPLATE_TYPE_LABEL,
   TEMPLATE_TYPE_VM,
@@ -24,6 +27,7 @@ export const useVmTemplatesResources = (namespace: string): useVmTemplatesResour
     isList: true,
   });
   const [dataSources] = useK8sWatchResource<DataSourceKind[]>({
+    namespace: isUpstream() ? KUBEVIRT_OS_IMAGES_NS : OPENSHIFT_OS_IMAGES_NS,
     kind: kubevirtReferenceForModel(DataSourceModel),
     isList: true,
   });

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details-page.tsx
@@ -3,6 +3,7 @@ import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { match as routerMatch } from 'react-router';
 import { DetailsPage } from '@console/internal/components/factory/details';
+import { isUpstream } from '@console/internal/components/utils';
 import { navFactory } from '@console/internal/components/utils/horizontal-nav';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { PersistentVolumeClaimModel, PodModel, TemplateModel } from '@console/internal/models';
@@ -12,6 +13,7 @@ import {
   PodKind,
   TemplateKind,
 } from '@console/internal/module/k8s/types';
+import { KUBEVIRT_OS_IMAGES_NS, OPENSHIFT_OS_IMAGES_NS } from '../../constants';
 import {
   VIRTUALMACHINES_BASE_URL,
   VIRTUALMACHINES_TEMPLATES_BASE_URL,
@@ -65,6 +67,7 @@ export const VMTemplateDetailsPage: React.FC<VMTemplateDetailsPageProps> = (prop
     namespace,
   });
   const [dataSources, dataSourcesLoaded] = useK8sWatchResource<DataSourceKind[]>({
+    namespace: isUpstream() ? KUBEVIRT_OS_IMAGES_NS : OPENSHIFT_OS_IMAGES_NS,
     kind: kubevirtReferenceForModel(DataSourceModel),
     isList: true,
   });

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -4,8 +4,14 @@ import { useTranslation } from 'react-i18next';
 import { match } from 'react-router';
 import { RowFilter } from '@console/dynamic-plugin-sdk';
 import { ListPage, MultiListPage } from '@console/internal/components/factory';
+import { isUpstream } from '@console/internal/components/utils';
 import { PersistentVolumeClaimModel, PodModel, TemplateModel } from '@console/internal/models';
-import { CDI_APP_LABEL, VMWizardName } from '../../constants';
+import {
+  CDI_APP_LABEL,
+  KUBEVIRT_OS_IMAGES_NS,
+  OPENSHIFT_OS_IMAGES_NS,
+  VMWizardName,
+} from '../../constants';
 import {
   customizeWizardBaseURLBuilder,
   VIRTUALMACHINES_TEMPLATES_BASE_URL,
@@ -100,6 +106,7 @@ const VirtualMachineTemplatesPage: React.FC<VirtualMachineTemplatesPageProps &
       kind: kubevirtReferenceForModel(DataSourceModel),
       isList: true,
       prop: 'dataSources',
+      namespace: isUpstream() ? KUBEVIRT_OS_IMAGES_NS : OPENSHIFT_OS_IMAGES_NS,
       optional: true,
     },
     {


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2038034

**Analysis / Root cause**:
`DataSource` resource is existing in `openshift-virtualization-os-images` namespace,
to grant a normal user access to it, we need to specify the namespace when we fetch `DataSource`

**Solution Description**:
adding `openshift-virtualization-os-images` as namespace when trying to watch for `DataSource` resource

**Screen shots / Gifs for design review**:

**Before**:

![before](https://user-images.githubusercontent.com/67270715/148768573-c18143cf-13c1-4992-a29b-340d0b860ae4.png)

![before-nonpriv-user](https://user-images.githubusercontent.com/67270715/148768581-cc5156a7-93ba-4195-8102-dba030685896.png)

**After**:

![after-nonpriv-user](https://user-images.githubusercontent.com/67270715/148768657-f01ce2c1-768b-4702-9d10-0a32178f9091.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>