### PR TITLE
Bug 2039770: Monitoring: use namespace to detect the active perspective instead of useActivePerspective hook

### DIFF
--- a/frontend/public/components/monitoring/dashboards/graph.tsx
+++ b/frontend/public/components/monitoring/dashboards/graph.tsx
@@ -1,4 +1,3 @@
-import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import * as React from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
@@ -7,6 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { dashboardsSetEndTime, dashboardsSetTimespan } from '../../../actions/observe';
 import { RootState } from '../../../redux';
 import { FormatSeriesTitle, QueryBrowser } from '../query-browser';
+import { getActivePerspective } from './monitoring-dashboard-utils';
 
 type Props = {
   formatSeriesTitle?: FormatSeriesTitle;
@@ -30,7 +30,7 @@ const Graph: React.FC<Props> = ({
   namespace,
 }) => {
   const dispatch = useDispatch();
-  const [activePerspective] = useActivePerspective();
+  const activePerspective = getActivePerspective(namespace);
   const endTime = useSelector(({ observe }: RootState) =>
     observe.getIn(['dashboards', activePerspective, 'endTime']),
   );


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=2039770

**Analysis / Root cause**: 
When the user opens the Observe > Dashboard in admin or developer perspective and switches the perspective in another tab, the observe dashboard doesn't load the right time-range from the browser URL and does not react to any time-range change.

**Solution Description**: 
use namespace to detect the active perspective instead of useActivePerspective hook 

**Screen shots / Gifs for design review**: 
![Kapture 2022-01-13 at 18 12 17](https://user-images.githubusercontent.com/2561818/149332398-1e6ec1fd-4af9-41d1-ab04-5912df356f95.gif)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge