### PR TITLE
Bug 2051657: removed `Tech preview` badge

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
@@ -9,7 +9,6 @@ import {
   AlertActionLink,
   WizardContextConsumer,
 } from '@patternfly/react-core';
-import { TechPreviewBadge } from '@console/shared';
 import { CreateStepsSC } from '../constants';
 import '../components/ocs-install/ocs-install.scss';
 import { EncryptionType } from '../types';
@@ -45,7 +44,6 @@ export const VALIDATIONS = (type: keyof typeof ValidationType, t: TFunction): Va
         title: (
           <div className="ceph-minimal-deployment-alert__header">
             {t('ceph-storage-plugin~A minimal cluster deployment will be performed.')}
-            <TechPreviewBadge />
           </div>
         ),
         text: t(


### PR DESCRIPTION
Removing `Tech preview` badge from the Create-storage-class -> Capacity and nodes page.

 
![image](https://user-images.githubusercontent.com/41220684/153191509-05275474-24ed-4ddf-a76d-562a46261441.png)
![image](https://user-images.githubusercontent.com/41220684/153237954-e88b7681-226e-44f3-8264-013bfb0485ec.png)

