### PR TITLE
Bug 2039057: Adjust kind column to target width in API explorer page

### DIFF
--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -109,10 +109,10 @@ const Group: React.FC<{ value: string }> = ({ value }) => {
   return _.isEmpty(rest) ? (
     <>{value}</>
   ) : (
-    <>
+    <span className="co-break-word">
       {first}
       <span className="text-muted">.{rest.join('.')}</span>
-    </>
+    </span>
   );
 };
 


### PR DESCRIPTION

After viewing the [source code](https://github.com/openshift/console/blob/6ec8376f04dba815ab5042733cc7c3c0790d7ff0/frontend/public/components/api-explorer.tsx#L119), I found that the original style should be first column width 25, second 16,but [Group function](https://github.com/openshift/console/blob/6ec8376f04dba815ab5042733cc7c3c0790d7ff0/frontend/public/components/api-explorer.tsx#L103) affect the style.

Result: Header row shows in proportion.In Group column,first row shows the first api,second shows rest api,clicking on the api content can still copy all.

Before:
![截图_选择区域_20220111145608](https://user-images.githubusercontent.com/39036074/148895494-07cf7d3c-d042-44ce-8bb0-513a2142c9c2.jpg)

After:
![截图_选择区域_20220111144018](https://user-images.githubusercontent.com/39036074/148894762-5a890d79-bd9e-4103-8db9-07138f8bfa27.jpg)
