### PR TITLE
Bug 2041475: Add function names to components which are wrapped in memo to get their name in the react dev tools

### DIFF
--- a/frontend/packages/console-app/src/components/detect-language/DetectLanguage.tsx
+++ b/frontend/packages/console-app/src/components/detect-language/DetectLanguage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { usePreferredLanguage, useLanguage } from '../user-preferences/language';
 
-const DetectLanguage: React.MemoExoticComponent<() => any> = React.memo(() => {
+const DetectLanguage: React.MemoExoticComponent<() => any> = React.memo(function DetectLanguage() {
   const [preferredLanguage, , preferredLanguageLoaded] = usePreferredLanguage();
   useLanguage(preferredLanguage, preferredLanguageLoaded);
   return null;

--- a/frontend/packages/console-shared/src/components/error/error-boundary.tsx
+++ b/frontend/packages/console-shared/src/components/error/error-boundary.tsx
@@ -45,11 +45,15 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
   }
 }
 
-export const withFallback: WithFallback = (Component, FallbackComponent) => (props) => (
-  <ErrorBoundary FallbackComponent={FallbackComponent}>
-    <Component {...props} />
-  </ErrorBoundary>
-);
+export const withFallback: WithFallback = (WrappedComponent, FallbackComponent) => {
+  const Component = (props) => (
+    <ErrorBoundary FallbackComponent={FallbackComponent}>
+      <WrappedComponent {...props} />
+    </ErrorBoundary>
+  );
+  Component.displayName = `withFallback(${WrappedComponent.displayName || WrappedComponent.name})`;
+  return Component;
+};
 
 export type WithFallback = <P = {}>(
   Component: React.ComponentType<P>,

--- a/frontend/packages/console-shared/src/hoc/withLastNamespace.tsx
+++ b/frontend/packages/console-shared/src/hoc/withLastNamespace.tsx
@@ -8,13 +8,18 @@ type WithLastNamespaceProps = {
 
 export const withLastNamespace = <Props extends WithLastNamespaceProps>(
   WrappedComponent: React.ComponentType<Props>,
-): React.FC<Omit<Props, keyof WithLastNamespaceProps>> => (props: Props) => {
-  const [activeNamespace, setActiveNamespace] = useActiveNamespace();
-  return (
-    <WrappedComponent
-      {...props}
-      activeNamespace={activeNamespace}
-      setActiveNamespace={setActiveNamespace}
-    />
-  );
+): React.FC<Omit<Props, keyof WithLastNamespaceProps>> => {
+  const Component = (props: Props) => {
+    const [activeNamespace, setActiveNamespace] = useActiveNamespace();
+    return (
+      <WrappedComponent
+        {...props}
+        activeNamespace={activeNamespace}
+        setActiveNamespace={setActiveNamespace}
+      />
+    );
+  };
+  Component.displayName = `withLastNamespace(${WrappedComponent.displayName ||
+    WrappedComponent.name})`;
+  return Component;
 };

--- a/frontend/packages/console-shared/src/hoc/withQuickStartContext.tsx
+++ b/frontend/packages/console-shared/src/hoc/withQuickStartContext.tsx
@@ -7,7 +7,12 @@ type WithQuickStartContextProps = {
 
 export const withQuickStartContext = <Props extends WithQuickStartContextProps>(
   WrappedComponent: React.ComponentType<Props>,
-): React.FC<Omit<Props, keyof WithQuickStartContextProps>> => (props: Props) => {
-  const quickStartContext = React.useContext(QuickStartContext);
-  return <WrappedComponent {...props} quickStartContext={quickStartContext} />;
+): React.FC<Omit<Props, keyof WithQuickStartContextProps>> => {
+  const Component = (props: Props) => {
+    const quickStartContext = React.useContext(QuickStartContext);
+    return <WrappedComponent {...props} quickStartContext={quickStartContext} />;
+  };
+  Component.displayName = `withQuickStartContext(${WrappedComponent.displayName ||
+    WrappedComponent.name})`;
+  return Component;
 };

--- a/frontend/packages/console-shared/src/hoc/withTelemetry.tsx
+++ b/frontend/packages/console-shared/src/hoc/withTelemetry.tsx
@@ -7,7 +7,11 @@ type WithTelemetryProps = {
 
 export const withTelemetry = <Props extends WithTelemetryProps>(
   WrappedComponent: React.ComponentType<Props>,
-): React.FC<Omit<Props, keyof WithTelemetryProps>> => (props: Props) => {
-  const fireTelemetryEvent = useTelemetry();
-  return <WrappedComponent {...props} fireTelemetryEvent={fireTelemetryEvent} />;
+): React.FC<Omit<Props, keyof WithTelemetryProps>> => {
+  const Component = (props: Props) => {
+    const fireTelemetryEvent = useTelemetry();
+    return <WrappedComponent {...props} fireTelemetryEvent={fireTelemetryEvent} />;
+  };
+  Component.displayName = `withTelemetry(${WrappedComponent.displayName || WrappedComponent.name})`;
+  return Component;
 };

--- a/frontend/packages/console-shared/src/hoc/withUserSettings.tsx
+++ b/frontend/packages/console-shared/src/hoc/withUserSettings.tsx
@@ -11,9 +11,14 @@ export const withUserSettings = <Props extends WithUserSettingsProps<T>, T = str
   defaultvalue?: T,
 ) => (
   WrappedComponent: React.ComponentType<Props>,
-): React.FC<Omit<Props, keyof WithUserSettingsProps<T>>> => (props: Props) => {
-  const [state, setState, loaded] = useUserSettings(configStorageKey, defaultvalue);
-  return loaded ? (
-    <WrappedComponent {...props} userSettingState={state} setUserSettingState={setState} />
-  ) : null;
+): React.FC<Omit<Props, keyof WithUserSettingsProps<T>>> => {
+  const Component = (props: Props) => {
+    const [state, setState, loaded] = useUserSettings(configStorageKey, defaultvalue);
+    return loaded ? (
+      <WrappedComponent {...props} userSettingState={state} setUserSettingState={setState} />
+    ) : null;
+  };
+  Component.displayName = `withUserSettings(${WrappedComponent.displayName ||
+    WrappedComponent.name})`;
+  return Component;
 };

--- a/frontend/packages/console-shared/src/hoc/withUserSettingsCompatibility.tsx
+++ b/frontend/packages/console-shared/src/hoc/withUserSettingsCompatibility.tsx
@@ -16,14 +16,19 @@ export const withUserSettingsCompatibility = <
   sync: boolean = false,
 ) => (
   WrappedComponent: React.ComponentType<Props>,
-): React.FC<Omit<Props, keyof WithUserSettingsCompatibilityProps<T>>> => (props: Props) => {
-  const [state, setState, loaded] = useUserSettingsCompatibility(
-    configStorageKey,
-    localStoragekey,
-    defaultvalue,
-    sync,
-  );
-  return loaded ? (
-    <WrappedComponent {...props} userSettingState={state} setUserSettingState={setState} />
-  ) : null;
+): React.FC<Omit<Props, keyof WithUserSettingsCompatibilityProps<T>>> => {
+  const Component = (props: Props) => {
+    const [state, setState, loaded] = useUserSettingsCompatibility(
+      configStorageKey,
+      localStoragekey,
+      defaultvalue,
+      sync,
+    );
+    return loaded ? (
+      <WrappedComponent {...props} userSettingState={state} setUserSettingState={setState} />
+    ) : null;
+  };
+  Component.displayName = `withUserSettingsCompatibility(${WrappedComponent.displayName ||
+    WrappedComponent.name})`;
+  return Component;
 };

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/PodSet.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/PodSet.tsx
@@ -53,7 +53,13 @@ export const podSetInnerRadius = (size: number, data: PodRCData) => {
   return radius - innerStrokeWidth - podStatusInset;
 };
 
-const PodSet: React.FC<PodSetProps> = React.memo(({ size, data, x = 0, y = 0, showPodCount }) => {
+const PodSet: React.FC<PodSetProps> = React.memo(function PodSet({
+  size,
+  data,
+  x = 0,
+  y = 0,
+  showPodCount,
+}) {
   const { t } = useTranslation();
   const { podStatusOuterRadius, podStatusInnerRadius, podStatusStrokeWidth } = calculateRadius(
     size,

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
@@ -39,54 +39,62 @@ type WorkloadPodsNodeProps = WorkloadNodeProps & {
   donutStatus: PodRCData;
 };
 
-const WorkloadPodsNode: React.FC<WorkloadPodsNodeProps> = observer(
-  ({ donutStatus, element, urlAnchorRef, canDrop, dropTarget, dropTooltip, ...rest }) => {
-    const { t } = useTranslation();
-    const { width, height } = element.getDimensions();
-    const workloadData = element.getData().data;
-    const filters = useDisplayFilters();
-    const size = Math.min(width, height);
-    const { radius, decoratorRadius } = calculateRadius(size);
-    const cx = width / 2;
-    const cy = height / 2;
-    const tipContent = dropTooltip || t('topology~Create a visual connector');
-    const showPodCountFilter = getFilterById(SHOW_POD_COUNT_FILTER_ID, filters);
-    const showPodCount = showPodCountFilter?.value ?? false;
-    const { decorators } = element.getGraph().getData();
-    const nodeDecorators = getNodeDecorators(element, decorators, cx, cy, radius, decoratorRadius);
-    const iconImageUrl =
-      getImageForIconClass(workloadData.builderImage) ?? workloadData.builderImage;
-    return (
-      <g>
-        <Tooltip
-          content={tipContent}
-          trigger="manual"
-          isVisible={dropTarget && canDrop}
-          animationDuration={0}
+const WorkloadPodsNode: React.FC<WorkloadPodsNodeProps> = observer(function WorkloadPodsNode({
+  donutStatus,
+  element,
+  urlAnchorRef,
+  canDrop,
+  dropTarget,
+  dropTooltip,
+  ...rest
+}) {
+  const { t } = useTranslation();
+  const { width, height } = element.getDimensions();
+  const workloadData = element.getData().data;
+  const filters = useDisplayFilters();
+  const size = Math.min(width, height);
+  const { radius, decoratorRadius } = calculateRadius(size);
+  const cx = width / 2;
+  const cy = height / 2;
+  const tipContent = dropTooltip || t('topology~Create a visual connector');
+  const showPodCountFilter = getFilterById(SHOW_POD_COUNT_FILTER_ID, filters);
+  const showPodCount = showPodCountFilter?.value ?? false;
+  const { decorators } = element.getGraph().getData();
+  const nodeDecorators = getNodeDecorators(element, decorators, cx, cy, radius, decoratorRadius);
+  const iconImageUrl = getImageForIconClass(workloadData.builderImage) ?? workloadData.builderImage;
+  return (
+    <g>
+      <Tooltip
+        content={tipContent}
+        trigger="manual"
+        isVisible={dropTarget && canDrop}
+        animationDuration={0}
+      >
+        <BaseNode
+          className="odc-workload-node"
+          outerRadius={radius}
+          innerRadius={donutStatus ? podSetInnerRadius(size, donutStatus) : 0}
+          icon={!showPodCount ? iconImageUrl : undefined}
+          kind={workloadData.kind}
+          element={element}
+          dropTarget={dropTarget}
+          canDrop={canDrop}
+          {...rest}
+          attachments={nodeDecorators}
         >
-          <BaseNode
-            className="odc-workload-node"
-            outerRadius={radius}
-            innerRadius={donutStatus ? podSetInnerRadius(size, donutStatus) : 0}
-            icon={!showPodCount ? iconImageUrl : undefined}
-            kind={workloadData.kind}
-            element={element}
-            dropTarget={dropTarget}
-            canDrop={canDrop}
-            {...rest}
-            attachments={nodeDecorators}
-          >
-            {donutStatus ? (
-              <PodSet size={size} x={cx} y={cy} data={donutStatus} showPodCount={showPodCount} />
-            ) : null}
-          </BaseNode>
-        </Tooltip>
-      </g>
-    );
-  },
-);
+          {donutStatus ? (
+            <PodSet size={size} x={cx} y={cy} data={donutStatus} showPodCount={showPodCount} />
+          ) : null}
+        </BaseNode>
+      </Tooltip>
+    </g>
+  );
+});
 
-const WorkloadNode: React.FC<WorkloadNodeProps> = observer(({ element, ...rest }) => {
+const WorkloadNode: React.FC<WorkloadNodeProps> = observer(function WorkloadNode({
+  element,
+  ...rest
+}) {
   const resource = getTopologyResourceObject(element.getData());
   const { podData, loadError, loaded } = usePodsWatcher(
     resource,

--- a/frontend/packages/topology/src/components/list-view/ListElementWrapper.tsx
+++ b/frontend/packages/topology/src/components/list-view/ListElementWrapper.tsx
@@ -13,7 +13,7 @@ interface ListElementWrapperProps {
 
 // in a separate component so that changes to behaviors do not re-render children
 const ListElementComponent: React.FC<ListElementWrapperProps> = observer(
-  ({ item, selectedIds, onSelect, children }) => {
+  function ListElementComponent({ item, selectedIds, onSelect, children }) {
     const type = item.getType();
 
     const Component = React.useMemo(() => listViewNodeComponentFactory(type), [type]);
@@ -26,38 +26,44 @@ const ListElementComponent: React.FC<ListElementWrapperProps> = observer(
 );
 
 const ListElementChildren: React.FC<ListElementWrapperProps> = observer(
-  ({ item, selectedIds, onSelect }) => (
-    <>
-      {item
-        .getChildren()
-        .filter(isNode)
-        .sort((a, b) =>
-          labelForNodeKind(getResourceKind(a)).localeCompare(labelForNodeKind(getResourceKind(b))),
-        )
-        .map((e) => (
-          <ListElementWrapper
-            key={e.getId()}
-            item={e as Node}
-            onSelect={onSelect}
-            selectedIds={selectedIds}
-          />
-        ))}
-    </>
-  ),
-);
-
-const ListElementWrapper: React.FC<ListElementWrapperProps> = observer(
-  ({ item, selectedIds, onSelect }) => {
-    if (!item.isVisible()) {
-      return null;
-    }
-
+  function ListElementChildren({ item, selectedIds, onSelect }) {
     return (
-      <ListElementComponent item={item} onSelect={onSelect} selectedIds={selectedIds}>
-        <ListElementChildren item={item} onSelect={onSelect} selectedIds={selectedIds} />
-      </ListElementComponent>
+      <>
+        {item
+          .getChildren()
+          .filter(isNode)
+          .sort((a, b) =>
+            labelForNodeKind(getResourceKind(a)).localeCompare(
+              labelForNodeKind(getResourceKind(b)),
+            ),
+          )
+          .map((e) => (
+            <ListElementWrapper
+              key={e.getId()}
+              item={e as Node}
+              onSelect={onSelect}
+              selectedIds={selectedIds}
+            />
+          ))}
+      </>
     );
   },
 );
+
+const ListElementWrapper: React.FC<ListElementWrapperProps> = observer(function ListElementWrapper({
+  item,
+  selectedIds,
+  onSelect,
+}) {
+  if (!item.isVisible()) {
+    return null;
+  }
+
+  return (
+    <ListElementComponent item={item} onSelect={onSelect} selectedIds={selectedIds}>
+      <ListElementChildren item={item} onSelect={onSelect} selectedIds={selectedIds} />
+    </ListElementComponent>
+  );
+});
 
 export default ListElementWrapper;

--- a/frontend/packages/topology/src/components/page/TopologyDataRenderer.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyDataRenderer.tsx
@@ -10,30 +10,32 @@ interface TopologyDataRendererProps {
   viewType: TopologyViewType;
 }
 
-const TopologyDataRenderer: React.FC<TopologyDataRendererProps> = observer(({ viewType }) => {
-  const { t } = useTranslation();
-  const { namespace, model, loaded, loadError } = React.useContext<ExtensibleModel>(ModelContext);
+const TopologyDataRenderer: React.FC<TopologyDataRendererProps> = observer(
+  function TopologyDataRenderer({ viewType }) {
+    const { t } = useTranslation();
+    const { namespace, model, loaded, loadError } = React.useContext<ExtensibleModel>(ModelContext);
 
-  return (
-    <StatusBox
-      skeleton={
-        viewType === TopologyViewType.list && (
-          <div className="co-m-pane__body skeleton-overview">
-            <div className="skeleton-overview--head" />
-            <div className="skeleton-overview--tile" />
-            <div className="skeleton-overview--tile" />
-            <div className="skeleton-overview--tile" />
-          </div>
-        )
-      }
-      data={model}
-      label={t('topology~Topology')}
-      loaded={loaded}
-      loadError={loadError}
-    >
-      <DroppableTopologyComponent viewType={viewType} model={model} namespace={namespace} />
-    </StatusBox>
-  );
-});
+    return (
+      <StatusBox
+        skeleton={
+          viewType === TopologyViewType.list && (
+            <div className="co-m-pane__body skeleton-overview">
+              <div className="skeleton-overview--head" />
+              <div className="skeleton-overview--tile" />
+              <div className="skeleton-overview--tile" />
+              <div className="skeleton-overview--tile" />
+            </div>
+          )
+        }
+        data={model}
+        label={t('topology~Topology')}
+        loaded={loaded}
+        loadError={loadError}
+      >
+        <DroppableTopologyComponent viewType={viewType} model={model} namespace={namespace} />
+      </StatusBox>
+    );
+  },
+);
 
 export default TopologyDataRenderer;

--- a/frontend/packages/topology/src/components/page/TopologyPageToolbar.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyPageToolbar.tsx
@@ -20,7 +20,7 @@ interface TopologyPageToolbarProps {
 }
 
 const TopologyPageToolbar: React.FC<TopologyPageToolbarProps> = observer(
-  ({ viewType, onViewChange }) => {
+  function TopologyPageToolbar({ viewType, onViewChange }) {
     const { t } = useTranslation();
     const isMobile = useIsMobile();
     const { extensions } = React.useContext<FileUploadContextType>(FileUploadContext);

--- a/frontend/packages/topology/src/components/utils/subscribeOverviewAlerts.ts
+++ b/frontend/packages/topology/src/components/utils/subscribeOverviewAlerts.ts
@@ -1,13 +1,13 @@
 import { Alert } from '@console/internal/components/monitoring/types';
 import { fetchMonitoringAlerts } from '@console/internal/components/overview/metricUtils';
 
-type StopOverviewAUpdater = () => void;
+type UnsubscribeCallback = () => void;
 
-export const useOverviewAlertsUpdater = (
+export const subscribeOverviewAlerts = (
   namespace: string,
   updateMonitoringAlerts: (alerts: Alert[]) => void,
   interval: number = 15 * 1000,
-): StopOverviewAUpdater => {
+): UnsubscribeCallback => {
   let alertsInterval: any = null;
 
   const fetchAlerts = (): void => {

--- a/frontend/packages/topology/src/components/utils/subscribeOverviewMetrics.ts
+++ b/frontend/packages/topology/src/components/utils/subscribeOverviewMetrics.ts
@@ -7,14 +7,14 @@ import {
 } from '@console/internal/components/overview/metricUtils';
 import { METRICS_POLL_INTERVAL } from '@console/shared/src';
 
-type StopOverviewMetricsUpdater = () => void;
+type UnsubscribeCallback = () => void;
 
-export const useOverviewMetricsUpdater = (
+export const subscribeOverviewMetrics = (
   namespace: string,
   metrics: OverviewMetrics,
   updateMetrics: (metrics: OverviewMetrics) => void,
   interval: number = METRICS_POLL_INTERVAL,
-): StopOverviewMetricsUpdater => {
+): UnsubscribeCallback => {
   let metricsInterval = null;
 
   const fetchMetrics = () => {

--- a/frontend/packages/topology/src/utils/withEditReviewAccess.tsx
+++ b/frontend/packages/topology/src/utils/withEditReviewAccess.tsx
@@ -22,5 +22,7 @@ export const withEditReviewAccess = (verb: K8sVerb) => (WrappedComponent: React.
     });
     return <WrappedComponent {...(props as any)} canEdit={editAccess} />;
   };
+  Component.displayName = `withEditReviewAccess(${WrappedComponent.displayName ||
+    WrappedComponent.name})`;
   return observer(Component);
 };

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -229,7 +229,7 @@ class App_ extends React.PureComponent {
   }
 }
 
-const AppWithExtensions = withTranslation()((props) => {
+const AppWithExtensions = withTranslation()(function AppWithExtensions(props) {
   const [reduxReducerExtensions, reducersResolved] = useResolvedExtensions(isReduxReducer);
   const [contextProviderExtensions, providersResolved] = useResolvedExtensions(isContextProvider);
 
@@ -265,7 +265,7 @@ const AppRouter = () => {
   );
 };
 
-const CaptureTelemetry = React.memo(() => {
+const CaptureTelemetry = React.memo(function CaptureTelemetry() {
   const fireTelemetryEvent = useTelemetry();
 
   // notify of identity change
@@ -300,7 +300,7 @@ const CaptureTelemetry = React.memo(() => {
   return null;
 });
 
-const PollConsoleUpdates = React.memo(() => {
+const PollConsoleUpdates = React.memo(function PollConsoleUpdates() {
   const toastContext = useToast();
   const { t } = useTranslation();
 

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -324,7 +324,12 @@ const namespacesRowStateToProps = ({ UI }) => ({
 });
 
 const NamespacesTableRow = connect(namespacesRowStateToProps)(
-  withTranslation()(({ obj: ns, metrics, customData: { tableColumns }, t }) => {
+  withTranslation()(function NamespacesTableRow({
+    obj: ns,
+    metrics,
+    customData: { tableColumns },
+    t,
+  }) {
     const name = getName(ns);
     const requester = getRequester(ns);
     const bytes = metrics?.memory?.[name];
@@ -421,7 +426,7 @@ export const NamespacesList = connect(
     COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY,
     undefined,
     true,
-  )(({ userSettingState: tableColumns, ...props }) => {
+  )(function NamespacesList({ userSettingState: tableColumns, ...props }) {
     const { setNamespaceMetrics } = props;
     React.useEffect(() => {
       const updateMetrics = () => fetchNamespaceMetrics().then(setNamespaceMetrics);
@@ -473,7 +478,7 @@ export const NamespacesPage = withUserSettingsCompatibility(
   COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY,
   undefined,
   true,
-)(({ userSettingState: tableColumns, ...props }) => {
+)(function NamespacesPage({ userSettingState: tableColumns, ...props }) {
   const { t } = useTranslation();
   const selectedColumns =
     tableColumns?.[NamespacesColumnManagementID]?.length > 0
@@ -590,7 +595,7 @@ const getProjectSelectedColumns = ({ showMetrics, showActions }) => {
 
 const ProjectLink = connect(null, {
   filterList: k8sActions.filterList,
-})(({ project, filterList }) => {
+})(function ProjectLink({ project, filterList }) {
   const [, setLastNamespace] = useUserSettingsCompatibility(
     LAST_NAMESPACE_NAME_USER_SETTINGS_KEY,
     LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
@@ -639,7 +644,7 @@ const projectRowStateToProps = ({ UI }) => ({
 });
 
 const ProjectTableRow = connect(projectRowStateToProps)(
-  withTranslation()(({ obj: project, customData = {}, metrics, t }) => {
+  withTranslation()(function ProjectTableRow({ obj: project, customData = {}, metrics, t }) {
     const name = getName(project);
     const requester = getRequester(project);
     const {
@@ -749,7 +754,6 @@ const ProjectTableRow = connect(projectRowStateToProps)(
     );
   }),
 );
-ProjectTableRow.displayName = 'ProjectTableRow';
 
 export const ProjectsTable = (props) => {
   const { t } = useTranslation();
@@ -785,7 +789,13 @@ const ProjectList_ = connectToFlags(
     COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY,
     undefined,
     true,
-  )(({ data, flags, setNamespaceMetrics, userSettingState: tableColumns, ...tableProps }) => {
+  )(function ProjectList_({
+    data,
+    flags,
+    setNamespaceMetrics,
+    userSettingState: tableColumns,
+    ...tableProps
+  }) {
     const canGetNS = flags[FLAGS.CAN_GET_NS];
     const showMetrics = PROMETHEUS_BASE_PATH && canGetNS && window.screen.width >= 1200;
     /* eslint-disable react-hooks/exhaustive-deps */
@@ -803,12 +813,6 @@ const ProjectList_ = connectToFlags(
       tableColumns?.[projectColumnManagementID]?.length > 0
         ? new Set(tableColumns[projectColumnManagementID])
         : null;
-
-    // Don't render the table until we know whether we can get metrics. It's
-    // not possible to change the table headers once the component is mounted.
-    if (flagPending(canGetNS)) {
-      return null;
-    }
 
     const ProjectEmptyMessage = () => (
       <MsgBox
@@ -835,6 +839,12 @@ const ProjectList_ = connectToFlags(
       }),
       [showMetrics, tableColumns],
     );
+
+    // Don't render the table until we know whether we can get metrics. It's
+    // not possible to change the table headers once the component is mounted.
+    if (flagPending(canGetNS)) {
+      return null;
+    }
 
     return (
       <Table
@@ -866,7 +876,7 @@ export const ProjectsPage = connectToFlags(
     COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY,
     undefined,
     true,
-  )(({ flags, userSettingState: tableColumns, ...rest }) => {
+  )(function ProjectsPage({ flags, userSettingState: tableColumns, ...rest }) {
     // Skip self-subject access review for projects since they use a special project request API.
     // `FLAGS.CAN_CREATE_PROJECT` determines if the user can create projects.
     const canGetNS = flags[FLAGS.CAN_GET_NS];

--- a/frontend/public/components/nav/index.tsx
+++ b/frontend/public/components/nav/index.tsx
@@ -11,20 +11,22 @@ type NavigationProps = {
   isNavOpen: boolean;
 };
 
-export const Navigation: React.FC<NavigationProps> = React.memo(
-  ({ isNavOpen, onNavSelect, onPerspectiveSelected }) => {
-    const { t } = useTranslation();
-    return (
-      <PageSidebar
-        nav={
-          <Nav aria-label={t('public~Nav')} onSelect={onNavSelect} theme="dark">
-            <NavHeader onPerspectiveSelected={onPerspectiveSelected} />
-            <PerspectiveNav />
-          </Nav>
-        }
-        isNavOpen={isNavOpen}
-        theme="dark"
-      />
-    );
-  },
-);
+export const Navigation: React.FC<NavigationProps> = React.memo(function Navigation({
+  isNavOpen,
+  onNavSelect,
+  onPerspectiveSelected,
+}) {
+  const { t } = useTranslation();
+  return (
+    <PageSidebar
+      nav={
+        <Nav aria-label={t('public~Nav')} onSelect={onNavSelect} theme="dark">
+          <NavHeader onPerspectiveSelected={onPerspectiveSelected} />
+          <PerspectiveNav />
+        </Nav>
+      }
+      isNavOpen={isNavOpen}
+      theme="dark"
+    />
+  );
+});


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2041475

**Analysis / Root cause**: 
The react "compiler" automatically knows component names for functions:

```tsx
ComonentA(props) { return null; }
```

For arrow functions this works only if they are directly assigned to a variable:

```tsx
const CompontentB = (props) => null
```

This doesn't work when the component is wrapped in `React.memo` or when it is wrapped in a `with...` HOC function.

**Solution Description**: 

1. Add `function` keyword to some components which are wrapped with React.memo or `observer` like `PodSet` so that the component name is clear:

```tsx
const CompontentC = React.memo((props) => null) { ... }
```

to

```tsx
const CompontentC = React.memo(function CompontentC(props) { ....
```

For example: `WorkloadPodsNode`, `TopologyListViewComponent`, `TopologyListView`, `AppWithExtensions`, `AppRouter`, `CaptureTelemetry`, `PollConsoleUpdates`, `NamespacesList`, `NamespacesPage`

2. Added an explicit displayName to component wrapper/HOC `withFallback`, `withLastNamespace`, `withserSettings`, etc.

3. Renamed this "hook" to a "utils" because it is called in useEffect (which should not call hooks itself) and in fact it is not a hook.

```diff
-import { useOverviewAlertsUpdater } from '../hooks/useOverviewAlertsUpdater';
-import { useOverviewMetricsUpdater } from '../hooks/useOverviewMetricsUpdater';
+import { subscribeOverviewAlerts } from '../utils/subscribeOverviewAlerts';
+import { subscribeOverviewMetrics } from '../utils/subscribeOverviewMetrics';
```

4. Moved a conditional return before a `useEffect` in `namespace.jsx` so that this conforms to the general hook rules.

**Screenshots of the dev tools**: 

App root components:
<table><tr>
<td><img src="https://user-images.githubusercontent.com/139310/149760818-a4a12f66-5741-4dbd-b1a8-79a006834618.png" />
</td>
<td><img src="https://user-images.githubusercontent.com/139310/149760806-c4c70a6c-0d1d-47a5-a727-283f3112af9e.png" /></td>
</tr></table>

With last namespace:
<table><tr>
<td><img src="https://user-images.githubusercontent.com/139310/149761246-c47f8c55-c967-460e-8917-94f07b20a968.png" />
</td>
<td><img src="https://user-images.githubusercontent.com/139310/149761276-21042f60-1176-4242-9329-732607274b4c.png" /></td>
</tr></table>

WorkloadPodsNode:
<table><tr>
<td><img src="https://user-images.githubusercontent.com/139310/149761612-a1fcd061-9ab7-4685-b4df-ca719be61bb0.png" />
</td>
<td><img src="https://user-images.githubusercontent.com/139310/149761618-e64dc1cb-305a-4c99-9933-92a06a918837.png" /></td>
</tr></table>

PodSet:
<table><tr>
<td><img src="https://user-images.githubusercontent.com/139310/149761740-6d66e964-fc1b-43b3-bd3d-6ce22acaf675.png" />
</td>
<td><img src="https://user-images.githubusercontent.com/139310/149761746-80aa86c0-1353-4a45-9eb9-55bc4790c26d.png" /></td>
</tr></table>

TopologyListView:
<table><tr>
<td><img src="https://user-images.githubusercontent.com/139310/149762017-69763382-7fb4-4cd0-a829-f8c0db7db4a5.png" />
</td>
<td><img src="https://user-images.githubusercontent.com/139310/149762019-f195aade-54c0-4478-ad20-e31ca222968c.png" /></td>
</tr></table>

**Unit test coverage report**: 
Unchanged

**Test setup:**
Check if the components and pages still work.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
