### PR TITLE
Bug 2009345: Fix potential issues with namespaces that contains just numbers (crashes on 4.7)

### DIFF
--- a/frontend/packages/console-app/src/components/detect-namespace/useLastNamespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/useLastNamespace.ts
@@ -8,8 +8,14 @@ export const useLastNamespace = (): [
   string,
   React.Dispatch<React.SetStateAction<string>>,
   boolean,
-] =>
-  useUserSettingsCompatibility<string>(
-    LAST_NAMESPACE_NAME_USER_SETTINGS_KEY,
-    LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
-  );
+] => {
+  const [lastNamespace, setLastNamespace, lastNamespaceLoaded] = useUserSettingsCompatibility<
+    string
+  >(LAST_NAMESPACE_NAME_USER_SETTINGS_KEY, LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY);
+
+  // This toString is workaround because the useUserSettings hook returns a number or boolean
+  // when the saved value represents a number (1234) or boolean (true/false).
+  // This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2009345.
+  // We will implement a more generic fix with https://issues.redhat.com/browse/ODC-6514
+  return [lastNamespace?.toString(), setLastNamespace, lastNamespaceLoaded];
+};

--- a/frontend/packages/console-app/src/components/user-preferences/namespace/usePreferredNamespace.ts
+++ b/frontend/packages/console-app/src/components/user-preferences/namespace/usePreferredNamespace.ts
@@ -7,5 +7,10 @@ export const usePreferredNamespace = (): [string, Dispatch<SetStateAction<string
   const [preferredNamespace, setPreferredNamespace, preferredNamespaceLoaded] = useUserSettings<
     string
   >(PREFERRED_NAMESPACE_USER_SETTING_KEY);
-  return [preferredNamespace, setPreferredNamespace, preferredNamespaceLoaded];
+
+  // This toString is workaround because the useUserSettings hook returns a number or boolean
+  // when the saved value represents a number (1234) or boolean (true/false).
+  // This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2009345.
+  // We will implement a more generic fix with https://issues.redhat.com/browse/ODC-6514
+  return [preferredNamespace?.toString(), setPreferredNamespace, preferredNamespaceLoaded];
 };


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2009345

**Analysis / Root cause**: 
The last-used namespace was saved in the user settings `ConfigMap` and was NOT serialized by this method because its already a string. But the issue is that the deserialization method expects that these values are INVALID JSON strings.

For example, the string `"my-namespace"` was returned in the catch block as it is. But this doesn't work for the last-used namespace string `"1234"` because it could be parsed and returned as 1234 (number).

https://github.com/openshift/console/blob/a29393276bd16974162fa11462aeb1f1129747ad/frontend/packages/console-shared/src/utils/user-settings.ts#L58-L67

**Solution Description**: 
The initial PR tried to solve this in a generic way, which wasn't that easy. We will implement this in a more generic way with https://issues.redhat.com/browse/ODC-6514

For now this just adds a workaround after loading the namespace and adds `?.toString()` here.

**Screen shots / Gifs for design review**: 
UI is uneffected.

**Unit test coverage report**: 
Not changed

**Test setup:**
Please note, this PR fixes just a potential issue on master. But we want backport this to 4.7 because it results in a crash there.

1. Create a namespace with just numbers (1234)
2. Switch to that namespace
3. Reload the console and open a URL without the namespace included (`/` or `/add` for example)

This issue has different behavior on the different versions and it is primarily here to fix a crash in 4.7. So this might be the most interesting PR.

* 4.6: Just works fine
* 4.7: Crash
* 4.8: Does not crash, but the namespace was not automatically selected when switching to it.
* 4.9-4.11: Works fine, but update the hook to fix potential other issues when a namespace is a number.

PRs:

* master: #11126
* 4.10: #11132
* 4.9: #11133
* 4.8: #11134
* 4.7: #11135

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
