### PR TITLE
Bug 2046517: Recommendations notification header shows when there isn't any recommendations

### DIFF
--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -28,7 +28,10 @@ import {
 
 import { getClusterID } from '../module/k8s/cluster-settings';
 
-import { ServiceLevelNotification } from '@console/internal/components/utils/service-level';
+import {
+  ServiceLevelNotification,
+  useShowServiceLevelNotifications,
+} from '@console/internal/components/utils/service-level';
 import { getAlertsAndRules, alertURL } from '@console/internal/components/monitoring/utils';
 import { NotificationAlerts } from '@console/internal/reducers/observe';
 import { RedExclamationCircleIcon } from '@console/shared';
@@ -128,17 +131,6 @@ export const getAlertActions = (actionsExtensions: ResolvedExtension<AlertAction
   return alertActions;
 };
 
-const SupportNotification = (cv: ClusterVersionKind, toggleNotificationDrawer: () => void) => {
-  const clusterID = getClusterID(cv);
-  return (
-    <ServiceLevelNotification
-      key="service-level-notification"
-      clusterID={clusterID}
-      toggleNotificationDrawer={toggleNotificationDrawer}
-    />
-  );
-};
-
 const getUpdateNotificationEntries = (
   cv: ClusterVersionKind,
   isEditable: boolean,
@@ -155,9 +147,6 @@ const getUpdateNotificationEntries = (
   const newerChannelVersion = splitClusterVersionChannel(newerChannel)?.version;
   const entries = [];
 
-  if (SupportNotification(cv, toggleNotificationDrawer) !== null) {
-    entries.push(SupportNotification(cv, toggleNotificationDrawer));
-  }
   if (!_.isEmpty(updateData)) {
     entries.push(
       <NotificationEntry
@@ -217,6 +206,9 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
     resource: 'prometheusrules',
     verb: 'list',
   });
+  const clusterID = getClusterID(useClusterVersion());
+  const showServiceLevelNotification = useShowServiceLevelNotifications(clusterID);
+
   React.useEffect(() => {
     if (rulesAccess) {
       const poll: NotificationPoll = (url, key: 'notificationAlerts' | 'silences', dataHandler) => {
@@ -421,6 +413,15 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
       </NotificationCategory>
     ) : null;
 
+  if (showServiceLevelNotification) {
+    updateList.push(
+      <ServiceLevelNotification
+        key="service-level-notification"
+        clusterID={clusterID}
+        toggleNotificationDrawer={toggleNotificationDrawer}
+      />,
+    );
+  }
   const recommendationsCategory: React.ReactElement = !_.isEmpty(updateList) ? (
     <NotificationCategory
       key="recommendations"

--- a/frontend/public/components/utils/service-level.tsx
+++ b/frontend/public/components/utils/service-level.tsx
@@ -184,8 +184,7 @@ const useGetServiceLevel = (
   const [loadingSecret, loadingServiceLevel, loadServiceLevel] = useLoadServiceLevel();
 
   React.useEffect(() => {
-    if (clusterID !== clusterIDParam) {
-      // only load if clusterID passed is different than what is in Redux store
+    if (clusterID !== clusterIDParam && !loadingSecret && !loadingServiceLevel) {
       loadServiceLevel(clusterIDParam);
     }
     // only on clusterID change
@@ -271,14 +270,20 @@ export const useServiceLevelTitle = (): string => {
   return t('public~Service Level Agreement (SLA)');
 };
 
+export const useShowServiceLevelNotifications = (clusterID: string): boolean => {
+  const { level } = useGetServiceLevel(clusterID);
+  return level && (level === 'Eval' || level === 'None');
+};
+
 export const ServiceLevelNotification: React.FC<{
   clusterID?: string;
   toggleNotificationDrawer: () => void;
 }> = ({ clusterID, toggleNotificationDrawer }) => {
   const { t } = useTranslation();
   const { level, daysRemaining, trialDateEnd } = useGetServiceLevel(clusterID);
+  const showServiceLevelNotification = useShowServiceLevelNotifications(clusterID);
 
-  if (!level || (level !== 'Eval' && level !== 'None')) {
+  if (!showServiceLevelNotification) {
     return null;
   }
   let notificationStart = '';


### PR DESCRIPTION
This was a bug related to the recently merged PR: https://github.com/openshift/console/pull/10551

This fixes an issue where if the support level isn't trial and there weren't any other recommended notifications, the recommended notification header would show with nothing below.

Non-trial support level:
<img width="400" alt="Screen Shot 2022-01-26 at 9 54 27 PM" src="https://user-images.githubusercontent.com/82059948/151289242-029c49dd-f7ba-4108-9cdf-15b28cd6d9df.png">

Trial support level:
<img width="425" alt="Screen Shot 2022-01-26 at 9 40 34 PM" src="https://user-images.githubusercontent.com/82059948/151289286-86e47024-3495-49bc-9883-cd5d3cffe523.png">

