### PR TITLE
Bug 2039776: Monitoring: show a error message if wrong dashboard name is passed to the URL

### DIFF
--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -155,7 +155,15 @@ const FilterSelect: React.FC<FilterSelectProps> = ({
       onSelect={onSelect}
       onToggle={onToggle}
       onTypeaheadInputChanged={(v) => setFilterText(v.toLowerCase())}
-      placeholderText={items[selectedKey]}
+      placeholderText={
+        Object.keys(items).includes(selectedKey) ? (
+          items[selectedKey]
+        ) : (
+          <>
+            <RedExclamationCircleIcon /> {t('public~Select a dashboard from the dropdown')}
+          </>
+        )
+      }
     >
       {_.map(filteredItems, (v, k) => (
         <OptionComponent key={k} itemKey={k} />

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -950,6 +950,7 @@
   "Custom time range": "Custom time range",
   "To": "To",
   "Filter options": "Filter options",
+  "Select a dashboard from the dropdown": "Select a dashboard from the dropdown",
   "Error loading options": "Error loading options",
   "Dashboard": "Dashboard",
   "Refresh interval": "Refresh interval",


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=2039776

**Analysis / Root cause:**
When the user saves or shares a dashboard URL it contains the dashboard parameter. If the dashboard could not be found the page looks incomplete.

The Dashboard dropdown doesn't show any info that the user can still select something.

**Solution Description:**
Show a message to select a dashboard from the dropdown.

**GIF:**
![Kapture 2022-01-15 at 01 58 30](https://user-images.githubusercontent.com/2561818/149581712-509679fd-8084-40a2-980d-29b66136011a.gif)

