### PR TITLE
Bug 2059674: Adjusts the Dynamic Demo Plugin and the SDK to meet on the usecases

### DIFF
--- a/dynamic-demo-plugin/src/components/k8sConsumer/K8sAPIConsumer.tsx
+++ b/dynamic-demo-plugin/src/components/k8sConsumer/K8sAPIConsumer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'react-i18next';
 import {
   Alert,
   AlertGroup,
@@ -9,12 +9,22 @@ import {
   Page,
   PageSection,
   Title,
-} from "@patternfly/react-core";
-import { getGroupVersionKindForResource, k8sCreate, k8sDelete, k8sGet, k8sList, k8sPatch, K8sResourceCommon, k8sUpdate, useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
+} from '@patternfly/react-core';
+import {
+  getGroupVersionKindForResource,
+  k8sCreate,
+  k8sDelete,
+  k8sGet,
+  k8sList,
+  k8sPatch,
+  K8sResourceCommon,
+  k8sUpdate,
+  useK8sModel,
+} from '@openshift-console/dynamic-plugin-sdk';
 import { mockDeploymetData } from './k8s-data';
 
 const K8sAPIConsumer: React.FC = () => {
-  const { t } = useTranslation("plugin__console-demo-plugin");
+  const { t } = useTranslation('plugin__console-demo-plugin');
   const [k8sModel] = useK8sModel(getGroupVersionKindForResource(mockDeploymetData));
   const [errData, setErrData] = React.useState<string>();
   const [k8sCreateData, setK8sCreateData] = React.useState<K8sResourceCommon>();
@@ -25,148 +35,161 @@ const K8sAPIConsumer: React.FC = () => {
   const [k8sDeleteData, setK8sDeleteData] = React.useState<K8sResourceCommon>();
 
   const k8sCreateClick = () => {
-    k8sCreate({model: k8sModel, data: mockDeploymetData}).then((response) => {
-      setErrData('');
-      setK8sCreateData(response);
-    })
-    .catch((e) => {
-      setErrData(e.message)
-      console.error(e);
-     }
-    );
-  }
+    k8sCreate({ model: k8sModel, data: mockDeploymetData })
+      .then((response) => {
+        setErrData('');
+        setK8sCreateData(response);
+      })
+      .catch((e) => {
+        setErrData(e.message);
+        console.error(e);
+      });
+  };
 
   const k8sGetClick = () => {
-    k8sGet({model: k8sModel, name: 'sampleapp', ns:'default'}).then((response) => {
-      setErrData('');
-      setK8sGetData(response);
-    })
-    .catch((e) => {
-      setErrData(e.message)
-      console.error(e);
-     }
-    );
-  }
+    k8sGet({ model: k8sModel, name: 'sampleapp', ns: 'default' })
+      .then((response) => {
+        setErrData('');
+        setK8sGetData(response);
+      })
+      .catch((e) => {
+        setErrData(e.message);
+        console.error(e);
+      });
+  };
 
   const k8sPatchClick = () => {
-    const patchData = [{
-      op: 'replace',
-      path: '/metadata/labels',
-      value: {
-        app: 'httpd',
-        appPatch: 'patch',
+    const patchData = [
+      {
+        op: 'replace',
+        path: '/metadata/labels',
+        value: {
+          app: 'httpd',
+          appPatch: 'patch',
+        },
       },
-    }];
-    
-    k8sPatch({model: k8sModel, resource: mockDeploymetData, data: patchData}).then((response) => {
-      setErrData('');
-      setK8sPatchData(response);
-    })
-    .catch((e) => {
-      setErrData(e.message)
-      console.error(e);
-     }
-    );
-  }
+    ];
+
+    k8sPatch({ model: k8sModel, resource: mockDeploymetData, data: patchData })
+      .then((response) => {
+        setErrData('');
+        setK8sPatchData(response);
+      })
+      .catch((e) => {
+        setErrData(e.message);
+        console.error(e);
+      });
+  };
 
   const k8sUpdateClick = () => {
     const updatedData = {
       ...mockDeploymetData,
-       metadata: {
-         ...mockDeploymetData.metadata,
-         labels: {
+      metadata: {
+        ...mockDeploymetData.metadata,
+        labels: {
           app: 'httpd',
           appUpdate: 'updated',
         },
-      }
+      },
     };
-    k8sUpdate({model: k8sModel, data: updatedData}).then((response) => {
-      setErrData('');
-      setK8sUpdateData(response);
-    })
-    .catch((e) => {
-      setErrData(e.message)
-      console.error(e);
-     }
-    );
-  }
+    k8sUpdate({ model: k8sModel, data: updatedData })
+      .then((response) => {
+        setErrData('');
+        setK8sUpdateData(response);
+      })
+      .catch((e) => {
+        setErrData(e.message);
+        console.error(e);
+      });
+  };
 
   const k8sListClick = () => {
-    k8sList({model: k8sModel, queryParams: {ns: 'default'}}).then((response) => {
-      setErrData('');
-      setK8sListData(response);
-    })
-    .catch((e) => {
-      setErrData(e.message)
-      console.error(e);
-     }
-    );
-  }
+    k8sList({ model: k8sModel, queryParams: { ns: 'default' } })
+      .then((response) => {
+        setErrData('');
+        if (Array.isArray(response)) {
+          setK8sListData(response);
+        } else {
+          setK8sListData(response.items);
+        }
+      })
+      .catch((e) => {
+        setErrData(e.message);
+        console.error(e);
+      });
+  };
 
   const k8sDeleteClick = () => {
-    k8sDelete({model: k8sModel, resource: mockDeploymetData}).then((response) => {
-      setErrData('');
-      setK8sDeleteData(response);
-    })
-    .catch((e) => {
-      setErrData(e.message)
-      console.error(e);
-     }
-    );
-  }
-
+    k8sDelete({ model: k8sModel, resource: mockDeploymetData })
+      .then((response) => {
+        setErrData('');
+        setK8sDeleteData(response);
+      })
+      .catch((e) => {
+        setErrData(e.message);
+        console.error(e);
+      });
+  };
 
   return (
     <Page
       additionalGroupedContent={
         <PageSection variant="light">
-          <Title headingLevel="h1">
-            {t("K8s API from Dynamic Plugin SDK")}
-          </Title>
+          <Title headingLevel="h1">{t('K8s API from Dynamic Plugin SDK')}</Title>
         </PageSection>
       }
     >
       <PageSection>
-        {errData && <AlertGroup>
-            <Alert
-              title={errData}
-              variant="warning"
-              isInline
-            />
-          </AlertGroup>}
+        {errData && (
+          <AlertGroup>
+            <Alert title={errData} variant="warning" isInline />
+          </AlertGroup>
+        )}
         <Card>
           <CardBody>
-            <Button isBlock onClick={k8sCreateClick}>{t("k8sCreate")}</Button>
+            <Button isBlock onClick={k8sCreateClick}>
+              {t('k8sCreate')}
+            </Button>
             <ConsoleK8sAPIConsumer data={k8sCreateData} />
           </CardBody>
         </Card>
         <Card>
           <CardBody>
-            <Button isBlock onClick={k8sGetClick}>{t("k8sGet")}</Button>
+            <Button isBlock onClick={k8sGetClick}>
+              {t('k8sGet')}
+            </Button>
             <ConsoleK8sAPIConsumer data={k8sGetData} />
           </CardBody>
         </Card>
         <Card>
           <CardBody>
-            <Button isBlock onClick={k8sPatchClick}>{t("k8sPatch")}</Button>
+            <Button isBlock onClick={k8sPatchClick}>
+              {t('k8sPatch')}
+            </Button>
             <ConsoleK8sAPIConsumer data={k8sPatchData} />
           </CardBody>
         </Card>
         <Card>
           <CardBody>
-            <Button isBlock onClick={k8sUpdateClick}>{t("k8sUpdate")}</Button>
+            <Button isBlock onClick={k8sUpdateClick}>
+              {t('k8sUpdate')}
+            </Button>
             <ConsoleK8sAPIConsumer data={k8sUpdateData} />
           </CardBody>
         </Card>
         <Card>
           <CardBody>
-            <Button isBlock onClick={k8sListClick}>{t("k8sList")}</Button>
+            <Button isBlock onClick={k8sListClick}>
+              {t('k8sList')}
+            </Button>
             <ConsoleK8sAPIConsumer data={k8sListData} />
           </CardBody>
         </Card>
         <Card>
           <CardBody>
-            <Button isBlock onClick={k8sDeleteClick}>{t("k8sDelete")}</Button>
+            <Button isBlock onClick={k8sDeleteClick}>
+              {t('k8sDelete')}
+            </Button>
             <ConsoleK8sAPIConsumer data={k8sDeleteData} />
           </CardBody>
         </Card>
@@ -175,10 +198,8 @@ const K8sAPIConsumer: React.FC = () => {
   );
 };
 
-const ConsoleK8sAPIConsumer: React.FC<{data: any}> = ({data}) => {
-  return (
-      <pre>{JSON.stringify(data, null, 2)}</pre>
-  );
+const ConsoleK8sAPIConsumer: React.FC<{ data: any }> = ({ data }) => {
+  return <pre>{JSON.stringify(data, null, 2)}</pre>;
 };
 
 export default K8sAPIConsumer;

--- a/dynamic-demo-plugin/src/components/k8sConsumer/K8sAPIConsumer.tsx
+++ b/dynamic-demo-plugin/src/components/k8sConsumer/K8sAPIConsumer.tsx
@@ -15,7 +15,7 @@ import {
   k8sCreate,
   k8sDelete,
   k8sGet,
-  k8sList,
+  k8sListItems,
   k8sPatch,
   K8sResourceCommon,
   k8sUpdate,
@@ -104,14 +104,10 @@ const K8sAPIConsumer: React.FC = () => {
   };
 
   const k8sListClick = () => {
-    k8sList({ model: k8sModel, queryParams: { ns: 'default' } })
+    k8sListItems({ model: k8sModel, queryParams: { ns: 'default' } })
       .then((response) => {
         setErrData('');
-        if (Array.isArray(response)) {
-          setK8sListData(response);
-        } else {
-          setK8sListData(response.items);
-        }
+        setK8sListData(response);
       })
       .catch((e) => {
         setErrData(e.message);

--- a/dynamic-demo-plugin/src/components/k8sConsumer/k8s-data.ts
+++ b/dynamic-demo-plugin/src/components/k8sConsumer/k8s-data.ts
@@ -28,6 +28,7 @@ export const mockDeploymetData = {
             image: 'image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest',
             ports: [
               {
+                protocol: 'tcp',
                 containerPort: 8080,
               },
             ],

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -77,7 +77,7 @@ export {
   checkAccess,
   useAccessReview,
   useAccessReviewAllowed,
-} from '@console/dynamic-plugin-sdk/src/app/components/utils/rbac';
+} from '../app/components/utils/rbac';
 
 export {
   useK8sModel,
@@ -100,6 +100,7 @@ export {
   k8sPatchResource as k8sPatch,
   k8sDeleteResource as k8sDelete,
   k8sListResource as k8sList,
+  k8sListResourceItems as k8sListItems,
 } from '../utils/k8s';
 export {
   getAPIVersionForModel,

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-resource.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-resource.ts
@@ -414,3 +414,17 @@ export const k8sListResource: K8sListResource = adapterFunc(k8sList, [
   'requestInit',
   'cluster',
 ]);
+
+/**
+ * Same interface as {@link k8sListResource} but returns the sub items.
+ * @see K8sListResource
+ */
+export const k8sListResourceItems = <R extends K8sResourceCommon>(
+  options: OptionsList,
+): Promise<R[]> =>
+  k8sListResource<R>(options).then((response) => {
+    if (Array.isArray(response)) {
+      return response;
+    }
+    return response.items;
+  });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-resource.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-resource.ts
@@ -320,8 +320,8 @@ export const k8sKill = <R extends K8sResourceCommon>(
 type OptionsDelete<R> = BaseOptions & {
   model: K8sModel;
   resource: R;
-  requestInit: RequestInit;
-  json: Record<string, any>;
+  requestInit?: RequestInit;
+  json?: Record<string, any>;
 };
 
 type K8sDeleteResource = <R extends K8sResourceCommon>(options: OptionsDelete<R>) => Promise<R>;
@@ -391,7 +391,7 @@ export const k8sList = (
 type OptionsList = {
   model: K8sModel;
   queryParams: { [key: string]: any };
-  requestInit: RequestInit;
+  requestInit?: RequestInit;
 };
 
 type K8sListResource = <R extends K8sResourceCommon>(


### PR DESCRIPTION
Fixes build issues with the Dynamic Demo Plugin.

`K8sAPIConsumer.tsx` Formatting changes - Not sure why, but our demo plugin wasn't lint'ed/prettier'ed to the same structure as the monorepo. Seems like an oversight but probably because of configuration issues. My IDE caught this as it's configured to look for it and apply it when applicable. I can undo the formatting changes if needed.

Odd our Delete & List commands had required properties. Adjusted to fix them (the real issue).