### PR TITLE
Bug 2022253: fix web terminal resize layout issue

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.scss
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.scss
@@ -3,5 +3,6 @@
     background-color: #000;
     color: var(--pf-global--Color--light-100);
     height: 100%;
+    overflow: hidden;
   }
 }

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -25,6 +25,11 @@ body,
   height: 100% // doesn't work on safari without height
 }
 
+.co-m-app__content > .pf-c-page {
+  height: 0;
+  flex: 1;
+}
+
 .co-p-has-sidebar {
   position: relative;
   display: flex;


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/OCPBUGSM-37085
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Kapture 2022-01-27 at 14 41 38](https://user-images.githubusercontent.com/9278015/151330762-09d1a19b-ed3a-42f8-ae50-9a46c99bc9e9.gif)


**Unit test coverage report**: None
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

- Install WebTerminal operator
- Click on Web terminal icon in masthead to open terminal
- Resize web terminal window

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge
