### PR TITLE
Bug 2039647: Use namespaced links for dev perspective nav items

### DIFF
--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -358,6 +358,7 @@
       "section": "top",
       "name": "%devconsole~Observe%",
       "href": "/dev-monitoring",
+      "namespaced": true,
       "dataAttributes": {
         "data-quickstart-id": "qs-nav-monitoring",
         "data-tour-id": "tour-monitoring-nav",

--- a/frontend/packages/gitops-plugin/console-extensions.json
+++ b/frontend/packages/gitops-plugin/console-extensions.json
@@ -9,6 +9,7 @@
       "insertBefore": "helm",
       "name": "%gitops-plugin~Environments%",
       "href": "/environments",
+      "namespaced": true,
       "dataAttributes": {
         "data-test-id": "environments-header"
       }

--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -563,6 +563,7 @@
       "insertAfter": "builds",
       "name": "%pipelines-plugin~Pipelines%",
       "href": "/dev-pipelines",
+      "namespaced": true,
       "dataAttributes": {
         "data-quickstart-id": "qs-nav-pipelines",
         "data-test-id": "pipeline-header"


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-39288
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Some dev perspective nav items did not use namespaced URLs.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Use namespaced URLs for those nav items.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/152817370-15eabff0-7b66-4a05-b342-7b3d93acf64e.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Test setup:**
1. Open a topology view for project A
2. Create a new tab, open topology view for project B
3. Switch back to project A tab, right click on (Pipelines, Observe and Environments) and select new tab
4. The new tab is for project B, not project A
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
