### PR TITLE
Bug 2049483: Revert "fix annotations on updating workload"

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/topology-details.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/topology-details.ts
@@ -37,7 +37,9 @@ export type DetailsTabSection = ExtensionDeclaration<
      * @param renderNull should be used for section that defines Adapter to
      *  determine if adapter component renders null or not
      * */
-    section: CodeRef<DetailsTabSectionCallback>;
+    section: CodeRef<
+      (element: GraphElement, renderNull?: () => null) => React.Component | undefined
+    >;
     /** Insert this item before the item referenced here.
      * For arrays, the first one found in order is used.
      * */
@@ -167,8 +169,3 @@ export type PodsAdapterDataType<E = K8sResourceCommon> = {
 export type NetworkAdapterType = {
   resource: K8sResourceCommon;
 };
-
-export type DetailsTabSectionCallback = (
-  element: GraphElement,
-  renderNull?: () => null,
-) => React.Component | undefined;

--- a/frontend/packages/topology/src/components/side-bar/providers/SideBarTabLoader.tsx
+++ b/frontend/packages/topology/src/components/side-bar/providers/SideBarTabLoader.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { GraphElement, isEdge, observer } from '@patternfly/react-topology';
+import { GraphElement, isEdge } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
 import {
   DetailsTab,
   DetailsTabSection,
-  DetailsTabSectionCallback,
   isDetailsTab,
   isDetailsTabSection,
   useResolvedExtensions,
@@ -16,21 +15,7 @@ import { getResource } from '@console/topology/src/utils';
 import { DefaultResourceSideBar } from '../DefaultResourceSideBar';
 import TopologyEdgeResourcesPanel from '../TopologyEdgeResourcesPanel';
 
-type TabSectionProps = {
-  element?: GraphElement;
-  sectionCallback?: DetailsTabSectionCallback;
-  renderNull?: () => null;
-};
-const TabSection: React.FC<TabSectionProps> = observer(function TabSection({
-  element,
-  sectionCallback,
-  renderNull,
-}) {
-  if (element && sectionCallback) {
-    return <>{sectionCallback(element, renderNull)}</>;
-  }
-  return null;
-});
+const TabSection: React.FC = ({ children }) => <>{children}</>;
 
 type SideBarTabLoaderProps = {
   element: GraphElement;
@@ -73,9 +58,7 @@ const SideBarTabLoader: React.FC<SideBarTabLoaderProps> = ({ element, children }
     return resolved
       ? tabSectionExtensions.reduce((tabs, { properties: { tab, section, ...rest } }) => {
           const [index, callback] = renderNull(tab);
-          const resolvedSection = (
-            <TabSection sectionCallback={section} renderNull={callback} element={element} />
-          );
+          const resolvedSection = section(element, callback);
           if (!resolvedSection) {
             renderSection.current[tab][index] = false;
             return tabs;
@@ -103,7 +86,7 @@ const SideBarTabLoader: React.FC<SideBarTabLoaderProps> = ({ element, children }
         resolvedSection: React.ReactNode;
         id: string;
       }>(tabSections[id]).map(({ id: tsId, resolvedSection }) => (
-        <React.Fragment key={tsId}>{resolvedSection}</React.Fragment>
+        <TabSection key={tsId}>{resolvedSection}</TabSection>
       ));
       return [...acc, { name: label, component: () => <>{tabContent}</> }];
     }, []);


### PR DESCRIPTION
This reverts commit af332e05660edf4c59bd6173681ee0385d8a98c6.

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=2049483

Problem:
Sidepanel for Connectors/workload in topology shows invalid tabs.
This problem was introduced in https://github.com/openshift/console/pull/10573.

Solution:
revert changes made in https://github.com/openshift/console/pull/10573 and reopen the corresponding bug.