### PR TITLE
ODC-6453: Allow multiple namespaces to be deleted as part of cleanup

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/dev-console/integration-tests/support/commands/hooks.ts
@@ -6,7 +6,8 @@ before(() => {
 });
 
 after(() => {
-  cy.exec(`oc delete namespace ${Cypress.env('NAMESPACE')}`, { failOnNonZeroExit: false });
+  const namespaces: string[] = Cypress.env('NAMESPACES') || [];
+  cy.exec(`oc delete namespace ${namespaces.join(' ')}`, { failOnNonZeroExit: false });
   // cy.logout();
 });
 

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -192,6 +192,11 @@ export const projectNameSpace = {
           cy.byTestDropDownMenu('#CREATE_RESOURCE_ACTION#').click();
           projectNameSpace.enterProjectName(projectName);
           cy.byTestID('confirm-action').click();
+          const namespaces: string[] = Cypress.env('NAMESPACES') || [];
+          if (!namespaces.includes(projectName)) {
+            namespaces.push(projectName);
+          }
+          Cypress.env('NAMESPACES', namespaces);
           app.waitForLoad();
         } else {
           cy.get('[data-test="namespace-dropdown-menu"]')
@@ -205,6 +210,11 @@ export const projectNameSpace = {
               cy.byTestDropDownMenu('#CREATE_RESOURCE_ACTION#').click();
               projectNameSpace.enterProjectName(projectName);
               cy.byTestID('confirm-action').click();
+              const namespaces: string[] = Cypress.env('NAMESPACES') || [];
+              if (!namespaces.includes(projectName)) {
+                namespaces.push(projectName);
+              }
+              Cypress.env('NAMESPACES', namespaces);
               app.waitForLoad();
             }
           });

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/common/project-creation.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/common/project-creation.ts
@@ -6,7 +6,13 @@ When('user enters project name as {string} in Create Project modal', (projectNam
   const d = new Date();
   const timestamp = d.getTime();
   projectNameSpace.enterProjectName(`${projectName}-${timestamp}-ns`);
-  Cypress.env('NAMESPACE', `${projectName}-${timestamp}-ns`);
+  const finalName = `${projectName}-${timestamp}-ns`;
+  Cypress.env('NAMESPACE', finalName);
+  const namespaces: string[] = Cypress.env('NAMESPACES') || [];
+  if (!namespaces.includes(finalName)) {
+    namespaces.push(finalName);
+  }
+  Cypress.env('NAMESPACES', namespaces);
 });
 
 When('user clicks Create button present in Create Project modal', () => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/userPreferences/user-preferences-dev-perspective.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/userPreferences/user-preferences-dev-perspective.ts
@@ -101,9 +101,6 @@ Then('user can see project {string} is selected', (projectName: string) => {
     'contain.text',
     projectName,
   );
-  cy.exec(`oc delete namespace ${Cypress.env('NAMESPACE', projectName)}`, {
-    failOnNonZeroExit: false,
-  });
 });
 
 When('user types project {string} in search bar', (preference: string) => {

--- a/frontend/packages/gitops-plugin/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/gitops-plugin/integration-tests/support/commands/hooks.ts
@@ -9,6 +9,7 @@ before(() => {
 });
 
 after(() => {
-  cy.exec(`oc delete namespace ${Cypress.env('NAMESPACE')}`, { failOnNonZeroExit: false });
+  const namespaces: string[] = Cypress.env('NAMESPACES') || [];
+  cy.exec(`oc delete namespace ${namespaces.join(' ')}`, { failOnNonZeroExit: false });
   // cy.logout();
 });

--- a/frontend/packages/knative-plugin/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/commands/hooks.ts
@@ -33,7 +33,8 @@ beforeEach(() => {
 });
 
 after(() => {
-  cy.exec(`oc delete namespace ${Cypress.env('NAMESPACE')}`, { failOnNonZeroExit: false });
+  const namespaces: string[] = Cypress.env('NAMESPACES') || [];
+  cy.exec(`oc delete namespace ${namespaces.join(' ')}`, { failOnNonZeroExit: false });
   // cy.logout();
 });
 

--- a/frontend/packages/pipelines-plugin/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/commands/hooks.ts
@@ -9,8 +9,9 @@ before(() => {
 });
 
 after(() => {
-  cy.log(`Deleting "${Cypress.env('NAMESPACE')}" namespace`);
-  cy.exec(`oc delete namespace ${Cypress.env('NAMESPACE')}`, {
+  const namespaces: string[] = Cypress.env('NAMESPACES') || [];
+  cy.log(`Deleting "${namespaces.join(' ')}" namespace`);
+  cy.exec(`oc delete namespace ${namespaces.join(' ')}`, {
     failOnNonZeroExit: false,
     timeout: 180000,
   });

--- a/frontend/packages/topology/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/topology/integration-tests/support/commands/hooks.ts
@@ -7,7 +7,8 @@ before(() => {
 });
 
 after(() => {
-  cy.exec(`oc delete namespace ${Cypress.env('NAMESPACE')}`, {
+  const namespaces: string[] = Cypress.env('NAMESPACES') || [];
+  cy.exec(`oc delete namespace ${namespaces.join(' ')}`, {
     failOnNonZeroExit: false,
     timeout: 180000,
   });

--- a/frontend/packages/topology/integration-tests/support/step-definitions/export-application/export-of-application.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/export-application/export-of-application.ts
@@ -69,11 +69,6 @@ Then(
     cy.get(exportModalButton(el3)).should('be.visible');
     cy.get(exportModalButton(el4)).should('be.visible');
     cy.get(exportModalButton('Ok')).click();
-    // Need to handle below deletion of namespace better with task ODC-6453
-    cy.exec(`oc delete namespace ${Cypress.env('NAMESPACE')}`, {
-      failOnNonZeroExit: false,
-      timeout: 180000,
-    });
   },
 );
 


### PR DESCRIPTION
Current after hook implementation only allows a single namespace to be deleted on cleanup. Extending the hooks so an arbitrary number of namespaces may be wiped after tests.