### PR TITLE
Bug 2051433: [release-4.10] Create HANA VM does not use values from customized HANA templates

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
@@ -6,6 +6,7 @@ import { K8sKind, TemplateKind } from '@console/internal/module/k8s';
 import { VMWizardMode, VMWizardName } from '../../constants/vm';
 import { CustomizeSourceFunction } from '../../hooks/use-customize-source-modal';
 import { SupportModalFunction } from '../../hooks/use-support-modal';
+import { VMTemplateWrapper } from '../../k8s/wrapper/vm/vm-template-wrapper';
 import { VirtualMachineModel } from '../../models';
 import { getNamespace } from '../../selectors';
 import { isCommonTemplate } from '../../selectors/vm-template/basic';
@@ -48,6 +49,7 @@ const newTemplateFromCommon: MenuAction = (kind, vmTemplate, { namespace }) => (
     template: vmTemplate.variants[0],
   }),
   accessReview: asAccessReview(kind, vmTemplate, 'patch'),
+  isDisabled: new VMTemplateWrapper(vmTemplate.variants[0]).getWorkloadProfile() === 'saphana',
 });
 
 const vmTemplateCreateVMAction: MenuAction = (


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2051433

**Solution Description**:
Disabling `Create new template` from SAP HANA as its not working properly at the moment.

**Screen shots / Gifs for design review**:

**Before**:

![before](https://user-images.githubusercontent.com/67270715/152975180-feaa62db-633f-486b-8f95-45f14429f490.png)

**After**:

![after](https://user-images.githubusercontent.com/67270715/152975198-e0c04904-5503-4b97-8859-7b11cc6f1df4.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>