### PR TITLE
Bug 2058051: Exposing Kubevirt dynamic plugin missing components

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
@@ -2,10 +2,13 @@
 import {
   ActivityItemProps,
   ActivityBodyProps,
+  AnnotationsModalProps,
   RecentEventsBodyProps,
   OngoingActivityBodyProps,
   AlertsBodyProps,
   AlertItemProps,
+  CreateModalLauncherResult,
+  ModalComponentProps,
   HealthItemProps,
   ResourceInventoryItemProps,
   DetailItemProps,
@@ -52,6 +55,12 @@ export const VirtualizedGrid: React.FC<VirtualizedGridProps> = require('@console
   .default;
 export const LazyActionMenu: React.FC<LazyActionMenuProps> = require('@console/shared/src/components/actions/LazyActionMenu')
   .default;
+
+export const LabelsModal: CreateModalLauncherResult<ModalComponentProps> = require('@console/internal/components/modals/labels-modal')
+  .labelsModal;
+
+export const AnnotationsModal: CreateModalLauncherResult<AnnotationsModalProps> = require('@console/internal/components/modals/tags')
+  .annotationsModal;
 
 export const useUtilizationDuration: UseUtilizationDuration = require('@console/shared/src/hooks/useUtilizationDuration')
   .useUtilizationDuration;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
@@ -1,3 +1,4 @@
+import { K8sResourceKind } from '../app/k8s/actions/k8s';
 import {
   K8sResourceCommon,
   FirehoseResult,
@@ -8,7 +9,7 @@ import {
   TopConsumerPopoverProps,
   LIMIT_STATE,
 } from '../extensions/console-types';
-import { K8sModel, Alert } from './common-types';
+import { K8sModel, Alert, K8sKind } from './common-types';
 
 type WithClassNameProps<R = {}> = R & {
   className?: string;
@@ -249,3 +250,54 @@ export enum ActionMenuVariant {
   KEBAB = 'plain',
   DROPDOWN = 'default',
 }
+
+export type HandlePromiseProps = {
+  handlePromise: <T>(
+    promise: Promise<T>,
+    onFulfill?: (res) => void,
+    onError?: (errorMsg: string) => void,
+  ) => void;
+  inProgress: boolean;
+  errorMessage: string;
+};
+
+export type TagsModalProps = {
+  tags?: { [key: string]: string };
+  path: string;
+  titleKey: string;
+  kind: K8sKind;
+  resource: K8sResourceKind;
+  inProgress: boolean;
+  errorMessage: string;
+  cancel?: () => void;
+  close?: () => void;
+} & HandlePromiseProps;
+
+export type LabelsModalProps = {
+  kind: K8sKind;
+  resource: K8sResourceKind;
+  blocking: boolean;
+  errorMessage: string;
+  cancel?: () => void;
+  close?: () => void;
+} & HandlePromiseProps;
+
+export type AnnotationsModalProps = Omit<TagsModalProps, 'path' | 'tags'>;
+
+export type CreateModalLauncherProps = {
+  blocking?: boolean;
+  modalClassName?: string;
+};
+
+export type ModalComponentProps = {
+  cancel?: () => void;
+  close?: () => void;
+};
+
+export type CreateModalLauncherResult<P extends ModalComponentProps> = (
+  props: P & CreateModalLauncherProps,
+) => { result: Promise<{}> };
+
+export type CreateModalLauncher = <P extends ModalComponentProps>(
+  C: React.ComponentType<P>,
+) => CreateModalLauncherResult<P>;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/k8s/actions/k8s.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/k8s/actions/k8s.ts
@@ -7,7 +7,7 @@ import { k8sList, k8sGet } from '../../../utils/k8s/k8s-resource';
 import { k8sWatch } from '../../../utils/k8s/k8s-utils';
 import { getImpersonate, getActiveCluster } from '../../core/reducers/coreSelectors';
 
-type K8sResourceKind = K8sResourceCommon & {
+export type K8sResourceKind = K8sResourceCommon & {
   spec?: {
     selector?: Selector | MatchLabels;
     [key: string]: any;

--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -9,6 +9,12 @@ import { ActionGroup, Button } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';
 import CloseButton from '@console/shared/src/components/close-button';
+import {
+  CreateModalLauncher,
+  CreateModalLauncherProps,
+  ModalComponentProps,
+  CreateModalLauncherResult,
+} from '@console/dynamic-plugin-sdk/src/api/internal-types';
 
 import store from '../../redux';
 import { ButtonBar } from '../utils/button-bar';
@@ -183,16 +189,6 @@ export type GetModalContainer = (onClose: (e?: React.SyntheticEvent) => void) =>
 
 type CreateModal = (getModalContainer: GetModalContainer) => { result: Promise<any> };
 
-export type CreateModalLauncherProps = {
-  blocking?: boolean;
-  modalClassName?: string;
-};
-
-export type ModalComponentProps = {
-  cancel?: () => void;
-  close?: () => void;
-};
-
 export type ModalTitleProps = {
   className?: string;
   close?: (e: React.SyntheticEvent<any, Event>) => void;
@@ -221,6 +217,9 @@ export type ModalSubmitFooterProps = {
   submitDanger?: boolean;
 };
 
-export type CreateModalLauncher = <P extends ModalComponentProps>(
-  C: React.ComponentType<P>,
-) => (props: P & CreateModalLauncherProps) => { result: Promise<{}> };
+export {
+  CreateModalLauncher,
+  CreateModalLauncherProps,
+  ModalComponentProps,
+  CreateModalLauncherResult,
+};

--- a/frontend/public/components/modals/tags.tsx
+++ b/frontend/public/components/modals/tags.tsx
@@ -1,10 +1,15 @@
 import * as _ from 'lodash-es';
+import {
+  AnnotationsModalProps,
+  TagsModalProps,
+} from '@console/dynamic-plugin-sdk/src/api/internal-types';
+
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { k8sPatch, K8sResourceKind, K8sKind } from '../../module/k8s';
+import { k8sPatch } from '../../module/k8s';
 import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
-import { NameValueEditorPair, withHandlePromise, HandlePromiseProps } from '../utils';
+import { NameValueEditorPair, withHandlePromise } from '../utils';
 import { AsyncComponent } from '../utils/async';
 
 /**
@@ -75,19 +80,5 @@ export const annotationsModal = createModalLauncher((props: AnnotationsModalProp
     {...props}
   />
 ));
-
-type TagsModalProps = {
-  tags?: { [key: string]: string };
-  path: string;
-  titleKey: string;
-  kind: K8sKind;
-  resource: K8sResourceKind;
-  inProgress: boolean;
-  errorMessage: string;
-  cancel?: () => void;
-  close?: () => void;
-} & HandlePromiseProps;
-
-type AnnotationsModalProps = Omit<TagsModalProps, 'path' | 'tags'>;
 
 TagsModal.displayName = 'TagsModal';

--- a/frontend/public/components/utils/promise-component.tsx
+++ b/frontend/public/components/utils/promise-component.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import i18next from 'i18next';
 import { useTranslation } from 'react-i18next';
+import { HandlePromiseProps } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 
 export const withHandlePromise: WithHandlePromise = (Component) => (props) => {
   const [inProgress, setInProgress] = React.useState(false);
@@ -78,15 +79,7 @@ export class PromiseComponent<P, S extends PromiseComponentState> extends React.
   }
 }
 
-export type HandlePromiseProps = {
-  handlePromise: <T>(
-    promise: Promise<T>,
-    onFulfill?: (res) => void,
-    onError?: (errorMsg: string) => void,
-  ) => void;
-  inProgress: boolean;
-  errorMessage: string;
-};
+export { HandlePromiseProps };
 
 export type WithHandlePromise = <P extends HandlePromiseProps>(
   C: React.ComponentType<P>,


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

This PR exposes the following via Console internal SDK package @openshift-console/dynamic-plugin-sdk-internal

1. ~~DroppableEditYAML~~ - is now in a separate PR - https://github.com/openshift/console/pull/11113
2.  LabelsModal
3. AnnotationsModal