### PR TITLE
Bug 2039743: Fix react "missing key" warning when open operator hub detail page (and maybe others as well)

### DIFF
--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -222,9 +222,7 @@ NavBar.displayName = 'NavBar';
 
 export const HorizontalNav = React.memo((props: HorizontalNavProps) => {
   const renderContent = (routes: JSX.Element[]) => {
-    const { createRedirect, noStatusBox, obj, EmptyMsg, label } = props;
-    // Handle cases where matching Routes do not exist and show the details page instead of a blank page
-    createRedirect && routes.length >= 1 && routes.push(<Redirect to={routes[0].props.path} />);
+    const { noStatusBox, obj, EmptyMsg, label } = props;
     const content = (
       <React.Suspense fallback={<LoadingBox />}>
         <Switch>{routes}</Switch>
@@ -331,6 +329,10 @@ export const HorizontalNav = React.memo((props: HorizontalNavProps) => {
     };
     return <Route path={path} exact key={p.nameKey || p.name} render={render} />;
   });
+  // Handle cases where matching Routes do not exist and show the details page instead of a blank page
+  if (props.createRedirect && routes.length >= 1) {
+    routes.push(<Redirect key="fallback_redirect" to={routes[0].props.path} />);
+  }
 
   return (
     <div className={classNames('co-m-page__body', props.className)}>


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2039743

**Analysis / Root cause**: 
The programmatically added fallback `Redirect` doesn't have a key and was rendered as array. React warns about that.

**Solution Description**: 
Add a static key "fallback_redirect", also move the if statement closer to the routes generation instead of an inner "renderContent" function.

**Screen shots / Gifs for design review**: 
UX is unchanged. Before it shows this react warning, which doens't happen now anymore.

**Unit test coverage report**: 
Untouched.

**Test setup:**
1. Open the browser console to see react warnings and errors
2. Navigate to the operator hub and install an operator, for example the Primer operator
3. Navigate to the installed operator detail page

Before it shows an error in the browser console which is not shown anymore.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/cc @divyanshiGupta
