### PR TITLE
Bug 2033492: Highlight moves from Template to VirtualMachines while open template wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/console-extensions.json
+++ b/frontend/packages/kubevirt-plugin/console-extensions.json
@@ -148,6 +148,19 @@
     "type": "console.page/route",
     "properties": {
       "exact": true,
+      "path": ["/k8s/ns/:ns/virtualmachinetemplates/~new/customize"],
+      "component": {
+        "$codeRef": "CreateVMWizardPage.CreateVMWizardPage"
+      }
+    },
+    "flags": {
+      "required": ["KUBEVIRT"]
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
       "path": ["/k8s/ns/:ns/virtualmachinetemplates/~new"],
       "component": {
         "$codeRef": "VMCreateYAML.VMCreateYAML"

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -12,10 +12,7 @@ import {
   OPENSHIFT_OS_IMAGES_NS,
   VMWizardName,
 } from '../../constants';
-import {
-  customizeWizardBaseURLBuilder,
-  VIRTUALMACHINES_TEMPLATES_BASE_URL,
-} from '../../constants/url-params';
+import { VIRTUALMACHINES_TEMPLATES_BASE_URL } from '../../constants/url-params';
 import {
   TEMPLATE_TYPE_BASE,
   TEMPLATE_TYPE_LABEL,
@@ -144,17 +141,9 @@ const VirtualMachineTemplatesPage: React.FC<VirtualMachineTemplatesPageProps &
       [VMWizardName.YAML]: t('kubevirt-plugin~With YAML'),
     },
     createLink: (itemName: string) => {
-      const baseUrlWizard = customizeWizardBaseURLBuilder(namespace);
-      const baseURLYaml = `/k8s/ns/${namespace || 'default'}/${VIRTUALMACHINES_TEMPLATES_BASE_URL}`;
-
-      switch (itemName) {
-        case VMWizardName.WIZARD:
-          return `${baseUrlWizard}?mode=template`;
-        case VMWizardName.YAML:
-          return `${baseURLYaml}/~new?mode=template`;
-        default:
-          return `${baseUrlWizard}?mode=template`;
-      }
+      const customize = itemName === VMWizardName.WIZARD ? '/customize' : '';
+      return `/k8s/ns/${namespace ||
+        'default'}/${VIRTUALMACHINES_TEMPLATES_BASE_URL}/~new${customize}?mode=template`;
     },
   };
 


### PR DESCRIPTION
**Fix:**
https://bugzilla.redhat.com/show_bug.cgi?id=2033492

**Analysis / Root cause:**
'create virtual machine template with wizard' page has the base url of Virtual Machine page

**Solution Description:**
Change url to 'create template with wizard' page using the same base url of Templates page
