### PR TITLE
Bug 2036989: Prevent route external link icon and copy-to-clipboard icon from wrapping separately from its associated inline text.

### DIFF
--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -120,7 +120,7 @@ export const RouteLinkAndCopy: React.FC<RouteLinkAndCopyProps> = ({
 
 // Renders LinkAndCopy for non subdomains
 export const RouteLocation: React.FC<RouteHostnameProps> = ({ obj }) => (
-  <div>
+  <div className="co-break-word">
     {isWebRoute(obj) ? (
       <RouteLinkAndCopy route={obj} additionalClassName="co-external-link--block" />
     ) : (

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -107,24 +107,27 @@ export const ExternalLinkWithCopy: React.FC<ExternalLinkWithCopyProps> = ({
   ];
 
   return (
-    <div className={classNames('co-external-link-with-copy', additionalClassName)}>
+    <div className={classNames(additionalClassName)}>
       <a href={link} target="_blank" rel="noopener noreferrer" data-test-id={dataTestID}>
         {text ?? link}
+      </a>
+      <span className="co-icon-nowrap">
+        &nbsp;
         <span className="co-external-link-with-copy__icon co-external-link-with-copy__externallinkicon">
           <ExternalLinkAltIcon />
         </span>
-      </a>
-      <Tooltip content={tooltipContent} trigger="click mouseenter focus" exitDelay={1250}>
-        <CTC text={link} onCopy={() => setCopied(true)}>
-          <span
-            onMouseEnter={() => setCopied(false)}
-            className="co-external-link-with-copy__icon co-external-link-with-copy__copyicon"
-          >
-            <CopyIcon />
-            <span className="sr-only">{t('public~Copy to clipboard')}</span>
-          </span>
-        </CTC>
-      </Tooltip>
+        <Tooltip content={tooltipContent} trigger="click mouseenter focus" exitDelay={1250}>
+          <CTC text={link} onCopy={() => setCopied(true)}>
+            <span
+              onMouseEnter={() => setCopied(false)}
+              className="co-external-link-with-copy__icon co-external-link-with-copy__copyicon"
+            >
+              <CopyIcon />
+              <span className="sr-only">{t('public~Copy to clipboard')}</span>
+            </span>
+          </CTC>
+        </Tooltip>
+      </span>
     </div>
   );
 };

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -276,8 +276,6 @@ dl.co-inline {
 }
 
 .co-external-link-with-copy {
-  display: inline-block;
-  padding-right: $co-external-link-padding-right;
   &__icon {
     color: var(--pf-global--link--Color);
     cursor: pointer;
@@ -291,6 +289,12 @@ dl.co-inline {
   &__copyicon {
     margin-left: var(--pf-global--spacer--md);
   }
+}
+
+// Prevent inline appended icons from wrapping separately without its associated text
+.co-icon-nowrap {
+  display: inline;
+  white-space: nowrap;
 }
 
 .co-goto-arrow::after {


### PR DESCRIPTION
This bug https://bugzilla.redhat.com/show_bug.cgi?id=2036989 requests the `copy-to-clipboard` icon not wrap separately from the text link, which also has an external icon appended that wraps separately.

UPDATED: I have switched back the original display where `copy-to-clipboard` icon appears inline with the `external-link` icon. And wrapped them in a new class `co-icon-nowrap` plus `&nbsp;` to prevent them for wrapping without the associated link.

Note this link with icons also appears in the Routes list table (which currently doesn't word-break correctly) so I also added `co-break-word` to it's parent `div`


**Before**
<img width="1120" alt="copy-bug" src="https://user-images.githubusercontent.com/1874151/149808323-6f19fcca-258a-420a-b5f2-3d4b13867a05.png">
---
<img width="1032" alt="Screen Shot 2022-01-18 at 8 01 52 PM" src="https://user-images.githubusercontent.com/1874151/150160297-cea4aa2a-39cd-442a-b285-943e72d8bb59.png">

----

**After**
<img width="1042" alt="Screen Shot 2022-01-18 at 7 54 57 PM" src="https://user-images.githubusercontent.com/1874151/150160160-0bb93405-d63e-4096-bb8e-8bc1a72327f3.png">
---
<img width="1006" alt="Screen Shot 2022-01-18 at 7 53 47 PM" src="https://user-images.githubusercontent.com/1874151/150160185-b7f57d46-84ab-4977-879e-5193b16952d6.png">

