### PR TITLE
Bug 2050637: add a hardcoded blog link as fallback in guided tours

### DIFF
--- a/frontend/packages/dev-console/src/components/guided-tour/GuidedTourText.tsx
+++ b/frontend/packages/dev-console/src/components/guided-tour/GuidedTourText.tsx
@@ -77,9 +77,9 @@ const FinishTourText: React.FC = () => {
     optional: true,
   });
   const { t } = useTranslation();
-  const openshiftBlogLink = consoleLinks.filter(
-    (link: K8sResourceKind) => link.metadata.name === 'openshift-blog',
-  )[0]?.spec?.href;
+  const openshiftBlogLink =
+    consoleLinks.filter((link: K8sResourceKind) => link.metadata.name === 'openshift-blog')[0]?.spec
+      ?.href || 'https://developers.redhat.com/products/openshift/whats-new';
   // declaring openshiftHelpBase instead of importing because it throws error while using it as tour extension
   const openshiftHelpBase =
     window.SERVER_FLAGS.documentationBaseURL || 'https://docs.okd.io/latest/';

--- a/frontend/packages/dev-console/src/components/guided-tour/GuidedTourText.tsx
+++ b/frontend/packages/dev-console/src/components/guided-tour/GuidedTourText.tsx
@@ -70,7 +70,7 @@ export const SearchTourText: React.FC = () => {
 
 export const searchTourText = <SearchTourText />;
 
-const FinishTourText: React.FC = () => {
+export const FinishTourText: React.FC = () => {
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     kind: referenceForModel(ConsoleLinkModel),
@@ -86,11 +86,21 @@ const FinishTourText: React.FC = () => {
   return (
     <Trans t={t} ns="devconsole">
       Stay up-to-date with everything OpenShift on our{' '}
-      <a href={openshiftBlogLink} target="_blank" rel="noopener noreferrer">
+      <a
+        href={openshiftBlogLink}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-test="openshift-blog-link"
+      >
         blog
       </a>{' '}
       or continue to learn more in our{' '}
-      <a href={openshiftHelpBase} target="_blank" rel="noopener noreferrer">
+      <a
+        href={openshiftHelpBase}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-test="openshift-docs-link"
+      >
         documentation
       </a>
       .

--- a/frontend/packages/dev-console/src/components/guided-tour/__tests__/GuidedTourText.spec.tsx
+++ b/frontend/packages/dev-console/src/components/guided-tour/__tests__/GuidedTourText.spec.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { cleanup, configure, render, screen } from '@testing-library/react';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { FinishTourText } from '../GuidedTourText';
+
+configure({ testIdAttribute: 'data-test' });
+
+jest.mock('@console/internal/components/utils/k8s-watch-hook', () => {
+  return {
+    useK8sWatchResource: jest.fn(),
+  };
+});
+
+describe('GuidedTourText', () => {
+  afterEach(() => cleanup());
+
+  it('should render openshift-blog and openshift-docs link', () => {
+    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true, '']);
+    render(<FinishTourText />);
+
+    screen.getByTestId('openshift-blog-link');
+    screen.getByTestId('openshift-docs-link');
+  });
+
+  it('should render the openshift-blog href with link from consoleLinks', () => {
+    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([
+      [{ metadata: { name: 'openshift-blog' }, spec: { href: 'https://blog.openshift.com/' } }],
+      true,
+      '',
+    ]);
+    const { getByTestId } = render(<FinishTourText />);
+    expect(getByTestId('openshift-blog-link').getAttribute('href')).toEqual(
+      'https://blog.openshift.com/',
+    );
+  });
+
+  it('should render the openshift-blog href with default link if consoleLinks are not available', () => {
+    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true, '']);
+    const { getByTestId } = render(<FinishTourText />);
+    expect(getByTestId('openshift-blog-link').getAttribute('href')).toEqual(
+      'https://developers.redhat.com/products/openshift/whats-new',
+    );
+  });
+
+  it('should render openshift-docs href with default link', () => {
+    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true, '']);
+    const { getByTestId } = render(<FinishTourText />);
+    expect(getByTestId('openshift-docs-link').getAttribute('href')).toEqual(
+      'https://docs.okd.io/latest/',
+    );
+  });
+});


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/OCPBUGSM-40325
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: ConsoleLinks CR is not available at times which causes the blog link to be undefined
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: add a fallback link for blogs
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Kapture 2022-03-02 at 12 16 24](https://user-images.githubusercontent.com/9278015/156310926-9d9e84bd-3787-4cc3-a171-d215da203789.gif)

**Unit test coverage report**: None
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
