### PR TITLE
[release-4.8] Bug 2044571: Update CRW operator name to fix failing e2e tests

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -5,7 +5,7 @@ import { nav } from '../../../integration-tests-cypress/views/nav';
 import { GlobalInstalledNamespace, operator, TestOperandProps } from '../views/operator.view';
 
 const testOperator = {
-  name: 'Red Hat CodeReady Workspaces',
+  name: 'Red Hat CodeReady Workspaces for Devfile v1 and v2',
   operatorHubCardTestID: 'codeready-workspaces-redhat-operators-openshift-marketplace',
   installedNamespace: testName,
 };


### PR DESCRIPTION
Manual cherry-pick of #10910 to fix our CI also for 4.8 backports, for example, #10376