### PR TITLE
Include the namespace-scoped Helm Chart Repositories in the dev catalog

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogFilters.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogFilters.tsx
@@ -30,18 +30,20 @@ const CatalogFilters: React.FC<CatalogFiltersProps> = ({
     // TODO remove when adopting https://github.com/patternfly/patternfly-react/issues/5139
     const dummyProps = {} as any;
     return (
-      <FilterSidePanelCategoryItem
-        key={filterName}
-        count={count}
-        checked={active}
-        onClick={(e: React.ChangeEvent<HTMLInputElement>) =>
-          onFilterChange(groupName, filterName, e.target.checked)
-        }
-        data-test={`${groupName}-${_.kebabCase(filterName)}`}
-        {...dummyProps}
-      >
-        {label}
-      </FilterSidePanelCategoryItem>
+      label && (
+        <FilterSidePanelCategoryItem
+          key={filterName}
+          count={count}
+          checked={active}
+          onClick={(e: React.ChangeEvent<HTMLInputElement>) =>
+            onFilterChange(groupName, filterName, e.target.checked)
+          }
+          data-test={`${groupName}-${_.kebabCase(filterName)}`}
+          {...dummyProps}
+        >
+          {label}
+        </FilterSidePanelCategoryItem>
+      )
     );
   };
 

--- a/frontend/packages/helm-plugin/src/catalog/providers/useHelmCharts.tsx
+++ b/frontend/packages/helm-plugin/src/catalog/providers/useHelmCharts.tsx
@@ -5,7 +5,7 @@ import { ExtensionHook, CatalogItem, WatchK8sResource } from '@console/dynamic-p
 import { coFetch } from '@console/internal/co-fetch';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
-import { APIError } from '@console/shared';
+import { APIError, useActiveNamespace } from '@console/shared';
 import { HelmChartRepositoryModel } from '../../models';
 import { HelmChartEntries } from '../../types/helm-types';
 import { normalizeHelmCharts } from '../utils/catalog-utils';
@@ -14,6 +14,7 @@ const useHelmCharts: ExtensionHook<CatalogItem[]> = ({
   namespace,
 }): [CatalogItem[], boolean, any] => {
   const { t } = useTranslation();
+  const [activeNamespace] = useActiveNamespace();
   const [helmCharts, setHelmCharts] = React.useState<HelmChartEntries>();
   const [loadedError, setLoadedError] = React.useState<APIError>();
 
@@ -28,7 +29,7 @@ const useHelmCharts: ExtensionHook<CatalogItem[]> = ({
 
   React.useEffect(() => {
     let mounted = true;
-    coFetch('/api/helm/charts/index.yaml')
+    coFetch(`/api/helm/charts/index.yaml?namespace=${activeNamespace}`)
       .then(async (res) => {
         if (mounted) {
           const yaml = await res.text();
@@ -43,7 +44,7 @@ const useHelmCharts: ExtensionHook<CatalogItem[]> = ({
         }
       });
     return () => (mounted = false);
-  }, []);
+  }, [activeNamespace]);
 
   const normalizedHelmCharts: CatalogItem[] = React.useMemo(
     () => normalizeHelmCharts(helmCharts, chartRepositories, namespace, t),

--- a/frontend/packages/helm-plugin/src/components/forms/__tests__/HelmInstallUpgradeForm.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/__tests__/HelmInstallUpgradeForm.spec.tsx
@@ -54,6 +54,7 @@ const props: React.ComponentProps<typeof HelmInstallUpgradeForm> = {
   ...componentProps,
   ...formikFormProps,
   values: formValues,
+  namespace: 'xyz',
 };
 
 describe('HelmInstallUpgradeForm', () => {

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartVersionDropdown.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartVersionDropdown.tsx
@@ -34,6 +34,7 @@ export type HelmChartVersionDropdownProps = {
   chartName: string;
   helmAction: string;
   onVersionChange: (chart: HelmChart) => void;
+  namespace: string;
 };
 type ModalCallback = () => void;
 
@@ -42,6 +43,7 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
   chartName,
   helmAction,
   onVersionChange,
+  namespace,
 }) => {
   const { t } = useTranslation();
   const {
@@ -110,7 +112,7 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
       let json: { entries: HelmChartEntries };
 
       try {
-        const response = await coFetch('/api/helm/charts/index.yaml');
+        const response = await coFetch(`/api/helm/charts/index.yaml?namespace=${namespace}`);
         const yaml = await response.text();
         json = safeLoad(yaml);
       } catch {
@@ -130,7 +132,7 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
     return () => {
       ignore = true;
     };
-  }, [chartName, chartRepoName, chartRepositories, t]);
+  }, [chartName, chartRepoName, chartRepositories, t, namespace]);
 
   const onChartVersionChange = (value: string) => {
     const [version, repoName] = value.split('--');

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
@@ -26,6 +26,7 @@ export interface HelmInstallUpgradeFormProps {
   chartMetaDescription: React.ReactNode;
   onVersionChange: (chart: HelmChart) => void;
   chartError: Error;
+  namespace: string;
 }
 
 const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUpgradeFormProps> = ({
@@ -41,6 +42,7 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
   chartMetaDescription,
   onVersionChange,
   chartError,
+  namespace,
 }) => {
   const { t } = useTranslation();
   const { chartName, chartVersion, chartReadme, formData, formSchema, editorType } = values;
@@ -133,6 +135,7 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
                 chartVersion={chartVersion}
                 helmAction={helmAction}
                 onVersionChange={onVersionChange}
+                namespace={namespace}
               />
             </GridItem>
           </Grid>

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
@@ -240,6 +240,7 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
             helmActionConfig={config}
             onVersionChange={setChartData}
             chartError={chartError}
+            namespace={namespace}
           />
         )}
       </Formik>


### PR DESCRIPTION
**Story:**
https://issues.redhat.com/browse/ODC-6404

**Solution description:**
- Passed the namespace as the query parameter in the index.yaml API endpoint to fetch all the cluster scoped and the namespace scoped helm charts

**GIF:**
![Peek 2022-01-20 02-17](https://user-images.githubusercontent.com/22490998/150211229-00536265-d5d9-4cce-90a9-b49f1dc009f7.gif)

**Test setup:**
- Create the CRD https://github.com/zonggen/api/blob/96b33b94bdf26958d4c2f136039241e79da9938e/helm/v1beta1/0000_10-project-helm-chart-repository.crd.yaml
- Create the CR

> apiVersion: helm.openshift.io/v1beta1
kind: ProjectHelmChartRepository
metadata:
  name: ibm-repo
  namespace: deb
spec:
  connectionConfig:
    url:  https://raw.githubusercontent.com/IBM/charts/master/repo/community/index.yaml

