### PR TITLE
Bug 2039315: Filter superseded helm secrets and fix firehose to support partial metadata

### DIFF
--- a/frontend/packages/helm-plugin/console-extensions.json
+++ b/frontend/packages/helm-plugin/console-extensions.json
@@ -193,7 +193,20 @@
       "id": "helm-topology-model-factory",
       "priority": 400,
       "resources": {
-        "secrets": { "opts": { "isList": true, "kind": "Secret", "optional": true } }
+        "secrets": {
+          "opts": {
+            "isList": true,
+            "kind": "Secret",
+            "optional": true,
+            "selector": {
+              "matchLabels": { "owner": "helm" },
+              "matchExpressions": [
+                { "key": "status", "operator": "NotEquals", "values": ["superseded"] }
+              ]
+            },
+            "partialMetadata": true
+          }
+        }
       },
       "getDataModel": { "$codeRef": "helmTopology.getHelmTopologyDataModel" },
       "isResourceDepicted": { "$codeRef": "helmTopology.isHelmResourceInModel" }

--- a/frontend/packages/helm-plugin/src/actions/providers.ts
+++ b/frontend/packages/helm-plugin/src/actions/providers.ts
@@ -30,10 +30,12 @@ export const useHelmActionProviderForTopology = (element: GraphElement) => {
     const nodeType = element.getType();
     if (nodeType !== TYPE_HELM_RELEASE) return undefined;
     const releaseName = element.getLabel();
+    const resource = getResource(element);
+    if (!resource?.metadata) return null;
     const {
       namespace,
       labels: { version },
-    } = getResource(element).metadata;
+    } = resource.metadata;
     return {
       release: {
         name: releaseName,

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
@@ -47,7 +47,10 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace }) => {
       kind: SecretModel.kind,
       namespaced: true,
       optional: true,
-      selector: { matchLabels: { owner: 'helm' } },
+      selector: {
+        matchLabels: { owner: 'helm' },
+        matchExpressions: [{ key: 'status', operator: 'NotEquals', values: ['superseded'] }],
+      },
       partialMetadata: true,
     }),
     [namespace],

--- a/frontend/packages/helm-plugin/src/topology/helm-data-transformer.ts
+++ b/frontend/packages/helm-plugin/src/topology/helm-data-transformer.ts
@@ -43,7 +43,6 @@ export const getTopologyHelmReleaseGroupItem = (
   const resourceKindName = getHelmReleaseKey(obj);
   const helmResources = helmResourcesMap[resourceKindName];
   const releaseName = helmResources?.releaseName;
-  const releaseVersion = helmResources?.releaseVersion;
   const releaseNotes = helmResources?.releaseNotes;
   const uid = obj?.metadata?.uid ?? null;
   const returnData = [];
@@ -53,8 +52,7 @@ export const getTopologyHelmReleaseGroupItem = (
   }
 
   const secret = secrets.find((nextSecret) => {
-    const { labels } = nextSecret.metadata;
-    return labels?.name === releaseName && labels?.version === releaseVersion.toString();
+    return nextSecret.metadata.labels?.name === releaseName;
   });
 
   if (secret) {

--- a/frontend/packages/helm-plugin/src/topology/helmResources.ts
+++ b/frontend/packages/helm-plugin/src/topology/helmResources.ts
@@ -5,6 +5,10 @@ export const getHelmWatchedResources = (namespace: string) => {
       kind: 'Secret',
       namespace,
       optional: true,
+      selector: {
+        matchLabels: { owner: 'helm' },
+        matchExpressions: [{ key: 'status', operator: 'NotEquals', values: ['superseded'] }],
+      },
       partialMetadata: true,
     },
   };

--- a/frontend/packages/helm-plugin/src/topology/sidebar/release-panel/resource-link.tsx
+++ b/frontend/packages/helm-plugin/src/topology/sidebar/release-panel/resource-link.tsx
@@ -8,7 +8,9 @@ import { TYPE_HELM_RELEASE } from '../../components/const';
 const helmReleasePanelResourceLink = (element: GraphElement) => {
   if (element.getType() !== TYPE_HELM_RELEASE) return undefined;
   const name = element.getLabel();
-  const { namespace } = getResource(element).metadata;
+  const resource = getResource(element);
+  if (!resource?.metadata) return null;
+  const { namespace } = resource.metadata;
   return (
     <>
       <ResourceIcon className="co-m-resource-icon--lg" kind="HelmRelease" />

--- a/frontend/packages/helm-plugin/src/topology/sidebar/release-panel/tab-sections.tsx
+++ b/frontend/packages/helm-plugin/src/topology/sidebar/release-panel/tab-sections.tsx
@@ -36,16 +36,18 @@ export const getHelmReleasePanelDetailsTabSection = (element: GraphElement) => {
 export const getHelmReleasePanelResourceTabSection = (element: GraphElement) => {
   if (element.getType() !== TYPE_HELM_RELEASE) return undefined;
   const { manifestResources } = element.getData().data;
-  const { namespace } = getResource(element).metadata;
+  const resource = getResource(element);
+  if (!manifestResources || !resource?.metadata) return null;
+  const { namespace } = resource.metadata;
 
-  return manifestResources ? (
+  return (
     <div className="overview__sidebar-pane-body">
       <TopologyGroupResourcesPanel
         manifestResources={manifestResources}
         releaseNamespace={namespace}
       />
     </div>
-  ) : null;
+  );
 };
 
 export const getHelmReleasePanelReleaseNotesTabSection = (element: GraphElement) => {

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -223,10 +223,10 @@ export const Firehose = connect(
           });
       }
 
-      firehoses.forEach(({ id, query, k8sKind, isList, name, namespace }) =>
+      firehoses.forEach(({ id, query, k8sKind, isList, name, namespace, partialMetadata }) =>
         isList
-          ? watchK8sList(id, query, k8sKind)
-          : watchK8sObject(id, name, namespace, query, k8sKind),
+          ? watchK8sList(id, query, k8sKind, null, partialMetadata)
+          : watchK8sObject(id, name, namespace, query, k8sKind, partialMetadata),
       );
       this.setState({ firehoses });
     }
@@ -281,6 +281,7 @@ Firehose.propTypes = {
       isList: PropTypes.bool,
       optional: PropTypes.bool, // do not block children-rendering while resource is still being loaded; do not fail if resource is missing (404)
       limit: PropTypes.number,
+      partialMetadata: PropTypes.bool,
     }),
   ).isRequired,
 };


### PR DESCRIPTION
**Note - This is a follow up PR to https://github.com/openshift/console/pull/10754 and second part of the fix we need for https://bugzilla.redhat.com/show_bug.cgi?id=1999796.** 

**Fixes**: https://issues.redhat.com/browse/OCPBUGSM-39230
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Helm release list page and topology was fetching all the secrets even though we only need latest secrets that are actually deployed.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
- Filter out superseded secrets using label selector.
- Add support for partial metadata in firehose for topology.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: No UI change.
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
