### PR TITLE
Bug 2046496: Update the list Toolbar to use ToolbarToggleGroup when less than 769px width

### DIFF
--- a/frontend/public/components/_filter-toolbar.scss
+++ b/frontend/public/components/_filter-toolbar.scss
@@ -24,7 +24,6 @@
 
 .co-filter-search--full-width {
   flex-grow: 1;
-  max-width: 370px;
   .has-feedback {
     width: 100%;
   }

--- a/frontend/public/components/_nav-title.scss
+++ b/frontend/public/components/_nav-title.scss
@@ -25,9 +25,6 @@
     padding-right: $pf-global-gutter--md;
   }
   &--row {
-    @media (max-width: $screen-xs-max) {
-      margin-bottom: 30px;
-    }
     @media (min-width: $screen-sm) {
       display: flex;
       flex-direction: row;

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -15,7 +15,9 @@ import {
   ToolbarChip,
   ToolbarContent,
   ToolbarFilter,
+  ToolbarGroup,
   ToolbarItem,
+  ToolbarToggleGroup,
   Tooltip,
 } from '@patternfly/react-core';
 import { FilterIcon, ColumnsIcon } from '@patternfly/react-icons';
@@ -280,138 +282,142 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
 
   return (
     <Toolbar
-      className="co-toolbar-no-padding"
+      className="co-toolbar-no-padding pf-m-toggle-group-container"
       data-test="filter-toolbar"
       id="filter-toolbar"
       clearAllFilters={clearAll}
       clearFiltersButtonText={t('public~Clear all filters')}
     >
       <ToolbarContent>
-        {rowFilters?.length > 0 && (
-          <ToolbarItem>
-            {_.reduce(
-              Object.keys(filters),
-              (acc, key) => (
-                <ToolbarFilter
-                  key={key}
-                  chips={_.intersection(selectedRowFilters, filters[key]).map((item) => {
-                    return {
-                      key: item,
-                      node: filtersNameMap[item],
-                    };
-                  })}
-                  deleteChip={(filter, chip: ToolbarChip) => updateRowFilterSelected([chip.key])}
-                  categoryName={key}
-                  deleteChipGroup={() => clearAllRowFilter(key)}
-                  chipGroupCollapsedText={t('public~{{numRemaining}} more', {
-                    numRemaining: '${remaining}',
-                  })}
-                  chipGroupExpandedText={t('public~Show less')}
-                >
-                  {acc}
-                </ToolbarFilter>
-              ),
-              <div data-test-id="filter-dropdown-toggle">
-                <Select
-                  placeholderText={
-                    <span>
-                      <FilterIcon className="span--icon__right-margin" />
-                      {t('public~Filter')}
-                    </span>
-                  }
-                  isOpen={isOpen}
-                  onToggle={() => {
-                    setOpen(!isOpen);
-                  }}
-                  onSelect={onRowFilterSelect}
-                  variant={SelectVariant.checkbox}
-                  selections={selectedRowFilters}
-                  isCheckboxSelectionBadgeHidden
-                  isGrouped
-                  maxHeight="60vh"
-                >
-                  {dropdownItems}
-                </Select>
-              </div>,
-            )}
-          </ToolbarItem>
-        )}
-        {!hideNameLabelFilters && (
-          <ToolbarItem className="co-filter-search--full-width">
-            <ToolbarFilter
-              deleteChipGroup={() => {
-                setLabelInputText('');
-                applyLabelFilters([]);
-              }}
-              chips={labelFilters}
-              deleteChip={(f, chip: string) => {
-                setLabelInputText('');
-                applyLabelFilters(_.difference(labelFilters, [chip]));
-              }}
-              categoryName={t('public~Label')}
-            >
+        <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="md">
+          {rowFilters?.length > 0 && (
+            <ToolbarItem>
+              {_.reduce(
+                Object.keys(filters),
+                (acc, key) => (
+                  <ToolbarFilter
+                    key={key}
+                    chips={_.intersection(selectedRowFilters, filters[key]).map((item) => {
+                      return {
+                        key: item,
+                        node: filtersNameMap[item],
+                      };
+                    })}
+                    deleteChip={(filter, chip: ToolbarChip) => updateRowFilterSelected([chip.key])}
+                    categoryName={key}
+                    deleteChipGroup={() => clearAllRowFilter(key)}
+                    chipGroupCollapsedText={t('public~{{numRemaining}} more', {
+                      numRemaining: '${remaining}',
+                    })}
+                    chipGroupExpandedText={t('public~Show less')}
+                  >
+                    {acc}
+                  </ToolbarFilter>
+                ),
+                <div data-test-id="filter-dropdown-toggle">
+                  <Select
+                    placeholderText={
+                      <span>
+                        <FilterIcon className="span--icon__right-margin" />
+                        {t('public~Filter')}
+                      </span>
+                    }
+                    isOpen={isOpen}
+                    onToggle={() => {
+                      setOpen(!isOpen);
+                    }}
+                    onSelect={onRowFilterSelect}
+                    variant={SelectVariant.checkbox}
+                    selections={selectedRowFilters}
+                    isCheckboxSelectionBadgeHidden
+                    isGrouped
+                    maxHeight="60vh"
+                  >
+                    {dropdownItems}
+                  </Select>
+                </div>,
+              )}
+            </ToolbarItem>
+          )}
+          {!hideNameLabelFilters && (
+            <ToolbarItem className="co-filter-search--full-width">
               <ToolbarFilter
-                chips={nameInputText ? [nameInputText] : []}
-                deleteChip={() => {
-                  setNameInputText('');
-                  applyNameFilter('');
+                deleteChipGroup={() => {
+                  setLabelInputText('');
+                  applyLabelFilters([]);
                 }}
-                categoryName={translatedNameFilterTitle}
+                chips={labelFilters}
+                deleteChip={(f, chip: string) => {
+                  setLabelInputText('');
+                  applyLabelFilters(_.difference(labelFilters, [chip]));
+                }}
+                categoryName={t('public~Label')}
               >
-                <div className="pf-c-input-group">
-                  {!hideLabelFilter && (
-                    <DropdownInternal
-                      items={filterDropdownItems}
-                      onChange={(type) => setFilterType(FilterType[type])}
-                      selectedKey={filterType}
-                      title={translateFilterType(filterType)}
-                    />
-                  )}
-                  {filterType === FilterType.LABEL ? (
-                    <AutocompleteInput
-                      className="co-text-node"
-                      onSuggestionSelect={(selected) => {
-                        applyLabelFilters(_.uniq([...labelFilters, selected]));
-                      }}
-                      showSuggestions
-                      textValue={labelInputText}
-                      setTextValue={setLabelInputText}
-                      placeholder={labelFilterPlaceholder ?? t('public~Search by label...')}
-                      data={data}
-                      labelPath={labelPath}
-                    />
-                  ) : (
-                    <TextFilter
-                      data-test="name-filter-input"
-                      value={nameInputText}
-                      onChange={(value: string) => {
-                        setNameInputText(value);
-                        debounceApplyNameFilter(value);
-                      }}
-                      placeholder={nameFilterPlaceholder ?? t('public~Search by name...')}
-                    />
-                  )}
-                </div>
+                <ToolbarFilter
+                  chips={nameInputText ? [nameInputText] : []}
+                  deleteChip={() => {
+                    setNameInputText('');
+                    applyNameFilter('');
+                  }}
+                  categoryName={translatedNameFilterTitle}
+                >
+                  <div className="pf-c-input-group">
+                    {!hideLabelFilter && (
+                      <DropdownInternal
+                        items={filterDropdownItems}
+                        onChange={(type) => setFilterType(FilterType[type])}
+                        selectedKey={filterType}
+                        title={translateFilterType(filterType)}
+                      />
+                    )}
+                    {filterType === FilterType.LABEL ? (
+                      <AutocompleteInput
+                        className="co-text-node"
+                        onSuggestionSelect={(selected) => {
+                          applyLabelFilters(_.uniq([...labelFilters, selected]));
+                        }}
+                        showSuggestions
+                        textValue={labelInputText}
+                        setTextValue={setLabelInputText}
+                        placeholder={labelFilterPlaceholder ?? t('public~Search by label...')}
+                        data={data}
+                        labelPath={labelPath}
+                      />
+                    ) : (
+                      <TextFilter
+                        data-test="name-filter-input"
+                        value={nameInputText}
+                        onChange={(value: string) => {
+                          setNameInputText(value);
+                          debounceApplyNameFilter(value);
+                        }}
+                        placeholder={nameFilterPlaceholder ?? t('public~Search by name...')}
+                      />
+                    )}
+                  </div>
+                </ToolbarFilter>
               </ToolbarFilter>
-            </ToolbarFilter>
-          </ToolbarItem>
-        )}
+            </ToolbarItem>
+          )}
+        </ToolbarToggleGroup>
         {columnLayout?.id && !hideColumnManagement && (
-          <ToolbarItem>
-            <Tooltip content={t('public~Manage columns')}>
-              <Button
-                variant="plain"
-                onClick={() =>
-                  createColumnManagementModal({
-                    columnLayout,
-                  })
-                }
-                aria-label={t('public~Column management')}
-              >
-                <ColumnsIcon />
-              </Button>
-            </Tooltip>
-          </ToolbarItem>
+          <ToolbarGroup>
+            <ToolbarItem>
+              <Tooltip content={t('public~Manage columns')}>
+                <Button
+                  variant="plain"
+                  onClick={() =>
+                    createColumnManagementModal({
+                      columnLayout,
+                    })
+                  }
+                  aria-label={t('public~Column management')}
+                >
+                  <ColumnsIcon />
+                </Button>
+              </Tooltip>
+            </ToolbarItem>
+          </ToolbarGroup>
         )}
       </ToolbarContent>
     </Toolbar>

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -25,9 +25,10 @@ form.pf-c-form {
   vertical-align: top; // PF defaults to baseline which doesn't align correctly when Operator logos are within the table
 }
 
-.co-toolbar-no-padding.pf-c-toolbar {
-  --pf-c-toolbar__content--PaddingLeft: 0;
-  --pf-c-toolbar__content--PaddingRight: 0;
+.co-toolbar-no-padding .pf-c-toolbar__content {
+  // use negative margins so that pf-c-toolbar__expandable-content extends to the edges at mobile
+  margin-left: -$pf-global-gutter;
+  margin-right: -$pf-global-gutter;
   --pf-c-toolbar--PaddingTop: 0;
   --pf-c-toolbar--RowGap: var(--pf-global--spacer--md);
 }


### PR DESCRIPTION
The list filters and column management buttons display awkwardly at mobile. These changes enable the `ToolbarToggleGroup` with filter `<button>` to show filtering options at mobile. 
cc @spadgett 
**Before**
<img width="360" alt="Screen Shot 2022-02-15 at 5 18 02 PM" src="https://user-images.githubusercontent.com/1874151/154159722-9adce55f-aedb-4e58-88c2-bfa21307c5e1.png">

**After**
<img width="357" alt="Screen Shot 2022-02-15 at 4 54 19 PM" src="https://user-images.githubusercontent.com/1874151/154159764-23b66d10-b836-4982-bd02-11b400cfb26d.png">

<img width="362" alt="Screen Shot 2022-02-15 at 5 27 29 PM" src="https://user-images.githubusercontent.com/1874151/154160287-03b33a65-ec51-4963-b238-519f2d796e88.png">

Fix bug https://bugzilla.redhat.com/show_bug.cgi?id=2046496