### PR TITLE
Bug 2014420: Remove depracated v2v resources from plugin config

### DIFF
--- a/frontend/packages/kubevirt-plugin/console-extensions.json
+++ b/frontend/packages/kubevirt-plugin/console-extensions.json
@@ -527,20 +527,6 @@
     }
   },
   {
-    "type": "console.dashboards/overview/activity/resource",
-    "properties": {
-      "component": { "$codeRef": "dashboardActivity.V2VImportActivity" },
-      "getTimestamp": { "$codeRef": "dashboardActivity.getTimestamp" },
-      "isActivity": { "$codeRef": "dashboardActivity.isPodActivity" },
-      "k8sResource": {
-        "$codeRef": "dashboardActivity.k8sPodResource"
-      }
-    },
-    "flags": {
-      "required": ["KUBEVIRT"]
-    }
-  },
-  {
     "type": "console.topology/component/factory",
     "properties": {
       "getFactory": {
@@ -592,13 +578,6 @@
         },
         "dataVolumes": {
           "model": { "kind": "DataVolume", "group": "cdi.kubevirt.io" },
-          "opts": {
-            "isList": true,
-            "optional": true
-          }
-        },
-        "vmImports": {
-          "model": { "kind": "VirtualMachineImport", "group": "v2v.kubevirt.io" },
           "opts": {
             "isList": true,
             "optional": true


### PR DESCRIPTION
Fix: https://bugzilla.redhat.com/show_bug.cgi?id=2039381

Analysis:
topology breaks as the deprecated `VirtualMachineImport` were not discovered on CNV 4.10


Screenshots:
Before:
![topology-before](https://user-images.githubusercontent.com/2181522/151390603-c8415291-5f50-4f9b-858e-a20abd71b168.png)

After:
![topology](https://user-images.githubusercontent.com/2181522/151390657-e9c1149e-eb14-4676-b1c5-1c541b4c6c46.png)
