### PR TITLE
Gherkin and automation for workload sidebar entry for pipeline triggers

### DIFF
--- a/frontend/packages/topology/integration-tests/features/topology/pipelines-on-topology.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/pipelines-on-topology.feature
@@ -3,7 +3,7 @@ Feature: Improve the integration of Pipelines & Builds.
               As a user, I want to see pipelines instead of build
 
         Background:
-            Given user has installed OpenShift Pipelines operator using cli
+            Given user has installed OpenShift Pipelines Operator
               And user is at developer perspective
               And user has created or selected namespace "aut-topology"
 
@@ -125,3 +125,16 @@ Feature: Improve the integration of Pipelines & Builds.
                   | resource_type     | workload_name   | builder_image1 | builder_image2 |
                   | deployment        | nodejs-ex-git-1 | Node.js        | Nginx          |
                   | deployment config | django-ex.git-1 | Python         | Httpd          |
+
+
+        @regression @odc-6375
+        Scenario Outline: Topology sidebar has Triggers section in Resources tab: T-01-TC10
+            Given user has created workload "<workload_name>" with resource type "<resource_type>" with pipeline
+             When user navigates to Topology page
+              And user clicks on workload "<workload_name>" to open sidebar
+             Then user can see "Triggers" section in Resources tab
+
+        Examples:
+                  | resource_type     | workload_name   |
+                  | deployment        | nodejs-ex-git-1 |
+                  | deployment config | dancer-ex-git-1 |

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-side-pane-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-side-pane-page.ts
@@ -27,9 +27,7 @@ export const topologySidePane = {
   },
   verifySection: (sectionTitle: string) => {
     cy.get(topologyPO.sidePane.dialog).within(() => {
-      cy.get(topologyPO.sidePane.sectionTitle)
-        .contains(sectionTitle)
-        .should('be.visible');
+      cy.contains(topologyPO.sidePane.sectionTitle, sectionTitle).should('be.visible');
     });
   },
   verifyActions: (...actions: string[]) => {

--- a/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
@@ -19,6 +19,7 @@ import {
 import {
   verifyAndInstallGitopsPrimerOperator,
   verifyAndInstallKnativeOperator,
+  verifyAndInstallPipelinesOperator,
 } from '@console/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster';
 import { topologyPO } from '@console/topology/integration-tests/support/page-objects/topology-po';
 import { topologyPage } from '@console/topology/integration-tests/support/pages/topology/topology-page';
@@ -200,4 +201,8 @@ When('user enters Name as {string}', (name: string) => {
 
 Given('user has installed Gitops primer Operator', () => {
   verifyAndInstallGitopsPrimerOperator();
+});
+
+Given('user has installed OpenShift Pipelines Operator', () => {
+  verifyAndInstallPipelinesOperator();
 });

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/pipelines-on-topology.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/pipelines-on-topology.ts
@@ -1,0 +1,34 @@
+import { When, Then, Given } from 'cypress-cucumber-preprocessor/steps';
+import { devNavigationMenu } from '@console/dev-console/integration-tests/support/constants/global';
+import { createGitWorkload } from '@console/dev-console/integration-tests/support/pages';
+import { navigateTo } from '@console/dev-console/integration-tests/support/pages/app';
+import { topologyPage, topologySidePane } from '../../pages/topology';
+
+Given(
+  'user has created workload {string} with resource type {string} with pipeline',
+  (componentName: string, resourceName: string) => {
+    navigateTo(devNavigationMenu.Add);
+    createGitWorkload(
+      'https://github.com/sclorg/nodejs-ex.git',
+      componentName,
+      resourceName,
+      'nodejs-ex-git-app',
+      true,
+    );
+  },
+);
+
+When('user navigates to Topology page', () => {
+  navigateTo(devNavigationMenu.Topology);
+});
+
+When('user clicks on workload {string} to open sidebar', (workloadName: string) => {
+  topologyPage.componentNode(workloadName).click({ force: true });
+  topologyPage.waitForLoad();
+});
+
+Then('user can see {string} section in Resources tab', (heading: string) => {
+  topologySidePane.selectTab('Resources');
+  topologySidePane.verifyTab('Resources');
+  topologySidePane.verifySection(heading);
+});


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-6375
Story: https://issues.redhat.com/browse/ODC-6426

Acceptance criteria:

- A webhook url exists for the generated pipeline when user selects "add pipeline" in the import-from-git flow
- User is provided with guidance on how to add the webhook url to their Git repository as a webhook to trigger the pipeline on Git events


**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]

**Fix**: https://issues.redhat.com/browse/ODC-6457


**Test Setup**:

Cluster should be running on local

Check the TAGS in frontend/packages/topology/integration-tests/cypress.json file be: ""(@pre-condition or @smoke or @regression) and @[odc-6375](https://issues.redhat.com/browse/odc-6375) and not (@manual or @to-do or @un-verified or @broken-test)"",


Command to execute:

Run a cluster locally and execute the command `npm run test-cypress-topology` simultaneously

Execute the pipelines-on-topology.feature file

**Browser**
Chrome 90

**Test Execution Screenshot:**
![Screenshot from 2022-01-13 19-13-25](https://user-images.githubusercontent.com/10252230/149341199-c0209f16-713c-4a68-8ba6-0e4e8a56ab56.png)
