### PR TITLE
Fix ActionContext warning

### DIFF
--- a/frontend/packages/console-shared/src/components/actions/types.ts
+++ b/frontend/packages/console-shared/src/components/actions/types.ts
@@ -1,10 +1,5 @@
 import { Action, ActionGroup } from '@console/dynamic-plugin-sdk';
 
-export {
-  ActionContext,
-  ActionMenuVariant,
-} from '@console/dynamic-plugin-sdk/src/api/internal-types';
-
 export type MenuOption = Action | GroupedMenuOption;
 
 export type GroupedMenuOption = ActionGroup['properties'] & {
@@ -23,3 +18,16 @@ export type ActionService = {
   loaded: boolean;
   error: any;
 };
+
+/** Type from @console/dynamic-plugin-sdk/src/api/internal-types */
+// Copied version to fix a warning because of an cycling dependency between console-shared and dynamic-plugin-sdk
+export type ActionContext = {
+  [contextId: string]: any;
+};
+
+/** Type from @console/dynamic-plugin-sdk/src/api/internal-types */
+// Copied version to fix a warning because of an cycling dependency between console-shared and dynamic-plugin-sdk
+export enum ActionMenuVariant {
+  KEBAB = 'plain',
+  DROPDOWN = 'default',
+}


### PR DESCRIPTION
**Fixes**: 
todo

**Analysis / Root cause**: 
Didn't lookup which PRs introduce this, but it happens because of cycling dependencies between console-shared and dynamic-plugin-sdk.

**Solution Description**: 
As a workaround to fix this annoying ActionContext warning by cloning some types instead of using an export from the other package.

**Screen shots / Gifs for design review**: 


**Unit test coverage report**: 
not touched

**Test setup:**
Run `yarn dev` and open the console.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
