### PR TITLE
[release-4.7] Bug 2055411: Filter superseded helm secrets and fix firehose to support partial metadata

### DIFF
--- a/frontend/__tests__/actions/k8s.spec.ts
+++ b/frontend/__tests__/actions/k8s.spec.ts
@@ -153,6 +153,51 @@ describe(k8sActions.ActionType.StartWatchK8sList, () => {
     watchK8sList('another-redux-id', {}, model)(dispatch, getState);
   });
 
+  it('send partial metadata headers to k8sList when partialMetadata is true', (done) => {
+    const k8sList = spyOn(k8sResource, 'k8sList').and.callFake(
+      (k8sKind, params, raw, requestOptions) => {
+        expect(params.limit).toEqual(250);
+        expect(requestOptions.headers).toEqual(k8sActions.partialObjectMetadataListHeader);
+
+        if (k8sList.calls.count() === 1 || k8sList.calls.count() === 11) {
+          expect(params.continue).toBeUndefined();
+        } else {
+          expect(params.continue).toEqual('toNextPage');
+        }
+        resourceList.metadata.resourceVersion = (
+          parseInt(resourceList.metadata.resourceVersion, 10) + 1
+        ).toString();
+        resourceList.metadata.continue =
+          parseInt(resourceList.metadata.resourceVersion, 10) < 10 ? 'toNextPage' : undefined;
+
+        return resourceList;
+      },
+    );
+
+    let returnedItems = 0;
+    const dispatch = jasmine.createSpy('dispatch').and.callFake((action) => {
+      if (action.type === k8sActions.ActionType.BulkAddToList) {
+        const bulkAddToListCalls = dispatch.calls
+          .allArgs()
+          .filter((args) => args[0].type === k8sActions.ActionType.BulkAddToList);
+
+        expect(action.payload.k8sObjects).toEqual(resourceList.items);
+        expect(bulkAddToListCalls.length).toEqual(k8sList.calls.count() - 1);
+
+        returnedItems += action.payload.k8sObjects.length;
+
+        if (bulkAddToListCalls.length === 9) {
+          expect(returnedItems).toEqual(resourceList.items.length * bulkAddToListCalls.length);
+          done();
+        }
+      } else if (action.type === k8sActions.ActionType.Errored) {
+        fail(action.payload.k8sObjects);
+      }
+    });
+
+    k8sActions.watchK8sList('one-more-redux-id', {}, model, null, true)(dispatch, getState);
+  });
+
   xit('stops incrementally fetching if `stopK8sWatch` action is dispatched', () => {
     // TODO(alecmerdler)
   });

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
@@ -12,7 +12,10 @@ import { SortByDirection } from '@patternfly/react-table';
 import { CustomResourceList } from '@console/shared';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { SecretModel } from '@console/internal/models';
-import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import {
+  useK8sWatchResource,
+  WatchK8sResource,
+} from '@console/internal/components/utils/k8s-watch-hook';
 import { StatusBox } from '@console/internal/components/utils';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import {
@@ -36,14 +39,17 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace }) => {
   const [releasesLoaded, setReleasesLoaded] = React.useState<boolean>(false);
   const [loadError, setLoadError] = React.useState<string>();
   const [releases, setReleases] = React.useState([]);
-  const secretResource = React.useMemo(
+  const secretResource = React.useMemo<WatchK8sResource>(
     () => ({
       isList: true,
       namespace,
       kind: SecretModel.kind,
       namespaced: true,
       optional: true,
-      selector: { matchLabels: { owner: 'helm' } },
+      selector: {
+        matchLabels: { owner: 'helm' },
+        matchExpressions: [{ key: 'status', operator: 'NotEquals', values: ['superseded'] }],
+      },
       partialMetadata: true,
     }),
     [namespace],

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
@@ -44,6 +44,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace }) => {
       namespaced: true,
       optional: true,
       selector: { matchLabels: { owner: 'helm' } },
+      partialMetadata: true,
     }),
     [namespace],
   );

--- a/frontend/packages/helm-plugin/src/topology/TopologyHelmReleasePanel.tsx
+++ b/frontend/packages/helm-plugin/src/topology/TopologyHelmReleasePanel.tsx
@@ -48,7 +48,7 @@ export const ConnectedTopologyHelmReleasePanel: React.FC<TopologyHelmReleasePane
   const secret = helmRelease.getData().resources.obj;
   const { manifestResources, releaseNotes } = helmRelease.getData().data;
   const name = helmRelease.getLabel();
-  const { namespace } = getResource(helmRelease).metadata;
+  const { namespace } = getResource(helmRelease)?.metadata;
 
   const detailsComponent = !secret
     ? () => (
@@ -64,7 +64,7 @@ export const ConnectedTopologyHelmReleasePanel: React.FC<TopologyHelmReleasePane
     : navFactory.details(HelmReleaseOverview).component;
 
   const resourcesComponent = () =>
-    manifestResources ? (
+    namespace && manifestResources ? (
       <div className="overview__sidebar-pane-body">
         <TopologyGroupResourcesPanel
           manifestResources={manifestResources}
@@ -82,7 +82,7 @@ export const ConnectedTopologyHelmReleasePanel: React.FC<TopologyHelmReleasePane
         <h1 className="co-m-pane__heading">
           <div className="co-m-pane__name co-resource-item">
             <ResourceIcon className="co-m-resource-icon--lg" kind="HelmRelease" />
-            {name && (
+            {namespace && name && (
               <Link
                 to={`/helm-releases/ns/${namespace}/release/${name}`}
                 className="co-resource-item__resource-name"

--- a/frontend/packages/helm-plugin/src/topology/helm-data-transformer.ts
+++ b/frontend/packages/helm-plugin/src/topology/helm-data-transformer.ts
@@ -43,7 +43,6 @@ export const getTopologyHelmReleaseGroupItem = (
   const resourceKindName = getHelmReleaseKey(obj);
   const helmResources = helmResourcesMap[resourceKindName];
   const releaseName = helmResources?.releaseName;
-  const releaseVersion = helmResources?.releaseVersion;
   const releaseNotes = helmResources?.releaseNotes;
   const uid = obj?.metadata?.uid ?? null;
   const returnData = [];
@@ -53,8 +52,7 @@ export const getTopologyHelmReleaseGroupItem = (
   }
 
   const secret = secrets.find((nextSecret) => {
-    const { labels } = nextSecret.metadata;
-    return labels?.name?.includes(releaseName) && labels?.version === releaseVersion.toString();
+    return nextSecret.metadata.labels?.name === releaseName;
   });
 
   if (secret) {

--- a/frontend/packages/helm-plugin/src/topology/helm-topology-plugin.tsx
+++ b/frontend/packages/helm-plugin/src/topology/helm-topology-plugin.tsx
@@ -26,6 +26,7 @@ const getHelmWatchedResources = (namespace: string): WatchK8sResources<any> => {
       kind: 'Secret',
       namespace,
       optional: true,
+      partialMetadata: true,
     },
   };
 };

--- a/frontend/packages/helm-plugin/src/topology/helm-topology-plugin.tsx
+++ b/frontend/packages/helm-plugin/src/topology/helm-topology-plugin.tsx
@@ -27,6 +27,10 @@ const getHelmWatchedResources = (namespace: string): WatchK8sResources<any> => {
       namespace,
       optional: true,
       partialMetadata: true,
+      selector: {
+        matchLabels: { owner: 'helm' },
+        matchExpressions: [{ key: 'status', operator: 'NotEquals', values: ['superseded'] }],
+      },
     },
   };
 };

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -222,10 +222,10 @@ export const Firehose = connect(
           });
       }
 
-      firehoses.forEach(({ id, query, k8sKind, isList, name, namespace }) =>
+      firehoses.forEach(({ id, query, k8sKind, isList, name, namespace, partialMetadata }) =>
         isList
-          ? watchK8sList(id, query, k8sKind)
-          : watchK8sObject(id, name, namespace, query, k8sKind),
+          ? watchK8sList(id, query, k8sKind, null, partialMetadata)
+          : watchK8sObject(id, name, namespace, query, k8sKind, partialMetadata),
       );
       this.setState({ firehoses });
     }
@@ -280,6 +280,7 @@ Firehose.propTypes = {
       isList: PropTypes.bool,
       optional: PropTypes.bool, // do not block children-rendering while resource is still being loaded; do not fail if resource is missing (404)
       limit: PropTypes.number,
+      partialMetadata: PropTypes.bool,
     }),
   ).isRequired,
 };

--- a/frontend/public/components/utils/k8s-watch-hook.ts
+++ b/frontend/public/components/utils/k8s-watch-hook.ts
@@ -31,8 +31,15 @@ const getIDAndDispatch: GetIDAndDispatch = (resource, k8sModel) => {
   );
   const id = makeReduxID(k8sModel, query);
   const dispatch = resource.isList
-    ? k8sActions.watchK8sList(id, query, k8sModel)
-    : k8sActions.watchK8sObject(id, resource.name, resource.namespace, query, k8sModel);
+    ? k8sActions.watchK8sList(id, query, k8sModel, null, resource.partialMetadata)
+    : k8sActions.watchK8sObject(
+        id,
+        resource.name,
+        resource.namespace,
+        query,
+        k8sModel,
+        resource.partialMetadata,
+      );
   return { id, dispatch };
 };
 
@@ -263,4 +270,5 @@ export type WatchK8sResource = {
   limit?: number;
   fieldSelector?: string;
   optional?: boolean;
+  partialMetadata?: boolean;
 };

--- a/frontend/public/module/k8s/resource.js
+++ b/frontend/public/module/k8s/resource.js
@@ -57,8 +57,8 @@ export const watchURL = (kind, options) => {
   return resourceURL(kind, opts);
 };
 
-export const k8sGet = (kind, name, ns, opts) =>
-  coFetchJSON(resourceURL(kind, Object.assign({ ns, name }, opts)));
+export const k8sGet = (kind, name, ns, opts, options) =>
+  coFetchJSON(resourceURL(kind, Object.assign({ ns, name }, opts)), 'GET', options);
 
 export const k8sCreate = (kind, data, opts = {}) => {
   return coFetchJSON.post(

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -62,7 +62,7 @@ export type K8sResourceCondition = {
 
 export type MatchExpression = {
   key: string;
-  operator: 'Exists' | 'DoesNotExist' | 'In' | 'NotIn' | 'Equals' | 'NotEqual';
+  operator: 'Exists' | 'DoesNotExist' | 'In' | 'NotIn' | 'Equals' | 'NotEqual' | 'NotEquals';
   values?: string[];
   value?: string;
 };


### PR DESCRIPTION
This is a manually cherry-pick/backport of #10936, this PR depends on #11077 (first commit) that should be reviewed/merged first.

4.10: https://bugzilla.redhat.com/show_bug.cgi?id=2039315
4.9: https://bugzilla.redhat.com/show_bug.cgi?id=2044292
4.8: https://bugzilla.redhat.com/show_bug.cgi?id=2046215
4.7: https://bugzilla.redhat.com/show_bug.cgi?id=2055411

**Merge notes**
Just need to add one extra type definition to support operator "NotEquals".

On release-4.7 branch:
![image](https://user-images.githubusercontent.com/139310/154355057-faada08c-c371-4747-b985-c72b73679e66.png)

With this PR:
![image](https://user-images.githubusercontent.com/139310/154354486-0309d912-36ba-4b0e-b05f-0e23558364a3.png)
