### PR TITLE
Bug 2046596: Customized wizard PVC name

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os.tsx
@@ -13,7 +13,7 @@ import {
   getFlavors,
   getWorkloadProfiles,
 } from '../../../../selectors/vm-template/combined-dependent';
-import { OperatingSystemRecord } from '../../../../types';
+import { OperatingSystemRecord, OperationSystemField } from '../../../../types';
 import {
   iGet,
   iGetIsLoaded,
@@ -140,7 +140,7 @@ export const OS: React.FC<OSProps> = React.memo(
         const isBaseImageUploading =
           iGetAnnotation(baseImageFoundInCluster, CDI_UPLOAD_POD_ANNOTATION) ===
           CDI_PVC_PHASE_RUNNING;
-        const osField: any = {
+        const osField: OperationSystemField = {
           id: operatingSystem.id,
           name: operatingSystem.name,
           baseImageFoundInCluster,
@@ -192,7 +192,20 @@ export const OS: React.FC<OSProps> = React.memo(
         return osField;
       },
     );
-    const baseImage = operatingSystemBaseImages.find((image) => image.id === os);
+    const [baseImage, setBaseImage] = React.useState<OperationSystemField>();
+
+    React.useEffect(() => {
+      const osImage = operatingSystemBaseImages.find((image) => image.id === os);
+      const matchingDataSourcePVC = findDataSourcePVC(
+        dataSources,
+        pvcs,
+        osImage?.pvcName,
+        osImage?.pvcNamespace,
+      );
+      if (osImage && dataSources && pvcs && !baseImage) {
+        setBaseImage({ ...osImage, pvcName: iGetName(matchingDataSourcePVC) || osImage.pvcName });
+      }
+    }, [baseImage, dataSources, operatingSystemBaseImages, os, pvcs]);
 
     const numOfMountedDisks = cloneBaseDiskImage + mountWindowsGuestTools; // using boolean addition operator to count true
     const mountedDisksHelpMsg = numOfMountedDisks > 0 && (

--- a/frontend/packages/kubevirt-plugin/src/types/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/types.ts
@@ -1,3 +1,6 @@
+import * as React from 'react';
+import { Map as ImmutableMap } from 'immutable';
+import { PersistentVolumeClaimKind } from '@console/internal/module/k8s';
 import { DeviceType } from '../constants';
 import { V1Disk } from './api';
 import { V1NetworkInterface } from './vm';
@@ -18,4 +21,15 @@ export type OperatingSystemRecord = {
   baseImageName?: string;
   baseImageNamespace?: string;
   baseImageRecomendedSize?: any;
+};
+
+export type OperationSystemField = {
+  id: string;
+  name: string;
+  baseImageFoundInCluster: ImmutableMap<string, PersistentVolumeClaimKind>;
+  message: string;
+  longMessage?: string | React.ReactElement<any, any>;
+  checkboxDescription: string;
+  pvcName?: string;
+  pvcNamespace?: string;
 };


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

Should be merged after this: https://github.com/openshift/console/pull/10945

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2046596

**Analysis / Root cause**: 
PVC name was taken from template os or hardcoded config

**Solution Description**: 
PVC name will be checked against DS and if a match will take DS PVC name.

**Screen shots / Gifs for design review**: 
After:
![image](https://user-images.githubusercontent.com/14824964/151784050-72efb238-08e0-4b20-a428-99f971d9d92e.png)

Before:
![image](https://user-images.githubusercontent.com/14824964/151784215-bc05763a-ddbf-4eaf-bfa2-bbe04f39f3dc.png)
