### PR TITLE
Bug 2041093: Changed validation of adding file content from not empty to not contain parsing errors

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/advanced-tab/sysprep/SysprepFileField.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/advanced-tab/sysprep/SysprepFileField.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { FileUpload, Text, TextVariants } from '@patternfly/react-core';
+import { isEmpty } from 'lodash';
 import { useTranslation } from 'react-i18next';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
@@ -38,8 +39,12 @@ const SysprepFileField: React.FC<SysprepFileFieldProps> = ({ id }) => {
         fileName,
       }));
 
-      xml.parseString(value || '', (parseError, parseResult) => {
-        parseResult && dispatch(SysprepActions[SysprepActionsNames.updateValue]({ [id]: value }));
+      xml.parseString(value, (parseError) => {
+        dispatch(
+          SysprepActions[SysprepActionsNames.updateValue]({
+            [id]: !parseError && !isEmpty(value) ? value : null,
+          }),
+        );
         setData((currentSysprepFile) => ({
           ...currentSysprepFile,
           validated: parseError ? ValidatedOptions.error : ValidatedOptions.default,


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2041093

**Analysis / Root cause**: 
Empty xml file was providing null and would add to configmap.

**Solution Description**: 
It will check if there isn't parsing XML errors, if none, it will be added, even if empty XML

**Screen shots / Gifs for design review**: 
After:
![image](https://user-images.githubusercontent.com/14824964/150317395-a1ab39ab-b6ac-45fa-8b28-89a5f4bd3f4a.png)

Before:
![image](https://user-images.githubusercontent.com/14824964/150317683-d7c3e570-5d26-4d8b-a2cc-2bfd8d298525.png)
