### PR TITLE
Bug 2048276: test-cypress.sh script: Add curly brackets around nightly var

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -79,7 +79,7 @@ if [ -n "${pkg-}" ]; then
     yarn_script="$yarn_script-$pkg"
 fi
 
-if [ -n "$nightly-" ]; then
+if [ -n "${nightly-}" ]; then
   yarn_script="$yarn_script-nightly"
 elif [ -n "${headless-}" ]; then
   yarn_script="$yarn_script-headless"


### PR DESCRIPTION
In `test-cypress.sh` scripts curly brackets are missing in the for the `nightly` parameter.

Signed-off-by: yaacov <kobi.zamir@gmail.com>