### PR TITLE
Bug 2053304: Fix debug route and add testcases

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/app/debug-pod.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/debug-pod.spec.ts
@@ -1,0 +1,87 @@
+import { checkErrors, testName } from '../../support';
+import { detailsPage } from '../../views/details-page';
+import { errorMessage } from '../../views/form';
+import { listPage } from '../../views/list-page';
+import { modal } from '../../views/modal';
+import { nav } from '../../views/nav';
+import * as yamlEditor from '../../views/yaml-editor';
+
+const POD_NAME = `pod1`;
+const CONTAINER_NAME = `container1`;
+const XTERM_CLASS = `[class="xterm-viewport"]`;
+const podToDebug = `apiVersion: v1
+kind: Pod
+metadata:
+  name: ${POD_NAME}
+spec:
+  containers:
+    - name: ${CONTAINER_NAME}
+      image: quay.io/fedora/fedora
+  restartPolicy: Always`;
+
+describe('Debug pod', () => {
+  before(() => {
+    cy.login();
+    cy.visit('/');
+    nav.sidenav.switcher.changePerspectiveTo('Administrator');
+    nav.sidenav.switcher.shouldHaveText('Administrator');
+    cy.createProject(testName);
+  });
+
+  afterEach(() => {
+    checkErrors();
+  });
+
+  after(() => {
+    cy.visit(`/k8s/ns/${testName}/pods`);
+    listPage.rows.shouldBeLoaded();
+    listPage.filter.byName(POD_NAME);
+    listPage.rows.clickKebabAction(POD_NAME, 'Delete Pod');
+    modal.shouldBeOpened();
+    modal.submit();
+    modal.shouldBeClosed();
+    cy.deleteProject(testName);
+    cy.logout();
+  });
+
+  it('Create pod that has crashbackloop error', () => {
+    cy.visit(`/k8s/ns/${testName}/import`);
+    yamlEditor.isImportLoaded();
+    yamlEditor.setEditorContent(podToDebug).then(() => {
+      yamlEditor.clickSaveCreateButton();
+      cy.get(errorMessage).should('not.exist');
+      detailsPage.titleShouldContain(POD_NAME);
+    });
+  });
+
+  it('Opens debug terminal page from Logs subsection', () => {
+    cy.visit(`/k8s/ns/${testName}/pods`);
+    listPage.rows.shouldExist(POD_NAME);
+    cy.visit(`/k8s/ns/${testName}/pods/${POD_NAME}`);
+    detailsPage.isLoaded();
+    detailsPage.selectTab('Logs');
+    detailsPage.isLoaded();
+    cy.byTestID('debug-container-link').click();
+    listPage.titleShouldHaveText(`Debug ${CONTAINER_NAME}`);
+    cy.get(XTERM_CLASS).should('exist');
+  });
+
+  it('Opens debug terminal page from Pod Details - Status tool tip', () => {
+    cy.visit(`/k8s/ns/${testName}/pods/${POD_NAME}`);
+    detailsPage.isLoaded();
+    cy.byTestID('popover-status-button').click();
+    cy.byTestID(`popup-debug-container-link-${CONTAINER_NAME}`).click();
+    listPage.titleShouldHaveText(`Debug ${CONTAINER_NAME}`);
+    cy.get(XTERM_CLASS).should('exist');
+  });
+
+  it('Opens debug terminal page from Pods Page - Status tool tip', () => {
+    cy.visit(`/k8s/ns/${testName}/pods`);
+    listPage.rows.shouldExist(POD_NAME);
+    listPage.rows.clickStatusButton(POD_NAME);
+    // Click on first debug link
+    cy.byTestID(`popup-debug-container-link-${CONTAINER_NAME}`).click();
+    listPage.titleShouldHaveText(`Debug ${CONTAINER_NAME}`);
+    cy.get(XTERM_CLASS).should('exist');
+  });
+});

--- a/frontend/packages/integration-tests-cypress/views/list-page.ts
+++ b/frontend/packages/integration-tests-cypress/views/list-page.ts
@@ -90,6 +90,14 @@ export const listPage = {
         });
       cy.byTestActionID(actionName).click();
     },
+    clickStatusButton: (resourceName: string) => {
+      cy.get(`[data-test-rows="resource-row"]`)
+        .contains(resourceName)
+        .parents('tr')
+        .within(() => {
+          cy.byTestID('popover-status-button').click();
+        });
+    },
     hasLabel: (resourceName: string, label: string) => {
       cy.get(`[data-test-rows="resource-row"]`)
         .contains(resourceName)

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -684,6 +684,14 @@ const AppContents: React.FC<{}> = () => {
       <Route path="/k8s/cluster/:plural/~new" exact component={CreateResource} />
       <Route path="/k8s/cluster/:plural/:name" component={ResourceDetailsPage} />
       <LazyRoute
+        path="/k8s/ns/:ns/pods/:podName/containers/:name/debug"
+        loader={() =>
+          import('./debug-terminal' /* webpackChunkName: "debug-terminal" */).then(
+            (m) => m.DebugTerminalPage,
+          )
+        }
+      />
+      <LazyRoute
         path="/k8s/ns/:ns/pods/:podName/containers/:name"
         loader={() => import('./container').then((m) => m.ContainersDetailsPage)}
       />

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -628,7 +628,7 @@ const PodStatusPopover: React.FC<PodStatusPopoverProps> = ({
 }) => {
   return (
     <Popover headerContent={headerContent} bodyContent={bodyContent} footerContent={footerContent}>
-      <Button variant="link" isInline>
+      <Button variant="link" isInline data-test="popover-status-button">
         <Status status={status} />
       </Button>
     </Popover>
@@ -695,6 +695,7 @@ export const PodStatus: React.FC<PodStatusProps> = ({ pod }) => {
                       pod.metadata.name,
                       pod.metadata.namespace,
                     )}/containers/${container.name}/debug`}
+                    data-test={`popup-debug-container-link-${container.name}`}
                   >
                     {t('public~Debug container {{name}}', { name: container.name })}
                   </Link>

--- a/frontend/public/components/utils/resource-log.tsx
+++ b/frontend/public/components/utils/resource-log.tsx
@@ -263,6 +263,7 @@ export const LogControls: React.FC<LogControlsProps> = ({
               resource.metadata.name,
               resource.metadata.namespace,
             )}/containers/${containerName}/debug`}
+            data-test="debug-container-link"
           >
             {label}
           </Link>


### PR DESCRIPTION
Merge of [PR 10856](https://github.com/openshift/console/pull/10856) deleted the route for the debug pod page.  This has been re-added.

However, there was no test coverage that actually verified the debug page was loading properly, which there should have been.  I have added testcases to ensure the debug links work and that the debug pod starts as expected.

Note: One of my test is currently disabled because of an issue testing a popup. @dtaylor113 

@karthikjeeyar @spadgett @alimobrem 