### PR TITLE
Bug 2054630: Fix history stack handling when opening the silence alerts form

### DIFF
--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -105,7 +105,7 @@ const pollers = {};
 const pollerTimeouts = {};
 
 const silenceAlert = (alert: Alert) => ({
-  callback: () => history.replace(`${SilenceResource.plural}/~new?${labelsToParams(alert.labels)}`),
+  callback: () => history.push(`${SilenceResource.plural}/~new?${labelsToParams(alert.labels)}`),
   label: i18next.t('public~Silence alert'),
 });
 


### PR DESCRIPTION
**Fixes**: https://bugzilla.redhat.com/show_bug.cgi?id=2054630

**Solution**: Use push instead of replace to allow the user to go back to the correct page when cancelling.

https://user-images.githubusercontent.com/5461414/155974645-765d01be-420d-4099-b002-77774abb66bb.mov


