### PR TITLE
Bug 2034362: Update description of disk interface

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -1015,7 +1015,7 @@
   "sata": "sata",
   "Supported by most operating systems including Windows out of the box. Offers lower performance compared to virtio. Consider using it for CD-ROM devices": "Supported by most operating systems including Windows out of the box. Offers lower performance compared to virtio. Consider using it for CD-ROM devices",
   "scsi": "scsi",
-  "Useful when the VM wants to interact with the device using direct scsi commands. Supported by most operating systems including Windows out of the box. Offers lower performance compared to virtio": "Useful when the VM wants to interact with the device using direct scsi commands. Supported by most operating systems including Windows out of the box. Offers lower performance compared to virtio",
+  "Paravirtualized iSCSI HDD driver offers similar functionality to the virtio-block device, with some additional enhancements. In particular, this driver supports adding hundreds of devices, and names devices using the standard SCSI device naming scheme": "Paravirtualized iSCSI HDD driver offers similar functionality to the virtio-block device, with some additional enhancements. In particular, this driver supports adding hundreds of devices, and names devices using the standard SCSI device naming scheme",
   "Migration - Pending": "Migration - Pending",
   "Migration - Scheduling": "Migration - Scheduling",
   "Migration - Preparing Target": "Migration - Preparing Target",

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/storage/disk-bus.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/storage/disk-bus.ts
@@ -20,9 +20,9 @@ export class DiskBus extends SelectDropdownObjectEnum<string> {
   static readonly SCSI = new DiskBus('scsi', {
     // t('kubevirt-plugin~scsi')
     labelKey: 'kubevirt-plugin~scsi',
-    // t('kubevirt-plugin~Useful when the VM wants to interact with the device using direct scsi commands. Supported by most operating systems including Windows out of the box. Offers lower performance compared to virtio')
+    // t('kubevirt-plugin~Paravirtualized iSCSI HDD driver offers similar functionality to the virtio-block device, with some additional enhancements. In particular, this driver supports adding hundreds of devices, and names devices using the standard SCSI device naming scheme')
     descriptionKey:
-      'kubevirt-plugin~Useful when the VM wants to interact with the device using direct scsi commands. Supported by most operating systems including Windows out of the box. Offers lower performance compared to virtio.',
+      'kubevirt-plugin~Paravirtualized iSCSI HDD driver offers similar functionality to the virtio-block device, with some additional enhancements. In particular, this driver supports adding hundreds of devices, and names devices using the standard SCSI device naming scheme.',
   });
 
   private static readonly ALL = Object.freeze(


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2034362

**Analysis / Root cause**:
"The scsi option is actually virtio-scsi not the standard scsi interface. which means that it still requires the virtio drivers to be loaded on guest VMs and it actually performs the same if not better than virtio."

**Solution Description:**
Update the description in the _Interface_ drop down menu when adding disk to a new VM for the scsi, as its description was incorrect.

**Screen shots / Gifs for design review:**
Before:
![before](https://user-images.githubusercontent.com/13417815/149153913-a1272947-6cbd-4a2b-8dc6-2710d1262507.png)

After:
![after](https://user-images.githubusercontent.com/13417815/149402236-3803d40f-6d65-4795-b2d6-ca5f3bdc8d49.png)
