### PR TITLE
Bug 2046618: Add started-by annotation to pipelines created with "Start last run"

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/utils.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import { getActiveUserName } from '@console/internal/actions/ui';
 import { getRandomChars } from '@console/shared';
 import { PipelineRunModel } from '../../../../models';
 import {
@@ -14,7 +15,12 @@ import {
   PipelineRunParam,
 } from '../../../../types';
 import { getPipelineRunParams, getPipelineRunWorkspaces } from '../../../../utils/pipeline-utils';
-import { TektonResourceLabel, VolumeTypes, preferredNameAnnotation } from '../../const';
+import {
+  TektonResourceLabel,
+  VolumeTypes,
+  preferredNameAnnotation,
+  StartedByAnnotation,
+} from '../../const';
 import { CREATE_PIPELINE_RESOURCE, initialResourceFormValues } from './const';
 import {
   CommonPipelineModalFormikValues,
@@ -87,6 +93,9 @@ export const getPipelineRunData = (
     {},
     pipeline?.metadata?.annotations,
     latestRun?.metadata?.annotations,
+    {
+      [StartedByAnnotation.user]: getActiveUserName(),
+    },
     !latestRun?.spec.pipelineRef &&
       !latestRun?.metadata.annotations?.[preferredNameAnnotation] && {
         [preferredNameAnnotation]: pipelineName,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-39963
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
PipelineRuns created using the start last run button in pipeline details page & list view did not update the started-by annotation.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Add/update the started-by annotation when creating pipelineRuns using the "start last run" button.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/152788493-478ca248-e3ba-43a2-b03c-b0b3fb01b446.mp4


<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Test setup:**
- Start a pipeline as any user.
- Use the "start last run" button to start the same pipeline as another user.
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
