### PR TITLE
`valut` typo fixed

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/kms-config/kms-config.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/kms-config/kms-config.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { useFlag } from '@console/shared/src/hooks/flag';
-import { ValutConfigure } from './vault-config';
+import { VaultConfigure } from './vault-config';
 import { HpcsConfigure } from './hpcs-config';
 import { EncryptionDispatch, KMSConfigureProps } from './providers';
 import { isLengthUnity } from './utils';
@@ -14,7 +14,7 @@ const KMSProviders = [
   {
     name: 'Vault',
     value: ProviderNames.VAULT,
-    Component: ValutConfigure,
+    Component: VaultConfigure,
   },
   {
     name: 'Hyper Protect Crypto Services',

--- a/frontend/packages/ceph-storage-plugin/src/components/kms-config/vault-config.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/kms-config/vault-config.tsx
@@ -39,7 +39,7 @@ import {
 
 import './kms-config.scss';
 
-export const ValutConfigure: React.FC<KMSConfigureProps> = ({
+export const VaultConfigure: React.FC<KMSConfigureProps> = ({
   state,
   dispatch,
   className,
@@ -117,7 +117,7 @@ export const ValutConfigure: React.FC<KMSConfigureProps> = ({
           </FormSelect>
         </FormGroup>
       )}
-      <ValutConnectionForm
+      <VaultConnectionForm
         {...{
           t,
           state,
@@ -133,7 +133,7 @@ export const ValutConfigure: React.FC<KMSConfigureProps> = ({
   );
 };
 
-const ValutConnectionForm: React.FC<ValutConnectionFormProps> = ({
+const VaultConnectionForm: React.FC<VaultConnectionFormProps> = ({
   t,
   state,
   vaultState,
@@ -309,7 +309,7 @@ const ValutConnectionForm: React.FC<ValutConnectionFormProps> = ({
   );
 };
 
-export type ValutConnectionFormProps = {
+export type VaultConnectionFormProps = {
   state:
     | InternalClusterState
     | State


### PR DESCRIPTION
The typo `valut` was fixed and was converted to `vault`.