### PR TITLE
Bug 2038772: Monitoring: Handle service monitors with undefined matchLabels

### DIFF
--- a/frontend/public/components/monitoring/targets.tsx
+++ b/frontend/public/components/monitoring/targets.tsx
@@ -52,7 +52,8 @@ const ServiceMonitor: React.FC<{ target: Target }> = ({ target }) => {
     monitors,
     ({ spec }) =>
       service &&
-      new LabelSelector(spec.selector).matchesLabels(service.metadata.labels ?? {}) &&
+      (spec.selector.matchLabels === undefined ||
+        new LabelSelector(spec.selector).matchesLabels(service.metadata.labels ?? {})) &&
       (spec.namespaceSelector?.matchNames === undefined ||
         _.includes(spec.namespaceSelector?.matchNames, service.metadata.namespace)),
   );


### PR DESCRIPTION
When `matchLabels` is `undefined`, we should still match services if the
namespace matches.