### PR TITLE
Bug 2037664: Override the PatternFly default vertical alignment value within tables to correctly align cell contents.

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -700,21 +700,23 @@ export const ClusterServiceVersionList: React.FC<ClusterServiceVersionListProps>
   );
 
   return (
-    <Table
-      data={filterOperators(data, allNamespaceActive)}
-      {...rest}
-      aria-label={t('olm~Installed Operators')}
-      Header={allNamespaceActive ? AllProjectsTableHeader : SingleProjectTableHeader}
-      Row={InstalledOperatorTableRow}
-      EmptyMsg={CSVListEmptyMsg}
-      NoDataEmptyMsg={CSVListNoDataEmptyMsg}
-      virtualize
-      customData={customData}
-      customSorts={{
-        formatTargetNamespaces,
-        getOperatorNamespace,
-      }}
-    />
+    <div className="co-installed-operators">
+      <Table
+        data={filterOperators(data, allNamespaceActive)}
+        {...rest}
+        aria-label={t('olm~Installed Operators')}
+        Header={allNamespaceActive ? AllProjectsTableHeader : SingleProjectTableHeader}
+        Row={InstalledOperatorTableRow}
+        EmptyMsg={CSVListEmptyMsg}
+        NoDataEmptyMsg={CSVListNoDataEmptyMsg}
+        virtualize
+        customData={customData}
+        customSorts={{
+          formatTargetNamespaces,
+          getOperatorNamespace,
+        }}
+      />
+    </div>
   );
 };
 

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -21,6 +21,10 @@ form.pf-c-form {
   }
 }
 
+.co-installed-operators .pf-c-table tbody>tr>* {
+  vertical-align: top; // PF defaults to baseline which doesn't align correctly when Operator logos are within the table
+}
+
 .co-toolbar-no-padding.pf-c-toolbar {
   --pf-c-toolbar__content--PaddingLeft: 0;
   --pf-c-toolbar__content--PaddingRight: 0;


### PR DESCRIPTION
Also fix alignment yaml sidebar breadcrumbs by moving `<TextContent>` from wrapping `<Breadcrumb>` components. Which is caused by PatternFly `.pf-c-content` nested rules.

**before**
<img width="1018" alt="Screen Shot 2022-01-11 at 6 28 29 PM" src="https://user-images.githubusercontent.com/1874151/149178404-0bc5f7ee-1a6f-4484-aaf6-d760b046de39.png">
**after**
<img width="1017" alt="Screen Shot 2022-01-11 at 6 27 42 PM" src="https://user-images.githubusercontent.com/1874151/149178582-715aeb71-6223-40e7-9082-3cd989772bd6.png">
