### PR TITLE
Bug 2056496: update upload jar flow for no builder image

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -437,6 +437,7 @@
   "Optional Java arguments": "Optional Java arguments",
   "Optional Java arguments are saved as JAVA_ARGS environment variable to customize your application.": "Optional Java arguments are saved as JAVA_ARGS environment variable to customize your application.",
   "JAVA_ARGS": "JAVA_ARGS",
+  "No associated Builder Image is found for Java.": "No associated Builder Image is found for Java.",
   "JAR file uploading": "JAR file uploading",
   "JAR file is uploading to {{namespace}}. You can view the upload progress in the build logs. This may take a few minutes. If you exit the browser while upload is in progress it may fail.": "JAR file is uploading to {{namespace}}. You can view the upload progress in the build logs. This may take a few minutes. If you exit the browser while upload is in progress it may fail.",
   "View build logs": "View build logs",

--- a/frontend/packages/dev-console/src/components/import/jar/UploadJar.tsx
+++ b/frontend/packages/dev-console/src/components/import/jar/UploadJar.tsx
@@ -44,7 +44,7 @@ const UploadJar: React.FunctionComponent<UploadJarProps> = ({
   const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
   const application = forApplication || '';
   const activeApplication = application !== ALL_APPLICATIONS_KEY ? application : '';
-  const { name: imageName, recentTag: tag } = builderImage;
+  const { name: imageName, recentTag: tag } = builderImage || {};
 
   const initialBaseValues: BaseFormData = getBaseInitialValues(namespace, activeApplication);
   const initialValues: UploadJarFormData = {
@@ -62,9 +62,7 @@ const UploadJar: React.FunctionComponent<UploadJarProps> = ({
     runtimeIcon: 'java',
     image: {
       ...initialBaseValues.image,
-      selected: imageName,
-      tag: tag.name,
-      tagObj: tag,
+      ...(imageName && tag?.name && { selected: imageName, tag: tag.name, tagObj: tag }),
     },
     import: {
       showEditImportStrategy: true,

--- a/frontend/packages/dev-console/src/components/import/jar/UploadJarForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/jar/UploadJarForm.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Alert } from '@patternfly/react-core';
 import { FormikProps, FormikValues } from 'formik';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -18,7 +19,7 @@ import JarSection from './section/JarSection';
 export type UploadJarFormProps = {
   namespace: string;
   projects: WatchK8sResultsObject<K8sResourceKind[]>;
-  builderImage: BuilderImage;
+  builderImage?: BuilderImage;
 };
 
 const UploadJarForm: React.FunctionComponent<FormikProps<FormikValues> & UploadJarFormProps> = ({
@@ -44,11 +45,21 @@ const UploadJarForm: React.FunctionComponent<FormikProps<FormikValues> & UploadJ
         <JarSection />
         <IconSection />
         <FormSection>
-          <BuilderImageTagSelector
-            selectedBuilderImage={builderImage}
-            selectedImageTag={selectedImagetag}
-            showImageInfo={false}
-          />
+          {builderImage && selectedImagetag ? (
+            <BuilderImageTagSelector
+              selectedBuilderImage={builderImage}
+              selectedImageTag={selectedImagetag}
+              showImageInfo={false}
+            />
+          ) : (
+            <Alert
+              variant="warning"
+              title={t('devconsole~Unable to detect the Builder Image.')}
+              isInline
+            >
+              {t('devconsole~No associated Builder Image is found for Java.')}
+            </Alert>
+          )}
         </FormSection>
         <AppSection
           project={values.project}

--- a/frontend/packages/dev-console/src/components/import/jar/UploadJarPage.tsx
+++ b/frontend/packages/dev-console/src/components/import/jar/UploadJarPage.tsx
@@ -43,9 +43,11 @@ const UploadJarPage: React.FunctionComponent<UploadJarPageProps> = ({ match, loc
 
   if (!isResourceLoaded) return <LoadingBox />;
 
-  const { [imageStreamName]: builderImage }: NormalizedBuilderImages = normalizeBuilderImages(
-    resources.imagestream.data,
-  );
+  let normalizedJavaImages: NormalizedBuilderImages;
+  const { loaded: isLoaded, data: isData, loadError: isLoadError } = resources.imagestream;
+  if (isLoaded && !isLoadError) {
+    normalizedJavaImages = normalizeBuilderImages(isData);
+  }
 
   return (
     <NamespacedPage disabled variant={NamespacedPageVariants.light}>
@@ -61,7 +63,7 @@ const UploadJarPage: React.FunctionComponent<UploadJarPageProps> = ({ match, loc
             forApplication={desiredApplication}
             namespace={namespace}
             projects={resources.projects as WatchK8sResultsObject<K8sResourceKind[]>}
-            builderImage={builderImage}
+            builderImage={normalizedJavaImages?.[imageStreamName]}
             contextualSource={params.get(QUERY_PROPERTIES.CONTEXT_SOURCE)}
           />
         )}

--- a/frontend/packages/dev-console/src/components/import/jar/__tests__/UploadJarForm.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/jar/__tests__/UploadJarForm.spec.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Alert } from '@patternfly/react-core';
 import { shallow } from 'enzyme';
 import { ImageTag } from '@console/dev-console/src/utils/imagestream-utils';
 import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
@@ -13,12 +14,12 @@ import UploadJarForm from '../UploadJarForm';
 let UploadJarFormProps: React.ComponentProps<typeof UploadJarForm>;
 
 describe('UploadJarForm', () => {
+  const tagData: ImageTag = {
+    name: 'openjdk-11-el7',
+    generation: 2,
+    annotations: {},
+  };
   beforeEach(() => {
-    const tagData: ImageTag = {
-      name: 'openjdk-11-el7',
-      generation: 2,
-      annotations: {},
-    };
     UploadJarFormProps = {
       ...formikFormProps,
       values: {
@@ -52,5 +53,28 @@ describe('UploadJarForm', () => {
     expect(wrapper.find(AppSection).exists()).toBe(true);
     expect(wrapper.find(ResourceSection).exists()).toBe(true);
     expect(wrapper.find(AdvancedSection).exists()).toBe(true);
+  });
+
+  it('should not render BuilderImageTagSelector if builderImage is not present and show alert', () => {
+    const updatedProps = {
+      ...formikFormProps,
+      values: {
+        image: { tag: tagData },
+      },
+      namespace: 'my-app',
+      projects: {
+        loaded: true,
+        data: [],
+        loadError: null,
+      },
+    };
+    const wrapper = shallow(<UploadJarForm {...updatedProps} />);
+    expect(wrapper.find(JarSection).exists()).toBe(true);
+    expect(wrapper.find(IconSection).exists()).toBe(true);
+    expect(wrapper.find(AppSection).exists()).toBe(true);
+    expect(wrapper.find(ResourceSection).exists()).toBe(true);
+    expect(wrapper.find(AdvancedSection).exists()).toBe(true);
+    expect(wrapper.find(Alert).exists()).toBe(true);
+    expect(wrapper.find(BuilderImageTagSelector).exists()).toBe(false);
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2056496

**Analysis / Root cause**: 
If the image does not exist for builder image then upload jar form crashes

**Solution Description**: 
update upload jar flow for no builder image and show user with a warning message

**Screenshots / Gifs for design review**: 

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/5129024/155553260-b460b0e4-9aca-448d-b99a-0c3e6cd57f4e.png">



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge