### PR TITLE
Bug 2043117: Make recommended operator links internal

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/RecommendedOperatorsCard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/RecommendedOperatorsCard.tsx
@@ -23,13 +23,11 @@ export const RecommendedOperatorsCard: React.FC = () => {
       id: 'openshift-virtualization-ocs',
       title: t('kubevirt-plugin~OpenShift Container Storage'),
       href: '/operatorhub/all-namespaces?keyword=OCS',
-      external: true,
     },
     {
       id: 'openshift-virtualization-mtv',
       title: t('kubevirt-plugin~Migration Toolkit for Virtualization'),
       href: '/operatorhub/all-namespaces?keyword=MTV',
-      external: true,
     },
   ];
 


### PR DESCRIPTION
This PR changes the links in the recommended operators section of the getting started card into internal links.

Screenshot before:
![Selection_042](https://user-images.githubusercontent.com/8544299/150382511-f4b1270d-3502-4ae2-baa5-40845c7c5a9e.png)


Screenshot after:
![Selection_043](https://user-images.githubusercontent.com/8544299/150382272-c2d3dd94-2635-4702-ac60-4e1c886078c5.png)