### PR TITLE
[release-4.9] Bug 2047350: Fix TypeError when application has HelmRelease

### DIFF
--- a/frontend/packages/topology/src/actions/groupActions.ts
+++ b/frontend/packages/topology/src/actions/groupActions.ts
@@ -32,7 +32,10 @@ const cleanUpWorkloadNode = async (workload: OdcNodeModel): Promise<K8sResourceK
 const deleteGroup = (application: TopologyApplicationObject) => {
   // accessReview needs a resource but group is not a k8s resource,
   // so currently picking the first resource to do the rbac checks (might change in future)
-  const primaryResource = application.resources[0].resource;
+  const primaryResource = application.resources?.find((node) => node.resource)?.resource;
+  if (!primaryResource) {
+    return null;
+  }
   const resourceModel = modelFor(primaryResource.kind)
     ? modelFor(primaryResource.kind)
     : modelFor(referenceFor(primaryResource));
@@ -62,7 +65,10 @@ const addResourcesMenu = (
   application: TopologyApplicationObject,
   connectorSource?: Node,
 ) => {
-  const primaryResource = application.resources[0].resource;
+  const primaryResource = application.resources?.find((node) => node.resource)?.resource;
+  if (!primaryResource) {
+    return [];
+  }
   const connectorSourceObj = getResource(connectorSource) || {};
   let resourceMenu: MenuOptions = addGroupResourceMenu;
   resourceMenu = getKnativeContextMenuAction(graphData, resourceMenu, connectorSource, true);
@@ -95,6 +101,7 @@ export const groupActions = (
   application: TopologyApplicationObject,
   connectorSource?: Node,
 ): KebabOption[] => {
+  const deleteItem = deleteGroup(application);
   const addItems = graphData ? addResourcesMenu(graphData, application, connectorSource) : [];
-  return !connectorSource ? [deleteGroup(application), ...addItems] : addItems;
+  return !connectorSource && deleteItem ? [deleteItem, ...addItems] : addItems;
 };

--- a/frontend/packages/topology/src/components/application-panel/TopologyApplicationResources.tsx
+++ b/frontend/packages/topology/src/components/application-panel/TopologyApplicationResources.tsx
@@ -19,7 +19,9 @@ const TopologyApplicationResources: React.FC<TopologyApplicationResourcesProps> 
 }) => {
   const { t } = useTranslation();
   const resourcesData = resources.reduce((acc, { resource }) => {
-    acc[resource.kind] = [...(acc[resource.kind] ? acc[resource.kind] : []), resource];
+    if (resource?.kind) {
+      acc[resource.kind] = [...(acc[resource.kind] ? acc[resource.kind] : []), resource];
+    }
     return acc;
   }, {});
 


### PR DESCRIPTION
This PR includes the automated cherry-pick of #10742 by @vikram-raj as well as a 2nd commit which fixes another error (NPE) when selecting an application with just a Helm Release in it.

Fixed error:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'metadata')
    at groupActions.ts:74:1
    at arrayReduce (_arrayReduce.js:21:1)
    at Module.reduce (reduce.js:48:1)
    at addResourcesMenu (groupActions.ts:69:1)
    at groupActions (groupActions.ts:98:1)
    at TopologyApplicationPanel (TopologyApplicationPanel.tsx:24:1)
    ...

The above error occurred in the <TopologyApplicationPanel> component:
    at TopologyApplicationPanel
    at div
    at div
    at TopologySideBar
    at TopologySideBar
    ...

TypeError: Cannot read properties of undefined (reading 'metadata')
    at groupActions.ts:74:1
    at arrayReduce (_arrayReduce.js:21:1)
    at Module.reduce (reduce.js:48:1)
    at addResourcesMenu (groupActions.ts:69:1)
    at groupActions (groupActions.ts:98:1)
    at TopologyApplicationPanel (TopologyApplicationPanel.tsx:24:1)
    ...
```

@vikram-raj Can you please take a look if this is fine for you? I think this PR can replace #10958 because its included here.