### PR TITLE
[release-4.9] Bug 2044287: Add support for fetching partial metadata and fix helm list page crash

### DIFF
--- a/frontend/__tests__/actions/k8s.spec.ts
+++ b/frontend/__tests__/actions/k8s.spec.ts
@@ -153,6 +153,51 @@ describe(k8sActions.ActionType.StartWatchK8sList, () => {
     watchK8sList('another-redux-id', {}, model)(dispatch, getState);
   });
 
+  it('send partial metadata headers to k8sList when partialMetadata is true', (done) => {
+    const k8sList = spyOn(k8sResource, 'k8sList').and.callFake(
+      (k8sKind, params, raw, requestOptions) => {
+        expect(params.limit).toEqual(250);
+        expect(requestOptions.headers).toEqual(k8sActions.partialObjectMetadataListHeader);
+
+        if (k8sList.calls.count() === 1 || k8sList.calls.count() === 11) {
+          expect(params.continue).toBeUndefined();
+        } else {
+          expect(params.continue).toEqual('toNextPage');
+        }
+        resourceList.metadata.resourceVersion = (
+          parseInt(resourceList.metadata.resourceVersion, 10) + 1
+        ).toString();
+        resourceList.metadata.continue =
+          parseInt(resourceList.metadata.resourceVersion, 10) < 10 ? 'toNextPage' : undefined;
+
+        return resourceList;
+      },
+    );
+
+    let returnedItems = 0;
+    const dispatch = jasmine.createSpy('dispatch').and.callFake((action) => {
+      if (action.type === k8sActions.ActionType.BulkAddToList) {
+        const bulkAddToListCalls = dispatch.calls
+          .allArgs()
+          .filter((args) => args[0].type === k8sActions.ActionType.BulkAddToList);
+
+        expect(action.payload.k8sObjects).toEqual(resourceList.items);
+        expect(bulkAddToListCalls.length).toEqual(k8sList.calls.count() - 1);
+
+        returnedItems += action.payload.k8sObjects.length;
+
+        if (bulkAddToListCalls.length === 9) {
+          expect(returnedItems).toEqual(resourceList.items.length * bulkAddToListCalls.length);
+          done();
+        }
+      } else if (action.type === k8sActions.ActionType.Errored) {
+        fail(action.payload.k8sObjects);
+      }
+    });
+
+    k8sActions.watchK8sList('one-more-redux-id', {}, model, null, true)(dispatch, getState);
+  });
+
   xit('stops incrementally fetching if `stopK8sWatch` action is dispatched', () => {
     // TODO(alecmerdler)
   });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -165,6 +165,7 @@ export type WatchK8sResource = {
   limit?: number;
   fieldSelector?: string;
   optional?: boolean;
+  partialMetadata?: boolean;
 };
 
 export type ResourcesObject = { [key: string]: K8sResourceCommon | K8sResourceCommon[] };

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
@@ -48,6 +48,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace }) => {
       namespaced: true,
       optional: true,
       selector: { matchLabels: { owner: 'helm' } },
+      partialMetadata: true,
     }),
     [namespace],
   );

--- a/frontend/packages/helm-plugin/src/topology/helmResources.ts
+++ b/frontend/packages/helm-plugin/src/topology/helmResources.ts
@@ -5,6 +5,7 @@ export const getHelmWatchedResources = (namespace: string) => {
       kind: 'Secret',
       namespace,
       optional: true,
+      partialMetadata: true,
     },
   };
 };

--- a/frontend/public/actions/k8s.ts
+++ b/frontend/public/actions/k8s.ts
@@ -32,6 +32,14 @@ export enum ActionType {
   UpdateListFromWS = 'updateListFromWS',
 }
 
+export const partialObjectMetadataListHeader = {
+  Accept: 'application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io,application/json',
+};
+
+export const partialObjectMetadataHeader = {
+  Accept: 'application/json;as=PartialObjectMetadata;v=v1;g=meta.k8s.io,application/json',
+};
+
 const WS = {} as { [id: string]: WebSocket & any };
 const POLLs = {};
 const REF_COUNTS = {};
@@ -83,6 +91,7 @@ export const watchK8sObject = (
   namespace: string,
   query: { [key: string]: string },
   k8sType: K8sKind,
+  partialMetadata = false,
 ) => (dispatch: Dispatch, getState) => {
   if (id in REF_COUNTS) {
     REF_COUNTS[id] += 1;
@@ -96,8 +105,14 @@ export const watchK8sObject = (
     delete query.name;
   }
 
+  const requestOptions: RequestInit = partialMetadata
+    ? {
+        headers: partialObjectMetadataHeader,
+      }
+    : {};
+
   const poller = () => {
-    k8sGet(k8sType, name, namespace).then(
+    k8sGet(k8sType, name, namespace, null, requestOptions).then(
       (o) => dispatch(modifyObject(id, o)),
       (e) => dispatch(errored(id, e)),
     );
@@ -146,6 +161,7 @@ export const watchK8sList = (
   query: { [key: string]: string },
   k8skind: K8sKind,
   extraAction?,
+  partialMetadata = false,
 ) => (dispatch, getState) => {
   // Only one watch per unique list ID
   if (id in REF_COUNTS) {
@@ -163,6 +179,12 @@ export const watchK8sList = (
       return;
     }
 
+    const requestOptions: RequestInit = partialMetadata
+      ? {
+          headers: partialObjectMetadataListHeader,
+        }
+      : {};
+
     const response = await k8sList(
       k8skind,
       {
@@ -171,6 +193,7 @@ export const watchK8sList = (
         ...(continueToken ? { continue: continueToken } : {}),
       },
       true,
+      requestOptions,
     );
 
     if (!REF_COUNTS[id]) {

--- a/frontend/public/components/utils/k8s-watch-hook.ts
+++ b/frontend/public/components/utils/k8s-watch-hook.ts
@@ -37,8 +37,15 @@ const getIDAndDispatch: GetIDAndDispatch = (resource, k8sModel) => {
   );
   const id = makeReduxID(k8sModel, query);
   const dispatch = resource.isList
-    ? k8sActions.watchK8sList(id, query, k8sModel)
-    : k8sActions.watchK8sObject(id, resource.name, resource.namespace, query, k8sModel);
+    ? k8sActions.watchK8sList(id, query, k8sModel, null, resource.partialMetadata)
+    : k8sActions.watchK8sObject(
+        id,
+        resource.name,
+        resource.namespace,
+        query,
+        k8sModel,
+        resource.partialMetadata,
+      );
   return { id, dispatch };
 };
 


### PR DESCRIPTION
This is a manually cherry-pick/backport of https://github.com/openshift/console/pull/10754

**Merge notes:**
Could apply all changes without additional work. The files are just moved for SDK extraction and the variable `k8sActions` was renamed in the unit test to `sdkK8sActions` (4.10).

Changed unit test passes:

![image](https://user-images.githubusercontent.com/139310/150774181-725ad989-505c-4c03-be52-b964a530b6d9.png)

**Validation:**
Quickly confirmed that the k8s request on the "Helm Releases" list page contains the right `Accept` value:

![image](https://user-images.githubusercontent.com/139310/150774311-663aff71-d151-4a3d-ac85-c441dd55312e.png)
