### PR TITLE
createProject for non-admin users

### DIFF
--- a/frontend/packages/integration-tests-cypress/support/project.ts
+++ b/frontend/packages/integration-tests-cypress/support/project.ts
@@ -17,7 +17,9 @@ declare global {
 // ex: cy.createProject(name)
 Cypress.Commands.add('createProject', (name: string, devConsole: boolean = false) => {
   cy.log(`create project`);
-  cy.visit(`/k8s/cluster/projects`).its('yaml-create').should('be.visible');
+  cy.visit(`/k8s/cluster/projects`)
+    .its('yaml-create')
+    .should('be.visible');
   listPage.clickCreateYAMLbutton();
   modal.shouldBeOpened();
   cy.byTestID('input-name')

--- a/frontend/packages/integration-tests-cypress/support/project.ts
+++ b/frontend/packages/integration-tests-cypress/support/project.ts
@@ -17,8 +17,7 @@ declare global {
 // ex: cy.createProject(name)
 Cypress.Commands.add('createProject', (name: string, devConsole: boolean = false) => {
   cy.log(`create project`);
-  cy.visit(`/k8s/cluster/projects`);
-  listPage.rows.shouldBeLoaded();
+  cy.visit(`/k8s/cluster/projects`).its('yaml-create').should('be.visible');
   listPage.clickCreateYAMLbutton();
   modal.shouldBeOpened();
   cy.byTestID('input-name')


### PR DESCRIPTION
OCP QE uses this libs in their integration tests, in our CI env, the tests are run as non-admin user.

cy.createProject() method when logged in as developer fails, since it checks "listPage.rows.shouldBeLoaded()". If we don't care about listPage.rows.shouldBeLoaded() in createProject, proposed solution would also pause the execution and check for "Create Project" button is loaded before going further.