### PR TITLE
[release-4.7] Bug 2055403: Add support for fetching partial metadata and fix helm list page crash

### DIFF
--- a/frontend/__tests__/actions/k8s.spec.ts
+++ b/frontend/__tests__/actions/k8s.spec.ts
@@ -153,6 +153,51 @@ describe(k8sActions.ActionType.StartWatchK8sList, () => {
     watchK8sList('another-redux-id', {}, model)(dispatch, getState);
   });
 
+  it('send partial metadata headers to k8sList when partialMetadata is true', (done) => {
+    const k8sList = spyOn(k8sResource, 'k8sList').and.callFake(
+      (k8sKind, params, raw, requestOptions) => {
+        expect(params.limit).toEqual(250);
+        expect(requestOptions.headers).toEqual(k8sActions.partialObjectMetadataListHeader);
+
+        if (k8sList.calls.count() === 1 || k8sList.calls.count() === 11) {
+          expect(params.continue).toBeUndefined();
+        } else {
+          expect(params.continue).toEqual('toNextPage');
+        }
+        resourceList.metadata.resourceVersion = (
+          parseInt(resourceList.metadata.resourceVersion, 10) + 1
+        ).toString();
+        resourceList.metadata.continue =
+          parseInt(resourceList.metadata.resourceVersion, 10) < 10 ? 'toNextPage' : undefined;
+
+        return resourceList;
+      },
+    );
+
+    let returnedItems = 0;
+    const dispatch = jasmine.createSpy('dispatch').and.callFake((action) => {
+      if (action.type === k8sActions.ActionType.BulkAddToList) {
+        const bulkAddToListCalls = dispatch.calls
+          .allArgs()
+          .filter((args) => args[0].type === k8sActions.ActionType.BulkAddToList);
+
+        expect(action.payload.k8sObjects).toEqual(resourceList.items);
+        expect(bulkAddToListCalls.length).toEqual(k8sList.calls.count() - 1);
+
+        returnedItems += action.payload.k8sObjects.length;
+
+        if (bulkAddToListCalls.length === 9) {
+          expect(returnedItems).toEqual(resourceList.items.length * bulkAddToListCalls.length);
+          done();
+        }
+      } else if (action.type === k8sActions.ActionType.Errored) {
+        fail(action.payload.k8sObjects);
+      }
+    });
+
+    k8sActions.watchK8sList('one-more-redux-id', {}, model, null, true)(dispatch, getState);
+  });
+
   xit('stops incrementally fetching if `stopK8sWatch` action is dispatched', () => {
     // TODO(alecmerdler)
   });

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
@@ -44,6 +44,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace }) => {
       namespaced: true,
       optional: true,
       selector: { matchLabels: { owner: 'helm' } },
+      partialMetadata: true,
     }),
     [namespace],
   );

--- a/frontend/packages/helm-plugin/src/topology/helm-topology-plugin.tsx
+++ b/frontend/packages/helm-plugin/src/topology/helm-topology-plugin.tsx
@@ -26,6 +26,7 @@ const getHelmWatchedResources = (namespace: string): WatchK8sResources<any> => {
       kind: 'Secret',
       namespace,
       optional: true,
+      partialMetadata: true,
     },
   };
 };

--- a/frontend/public/components/utils/k8s-watch-hook.ts
+++ b/frontend/public/components/utils/k8s-watch-hook.ts
@@ -31,8 +31,15 @@ const getIDAndDispatch: GetIDAndDispatch = (resource, k8sModel) => {
   );
   const id = makeReduxID(k8sModel, query);
   const dispatch = resource.isList
-    ? k8sActions.watchK8sList(id, query, k8sModel)
-    : k8sActions.watchK8sObject(id, resource.name, resource.namespace, query, k8sModel);
+    ? k8sActions.watchK8sList(id, query, k8sModel, null, resource.partialMetadata)
+    : k8sActions.watchK8sObject(
+        id,
+        resource.name,
+        resource.namespace,
+        query,
+        k8sModel,
+        resource.partialMetadata,
+      );
   return { id, dispatch };
 };
 
@@ -263,4 +270,5 @@ export type WatchK8sResource = {
   limit?: number;
   fieldSelector?: string;
   optional?: boolean;
+  partialMetadata?: boolean;
 };

--- a/frontend/public/module/k8s/resource.js
+++ b/frontend/public/module/k8s/resource.js
@@ -57,8 +57,8 @@ export const watchURL = (kind, options) => {
   return resourceURL(kind, opts);
 };
 
-export const k8sGet = (kind, name, ns, opts) =>
-  coFetchJSON(resourceURL(kind, Object.assign({ ns, name }, opts)));
+export const k8sGet = (kind, name, ns, opts, options) =>
+  coFetchJSON(resourceURL(kind, Object.assign({ ns, name }, opts)), 'GET', options);
 
 export const k8sCreate = (kind, data, opts = {}) => {
   return coFetchJSON.post(


### PR DESCRIPTION
This is a manually cherry-pick/backport of #10932

4.10: https://bugzilla.redhat.com/show_bug.cgi?id=1999796
4.9: https://bugzilla.redhat.com/show_bug.cgi?id=2044287
4.8: https://bugzilla.redhat.com/show_bug.cgi?id=2046051
4.7: https://bugzilla.redhat.com/show_bug.cgi?id=2055403

**Merge notes:**
Cherry-picked. Solved merge conflict by adding the new type definition (`partialMetadata` attribute) somewhere else.

release-4.7 branch without this PR:
![image](https://user-images.githubusercontent.com/139310/154352257-2d4f059c-4169-40ab-8854-71adf88676cf.png)

With this PR:
![image](https://user-images.githubusercontent.com/139310/154351966-1bf289c4-b481-4ba5-ba40-5f78de11921b.png)
