### PR TITLE
Bug 2028821: Misspelled label in ODF management UI

### DIFF
--- a/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
+++ b/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
@@ -378,7 +378,7 @@
   "Accounts": "Accounts",
   "Metric": "Metric",
   "I/O Operations": "I/O Operations",
-  "Logial Used Capacity": "Logial Used Capacity",
+  "Logical Used Capacity": "Logical Used Capacity",
   "Physical vs. Logical used capacity": "Physical vs. Logical used capacity",
   "Egress": "Egress",
   "Latency": "Latency",

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/object-service/data-consumption-card/data-consumption-card-dropdown.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/object-service/data-consumption-card/data-consumption-card-dropdown.tsx
@@ -49,7 +49,7 @@ export const DataConsumptionDropdown: React.FC<DataConsumptionDropdownProps> = (
         items: [
           { name: t('ceph-storage-plugin~I/O Operations'), id: Metrics.IOPS },
           ...(selectedBreakdown === Breakdown.ACCOUNTS
-            ? [{ name: t('ceph-storage-plugin~Logial Used Capacity'), id: Metrics.LOGICAL }]
+            ? [{ name: t('ceph-storage-plugin~Logical Used Capacity'), id: Metrics.LOGICAL }]
             : [
                 {
                   name: t('ceph-storage-plugin~Physical vs. Logical used capacity'),

--- a/frontend/packages/ceph-storage-plugin/src/constants/data-consumption.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/data-consumption.ts
@@ -10,7 +10,7 @@ export enum Breakdown {
 
 export enum Metrics {
   IOPS = 'I/O Operations',
-  LOGICAL = 'Logial Used Capacity',
+  LOGICAL = 'Logical Used Capacity',
   EGRESS = 'Egress',
   PHY_VS_LOG = 'Physical Vs Logical Usage',
   LATENCY = 'Latency',


### PR DESCRIPTION
The typo was fixed `Logial` -> `Logical` in the ODF management UI

![image](https://user-images.githubusercontent.com/41220684/153827964-a7c262a9-cc54-4654-b5f0-675885e2664b.png)
![image](https://user-images.githubusercontent.com/41220684/153827898-223b03eb-a82d-4fef-a953-c2592a6486f9.png)
