### PR TITLE
feat(theme): added theme file

### DIFF
--- a/frontend/packages/console-shared/src/components/getting-started/QuickStartGettingStartedCard.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/QuickStartGettingStartedCard.tsx
@@ -117,9 +117,9 @@ export const QuickStartGettingStartedCard: React.FC<QuickStartGettingStartedCard
         return (
           <GettingStartedCard
             id="quick-start"
-            icon={<RouteIcon color="var(--os-global--palette--purple-600)" aria-hidden="true" />}
+            icon={<RouteIcon color="var(--co-global--palette--purple-600)" aria-hidden="true" />}
             title={title || t('console-shared~Build with guided documentation')}
-            titleColor={'var(--os-global--palette--purple-700)'}
+            titleColor={'var(--co-global--palette--purple-700)'}
             description={
               description ||
               t(

--- a/frontend/packages/console-shared/src/components/getting-started/QuickStartGettingStartedCard.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/QuickStartGettingStartedCard.tsx
@@ -117,9 +117,9 @@ export const QuickStartGettingStartedCard: React.FC<QuickStartGettingStartedCard
         return (
           <GettingStartedCard
             id="quick-start"
-            icon={<RouteIcon color="var(--pf-global--palette--purple-600)" aria-hidden="true" />}
+            icon={<RouteIcon color="var(--os-global--palette--purple-600)" aria-hidden="true" />}
             title={title || t('console-shared~Build with guided documentation')}
-            titleColor={'var(--pf-global--palette--purple-700)'}
+            titleColor={'var(--os-global--palette--purple-700)'}
             description={
               description ||
               t(

--- a/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
@@ -57,7 +57,7 @@ export const DeveloperFeaturesGettingStartedCard: React.FC = () => {
       id="developer-features"
       icon={<FlagIcon color="var(--pf-global--palette--orange-300)" aria-hidden="true" />}
       title={t('devconsole~Explore new developer features')}
-      titleColor={'var(--os-global--palette--gold-700)'}
+      titleColor={'var(--co-global--palette--gold-700)'}
       description={t(
         'devconsole~Explore new features and resources within the developer perspective.',
       )}

--- a/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
@@ -57,7 +57,7 @@ export const DeveloperFeaturesGettingStartedCard: React.FC = () => {
       id="developer-features"
       icon={<FlagIcon color="var(--pf-global--palette--orange-300)" aria-hidden="true" />}
       title={t('devconsole~Explore new developer features')}
-      titleColor={'var(--pf-global--palette--gold-700)'}
+      titleColor={'var(--os-global--palette--gold-700)'}
       description={t(
         'devconsole~Explore new features and resources within the developer perspective.',
       )}

--- a/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
@@ -57,7 +57,7 @@ export const DeveloperFeaturesGettingStartedCard: React.FC = () => {
       id="developer-features"
       icon={<FlagIcon color="var(--pf-global--palette--orange-300)" aria-hidden="true" />}
       title={t('devconsole~Explore new developer features')}
-      titleColor={'var(--co-global--palette--gold-700)'}
+      titleColor={'var(--co-global--palette--orange-700)'}
       description={t(
         'devconsole~Explore new features and resources within the developer perspective.',
       )}

--- a/frontend/packages/dev-console/src/components/add/SampleGettingStartedCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/SampleGettingStartedCard.tsx
@@ -85,7 +85,7 @@ export const SampleGettingStartedCard: React.FC<SampleGettingStartedCardProps> =
             id="samples"
             icon={<CatalogIcon color="var(--pf-global--primary-color--100)" aria-hidden="true" />}
             title={t('devconsole~Create applications using samples')}
-            titleColor={'var(--os-global--palette--blue-600)'}
+            titleColor={'var(--co-global--palette--blue-600)'}
             description={t(
               'devconsole~Choose a code sample to get started creating an application with.',
             )}

--- a/frontend/packages/dev-console/src/components/add/SampleGettingStartedCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/SampleGettingStartedCard.tsx
@@ -83,7 +83,7 @@ export const SampleGettingStartedCard: React.FC<SampleGettingStartedCardProps> =
         return (
           <GettingStartedCard
             id="samples"
-            icon={<CatalogIcon color="var(--pf-global--primary-color--100)" aria-hidden="true" />}
+            icon={<CatalogIcon color="var(--co-global--palette--blue-600)" aria-hidden="true" />}
             title={t('devconsole~Create applications using samples')}
             titleColor={'var(--co-global--palette--blue-600)'}
             description={t(

--- a/frontend/packages/dev-console/src/components/add/SampleGettingStartedCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/SampleGettingStartedCard.tsx
@@ -85,7 +85,7 @@ export const SampleGettingStartedCard: React.FC<SampleGettingStartedCardProps> =
             id="samples"
             icon={<CatalogIcon color="var(--pf-global--primary-color--100)" aria-hidden="true" />}
             title={t('devconsole~Create applications using samples')}
-            titleColor={'var(--pf-global--palette--blue-600)'}
+            titleColor={'var(--os-global--palette--blue-600)'}
             description={t(
               'devconsole~Choose a code sample to get started creating an application with.',
             )}

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/FeatureHighlightsCard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/FeatureHighlightsCard.tsx
@@ -53,7 +53,7 @@ export const FeatureHighlightsCard: React.FC = () => {
         />
       }
       title={t('kubevirt-plugin~Feature highlights')}
-      titleColor={'var(--pf-global--palette--blue-600)'}
+      titleColor={'var(--os-global--palette--blue-600)'}
       description={t(
         'kubevirt-plugin~Read about the latest information and key virtualization features on the Virtualization highlights.',
       )}

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/FeatureHighlightsCard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/FeatureHighlightsCard.tsx
@@ -46,11 +46,7 @@ export const FeatureHighlightsCard: React.FC = () => {
     <GettingStartedCard
       id="feature-highlights"
       icon={
-        <i
-          className="fas fa-blog"
-          color="var(--pf-global--primary-color--100)"
-          aria-hidden="true"
-        />
+        <i className="fas fa-blog" color="var(--co-global--palette--blue-600)" aria-hidden="true" />
       }
       title={t('kubevirt-plugin~Feature highlights')}
       titleColor={'var(--co-global--palette--blue-600)'}

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/FeatureHighlightsCard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/FeatureHighlightsCard.tsx
@@ -53,7 +53,7 @@ export const FeatureHighlightsCard: React.FC = () => {
         />
       }
       title={t('kubevirt-plugin~Feature highlights')}
-      titleColor={'var(--os-global--palette--blue-600)'}
+      titleColor={'var(--co-global--palette--blue-600)'}
       description={t(
         'kubevirt-plugin~Read about the latest information and key virtualization features on the Virtualization highlights.',
       )}

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/RecommendedOperatorsCard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/RecommendedOperatorsCard.tsx
@@ -42,7 +42,7 @@ export const RecommendedOperatorsCard: React.FC = () => {
         />
       }
       title={t('kubevirt-plugin~Recommended Operators')}
-      titleColor={'var(--pf-global--palette--blue-600)'}
+      titleColor={'var(--os-global--palette--blue-600)'}
       description={t(
         'kubevirt-plugin~Ease operational complexity with virtualization by using Operators.',
       )}

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/RecommendedOperatorsCard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/RecommendedOperatorsCard.tsx
@@ -42,7 +42,7 @@ export const RecommendedOperatorsCard: React.FC = () => {
         />
       }
       title={t('kubevirt-plugin~Recommended Operators')}
-      titleColor={'var(--os-global--palette--blue-600)'}
+      titleColor={'var(--co-global--palette--blue-600)'}
       description={t(
         'kubevirt-plugin~Ease operational complexity with virtualization by using Operators.',
       )}

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
@@ -36,7 +36,7 @@ export const ClusterSetupGettingStartedCard: React.FC = () => {
       id="cluster-setup"
       icon={<ClipboardCheckIcon color="var(--pf-global--primary-color--100)" aria-hidden="true" />}
       title={t('public~Set up your cluster')}
-      titleColor={'var(--pf-global--palette--blue-600)'}
+      titleColor={'var(--os-global--palette--blue-600)'}
       description={t('public~Finish setting up your cluster with recommended configurations.')}
       links={links}
       moreLink={moreLink}

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
@@ -34,7 +34,7 @@ export const ClusterSetupGettingStartedCard: React.FC = () => {
   return (
     <GettingStartedCard
       id="cluster-setup"
-      icon={<ClipboardCheckIcon color="var(--pf-global--primary-color--100)" aria-hidden="true" />}
+      icon={<ClipboardCheckIcon color="var(--co-global--palette--blue-600)" aria-hidden="true" />}
       title={t('public~Set up your cluster')}
       titleColor={'var(--co-global--palette--blue-600)'}
       description={t('public~Finish setting up your cluster with recommended configurations.')}

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
@@ -36,7 +36,7 @@ export const ClusterSetupGettingStartedCard: React.FC = () => {
       id="cluster-setup"
       icon={<ClipboardCheckIcon color="var(--pf-global--primary-color--100)" aria-hidden="true" />}
       title={t('public~Set up your cluster')}
-      titleColor={'var(--os-global--palette--blue-600)'}
+      titleColor={'var(--co-global--palette--blue-600)'}
       description={t('public~Finish setting up your cluster with recommended configurations.')}
       links={links}
       moreLink={moreLink}

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
@@ -38,9 +38,9 @@ export const ExploreAdminFeaturesGettingStartedCard: React.FC = () => {
   return (
     <GettingStartedCard
       id="admin-features"
-      icon={<FlagIcon color="var(--pf-global--palette--orange-300)" aria-hidden="true" />}
+      icon={<FlagIcon color="var(--co-global--palette--orange-700)" aria-hidden="true" />}
       title={t('public~Explore new admin features')}
-      titleColor={'var(--co-global--palette--gold-700)'}
+      titleColor={'var(--co-global--palette--orange-700)'}
       description={t('public~Explore new features and resources within the admin perspective.')}
       links={links}
       moreLink={moreLink}

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
@@ -40,7 +40,7 @@ export const ExploreAdminFeaturesGettingStartedCard: React.FC = () => {
       id="admin-features"
       icon={<FlagIcon color="var(--pf-global--palette--orange-300)" aria-hidden="true" />}
       title={t('public~Explore new admin features')}
-      titleColor={'var(--pf-global--palette--gold-700)'}
+      titleColor={'var(--co-global--palette--gold-700)'}
       description={t('public~Explore new features and resources within the admin perspective.')}
       links={links}
       moreLink={moreLink}

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -114,3 +114,6 @@
 @import 'components/dashboard/project-dashboard/details-card';
 
 @import 'components/nav/nav-header';
+
+// Themes
+@import 'style/theme-dark';

--- a/frontend/public/style/_theme-dark.scss
+++ b/frontend/public/style/_theme-dark.scss
@@ -1,0 +1,20 @@
+:root {
+  --os-global--palette--blue-600: var(--pf-global--palette--blue-600);
+  --os-global--palette--purple-600: var(--pf-global--palette--purple-600);
+  --os-global--palette--gold-700: var(--pf-global--palette--gold-700);
+  --os-global--palette--purple-700: var(--pf-global--palette--purple-700);
+
+  // dark
+  --os-global--dark--palette--blue-600: var(--pf-global--palette--blue-200);
+  --os-global--dark--palette--purple-600: var(--pf-global--palette--purple-200);
+  --os-global--dark--palette--gold-700: var(--pf-global--palette--gold-200);
+  --os-global--dark--palette--purple-700: var(--pf-global--palette--purple-200);
+}
+
+// :where(#{$pf-theme-dark-class}) {
+:root:where(.pf-theme-dark) {
+  --os-global--palette--blue-600: var(--os-global--dark--palette--blue-600);
+  --os-global--palette--purple-600: var(--os-global--dark--palette--purple-600);
+  --os-global--palette--gold-700: var(--os-global--dark--palette--gold-700);
+  --os-global--palette--purple-700: var(--os-global--dark--palette--purple-600);
+}

--- a/frontend/public/style/_theme-dark.scss
+++ b/frontend/public/style/_theme-dark.scss
@@ -1,20 +1,20 @@
 :root {
-  --os-global--palette--blue-600: var(--pf-global--palette--blue-600);
-  --os-global--palette--purple-600: var(--pf-global--palette--purple-600);
-  --os-global--palette--gold-700: var(--pf-global--palette--gold-700);
-  --os-global--palette--purple-700: var(--pf-global--palette--purple-700);
+  --co-global--palette--blue-600: var(--pf-global--palette--blue-600);
+  --co-global--palette--purple-600: var(--pf-global--palette--purple-600);
+  --co-global--palette--gold-700: var(--pf-global--palette--gold-700);
+  --co-global--palette--purple-700: var(--pf-global--palette--purple-700);
 
   // dark
-  --os-global--dark--palette--blue-600: var(--pf-global--palette--blue-200);
-  --os-global--dark--palette--purple-600: var(--pf-global--palette--purple-200);
-  --os-global--dark--palette--gold-700: var(--pf-global--palette--gold-200);
-  --os-global--dark--palette--purple-700: var(--pf-global--palette--purple-200);
+  --co-global--dark--palette--blue-600: var(--pf-global--palette--blue-200);
+  --co-global--dark--palette--purple-600: var(--pf-global--palette--purple-200);
+  --co-global--dark--palette--gold-700: var(--pf-global--palette--gold-200);
+  --co-global--dark--palette--purple-700: var(--pf-global--palette--purple-200);
 }
 
 // :where(#{$pf-theme-dark-class}) {
 :root:where(.pf-theme-dark) {
-  --os-global--palette--blue-600: var(--os-global--dark--palette--blue-600);
-  --os-global--palette--purple-600: var(--os-global--dark--palette--purple-600);
-  --os-global--palette--gold-700: var(--os-global--dark--palette--gold-700);
-  --os-global--palette--purple-700: var(--os-global--dark--palette--purple-600);
+  --co-global--palette--blue-600: var(--co-global--dark--palette--blue-600);
+  --co-global--palette--purple-600: var(--co-global--dark--palette--purple-600);
+  --pf-global--palette--gold-700: var(--co-global--dark--palette--gold-700);
+  --co-global--palette--purple-700: var(--co-global--dark--palette--purple-600);
 }

--- a/frontend/public/style/_theme-dark.scss
+++ b/frontend/public/style/_theme-dark.scss
@@ -11,7 +11,6 @@
   --co-global--dark--palette--purple-700: var(--pf-global--palette--purple-200);
 }
 
-// :where(#{$pf-theme-dark-class}) {
 :root:where(.pf-theme-dark) {
   --co-global--palette--blue-600: var(--co-global--dark--palette--blue-600);
   --co-global--palette--purple-600: var(--co-global--dark--palette--purple-600);

--- a/frontend/public/style/_theme-dark.scss
+++ b/frontend/public/style/_theme-dark.scss
@@ -1,19 +1,19 @@
 :root {
   --co-global--palette--blue-600: var(--pf-global--palette--blue-600);
   --co-global--palette--purple-600: var(--pf-global--palette--purple-600);
-  --co-global--palette--gold-700: var(--pf-global--palette--gold-700);
+  --co-global--palette--orange-700: var(--pf-global--palette--orange-700);
   --co-global--palette--purple-700: var(--pf-global--palette--purple-700);
 
   // dark
   --co-global--dark--palette--blue-600: var(--pf-global--palette--blue-200);
   --co-global--dark--palette--purple-600: var(--pf-global--palette--purple-200);
-  --co-global--dark--palette--gold-700: var(--pf-global--palette--gold-200);
+  --co-global--dark--palette--orange-700: var(--pf-global--palette--orange-200);
   --co-global--dark--palette--purple-700: var(--pf-global--palette--purple-200);
 }
 
 :root:where(.pf-theme-dark) {
   --co-global--palette--blue-600: var(--co-global--dark--palette--blue-600);
   --co-global--palette--purple-600: var(--co-global--dark--palette--purple-600);
-  --pf-global--palette--gold-700: var(--co-global--dark--palette--gold-700);
+  --pf-global--palette--orange-700: var(--co-global--dark--palette--orange-700);
   --co-global--palette--purple-700: var(--co-global--dark--palette--purple-600);
 }


### PR DESCRIPTION
This PR adds a dark theme file, imports it, and updates the dashboard overview card header colors. 

Before: 

![Screen Shot 2022-03-07 at 3 35 35 PM](https://user-images.githubusercontent.com/5385435/157113968-c8184cef-d2a0-4f0c-82e5-8c954b9ca10f.png)

After: 

![Screen Shot 2022-03-07 at 3 34 16 PM](https://user-images.githubusercontent.com/5385435/157113948-65956aa5-f5a9-44bd-b3e7-41c673b4d495.png)

