### PR TITLE
Bug 2058623: updates versions for kafka and kafkaTopic

### DIFF
--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -1454,7 +1454,7 @@
     "properties": {
       "model": {
         "group": "kafka.strimzi.io",
-        "version": "v1beta1",
+        "version": "v1beta2",
         "kind": "Kafka"
       },
       "label": "%knative-plugin~Kafka%",
@@ -1467,7 +1467,7 @@
     "properties": {
       "model": {
         "group": "kafka.strimzi.io",
-        "version": "v1beta1",
+        "version": "v1beta2",
         "kind": "KafkaTopic"
       },
       "label": "%knative-plugin~KafkaTopic%",

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -193,7 +193,7 @@ export const CamelIntegrationModel: K8sKind = {
 
 export const KafkaModel: K8sKind = {
   apiGroup: STRIMZI_KAFKA_APIGROUP,
-  apiVersion: 'v1beta1',
+  apiVersion: 'v1beta2',
   kind: 'Kafka',
   label: 'Kafka',
   // t('knative-plugin~Kafka')
@@ -211,7 +211,7 @@ export const KafkaModel: K8sKind = {
 
 export const KafkaTopicModel: K8sKind = {
   apiGroup: STRIMZI_KAFKA_APIGROUP,
-  apiVersion: 'v1beta1',
+  apiVersion: 'v1beta2',
   kind: 'KafkaTopic',
   label: 'KafkaTopic',
   // t('knative-plugin~KafkaTopic')


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2058623

**Analysis / Root cause**: 
Bootstrap server dropdown menu in Create Event Source- KafkaSource form is empty even if it's created

**Solution Description**: 
Bootstrap server's data is loaded from kafka CR and it's apiVersion supports upgraded to `v1Beta2` thus updating the model apiVersion

**Screen shots / Gifs for design review**: 

<img width="1487" alt="image" src="https://user-images.githubusercontent.com/5129024/156011245-d47fdc38-6cee-4df3-bc54-ccf739f75212.png">



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge