### PR TITLE
Bug 2053501: Decode secrets before authorizing repository

### DIFF
--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -86,7 +86,6 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
       secret: '',
       isUrlValidating: false,
       validated: ValidatedOptions.default,
-      secretResource: {},
     },
     docker: {
       dockerfilePath: '',

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -407,7 +407,7 @@ const GitSection: React.FC<GitSectionProps> = ({
   }, [handleGitUrlChange, sampleRepo, setFieldTouched, setFieldValue, tag]);
 
   React.useEffect(() => {
-    (!dirty || gitDirTouched || gitTypeTouched || formReloadCount) &&
+    (!dirty || gitDirTouched || gitTypeTouched || formReloadCount || values.git.secretResource) &&
       values.git.url &&
       debouncedHandleGitUrlChange(values.git.url, values.git.ref, values.git.dir);
   }, [
@@ -420,6 +420,7 @@ const GitSection: React.FC<GitSectionProps> = ({
     values.git.ref,
     values.git.dir,
     values.git.type,
+    values.git.secretResource,
     gitTypeTouched,
   ]);
 

--- a/frontend/packages/dev-console/src/components/import/git/SourceSecretSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/SourceSecretSelector.tsx
@@ -47,8 +47,12 @@ const SourceSecretSelector: React.FC<{
   };
 
   React.useEffect(() => {
-    loaded && !loadError && data && setFieldValue(`${fieldPrefix}git.secretResource`, data);
-  }, [loaded, loadError, data, setFieldValue, fieldPrefix]);
+    loaded &&
+      !loadError &&
+      secret &&
+      data &&
+      setFieldValue(`${fieldPrefix}git.secretResource`, data);
+  }, [loaded, loadError, secret, data, setFieldValue, fieldPrefix]);
 
   return (
     <>

--- a/frontend/packages/git-service/src/services/bitbucket-service.ts
+++ b/frontend/packages/git-service/src/services/bitbucket-service.ts
@@ -26,7 +26,7 @@ export class BitbucketService extends BaseService {
     switch (this.gitsource.secretType) {
       case SecretType.BASIC_AUTH: {
         const { username, password } = this.gitsource.secretContent;
-        const encodedAuth = Base64.encode(`${username}:${password}`);
+        const encodedAuth = Base64.encode(`${Base64.decode(username)}:${Base64.decode(password)}`);
         return { Authorization: `Basic ${encodedAuth}` };
       }
       default:

--- a/frontend/packages/git-service/src/services/github-service.ts
+++ b/frontend/packages/git-service/src/services/github-service.ts
@@ -1,5 +1,6 @@
 import * as Octokit from '@octokit/rest';
 import * as GitUrlParse from 'git-url-parse';
+import { Base64 } from 'js-base64';
 import {
   GitSource,
   SecretType,
@@ -27,7 +28,8 @@ export class GithubService extends BaseService {
     switch (this.gitsource.secretType) {
       case SecretType.PERSONAL_ACCESS_TOKEN:
       case SecretType.BASIC_AUTH:
-        return { auth: this.gitsource.secretContent };
+      case SecretType.OAUTH:
+        return { auth: Base64.decode(this.gitsource.secretContent.password) };
       default:
         return null;
     }

--- a/frontend/packages/git-service/src/services/gitlab-service.ts
+++ b/frontend/packages/git-service/src/services/gitlab-service.ts
@@ -1,6 +1,7 @@
 import * as GitUrlParse from 'git-url-parse';
 import { Gitlab } from 'gitlab';
 import i18n from 'i18next';
+import { Base64 } from 'js-base64';
 import {
   GitSource,
   SecretType,
@@ -78,7 +79,7 @@ export class GitlabService extends BaseService {
       case SecretType.PERSONAL_ACCESS_TOKEN:
       case SecretType.OAUTH:
       case SecretType.BASIC_AUTH:
-        return this.gitsource.secretContent.password;
+        return Base64.decode(this.gitsource.secretContent.password);
       default:
         return null;
     }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-40626
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Secret was not decoded before being used for authorization.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Decode the secret before auth.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/154282564-6bb595ec-9b02-486e-bd5e-2ee69fade4e1.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Test setup:**
1. Navigate to +Add > git import
2. Enter a private git repository
3. In advanced git options create a secret with personal access token and select it

<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
