### PR TITLE
Bug 2039462: fix width of dropdowns in the userpreferences applications tab

### DIFF
--- a/frontend/packages/console-app/src/components/user-preferences/UserPreferenceForm.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/UserPreferenceForm.tsx
@@ -3,6 +3,8 @@ import { Form } from '@patternfly/react-core';
 import { ResolvedUserPreferenceItem } from './types';
 import UserPreferenceField from './UserPreferenceField';
 
+import './UserPreferenceForm.scss';
+
 type UserPreferenceFormProps = { items: ResolvedUserPreferenceItem[] };
 
 const UserPreferenceForm: React.FC<UserPreferenceFormProps> = ({ items }) =>


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2039462

**Root analysis:**
The css styles added for the User Preferences form were not being used and the form fields took the length of the description text as the width

**Solution description:**
imported the CSS file in the component form, now all the fields in all the tabs are of same width

**Screenshot:**
![Screenshot from 2022-01-28 18-57-59](https://user-images.githubusercontent.com/22490998/151606557-e398e8f7-b0ff-436c-bfe5-e78893a7ab39.png)
![Screenshot from 2022-01-28 18-57-50](https://user-images.githubusercontent.com/22490998/151606562-ac578601-c83c-4f13-9814-fff4a836ec82.png), 
![Screenshot from 2022-01-28 18-55-19](https://user-images.githubusercontent.com/22490998/151606567-da2cbce0-3587-4a35-974d-ba01d0d662ba.png)

