### PR TITLE
Bug 2041774: defaulting to s2i if git type can't be figured out

### DIFF
--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -110,9 +110,9 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
       loadError: null,
       strategies: [],
       selectedStrategy: {
-        name: 'Devfile',
-        type: ImportStrategy.DEVFILE,
-        priority: 2,
+        name: 'Builder Image',
+        type: ImportStrategy.S2I,
+        priority: 0,
         detectedFiles: [],
       },
       recommendedStrategy: null,

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -284,9 +284,9 @@ const GitSection: React.FC<GitSectionProps> = ({
           loadError: null,
           strategies: [],
           selectedStrategy: {
-            name: 'Devfile',
-            type: ImportStrategy.DEVFILE,
-            priority: 2,
+            name: 'Builder Image',
+            type: ImportStrategy.S2I,
+            priority: 0,
             detectedFiles: [],
           },
           recommendedStrategy: null,


### PR DESCRIPTION
**Fixes**: 
[BZ2033098](https://issues.redhat.com/browse/OCPBUGSM-39492)

**Analysis / Root cause**: 
If a user wants to import from a private git hosting instance or a private repo we cannot automatically find out the import type. Previously the import strategy defaulted to `Devfile`. As @serenamarie125 mentioned in https://coreos.slack.com/archives/CHC2R6AGG/p1642608881018300 this is a bug and we should default to `Builder Image`.

**Expected results**: 
Default to `Builder Image`

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge