### PR TITLE
Bug 2030240: Hide virtualization overview for non-admin users

### DIFF
--- a/frontend/packages/kubevirt-plugin/console-extensions.json
+++ b/frontend/packages/kubevirt-plugin/console-extensions.json
@@ -54,7 +54,7 @@
       "prefixNamespaced": false
     },
     "flags": {
-      "required": ["KUBEVIRT"]
+      "required": ["KUBEVIRT", "CAN_GET_NS", "OPENSHIFT"]
     }
   },
   {
@@ -216,7 +216,7 @@
       }
     },
     "flags": {
-      "required": ["KUBEVIRT"]
+      "required": ["KUBEVIRT", "CAN_GET_NS", "OPENSHIFT"]
     }
   },
   {

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/inventory-card/ResourcesSection.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/inventory-card/ResourcesSection.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { Stack, StackItem } from '@patternfly/react-core';
-import { FirehoseResult, isUpstream } from '@console/internal/components/utils';
+import { FirehoseResult } from '@console/internal/components/utils';
 import { NodeModel, TemplateModel } from '@console/internal/models';
 import { K8sResourceCommon, K8sResourceKind, TemplateKind } from '@console/internal/module/k8s';
 import { NetworkAttachmentDefinitionModel } from '@console/network-attachment-definition-plugin';
 import { ResourceInventoryItem } from '@console/shared/src/components/dashboard/inventory-card/InventoryItem';
-import { KUBEVIRT_OS_IMAGES_NS, OPENSHIFT_OS_IMAGES_NS } from '../../../constants';
 import { VirtualMachineModel } from '../../../models';
 import { VMKind } from '../../../types';
+import { getOSImagesNS } from '../../../utils/common';
 import { flattenTemplates } from '../../vm-templates/utils';
 
 import './virt-overview-inventory-card.scss';
@@ -27,11 +27,7 @@ export type ResourcesSectionProps = {
 
 export const ResourcesSection: React.FC<ResourcesSectionProps> = ({ resources }) => {
   const templates = React.useMemo(() => getTemplates(resources), [resources]);
-
-  const dataSourceNS = React.useMemo(
-    () => (isUpstream() ? KUBEVIRT_OS_IMAGES_NS : OPENSHIFT_OS_IMAGES_NS),
-    [],
-  );
+  const dataSourceNS = React.useMemo(() => getOSImagesNS(), []);
 
   return (
     <Stack hasGutter className="kv-inventory-card__resources--container">

--- a/frontend/packages/kubevirt-plugin/src/utils/common.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/common.ts
@@ -1,4 +1,6 @@
 import * as _ from 'lodash';
+import { isUpstream } from '@console/internal/components/utils';
+import { KUBEVIRT_OS_IMAGES_NS, OPENSHIFT_OS_IMAGES_NS } from '../constants';
 
 export const omitEmpty = (obj, justUndefined = false) => {
   const omit = (o) => {
@@ -27,3 +29,6 @@ export const omitEmpty = (obj, justUndefined = false) => {
 
 export const isSetEqual = (set: Set<any>, otherSet: Set<any>) =>
   set.size === otherSet.size && [...set].every((s) => otherSet.has(s));
+
+export const getOSImagesNS = (): string =>
+  isUpstream() ? KUBEVIRT_OS_IMAGES_NS : OPENSHIFT_OS_IMAGES_NS;


### PR DESCRIPTION
The current version of the virtualization overview only works for the cluster admins. This PR hides it from users who aren't cluster-admins.