### PR TITLE
default apiDiscovery in SDK

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/AppInitSDK.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/AppInitSDK.tsx
@@ -2,12 +2,14 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { Store } from 'redux';
 import { setUtilsConfig, UtilsConfig } from './configSetup';
+import { initApiDiscovery } from './k8s/api-discovery/api-discovery';
+import { InitApiDiscovery } from './k8s/api-discovery/api-discovery-types';
 import { useReduxStore } from './useReduxStore';
 
 type AppInitSDKProps = {
   children: React.ReactNode;
   configurations: {
-    apiDiscovery: (store: Store<any>) => void;
+    apiDiscovery?: InitApiDiscovery;
     appFetch: UtilsConfig['appFetch'];
     /** @deprecated - will be removed later when we have an interface for plugin */
     initPlugins?: (store: Store<any>) => void;
@@ -34,15 +36,14 @@ type AppInitSDKProps = {
  */
 const AppInitSDK: React.FC<AppInitSDKProps> = ({ children, configurations }) => {
   const { store, storeContextPresent } = useReduxStore();
-
   React.useEffect(() => {
-    const { appFetch, apiDiscovery, initPlugins } = configurations;
+    const { appFetch, initPlugins, apiDiscovery = initApiDiscovery } = configurations;
     try {
       setUtilsConfig({ appFetch });
-      apiDiscovery(store);
       if (initPlugins) {
         initPlugins(store);
       }
+      apiDiscovery(store);
     } catch (e) {
       // eslint-disable-next-line no-console
       console.warn(e);

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/__tests__/AppInitSDK.spec.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/__tests__/AppInitSDK.spec.tsx
@@ -5,6 +5,7 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import AppInitSDK from '../AppInitSDK';
 import * as configSetup from '../configSetup';
+import * as apiDiscovery from '../k8s/api-discovery/api-discovery';
 import * as hooks from '../useReduxStore';
 
 jest.mock('react-redux', () => {
@@ -79,8 +80,10 @@ describe('AppInitSDK', () => {
     expect(configSetupSpy).toHaveBeenCalledWith({ appFetch: mockConfig.appFetch });
   });
 
-  it('should call apiDiscovery with store instance', () => {
+  it('should call apiDiscovery with store instance if provided and not default one', () => {
     useReduxStoreSpy.mockImplementation(() => ({ store, storeContextPresent: true }));
+    const initApiDiscoverySpy = jest.spyOn(apiDiscovery, 'initApiDiscovery');
+    initApiDiscoverySpy.mockImplementation(jest.fn());
     mount(
       <AppInitSDK configurations={mockConfig}>
         <div data-test-id="child-id">Hello!!</div>
@@ -89,5 +92,23 @@ describe('AppInitSDK', () => {
     expect(mockConfig.apiDiscovery).toHaveBeenCalled();
     expect(mockConfig.apiDiscovery).toHaveBeenCalledTimes(1);
     expect(mockConfig.apiDiscovery).toHaveBeenCalledWith(store);
+    expect(initApiDiscoverySpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should trigger default apiDiscovery if apiDiscovery is not provided with config', () => {
+    const mockConfigData = {
+      appFetch: jest.fn(),
+    };
+    useReduxStoreSpy.mockImplementation(() => ({ store, storeContextPresent: false }));
+    const initApiDiscoverySpy = jest.spyOn(apiDiscovery, 'initApiDiscovery');
+    initApiDiscoverySpy.mockImplementation(jest.fn());
+    mount(
+      <AppInitSDK configurations={mockConfigData}>
+        <div data-test-id="child-id">Hello!!</div>
+      </AppInitSDK>,
+    );
+    expect(initApiDiscoverySpy).toHaveBeenCalled();
+    expect(initApiDiscoverySpy).toHaveBeenCalledTimes(1);
+    expect(initApiDiscoverySpy).toHaveBeenCalledWith(store);
   });
 });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/k8s/api-discovery/api-discovery-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/k8s/api-discovery/api-discovery-types.ts
@@ -1,0 +1,19 @@
+import { Store, AnyAction } from 'redux';
+import { ActionType as Action } from 'typesafe-actions';
+import { K8sVerb } from '../../../extensions/console-types';
+
+export type InitApiDiscovery = (store: Store<any, Action<AnyAction>>) => void;
+
+export type APIResourceList = {
+  kind: 'APIResourceList';
+  apiVersion: 'v1';
+  groupVersion: string;
+  resources?: {
+    name: string;
+    singularName?: string;
+    namespaced?: boolean;
+    kind: string;
+    verbs: K8sVerb[];
+    shortNames?: string[];
+  }[];
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/k8s/api-discovery/api-discovery.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/k8s/api-discovery/api-discovery.ts
@@ -1,0 +1,159 @@
+import * as _ from 'lodash';
+import { plural } from 'pluralize';
+import { Dispatch } from 'react-redux';
+import { DiscoveryResources, K8sModel } from '../../../api/common-types';
+import { consoleFetchJSON } from '../../../utils/fetch/console-fetch';
+import { k8sBasePath } from '../../../utils/k8s/k8s';
+import { kindToAbbr } from '../../../utils/k8s/k8s-get-resource';
+import { getResourcesInFlight, receivedResources } from '../actions/k8s';
+import { APIResourceList, InitApiDiscovery } from './api-discovery-types';
+import { cacheResources, getCachedResources } from './discovery-cache';
+
+const POLLs = {};
+const apiDiscovery = 'apiDiscovery';
+const API_DISCOVERY_POLL_INTERVAL = 60_000;
+
+const pluralizeKind = (kind: string): string => {
+  // Use startCase to separate words so the last can be pluralized but remove spaces so as not to humanize
+  const pluralized = plural(_.startCase(kind)).replace(/\s+/g, '');
+  // Handle special cases like DB -> DBs (instead of DBS).
+  if (pluralized === `${kind}S`) {
+    return `${kind}s`;
+  }
+  return pluralized;
+};
+
+const defineModels = (list: APIResourceList): K8sModel[] => {
+  const groupVersionParts = list.groupVersion.split('/');
+  const apiGroup = groupVersionParts.length > 1 ? groupVersionParts[0] : null;
+  const apiVersion = groupVersionParts.length > 1 ? groupVersionParts[1] : list.groupVersion;
+  return list.resources
+    .filter(({ name }) => !name.includes('/'))
+    .map(({ name, singularName, namespaced, kind, verbs, shortNames }) => {
+      return {
+        kind,
+        namespaced,
+        verbs,
+        shortNames,
+        label: kind,
+        plural: name,
+        apiVersion,
+        abbr: kindToAbbr(kind),
+        ...(apiGroup ? { apiGroup } : {}),
+        labelPlural: pluralizeKind(kind),
+        path: name,
+        id: singularName,
+        crd: true,
+      };
+    });
+};
+
+const getResources = async (): Promise<DiscoveryResources> => {
+  const apiResourceData = await consoleFetchJSON(`${k8sBasePath}/apis`);
+  const groupVersionMap = apiResourceData.groups.reduce(
+    (acc, { name, versions, preferredVersion: { version } }) => {
+      acc[name] = {
+        versions: _.map(versions, 'version'),
+        preferredVersion: version,
+      };
+      return acc;
+    },
+    {},
+  );
+  const all: Promise<APIResourceList>[] = _.flatten(
+    apiResourceData.groups.map((group) =>
+      group.versions.map((version) => `/apis/${version.groupVersion}`),
+    ),
+  )
+    .concat(['/api/v1'])
+    .map((p) => consoleFetchJSON(`api/kubernetes${p}`).catch((err) => err));
+
+  return Promise.all(all).then((data) => {
+    const resourceSet = new Set<string>();
+    const namespacedSet = new Set<string>();
+    data.forEach(
+      (d) =>
+        d.resources &&
+        d.resources.forEach(({ namespaced, name }) => {
+          resourceSet.add(name);
+          namespaced && namespacedSet.add(name);
+        }),
+    );
+    const allResources = [...resourceSet].sort();
+
+    const safeResources = [];
+    const adminResources = [];
+    const models = _.flatten(data.filter((d) => d.resources).map(defineModels));
+    const coreResources = new Set([
+      'roles',
+      'rolebindings',
+      'clusterroles',
+      'clusterrolebindings',
+      'thirdpartyresources',
+      'nodes',
+      'secrets',
+    ]);
+    allResources.forEach((r) =>
+      coreResources.has(r.split('/')[0]) ? adminResources.push(r) : safeResources.push(r),
+    );
+    const configResources = _.filter(
+      models,
+      (m) => m.apiGroup === 'config.openshift.io' && m.kind !== 'ClusterOperator',
+    );
+    const clusterOperatorConfigResources = _.filter(
+      models,
+      (m) => m.apiGroup === 'operator.openshift.io',
+    );
+
+    return {
+      allResources,
+      safeResources,
+      adminResources,
+      configResources,
+      clusterOperatorConfigResources,
+      namespacedSet,
+      models,
+      groupVersionMap,
+    } as DiscoveryResources;
+  });
+};
+
+const updateResources = () => (dispatch: Dispatch) => {
+  dispatch(getResourcesInFlight());
+
+  getResources()
+    .then((resources) => {
+      // Cache the resources whenever discovery completes to improve console load times.
+      cacheResources(resources);
+      dispatch(receivedResources(resources));
+    })
+    // eslint-disable-next-line no-console
+    .catch((err) => console.error('Fetching resource failed:', err));
+};
+
+const startAPIDiscovery = () => (dispatch) => {
+  // eslint-disable-next-line no-console
+  console.log('API discovery method: Polling');
+  // Poll API discovery every 30 seconds since we can't watch CRDs
+  dispatch(updateResources());
+  if (POLLs[apiDiscovery]) {
+    clearTimeout(POLLs[apiDiscovery]);
+    delete POLLs[apiDiscovery];
+  }
+  POLLs[apiDiscovery] = setTimeout(
+    () => dispatch(startAPIDiscovery()),
+    API_DISCOVERY_POLL_INTERVAL,
+  );
+};
+
+export const initApiDiscovery: InitApiDiscovery = (storeInstance) => {
+  getCachedResources()
+    .then((resources) => {
+      if (resources) {
+        storeInstance.dispatch(receivedResources(resources));
+      }
+      // Still perform discovery to refresh the cache.
+      storeInstance.dispatch(startAPIDiscovery());
+    })
+    .catch(() => storeInstance.dispatch(startAPIDiscovery()));
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/k8s/api-discovery/discovery-cache.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/k8s/api-discovery/discovery-cache.ts
@@ -1,0 +1,31 @@
+const SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = 'sdk/api-discovery-resources';
+
+export const cacheResources = (resources) => {
+  try {
+    localStorage.setItem(SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY, JSON.stringify(resources));
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('Error caching API resources in localStorage', e);
+    throw new Error(e);
+  }
+};
+
+export const getCachedResources = async () => {
+  const resourcesJSON = localStorage.getItem(SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY);
+  if (!resourcesJSON) {
+    throw new Error(
+      `No API resources found in localStorage for key ${SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY}`,
+    );
+  }
+
+  // Clear cached resources after load as a safeguard. If there's any errors
+  // with the content that prevents the console from working, the bad data
+  // will not be loaded when the user refreshes the console. The cache will
+  // be refreshed when discovery completes.
+  localStorage.removeItem(SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY);
+
+  const resources = JSON.parse(resourcesJSON);
+  // eslint-disable-next-line no-console
+  console.log('Loaded cached API resources from localStorage');
+  return resources;
+};


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/HAC-390

**Description:**

- [x] Makes the prop for apiDiscovery optional in AppInitSDK
- [x] Uses the provided fetch call, make a call to get the resources it used
- [x] Setup the SDK store with the information provided

**Test Setup:**
Don't need to pass `apiDiscovery ` in `AppInitSDK`

https://github.com/openshift/console/blob/master/frontend/public/components/app.jsx#L493

**Tests**
- [ ] Add/update tests