### PR TITLE
Bug 2053685: (Topology) Performance improvement by reducing rerenderings and deep-copy toJSON() calls

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/k8s-watcher.spec.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/k8s-watcher.spec.tsx
@@ -75,8 +75,7 @@ describe('getReduxData', () => {
     const secondTime = getReduxData(immutableData, resource);
     expect(firstTime).toEqual({ a: 1, b: 2, c: 3 });
     expect(secondTime).toEqual({ a: 1, b: 2, c: 3 });
-    // TODO: Should be the same data
-    expect(firstTime).not.toBe(secondTime);
+    expect(firstTime).toBe(secondTime);
   });
 
   it('should return a new JSON object if the data has changed', () => {
@@ -102,11 +101,10 @@ describe('getReduxData', () => {
     expect(firstTime).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
     expect(secondTime).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
     // The array instance should be the same
-    expect(firstTime).not.toBe(secondTime);
-    // TODO: All included objects could be reused.
-    expect(firstTime[0]).not.toBe(secondTime[0]);
-    expect(firstTime[1]).not.toBe(secondTime[1]);
-    expect(firstTime[2]).not.toBe(secondTime[2]);
+    expect(firstTime).not.toBe(secondTime); // TODO???
+    expect(firstTime[0]).toBe(secondTime[0]);
+    expect(firstTime[1]).toBe(secondTime[1]);
+    expect(firstTime[2]).toBe(secondTime[2]);
   });
 
   it('should return the same JSON array and child objects for unchanged data ', () => {
@@ -123,9 +121,9 @@ describe('getReduxData', () => {
     expect(secondTime).toEqual([{ a: 1 }, { b: 2 }, { c: 4 }]);
     // The array should be changed
     expect(firstTime).not.toBe(secondTime);
-    // TODO: But the included object data should return the same instance
-    expect(firstTime[0]).not.toBe(secondTime[0]);
-    expect(firstTime[1]).not.toBe(secondTime[1]);
+    // But the included object data should return the same instance
+    expect(firstTime[0]).toBe(secondTime[0]);
+    expect(firstTime[1]).toBe(secondTime[1]);
     // Except for the changed object obviously
     expect(firstTime[2]).not.toBe(secondTime[2]);
   });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/k8s-watcher.spec.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/k8s-watcher.spec.tsx
@@ -1,0 +1,132 @@
+import {
+  List as ImmutableList,
+  Stack as ImmutableStack,
+  Set as ImmutableSet,
+  OrderedSet as ImmutableOrderedSet,
+  Map as ImmutableMap,
+  OrderedMap as ImmutableOrderedMap,
+} from 'immutable';
+import { WatchK8sResource } from '../../../../extensions/console-types';
+import { getReduxData } from '../k8s-watcher';
+
+describe('getReduxData', () => {
+  it('should return null for falsy values', () => {
+    const resource: WatchK8sResource = {};
+    expect(getReduxData(null, resource)).toBe(null);
+    expect(getReduxData(undefined, resource)).toBe(null);
+  });
+
+  it('should convert ImmutableList to pure JSON', () => {
+    const immutableData = ImmutableList([
+      ImmutableMap({ a: 1 }),
+      ImmutableMap({ b: 2 }),
+      ImmutableMap({ c: 3 }),
+    ]);
+    const resource: WatchK8sResource = { isList: true };
+    expect(getReduxData(immutableData, resource)).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
+  });
+
+  it('should convert ImmutableStack to pure JSON', () => {
+    const immutableData = ImmutableStack([
+      ImmutableMap({ a: 1 }),
+      ImmutableMap({ b: 2 }),
+      ImmutableMap({ c: 3 }),
+    ]);
+    const resource: WatchK8sResource = { isList: true };
+    expect(getReduxData(immutableData, resource)).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
+  });
+
+  it('should convert ImmutableSet to pure JSON', () => {
+    const immutableData = ImmutableSet([
+      ImmutableMap({ a: 1 }),
+      ImmutableMap({ b: 2 }),
+      ImmutableMap({ c: 3 }),
+    ]);
+    const resource: WatchK8sResource = { isList: true };
+    expect(getReduxData(immutableData, resource)).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
+  });
+
+  it('should convert ImmutableOrderedSet to pure JSON', () => {
+    const immutableData = ImmutableOrderedSet([
+      ImmutableMap({ a: 1 }),
+      ImmutableMap({ b: 2 }),
+      ImmutableMap({ c: 3 }),
+    ]);
+    const resource: WatchK8sResource = { isList: true };
+    expect(getReduxData(immutableData, resource)).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
+  });
+
+  it('should convert ImmutableMap to pure JSON', () => {
+    const immutableData = ImmutableMap({ a: 1, b: 2, c: 3 });
+    const resource: WatchK8sResource = {};
+    expect(getReduxData(immutableData, resource)).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it('should convert ImmutableOrderedMap to pure JSON', () => {
+    const immutableData = ImmutableOrderedMap({ a: 1, b: 2, c: 3 });
+    const resource: WatchK8sResource = {};
+    expect(getReduxData(immutableData, resource)).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it('should return the same JSON object for unchanged data', () => {
+    const immutableData = ImmutableMap({ a: 1, b: 2, c: 3 });
+    const resource: WatchK8sResource = {};
+    const firstTime = getReduxData(immutableData, resource);
+    const secondTime = getReduxData(immutableData, resource);
+    expect(firstTime).toEqual({ a: 1, b: 2, c: 3 });
+    expect(secondTime).toEqual({ a: 1, b: 2, c: 3 });
+    // TODO: Should be the same data
+    expect(firstTime).not.toBe(secondTime);
+  });
+
+  it('should return a new JSON object if the data has changed', () => {
+    const immutableData = ImmutableMap({ a: 1, b: 2, c: 3 });
+    const changedData = immutableData.set('c', 4);
+    const resource: WatchK8sResource = {};
+    const firstTime = getReduxData(immutableData, resource);
+    const secondTime = getReduxData(changedData, resource);
+    expect(firstTime).toEqual({ a: 1, b: 2, c: 3 });
+    expect(secondTime).toEqual({ a: 1, b: 2, c: 4 });
+    expect(firstTime).not.toBe(secondTime);
+  });
+
+  it('should return the same JSON array and child objects for unchanged data ', () => {
+    const immutableData = ImmutableList([
+      ImmutableMap({ a: 1 }),
+      ImmutableMap({ b: 2 }),
+      ImmutableMap({ c: 3 }),
+    ]);
+    const resource: WatchK8sResource = { isList: true };
+    const firstTime = getReduxData(immutableData, resource);
+    const secondTime = getReduxData(immutableData, resource);
+    expect(firstTime).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
+    expect(secondTime).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
+    // The array instance should be the same
+    expect(firstTime).not.toBe(secondTime);
+    // TODO: All included objects could be reused.
+    expect(firstTime[0]).not.toBe(secondTime[0]);
+    expect(firstTime[1]).not.toBe(secondTime[1]);
+    expect(firstTime[2]).not.toBe(secondTime[2]);
+  });
+
+  it('should return the same JSON array and child objects for unchanged data ', () => {
+    const immutableData = ImmutableList([
+      ImmutableMap({ a: 1 }),
+      ImmutableMap({ b: 2 }),
+      ImmutableMap({ c: 3 }),
+    ]);
+    const changedData = immutableData.setIn([2, 'c'], 4);
+    const resource: WatchK8sResource = { isList: true };
+    const firstTime = getReduxData(immutableData, resource);
+    const secondTime = getReduxData(changedData, resource);
+    expect(firstTime).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
+    expect(secondTime).toEqual([{ a: 1 }, { b: 2 }, { c: 4 }]);
+    // The array should be changed
+    expect(firstTime).not.toBe(secondTime);
+    // TODO: But the included object data should return the same instance
+    expect(firstTime[0]).not.toBe(secondTime[0]);
+    expect(firstTime[1]).not.toBe(secondTime[1]);
+    // Except for the changed object obviously
+    expect(firstTime[2]).not.toBe(secondTime[2]);
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sModels.spec.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sModels.spec.tsx
@@ -1,0 +1,143 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { combineReducers, createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import { receivedResources } from '@console/internal/actions/k8s';
+import { ConfigMapModel, SecretModel } from '@console/internal/models';
+import { SDKReducers } from '../../../../app';
+import { setPluginStore } from '../../k8s-utils';
+import { useK8sModels } from '../useK8sModels';
+
+// Redux wrapper
+let store;
+const Wrapper: React.FC = ({ children }) => <Provider store={store}>{children}</Provider>;
+
+// Object under test
+const modelUpdate = jest.fn();
+const WatchModels: React.FC<{}> = () => {
+  modelUpdate(...useK8sModels());
+  return null;
+};
+
+setPluginStore({ getExtensionsInUse: () => [] });
+
+beforeEach(() => {
+  store = createStore(combineReducers(SDKReducers), {}, applyMiddleware(thunk));
+  modelUpdate.mockClear();
+});
+
+describe('useK8sModels', () => {
+  it('should return in flight mode before resources are received', () => {
+    render(
+      <Wrapper>
+        <WatchModels />
+      </Wrapper>,
+    );
+
+    expect(modelUpdate).toHaveBeenCalledTimes(1);
+    const [models, inFlight] = modelUpdate.mock.calls[0];
+    expect(models).toEqual({});
+    expect(inFlight).toBe(false); // TODO: Should be true?
+  });
+
+  it('should return all models as JSON', () => {
+    store.dispatch(
+      receivedResources({
+        models: [ConfigMapModel, SecretModel],
+        adminResources: [],
+        allResources: [],
+        configResources: [],
+        clusterOperatorConfigResources: [],
+        namespacedSet: null,
+        safeResources: [],
+        groupVersionMap: {},
+      }),
+    );
+
+    render(
+      <Wrapper>
+        <WatchModels />
+      </Wrapper>,
+    );
+
+    expect(modelUpdate).toHaveBeenCalledTimes(1);
+    const [models, inFlight] = modelUpdate.mock.calls[0];
+    expect(models).toEqual({ ConfigMap: ConfigMapModel, Secret: SecretModel });
+    expect(inFlight).toBe(false);
+
+    // It was saved in immutable redux store and will be cloned.
+    expect(models.ConfigMap).not.toBe(ConfigMapModel);
+    expect(models.Secret).not.toBe(SecretModel);
+  });
+
+  it('should return the same model JSON when rerendering', () => {
+    store.dispatch(
+      receivedResources({
+        models: [ConfigMapModel, SecretModel],
+        adminResources: [],
+        allResources: [],
+        configResources: [],
+        clusterOperatorConfigResources: [],
+        namespacedSet: null,
+        safeResources: [],
+        groupVersionMap: {},
+      }),
+    );
+
+    const { rerender } = render(
+      <Wrapper>
+        <WatchModels />
+      </Wrapper>,
+    );
+    rerender(
+      <Wrapper>
+        <WatchModels />
+      </Wrapper>,
+    );
+
+    expect(modelUpdate).toHaveBeenCalledTimes(2);
+    const [models1] = modelUpdate.mock.calls[0];
+    const [models2] = modelUpdate.mock.calls[1];
+    expect(models1).toEqual({ ConfigMap: ConfigMapModel, Secret: SecretModel });
+    expect(models2).toEqual({ ConfigMap: ConfigMapModel, Secret: SecretModel });
+
+    // It was saved in immutable redux store and will be cloned.
+    expect(models1).not.toBe(models2);
+    expect(models1.ConfigMap).toBe(models2.ConfigMap);
+    expect(models1.Secret).toBe(models2.Secret);
+  });
+
+  it('should return the same model JSON when rendering twice', () => {
+    store.dispatch(
+      receivedResources({
+        models: [ConfigMapModel, SecretModel],
+        adminResources: [],
+        allResources: [],
+        configResources: [],
+        clusterOperatorConfigResources: [],
+        namespacedSet: null,
+        safeResources: [],
+        groupVersionMap: {},
+      }),
+    );
+
+    render(
+      <Wrapper>
+        <WatchModels />
+        <WatchModels />
+      </Wrapper>,
+    );
+
+    expect(modelUpdate).toHaveBeenCalledTimes(2);
+    const [models1] = modelUpdate.mock.calls[0];
+    const [models2] = modelUpdate.mock.calls[1];
+    expect(models1).toEqual({ ConfigMap: ConfigMapModel, Secret: SecretModel });
+    expect(models2).toEqual({ ConfigMap: ConfigMapModel, Secret: SecretModel });
+
+    // It was saved in immutable redux store and will be cloned.
+    expect(models1).not.toBe(models2);
+    expect(models1.ConfigMap).toBe(models2.ConfigMap);
+    expect(models1.Secret).toBe(models2.Secret);
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResource.data.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResource.data.tsx
@@ -1,0 +1,26 @@
+export { PodModel } from '@console/internal/models';
+
+export const podData = {
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: {
+    name: 'my-pod',
+    namespace: 'default',
+    resourceVersion: '123',
+  },
+};
+
+export const podList = {
+  apiVersion: 'v1',
+  kind: 'PodList',
+  items: ['my-pod1', 'my-pod2', 'my-pod3'].map((name) => ({
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name,
+      namespace: 'default',
+      resourceVersion: '123',
+    },
+  })),
+  metadata: { resourceVersion: '123' },
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResource.spec.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResource.spec.tsx
@@ -426,7 +426,7 @@ describe('useK8sWatchResource', () => {
     const itemWatcher1 = resourceUpdate.mock.calls[0][0];
     const itemWatcher2 = resourceUpdate.mock.calls[1][0];
     expect(itemWatcher1).toEqual(itemWatcher2);
-    expect(itemWatcher1).not.toBe(itemWatcher2);
+    expect(itemWatcher1).toBe(itemWatcher2);
 
     resourceUpdate.mockClear();
   });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResource.spec.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResource.spec.tsx
@@ -1,0 +1,433 @@
+import * as React from 'react';
+import { act, cleanup, render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { combineReducers, createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import { receivedResources } from '@console/internal/actions/k8s';
+import { SDKReducers } from '../../../../app';
+import { WatchK8sResource } from '../../../../extensions/console-types';
+import { k8sList, k8sGet } from '../../k8s-resource';
+import { setPluginStore, k8sWatch } from '../../k8s-utils';
+import { useK8sWatchResource } from '../useK8sWatchResource';
+import { PodModel, podData, podList } from './useK8sWatchResource.data';
+
+// Mock network calls
+jest.mock('../../k8s-resource', () => ({
+  k8sList: jest.fn(() => {}),
+  k8sGet: jest.fn(),
+}));
+jest.mock('../../k8s-utils', () => ({
+  ...require.requireActual('../../k8s-utils'),
+  k8sWatch: jest.fn(),
+}));
+const k8sListMock = k8sList as jest.Mock;
+const k8sGetMock = k8sGet as jest.Mock;
+const k8sWatchMock = k8sWatch as jest.Mock;
+
+// Redux wrapper
+let store;
+const Wrapper: React.FC = ({ children }) => <Provider store={store}>{children}</Provider>;
+
+// Object under test
+const resourceUpdate = jest.fn();
+const WatchResource: React.FC<{ initResource: WatchK8sResource }> = ({ initResource }) => {
+  resourceUpdate(...useK8sWatchResource(initResource));
+  return null;
+};
+
+beforeEach(() => {
+  // Init k8s redux store with just one model
+  setPluginStore({ getExtensionsInUse: () => [] });
+  store = createStore(combineReducers(SDKReducers), {}, applyMiddleware(thunk));
+  store.dispatch(
+    receivedResources({
+      models: [PodModel],
+      adminResources: [],
+      allResources: [],
+      configResources: [],
+      clusterOperatorConfigResources: [],
+      namespacedSet: null,
+      safeResources: [],
+      groupVersionMap: {},
+    }),
+  );
+
+  jest.useFakeTimers();
+  jest.resetAllMocks();
+
+  k8sListMock.mockReturnValue(Promise.resolve(podList));
+  k8sGetMock.mockReturnValue(Promise.resolve(podData));
+  const wsMock = {
+    onclose: () => wsMock,
+    ondestroy: () => wsMock,
+    onbulkmessage: () => wsMock,
+    destroy: () => wsMock,
+  };
+  k8sWatchMock.mockReturnValue(wsMock);
+});
+
+afterEach(async () => {
+  // Ensure that there is no timer left which triggers a rerendering
+  await act(async () => jest.runAllTimers());
+
+  cleanup();
+
+  // Ensure that there is no unexpected api calls
+  expect(k8sListMock).toHaveBeenCalledTimes(0);
+  expect(k8sGetMock).toHaveBeenCalledTimes(0);
+  expect(k8sWatchMock).toHaveBeenCalledTimes(0);
+  expect(resourceUpdate).toHaveBeenCalledTimes(0);
+
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+describe('useK8sWatchResource', () => {
+  it('should not fetch any data if watch parameter is null', async () => {
+    const initResource: WatchK8sResource = null;
+    render(
+      <Wrapper>
+        <WatchResource initResource={initResource} />
+      </Wrapper>,
+    );
+
+    expect(resourceUpdate).toHaveBeenCalledTimes(1);
+    expect(resourceUpdate.mock.calls[0]).toEqual([undefined, true, undefined]);
+    resourceUpdate.mockClear();
+  });
+
+  it('should not fetch any data if watch parameter is null also when rerender and unmount', () => {
+    const initResource: WatchK8sResource = null;
+    const { rerender, unmount } = render(
+      <Wrapper>
+        <WatchResource initResource={initResource} />
+      </Wrapper>,
+    );
+    rerender(
+      <Wrapper>
+        <WatchResource initResource={initResource} />
+      </Wrapper>,
+    );
+    unmount();
+
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0]).toEqual([undefined, true, undefined]);
+    expect(resourceUpdate.mock.calls[1]).toEqual([undefined, true, undefined]);
+    resourceUpdate.mockClear();
+  });
+
+  it('should return an empty array and fetch data (via list+watch) for a known model (PodModel)', async () => {
+    const initResource: WatchK8sResource = {
+      kind: 'Pod',
+      isList: true,
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResource={initResource} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call is fetched?
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0]).toEqual([[], false, undefined]);
+    expect(resourceUpdate.mock.calls[1]).toEqual([[], false, '']);
+
+    // Assert API calls
+    expect(k8sListMock).toHaveBeenCalledTimes(1);
+    expect(k8sListMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', limit: 250 },
+      true,
+      {},
+      'local-cluster',
+    ]);
+    k8sListMock.mockClear();
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sWatchMock).toHaveBeenCalledTimes(1);
+    expect(k8sWatchMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', resourceVersion: '123' },
+      { timeout: 60000 },
+    ]);
+    k8sWatchMock.mockClear();
+
+    expect(resourceUpdate).toHaveBeenCalledTimes(3);
+    expect(resourceUpdate.mock.calls[2]).toEqual([podList.items, true, '']);
+    resourceUpdate.mockClear();
+  });
+
+  it('should return an object and fetch data (via get+watch) for a known model (PodModel)', async () => {
+    const initResource: WatchK8sResource = {
+      kind: 'Pod',
+      name: 'my-pod',
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResource={initResource} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call is fetched?
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0]).toEqual([{}, false, undefined]);
+    // TODO: should this really switch from {} to null!?
+    expect(resourceUpdate.mock.calls[1]).toEqual([null, false, '']);
+    resourceUpdate.mockClear();
+
+    // Assert API calls
+    expect(k8sGetMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetMock.mock.calls[0]).toEqual([
+      PodModel,
+      'my-pod',
+      undefined,
+      { cluster: 'local-cluster' },
+      {},
+    ]);
+    k8sGetMock.mockClear();
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sWatchMock).toHaveBeenCalledTimes(1);
+    expect(k8sWatchMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', fieldSelector: 'metadata.name=my-pod' },
+      { subprotocols: undefined },
+    ]);
+    k8sWatchMock.mockClear();
+
+    // expect(resourceUpdate).toHaveBeenCalledTimes(3);
+    // expect(resourceUpdate.mock.calls[2]).toEqual([podList.items, true, '']);
+    resourceUpdate.mockClear();
+  });
+
+  it('should return an error state when fetching a list that fails', async () => {
+    k8sListMock.mockReturnValue(Promise.reject(new Error('Network issue')));
+
+    const initResource: WatchK8sResource = {
+      kind: 'Pod',
+      isList: true,
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResource={initResource} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call failed
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0]).toEqual([[], false, undefined]);
+    expect(resourceUpdate.mock.calls[1]).toEqual([[], false, '']);
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sListMock).toHaveBeenCalledTimes(1);
+    expect(k8sListMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', limit: 250 },
+      true,
+      {},
+      'local-cluster',
+    ]);
+    k8sListMock.mockClear();
+
+    expect(resourceUpdate.mock.calls[2]).toEqual([[], false, new Error('Network issue')]);
+    resourceUpdate.mockClear();
+  });
+
+  it('should return an error state when fetching a single item that fails', async () => {
+    k8sGetMock.mockReturnValue(Promise.reject(new Error('Network issue')));
+
+    const initResource: WatchK8sResource = {
+      kind: 'Pod',
+      name: 'my-pod',
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResource={initResource} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call failed
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0]).toEqual([{}, false, undefined]);
+    expect(resourceUpdate.mock.calls[1]).toEqual([null, false, '']);
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sGetMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetMock.mock.calls[0]).toEqual([
+      PodModel,
+      'my-pod',
+      undefined,
+      { cluster: 'local-cluster' },
+      {},
+    ]);
+    k8sGetMock.mockClear();
+
+    // TODO: Unexpected watch call! The watch call was not triggered when watching a list
+    expect(k8sWatchMock).toHaveBeenCalledTimes(1);
+    expect(k8sWatchMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', fieldSelector: 'metadata.name=my-pod' },
+      { subprotocols: undefined },
+    ]);
+    k8sWatchMock.mockClear();
+
+    expect(resourceUpdate.mock.calls[2]).toEqual([null, false, new Error('Network issue')]);
+    resourceUpdate.mockClear();
+  });
+
+  it('should return an error when try to fetch a list for an unknown model', async () => {
+    const initResource: WatchK8sResource = {
+      kind: 'Unknown',
+      isList: true,
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResource={initResource} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call is fetched?
+    expect(resourceUpdate).toHaveBeenCalledTimes(1);
+    expect(resourceUpdate.mock.calls[0]).toEqual([[], true, new Error('Model does not exist')]);
+    resourceUpdate.mockClear();
+  });
+
+  it('should return an error when try to fetch a single item for an unknown model', async () => {
+    const initResource: WatchK8sResource = {
+      kind: 'Unknown',
+      name: 'unknown-resource',
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResource={initResource} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call is fetched?
+    expect(resourceUpdate).toHaveBeenCalledTimes(1);
+    expect(resourceUpdate.mock.calls[0]).toEqual([{}, true, new Error('Model does not exist')]);
+    resourceUpdate.mockClear();
+  });
+
+  it('should not call the same data twice if two components watching for the same resource list', async () => {
+    const initResource: WatchK8sResource = {
+      kind: 'Pod',
+      isList: true,
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResource={initResource} />
+        <WatchResource initResource={initResource} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call is fetched?
+    expect(resourceUpdate).toHaveBeenCalledTimes(4);
+    expect(resourceUpdate.mock.calls[0]).toEqual([[], false, undefined]);
+    expect(resourceUpdate.mock.calls[1]).toEqual([[], false, undefined]);
+    expect(resourceUpdate.mock.calls[2]).toEqual([[], false, '']);
+    expect(resourceUpdate.mock.calls[3]).toEqual([[], false, '']);
+    resourceUpdate.mockClear();
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sListMock).toHaveBeenCalledTimes(1);
+    expect(k8sListMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', limit: 250 },
+      true,
+      {},
+      'local-cluster',
+    ]);
+    k8sListMock.mockClear();
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sWatchMock).toHaveBeenCalledTimes(1);
+    expect(k8sWatchMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', resourceVersion: '123' },
+      { timeout: 60000 },
+    ]);
+    k8sWatchMock.mockClear();
+
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0]).toEqual([podList.items, true, '']);
+    expect(resourceUpdate.mock.calls[1]).toEqual([podList.items, true, '']);
+
+    const itemsWatcher1 = resourceUpdate.mock.calls[0][0];
+    const itemsWatcher2 = resourceUpdate.mock.calls[1][0];
+    expect(itemsWatcher1).toEqual(itemsWatcher2);
+    // Unluckly the data are not the same at the moment
+    expect(itemsWatcher1).not.toBe(itemsWatcher2);
+
+    resourceUpdate.mockClear();
+  });
+
+  it('should not call the same data twice if two components watching for the same resource by name', async () => {
+    const initResource: WatchK8sResource = {
+      kind: 'Pod',
+      name: 'my-pod',
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResource={initResource} />
+        <WatchResource initResource={initResource} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call is fetched?
+    expect(resourceUpdate).toHaveBeenCalledTimes(4);
+    expect(resourceUpdate.mock.calls[0]).toEqual([{}, false, undefined]);
+    expect(resourceUpdate.mock.calls[1]).toEqual([{}, false, undefined]);
+    // TODO: should this really switch from {} to null!?
+    expect(resourceUpdate.mock.calls[2]).toEqual([null, false, '']);
+    expect(resourceUpdate.mock.calls[3]).toEqual([null, false, '']);
+    resourceUpdate.mockClear();
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sGetMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetMock.mock.calls[0]).toEqual([
+      PodModel,
+      'my-pod',
+      undefined,
+      { cluster: 'local-cluster' },
+      {},
+    ]);
+    k8sGetMock.mockClear();
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sWatchMock).toHaveBeenCalledTimes(1);
+    expect(k8sWatchMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', fieldSelector: 'metadata.name=my-pod' },
+      { subprotocols: undefined },
+    ]);
+    k8sWatchMock.mockClear();
+
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0]).toEqual([podData, true, '']);
+    expect(resourceUpdate.mock.calls[1]).toEqual([podData, true, '']);
+
+    const itemWatcher1 = resourceUpdate.mock.calls[0][0];
+    const itemWatcher2 = resourceUpdate.mock.calls[1][0];
+    expect(itemWatcher1).toEqual(itemWatcher2);
+    expect(itemWatcher1).not.toBe(itemWatcher2);
+
+    resourceUpdate.mockClear();
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResources.data.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResources.data.tsx
@@ -1,0 +1,26 @@
+export { PodModel } from '@console/internal/models';
+
+export const podData = {
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: {
+    name: 'my-pod',
+    namespace: 'default',
+    resourceVersion: '123',
+  },
+};
+
+export const podList = {
+  apiVersion: 'v1',
+  kind: 'PodList',
+  items: ['my-pod1', 'my-pod2', 'my-pod3'].map((name) => ({
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name,
+      namespace: 'default',
+      resourceVersion: '123',
+    },
+  })),
+  metadata: { resourceVersion: '123' },
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResources.spec.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResources.spec.tsx
@@ -606,7 +606,7 @@ describe('useK8sWatchResource', () => {
     const itemWatcher1 = resourceUpdate.mock.calls[0][0].pod.data;
     const itemWatcher2 = resourceUpdate.mock.calls[1][0].pod.data;
     expect(itemWatcher1).toEqual(itemWatcher2);
-    expect(itemWatcher1).not.toBe(itemWatcher2);
+    expect(itemWatcher1).toBe(itemWatcher2);
 
     resourceUpdate.mockClear();
   });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResources.spec.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResources.spec.tsx
@@ -1,0 +1,613 @@
+import * as React from 'react';
+import { act, cleanup, render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { combineReducers, createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import { receivedResources } from '@console/internal/actions/k8s';
+import { SDKReducers } from '../../../../app';
+import { WatchK8sResources } from '../../../../extensions/console-types';
+import { k8sList, k8sGet } from '../../k8s-resource';
+import { setPluginStore, k8sWatch } from '../../k8s-utils';
+import { useK8sWatchResources } from '../useK8sWatchResources';
+import { PodModel, podData, podList } from './useK8sWatchResource.data';
+
+// Mock network calls
+jest.mock('../../k8s-resource', () => ({
+  k8sList: jest.fn(() => {}),
+  k8sGet: jest.fn(),
+}));
+jest.mock('../../k8s-utils', () => ({
+  ...require.requireActual('../../k8s-utils'),
+  k8sWatch: jest.fn(),
+}));
+const k8sListMock = k8sList as jest.Mock;
+const k8sGetMock = k8sGet as jest.Mock;
+const k8sWatchMock = k8sWatch as jest.Mock;
+
+// Redux wrapper
+let store;
+const Wrapper: React.FC = ({ children }) => <Provider store={store}>{children}</Provider>;
+
+// Object under test
+const resourceUpdate = jest.fn();
+const WatchResource: React.FC<{ initResources: WatchK8sResources<{}> }> = ({ initResources }) => {
+  resourceUpdate(useK8sWatchResources(initResources));
+  return null;
+};
+
+beforeEach(() => {
+  // Init k8s redux store with just one model
+  setPluginStore({ getExtensionsInUse: () => [] });
+  store = createStore(combineReducers(SDKReducers), {}, applyMiddleware(thunk));
+  store.dispatch(
+    receivedResources({
+      models: [PodModel],
+      adminResources: [],
+      allResources: [],
+      configResources: [],
+      clusterOperatorConfigResources: [],
+      namespacedSet: null,
+      safeResources: [],
+      groupVersionMap: {},
+    }),
+  );
+
+  jest.useFakeTimers();
+  jest.resetAllMocks();
+
+  k8sListMock.mockReturnValue(Promise.resolve(podList));
+  k8sGetMock.mockReturnValue(Promise.resolve(podData));
+  const wsMock = {
+    onclose: () => wsMock,
+    ondestroy: () => wsMock,
+    onbulkmessage: () => wsMock,
+    destroy: () => wsMock,
+  };
+  k8sWatchMock.mockReturnValue(wsMock);
+});
+
+afterEach(async () => {
+  // Ensure that there is no timer left which triggers a rerendering
+  await act(async () => jest.runAllTimers());
+
+  cleanup();
+
+  // Ensure that there is no unexpected api calls
+  expect(k8sListMock).toHaveBeenCalledTimes(0);
+  expect(k8sGetMock).toHaveBeenCalledTimes(0);
+  expect(k8sWatchMock).toHaveBeenCalledTimes(0);
+  expect(resourceUpdate).toHaveBeenCalledTimes(0);
+
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+describe('useK8sWatchResource', () => {
+  it('should not fetch any data if watch parameter is empty', async () => {
+    const initResources: WatchK8sResources<{}> = {};
+    render(
+      <Wrapper>
+        <WatchResource initResources={initResources} />
+      </Wrapper>,
+    );
+
+    expect(resourceUpdate).toHaveBeenCalledTimes(1);
+    expect(resourceUpdate.mock.calls[0]).toEqual([{}]);
+    resourceUpdate.mockClear();
+  });
+
+  it('should not fetch any data if watch parameter is empty also when rerender and unmount', () => {
+    const initResources: WatchK8sResources<{}> = {};
+    const { rerender, unmount } = render(
+      <Wrapper>
+        <WatchResource initResources={initResources} />
+      </Wrapper>,
+    );
+    rerender(
+      <Wrapper>
+        <WatchResource initResources={initResources} />
+      </Wrapper>,
+    );
+    unmount();
+
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0]).toEqual([{}]);
+    expect(resourceUpdate.mock.calls[1]).toEqual([{}]);
+    resourceUpdate.mockClear();
+  });
+
+  it('should return an empty array and fetch data (via list+watch) for a known model (PodModel)', async () => {
+    const initResources: WatchK8sResources<{}> = {
+      pods: {
+        kind: 'Pod',
+        isList: true,
+      },
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResources={initResources} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call is fetched?
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0]).toEqual([
+      { pods: { data: [], loaded: false, loadError: undefined } },
+    ]);
+    expect(resourceUpdate.mock.calls[1]).toEqual([
+      { pods: { data: [], loaded: false, loadError: '' } },
+    ]);
+
+    // Assert API calls
+    expect(k8sListMock).toHaveBeenCalledTimes(1);
+    expect(k8sListMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', limit: 250 },
+      true,
+      {},
+      'local-cluster',
+    ]);
+    k8sListMock.mockClear();
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sWatchMock).toHaveBeenCalledTimes(1);
+    expect(k8sWatchMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', resourceVersion: '123' },
+      { timeout: 60000 },
+    ]);
+    k8sWatchMock.mockClear();
+
+    expect(resourceUpdate).toHaveBeenCalledTimes(3);
+    expect(resourceUpdate.mock.calls[2]).toEqual([
+      {
+        pods: {
+          data: podList.items,
+          loaded: true,
+          loadError: '',
+        },
+      },
+    ]);
+    resourceUpdate.mockClear();
+  });
+
+  it('should return an object and fetch data (via get+watch) for a known model (PodModel)', async () => {
+    const initResources: WatchK8sResources<{}> = {
+      pod: {
+        kind: 'Pod',
+        name: 'my-pod',
+      },
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResources={initResources} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call is fetched?
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0]).toEqual([
+      {
+        pod: {
+          data: {},
+          loaded: false,
+          loadError: undefined,
+        },
+      },
+    ]);
+    // TODO: should this really switch from {} to null!?
+    expect(resourceUpdate.mock.calls[1]).toEqual([
+      {
+        pod: {
+          data: null,
+          loaded: false,
+          loadError: '',
+        },
+      },
+    ]);
+    resourceUpdate.mockClear();
+
+    // Assert API calls
+    expect(k8sGetMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetMock.mock.calls[0]).toEqual([
+      PodModel,
+      'my-pod',
+      undefined,
+      { cluster: 'local-cluster' },
+      {},
+    ]);
+    k8sGetMock.mockClear();
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sWatchMock).toHaveBeenCalledTimes(1);
+    expect(k8sWatchMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', fieldSelector: 'metadata.name=my-pod' },
+      { subprotocols: undefined },
+    ]);
+    k8sWatchMock.mockClear();
+
+    // expect(resourceUpdate).toHaveBeenCalledTimes(3);
+    // expect(resourceUpdate.mock.calls[2]).toEqual([[podList.items, true, '']]);
+    resourceUpdate.mockClear();
+  });
+
+  it('should return an error state when fetching a list that fails', async () => {
+    k8sListMock.mockReturnValue(Promise.reject(new Error('Network issue')));
+
+    const initResources: WatchK8sResources<{}> = {
+      pods: {
+        kind: 'Pod',
+        isList: true,
+      },
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResources={initResources} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call failed
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0]).toEqual([
+      {
+        pods: {
+          data: [],
+          loaded: false,
+          loadError: undefined,
+        },
+      },
+    ]);
+    expect(resourceUpdate.mock.calls[1]).toEqual([
+      {
+        pods: {
+          data: [],
+          loaded: false,
+          loadError: '',
+        },
+      },
+    ]);
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sListMock).toHaveBeenCalledTimes(1);
+    expect(k8sListMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', limit: 250 },
+      true,
+      {},
+      'local-cluster',
+    ]);
+    k8sListMock.mockClear();
+
+    expect(resourceUpdate.mock.calls[2]).toEqual([
+      {
+        pods: {
+          data: [],
+          loaded: false,
+          loadError: new Error('Network issue'),
+        },
+      },
+    ]);
+    resourceUpdate.mockClear();
+  });
+
+  it('should return an error state when fetching a single item that fails', async () => {
+    k8sGetMock.mockReturnValue(Promise.reject(new Error('Network issue')));
+
+    const initResources: WatchK8sResources<{}> = {
+      pod: {
+        kind: 'Pod',
+        name: 'my-pod',
+      },
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResources={initResources} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call failed
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0]).toEqual([
+      {
+        pod: {
+          data: {},
+          loaded: false,
+          loadError: undefined,
+        },
+      },
+    ]);
+    expect(resourceUpdate.mock.calls[1]).toEqual([
+      {
+        pod: {
+          data: null,
+          loaded: false,
+          loadError: '',
+        },
+      },
+    ]);
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sGetMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetMock.mock.calls[0]).toEqual([
+      PodModel,
+      'my-pod',
+      undefined,
+      { cluster: 'local-cluster' },
+      {},
+    ]);
+    k8sGetMock.mockClear();
+
+    // TODO: Unexpected watch call! The watch call was not triggered when watching a list
+    expect(k8sWatchMock).toHaveBeenCalledTimes(1);
+    expect(k8sWatchMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', fieldSelector: 'metadata.name=my-pod' },
+      { subprotocols: undefined },
+    ]);
+    k8sWatchMock.mockClear();
+
+    expect(resourceUpdate.mock.calls[2]).toEqual([
+      {
+        pod: {
+          data: null,
+          loaded: false,
+          loadError: new Error('Network issue'),
+        },
+      },
+    ]);
+    resourceUpdate.mockClear();
+  });
+
+  it('should return an error when try to fetch a list for an unknown model', async () => {
+    const initResources: WatchK8sResources<{}> = {
+      unknown: {
+        kind: 'Unknown',
+        isList: true,
+      },
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResources={initResources} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call is fetched?
+    expect(resourceUpdate).toHaveBeenCalledTimes(1);
+    expect(resourceUpdate.mock.calls[0]).toEqual([
+      {
+        unknown: {
+          data: [],
+          loaded: true,
+          loadError: new Error('Model does not exist'),
+        },
+      },
+    ]);
+    resourceUpdate.mockClear();
+  });
+
+  it('should return an error when try to fetch a single item for an unknown model', async () => {
+    const initResources: WatchK8sResources<{}> = {
+      unknown: {
+        kind: 'Unknown',
+        name: 'unknown-resource',
+      },
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResources={initResources} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call is fetched?
+    expect(resourceUpdate).toHaveBeenCalledTimes(1);
+    expect(resourceUpdate.mock.calls[0]).toEqual([
+      {
+        unknown: {
+          data: {},
+          loaded: true,
+          loadError: new Error('Model does not exist'),
+        },
+      },
+    ]);
+    resourceUpdate.mockClear();
+  });
+
+  it('should not call the same data twice if two components watching for the same resource list', async () => {
+    const initResources: WatchK8sResources<{}> = {
+      pods: {
+        kind: 'Pod',
+        isList: true,
+      },
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResources={initResources} />
+        <WatchResource initResources={initResources} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call is fetched?
+    expect(resourceUpdate).toHaveBeenCalledTimes(4);
+    expect(resourceUpdate.mock.calls[0]).toEqual([
+      { pods: { data: [], loaded: false, loadError: undefined } },
+    ]);
+    expect(resourceUpdate.mock.calls[1]).toEqual([
+      { pods: { data: [], loaded: false, loadError: undefined } },
+    ]);
+    expect(resourceUpdate.mock.calls[2]).toEqual([
+      { pods: { data: [], loaded: false, loadError: '' } },
+    ]);
+    expect(resourceUpdate.mock.calls[3]).toEqual([
+      { pods: { data: [], loaded: false, loadError: '' } },
+    ]);
+    resourceUpdate.mockClear();
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sListMock).toHaveBeenCalledTimes(1);
+    expect(k8sListMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', limit: 250 },
+      true,
+      {},
+      'local-cluster',
+    ]);
+    k8sListMock.mockClear();
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sWatchMock).toHaveBeenCalledTimes(1);
+    expect(k8sWatchMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', resourceVersion: '123' },
+      { timeout: 60000 },
+    ]);
+    k8sWatchMock.mockClear();
+
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0]).toEqual([
+      {
+        pods: {
+          data: podList.items,
+          loaded: true,
+          loadError: '',
+        },
+      },
+    ]);
+    expect(resourceUpdate.mock.calls[1]).toEqual([
+      {
+        pods: {
+          data: podList.items,
+          loaded: true,
+          loadError: '',
+        },
+      },
+    ]);
+
+    const itemsWatcher1 = resourceUpdate.mock.calls[0][0].pods.data;
+    const itemsWatcher2 = resourceUpdate.mock.calls[1][0].pods.data;
+    expect(itemsWatcher1).toEqual(itemsWatcher2);
+    // Unluckly the data are not the same at the moment
+    expect(itemsWatcher1).not.toBe(itemsWatcher2);
+
+    resourceUpdate.mockClear();
+  });
+
+  it('should not call the same data twice if two components watching for the same resource by name', async () => {
+    const initResources: WatchK8sResources<{}> = {
+      pod: {
+        kind: 'Pod',
+        name: 'my-pod',
+      },
+    };
+    render(
+      <Wrapper>
+        <WatchResource initResources={initResources} />
+        <WatchResource initResources={initResources} />
+      </Wrapper>,
+    );
+
+    // Get updated after the list call is fetched?
+    expect(resourceUpdate).toHaveBeenCalledTimes(4);
+    expect(resourceUpdate.mock.calls[0]).toEqual([
+      {
+        pod: {
+          data: {},
+          loaded: false,
+          loadError: undefined,
+        },
+      },
+    ]);
+    expect(resourceUpdate.mock.calls[1]).toEqual([
+      {
+        pod: {
+          data: {},
+          loaded: false,
+          loadError: undefined,
+        },
+      },
+    ]);
+    // TODO: should this really switch from {} to null!?
+    expect(resourceUpdate.mock.calls[2]).toEqual([
+      {
+        pod: {
+          data: null,
+          loaded: false,
+          loadError: '',
+        },
+      },
+    ]);
+    expect(resourceUpdate.mock.calls[3]).toEqual([
+      {
+        pod: {
+          data: null,
+          loaded: false,
+          loadError: '',
+        },
+      },
+    ]);
+    resourceUpdate.mockClear();
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sGetMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetMock.mock.calls[0]).toEqual([
+      PodModel,
+      'my-pod',
+      undefined,
+      { cluster: 'local-cluster' },
+      {},
+    ]);
+    k8sGetMock.mockClear();
+
+    await act(async () => jest.runAllTimers());
+
+    // Assert API calls
+    expect(k8sWatchMock).toHaveBeenCalledTimes(1);
+    expect(k8sWatchMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', fieldSelector: 'metadata.name=my-pod' },
+      { subprotocols: undefined },
+    ]);
+    k8sWatchMock.mockClear();
+
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0]).toEqual([
+      {
+        pod: {
+          data: podData,
+          loaded: true,
+          loadError: '',
+        },
+      },
+    ]);
+    expect(resourceUpdate.mock.calls[1]).toEqual([
+      {
+        pod: {
+          data: podData,
+          loaded: true,
+          loadError: '',
+        },
+      },
+    ]);
+
+    const itemWatcher1 = resourceUpdate.mock.calls[0][0].pod.data;
+    const itemWatcher2 = resourceUpdate.mock.calls[1][0].pod.data;
+    expect(itemWatcher1).toEqual(itemWatcher2);
+    expect(itemWatcher1).not.toBe(itemWatcher2);
+
+    resourceUpdate.mockClear();
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/k8s-watcher.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/k8s-watcher.ts
@@ -47,15 +47,25 @@ export const makeQuery: MakeQuery = (namespace, labelSelector, fieldSelector, na
   return query;
 };
 
+export const INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL = Symbol('_cachedToJSResult');
+
 export const getReduxData = (immutableData, resource: WatchK8sResource) => {
   if (!immutableData) {
     return null;
   }
   if (resource.isList) {
-    return immutableData.toArray().map((a) => a.toJSON());
+    return immutableData.toArray().map((a) => {
+      if (!a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL]) {
+        a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = a.toJSON();
+      }
+      return a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL];
+    });
   }
   if (immutableData.toJSON) {
-    return immutableData.toJSON();
+    if (!immutableData[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL]) {
+      immutableData[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = immutableData.toJSON();
+    }
+    return immutableData[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL];
   }
   return null;
 };

--- a/frontend/public/components/utils/__tests__/firehose.data.tsx
+++ b/frontend/public/components/utils/__tests__/firehose.data.tsx
@@ -1,0 +1,42 @@
+import { Map as ImmutableMap } from 'immutable';
+
+export { PodModel } from '../../../models';
+
+export const podData = {
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: {
+    name: 'my-pod',
+    namespace: 'default',
+    resourceVersion: '123',
+  },
+};
+
+export const podList = {
+  apiVersion: 'v1',
+  kind: 'PodList',
+  items: ['my-pod1', 'my-pod2', 'my-pod3'].map((name) => ({
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name,
+      namespace: 'default',
+      resourceVersion: '123',
+    },
+  })),
+  metadata: { resourceVersion: '123' },
+};
+
+export const firehoseChildPropsWithoutModels = {
+  cluster: 'local-cluster',
+  inFlight: false,
+  k8sModels: ImmutableMap({}),
+  reduxIDs: [],
+  resources: {},
+  loaded: true,
+  loadError: undefined,
+  filters: {},
+  watchK8sList: expect.any(Function),
+  watchK8sObject: expect.any(Function),
+  stopK8sWatch: expect.any(Function),
+};

--- a/frontend/public/components/utils/__tests__/firehose.spec.tsx
+++ b/frontend/public/components/utils/__tests__/firehose.spec.tsx
@@ -1,0 +1,892 @@
+import * as React from 'react';
+import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
+import { combineReducers, createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import { Provider } from 'react-redux';
+import { act, cleanup, render } from '@testing-library/react';
+import { SDKReducers } from '@console/dynamic-plugin-sdk/src/app';
+import { k8sList, k8sGet } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-resource';
+import { setPluginStore, k8sWatch } from '@console/dynamic-plugin-sdk/src/utils/k8s';
+import { receivedResources } from '../../../actions/k8s';
+import { processReduxId, Firehose } from '../firehose';
+import { PodModel, podData, podList, firehoseChildPropsWithoutModels } from './firehose.data';
+
+// Mock network calls
+jest.mock('@console/dynamic-plugin-sdk/src/utils/k8s/k8s-resource', () => ({
+  k8sList: jest.fn(() => {}),
+  k8sGet: jest.fn(),
+}));
+jest.mock('@console/dynamic-plugin-sdk/src/utils/k8s', () => ({
+  ...require.requireActual('@console/dynamic-plugin-sdk/src/utils/k8s'),
+  k8sWatch: jest.fn(),
+}));
+const k8sListMock = k8sList as jest.Mock;
+const k8sGetMock = k8sGet as jest.Mock;
+const k8sWatchMock = k8sWatch as jest.Mock;
+
+// Redux wrapper
+let store;
+const Wrapper: React.FC = ({ children }) => <Provider store={store}>{children}</Provider>;
+
+// Object under test
+const resourceUpdate = jest.fn();
+const Child: React.FC = (props) => {
+  resourceUpdate(props);
+  return null;
+};
+
+describe('processReduxId', () => {
+  const k8s = ImmutableMap({
+    ['Pods']: ImmutableMap({
+      data: ImmutableList(
+        ['my-pod1', 'my-pod2', 'my-pod3'].map((name) =>
+          ImmutableMap({
+            apiVersion: 'v1',
+            kind: 'Pod',
+            metadata: {
+              name,
+              namespace: 'default',
+              resourceVersion: '123',
+            },
+          }),
+        ),
+      ),
+    }),
+    ['Pods~~~my-pod']: ImmutableMap({
+      data: ImmutableMap({
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: {
+          name: 'my-pod',
+          namespace: 'default',
+          resourceVersion: '123',
+        },
+      }),
+    }),
+  });
+
+  it('should return an empty object when reduxID prop is missing', () => {
+    const props = { kind: 'UnknownKind' };
+    expect(processReduxId({ k8s }, props)).toEqual({});
+  });
+
+  it("should return an object without data when extract a list which doesn't exist", () => {
+    const props = {
+      reduxID: 'Unknown',
+      kind: 'Pod',
+      isList: true,
+    };
+    expect(processReduxId({ k8s }, props)).toEqual({
+      data: undefined,
+      filters: {},
+      kind: 'Pod',
+      loadError: undefined,
+      loaded: undefined,
+      optional: undefined,
+      selected: undefined,
+    });
+  });
+
+  it("should return an empty object when extract a single item which doesn't exist", () => {
+    const props = {
+      reduxID: 'Unknown',
+      kind: 'Pod',
+      isList: false,
+    };
+    expect(processReduxId({ k8s }, props)).toEqual({});
+  });
+
+  it('should return an Firehose object with data when extract a list', () => {
+    const props = {
+      reduxID: 'Pods',
+      kind: 'Pod',
+      isList: true,
+    };
+    expect(processReduxId({ k8s }, props)).toEqual({
+      kind: 'Pod',
+      data: [
+        {
+          apiVersion: 'v1',
+          kind: 'Pod',
+          metadata: { name: 'my-pod1', namespace: 'default', resourceVersion: '123' },
+        },
+        {
+          apiVersion: 'v1',
+          kind: 'Pod',
+          metadata: { name: 'my-pod2', namespace: 'default', resourceVersion: '123' },
+        },
+        {
+          apiVersion: 'v1',
+          kind: 'Pod',
+          metadata: { name: 'my-pod3', namespace: 'default', resourceVersion: '123' },
+        },
+      ],
+      filters: {},
+      loadError: undefined,
+      loaded: undefined,
+      optional: undefined,
+      selected: undefined,
+    });
+  });
+
+  it('should return an Firehose object with data when extract a single item', () => {
+    const props = {
+      reduxID: 'Pods~~~my-pod',
+      kind: 'Pod',
+      isList: false,
+    };
+    expect(processReduxId({ k8s }, props)).toEqual({
+      data: {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'my-pod', namespace: 'default', resourceVersion: '123' },
+      },
+      optional: undefined,
+    });
+  });
+});
+
+describe('Firehose', () => {
+  beforeEach(() => {
+    // Init k8s redux store with just one model
+    setPluginStore({ getExtensionsInUse: () => [] });
+    store = createStore(combineReducers(SDKReducers), {}, applyMiddleware(thunk));
+    store.dispatch(
+      receivedResources({
+        models: [PodModel],
+        adminResources: [],
+        allResources: [],
+        configResources: [],
+        clusterOperatorConfigResources: [],
+        namespacedSet: null,
+        safeResources: [],
+        groupVersionMap: {},
+      }),
+    );
+
+    jest.useFakeTimers();
+    jest.resetAllMocks();
+
+    k8sListMock.mockReturnValue(Promise.resolve(podList));
+    k8sGetMock.mockReturnValue(Promise.resolve(podData));
+    const wsMock = {
+      onclose: () => wsMock,
+      ondestroy: () => wsMock,
+      onbulkmessage: () => wsMock,
+      destroy: () => wsMock,
+    };
+    k8sWatchMock.mockReturnValue(wsMock);
+  });
+
+  afterEach(async () => {
+    // Ensure that there is no timer left which triggers a rerendering
+    await act(async () => jest.runAllTimers());
+
+    cleanup();
+
+    // Ensure that there is no unexpected api calls
+    expect(k8sListMock).toHaveBeenCalledTimes(0);
+    expect(k8sGetMock).toHaveBeenCalledTimes(0);
+    expect(k8sWatchMock).toHaveBeenCalledTimes(0);
+    expect(resourceUpdate).toHaveBeenCalledTimes(0);
+
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('should return an empty object when reduxID prop is missing (also when rerender or unmount)', async () => {
+    const { rerender, unmount } = render(
+      <Wrapper>
+        <Firehose resources={[]}>
+          <Child />
+        </Firehose>
+      </Wrapper>,
+    );
+    rerender(
+      <Wrapper>
+        <Firehose resources={[]}>
+          <Child />
+        </Firehose>
+      </Wrapper>,
+    );
+    unmount();
+
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0][0]).toEqual(firehoseChildPropsWithoutModels);
+    expect(resourceUpdate.mock.calls[1][0]).toEqual(firehoseChildPropsWithoutModels);
+    resourceUpdate.mockClear();
+  });
+
+  it('should fetch and update child props when requesting a list of resources successfully', async () => {
+    const resources = [
+      {
+        prop: 'pods',
+        kind: 'Pod',
+        isList: true,
+        namespace: 'my-namespace',
+      },
+    ];
+    const { rerender, unmount } = render(
+      <Wrapper>
+        <Firehose resources={resources}>
+          <Child />
+        </Firehose>
+      </Wrapper>,
+    );
+
+    expect(k8sListMock).toHaveBeenCalledTimes(1);
+    expect(k8sListMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', limit: 250, ns: 'my-namespace' },
+      true,
+      {},
+      'local-cluster',
+    ]);
+    k8sListMock.mockClear();
+
+    // Expect initial render child-props
+    const podsNotLoadedYet = {
+      kind: 'Pod',
+      data: [],
+      loaded: false,
+      loadError: '',
+      filters: {},
+      selected: null,
+      optional: undefined,
+    };
+    const podsNotLoadedYetProps = {
+      ...firehoseChildPropsWithoutModels,
+      k8sModels: ImmutableMap({ Pod: PodModel }),
+      reduxIDs: ['local-clustercore~v1~Pod---{"ns":"my-namespace"}'],
+      loaded: false,
+      // Yes, same data twice at the moment.
+      pods: podsNotLoadedYet,
+      resources: { pods: podsNotLoadedYet },
+    };
+    expect(resourceUpdate).toHaveBeenCalledTimes(1);
+    expect(resourceUpdate.mock.calls[0][0]).toEqual(podsNotLoadedYetProps);
+
+    // Finish API call
+    await act(async () => jest.runAllTimers());
+
+    // Expect updated child-props
+    const podsLoaded = {
+      kind: 'Pod',
+      data: ['my-pod1', 'my-pod2', 'my-pod3'].map((name) => ({
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: {
+          name,
+          namespace: 'default',
+          resourceVersion: '123',
+        },
+      })),
+      loaded: true,
+      loadError: '',
+      filters: {},
+      selected: null,
+      optional: undefined,
+    };
+    const podsLoadedProps = {
+      ...firehoseChildPropsWithoutModels,
+      k8sModels: ImmutableMap({ Pod: PodModel }),
+      reduxIDs: ['local-clustercore~v1~Pod---{"ns":"my-namespace"}'],
+      loaded: true,
+      // Yes, same data twice at the moment.
+      pods: podsLoaded,
+      resources: { pods: podsLoaded },
+    };
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[1][0]).toEqual(podsLoadedProps);
+
+    // Check rerender and unmount
+    rerender(
+      <Wrapper>
+        <Firehose resources={resources}>
+          <Child />
+        </Firehose>
+      </Wrapper>,
+    );
+    unmount();
+    expect(resourceUpdate).toHaveBeenCalledTimes(3);
+    expect(resourceUpdate.mock.calls[2][0]).toEqual(podsLoadedProps);
+
+    resourceUpdate.mockClear();
+  });
+
+  it('should fetch and update child props when requesting a single resource successfully', async () => {
+    const resources = [
+      {
+        prop: 'pod',
+        kind: 'Pod',
+        namespace: 'my-namespace',
+        name: 'my-pod',
+      },
+    ];
+    const { rerender, unmount } = render(
+      <Wrapper>
+        <Firehose resources={resources}>
+          <Child />
+        </Firehose>
+      </Wrapper>,
+    );
+
+    expect(k8sGetMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetMock.mock.calls[0]).toEqual([
+      PodModel,
+      'my-pod',
+      'my-namespace',
+      { cluster: 'local-cluster' },
+      {},
+    ]);
+    k8sGetMock.mockClear();
+
+    // Expect initial render child-props
+    const podNotLoadedYet = {
+      data: {},
+      loaded: false,
+      loadError: '',
+      optional: undefined,
+    };
+    const podsNotLoadedYetProps = {
+      ...firehoseChildPropsWithoutModels,
+      k8sModels: ImmutableMap({ Pod: PodModel }),
+      reduxIDs: ['local-clustercore~v1~Pod---{"ns":"my-namespace","name":"my-pod"}'],
+      loaded: false,
+      // Yes, same data twice at the moment.
+      pod: podNotLoadedYet,
+      resources: { pod: podNotLoadedYet },
+    };
+    expect(resourceUpdate).toHaveBeenCalledTimes(1);
+    expect(resourceUpdate.mock.calls[0][0]).toEqual(podsNotLoadedYetProps);
+
+    // Finish API call
+    await act(async () => jest.runAllTimers());
+
+    // Expect updated child-props
+    const podLoaded = {
+      data: {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: {
+          name: 'my-pod',
+          namespace: 'default',
+          resourceVersion: '123',
+        },
+      },
+      loaded: true,
+      loadError: '',
+      optional: undefined,
+    };
+    const podLoadedProps = {
+      ...firehoseChildPropsWithoutModels,
+      k8sModels: ImmutableMap({ Pod: PodModel }),
+      reduxIDs: ['local-clustercore~v1~Pod---{"ns":"my-namespace","name":"my-pod"}'],
+      loaded: true,
+      // Yes, same data twice at the moment.
+      pod: podLoaded,
+      resources: { pod: podLoaded },
+    };
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[1][0]).toEqual(podLoadedProps);
+
+    // Check rerender and unmount
+    rerender(
+      <Wrapper>
+        <Firehose resources={resources}>
+          <Child />
+        </Firehose>
+      </Wrapper>,
+    );
+    unmount();
+    expect(resourceUpdate).toHaveBeenCalledTimes(3);
+    expect(resourceUpdate.mock.calls[2][0]).toEqual(podLoadedProps);
+
+    resourceUpdate.mockClear();
+  });
+
+  it('should fetch and update child props when requesting a list of resources fails', async () => {
+    k8sListMock.mockReturnValue(Promise.reject(new Error('Network issue')));
+    const resources = [
+      {
+        prop: 'pods',
+        kind: 'Pod',
+        isList: true,
+        namespace: 'my-namespace',
+      },
+    ];
+    const { rerender, unmount } = render(
+      <Wrapper>
+        <Firehose resources={resources}>
+          <Child />
+        </Firehose>
+      </Wrapper>,
+    );
+
+    expect(k8sListMock).toHaveBeenCalledTimes(1);
+    expect(k8sListMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', limit: 250, ns: 'my-namespace' },
+      true,
+      {},
+      'local-cluster',
+    ]);
+    k8sListMock.mockClear();
+
+    // Expect initial render child-props
+    const podsNotLoadedYet = {
+      kind: 'Pod',
+      data: [],
+      loaded: false,
+      loadError: '',
+      filters: {},
+      selected: null,
+      optional: undefined,
+    };
+    const podsNotLoadedYetProps = {
+      ...firehoseChildPropsWithoutModels,
+      k8sModels: ImmutableMap({ Pod: PodModel }),
+      reduxIDs: ['local-clustercore~v1~Pod---{"ns":"my-namespace"}'],
+      loaded: false,
+      // Yes, same data twice at the moment.
+      pods: podsNotLoadedYet,
+      resources: { pods: podsNotLoadedYet },
+    };
+    expect(resourceUpdate).toHaveBeenCalledTimes(1);
+    expect(resourceUpdate.mock.calls[0][0]).toEqual(podsNotLoadedYetProps);
+
+    // Finish API call
+    await act(async () => jest.runAllTimers());
+
+    // Expect updated child-props
+    const podsLoaded = {
+      kind: 'Pod',
+      data: [],
+      loaded: false,
+      loadError: new Error('Network issue'),
+      filters: {},
+      selected: null,
+      optional: undefined,
+    };
+    const podsLoadedProps = {
+      ...firehoseChildPropsWithoutModels,
+      k8sModels: ImmutableMap({ Pod: PodModel }),
+      reduxIDs: ['local-clustercore~v1~Pod---{"ns":"my-namespace"}'],
+      loaded: false,
+      loadError: new Error('Network issue'),
+      // Yes, same data twice at the moment.
+      pods: podsLoaded,
+      resources: { pods: podsLoaded },
+    };
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[1][0]).toEqual(podsLoadedProps);
+
+    // Check rerender and unmount
+    rerender(
+      <Wrapper>
+        <Firehose resources={resources}>
+          <Child />
+        </Firehose>
+      </Wrapper>,
+    );
+    unmount();
+    expect(resourceUpdate).toHaveBeenCalledTimes(3);
+    expect(resourceUpdate.mock.calls[2][0]).toEqual(podsLoadedProps);
+
+    resourceUpdate.mockClear();
+  });
+
+  it('should fetch and update child props when requesting a single resource fails', async () => {
+    k8sGetMock.mockReturnValue(Promise.reject(new Error('Network issue')));
+    const resources = [
+      {
+        prop: 'pod',
+        kind: 'Pod',
+        namespace: 'my-namespace',
+        name: 'my-pod',
+      },
+    ];
+    const { rerender, unmount } = render(
+      <Wrapper>
+        <Firehose resources={resources}>
+          <Child />
+        </Firehose>
+      </Wrapper>,
+    );
+
+    expect(k8sGetMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetMock.mock.calls[0]).toEqual([
+      PodModel,
+      'my-pod',
+      'my-namespace',
+      { cluster: 'local-cluster' },
+      {},
+    ]);
+    k8sGetMock.mockClear();
+
+    // Expect initial render child-props
+    const podNotLoadedYet = {
+      data: {},
+      loaded: false,
+      loadError: '',
+      optional: undefined,
+    };
+    const podsNotLoadedYetProps = {
+      ...firehoseChildPropsWithoutModels,
+      k8sModels: ImmutableMap({ Pod: PodModel }),
+      reduxIDs: ['local-clustercore~v1~Pod---{"ns":"my-namespace","name":"my-pod"}'],
+      loaded: false,
+      // Yes, same data twice at the moment.
+      pod: podNotLoadedYet,
+      resources: { pod: podNotLoadedYet },
+    };
+    expect(resourceUpdate).toHaveBeenCalledTimes(1);
+    expect(resourceUpdate.mock.calls[0][0]).toEqual(podsNotLoadedYetProps);
+
+    // Finish API call
+    await act(async () => jest.runAllTimers());
+
+    // Expect updated child-props
+    const podLoaded = {
+      data: {},
+      loaded: false,
+      loadError: new Error('Network issue'),
+      optional: undefined,
+    };
+    const podLoadedProps = {
+      ...firehoseChildPropsWithoutModels,
+      k8sModels: ImmutableMap({ Pod: PodModel }),
+      reduxIDs: ['local-clustercore~v1~Pod---{"ns":"my-namespace","name":"my-pod"}'],
+      loaded: false,
+      loadError: new Error('Network issue'),
+      // Yes, same data twice at the moment.
+      pod: podLoaded,
+      resources: { pod: podLoaded },
+    };
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[1][0]).toEqual(podLoadedProps);
+
+    // Check rerender and unmount
+    rerender(
+      <Wrapper>
+        <Firehose resources={resources}>
+          <Child />
+        </Firehose>
+      </Wrapper>,
+    );
+    unmount();
+    expect(resourceUpdate).toHaveBeenCalledTimes(3);
+    expect(resourceUpdate.mock.calls[2][0]).toEqual(podLoadedProps);
+
+    resourceUpdate.mockClear();
+  });
+
+  it('should set the props to all childrens and fetch the data just once', async () => {
+    const resources = [
+      {
+        prop: 'pods',
+        kind: 'Pod',
+        isList: true,
+        namespace: 'my-namespace',
+      },
+      {
+        prop: 'pod',
+        kind: 'Pod',
+        namespace: 'my-namespace',
+        name: 'my-pod',
+      },
+    ];
+    render(
+      <Wrapper>
+        <Firehose resources={resources}>
+          <Child />
+          <Child />
+        </Firehose>
+      </Wrapper>,
+    );
+
+    // Assert that API calls are just triggered once
+    expect(k8sListMock).toHaveBeenCalledTimes(1);
+    expect(k8sListMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', limit: 250, ns: 'my-namespace' },
+      true,
+      {},
+      'local-cluster',
+    ]);
+    k8sListMock.mockClear();
+    expect(k8sGetMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetMock.mock.calls[0]).toEqual([
+      PodModel,
+      'my-pod',
+      'my-namespace',
+      { cluster: 'local-cluster' },
+      {},
+    ]);
+    k8sGetMock.mockClear();
+
+    // Expect initial render child-props
+    const podsNotLoadedYet = {
+      kind: 'Pod',
+      data: [],
+      loaded: false,
+      loadError: '',
+      filters: {},
+      selected: null,
+      optional: undefined,
+    };
+    const podNotLoadedYet = {
+      data: {},
+      loaded: false,
+      loadError: '',
+      optional: undefined,
+    };
+    const notLoadedYetProps = {
+      ...firehoseChildPropsWithoutModels,
+      k8sModels: ImmutableMap({ Pod: PodModel }),
+      reduxIDs: [
+        'local-clustercore~v1~Pod---{"ns":"my-namespace"}',
+        'local-clustercore~v1~Pod---{"ns":"my-namespace","name":"my-pod"}',
+      ],
+      loaded: false,
+      // Yes, same data twice at the moment.
+      pods: podsNotLoadedYet,
+      pod: podNotLoadedYet,
+      resources: { pods: podsNotLoadedYet, pod: podNotLoadedYet },
+    };
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0][0]).toEqual(notLoadedYetProps);
+    expect(resourceUpdate.mock.calls[1][0]).toEqual(notLoadedYetProps);
+
+    // Finish API call
+    await act(async () => jest.runAllTimers());
+
+    // Expect updated child-props
+    const podsLoaded = {
+      kind: 'Pod',
+      data: ['my-pod1', 'my-pod2', 'my-pod3'].map((name) => ({
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: {
+          name,
+          namespace: 'default',
+          resourceVersion: '123',
+        },
+      })),
+      loaded: true,
+      loadError: '',
+      filters: {},
+      selected: null,
+      optional: undefined,
+    };
+    const podLoaded = {
+      data: {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: {
+          name: 'my-pod',
+          namespace: 'default',
+          resourceVersion: '123',
+        },
+      },
+      loaded: true,
+      loadError: '',
+      optional: undefined,
+    };
+    const loadedProps = {
+      ...firehoseChildPropsWithoutModels,
+      k8sModels: ImmutableMap({ Pod: PodModel }),
+      reduxIDs: [
+        'local-clustercore~v1~Pod---{"ns":"my-namespace"}',
+        'local-clustercore~v1~Pod---{"ns":"my-namespace","name":"my-pod"}',
+      ],
+      loaded: true,
+      // Yes, same data twice at the moment.
+      pods: podsLoaded,
+      pod: podLoaded,
+      resources: { pods: podsLoaded, pod: podLoaded },
+    };
+    expect(resourceUpdate).toHaveBeenCalledTimes(6);
+    // skip rerendering 2 so that both data sets are loaded
+    expect(resourceUpdate.mock.calls[4][0]).toEqual(loadedProps);
+    expect(resourceUpdate.mock.calls[5][0]).toEqual(loadedProps);
+    const propsChildA = resourceUpdate.mock.calls[4][0];
+    const propsChildB = resourceUpdate.mock.calls[5][0];
+    resourceUpdate.mockClear();
+
+    // Check that all data shares the same identity for the loaded data.
+    expect(propsChildA).toEqual(propsChildB);
+    expect(propsChildA).not.toBe(propsChildB); // TODO: These props could be the same, or?
+
+    // pods 'resource' object (with data, loaded, etc.) object
+    expect(propsChildA.pods).toBe(propsChildB.pods);
+    expect(propsChildA.pods.data).toBe(propsChildB.pods.data);
+    expect(propsChildA.pods.data[0]).toBe(propsChildB.pods.data[0]);
+    expect(propsChildA.resources.pods).toBe(propsChildB.resources.pods);
+    expect(propsChildA.resources.pods.data).toBe(propsChildB.resources.pods.data);
+    expect(propsChildA.resources.pods.data[0]).toBe(propsChildB.resources.pods.data[0]);
+
+    // pod 'resource' object (with data, loaded, etc.) object
+    expect(propsChildA.pod).toBe(propsChildB.pod);
+    expect(propsChildA.pod.data).toBe(propsChildB.pod.data);
+    expect(propsChildA.resources.pod).toBe(propsChildB.resources.pod);
+    expect(propsChildA.resources.pod.data).toBe(propsChildB.resources.pod.data);
+  });
+
+  it('should fetch data just once when two Firehose components requests the same data', async () => {
+    const resources = [
+      {
+        prop: 'pods',
+        kind: 'Pod',
+        isList: true,
+        namespace: 'my-namespace',
+      },
+      {
+        prop: 'pod',
+        kind: 'Pod',
+        namespace: 'my-namespace',
+        name: 'my-pod',
+      },
+    ];
+    render(
+      <Wrapper>
+        <Firehose resources={resources}>
+          <Child />
+        </Firehose>
+        <Firehose resources={resources}>
+          <Child />
+        </Firehose>
+      </Wrapper>,
+    );
+
+    // Assert that API calls are just triggered once
+    expect(k8sListMock).toHaveBeenCalledTimes(1);
+    expect(k8sListMock.mock.calls[0]).toEqual([
+      PodModel,
+      { cluster: 'local-cluster', limit: 250, ns: 'my-namespace' },
+      true,
+      {},
+      'local-cluster',
+    ]);
+    k8sListMock.mockClear();
+    expect(k8sGetMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetMock.mock.calls[0]).toEqual([
+      PodModel,
+      'my-pod',
+      'my-namespace',
+      { cluster: 'local-cluster' },
+      {},
+    ]);
+    k8sGetMock.mockClear();
+
+    // Expect initial render child-props
+    const podsNotLoadedYet = {
+      kind: 'Pod',
+      data: [],
+      loaded: false,
+      loadError: '',
+      filters: {},
+      selected: null,
+      optional: undefined,
+    };
+    const podNotLoadedYet = {
+      data: {},
+      loaded: false,
+      loadError: '',
+      optional: undefined,
+    };
+    const podsNotLoadedYetProps = {
+      ...firehoseChildPropsWithoutModels,
+      k8sModels: ImmutableMap({ Pod: PodModel }),
+      reduxIDs: [
+        'local-clustercore~v1~Pod---{"ns":"my-namespace"}',
+        'local-clustercore~v1~Pod---{"ns":"my-namespace","name":"my-pod"}',
+      ],
+      loaded: false,
+      // Yes, same data twice at the moment.
+      pods: podsNotLoadedYet,
+      pod: podNotLoadedYet,
+      resources: { pods: podsNotLoadedYet, pod: podNotLoadedYet },
+    };
+    expect(resourceUpdate).toHaveBeenCalledTimes(2);
+    expect(resourceUpdate.mock.calls[0][0]).toEqual(podsNotLoadedYetProps);
+    expect(resourceUpdate.mock.calls[1][0]).toEqual(podsNotLoadedYetProps);
+
+    // Finish API call
+    await act(async () => jest.runAllTimers());
+
+    // Expect updated child-props
+    const podsLoaded = {
+      kind: 'Pod',
+      data: ['my-pod1', 'my-pod2', 'my-pod3'].map((name) => ({
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: {
+          name,
+          namespace: 'default',
+          resourceVersion: '123',
+        },
+      })),
+      loaded: true,
+      loadError: '',
+      filters: {},
+      selected: null,
+      optional: undefined,
+    };
+    const podLoaded = {
+      data: {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: {
+          name: 'my-pod',
+          namespace: 'default',
+          resourceVersion: '123',
+        },
+      },
+      loaded: true,
+      loadError: '',
+      optional: undefined,
+    };
+    const podsLoadedProps = {
+      ...firehoseChildPropsWithoutModels,
+      k8sModels: ImmutableMap({ Pod: PodModel }),
+      reduxIDs: [
+        'local-clustercore~v1~Pod---{"ns":"my-namespace"}',
+        'local-clustercore~v1~Pod---{"ns":"my-namespace","name":"my-pod"}',
+      ],
+      loaded: true,
+      // Yes, same data twice at the moment.
+      pods: podsLoaded,
+      pod: podLoaded,
+      resources: { pods: podsLoaded, pod: podLoaded },
+    };
+    expect(resourceUpdate).toHaveBeenCalledTimes(6);
+    // skip rerendering 2 so that both data sets are loaded
+    expect(resourceUpdate.mock.calls[4][0]).toEqual(podsLoadedProps);
+    expect(resourceUpdate.mock.calls[5][0]).toEqual(podsLoadedProps);
+    const propsChildA = resourceUpdate.mock.calls[4][0];
+    const propsChildB = resourceUpdate.mock.calls[5][0];
+    resourceUpdate.mockClear();
+
+    // Check that all data shares the same identity for the loaded data.
+    expect(propsChildA).not.toEqual(propsChildB); // Compared values have no visual difference, but should be equal, or?
+    expect(propsChildA).not.toBe(propsChildB); // Compared values have no visual difference, but should be the same, or?
+
+    // pods 'resource' object (with data, loaded, etc.) object
+    expect(propsChildA.pods).toEqual(propsChildB.pods);
+    expect(propsChildA.pods).not.toBe(propsChildB.pods); // Could be the same?
+    expect(propsChildA.pods.data).not.toBe(propsChildB.pods.data); // TODO: Should be the same!
+    expect(propsChildA.pods.data[0]).not.toBe(propsChildB.pods.data[0]); // TODO: Should be the same!
+
+    expect(propsChildA.resources.pods).toEqual(propsChildB.resources.pods);
+    expect(propsChildA.resources.pods).not.toBe(propsChildB.resources.pods); // Could be the same?
+    expect(propsChildA.resources.pods.data).not.toBe(propsChildB.resources.pods.data); // TODO: Should be the same!
+    expect(propsChildA.resources.pods.data[0]).not.toBe(propsChildB.resources.pods.data[0]); // TODO: Should be the same!
+
+    // pod 'resource' object (with data, loaded, etc.) object
+    expect(propsChildA.pod).not.toBe(propsChildB.pod); // Could be the same?
+    expect(propsChildA.pod.data).not.toBe(propsChildB.pod.data); // TODO: Should be the same!
+    expect(propsChildA.resources.pod).not.toBe(propsChildB.resources.pod); // Should be the same!
+    expect(propsChildA.resources.pod.data).not.toBe(propsChildB.resources.pod.data); // TODO: Should be the same!
+  });
+});

--- a/frontend/public/components/utils/__tests__/firehose.spec.tsx
+++ b/frontend/public/components/utils/__tests__/firehose.spec.tsx
@@ -875,18 +875,18 @@ describe('Firehose', () => {
     // pods 'resource' object (with data, loaded, etc.) object
     expect(propsChildA.pods).toEqual(propsChildB.pods);
     expect(propsChildA.pods).not.toBe(propsChildB.pods); // Could be the same?
-    expect(propsChildA.pods.data).not.toBe(propsChildB.pods.data); // TODO: Should be the same!
-    expect(propsChildA.pods.data[0]).not.toBe(propsChildB.pods.data[0]); // TODO: Should be the same!
+    expect(propsChildA.pods.data).toBe(propsChildB.pods.data);
+    expect(propsChildA.pods.data[0]).toBe(propsChildB.pods.data[0]);
 
     expect(propsChildA.resources.pods).toEqual(propsChildB.resources.pods);
     expect(propsChildA.resources.pods).not.toBe(propsChildB.resources.pods); // Could be the same?
-    expect(propsChildA.resources.pods.data).not.toBe(propsChildB.resources.pods.data); // TODO: Should be the same!
-    expect(propsChildA.resources.pods.data[0]).not.toBe(propsChildB.resources.pods.data[0]); // TODO: Should be the same!
+    expect(propsChildA.resources.pods.data).toBe(propsChildB.resources.pods.data);
+    expect(propsChildA.resources.pods.data[0]).toBe(propsChildB.resources.pods.data[0]);
 
     // pod 'resource' object (with data, loaded, etc.) object
-    expect(propsChildA.pod).not.toBe(propsChildB.pod); // Could be the same?
-    expect(propsChildA.pod.data).not.toBe(propsChildB.pod.data); // TODO: Should be the same!
-    expect(propsChildA.resources.pod).not.toBe(propsChildB.resources.pod); // Should be the same!
-    expect(propsChildA.resources.pod.data).not.toBe(propsChildB.resources.pod.data); // TODO: Should be the same!
+    expect(propsChildA.pod).not.toBe(propsChildB.pod); // Should be the same?
+    expect(propsChildA.data).not.toBe(propsChildB.pod.data); // Should be the same?
+    expect(propsChildA.resources.pod).not.toBe(propsChildB.resources.pod); // Should be the same?
+    expect(propsChildA.resources.pod.data).not.toBe(propsChildB.resources.pod.data); // Should be the same?
   });
 });

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -7,7 +7,10 @@ import { Map as ImmutableMap } from 'immutable';
 import { inject } from './inject';
 import { makeReduxID, makeQuery } from './k8s-watcher';
 import * as k8sActions from '../../actions/k8s';
-import { getActiveCluster } from '@console/dynamic-plugin-sdk';
+import {
+  getActiveCluster,
+  INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL,
+} from '@console/dynamic-plugin-sdk';
 
 const shallowMapEquals = (a, b) => {
   if (a === b || (a.size === 0 && b.size === 0)) {
@@ -30,17 +33,30 @@ export const processReduxId = ({ k8s }, props) => {
     let stuff = k8s.get(reduxID);
     if (stuff) {
       stuff = stuff.toJS();
+      // TODO: To cache also single resources we need to remove this attribute.
       stuff.optional = props.optional;
     }
     return stuff || {};
   }
 
-  const data = k8s.getIn([reduxID, 'data']);
+  let data = k8s.getIn([reduxID, 'data']);
   const _filters = k8s.getIn([reduxID, 'filters']);
   const selected = k8s.getIn([reduxID, 'selected']);
 
+  if (data) {
+    if (!data[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL]) {
+      data[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = data.toArray().map((a) => {
+        if (!a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL]) {
+          a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = a.toJSON();
+        }
+        return a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL];
+      });
+    }
+    data = data[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL];
+  }
+
   return {
-    data: data && data.toArray().map((p) => p.toJSON()),
+    data,
     // This is a hack to allow filters passed down from props to make it to
     // the injected component. Ideally filters should all come from redux.
     filters: _.extend({}, _filters && _filters.toJS(), filters),

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -19,7 +19,7 @@ const shallowMapEquals = (a, b) => {
   return a.every((v, k) => b.get(k) === v);
 };
 
-const processReduxId = ({ k8s }, props) => {
+export const processReduxId = ({ k8s }, props) => {
   const { reduxID, isList, filters } = props;
 
   if (!reduxID) {


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2053685

**Tl;dr**
First commit adds only tests, second commit adds caching for previously deep-cloned data.
This cache of the JSON data which are already used in the topology allows the topology and many other components to do less useMemo, useEffect, re-calculations and re-renderings. In topology, this happens because an object replacement in a GraphNode rerenders it.

**Analysis / Root cause**:
While analyzing our topology performance issues I found two (main) issues which are addressed in this PR. (This is not the first and not the last PR for topology.)

1. The topology components rerenders too much, also when only a part of the data has changed.
2. A lot of time is consumed in the immutable `toJSON()` method.

After further investigation I noticed that the toJSON function is called in `Firehose`, `useK8sWatchResource` and `useK8sWatchResources` when converting an immutable object to JSON. This happens whenever a component is rendered and uses one of the hooks.

It also rerenders or recalculates hooks to often with the same data because the created JSON object contains the same data in a new, deep-clone object or array. But `Memo`d-components, hooks dependencies, and other optimizations like the topology `mobx` graph tree depends on an identity to check to rerender components..

**Solution Description**: 
This PR improves the topology performance or the performance of many different pages with an "immutable toJSON" result cache in `firehose.jsx` and `k8s-watcher.tsx`

It adds a cache and saves the converted JSON data at the immutable object itself. (Thanks Christian for this great idea.)

:recycle:  To see and test what will change with this caching I first added some tests to the Firehose component and the hooks.

1. The first commit just adds test for the status quo.
2. The second commit adds the caching and updates the tests so that it should be easier to see which objects are reused now.

:question: Why not just remove Immutable from the Redux store?!

I think removing Immutable would be a good idea. For the future.

But adding this cache has some benefits for the moment: It's easier and safer to add/test/verify and I hope that we can backport this. I don't expect that we would backport a rewrite of the reducers, and selectors, etc.

:warning:  Potential risk: Reused data models (redux state) is now reused over time and by different components. Changing such a data object would be a bad practice similar to changing a props object.

### Videos

#### Before - Load topology with many deployments (in my case 84)

https://user-images.githubusercontent.com/139310/152451159-4b2612b5-0391-435e-be42-97dfd986c369.mp4

#### After - Load topology with many deployments (in my case 84)

https://user-images.githubusercontent.com/139310/152451174-76b9dcfc-4cbc-4297-b57c-1ee75c7e80fe.mp4

#### Before - Stay on the topology page with many deployments (here 84) and delete a random pod every 3 second

https://user-images.githubusercontent.com/139310/152451186-cc01c17a-d63b-4f42-9bab-943584a100c3.mp4

#### After - Stay on the topology page with many deployments (here 84) and delete a random pod every 3 second

https://user-images.githubusercontent.com/139310/152451200-16fd63f9-74d2-437a-a917-2c37264d235e.mp4


### Performance screenshots

#### Before - Load topology with many deployments (in my case 84)

![before-topology-first-40sec](https://user-images.githubusercontent.com/139310/152450886-ae762f46-8b6f-4f3f-9f8b-84b9a6e7c26a.png)

#### After - Load topology with many deployments (in my case 84)

![after-topology-load](https://user-images.githubusercontent.com/139310/152451003-3a75c306-62ea-498a-b6f0-9677fe8fa85a.png)

#### Before - Stay on the topology page with many deployments (here 84) and delete a random pod every 3 second

![before-topology-updatepods-40sec](https://user-images.githubusercontent.com/139310/152450943-6723524d-3b7d-4d85-85ca-2094a0e5dc05.png)

#### After - Stay on the topology page with many deployments (here 84) and delete a random pod every 3 second

todo

**Screen shots / Gifs for design review**: 
UI isn't changed. Here are som

**Unit test coverage report**: 
Added a lot of tests for the existing components `Firehose`, `useK8sWatchResource` and `useK8sWatchResources` to check the status quo and track the difference with this PR.

**Test setup:**
1. Create a project/namespace with a lot of Deployments (50+)
2. Open the topology
3. Delete some pods

You can find some scripts to create a cluster with a lot of load here: https://github.com/jerolimov/openshift/tree/master/loadtest

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
