### PR TITLE
Bug 2019564: attach owner reference to resources created on creating a user to allow garbage collection

### DIFF
--- a/pkg/usersettings/handlers.go
+++ b/pkg/usersettings/handlers.go
@@ -176,5 +176,5 @@ func (h *UserSettingsHandler) getUserSettingMeta(context context.Context, user *
 		return nil, err
 	}
 
-	return newUserSettingMeta(userInfo.GetName(), string(userInfo.GetUID()))
+	return newUserSettingMeta(userInfo)
 }

--- a/pkg/usersettings/types.go
+++ b/pkg/usersettings/types.go
@@ -1,10 +1,15 @@
 package usersettings
 
+import (
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 type UserSettingMeta struct {
 	Username string
 	UID      string
 	// The resource identifier contains "kubeadmin" for the kubeadmin and the user uid otherwise.
 	ResourceIdentifier string
+	OwnerReferences    []meta.OwnerReference
 }
 
 func (r *UserSettingMeta) getConfigMapName() string {


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2019564

**Analysis/Root cause:**
Creating a `User` in console automatically creates three resources in the namespace `openshift-console-user-settings`, viz. `a Role, a RoleBinding and a ConfigMap`. Even though these resources are specific to the `User`, but they are not dependent on the it.
So, when the `User` is deleted, these resources do not get deleted with the user and persists as remnants of the user in the `openshift-console-user-settings`.

**Solution/Description:**
At the time of creation of the resources for a `User`, an `ownerReference` referencing the `User` object is added to their `metadata`  which makes the resources dependent on the `User`. This allows garbage collection to automatically delete the resources when the `User` no longer exists.

**Screens:**

https://user-images.githubusercontent.com/38663217/157125850-b857e4b9-ac18-43d3-a334-74110a828d56.mp4

**Test Coverage:**
```
go test -coverprofile=coverage.out ./pkg/usersettings
ok      github.com/openshift/console/pkg/usersettings   0.010s  coverage: 19.1% of statements
❯ go tool cover -func=coverage.out
github.com/openshift/console/pkg/usersettings/handlers.go:37:   HandleUserSettings              0.0%
github.com/openshift/console/pkg/usersettings/handlers.go:80:   sendErrorResponse               0.0%
github.com/openshift/console/pkg/usersettings/handlers.go:93:   getUserSettings                 0.0%
github.com/openshift/console/pkg/usersettings/handlers.go:99:   createUserSettings              0.0%
github.com/openshift/console/pkg/usersettings/handlers.go:131:  deleteUserSettings              0.0%
github.com/openshift/console/pkg/usersettings/handlers.go:150:  createServiceAccountClient      0.0%
github.com/openshift/console/pkg/usersettings/handlers.go:159:  createUserProxyClient           0.0%
github.com/openshift/console/pkg/usersettings/handlers.go:168:  getUserSettingMeta              0.0%
github.com/openshift/console/pkg/usersettings/helpers.go:12:    newUserSettingMeta              100.0%
github.com/openshift/console/pkg/usersettings/helpers.go:43:    createRole                      100.0%
github.com/openshift/console/pkg/usersettings/helpers.go:76:    createRoleBinding               100.0%
github.com/openshift/console/pkg/usersettings/helpers.go:101:   createConfigMap                 100.0%
github.com/openshift/console/pkg/usersettings/types.go:15:      getConfigMapName                100.0%
github.com/openshift/console/pkg/usersettings/types.go:19:      getRoleName                     100.0%
github.com/openshift/console/pkg/usersettings/types.go:23:      getRoleBindingName              100.0%
total:                                                          (statements)                    19.1%
```

Browser conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge