### PR TITLE
Bug 2013144: catalog category filters can be opened via ctrl+click now

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogCategories.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogCategories.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { VerticalTabs, VerticalTabsTab } from '@patternfly/react-catalog-view-extension';
 import * as cx from 'classnames';
 import * as _ from 'lodash';
+import { Link } from 'react-router-dom';
+import { isModifiedEvent } from '@console/shared/src/utils';
 import { getURLWithParams } from '../utils/catalog-utils';
 import { hasActiveDescendant, isActiveTab } from '../utils/category-utils';
 import { CatalogCategory, CatalogQueryParams } from '../utils/types';
@@ -36,14 +38,23 @@ const CatalogCategories: React.FC<CatalogCategoriesProp> = ({
     return (
       <VerticalTabsTab
         key={id}
-        title={label}
         active={active}
         className={tabClasses}
-        onActivate={() => onSelectCategory(id)}
         hasActiveDescendant={hasActiveDescendant(selectedCategory, category)}
         shown={toplevelCategory}
         data-test={`tab ${id}`}
-        href={getURLWithParams(CatalogQueryParams.CATEGORY, id)}
+        component={() => (
+          <Link
+            to={getURLWithParams(CatalogQueryParams.CATEGORY, id)}
+            onClick={(e) => {
+              if (isModifiedEvent(e)) return;
+              e.preventDefault();
+              onSelectCategory(id);
+            }}
+          >
+            {label}
+          </Link>
+        )}
       >
         {subcategories && (
           <VerticalTabs restrictTabs activeTab={isActiveTab(selectedCategoryID, category)}>

--- a/frontend/public/components/utils/tile-view-page.jsx
+++ b/frontend/public/components/utils/tile-view-page.jsx
@@ -21,6 +21,8 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { getURLWithParams, VirtualizedGrid } from '@console/shared';
+import { Link } from 'react-router-dom';
+import { isModifiedEvent } from '@console/shared/src/utils';
 
 import { history } from './router';
 import { isModalOpen } from '../modals';
@@ -689,14 +691,25 @@ export class TileViewPage extends React.Component {
     return (
       <VerticalTabsTab
         key={id}
-        title={label}
         active={active}
         className={tabClasses}
-        onActivate={() => this.selectCategory(id)}
         hasActiveDescendant={hasActiveDescendant(selectedCategoryId, category)}
         shown={shown}
         data-test={id}
-        href={getURLWithParams(FilterTypes.category, id)}
+        component={() => (
+          <Link
+            to={getURLWithParams(FilterTypes.category, id)}
+            onClick={(e) => {
+              if (isModifiedEvent(e)) {
+                return;
+              }
+              e.preventDefault();
+              this.selectCategory(id);
+            }}
+          >
+            {label}
+          </Link>
+        )}
       >
         {subcategories && (
           <VerticalTabs restrictTabs activeTab={isActiveTab(selectedCategoryId, category)}>


### PR DESCRIPTION
**Fixes**: [BZ2013144](https://bugzilla.redhat.com/show_bug.cgi?id=2013144)

**Analysis / Root cause**: 
For the Catalog we use a the Patternfly component `VerticalTabsTab` which should allow a user to open the link with `right click > open in new tab` and `ctrl+click` in a new tab. Unfortunately the component always used an `<a>` tag combined with an onClick listener that used the `preventDefault` method. This construct concluded in a state where the user could not open the page with `ctrl+click`.

**Solution Description**: 
I made a [change](https://github.com/patternfly/patternfly-react/pull/6901) to the Patternfly component which takes a custom base component for rendering now. We can now pass in a `<Link>` component which is necessary for our router to route correctly. 

/cc @rhamilto 