### PR TITLE
Bug 2052956: fix duplicate edit app action on installing virtualization operator

### DIFF
--- a/frontend/packages/kubevirt-plugin/console-extensions.json
+++ b/frontend/packages/kubevirt-plugin/console-extensions.json
@@ -674,6 +674,16 @@
     }
   },
   {
+    "type": "console.action/provider",
+    "properties": {
+      "contextId": "topology-actions",
+      "provider": { "$codeRef": "actions.useModifyApplicationActionProvider" }
+    },
+    "flags": {
+      "required": ["KUBEVIRT"]
+    }
+  },
+  {
     "type": "console.action/resource-provider",
     "properties": {
       "model": {

--- a/frontend/packages/kubevirt-plugin/src/actions/provider.ts
+++ b/frontend/packages/kubevirt-plugin/src/actions/provider.ts
@@ -1,14 +1,18 @@
 import * as React from 'react';
+import { GraphElement } from '@patternfly/react-topology';
 import { CommonActionFactory } from '@console/app/src/actions/creators/common-factory';
+import { modelFor } from '@console/dynamic-plugin-sdk/src/lib-internal-kubevirt';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
+import { getModifyApplicationAction } from '@console/topology/src/actions';
 import { VmActionFactory, VmiActionFactory } from '../components/vms/menu-actions';
 import { useVMStatus } from '../hooks/use-vm-status';
 import { VirtualMachineInstanceModel } from '../models';
 import { kubevirtReferenceForModel } from '../models/kubevirtReferenceForModel';
 import { isVMRunningOrExpectedRunning } from '../selectors/vm/selectors';
 import { isVMIPaused } from '../selectors/vmi';
+import { TYPE_VIRTUAL_MACHINE } from '../topology/components/const';
 import { VMIKind, VMKind } from '../types';
 
 export const useVmActionsProvider = (vm: VMKind) => {
@@ -82,4 +86,18 @@ export const useVmiActionsProvider = (vm: VMKind) => {
       : [];
   }, [k8sModel, vm, vmStatusBundle, vmi]);
   return React.useMemo(() => [actions, !inFlight, undefined], [actions, inFlight]);
+};
+
+export const useModifyApplicationActionProvider = (element: GraphElement) => {
+  const actions = React.useMemo(() => {
+    if (element.getType() !== TYPE_VIRTUAL_MACHINE) return undefined;
+    const resource = element.getData().resources.obj;
+    const k8sKind = modelFor(referenceFor(resource));
+    return [getModifyApplicationAction(k8sKind, resource, 'vm-action-start')];
+  }, [element]);
+
+  return React.useMemo(() => {
+    if (!actions) return [[], true, undefined];
+    return [actions, true, undefined];
+  }, [actions]);
 };

--- a/frontend/packages/topology/console-extensions.json
+++ b/frontend/packages/topology/console-extensions.json
@@ -246,15 +246,5 @@
       "contextId": "topology-actions",
       "provider": { "$codeRef": "actions.useTopologyVisualConnectorActionProvider" }
     }
-  },
-  {
-    "type": "console.action/provider",
-    "properties": {
-    "contextId": "topology-actions",
-    "provider": { "$codeRef": "actions.useEditApplicationTopologyActionsProvider" }
-    },
-    "flags": {
-      "required": ["KUBEVIRT"]
-    }
   }
 ]

--- a/frontend/packages/topology/src/actions/provider.ts
+++ b/frontend/packages/topology/src/actions/provider.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import { Edge, GraphElement, Node } from '@patternfly/react-topology';
-import { K8sResourceKind, modelFor, referenceFor } from '@console/internal/module/k8s';
+import { Edge, GraphElement } from '@patternfly/react-topology';
+import { modelFor, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { TYPE_WORKLOAD, TYPE_CONNECTS_TO } from '../const';
 import { getResource } from '../utils';
@@ -36,13 +36,4 @@ export const useTopologyVisualConnectorActionProvider = (element: Edge) => {
     if (!actions) return [[], true, undefined];
     return [actions, !inFlight, undefined];
   }, [actions, inFlight]);
-};
-
-export const useEditApplicationTopologyActionsProvider = (element: Node) => {
-  const resource: K8sResourceKind = getResource(element);
-  const [, inFlight] = useK8sModel(referenceFor(resource));
-  const actions = useMemo(() => {
-    return [getModifyApplicationAction(modelFor(referenceFor(resource)), resource)];
-  }, [resource]);
-  return useMemo(() => [actions, !inFlight, undefined], [actions, inFlight]);
 };


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGSM-40558

**Root analysis:**
the `useEditApplicationTopologyActionsProvider` hook is called when the KUBEVIRT flag is set, and it has no conditions to differentiate between a virtual machine and a workload. This is why when the virtualization operator is installed the edit app grouping would show up twice, once because of `useTopologyWorkloadActionProvider` and again for `useEditApplicationTopologyActionsProvider`

**Solution description:**
moved the hook to kubevirt plugin providers.

**GIF:**
![edit-app](https://user-images.githubusercontent.com/22490998/154329618-6d98905b-cec6-4a51-824f-3a642f7da687.gif)

/kind bug