### PR TITLE
Bug 2054950: Display correct disk size in Edit disk modal

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -16,6 +16,7 @@ import {
   ExternalLink,
   FirehoseResult,
   HandlePromiseProps,
+  humanizeBinaryBytes,
   LoadingInline,
   withHandlePromise,
 } from '@console/internal/components/utils';
@@ -192,8 +193,13 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
   );
 
   const [size, setSize] = React.useState<string>(
-    combinedDiskSize ? `${combinedDiskSize.value}` : '',
+    combinedDiskSize
+      ? combinedDiskSize.unit
+        ? `${combinedDiskSize.value}`
+        : `${humanizeBinaryBytes(combinedDiskSize.value).value}`
+      : '',
   );
+
   const [unit, setUnit] = React.useState<string>(
     (combinedDiskSize && combinedDiskSize.unit) || BinaryUnit.Gi,
   );


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2054950

**Analysis / Root cause:**
A large number in bytes was displayed in the disk _Size_ field, in the _Edit disk_ modal, when creating a VM from template that has a boot source. This has happened in case when `combinedDiskSize.unit` value was `undefined`, but set to '`GiB'` by default [here](https://github.com/openshift/console/compare/master...hstastna:BZ_large_number_edit_disk_size?expand=1#diff-5bbfd332b94f8d7c02f44ad0ebd1dc30b7941c03371ae8f3b85d8599e5f8feeeR204).

**Solution Description:**
Display the correct size in _GiB_ instead. Use `humanizeBinaryBytes` to convert the value to _GiB_ and set the state for _Edit disk_ modal correctly.

**Screen shots / Gifs for design review:**
Before:
![edit_before](https://user-images.githubusercontent.com/13417815/155712981-63ca94d6-40ea-4482-898b-79a8c50a9a2d.png)

After:
![edit_after](https://user-images.githubusercontent.com/13417815/155712997-4c9a774d-76ca-4af8-b97c-7a53782847dd.png)

