### PR TITLE
Bug 2039678: Check if 'auths' key when switching between create image secret subforms

### DIFF
--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -580,7 +580,7 @@ class CreateConfigSubformWithTranslation extends React.Component<
       // If user creates a new image secret by filling out the form a 'kubernetes.io/dockerconfigjson' secret will be created.
       isDockerconfigjson: _.isEmpty(this.props.stringData) || !!this.props.stringData[AUTHS_KEY],
       secretEntriesArray: this.imageSecretObjectToArray(
-        this.props.stringData[AUTHS_KEY] || this.props.stringData,
+        this.props.stringData?.[AUTHS_KEY] || this.props.stringData,
       ),
       hasDuplicate: false,
     };


### PR DESCRIPTION
/assign @kdoberst 

FYI we should backport this down to 4.7