### PR TITLE
Bug 2052874: node pod manager columns namespace option checkbox invalid

### DIFF
--- a/frontend/__tests__/components/modals/column-management-modal.spec.tsx
+++ b/frontend/__tests__/components/modals/column-management-modal.spec.tsx
@@ -68,64 +68,6 @@ const columnLayout = [
   },
 ];
 
-const columnLayoutNamespaceDisabled = [
-  {
-    title: 'Name',
-    id: 'name',
-  },
-  {
-    title: 'Namespace',
-    id: 'namespace',
-  },
-  {
-    title: 'Status',
-    id: 'status',
-  },
-  {
-    title: 'Ready',
-    id: 'ready',
-  },
-  {
-    title: 'Restarts',
-    id: 'restarts',
-  },
-  {
-    title: 'Owner',
-    id: 'owner',
-  },
-  {
-    title: 'Memory',
-    id: 'memory',
-  },
-  {
-    title: 'CPU',
-    id: 'cpu',
-  },
-  {
-    title: 'Created',
-    id: 'created',
-  },
-  {
-    title: 'Node',
-    additional: true,
-    id: 'node',
-  },
-  {
-    title: 'Labels',
-    additional: true,
-    id: 'labels',
-  },
-  {
-    title: 'IP Address',
-    additional: true,
-    id: 'ipaddress',
-  },
-  {
-    title: '',
-    id: '',
-  },
-];
-
 describe(ColumnManagementModal.displayName, () => {
   let wrapper;
   beforeEach(() => {
@@ -165,11 +107,44 @@ describe(ColumnManagementModal.displayName, () => {
   it('renders 12 checkboxes with name, and last 3 disabled', () => {
     const checkboxItems = wrapper.find(DataListCheck);
     expect(checkboxItems.length).toEqual(12);
-    expect(checkboxItems.at(0).props().isDisabled).toEqual(true); // namespace is always disabled
+    expect(checkboxItems.at(0).props().isDisabled).toEqual(true); // name is always disabled
     expect(checkboxItems.at(1).props().isDisabled).toEqual(false); // all default columns should be enabled
     expect(checkboxItems.at(8).props().isDisabled).toEqual(false); // all default columns should be enabled
     expect(checkboxItems.at(9).props().isDisabled).toEqual(true); // all additional columns should be disabled
     expect(checkboxItems.at(11).props().isDisabled).toEqual(true); // all additional columns should be disabled
+  });
+
+  it('renders 12 checkboxes with namespace checked and disabled, if showNamespaceOverride is true', () => {
+    wrapper = mount(
+      <Provider store={store}>
+        <ColumnManagementModal
+          columnLayout={{
+            columns: columnLayout,
+            id: columnManagementID,
+            selectedColumns: new Set(
+              columnLayout.reduce((acc, column) => {
+                if (column.id && !column.additional && column.id !== 'cpu') {
+                  acc.push(column.id);
+                }
+                return acc;
+              }, []),
+            ),
+            showNamespaceOverride: true,
+            type: columnManagementType,
+          }}
+          userSettingState={null}
+          setUserSettingState={jest.fn()}
+        />
+      </Provider>,
+    );
+
+    const checkboxItems = wrapper.find(DataListCheck);
+    const namespaceCheckBoxProps = checkboxItems.at(1).props();
+
+    expect(checkboxItems.length).toEqual(12);
+    expect(namespaceCheckBoxProps.name).toEqual('Namespace');
+    expect(namespaceCheckBoxProps.checked).toEqual(true);
+    expect(namespaceCheckBoxProps.isDisabled).toEqual(true);
   });
 
   it('renders a single disabled checkbox when under MAX columns', () => {
@@ -177,10 +152,10 @@ describe(ColumnManagementModal.displayName, () => {
       <Provider store={store}>
         <ColumnManagementModal
           columnLayout={{
-            columns: columnLayoutNamespaceDisabled,
+            columns: columnLayout,
             id: columnManagementID,
             selectedColumns: new Set(
-              columnLayoutNamespaceDisabled.reduce((acc, column) => {
+              columnLayout.reduce((acc, column) => {
                 if (column.id && !column.additional && column.id !== 'cpu') {
                   acc.push(column.id);
                 }

--- a/frontend/public/components/modals/column-management-modal.tsx
+++ b/frontend/public/components/modals/column-management-modal.tsx
@@ -22,42 +22,54 @@ import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '.
 export const MAX_VIEW_COLS = 9;
 
 export const NAME_COLUMN_ID = 'name';
-const readOnlyColumns = new Set([NAME_COLUMN_ID]);
+export const NAMESPACE_COLUMN_ID = 'namespace';
 
 const DataListRow: React.FC<DataListRowProps> = ({
   checkedColumns,
   column,
   onChange,
   disableUncheckedRow,
-}) => (
-  <DataListItem
-    aria-labelledby={`table-column-management-item-${column.id}`}
-    key={column.id}
-    className="pf-c-data-list__item--transparent-bg"
-  >
-    <DataListItemRow>
-      <DataListCheck
-        isDisabled={
-          (disableUncheckedRow && !checkedColumns.has(column.id)) || readOnlyColumns.has(column.id)
-        }
-        aria-labelledby={`table-column-management-item-${column.id}`}
-        checked={checkedColumns.has(column.id)}
-        name={column.title}
-        id={column.id}
-        onChange={onChange}
-      />
-      <DataListItemCells
-        dataListCells={[
-          <DataListCell id={`table-column-management-item-${column.id}`} key={column.id}>
-            <label className="co-label--plain" htmlFor={column.id}>
-              {column.title}
-            </label>
-          </DataListCell>,
-        ]}
-      />
-    </DataListItemRow>
-  </DataListItem>
-);
+  showNamespaceOverride,
+}) => {
+  const readOnlyColumns = new Set(
+    showNamespaceOverride ? [NAME_COLUMN_ID, NAMESPACE_COLUMN_ID] : [NAME_COLUMN_ID],
+  );
+
+  if (showNamespaceOverride) {
+    checkedColumns.add(NAMESPACE_COLUMN_ID);
+  }
+
+  return (
+    <DataListItem
+      aria-labelledby={`table-column-management-item-${column.id}`}
+      key={column.id}
+      className="pf-c-data-list__item--transparent-bg"
+    >
+      <DataListItemRow>
+        <DataListCheck
+          isDisabled={
+            (disableUncheckedRow && !checkedColumns.has(column.id)) ||
+            readOnlyColumns.has(column.id)
+          }
+          aria-labelledby={`table-column-management-item-${column.id}`}
+          checked={checkedColumns.has(column.id)}
+          name={column.title}
+          id={column.id}
+          onChange={onChange}
+        />
+        <DataListItemCells
+          dataListCells={[
+            <DataListCell id={`table-column-management-item-${column.id}`} key={column.id}>
+              <label className="co-label--plain" htmlFor={column.id}>
+                {column.title}
+              </label>
+            </DataListCell>,
+          ]}
+        />
+      </DataListItemRow>
+    </DataListItem>
+  );
+};
 
 export const ColumnManagementModal: React.FC<ColumnManagementModalProps &
   WithUserSettingsCompatibilityProps<object>> = ({
@@ -143,6 +155,9 @@ export const ColumnManagementModal: React.FC<ColumnManagementModalProps &
                     disableUncheckedRow={areMaxColumnsDisplayed}
                     column={defaultColumn}
                     checkedColumns={checkedColumns}
+                    showNamespaceOverride={
+                      columnLayout ? columnLayout.showNamespaceOverride : false
+                    }
                   />
                 ))}
               </DataList>
@@ -198,6 +213,7 @@ type DataListRowProps = {
   onChange: (checked: boolean, event: React.SyntheticEvent) => void;
   disableUncheckedRow: boolean;
   checkedColumns: Set<string>;
+  showNamespaceOverride?: boolean;
 };
 
 export type ColumnManagementModalProps = {


### PR DESCRIPTION
Add functionality to the "ColumnManagementModal", that if the "showNamespaceOverride" option is set for a page (f.e. for the PodsPage -> propagates to the columnLayout and is now also propagated to ColumnManagementModal) the namespace column should be selected in the ColumnManagementModal and should also be disabled. Add the test for this new functionality also.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2052874