### PR TITLE
Bug 2035146: Removed not useful error

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -1070,7 +1070,6 @@
   "Disk name is too short": "Disk name is too short",
   "Disk with this name already exists!": "Disk with this name already exists!",
   "PVC with this name is already used by this VM!": "PVC with this name is already used by this VM!",
-  "PVC cannot be empty": "PVC cannot be empty",
   "Size must be positive": "Size must be positive",
   "NIC name cannot be empty": "NIC name cannot be empty",
   "NIC name name can contain only alphanumeric characters": "NIC name name can contain only alphanumeric characters",

--- a/frontend/packages/kubevirt-plugin/src/utils/validations/vm/disk.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/validations/vm/disk.ts
@@ -42,12 +42,6 @@ const validatePVCName = (pvcName: string, usedPVCNames: Set<string>): Validation
     // t('kubevirt-plugin~PVC with this name is already used by this VM!')
     return asValidationObject('kubevirt-plugin~PVC with this name is already used by this VM!');
   }
-
-  if (!pvcName) {
-    // t('kubevirt-plugin~PVC cannot be empty')
-    return asValidationObject('kubevirt-plugin~PVC cannot be empty');
-  }
-
   return null;
 };
 


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2035146

**Analysis / Root cause**: 
This error message is not useful, as the field is already mandatory.

**Solution Description**: 
After a conversation with QE we decided to remove it.
@gouyang 

**Screen shots / Gifs for design review**: 
Before:
![image](https://user-images.githubusercontent.com/14824964/149094097-0a6a2f7f-9f98-421f-a1b8-e902d7609bfe.png)

After:
![image](https://user-images.githubusercontent.com/14824964/149094066-e8d21ebb-5d2a-476c-b07b-276f4fd6921e.png)
