### PR TITLE
Bug 2014464: Fix navigation spacing in dev (generic) perspective

### DIFF
--- a/frontend/public/components/nav/_perspective-nav.scss
+++ b/frontend/public/components/nav/_perspective-nav.scss
@@ -6,7 +6,7 @@
       border: none;
     }
   }
-  .pf-c-nav__section {
+  .pf-c-nav__section.no-title {
     --pf-c-nav__section--MarginTop: 0;
     .pf-c-nav__section-title {
       --pf-c-nav__section-title--PaddingBottom: 0;

--- a/frontend/public/components/nav/perspective-nav.tsx
+++ b/frontend/public/components/nav/perspective-nav.tsx
@@ -110,7 +110,9 @@ const PerspectiveNav: React.FC<{}> = () => {
     <div className="oc-perspective-nav">
       <PluginNavItems items={orderedNavItems} />
       {pinnedResourcesLoaded && pinnedResources?.length ? (
-        <NavGroup title="">{getPinnedItems()}</NavGroup>
+        <NavGroup title="" className="no-title">
+          {getPinnedItems()}
+        </NavGroup>
       ) : null}
     </div>
   );

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -234,7 +234,7 @@ export const NavSection = connect(navSectionStateToProps)(
 
           if (isGrouped) {
             return (
-              <NavGroup title="" data-quickstart-id={dataQuickStartId}>
+              <NavGroup title="" data-quickstart-id={dataQuickStartId} className="no-title">
                 {children}
               </NavGroup>
             );


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2014464

**Analysis / Root cause**: 
Removing margin-top doesn't work after some PF update or component restructuring on our side. Anyway, it's missing now.

**Solution Description**: 
Adding a small, even more explicit `className="no-title"` class and set it when title was set to `""`

**Screen shots / Gifs for design review**: 

cc @openshift/team-devconsole-ux @beaumorley 

Before:

![image](https://user-images.githubusercontent.com/139310/149184485-13d1e48e-362c-4a32-9761-416d2e92ff2c.png)

After:

![image](https://user-images.githubusercontent.com/139310/149184297-f45dd53a-dbf4-4a28-aa90-e8e535a92280.png)


**Unit test coverage report**: 
Untouched

**Test setup:**
Just open the admin and developer perspectives and check their spacing. Compare it to 4.9. 

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
