### PR TITLE
Bug 2046595: Adding missing PVC name - sourceStatus

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/create-vm-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/create-vm-form.tsx
@@ -172,7 +172,7 @@ export const CreateVMForm: React.FC<CreateVMFormProps> = ({
 
   let source: React.ReactNode;
   let cdRom = false;
-  if (customSource?.dataSource) {
+  if (customSource?.dataSource && !sourceStatus) {
     cdRom = customSource.cdRom?.value;
     switch (DataVolumeSourceType.fromString(customSource.dataSource?.value)) {
       case DataVolumeSourceType.HTTP:

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/simple-create.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/simple-create.ts
@@ -143,7 +143,7 @@ export const prepareVM = async (
     let rootDataVolume;
     let isCDRom: boolean;
 
-    if (customSource?.dataSource?.value) {
+    if (customSource?.dataSource?.value && !sourceStatus) {
       isCDRom = customSource.cdRom?.value;
       rootDataVolume = getRootDataVolume({
         name: rootVolume.getDataVolumeName(),


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2046595

**Analysis / Root cause**: 
CusotmSource is picked by default always, no matter is sourceStatus exist

**Solution Description**: 
if sourceStatus exist it will pick it before going to customSource default.

**Screen shots / Gifs for design review**: 
After:
![image](https://user-images.githubusercontent.com/14824964/151376644-9a91959a-6a2b-44c2-93b4-b168195d67d4.png)
Before:
![image](https://user-images.githubusercontent.com/14824964/151376997-0ce4a6e5-9165-495b-b617-bbd9886c2532.png)
