### PR TITLE
Bug 2053168: Fix dynamic plugin SDK typescript IDE errors

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
@@ -4,5 +4,7 @@ import { UseActivePerspective } from '../extensions/console-types';
 export const useActivePerspective: UseActivePerspective = require('@console/dynamic-plugin-sdk/src/perspective/useActivePerspective')
   .default;
 
+export * from '../perspective/perspective-context';
+
 // Dynamic plugin SDK core APIs
 export * from './dynamic-core-api';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -22,6 +22,9 @@ import {
 } from '../extensions/console-types';
 import { StatusPopupSectionProps, StatusPopupItemProps } from '../extensions/dashboard-types';
 
+export * from '../app/components';
+export * from './common-types';
+
 export const useResolvedExtensions: UseResolvedExtensions = require('@console/dynamic-plugin-sdk/src/api/useResolvedExtensions')
   .useResolvedExtensions;
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -70,20 +70,20 @@ export const useListPageFilter: UseListPageFilter = require('@console/internal/c
   .useListPageFilter;
 export const ResourceLink: React.FC<ResourceLinkProps> = require('@console/internal/components/utils/resource-link')
   .ResourceLink;
-export { default as ResourceStatus } from '@console/dynamic-plugin-sdk/src/app/components/utils/resource-status';
+export { default as ResourceStatus } from '../app/components/utils/resource-status';
 
 export {
   useK8sModel,
   useK8sModels,
   useK8sWatchResource,
   useK8sWatchResources,
-} from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks';
+} from '../utils/k8s/hooks';
 
 export {
   consoleFetch,
   consoleFetchJSON,
   consoleFetchText,
-} from '@console/dynamic-plugin-sdk/src/utils/fetch';
+} from '../utils/fetch';
 
 // Expose K8s CRUD utilities as below
 export {
@@ -93,12 +93,12 @@ export {
   k8sPatchResource as k8sPatch,
   k8sDeleteResource as k8sDelete,
   k8sListResource as k8sList,
-} from '@console/dynamic-plugin-sdk/src/utils/k8s';
+} from '../utils/k8s';
 export {
   getAPIVersionForModel,
   getGroupVersionKindForResource,
   getGroupVersionKindForModel,
-} from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';
+} from '../utils/k8s/k8s-ref';
 
 export const StatusPopupSection: React.FC<StatusPopupSectionProps> = require('@console/shared/src/components/dashboard/status-card/StatusPopup')
   .StatusPopupSection;
@@ -119,4 +119,4 @@ export const InventoryItemStatus: React.FC<InventoryItemStatusProps> = require('
 export const InventoryItemLoading: React.FC = require('@console/shared/src/components/dashboard/inventory-card/InventoryCard')
   .InventoryItemLoading;
 
-export { useFlag } from '@console/dynamic-plugin-sdk/src/utils/flags';
+export { useFlag } from '../utils/flags';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/host-app-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/host-app-api.ts
@@ -1,11 +1,4 @@
-export { default as AppInitSDK } from '@console/dynamic-plugin-sdk/src/app/AppInitSDK';
-export { SDKReducers } from '@console/dynamic-plugin-sdk/src/app/redux';
-export {
-  setUser,
-  beginImpersonate,
-  endImpersonate,
-} from '@console/dynamic-plugin-sdk/src/app/core/actions/core';
-export {
-  getUser,
-  getImpersonate,
-} from '@console/dynamic-plugin-sdk/src/app/core/reducers/coreSelectors';
+export { default as AppInitSDK } from '../app/AppInitSDK';
+export { SDKReducers } from '../app/redux';
+export { setUser, beginImpersonate, endImpersonate } from '../app/core/actions/core';
+export { getUser, getImpersonate } from '../app/core/reducers/coreSelectors';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/host-app-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/host-app-api.ts
@@ -1,4 +1,11 @@
-export { default as AppInitSDK } from '../app/AppInitSDK';
-export { SDKReducers } from '../app/redux';
-export { setUser, beginImpersonate, endImpersonate } from '../app/core/actions/core';
-export { getUser, getImpersonate } from '../app/core/reducers/coreSelectors';
+export { default as AppInitSDK } from '@console/dynamic-plugin-sdk/src/app/AppInitSDK';
+export { SDKReducers } from '@console/dynamic-plugin-sdk/src/app/redux';
+export {
+  setUser,
+  beginImpersonate,
+  endImpersonate,
+} from '@console/dynamic-plugin-sdk/src/app/core/actions/core';
+export {
+  getUser,
+  getImpersonate,
+} from '@console/dynamic-plugin-sdk/src/app/core/reducers/coreSelectors';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * monorepo entrypoint for the dynamic plugin SDK
+ *
+ * Not published to NPM
+ */
+
 // Plugin APIs and types
 export * from './api/useResolvedExtensions';
 export * from './api/common-types';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/index.ts
@@ -1,7 +1,7 @@
 /**
- * monorepo entrypoint for the dynamic plugin SDK
+ * @file Entrypoint for the Console dynamic plugin SDK monorepo package.
  *
- * Not published to NPM
+ * Not published to npmjs; all Console monorepo packages are marked as private.
  */
 
 // Plugin APIs and types

--- a/frontend/packages/console-dynamic-plugin-sdk/src/lib-core.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/lib-core.ts
@@ -1,7 +1,7 @@
 /**
- * lib-core entrypoint for the dynamic plugin SDK
+ * @file Entrypoint for the `@openshift-console/dynamic-plugin-sdk` package published to npmjs.
  *
- * Published to NPM
+ * Provides core APIs, types and utilities used by dynamic plugins at runtime.
  */
 
 export * from './extensions';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/lib-core.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/lib-core.ts
@@ -1,2 +1,8 @@
+/**
+ * lib-core entrypoint for the dynamic plugin SDK
+ *
+ * Published to NPM
+ */
+
 export * from './extensions';
 export * from './api/core-api';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/lib-internal-kubevirt.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/lib-internal-kubevirt.ts
@@ -1,1 +1,7 @@
+/**
+ * @file Entrypoint for the `@openshift-console/dynamic-plugin-sdk-internal-kubevirt` package published to npmjs.
+ *
+ * Internal package to support KubeVirt plugin migration.
+ */
+
 export * from './api/internal-api-kubevirt';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/lib-internal.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/lib-internal.ts
@@ -1,1 +1,7 @@
+/**
+ * @file Entrypoint for the `@openshift-console/dynamic-plugin-sdk-internal` package published to npmjs.
+ *
+ * Internal package exposing additional code.
+ */
+
 export * from './api/internal-api';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/lib-webpack.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/lib-webpack.ts
@@ -1,1 +1,7 @@
+/**
+ * @file Entrypoint for the `@openshift-console/dynamic-plugin-sdk-webpack` package published to npmjs.
+ *
+ * Provides webpack plugin `ConsoleRemotePlugin` used to build all dynamic plugin assets.
+ */
+
 export { ConsoleRemotePlugin } from './webpack/ConsoleRemotePlugin';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource.ts
@@ -3,7 +3,7 @@ import { Map as ImmutableMap } from 'immutable';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector, useDispatch } from 'react-redux';
-import { getActiveCluster } from '../../../app';
+import { getActiveCluster } from '../../../app/core/reducers/coreSelectors';
 import * as k8sActions from '../../../app/k8s/actions/k8s';
 import { getReduxIdPayload } from '../../../app/k8s/reducers/k8sSelector';
 import { SDKStoreState } from '../../../app/redux-types';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource.ts
@@ -3,7 +3,7 @@ import { Map as ImmutableMap } from 'immutable';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector, useDispatch } from 'react-redux';
-import { getActiveCluster } from '@console/dynamic-plugin-sdk/src/app';
+import { getActiveCluster } from '../../../app';
 import * as k8sActions from '../../../app/k8s/actions/k8s';
 import { getReduxIdPayload } from '../../../app/k8s/reducers/k8sSelector';
 import { SDKStoreState } from '../../../app/redux-types';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources.ts
@@ -4,8 +4,8 @@ import { Map as ImmutableMap } from 'immutable';
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector, useDispatch } from 'react-redux';
 import { createSelectorCreator, defaultMemoize } from 'reselect';
-import { getActiveCluster, SDKStoreState } from '@console/dynamic-plugin-sdk/src/app';
 import { K8sModel } from '../../../api/common-types';
+import { getActiveCluster, SDKStoreState } from '../../../app';
 import * as k8sActions from '../../../app/k8s/actions/k8s';
 import { UseK8sWatchResources } from '../../../extensions/console-types';
 import {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources.ts
@@ -5,8 +5,9 @@ import { Map as ImmutableMap } from 'immutable';
 import { useSelector, useDispatch } from 'react-redux';
 import { createSelectorCreator, defaultMemoize } from 'reselect';
 import { K8sModel } from '../../../api/common-types';
-import { getActiveCluster, SDKStoreState } from '../../../app';
+import { getActiveCluster } from '../../../app/core/reducers/coreSelectors';
 import * as k8sActions from '../../../app/k8s/actions/k8s';
+import { SDKStoreState } from '../../../app/redux-types';
 import { UseK8sWatchResources } from '../../../extensions/console-types';
 import {
   transformGroupVersionKindToReference,


### PR DESCRIPTION
With some of the console logic migration into the SDK, we mistakenly used
aliased path imports. These are ignored by typescript.
IE: `@console/dynamic-plugin-sdk/src/utils/k8s/hooks`

These should be relative to play nice with typescript
IE: `../utils/k8s/hooks`

See: https://bugzilla.redhat.com/show_bug.cgi?id=2053168