### PR TITLE
Bug 2040661: Fix different react warnings when leaving topology

### DIFF
--- a/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
@@ -81,6 +81,7 @@ describe('useUserSettings', () => {
   it('should create and update user settings if watcher returns 404 Not found (returned for kubeadmins who have access to the openshift-console-user-settings namespace)', async () => {
     // Mock loading
     useK8sWatchResourceMock.mockReturnValue([null, false, null]);
+    updateConfigMapMock.mockReturnValue(Promise.resolve({}));
 
     const { result, rerender } = testHook(() => useUserSettings('console.key', 'default value'));
 
@@ -122,6 +123,7 @@ describe('useUserSettings', () => {
   it('should create and update user settings if watcher returns 403 Forbidden (returned for users who could not access non existing ConfigMaps in openshift-console-user-settings namespace)', async () => {
     // Mock loading
     useK8sWatchResourceMock.mockReturnValue([null, false, null]);
+    updateConfigMapMock.mockReturnValue(Promise.resolve({}));
 
     const { result, rerender } = testHook(() => useUserSettings('console.key', 'default value'));
 
@@ -163,6 +165,7 @@ describe('useUserSettings', () => {
   it('should return default value for an empty configmap after switching from loading to loaded', async () => {
     // Mock loading
     useK8sWatchResourceMock.mockReturnValue([null, false, null]);
+    updateConfigMapMock.mockReturnValue(Promise.resolve({}));
 
     const { result, rerender } = testHook(() => useUserSettings('console.key', 'default value'));
 
@@ -212,6 +215,7 @@ describe('useUserSettings', () => {
   it('should return default value for an unknown key if data is already loaded (hook is used twice)', async () => {
     // Mock already loaded data
     useK8sWatchResourceMock.mockReturnValue([emptyConfigMap, true, null]);
+    updateConfigMapMock.mockReturnValue(Promise.resolve({}));
 
     const { result } = testHook(() => useUserSettings('console.key', 'default value'));
 

--- a/frontend/packages/console-shared/src/hooks/usePodsWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/usePodsWatcher.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useSafetyFirst } from '@console/internal/components/safety-first';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { PodRCData } from '../types';
@@ -11,9 +12,9 @@ export const usePodsWatcher = (
   kind?: string,
   namespace?: string,
 ): { loaded: boolean; loadError: string; podData: PodRCData } => {
-  const [loaded, setLoaded] = React.useState<boolean>(false);
-  const [loadError, setLoadError] = React.useState<string>('');
-  const [podData, setPodData] = React.useState<PodRCData>();
+  const [loaded, setLoaded] = useSafetyFirst<boolean>(false);
+  const [loadError, setLoadError] = useSafetyFirst<string>('');
+  const [podData, setPodData] = useSafetyFirst<PodRCData>(undefined);
   const watchKind = kind || resource.kind;
   const watchNS = namespace || resource.metadata.namespace;
   const watchedResources = React.useMemo(() => getResourcesToWatchForPods(watchKind, watchNS), [
@@ -40,7 +41,7 @@ export const usePodsWatcher = (
         setLoaded(true);
       }
     },
-    [watchKind],
+    [setLoadError, setLoaded, setPodData, watchKind],
   );
 
   const debouncedUpdateResources = useDebounceCallback(updateResults, 250);

--- a/frontend/packages/topology/src/components/graph-view/components/edges/CreateConnector.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/edges/CreateConnector.tsx
@@ -26,10 +26,13 @@ const CreateConnector: React.FC<CreateConnectorProps> = ({
     setHover(false);
     clearTimeout(unsetHandle.current);
     unsetHandle.current = window.setTimeout(() => {
-      setHover(dragging);
+      if (unsetHandle.current) {
+        setHover(dragging);
+      }
     }, 2000);
     return () => {
       clearTimeout(unsetHandle.current);
+      unsetHandle.current = null;
     };
   }, [endPoint.x, endPoint.y, dragging]);
 

--- a/frontend/public/components/utils/managed-by.tsx
+++ b/frontend/public/components/utils/managed-by.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { ResourceIcon } from './resource-icon';
-import { resourcePathFromModel } from './resource-link';
+import { resourcePathFromModel, ResourceLink } from './resource-link';
 import {
   K8sResourceCommon,
   referenceForOwnerRef,
@@ -12,10 +12,10 @@ import {
   modelFor,
   k8sList,
 } from '../../module/k8s';
+import { useSafetyFirst } from '../safety-first';
 import { findOwner, matchOwnerAndCSV } from '../../module/k8s/managed-by';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
-import { ResourceLink } from '.';
 
 export const ManagedByOperatorResourceLink: React.SFC<ManagerLinkProps> = ({
   csvName,
@@ -50,7 +50,7 @@ export const ManagedByOperatorResourceLink: React.SFC<ManagerLinkProps> = ({
 
 export const ManagedByOperatorLink: React.SFC<ManagedByLinkProps> = ({ obj, className }) => {
   const { t } = useTranslation();
-  const [data, setData] = React.useState<ClusterServiceVersionKind[] | undefined>();
+  const [data, setData] = useSafetyFirst<ClusterServiceVersionKind[] | undefined>(undefined);
   const namespace = obj.metadata.namespace;
   React.useEffect(() => {
     if (!namespace) {
@@ -62,7 +62,7 @@ export const ManagedByOperatorLink: React.SFC<ManagedByLinkProps> = ({ obj, clas
         // eslint-disable-next-line no-console
         console.error('Could not fetch CSVs', e);
       });
-  }, [namespace]);
+  }, [namespace, setData]);
   const owner = findOwner(obj, data);
   const csv = data && owner ? matchOwnerAndCSV(owner, data) : undefined;
 


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2040661

**Analysis / Root cause**: 
There were different components that triggers an update on unmounted components when leaving topology.

**Solution Description**: 
Check that the component is still mounted:

1. `usePodsWatcher` uses a debounce to update the topology, replaced `useState` with `useSafetyFirst` hook
2. `useUserSettings`, add mounted ref, renamed all setState methods to `*Unsafe` and add new methods which checks mounted ref before calling the `*Unsafe` setter. Added comments and grouped the states a little bit.
3. `useUserSettings`, also catches an error on `updateConfigMap` to fix "unhandled promise error" log message.
4. `useUserSettingsLocalStorage`, because it has its own setData, wrap these also with an mounted ref check.
5. `CreateConnector`, when leaving the topology there are two `useHover` errors logged. This one, the other illegal setState was trigger from patternfly/topology. I created a similar PR there as well: https://github.com/patternfly/patternfly-react/pull/6779
6. Also saw an invalid setState update on an unmounted component in ManagedByOperatorLink, replaced `useState` here as well with `useSafetyFirst`.

**Screen shots / Gifs for design review**: 
UI not changed

**Unit test coverage report**: 
Untouched

**Test setup:**
1. Switch to dev perspective
2. Import an application
3. Switch to topology and leave it again. Try this slowly and quickly to get a different set of warnings.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
