### PR TITLE
CONSOLE-3081: [Dark theme] Changes to support the events and project select bar when in dark theme mode

### DIFF
--- a/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.scss
+++ b/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.scss
@@ -23,7 +23,8 @@
 // more closely match the custom DropDown based drop down.
 // These are displayed side by site in the Developer view > Topology view.active.
 // Once the custom DropDown component changes to the PatternFly component, these styles can be removed.
-.co-namespace-dropdown__menu-toggle {
+.pf-c-menu-toggle.co-namespace-dropdown__menu-toggle {
+  background-color: var(--co-namespace-dropdown__menu-toggle--BackgroundColor, inherit); // Button should inherit the same backgound as the co-namespace-bar
   font-size: ($font-size-base + 1) !important;
   padding: 2px 0 !important;
   width: 100%;

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -61,7 +61,7 @@ $dropdown-background--hover: $pf-color-black-200; // pf-c-dropdown__menu-item--h
 }
 
 .co-namespace-bar {
-  border-bottom: 1px solid $color-grey-background-border;
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   padding: 0 $pf-global-gutter;
   white-space: nowrap;
 

--- a/frontend/public/components/_horizontal-nav.scss
+++ b/frontend/public/components/_horizontal-nav.scss
@@ -1,7 +1,7 @@
 $co-m-horizontal-nav__menu-item-link-padding-lr: $pf-global-gutter;
 
 .co-m-horizontal-nav__menu {
-  border-bottom: 1px solid var(--pf-global--BorderColor--100);
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   display: flex;
   flex-shrink: 0; // prevent collapse of tabs
   list-style: none;
@@ -15,7 +15,7 @@ $co-m-horizontal-nav__menu-item-link-padding-lr: $pf-global-gutter;
     padding-left: ($pf-global-gutter--md - $pf-global-gutter);
   }
   &--within-sidebar {
-    border-top: 1px solid var(--pf-global--BorderColor--100);
+    border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
     margin-bottom: $pf-global-gutter--md !important;
     margin-left: -$pf-global-gutter;
     margin-right: -$pf-global-gutter;

--- a/frontend/public/components/_nav-title.scss
+++ b/frontend/public/components/_nav-title.scss
@@ -32,7 +32,7 @@
     }
   }
   &--detail {
-    border-bottom: 1px solid var(--pf-global--BorderColor--100);
+    border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
     flex-shrink: 0; // do not allow to shrink
   }
   // Positioned after --detail to take precedence, since they will be a siblings

--- a/frontend/public/components/_sysevent-icon.scss
+++ b/frontend/public/components/_sysevent-icon.scss
@@ -1,8 +1,8 @@
 .co-sysevent-icon {
   background-color: var(--pf-global--BackgroundColor--100);
-  border: solid 3px $pf-color-black-200;
-  border-radius: 50%;
-  color: #fff;
+  border: var(--pf-global--BorderWidth--lg) solid var(--pf-global--BorderColor--300);
+  border-radius: var(--pf-global--BorderRadius--lg);
+  color: var(--pf-global--Color--100);
   position: relative;
   z-index: 10;
   height: 18px;

--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -1,5 +1,3 @@
-$color-dark-border: #ddd;
-
 .co-sysevent-stream {
   padding: 60px 0 50px 0;
   position: relative;
@@ -17,7 +15,7 @@ $color-dark-border: #ddd;
 }
 
 .co-sysevent-stream__connection-error {
-  color: $pf-color-red-100;
+  color: var(--pf-global--danger-color--100);
 }
 
 .co-sysevent-stream__timeline {
@@ -42,8 +40,8 @@ $color-dark-border: #ddd;
 
 .co-sysevent-stream__status-box-empty {
   border-style: solid;
-  border-color: $pf-color-black-200;
-  border-width: 1px 0;
+  border-color: var(--pf-global--BorderColor--300);
+  border-width: var(--pf-global--BorderWidth--sm) 0;
 }
 
 .co-sysevent-stream__timeline__end-message {
@@ -74,9 +72,8 @@ $color-dark-border: #ddd;
 }
 
 .co-sysevent__box {
-  background-color: var(--pf-global--BackgroundColor--100);; // prevent overlapping text if events overlap each other
-  border: solid 1px $color-dark-border;
-  border-bottom-color: $pf-color-black-200;
+  background-color: var(--pf-global--BackgroundColor--100); // prevent overlapping text if events overlap each other
+  border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
   flex: none;
   padding: 10px;
   width: 100%;
@@ -140,7 +137,7 @@ $color-dark-border: #ddd;
 }
 
 .co-sysevent__icon-line {
-  background-color: $pf-color-black-200;
+  background-color: var(--pf-global--BorderColor--300); // connector line that matches the .co-sysevent-stream__timeline and .co-sysevent__box border color
   height: 3px;
   position: absolute;
   top: 50%;
@@ -156,7 +153,7 @@ $color-dark-border: #ddd;
 
   .co-sysevent__box {
     flex: 1 2 auto;
-    border: solid 1px $pf-color-black-200;
+    border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
     min-width: 0%; // necessary for wrapping since its a flex child
   }
 
@@ -170,8 +167,8 @@ $color-dark-border: #ddd;
   }
 
   .co-sysevent-stream__timeline {
-    border-bottom: 3px solid $pf-color-black-200;
-    border-left: 3px solid $pf-color-black-200;
+    border-bottom: var(--pf-global--BorderWidth--lg) solid var(--pf-global--BorderColor--300);
+    border-left: var(--pf-global--BorderWidth--lg) solid var(--pf-global--BorderColor--300);
     margin-left: 10px;
     &--empty {
       border: 0;

--- a/frontend/public/components/_toggle-play.scss
+++ b/frontend/public/components/_toggle-play.scss
@@ -1,5 +1,6 @@
 .co-toggle-play.pf-c-button {
-  border: 3px solid $pf-color-black-200;
+  background-color: var(--pf-global--BackgroundColor--100);
+  border: var(--pf-global--BorderWidth--lg) solid var(--pf-global--BorderColor--100);
   border-radius: 50%;
   height: 32px;
   margin-right: 15px;
@@ -18,6 +19,6 @@
   }
 
   &.co-toggle-play--active {
-    border-color: $pf-color-green-300;
+    border-color: var(--pf-global--palette--green-300); // brighter green that works for both light and dark themes
   }
 }

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -383,7 +383,7 @@ $monitoring-line-height: 18px;
 
 .query-browser__query-controls {
   align-items: center;
-  border: solid $color-grey-background-border;
+  border: solid var(--pf-global--BorderColor--100);
   border-width: 1px 0;
   display: flex;
   padding: 10px 0;
@@ -395,18 +395,18 @@ $monitoring-line-height: 18px;
 }
 
 .query-browser__series-btn {
-  border: 1px solid transparent;
+  border: var(--pf-global--BorderWidth--sm) solid transparent;
   border-radius: var(--pf-global--BorderRadius--sm);
   height: 20px;
   padding: 0 !important;
   width: 20px;
   &--disabled {
-    border: 1px solid #888 !important;
+    border: var(--pf-global--BorderWidth--sm) solid #888 !important;
   }
 }
 
 .query-browser__series-btn-wrap {
-  border: 1px solid transparent;
+  border: var(--pf-global--BorderWidth--sm) solid transparent;
   border-radius: var(--pf-global--BorderRadius--sm);
   display: flex;
   height: 26px;
@@ -457,7 +457,7 @@ $monitoring-line-height: 18px;
 }
 
 .query-browser__table-message {
-  border-bottom: solid 1px $color-grey-background-border;
+  border-bottom: solid 1px var(--pf-global--BorderColor--100);
   padding: 10px 20px;
 }
 
@@ -524,7 +524,7 @@ $monitoring-line-height: 18px;
 }
 
 .query-browser__wrapper {
-  border: 1px solid $color-grey-background-border;
+  border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   margin: 0 0 20px 0;
   overflow: visible;
   padding: 10px;

--- a/frontend/public/components/utils/_file-input.scss
+++ b/frontend/public/components/utils/_file-input.scss
@@ -29,7 +29,7 @@
   }
 
   .co-file-dropzone-container {
-    border: 3px solid $color-grey-background-border;
+    border: var(--pf-global--BorderWidth--lg) solid var(--pf-global--BorderColor--100);
     background: rgba(0,0,0,0.3);
     bottom: 0;
     color: #fff;

--- a/frontend/public/components/utils/_status-box.scss
+++ b/frontend/public/components/utils/_status-box.scss
@@ -2,18 +2,18 @@
   padding: 40px 20px;
 
   &__title {
-    color: #333;
+    color: var(--pf-global--Color--100);
     font-size: 18px;
     margin-bottom: 20px;
     text-align: center;
 
     .cos-error-title {
-      color: $pf-color-red-100;
+      color: var(--pf-global--danger-color--100);
     }
   }
 
   &__detail {
-    color: $color-text-muted;
+    color: var(--pf-global--Color--200);
     font-size: $font-size-base;
     max-width: 500px;
     margin: 0 auto;

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -27,7 +27,7 @@ dl.co-inline {
     padding-bottom: 0;
   }
   + .co-m-pane__body {
-    border-top: 1px solid $color-grey-background-border;
+    border-top: 1px solid var(--pf-global--BorderColor--100);
     margin-top: 0;
     padding-top: $pf-global-gutter--md;
   }

--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -54,7 +54,6 @@ $color-application-dark: $pf-color-green-500;
 $color-configmap-dark: $pf-color-purple-600;
 $color-container-dark: $pf-color-blue-300;
 $color-error: $pf-color-red-100;
-$color-grey-background-border: #ccc;
 $color-ingress-dark: $pf-color-purple-700;
 $color-namespace-dark: $pf-color-green-600;
 $color-node-dark: $pf-color-purple-400;

--- a/frontend/public/style/ancillary/_bootstrap-residual.scss
+++ b/frontend/public/style/ancillary/_bootstrap-residual.scss
@@ -207,5 +207,5 @@ pre code {
 }
 
 .text-secondary {
-  color: $color-text-secondary;
+  color: var(--pf-global--Color--200)
 }


### PR DESCRIPTION
Components effected

Events 
- Use PF global variables that switch colors based on theme
<img width="1278" alt="Screen Shot 2022-03-03 at 4 01 58 PM" src="https://user-images.githubusercontent.com/1874151/156653822-a6c89ef5-a6d4-4747-ae15-0778bc83fdaf.png">

Project select bar and menu 
![localhost_9000_k8s_ns_openshift-monitoring_events(1280x800 MBP 13_)](https://user-images.githubusercontent.com/1874151/157768009-a14f3b16-0343-4fc9-ad0c-b3876f363dc1.png)


