### PR TITLE
Bug 2051558: omit rolebindings with no subjects

### DIFF
--- a/frontend/packages/dev-console/src/components/project-access/__tests__/project-access-form-data.ts
+++ b/frontend/packages/dev-console/src/components/project-access/__tests__/project-access-form-data.ts
@@ -147,6 +147,17 @@ export const roleBindingsWithRequiredRoles = [
       },
     ],
   },
+  {
+    metadata: {
+      name: 'check-edit',
+      namespace: 'xyz',
+    },
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'ClusterRole',
+      name: 'edit',
+    },
+  },
 ];
 
 export const roleBindingsWithRequiredAttributes = [

--- a/frontend/packages/dev-console/src/components/project-access/project-access-form-utils-types.ts
+++ b/frontend/packages/dev-console/src/components/project-access/project-access-form-utils-types.ts
@@ -20,7 +20,7 @@ type ApiGroupType = {
 
 export type RoleBinding = K8sResourceCommon & {
   roleRef: ApiGroupType;
-  subjects: ApiGroupType[];
+  subjects?: ApiGroupType[];
 };
 
 export const roleBinding: RoleBinding = {

--- a/frontend/packages/dev-console/src/components/project-access/project-access-form-utils.ts
+++ b/frontend/packages/dev-console/src/components/project-access/project-access-form-utils.ts
@@ -33,7 +33,7 @@ export const getUsersFromSubject = (user: RoleBinding): UserRoleBinding[] =>
   }));
 
 export const getUserRoleBindings = (roleBindings: RoleBinding[]): UserRoleBinding[] =>
-  _.flatten(roleBindings.map((user) => getUsersFromSubject(user)));
+  _.filter(_.flatten(roleBindings.map((user) => getUsersFromSubject(user))), undefined);
 
 export const ignoreRoleBindingName = (roleBinding: UserRoleBinding[]) => {
   const res = roleBinding.map((obj) => ({ user: obj.user, role: obj.role }));


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2051558

**Root analysis:**
The `subject name` is considered mandatory while creating a rolebinding using the create role binding form, but seems like the user can create one without the above property through yaml.

**Solution description:**
Since the value displayed under the Name column in the project access page is the subject name mentioned in the role binding CR so the role binding without this property is not listed on the project access page.

/kind bug
