### PR TITLE
Bug 2041763: Fix handling of the `defaultSortField` prop for tables

### DIFF
--- a/frontend/public/components/factory/table-data-hook.ts
+++ b/frontend/public/components/factory/table-data-hook.ts
@@ -124,7 +124,7 @@ export const useTableData = ({
       const sortFunc = currentSortFunc || defaultSortFunc;
       const sortField = currentSortField || (currentSortFunc ? undefined : defaultSortField);
       if (sortField) {
-        sortBy = (resource) => sorts.string(_.get(resource, currentSortField, ''));
+        sortBy = (resource) => sorts.string(_.get(resource, sortField, ''));
       } else if (sortFunc && customSorts?.[sortFunc]) {
         // Sort resources by a function in the 'customSorts' prop
         sortBy = customSorts[sortFunc];


### PR DESCRIPTION
Looks like `useTableData` was not applying its `defaultSortField` prop correctly.

However, I'm not sure why the default sort (normally by the Name column) actually seems to work correctly for most tables?

/cc @rawagner