### PR TITLE
Bug 2058051: Exposing Kubevirt dynamic plugin missing yaml editor

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
@@ -10,6 +10,7 @@ import {
   ResourceInventoryItemProps,
   DetailItemProps,
   DetailsBodyProps,
+  DroppableEditYAMLProps,
   UtilizationItemProps,
   UtilizationBodyProps,
   UtilizationDurationDropdownProps,
@@ -52,6 +53,9 @@ export const VirtualizedGrid: React.FC<VirtualizedGridProps> = require('@console
   .default;
 export const LazyActionMenu: React.FC<LazyActionMenuProps> = require('@console/shared/src/components/actions/LazyActionMenu')
   .default;
+
+export const DroppableEditYAML: React.FC<DroppableEditYAMLProps> = require('@console/internal/components/droppable-edit-yaml')
+  .DroppableEditYAML;
 
 export const useUtilizationDuration: UseUtilizationDuration = require('@console/shared/src/hooks/useUtilizationDuration')
   .useUtilizationDuration;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
@@ -249,3 +249,8 @@ export enum ActionMenuVariant {
   KEBAB = 'plain',
   DROPDOWN = 'default',
 }
+
+export type DroppableEditYAMLProps = {
+  allowMultiple?: boolean;
+  obj: string;
+};

--- a/frontend/public/components/droppable-edit-yaml.tsx
+++ b/frontend/public/components/droppable-edit-yaml.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { NativeTypes } from 'react-dnd-html5-backend';
 import { DropTarget } from 'react-dnd';
+import { DroppableEditYAMLProps } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 
 import { EditYAML } from './edit-yaml';
 import withDragDropContext from './utils/drag-drop-context';
@@ -123,10 +124,7 @@ type EditYAMLProps = {
   clearFileUpload: () => void;
 };
 
-export type DroppableEditYAMLProps = {
-  allowMultiple?: boolean;
-  obj: string;
-};
+export { DroppableEditYAMLProps };
 
 export type DroppedFile = {
   error?: string;


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

This PR exposes the following via Console internal SDK package @openshift-console/dynamic-plugin-sdk-internal

1. DroppableEditYAML