### PR TITLE
Bug 2044454: update resources on change and remove renderNull Callback

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/topology-details.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/topology-details.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
+import { ExtensionHook } from '../api/common-types';
 import { Extension, CodeRef, ExtensionDeclaration } from '../types';
 import { K8sResourceCommon } from './console-types';
 import { BuildConfigData } from './topology-types';
@@ -34,12 +35,8 @@ export type DetailsTabSection = ExtensionDeclaration<
     tab: string;
     /** Returns a section for the graph element or undefined if not provided.
      * SDK component: <Section title={<optional>}>... padded area </Section>
-     * @param renderNull should be used for section that defines Adapter to
-     *  determine if adapter component renders null or not
      * */
-    section: CodeRef<
-      (element: GraphElement, renderNull?: () => null) => React.Component | undefined
-    >;
+    section: CodeRef<DetailsTabSectionCallback>;
     /** Insert this item before the item referenced here.
      * For arrays, the first one found in order is used.
      * */
@@ -169,3 +166,5 @@ export type PodsAdapterDataType<E = K8sResourceCommon> = {
 export type NetworkAdapterType = {
   resource: K8sResourceCommon;
 };
+
+export type DetailsTabSectionCallback = ExtensionHook<React.ReactElement | undefined, GraphElement>;

--- a/frontend/packages/dev-console/src/components/topology/hpa-tab-section.tsx
+++ b/frontend/packages/dev-console/src/components/topology/hpa-tab-section.tsx
@@ -1,18 +1,24 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import TopologySideBarTabSection from '@console/topology/src/components/side-bar/TopologySideBarTabSection';
 import { TYPE_WORKLOAD } from '@console/topology/src/const';
 import { HPAOverview } from '../hpa/HpaOverview';
 
-export const getHpaTabSectionForTopologySideBar = (element: GraphElement) => {
-  if (element.getType() !== TYPE_WORKLOAD) return undefined;
+export const getHpaTabSectionForTopologySideBar: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== TYPE_WORKLOAD) {
+    return [undefined, true, undefined];
+  }
   const data = element.getData();
   const { hpas } = data?.resources ?? {};
-  return hpas ? (
+  const section = hpas ? (
     <TopologySideBarTabSection>
       <HPAOverview hpas={hpas} />
     </TopologySideBarTabSection>
   ) : (
     undefined
   );
+  return [section, true, undefined];
 };

--- a/frontend/packages/dev-console/src/components/topology/observe-tab-section.tsx
+++ b/frontend/packages/dev-console/src/components/topology/observe-tab-section.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import {
   DaemonSetModel,
   DeploymentConfigModel,
@@ -9,11 +10,8 @@ import {
 import { getResource } from '@console/topology/src/utils';
 import MonitoringTab from '../monitoring/overview/MonitoringTab';
 
-export const getObserveSideBarTabSection = (element: GraphElement) => {
+export const getObserveSideBarTabSection: DetailsTabSectionCallback = (element: GraphElement) => {
   const resource = getResource(element);
-  if (!resource) {
-    return undefined;
-  }
   if (
     !resource ||
     ![
@@ -21,9 +19,11 @@ export const getObserveSideBarTabSection = (element: GraphElement) => {
       DeploymentModel.kind,
       StatefulSetModel.kind,
       DaemonSetModel.kind,
-    ].includes(resource?.kind)
-  )
-    return undefined;
+    ].includes(resource.kind)
+  ) {
+    return [undefined, true, undefined];
+  }
   const { resources } = element.getData();
-  return resources ? <MonitoringTab item={resources} /> : undefined;
+  const section = resources ? <MonitoringTab item={resources} /> : undefined;
+  return [section, true, undefined];
 };

--- a/frontend/packages/dev-console/src/components/topology/sbr-sidebar/tab-section.tsx
+++ b/frontend/packages/dev-console/src/components/topology/sbr-sidebar/tab-section.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Edge, GraphElement } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
-import { K8sResourceCommon } from '@console/dynamic-plugin-sdk/src';
+import { K8sResourceCommon } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { ResourceSummary, SectionHeading } from '@console/internal/components/utils';
 import TopologyEdgeResourcesPanel from '@console/topology/src/components/side-bar/TopologyEdgeResourcesPanel';
 import { TYPE_SERVICE_BINDING } from '@console/topology/src/const';
@@ -17,13 +18,19 @@ const DetailsSection: React.FC<{ resource: K8sResourceCommon }> = ({ resource })
   );
 };
 
-export const getSbrPanelDetailsSection = (element: GraphElement) => {
-  if (element.getType() !== TYPE_SERVICE_BINDING) return undefined;
+export const getSbrPanelDetailsSection: DetailsTabSectionCallback = (element: GraphElement) => {
+  if (element.getType() !== TYPE_SERVICE_BINDING) {
+    return [undefined, true, undefined];
+  }
   const resource = getResource(element);
-  return <DetailsSection resource={resource} />;
+  const section = <DetailsSection resource={resource} />;
+  return [section, true, undefined];
 };
 
-export const getSbrPanelResourceSection = (element: Edge) => {
-  if (element.getType() !== TYPE_SERVICE_BINDING) return undefined;
-  return <TopologyEdgeResourcesPanel edge={element} />;
+export const getSbrPanelResourceSection: DetailsTabSectionCallback = (element: Edge) => {
+  if (element.getType() !== TYPE_SERVICE_BINDING) {
+    return [undefined, true, undefined];
+  }
+  const section = <TopologyEdgeResourcesPanel edge={element} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/helm-plugin/src/topology/sidebar/release-panel/tab-sections.tsx
+++ b/frontend/packages/helm-plugin/src/topology/sidebar/release-panel/tab-sections.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { StatusBox } from '@console/internal/components/utils/status-box';
 import TopologyGroupResourcesPanel from '@console/topology/src/components/side-bar/TopologyGroupResourcesPanel';
 import { getResource } from '@console/topology/src/utils';
@@ -28,19 +29,30 @@ const HelmReleasePanelDetailsTabSection: React.FC<{ element: GraphElement }> = (
   );
 };
 
-export const getHelmReleasePanelDetailsTabSection = (element: GraphElement) => {
-  if (element.getType() !== TYPE_HELM_RELEASE) return undefined;
-  return <HelmReleasePanelDetailsTabSection element={element} />;
+export const getHelmReleasePanelDetailsTabSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== TYPE_HELM_RELEASE) {
+    return [undefined, true, undefined];
+  }
+  const section = <HelmReleasePanelDetailsTabSection element={element} />;
+  return [section, true, undefined];
 };
 
-export const getHelmReleasePanelResourceTabSection = (element: GraphElement) => {
-  if (element.getType() !== TYPE_HELM_RELEASE) return undefined;
+export const getHelmReleasePanelResourceTabSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== TYPE_HELM_RELEASE) {
+    return [undefined, true, undefined];
+  }
   const { manifestResources } = element.getData().data;
   const resource = getResource(element);
-  if (!manifestResources || !resource?.metadata) return null;
+  if (!manifestResources || !resource?.metadata) {
+    return [null, true, undefined];
+  }
   const { namespace } = resource.metadata;
 
-  return (
+  const section = (
     <div className="overview__sidebar-pane-body">
       <TopologyGroupResourcesPanel
         manifestResources={manifestResources}
@@ -48,10 +60,16 @@ export const getHelmReleasePanelResourceTabSection = (element: GraphElement) => 
       />
     </div>
   );
+  return [section, true, undefined];
 };
 
-export const getHelmReleasePanelReleaseNotesTabSection = (element: GraphElement) => {
-  if (element.getType() !== TYPE_HELM_RELEASE) return undefined;
+export const getHelmReleasePanelReleaseNotesTabSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== TYPE_HELM_RELEASE) {
+    return [undefined, true, undefined];
+  }
   const { releaseNotes } = element.getData().data;
-  return <TopologyHelmReleaseNotesPanel releaseNotes={releaseNotes} />;
+  const section = <TopologyHelmReleaseNotesPanel releaseNotes={releaseNotes} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-common-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-common-tab-sections.tsx
@@ -6,6 +6,7 @@ import {
   K8sResourceCommon,
   PodsAdapterDataType,
 } from '@console/dynamic-plugin-sdk/src';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { PodModel } from '@console/internal/models';
 import { PodKind, podPhase, referenceForModel } from '@console/internal/module/k8s';
@@ -83,7 +84,7 @@ export const getKnativeSidepanelPodsAdapterSection = (
   return undefined;
 };
 
-export const getKnativeSidepanelDetailsTab = (element: GraphElement) => {
+export const getKnativeSidepanelDetailsTab: DetailsTabSectionCallback = (element: GraphElement) => {
   if (
     [
       TYPE_EVENT_PUB_SUB_LINK,
@@ -95,34 +96,46 @@ export const getKnativeSidepanelDetailsTab = (element: GraphElement) => {
     ].includes(element.getType())
   ) {
     const knObj = element.getData().resources;
-    return <KnativeOverviewDetails item={knObj} />;
+    const section = <KnativeOverviewDetails item={knObj} />;
+    return [section, true, undefined];
   }
-  return undefined;
+  return [undefined, true, undefined];
 };
 
-export const getKnativeSidePanelEventSinkDetailsTab = (element: GraphElement) => {
+export const getKnativeSidePanelEventSinkDetailsTab: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
   if (element.getType() === NodeType.EventSink) {
     const knObj = element.getData().resources;
-    return <KnativeEventSinkOverviewDetails item={knObj} />;
+    const section = <KnativeEventSinkOverviewDetails item={knObj} />;
+    return [section, true, undefined];
   }
-  return undefined;
+  return [undefined, true, undefined];
 };
 
-export const getKnativeSidepanelRoutesSection = (element: GraphElement) => {
+export const getKnativeSidepanelRoutesSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
   if (element.getType() === NodeType.KnService || element.getType() === NodeType.Revision) {
     const knObj = element.getData().resources;
     const resource = getResource(element);
-    return (
+    const section = (
       <TopologySideBarTabSection>
         <KSRoutesOverviewList ksroutes={knObj.ksroutes} resource={resource} />
       </TopologySideBarTabSection>
     );
+    return [section, true, undefined];
   }
-  return undefined;
+  return [undefined, true, undefined];
 };
 
-export const getKnativeSidepanelEventSourcesSection = (element: GraphElement) => {
-  if (![TYPE_KNATIVE_SERVICE, TYPE_SINK_URI].includes(element.getType())) return undefined;
+export const getKnativeSidepanelEventSourcesSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (![TYPE_KNATIVE_SERVICE, TYPE_SINK_URI].includes(element.getType())) {
+    return [undefined, true, undefined];
+  }
   const knObj = element.getData().resources;
-  return <EventSourcesOverviewList items={knObj.eventSources} />;
+  const section = <EventSourcesOverviewList items={knObj.eventSources} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-connectors-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-connectors-tab-sections.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Edge } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import TopologyEdgeResourcesPanel from '@console/topology/src/components/side-bar/TopologyEdgeResourcesPanel';
 import {
   TYPE_EVENT_SINK_LINK,
@@ -8,7 +9,9 @@ import {
   TYPE_REVISION_TRAFFIC,
 } from '../const';
 
-export const getKnativeConnectorSidepanelResourceSection = (element: Edge) => {
+export const getKnativeConnectorSidepanelResourceSection: DetailsTabSectionCallback = (
+  element: Edge,
+) => {
   if (
     ![
       TYPE_REVISION_TRAFFIC,
@@ -17,7 +20,8 @@ export const getKnativeConnectorSidepanelResourceSection = (element: Edge) => {
       TYPE_EVENT_SINK_LINK,
     ].includes(element.getType())
   ) {
-    return undefined;
+    return [undefined, true, undefined];
   }
-  return <TopologyEdgeResourcesPanel edge={element} />;
+  const section = <TopologyEdgeResourcesPanel edge={element} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-eventsource-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-eventsource-tab-sections.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { ExternalLink, ResourceIcon } from '@console/internal/components/utils';
 import { referenceFor } from '@console/internal/module/k8s';
 import TopologySideBarTabSection from '@console/topology/src/components/side-bar/TopologySideBarTabSection';
@@ -10,17 +11,19 @@ import { isDynamicEventResourceKind } from '../../utils/fetch-dynamic-eventsourc
 import { TYPE_SINK_URI } from '../const';
 import { KameletType } from '../topology-types';
 
-export const getKnativeSidepanelSinkSection = (element: GraphElement) => {
+export const getKnativeSidepanelSinkSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
   const resource = getResource(element);
   const data = element.getData();
   if (!resource) {
-    return undefined;
+    return [undefined, true, undefined];
   }
   if (
     isDynamicEventResourceKind(referenceFor(resource)) ||
     (resource.kind === CamelKameletBindingModel.kind && data.kameletType === KameletType.Source)
   ) {
-    return (
+    const section = (
       <TopologySideBarTabSection>
         <EventSourceResources
           obj={resource}
@@ -28,8 +31,9 @@ export const getKnativeSidepanelSinkSection = (element: GraphElement) => {
         />
       </TopologySideBarTabSection>
     );
+    return [section, true, undefined];
   }
-  return undefined;
+  return [undefined, true, undefined];
 };
 
 export const getKnativeURISinkResourceLink = (element: GraphElement) => {

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-pubsub-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-pubsub-tab-sections.tsx
@@ -1,14 +1,20 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import EventPubSubResources from '../../components/overview/EventPubSubResources';
 import { TYPE_EVENT_PUB_SUB, TYPE_EVENT_PUB_SUB_LINK } from '../const';
 
-export const getResourceTabPubSubSectionForTopologySidebar = (element: GraphElement) => {
-  if (![TYPE_EVENT_PUB_SUB, TYPE_EVENT_PUB_SUB_LINK].includes(element.getType())) return undefined;
+export const getResourceTabPubSubSectionForTopologySidebar: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (![TYPE_EVENT_PUB_SUB, TYPE_EVENT_PUB_SUB_LINK].includes(element.getType())) {
+    return [undefined, true, undefined];
+  }
   const itemResources = element.getData();
-  return (
+  const section = (
     <div className="overview__sidebar-pane-body">
       <EventPubSubResources item={itemResources.resources} />
     </div>
   );
+  return [section, true, undefined];
 };

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-resource-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-resource-tab-sections.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
-import {
-  SidebarSectionHeading,
-  ResourceLink,
-  ExternalLink,
-} from '@console/internal/components/utils';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
+import { SidebarSectionHeading, ResourceLink, ExternalLink } from '@console/internal/components/utils';
 import { K8sResourceKind, referenceFor, PodKind, podPhase } from '@console/internal/module/k8s';
 import { AllPodStatus, usePodsWatcher } from '@console/shared';
 import TopologySideBarTabSection from '@console/topology/src/components/side-bar/TopologySideBarTabSection';
@@ -56,16 +53,19 @@ export const EventSinkSourceSection: React.FC<{ resource: K8sResourceKind }> = (
   );
 };
 
-export const getKnativeSidepanelEventSinkSection = (element: GraphElement) => {
+export const getKnativeSidepanelEventSinkSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
   if (element.getType() === NodeType.EventSink) {
     const resource = getResource(element);
-    return resource ? (
+    const section = resource ? (
       <TopologySideBarTabSection>
         <EventSinkSourceSection resource={resource} />
       </TopologySideBarTabSection>
     ) : null;
+    return [section, true, undefined];
   }
-  return undefined;
+  return [undefined, true, undefined];
 };
 
 export const usePodsForEventSink = (resource: K8sResourceKind, data) => {

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-revision-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-revision-tab-sections.tsx
@@ -1,27 +1,38 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import TopologySideBarTabSection from '@console/topology/src/components/side-bar/TopologySideBarTabSection';
 import { getResource } from '@console/topology/src/utils';
 import ConfigurationsOverviewList from '../../components/overview/ConfigurationsOverviewList';
 import DeploymentOverviewList from '../../components/overview/DeploymentOverviewList';
 import { NodeType } from '../topology-types';
 
-export const getKnativeSidepanelDeploymentSection = (element: GraphElement) => {
-  if (element.getType() !== NodeType.Revision) return undefined;
+export const getKnativeSidepanelDeploymentSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== NodeType.Revision) {
+    return [undefined, true, undefined];
+  }
   const resource = getResource(element);
-  return (
+  const section = (
     <TopologySideBarTabSection>
       <DeploymentOverviewList resource={resource} />
     </TopologySideBarTabSection>
   );
+  return [section, true, undefined];
 };
 
-export const getKnativeSidepanelConfigurationsSection = (element: GraphElement) => {
-  if (element.getType() !== NodeType.Revision) return undefined;
+export const getKnativeSidepanelConfigurationsSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== NodeType.Revision) {
+    return [undefined, true, undefined];
+  }
   const knObj = element.getData().resources;
-  return (
+  const section = (
     <TopologySideBarTabSection>
       <ConfigurationsOverviewList configurations={knObj.configurations} />
     </TopologySideBarTabSection>
   );
+  return [section, true, undefined];
 };

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-service-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-service-tab-sections.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import { AdapterDataType } from '@console/dynamic-plugin-sdk/src';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { BuildConfigData, useBuildConfigsWatcher } from '@console/shared';
 import TopologySideBarTabSection from '@console/topology/src/components/side-bar/TopologySideBarTabSection';
 import { getResource } from '@console/topology/src/utils';
@@ -13,15 +14,20 @@ import {
   TriggersOverviewList,
 } from './KnativeOverviewSections';
 
-export const getKnativeSidepanelRevisionSection = (element: GraphElement) => {
-  if (element.getType() !== NodeType.KnService) return undefined;
+export const getKnativeSidepanelRevisionSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== NodeType.KnService) {
+    return [undefined, true, undefined];
+  }
   const knObj = element.getData().resources;
   const resource = getResource(element);
-  return (
+  const section = (
     <TopologySideBarTabSection>
       <RevisionsOverviewList revisions={knObj.revisions} service={resource} />
     </TopologySideBarTabSection>
   );
+  return [section, true, undefined];
 };
 
 export const getKnativeSidepanelBuildAdapterSection = (
@@ -32,25 +38,39 @@ export const getKnativeSidepanelBuildAdapterSection = (
   return { resource, provider: useBuildConfigsWatcher };
 };
 
-export const getKnativeSidepanelSubscriptionsSection = (element: GraphElement) => {
-  if (element.getType() !== NodeType.KnService) return undefined;
+export const getKnativeSidepanelSubscriptionsSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== NodeType.KnService) {
+    return [undefined, true, undefined];
+  }
   const knObj = element.getData().resources;
   const { subscribers } = knObj;
   const [channels] = getSubscriberByType(subscribers);
-  return <SubscriptionsOverviewList subscriptions={channels} />;
+  const section = <SubscriptionsOverviewList subscriptions={channels} />;
+  return [section, true, undefined];
 };
 
-export const getKnativeSidepanelTriggersSection = (element: GraphElement) => {
-  if (element.getType() !== NodeType.KnService) return undefined;
+export const getKnativeSidepanelTriggersSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== NodeType.KnService) {
+    return [undefined, true, undefined];
+  }
   const knObj = element.getData().resources;
   const { subscribers } = knObj;
   const [, brokers] = getSubscriberByType(subscribers);
-  return <TriggersOverviewList subscriptions={brokers} />;
+  const section = <TriggersOverviewList subscriptions={brokers} />;
+  return [section, true, undefined];
 };
 
-export const getKnativeSidepanelDomainMappingsSection = (element: GraphElement) => {
-  if (element.getType() !== NodeType.KnService) return undefined;
+export const getKnativeSidepanelDomainMappingsSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== NodeType.KnService) {
+    return [undefined, true, undefined];
+  }
   const knObj = element.getData().resources;
-
-  return <DomainMappingsOverviewList items={knObj.domainMappings} />;
+  const section = <DomainMappingsOverviewList items={knObj.domainMappings} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/kubevirt-plugin/src/topology/vm-tab-sections.tsx
+++ b/frontend/packages/kubevirt-plugin/src/topology/vm-tab-sections.tsx
@@ -7,6 +7,7 @@ import {
   NetworkAdapterType,
   PodsAdapterDataType,
 } from '@console/dynamic-plugin-sdk/src';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { ResourceIcon, resourcePathFromModel } from '@console/internal/components/utils';
 import { getResource } from '@console/topology/src/utils';
 import { VirtualMachineModel } from '../models';
@@ -16,9 +17,14 @@ import { TYPE_VIRTUAL_MACHINE } from './components/const';
 import { TopologyVmDetailsPanel } from './TopologyVmDetailsPanel';
 import { VMNode } from './types';
 
-export const getVmSidePanelDetailsTabSection = (element: GraphElement) => {
-  if (element.getType() !== TYPE_VIRTUAL_MACHINE) return undefined;
-  return <TopologyVmDetailsPanel vmNode={element as VMNode} />;
+export const getVmSidePanelDetailsTabSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== TYPE_VIRTUAL_MACHINE) {
+    return [undefined, true, undefined];
+  }
+  const section = <TopologyVmDetailsPanel vmNode={element as VMNode} />;
+  return [section, true, undefined];
 };
 
 const usePodsAdapterForVm = (resource: K8sResourceCommon): PodsAdapterDataType => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/topology/operator-link-tab-section.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/topology/operator-link-tab-section.tsx
@@ -1,20 +1,25 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { ManagedByOperatorLink } from '@console/internal/components/utils/managed-by';
 import TopologySideBarTabSection from '@console/topology/src/components/side-bar/TopologySideBarTabSection';
 import { TYPE_WORKLOAD } from '@console/topology/src/const';
 import { getResource } from '@console/topology/src/utils';
 
-export const getManagedByOperatorLinkSideBarTabSection = (element: GraphElement) => {
-  if (element.getType() !== TYPE_WORKLOAD && !element.getData()?.data?.isKnativeResource)
-    return undefined;
+export const getManagedByOperatorLinkSideBarTabSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== TYPE_WORKLOAD && !element.getData()?.data?.isKnativeResource) {
+    return [undefined, true, undefined];
+  }
   const resource = getResource(element);
   if (!resource) {
-    return undefined;
+    return [undefined, true, undefined];
   }
-  return (
+  const section = (
     <TopologySideBarTabSection>
       <ManagedByOperatorLink obj={resource} />
     </TopologySideBarTabSection>
   );
+  return [section, true, undefined];
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/topology/sidebar/details-sections.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/topology/sidebar/details-sections.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { ResourceSummary, SectionHeading } from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { TYPE_OPERATOR_BACKED_SERVICE } from '@console/topology/src/operators/components/const';
@@ -15,8 +16,13 @@ const DetailsSection: React.FC<{ resource: K8sResourceKind }> = ({ resource }) =
   );
 };
 
-export const getOperatorBackedPanelDetailsSection = (element: GraphElement) => {
-  if (element.getType() !== TYPE_OPERATOR_BACKED_SERVICE) return undefined;
+export const getOperatorBackedPanelDetailsSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== TYPE_OPERATOR_BACKED_SERVICE) {
+    return [undefined, true, undefined];
+  }
   const data = element.getData();
-  return <DetailsSection resource={data.resource} />;
+  const section = <DetailsSection resource={data.resource} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/topology/sidebar/resource-sections.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/topology/sidebar/resource-sections.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { TopologyDataObject } from '@console/dynamic-plugin-sdk/src/extensions/topology-types';
 import { StatusBox } from '@console/internal/components/utils';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
@@ -43,7 +44,12 @@ const ResourceSection: React.FC<{ item: TopologyDataObject<OperatorGroupData> }>
   );
 };
 
-export const getOperatorBackedPanelResourceSection = (element: GraphElement) => {
-  if (element.getType() !== TYPE_OPERATOR_BACKED_SERVICE) return undefined;
-  return <ResourceSection item={element.getData()} />;
+export const getOperatorBackedPanelResourceSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== TYPE_OPERATOR_BACKED_SERVICE) {
+    return [undefined, true, undefined];
+  }
+  const section = <ResourceSection item={element.getData()} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/pipelines-plugin/src/topology/pipeline-tab-section.tsx
+++ b/frontend/packages/pipelines-plugin/src/topology/pipeline-tab-section.tsx
@@ -1,16 +1,20 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import TopologySideBarTabSection from '@console/topology/src/components/side-bar/TopologySideBarTabSection';
 import PipelinesOverview from '../components/pipelines/pipeline-overview/PipelineOverview';
 
-export const getPipelinesSideBarTabSection = (element: GraphElement) => {
+export const getPipelinesSideBarTabSection: DetailsTabSectionCallback = (element: GraphElement) => {
   const data = element.getData();
   const resources = data?.resources;
   // This check is based on the properties added through getPipelinesDataModelReconciler
-  if (!resources?.pipelines) return undefined;
-  return (
+  if (!resources?.pipelines) {
+    return [undefined, true, undefined];
+  }
+  const section = (
     <TopologySideBarTabSection>
       <PipelinesOverview item={resources} />
     </TopologySideBarTabSection>
   );
+  return [section, true, undefined];
 };

--- a/frontend/packages/rhoas-plugin/src/topology/sidebar/kafka-connection-tab-section.tsx
+++ b/frontend/packages/rhoas-plugin/src/topology/sidebar/kafka-connection-tab-section.tsx
@@ -1,19 +1,30 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { getResource } from '@console/topology/src/utils';
 import { KafkaConnection } from '../../utils/rhoas-types';
 import { TYPE_MANAGED_KAFKA_CONNECTION } from '../components/const';
 import { DetailsComponent } from '../components/DetailsComponent';
 import { ResourcesComponent } from '../components/ResourceComponent';
 
-export const getDetailsTabSectionForTopologySideBar = (element: GraphElement) => {
-  if (element.getType() !== TYPE_MANAGED_KAFKA_CONNECTION) return undefined;
+export const getDetailsTabSectionForTopologySideBar: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== TYPE_MANAGED_KAFKA_CONNECTION) {
+    return [undefined, true, undefined];
+  }
   const resource = getResource<KafkaConnection>(element);
-  return <DetailsComponent obj={resource} />;
+  const section = <DetailsComponent obj={resource} />;
+  return [section, true, undefined];
 };
 
-export const getResourceTabSectionForTopologySideBar = (element: GraphElement) => {
-  if (element.getType() !== TYPE_MANAGED_KAFKA_CONNECTION) return undefined;
+export const getResourceTabSectionForTopologySideBar: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== TYPE_MANAGED_KAFKA_CONNECTION) {
+    return [undefined, true, undefined];
+  }
   const resource = getResource<KafkaConnection>(element);
-  return <ResourcesComponent obj={resource} />;
+  const section = <ResourcesComponent obj={resource} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/topology/console-extensions.json
+++ b/frontend/packages/topology/console-extensions.json
@@ -92,7 +92,7 @@
     "properties": {
       "id": "topology-tab-section-pods-overview",
       "tab": "topology-side-bar-tab-resource",
-      "section": { "$codeRef": "workload.getPodsSideBarTabSection" }
+      "section": { "$codeRef": "workload.usePodsSideBarTabSection" }
     }
   },
   {
@@ -108,7 +108,7 @@
     "properties": {
       "id": "topology-tab-section-builds-overview",
       "tab": "topology-side-bar-tab-resource",
-      "section": { "$codeRef": "workload.getBuildsSideBarTabSection" }
+      "section": { "$codeRef": "workload.useBuildsSideBarTabSection" }
     }
   },
   {
@@ -116,7 +116,7 @@
     "properties": {
       "id": "topology-tab-section-network-overview",
       "tab": "topology-side-bar-tab-resource",
-      "section": { "$codeRef": "workload.getNetworkingSideBarTabSection" }
+      "section": { "$codeRef": "workload.useNetworkingSideBarTabSection" }
     }
   },
   {

--- a/frontend/packages/topology/src/components/application-panel/application-resource-tab-section.tsx
+++ b/frontend/packages/topology/src/components/application-panel/application-resource-tab-section.tsx
@@ -1,14 +1,20 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { TYPE_APPLICATION_GROUP } from '../../const';
 import TopologyApplicationResources from './TopologyApplicationResources';
 
-export const getApplicationPanelResourceTabSection = (element: GraphElement) => {
-  if (element.getType() !== TYPE_APPLICATION_GROUP) return undefined;
-  return (
+export const getApplicationPanelResourceTabSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== TYPE_APPLICATION_GROUP) {
+    return [undefined, true, undefined];
+  }
+  const section = (
     <TopologyApplicationResources
       resources={element.getData().groupResources}
       group={element.getLabel()}
     />
   );
+  return [section, true, undefined];
 };

--- a/frontend/packages/topology/src/components/side-bar/providers/SideBarTabLoader.tsx
+++ b/frontend/packages/topology/src/components/side-bar/providers/SideBarTabLoader.tsx
@@ -1,21 +1,17 @@
 import * as React from 'react';
-import { GraphElement, isEdge } from '@patternfly/react-topology';
-import { useTranslation } from 'react-i18next';
+import { GraphElement } from '@patternfly/react-topology';
 import {
   DetailsTab,
   DetailsTabSection,
   isDetailsTab,
   isDetailsTabSection,
+  ResolvedExtension,
   useResolvedExtensions,
 } from '@console/dynamic-plugin-sdk';
 import { Tab } from '@console/internal/components/utils';
 import { useExtensions } from '@console/plugin-sdk';
 import { orderExtensionBasedOnInsertBeforeAndAfter } from '@console/shared';
-import { getResource } from '@console/topology/src/utils';
-import { DefaultResourceSideBar } from '../DefaultResourceSideBar';
-import TopologyEdgeResourcesPanel from '../TopologyEdgeResourcesPanel';
-
-const TabSection: React.FC = ({ children }) => <>{children}</>;
+import TabSection from './TabSection';
 
 type SideBarTabLoaderProps = {
   element: GraphElement;
@@ -23,11 +19,6 @@ type SideBarTabLoaderProps = {
 };
 
 const SideBarTabLoader: React.FC<SideBarTabLoaderProps> = ({ element, children }) => {
-  const { t } = useTranslation();
-  const [isSectionRendered, setIsSectionRendered] = React.useState<{ [tab: string]: boolean[] }>(
-    {},
-  );
-  const renderSection = React.useRef<{ [tab: string]: boolean[] }>({});
   const tabExtensions = useExtensions<DetailsTab>(isDetailsTab);
   const [tabSectionExtensions, resolved] = useResolvedExtensions<DetailsTabSection>(
     isDetailsTabSection,
@@ -40,76 +31,27 @@ const SideBarTabLoader: React.FC<SideBarTabLoaderProps> = ({ element, children }
     [tabExtensions],
   );
 
-  const renderNull = React.useCallback((tab: string): [number, () => null] => {
-    renderSection.current[tab]
-      ? renderSection.current[tab].push(true)
-      : (renderSection.current[tab] = [true]);
-    const index = renderSection.current[tab].length - 1;
-    return [
-      index,
-      (): null => {
-        renderSection.current[tab][index] = false;
-        setIsSectionRendered(renderSection.current);
-        return null;
-      },
-    ];
-  }, []);
-  const tabSections = React.useMemo(() => {
-    return resolved
-      ? tabSectionExtensions.reduce((tabs, { properties: { tab, section, ...rest } }) => {
-          const [index, callback] = renderNull(tab);
-          const resolvedSection = section(element, callback);
-          if (!resolvedSection) {
-            renderSection.current[tab][index] = false;
-            return tabs;
-          }
-          return {
-            ...tabs,
-            ...(tabs.hasOwnProperty(tab)
-              ? { [tab]: [...tabs[tab], { ...rest, resolvedSection }] }
-              : { [tab]: [{ ...rest, resolvedSection }] }),
-          };
-        }, {})
-      : {};
-  }, [resolved, tabSectionExtensions, element, renderNull]);
+  const orderedTabSections = React.useMemo<ResolvedExtension<DetailsTabSection>['properties'][]>(
+    () =>
+      resolved
+        ? orderExtensionBasedOnInsertBeforeAndAfter<
+            ResolvedExtension<DetailsTabSection>['properties']
+          >(tabSectionExtensions.map(({ properties }) => properties))
+        : [],
+    [tabSectionExtensions, resolved],
+  );
 
-  const [tabs, loaded] = React.useMemo(() => {
-    if (Object.keys(tabSections).length === 0) return [[], false];
-
-    const resolvedTabs = orderedTabs.reduce((acc, { id, label }) => {
-      if (
-        !tabSections.hasOwnProperty(id) ||
-        (isSectionRendered[id] && !isSectionRendered[id].some((s) => s))
-      )
-        return acc;
-      const tabContent = orderExtensionBasedOnInsertBeforeAndAfter<{
-        resolvedSection: React.ReactNode;
-        id: string;
-      }>(tabSections[id]).map(({ id: tsId, resolvedSection }) => (
-        <TabSection key={tsId}>{resolvedSection}</TabSection>
-      ));
-      return [...acc, { name: label, component: () => <>{tabContent}</> }];
-    }, []);
-
-    return [resolvedTabs, true];
-  }, [tabSections, isSectionRendered, orderedTabs]);
-
-  // show default side bar
-  if (tabs.length === 0) {
-    const resource = getResource(element);
-    resource &&
-      tabs.push({
-        name: t('topology~Details'),
-        component: () => <DefaultResourceSideBar resource={resource} />,
-      });
-    isEdge(element) &&
-      tabs.push({
-        name: t('topology~Resources'),
-        component: () => <TopologyEdgeResourcesPanel edge={element} />,
-      });
-  }
-
-  return children(tabs, loaded);
+  return resolved ? (
+    <TabSection
+      element={element}
+      tabExtensions={orderedTabs}
+      tabSectionExtensions={orderedTabSections}
+    >
+      {children}
+    </TabSection>
+  ) : (
+    children([], false)
+  );
 };
 
 export default SideBarTabLoader;

--- a/frontend/packages/topology/src/components/side-bar/providers/TabSection.tsx
+++ b/frontend/packages/topology/src/components/side-bar/providers/TabSection.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { GraphElement, isEdge, observer } from '@patternfly/react-topology';
+import { useTranslation } from 'react-i18next';
+import { DetailsTab, DetailsTabSection, ResolvedExtension } from '@console/dynamic-plugin-sdk';
+import { Tab } from '@console/internal/components/utils';
+import { orderExtensionBasedOnInsertBeforeAndAfter } from '@console/shared';
+import { getResource } from '@console/topology/src/utils';
+import { DefaultResourceSideBar } from '../DefaultResourceSideBar';
+import TopologyEdgeResourcesPanel from '../TopologyEdgeResourcesPanel';
+
+type TabSection = Omit<
+  DetailsTabSection['properties'] & { resolvedSection: React.ReactNode },
+  'section' | 'tab'
+>;
+
+type TabSectionProps = {
+  element: GraphElement;
+  children: (tabs: Tab[], loaded: boolean) => React.ReactElement;
+  tabSectionExtensions: ResolvedExtension<DetailsTabSection>['properties'][];
+  tabExtensions: DetailsTab['properties'][];
+};
+
+const TabSection: React.FC<TabSectionProps> = ({
+  element,
+  children,
+  tabSectionExtensions,
+  tabExtensions,
+}) => {
+  const { t } = useTranslation();
+
+  // resolving hooks in loop since number of extensions will remain the same
+  const tabSections: { [key: string]: TabSection[] } = tabSectionExtensions.reduce(
+    (acc, { section, tab, ...rest }) => {
+      const [resolvedSection] = section(element);
+      if (!resolvedSection) {
+        return acc;
+      }
+      return {
+        ...acc,
+        ...(acc.hasOwnProperty(tab)
+          ? { [tab]: [...acc[tab], { ...rest, resolvedSection }] }
+          : { [tab]: [{ ...rest, resolvedSection }] }),
+      };
+    },
+    {},
+  );
+
+  const [tabs, tabsLoaded] = React.useMemo(() => {
+    if (Object.keys(tabSections).length === 0) return [[], false];
+
+    const resolvedTabs: Tab[] = tabExtensions.reduce((acc, { id, label }) => {
+      if (!tabSections.hasOwnProperty(id)) {
+        return acc;
+      }
+      const tabContent = orderExtensionBasedOnInsertBeforeAndAfter<{
+        resolvedSection: React.ReactNode;
+        id: string;
+      }>(tabSections[id]).map(({ id: tsId, resolvedSection }) => (
+        <React.Fragment key={tsId}>{resolvedSection}</React.Fragment>
+      ));
+      return [...acc, { name: label, component: () => <>{tabContent}</> }];
+    }, []);
+
+    return [resolvedTabs, true];
+  }, [tabSections, tabExtensions]);
+
+  // show default side bar
+  if (tabsLoaded && tabs.length === 0) {
+    const resource = getResource(element);
+    resource &&
+      tabs.push({
+        name: t('topology~Details'),
+        component: () => <DefaultResourceSideBar resource={resource} />,
+      });
+    isEdge(element) &&
+      tabs.push({
+        name: t('topology~Resources'),
+        component: () => <TopologyEdgeResourcesPanel edge={element} />,
+      });
+  }
+
+  return children(tabs, tabsLoaded);
+};
+
+export default observer(TabSection);

--- a/frontend/packages/topology/src/components/visual-connector/resource-tab-section.tsx
+++ b/frontend/packages/topology/src/components/visual-connector/resource-tab-section.tsx
@@ -1,9 +1,15 @@
 import * as React from 'react';
 import { Edge, GraphElement } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { TYPE_CONNECTS_TO } from '../../const';
 import TopologyEdgeResourcesPanel from '../side-bar/TopologyEdgeResourcesPanel';
 
-export const getVisualConnectorResourceTabSection = (element: GraphElement) => {
-  if (element.getType() !== TYPE_CONNECTS_TO) return undefined;
-  return <TopologyEdgeResourcesPanel edge={element as Edge} />;
+export const getVisualConnectorResourceTabSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
+  if (element.getType() !== TYPE_CONNECTS_TO) {
+    return [undefined, true, undefined];
+  }
+  const section = <TopologyEdgeResourcesPanel edge={element as Edge} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/topology/src/components/workload/CronJobSideBarDetails.tsx
+++ b/frontend/packages/topology/src/components/workload/CronJobSideBarDetails.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { DetailsItem, ResourceSummary, Timestamp } from '@console/internal/components/utils';
 import { CronJobModel } from '@console/internal/models';
 import { CronJobKind } from '@console/internal/module/k8s';
@@ -47,8 +48,11 @@ const CronJobSideBarDetails: React.FC<CronJobSideBarDetailsProps> = ({ cronjob }
   );
 };
 
-export const getCronJobSideBarDetails = (element: GraphElement) => {
+export const getCronJobSideBarDetails: DetailsTabSectionCallback = (element: GraphElement) => {
   const resource = getResource<CronJobKind>(element);
-  if (!resource || resource.kind !== CronJobModel.kind) return undefined;
-  return <CronJobSideBarDetails cronjob={resource} />;
+  if (!resource || resource.kind !== CronJobModel.kind) {
+    return [undefined, true, undefined];
+  }
+  const section = <CronJobSideBarDetails cronjob={resource} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/topology/src/components/workload/DaemonSetSideBarDetails.tsx
+++ b/frontend/packages/topology/src/components/workload/DaemonSetSideBarDetails.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { DaemonSetDetailsList } from '@console/internal/components/daemon-set';
 import { ResourceSummary, StatusBox } from '@console/internal/components/utils';
 import { DaemonSetModel } from '@console/internal/models';
@@ -37,8 +38,11 @@ const DaemonSetSideBarDetails: React.FC<DaemonSetOverviewDetailsProps> = ({ ds }
   );
 };
 
-export const getDaemonSetSideBarDetails = (element: GraphElement) => {
+export const getDaemonSetSideBarDetails: DetailsTabSectionCallback = (element: GraphElement) => {
   const resource = getResource(element);
-  if (!resource || resource.kind !== DaemonSetModel.kind) return undefined;
-  return <DaemonSetSideBarDetails ds={resource} />;
+  if (!resource || resource.kind !== DaemonSetModel.kind) {
+    return [undefined, true, undefined];
+  }
+  const section = <DaemonSetSideBarDetails ds={resource} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/topology/src/components/workload/DeploymentConfigSideBarDetails.tsx
+++ b/frontend/packages/topology/src/components/workload/DeploymentConfigSideBarDetails.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { DeploymentConfigDetailsList } from '@console/internal/components/deployment-config';
 import {
   LoadingInline,
@@ -48,8 +49,13 @@ const DeploymentConfigSideBarDetails: React.FC<DeploymentConfigSideBarDetailsPro
   );
 };
 
-export const getDeploymentConfigSideBarDetails = (element: GraphElement) => {
+export const getDeploymentConfigSideBarDetails: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
   const resource = getResource(element);
-  if (!resource || resource.kind !== DeploymentConfigModel.kind) return undefined;
-  return <DeploymentConfigSideBarDetails dc={resource} />;
+  if (!resource || resource.kind !== DeploymentConfigModel.kind) {
+    return [undefined, true, undefined];
+  }
+  const section = <DeploymentConfigSideBarDetails dc={resource} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/topology/src/components/workload/DeploymentSideBarDetails.tsx
+++ b/frontend/packages/topology/src/components/workload/DeploymentSideBarDetails.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { DeploymentDetailsList } from '@console/internal/components/deployment';
 import {
   LoadingInline,
@@ -48,8 +49,11 @@ const DeploymentSideBarDetails: React.FC<DeploymentSideBarDetailsProps> = ({ dep
   );
 };
 
-export const getDeploymentSideBarDetails = (element: GraphElement) => {
+export const getDeploymentSideBarDetails: DetailsTabSectionCallback = (element: GraphElement) => {
   const resource = getResource<DeploymentKind>(element);
-  if (!resource || resource.kind !== DeploymentModel.kind) return undefined;
-  return <DeploymentSideBarDetails deployment={resource} />;
+  if (!resource || resource.kind !== DeploymentModel.kind) {
+    return [undefined, true, undefined];
+  }
+  const section = <DeploymentSideBarDetails deployment={resource} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/topology/src/components/workload/JobSideBarDetails.tsx
+++ b/frontend/packages/topology/src/components/workload/JobSideBarDetails.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import {
   DetailsItem,
   ResourceSummary,
@@ -45,8 +46,11 @@ const JobSideBarDetails: React.FC<JobSideBarDetailsProps> = ({ job }) => {
   );
 };
 
-export const getJobSideBarDetails = (element: GraphElement) => {
+export const getJobSideBarDetails: DetailsTabSectionCallback = (element: GraphElement) => {
   const resource = getResource<JobKind>(element);
-  if (!resource || resource.kind !== JobModel.kind) return undefined;
-  return <JobSideBarDetails job={resource} />;
+  if (!resource || resource.kind !== JobModel.kind) {
+    return [undefined, true, undefined];
+  }
+  const section = <JobSideBarDetails job={resource} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/topology/src/components/workload/PodSideBarDetails.tsx
+++ b/frontend/packages/topology/src/components/workload/PodSideBarDetails.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { PodDetailsList, PodResourceSummary } from '@console/internal/components/pod';
 import { PodModel } from '@console/internal/models';
 import { PodKind } from '@console/internal/module/k8s';
@@ -26,8 +27,11 @@ const PodSideBarDetails: React.FC<PodSideBarDetailsProps> = ({ pod }) => {
   );
 };
 
-export const getPodSideBarDetails = (element: GraphElement) => {
+export const getPodSideBarDetails: DetailsTabSectionCallback = (element: GraphElement) => {
   const resource = getResource<PodKind>(element);
-  if (!resource || resource.kind !== PodModel.kind) return undefined;
-  return <PodSideBarDetails pod={resource} />;
+  if (!resource || resource.kind !== PodModel.kind) {
+    return [undefined, true, undefined];
+  }
+  const section = <PodSideBarDetails pod={resource} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/topology/src/components/workload/StatefulSetSideBarDetails.tsx
+++ b/frontend/packages/topology/src/components/workload/StatefulSetSideBarDetails.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { ResourceSummary } from '@console/internal/components/utils';
 import { StatefulSetModel } from '@console/internal/models';
 import { K8sResourceKind } from '@console/internal/module/k8s';
@@ -19,8 +20,11 @@ const StatefulSetSideBarDetails: React.FC<StatefulSetSideBarDetailsProps> = ({ s
   </div>
 );
 
-export const getStatefulSetSideBarDetails = (element: GraphElement) => {
+export const getStatefulSetSideBarDetails: DetailsTabSectionCallback = (element: GraphElement) => {
   const resource = getResource(element);
-  if (!resource || resource.kind !== StatefulSetModel.kind) return undefined;
-  return <StatefulSetSideBarDetails ss={resource} />;
+  if (!resource || resource.kind !== StatefulSetModel.kind) {
+    return [undefined, true, undefined];
+  }
+  const section = <StatefulSetSideBarDetails ss={resource} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/topology/src/components/workload/jobs-tab-section.tsx
+++ b/frontend/packages/topology/src/components/workload/jobs-tab-section.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import { K8sResourceCommon } from '@console/dynamic-plugin-sdk/src';
+import { DetailsTabSectionCallback } from '@console/dynamic-plugin-sdk/src/extensions/topology-details';
 import { CronJobModel } from '@console/internal/models';
 import { useJobsForCronJobWatcher } from '@console/shared';
 import { getResource } from '../../utils';
@@ -16,8 +17,11 @@ const JobsTabSection: React.FC<{ resource: K8sResourceCommon }> = ({ resource })
   );
 };
 
-export const getJobsSideBarTabSection = (element: GraphElement) => {
+export const getJobsSideBarTabSection: DetailsTabSectionCallback = (element: GraphElement) => {
   const resource = getResource(element);
-  if (!resource || resource.kind !== CronJobModel.kind) return undefined;
-  return <JobsTabSection resource={resource} />;
+  if (!resource || resource.kind !== CronJobModel.kind) {
+    return [undefined, true, undefined];
+  }
+  const section = <JobsTabSection resource={resource} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/topology/src/components/workload/network-tab-section.tsx
+++ b/frontend/packages/topology/src/components/workload/network-tab-section.tsx
@@ -5,15 +5,27 @@ import {
   useResolvedExtensions,
   NetworkAdapter,
   K8sResourceCommon,
+  DetailsTabSectionCallback,
 } from '@console/dynamic-plugin-sdk';
 import TopologySideBarTabSection from '../side-bar/TopologySideBarTabSection';
 import { NetworkingOverview } from './NetworkingOverview';
 import { getDataFromAdapter } from './utils';
 
-const NetworkTabSection: React.FC<{ element: GraphElement; renderNull: () => null }> = ({
-  element,
-  renderNull,
-}) => {
+const NetworkTabSection: React.FC<{
+  networkAdapter: {
+    resource: K8sResourceCommon;
+  };
+}> = ({ networkAdapter }) => {
+  return networkAdapter ? (
+    <TopologySideBarTabSection>
+      <NetworkingOverview obj={networkAdapter.resource} />
+    </TopologySideBarTabSection>
+  ) : null;
+};
+
+export const useNetworkingSideBarTabSection: DetailsTabSectionCallback = (
+  element: GraphElement,
+) => {
   const [networkAdapterExtensions, extensionsLoaded] = useResolvedExtensions<NetworkAdapter>(
     isNetworkAdapter,
   );
@@ -25,20 +37,9 @@ const NetworkTabSection: React.FC<{ element: GraphElement; renderNull: () => nul
       ]),
     [element, extensionsLoaded, networkAdapterExtensions],
   );
-
-  React.useEffect(() => {
-    if (!networkAdapter) {
-      renderNull();
-    }
-  }, [networkAdapter, renderNull]);
-
-  return networkAdapter ? (
-    <TopologySideBarTabSection>
-      <NetworkingOverview obj={networkAdapter.resource} />
-    </TopologySideBarTabSection>
-  ) : null;
-};
-
-export const getNetworkingSideBarTabSection = (element: GraphElement, renderNull: () => null) => {
-  return <NetworkTabSection element={element} renderNull={renderNull} />;
+  if (!networkAdapter) {
+    return [undefined, true, undefined];
+  }
+  const section = <NetworkTabSection networkAdapter={networkAdapter} />;
+  return [section, true, undefined];
 };

--- a/frontend/packages/topology/src/components/workload/pods-tab-section.tsx
+++ b/frontend/packages/topology/src/components/workload/pods-tab-section.tsx
@@ -6,6 +6,7 @@ import {
   PodsAdapterDataType,
   PodAdapter,
   useResolvedExtensions,
+  DetailsTabSectionCallback,
 } from '@console/dynamic-plugin-sdk';
 import { PodKind } from '@console/internal/module/k8s';
 import { PodsOverviewContent } from '@console/shared/src/components/pod/PodsOverview';
@@ -13,34 +14,18 @@ import TopologySideBarTabSection from '../side-bar/TopologySideBarTabSection';
 import ResolveAdapter from './ResolveAdapter';
 import { getDataFromAdapter } from './utils';
 
-const PodsTabSection: React.FC<{ element: GraphElement; renderNull: () => null }> = ({
-  element,
-  renderNull,
-}) => {
-  const [podAdapterExtension, podAdapterExtensionResolved] = useResolvedExtensions<PodAdapter>(
-    isPodAdapter,
-  );
+const PodsTabSection: React.FC<{
+  podAdapter: AdapterDataType<PodsAdapterDataType<PodKind>>;
+  podAdapterExtensionResolved: boolean;
+}> = ({ podAdapter, podAdapterExtensionResolved }) => {
   const [{ data: podsData, loaded: podsDataLoaded }, setPodData] = React.useState<{
     data?: PodsAdapterDataType<PodKind>;
     loaded: boolean;
   }>({ loaded: false });
-  const podAdapter = React.useMemo(
-    () =>
-      getDataFromAdapter<AdapterDataType<PodsAdapterDataType<PodKind>>, PodAdapter>(element, [
-        podAdapterExtension,
-        podAdapterExtensionResolved,
-      ]),
-    [element, podAdapterExtension, podAdapterExtensionResolved],
-  );
+
   const handleAdapterResolved = React.useCallback((data) => {
     setPodData({ data, loaded: true });
   }, []);
-
-  React.useEffect(() => {
-    if (!podAdapter) {
-      renderNull();
-    }
-  }, [podAdapter, renderNull]);
 
   return podAdapter ? (
     <TopologySideBarTabSection>
@@ -59,6 +44,26 @@ const PodsTabSection: React.FC<{ element: GraphElement; renderNull: () => null }
   ) : null;
 };
 
-export const getPodsSideBarTabSection = (element: GraphElement, renderNull: () => null) => {
-  return <PodsTabSection element={element} renderNull={renderNull} />;
+export const usePodsSideBarTabSection: DetailsTabSectionCallback = (element: GraphElement) => {
+  const [podAdapterExtension, podAdapterExtensionResolved] = useResolvedExtensions<PodAdapter>(
+    isPodAdapter,
+  );
+  const podAdapter = React.useMemo(
+    () =>
+      getDataFromAdapter<AdapterDataType<PodsAdapterDataType<PodKind>>, PodAdapter>(element, [
+        podAdapterExtension,
+        podAdapterExtensionResolved,
+      ]),
+    [element, podAdapterExtension, podAdapterExtensionResolved],
+  );
+  if (!podAdapter) {
+    return [undefined, true, undefined];
+  }
+  const section = (
+    <PodsTabSection
+      podAdapter={podAdapter}
+      podAdapterExtensionResolved={podAdapterExtensionResolved}
+    />
+  );
+  return [section, true, undefined];
 };


### PR DESCRIPTION
Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=2044454
https://bugzilla.redhat.com/show_bug.cgi?id=2009189

Problem/Statement:
Values in topology sidebar does not reflect the current state of the workload. Any change to the workload, e.g annotations, does not reflect in the sidebar.

Description/Solution:
- use `observer` HOC to update the topology element being passed to the sidebar
- remove the `renderNull` property and refactor the extension to accept hooks to render sections that uses adapter.

Screens:
https://user-images.githubusercontent.com/38663217/155294582-bb2fd2cd-8f53-4995-bfcc-044b152fd93b.mp4

Browser conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge