### PR TITLE
disable helm on multi cluster environment

### DIFF
--- a/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { FlagIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import * as semver from 'semver';
-import { ALL_NAMESPACES_KEY, useActiveNamespace, useOpenShiftVersion } from '@console/shared/src';
+import {
+  ALL_NAMESPACES_KEY,
+  useActiveNamespace,
+  useFlag,
+  useOpenShiftVersion,
+} from '@console/shared/src';
 import {
   GettingStartedLink,
   GettingStartedCard,
@@ -12,6 +17,7 @@ import { getDisabledAddActions } from '../../utils/useAddActionExtensions';
 export const DeveloperFeaturesGettingStartedCard: React.FC = () => {
   const { t } = useTranslation();
   const [activeNamespace] = useActiveNamespace();
+  const isHelmEnabled = useFlag('OPENSHIFT_HELM');
   const parsed = semver.parse(useOpenShiftVersion());
   // Show only major and minor version.
   const version = parsed ? `${parsed.major}.${parsed.minor}` : '';
@@ -19,7 +25,7 @@ export const DeveloperFeaturesGettingStartedCard: React.FC = () => {
   const links: GettingStartedLink[] = [];
 
   const disabledAddActions = getDisabledAddActions();
-  if (!disabledAddActions?.includes('helm')) {
+  if (isHelmEnabled && !disabledAddActions?.includes('helm')) {
     links.push({
       id: 'helm-charts',
       title: t('devconsole~Discover certified Helm Charts'),

--- a/frontend/packages/dev-console/src/components/add/__tests__/DeveloperFeaturesGettingStartedCard.spec.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/DeveloperFeaturesGettingStartedCard.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { ALL_NAMESPACES_KEY, useActiveNamespace } from '@console/shared/src';
+import { ALL_NAMESPACES_KEY, useActiveNamespace, useFlag } from '@console/shared/src';
 import { GettingStartedCard } from '@console/shared/src/components/getting-started';
 import { DeveloperFeaturesGettingStartedCard } from '../DeveloperFeaturesGettingStartedCard';
 
@@ -8,6 +8,7 @@ jest.mock('@console/shared/src', () => ({
   ...require.requireActual('@console/shared/src'),
   useActiveNamespace: jest.fn(),
   useOpenShiftVersion: () => '4.8.0',
+  useFlag: jest.fn<boolean>(),
 }));
 
 // Workaround because getting-started exports also useGettingStartedShowState
@@ -25,6 +26,7 @@ jest.mock(
 );
 
 const useActiveNamespaceMock = useActiveNamespace as jest.Mock;
+const useFlagMock = useFlag as jest.Mock;
 
 afterEach(() => {
   delete window.SERVER_FLAGS.addPage;
@@ -33,6 +35,7 @@ afterEach(() => {
 describe('DeveloperFeaturesGettingStartedCard', () => {
   it('should contain links to current active namespace', () => {
     useActiveNamespaceMock.mockReturnValue(['active-namespace']);
+    useFlagMock.mockReturnValue(true);
 
     const wrapper = shallow(<DeveloperFeaturesGettingStartedCard />);
 
@@ -61,7 +64,7 @@ describe('DeveloperFeaturesGettingStartedCard', () => {
 
   it('should not show helm link when helm card is disabled', () => {
     window.SERVER_FLAGS.addPage = '{ "disabledActions": "helm" }';
-
+    useFlagMock.mockReturnValue(true);
     useActiveNamespaceMock.mockReturnValue(['active-namespace']);
 
     const wrapper = shallow(<DeveloperFeaturesGettingStartedCard />);
@@ -86,7 +89,7 @@ describe('DeveloperFeaturesGettingStartedCard', () => {
 
   it('should contain links without namespace if all namespaces are active', () => {
     useActiveNamespaceMock.mockReturnValue([ALL_NAMESPACES_KEY]);
-
+    useFlagMock.mockReturnValue(true);
     const wrapper = shallow(<DeveloperFeaturesGettingStartedCard />);
 
     expect(wrapper.find(GettingStartedCard).props().title).toEqual(
@@ -102,6 +105,30 @@ describe('DeveloperFeaturesGettingStartedCard', () => {
         id: 'topology',
         title: 'Start building your application quickly in topology',
         href: '/topology/all-namespaces?catalogSearch=',
+      },
+    ]);
+    expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
+      id: 'whats-new',
+      title: "What's new in OpenShift 4.8",
+      href: 'https://developers.redhat.com/products/openshift/whats-new',
+      external: true,
+    });
+  });
+
+  it('should not show helm link when helm fetaure flag is disabled', () => {
+    useFlagMock.mockReturnValue(false);
+    useActiveNamespaceMock.mockReturnValue(['active-namespace']);
+
+    const wrapper = shallow(<DeveloperFeaturesGettingStartedCard />);
+
+    expect(wrapper.find(GettingStartedCard).props().title).toEqual(
+      'Explore new developer features',
+    );
+    expect(wrapper.find(GettingStartedCard).props().links).toEqual([
+      {
+        id: 'topology',
+        title: 'Start building your application quickly in topology',
+        href: '/topology/ns/active-namespace?catalogSearch=',
       },
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({

--- a/frontend/packages/helm-plugin/src/utils/helm-detection-utils.ts
+++ b/frontend/packages/helm-plugin/src/utils/helm-detection-utils.ts
@@ -1,3 +1,4 @@
+import isMultiClusterEnabled from '@console/app/src/utils/isMultiClusterEnabled';
 import { SetFeatureFlag } from '@console/dynamic-plugin-sdk';
 import { fetchK8s } from '@console/internal/graphql/client';
 import { K8sResourceKind, ListKind } from '@console/internal/module/k8s';
@@ -14,6 +15,10 @@ const checkDisabledHelmCharts = (helmChartRepositories: K8sResourceKind[]): bool
 
 export const detectHelmChartRepositories = async (setFeatureFlag: SetFeatureFlag) => {
   let id = null;
+  if (isMultiClusterEnabled()) {
+    setFeatureFlag(FLAG_OPENSHIFT_HELM, false);
+    return;
+  }
   const fetchHelmChartRepositories = () =>
     fetchK8s<ListKind<K8sResourceKind>>(HelmChartRepositoryModel)
       .then((list) => {


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/ODC-6469

**Screenshot/GIF:**

When in a multiCluster environment

Helm Tab

![image](https://user-images.githubusercontent.com/5129024/150836251-1226f0c6-7b9d-4062-ab7d-35c543f8a218.png)

Add Page

![image](https://user-images.githubusercontent.com/5129024/150838024-905c0ded-567d-485d-bd86-d6aead4298b6.png)


Catalog

![image](https://user-images.githubusercontent.com/5129024/150838133-8fd525ed-97b8-4362-9a4b-853d73a6a5f4.png)


**Test Setup:**

Verify in multi cluster environment or Manually set window.SERVER_FLAGS.clusters = [ 'clustera', 'clusterb'] . This data must exist before render


**Tests**

![image](https://user-images.githubusercontent.com/5129024/150849424-61b1ed37-2f09-4738-9127-f353f50e26fd.png)
