### PR TITLE
Bug 2060894: Preceding/Trailing Whitespaces In Form Elements on the add page

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/BaseInputField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/BaseInputField.tsx
@@ -14,6 +14,7 @@ const BaseInputField: React.FC<BaseInputFieldProps & {
   children,
   name,
   onChange,
+  onBlur,
   helpTextInvalid,
   validated,
   ...props
@@ -43,6 +44,10 @@ const BaseInputField: React.FC<BaseInputFieldProps & {
         onChange: (value, event) => {
           field.onChange(event);
           onChange && onChange(event);
+        },
+        onBlur: (event) => {
+          field.onBlur(event);
+          onBlur && onBlur(event);
         },
       })}
     </FormGroup>

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -490,13 +490,16 @@ const GitSection: React.FC<GitSectionProps> = ({
         helpText={helpText}
         helpTextInvalid={helpText}
         validated={validated}
-        onChange={(e: React.SyntheticEvent) => {
+        onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
+          const trimmedURL = e.target.value.trim();
+          if (e.target.value !== trimmedURL) {
+            setFieldValue('git.url', trimmedURL);
+            debouncedHandleGitUrlChange(trimmedURL, values.git.ref, values.git.dir);
+          }
+        }}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           resetFields();
-          debouncedHandleGitUrlChange(
-            (e.target as HTMLInputElement).value,
-            values.git.ref,
-            values.git.dir,
-          );
+          debouncedHandleGitUrlChange(e.target.value.trim(), values.git.ref, values.git.dir);
         }}
         data-test-id="git-form-input-url"
         required

--- a/frontend/packages/topology/src/components/dropdowns/ApplicationSelector.tsx
+++ b/frontend/packages/topology/src/components/dropdowns/ApplicationSelector.tsx
@@ -69,8 +69,13 @@ const ApplicationSelector: React.FC<ApplicationSelectorProps> = ({
     },
   ];
 
-  const handleAppChange = (event) => {
-    setApplicationExists(availableApplications.current.includes(event.target.value));
+  const handleAppChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setApplicationExists(availableApplications.current.includes(event.target.value.trim()));
+  };
+
+  const handleAppBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    const trimmedApplicationName = event.target.value.trim();
+    setFieldValue(nameField.name, trimmedApplicationName);
   };
 
   const label = t('topology~Application');
@@ -121,6 +126,7 @@ const ApplicationSelector: React.FC<ApplicationSelectorProps> = ({
           helpText={inputHelpText}
           validated={applicationExists ? ValidatedOptions.warning : ValidatedOptions.default}
           onChange={handleAppChange}
+          onBlur={handleAppBlur}
         />
       )}
     </>

--- a/frontend/packages/topology/src/components/dropdowns/__tests__/ApplicationSelector.spec.tsx
+++ b/frontend/packages/topology/src/components/dropdowns/__tests__/ApplicationSelector.spec.tsx
@@ -107,4 +107,17 @@ describe('ApplicationSelector', () => {
     expect(setFieldValue).toHaveBeenCalledWith('application.name', undefined);
     expect(setFieldValue).toHaveBeenCalledTimes(2);
   });
+
+  it('should trim the spaces in the application name', () => {
+    spyUseField
+      .mockReturnValueOnce([{ value: CREATE_APPLICATION_KEY, name: 'application.selectedKey' }, {}])
+      .mockReturnValueOnce([{ value: '', name: 'application.name' }, {}]);
+    wrapper.setProps({ noProjectsAvailable: false });
+    wrapper
+      .find(InputField)
+      .props()
+      .onBlur({ target: { value: ' test-application ' } });
+
+    expect(setFieldValue).toHaveBeenCalledWith('application.name', 'test-application');
+  });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-1749

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
The user accesses the 'Import from git' form and copies/pastes a link into the git repo field. This paste comes with extra whitespace (before or after). The user doesn't recognize this issue and attempts to move on with the form. They see `Invalid Git URL` without any context that there is additional whitespace.  
A similar issue is also seen in the 'Deploy Image' page, where the user has to provide the `Application Name`.


**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
When a user pastes the Git URL with Preceding/Trailing Whitespaces in the form input and clicks anywhere outside, the `onBlur` event will run and trim the whitespaces before the Validation happens in the Form Element.  
The same solution is also applied in the Application Name field of the Deploy Image page.


**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

_Git Add URL Page:_
![f8535f2c-e66d-41b0-a61f-c5add719e35b (1)](https://user-images.githubusercontent.com/47265560/154316247-1d4fd211-1dcb-4630-bd62-ab9c0a3714e3.gif)

_Deploy Image Page:_
![26f89532-0f98-4e4e-9de2-40f64f4de807 (1)](https://user-images.githubusercontent.com/47265560/154319257-9c8069db-392d-43e4-9260-621fbe1211fb.gif)


**Unit test coverage report**: 
<!-- Attach test coverage report -->
_Added a test case to test whether the Preceding/Trailing Whitespaces in **Application Name** in the Deploy Image Page is getting removed_
```
 PASS  packages/topology/src/components/dropdowns/__tests__/ApplicationSelector.spec.tsx (19.873s)
  ApplicationSelector
    ✓ should show InputField if no projects are available (32ms)
    ✓ should show ApplicationDropdown if projects are available (8ms)
    ✓ should reset the selectedKey if the applications are not loaded (8ms)
    ✓ should reset the application name if the application list is empty (4ms)
    ✓ should set the application name and selectedKey on dropdown change (4ms)
    ✓ should not set the application name on dropdown change if the application is undefined (4ms)
    ✓ should trim the spaces in the application name (3ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        22.445s
Ran all test suites matching /\/home\/akundu\/Desktop\/openshift\/console\/frontend\/packages\/topology\/src\/components\/dropdowns\/__tests__\/ApplicationSelector.spec.tsx/i.
Done in 25.73s.
```


**Test setup:**
<!-- If any setup is required to test this PR, mention the details -->
_Git Add URL Page:_
1. Navigate to +Add > Import from Git
2. Enter a Git repository URL with spaces.

_Deploy Image Page:_
1.  Navigate to +Add > Container Images
2. Enter an Image Name
3. Select Create Application in Application Section
4. Type an Application Name with spaces


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge







