### PR TITLE
Bug 2046531: Remove schema subdir from dynamic plugin sdk

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/package.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "main": "src/index.ts",
   "scripts": {
-    "clean": "rm -rf dist generated",
+    "clean": "rm -rf dist generated schema",
     "build": "yarn clean && yarn validate && yarn compile && yarn generate",
     "compile": "for ext in '' '-internal' '-host-app' '-internal-kubevirt' '-webpack' ; do ./node_modules/.bin/tsc -p tsconfig${ext}.json || exit $? ; done",
     "generate": "yarn generate-schema && yarn generate-doc && yarn generate-pkg-assets",


### PR DESCRIPTION
When you build the console in version 4.9 the subdirectory [...]/packages/console-dynamic-plugin-sdk/schema gets created. In 4.10 it's created under [...]/packages/console-dynamic-plugin-sdk/generated/schema. So if you "./build.sh" under 4.9 and then switch to 4.10 and do "./clean.sh" and "./build.sh" the build fails, because only the subdirectory "generated/schema" was removed and the one on the same level as the directory "generated" is still present.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2046531