### PR TITLE
Monitoring: Add duplicate query option to kebab menu

### DIFF
--- a/frontend/public/actions/observe.ts
+++ b/frontend/public/actions/observe.ts
@@ -12,6 +12,7 @@ export enum ActionType {
   DashboardsSetTimespan = 'dashboardsSetTimespan',
   DashboardsVariableOptionsLoaded = 'dashboardsVariableOptionsLoaded',
   QueryBrowserAddQuery = 'queryBrowserAddQuery',
+  QueryBrowserDuplicateQuery = 'queryBrowserDuplicateQuery',
   QueryBrowserDeleteAllQueries = 'queryBrowserDeleteAllQueries',
   QueryBrowserDeleteAllSeries = 'queryBrowserDeleteAllSeries',
   QueryBrowserDeleteQuery = 'queryBrowserDeleteQuery',
@@ -85,6 +86,9 @@ export const toggleGraphs = () => action(ActionType.ToggleGraphs);
 
 export const queryBrowserAddQuery = () => action(ActionType.QueryBrowserAddQuery);
 
+export const queryBrowserDuplicateQuery = (index: number) =>
+  action(ActionType.QueryBrowserDuplicateQuery, { index });
+
 export const queryBrowserDeleteAllQueries = () => action(ActionType.QueryBrowserDeleteAllQueries);
 
 export const queryBrowserDeleteAllSeries = () => action(ActionType.QueryBrowserDeleteAllSeries);
@@ -136,6 +140,7 @@ const actions = {
   dashboardsSetTimespan,
   dashboardsVariableOptionsLoaded,
   queryBrowserAddQuery,
+  queryBrowserDuplicateQuery,
   queryBrowserDeleteAllQueries,
   queryBrowserDeleteAllSeries,
   queryBrowserDeleteQuery,

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -40,6 +40,7 @@ import { RedExclamationCircleIcon, YellowExclamationTriangleIcon } from '@consol
 
 import {
   queryBrowserAddQuery,
+  queryBrowserDuplicateQuery,
   queryBrowserDeleteAllQueries,
   queryBrowserDeleteQuery,
   queryBrowserInsertText,
@@ -559,6 +560,10 @@ const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
     focusedQuery = undefined;
   }, [dispatch, index]);
 
+  const doClone = React.useCallback(() => {
+    dispatch(queryBrowserDuplicateQuery(index));
+  }, [dispatch, index]);
+
   return (
     <Kebab
       options={[
@@ -571,6 +576,7 @@ const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
           callback: toggleAllSeries,
         },
         { label: t('public~Delete query'), callback: doDelete },
+        { label: t('public~Duplicate query'), callback: doClone },
       ]}
     />
   );

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -992,6 +992,7 @@
   "Hide all series": "Hide all series",
   "Show all series": "Show all series",
   "Delete query": "Delete query",
+  "Duplicate query": "Duplicate query",
   "Error loading values": "Error loading values",
   "No query entered": "No query entered",
   "Enter a query in the box below to explore metrics for this cluster.": "Enter a query in the box below to explore metrics for this cluster.",

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -158,6 +158,19 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
         state.getIn(['queryBrowser', 'queries']).push(newQueryBrowserQuery()),
       );
 
+    case ActionType.QueryBrowserDuplicateQuery: {
+      const index = action.payload.index;
+      const originQueryText = state.getIn(['queryBrowser', 'queries', index, 'text']);
+      const duplicate = newQueryBrowserQuery().merge({
+        text: originQueryText,
+        isEnabled: false,
+      });
+      return state.setIn(
+        ['queryBrowser', 'queries'],
+        state.getIn(['queryBrowser', 'queries']).push(duplicate),
+      );
+    }
+
     case ActionType.QueryBrowserDeleteAllQueries:
       return state.setIn(['queryBrowser', 'queries'], ImmutableList([newQueryBrowserQuery()]));
 


### PR DESCRIPTION
Allow users to conveniently duplicate an existing query

[https://issues.redhat.com/browse/MON-785](https://issues.redhat.com/browse/MON-785)

https://user-images.githubusercontent.com/5461414/152766448-7240cfcf-b6f5-4131-9556-9c8cc5cef622.mov

