### PR TITLE
Gherkin and automation for helm chart registry to be namespace scoped

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -112,6 +112,7 @@ export const catalogPO = {
   cardList: '[role="grid"]',
   cardHeader: '.pf-c-badge.pf-m-read',
   groupByMenu: 'pf-c-dropdown__menu',
+  chartRepositoryGroup: '[data-test-group-name="chartRepositoryTitle"]',
   catalogTypeLink: 'li.vertical-tabs-pf-tab.shown.text-capitalize.co-catalog-tab__empty',
   catalogTypes: {
     operatorBacked: '[data-test="kind-cluster-service-version"]',

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
@@ -186,6 +186,26 @@ export const catalogPage = {
         expect('Helm Charts').toContain($el.text());
       });
   },
+  verifyChartRepoAvailable: (helmRepo: string) => {
+    const repo = helmRepo
+      .replace(/([A-Z])/g, ' $1')
+      .replace(/\s+/g, '-')
+      .toLowerCase()
+      .trim();
+    cy.get(catalogPO.chartRepositoryGroup).within(() => {
+      cy.get(`[data-test="chartRepositoryTitle${repo}"]`).should('be.visible');
+    });
+  },
+  verifyChartRepoNotAvailable: (helmRepo: string) => {
+    const repo = helmRepo
+      .replace(/([A-Z])/g, ' $1')
+      .replace(/\s+/g, '-')
+      .toLowerCase()
+      .trim();
+    cy.get(catalogPO.chartRepositoryGroup).within(() => {
+      cy.get(`[data-test="chartRepositoryTitle${repo}"]`).should('not.exist');
+    });
+  },
   verifyFilterByKeywordField: () => {
     cy.get('.pf-c-search-input__text-input').should('be.visible');
   },

--- a/frontend/packages/helm-plugin/integration-tests/features/helm/install-helm-chart.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/install-helm-chart.feature
@@ -2,8 +2,10 @@
 Feature: Install the Helm Release
               As a user, I want to install the helm release
 
+
         Background:
             Given user has created or selected namespace "aut-helm"
+
 
 
         @smoke
@@ -117,3 +119,38 @@ Feature: Install the Helm Release
              When user selects "Helm Chart" card from Add page
               And user clicks on helm chart with blue tick
              Then user will see Blue certified badge associated with heading of the helm chart
+
+
+        @regression @odc-5713
+        Scenario Outline: Namespace-scoped Helm Chart Repositories in the dev catalog: HR-06-TC12
+            Given user is at Add page
+            # Uncomment below for cluster not having projecthelmchartrepositories CRD
+            #   And user has applied namespaced CRD yaml "<crd_yaml>"
+              And user has added namespaced helm chart repo yaml "<cr_yaml>" in namespace "aut-helm"
+             When user selects Helm Chart card from Add page
+             Then user will see "Ibm Repo" under Chart repositories filter
+              And user will not see "Ibm Repo" under Chart repositories filter in a new namespace "test-helm1"
+
+        Examples:
+                  | crd_yaml                           | cr_yaml                                         |
+                  | test-data/namespaced-helm-crd.yaml | test-data/namespaced-helm-chart-repository.yaml |
+
+
+        @regression @manual @odc-5713
+        Scenario: Creating projecthelmchartrepository by non-admin user: HR-06-TC13
+            Given user is at Add page
+            # Uncomment below for cluster not having projecthelmchartrepositories CRD
+            #   And user has applied namespaced CRD yaml "namespaced-helm-chart-repository.yaml"
+              And user has logged in as consoledeveloper
+             When user adds projecthelmchartrepository CR with yaml "namespaced-helm-crd"
+              And user selects Helm Chart card from Add page
+             Then user will see "Ibm Repo" under Chart repositories filter
+              And user will not see "Ibm Repo" under Chart repositories filter in a new namespace "test-helm2"
+
+
+        @regression @odc-5713
+        Scenario: Quick starts link in the helm dev catalog description: HR-06-TC14
+            Given user is at Add page
+             When user selects Helm Chart card from Add page
+              And user clicks on quick start link in helm catalog description
+             Then user will see "Add Helm Chart Repositories to extend the Developer Catalog for your project" quick start

--- a/frontend/packages/helm-plugin/integration-tests/test-data/namespaced-helm-chart-repository.yaml
+++ b/frontend/packages/helm-plugin/integration-tests/test-data/namespaced-helm-chart-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: helm.openshift.io/v1beta1
+kind: ProjectHelmChartRepository
+metadata:
+  name: ibm-repo
+  namespace: aut-helm
+spec:
+  connectionConfig:
+    url: https://raw.githubusercontent.com/IBM/charts/master/repo/community/index.yaml

--- a/frontend/packages/helm-plugin/integration-tests/test-data/namespaced-helm-crd.yaml
+++ b/frontend/packages/helm-plugin/integration-tests/test-data/namespaced-helm-crd.yaml
@@ -1,0 +1,130 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1084
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: projecthelmchartrepositories.helm.openshift.io
+spec:
+  group: helm.openshift.io
+  names:
+    kind: ProjectHelmChartRepository
+    listKind: ProjectHelmChartRepositoryList
+    plural: projecthelmchartrepositories
+    singular: projecthelmchartrepository
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: "ProjectHelmChartRepository holds namespace-wide configuration for proxied Helm chart repository \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                connectionConfig:
+                  description: Required configuration for connecting to the chart repo
+                  type: object
+                  properties:
+                    ca:
+                      description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca-bundle.crt" is used to locate the data. If empty, the default system roots are used. The namespace for this config map is openshift-config.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced config map
+                          type: string
+                    tlsClientConfig:
+                      description: tlsClientConfig is an optional reference to a secret by name that contains the PEM-encoded TLS client certificate and private key to present when connecting to the server. The key "tls.crt" is used to locate the client certificate. The key "tls.key" is used to locate the private key. The namespace for this secret is openshift-config.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced secret
+                          type: string
+                    url:
+                      description: Chart repository URL
+                      type: string
+                      maxLength: 2048
+                      pattern: ^https?:\/\/
+                description:
+                  description: Optional human readable repository description, it can be used by UI for displaying purposes
+                  type: string
+                  maxLength: 2048
+                  minLength: 1
+                disabled:
+                  description: If set to true, disable the repo usage in the cluster/namespace
+                  type: boolean
+                name:
+                  description: Optional associated human readable repository name, it can be used by UI for displaying purposes
+                  type: string
+                  maxLength: 100
+                  minLength: 1
+            status:
+              description: Observed status of the repository within the namespace..
+              type: object
+              properties:
+                conditions:
+                  description: conditions is a list of conditions and their statuses
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-5713
Story: https://issues.redhat.com/browse/ODC-6419
Acceptance criteria:

- As a non privileged user, I should be able to connect my Helm Chart Repository to my project, so I can access the Helm Charts from the DevConsole catalog



**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]

**Fix**: https://issues.redhat.com/browse/ODC-6470


**Test Setup**:

Cluster should be running on local

Check the TAGS in frontend/packages/topology/integration-tests/cypress.json file be: ""(@pre-condition or @smoke or @regression) and @[odc-5713](https://issues.redhat.com/browse/odc-5713) and not (@manual or @to-do or @un-verified or @broken-test)"",


Command to execute:

Run a cluster locally and execute the command `npm run test-cypress-helm` simultaneously

Execute the install-helm-chart.feature file

**Browser**
Chrome 93

**Test Execution Screenshot:**
