### PR TITLE
Bug 2039619: - [AWS] In tree provisioner storageclass aws disk type should contain 'gp3' and csi provisioner storageclass default aws disk type should be 'gp3' 

### DIFF
--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -171,7 +171,7 @@ class StorageClassFormWithTranslation extends React.Component<
       parameters: {
         type: {
           name: 'Type', // t('public~Type')
-          values: { io1: 'io1', gp2: 'gp2', gp3: 'gp3', sc1: 'sc1', st1: 'st1' },
+          values: { io1: 'io1', gp2: 'gp2', sc1: 'sc1', st1: 'st1' },
           hintText: 'Select AWS Type',
         },
         iopsPerGB: {


### PR DESCRIPTION
Reverted the change due to QA updated comment.


![Screen Shot 2022-01-25 at 9 16 05 AM](https://user-images.githubusercontent.com/15249132/150993460-95017bcf-6ab3-4bb5-8347-350f9b3d334e.png)
