### PR TITLE
[release-4.9] Bug 2044089: Update CRW operator name to fix failing e2e tests

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -5,7 +5,7 @@ import { nav } from '../../../integration-tests-cypress/views/nav';
 import { GlobalInstalledNamespace, operator, TestOperandProps } from '../views/operator.view';
 
 const testOperator = {
-  name: 'Red Hat CodeReady Workspaces',
+  name: 'Red Hat CodeReady Workspaces for Devfile v1 and v2',
   operatorHubCardTestID: 'codeready-workspaces-redhat-operators-openshift-marketplace',
   installedNamespace: testName,
 };

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-uninstall.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-uninstall.spec.ts
@@ -5,7 +5,7 @@ import { nav } from '../../../integration-tests-cypress/views/nav';
 import { operator, TestOperandProps } from '../views/operator.view';
 
 const testOperator = {
-  name: 'Red Hat CodeReady Workspaces',
+  name: 'Red Hat CodeReady Workspaces for Devfile v1 and v2',
   operatorHubCardTestID: 'codeready-workspaces-redhat-operators-openshift-marketplace',
   installedNamespace: testName,
 };


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2044089

**Analysis / Root cause**: 
All our 4.9 backports are currently stuck and could not be merged because an e2e test for the CRW integration doesn't pass anymore. The test checks if the exact `displayName` was part of the "Installed operators" page after installing it.

```
  1) Installing "Red Hat CodeReady Workspaces" operator in test-jmmhh
       Installs Red Hat CodeReady Workspaces operator in test-jmmhh and creates CodeReady Workspaces instance Specification operand instance:
     AssertionError: Timed out retrying after 30000ms: Expected to find element: `[data-test-id="operator-install-btn"]`, but never found it.
      at Context.eval (https://console-openshift-console.apps.ci-op-tnv4lhm2-a596c.**********************/__cypress/tests?p=tests/operator-install-single-namespace.spec.ts:13659:57)
```

All 4.9 jobs failing at the moment:

![image](https://user-images.githubusercontent.com/139310/150686155-ad210552-b082-4af7-ae28-c01529247989.png)

**Solution Description**: 
Installed Operator page on 4.9 and 4.10 looks now like this (see also data-test-operator-row):

![Screenshot from 2022-01-23 16-07-20](https://user-images.githubusercontent.com/139310/150686211-455f3137-ed26-4690-8f9c-c72b52031db3.png)

Update the expected CRW operator name from "Red Hat CodeReady Workspaces" to "Red Hat CodeReady Workspaces for Devfile v1 and v2".

**Screen shots / Gifs for design review**: 
Unchanged

**Unit test coverage report**: 
Unchanged

**Test setup:**
If this PR passes again we are fine. :smirk: 

**Browser conformance**: 
Unrelated
