### PR TITLE
Bug 2015420: Add VMs resource to project's intentory card

### DIFF
--- a/frontend/packages/kubevirt-plugin/console-extensions.json
+++ b/frontend/packages/kubevirt-plugin/console-extensions.json
@@ -493,6 +493,16 @@
     }
   },
   {
+    "type": "console.dashboards/project/overview/item",
+    "properties": {
+      "mapper": { "$codeRef": "dashboardInventory.getVMStatusGroups" },
+      "model": { "$codeRef": "models.VirtualMachineModel" }
+    },
+    "flags": {
+      "required": ["KUBEVIRT"]
+    }
+  },
+  {
     "type": "console.dashboards/overview/inventory/item/group",
     "properties": {
       "id": "vm-stopped",


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2015420

**Analysis / Root cause + Solution Description**:
Adding the missing dashboard project overview item in console-extentions

**Screen shots / Gifs for design review**:

**Before**:

![before](https://user-images.githubusercontent.com/67270715/149377177-924f0fdd-faac-4fdc-abcd-34b805f80c0a.png)

**After**:

![after-2](https://user-images.githubusercontent.com/67270715/149377114-f3296040-667e-4d2e-90e9-1f2365aa581b.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>