### PR TITLE
Bug 2039244: Add null checks in ActionMenu to fix helm history page crash

### DIFF
--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenu.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenu.tsx
@@ -29,7 +29,7 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
   const menuRef = React.useRef<HTMLDivElement>(null);
   const toggleRef = React.useRef<HTMLButtonElement>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const menuOptions = options.length > 0 ? options : actions;
+  const menuOptions = options?.length > 0 ? options : actions;
 
   const hideMenu = () => {
     setIsOpen(false);
@@ -78,7 +78,7 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
     <Menu ref={menuRef} containsFlyout onSelect={hideMenu}>
       <MenuContent data-test-id="action-items" translate="no">
         <MenuList>
-          <ActionMenuContent options={menuOptions} onClick={hideMenu} focusItem={options[0]} />
+          <ActionMenuContent options={menuOptions} onClick={hideMenu} focusItem={menuOptions[0]} />
         </MenuList>
       </MenuContent>
     </Menu>


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/OCPBUGSM-39219
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: ActionMenu component was trying to access length of options which might be `undefined` in some cases. This regression was introduced in this PR - https://github.com/openshift/console/pull/10139/files#diff-ea2aa8bbd09fd8603d8bce63e18ea1e5dcd03d63780f791a2e60b369aa1152f7R32.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Add null checks where required.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: No UI Change.
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

Before - 

https://user-images.githubusercontent.com/6041994/148957652-cb7b4fe6-31aa-4a48-ab2a-623bf9c4c316.mov



After - 

https://user-images.githubusercontent.com/6041994/148957670-0e9ae4c5-4c49-4a78-9c89-54eeccb74098.mov

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
