### PR TITLE
CONSOLE-3087: Fix ActionContext type warning in components/actions/types.ts

### DIFF
--- a/frontend/packages/console-shared/src/components/actions/types.ts
+++ b/frontend/packages/console-shared/src/components/actions/types.ts
@@ -1,12 +1,9 @@
 import { Action, ActionGroup } from '@console/dynamic-plugin-sdk';
+import { ActionContext as ActionContextType } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 
-export type {
-  ActionContext
-} from '@console/dynamic-plugin-sdk/src/api/internal-types';
+export { ActionMenuVariant } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 
-export {
-  ActionMenuVariant
-} from '@console/dynamic-plugin-sdk/src/api/internal-types';
+export type ActionContext = ActionContextType;
 
 export type MenuOption = Action | GroupedMenuOption;
 

--- a/frontend/packages/console-shared/src/components/actions/types.ts
+++ b/frontend/packages/console-shared/src/components/actions/types.ts
@@ -1,8 +1,11 @@
 import { Action, ActionGroup } from '@console/dynamic-plugin-sdk';
 
+export type {
+  ActionContext
+} from '@console/dynamic-plugin-sdk/src/api/internal-types';
+
 export {
-  ActionContext,
-  ActionMenuVariant,
+  ActionMenuVariant
 } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 
 export type MenuOption = Action | GroupedMenuOption;


### PR DESCRIPTION
See thread in slack: https://coreos.slack.com/archives/C6A3NV5J9/p1646236086835589

Warning seems to have been introduced in https://github.com/openshift/console/pull/11074

### Before:
<img width="725" alt="image" src="https://user-images.githubusercontent.com/21317056/156414283-eebd505d-39c5-448f-abbf-a536e5124dab.png">

### After:
<img width="329" alt="image" src="https://user-images.githubusercontent.com/21317056/156414119-063435c2-214c-417b-aaed-fc32e5d67da7.png">

CC @vojtechszocs @andrewballantyne 