### PR TITLE
Bug 2039756: Fix react warning on operator hub description component, used for example on the KnativeServing detail page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -621,7 +621,12 @@ export const OperandDetails = connectToModel(({ crd, csv, kindObj, obj }: Operan
         )}
       {conditionsStatusDescriptors?.length > 0 &&
         conditionsStatusDescriptors.map((descriptor) => (
-          <DescriptorConditions descriptor={descriptor} schema={schema} obj={obj} />
+          <DescriptorConditions
+            key={descriptor.path}
+            descriptor={descriptor}
+            schema={schema}
+            obj={obj}
+          />
         ))}
     </div>
   );


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2039756

**Analysis / Root cause**: 
Missing key when mapping descriptions.

**Solution Description**: 
Use description.path as key, similar to other loops in this file.

**Screen shots / Gifs for design review**: 
UX is unchanged.

**Unit test coverage report**: 
Untouched.

**Test setup:**
1. Install OpenShift Serverless operator
2. Switch to knative-serving and create a KnativeServing resource from the operator detail page
3. Open the new resource (Knative Serving detail page)

Before it shows an error in the browser console which is not shown anymore.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/cc @divyanshiGupta
