### PR TITLE
Trim trailing whitespace in test names.

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crud/secrets.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/secrets.spec.ts
@@ -48,7 +48,7 @@ describe('Create key/value secrets', () => {
     cy.logout();
   });
 
-  it(`Validate a key/value secret whose value is a binary file `, () => {
+  it(`Validate a key/value secret whose value is a binary file`, () => {
     populateSecretForm(binarySecretName, secretKey, binaryFilename);
     cy.byLegacyTestID('file-input-textarea').should('not.exist');
     cy.get(infoMessage).should('exist');
@@ -66,7 +66,7 @@ describe('Create key/value secrets', () => {
     });
   });
 
-  it(`Validate a key/value secret whose value is an ascii file `, () => {
+  it(`Validate a key/value secret whose value is an ascii file`, () => {
     populateSecretForm(asciiSecretName, secretKey, asciiFilename);
     cy.byLegacyTestID('file-input-textarea').should('exist');
     cy.get(infoMessage).should('not.exist');
@@ -84,7 +84,7 @@ describe('Create key/value secrets', () => {
     });
   });
 
-  it(`Validate a key/value secret whose value is a unicode file `, () => {
+  it(`Validate a key/value secret whose value is a unicode file`, () => {
     populateSecretForm(unicodeSecretName, secretKey, unicodeFilename);
     cy.byLegacyTestID('file-input-textarea').should('exist');
     cy.get(infoMessage).should('not.exist');


### PR DESCRIPTION
This caused some bugs in sippy as test names have to be treated as
somewhat of an identifier in a few databases around the product, some of
which are trimming. We're fixing on that end but figured we should fix
the root of the problem as well.
