### PR TITLE
Bug 1934304: Sum total memory of unnamed container only

### DIFF
--- a/frontend/packages/console-app/src/queries.ts
+++ b/frontend/packages/console-app/src/queries.ts
@@ -28,7 +28,7 @@ export const PressureQueries = {
       model: PodModel,
       fieldSelector: `spec.nodeName=${node}`,
       metric: 'pod',
-      query: `(sort_desc(topk(25,sum by(pod, namespace) (container_memory_working_set_bytes{node="${node}"}))))`,
+      query: `(sort_desc(topk(25,sum by(pod, namespace) (container_memory_working_set_bytes{node="${node}", container=""}))))`,
     },
   ],
 


### PR DESCRIPTION
3 metrics are reported for the same pod from 3 different containers.
Hence we were getting 2x values. ( 2 containers are reporting the same value while 1 of them is reporting something slightly different).
Metrics: 
![Screenshot from 2022-02-16 15-22-28](https://user-images.githubusercontent.com/54092533/154237416-17e66e6f-3078-44f3-876a-a26439466901.png)
