### PR TITLE
Bug 2046598: Display disk size in GiB in VM customize wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/review-tab/storage-review.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/review-tab/storage-review.tsx
@@ -4,7 +4,12 @@ import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-t
 import { Trans, useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { Firehose, FirehoseResult, resourcePath } from '@console/internal/components/utils';
+import {
+  Firehose,
+  FirehoseResult,
+  humanizeBinaryBytes,
+  resourcePath,
+} from '@console/internal/components/utils';
 import { PersistentVolumeClaimModel, StorageClassModel } from '@console/internal/models';
 import { StorageClassResourceKind } from '@console/internal/module/k8s';
 import { CombinedDisk } from '../../../../k8s/wrapper/vm/combined-disk';
@@ -107,7 +112,7 @@ const StorageReviewFirehose: React.FC<StorageReviewFirehoseProps> = ({
     return [
       combinedDisk.getName(),
       combinedDisk.getSourceValue(),
-      combinedDisk.getReadableSize(),
+      combinedDisk.getSize() && humanizeBinaryBytes(combinedDisk.getSize().value).string,
       combinedDisk.getDiskInterface(),
       combinedDisk.getStorageClassName(),
       combinedDisk.getAccessModes()?.join(', '),

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-tab.tsx
@@ -16,7 +16,12 @@ import {
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
-import { ExternalLink, Firehose, FirehoseResult } from '@console/internal/components/utils';
+import {
+  ExternalLink,
+  Firehose,
+  FirehoseResult,
+  humanizeBinaryBytes,
+} from '@console/internal/components/utils';
 import { PersistentVolumeClaimModel } from '@console/internal/models';
 import { DeviceType } from '../../../../constants/vm';
 import { ProvisionSource } from '../../../../constants/vm/provision-source';
@@ -83,7 +88,7 @@ const getStoragesData = (
       name: combinedDisk.getName(),
       source: combinedDisk.getSourceValue(),
       diskInterface: combinedDisk.getDiskInterface(),
-      size: combinedDisk.getReadableSize(),
+      size: combinedDisk.getSize() && humanizeBinaryBytes(combinedDisk.getSize().value).string,
       storageClass: combinedDisk.getStorageClassName(),
       type: combinedDisk.getType(),
     };


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2046598

**Analysis / Root cause**:
Auto-update boot source size was calculated in bytes in customize wizard when creating a VM (_Storage_ and _Review_ steps), which was hard to read.

**Solution Description**:
Display the size in 'GiB' instead of 'B', use `humanizeBinaryBytes` function for it, similarly as in some other places in the code.

**Screen shots / Gifs for design review**:
Before:
![before1](https://user-images.githubusercontent.com/13417815/153323175-8d2ab8ec-ef5d-460a-a798-38fabc661b41.png)
![before2](https://user-images.githubusercontent.com/13417815/153323186-990f0bad-8484-475a-a22e-145223231ab5.png)

After:
![after1](https://user-images.githubusercontent.com/13417815/153463680-7b3ccf53-47c5-4ad0-aa2e-a7c7254a9672.png)
![after2](https://user-images.githubusercontent.com/13417815/153463702-0a6ecd34-d5aa-4e8e-b818-fb5a1a1c669a.png)

