### PR TITLE
Bug 2059654: update ConsolePlugin proxy settings

### DIFF
--- a/dynamic-demo-plugin/README.md
+++ b/dynamic-demo-plugin/README.md
@@ -69,16 +69,15 @@ spec:
 
 In case the plugin needs to communicate with some in-cluster service, it can
 declare a service proxy in its `ConsolePlugin` resource using the
-`spec.proxy.services` array field. A service `name`, `namespace` and `port`
+`spec.proxy` array field. Each entry needs to specify type and alias of the proxy, under the `type` and `alias` field. For the `Service` proxy type, a `service` field with `name`, `namespace` and `port`
 needs to be specified.
 
 Console backend exposes following endpoint in order to proxy the communication
 between plugin and the service:
-`/api/proxy/namespace/<service-namespace>/service/<service-name>:<port-number>/<request-path>?<optional-query-parameters>`
+`/api/proxy/plugin/<plugin-name>/<proxy-alias>/<request-path>?<optional-query-parameters>`
 
-An example proxy request path from plugin to `helm-charts` service,
-in `helm` namespace to list ten helm releases:
-`/api/proxy/namespace/helm/service/helm-charts:8443/releases?limit=10`
+An example proxy request path from `helm` plugin with a `helm-charts` service to list ten helm releases:
+`/api/proxy/plugin/helm/helm-charts/releases?limit=10`
 
 Proxied request will use [service CA bundle](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/security_and_compliance/certificate-types-and-descriptions#cert-types-service-ca-certificates) by default. The service must use HTTPS.
 If the service uses a custom service CA, the `caCertificate` field
@@ -93,8 +92,10 @@ then passed in the HTTP `Authorization` request header, for example:
 # ...
 spec:
   proxy:
-    services:
-    - name: helm-charts
+  - type: Service
+    alias: helm-charts
+    service:
+      name: helm-charts
       namespace: helm
       port: 8443
       caCertificate: '-----BEGIN CERTIFICATE-----\nMIID....'

--- a/dynamic-demo-plugin/oc-manifest.yaml
+++ b/dynamic-demo-plugin/oc-manifest.yaml
@@ -87,8 +87,10 @@ spec:
     port: 9001
     basePath: '/'
   proxy:
-    services:
-      - name: thanos-querier
-        namespace: openshift-monitoring
-        port: 9091
-        authorize: true
+  - type: Service
+    alias: thanos-querier
+    service:
+      name: thanos-querier
+      namespace: openshift-monitoring
+      port: 9091
+      authorize: true

--- a/dynamic-demo-plugin/src/components/ExampleProxyPage.tsx
+++ b/dynamic-demo-plugin/src/components/ExampleProxyPage.tsx
@@ -39,7 +39,7 @@ const ExampleProxyResponse: React.FC = () => {
   const [data, setData] = React.useState();
 
   React.useEffect(() => {
-    consoleFetchJSON('/api/proxy/namespace/openshift-monitoring/service/thanos-querier:9091/api/v1/rules')
+    consoleFetchJSON('/api/proxy/plugin/console-demo-plugin/thanos-querier/api/v1/rules')
       .then((response) => {
         setData(response);
       })


### PR DESCRIPTION
With the changes added in [the PR](https://github.com/openshift/console-operator/pull/613), consoleplugin proxy setting has been updated, we need to change `oc-manifest.yaml` to deploy plugin successfully

```
oc apply -f dynamic-demo-plugin/oc-manifest.yaml
namespace/console-demo-plugin created
deployment.apps/console-demo-plugin created
service/console-demo-plugin created
The ConsolePlugin "console-demo-plugin" is invalid: spec.proxy: Invalid value: "object": spec.proxy in body must be of type array: "object"

```