### PR TITLE
Bug 2052953: clear dashboard variables for dev perspective on unmount

### DIFF
--- a/frontend/public/actions/observe.ts
+++ b/frontend/public/actions/observe.ts
@@ -7,6 +7,7 @@ export enum ActionType {
   AlertingSetRules = 'alertingSetRules',
   DashboardsPatchAllVariables = 'dashboardsPatchAllVariables',
   DashboardsPatchVariable = 'dashboardsPatchVariable',
+  DashboardsClearVariables = 'dashboardsClearVariables',
   DashboardsSetEndTime = 'dashboardsSetEndTime',
   DashboardsSetPollInterval = 'dashboardsSetPollInterval',
   DashboardsSetTimespan = 'dashboardsSetTimespan',
@@ -33,6 +34,9 @@ export const dashboardsPatchVariable = (key: string, patch: any, perspective: st
 
 export const dashboardsPatchAllVariables = (variables: any, perspective: string) =>
   action(ActionType.DashboardsPatchAllVariables, { variables, perspective });
+
+export const DashboardsClearVariables = (perspective: string) =>
+  action(ActionType.DashboardsClearVariables, { perspective });
 
 export const dashboardsSetEndTime = (endTime: number, perspective: string) =>
   action(ActionType.DashboardsSetEndTime, { endTime, perspective });
@@ -131,6 +135,7 @@ const actions = {
   alertingSetRules,
   dashboardsPatchAllVariables,
   dashboardsPatchVariable,
+  DashboardsClearVariables,
   dashboardsSetEndTime,
   dashboardsSetPollInterval,
   dashboardsSetTimespan,

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -29,6 +29,7 @@ import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
 import { withFallback } from '@console/shared/src/components/error/error-boundary';
 
 import {
+  DashboardsClearVariables,
   dashboardsPatchAllVariables,
   dashboardsPatchVariable,
   dashboardsSetEndTime,
@@ -653,6 +654,16 @@ const MonitoringDashboardsPage: React.FC<MonitoringDashboardsPageProps> = ({ mat
 
   // Clear queries on unmount
   React.useEffect(() => () => dispatch(queryBrowserDeleteAllQueries()), [dispatch]);
+
+  // Clear variables on unmount for dev perspective
+  React.useEffect(
+    () => () => {
+      if (activePerspective === 'dev') {
+        dispatch(DashboardsClearVariables(activePerspective));
+      }
+    },
+    [activePerspective, dispatch],
+  );
 
   const boardItems = React.useMemo(
     () =>

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -83,6 +83,9 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
         ImmutableMap(action.payload.variables),
       );
 
+    case ActionType.DashboardsClearVariables:
+      return state.setIn(['dashboards', action.payload.perspective, 'variables'], ImmutableMap());
+
     case ActionType.DashboardsSetEndTime:
       return state.setIn(
         ['dashboards', action.payload.perspective, 'endTime'],


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2052953

**Analysis / Root cause**: 

Observe dashboard from dev console always opens for last viewed workload instead of the selected one form topology.

variables were set in-store and were preferred over URL (this can be observed if the user clicks on view dashboard from topology for one of the workloads)

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Clear dashboard variables for dev perspective  from the store on unmount

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge