### PR TITLE
Bug 2040655: Fix that user settings update fails when selecting application in topology sidebar

### DIFF
--- a/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
@@ -212,6 +212,27 @@ describe('useUserSettings', () => {
     expect(consoleMock).toHaveBeenCalledTimes(0);
   });
 
+  it('should return saved value for an known key which contains invalid characters', async () => {
+    // Mock saved ConfigMap
+    const savedDataWithEncodedCharConfigMap: ConfigMapKind = {
+      ...emptyConfigMap,
+      data: {
+        'invalid-char-_-is-replaced-with-an-underline': 'saved value',
+      },
+    };
+    useK8sWatchResourceMock.mockReturnValue([savedDataWithEncodedCharConfigMap, true, null]);
+
+    const { result } = testHook(() =>
+      useUserSettings('invalid-char-:-is-replaced-with-an-underline', 'default value'),
+    );
+
+    // Expect saved value with loaded
+    expect(result.current).toEqual(['saved value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(0);
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(0);
+    expect(consoleMock).toHaveBeenCalledTimes(0);
+  });
+
   it('should return default value for an unknown key if data is already loaded (hook is used twice)', async () => {
     // Mock already loaded data
     useK8sWatchResourceMock.mockReturnValue([emptyConfigMap, true, null]);

--- a/frontend/packages/console-shared/src/hooks/useUserSettings.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettings.ts
@@ -44,7 +44,7 @@ export const useUserSettings = <T>(
   React.useEffect(() => () => (mounted.current = false), []);
 
   // Keys and values
-  const keyRef = React.useRef<string>(key);
+  const keyRef = React.useRef<string>(key?.replace(/[^-._a-zA-Z0-9]/g, '_'));
   const defaultValueRef = React.useRef<T>(defaultValue);
 
   // Settings


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2040655

**Analysis / Root cause**: 
When selecting an application in the topology there is a network call failing. Got this error message in the browser console:

```
user-settings.ts:46 Could not update (patch) user settings ConfigMap HttpError:
  Error "Invalid value: "console.sideBarAlerts.health-check-alert.group:nodeinfo-app":
  a valid config key must consist of alphanumeric characters, '-', '_' or '.'
  (e.g. 'key.name',  or 'KEY_NAME',  or 'key-name', regex used for validation is
  '[-._a-zA-Z0-9]+')" for field "data[console.sideBarAlerts.health-check-alert.group:nodeinfo-app]".
    at console-fetch-utils.ts:99:1
```

The PATCH call to the ConfigMap shows this payload:

```js
{
  "data": {
    "console.sideBarAlerts.health-check-alert.group:nodeinfo-app": "true"
  }
}
```

**Solution Description**: 
Update `useUserSettings` and replace all unallowed keys (not matching `[-._a-zA-Z0-9]`) with an underline.

**Screen shots / Gifs for design review**: 
UI doesn't changed.

**Unit test coverage report**: 
Add one new test.

```
 PASS  packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts (7.14s)
  useUserSettings
    ✓ should create and update user settings if watcher returns 404 Not found (returned for kubeadmins who have access to the openshift-console-user-settings namespace) (133ms)
    ✓ should create and update user settings if watcher returns 403 Forbidden (returned for users who could not access non existing ConfigMaps in openshift-console-user-settings namespace) (7ms)
    ✓ should return default value for an empty configmap after switching from loading to loaded (4ms)
    ✓ should return saved value for an known key after switching from loading to loaded (4ms)
    ✓ should return saved value for an known key which contains invalid characters (3ms)
    ✓ should return default value for an unknown key if data is already loaded (hook is used twice) (5ms)
    ✓ should return saved value for an known key if data is already loaded (hook is used twice) (4ms)
    ✓ should return latest user settings value after switching from loading to loaded (10ms)
    ✓ should return latest user settings value in loaded state (hook is used twice) (3ms)
    ✓ should trigger update user settings when setter was called (33ms)
    ✓ should provide the default value for user settings without sync and setter if there is no old value (1070ms)
    ✓ should provide the default value for user settings with sync and setter if there is no old value (4ms)
    ✓ should provide the old value for user settings without sync and setter if there is an old value (2ms)
    ✓ should provide the old value for user settings with sync and setter if there is an old value (2ms)
    ✓ should provide an updated value for user settings wuthout sync and setter if there is was an update in the meantime (1ms)
    ✓ should provide an updated value for user settings with sync and setter if there is was an update in the meantime (3ms)
    ✓ should fallback to localStorage if creation fails and watch returns 404 Not found (returned for kubeadmin who have acess to the openshift-console-user-settings namespace) (3ms)
    ✓ should fallback to localStorage if creation fails and watch return 403 Forbidden (returned for users who could not access non existing ConfigMaps in openshift-console-user-settings namespace) (2ms)
    ✓ should fallback to localStorage if creation fails and watch returns any other error then Not Found or Forbidden (2ms)
    ✓ should use session storage when impersonating (511ms)

Test Suites: 1 passed, 1 total
Tests:       20 passed, 20 total
```

**Test setup:**
1. Switch to dev perspective
2. Import an application
3. Switch to topology and open the application in the sidebar

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
