### PR TITLE
Bug 2038115: Make namespace bar full width and sticky in console

### DIFF
--- a/frontend/packages/dev-console/src/components/NamespacedPage.scss
+++ b/frontend/packages/dev-console/src/components/NamespacedPage.scss
@@ -10,6 +10,7 @@
     flex-direction: column;
     background-color: var(--pf-global--Color--light-200);
     position: relative;
+    overflow: auto;
 
     &.is-light {
       background-color: var(--pf-global--Color--light-100);

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -201,6 +201,520 @@ const AppContents: React.FC<{}> = () => {
     [activePerspective, setActivePerspective, routePageExtensions, dynamicRoutePages],
   );
 
+  const contentRouter = (
+    <Switch>
+      {pluginPageRoutes}
+
+      <Route path={['/all-namespaces', '/ns/:ns']} component={RedirectComponent} />
+      <LazyRoute
+        path="/dashboards"
+        loader={() =>
+          import(
+            './dashboard/dashboards-page/dashboards' /* webpackChunkName: "dashboards" */
+          ).then((m) => m.DashboardsPage)
+        }
+      />
+
+      {/* Redirect legacy routes to avoid breaking links */}
+      <Redirect from="/cluster-status" to="/dashboards" />
+      <Redirect from="/status/all-namespaces" to="/dashboards" />
+      <Redirect from="/status/ns/:ns" to="/k8s/cluster/projects/:ns" />
+      <Route path="/status" exact component={NamespaceRedirect} />
+      <Redirect from="/overview/all-namespaces" to="/dashboards" />
+      <Redirect from="/overview/ns/:ns" to="/k8s/cluster/projects/:ns/workloads" />
+      <Route path="/overview" exact component={NamespaceRedirect} />
+
+      <LazyRoute
+        path="/api-explorer"
+        exact
+        loader={() =>
+          import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
+            (m) => m.APIExplorerPage,
+          )
+        }
+      />
+      <LazyRoute
+        path="/api-resource/cluster/:plural"
+        loader={() =>
+          import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
+            (m) => m.APIResourcePage,
+          )
+        }
+      />
+      <LazyRoute
+        path="/api-resource/all-namespaces/:plural"
+        loader={() =>
+          import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
+            NamespaceFromURL(m.APIResourcePage),
+          )
+        }
+      />
+      <LazyRoute
+        path="/api-resource/ns/:ns/:plural"
+        loader={() =>
+          import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
+            NamespaceFromURL(m.APIResourcePage),
+          )
+        }
+      />
+
+      <LazyRoute
+        path="/command-line-tools"
+        exact
+        loader={() =>
+          import('./command-line-tools' /* webpackChunkName: "command-line-tools" */).then(
+            (m) => m.CommandLineToolsPage,
+          )
+        }
+      />
+
+      <Route path="/operatorhub" exact component={NamespaceRedirect} />
+      <LazyRoute
+        path="/provisionedservices/all-namespaces"
+        loader={() =>
+          import('./provisioned-services' /* webpackChunkName: "provisionedservices" */).then(
+            (m) => m.ProvisionedServicesPage,
+          )
+        }
+      />
+      <LazyRoute
+        path="/provisionedservices/ns/:ns"
+        loader={() =>
+          import('./provisioned-services' /* webpackChunkName: "provisionedservices" */).then(
+            (m) => m.ProvisionedServicesPage,
+          )
+        }
+      />
+      <Route path="/provisionedservices" component={NamespaceRedirect} />
+
+      <LazyRoute
+        path="/brokermanagement"
+        loader={() =>
+          import('./broker-management' /* webpackChunkName: "brokermanagment" */).then(
+            (m) => m.BrokerManagementPage,
+          )
+        }
+      />
+
+      <LazyRoute
+        path="/catalog/instantiate-template"
+        exact
+        loader={() =>
+          import('./instantiate-template' /* webpackChunkName: "instantiate-template" */).then(
+            (m) => m.InstantiateTemplatePage,
+          )
+        }
+      />
+
+      <Route
+        path="/k8s/ns/:ns/alertmanagers/:name"
+        exact
+        render={({ match }) => (
+          <Redirect
+            to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${
+              match.params.name
+            }`}
+          />
+        )}
+      />
+
+      <LazyRoute
+        path="/k8s/all-namespaces/events"
+        exact
+        loader={() =>
+          import('./events' /* webpackChunkName: "events" */).then((m) =>
+            NamespaceFromURL(m.EventStreamPage),
+          )
+        }
+      />
+      <LazyRoute
+        path="/k8s/ns/:ns/events"
+        exact
+        loader={() =>
+          import('./events' /* webpackChunkName: "events" */).then((m) =>
+            NamespaceFromURL(m.EventStreamPage),
+          )
+        }
+      />
+      <Route path="/search/all-namespaces" exact component={NamespaceFromURL(SearchPage)} />
+      <Route path="/search/ns/:ns" exact component={NamespaceFromURL(SearchPage)} />
+      <Route path="/search" exact component={NamespaceRedirect} />
+
+      <LazyRoute
+        path="/k8s/all-namespaces/import"
+        exact
+        loader={() =>
+          import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
+            NamespaceFromURL(m.ImportYamlPage),
+          )
+        }
+      />
+      <LazyRoute
+        path="/k8s/ns/:ns/import/"
+        exact
+        loader={() =>
+          import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
+            NamespaceFromURL(m.ImportYamlPage),
+          )
+        }
+      />
+
+      {
+        // These pages are temporarily disabled. We need to update the safe resources list.
+        // <LazyRoute path="/k8s/cluster/clusterroles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+        // <LazyRoute path="/k8s/cluster/clusterroles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+      }
+
+      {
+        // <LazyRoute path="/k8s/ns/:ns/roles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+        // <LazyRoute path="/k8s/ns/:ns/roles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+      }
+
+      <LazyRoute
+        path="/k8s/ns/:ns/secrets/~new/:type"
+        exact
+        kind="Secret"
+        loader={() =>
+          import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
+            (m) => m.CreateSecret,
+          )
+        }
+      />
+      <LazyRoute
+        path="/k8s/ns/:ns/secrets/:name/edit"
+        exact
+        kind="Secret"
+        loader={() =>
+          import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
+            (m) => m.EditSecret,
+          )
+        }
+      />
+      <LazyRoute
+        path="/k8s/ns/:ns/secrets/:name/edit-yaml"
+        exact
+        kind="Secret"
+        loader={() => import('./create-yaml').then((m) => m.EditYAMLPage)}
+      />
+
+      <LazyRoute
+        path="/k8s/ns/:ns/networkpolicies/~new/form"
+        exact
+        kind="NetworkPolicy"
+        loader={() =>
+          import(
+            '@console/app/src/components/network-policies/create-network-policy' /* webpackChunkName: "create-network-policy" */
+          ).then((m) => m.CreateNetworkPolicy)
+        }
+      />
+
+      <LazyRoute
+        path="/k8s/ns/:ns/routes/~new/form"
+        exact
+        kind="Route"
+        loader={() =>
+          import('./routes/create-route' /* webpackChunkName: "create-route" */).then(
+            (m) => m.CreateRoute,
+          )
+        }
+      />
+
+      <LazyRoute
+        path="/k8s/cluster/rolebindings/~new"
+        exact
+        loader={() =>
+          import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
+        }
+        kind="RoleBinding"
+      />
+      <LazyRoute
+        path="/k8s/ns/:ns/rolebindings/~new"
+        exact
+        loader={() =>
+          import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
+        }
+        kind="RoleBinding"
+      />
+      <LazyRoute
+        path="/k8s/ns/:ns/rolebindings/:name/copy"
+        exact
+        kind="RoleBinding"
+        loader={() =>
+          import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
+        }
+      />
+      <LazyRoute
+        path="/k8s/ns/:ns/rolebindings/:name/edit"
+        exact
+        kind="RoleBinding"
+        loader={() =>
+          import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
+        }
+      />
+      <LazyRoute
+        path="/k8s/cluster/clusterrolebindings/:name/copy"
+        exact
+        kind="ClusterRoleBinding"
+        loader={() =>
+          import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
+        }
+      />
+      <LazyRoute
+        path="/k8s/cluster/clusterrolebindings/:name/edit"
+        exact
+        kind="ClusterRoleBinding"
+        loader={() =>
+          import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
+        }
+      />
+      <LazyRoute
+        path="/k8s/ns/:ns/:plural/:name/attach-storage"
+        exact
+        loader={() =>
+          import('./storage/attach-storage' /* webpackChunkName: "attach-storage" */).then(
+            (m) => m.default,
+          )
+        }
+      />
+
+      <LazyRoute
+        path="/k8s/ns/:ns/persistentvolumeclaims/~new/form"
+        exact
+        kind="PersistentVolumeClaim"
+        loader={() =>
+          import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(
+            (m) => m.CreatePVC,
+          )
+        }
+      />
+
+      <LazyRoute
+        path={`/k8s/ns/:ns/${VolumeSnapshotModel.plural}/~new/form`}
+        exact
+        loader={() =>
+          import(
+            '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
+          ).then((m) => m.VolumeSnapshot)
+        }
+      />
+
+      <LazyRoute
+        path={`/k8s/all-namespaces/${VolumeSnapshotModel.plural}/~new/form`}
+        exact
+        loader={() =>
+          import(
+            '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
+          ).then((m) => m.VolumeSnapshot)
+        }
+      />
+
+      <LazyRoute
+        path="/monitoring/alerts"
+        exact
+        loader={() =>
+          import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+            (m) => m.MonitoringUI,
+          )
+        }
+      />
+      <LazyRoute
+        path="/monitoring/alertrules"
+        exact
+        loader={() =>
+          import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+            (m) => m.MonitoringUI,
+          )
+        }
+      />
+      <LazyRoute
+        path="/monitoring/silences"
+        exact
+        loader={() =>
+          import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+            (m) => m.MonitoringUI,
+          )
+        }
+      />
+      <LazyRoute
+        path="/monitoring/alertmanageryaml"
+        exact
+        loader={() =>
+          import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+            (m) => m.MonitoringUI,
+          )
+        }
+      />
+      <LazyRoute
+        path="/monitoring/alertmanagerconfig"
+        exact
+        loader={() =>
+          import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+            (m) => m.MonitoringUI,
+          )
+        }
+      />
+      <LazyRoute
+        path="/monitoring/alertmanagerconfig/receivers/~new"
+        exact
+        loader={() =>
+          import(
+            './monitoring/receiver-forms/alert-manager-receiver-forms' /* webpackChunkName: "receiver-forms" */
+          ).then((m) => m.CreateReceiver)
+        }
+      />
+      <LazyRoute
+        path="/monitoring/alertmanagerconfig/receivers/:name/edit"
+        exact
+        loader={() =>
+          import(
+            './monitoring/receiver-forms/alert-manager-receiver-forms' /* webpackChunkName: "receiver-forms" */
+          ).then((m) => m.EditReceiver)
+        }
+      />
+      <LazyRoute
+        path="/monitoring"
+        loader={() =>
+          import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+            (m) => m.MonitoringUI,
+          )
+        }
+      />
+
+      <LazyRoute
+        path="/settings/idp/github"
+        exact
+        loader={() =>
+          import(
+            './cluster-settings/github-idp-form' /* webpackChunkName: "github-idp-form" */
+          ).then((m) => m.AddGitHubPage)
+        }
+      />
+      <LazyRoute
+        path="/settings/idp/gitlab"
+        exact
+        loader={() =>
+          import(
+            './cluster-settings/gitlab-idp-form' /* webpackChunkName: "gitlab-idp-form" */
+          ).then((m) => m.AddGitLabPage)
+        }
+      />
+      <LazyRoute
+        path="/settings/idp/google"
+        exact
+        loader={() =>
+          import(
+            './cluster-settings/google-idp-form' /* webpackChunkName: "google-idp-form" */
+          ).then((m) => m.AddGooglePage)
+        }
+      />
+      <LazyRoute
+        path="/settings/idp/htpasswd"
+        exact
+        loader={() =>
+          import(
+            './cluster-settings/htpasswd-idp-form' /* webpackChunkName: "htpasswd-idp-form" */
+          ).then((m) => m.AddHTPasswdPage)
+        }
+      />
+      <LazyRoute
+        path="/settings/idp/keystone"
+        exact
+        loader={() =>
+          import(
+            './cluster-settings/keystone-idp-form' /* webpackChunkName: "keystone-idp-form" */
+          ).then((m) => m.AddKeystonePage)
+        }
+      />
+      <LazyRoute
+        path="/settings/idp/ldap"
+        exact
+        loader={() =>
+          import('./cluster-settings/ldap-idp-form' /* webpackChunkName: "ldap-idp-form" */).then(
+            (m) => m.AddLDAPPage,
+          )
+        }
+      />
+      <LazyRoute
+        path="/settings/idp/oidconnect"
+        exact
+        loader={() =>
+          import(
+            './cluster-settings/openid-idp-form' /* webpackChunkName: "openid-idp-form" */
+          ).then((m) => m.AddOpenIDIDPPage)
+        }
+      />
+      <LazyRoute
+        path="/settings/idp/basicauth"
+        exact
+        loader={() =>
+          import(
+            './cluster-settings/basicauth-idp-form' /* webpackChunkName: "basicauth-idp-form" */
+          ).then((m) => m.AddBasicAuthPage)
+        }
+      />
+      <LazyRoute
+        path="/settings/idp/requestheader"
+        exact
+        loader={() =>
+          import(
+            './cluster-settings/request-header-idp-form' /* webpackChunkName: "request-header-idp-form" */
+          ).then((m) => m.AddRequestHeaderPage)
+        }
+      />
+      <LazyRoute
+        path="/settings/cluster"
+        loader={() =>
+          import(
+            './cluster-settings/cluster-settings' /* webpackChunkName: "cluster-settings" */
+          ).then((m) => m.ClusterSettingsPage)
+        }
+      />
+
+      <LazyRoute
+        path={'/k8s/cluster/storageclasses/~new/form'}
+        exact
+        loader={() =>
+          import('./storage-class-form' /* webpackChunkName: "storage-class-form" */).then(
+            (m) => m.StorageClassForm,
+          )
+        }
+      />
+
+      <Route path="/k8s/cluster/:plural" exact component={ResourceListPage} />
+      <Route path="/k8s/cluster/:plural/~new" exact component={CreateResource} />
+      <Route path="/k8s/cluster/:plural/:name" component={ResourceDetailsPage} />
+      <LazyRoute
+        path="/k8s/ns/:ns/pods/:podName/containers/:name"
+        loader={() => import('./container').then((m) => m.ContainersDetailsPage)}
+      />
+      <Route path="/k8s/ns/:ns/:plural/~new" component={CreateResource} />
+      <Route path="/k8s/ns/:ns/:plural/:name" component={ResourceDetailsPage} />
+      <Route path="/k8s/ns/:ns/:plural" exact component={ResourceListPage} />
+
+      <Route path="/k8s/all-namespaces/:plural" exact component={ResourceListPage} />
+      <Route path="/k8s/all-namespaces/:plural/:name" component={ResourceDetailsPage} />
+
+      {inactivePluginPageRoutes}
+
+      <LazyRoute
+        path="/error"
+        exact
+        loader={() => import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage)}
+      />
+      <Route path="/" exact component={DefaultPage} />
+
+      {allPluginsProcessed ? (
+        <LazyRoute
+          loader={() =>
+            import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage404)
+          }
+        />
+      ) : (
+        <Route component={LoadingBox} />
+      )}
+    </Switch>
+  );
+
   return (
     <div id="content">
       <PageSection
@@ -211,537 +725,15 @@ const AppContents: React.FC<{}> = () => {
         <GlobalNotifications />
         <Route path={namespacedRoutes} component={NamespaceBar} />
       </PageSection>
-
-      <PageSection
-        variant={PageSectionVariants.light}
-        id="content-scrollable"
-        className="pf-page__main-section--flex"
-        padding={{ default: 'noPadding' }}
-      >
-        <React.Suspense fallback={<LoadingBox />}>
-          <Switch>
-            {pluginPageRoutes}
-
-            <Route path={['/all-namespaces', '/ns/:ns']} component={RedirectComponent} />
-            <LazyRoute
-              path="/dashboards"
-              loader={() =>
-                import(
-                  './dashboard/dashboards-page/dashboards' /* webpackChunkName: "dashboards" */
-                ).then((m) => m.DashboardsPage)
-              }
-            />
-
-            {/* Redirect legacy routes to avoid breaking links */}
-            <Redirect from="/cluster-status" to="/dashboards" />
-            <Redirect from="/status/all-namespaces" to="/dashboards" />
-            <Redirect from="/status/ns/:ns" to="/k8s/cluster/projects/:ns" />
-            <Route path="/status" exact component={NamespaceRedirect} />
-            <Redirect from="/overview/all-namespaces" to="/dashboards" />
-            <Redirect from="/overview/ns/:ns" to="/k8s/cluster/projects/:ns/workloads" />
-            <Route path="/overview" exact component={NamespaceRedirect} />
-
-            <LazyRoute
-              path="/api-explorer"
-              exact
-              loader={() =>
-                import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
-                  (m) => m.APIExplorerPage,
-                )
-              }
-            />
-            <LazyRoute
-              path="/api-resource/cluster/:plural"
-              loader={() =>
-                import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
-                  (m) => m.APIResourcePage,
-                )
-              }
-            />
-            <LazyRoute
-              path="/api-resource/all-namespaces/:plural"
-              loader={() =>
-                import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
-                  NamespaceFromURL(m.APIResourcePage),
-                )
-              }
-            />
-            <LazyRoute
-              path="/api-resource/ns/:ns/:plural"
-              loader={() =>
-                import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
-                  NamespaceFromURL(m.APIResourcePage),
-                )
-              }
-            />
-
-            <LazyRoute
-              path="/command-line-tools"
-              exact
-              loader={() =>
-                import('./command-line-tools' /* webpackChunkName: "command-line-tools" */).then(
-                  (m) => m.CommandLineToolsPage,
-                )
-              }
-            />
-
-            <Route path="/operatorhub" exact component={NamespaceRedirect} />
-            <LazyRoute
-              path="/provisionedservices/all-namespaces"
-              loader={() =>
-                import('./provisioned-services' /* webpackChunkName: "provisionedservices" */).then(
-                  (m) => m.ProvisionedServicesPage,
-                )
-              }
-            />
-            <LazyRoute
-              path="/provisionedservices/ns/:ns"
-              loader={() =>
-                import('./provisioned-services' /* webpackChunkName: "provisionedservices" */).then(
-                  (m) => m.ProvisionedServicesPage,
-                )
-              }
-            />
-            <Route path="/provisionedservices" component={NamespaceRedirect} />
-
-            <LazyRoute
-              path="/brokermanagement"
-              loader={() =>
-                import('./broker-management' /* webpackChunkName: "brokermanagment" */).then(
-                  (m) => m.BrokerManagementPage,
-                )
-              }
-            />
-
-            <LazyRoute
-              path="/catalog/instantiate-template"
-              exact
-              loader={() =>
-                import(
-                  './instantiate-template' /* webpackChunkName: "instantiate-template" */
-                ).then((m) => m.InstantiateTemplatePage)
-              }
-            />
-
-            <Route
-              path="/k8s/ns/:ns/alertmanagers/:name"
-              exact
-              render={({ match }) => (
-                <Redirect
-                  to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${
-                    match.params.name
-                  }`}
-                />
-              )}
-            />
-
-            <LazyRoute
-              path="/k8s/all-namespaces/events"
-              exact
-              loader={() =>
-                import('./events' /* webpackChunkName: "events" */).then((m) =>
-                  NamespaceFromURL(m.EventStreamPage),
-                )
-              }
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/events"
-              exact
-              loader={() =>
-                import('./events' /* webpackChunkName: "events" */).then((m) =>
-                  NamespaceFromURL(m.EventStreamPage),
-                )
-              }
-            />
-            <Route path="/search/all-namespaces" exact component={NamespaceFromURL(SearchPage)} />
-            <Route path="/search/ns/:ns" exact component={NamespaceFromURL(SearchPage)} />
-            <Route path="/search" exact component={NamespaceRedirect} />
-
-            <LazyRoute
-              path="/k8s/all-namespaces/import"
-              exact
-              loader={() =>
-                import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
-                  NamespaceFromURL(m.ImportYamlPage),
-                )
-              }
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/import/"
-              exact
-              loader={() =>
-                import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
-                  NamespaceFromURL(m.ImportYamlPage),
-                )
-              }
-            />
-
-            {
-              // These pages are temporarily disabled. We need to update the safe resources list.
-              // <LazyRoute path="/k8s/cluster/clusterroles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-              // <LazyRoute path="/k8s/cluster/clusterroles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-            }
-
-            {
-              // <LazyRoute path="/k8s/ns/:ns/roles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-              // <LazyRoute path="/k8s/ns/:ns/roles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-            }
-
-            <LazyRoute
-              path="/k8s/ns/:ns/secrets/~new/:type"
-              exact
-              kind="Secret"
-              loader={() =>
-                import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
-                  (m) => m.CreateSecret,
-                )
-              }
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/secrets/:name/edit"
-              exact
-              kind="Secret"
-              loader={() =>
-                import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
-                  (m) => m.EditSecret,
-                )
-              }
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/secrets/:name/edit-yaml"
-              exact
-              kind="Secret"
-              loader={() => import('./create-yaml').then((m) => m.EditYAMLPage)}
-            />
-
-            <LazyRoute
-              path="/k8s/ns/:ns/networkpolicies/~new/form"
-              exact
-              kind="NetworkPolicy"
-              loader={() =>
-                import(
-                  '@console/app/src/components/network-policies/create-network-policy' /* webpackChunkName: "create-network-policy" */
-                ).then((m) => m.CreateNetworkPolicy)
-              }
-            />
-
-            <LazyRoute
-              path="/k8s/ns/:ns/routes/~new/form"
-              exact
-              kind="Route"
-              loader={() =>
-                import('./routes/create-route' /* webpackChunkName: "create-route" */).then(
-                  (m) => m.CreateRoute,
-                )
-              }
-            />
-
-            <LazyRoute
-              path="/k8s/cluster/rolebindings/~new"
-              exact
-              loader={() =>
-                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
-              }
-              kind="RoleBinding"
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/rolebindings/~new"
-              exact
-              loader={() =>
-                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
-              }
-              kind="RoleBinding"
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/rolebindings/:name/copy"
-              exact
-              kind="RoleBinding"
-              loader={() =>
-                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
-              }
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/rolebindings/:name/edit"
-              exact
-              kind="RoleBinding"
-              loader={() =>
-                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
-              }
-            />
-            <LazyRoute
-              path="/k8s/cluster/clusterrolebindings/:name/copy"
-              exact
-              kind="ClusterRoleBinding"
-              loader={() =>
-                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
-              }
-            />
-            <LazyRoute
-              path="/k8s/cluster/clusterrolebindings/:name/edit"
-              exact
-              kind="ClusterRoleBinding"
-              loader={() =>
-                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
-              }
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/:plural/:name/attach-storage"
-              exact
-              loader={() =>
-                import('./storage/attach-storage' /* webpackChunkName: "attach-storage" */).then(
-                  (m) => m.default,
-                )
-              }
-            />
-
-            <LazyRoute
-              path="/k8s/ns/:ns/persistentvolumeclaims/~new/form"
-              exact
-              kind="PersistentVolumeClaim"
-              loader={() =>
-                import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(
-                  (m) => m.CreatePVC,
-                )
-              }
-            />
-
-            <LazyRoute
-              path={`/k8s/ns/:ns/${VolumeSnapshotModel.plural}/~new/form`}
-              exact
-              loader={() =>
-                import(
-                  '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
-                ).then((m) => m.VolumeSnapshot)
-              }
-            />
-
-            <LazyRoute
-              path={`/k8s/all-namespaces/${VolumeSnapshotModel.plural}/~new/form`}
-              exact
-              loader={() =>
-                import(
-                  '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
-                ).then((m) => m.VolumeSnapshot)
-              }
-            />
-
-            <LazyRoute
-              path="/monitoring/alerts"
-              exact
-              loader={() =>
-                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                  (m) => m.MonitoringUI,
-                )
-              }
-            />
-            <LazyRoute
-              path="/monitoring/alertrules"
-              exact
-              loader={() =>
-                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                  (m) => m.MonitoringUI,
-                )
-              }
-            />
-            <LazyRoute
-              path="/monitoring/silences"
-              exact
-              loader={() =>
-                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                  (m) => m.MonitoringUI,
-                )
-              }
-            />
-            <LazyRoute
-              path="/monitoring/alertmanageryaml"
-              exact
-              loader={() =>
-                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                  (m) => m.MonitoringUI,
-                )
-              }
-            />
-            <LazyRoute
-              path="/monitoring/alertmanagerconfig"
-              exact
-              loader={() =>
-                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                  (m) => m.MonitoringUI,
-                )
-              }
-            />
-            <LazyRoute
-              path="/monitoring/alertmanagerconfig/receivers/~new"
-              exact
-              loader={() =>
-                import(
-                  './monitoring/receiver-forms/alert-manager-receiver-forms' /* webpackChunkName: "receiver-forms" */
-                ).then((m) => m.CreateReceiver)
-              }
-            />
-            <LazyRoute
-              path="/monitoring/alertmanagerconfig/receivers/:name/edit"
-              exact
-              loader={() =>
-                import(
-                  './monitoring/receiver-forms/alert-manager-receiver-forms' /* webpackChunkName: "receiver-forms" */
-                ).then((m) => m.EditReceiver)
-              }
-            />
-            <LazyRoute
-              path="/monitoring"
-              loader={() =>
-                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                  (m) => m.MonitoringUI,
-                )
-              }
-            />
-
-            <LazyRoute
-              path="/settings/idp/github"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/github-idp-form' /* webpackChunkName: "github-idp-form" */
-                ).then((m) => m.AddGitHubPage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/gitlab"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/gitlab-idp-form' /* webpackChunkName: "gitlab-idp-form" */
-                ).then((m) => m.AddGitLabPage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/google"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/google-idp-form' /* webpackChunkName: "google-idp-form" */
-                ).then((m) => m.AddGooglePage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/htpasswd"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/htpasswd-idp-form' /* webpackChunkName: "htpasswd-idp-form" */
-                ).then((m) => m.AddHTPasswdPage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/keystone"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/keystone-idp-form' /* webpackChunkName: "keystone-idp-form" */
-                ).then((m) => m.AddKeystonePage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/ldap"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/ldap-idp-form' /* webpackChunkName: "ldap-idp-form" */
-                ).then((m) => m.AddLDAPPage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/oidconnect"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/openid-idp-form' /* webpackChunkName: "openid-idp-form" */
-                ).then((m) => m.AddOpenIDIDPPage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/basicauth"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/basicauth-idp-form' /* webpackChunkName: "basicauth-idp-form" */
-                ).then((m) => m.AddBasicAuthPage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/requestheader"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/request-header-idp-form' /* webpackChunkName: "request-header-idp-form" */
-                ).then((m) => m.AddRequestHeaderPage)
-              }
-            />
-            <LazyRoute
-              path="/settings/cluster"
-              loader={() =>
-                import(
-                  './cluster-settings/cluster-settings' /* webpackChunkName: "cluster-settings" */
-                ).then((m) => m.ClusterSettingsPage)
-              }
-            />
-
-            <LazyRoute
-              path={'/k8s/cluster/storageclasses/~new/form'}
-              exact
-              loader={() =>
-                import('./storage-class-form' /* webpackChunkName: "storage-class-form" */).then(
-                  (m) => m.StorageClassForm,
-                )
-              }
-            />
-
-            <Route path="/k8s/cluster/:plural" exact component={ResourceListPage} />
-            <Route path="/k8s/cluster/:plural/~new" exact component={CreateResource} />
-            <Route path="/k8s/cluster/:plural/:name" component={ResourceDetailsPage} />
-            <LazyRoute
-              path="/k8s/ns/:ns/pods/:podName/containers/:name/debug"
-              loader={() =>
-                import('./debug-terminal' /* webpackChunkName: "debug-terminal" */).then(
-                  (m) => m.DebugTerminalPage,
-                )
-              }
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/pods/:podName/containers/:name"
-              loader={() => import('./container').then((m) => m.ContainersDetailsPage)}
-            />
-            <Route path="/k8s/ns/:ns/:plural/~new" component={CreateResource} />
-            <Route path="/k8s/ns/:ns/:plural/:name" component={ResourceDetailsPage} />
-            <Route path="/k8s/ns/:ns/:plural" exact component={ResourceListPage} />
-
-            <Route path="/k8s/all-namespaces/:plural" exact component={ResourceListPage} />
-            <Route path="/k8s/all-namespaces/:plural/:name" component={ResourceDetailsPage} />
-
-            {inactivePluginPageRoutes}
-
-            <LazyRoute
-              path="/error"
-              exact
-              loader={() =>
-                import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage)
-              }
-            />
-            <Route path="/" exact component={DefaultPage} />
-
-            {allPluginsProcessed ? (
-              <LazyRoute
-                loader={() =>
-                  import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage404)
-                }
-              />
-            ) : (
-              <Route component={LoadingBox} />
-            )}
-          </Switch>
-        </React.Suspense>
-      </PageSection>
+      <div id="content-scrollable">
+        <PageSection
+          variant={PageSectionVariants.light}
+          className="pf-page__main-section--flex"
+          padding={{ default: 'noPadding' }}
+        >
+          <React.Suspense fallback={<LoadingBox />}>{contentRouter}</React.Suspense>
+        </PageSection>
+      </div>
     </div>
   );
 };

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -10,8 +10,13 @@ body,
   display: flex;
   flex-basis: 100%;
   flex-direction: column;
+  height: 100%;
 }
 
+#content-scrollable {
+  overflow: auto;
+  height: 100%;
+}
 .co-m-page__body {
   display: flex;
   flex: 1 0 auto;
@@ -22,7 +27,7 @@ body,
   display: flex;
   flex: 1 0 auto;
   flex-direction: column;
-  height: 100% // doesn't work on safari without height
+  height: 100%; // doesn't work on safari without height
 }
 
 .co-p-has-sidebar {

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -162,6 +162,7 @@ form.pf-c-form {
   .pf-page__main-section--flex {
     display: flex;
     flex-direction: column;
+    height: 100%;
   }
 }
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGSM-39111

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

The scrollbar is attached to the whole content area in the console.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Previously, the main content area was scrollable, but we need only the content-scrollable area to be scrollable and the namespace bar which is above the content-scrollable area should occupy full width of the screen.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

Before:
![Screenshot 2022-01-17 at 4 17 30 PM](https://user-images.githubusercontent.com/9964343/149756182-09ae774c-da38-4a90-84b7-64d293fcfd53.png)

After:
![Screenshot 2022-01-17 at 4 18 24 PM](https://user-images.githubusercontent.com/9964343/149756232-48d0f44c-4653-463c-a71d-96649e5a77b4.png)

https://user-images.githubusercontent.com/9964343/149753920-46a9d1a0-1c5a-484a-83d5-25c4af8dd00f.mov

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc: @serenamarie125 @christianvogt 