### PR TITLE
[release-4.9] Bug 2047633: Fix Model does not exist when watching primer exports

### DIFF
--- a/frontend/packages/topology/src/components/export-app/ExportApplication.tsx
+++ b/frontend/packages/topology/src/components/export-app/ExportApplication.tsx
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 import { useTranslation, Trans } from 'react-i18next';
 import { useAccessReview } from '@console/internal/components/utils';
 import { dateTimeFormatter } from '@console/internal/components/utils/datetime';
+import { referenceForModel } from '@console/internal/module/k8s';
 import {
   useFlag,
   useIsMobile,
@@ -52,9 +53,9 @@ const ExportApplication: React.FC<ExportApplicationProps> = ({ namespace, isDisa
       const exportAppToastConfig = {
         ...exportAppToast,
         [key]: {
+          kind: referenceForModel(ExportModel),
           uid: exportResp.metadata.uid,
           name: exportResp.metadata.name,
-          kind: exportResp.kind,
           namespace,
         },
       };

--- a/frontend/packages/topology/src/components/export-app/export-app-context.ts
+++ b/frontend/packages/topology/src/components/export-app/export-app-context.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { AlertVariant } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { WatchK8sResource } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { USERSETTINGS_PREFIX, useToast, useUserSettings } from '@console/shared/src';
@@ -21,8 +22,8 @@ export const useExportAppFormToast = () => {
     ExportAppUserSettings
   >(`${USERSETTINGS_PREFIX}.exportApp`, {}, true);
 
-  const exportAppWatchResources = React.useMemo(() => {
-    if (!exportAppToastLoaded && _.isEmpty(exportAppToast)) return {};
+  const exportAppWatchResources = React.useMemo<Record<string, WatchK8sResource>>(() => {
+    if (!exportAppToastLoaded || _.isEmpty(exportAppToast)) return {};
     const keys = Object.keys(exportAppToast);
     const watchRes = keys.reduce((acc, k) => {
       const { kind, name, namespace: resNamespace } = exportAppToast[k];
@@ -35,7 +36,7 @@ export const useExportAppFormToast = () => {
         optional: true,
       };
       return acc;
-    }, {});
+    }, {} as Record<string, WatchK8sResource>);
     return watchRes;
   }, [exportAppToast, exportAppToastLoaded]);
 


### PR DESCRIPTION
This is a manual backport of #10800

**Backport notes**
The mentioned PR contains also some refactorings and changes for the "View logs" button we introduced in 4.10.

For this backport it's enough to save the full model reference (apiGroup, apiVersion and kind) in the kind user settings.

User settings value before:

```json
{
  "christoph-primer": {
    "kind":"Export",
    "uid":"9e9000e9-5c57-41b7-9231-6749109278c8",
    "name":"primer",
    "namespace":"christoph"
  }
}
```

User settings value with this PR:

```json
{
  "christoph-primer": {
    "kind":"primer.gitops.io~v1alpha1~Export",
    "uid":"9e9000e9-5c57-41b7-9231-6749109278c8",
    "name":"primer",
    "namespace":"christoph"
  }
}
```

**Verification**
Just tested an export in topology.
