### PR TITLE
Bug 2040782: Fix that import YAML page blocks input with more then one generateName attributes

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -482,7 +482,8 @@ export const EditYAML_ = connect(stateToProps)(
             });
             if (!hasErrors) {
               //Check for duplicate name/kinds. ~ is not a valid name character, so use it to separate the fields
-              const uniqueEntries = _.uniqBy(objs, (obj) =>
+              const filteredEntried = _.filter(objs, (obj) => !obj.metadata.generateName);
+              const uniqueEntries = _.uniqBy(filteredEntried, (obj) =>
                 [
                   obj.metadata.name,
                   obj.metadata.namespace,
@@ -490,7 +491,7 @@ export const EditYAML_ = connect(stateToProps)(
                   groupVersionFor(obj.apiVersion).group,
                 ].join('~'),
               );
-              if (uniqueEntries.length !== objs.length) {
+              if (uniqueEntries.length !== filteredEntried.length) {
                 this.handleError(
                   t('public~Resources in the same namespace and API group must have unique names'),
                 );


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2040782

**Analysis / Root cause**: 
The import page stops users from importing duplicate resources in one yaml. This detection expects that all resources should have a unique API group, kind, name, and namespace combination. But resources with a `generateName` metadata attribute should be ignored because they generate a unique name on creation.

**Solution Description**: 
Filter our resources with a `generateName` metadata attribute before searching for duplicates.

**Screen shots / Gifs for design review**: 
UX doesn't change. Before it shows an alert:

> An error occurred
> Resources in the same namespace and API group must have unique names

With this change, the form can be submitted and the resources could be created well.

The import status page doesn't show the `generateName`, I opened another PR for this page: #10850

**Unit test coverage report**: 
Unchanged as there are no old tests to extend.

**Test setup:**
1. Navigate to the Import YAM page by clicking the + icon in the top right corner
2. Try to import this YAML for example:

```yaml
apiVersion: primer.gitops.io/v1alpha1
kind: Export
metadata: 
  generateName: new-export-
spec: 
  method: 'download'
---
apiVersion: primer.gitops.io/v1alpha1
kind: Export
metadata: 
  generateName: new-export-
spec: 
  method: 'download'
```

3. Press create


**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
