### PR TITLE
Bug 2034551: Fix name filter updates when input is cleared

### DIFF
--- a/frontend/public/components/factory/ListPage/filter-hook.ts
+++ b/frontend/public/components/factory/ListPage/filter-hook.ts
@@ -26,7 +26,7 @@ export const useListPageFilter: UseListPageFilter = (data, rowFilters, staticFil
   React.useEffect(() => {
     const params = new URLSearchParams(location.search);
     const name = params.get('name');
-    if (name && name !== filter?.name?.selected?.[0]) {
+    if (name !== filter?.name?.selected?.[0]) {
       setFilter((state) => ({ ...state, name: { selected: [name] } }));
     }
   }, [filter, location]);

--- a/frontend/public/components/factory/list-page.tsx
+++ b/frontend/public/components/factory/list-page.tsx
@@ -129,9 +129,7 @@ export const ListPageWrapper: React.FC<ListPageWrapperProps> = (props) => {
   const memoizedIds = useDeepCompareMemoize(reduxIDs);
 
   React.useEffect(() => {
-    if (nameFilter) {
-      memoizedIds.forEach((id) => dispatch(filterList(id, 'name', { selected: [nameFilter] })));
-    }
+    memoizedIds.forEach((id) => dispatch(filterList(id, 'name', { selected: [nameFilter] })));
   }, [dispatch, nameFilter, memoizedIds]);
 
   const data = flatten ? flatten(resources) : [];


### PR DESCRIPTION
There was a too defensive check for false-y values. But these false-y values are still valid so removing the check fixes the issue.