### PR TITLE
Bug 2046601: Createvm crash on null

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/create.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/create.ts
@@ -164,7 +164,7 @@ export const createVM = async (params: CreateVMParams) => {
     const processedTemplate = await k8sCreate<TemplateKind>(
       ProcessedTemplatesModel,
       template.asResource(),
-      null,
+      undefined,
       { disableHistory: true },
     ); // temporary
 


### PR DESCRIPTION
Fix: https://bugzilla.redhat.com/show_bug.cgi?id=2046601 (customize flow)

Analysis: 
`k8sCreate` looks at null as a parmater instead of missing value

Screenshots:
After:
![customize-after](https://user-images.githubusercontent.com/2181522/151398132-237626e1-202b-4914-b5ed-a305ffc35d5d.gif)

Before:
![customize-before](https://user-images.githubusercontent.com/2181522/151398157-778d2936-e199-4154-b47c-2f13e5c31b5a.gif)

