### PR TITLE
Bug 2028366: no hide table/show table button before the search filed on metrics tab

### DIFF
--- a/frontend/__tests__/components/monitoring/metrics.spec.tsx
+++ b/frontend/__tests__/components/monitoring/metrics.spec.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import {
+  QueryBrowserPage,
+  QueryCreationWrapper,
+} from '@console/internal/components/monitoring/metrics';
+import { shallow, ShallowWrapper } from 'enzyme';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useSelector } from 'react-redux';
+
+jest.mock('react-redux', () => {
+  const ActualReactRedux = require.requireActual('react-redux');
+  return {
+    ...ActualReactRedux,
+    useSelector: jest.fn(),
+    useDispatch: jest.fn(),
+  };
+});
+
+describe(QueryBrowserPage.displayName, () => {
+  let queryCreationWrapper: ShallowWrapper;
+
+  it('should not render the `QueriesControls` and the `QueriesList`, when the hideTable state is set to true', () => {
+    // Mocks the hideTable state
+    useSelector.mockReturnValue(true);
+    queryCreationWrapper = shallow(<QueryCreationWrapper />);
+
+    expect(queryCreationWrapper.isEmptyRender()).toBe(true);
+  });
+
+  it('should render the `QueriesControls` and the `QueriesList`, when the hideTable state is set to false', () => {
+    // Mocks the hideTable state
+    useSelector.mockReturnValue(false);
+    queryCreationWrapper = shallow(<QueryCreationWrapper />);
+
+    expect(queryCreationWrapper.isEmptyRender()).toBe(false);
+  });
+});

--- a/frontend/public/actions/observe.ts
+++ b/frontend/public/actions/observe.ts
@@ -26,6 +26,7 @@ export enum ActionType {
   QueryBrowserToggleSeries = 'queryBrowserToggleSeries',
   SetAlertCount = 'SetAlertCount',
   ToggleGraphs = 'toggleGraphs',
+  ToggleTable = 'toggleTable',
 }
 
 export const dashboardsPatchVariable = (key: string, patch: any, perspective: string) =>
@@ -82,6 +83,8 @@ export const alertingSetRules = (key: 'rules' | 'devRules', rules: Rule[], persp
   action(ActionType.AlertingSetRules, { key, data: rules, perspective });
 
 export const toggleGraphs = () => action(ActionType.ToggleGraphs);
+
+export const toggleTable = () => action(ActionType.ToggleTable);
 
 export const queryBrowserAddQuery = () => action(ActionType.QueryBrowserAddQuery);
 
@@ -150,6 +153,7 @@ const actions = {
   queryBrowserToggleSeries,
   setAlertCount,
   toggleGraphs,
+  toggleTable,
 };
 
 export type ObserveAction = Action<typeof actions>;

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -15,6 +15,7 @@ import {
   AngleRightIcon,
   ChartLineIcon,
   CompressIcon,
+  TableIcon,
 } from '@patternfly/react-icons';
 import {
   ISortBy,
@@ -51,6 +52,7 @@ import {
   queryBrowserToggleIsEnabled,
   queryBrowserToggleSeries,
   toggleGraphs,
+  toggleTable,
 } from '../../actions/observe';
 import { RootState } from '../../redux';
 import { fuzzyCaseInsensitive } from '../factory/table-filters';
@@ -201,6 +203,28 @@ export const ToggleGraph: React.FC<{}> = () => {
       variant="link"
     >
       {icon} {hideGraphs ? t('public~Show graph') : t('public~Hide graph')}
+    </Button>
+  );
+};
+
+const ToggleTable: React.FC = () => {
+  const { t } = useTranslation();
+
+  const hideTable = useSelector(({ observe }: RootState) => !!observe.get('hideTable'));
+
+  const dispatch = useDispatch();
+  const toggle = React.useCallback(() => dispatch(toggleTable()), [dispatch]);
+
+  const icon = hideTable ? <TableIcon /> : <CompressIcon />;
+
+  return (
+    <Button
+      type="button"
+      className="pf-m-link--align-right query-browser__toggle-graph"
+      onClick={toggle}
+      variant="link"
+    >
+      {icon} {hideTable ? t('public~Show table') : t('public~Hide table')}
     </Button>
   );
 };
@@ -993,18 +1017,16 @@ const QueryBrowserPage_: React.FC<{}> = () => {
         <div className="row">
           <div className="col-xs-12">
             <QueryBrowserWrapper />
-            <div className="query-browser__controls">
-              <div className="query-browser__controls--left">
-                <MetricsDropdown />
-              </div>
-              <div className="query-browser__controls--right">
-                <ActionGroup className="pf-c-form pf-c-form__group--no-top-margin">
-                  <AddQueryButton />
-                  <RunQueriesButton />
-                </ActionGroup>
-              </div>
-            </div>
-            <QueriesList />
+          </div>
+        </div>
+        <div className="row">
+          <div className="col-xs-12">
+            <ToggleTable />
+          </div>
+        </div>
+        <div className="row">
+          <div className="col-xs-12">
+            <QueryCreationWrapper />
           </div>
         </div>
       </div>
@@ -1012,6 +1034,38 @@ const QueryBrowserPage_: React.FC<{}> = () => {
   );
 };
 export const QueryBrowserPage = withFallback(QueryBrowserPage_);
+QueryBrowserPage.displayName = 'QueryBrowserPage';
+
+export const QueryCreationWrapper: React.FC = () => {
+  const hideTable = useSelector(({ observe }: RootState) => !!observe.get('hideTable'));
+
+  if (hideTable) {
+    return null;
+  }
+
+  return (
+    <>
+      <QueriesControls />
+      <QueriesList />
+    </>
+  );
+};
+
+const QueriesControls: React.FC = () => {
+  return (
+    <div className="query-browser__controls">
+      <div className="query-browser__controls--left">
+        <MetricsDropdown />
+      </div>
+      <div className="query-browser__controls--right">
+        <ActionGroup className="pf-c-form pf-c-form__group--no-top-margin">
+          <AddQueryButton />
+          <RunQueriesButton />
+        </ActionGroup>
+      </div>
+    </div>
+  );
+};
 
 type MetricsDropdownItems = {
   [key: string]: string;

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -152,6 +152,9 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
     case ActionType.ToggleGraphs:
       return state.set('hideGraphs', !state.get('hideGraphs'));
 
+    case ActionType.ToggleTable:
+      return state.set('hideTable', !state.get('hideTable'));
+
     case ActionType.QueryBrowserAddQuery:
       return state.setIn(
         ['queryBrowser', 'queries'],


### PR DESCRIPTION
Add a show/hide table button, which hides created queries, query creation dialog and the query controls.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2028366