### PR TITLE
Bug 2013127: allow catalog categories and cards to open in new tab

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogCategories.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogCategories.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { VerticalTabs, VerticalTabsTab } from '@patternfly/react-catalog-view-extension';
 import * as cx from 'classnames';
 import * as _ from 'lodash';
+import { getURLWithParams } from '../utils/catalog-utils';
 import { hasActiveDescendant, isActiveTab } from '../utils/category-utils';
-import { CatalogCategory } from '../utils/types';
+import { CatalogCategory, CatalogQueryParams } from '../utils/types';
 
 type CatalogCategoriesProp = {
   categories: CatalogCategory[];
@@ -42,6 +43,7 @@ const CatalogCategories: React.FC<CatalogCategoriesProp> = ({
         hasActiveDescendant={hasActiveDescendant(selectedCategory, category)}
         shown={toplevelCategory}
         data-test={`tab ${id}`}
+        href={getURLWithParams(CatalogQueryParams.CATEGORY, id)}
       >
         {subcategories && (
           <VerticalTabs restrictTabs activeTab={isActiveTab(selectedCategoryID, category)}>

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -23,6 +23,8 @@ import {
   Modal,
   useUserSettingsCompatibility,
 } from '@console/shared';
+import { getURLWithParams } from '@console/shared/src/components/catalog/utils';
+import { isModifiedEvent } from '@console/shared/src/utils';
 import { DefaultCatalogSource, DefaultCatalogSourceDisplayName } from '../../const';
 import { SubscriptionModel } from '../../models';
 import { communityOperatorWarningModal } from './operator-hub-community-provider-modal';
@@ -352,7 +354,12 @@ const OperatorHubTile: React.FC<OperatorHubTileProps> = ({ item, onClick }) => {
       icon={icon}
       vendor={vendor}
       description={description}
-      onClick={() => onClick(item)}
+      onClick={(e: React.MouseEvent<HTMLElement>) => {
+        if (isModifiedEvent(e)) return;
+        e.preventDefault();
+        onClick(item);
+      }}
+      href={getURLWithParams('details-item', item.uid)}
       footer={
         installed && !item.isInstalling ? (
           <span>

--- a/frontend/public/components/utils/tile-view-page.jsx
+++ b/frontend/public/components/utils/tile-view-page.jsx
@@ -20,7 +20,7 @@ import {
   Title,
   TextInput,
 } from '@patternfly/react-core';
-import { VirtualizedGrid } from '@console/shared';
+import { getURLWithParams, VirtualizedGrid } from '@console/shared';
 
 import { history } from './router';
 import { isModalOpen } from '../modals';
@@ -696,6 +696,7 @@ export class TileViewPage extends React.Component {
         hasActiveDescendant={hasActiveDescendant(selectedCategoryId, category)}
         shown={shown}
         data-test={id}
+        href={getURLWithParams(FilterTypes.category, id)}
       >
         {subcategories && (
           <VerticalTabs restrictTabs activeTab={isActiveTab(selectedCategoryId, category)}>


### PR DESCRIPTION
Ctrl/Cmd + Click does not work on category filters as [e.preventDefault() is always fired  in `<VerticalTabsTab>`](https://github.com/patternfly/patternfly-react/blob/main/packages/react-catalog-view-extension/src/components/VerticalTabs/VerticalTabsTab.tsx#L45).  I've opened an upstream issue to address --> see https://github.com/patternfly/patternfly-react/issues/6805.

Ctrl/Cmd + Click-ing a tile in the OperatorHub can result in bypassing the optional community operator warning modal, but this is the same behavior that occurs if you manually navigate to the URL directly or refresh the browser (in other words, this is an existing bug).

https://user-images.githubusercontent.com/895728/149592430-cd045d54-9454-49e2-9bcd-53185ebd6d7b.mov

Note the Bugzilla mentions this bug also exists on the `Source` filters, but that is erroneous as the source filters are checkboxes and not links.

