### PR TITLE
[release-4.8] Bug 2046051: Add support for fetching partial metadata and fix helm list page crash

### DIFF
--- a/frontend/__tests__/actions/k8s.spec.ts
+++ b/frontend/__tests__/actions/k8s.spec.ts
@@ -153,6 +153,51 @@ describe(k8sActions.ActionType.StartWatchK8sList, () => {
     watchK8sList('another-redux-id', {}, model)(dispatch, getState);
   });
 
+  it('send partial metadata headers to k8sList when partialMetadata is true', (done) => {
+    const k8sList = spyOn(k8sResource, 'k8sList').and.callFake(
+      (k8sKind, params, raw, requestOptions) => {
+        expect(params.limit).toEqual(250);
+        expect(requestOptions.headers).toEqual(k8sActions.partialObjectMetadataListHeader);
+
+        if (k8sList.calls.count() === 1 || k8sList.calls.count() === 11) {
+          expect(params.continue).toBeUndefined();
+        } else {
+          expect(params.continue).toEqual('toNextPage');
+        }
+        resourceList.metadata.resourceVersion = (
+          parseInt(resourceList.metadata.resourceVersion, 10) + 1
+        ).toString();
+        resourceList.metadata.continue =
+          parseInt(resourceList.metadata.resourceVersion, 10) < 10 ? 'toNextPage' : undefined;
+
+        return resourceList;
+      },
+    );
+
+    let returnedItems = 0;
+    const dispatch = jasmine.createSpy('dispatch').and.callFake((action) => {
+      if (action.type === k8sActions.ActionType.BulkAddToList) {
+        const bulkAddToListCalls = dispatch.calls
+          .allArgs()
+          .filter((args) => args[0].type === k8sActions.ActionType.BulkAddToList);
+
+        expect(action.payload.k8sObjects).toEqual(resourceList.items);
+        expect(bulkAddToListCalls.length).toEqual(k8sList.calls.count() - 1);
+
+        returnedItems += action.payload.k8sObjects.length;
+
+        if (bulkAddToListCalls.length === 9) {
+          expect(returnedItems).toEqual(resourceList.items.length * bulkAddToListCalls.length);
+          done();
+        }
+      } else if (action.type === k8sActions.ActionType.Errored) {
+        fail(action.payload.k8sObjects);
+      }
+    });
+
+    k8sActions.watchK8sList('one-more-redux-id', {}, model, null, true)(dispatch, getState);
+  });
+
   xit('stops incrementally fetching if `stopK8sWatch` action is dispatched', () => {
     // TODO(alecmerdler)
   });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/api-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/api-types.ts
@@ -10,6 +10,7 @@ export type WatchK8sResource = {
   limit?: number;
   fieldSelector?: string;
   optional?: boolean;
+  partialMetadata?: boolean;
 };
 
 export type WatchK8sResult<R extends K8sResourceCommon | K8sResourceCommon[]> = [R, boolean, any];

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -155,6 +155,7 @@ export type WatchK8sResource = {
   limit?: number;
   fieldSelector?: string;
   optional?: boolean;
+  partialMetadata?: boolean;
 };
 
 export type ResourcesObject = { [key: string]: K8sResourceCommon | K8sResourceCommon[] };

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
@@ -44,6 +44,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace }) => {
       namespaced: true,
       optional: true,
       selector: { matchLabels: { owner: 'helm' } },
+      partialMetadata: true,
     }),
     [namespace],
   );

--- a/frontend/packages/helm-plugin/src/topology/helm-topology-plugin.tsx
+++ b/frontend/packages/helm-plugin/src/topology/helm-topology-plugin.tsx
@@ -26,6 +26,7 @@ const getHelmWatchedResources = (namespace: string): WatchK8sResources<any> => {
       kind: 'Secret',
       namespace,
       optional: true,
+      partialMetadata: true,
     },
   };
 };

--- a/frontend/public/components/utils/k8s-watch-hook.ts
+++ b/frontend/public/components/utils/k8s-watch-hook.ts
@@ -47,8 +47,15 @@ const getIDAndDispatch: GetIDAndDispatch = (resource, k8sModel) => {
   );
   const id = makeReduxID(k8sModel, query);
   const dispatch = resource.isList
-    ? k8sActions.watchK8sList(id, query, k8sModel)
-    : k8sActions.watchK8sObject(id, resource.name, resource.namespace, query, k8sModel);
+    ? k8sActions.watchK8sList(id, query, k8sModel, null, resource.partialMetadata)
+    : k8sActions.watchK8sObject(
+        id,
+        resource.name,
+        resource.namespace,
+        query,
+        k8sModel,
+        resource.partialMetadata,
+      );
   return { id, dispatch };
 };
 

--- a/frontend/public/module/k8s/resource.js
+++ b/frontend/public/module/k8s/resource.js
@@ -57,8 +57,8 @@ export const watchURL = (kind, options) => {
   return resourceURL(kind, opts);
 };
 
-export const k8sGet = (kind, name, ns, opts) =>
-  coFetchJSON(resourceURL(kind, Object.assign({ ns, name }, opts)));
+export const k8sGet = (kind, name, ns, opts, options) =>
+  coFetchJSON(resourceURL(kind, Object.assign({ ns, name }, opts)), 'GET', options);
 
 export const k8sCreate = (kind, data, opts = {}) => {
   return coFetchJSON.post(


### PR DESCRIPTION
This is a manually cherry-pick/backport of #10914

4.10: https://bugzilla.redhat.com/show_bug.cgi?id=1999796
4.9: https://bugzilla.redhat.com/show_bug.cgi?id=2044287
4.8: https://bugzilla.redhat.com/show_bug.cgi?id=2046051

**Merge notes:**
Cherry-picked. Diff. from #10914

* Definition of `getHelmWatchedResources` was `frontend/packages/helm-plugin/src/topology/helm-topology-plugin.tsx` instead of `frontend/packages/helm-plugin/src/topology/helmResources.ts`
* Need to add the new type prop `partialMetadata?: boolean;` also in `frontend/packages/console-dynamic-plugin-sdk/src/api/api-types.ts`
* And need to add the `options` parameter to `k8sGet` in `public/module/k8s/resource.js`

Changed unit test passes:

![image](https://user-images.githubusercontent.com/139310/151134376-9843f051-2612-4eeb-b2c5-cfe390f4eefd.png)

**Validation:**
Quickly confirmed the change on my local cluster.

release-4.8 without this PR:
![image](https://user-images.githubusercontent.com/139310/151134773-59d0a38a-e1a8-4673-af54-6c494bd04736.png)


With this PR:
![image](https://user-images.githubusercontent.com/139310/151134539-e91e3372-6196-4d7c-94cf-6f43bbfe1b65.png)


