### PR TITLE
Bug 2038768: Monitoring: Fix Targets list page filters

### DIFF
--- a/frontend/public/components/monitoring/targets.tsx
+++ b/frontend/public/components/monitoring/targets.tsx
@@ -211,7 +211,7 @@ const getRowProps = (target: Target) => ({ id: target.scrapeUrl, title: target.l
 const List: React.FC<ListProps> = ({ loaded, loadError, targets }) => {
   const { t } = useTranslation();
 
-  const filters = useSelector(({ k8s }: RootState) => k8s.getIn([REDUX_ID, 'filters']));
+  const filters = useSelector(({ sdkK8s }: RootState) => sdkK8s.getIn([REDUX_ID, 'filters']));
 
   const Header = () => [
     {


### PR DESCRIPTION
The PR that added the Targets UI conflicted with PR #10595, which
renamed `k8s` to `sdkK8s`.