### PR TITLE
Bug 2048631: missing volumes list in snapshot modal

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-modal/SupportedSnapshotVolumesList.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-modal/SupportedSnapshotVolumesList.tsx
@@ -1,17 +1,20 @@
 import * as React from 'react';
 import { ExpandableSection, Stack, StackItem } from '@patternfly/react-core';
+import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 const SupportedSnapshotVolumesList = ({ supportedVolumes }: SupportedSnapshotVolumesListProps) => {
   const { t } = useTranslation();
-
-  if (supportedVolumes) {
+  const [isExpanded, setIsExpanded] = React.useState<boolean>(true);
+  if (_.isEmpty(supportedVolumes)) {
     return null;
   }
 
   return (
     <StackItem>
       <ExpandableSection
+        isExpanded={isExpanded}
+        onClick={() => setIsExpanded((prev) => !prev)}
         toggleText={t('kubevirt-plugin~Disks included in this snapshot ({{count}})', {
           count: supportedVolumes?.length,
         })}


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2048631

**Analysis / Root cause**:
incorrect boolean check

**Solution Description**:
adjusting the boolean check
expanding volumes included in snapshot by default.

**Screen shots / Gifs for design review**:

**Before**:

![before](https://user-images.githubusercontent.com/67270715/151841621-1070ceb4-56ee-47bf-9a0c-a0dd8003316b.png)

**After**:

![after](https://user-images.githubusercontent.com/67270715/151841640-23df34af-1fab-4fe0-b70d-3bc0fbb30645.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>