### PR TITLE
Bug 2037625: Always show ResourceQuota charts

### DIFF
--- a/frontend/public/components/dashboard/project-dashboard/resource-quota-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/resource-quota-card.tsx
@@ -5,7 +5,6 @@ import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import ResourceQuotaBody from '@console/shared/src/components/dashboard/resource-quota-card/ResourceQuotaBody';
 import ResourceQuotaItem from '@console/shared/src/components/dashboard/resource-quota-card/ResourceQuotaItem';
 import AppliedClusterResourceQuotaItem from '@console/shared/src/components/dashboard/resource-quota-card/AppliedClusterResourceQuotaItem';
-import { getQuotaResourceTypes, hasComputeResources } from '../../resource-quota';
 import { FirehoseResult, FirehoseResource } from '../../utils';
 import { AppliedClusterResourceQuotaModel, ResourceQuotaModel } from '../../../models';
 import { withDashboardResources, DashboardItemProps } from '../with-dashboard-resources';
@@ -56,26 +55,22 @@ export const ResourceQuotaCard = withDashboardResources(
         </CardHeader>
         <CardBody>
           <ResourceQuotaBody error={!!rqLoadError} isLoading={!rqLoaded}>
-            {quotas
-              .filter((rq) => hasComputeResources(getQuotaResourceTypes(rq)))
-              .map((rq) => (
-                <ResourceQuotaItem key={rq.metadata.uid} resourceQuota={rq} />
-              ))}
+            {quotas.map((rq) => (
+              <ResourceQuotaItem key={rq.metadata.uid} resourceQuota={rq} />
+            ))}
           </ResourceQuotaBody>
           <ResourceQuotaBody
             error={!!acrqLoadError}
             isLoading={!acrqLoaded}
             noText={t('public~No AppliedClusterResourceQuotas')}
           >
-            {clusterQuotas
-              .filter((rq) => hasComputeResources(getQuotaResourceTypes(rq)))
-              .map((rq) => (
-                <AppliedClusterResourceQuotaItem
-                  key={rq.metadata.uid}
-                  resourceQuota={rq}
-                  namespace={obj.metadata.name}
-                />
-              ))}
+            {clusterQuotas.map((rq) => (
+              <AppliedClusterResourceQuotaItem
+                key={rq.metadata.uid}
+                resourceQuota={rq}
+                namespace={obj.metadata.name}
+              />
+            ))}
           </ResourceQuotaBody>
         </CardBody>
       </Card>

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -509,7 +509,6 @@ export const hasComputeResources = (resourceTypes) => {
 const Details = ({ obj: rq, match }) => {
   const { t } = useTranslation();
   const resourceTypes = getQuotaResourceTypes(rq);
-  const showChartRow = hasComputeResources(resourceTypes);
   const scopes = rq.spec?.scopes ?? rq.spec?.quota?.scopes;
   const reference = referenceFor(rq);
   const isACRQ = reference === appliedClusterQuotaReference;
@@ -535,9 +534,7 @@ const Details = ({ obj: rq, match }) => {
     <>
       <div className="co-m-pane__body">
         <SectionHeading text={text} />
-        {showChartRow && (
-          <QuotaGaugeCharts quota={rq} resourceTypes={resourceTypes} namespace={namespace} />
-        )}
+        <QuotaGaugeCharts quota={rq} resourceTypes={resourceTypes} namespace={namespace} />
         <div className="row">
           <div className="col-sm-6">
             <ResourceSummary resource={rq}>


### PR DESCRIPTION
I spoke to Yadan and it sounds like there are user experience issues with the existing chart behavior for ResourceQuotas. Yadan thought it would be better to always display the charts rather than only display them if certain data points are set. I am removing the checks for all RQs, CRQs, and ACRQs so we can display the charts.

Projects page:
<img width="515" alt="Screen Shot 2022-02-09 at 3 03 21 PM" src="https://user-images.githubusercontent.com/7014965/153281109-5bfb0343-dc11-4b7a-89cc-30893a0f2d1d.png">

<img width="521" alt="Screen Shot 2022-02-09 at 3 05 41 PM" src="https://user-images.githubusercontent.com/7014965/153281456-c7f69a89-8aac-48eb-b5d2-bd11ba7a6d93.png">

RQ details page:
<img width="1064" alt="Screen Shot 2022-02-09 at 3 03 51 PM" src="https://user-images.githubusercontent.com/7014965/153281177-cb304064-61e9-4210-9cf7-e8f746f8a735.png">

<img width="1061" alt="Screen Shot 2022-02-09 at 3 04 57 PM" src="https://user-images.githubusercontent.com/7014965/153281484-15d472c3-4ae4-4c78-b8dc-c6e2e51b1f8a.png">

<img width="1059" alt="Screen Shot 2022-02-09 at 3 05 08 PM" src="https://user-images.githubusercontent.com/7014965/153281501-6cf12004-3c1f-487d-bf44-274f3c7aaee7.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2037625.