### PR TITLE
Bug 2057054: Improves K8s Utils Return Type

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/__tests__/k8s-resource.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/__tests__/k8s-resource.spec.ts
@@ -59,9 +59,10 @@ describe('k8s-Resource', () => {
   });
 
   it('k8sGetResource should call consoleFetchJSON', async () => {
-    spyCoFetchJSON.mockReturnValueOnce(Promise.resolve({}));
-    await k8sGetResource({ model: MockPodModel, name: 'my-pod' });
+    spyCoFetchJSON.mockReturnValueOnce(Promise.resolve({ kind: 'Pod' }));
+    const result = await k8sGetResource({ model: MockPodModel, name: 'my-pod' });
     expect(spyCoFetchJSON).toHaveBeenCalled();
     expect(spyCoFetchJSON).toHaveBeenCalledTimes(1);
+    expect(result.kind).toBeDefined();
   });
 });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-resource.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-resource.ts
@@ -16,7 +16,7 @@ type BaseOptions = {
 type AdapterFunc = <D extends BaseOptions>(
   func: Function,
   knownArgs: string[],
-) => (options: D) => Promise<Response>;
+) => (options: D) => Promise<any>;
 
 /**
  * An adapter function to call the underlying APIs with provided options.
@@ -77,7 +77,7 @@ type OptionsGet = BaseOptions & {
   requestInit?: RequestInit;
 };
 
-type K8sGetResource = (options: OptionsGet) => Promise<Response>;
+type K8sGetResource = <R extends K8sResourceCommon>(options: OptionsGet) => Promise<R>;
 
 /**
  * It fetches a resource from the cluster, based on the provided options.
@@ -129,9 +129,7 @@ type OptionsCreate<R> = BaseOptions & {
   data: R;
 };
 
-type K8sCreateResource = <R extends K8sResourceCommon>(
-  options: OptionsCreate<R>,
-) => Promise<Response>;
+type K8sCreateResource = <R extends K8sResourceCommon>(options: OptionsCreate<R>) => Promise<R>;
 
 /**
  * It creates a resource in the cluster, based on the provided options.
@@ -186,9 +184,7 @@ type OptionsUpdate<R> = BaseOptions & {
   data: R;
 };
 
-type K8sUpdateResource = <R extends K8sResourceCommon>(
-  options: OptionsUpdate<R>,
-) => Promise<Response>;
+type K8sUpdateResource = <R extends K8sResourceCommon>(options: OptionsUpdate<R>) => Promise<R>;
 /**
  * It updates the entire resource in the cluster, based on provided options.
  * When a client needs to replace an existing resource entirely, they can use k8sUpdate.
@@ -260,9 +256,7 @@ type OptionsPatch<R> = BaseOptions & {
   data: Patch[];
 };
 
-type K8sPatchResource = <R extends K8sResourceCommon>(
-  options: OptionsPatch<R>,
-) => Promise<Response>;
+type K8sPatchResource = <R extends K8sResourceCommon>(options: OptionsPatch<R>) => Promise<R>;
 
 /**
  * It patches any resource in the cluster, based on provided options.
@@ -330,9 +324,7 @@ type OptionsDelete<R> = BaseOptions & {
   json: Record<string, any>;
 };
 
-type K8sDeleteResource = <R extends K8sResourceCommon>(
-  options: OptionsDelete<R>,
-) => Promise<Response>;
+type K8sDeleteResource = <R extends K8sResourceCommon>(options: OptionsDelete<R>) => Promise<R>;
 
 /**
  * It deletes resources from the cluster, based on the provided model, resource.
@@ -402,7 +394,9 @@ type OptionsList = {
   requestInit: RequestInit;
 };
 
-type K8sListResource = (options: OptionsList) => Promise<Response>;
+type K8sListResource = <R extends K8sResourceCommon>(
+  options: OptionsList,
+) => Promise<R[] | (K8sResourceCommon & { items: R[] })>;
 
 /**
  * It lists the resources as an array in the cluster, based on provided options.


### PR DESCRIPTION
Cleans the typing for `k8s{CRUD}Resource` calls that are exported as `K8s{CRUD}`. The return type of `Response` was not accurate.

NOTE: This change is temporary fix until we consume the HAC-Core effort which improves the calling system significantly. See the [k8s-resouce.ts](https://github.com/openshift/dynamic-plugin-sdk/blob/main/packages/lib-utils/src/k8s/k8s-resource.ts) file in dynamic-plugic-sdk 

We could alternatively try to move that code by itself early, but I would not recommend it as it would duplicate the effort of the Core SDK Package. 