### PR TITLE
Bug 2051775: Allow custom template namespace

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
@@ -18,7 +18,6 @@ import { VMWizardURLParams } from '../../constants/url-params';
 import {
   TEMPLATE_TYPE_BASE,
   TEMPLATE_TYPE_LABEL,
-  TEMPLATE_TYPE_VM,
   VMWizardMode,
   VMWizardView,
 } from '../../constants/vm';
@@ -477,7 +476,12 @@ export const CreateVMWizardPageComponent: React.FC<CreateVMWizardPageComponentPr
           getResource(TemplateModel, {
             namespace: activeNamespace,
             prop: VMWizardProps.userTemplates,
-            matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_VM },
+            matchExpressions: [
+              {
+                key: TEMPLATE_TYPE_LABEL,
+                operator: 'Exists',
+              },
+            ],
           }),
         );
       }
@@ -489,7 +493,12 @@ export const CreateVMWizardPageComponent: React.FC<CreateVMWizardPageComponentPr
             namespace: initialData.userTemplateNs,
             prop: VMWizardProps.userTemplate,
             isList: false,
-            matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_VM },
+            matchExpressions: [
+              {
+                key: TEMPLATE_TYPE_LABEL,
+                operator: 'Exists',
+              },
+            ],
           }),
         );
       }

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/storage-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/storage-tab-state-update.ts
@@ -340,8 +340,7 @@ const initialStorageWindowsPVCUpdater = ({ id, prevState, dispatch, getState }: 
   const state = getState();
   const relevantOptions = iGetRelevantTemplateSelectors(state, id);
   const iCommonTemplates = iGetLoadedCommonData(state, id, VMWizardProps.commonTemplates);
-  const template =
-    iCommonTemplates && iGetRelevantTemplate(iCommonTemplates, relevantOptions).toJS();
+  const template = iCommonTemplates && iGetRelevantTemplate(iCommonTemplates, relevantOptions);
   const iStorageClassConfigMap = iGetLoadedCommonData(
     state,
     id,
@@ -371,8 +370,8 @@ const initialStorageWindowsPVCUpdater = ({ id, prevState, dispatch, getState }: 
     );
   })?.metadata?.labels?.[LABEL_CDROM_SOURCE];
 
-  if (isCdRom && removableRootDisk && iStorageClassConfigMap) {
-    if (isWindowsTemplate(template)) {
+  if (isCdRom && removableRootDisk && iStorageClassConfigMap && template) {
+    if (isWindowsTemplate(template.toJS())) {
       dispatch(
         vmWizardInternalActions[InternalActionType.UpdateStorage](id, {
           id: getNextIDResolver(storages),

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/hooks/use-vm-templates-resources.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/hooks/use-vm-templates-resources.tsx
@@ -9,7 +9,6 @@ import {
   OPENSHIFT_OS_IMAGES_NS,
   TEMPLATE_TYPE_BASE,
   TEMPLATE_TYPE_LABEL,
-  TEMPLATE_TYPE_VM,
 } from '../../../constants';
 import { useBaseImages } from '../../../hooks/use-base-images';
 import { DataSourceModel, DataVolumeModel } from '../../../models';
@@ -22,7 +21,12 @@ export const useVmTemplatesResources = (namespace: string): useVmTemplatesResour
     kind: TemplateModel.kind,
     namespace,
     selector: {
-      matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_VM },
+      matchExpressions: [
+        {
+          key: TEMPLATE_TYPE_LABEL,
+          operator: 'Exists',
+        },
+      ],
     },
     isList: true,
   });

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/inventory-card/VirtOverviewInventoryCard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/inventory-card/VirtOverviewInventoryCard.tsx
@@ -9,7 +9,7 @@ import { FirehoseResource } from '@console/internal/components/utils/types';
 import { NodeModel, TemplateModel } from '@console/internal/models/index';
 import { K8sResourceKind } from '@console/internal/module/k8s/types';
 import { NetworkAttachmentDefinitionModel } from '@console/network-attachment-definition-plugin';
-import { TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_LABEL, TEMPLATE_TYPE_VM } from '../../../constants';
+import { TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_LABEL } from '../../../constants';
 import { VirtualMachineModel } from '../../../models';
 import { kubevirtReferenceForModel } from '../../../models/kubevirtReferenceForModel';
 import { ResourcesSection } from './ResourcesSection';
@@ -29,7 +29,12 @@ const vmTemplatesResource = {
   isList: true,
   prop: 'vmTemplates',
   selector: {
-    matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_VM },
+    matchExpressions: [
+      {
+        key: TEMPLATE_TYPE_LABEL,
+        operator: 'Exists',
+      },
+    ],
   },
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/customize-source/CustomizeSourceForm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/customize-source/CustomizeSourceForm.tsx
@@ -35,9 +35,7 @@ import {
   OPENSHIFT_OS_IMAGES_NS,
   TEMPLATE_PROVIDER_ANNOTATION,
   TEMPLATE_SUPPORT_LEVEL,
-  TEMPLATE_TYPE_BASE,
   TEMPLATE_TYPE_LABEL,
-  TEMPLATE_TYPE_VM,
   VM_CUSTOMIZE_LABEL,
 } from '../../../constants';
 import { VIRTUALIZATION_BASE_URL } from '../../../constants/url-params';
@@ -89,9 +87,8 @@ const CustomizeSourceForm: React.FC<RouteComponentProps> = ({ location }) => {
     selector: {
       matchExpressions: [
         {
-          operator: 'In',
           key: TEMPLATE_TYPE_LABEL,
-          values: [TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_VM],
+          operator: 'Exists',
         },
       ],
     },

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -13,12 +13,7 @@ import {
   VMWizardName,
 } from '../../constants';
 import { VIRTUALMACHINES_TEMPLATES_BASE_URL } from '../../constants/url-params';
-import {
-  TEMPLATE_TYPE_BASE,
-  TEMPLATE_TYPE_LABEL,
-  TEMPLATE_TYPE_VM,
-  VM_CUSTOMIZE_LABEL,
-} from '../../constants/vm';
+import { TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_LABEL, VM_CUSTOMIZE_LABEL } from '../../constants/vm';
 import {
   DataSourceModel,
   DataVolumeModel,
@@ -75,7 +70,12 @@ const VirtualMachineTemplatesPage: React.FC<VirtualMachineTemplatesPageProps &
       namespace,
       prop: 'vmTemplates',
       selector: {
-        matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_VM },
+        matchExpressions: [
+          {
+            key: TEMPLATE_TYPE_LABEL,
+            operator: 'Exists',
+          },
+        ],
       },
     },
     {

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
@@ -17,7 +17,6 @@ import {
 import { VIRTUALMACHINES_BASE_URL } from '../../constants/url-params';
 import {
   TEMPLATE_TYPE_LABEL,
-  TEMPLATE_TYPE_VM,
   VM_DETAIL_ENVIRONMENT,
   VM_DETAIL_SNAPSHOTS,
 } from '../../constants/vm';
@@ -123,7 +122,12 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
       isList: true,
       namespace,
       prop: 'templates',
-      matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_VM },
+      matchExpressions: [
+        {
+          key: TEMPLATE_TYPE_LABEL,
+          operator: 'Exists',
+        },
+      ],
     }),
     {
       kind: kubevirtReferenceForModel(VirtualMachineInstanceMigrationModel),

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-running-vms-per-template-resources.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-running-vms-per-template-resources.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { TemplateModel } from '@console/internal/models';
 import { K8sResourceCommon, TemplateKind } from '@console/internal/module/k8s';
-import { TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_LABEL, TEMPLATE_TYPE_VM } from '../constants';
+import { TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_LABEL } from '../constants';
 import { VirtualMachineModel } from '../models';
 import { kubevirtReferenceForModel } from '../models/kubevirtReferenceForModel';
 import { VMKind } from '../types';
@@ -30,7 +30,12 @@ export const useRunningVMsPerTemplateResources = (): {
       kind: kubevirtReferenceForModel(TemplateModel),
       isList: true,
       selector: {
-        matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_VM },
+        matchExpressions: [
+          {
+            key: TEMPLATE_TYPE_LABEL,
+            operator: 'Exists',
+          },
+        ],
       },
     },
     vmCommonTemplates: {


### PR DESCRIPTION
Description:
In 4.10 the common template namespace is user defined, common templates can be in any namespace, not just "openshift"
When user use a namespace that is not "openshift" for the common template, no common templates are available even if the new namespace is readable to the user.

Fix:
Get all virtual machine templates from current namespace, common and user, not just user as we did pre 4.10.

Screenshots
![template-create-works](https://user-images.githubusercontent.com/2181522/154017501-ba3a1362-7ac1-4f56-8315-f70cc5d637f7.png)
![templates-not-in-openshift](https://user-images.githubusercontent.com/2181522/154017507-6bb13517-0f87-4b8d-adad-d20a27ad751c.png)
![templates-in-default](https://user-images.githubusercontent.com/2181522/154017509-df3cef32-872b-476a-8545-52f363d0fcf1.png)

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=2051775
https://bugzilla.redhat.com/show_bug.cgi?id=2051378

Signed-off-by: yzamir <yzamir@redhat.com>