### PR TITLE
Bug 2044704: Revert "Monitoring: Add runbook URLs to alert and rule details pages"

### DIFF
--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -91,7 +91,7 @@ import { ActionsMenu } from '../utils/dropdown';
 import { Firehose } from '../utils/firehose';
 import { SectionHeading, ActionButtons, BreadCrumbs } from '../utils/headings';
 import { Kebab } from '../utils/kebab';
-import { ExternalLink, getURLSearchParams, LinkifyExternal } from '../utils/link';
+import { getURLSearchParams, LinkifyExternal } from '../utils/link';
 import { ResourceLink } from '../utils/resource-link';
 import { history } from '../utils/router';
 import { LoadingInline, StatusBox } from '../utils/status-box';
@@ -672,9 +672,6 @@ const AlertsDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const labels: PrometheusLabels = React.useMemo(() => alert?.labels, [labelsMemoKey]);
 
-  // eslint-disable-next-line camelcase
-  const runbookURL = alert?.annotations?.runbook_url;
-
   return (
     <>
       <Helmet>
@@ -762,14 +759,6 @@ const AlertsDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
                           labels={labels}
                           template={rule?.annotations?.message}
                         />
-                      </dd>
-                    </>
-                  )}
-                  {runbookURL && (
-                    <>
-                      <dt>{t('public~Runbook')}</dt>
-                      <dd>
-                        <ExternalLink href={runbookURL} text={runbookURL} />
                       </dd>
                     </>
                   )}
@@ -934,9 +923,6 @@ const AlertRulesDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
     return `${nameLabel}{${_.map(otherLabels, (v, k) => `${k}="${v}"`).join(',')}}`;
   };
 
-  // eslint-disable-next-line camelcase
-  const runbookURL = rule?.annotations?.runbook_url;
-
   return (
     <>
       <Helmet>
@@ -998,14 +984,6 @@ const AlertRulesDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
                       <dt>{t('public~Message')}</dt>
                       <dd>
                         <PrometheusTemplate text={rule.annotations.message} />
-                      </dd>
-                    </>
-                  )}
-                  {runbookURL && (
-                    <>
-                      <dt>{t('public~Runbook')}</dt>
-                      <dd>
-                        <ExternalLink href={runbookURL} text={runbookURL} />
                       </dd>
                     </>
                   )}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -924,7 +924,6 @@
   "Alerts": "Alerts",
   "Alert details": "Alert details",
   "Severity": "Severity",
-  "Runbook": "Runbook",
   "Alerting rule": "Alerting rule",
   "Silenced by": "Silenced by",
   "Active since": "Active since",


### PR DESCRIPTION
The runbook docs are not ready yet, so reverting this change for now.

This reverts commit da4644bba921611c4da8f40649e76fa7f75e253a.