### PR TITLE
Bug 2052095: Fix auth redirect loop caused by duplicate state-token cookie

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -27,7 +27,7 @@ import (
 const (
 	CSRFCookieName    = "csrf-token"
 	CSRFHeader        = "X-CSRFToken"
-	stateCookieName   = "state-token"
+	stateCookieName   = "login-state"
 	errorOAuth        = "oauth_error"
 	errorLoginState   = "login_state_error"
 	errorCookie       = "cookie_error"


### PR DESCRIPTION
Changing the name of the cookie should resolve the redirect loop issue. This will leave an orphaned 'state-token' cookie with no side effects.