### PR TITLE
Bug 2047320: Fix that new route annotations doesn't work on Knative Services

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__mocks__/deployImage-validation-mock.ts
+++ b/frontend/packages/dev-console/src/components/import/__mocks__/deployImage-validation-mock.ts
@@ -155,7 +155,6 @@ export const mockImageStreamData = {
         name: 'latest',
         annotations: {
           'openshift.io/generated-by': 'OpenShiftWebConsole',
-          'app.openshift.io/route-disabled': 'false',
           'openshift.io/imported-from': 'myimage',
         },
         from: { kind: 'DockerImage', name: 'myimage' },

--- a/frontend/packages/dev-console/src/utils/__tests__/__snapshots__/shared-submit-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/utils/__tests__/__snapshots__/shared-submit-utils.spec.ts.snap
@@ -6,7 +6,6 @@ Object {
   "kind": "Route",
   "metadata": Object {
     "defaultAnnotations": Object {
-      "app.openshift.io/route-disabled": "false",
       "openshift.io/generated-by": "OpenShiftWebConsole",
     },
     "labels": Object {
@@ -42,7 +41,6 @@ Object {
   "kind": "Route",
   "metadata": Object {
     "defaultAnnotations": Object {
-      "app.openshift.io/route-disabled": "false",
       "app.openshift.io/vcs-ref": "",
       "app.openshift.io/vcs-uri": "https://github.com/test/repo",
       "openshift.io/generated-by": "OpenShiftWebConsole",
@@ -80,7 +78,6 @@ Object {
   "kind": "Service",
   "metadata": Object {
     "annotations": Object {
-      "app.openshift.io/route-disabled": "false",
       "openshift.io/generated-by": "OpenShiftWebConsole",
     },
     "labels": Object {
@@ -110,7 +107,6 @@ Object {
   "kind": "Service",
   "metadata": Object {
     "annotations": Object {
-      "app.openshift.io/route-disabled": "false",
       "app.openshift.io/vcs-ref": "",
       "app.openshift.io/vcs-uri": "https://github.com/test/repo",
       "openshift.io/generated-by": "OpenShiftWebConsole",

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -44,17 +44,22 @@ export const getAppLabels = ({
   return labels;
 };
 
+export const getCommonAnnotations = () => {
+  return {
+    'openshift.io/generated-by': 'OpenShiftWebConsole',
+  };
+};
+
+export const getRouteAnnotations = () => {
+  return {
+    [ROUTE_DISABLED_ANNOTATION]: 'false',
+  };
+};
+
 export const getGitAnnotations = (gitURL: string, gitRef?: string) => {
   return {
     'app.openshift.io/vcs-uri': gitURL,
     'app.openshift.io/vcs-ref': gitRef || '',
-  };
-};
-
-export const getCommonAnnotations = () => {
-  return {
-    'openshift.io/generated-by': 'OpenShiftWebConsole',
-    [ROUTE_DISABLED_ANNOTATION]: 'false',
   };
 };
 

--- a/frontend/packages/knative-plugin/src/topology/components/decorators/getServiceRouteDecorator.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/decorators/getServiceRouteDecorator.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { Node } from '@patternfly/react-topology/src/types';
+import { ROUTE_DISABLED_ANNOTATION, ROUTE_URL_ANNOTATION } from '@console/topology/src/const';
+import { getResource } from '@console/topology/src/utils';
 import { TYPE_KNATIVE_SERVICE } from '../../const';
 import ServiceRouteDecorator from './ServiceRouteDecorator';
 
@@ -7,11 +9,15 @@ export const getServiceRouteDecorator = (element: Node, radius: number, x: numbe
   if (element.getType() !== TYPE_KNATIVE_SERVICE || element.isCollapsed()) {
     return null;
   }
+  const resourceObj = getResource(element);
   const { data } = element.getData();
-  const hasDataUrl = !!data.url;
 
-  if (!hasDataUrl) {
+  const disabled = resourceObj?.metadata?.annotations?.[ROUTE_DISABLED_ANNOTATION] === 'true';
+  const annotationURL = resourceObj?.metadata?.annotations?.[ROUTE_URL_ANNOTATION];
+  const url = annotationURL || data.url;
+
+  if (disabled || !url || !(url.startsWith('http://') || url.startsWith('https://'))) {
     return null;
   }
-  return <ServiceRouteDecorator key="service-route" url={data.url} radius={radius} x={x} y={y} />;
+  return <ServiceRouteDecorator key="service-route" url={url} radius={radius} x={x} y={y} />;
 };

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -1014,9 +1014,9 @@ export const createTopologyPubSubNodeData = (
 };
 
 /**
- * get the route data
+ * Get the route URL for the matching revision name
  */
-export const getRouteData = (resource: K8sResourceKind, ksroutes: K8sResourceKind[]): string => {
+export const getRoutesURL = (resource: K8sResourceKind, ksroutes: K8sResourceKind[]): string => {
   if (ksroutes && ksroutes.length > 0 && !_.isEmpty(ksroutes[0].status)) {
     const trafficData: { [x: string]: any } = _.find(ksroutes[0].status.traffic, {
       revisionName: resource.metadata.name,

--- a/frontend/packages/knative-plugin/src/utils/useRoutesURL.ts
+++ b/frontend/packages/knative-plugin/src/utils/useRoutesURL.ts
@@ -1,21 +1,34 @@
 import * as React from 'react';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
+import { ROUTE_DISABLED_ANNOTATION, ROUTE_URL_ANNOTATION } from '@console/topology/src/const';
 import { RouteModel } from '../models';
-import { getRouteData } from '../topology/knative-topology-utils';
+import { getRoutesURL } from '../topology/knative-topology-utils';
 
 export const useRoutesURL = (resource: K8sResourceKind): string => {
-  const { namespace } = resource.metadata;
-  const [allRoutes, loaded, loadError] = useK8sWatchResource<K8sResourceKind[]>({
-    isList: true,
-    kind: referenceForModel(RouteModel),
-    namespace,
-    optional: true,
-  });
+  const { namespace, annotations } = resource.metadata;
+  const disabled = annotations?.[ROUTE_DISABLED_ANNOTATION] === 'true';
+  const annotationURL = annotations?.[ROUTE_URL_ANNOTATION];
+
+  // Don't watch for routes if we know the URL already.
+  const [allRoutes, loaded, loadError] = useK8sWatchResource<K8sResourceKind[]>(
+    disabled || annotationURL
+      ? {}
+      : {
+          // TODO: Can we fetch only the releated routes here?
+          isList: true,
+          kind: referenceForModel(RouteModel),
+          namespace,
+          optional: true,
+        },
+  );
 
   const routes = loaded && !loadError ? allRoutes : [];
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const url = React.useMemo(() => getRouteData(resource, routes), [routes]);
+  const watchedURL = React.useMemo(() => getRoutesURL(resource, routes), [resource, routes]);
 
+  const url = annotationURL || watchedURL;
+  if (disabled || !url || !(url.startsWith('http://') || url.startsWith('https://'))) {
+    return null;
+  }
   return url;
 };

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/UrlDecorator.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/UrlDecorator.tsx
@@ -3,7 +3,6 @@ import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Node } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
-import { ROUTE_URL_ANNOTATION, ROUTE_DISABLED_ANNOTATION } from '../../../../../const';
 import { useRoutesURL } from '../../../../../data-transforms/useRoutesURL';
 import { getResource } from '../../../../../utils';
 import Decorator from './Decorator';
@@ -19,17 +18,13 @@ const UrlDecorator: React.FC<DefaultDecoratorProps> = ({ element, radius, x, y }
   const { t } = useTranslation();
   const resourceObj = getResource(element);
   const url = useRoutesURL(resourceObj);
-  const routeURL = resourceObj?.metadata?.annotations?.[ROUTE_URL_ANNOTATION];
-  const disabledRoute = resourceObj?.metadata?.annotations?.[ROUTE_DISABLED_ANNOTATION];
-  const decoratorURL = routeURL || url;
-
-  if (!url || disabledRoute === 'true') {
+  if (!url) {
     return null;
   }
   const label = t('topology~Open URL');
   return (
     <Tooltip key="route" content={label} position={TooltipPosition.right}>
-      <Decorator x={x} y={y} radius={radius} href={decoratorURL} external ariaLabel={label}>
+      <Decorator x={x} y={y} radius={radius} href={url} external ariaLabel={label}>
         <g transform={`translate(-${radius / 2}, -${radius / 2})`}>
           <ExternalLinkAltIcon style={{ fontSize: radius }} title={label} />
         </g>

--- a/frontend/packages/topology/src/data-transforms/useRoutesURL.ts
+++ b/frontend/packages/topology/src/data-transforms/useRoutesURL.ts
@@ -1,14 +1,20 @@
 import * as React from 'react';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { useRoutesWatcher } from '@console/shared';
+import { ROUTE_DISABLED_ANNOTATION, ROUTE_URL_ANNOTATION } from '../const';
 import { getRoutesURL } from '../utils/topology-utils';
 
 export const useRoutesURL = (resource: K8sResourceKind): string => {
+  const disabled = resource?.metadata?.annotations?.[ROUTE_DISABLED_ANNOTATION] === 'true';
+  const annotationURL = resource?.metadata?.annotations?.[ROUTE_URL_ANNOTATION];
+
   const routeResources = useRoutesWatcher(resource);
-
   const routes = routeResources.loaded && !routeResources.loadError ? routeResources.routes : [];
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const url = React.useMemo(() => getRoutesURL(resource, routes), [routes]);
+  const watchedURL = React.useMemo(() => getRoutesURL(resource, routes), [resource, routes]);
 
+  const url = annotationURL || watchedURL;
+  if (disabled || !url || !(url.startsWith('http://') || url.startsWith('https://'))) {
+    return null;
+  }
   return url;
 };


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2047320
https://bugzilla.redhat.com/show_bug.cgi?id=2038802

**Analysis / Root cause**: 
Knative Services uses another URL decorator then Deployments and DeploymentConfigs. For this, it was needed to apply the same or similar change also in ServiceRouteDecorator.

**Solution Description**: 
1. Check annotations also in (Knative) ServiceRouteDecorator
2. The default annotation for this (`app.openshift.io/route-disabled: 'false') was also only added for Deployments and DeploymentConfigs. Also, add this now to Knative Services.
3. But it was added to all annotations all over the import flow. But we should not tag InputStreams with this annotation. So I split it in `getCommonAnnotations` and `getRouteAnnotations`.
4. And finally, we should not render non-valid web URLs. With a custom URL like `javascript:alert(1)` an admin can run javascript in the context of the console. For this added a check that URLs should start with `http://` or `https://`

**Screen shots / Gifs for design review**: 
![Peek 2022-01-27 17-04](https://user-images.githubusercontent.com/139310/151396798-5717a232-1eed-4b55-a741-68dd4d92fc2e.gif)

**Unit test coverage report**: 
Updated, nothing special added here

**Test setup:**
1. Install the Serverless operator
2. Import an app from container image or git and select "Serverless Service"
3. Set the annotation app.openshift.io/route-url to an URL or app.openshift.io/route-disabled to true.

Test different setups.
* Import from git, import from container image
* Deployment, DeploymentConfig and Knative Services

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
