### PR TITLE
Bug 2042274: Storage API should be used when upload PVC

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
@@ -202,7 +202,7 @@ export const UploadPVCForm: React.FC<UploadPVCFormProps> = ({
           source: {
             upload: {},
           },
-          pvc: {
+          storage: {
             storageClassName,
             accessModes: [accessMode],
             volumeMode,
@@ -217,7 +217,7 @@ export const UploadPVCForm: React.FC<UploadPVCFormProps> = ({
 
       return obj;
     };
-    onChange(updateDV);
+    onChange(updateDV());
   }, [
     accessMode,
     volumeMode,


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2042274

**Analysis / Root cause**:
using old API with `pvc`

**Solution Description**:
switch to new `storage` API

**Screen shots / Gifs for design review**:

**After**:

https://user-images.githubusercontent.com/67270715/151203300-90a36dbe-62e2-4f67-930f-96d04fe80768.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>