### PR TITLE
Bug 2048442: Disabling Vault SA based auth for storage class encryption

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/kms-config/providers.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/kms-config/providers.ts
@@ -29,6 +29,7 @@ export type AdvancedKMSModalProps = {
     | Pick<WizardState['securityAndNetwork'], 'encryption' | 'kms'>;
   dispatch: EncryptionDispatch;
   mode?: string;
+  isWizardFlow?: boolean;
 } & HandlePromiseProps &
   ModalComponentProps;
 

--- a/frontend/packages/ceph-storage-plugin/src/components/kms-config/utils.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/kms-config/utils.tsx
@@ -183,7 +183,6 @@ const createCsiVaultResources = (
     VAULT_TLS_SERVER_NAME: kms.tls,
     VAULT_CLIENT_CERT: kms.clientCert?.metadata.name,
     VAULT_CLIENT_KEY: kms.clientKey?.metadata.name,
-    VAULT_NAMESPACE: kms.providerNamespace,
     VAULT_CACERT_FILE: kms.caCertFile,
     VAULT_CLIENT_CERT_FILE: kms.clientCertFile,
     VAULT_CLIENT_KEY_FILE: kms.clientKeyFile,
@@ -195,6 +194,7 @@ const createCsiVaultResources = (
       csiConfigData = {
         ...csiConfigData,
         VAULT_TOKEN_NAME: KMSVaultCSISecretName,
+        VAULT_NAMESPACE: kms.providerNamespace,
       };
       // token creation on ceph-csi deployment namespace from installation flow
       if (kms.authValue.value) {
@@ -277,12 +277,15 @@ const createClusterVaultResources = (
     VAULT_TLS_SERVER_NAME: kms.tls,
     VAULT_CLIENT_CERT: kms.clientCert?.metadata.name,
     VAULT_CLIENT_KEY: kms.clientKey?.metadata.name,
-    VAULT_NAMESPACE: kms.providerNamespace,
     VAULT_AUTH_METHOD: kms.authMethod,
   };
 
   switch (kms.authMethod) {
     case VaultAuthMethods.TOKEN:
+      vaultConfigData = {
+        ...vaultConfigData,
+        VAULT_NAMESPACE: kms.providerNamespace,
+      };
       clusterKmsResources.push(
         k8sCreate(SecretModel, getKmsVaultSecret(kms.authValue.value, KMSVaultTokenSecretName)),
       );
@@ -291,6 +294,7 @@ const createClusterVaultResources = (
       vaultConfigData = {
         ...vaultConfigData,
         VAULT_AUTH_KUBERNETES_ROLE: kms.authValue.value,
+        VAULT_AUTH_MOUNT_PATH: kms.providerAuthPath,
       };
       break;
     default:

--- a/frontend/packages/ceph-storage-plugin/src/components/kms-config/vault-config.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/kms-config/vault-config.tsx
@@ -72,15 +72,15 @@ export const ValutConfigure: React.FC<KMSConfigureProps> = ({
     (authMethod) =>
       (encryption.clusterWide
         ? authMethod.supportedEncryptionType.includes(KmsEncryptionLevel.CLUSTER_WIDE)
-        : true) &&
+        : false) ||
       (encryption.storageClass
         ? authMethod.supportedEncryptionType.includes(KmsEncryptionLevel.STORAGE_CLASS)
-        : true),
+        : false),
   );
 
   const vaultAuthMethods = filteredVaultAuthMethodMapping.map((authMethod) => authMethod.value);
   if (!vaultAuthMethods.includes(vaultState.authMethod)) {
-    if (isKmsVaultSASupported) {
+    if (isKmsVaultSASupported && vaultAuthMethods.includes(VaultAuthMethods.KUBERNETES)) {
       // From 4.10 kubernetes is default auth method
       setAuthMethod(VaultAuthMethods.KUBERNETES);
     } else {
@@ -176,6 +176,7 @@ const ValutConnectionForm: React.FC<ValutConnectionFormProps> = ({
       state,
       dispatch,
       mode,
+      isWizardFlow,
     });
 
   // vault state update

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/advanced-kms-modal/advanced-vault-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/advanced-kms-modal/advanced-vault-modal.tsx
@@ -23,7 +23,7 @@ import { VaultConfig, ProviderNames, VaultAuthMethods } from '../../../types';
 import './advanced-kms-modal.scss';
 
 export const AdvancedVaultModal = withHandlePromise((props: AdvancedKMSModalProps) => {
-  const { close, cancel, errorMessage, inProgress, state, dispatch, mode } = props;
+  const { close, cancel, errorMessage, inProgress, state, dispatch, mode, isWizardFlow } = props;
   const kms: VaultConfig = state.kms?.[ProviderNames.VAULT] || state.kms;
 
   const { t } = useTranslation();
@@ -149,23 +149,26 @@ export const AdvancedVaultModal = withHandlePromise((props: AdvancedKMSModalProp
               data-test="kms-service-backend-path"
             />
           </FormGroup>
-          {kms.authMethod === VaultAuthMethods.KUBERNETES && state.encryption.storageClass && (
-            <>
-              <FormGroup
-                fieldId="kms-auth-path"
-                label={t('ceph-storage-plugin~Authentication Path')}
-                className="ceph-advanced-kms__form-body"
-              >
-                <TextInput
-                  value={authPath}
-                  onChange={setAuthPath}
-                  type="text"
-                  id="kms-service-auth-path"
-                  name="kms-service-auth-path"
-                  data-test="kms-service-auth-path"
-                />
-              </FormGroup>
+          {kms.authMethod === VaultAuthMethods.KUBERNETES && (
+            <FormGroup
+              fieldId="kms-auth-path"
+              label={t('ceph-storage-plugin~Authentication Path')}
+              className="ceph-advanced-kms__form-body"
+            >
+              <TextInput
+                value={authPath}
+                onChange={setAuthPath}
+                type="text"
+                id="kms-service-auth-path"
+                name="kms-service-auth-path"
+                data-test="kms-service-auth-path"
+              />
+            </FormGroup>
+          )}
 
+          {kms.authMethod === VaultAuthMethods.KUBERNETES &&
+            state.encryption.storageClass &&
+            !isWizardFlow && (
               <FormGroup
                 fieldId="kms-auth-namespace"
                 label={t('ceph-storage-plugin~Authentication Namespace')}
@@ -180,8 +183,7 @@ export const AdvancedVaultModal = withHandlePromise((props: AdvancedKMSModalProp
                   data-test="kms-service-auth-namespace"
                 />
               </FormGroup>
-            </>
-          )}
+            )}
 
           <FormGroup
             fieldId="kms-service-tls"
@@ -197,24 +199,26 @@ export const AdvancedVaultModal = withHandlePromise((props: AdvancedKMSModalProp
               name="kms-service-tls"
             />
           </FormGroup>
-          <FormGroup
-            fieldId="kms-service-namespace"
-            label={t('ceph-storage-plugin~Vault Enterprise Namespace')}
-            className="ceph-advanced-kms__form-body"
-            labelIcon={<FieldLevelHelp>{vaultNamespaceTooltip}</FieldLevelHelp>}
-            helperText={t(
-              'ceph-storage-plugin~The name must be accurate and must match the service namespace',
-            )}
-          >
-            <TextInput
-              value={providerNS}
-              onChange={setProvideNS}
-              type="text"
-              id="kms-service-namespace"
-              name="kms-service-namespace"
-              placeholder="kms-namespace"
-            />
-          </FormGroup>
+          {kms.authMethod === VaultAuthMethods.TOKEN && (
+            <FormGroup
+              fieldId="kms-service-namespace"
+              label={t('ceph-storage-plugin~Vault Enterprise Namespace')}
+              className="ceph-advanced-kms__form-body"
+              labelIcon={<FieldLevelHelp>{vaultNamespaceTooltip}</FieldLevelHelp>}
+              helperText={t(
+                'ceph-storage-plugin~The name must be accurate and must match the service namespace',
+              )}
+            >
+              <TextInput
+                value={providerNS}
+                onChange={setProvideNS}
+                type="text"
+                id="kms-service-namespace"
+                name="kms-service-namespace"
+                placeholder="kms-namespace"
+              />
+            </FormGroup>
+          )}
           <FormGroup
             fieldId="kms-service-ca-cert"
             label={t('ceph-storage-plugin~CA Certificate')}

--- a/frontend/packages/ceph-storage-plugin/src/constants/kms.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/kms.ts
@@ -16,7 +16,7 @@ export const KMS_PROVIDER = 'KMS_PROVIDER';
 export const SupportedProviders = {
   [ProviderNames.VAULT]: {
     group: 'Vault',
-    supported: [KmsImplementations.VAULT_TOKENS, KmsImplementations.VAULT_TENANT_SA],
+    supported: [KmsImplementations.VAULT_TOKENS],
   },
   [ProviderNames.HPCS]: {
     group: 'Hyper Protect Crypto Services',

--- a/frontend/packages/ceph-storage-plugin/src/types.ts
+++ b/frontend/packages/ceph-storage-plugin/src/types.ts
@@ -252,7 +252,7 @@ export const VaultAuthMethodMapping: {
   [VaultAuthMethods.KUBERNETES]: {
     name: 'Kubernetes',
     value: VaultAuthMethods.KUBERNETES,
-    supportedEncryptionType: [KmsEncryptionLevel.CLUSTER_WIDE, KmsEncryptionLevel.STORAGE_CLASS],
+    supportedEncryptionType: [KmsEncryptionLevel.CLUSTER_WIDE],
   },
   [VaultAuthMethods.TOKEN]: {
     name: 'Token',
@@ -289,18 +289,19 @@ export type VaultCommonConfigMap = {
   VAULT_CLIENT_CERT_FILE?: string;
   VAULT_CLIENT_KEY?: string;
   VAULT_CLIENT_KEY_FILE?: string;
-  VAULT_NAMESPACE?: string;
   VAULT_AUTH_METHOD?: string;
 };
 
 export type VaultTokenConfigMap = {
   VAULT_TOKEN_NAME: string;
+  VAULT_NAMESPACE?: string;
 } & VaultCommonConfigMap;
 
 export type VaultSAConfigMap = {
   VAULT_AUTH_KUBERNETES_ROLE?: string;
   VAULT_AUTH_PATH?: string;
   VAULT_AUTH_NAMESPACE?: string;
+  VAULT_AUTH_MOUNT_PATH?: string;
 } & VaultCommonConfigMap;
 
 export type VaultConfigMap = VaultTokenConfigMap | VaultSAConfigMap;


### PR DESCRIPTION
From4.10 KMS UI following fields are going to hide:
    - In the storageclass creation page, we hide the option to select the kubernetes auth method (multi-tenancy for PV encryption), which in turn hides the auth  Authentication Path and  Authentication Namespace and fields.
   - In the storagesystem creation page (deployment), if storageclass encryption is enabled and kubernetes authentication method is enabled, we do not create an encrypted SC as part of the deployment for now.
  - In addition to these, when kubernetes authentication method is selected, we also disable/hide the Vault Enterprise Namespace field on both places.


Signed-off-by: Gowtham Shanmugasundaram <gshanmug@redhat.com>