### PR TITLE
Bug 2039056: Fix alignment of the schema breadcrumbs …

### DIFF
--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -94,7 +94,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
     _.get(allDefinitions, [ref, 'format']) || _.get(allDefinitions, [ref, 'type']);
 
   return (
-    <TextContent>
+    <>
       {!_.isEmpty(breadcrumbs) && (
         <Breadcrumb className="pf-c-breadcrumb--no-padding-top co-break-word">
           {breadcrumbs.map((crumb, i) => {
@@ -118,49 +118,51 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
           })}
         </Breadcrumb>
       )}
-      {description && (
-        <p className="co-break-word co-pre-wrap">
-          <LinkifyExternal>{description}</LinkifyExternal>
-        </p>
-      )}
-      {_.isEmpty(currentProperties) ? (
-        <EmptyBox label={t('public~Properties')} />
-      ) : (
-        <ul className="co-resource-sidebar-list pf-c-list">
-          {_.map(currentProperties, (definition: SwaggerDefinition, name: string) => {
-            const path = getDrilldownPath(name);
-            const definitionType = definition.type || getTypeForRef(getRef(definition));
-            return (
-              <li key={name} className="co-resource-sidebar-item">
-                <h5 className="co-resource-sidebar-item__header co-break-word">
-                  <CamelCaseWrap value={name} />
-                  &nbsp;
-                  <small>
-                    <span className="co-break-word">{definitionType}</span>
-                    {required.has(name) && <> &ndash; required</>}
-                  </small>
-                </h5>
-                {definition.description && (
-                  <p className="co-break-word co-pre-wrap">
-                    <LinkifyExternal>{definition.description}</LinkifyExternal>
-                  </p>
-                )}
-                {path && (
-                  <Button
-                    type="button"
-                    onClick={(e) => drilldown(e, name, definition.description, path)}
-                    isInline
-                    variant="link"
-                  >
-                    {t('public~View details')}
-                  </Button>
-                )}
-              </li>
-            );
-          })}
-        </ul>
-      )}
-    </TextContent>
+      <TextContent>
+        {description && (
+          <p className="co-break-word co-pre-wrap">
+            <LinkifyExternal>{description}</LinkifyExternal>
+          </p>
+        )}
+        {_.isEmpty(currentProperties) ? (
+          <EmptyBox label={t('public~Properties')} />
+        ) : (
+          <ul className="co-resource-sidebar-list pf-c-list">
+            {_.map(currentProperties, (definition: SwaggerDefinition, name: string) => {
+              const path = getDrilldownPath(name);
+              const definitionType = definition.type || getTypeForRef(getRef(definition));
+              return (
+                <li key={name} className="co-resource-sidebar-item">
+                  <h5 className="co-resource-sidebar-item__header co-break-word">
+                    <CamelCaseWrap value={name} />
+                    &nbsp;
+                    <small>
+                      <span className="co-break-word">{definitionType}</span>
+                      {required.has(name) && <> &ndash; required</>}
+                    </small>
+                  </h5>
+                  {definition.description && (
+                    <p className="co-break-word co-pre-wrap">
+                      <LinkifyExternal>{definition.description}</LinkifyExternal>
+                    </p>
+                  )}
+                  {path && (
+                    <Button
+                      type="button"
+                      onClick={(e) => drilldown(e, name, definition.description, path)}
+                      isInline
+                      variant="link"
+                    >
+                      {t('public~View details')}
+                    </Button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </TextContent>
+    </>
   );
 };
 


### PR DESCRIPTION
by moving `<TextContent>` from wrapping `<Breadcrumb>` component. PatternFly `.pf-c-content` nested rules cause alignment and margin issues.

Fix bug https://bugzilla.redhat.com/show_bug.cgi?id=2039056
cc @spadgett 

**before**
<img width="691" alt="schema-breadcrumbs" src="https://user-images.githubusercontent.com/1874151/149191832-a4dd5af5-c905-41fc-be46-dac6b0fab4d9.png">


**after**
<img width="702" alt="Screen Shot 2022-01-12 at 12 12 14 PM" src="https://user-images.githubusercontent.com/1874151/149191851-49eb26de-f4f5-411b-a5cd-fd5db01c286b.png">
