### PR TITLE
Bug 2041671: Redirect to list after template deletion

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/delete-vm-template-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/delete-vm-template-modal.tsx
@@ -54,7 +54,7 @@ export const DeleteVMTemplateModal = withHandlePromise((props: DeleteVMTemplateM
 
     return handlePromise(promise, () => {
       close();
-      redirectToList(vmTemplateUpToDate, 'templates');
+      redirectToList(vmTemplateUpToDate, true);
     });
   };
 

--- a/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/utils.ts
@@ -1,12 +1,20 @@
 import { history } from '@console/internal/components/utils';
-import { VIRTUALMACHINES_BASE_URL } from '../../../constants/url-params';
+import {
+  VIRTUALMACHINES_BASE_URL,
+  VIRTUALMACHINES_TEMPLATES_BASE_URL,
+} from '../../../constants/url-params';
 import { getName, getNamespace } from '../../../selectors';
 import { VMGenericLikeEntityKind } from '../../../types/vmLike';
 
-export const redirectToList = (vmi: VMGenericLikeEntityKind, tab?: 'templates' | '' | null) => {
+export const redirectToList = (vmi: VMGenericLikeEntityKind, isTemplate?: boolean) => {
   // If we are currently on the deleted resource's page, redirect to the resource list page
   const re = new RegExp(`/${getName(vmi)}(/|$)`);
+
   if (re.test(window.location.pathname)) {
-    history.push(`/k8s/ns/${getNamespace(vmi)}/${VIRTUALMACHINES_BASE_URL}/${tab || ''}`);
+    history.push(
+      `/k8s/ns/${getNamespace(vmi)}/${
+        isTemplate ? VIRTUALMACHINES_TEMPLATES_BASE_URL : VIRTUALMACHINES_BASE_URL
+      }/`,
+    );
   }
 };


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2041671

**Solution Description**:
Fix the error, redirect to the proper page - VM Templates list, after deletion of the VM Template form its _Details_ page, by using the `VIRTUALMACHINES_TEMPLATES_BASE_URL` in the `redirectToList`. Seems that the case for the redirection to the proper list regarding templates was missing.

_Note:_
I've checked also deletion of the VMs/VM templates from the list, it should work, too.

**Screen shots / Gifs for design review**
Before:
![before](https://user-images.githubusercontent.com/13417815/150838261-79f67c1f-3754-4f6f-ac91-164d92e688e5.png)

After:
![after](https://user-images.githubusercontent.com/13417815/150838273-27c8fdc7-b806-4f30-9d25-8ee632ffb119.png)

