### PR TITLE
Add KamletBinding Visualization

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/topology-details.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/topology-details.ts
@@ -151,9 +151,10 @@ export type DetailsResourceAlertContent = {
   actionLinks?: React.ReactNode;
 };
 
-export type AdapterDataType<D = {}> = {
+export type AdapterDataType<D = {}, T = {}> = {
   resource: K8sResourceCommon;
-  provider: (resource: K8sResourceCommon) => D;
+  data?: T;
+  provider: (resource: K8sResourceCommon, data?: T) => D;
 };
 
 export type PodsAdapterDataType<E = K8sResourceCommon> = {

--- a/frontend/packages/console-shared/src/components/pod/PodsOverview.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodsOverview.tsx
@@ -135,7 +135,7 @@ type PodOverviewItemProps = {
 const PodsOverviewList: React.FC<PodOverviewListProps> = ({ pods }) => (
   <ul className="list-group">
     {_.map(pods, (pod) => (
-      <PodOverviewItem key={pod.metadata.uid} pod={pod} />
+      <PodOverviewItem key={pod.metadata?.uid} pod={pod} />
     ))}
   </ul>
 );

--- a/frontend/packages/console-shared/src/components/pod/PodsOverview.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodsOverview.tsx
@@ -135,7 +135,7 @@ type PodOverviewItemProps = {
 const PodsOverviewList: React.FC<PodOverviewListProps> = ({ pods }) => (
   <ul className="list-group">
     {_.map(pods, (pod) => (
-      <PodOverviewItem key={pod.metadata?.uid} pod={pod} />
+      <PodOverviewItem key={pod.metadata.uid} pod={pod} />
     ))}
   </ul>
 );

--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -1063,6 +1063,16 @@
     "type": "console.action/provider",
     "properties": {
       "contextId": "topology-actions",
+      "provider": { "$codeRef": "actions.useKnativeEventSinkActionProvider" }
+    },
+    "flags": {
+      "required": ["KNATIVE_EVENTING"]
+    }
+  },
+  {
+    "type": "console.action/provider",
+    "properties": {
+      "contextId": "topology-actions",
       "provider": { "$codeRef": "actions.useEventSourcesActionsProviderForTopology" }
     },
     "flags": {
@@ -1526,6 +1536,40 @@
     },
     "flags": {
       "required": ["KNATIVE_EVENTING"]
+    }
+  },
+  {
+    "type": "console.topology/details/tab-section",
+    "properties": {
+      "id": "topology-tab-section-kn-event-sink-details",
+      "tab": "topology-side-bar-tab-details",
+      "section": {
+        "$codeRef": "knativeTopologySidebar.getKnativeSidePanelEventSinkDetailsTab"
+      }
+    },
+    "flags": {
+      "required": ["KNATIVE_SERVING_SERVICE", "KNATIVE_SERVING_REVISION", "KNATIVE_EVENTING"]
+    }
+  },
+  {
+    "type": "console.topology/details/tab-section",
+    "properties": {
+      "id": "topology-tab-section-kn-event-sink-output-target",
+      "tab": "topology-side-bar-tab-resource",
+      "section": {
+        "$codeRef": "knativeTopologySidebar.getKnativeSidepanelEventSinkSection"
+      }
+    },
+    "flags": {
+      "required": ["KNATIVE_SERVING_SERVICE", "KNATIVE_SERVING_REVISION", "KNATIVE_EVENTING"]
+    }
+  },
+  {
+    "type": "console.topology/adapter/pod",
+    "properties": {
+      "adapt": {
+        "$codeRef": "knativeTopologySidebar.getEventSinkPodsApdapter"
+      }
     }
   }
 ]

--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -1570,6 +1570,9 @@
       "adapt": {
         "$codeRef": "knativeTopologySidebar.getEventSinkPodsApdapter"
       }
+    },
+    "flags": {
+      "required": ["KNATIVE_SERVING", "KNATIVE_EVENTING"]
     }
   }
 ]

--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -239,10 +239,13 @@
   "Move sink to URI": "Move sink to URI",
   "Open URI": "Open URI",
   "Event source connector": "Event source connector",
+  "Event sink connector": "Event sink connector",
   "Kafka connector": "Kafka connector",
   "Traffic distribution connector": "Traffic distribution connector",
   "Unable to create kafka connector as bootstrapServerHost or secret is not available in target resource.": "Unable to create kafka connector as bootstrapServerHost or secret is not available in target resource.",
   "Knative Services": "Knative Services",
   "All Revisions are autoscaled to 0.": "All Revisions are autoscaled to 0.",
+  "Output Target": "Output Target",
+  "No output target found for this resource.": "No output target found for this resource.",
   "Domain mappings": "Domain mappings"
 }

--- a/frontend/packages/knative-plugin/src/actions/providers.ts
+++ b/frontend/packages/knative-plugin/src/actions/providers.ts
@@ -26,6 +26,7 @@ import {
   TYPE_EVENT_SOURCE_LINK,
   TYPE_REVISION_TRAFFIC,
   TYPE_KAFKA_CONNECTION_LINK,
+  TYPE_EVENT_SINK,
 } from '../topology/const';
 import { isEventingChannelResourceKind } from '../utils/fetch-dynamic-eventsources-utils';
 import { AddBrokerAction } from './add-broker';
@@ -273,4 +274,21 @@ export const topologyServerlessActionsFilter = (
     return false;
   }
   return true;
+};
+
+export const useKnativeEventSinkActionProvider = (element: Node) => {
+  const resource = element.getData()?.resources?.obj;
+  const type = element.getType();
+  const [k8sModel] = useK8sModel(referenceFor(resource));
+  const actions = React.useMemo(() => {
+    if (type !== TYPE_EVENT_SINK) return undefined;
+    return k8sModel && resource ? getCommonResourceActions(k8sModel, resource) : undefined;
+  }, [type, k8sModel, resource]);
+
+  return React.useMemo(() => {
+    if (!actions) {
+      return [[], true, undefined];
+    }
+    return [actions, true, undefined];
+  }, [actions]);
 };

--- a/frontend/packages/knative-plugin/src/actions/providers.ts
+++ b/frontend/packages/knative-plugin/src/actions/providers.ts
@@ -277,13 +277,13 @@ export const topologyServerlessActionsFilter = (
 };
 
 export const useKnativeEventSinkActionProvider = (element: Node) => {
-  const resource = element.getData()?.resources?.obj;
-  const type = element.getType();
+  const resource = element.getData()?.resources?.obj || {};
   const [k8sModel] = useK8sModel(referenceFor(resource));
   const actions = React.useMemo(() => {
-    if (type !== TYPE_EVENT_SINK) return undefined;
+    const type = element.getType();
+    if (type !== TYPE_EVENT_SINK || !k8sModel) return undefined;
     return k8sModel && resource ? getCommonResourceActions(k8sModel, resource) : undefined;
-  }, [type, k8sModel, resource]);
+  }, [element, k8sModel, resource]);
 
   return React.useMemo(() => {
     if (!actions) {

--- a/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
@@ -7,7 +7,9 @@ import {
   K8sResourceKind,
 } from '@console/internal/module/k8s';
 import { TopologyDataResources } from '@console/topology/src/topology-types';
+import { CamelKameletModel, DomainMappingModel } from '../..';
 import {
+  SERVERLESS_FUNCTION_LABEL,
   EVENTING_IMC_KIND,
   EVENT_SOURCE_API_SERVER_KIND,
   EVENT_SOURCE_CAMEL_KIND,
@@ -15,7 +17,6 @@ import {
   EVENT_SOURCE_SINK_BINDING_KIND,
   KNATIVE_EVENT_MESSAGE_APIGROUP,
   KNATIVE_EVENT_SOURCE_APIGROUP,
-  SERVERLESS_FUNCTION_LABEL,
   EVENT_SOURCE_CONTAINER_KIND,
   EVENT_SOURCE_CRONJOB_KIND,
   KNATIVE_EVENT_SOURCE_APIGROUP_DEP,
@@ -1199,6 +1200,12 @@ const sampleTriggers: FirehoseResult = {
   data: [EventTriggerObj],
 };
 
+const sampleKamelets: FirehoseResult = {
+  loaded: true,
+  loadError: '',
+  data: [],
+};
+
 export const MockKnativeResources: TopologyDataResources = {
   deployments: sampleKnativeDeployments,
   deploymentConfigs: sampleKnativeDeploymentConfigs,
@@ -1247,8 +1254,9 @@ export const MockKnativeResources: TopologyDataResources = {
   clusterServiceVersions: sampleClusterServiceVersions,
   triggers: sampleTriggers,
   brokers: sampleBrokers,
-  kameletbindings: sampleSourceKameletBinding,
-  domainmappings: sampleDomainMapping,
+  [CamelKameletBindingModel.plural]: sampleSourceKameletBinding,
+  [DomainMappingModel.plural]: sampleDomainMapping,
+  [CamelKameletModel.plural]: sampleKamelets,
 };
 
 export const MockKnativeBuildConfig = {

--- a/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
@@ -7,7 +7,6 @@ import {
   K8sResourceKind,
 } from '@console/internal/module/k8s';
 import { TopologyDataResources } from '@console/topology/src/topology-types';
-import { CamelKameletModel, DomainMappingModel } from '../..';
 import {
   SERVERLESS_FUNCTION_LABEL,
   EVENTING_IMC_KIND,
@@ -23,6 +22,8 @@ import {
   EVENT_SOURCE_PING_KIND,
 } from '../../const';
 import {
+  CamelKameletModel,
+  DomainMappingModel,
   ServiceModel,
   RevisionModel,
   RouteModel,

--- a/frontend/packages/knative-plugin/src/topology/components/anchors/EventSinkSourceAnchor.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/anchors/EventSinkSourceAnchor.ts
@@ -1,0 +1,12 @@
+import { AbstractAnchor, Point } from '@patternfly/react-topology';
+
+export default class EventSinkSourceAnchor extends AbstractAnchor {
+  getLocation(): Point {
+    return this.getReferencePoint();
+  }
+
+  getReferencePoint(): Point {
+    const bounds = this.owner.getBounds();
+    return new Point(bounds.right(), bounds.y + bounds.height / 2);
+  }
+}

--- a/frontend/packages/knative-plugin/src/topology/components/anchors/EventSinkTargetAnchor.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/anchors/EventSinkTargetAnchor.ts
@@ -1,0 +1,13 @@
+import { AbstractAnchor, Point } from '@patternfly/react-topology';
+import { EVENT_MARKER_RADIUS } from '../../const';
+
+export default class EventSinkTargetAnchor extends AbstractAnchor {
+  getLocation(): Point {
+    return this.getReferencePoint();
+  }
+
+  getReferencePoint(): Point {
+    const bounds = this.owner.getBounds();
+    return new Point(bounds.x - EVENT_MARKER_RADIUS, bounds.y + bounds.height / 2);
+  }
+}

--- a/frontend/packages/knative-plugin/src/topology/components/edges/EventSinkLink.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/edges/EventSinkLink.tsx
@@ -9,7 +9,7 @@ type EventSinkLinkProps = {
 };
 
 const EventSinkLink: React.FC<EventSinkLinkProps> = ({ element, ...others }) => {
-  const markerPoint = element.getStartPoint();
+  const markerPoint = element.getEndPoint();
 
   return (
     <BaseEdge className="odc-event-source-link" element={element} {...others}>

--- a/frontend/packages/knative-plugin/src/topology/components/edges/EventSinkLink.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/edges/EventSinkLink.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Edge, observer } from '@patternfly/react-topology';
+import { BaseEdge } from '@console/topology/src/components/graph-view';
+import { EVENT_MARKER_RADIUS } from '../../const';
+import './EventSourceLink.scss';
+
+type EventSinkLinkProps = {
+  element: Edge;
+};
+
+const EventSinkLink: React.FC<EventSinkLinkProps> = ({ element, ...others }) => {
+  const markerPoint = element.getStartPoint();
+
+  return (
+    <BaseEdge className="odc-event-source-link" element={element} {...others}>
+      <circle
+        className="topology-connector-arrow"
+        cx={markerPoint.x}
+        cy={markerPoint.y}
+        r={EVENT_MARKER_RADIUS}
+      />
+    </BaseEdge>
+  );
+};
+
+export default observer(EventSinkLink);

--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
@@ -29,8 +29,11 @@ import {
   TYPE_SINK_URI,
   TYPE_EVENT_SOURCE_KAFKA,
   TYPE_KAFKA_CONNECTION_LINK,
+  TYPE_EVENT_SINK,
+  TYPE_EVENT_SINK_LINK,
 } from '../const';
 import EventingPubSubLink from './edges/EventingPubSubLink';
+import EventSinkLink from './edges/EventSinkLink';
 import EventSourceLink from './edges/EventSourceLink';
 import KafkaConnectionLink from './edges/KafkaConnectionLink';
 import TrafficLink from './edges/TrafficLink';
@@ -48,6 +51,7 @@ import {
   kafkaSourceCreateConnectorCallback,
 } from './knativeComponentUtils';
 import EventingPubSubNode from './nodes/EventingPubSubNode';
+import EventSink from './nodes/EventSink';
 import EventSource from './nodes/EventSource';
 import RevisionNode from './nodes/RevisionNode';
 import SinkUriNode from './nodes/SinkUriNode';
@@ -95,6 +99,12 @@ export const getKnativeComponentFactory = (
           ),
         ),
       );
+    case TYPE_EVENT_SINK:
+      return withEditReviewAccess('patch')(
+        withDragNode(nodeDragSourceSpec(type))(
+          withSelection({ controlled: true })(withContextMenu(contextMenuActions)(EventSink)),
+        ),
+      );
     case TYPE_EVENT_PUB_SUB:
       return withCreateConnector(createConnectorCallback(), CreateConnector, '', {
         dragOperation,
@@ -129,6 +139,8 @@ export const getKnativeComponentFactory = (
       return TrafficLink;
     case TYPE_EVENT_SOURCE_LINK:
       return withTargetDrag(eventSourceLinkDragSourceSpec())(EventSourceLink);
+    case TYPE_EVENT_SINK_LINK:
+      return EventSinkLink;
     case TYPE_EVENT_SOURCE_KAFKA:
       return withCreateConnector(kafkaSourceCreateConnectorCallback, CreateConnector, '', {
         dragOperation: dragOperationKafka,

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react';
+import { SignInAltIcon } from '@patternfly/react-icons';
+import {
+  Node,
+  observer,
+  useHover,
+  WithSelectionProps,
+  WithDndDropProps,
+  WithContextMenuProps,
+  useSvgAnchor,
+  useCombineRefs,
+  WithDragNodeProps,
+  createSvgIdUrl,
+  WithCreateConnectorProps,
+  Edge,
+} from '@patternfly/react-topology';
+import * as classNames from 'classnames';
+import {
+  NodeShadows,
+  NODE_SHADOW_FILTER_ID_HOVER,
+  NODE_SHADOW_FILTER_ID,
+  PodSet,
+} from '@console/topology/src/components/graph-view';
+import SvgBoxedText from '@console/topology/src/components/svg/SvgBoxedText';
+import {
+  useSearchFilter,
+  useDisplayFilters,
+  getFilterById,
+  SHOW_LABELS_FILTER_ID,
+  useAllowEdgeCreation,
+} from '@console/topology/src/filters';
+import { getEventSourceIcon } from '../../../utils/get-knative-icon';
+import { usePodsForRevisions } from '../../../utils/usePodsForRevisions';
+import { TYPE_KAFKA_CONNECTION_LINK } from '../../const';
+
+import './EventSource.scss';
+
+export type EventSinkProps = {
+  element: Node;
+  dragging?: boolean;
+  edgeDragging?: boolean;
+} & WithSelectionProps &
+  WithDragNodeProps &
+  WithDndDropProps &
+  WithContextMenuProps &
+  WithCreateConnectorProps;
+
+const EventSink: React.FC<EventSinkProps> = ({
+  element,
+  selected,
+  onSelect,
+  onContextMenu,
+  contextMenuOpen,
+  dragNodeRef,
+  dndDropRef,
+  dragging,
+  edgeDragging,
+  onShowCreateConnector,
+  onHideCreateConnector,
+}) => {
+  const svgAnchorRef = useSvgAnchor();
+  const [hover, hoverRef] = useHover();
+  const groupRefs = useCombineRefs(dragNodeRef, dndDropRef, hoverRef);
+  const { data, resources, resource } = element.getData();
+  const [filtered] = useSearchFilter(element.getLabel(), resource?.metadata?.labels);
+  const displayFilters = useDisplayFilters();
+  const showLabelsFilter = getFilterById(SHOW_LABELS_FILTER_ID, displayFilters);
+  const showLabels = showLabelsFilter?.value || hover;
+  const { width, height } = element.getBounds();
+  const size = Math.min(width, height);
+  const allowEdgeCreation = useAllowEdgeCreation();
+  const isKafkaConnectionLinkPresent =
+    element.getSourceEdges()?.filter((edge: Edge) => edge.getType() === TYPE_KAFKA_CONNECTION_LINK)
+      .length > 0;
+  const revisionIds = resources.revisions.map((revision) => revision.metadata.uid);
+  const { loaded, loadError, pods } = usePodsForRevisions(revisionIds, resource.metadata.namespace);
+  const donutStatus = React.useMemo(() => {
+    if (loaded && !loadError) {
+      const [current, previous] = pods;
+      const isRollingOut = !!current && !!previous;
+      return {
+        obj: resource,
+        current,
+        previous,
+        isRollingOut,
+        pods: [...(current?.pods || []), ...(previous?.pods || [])],
+      };
+    }
+    return null;
+  }, [loaded, loadError, pods, resource]);
+
+  React.useLayoutEffect(() => {
+    if (allowEdgeCreation && !isKafkaConnectionLinkPresent) {
+      if (hover) {
+        onShowCreateConnector && onShowCreateConnector();
+      } else {
+        onHideCreateConnector && onHideCreateConnector();
+      }
+    }
+  }, [
+    hover,
+    onShowCreateConnector,
+    onHideCreateConnector,
+    allowEdgeCreation,
+    isKafkaConnectionLinkPresent,
+  ]);
+
+  return (
+    <g
+      className={classNames('odc-event-source', {
+        'is-filtered': filtered,
+        'is-dragging': dragging || edgeDragging,
+        'is-selected': selected,
+      })}
+      onClick={onSelect}
+      onContextMenu={onContextMenu}
+      ref={groupRefs}
+    >
+      <NodeShadows />
+      <polygon
+        key={hover || dragging || contextMenuOpen ? 'polygon-hover' : 'polygon'}
+        className="odc-event-source__bg"
+        ref={svgAnchorRef}
+        filter={createSvgIdUrl(
+          hover || dragging || contextMenuOpen
+            ? NODE_SHADOW_FILTER_ID_HOVER
+            : NODE_SHADOW_FILTER_ID,
+        )}
+        points={`${width / 2}, ${(height - size) / 2} ${width - (width - size) / 2},${height /
+          2} ${width / 2},${height - (height - size) / 2} ${(width - size) / 2},${height / 2}`}
+      />
+      {donutStatus && <PodSet size={size * 0.75} x={width / 2} y={height / 2} data={donutStatus} />}
+      <image
+        x={width * 0.33}
+        y={height * 0.33}
+        width={size * 0.35}
+        height={size * 0.35}
+        xlinkHref={getEventSourceIcon(data.kind, resources.obj)}
+      />
+
+      {showLabels && (data.kind || element.getLabel()) && (
+        <SvgBoxedText
+          className="odc-base-node__label"
+          x={width / 2}
+          y={(height + size) / 2 + 20}
+          paddingX={8}
+          paddingY={4}
+          kind={data.kind}
+          typeIcon={<SignInAltIcon />}
+        >
+          {element.getLabel()}
+        </SvgBoxedText>
+      )}
+    </g>
+  );
+};
+
+export default observer(EventSink);

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
@@ -13,6 +13,8 @@ import {
   createSvgIdUrl,
   WithCreateConnectorProps,
   Edge,
+  useAnchor,
+  AnchorEnd,
 } from '@patternfly/react-topology';
 import * as classNames from 'classnames';
 import {
@@ -31,7 +33,8 @@ import {
 } from '@console/topology/src/filters';
 import { getEventSourceIcon } from '../../../utils/get-knative-icon';
 import { usePodsForRevisions } from '../../../utils/usePodsForRevisions';
-import { TYPE_KAFKA_CONNECTION_LINK } from '../../const';
+import { TYPE_EVENT_SINK_LINK, TYPE_KAFKA_CONNECTION_LINK } from '../../const';
+import EventSinkTargetAnchor from '../anchors/EventSinkTargetAnchor';
 
 import './EventSource.scss';
 
@@ -59,6 +62,7 @@ const EventSink: React.FC<EventSinkProps> = ({
   onHideCreateConnector,
 }) => {
   const svgAnchorRef = useSvgAnchor();
+  useAnchor(EventSinkTargetAnchor, AnchorEnd.target, TYPE_EVENT_SINK_LINK);
   const [hover, hoverRef] = useHover();
   const groupRefs = useCombineRefs(dragNodeRef, dndDropRef, hoverRef);
   const { data, resources, resource } = element.getData();
@@ -72,7 +76,7 @@ const EventSink: React.FC<EventSinkProps> = ({
   const isKafkaConnectionLinkPresent =
     element.getSourceEdges()?.filter((edge: Edge) => edge.getType() === TYPE_KAFKA_CONNECTION_LINK)
       .length > 0;
-  const revisionIds = resources.revisions.map((revision) => revision.metadata.uid);
+  const revisionIds = resources.revisions?.map((revision) => revision.metadata.uid);
   const { loaded, loadError, pods } = usePodsForRevisions(revisionIds, resource.metadata.namespace);
   const donutStatus = React.useMemo(() => {
     if (loaded && !loadError) {

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
@@ -40,6 +40,8 @@ import {
   EventingBrokerModel,
   EventingSubscriptionModel,
 } from '../../../models';
+import { TYPE_EVENT_SINK_LINK } from '../../const';
+import EventSinkSourceAnchor from '../anchors/EventSinkSourceAnchor';
 import PubSubSourceAnchor from '../anchors/PubSubSourceAnchor';
 import PubSubTargetAnchor from '../anchors/PubSubTargetAnchor';
 
@@ -76,6 +78,7 @@ const EventingPubSubNode: React.FC<EventingPubSubNodeProps> = ({
   useAnchor(PubSubTargetAnchor, AnchorEnd.target);
   useAnchor(RectAnchor, AnchorEnd.source, TYPE_AGGREGATE_EDGE);
   useAnchor(RectAnchor, AnchorEnd.target, TYPE_AGGREGATE_EDGE);
+  useAnchor(EventSinkSourceAnchor, AnchorEnd.source, TYPE_EVENT_SINK_LINK);
   const [hover, hoverRef] = useHover();
 
   const { t } = useTranslation();

--- a/frontend/packages/knative-plugin/src/topology/const.ts
+++ b/frontend/packages/knative-plugin/src/topology/const.ts
@@ -1,8 +1,10 @@
 import { DEFAULT_GROUP_PAD, GROUP_WIDTH } from '@console/topology/src/const';
 
 export const TYPE_EVENT_SOURCE = 'event-source';
+export const TYPE_EVENT_SINK = 'event-sink';
 export const TYPE_EVENT_SOURCE_KAFKA = 'event-source-kafka';
 export const TYPE_EVENT_SOURCE_LINK = 'event-source-link';
+export const TYPE_EVENT_SINK_LINK = 'event-sink-link';
 export const TYPE_KAFKA_CONNECTION_LINK = 'event-source-kafka-link';
 export const TYPE_EVENT_PUB_SUB = 'event-pubsub';
 export const TYPE_EVENT_PUB_SUB_LINK = 'event-pubsub-link';

--- a/frontend/packages/knative-plugin/src/topology/data-transformer.ts
+++ b/frontend/packages/knative-plugin/src/topology/data-transformer.ts
@@ -100,7 +100,7 @@ export const getKnativeTopologyDataModel = (
     if (n.type === NodeType.KnService) {
       if (
         camelSinkKameletBindings.findIndex((binding) =>
-          n.resource.metadata?.labels?.[CAMEL_SOURCE_INTEGRATION].startsWith(
+          n.resource.metadata?.labels?.[CAMEL_SOURCE_INTEGRATION]?.startsWith(
             binding.metadata?.name,
           ),
         ) > -1
@@ -112,7 +112,7 @@ export const getKnativeTopologyDataModel = (
     if (n.type === NodeType.Revision) {
       if (
         camelSinkKameletBindings.findIndex((binding) =>
-          n.resource.metadata?.labels?.[CAMEL_SOURCE_INTEGRATION].startsWith(
+          n.resource.metadata?.labels?.[CAMEL_SOURCE_INTEGRATION]?.startsWith(
             binding.metadata?.name,
           ),
         ) > -1

--- a/frontend/packages/knative-plugin/src/topology/listView/knativeListViewComponentFactory.ts
+++ b/frontend/packages/knative-plugin/src/topology/listView/knativeListViewComponentFactory.ts
@@ -9,6 +9,7 @@ import {
   TYPE_EVENT_PUB_SUB_LINK,
   TYPE_KNATIVE_REVISION,
   TYPE_EVENT_SOURCE_KAFKA,
+  TYPE_EVENT_SINK_LINK,
 } from '../const';
 import { KnativeRevisionListViewNode } from './KnativeRevisionListViewNode';
 import { KnativeServiceListViewNode } from './KnativeServiceListViewNode';
@@ -34,6 +35,7 @@ export const knativeListViewNodeComponentFactory = (
     case TYPE_EVENT_PUB_SUB_LINK:
     case TYPE_EVENT_SOURCE:
     case TYPE_EVENT_SOURCE_LINK:
+    case TYPE_EVENT_SINK_LINK:
     case TYPE_EVENT_PUB_SUB:
     case TYPE_EVENT_SOURCE_KAFKA:
       return NoStatusListViewNode;

--- a/frontend/packages/knative-plugin/src/topology/sidebar/KnativeOverviewSections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/KnativeOverviewSections.tsx
@@ -103,3 +103,37 @@ export const KnativeOverviewDetails: React.FC<KnativeOverviewDetailsProps> = ({ 
     </div>
   );
 };
+
+export const KnativeEventSinkPodRing: React.FC<KnativeOverviewDetailsProps> = ({ item }) => {
+  const { revisions, obj } = item as { obj: K8sResourceKind; revisions: K8sResourceKind[] };
+  const { pods } = usePodsForRevisions(
+    revisions?.map((r) => r.metadata.uid),
+    obj.metadata.namespace,
+  );
+  return (
+    <div className="resource-overview__pod-counts">
+      <PodRing
+        pods={pods?.[0]?.pods || []}
+        obj={obj}
+        rc={pods?.[0]?.obj}
+        resourceKind={RevisionModel}
+        enableScaling={false}
+        path="/spec/replicas"
+      />
+    </div>
+  );
+};
+
+export const KnativeEventSinkOverviewDetails: React.FC<KnativeOverviewDetailsProps> = ({
+  item,
+}) => {
+  const { obj } = item;
+  return (
+    <div className="overview__sidebar-pane-body resource-overview__body">
+      <KnativeEventSinkPodRing item={item} />
+      <div className="resource-overview__summary">
+        <ResourceSummary resource={obj} />
+      </div>
+    </div>
+  );
+};

--- a/frontend/packages/knative-plugin/src/topology/sidebar/index.ts
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/index.ts
@@ -13,6 +13,7 @@ export {
   getKnativeSidepanelRoutesSection,
   getKnativeSidepanelPodsAdapterSection,
   getKnativeSidepanelEventSourcesSection,
+  getKnativeSidePanelEventSinkDetailsTab,
 } from './knative-common-tab-sections';
 
 export {
@@ -26,3 +27,8 @@ export {
 } from './knative-eventsource-tab-sections';
 
 export { getKnativeConnectorSidepanelResourceSection } from './knative-connectors-tab-sections';
+
+export {
+  getKnativeSidepanelEventSinkSection,
+  getEventSinkPodsApdapter,
+} from './knative-resource-tab-sections';

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-common-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-common-tab-sections.tsx
@@ -18,7 +18,11 @@ import { RevisionKind } from '../../types';
 import { usePodsForRevisions } from '../../utils/usePodsForRevisions';
 import { TYPE_EVENT_PUB_SUB_LINK, TYPE_KNATIVE_SERVICE, TYPE_SINK_URI } from '../const';
 import { NodeType } from '../topology-types';
-import { KnativeOverviewDetails, EventSourcesOverviewList } from './KnativeOverviewSections';
+import {
+  KnativeOverviewDetails,
+  EventSourcesOverviewList,
+  KnativeEventSinkOverviewDetails,
+} from './KnativeOverviewSections';
 
 const usePodsAdapterForKnative = (resource: K8sResourceCommon): PodsAdapterDataType => {
   const { t } = useTranslation();
@@ -92,6 +96,14 @@ export const getKnativeSidepanelDetailsTab = (element: GraphElement) => {
   ) {
     const knObj = element.getData().resources;
     return <KnativeOverviewDetails item={knObj} />;
+  }
+  return undefined;
+};
+
+export const getKnativeSidePanelEventSinkDetailsTab = (element: GraphElement) => {
+  if (element.getType() === NodeType.EventSink) {
+    const knObj = element.getData().resources;
+    return <KnativeEventSinkOverviewDetails item={knObj} />;
   }
   return undefined;
 };

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-connectors-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-connectors-tab-sections.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Edge } from '@patternfly/react-topology';
 import TopologyEdgeResourcesPanel from '@console/topology/src/components/side-bar/TopologyEdgeResourcesPanel';
 import {
+  TYPE_EVENT_SINK_LINK,
   TYPE_EVENT_SOURCE_LINK,
   TYPE_KAFKA_CONNECTION_LINK,
   TYPE_REVISION_TRAFFIC,
@@ -9,9 +10,12 @@ import {
 
 export const getKnativeConnectorSidepanelResourceSection = (element: Edge) => {
   if (
-    ![TYPE_REVISION_TRAFFIC, TYPE_EVENT_SOURCE_LINK, TYPE_KAFKA_CONNECTION_LINK].includes(
-      element.getType(),
-    )
+    ![
+      TYPE_REVISION_TRAFFIC,
+      TYPE_EVENT_SOURCE_LINK,
+      TYPE_KAFKA_CONNECTION_LINK,
+      TYPE_EVENT_SINK_LINK,
+    ].includes(element.getType())
   ) {
     return undefined;
   }

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-eventsource-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-eventsource-tab-sections.tsx
@@ -8,15 +8,17 @@ import EventSourceResources from '../../components/overview/EventSourceResources
 import { CamelKameletBindingModel } from '../../models';
 import { isDynamicEventResourceKind } from '../../utils/fetch-dynamic-eventsources-utils';
 import { TYPE_SINK_URI } from '../const';
+import { KameletType } from '../topology-types';
 
 export const getKnativeSidepanelSinkSection = (element: GraphElement) => {
   const resource = getResource(element);
+  const data = element.getData();
   if (!resource) {
     return undefined;
   }
   if (
     isDynamicEventResourceKind(referenceFor(resource)) ||
-    resource.kind === CamelKameletBindingModel.kind
+    (resource.kind === CamelKameletBindingModel.kind && data.kameletType === KameletType.Source)
   ) {
     return (
       <TopologySideBarTabSection>

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-resource-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-resource-tab-sections.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { GraphElement } from '@patternfly/react-topology';
+import { useTranslation } from 'react-i18next';
+import { SidebarSectionHeading, ResourceLink } from '@console/internal/components/utils';
+import { K8sResourceKind, referenceFor, PodKind, podPhase } from '@console/internal/module/k8s';
+import { AllPodStatus } from '@console/shared/src';
+import TopologySideBarTabSection from '@console/topology/src/components/side-bar/TopologySideBarTabSection';
+import { getResource } from '@console/topology/src/utils';
+import { usePodsForRevisions } from '../../utils/usePodsForRevisions';
+import { NodeType } from '../topology-types';
+
+export const EventSinkOutputTargetSection: React.FC<{ resource: K8sResourceKind }> = ({
+  resource,
+}) => {
+  const { t } = useTranslation();
+  const target = resource?.spec?.source?.ref;
+  const reference = referenceFor(target);
+  return (
+    <>
+      <SidebarSectionHeading text={t('knative-plugin~Output Target')} />
+      {target ? (
+        <ul className="list-group">
+          <li className="list-group-item">
+            {target && (
+              <ResourceLink
+                kind={reference}
+                name={target.name}
+                namespace={resource.metadata.namespace}
+              />
+            )}
+          </li>
+        </ul>
+      ) : (
+        <span className="text-muted">
+          {t('knative-plugin~No output target found for this resource.')}
+        </span>
+      )}
+    </>
+  );
+};
+
+export const getKnativeSidepanelEventSinkSection = (element: GraphElement) => {
+  if (element.getType() === NodeType.EventSink) {
+    const resource = getResource(element);
+    return resource ? (
+      <TopologySideBarTabSection>
+        <EventSinkOutputTargetSection resource={resource} />
+      </TopologySideBarTabSection>
+    ) : null;
+  }
+  return undefined;
+};
+
+export const usePodsForEventSink = (resource: K8sResourceKind, data) => {
+  const { t } = useTranslation();
+  const { pods, loaded, loadError } = usePodsForRevisions(
+    data?.revisions.map((r) => r.metadata.uid) ?? '',
+    resource.metadata.namespace,
+  );
+  return React.useMemo(
+    () => ({
+      pods: pods.reduce(
+        (acc, currValue) => [
+          ...acc,
+          ...currValue.pods.filter((p) => podPhase(p as PodKind) !== AllPodStatus.AutoScaledTo0),
+        ],
+        [],
+      ),
+      emptyText: t('knative-plugin~All Revisions are autoscaled to 0.'),
+      loaded,
+      loadError,
+    }),
+    [loadError, loaded, pods, t],
+  );
+};
+
+export const getEventSinkPodsApdapter = (element: GraphElement) => {
+  if (element.getType() === NodeType.EventSink) {
+    const resource = getResource(element);
+    const resources = element.getData()?.resources;
+    return { resource, provider: usePodsForEventSink, data: { revisions: resources.revisions } };
+  }
+  return undefined;
+};

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-resource-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-resource-tab-sections.tsx
@@ -54,7 +54,7 @@ export const getKnativeSidepanelEventSinkSection = (element: GraphElement) => {
 export const usePodsForEventSink = (resource: K8sResourceKind, data) => {
   const { t } = useTranslation();
   const { pods, loaded, loadError } = usePodsForRevisions(
-    data?.revisions.map((r) => r.metadata.uid) ?? '',
+    data?.revisions?.map((r) => r.metadata.uid) ?? '',
     resource.metadata.namespace,
   );
   return React.useMemo(

--- a/frontend/packages/knative-plugin/src/topology/topology-types.ts
+++ b/frontend/packages/knative-plugin/src/topology/topology-types.ts
@@ -5,6 +5,7 @@ import { KnativeItem } from '../utils/get-knative-resources';
 
 export enum NodeType {
   EventSource = 'event-source',
+  EventSink = 'event-sink',
   KnService = 'knative-service',
   Revision = 'knative-revision',
   PubSub = 'event-pubsub',
@@ -16,8 +17,14 @@ export enum NodeType {
 export enum EdgeType {
   Traffic = 'revision-traffic',
   EventSource = 'event-source-link',
+  EventSink = 'event-sink-link',
   EventPubSubLink = 'event-pubsub-link',
   EventSourceKafkaLink = 'event-source-kafka-link',
+}
+
+export enum KameletType {
+  Sink = 'Sink',
+  Source = 'Source',
 }
 
 export type RevK8sResourceKind = K8sResourceKind & {

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -3,6 +3,7 @@ import { WatchK8sResources } from '@console/dynamic-plugin-sdk';
 import { FirehoseResource } from '@console/internal/components/utils';
 import { K8sResourceKind, PodKind, referenceForModel } from '@console/internal/module/k8s';
 import { KafkaConnectionModel } from '@console/rhoas-plugin/src/models';
+import { CamelKameletModel, GLOBAL_OPERATOR_NS } from '..';
 import { KNATIVE_SERVING_LABEL } from '../const';
 import {
   ServiceModel,
@@ -320,6 +321,23 @@ export const knativeCamelIntegrationsResourceWatchers = (
   };
 };
 
+export const knativeCamelKameletResourceWatchers = (namespace: string) => {
+  return {
+    [CamelKameletModel.plural]: {
+      isList: true,
+      kind: referenceForModel(CamelKameletModel),
+      namespace,
+      optional: true,
+    },
+    kameletGlobalNS: {
+      isList: true,
+      kind: referenceForModel(CamelKameletModel),
+      namespace: GLOBAL_OPERATOR_NS,
+      optional: true,
+    },
+  };
+};
+
 export const strimziResourcesWatcher = (namespace: string): WatchK8sResources<any> => {
   const strimziResources = {
     [KafkaModel.plural]: {
@@ -410,5 +428,6 @@ export const getKnativeResources = (namespace: string) => {
     ...knativeCamelIntegrationsResourceWatchers(namespace),
     ...knativeCamelKameletBindingResourceWatchers(namespace),
     ...knativeCamelDomainMappingResourceWatchers(namespace),
+    ...knativeCamelKameletResourceWatchers(namespace),
   };
 };

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -3,9 +3,9 @@ import { WatchK8sResources } from '@console/dynamic-plugin-sdk';
 import { FirehoseResource } from '@console/internal/components/utils';
 import { K8sResourceKind, PodKind, referenceForModel } from '@console/internal/module/k8s';
 import { KafkaConnectionModel } from '@console/rhoas-plugin/src/models';
-import { CamelKameletModel, GLOBAL_OPERATOR_NS } from '..';
-import { KNATIVE_SERVING_LABEL } from '../const';
+import { GLOBAL_OPERATOR_NS, KNATIVE_SERVING_LABEL } from '../const';
 import {
+  CamelKameletModel,
   ServiceModel,
   RevisionModel,
   ConfigurationModel,

--- a/frontend/packages/topology/src/components/side-bar/SelectedEntityDetails.tsx
+++ b/frontend/packages/topology/src/components/side-bar/SelectedEntityDetails.tsx
@@ -5,6 +5,7 @@ import {
   TYPE_EVENT_SOURCE_LINK,
   TYPE_REVISION_TRAFFIC,
   TYPE_KAFKA_CONNECTION_LINK,
+  TYPE_EVENT_SINK_LINK,
 } from '@console/knative-plugin/src/topology/const';
 import { TYPE_CONNECTS_TO, TYPE_SERVICE_BINDING } from '../../const';
 import ConnectedTopologyEdgePanel from './TopologyEdgePanel';
@@ -33,6 +34,7 @@ export const SelectedEntityDetails: React.FC<{ selectedEntity: GraphElement }> =
       [
         TYPE_REVISION_TRAFFIC,
         TYPE_EVENT_SOURCE_LINK,
+        TYPE_EVENT_SINK_LINK,
         TYPE_KAFKA_CONNECTION_LINK,
         TYPE_SERVICE_BINDING,
         TYPE_EVENT_PUB_SUB_LINK,

--- a/frontend/packages/topology/src/components/workload/ResolveAdapter.ts
+++ b/frontend/packages/topology/src/components/workload/ResolveAdapter.ts
@@ -1,18 +1,20 @@
 import * as React from 'react';
 import { K8sResourceCommon } from '@console/dynamic-plugin-sdk/src';
 
-type ResolveAdapterProps<D> = {
+type ResolveAdapterProps<D, T> = {
   resource: K8sResourceCommon;
-  useAdapterHook: (resource: K8sResourceCommon) => D;
+  data?: T;
+  useAdapterHook: (resource: K8sResourceCommon, data: T) => D;
   onAdapterDataResolved: (data: D) => void;
 };
 
-const ResolveAdapter = <D extends {}>({
+const ResolveAdapter = <D extends {}, T = {}>({
   resource,
+  data: customData,
   useAdapterHook,
   onAdapterDataResolved,
-}: ResolveAdapterProps<D>) => {
-  const data = useAdapterHook(resource);
+}: ResolveAdapterProps<D, T>) => {
+  const data = useAdapterHook(resource, customData);
 
   React.useEffect(() => {
     if (data) {

--- a/frontend/packages/topology/src/components/workload/pods-tab-section.tsx
+++ b/frontend/packages/topology/src/components/workload/pods-tab-section.tsx
@@ -47,6 +47,7 @@ const PodsTabSection: React.FC<{ element: GraphElement; renderNull: () => null }
       {podAdapterExtensionResolved && (
         <ResolveAdapter<PodsAdapterDataType<PodKind>>
           resource={podAdapter.resource}
+          data={podAdapter.data}
           useAdapterHook={podAdapter.provider}
           onAdapterDataResolved={handleAdapterResolved}
         />

--- a/frontend/packages/topology/src/operators/operatorsDataModelReconciler.ts
+++ b/frontend/packages/topology/src/operators/operatorsDataModelReconciler.ts
@@ -1,6 +1,10 @@
 import { Model, NodeShape } from '@patternfly/react-topology';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
-import { isOperatorBackedKnResource } from '@console/knative-plugin/src/topology/knative-topology-utils';
+import {
+  getKameletSinkAndSourceBindings,
+  isOperatorBackedKnResource,
+  isOperatorBackedKnSinkService,
+} from '@console/knative-plugin/src/topology/knative-topology-utils';
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager/src';
 import { getDefaultOperatorIcon, getImageForCSVIcon } from '@console/shared/src';
 import { TYPE_APPLICATION_GROUP } from '../const';
@@ -56,7 +60,7 @@ export const operatorsDataModelReconciler = (
     return;
   }
   const defaultIcon = getImageForIconClass(`icon-openshift`);
-
+  const { camelSinkKameletBindings } = getKameletSinkAndSourceBindings(resources);
   const obsGroupNodes: OdcNodeModel[] = [];
   installedOperators.forEach((csv) => {
     const crds = csv?.spec?.customresourcedefinitions?.owned ?? [];
@@ -69,6 +73,11 @@ export const operatorsDataModelReconciler = (
 
       // Hide operator backed if belong to source
       if (resources && isOperatorBackedKnResource(resource, resources)) {
+        return groupNodes;
+      }
+
+      // Hide operator backed if belong to sink
+      if (resources && isOperatorBackedKnSinkService(resource, camelSinkKameletBindings)) {
         return groupNodes;
       }
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6445

Note: Sahil did the main work in https://github.com/openshift/console/pull/10828, This PR is on top of sahil's changes and addresses the below items and review comments from the original PR

1. Fixed event sink connector edge
2. Added layout constraint, so that Kamlet binding will always stay on the left hand side just like event sources and channels and Knative services will stay on right side.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
Pod running:
![image](https://user-images.githubusercontent.com/9964343/150527827-200d5f4c-e4ae-4efa-a6ee-dfb3e13968ab.png)

Pod Scaled to 0:
![image](https://user-images.githubusercontent.com/9964343/150527972-d4143139-8bf0-49b9-b327-4d829bb0e61e.png)
Eventsource -> Channel -> SinkBinding
![image](https://user-images.githubusercontent.com/9964343/150527607-cb54d722-5049-4de2-a5ca-55740b8cf483.png)


https://user-images.githubusercontent.com/9964343/150284996-7621adf5-77de-444d-a266-686c4fd38658.mov



**Test setup:**
<!-- If any setup required to test this PR, mention the details -->


- Install Camel K operator
- Create a Channel
- Create Kamelet Sink using below yaml

```
apiVersion: camel.apache.org/v1alpha1
kind: KameletBinding
metadata:
  name: log-sink-binding
spec:
  source:
    ref:
      kind: Channel
      apiVersion: messaging.knative.dev/v1
      name: channel
  sink:
    ref:
      kind: Kamelet
      apiVersion: camel.apache.org/v1alpha1
      name: log-sink
```

