### PR TITLE
update version of quick-start library to latest

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -122,7 +122,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.9.0",
     "@patternfly/patternfly": "4.159.1",
-    "@patternfly/quickstarts": "1.2.3",
+    "@patternfly/quickstarts": "2.0.1",
     "@patternfly/react-catalog-view-extension": "4.26.4",
     "@patternfly/react-charts": "6.28.4",
     "@patternfly/react-core": "4.175.4",

--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.tsx
@@ -221,6 +221,7 @@ export const useValuesForQuickStartContext = (): QuickStartContextValues => {
   //   t('console-app~Your progress will be saved.'),
   // ];
   return {
+    useLegacyHeaderColors: true,
     language,
     resourceBundle: processedResourceBundle,
     activeQuickStartID,

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -21,7 +21,7 @@ form.pf-c-form {
   }
 }
 
-.co-installed-operators .pf-c-table tbody>tr>* {
+.co-installed-operators .pf-c-table tbody > tr > * {
   vertical-align: top; // PF defaults to baseline which doesn't align correctly when Operator logos are within the table
 }
 
@@ -139,7 +139,6 @@ form.pf-c-form {
 
 // Page
 .pf-c-page {
-
   &__header-brand-link {
     flex: 0 1 auto !important; // so link doesn't grow larger than logo
   }
@@ -308,4 +307,8 @@ ul.pf-c-select__menu,
 ul.pf-c-simple-list__list,
 ul.pf-c-tree-view__list {
   list-style: none !important;
+}
+
+.pfext-quick-start-content {
+  font-size: $font-size-base !important;
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1795,10 +1795,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.159.1.tgz#36a0dc7c31bd17acc64db5777dca33a541ffec73"
   integrity sha512-CPLE7yAmtETH8TAdQhHkyFmyvjGwsv/7PeR4k57DY9X4IHpx41m4SXrv9cBCr/+Uy8o2SjvE8dtlZb+h0rLByQ==
 
-"@patternfly/quickstarts@1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-1.2.3.tgz#cc27064a20b1753cb20e5777b33741d167eeb3ce"
-  integrity sha512-upJw+utpRotF7P9vojXbS6ke6rCKY+Jb7rCLaHzKGeFY6DUl9Go56P0RVLSqMb9PuxZZlOnKPVJFUalcrcvYQA==
+"@patternfly/quickstarts@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-2.0.1.tgz#8e8270782eae0e2476ccf4cdbbaa22c7c095097e"
+  integrity sha512-tbF1sqlkVb9rEriiHPnKAN5SercMxP27ty+PB87uZ/aF9YkvDD5BUuCbU3JR0e2qe189WksvLrgrAEaamh3gig==
   dependencies:
     "@patternfly/react-catalog-view-extension" "4.12.15"
     dompurify "^2.2.6"


### PR DESCRIPTION
Bumps the version of pattern `@patternfly/quickstarts` from `1.2.3` to `2.0.1`.

Needed to override a font change from https://github.com/patternfly/patternfly-quickstarts/pull/67 which increased the font size from `14px` to `16px` since the console uses a smaller font size than PF.
I didn't see any issues with this change when browsing several of our quick starts.

Applied `useLegacyHeaderColors: true` which then renders the header as white instead of blue.

![image](https://user-images.githubusercontent.com/14068621/149381244-8f275aab-801d-45f8-84c6-0e43d6f72017.png)

fyi @serenamarie125 @jschuler 