### PR TITLE
Bug 2054238: Update E2E to use 3scale operator

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
@@ -23,9 +23,11 @@ describe('Create namespace from install operators', () => {
   const nsName = `${testName}-ns`;
 
   it('creates namespace from operator install page', () => {
-    const operatorSelector = 'businessautomation-operator-redhat-operators-openshift-marketplace';
+    const operatorSelector = '3scale-operator-redhat-operators-openshift-marketplace';
+    const operatorName = 'Red Hat Integration - 3scale';
     cy.log('test namespace creation from dropdown');
     cy.visit(`/operatorhub/ns/${testName}`);
+    cy.byTestID('search-operatorhub').type(operatorName);
     cy.byTestID(operatorSelector).click();
     cy.byLegacyTestID('operator-install-btn').click({ force: true });
 

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -5,16 +5,16 @@ import { nav } from '../../../integration-tests-cypress/views/nav';
 import { GlobalInstalledNamespace, operator, TestOperandProps } from '../views/operator.view';
 
 const testOperator = {
-  name: 'Business Automation',
-  operatorHubCardTestID: 'businessautomation-operator-redhat-operators-openshift-marketplace',
+  name: 'Red Hat CodeReady Workspaces',
+  operatorHubCardTestID: 'codeready-workspaces-redhat-operators-openshift-marketplace',
   installedNamespace: testName,
 };
 
 const testOperand: TestOperandProps = {
-  name: 'KieApp',
-  kind: 'KieApp',
-  tabName: 'KieApp',
-  exampleName: `example-kieappk`,
+  name: 'CodeReady Workspaces instance Specification',
+  kind: 'CheCluster',
+  tabName: 'CodeReady Workspaces instance Specification',
+  exampleName: `codeready-workspaces`,
 };
 
 describe(`Installing "${testOperator.name}" operator in ${testOperator.installedNamespace}`, () => {

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -5,16 +5,16 @@ import { nav } from '../../../integration-tests-cypress/views/nav';
 import { GlobalInstalledNamespace, operator, TestOperandProps } from '../views/operator.view';
 
 const testOperator = {
-  name: 'Red Hat CodeReady Workspaces',
-  operatorHubCardTestID: 'codeready-workspaces-redhat-operators-openshift-marketplace',
+  name: 'Red Hat Integration - 3scale',
+  operatorHubCardTestID: '3scale-operator-redhat-operators-openshift-marketplace',
   installedNamespace: testName,
 };
 
 const testOperand: TestOperandProps = {
-  name: 'CodeReady Workspaces instance Specification',
-  kind: 'CheCluster',
-  tabName: 'CodeReady Workspaces instance Specification',
-  exampleName: `codeready-workspaces`,
+  name: '3scale Backend Schema',
+  kind: 'Backend',
+  tabName: '3scale Backend',
+  exampleName: `backend1-sample`,
 };
 
 describe(`Installing "${testOperator.name}" operator in ${testOperator.installedNamespace}`, () => {


### PR DESCRIPTION
The business automation operator is no longer passing our E2E tests (the install page changed).

This PR will temporarily update the E2E to use the 3scale operator in the E2E so we can unblock the pipeline.

Per @spadgett suggestion - we should investigate creating a simple operator for the sole purpose of testing the E2E as the out of the box operators may change.