### PR TITLE
Bug 2042619: Avoid runtime error when no CSVs

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/status-card/OperatorStatusBody.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/OperatorStatusBody.tsx
@@ -27,6 +27,10 @@ export const OperatorsSection: React.FC<OperatorsSectionProps> = ({
   );
   const operatorsHealthy = sortedOperatorStatuses.every((o) => o.status.health === HealthState.OK);
   const RowLoading = React.useCallback(() => <div className="co-status__operator-skeleton" />, []);
+  if (!operatorStatuses.length) {
+    return null;
+  }
+
   return (
     <StatusPopupSection
       firstColumn={

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/state-utils.ts
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/state-utils.ts
@@ -57,6 +57,9 @@ export const getOperatorsHealthState = (
   healthStatuses: OperatorHealth[],
   t: TFunction,
 ): { health: HealthState; detailMessage: string } => {
+  if (!healthStatuses.length) {
+    return { health: HealthState.OK, detailMessage: undefined };
+  }
   if (healthStatuses.some((s) => s.health === HealthState.NOT_AVAILABLE)) {
     return { health: HealthState.NOT_AVAILABLE, detailMessage: undefined };
   }

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/health-item.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/health-item.tsx
@@ -147,6 +147,9 @@ export const OperatorHealthItem = withDashboardResources<OperatorHealthItemProps
         return { health: HealthState.LOADING };
       }
       const operatorStatuses = o.getOperatorsWithStatuses(operatorResources);
+      if (!operatorStatuses.length) {
+        return { health: HealthState.OK };
+      }
       const importantStatuses = getMostImportantStatuses(operatorStatuses);
       return {
         health: importantStatuses[0].status.health,


### PR DESCRIPTION
Avoid errors on the Overview page when there are no CSVs. Most clusters
have at least a packageserver CSV, but that isn't the case on hypershift
since it runs outside the cluster.

<img width="366" alt="Screen Shot 2022-01-19 at 3 43 08 PM" src="https://user-images.githubusercontent.com/1167259/150210605-11dc075c-3aba-4aea-ab27-fe0bc17ab91d.png">

/assign @rawagner 
cc @csrwng 