### PR TITLE
Bug 2039619: - [AWS] In tree provisioner storageclass aws disk type should contain 'gp3' and csi provisioner storageclass default aws disk type should be 'gp3'

### DIFF
--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -114,14 +114,14 @@ class StorageClassFormWithTranslation extends React.Component<
         type: {
           name: 'Type', // t('public~Type')
           values: {
-            gp2: 'gp2',
             gp3: 'gp3',
+            gp2: 'gp2',
             io1: 'io1',
             sc1: 'sc1',
             st1: 'st1',
             standard: 'standard',
           },
-          hintText: 'Select AWS Type. Default is gp2',
+          hintText: 'Select AWS Type. Default is gp3',
         },
         iopsPerGB: {
           name: 'IOPS per GiB', // t('public~IOPS per GiB')
@@ -171,7 +171,7 @@ class StorageClassFormWithTranslation extends React.Component<
       parameters: {
         type: {
           name: 'Type', // t('public~Type')
-          values: { io1: 'io1', gp2: 'gp2', sc1: 'sc1', st1: 'st1' },
+          values: { io1: 'io1', gp2: 'gp2', gp3: 'gp3', sc1: 'sc1', st1: 'st1' },
           hintText: 'Select AWS Type',
         },
         iopsPerGB: {


### PR DESCRIPTION
### Before:
![Screen Shot 2022-01-14 at 9 34 37 AM](https://user-images.githubusercontent.com/15249132/149532847-34241ea3-6df6-4391-ac2e-ae193c2442a5.png)

![Screen Shot 2022-01-14 at 9 35 06 AM](https://user-images.githubusercontent.com/15249132/149532849-9ddea232-c131-4414-8621-ab1956c7ba3a.png)

### After:
![Screen Shot 2022-01-14 at 9 07 36 AM](https://user-images.githubusercontent.com/15249132/149532927-14ecb2f7-e1e9-414d-8c2c-6ec14d2d2bee.png)

![Screen Shot 2022-01-14 at 8 56 37 AM](https://user-images.githubusercontent.com/15249132/149532968-25d10a2a-cc11-4eba-8c01-650dbf343369.png)
