### PR TITLE
Bug 2061333: Add optional chaining to avoid npe

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/catalog/catalog-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/catalog-utils.ts
@@ -18,7 +18,7 @@ export const useTektonHubIntegration = () => {
     'config',
   );
   if (config && configLoaded && !configLoadErr) {
-    const devconsoleIntegrationEnabled = config.spec?.hub?.params.find(
+    const devconsoleIntegrationEnabled = config.spec?.hub?.params?.find(
       (p) => p.name === TEKTON_HUB_INTEGRATION_KEY,
     );
     return devconsoleIntegrationEnabled ? devconsoleIntegrationEnabled.value : true;


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGSM-41412

UI crashed when the user trying to visit pipeline builder on a cluster that was having pipeline operator in uninstalling phase, However not able to reproduce the issue, I have added a optional chaining to avoid potential failure.

Note: This bug is not reproducible in the 4.10/4.11 master.

cc: @vikram-raj 