### PR TITLE
Bug 2044421: Allow topology list to select application group

### DIFF
--- a/frontend/packages/topology/src/components/list-view/TopologyListViewAppGroup.tsx
+++ b/frontend/packages/topology/src/components/list-view/TopologyListViewAppGroup.tsx
@@ -76,6 +76,7 @@ const TopologyListViewAppGroup: React.FC<TopologyListViewAppGroupProps> = ({
     <DataListItem
       className="odc-topology-list-view__application"
       key={id}
+      id={id}
       aria-labelledby={`${id}_label`}
       isExpanded
     >


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2044421

**Root analysis:**
The DataListItem component requires the `id` value to select the data list item
This regression is introduced in this PR -  https://github.com/openshift/console/pull/10883/files#diff-60419c4ef60d95cbc4a7ac731aa3a5e75bb71bea2a3b2e16baafd0e3b42263e5L79

**Solution description:**
Passing id to the DataListItem component

**GIF:**
![Peek 2022-02-01 17-05](https://user-images.githubusercontent.com/22490998/151962652-a8c2f0b2-a769-45d7-b68c-5e7948041aeb.gif)

/kind bug