### PR TITLE
[release-4.9] Bug 2060449: Fix potential issues with namespaces that contains just numbers

### DIFF
--- a/frontend/packages/console-app/src/components/detect-namespace/useLastNamespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/useLastNamespace.ts
@@ -8,8 +8,14 @@ export const useLastNamespace = (): [
   string,
   React.Dispatch<React.SetStateAction<string>>,
   boolean,
-] =>
-  useUserSettingsCompatibility<string>(
-    LAST_NAMESPACE_NAME_USER_SETTINGS_KEY,
-    LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
-  );
+] => {
+  const [lastNamespace, setLastNamespace, lastNamespaceLoaded] = useUserSettingsCompatibility<
+    string
+  >(LAST_NAMESPACE_NAME_USER_SETTINGS_KEY, LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY);
+
+  // This toString is workaround because the useUserSettings hook returns a number or boolean
+  // when the saved value represents a number (1234) or boolean (true/false).
+  // This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2009345.
+  // We will implement a more generic fix with https://issues.redhat.com/browse/ODC-6514
+  return [lastNamespace?.toString(), setLastNamespace, lastNamespaceLoaded];
+};

--- a/frontend/packages/console-app/src/components/user-preferences/namespace/usePreferredNamespace.ts
+++ b/frontend/packages/console-app/src/components/user-preferences/namespace/usePreferredNamespace.ts
@@ -7,5 +7,10 @@ export const usePreferredNamespace = (): [string, Dispatch<SetStateAction<string
   const [preferredNamespace, setPreferredNamespace, preferredNamespaceLoaded] = useUserSettings<
     string
   >(PREFERRED_NAMESPACE_USER_SETTING_KEY);
-  return [preferredNamespace, setPreferredNamespace, preferredNamespaceLoaded];
+
+  // This toString is workaround because the useUserSettings hook returns a number or boolean
+  // when the saved value represents a number (1234) or boolean (true/false).
+  // This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2009345.
+  // We will implement a more generic fix with https://issues.redhat.com/browse/ODC-6514
+  return [preferredNamespace?.toString(), setPreferredNamespace, preferredNamespaceLoaded];
 };


### PR DESCRIPTION
Manually backport of #11129 

This issue has different behavior on the different versions and it is primarily here to fix a crash in 4.7:

* 4.6: Just works fine
* 4.7: Crash
* 4.8: Does not crash, but the namespace was not automatically selected when switching to it.
* 4.9-4.11: Works fine, but update the hook to fix potential other issues when a namespace is a number.

So this might be the most interesting PR:

* master: #11126
* 4.10: #11132
* 4.9: #11133
* 4.8: #11134
* 4.7: #11135
