### PR TITLE
Bug 2040653: Fix topology sidebar warns that another component is updated while rendering

### DIFF
--- a/frontend/packages/topology/src/components/workload/build-tab-section.tsx
+++ b/frontend/packages/topology/src/components/workload/build-tab-section.tsx
@@ -37,6 +37,13 @@ const BuildTabSection: React.FC<{ element: GraphElement; renderNull: () => null 
   const handleAdapterResolved = React.useCallback((data) => {
     setBuildConfigsData({ data, loaded: true });
   }, []);
+
+  React.useEffect(() => {
+    if (!buildAdapter) {
+      renderNull();
+    }
+  }, [buildAdapter, renderNull]);
+
   return buildAdapter ? (
     <TopologySideBarTabSection>
       {extensionsResolved && (
@@ -48,9 +55,7 @@ const BuildTabSection: React.FC<{ element: GraphElement; renderNull: () => null 
       )}
       {buildConfigsDataLoaded && <BuildOverview buildConfigs={buildConfigs.buildConfigs} />}
     </TopologySideBarTabSection>
-  ) : (
-    renderNull()
-  );
+  ) : null;
 };
 
 export const getBuildsSideBarTabSection = (element: GraphElement, renderNull: () => null) => {

--- a/frontend/packages/topology/src/components/workload/network-tab-section.tsx
+++ b/frontend/packages/topology/src/components/workload/network-tab-section.tsx
@@ -25,13 +25,18 @@ const NetworkTabSection: React.FC<{ element: GraphElement; renderNull: () => nul
       ]),
     [element, extensionsLoaded, networkAdapterExtensions],
   );
+
+  React.useEffect(() => {
+    if (!networkAdapter) {
+      renderNull();
+    }
+  }, [networkAdapter, renderNull]);
+
   return networkAdapter ? (
     <TopologySideBarTabSection>
       <NetworkingOverview obj={networkAdapter.resource} />
     </TopologySideBarTabSection>
-  ) : (
-    renderNull()
-  );
+  ) : null;
 };
 
 export const getNetworkingSideBarTabSection = (element: GraphElement, renderNull: () => null) => {

--- a/frontend/packages/topology/src/components/workload/pods-tab-section.tsx
+++ b/frontend/packages/topology/src/components/workload/pods-tab-section.tsx
@@ -35,6 +35,13 @@ const PodsTabSection: React.FC<{ element: GraphElement; renderNull: () => null }
   const handleAdapterResolved = React.useCallback((data) => {
     setPodData({ data, loaded: true });
   }, []);
+
+  React.useEffect(() => {
+    if (!podAdapter) {
+      renderNull();
+    }
+  }, [podAdapter, renderNull]);
+
   return podAdapter ? (
     <TopologySideBarTabSection>
       {podAdapterExtensionResolved && (
@@ -48,9 +55,7 @@ const PodsTabSection: React.FC<{ element: GraphElement; renderNull: () => null }
         <PodsOverviewContent obj={podAdapter.resource} {...podsData} />
       )}
     </TopologySideBarTabSection>
-  ) : (
-    renderNull()
-  );
+  ) : null;
 };
 
 export const getPodsSideBarTabSection = (element: GraphElement, renderNull: () => null) => {


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2040653

**Analysis / Root cause**: 
#10127 added a new `renderNull` function which updates a state while rendering. This results in a warning and should be avoided.

![image](https://user-images.githubusercontent.com/139310/149507589-b239de3e-c5c2-4dd2-895c-853bb4f3044a.png)

**Solution Description**: 
Move the `renderNull` callback into an `useEffect` and just return null in the render function.

Btw: I'm not happy about this back-propagating at all, but at least this fixes the warning.

**Screen shots / Gifs for design review**: 
UI not changed

**Unit test coverage report**: 
Not changed

**Test setup:**
1. Switch to dev perspective
2. Import an application
3. Switch to topology and open the sidebar

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/cc @sahil143 @invincibleJai 