### PR TITLE
Bug 2052986: fix console crashing in the edit deployment form

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-deployment/__mocks__/edit-deployment-data.ts
+++ b/frontend/packages/dev-console/src/components/edit-deployment/__mocks__/edit-deployment-data.ts
@@ -515,3 +515,140 @@ export const mockDeployment = {
   },
   status: {},
 };
+
+export const mockDeploymentConfig2 = {
+  ...mockDeploymentConfig,
+  spec: {
+    strategy: {
+      resources: {},
+      imageStreamData: {
+        post: {
+          containerName: '',
+          fromImageStreamTag: true,
+          image: {
+            image: {},
+            name: '',
+            ports: [],
+            status: {},
+            tag: '',
+          },
+          imageStream: {
+            image: '',
+            namespace: 'xyz',
+            tag: '',
+          },
+          imageStreamTag: {},
+          isi: {},
+          name: 'nodejs-ex-git',
+          project: { name: 'xyz' },
+        },
+        pre: {
+          containerName: '',
+          fromImageStreamTag: true,
+          image: {
+            image: {},
+            name: '',
+            ports: [],
+            status: {},
+            tag: '',
+          },
+          imageStream: {
+            image: '',
+            namespace: 'xyz',
+            tag: '',
+          },
+          imageStreamTag: {},
+          isi: {},
+          name: 'nodejs-ex-git',
+          project: { name: 'xyz' },
+        },
+      },
+      type: 'Rolling',
+      rollingParams: {
+        maxUnavailable: '25%',
+        maxSurge: '25%',
+        intervalSeconds: 1,
+        post: {
+          action: 'execNewPod',
+          lch: {
+            execNewPod: {
+              command: [''],
+              containerName: undefined,
+              env: undefined,
+            },
+          },
+        },
+        pre: {
+          action: 'execNewPod',
+          lch: {
+            execNewPod: {
+              command: [''],
+              containerName: undefined,
+              env: undefined,
+            },
+          },
+        },
+        timeoutSeconds: 600,
+      },
+    },
+    triggers: [
+      {
+        type: 'ImageChange',
+        imageChangeParams: {
+          automatic: true,
+          containerNames: ['nationalparks-py-dc'],
+          from: {
+            kind: 'ImageStreamTag',
+            namespace: 'div',
+            name: 'nationalparks-py-dc:latest',
+          },
+          lastTriggeredImage:
+            'image-registry.openshift-image-registry.svc:5000/div/nationalparks-py-dc@sha256:e187d5a42e4817792ef05b92871558eef47df5092d8c6256dc5d8369695117a0',
+        },
+      },
+      {
+        type: 'ConfigChange',
+      },
+    ],
+    replicas: 1,
+    revisionHistoryLimit: 10,
+    test: false,
+    selector: {
+      app: 'nationalparks-py-dc',
+      deploymentconfig: 'nationalparks-py-dc',
+    },
+    template: {
+      metadata: {
+        creationTimestamp: null,
+        labels: {
+          app: 'nationalparks-py-dc',
+          deploymentconfig: 'nationalparks-py-dc',
+        },
+      },
+      spec: {
+        containers: [
+          {
+            name: 'nationalparks-py-dc',
+            image:
+              'image-registry.openshift-image-registry.svc:5000/div/nationalparks-py-dc@sha256:e187d5a42e4817792ef05b92871558eef47df5092d8c6256dc5d8369695117a0',
+            ports: [
+              {
+                containerPort: 8080,
+                protocol: 'TCP',
+              },
+            ],
+            resources: {},
+            terminationMessagePath: '/dev/termination-log',
+            terminationMessagePolicy: 'File',
+            imagePullPolicy: 'Always',
+          },
+        ],
+        restartPolicy: 'Always',
+        terminationGracePeriodSeconds: 30,
+        dnsPolicy: 'ClusterFirst',
+        securityContext: {},
+        schedulerName: 'default-scheduler',
+      },
+    },
+  },
+};

--- a/frontend/packages/dev-console/src/components/edit-deployment/__tests__/DeploymentStrategySection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/edit-deployment/__tests__/DeploymentStrategySection.spec.tsx
@@ -6,6 +6,7 @@ import { Resources } from '../../import/import-types';
 import {
   mockDeployment,
   mockDeploymentConfig,
+  mockDeploymentConfig2,
   mockEditDeploymentData,
 } from '../__mocks__/edit-deployment-data';
 import MockForm from '../__mocks__/MockForm';
@@ -20,7 +21,7 @@ afterEach(() => cleanup());
 
 describe('DeploymentStrategySection(DeploymentConfig)', () => {
   it('should show strategy fields based on strategy type selected', async () => {
-    await waitFor(() =>
+    waitFor(() =>
       render(
         <MockForm handleSubmit={handleSubmit} enableReinitialize>
           {() => (
@@ -58,6 +59,81 @@ describe('DeploymentStrategySection(DeploymentConfig)', () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId('customParams')).not.toBeNull();
+    });
+  });
+
+  it('should render additional fields for Recreate strategy type', async () => {
+    waitFor(() =>
+      render(
+        <MockForm
+          handleSubmit={handleSubmit}
+          initialValues={{
+            ...mockEditDeploymentData,
+            formData: convertDeploymentToEditForm(mockDeploymentConfig2),
+          }}
+          enableReinitialize
+        >
+          {() => (
+            <Provider store={store}>
+              <DeploymentStrategySection
+                resourceObj={mockDeploymentConfig2}
+                resourceType={Resources.OpenShift}
+              />
+            </Provider>
+          )}
+        </MockForm>,
+      ),
+    );
+    const strategyDropdown = screen.getByRole('button', {
+      name: /strategy type/i,
+    });
+
+    fireEvent.click(strategyDropdown);
+
+    const recreateButton = screen.getByRole('button', { name: /recreate/i });
+
+    fireEvent.click(recreateButton);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('recreateParams')).not.toBeNull();
+    });
+
+    const advancedSection = screen.getByText('Show additional parameters and lifecycle hooks');
+
+    fireEvent.click(advancedSection);
+
+    await waitFor(() => {
+      expect(screen.getByText('Pre Lifecycle Hook')).not.toBeNull();
+      expect(screen.getByText('Mid Lifecycle Hook')).not.toBeNull();
+      expect(screen.getByText('Post Lifecycle Hook')).not.toBeNull();
+    });
+    const addMidLifecycleHook = screen.getByText('Add mid lifecycle hook');
+
+    fireEvent.click(addMidLifecycleHook);
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Runs a command in a new pod using the container from the deployment template. You can add additional environment variables and volumes',
+        ),
+      ).not.toBeNull();
+    });
+
+    let action = screen.getByText(
+      'Runs a command in a new pod using the container from the deployment template. You can add additional environment variables and volumes',
+    );
+    fireEvent.click(action);
+    await waitFor(() => {
+      expect(screen.getByText('Container name')).not.toBeNull();
+      expect(screen.getByText('Command')).not.toBeNull();
+    });
+
+    action = screen.getByText(
+      'Tags the current image as an image stream tag if the deployment succeeds',
+    );
+    fireEvent.click(action);
+    await waitFor(() => {
+      expect(screen.getByText('Container name')).not.toBeNull();
+      expect(screen.getByText('Tag as')).not.toBeNull();
     });
   });
 });

--- a/frontend/packages/dev-console/src/components/edit-deployment/deployment-strategy/DeploymentStrategySection.tsx
+++ b/frontend/packages/dev-console/src/components/edit-deployment/deployment-strategy/DeploymentStrategySection.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { FormikValues, useFormikContext } from 'formik';
+import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { DropdownField } from '@console/shared/src';
@@ -55,8 +56,7 @@ const DeploymentStrategySection: React.FC<DeploymentStrategySectionProps> = ({
     (value: DeploymentStrategyType) => {
       const strategyDefaultValues = getStrategyData(value, {}, resName, resNamespace, resourceType);
       const strategyData = {
-        ...strategyDefaultValues,
-        ...deploymentStrategy,
+        ..._.merge(strategyDefaultValues, deploymentStrategy),
         type: value,
       };
       initialValues.formData.deploymentStrategy = strategyData;


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGSM-40566

**Root analysis:**
When the initial values of strategy data (which is `deploymentStrategy` here ) contains only pre & post lifecycle hooks then on spreading, it overwrites the default strategy values (which contains all the 3 lifecycle hooks data) and removes the mid lifecycle hook from the final data

**Solution description:**
using lodash's merge

**GIF:**
![edit-dc](https://user-images.githubusercontent.com/22490998/153923551-a602dcfb-ca73-4a20-ae6a-6437938fadc6.gif)

/kind bug