### PR TITLE
Bug 2046598: Display disk size in correct units

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/review-tab/storage-review.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/review-tab/storage-review.tsx
@@ -4,12 +4,7 @@ import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-t
 import { Trans, useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import {
-  Firehose,
-  FirehoseResult,
-  humanizeBinaryBytes,
-  resourcePath,
-} from '@console/internal/components/utils';
+import { Firehose, FirehoseResult, resourcePath } from '@console/internal/components/utils';
 import { PersistentVolumeClaimModel, StorageClassModel } from '@console/internal/models';
 import { StorageClassResourceKind } from '@console/internal/module/k8s';
 import { CombinedDisk } from '../../../../k8s/wrapper/vm/combined-disk';
@@ -112,7 +107,7 @@ const StorageReviewFirehose: React.FC<StorageReviewFirehoseProps> = ({
     return [
       combinedDisk.getName(),
       combinedDisk.getSourceValue(),
-      combinedDisk.getSize() && humanizeBinaryBytes(combinedDisk.getSize().value).string,
+      combinedDisk.getReadableSize(),
       combinedDisk.getDiskInterface(),
       combinedDisk.getStorageClassName(),
       combinedDisk.getAccessModes()?.join(', '),

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-tab.tsx
@@ -16,12 +16,7 @@ import {
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
-import {
-  ExternalLink,
-  Firehose,
-  FirehoseResult,
-  humanizeBinaryBytes,
-} from '@console/internal/components/utils';
+import { ExternalLink, Firehose, FirehoseResult } from '@console/internal/components/utils';
 import { PersistentVolumeClaimModel } from '@console/internal/models';
 import { DeviceType } from '../../../../constants/vm';
 import { ProvisionSource } from '../../../../constants/vm/provision-source';
@@ -88,7 +83,7 @@ const getStoragesData = (
       name: combinedDisk.getName(),
       source: combinedDisk.getSourceValue(),
       diskInterface: combinedDisk.getDiskInterface(),
-      size: combinedDisk.getSize() && humanizeBinaryBytes(combinedDisk.getSize().value).string,
+      size: combinedDisk.getReadableSize(),
       storageClass: combinedDisk.getStorageClassName(),
       type: combinedDisk.getType(),
     };

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/data-volume-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/data-volume-wrapper.ts
@@ -1,3 +1,4 @@
+import { humanizeBinaryBytes } from '@console/internal/components/utils';
 import {
   BinaryUnit,
   stringValueUnitSplit,
@@ -68,6 +69,13 @@ export class DataVolumeWrapper extends K8sResourceObjectWithTypePropertyWrapper<
 
   getReadabableSize = () => {
     const { value, unit } = this.getSize();
+
+    // if only unit is undefined, the value has to be recalculated from B and the new unit set, for more readable output
+    if (value && !unit) {
+      const { value: newValue, unit: newUnit } = humanizeBinaryBytes(this.getSize().value);
+      return `${newValue} ${newUnit}`;
+    }
+
     return `${value} ${toIECUnit(unit) || BinaryUnit.B}`;
   };
 


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2046598

**Analysis / Root cause:**
The previous [fix](https://github.com/openshift/console/pull/11024) didn't include some of the scenarios when adding a new disk or editing the size of some existing one, in the customize wizard: the final disk size was always displayed in _B_, no matter the real unit, chosen by the user in the _Add/Edit disk_ modal window. However, there was always correct unit set, in the modal, at least.

**Solution Description:**
We need to take care about the special case when the unit isn't set and the large number in bytes is present. The logic for this case was missing. We need to recalculate the value and set a proper unit. This provides the expected output.
If there are already units set, we don't need/want the value to be recalculated.

**Screen shots / Gifs for design review:**
_Before:_
Editing a disk, setting the new disk size to 123 MiB:
![after1](https://user-images.githubusercontent.com/13417815/155625995-cd5c10ee-d741-427e-b53c-a01974bb027b.png)
The wrong disk size displayed after saving the changes of editing disk, always in bytes:
![before](https://user-images.githubusercontent.com/13417815/155626005-1cf11645-2b8f-43ff-b113-3456302d64f1.png)

_After:_
The correct size, correct units displayed, same as previously set in the Add/Edit disk modal:
![after2](https://user-images.githubusercontent.com/13417815/155625924-353bdf4a-071d-4f0d-af10-d1088652369d.png)

