### PR TITLE
Bug 2042829: Topology performance: Do not fetch HPA for each Deployment (Pod Ring)

### DIFF
--- a/frontend/packages/console-shared/src/hooks/hpa-hooks.ts
+++ b/frontend/packages/console-shared/src/hooks/hpa-hooks.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { HorizontalPodAutoscalerModel } from '@console/internal/models';
-import { HorizontalPodAutoscalerKind, k8sList } from '@console/internal/module/k8s';
+import { HorizontalPodAutoscalerKind } from '@console/internal/module/k8s';
 import { doesHpaMatch } from '../utils/hpa-utils';
 
 export const useRelatedHPA = (
@@ -10,57 +10,30 @@ export const useRelatedHPA = (
   workloadName: string,
   workloadNamespace: string,
 ): [HorizontalPodAutoscalerKind, boolean, string] => {
-  const [loaded, setLoaded] = React.useState<boolean>(false);
-  const [errorMessage, setErrorMessage] = React.useState<string>(null);
-  const [hpaName, setHPAName] = React.useState<string>(null);
+  // useRelatedHPA is used by PodRing which will be shown many many times on the topology.
+  // The topology loads all HPAs itself via useK8sWatchResource, and because our watch
+  // hooks are smart enough to do not watch the same resources twice, we can do this here
+  // without additional API calls.
+  // See also packages/topology/src/data-transforms/ModelContext.ts (getBaseWatchedResources)
+  const [hpas, loaded, error] = useK8sWatchResource<HorizontalPodAutoscalerKind[]>({
+    kind: HorizontalPodAutoscalerModel.kind,
+    namespace: workloadNamespace,
+    optional: true,
+    isList: true,
+  });
 
-  React.useEffect(() => {
-    let destroyed = false;
-    k8sList(HorizontalPodAutoscalerModel, { ns: workloadNamespace })
-      .then((hpaList: HorizontalPodAutoscalerKind[]) => {
-        if (destroyed) {
-          return;
-        }
-        const matchingHPA = hpaList.find(
-          doesHpaMatch({
-            apiVersion: workloadAPI,
-            kind: workloadKind,
-            metadata: { name: workloadName },
-          }),
-        );
-        setLoaded(true);
-        if (!matchingHPA) {
-          return;
-        }
-        setHPAName(matchingHPA.metadata.name);
-      })
-      .catch((error) => {
-        if (destroyed) {
-          return;
-        }
-        setLoaded(true);
-        setErrorMessage(
-          error?.message || `No matching ${HorizontalPodAutoscalerModel.label} found.`,
-        );
-      });
-    return () => {
-      destroyed = true;
-    };
-  }, [workloadAPI, workloadKind, workloadName, workloadNamespace]);
+  const matchingHpa = React.useMemo<HorizontalPodAutoscalerKind>(() => {
+    if (hpas && loaded && !error) {
+      return hpas.find(
+        doesHpaMatch({
+          apiVersion: workloadAPI,
+          kind: workloadKind,
+          metadata: { name: workloadName },
+        }),
+      );
+    }
+    return undefined; // similar to .find(() => false)
+  }, [hpas, loaded, error, workloadAPI, workloadKind, workloadName]);
 
-  const resource = React.useMemo(
-    () =>
-      hpaName && {
-        kind: HorizontalPodAutoscalerModel.kind,
-        name: hpaName,
-        namespace: workloadNamespace,
-      },
-    [hpaName, workloadNamespace],
-  );
-  const [hpa, hpaWatchLoaded, error] = useK8sWatchResource<HorizontalPodAutoscalerKind>(resource);
-
-  const hpaLoaded = loaded && hpaWatchLoaded;
-  const returnHPA = !error && hpa && hpaLoaded ? hpa : null;
-  const hpaError = error || errorMessage;
-  return [returnHPA, hpaLoaded, hpaError];
+  return [matchingHpa, loaded, error];
 };


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2042829

**Analysis / Root cause**: 
The topology loads the complete HorizontalPodAutoscalers (HPA) resource list for each Deployment which is shown on the topology. This happens because the HPA resource references the Deployment within the spec only.

The `PodRing` uses `useRelatedHPA` which fetches the full HPA list via `k8sList` in a hook. After that it watches just the matched HPA.

**Solution Description**: 
Instead of fetching the HPA list again and again we can just `useK8sWatchResource` and extract the result. The HPA list was already called by topology `ModelContext`, which fetches them for all resources together. See also `getBaseWatchedResources`

**Screen shots / Gifs for design review**: 
Before:
![before](https://user-images.githubusercontent.com/139310/150303809-4b18ddc3-d2e3-4ac7-bd1b-a0864996cb53.gif)

After:
![after](https://user-images.githubusercontent.com/139310/150303800-ae29e393-b877-42c7-b51a-9a40f6f7af96.gif)


**Unit test coverage report**: 
Unchanged

**Test setup:**
Test 1 if this reduces the API calls:
1. Import two Deployments
2. Open the network inspector of your browser and navigate to the topology
3. Reload the browser tab

Test 2 if HPA still works:
1. Add HPA to one of your deployments
2. Check that Autoscaling text is still shown in the PodRing

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
