### PR TITLE
Bug 2019892: Fix sample namespace bug

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -368,9 +368,10 @@ export const EditYAML_ = connect(stateToProps)(
           // If this is a namespaced resource, default to the active namespace when none is specified in the YAML.
           if (!obj.metadata.namespace && model.namespaced) {
             if (this.props.activeNamespace === ALL_NAMESPACES_KEY) {
-              return t('public~No "metadata.namespace" field found in YAML.');
+              obj.metadata.namespace = 'default';
+            } else {
+              obj.metadata.namespace = this.props.activeNamespace;
             }
-            obj.metadata.namespace = this.props.activeNamespace;
           }
         }
 


### PR DESCRIPTION
Added a default namespace of default for the YAML editor when the user is looking at all projects and trying to create a resource.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2019892.