### PR TITLE
Bug 2055702: e2e tests: enable serverless tests

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/operators-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/operators-page.ts
@@ -97,10 +97,7 @@ export const operatorsPage = {
       }
       case 'OpenShift Serverless Operator':
       case operators.ServerlessOperator: {
-        // cy.get(operatorsPO.operatorHub.serverlessOperatorCard).click();
-        cy.get(
-          '[data-test="serverless-operator-serverless-operator-openshift-marketplace"]',
-        ).click();
+        cy.get(operatorsPO.operatorHub.serverlessOperatorCard).click();
         break;
       }
       case 'OpenShift Virtualization':

--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -56,8 +56,7 @@ if [ -n "${nightly-}" ] && [ -z "${pkg-}" ]; then
   # heavily unstable/outdated tests in pipelines
   # yarn run test-cypress-pipelines-nightly
   yarn run test-cypress-topology-nightly
-  # disabled due to serverless operator not being available
-  # yarn run test-cypress-knative-nightly
+  yarn run test-cypress-knative-nightly
 
   exit $err;
 fi
@@ -67,8 +66,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-dev-console-headless
   yarn run test-cypress-olm-headless
   yarn run test-cypress-helm-headless
-  # disabled serverless as serverless operator is not availavle in operatorhub
-  # yarn run test-cypress-knative-headless
+  yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
   yarn run test-cypress-pipelines-headless
   exit;


### PR DESCRIPTION
Enable Serverless tests as Serverless operator is now available in Operator hub