### PR TITLE
Bug 2046597: Monitoring targets: Fix handling of duplicate service monitors

### DIFF
--- a/frontend/public/components/monitoring/targets.tsx
+++ b/frontend/public/components/monitoring/targets.tsx
@@ -50,8 +50,9 @@ const ServiceMonitor: React.FC<{ target: Target }> = ({ target }) => {
   // Now find the service monitor that corresponds to the service
   const monitor = _.find(
     monitors,
-    ({ spec }) =>
+    ({ metadata, spec }) =>
       service &&
+      target.scrapePool.includes(`/${metadata.namespace}/${metadata.name}/`) &&
       ((spec.selector.matchLabels === undefined && spec.selector.matchExpressions === undefined) ||
         new LabelSelector(spec.selector).matchesLabels(service.metadata.labels ?? {})) &&
       (spec.namespaceSelector?.matchNames === undefined ||


### PR DESCRIPTION
If multiple service monitors have exactly the same namespace selector
and label selector, we need to also look at the `metadata.name` field to
distinguish which corresponds to the target.

CC @simonpasquier 