### PR TITLE
Bug 2027613: use the correct Alertmanager tenancy proxy

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -534,6 +534,7 @@
   "Invalid Git URL.": "Invalid Git URL.",
   "We failed to detect the Git type. Please choose a Git type.": "We failed to detect the Git type. Please choose a Git type.",
   "Container port should be an integer": "Container port should be an integer",
+  "View Alerting Rule": "View Alerting Rule",
   "Severity": "Severity",
   "Alert state": "Alert state",
   "Notifications": "Notifications",

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlerts.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlerts.tsx
@@ -21,7 +21,12 @@ import {
 } from '@console/internal/components/monitoring/utils';
 import { getURLSearchParams, EmptyBox, LoadingBox } from '@console/internal/components/utils';
 import { RootState } from '@console/internal/redux';
-import { monitoringAlertRows, alertFilters, applyListSort } from './monitoring-alerts-utils';
+import {
+  monitoringAlertRows,
+  alertFilters,
+  applyListSort,
+  useAlertManagerSilencesDispatch,
+} from './monitoring-alerts-utils';
 import { MonitoringAlertColumn } from './MonitoringAlertColumn';
 
 import './MonitoringAlerts.scss';
@@ -62,6 +67,7 @@ export const MonitoringAlerts: React.FC<props> = ({ match, rules, filters, listS
     () => (!loading && !loadError ? getAlertsAndRules(response?.data) : { rules: [], alerts: [] }),
     [response, loadError, loading],
   );
+  useAlertManagerSilencesDispatch({ namespace });
 
   React.useEffect(() => {
     const sortThanosRules = _.sortBy(thanosAlertsAndRules.rules, alertingRuleStateOrder);

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceAlert.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceAlert.tsx
@@ -17,7 +17,6 @@ import {
   alertingRuleStateOrder,
   getAlertsAndRules,
 } from '@console/internal/components/monitoring/utils';
-import { refreshNotificationPollers } from '@console/internal/components/notification-drawer';
 import SilenceDurationDropDown from './SilenceDurationDropdown';
 
 type SilenceAlertProps = {
@@ -52,9 +51,10 @@ const SilenceAlert: React.FC<SilenceAlertProps> = ({ rule, namespace }) => {
     if (checked) {
       _.each(rule.silencedBy, (silence) => {
         coFetchJSON
-          .delete(`${ALERTMANAGER_TENANCY_BASE_PATH}/api/v2/silence/${silence.id}`)
+          .delete(
+            `${ALERTMANAGER_TENANCY_BASE_PATH}/api/v2/silence/${silence.id}?namespace=${namespace}`,
+          )
           .then(() => {
-            refreshNotificationPollers();
             // eslint-disable-next-line promise/no-nesting
             return coFetchJSON(
               `${PROMETHEUS_TENANCY_BASE_PATH}/api/v1/rules?namespace=${namespace}`,
@@ -86,6 +86,7 @@ const SilenceAlert: React.FC<SilenceAlertProps> = ({ rule, namespace }) => {
           <SilenceDurationDropDown
             silenceInProgress={(progress) => setIsInprogress(progress)}
             rule={rule}
+            namespace={namespace}
           />
         )
       }

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.tsx
@@ -13,10 +13,10 @@ import {
   AlertStates,
   Rule,
   RuleStates,
+  Silence,
   SilenceStates,
 } from '@console/internal/components/monitoring/types';
 import { isSilenced } from '@console/internal/components/monitoring/utils';
-import { refreshNotificationPollers } from '@console/internal/components/notification-drawer';
 import { Dropdown, LoadingInline } from '@console/internal/components/utils';
 import { parsePrometheusDuration } from '@console/internal/components/utils/datetime';
 import { RootState } from '@console/internal/redux';
@@ -25,6 +25,7 @@ import './SilenceDurationDropdown.scss';
 type SilenceDurationDropDownProps = {
   rule: Rule;
   silenceInProgress?: (progress: boolean) => void;
+  namespace: string;
 };
 
 const durations = {
@@ -37,6 +38,7 @@ const durations = {
 const SilenceDurationDropDown: React.FC<SilenceDurationDropDownProps> = ({
   rule,
   silenceInProgress,
+  namespace,
 }) => {
   const { t } = useTranslation();
   const [silencing, setSilencing] = React.useState(false);
@@ -68,26 +70,26 @@ const SilenceDurationDropDown: React.FC<SilenceDurationDropDownProps> = ({
     setSilencing(true);
     silenceInProgress && silenceInProgress(true);
     coFetchJSON
-      .post(`${ALERTMANAGER_TENANCY_BASE_PATH}/api/v2/silences`, payload)
-      .then(() => {
-        // eslint-disable-next-line promise/no-nesting
-        return coFetchJSON(`${ALERTMANAGER_TENANCY_BASE_PATH}/api/v2/silences`).then((silences) => {
-          refreshNotificationPollers();
-          rule.silencedBy = _.filter(
-            silences,
-            (s) => s.status.state === SilenceStates.Active && _.some(rule.alerts, isSilenced),
-          );
-          if (!_.isEmpty(rule.silencedBy)) {
-            _.each(rule.alerts, (a) => (a.state = AlertStates.Silenced));
-            rule.state = RuleStates.Silenced;
-          }
-          const ruleIndex = rules.findIndex((r) => r.id === rule.id);
-          const updatedRules = _.cloneDeep(rules);
-          updatedRules.splice(ruleIndex, 1, rule);
-          dispatch(alertingSetRules('devRules', updatedRules, 'dev'));
-          setSilencing(false);
-          silenceInProgress && silenceInProgress(false);
-        });
+      .post(`${ALERTMANAGER_TENANCY_BASE_PATH}/api/v2/silences?namespace=${namespace}`, payload)
+      .then(() =>
+        coFetchJSON(`${ALERTMANAGER_TENANCY_BASE_PATH}/api/v2/silences?namespace=${namespace}`),
+      )
+      .then((silences: Silence[]) => {
+        rule.silencedBy = _.filter(
+          silences,
+          (s: Silence) =>
+            s.status.state === SilenceStates.Active && _.some(rule.alerts, isSilenced),
+        );
+        if (!_.isEmpty(rule.silencedBy)) {
+          _.each(rule.alerts, (a) => (a.state = AlertStates.Silenced));
+          rule.state = RuleStates.Silenced;
+        }
+        const ruleIndex = rules.findIndex((r) => r.id === rule.id);
+        const updatedRules = _.cloneDeep(rules);
+        updatedRules.splice(ruleIndex, 1, rule);
+        dispatch(alertingSetRules('devRules', updatedRules, 'dev'));
+        setSilencing(false);
+        silenceInProgress && silenceInProgress(false);
       })
       .catch((err) => {
         setSilencing(false);

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -171,7 +171,7 @@ func (s *Server) prometheusProxyEnabled() bool {
 }
 
 func (s *Server) alertManagerProxyEnabled() bool {
-	return s.AlertManagerProxyConfig != nil
+	return s.AlertManagerProxyConfig != nil && s.AlertManagerTenancyProxyConfig != nil
 }
 
 func (s *Server) meteringProxyEnabled() bool {
@@ -434,7 +434,7 @@ func (s *Server) HTTPHandler() http.Handler {
 			alertManagerTenancyProxyAPIPath = alertManagerTenancyProxyEndpoint + "/api/"
 
 			alertManagerProxy        = proxy.NewProxy(s.AlertManagerProxyConfig)
-			alertManagerTenancyProxy = proxy.NewProxy(s.AlertManagerProxyConfig)
+			alertManagerTenancyProxy = proxy.NewProxy(s.AlertManagerTenancyProxyConfig)
 		)
 
 		handle(alertManagerProxyAPIPath, http.StripPrefix(


### PR DESCRIPTION
**fixes:** https://issues.redhat.com/browse/OCPBUGSM-37644

**Descriptions:**
- fix to use the correct Alertmanager tenancy proxy.
- use the alert manager tenancy endpoint in the dev console for silence alerts.
- poll the silences to silence the alert.

![Kapture 2022-04-19 at 00 11 03](https://user-images.githubusercontent.com/2561818/163858125-35eea6f1-b5c6-4fc7-99f7-091a02dc6126.gif)
