### PR TITLE
Bug 2002602: remove returning of err if json fails to parse

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-storage-class-form/ocs-storage-class-form.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-storage-class-form/ocs-storage-class-form.tsx
@@ -391,7 +391,8 @@ const ExistingKMSDropDown: React.FC<ExistingKMSDropDownProps> = ({
               );
             }
           } catch (err) {
-            return err;
+            // eslint-disable-next-line no-console
+            console.error(err);
           }
           return res;
         },


### PR DESCRIPTION
This removes the returning of err when JSON.parse() throws an exception.
We do that to allow other values in the configmap to be added in the
reduced array.

Configmap used: 
```yaml
kind: ConfigMap
apiVersion: v1

data:
  vault-tenant-sa-auth: |-
    {
      "encryptionKMSType": "vaulttenantsa",
      "vaultAddress": "https://vault.ocs.com:8200",
      "vaultBackendPath": "test-sa"
      "vaultCAVerify": "false"
    }
  vault-test: |-
    {
      "encryptionKMSType": "vaulttenantsa",
      "vaultAddress": "https://vault.ocs.com:8200",
      "vaultBackendPath": "test-sa",
      "vaultCAVerify": "false"
    }

```


before: 
![before](https://user-images.githubusercontent.com/24807435/153205708-e65b0563-c073-4316-b74f-3aeaf43e5379.png)
after:
![after](https://user-images.githubusercontent.com/24807435/153205740-2cc70072-a5e7-4c7f-affd-d0b1b8d45b8d.png)


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2002602