### PR TITLE
chore(vscode config): disabling the organizeImports functionality of …

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,16 +1,32 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[javascript]": {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": false,
+      "source.sortImports": false
+    }
   },
   "[javascriptreact]": {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": false,
+      "source.sortImports": false    
+    }
   },
   "[typescript]": {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": false,
+      "source.sortImports": false    
+    }
   },
   "[typescriptreact]": {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": false,
+      "source.sortImports": false    
+    }
   },
   "[json]": {
     "editor.formatOnSave": true


### PR DESCRIPTION
I have enabled the `organizeImports` method globally. However, this function is not compatible with our code base and reorganizes the imports every time I save a file. This setting is not enabled by default.