### PR TITLE
Bug 2061301: Add tooltips why add and delete buttons in knative traffic splitting modal are disabled

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -16,8 +16,6 @@ export interface FieldProps {
   required?: boolean;
   style?: React.CSSProperties;
   isReadOnly?: boolean;
-  disableDeleteRow?: boolean;
-  disableAddRow?: boolean;
   className?: string;
   isDisabled?: boolean;
   validated?: ValidatedOptions;
@@ -97,7 +95,6 @@ export interface ResourceLimitFieldProps extends FieldProps {
 
 export interface MultiColumnFieldProps extends FieldProps {
   addLabel?: string;
-  toolTip?: string;
   emptyValues: { [name: string]: string | boolean | string[] };
   emptyMessage?: string;
   headers: ({ name: string; required: boolean } | string)[];
@@ -105,6 +102,10 @@ export interface MultiColumnFieldProps extends FieldProps {
   children?: React.ReactNode;
   spans?: gridItemSpanValueShape[];
   rowRenderer?: (row: RowRendererProps) => React.ReactNode;
+  disableDeleteRow?: boolean;
+  tooltipDeleteRow?: string;
+  disableAddRow?: boolean;
+  tooltipAddRow?: string;
 }
 
 export interface YAMLEditorFieldProps extends FieldProps {

--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
@@ -23,8 +23,9 @@ const MultiColumnField: React.FC<MultiColumnFieldProps> = ({
   emptyMessage,
   isReadOnly,
   disableDeleteRow,
+  tooltipDeleteRow,
   disableAddRow,
-  toolTip,
+  tooltipAddRow,
   spans,
   complexFields,
   rowRenderer,
@@ -63,14 +64,14 @@ const MultiColumnField: React.FC<MultiColumnFieldProps> = ({
                 <MultiColumnFieldRow
                   key={`${index.toString()}`} // There is no other usable value for key prop in this case.
                   name={name}
-                  toolTip={toolTip}
                   rowIndex={index}
-                  onDelete={() => remove(index)}
                   isReadOnly={isReadOnly}
-                  disableDeleteRow={disableDeleteRow}
                   spans={fieldSpans}
                   complexFields={complexFields}
                   rowRenderer={rowRenderer}
+                  disableDeleteRow={disableDeleteRow}
+                  tooltipDeleteRow={tooltipDeleteRow}
+                  onDelete={() => remove(index)}
                 >
                   {children}
                 </MultiColumnFieldRow>
@@ -78,6 +79,7 @@ const MultiColumnField: React.FC<MultiColumnFieldProps> = ({
             {!isReadOnly && (
               <MultiColumnFieldFooter
                 disableAddRow={disableAddRow}
+                tooltipAddRow={tooltipAddRow}
                 addLabel={addLabel}
                 onAdd={() => push(emptyValues)}
               />

--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnFieldFooter.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnFieldFooter.tsx
@@ -1,32 +1,35 @@
 import * as React from 'react';
-import { Button } from '@patternfly/react-core';
+import { Button, Tooltip } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 
-export interface MultiColumnFieldHeader {
+export interface MultiColumnFieldFooterProps {
   addLabel?: string;
-  onAdd: () => void;
   disableAddRow?: boolean;
+  tooltipAddRow?: string;
+  onAdd: () => void;
 }
 
-const MultiColumnFieldFooter: React.FC<MultiColumnFieldHeader> = ({
+const MultiColumnFieldFooter: React.FC<MultiColumnFieldFooterProps> = ({
   addLabel,
-  onAdd,
   disableAddRow = false,
+  tooltipAddRow,
+  onAdd,
 }) => {
   const { t } = useTranslation();
-  return (
+  const button = (
     <Button
       data-test={'add-action'}
       variant="link"
-      isDisabled={disableAddRow}
-      onClick={onAdd}
+      isAriaDisabled={disableAddRow}
+      onClick={!disableAddRow ? onAdd : undefined}
       icon={<PlusCircleIcon />}
       isInline
     >
       {addLabel || t('console-shared~Add values')}
     </Button>
   );
+  return tooltipAddRow ? <Tooltip content={tooltipAddRow}>{button}</Tooltip> : button;
 };
 
 export default MultiColumnFieldFooter;

--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnFieldRow.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnFieldRow.tsx
@@ -15,10 +15,10 @@ import './MultiColumnField.scss';
 export interface RowRendererProps {
   fieldName: string;
   isReadOnly?: boolean;
-  disableDeleteRow?: boolean;
   spans: gridItemSpanValueShape[];
   complexFields?: boolean[];
-  toolTip?: string;
+  disableDeleteRow?: boolean;
+  tooltipDeleteRow?: string;
   onDelete: () => void;
 }
 export interface MultiColumnFieldRowProps extends Omit<RowRendererProps, 'fieldName'> {
@@ -33,9 +33,9 @@ const DEFAULT_ROW_RENDERER = ({
   complexFields,
   children,
   isReadOnly,
-  toolTip,
   spans,
   disableDeleteRow,
+  tooltipDeleteRow,
   onDelete,
 }): React.ReactNode => {
   const { t } = useTranslation();
@@ -60,15 +60,15 @@ const DEFAULT_ROW_RENDERER = ({
       </Grid>
       {!isReadOnly && (
         <div className={'odc-multi-column-field__col--button'}>
-          <Tooltip content={toolTip || t('console-shared~Remove')}>
+          <Tooltip content={tooltipDeleteRow || t('console-shared~Remove')}>
             <Button
               data-test="delete-row"
-              aria-label={toolTip || t('console-shared~Remove')}
+              aria-label={tooltipDeleteRow || t('console-shared~Remove')}
               variant={ButtonVariant.plain}
               type={ButtonType.button}
               isInline
-              onClick={onDelete}
-              isDisabled={disableDeleteRow}
+              onClick={!disableDeleteRow ? onDelete : undefined}
+              isAriaDisabled={disableDeleteRow}
             >
               <MinusCircleIcon />
             </Button>
@@ -81,12 +81,12 @@ const DEFAULT_ROW_RENDERER = ({
 
 const MultiColumnFieldRow: React.FC<MultiColumnFieldRowProps> = ({
   name,
-  toolTip,
   rowIndex,
   onDelete,
   children,
   isReadOnly,
   disableDeleteRow,
+  tooltipDeleteRow,
   spans,
   complexFields = [],
   rowRenderer = DEFAULT_ROW_RENDERER,
@@ -99,9 +99,9 @@ const MultiColumnFieldRow: React.FC<MultiColumnFieldRowProps> = ({
         complexFields,
         children,
         isReadOnly,
-        toolTip,
         spans,
         disableDeleteRow,
+        tooltipDeleteRow,
         onDelete,
       })}
     </>

--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/__tests__/MultiColumnFieldFooter.spec.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/__tests__/MultiColumnFieldFooter.spec.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { Button, Tooltip } from '@patternfly/react-core';
+import { shallow } from 'enzyme';
+import MultiColumnFieldFooter from '../MultiColumnFieldFooter';
+
+describe('MultiColumnFieldFooter', () => {
+  it('should render an enabled add button by default, but without a tooltip', () => {
+    const footer = shallow(<MultiColumnFieldFooter onAdd={jest.fn()} />);
+
+    const pfButton = footer.find(Button);
+    expect(pfButton.exists()).toBeTruthy();
+    expect(pfButton.props().children).toBe('Add values');
+    expect(pfButton.props().disabled).toBeFalsy();
+    expect(pfButton.props()['aria-disabled']).toBeFalsy();
+
+    const pfTooltip = footer.find(Tooltip);
+    expect(pfTooltip.exists()).toBeFalsy();
+  });
+
+  it('should render an disabled button without a tooltip when disableAddRow is true', () => {
+    const footer = shallow(<MultiColumnFieldFooter onAdd={jest.fn()} disableAddRow />);
+
+    const pfButton = footer.find(Button);
+    expect(pfButton.exists()).toBeTruthy();
+    expect(pfButton.props().children).toBe('Add values');
+    expect(pfButton.props().disabled).toBeFalsy();
+    expect(pfButton.props().isAriaDisabled).toBeTruthy();
+
+    const pfTooltip = footer.find(Tooltip);
+    expect(pfTooltip.exists()).toBeFalsy();
+  });
+
+  it('should render an disabled button with a tooltip when disableAddRow is true', () => {
+    const footer = shallow(
+      <MultiColumnFieldFooter
+        onAdd={jest.fn()}
+        disableAddRow
+        tooltipAddRow="Disabled add button"
+      />,
+    );
+
+    const pfButton = footer.find(Button);
+    expect(pfButton.exists()).toBeTruthy();
+    expect(pfButton.props().children).toBe('Add values');
+    expect(pfButton.props().disabled).toBeFalsy();
+    expect(pfButton.props().isAriaDisabled).toBeTruthy();
+
+    const pfTooltip = footer.find(Tooltip);
+    expect(pfTooltip.exists()).toBeTruthy();
+    expect(pfTooltip.props().content).toBe('Disabled add button');
+  });
+});

--- a/frontend/packages/console-shared/src/components/formik-fields/text-column-field/TextColumnItemContent.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/text-column-field/TextColumnItemContent.tsx
@@ -17,7 +17,7 @@ import {
   MergeNewValueUtil,
 } from './text-column-types';
 
-export type TextColumntItemContentProps = TextColumnItemProps & {
+export type TextColumnItemContentProps = TextColumnItemProps & {
   previewDropRef: (node) => void | null;
   dragRef: (node) => void | null;
   opacity: number;
@@ -44,7 +44,7 @@ const DEFAULT_CHILDREN = (
   );
 };
 
-const TextColumnItemContent: React.FC<TextColumntItemContentProps> = ({
+const TextColumnItemContent: React.FC<TextColumnItemContentProps> = ({
   name,
   dndEnabled,
   children = DEFAULT_CHILDREN,
@@ -55,7 +55,7 @@ const TextColumnItemContent: React.FC<TextColumntItemContentProps> = ({
   arrayHelpers,
   rowValues,
   disableDeleteRow,
-  tooltip,
+  tooltipDeleteRow,
   previewDropRef,
   dragRef,
   opacity,
@@ -87,9 +87,9 @@ const TextColumnItemContent: React.FC<TextColumntItemContentProps> = ({
         </FlexItem>
         {!isReadOnly && (
           <FlexItem>
-            <Tooltip content={tooltip || t('console-shared~Remove')}>
+            <Tooltip content={tooltipDeleteRow || t('console-shared~Remove')}>
               <Button
-                aria-label={tooltip || t('console-shared~Remove')}
+                aria-label={tooltipDeleteRow || t('console-shared~Remove')}
                 variant={ButtonVariant.plain}
                 type={ButtonType.button}
                 isInline

--- a/frontend/packages/console-shared/src/components/formik-fields/text-column-field/text-column-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/text-column-field/text-column-types.ts
@@ -20,7 +20,8 @@ export type TextColumnFieldProps = FieldProps & {
   name: string;
   label: string;
   addLabel?: string;
-  tooltip?: string;
+  disableDeleteRow?: boolean;
+  tooltipDeleteRow?: string;
   placeholder?: string;
   onChange?: OnChangeHandler;
   dndEnabled?: boolean;

--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -224,6 +224,8 @@
   "Add Revision": "Add Revision",
   "Split": "Split",
   "Tag": "Tag",
+  "Service must have at least one assigned revision": "Service must have at least one assigned revision",
+  "All revisions are already set to receive traffic": "All revisions are already set to receive traffic",
   "Select a Revision": "Select a Revision",
   "Set traffic distribution for the Revisions of the Knative Service": "Set traffic distribution for the Revisions of the Knative Service",
   "Resources": "Resources",

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingFields.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingFields.tsx
@@ -30,7 +30,17 @@ const TrafficSplittingFields: React.FC<Props> = ({ revisionItems, values }) => {
       ]}
       emptyValues={{ percent: '', tag: '', revisionName: '' }}
       disableDeleteRow={values.trafficSplitting.length === 1}
+      tooltipDeleteRow={
+        values.trafficSplitting.length === 1
+          ? t('knative-plugin~Service must have at least one assigned revision')
+          : undefined /* default */
+      }
       disableAddRow={values.trafficSplitting.length === size(revisionItems)}
+      tooltipAddRow={
+        values.trafficSplitting.length === size(revisionItems)
+          ? t('knative-plugin~All revisions are already set to receive traffic')
+          : null /* no tooltip */
+      }
       spans={[2, 3, 7]}
     >
       <InputField

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/__tests__/TrafficSplittingFields.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/__tests__/TrafficSplittingFields.spec.tsx
@@ -24,18 +24,13 @@ describe('TrafficSplittingFields', () => {
         values={{ trafficSplitting: [{ percent: 100, revisionName: 'overlayimage-fdqsf' }] }}
       />,
     );
-    expect(
-      wrapper
-        .find(MultiColumnField)
-        .first()
-        .props().disableDeleteRow,
-    ).toBe(true);
-    expect(
-      wrapper
-        .find(MultiColumnField)
-        .first()
-        .props().disableAddRow,
-    ).toBe(false);
+    const multiColumnField = wrapper.find(MultiColumnField).first();
+    expect(multiColumnField.props().disableDeleteRow).toBe(true);
+    expect(multiColumnField.props().tooltipDeleteRow).toBe(
+      'Service must have at least one assigned revision',
+    );
+    expect(multiColumnField.props().disableAddRow).toBe(false);
+    expect(multiColumnField.props().tooltipAddRow).toBe(null);
   });
 
   it('should not disable delete row button or add row button if number of values is more than one but less than total number of revisions', () => {
@@ -50,28 +45,20 @@ describe('TrafficSplittingFields', () => {
         }}
       />,
     );
-    expect(
-      wrapper
-        .find(MultiColumnField)
-        .first()
-        .props().disableDeleteRow,
-    ).toBe(false);
-    expect(
-      wrapper
-        .find(MultiColumnField)
-        .first()
-        .props().disableAddRow,
-    ).toBe(false);
+    const multiColumnField = wrapper.find(MultiColumnField).first();
+    expect(multiColumnField.props().disableDeleteRow).toBe(false);
+    expect(multiColumnField.props().tooltipDeleteRow).toBe(undefined);
+    expect(multiColumnField.props().disableAddRow).toBe(false);
+    expect(multiColumnField.props().tooltipAddRow).toBe(null);
   });
 
   it('should disable add button when no. of revisionName fields equals number of revisions', () => {
     const wrapper = shallow(<TrafficSplittingFields {...formProps} />);
-    expect(
-      wrapper
-        .find(MultiColumnField)
-        .first()
-        .props().disableAddRow,
-    ).toBe(true);
+    const multiColumnField = wrapper.find(MultiColumnField).first();
+    expect(multiColumnField.props().disableAddRow).toBe(true);
+    expect(multiColumnField.props().tooltipAddRow).toBe(
+      'All revisions are already set to receive traffic',
+    );
   });
 
   it('should exclude the revisions present in values from dropdown items', () => {
@@ -81,11 +68,11 @@ describe('TrafficSplittingFields', () => {
         values={{ trafficSplitting: [{ percent: 100, revisionName: 'overlayimage-fdqsf' }] }}
       />,
     );
-    expect(
-      wrapper
-        .find(TrafficModalRevisionsDropdownField)
-        .first()
-        .props().revisionItems['overlayimage-fdqsf'],
-    ).toBe(undefined);
+    const trafficModalRevisionsDropdownField = wrapper
+      .find(TrafficModalRevisionsDropdownField)
+      .first();
+    expect(trafficModalRevisionsDropdownField.props().revisionItems['overlayimage-fdqsf']).toBe(
+      undefined,
+    );
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5796
https://bugzilla.redhat.com/show_bug.cgi?id=2061301

**Analysis / Root cause**: 
Disabled text, no clear understanding why or how to fix it – nothing to gleam here other than you can't do it.

![image](https://user-images.githubusercontent.com/139310/155813233-33f08237-79dd-4ccc-94a0-f1fc12d938c9.png)

**Solution Description**: 
Add tooltips to the knative traffic splitting modal. On this way refactored and cleanup some props.

The delete button is disabled when there is row left, which means the Service should have at least one assigned Revision. New tooltip:

> Service must have at least one assigned revision

The add button is disabled when there are so many rows added as available revisions. So that the user can not assign any revision twice. New tooltip:

> All revisions are already set to receive traffic

**Screen shots / Gifs for design review**: 

:exclamation: 2nd tooltip on the screenshots and in the video is outdated, it is updated to the strings above, based on this https://github.com/openshift/console/pull/11106#issuecomment-1058490703

Delete:

![image](https://user-images.githubusercontent.com/139310/155813510-9c7e3f77-cc9f-4895-9166-99e889165409.png)

Add:

![image](https://user-images.githubusercontent.com/139310/155813541-30293afb-7822-478f-8504-da49c4bf3b05.png)

Full demo:

https://user-images.githubusercontent.com/139310/155813623-a1cb6f15-e83e-472a-a8b2-bebe673b0cb7.mp4

**Unit test coverage report**: 
Updated TrafficSplittingFields test and created new test for MultiColumnFieldFooter

**Test setup:**
1. Add Knative Service
2. Right click on it and go to Set traffic distribution

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
