### PR TITLE
Bug 2013109: Refresh toaster takes user to operatorhub page

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -50,6 +50,7 @@ import {
   useURLPoll,
   URL_POLL_DEFAULT_DELAY,
 } from '@console/internal/components/utils/url-poll-hook';
+import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
 import { init as initI18n } from '../i18n';
 import '../vendor.scss';
 import '../style.scss';
@@ -384,7 +385,7 @@ const PollConsoleUpdates = React.memo(function PollConsoleUpdates() {
         label: t('public~Refresh web console'),
         callback: () => {
           if (window.location.pathname.includes('/operatorhub/subscribe')) {
-            window.location.href = '/operatorhub';
+            window.location.href = `/k8s/all-namespaces/${ClusterServiceVersionModel.apiGroup}~${ClusterServiceVersionModel.apiVersion}~${ClusterServiceVersionModel.kind}`;
           } else {
             window.location.reload();
           }


### PR DESCRIPTION
We previously delivered a change to redirect users to the operatorhub page when the refresh toaster was clicked while an operator was being installed. See https://github.com/openshift/console/pull/10373

It makes more sense to redirect users to the installed operator page if they click the refresh toaster while an operator is installing.

https://bugzilla.redhat.com/show_bug.cgi?id=2013109

After the change:
![Mar-02-2022 13-16-42](https://user-images.githubusercontent.com/21317056/156423352-28c02372-20a6-45a4-b39c-b7289c33f421.gif)
