### PR TITLE
Bug 2000073: Show "project not found" error if a namespace selected via an URL doesn't exist

### DIFF
--- a/frontend/__tests__/components/namespace.spec.tsx
+++ b/frontend/__tests__/components/namespace.spec.tsx
@@ -34,12 +34,12 @@ describe(PullSecret.displayName, () => {
         done();
       });
 
-    wrapper = mount(<PullSecret namespace={testNamespace} />);
+    wrapper = mount(<PullSecret namespace={testNamespace} canViewSecrets={false} />);
   });
 
   it('does not render link if still loading', () => {
     spyOn(k8s, 'k8sGet').and.returnValue(Promise.resolve({ items: [] }));
-    wrapper = mount(<PullSecret namespace={testNamespace} />);
+    wrapper = mount(<PullSecret namespace={testNamespace} canViewSecrets={false} />);
 
     expect(wrapper.find(LoadingInline).exists()).toBe(true);
   });

--- a/frontend/__tests__/components/namespace.spec.tsx
+++ b/frontend/__tests__/components/namespace.spec.tsx
@@ -2,13 +2,38 @@ import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import Spy = jasmine.Spy;
 
-import { PullSecret } from '../../public/components/namespace';
+// FIXME upgrading redux types is causing many errors at this time
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useSelector } from 'react-redux';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+
+import {
+  PullSecret,
+  useNamespaceExist,
+  NamespaceNotFoundError,
+} from '../../public/components/namespace';
 import * as k8s from '../../public/module/k8s';
 import { LoadingInline } from '../../public/components/utils';
 import { testNamespace } from '../../__mocks__/k8sResourcesMocks';
-import { ServiceAccountModel } from '../../public/models';
+import { NamespaceModel, ProjectModel, ServiceAccountModel } from '../../public/models';
+import { testHook } from '../utils/hooks-utils';
+import { K8sResourceKind } from '../../public/module/k8s';
 
-describe(PullSecret.displayName, () => {
+jest.mock('react-redux', () => ({
+  ...require.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
+  ...require.requireActual('@console/internal/components/utils/k8s-watch-hook'),
+  useK8sWatchResource: jest.fn(),
+}));
+
+const useSelectorMock = useSelector as jest.Mock;
+const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
+
+describe('PullSecret', () => {
   let wrapper: ReactWrapper;
 
   const spyAndExpect = (spy: Spy) => (returnValue: any) =>
@@ -42,5 +67,130 @@ describe(PullSecret.displayName, () => {
     wrapper = mount(<PullSecret namespace={testNamespace} canViewSecrets={false} />);
 
     expect(wrapper.find(LoadingInline).exists()).toBe(true);
+  });
+});
+
+describe('useNamespaceExist', () => {
+  beforeEach(() => {
+    useSelectorMock.mockClear();
+    useK8sWatchResourceMock.mockClear();
+  });
+
+  it('should return exist=true when namespace parameter is not defined, should not watch any resource', () => {
+    useSelectorMock.mockReturnValue(true);
+    useK8sWatchResourceMock.mockReturnValue([undefined, true, undefined]);
+
+    const { result } = testHook(() => useNamespaceExist(null));
+
+    expect(result.current).toEqual([true, true, undefined]);
+    expect(useK8sWatchResourceMock).toHaveBeenCalledTimes(1);
+    expect(useK8sWatchResourceMock.mock.calls[0]).toEqual([null]);
+  });
+
+  it('should return exist=true when namespace is part of the project list', () => {
+    useSelectorMock.mockReturnValue(true);
+    const allProjects: K8sResourceKind[] = [
+      {
+        apiVersion: ProjectModel.apiVersion,
+        kind: ProjectModel.kind,
+        metadata: { name: 'existing-project' },
+      },
+    ];
+    useK8sWatchResourceMock.mockReturnValue([allProjects, true, undefined]);
+
+    const { result } = testHook(() => useNamespaceExist('existing-project'));
+
+    expect(result.current).toEqual([true, true, undefined]);
+    expect(useK8sWatchResourceMock).toHaveBeenCalledTimes(1);
+    expect(useK8sWatchResourceMock.mock.calls[0]).toEqual([
+      { isList: true, kind: ProjectModel.kind, optional: true },
+    ]);
+  });
+
+  it('should return exist=true when namespace is part of the namespace list', () => {
+    useSelectorMock.mockReturnValue(false);
+    const allNamespaces: K8sResourceKind[] = [
+      {
+        apiVersion: NamespaceModel.apiVersion,
+        kind: NamespaceModel.kind,
+        metadata: { name: 'existing-namespace' },
+      },
+    ];
+    useK8sWatchResourceMock.mockReturnValue([allNamespaces, true, undefined]);
+
+    const { result } = testHook(() => useNamespaceExist('existing-namespace'));
+
+    expect(result.current).toEqual([true, true, undefined]);
+    expect(useK8sWatchResourceMock).toHaveBeenCalledTimes(1);
+    expect(useK8sWatchResourceMock.mock.calls[0]).toEqual([
+      { isList: true, kind: NamespaceModel.kind, optional: true },
+    ]);
+  });
+
+  it('should return exist=false when namespace is not part of the project list', () => {
+    useSelectorMock.mockReturnValue(true);
+    const allNamespaces: K8sResourceKind[] = [
+      {
+        apiVersion: ProjectModel.apiVersion,
+        kind: ProjectModel.kind,
+        metadata: { name: 'existing-project' },
+      },
+    ];
+    useK8sWatchResourceMock.mockReturnValue([allNamespaces, true, undefined]);
+
+    const { result } = testHook(() => useNamespaceExist('missing-namespace'));
+
+    expect(result.current).toEqual([false, true, undefined]);
+    expect(useK8sWatchResourceMock).toHaveBeenCalledTimes(1);
+    expect(useK8sWatchResourceMock.mock.calls[0]).toEqual([
+      { isList: true, kind: ProjectModel.kind, optional: true },
+    ]);
+  });
+
+  it('should return exist=false when namespace is not part of the namespace list', () => {
+    useSelectorMock.mockReturnValue(true);
+    const allNamespaces: K8sResourceKind[] = [
+      {
+        apiVersion: NamespaceModel.apiVersion,
+        kind: NamespaceModel.kind,
+        metadata: { name: 'existing-namespace' },
+      },
+    ];
+    useK8sWatchResourceMock.mockReturnValue([allNamespaces, true, undefined]);
+
+    const { result } = testHook(() => useNamespaceExist('missing-namespace'));
+
+    expect(result.current).toEqual([false, true, undefined]);
+    expect(useK8sWatchResourceMock).toHaveBeenCalledTimes(1);
+    expect(useK8sWatchResourceMock.mock.calls[0]).toEqual([
+      { isList: true, kind: ProjectModel.kind, optional: true },
+    ]);
+  });
+
+  it('should return exist=true when API call fails', () => {
+    useSelectorMock.mockReturnValue(true);
+    useK8sWatchResourceMock.mockReturnValue([[], true, new Error('Network error')]);
+
+    const { result } = testHook(() => useNamespaceExist('doesnt-matter'));
+
+    expect(result.current).toEqual([true, true, new Error('Network error')]);
+    expect(useK8sWatchResourceMock).toHaveBeenCalledTimes(1);
+    expect(useK8sWatchResourceMock.mock.calls[0]).toEqual([
+      { isList: true, kind: ProjectModel.kind, optional: true },
+    ]);
+  });
+});
+
+describe('NamespaceNotFoundError', () => {
+  it('should render 404 Project not found if projects are used', () => {
+    useSelectorMock.mockReturnValue(true);
+    const wrapper = mount(<NamespaceNotFoundError />);
+    expect(wrapper.text()).toEqual('404: Project not found');
+  });
+
+  it('should render 404 Namespace not found if projects are not used', () => {
+    useSelectorMock.mockReturnValue(false);
+    const wrapper = mount(<NamespaceNotFoundError />);
+    expect(wrapper.text()).toEqual('404: Namespace not found');
   });
 });

--- a/frontend/__tests__/components/resource-list.spec.tsx
+++ b/frontend/__tests__/components/resource-list.spec.tsx
@@ -1,0 +1,205 @@
+import * as React from 'react';
+import { act } from 'react-dom/test-utils';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { mount } from 'enzyme';
+
+import { setPluginStore } from '@console/dynamic-plugin-sdk/src/utils/k8s';
+import storeHandler from '@console/dynamic-plugin-sdk/src/app/storeHandler';
+
+import { ResourceListPage, ResourceDetailsPage } from '../../public/components/resource-list';
+import { useNamespaceExist } from '../../public/components/namespace';
+import store from '../../public/redux';
+import { receivedResources } from '../../public/actions/k8s';
+import { PodModel } from '../../public/models';
+
+jest.mock('../../public/components/namespace', () => ({
+  ...require.requireActual('../../public/components/namespace'),
+  useNamespaceExist: jest.fn(),
+}));
+
+const useNamespaceExistMock = useNamespaceExist as jest.Mock;
+
+const Wrapper: React.FC<{}> = ({ children }) => (
+  <MemoryRouter>
+    <Provider store={store}>{children}</Provider>
+  </MemoryRouter>
+);
+
+beforeAll(() => {
+  setPluginStore({ getExtensionsInUse: () => [] });
+  // setUtilsConfig({ appFetch: appFetchMock });
+  storeHandler.setStore(store);
+  store.dispatch(
+    receivedResources({
+      models: [PodModel],
+      adminResources: [],
+      allResources: [],
+      configResources: [],
+      clusterOperatorConfigResources: [],
+      namespacedSet: null,
+      safeResources: [],
+      groupVersionMap: {},
+    }),
+  );
+});
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.resetAllMocks();
+});
+
+afterEach(async () => {
+  // Ensure that there is no timer left which triggers a rerendering
+  await act(async () => jest.runAllTimers());
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+describe('ResourceListPage', () => {
+  it('should render nothing if the namespace exist and the model is known', async () => {
+    useNamespaceExistMock.mockReturnValue([true, true, undefined]);
+
+    const wrapper = mount(
+      <Wrapper>
+        <ResourceListPage
+          flags={undefined}
+          match={{
+            params: {
+              ns: 'existing-namespace',
+              plural: 'pods',
+            },
+            isExact: true,
+            path: '',
+            url: '',
+          }}
+        />
+      </Wrapper>,
+    );
+
+    expect(wrapper.text()).toEqual('');
+  });
+
+  it('should render "Page not found" if the namespace exist and the model is unknown', async () => {
+    useNamespaceExistMock.mockReturnValue([true, true, undefined]);
+
+    const wrapper = mount(
+      <Wrapper>
+        <ResourceListPage
+          flags={undefined}
+          match={{
+            params: {
+              ns: 'existing-namespace',
+              plural: 'unknown-model',
+            },
+            isExact: true,
+            path: '',
+            url: '',
+          }}
+        />
+      </Wrapper>,
+    );
+
+    expect(wrapper.text()).toContain('Error404: Page Not Found');
+    expect(wrapper.text()).toContain(
+      'The server doesn\'t have a resource type "unknown-model". Try refreshing the page if it was recently added.',
+    );
+  });
+
+  it('should render "Namespace not found" if the namespace does not exist', async () => {
+    useNamespaceExistMock.mockReturnValue([false, true, undefined]);
+
+    const wrapper = mount(
+      <Wrapper>
+        <ResourceListPage
+          flags={undefined}
+          match={{
+            params: {
+              ns: 'nonexisting-namespace',
+              plural: 'pods',
+            },
+            isExact: true,
+            path: '',
+            url: '',
+          }}
+        />
+      </Wrapper>,
+    );
+
+    expect(wrapper.text()).toEqual('404: Namespace not found');
+  });
+});
+
+describe('ResourceDetailsPage', () => {
+  it('should render nothing if the namespace exist and the model is known', async () => {
+    useNamespaceExistMock.mockReturnValue([true, true, undefined]);
+
+    const wrapper = mount(
+      <Wrapper>
+        <ResourceDetailsPage
+          match={{
+            params: {
+              ns: 'existing-namespace',
+              name: 'existing-pod',
+              plural: 'pods',
+            },
+            isExact: true,
+            path: '',
+            url: '',
+          }}
+        />
+      </Wrapper>,
+    );
+
+    // The pod detail pages fetches some data.
+    await act(async () => jest.runAllTimers());
+
+    expect(wrapper.text()).toEqual('');
+  });
+
+  it('should render render "Page Not Found" if the namespace exist but the model is unknown', async () => {
+    useNamespaceExistMock.mockReturnValue([true, true, undefined]);
+
+    const wrapper = mount(
+      <Wrapper>
+        <ResourceDetailsPage
+          match={{
+            params: {
+              ns: 'existing-namespace',
+              name: 'existing-pod',
+              plural: 'unknown-model',
+            },
+            isExact: true,
+            path: '',
+            url: '',
+          }}
+        />
+      </Wrapper>,
+    );
+
+    expect(wrapper.text()).toContain('Error404: Page Not Found');
+  });
+
+  it('should render "Namespace not found" if the namespace does not exist', async () => {
+    useNamespaceExistMock.mockReturnValue([false, true, undefined]);
+
+    const wrapper = mount(
+      <Wrapper>
+        <ResourceDetailsPage
+          match={{
+            params: {
+              ns: 'nonexisting-namespace',
+              name: 'ignored-pod-name',
+              plural: 'pods',
+            },
+            isExact: true,
+            path: '',
+            url: '',
+          }}
+        />
+      </Wrapper>,
+    );
+
+    expect(wrapper.text()).toEqual('404: Namespace not found');
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/k8s/actions/k8s.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/k8s/actions/k8s.ts
@@ -50,7 +50,7 @@ export const stopWatchK8s = (id: string) => action(ActionType.StopWatchK8s, { id
 
 export const errored = (id: string, k8sObjects: any) =>
   action(ActionType.Errored, { id, k8sObjects });
-export const filterList = (id: string, name: string, value: FilterValue) =>
+export const filterList = (id: string, name: string, value: FilterValue | string) =>
   action(ActionType.FilterList, { id, name, value });
 
 export const partialObjectMetadataListHeader = {

--- a/frontend/packages/console-shared/src/components/actions/types.ts
+++ b/frontend/packages/console-shared/src/components/actions/types.ts
@@ -1,10 +1,5 @@
 import { Action, ActionGroup } from '@console/dynamic-plugin-sdk';
 
-export {
-  ActionContext,
-  ActionMenuVariant,
-} from '@console/dynamic-plugin-sdk/src/api/internal-types';
-
 export type MenuOption = Action | GroupedMenuOption;
 
 export type GroupedMenuOption = ActionGroup['properties'] & {
@@ -23,3 +18,12 @@ export type ActionService = {
   loaded: boolean;
   error: any;
 };
+
+export type ActionContext = {
+  [contextId: string]: any;
+};
+
+export enum ActionMenuVariant {
+  KEBAB = 'plain',
+  DROPDOWN = 'default',
+}

--- a/frontend/packages/dev-console/src/components/NamespacedPage.tsx
+++ b/frontend/packages/dev-console/src/components/NamespacedPage.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import * as cx from 'classnames';
-import { NamespaceBar } from '@console/internal/components/namespace';
+import {
+  NamespaceBar,
+  useNamespaceExist,
+  NamespaceNotFoundError,
+} from '@console/internal/components/namespace';
+import { useActiveNamespace } from '@console/shared/src/hooks';
 import NamespaceBarApplicationSelector from '@console/topology/src/components/dropdowns/NamespaceBarApplicationSelector';
 
 import './NamespacedPage.scss';
@@ -27,24 +32,29 @@ const NamespacedPage: React.FC<NamespacedPageProps> = ({
   hideApplications = false,
   variant = NamespacedPageVariants.default,
   toolbar,
-}) => (
-  <div className="odc-namespaced-page">
-    <NamespaceBar
-      disabled={disabled}
-      onNamespaceChange={onNamespaceChange}
-      hideProjects={hideProjects}
-    >
-      {!hideApplications && <NamespaceBarApplicationSelector disabled={disabled} />}
-      {toolbar && <div className="odc-namespaced-page__toolbar">{toolbar}</div>}
-    </NamespaceBar>
-    <div
-      className={cx('odc-namespaced-page__content', {
-        [`is-${variant}`]: variant !== NamespacedPageVariants.default,
-      })}
-    >
-      {children}
+}) => {
+  const [activeNamespace] = useActiveNamespace();
+  const [namespaceExist, namespaceLoaded] = useNamespaceExist(activeNamespace);
+
+  return (
+    <div className="odc-namespaced-page">
+      <NamespaceBar
+        disabled={disabled}
+        onNamespaceChange={onNamespaceChange}
+        hideProjects={hideProjects}
+      >
+        {!hideApplications && <NamespaceBarApplicationSelector disabled={disabled} />}
+        {toolbar && <div className="odc-namespaced-page__toolbar">{toolbar}</div>}
+      </NamespaceBar>
+      <div
+        className={cx('odc-namespaced-page__content', {
+          [`is-${variant}`]: variant !== NamespacedPageVariants.default,
+        })}
+      >
+        {namespaceLoaded && !namespaceExist ? <NamespaceNotFoundError /> : children}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default NamespacedPage;

--- a/frontend/packages/dev-console/src/components/__tests__/NamespacedPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/__tests__/NamespacedPage.spec.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import store from '@console/internal/redux';
+import { useActiveNamespace } from '@console/shared/src/hooks';
+import NamespacedPage from '../NamespacedPage';
+
+const Wrapper: React.FC<{}> = ({ children }) => <Provider store={store}>{children}</Provider>;
+
+jest.mock('react-redux', () => ({
+  ...require.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('@console/shared/src/hooks', () => ({
+  ...require.requireActual('@console/shared/src/hooks'),
+  useActiveNamespace: jest.fn(),
+}));
+
+jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
+  ...require.requireActual('@console/internal/components/utils/k8s-watch-hook'),
+  useK8sWatchResource: jest.fn(),
+}));
+
+const useActiveNamespaceMock = useActiveNamespace as jest.Mock;
+const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('NamespacedPage', () => {
+  it("should render Namespace not found if the active namespace doesn't exist", () => {
+    useActiveNamespaceMock.mockReturnValue('my-namespace');
+    const allProjects: K8sResourceKind[] = [
+      {
+        metadata: { name: 'existing-project' },
+      },
+    ];
+    useK8sWatchResourceMock.mockReturnValue([allProjects, true, undefined]);
+
+    const renderResult = render(
+      <Wrapper>
+        <NamespacedPage />
+      </Wrapper>,
+    );
+    expect(renderResult.getByText('404: Namespace not found')).toBeTruthy();
+  });
+});

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -290,9 +290,9 @@ export const RoleBindingsPage = ({
   namespace = undefined,
   showTitle = true,
   mock = false,
-  staticFilters,
-  name,
-  kind,
+  staticFilters = undefined,
+  name = undefined,
+  kind = undefined,
   createPath = `/k8s/cluster/rolebindings/~new${
     name && kind ? `?subjectName=${name}&subjectKind=${kind}` : ''
   }`,

--- a/frontend/public/components/namespace.tsx
+++ b/frontend/public/components/namespace.tsx
@@ -55,9 +55,16 @@ import {
   ServiceAccountModel,
 } from '../models';
 import { coFetchJSON } from '../co-fetch';
-import { k8sGet, referenceForModel } from '../module/k8s';
+import { k8sGet, K8sResourceKind, referenceForModel } from '../module/k8s';
 import * as UIActions from '../actions/ui';
-import { DetailsPage, ListPage, Table, TableData } from './factory';
+import {
+  DetailsPage,
+  DetailsPageProps,
+  ListPage,
+  RowFunctionArgs,
+  Table,
+  TableData,
+} from './factory';
 import {
   DetailsItem,
   ExternalLink,
@@ -309,7 +316,7 @@ NamespacesTableHeader.displayName = 'NamespacesTableHeader';
 const NamespacesColumnManagementID = referenceForModel(NamespaceModel);
 
 const getNamespacesSelectedColumns = () => {
-  return new Set(
+  return new Set<string>(
     NamespacesTableHeader().reduce((acc, column) => {
       if (column.id && !column.additional) {
         acc.push(column.id);
@@ -319,7 +326,10 @@ const getNamespacesSelectedColumns = () => {
   );
 };
 
-const NamespacesTableRow = ({ obj: ns, customData: { tableColumns } }) => {
+const NamespacesTableRow: React.FC<RowFunctionArgs<any, any>> = ({
+  obj: ns,
+  customData: { tableColumns },
+}) => {
   const { t } = useTranslation();
   const metrics = useSelector(({ UI }) => UI.getIn(['metrics', 'namespace']));
   const name = getName(ns);
@@ -328,7 +338,8 @@ const NamespacesTableRow = ({ obj: ns, customData: { tableColumns } }) => {
   const cores = metrics?.cpu?.[name];
   const description = getDescription(ns);
   const labels = ns.metadata.labels;
-  const columns = tableColumns?.length > 0 ? new Set(tableColumns) : getNamespacesSelectedColumns();
+  const columns =
+    tableColumns?.length > 0 ? new Set<string>(tableColumns) : getNamespacesSelectedColumns();
   return (
     <>
       <TableData className={namespaceColumnInfo.name.classes}>
@@ -421,7 +432,7 @@ export const NamespacesList = (props) => {
   }, [dispatch]);
   const selectedColumns =
     tableColumns?.[NamespacesColumnManagementID]?.length > 0
-      ? new Set(tableColumns[NamespacesColumnManagementID])
+      ? new Set<string>(tableColumns[NamespacesColumnManagementID])
       : null;
 
   const customData = React.useMemo(
@@ -437,7 +448,7 @@ export const NamespacesList = (props) => {
         {t('public~No namespaces found')}
       </Title>
       <EmptyStateBody>{t('public~No results match the filter criteria.')}</EmptyStateBody>
-      <EmptyStatePrimary />
+      <EmptyStatePrimary>{undefined}</EmptyStatePrimary>
     </EmptyState>
   );
 
@@ -466,7 +477,7 @@ export const NamespacesPage = (props) => {
   );
   const selectedColumns =
     tableColumns?.[NamespacesColumnManagementID]?.length > 0
-      ? new Set(tableColumns[NamespacesColumnManagementID])
+      ? new Set<string>(tableColumns[NamespacesColumnManagementID])
       : getNamespacesSelectedColumns();
   return (
     <ListPage
@@ -476,7 +487,7 @@ export const NamespacesPage = (props) => {
       canCreate={true}
       createHandler={() => createNamespaceModal({ blocking: true })}
       columnLayout={{
-        columns: NamespacesTableHeader(null, t).map((column) =>
+        columns: NamespacesTableHeader().map((column) =>
           _.pick(column, ['title', 'additional', 'id']),
         ),
         id: NamespacesColumnManagementID,
@@ -567,7 +578,7 @@ const projectTableHeader = ({ showMetrics, showActions }) => {
 };
 
 const getProjectSelectedColumns = ({ showMetrics, showActions }) => {
-  return new Set(
+  return new Set<string>(
     projectTableHeader({ showMetrics, showActions }).reduce((acc, column) => {
       if (column.id && !column.additional) {
         acc.push(column.id);
@@ -577,7 +588,7 @@ const getProjectSelectedColumns = ({ showMetrics, showActions }) => {
   );
 };
 
-const ProjectLink = ({ project }) => {
+const ProjectLink: React.FC<{ project: K8sResourceKind }> = ({ project }) => {
   const dispatch = useDispatch();
   const [, setLastNamespace] = useUserSettingsCompatibility(
     LAST_NAMESPACE_NAME_USER_SETTINGS_KEY,
@@ -622,7 +633,10 @@ const ProjectLink = ({ project }) => {
 const projectHeaderWithoutActions = () =>
   projectTableHeader({ showMetrics: false, showActions: false });
 
-const ProjectTableRow = ({ obj: project, customData = {} }) => {
+const ProjectTableRow: React.FC<RowFunctionArgs<any, any>> = ({
+  obj: project,
+  customData = {},
+}) => {
   const { t } = useTranslation();
   const metrics = useSelector(({ UI }) => UI.getIn(['metrics', 'namespace']));
   const name = getName(project);
@@ -641,7 +655,7 @@ const ProjectTableRow = ({ obj: project, customData = {} }) => {
   const labels = project.metadata.labels;
   const columns = isColumnManagementEnabled
     ? tableColumns?.length > 0
-      ? new Set(tableColumns)
+      ? new Set<string>(tableColumns)
       : getProjectSelectedColumns({ showMetrics, showActions })
     : null;
   return (
@@ -793,7 +807,7 @@ export const ProjectList = ({ data, ...tableProps }) => {
   }, [dispatch, showMetrics]);
   const selectedColumns =
     tableColumns?.[projectColumnManagementID]?.length > 0
-      ? new Set(tableColumns[projectColumnManagementID])
+      ? new Set<string>(tableColumns[projectColumnManagementID])
       : null;
 
   // Don't render the table until we know whether we can get metrics. It's
@@ -816,7 +830,7 @@ export const ProjectList = ({ data, ...tableProps }) => {
         {t('public~No projects found')}
       </Title>
       <EmptyStateBody>{t('public~No results match the filter criteria.')}</EmptyStateBody>
-      <EmptyStatePrimary />
+      <EmptyStatePrimary>{undefined}</EmptyStatePrimary>
     </EmptyState>
   );
 
@@ -869,7 +883,7 @@ export const ProjectsPage = (props) => {
         id: projectColumnManagementID,
         selectedColumns:
           tableColumns?.[projectColumnManagementID]?.length > 0
-            ? new Set(tableColumns[projectColumnManagementID])
+            ? new Set<string>(tableColumns[projectColumnManagementID])
             : null,
         type: t('public~Project'),
       }}
@@ -877,8 +891,9 @@ export const ProjectsPage = (props) => {
   );
 };
 
-/** @type {React.SFC<{namespace: K8sResourceKind}>} */
-export const PullSecret = (props) => {
+export const PullSecret: React.FC<{ namespace: K8sResourceKind; canViewSecrets: boolean }> = (
+  props,
+) => {
   const [isLoading, setIsLoading] = React.useState(true);
   const [data, setData] = React.useState([]);
   const [error, setError] = React.useState(false);
@@ -905,10 +920,10 @@ export const PullSecret = (props) => {
 
   const secrets = () => {
     if (error) {
-      return (<Alert variant="danger" isInline title={t('Error loading default pull Secrets')} />);
+      return <Alert variant="danger" isInline title={t('Error loading default pull Secrets')} />;
     }
     return data.length > 0 ? (
-      (data.map((secret) => (
+      data.map((secret) => (
         <div key={secret.name}>
           <ResourceLink
             kind="Secret"
@@ -917,12 +932,12 @@ export const PullSecret = (props) => {
             linkTo={canViewSecrets}
           />
         </div>
-      )))
+      ))
     ) : (
-      (<Button variant="link" type="button" isInline onClick={modal}>
+      <Button variant="link" type="button" isInline onClick={modal}>
         {t('public~Not configured')}
         <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
-      </Button>)
+      </Button>
     );
   };
 
@@ -934,7 +949,7 @@ export const PullSecret = (props) => {
   );
 };
 
-export const NamespaceLineCharts = ({ ns }) => {
+export const NamespaceLineCharts: React.FC<{ ns: K8sResourceKind }> = ({ ns }) => {
   const { t } = useTranslation();
   return (
     <div className="row">
@@ -959,7 +974,7 @@ export const NamespaceLineCharts = ({ ns }) => {
   );
 };
 
-export const TopPodsBarChart = ({ ns }) => {
+export const TopPodsBarChart: React.FC<{ ns: K8sResourceKind }> = ({ ns }) => {
   const { t } = useTranslation();
   return (
     <Bar
@@ -972,7 +987,7 @@ export const TopPodsBarChart = ({ ns }) => {
   );
 };
 
-const ResourceUsage = ({ ns }) => {
+const ResourceUsage: React.FC<{ ns: K8sResourceKind }> = ({ ns }) => {
   const { t } = useTranslation();
   const isPrometheusAvailable = usePrometheusGate();
   return isPrometheusAvailable ? (
@@ -984,7 +999,7 @@ const ResourceUsage = ({ ns }) => {
   ) : null;
 };
 
-export const NamespaceSummary = ({ ns }) => {
+export const NamespaceSummary: React.FC<{ ns: K8sResourceKind }> = ({ ns }) => {
   const { t } = useTranslation();
   const displayName = getDisplayName(ns);
   const description = getDescription(ns);
@@ -1054,7 +1069,7 @@ export const NamespaceSummary = ({ ns }) => {
 
 export const NamespaceDetails = ({ obj: ns, customData }) => {
   const { t } = useTranslation();
-  const [consoleLinks] = useK8sWatchResource({
+  const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     kind: referenceForModel(ConsoleLinkModel),
     optional: true,
@@ -1087,7 +1102,7 @@ export const NamespaceDetails = ({ obj: ns, customData }) => {
   );
 };
 
-const RolesPage = ({ obj: { metadata } }) => (
+const RolesPage: React.FC<{ obj: K8sResourceKind }> = ({ obj: { metadata } }) => (
   <RoleBindingsPage
     createPath={`/k8s/ns/${metadata.name}/rolebindings/~new`}
     namespace={metadata.name}
@@ -1143,8 +1158,12 @@ export const NamespaceBarDropdowns = ({
   );
 };
 
-/** @type {React.FC<{children?: ReactNode, disabled?: boolean, onNamespaceChange?: Function, hideProjects?: boolean}>} */
-export const NamespaceBar = ({ hideProjects = false, children, disabled, onNamespaceChange }) => {
+export const NamespaceBar: React.FC<{
+  children?: React.ReactNode;
+  disabled?: boolean;
+  onNamespaceChange?: Function;
+  hideProjects?: boolean;
+}> = ({ hideProjects = false, children, disabled, onNamespaceChange }) => {
   const useProjects = useSelector(({ k8s }) =>
     k8s.hasIn(['RESOURCES', 'models', ProjectModel.kind]),
   );
@@ -1157,11 +1176,12 @@ export const NamespaceBar = ({ hideProjects = false, children, disabled, onNames
       ) : (
         // Data from Firehose is not used directly by the NamespaceDropdown nor the children.
         // Data is used to determine if the StartGuide should be shown.
-        // See NamespaceBarDropdowns_  above.
+        // See NamespaceBarDropdowns above.
         <Firehose
           resources={[{ kind: getModel(useProjects).kind, prop: 'namespace', isList: true }]}
         >
           <NamespaceBarDropdowns
+            namespace={undefined}
             useProjects={useProjects}
             disabled={disabled}
             onNamespaceChange={onNamespaceChange}
@@ -1174,7 +1194,7 @@ export const NamespaceBar = ({ hideProjects = false, children, disabled, onNames
   );
 };
 
-export const NamespacesDetailsPage = (props) => (
+export const NamespacesDetailsPage: React.FC<DetailsPageProps> = (props) => (
   <DetailsPage
     {...props}
     menuActions={nsMenuActions}
@@ -1186,7 +1206,7 @@ export const NamespacesDetailsPage = (props) => (
   />
 );
 
-export const ProjectsDetailsPage = (props) => {
+export const ProjectsDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { t } = useTranslation();
   return (
     <DetailsPage

--- a/frontend/public/components/resource-list.tsx
+++ b/frontend/public/components/resource-list.tsx
@@ -31,17 +31,23 @@ import {
   ResourceListPage as DynamicResourceListPage,
   isResourceListPage as isDynamicResourceListPage,
 } from '@console/dynamic-plugin-sdk';
+import { useNamespaceExist, NamespaceNotFoundError } from './namespace';
 
 // Parameters can be in pros.params (in URL) or in props.route (attribute of Route tag)
 const allParams = (props) => Object.assign({}, _.get(props, 'match.params'), props);
 
 export const ResourceListPage = connectToPlural(
-  withStartGuide((props: ResourceListPageProps) => {
+  withStartGuide(function ResourceListPage(props: ResourceListPageProps) {
     const resourceListPageExtensions = useExtensions<ResourceListPageExt>(isResourceListPage);
     const dynamicResourceListPageExtensions = useExtensions<DynamicResourceListPage>(
       isDynamicResourceListPage,
     );
     const { kindObj, kindsInFlight, modelRef, noProjectsAvailable, ns, plural } = allParams(props);
+
+    const [namespaceExist, namespaceLoaded] = useNamespaceExist(ns);
+    if (namespaceLoaded && !namespaceExist) {
+      return <NamespaceNotFoundError />;
+    }
 
     if (!kindObj) {
       if (kindsInFlight) {
@@ -56,6 +62,7 @@ export const ResourceListPage = connectToPlural(
         />
       );
     }
+
     const ref = referenceForModel(kindObj);
     const componentLoader = getResourceListPages(
       resourceListPageExtensions,
@@ -81,13 +88,20 @@ export const ResourceListPage = connectToPlural(
   }),
 );
 
-export const ResourceDetailsPage = connectToPlural((props: ResourceDetailsPageProps) => {
+export const ResourceDetailsPage = connectToPlural(function ResourceDetailsPage(
+  props: ResourceDetailsPageProps,
+) {
   const detailsPageExtensions = useExtensions<ResourceDetailsPageExt>(isResourceDetailsPage);
   const dynamicResourceListPageExtensions = useExtensions<DynamicResourceDetailsPage>(
     isDynamicResourceDetailsPage,
   );
   const { name, ns, kindObj, kindsInFlight } = allParams(props);
   const decodedName = decodeURIComponent(name);
+
+  const [namespaceExist, namespaceLoaded] = useNamespaceExist(ns);
+  if (namespaceLoaded && !namespaceExist) {
+    return <NamespaceNotFoundError />;
+  }
 
   if (!name || !kindObj) {
     if (kindsInFlight) {

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1153,6 +1153,8 @@
   "Memory usage by pod (top 10)": "Memory usage by pod (top 10)",
   "Resource usage": "Resource usage",
   "NetworkPolicies": "NetworkPolicies",
+  "404: Project not found": "404: Project not found",
+  "404: Namespace not found": "404: Namespace not found",
   "Observe": "Observe",
   "Home": "Home",
   "Search": "Search",


### PR DESCRIPTION
**Fixes**: 
Bug https://bugzilla.redhat.com/show_bug.cgi?id=2000073
Similar reported as https://issues.redhat.com/browse/ODC-4474

**Analysis / Root cause**: 
The selected namespaced is saved in the redux store and there is no detection if another user (or the same in another tab) removes this namespace. The user can navigate between multiple screen without notice that his namespace doesn't exist.

(Btw: Our / the k8s API returns an empty array if the user asks for a non-existing namespace "pod list".)

If the latest or preferred namespace wasn't found, and if the user opens `/`, `/add`, `/topology`, etc., and the preferred or latest namespace is removed, the user will automatically switch back to pages that require the user to select a namespace.

But when the user opens a specific namespace via an URL, like `/add/ns/my-namespace`, `/topology/ns/my-namespace`, etc., this check isn't implemented.

But IMHO this is correct and should not be changed. When the user opens a bookmark, or a link from another associate, called "MY-TEST-NAMESPACE topology", we should not switch the namespace. In the worst case, the user didn't notice that the new namespace is MY-PRODUCTION-NAMESPACE"...

I assumed that this is an edge-case. I decided to NOT wait until the complete project list is fetched and also show the normal page if there is any error while fetching this data. So I hope this will also help in some edge-cases where the user could not see their own project but can create a resource? I'm unsure if this could happen. :smile: 

**Solution Description**: 
This change shows instead a "404 Project/Namespace not found" page if the user opens a namespace that doesn't exist.

## Similar to the cases where a resource is not found:

![image](https://user-images.githubusercontent.com/139310/155740670-c3a876fd-8ca1-474f-8b04-7352ec160298.png)

## New screen when the namespace in the URL doesn't exist:

![image](https://user-images.githubusercontent.com/139310/155748974-f8716bc5-9402-4815-b758-f8ec8a858b40.png)


This check is added to these shared components: NamespacedPage, ResourceListPage and ResourceDetailPage.

Because these three pages already fetch the complete project/namespace list for the `NamespaceDropdown`. So instead of another API call the "exist check" reuse the same data.

**Screenshots / Gifs for design review**: 

## Screen recording which shows different case before:

https://user-images.githubusercontent.com/139310/155741798-a34ed51e-1dd5-4707-a8fe-5076cec75c36.mp4

## Screen recording which shows different case after:

https://user-images.githubusercontent.com/139310/155741821-2dfd78c2-7997-40ae-907e-cae05393dc7a.mp4

## Tested some more screens:

You can see that there are some flickers when switching between pages in the dev console, that happens because each page reloads the project list again and again. I don't want to change this behavior as part of this ticket. I think this could be improved, but as said, this PR here should address more the edge case that the user opens a link with a non-existing project...

https://user-images.githubusercontent.com/139310/155741889-569da751-a895-40b1-a834-e6feaa819c39.mp4

**Unit test coverage report**: 
Added complete new tests

**Test setup:**
1. Open a URL that specifies a namespace, try existing and non-existing projects.
2. Try some edge cases.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
