### PR TITLE
Bug 2041769: Pipeline metrics: use prometheus-tenancy API to get data

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
@@ -64,3 +64,5 @@ export const DEFAULT_SAMPLES = 60;
 
 // Annotation for referencing pipeline name in case of PipelineRun with no reference to a Pipeline (embedded pipeline)
 export const preferredNameAnnotation = 'pipeline.openshift.io/preferredName';
+
+export const PIPELINE_NAMESPACE = 'openshift-pipelines';

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/hooks.ts
@@ -15,7 +15,7 @@ import { PipelineRunModel } from '../../models';
 import { PipelineRunKind } from '../../types';
 import { getLatestRun } from '../../utils/pipeline-augment';
 import { pipelinesTab } from '../../utils/pipeline-utils';
-import { DEFAULT_SAMPLES, TektonResourceLabel } from './const';
+import { DEFAULT_SAMPLES, PIPELINE_NAMESPACE, TektonResourceLabel } from './const';
 import { metricQueries, PipelineQuery } from './pipeline-metrics/pipeline-metrics-utils';
 
 type Match = RMatch<{ url: string }>;
@@ -84,6 +84,7 @@ export const usePipelineSuccessRatioPoll = ({ delay, namespace, name, timespan, 
       samples: 1,
       endTime: Date.now(),
       timespan,
+      namespace: PIPELINE_NAMESPACE,
     }),
     delay,
     namespace,
@@ -102,6 +103,7 @@ export const usePipelineRunTaskRunPoll = ({ delay, namespace, name, timespan, qu
       samples: DEFAULT_SAMPLES,
       endTime: Date.now(),
       timespan,
+      namespace: PIPELINE_NAMESPACE,
     }),
     delay,
     namespace,
@@ -123,6 +125,7 @@ export const usePipelineRunDurationPoll = ({
       samples: DEFAULT_SAMPLES,
       endTime: Date.now(),
       timespan,
+      namespace: PIPELINE_NAMESPACE,
     }),
     delay,
     namespace,
@@ -138,6 +141,7 @@ export const usePipelineRunPoll = ({ delay, namespace, name, timespan, queryPref
       samples: DEFAULT_SAMPLES,
       endTime: Date.now(),
       timespan,
+      namespace: PIPELINE_NAMESPACE,
     }),
     delay,
     namespace,


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2041769

**Analysis / Root cause**: 
On the Pipeline metrics page, API calls are failing with error 403 for the normal user as we are using Prometheus API to fetch the data.

**Solution Description**: 
use prometheus-tenancy API to get data
