### PR TITLE
[release-4.9] Bug 2044292: Filter superseded helm secrets and fix firehose to support partial metadata

### DIFF
--- a/frontend/__tests__/actions/k8s.spec.ts
+++ b/frontend/__tests__/actions/k8s.spec.ts
@@ -153,6 +153,51 @@ describe(k8sActions.ActionType.StartWatchK8sList, () => {
     watchK8sList('another-redux-id', {}, model)(dispatch, getState);
   });
 
+  it('send partial metadata headers to k8sList when partialMetadata is true', (done) => {
+    const k8sList = spyOn(k8sResource, 'k8sList').and.callFake(
+      (k8sKind, params, raw, requestOptions) => {
+        expect(params.limit).toEqual(250);
+        expect(requestOptions.headers).toEqual(k8sActions.partialObjectMetadataListHeader);
+
+        if (k8sList.calls.count() === 1 || k8sList.calls.count() === 11) {
+          expect(params.continue).toBeUndefined();
+        } else {
+          expect(params.continue).toEqual('toNextPage');
+        }
+        resourceList.metadata.resourceVersion = (
+          parseInt(resourceList.metadata.resourceVersion, 10) + 1
+        ).toString();
+        resourceList.metadata.continue =
+          parseInt(resourceList.metadata.resourceVersion, 10) < 10 ? 'toNextPage' : undefined;
+
+        return resourceList;
+      },
+    );
+
+    let returnedItems = 0;
+    const dispatch = jasmine.createSpy('dispatch').and.callFake((action) => {
+      if (action.type === k8sActions.ActionType.BulkAddToList) {
+        const bulkAddToListCalls = dispatch.calls
+          .allArgs()
+          .filter((args) => args[0].type === k8sActions.ActionType.BulkAddToList);
+
+        expect(action.payload.k8sObjects).toEqual(resourceList.items);
+        expect(bulkAddToListCalls.length).toEqual(k8sList.calls.count() - 1);
+
+        returnedItems += action.payload.k8sObjects.length;
+
+        if (bulkAddToListCalls.length === 9) {
+          expect(returnedItems).toEqual(resourceList.items.length * bulkAddToListCalls.length);
+          done();
+        }
+      } else if (action.type === k8sActions.ActionType.Errored) {
+        fail(action.payload.k8sObjects);
+      }
+    });
+
+    k8sActions.watchK8sList('one-more-redux-id', {}, model, null, true)(dispatch, getState);
+  });
+
   xit('stops incrementally fetching if `stopK8sWatch` action is dispatched', () => {
     // TODO(alecmerdler)
   });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/common-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/common-types.ts
@@ -59,9 +59,21 @@ export type K8sKind = {
   legacyPluralURL?: boolean;
 };
 
+enum Operator {
+  Exists = 'Exists',
+  DoesNotExist = 'DoesNotExist',
+  In = 'In',
+  NotIn = 'NotIn',
+  Equals = 'Equals',
+  NotEqual = 'NotEqual',
+  GreaterThan = 'GreaterThan',
+  LessThan = 'LessThan',
+  NotEquals = 'NotEquals',
+}
+
 type MatchExpression = {
   key: string;
-  operator: 'Exists' | 'DoesNotExist' | 'In' | 'NotIn' | 'Equals' | 'NotEqual';
+  operator: Operator | string;
   values?: string[];
   value?: string;
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -73,9 +73,21 @@ export type AccessReviewResourceAttributes = {
   namespace?: string;
 };
 
+export enum Operator {
+  Exists = 'Exists',
+  DoesNotExist = 'DoesNotExist',
+  In = 'In',
+  NotIn = 'NotIn',
+  Equals = 'Equals',
+  NotEqual = 'NotEqual',
+  GreaterThan = 'GreaterThan',
+  LessThan = 'LessThan',
+  NotEquals = 'NotEquals',
+}
+
 export type MatchExpression = {
   key: string;
-  operator: 'Exists' | 'DoesNotExist' | 'In' | 'NotIn' | 'Equals' | 'NotEqual';
+  operator: Operator | string;
   values?: string[];
   value?: string;
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -165,6 +165,7 @@ export type WatchK8sResource = {
   limit?: number;
   fieldSelector?: string;
   optional?: boolean;
+  partialMetadata?: boolean;
 };
 
 export type ResourcesObject = { [key: string]: K8sResourceCommon | K8sResourceCommon[] };

--- a/frontend/packages/helm-plugin/console-extensions.json
+++ b/frontend/packages/helm-plugin/console-extensions.json
@@ -182,7 +182,20 @@
       "id": "helm-topology-model-factory",
       "priority": 400,
       "resources": {
-        "secrets": { "opts": { "isList": true, "kind": "Secret", "optional": true } }
+        "secrets": {
+          "opts": {
+            "isList": true,
+            "kind": "Secret",
+            "optional": true,
+            "selector": {
+              "matchLabels": { "owner": "helm" },
+              "matchExpressions": [
+                { "key": "status", "operator": "NotEquals", "values": ["superseded"] }
+              ]
+            },
+            "partialMetadata": true
+          }
+        }
       },
       "getDataModel": { "$codeRef": "helmTopology.getHelmTopologyDataModel" },
       "isResourceDepicted": { "$codeRef": "helmTopology.isHelmResourceInModel" }

--- a/frontend/packages/helm-plugin/src/actions/providers.ts
+++ b/frontend/packages/helm-plugin/src/actions/providers.ts
@@ -28,10 +28,12 @@ export const useHelmActionProviderForTopology = (element: GraphElement) => {
   const scope = React.useMemo(() => {
     if (nodeType !== TYPE_HELM_RELEASE) return undefined;
     const releaseName = element.getLabel();
+    const resource = getResource(element);
+    if (!resource?.metadata) return null;
     const {
       namespace,
       labels: { version },
-    } = getResource(element).metadata;
+    } = resource.metadata;
     return {
       release: {
         name: releaseName,

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
@@ -47,7 +47,10 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace }) => {
       kind: SecretModel.kind,
       namespaced: true,
       optional: true,
-      selector: { matchLabels: { owner: 'helm' } },
+      selector: {
+        matchLabels: { owner: 'helm' },
+        matchExpressions: [{ key: 'status', operator: 'NotEquals', values: ['superseded'] }],
+      },
       partialMetadata: true,
     }),
     [namespace],

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
@@ -48,6 +48,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace }) => {
       namespaced: true,
       optional: true,
       selector: { matchLabels: { owner: 'helm' } },
+      partialMetadata: true,
     }),
     [namespace],
   );

--- a/frontend/packages/helm-plugin/src/topology/helm-data-transformer.ts
+++ b/frontend/packages/helm-plugin/src/topology/helm-data-transformer.ts
@@ -43,7 +43,6 @@ export const getTopologyHelmReleaseGroupItem = (
   const resourceKindName = getHelmReleaseKey(obj);
   const helmResources = helmResourcesMap[resourceKindName];
   const releaseName = helmResources?.releaseName;
-  const releaseVersion = helmResources?.releaseVersion;
   const releaseNotes = helmResources?.releaseNotes;
   const uid = obj?.metadata?.uid ?? null;
   const returnData = [];
@@ -53,8 +52,7 @@ export const getTopologyHelmReleaseGroupItem = (
   }
 
   const secret = secrets.find((nextSecret) => {
-    const { labels } = nextSecret.metadata;
-    return labels?.name?.includes(releaseName) && labels?.version === releaseVersion.toString();
+    return nextSecret.metadata.labels?.name === releaseName;
   });
 
   if (secret) {

--- a/frontend/packages/helm-plugin/src/topology/helmResources.ts
+++ b/frontend/packages/helm-plugin/src/topology/helmResources.ts
@@ -5,6 +5,10 @@ export const getHelmWatchedResources = (namespace: string) => {
       kind: 'Secret',
       namespace,
       optional: true,
+      selector: {
+        matchLabels: { owner: 'helm' },
+        matchExpressions: [{ key: 'status', operator: 'NotEquals', values: ['superseded'] }],
+      },
       partialMetadata: true,
     },
   };

--- a/frontend/packages/helm-plugin/src/topology/helmResources.ts
+++ b/frontend/packages/helm-plugin/src/topology/helmResources.ts
@@ -5,6 +5,7 @@ export const getHelmWatchedResources = (namespace: string) => {
       kind: 'Secret',
       namespace,
       optional: true,
+      partialMetadata: true,
     },
   };
 };

--- a/frontend/packages/helm-plugin/src/topology/sidebar/release-panel/resource-link.tsx
+++ b/frontend/packages/helm-plugin/src/topology/sidebar/release-panel/resource-link.tsx
@@ -8,7 +8,9 @@ import { TYPE_HELM_RELEASE } from '../../components/const';
 const helmReleasePanelResourceLink = (element: GraphElement) => {
   if (element.getType() !== TYPE_HELM_RELEASE) return undefined;
   const name = element.getLabel();
-  const { namespace } = getResource(element).metadata;
+  const resource = getResource(element);
+  if (!resource?.metadata) return null;
+  const { namespace } = resource.metadata;
   return (
     <>
       <ResourceIcon className="co-m-resource-icon--lg" kind="HelmRelease" />

--- a/frontend/packages/helm-plugin/src/topology/sidebar/release-panel/tab-sections.tsx
+++ b/frontend/packages/helm-plugin/src/topology/sidebar/release-panel/tab-sections.tsx
@@ -36,16 +36,18 @@ export const getHelmReleasePanelDetailsTabSection = (element: GraphElement) => {
 export const getHelmReleasePanelResourceTabSection = (element: GraphElement) => {
   if (element.getType() !== TYPE_HELM_RELEASE) return undefined;
   const { manifestResources } = element.getData().data;
-  const { namespace } = getResource(element).metadata;
+  const resource = getResource(element);
+  if (!manifestResources || !resource?.metadata) return null;
+  const { namespace } = resource.metadata;
 
-  return manifestResources ? (
+  return (
     <div className="overview__sidebar-pane-body">
       <TopologyGroupResourcesPanel
         manifestResources={manifestResources}
         releaseNamespace={namespace}
       />
     </div>
-  ) : null;
+  );
 };
 
 export const getHelmReleasePanelReleaseNotesTabSection = (element: GraphElement) => {

--- a/frontend/public/actions/k8s.ts
+++ b/frontend/public/actions/k8s.ts
@@ -32,6 +32,14 @@ export enum ActionType {
   UpdateListFromWS = 'updateListFromWS',
 }
 
+export const partialObjectMetadataListHeader = {
+  Accept: 'application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io,application/json',
+};
+
+export const partialObjectMetadataHeader = {
+  Accept: 'application/json;as=PartialObjectMetadata;v=v1;g=meta.k8s.io,application/json',
+};
+
 const WS = {} as { [id: string]: WebSocket & any };
 const POLLs = {};
 const REF_COUNTS = {};
@@ -83,6 +91,7 @@ export const watchK8sObject = (
   namespace: string,
   query: { [key: string]: string },
   k8sType: K8sKind,
+  partialMetadata = false,
 ) => (dispatch: Dispatch, getState) => {
   if (id in REF_COUNTS) {
     REF_COUNTS[id] += 1;
@@ -96,8 +105,14 @@ export const watchK8sObject = (
     delete query.name;
   }
 
+  const requestOptions: RequestInit = partialMetadata
+    ? {
+        headers: partialObjectMetadataHeader,
+      }
+    : {};
+
   const poller = () => {
-    k8sGet(k8sType, name, namespace).then(
+    k8sGet(k8sType, name, namespace, null, requestOptions).then(
       (o) => dispatch(modifyObject(id, o)),
       (e) => dispatch(errored(id, e)),
     );
@@ -146,6 +161,7 @@ export const watchK8sList = (
   query: { [key: string]: string },
   k8skind: K8sKind,
   extraAction?,
+  partialMetadata = false,
 ) => (dispatch, getState) => {
   // Only one watch per unique list ID
   if (id in REF_COUNTS) {
@@ -163,6 +179,12 @@ export const watchK8sList = (
       return;
     }
 
+    const requestOptions: RequestInit = partialMetadata
+      ? {
+          headers: partialObjectMetadataListHeader,
+        }
+      : {};
+
     const response = await k8sList(
       k8skind,
       {
@@ -171,6 +193,7 @@ export const watchK8sList = (
         ...(continueToken ? { continue: continueToken } : {}),
       },
       true,
+      requestOptions,
     );
 
     if (!REF_COUNTS[id]) {

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -222,10 +222,10 @@ export const Firehose = connect(
           });
       }
 
-      firehoses.forEach(({ id, query, k8sKind, isList, name, namespace }) =>
+      firehoses.forEach(({ id, query, k8sKind, isList, name, namespace, partialMetadata }) =>
         isList
-          ? watchK8sList(id, query, k8sKind)
-          : watchK8sObject(id, name, namespace, query, k8sKind),
+          ? watchK8sList(id, query, k8sKind, null, partialMetadata)
+          : watchK8sObject(id, name, namespace, query, k8sKind, partialMetadata),
       );
       this.setState({ firehoses });
     }
@@ -280,6 +280,7 @@ Firehose.propTypes = {
       isList: PropTypes.bool,
       optional: PropTypes.bool, // do not block children-rendering while resource is still being loaded; do not fail if resource is missing (404)
       limit: PropTypes.number,
+      partialMetadata: PropTypes.bool,
     }),
   ).isRequired,
 };

--- a/frontend/public/components/utils/k8s-watch-hook.ts
+++ b/frontend/public/components/utils/k8s-watch-hook.ts
@@ -37,8 +37,15 @@ const getIDAndDispatch: GetIDAndDispatch = (resource, k8sModel) => {
   );
   const id = makeReduxID(k8sModel, query);
   const dispatch = resource.isList
-    ? k8sActions.watchK8sList(id, query, k8sModel)
-    : k8sActions.watchK8sObject(id, resource.name, resource.namespace, query, k8sModel);
+    ? k8sActions.watchK8sList(id, query, k8sModel, null, resource.partialMetadata)
+    : k8sActions.watchK8sObject(
+        id,
+        resource.name,
+        resource.namespace,
+        query,
+        k8sModel,
+        resource.partialMetadata,
+      );
   return { id, dispatch };
 };
 


### PR DESCRIPTION
This is a manually cherry-pick/backport of https://github.com/openshift/console/pull/10754

The branch is based on #10812 because it depends on changes in this PR. The first commit will be merged there. Code review should set the focus on the second commit.

**Merge notes:**
I could apply most changes without additional work. Just the MatchExpression enum value doesn't match the existing type definition. I take the definition from the latest master so that they are the same.

(Also if I personally don't like that the Operator contains `NotEqual` and `NotEquals`. And also that the operator is now Operator | string. But we should fix this on the master branch and not in this PR.)

See also https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/src/api/common-types.ts#L69-L83

**Validation:**
Quickly confirmed that this change works fine by opening the topology. The k8s fetch for secrets contains the right labels:

![image](https://user-images.githubusercontent.com/139310/150781771-d0b32b67-c3b9-429e-bac4-2a31523780e0.png)

It doesn't return any Secret in a namespace which has (Deployments and) Secrets:

![image](https://user-images.githubusercontent.com/139310/150781844-97121c6f-35f4-48fe-b848-6aedd2ab0591.png)
