### PR TITLE
Bug 2030530: Remove quotation marks surrounding VM pwd

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/initialize-vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/initialize-vm.ts
@@ -46,15 +46,17 @@ const initializeStorage = (params: CreateVMParams, vm: VMWrapper) => {
         volumeWrapper.appendTypeData({ name: dataVolumeWrapper.getName() });
       }
     }
-
     if (volumeWrapper.getCloudInitNoCloud()) {
-      const cloudConfigHeader = volumeWrapper
+      const cloudInitNoCloudUserData = volumeWrapper
         .getCloudInitNoCloud()
-        ?.userData?.includes('#cloud-config');
-      !cloudConfigHeader &&
-        volumeWrapper.setCloudInitNoCloud({
-          userData: ['#cloud-config', volumeWrapper.getCloudInitNoCloud().userData].join('\n'),
-        });
+        ?.userData?.replace(/(password:\s)'(.*)'(\s)/g, '$1$2$3'); // remove extra single quotation marks
+
+      const cloudConfigHeader = cloudInitNoCloudUserData?.includes('#cloud-config');
+      volumeWrapper.setCloudInitNoCloud({
+        userData: cloudConfigHeader
+          ? cloudInitNoCloudUserData
+          : ['#cloud-config', cloudInitNoCloudUserData].join('\n'),
+      });
     }
 
     return {


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2030530

**Solution Description**:
Remove extra single quotation marks surrounding the password for the VM created via Customize wizard, regarding `cloudInitNoCloud` storage volume type.

**Screen shots / Gifs for design review**:
Before:
![before](https://user-images.githubusercontent.com/13417815/151044796-aa33ef78-d723-487f-87a8-b6629238e373.png)

After:
![after](https://user-images.githubusercontent.com/13417815/151044840-c5b11063-7b76-4af6-b694-7be3d094856c.png)

TODO:
- fix the scenario when the user fills in the pwd in the _Advanced_ section of VM creation, and uses the quotation marks