### PR TITLE
Bug 2054285: Show standalone resources as sink and not the one's owned by other resource

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/event-sources/form-fields/SinkResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/form-fields/SinkResources.tsx
@@ -6,8 +6,6 @@ import { isEmpty } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { getFieldId, ResourceDropdownField } from '@console/shared';
-import { EVENTING_CHANNEL_KIND } from '../../../../const';
-import { EventingBrokerModel } from '../../../../models';
 import { getDynamicChannelResourceList } from '../../../../utils/fetch-dynamic-eventsources-utils';
 import {
   knativeServingResourcesServices,
@@ -71,16 +69,8 @@ const SinkResources: React.FC<SinkResourcesProps> = ({ namespace, isMoveSink }) 
     }
   };
 
-  // filter out channels backing brokers
-  const resourceFilter = (resource: K8sResourceKind) => {
-    const {
-      metadata: { ownerReferences },
-    } = resource;
-    return (
-      !ownerReferences?.length ||
-      ![EVENTING_CHANNEL_KIND, EventingBrokerModel.kind].includes(ownerReferences[0].kind)
-    );
-  };
+  // filter out resource which are owned by other resource
+  const resourceFilter = ({ metadata }: K8sResourceKind) => !metadata?.ownerReferences?.length;
 
   return (
     <FormGroup

--- a/frontend/packages/knative-plugin/src/components/pub-sub/form-fields/PubSubSubscriber.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/form-fields/PubSubSubscriber.tsx
@@ -4,6 +4,7 @@ import { useFormikContext, FormikValues } from 'formik';
 import * as fuzzy from 'fuzzysearch';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import { ResourceDropdownField, getFieldId } from '@console/shared';
 import { getSinkableResources } from '../../../utils/get-knative-resources';
 import { craftResourceKey } from '../pub-sub-utils';
@@ -44,6 +45,9 @@ const PubSubSubscriber: React.FC = () => {
     setResourceAlert(_.isEmpty(resourceList));
   };
 
+  // filter out resource which are owned by other resource
+  const resourceFilter = ({ metadata }: K8sResourceKind) => !metadata?.ownerReferences?.length;
+
   return (
     <FormGroup
       fieldId={getFieldId('pubsub', 'subscriber')}
@@ -73,6 +77,7 @@ const PubSubSubscriber: React.FC = () => {
         customResourceKey={craftResourceKey}
         autoSelect
         disabled={resourceAlert}
+        resourceFilter={resourceFilter}
         onLoad={handleOnLoad}
       />
     </FormGroup>


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2054285

**Analysis / Root cause**: 

Sink for event sources and Trigger/Subscription shows all the resources(which we support as a sink) irrespective of they are standalone or an underlying resource created as part of backing KSVC, Broker, KameletBinding, etc


**Solution Description**: 
Added resource filter to show only standalone resources as sink and not the one's owned by another resource


**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

<img width="1477" alt="image" src="https://user-images.githubusercontent.com/5129024/154979977-9456e96c-eade-45ff-961e-d9baeac8f5d2.png">

<img width="1481" alt="image" src="https://user-images.githubusercontent.com/5129024/154980101-609a47f7-22ca-45fe-a323-0dbb76ccfd8f.png">


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge