### PR TITLE
Bug 2044724: Remove namespace column on VM list page when a project is selected

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-page-new.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-page-new.tsx
@@ -10,6 +10,7 @@ import {
 } from '@patternfly/react-core';
 import { RocketIcon, VirtualMachineIcon } from '@patternfly/react-icons';
 import { sortable } from '@patternfly/react-table';
+import * as classNames from 'classnames';
 import { TFunction } from 'i18next';
 import { Trans, useTranslation } from 'react-i18next';
 import { match } from 'react-router';
@@ -71,9 +72,9 @@ import VMIP from './VMIP';
 
 import './vm.scss';
 
-const tableColumnClasses = [
+const tableColumnClasses = (showNamespace: boolean) => [
   'pf-u-w-16-on-xl pf-u-w-50-on-xs',
-  'pf-m-hidden pf-m-visible-on-lg',
+  classNames('pf-m-hidden', { 'pf-m-visible-on-lg': showNamespace }),
   '',
   'pf-m-hidden pf-m-visible-on-xl',
   'pf-m-hidden pf-m-visible-on-xl',
@@ -82,7 +83,7 @@ const tableColumnClasses = [
   Kebab.columnClass,
 ];
 
-const VMHeader = (t: TFunction) => () =>
+const VMHeader = (t: TFunction, showNamespace: boolean) => () =>
   dimensifyHeader(
     [
       {
@@ -120,7 +121,7 @@ const VMHeader = (t: TFunction) => () =>
         title: '',
       },
     ],
-    tableColumnClasses,
+    tableColumnClasses(showNamespace),
   );
 
 const VMRow: React.FC<RowFunctionArgs<VMRowObjType, VmStatusResourcesValue>> = ({
@@ -129,7 +130,8 @@ const VMRow: React.FC<RowFunctionArgs<VMRowObjType, VmStatusResourcesValue>> = (
 }) => {
   const { vm, vmi } = obj;
   const { name, namespace, creationTimestamp, node } = obj.metadata;
-  const dimensify = dimensifyRow(tableColumnClasses);
+  const activeNamespace = useNamespace();
+  const dimensify = dimensifyRow(tableColumnClasses(!activeNamespace));
   const arePendingChanges = hasPendingChanges(vm, vmi);
   const printableStatus = obj?.metadata?.status;
   const status: VMStatus = getVmStatusFromPrintable(printableStatus);
@@ -252,13 +254,14 @@ const VMListEmpty: React.FC = () => {
 
 const VMList: React.FC<React.ComponentProps<typeof Table> & VMListProps> = (props) => {
   const { t } = useTranslation();
+  const activeNamespace = useNamespace();
   return (
     <div className="kv-vm-list">
       <Table
         {...props}
         EmptyMsg={VMListEmpty}
         aria-label={t('kubevirt-plugin~Virtual Machines')}
-        Header={VMHeader(t)}
+        Header={VMHeader(t, !activeNamespace)}
         Row={VMRow}
         virtualize
       />

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -10,6 +10,7 @@ import {
 } from '@patternfly/react-core';
 import { RocketIcon, VirtualMachineIcon } from '@patternfly/react-icons';
 import { sortable } from '@patternfly/react-table';
+import * as classNames from 'classnames';
 import { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
@@ -76,9 +77,9 @@ import VMIP from './VMIP';
 
 import './vm.scss';
 
-const tableColumnClasses = [
+const tableColumnClasses = (showNamespace: boolean) => [
   'pf-u-w-16-on-xl pf-u-w-50-on-xs',
-  'pf-m-hidden pf-m-visible-on-lg',
+  classNames('pf-m-hidden', { 'pf-m-visible-on-lg': showNamespace }),
   '',
   'pf-m-hidden pf-m-visible-on-xl',
   'pf-m-hidden pf-m-visible-on-lg',
@@ -86,7 +87,7 @@ const tableColumnClasses = [
   Kebab.columnClass,
 ];
 
-const VMHeader = (t: TFunction) => () =>
+const VMHeader = (t: TFunction, showNamespace: boolean) => () =>
   dimensifyHeader(
     [
       {
@@ -121,7 +122,7 @@ const VMHeader = (t: TFunction) => () =>
         title: '',
       },
     ],
-    tableColumnClasses,
+    tableColumnClasses(showNamespace),
   );
 
 const PendingChanges: React.FC = () => {
@@ -132,8 +133,8 @@ const PendingChanges: React.FC = () => {
 const VMRow: React.FC<RowFunctionArgs<VMRowObjType>> = ({ obj }) => {
   const { vm, vmi, vmImport } = obj;
   const { name, namespace, node, creationTimestamp, uid, vmStatusBundle } = obj.metadata;
-  const dimensify = dimensifyRow(tableColumnClasses);
-
+  const activeNamespace = useNamespace();
+  const dimensify = dimensifyRow(tableColumnClasses(!activeNamespace));
   const model =
     (vmImport && VirtualMachineImportModel) ||
     (vm && VirtualMachineModel) ||
@@ -242,13 +243,14 @@ const VMListEmpty: React.FC = () => {
 
 const VMList: React.FC<React.ComponentProps<typeof Table> & VMListProps> = (props) => {
   const { t } = useTranslation();
+  const activeNamespace = useNamespace();
   return (
     <div className="kv-vm-list">
       <Table
         {...props}
         EmptyMsg={VMListEmpty}
         aria-label={t('kubevirt-plugin~Virtual Machines')}
-        Header={VMHeader(t)}
+        Header={VMHeader(t, !activeNamespace)}
         Row={VMRow}
         virtualize
       />


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2044724

**Solution Description**:
Adding a check to see if the active namespace is and removing namespace solumn from VM list when `All projects` is selected.

**Screen shots / Gifs for design review**:

**Before**:

![before](https://user-images.githubusercontent.com/67270715/151187048-15c303de-cd91-426c-bf79-fb4b4869c953.png)

**After**:

![after](https://user-images.githubusercontent.com/67270715/151187058-19e92aca-aa83-49c3-b2be-3e48d3d7b83b.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>