### PR TITLE
[release-4.10] Bug 2046601: Dont assume its a pvc

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form-reducer.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form-reducer.ts
@@ -86,7 +86,7 @@ export type BootSourceAction =
   | { type: BOOT_ACTION_TYPE.SET_PROVIDER; payload: BootSourceState['provider']['value'] };
 
 export const initBootFormState: BootSourceState = {
-  dataSource: { value: 'pvc' },
+  dataSource: undefined,
   file: undefined,
   size: {
     value: {


### PR DESCRIPTION
Fix: https://bugzilla.redhat.com/show_bug.cgi?id=2046601 (simple flow)

Analysis:
`sourceRef` is a kind of PVC source but is not implemented into the disk wrapper, if the wrapper see that the `dataSource` is `pvc` it will not search for the `sourceRef` of the pvc.
To prevent the disk wrapper from engaging we need to make sure `dataSource` remains undefined.

Screenshots:

Before:
![before](https://user-images.githubusercontent.com/2181522/151371837-8cdde52f-5cc6-4586-85c6-296aaadb8c9d.gif)

After:
![after](https://user-images.githubusercontent.com/2181522/151371482-c8e7f78d-2d44-4b3e-9cce-493513d17381.gif)

