### PR TITLE
Bug 2037203: Add a scrollable legend to Running VMs graph

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -701,8 +701,6 @@
   "Running VMs per template": "Running VMs per template",
   "Running VMs per template donut chart": "Running VMs per template donut chart",
   "VMs": "VMs",
-  "{{count}}": "{{count}}",
-  "{{count}}_plural": "{{count}}s",
   "Metrics are collected by the OpenShift Monitoring Operator.": "Metrics are collected by the OpenShift Monitoring Operator.",
   "To see the vCPU metric, you must set the schedstats=enable kernel argument in the MachineConfig object.": "To see the vCPU metric, you must set the schedstats=enable kernel argument in the MachineConfig object.",
   "No data available": "No data available",

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/running-vms-per-template-card/RunningVMsChartLegend.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/running-vms-per-template-card/RunningVMsChartLegend.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Grid, GridItem } from '@patternfly/react-core';
+import {
+  RunningVMsChartLegendLabel,
+  RunningVMsChartLegendLabelItem,
+} from './RunningVMsChartLegendLabel';
+
+import './running-vms-per-template-card.scss';
+
+export const VMsChartLegend = ({ legendItems }) => {
+  const gridItems = [];
+  legendItems.forEach((item: RunningVMsChartLegendLabelItem) => {
+    const component = (
+      <GridItem span={6} key={item.name}>
+        <RunningVMsChartLegendLabel item={item} />
+      </GridItem>
+    );
+    gridItems.push(component);
+  });
+
+  return (
+    <div className="kv-running-vms-card__chart-legend">
+      <Grid hasGutter>{gridItems}</Grid>
+    </div>
+  );
+};

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/running-vms-per-template-card/RunningVMsChartLegendLabel.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/running-vms-per-template-card/RunningVMsChartLegendLabel.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+import './running-vms-per-template-card.scss';
+
+export type RunningVMsChartLegendLabelItem = {
+  name: string;
+  vmCount: number;
+  color: string;
+  namespace: string;
+};
+
+type RunningVMsChartLegendLabelProps = {
+  item: RunningVMsChartLegendLabelItem;
+};
+
+export const RunningVMsChartLegendLabel: React.FC<RunningVMsChartLegendLabelProps> = ({ item }) => {
+  const iconStyle = { color: item.color };
+  // const linkPath = `/k8s/ns/${item.namespace}/kubevirt.io~v1~VirtualMachine?labels=vm.kubevirt.io/template=${item.name}`
+  const linkPath = `/k8s/ns/${item.namespace}/virtualmachinetemplates/${item.name}`;
+
+  return (
+    <>
+      <i className="fas fa-square kv-running-vms-card__legend-label--color" style={iconStyle} />
+      <span className="kv-running-vms-card__legend-label--count">{item.vmCount}</span>{' '}
+      <Link to={linkPath}>{item.name}</Link>
+    </>
+  );
+};

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/running-vms-per-template-card/running-vms-per-template-card.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/running-vms-per-template-card/running-vms-per-template-card.scss
@@ -2,7 +2,7 @@
   font-size: 10px;
 }
 
-.kv-running-vms-card--gradient {
+.kv-running-vms-card__gradient {
   position: relative;
   &:after {
     background: linear-gradient(rgba(255, 255, 255, 0), var(--pf-global--BackgroundColor--100));
@@ -14,4 +14,18 @@
     position: absolute;
     width: calc(100% - var(--pf-global--spacer--lg));
   }
+}
+
+.kv-running-vms-card__chart-legend {
+  overflow: auto;
+  height: 90px;
+}
+
+.kv-running-vms-card__legend-label--color {
+  margin-right: var(--pf-global--spacer--xs);
+  overflow: auto;
+}
+
+.kv-running-vms-card__legend-label--count {
+  font-weight: 700;
 }

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/running-vms-per-template-card/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/running-vms-per-template-card/utils.ts
@@ -1,0 +1,38 @@
+import { LightMultiColorOrderedTheme } from '@patternfly/react-charts/dist/js/components/ChartTheme/themes/light/multi-color-ordered-theme';
+import * as _ from 'lodash';
+
+const swapArrayElems = (arr) => ([arr[0], arr[1]] = [arr[1], arr[0]]);
+
+export const getColorList = (numColors: number) => {
+  const originalColors = LightMultiColorOrderedTheme.pie.colorScale;
+  const numOriginalColors = originalColors.length;
+  const colorList = [].concat(originalColors);
+
+  if (numColors > numOriginalColors) {
+    // assemble an array of the required size by repeating colors
+    const fullMultiples = numColors / numOriginalColors;
+    const remainder = numColors % numOriginalColors;
+
+    // add full shuffled copies of the original list
+    for (let i = 1; i <= fullMultiples; i++) {
+      const shuffledColors = _.shuffle([].concat(originalColors));
+      if (shuffledColors[0] === colorList[colorList.length - 1]) {
+        // swap colors to avoid adjoining colors being equal
+        swapArrayElems(shuffledColors);
+      }
+      colorList.concat(shuffledColors);
+    }
+
+    // add a shuffled slice of the original list to meet length requirement
+    if (remainder) {
+      const shuffledRemainder = _.shuffle(originalColors.slice(0, remainder));
+      if (remainder > 1 && shuffledRemainder[0] === colorList[colorList.length - 1]) {
+        // swap colors to avoid adjoining colors being equal
+        swapArrayElems(shuffledRemainder);
+      }
+      colorList.concat(shuffledRemainder);
+    }
+  }
+
+  return colorList;
+};

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-running-vms-per-template-resources.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-running-vms-per-template-resources.ts
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
+import { TemplateModel } from '@console/internal/models';
+import { K8sResourceCommon, TemplateKind } from '@console/internal/module/k8s';
+import { TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_LABEL, TEMPLATE_TYPE_VM } from '../constants';
+import { VirtualMachineModel } from '../models';
+import { kubevirtReferenceForModel } from '../models/kubevirtReferenceForModel';
+import { VMKind } from '../types';
+import { useDebounceCallback } from './use-debounce';
+import { useDeepCompareMemoize } from './use-deep-compare-memoize';
+
+export const useRunningVMsPerTemplateResources = (): {
+  loaded: boolean;
+  loadError: string;
+  vms: VMKind[];
+  templates: TemplateKind[];
+} => {
+  const [loaded, setLoaded] = React.useState<boolean>(false);
+  const [loadError, setLoadError] = React.useState<string>('');
+  const [vms, setVMs] = React.useState<VMKind[]>([]);
+  const [templates, setTemplates] = React.useState<TemplateKind[]>([]);
+
+  const watchedResources = {
+    vms: {
+      kind: kubevirtReferenceForModel(VirtualMachineModel),
+      isList: true,
+      namespaced: false,
+    },
+    vmTemplates: {
+      kind: kubevirtReferenceForModel(TemplateModel),
+      isList: true,
+      selector: {
+        matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_VM },
+      },
+    },
+    vmCommonTemplates: {
+      kind: kubevirtReferenceForModel(TemplateModel),
+      isList: true,
+      namespace: 'openshift',
+      selector: {
+        matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_BASE },
+      },
+    },
+  };
+
+  const resources = useK8sWatchResources<{ [key: string]: K8sResourceCommon[] }>(watchedResources);
+
+  const updateResults = React.useCallback((updatedResources) => {
+    const errorKey = Object.keys(updatedResources).find((key) => updatedResources[key].loadError);
+    if (errorKey) {
+      setLoadError(updatedResources[errorKey].loadError);
+      return;
+    }
+    if (
+      Object.keys(updatedResources).length > 0 &&
+      Object.keys(updatedResources).every((key) => updatedResources[key].loaded)
+    ) {
+      setLoaded(true);
+      setLoadError(null);
+      setVMs(updatedResources?.vms?.data);
+      setTemplates([
+        ...updatedResources?.vmTemplates?.data,
+        ...updatedResources?.vmCommonTemplates?.data,
+      ]);
+    }
+  }, []);
+
+  const debouncedUpdateResources = useDebounceCallback(updateResults, 250);
+
+  React.useEffect(() => {
+    debouncedUpdateResources(resources);
+  }, [debouncedUpdateResources, resources]);
+
+  return useDeepCompareMemoize({ loaded, loadError, vms, templates });
+};


### PR DESCRIPTION
The default legend for PatterFly charts are SVG elements that aren't scrollable. This PR replaces that legend with an HTML element that allows for scrolling.

Screenshots:

Before:
![Selection_047](https://user-images.githubusercontent.com/8544299/151082846-84feb79f-a9d3-40e1-af95-671ec17c8c43.png)

After:
![Selection_046](https://user-images.githubusercontent.com/8544299/151082614-1a70fde5-7def-4451-81d2-76a5835e27d6.png)

