### PR TITLE
Bug 2038772: Monitoring: Fix handling of ServiceMonitor's matchExpressions

### DIFF
--- a/frontend/public/components/monitoring/targets.tsx
+++ b/frontend/public/components/monitoring/targets.tsx
@@ -52,7 +52,7 @@ const ServiceMonitor: React.FC<{ target: Target }> = ({ target }) => {
     monitors,
     ({ spec }) =>
       service &&
-      (spec.selector.matchLabels === undefined ||
+      ((spec.selector.matchLabels === undefined && spec.selector.matchExpressions === undefined) ||
         new LabelSelector(spec.selector).matchesLabels(service.metadata.labels ?? {})) &&
       (spec.namespaceSelector?.matchNames === undefined ||
         _.includes(spec.namespaceSelector?.matchNames, service.metadata.namespace)),


### PR DESCRIPTION
For the monitoring targets UI pages, we also need to handle the case
where a ServiceMonitor has `matchExpressions`, but no `matchLabels`.