### PR TITLE
Bug 2017001: Bug fix context menu position on topology

### DIFF
--- a/frontend/packages/topology/src/actions/__tests__/contextMenuActions.spec.ts
+++ b/frontend/packages/topology/src/actions/__tests__/contextMenuActions.spec.ts
@@ -49,8 +49,6 @@ describe('context menu actions', () => {
         resource,
       },
     };
-    expect(contextMenuActions(mockOperatorBackedServiceNode)[0].props.context).toEqual(
-      expectedContext,
-    );
+    expect(contextMenuActions(mockOperatorBackedServiceNode)).toEqual(expectedContext);
   });
 });

--- a/frontend/packages/topology/src/actions/contextMenuActions.tsx
+++ b/frontend/packages/topology/src/actions/contextMenuActions.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { Node, ContextSubMenuItem, ContextMenuItem } from '@patternfly/react-topology';
+import { Node, ContextSubMenuItem, ContextMenuItem, Graph } from '@patternfly/react-topology';
 import { Action } from '@console/dynamic-plugin-sdk/src';
 import { referenceFor } from '@console/internal/module/k8s';
 import {
-  ActionServiceProvider,
   getMenuOptionType,
   GroupedMenuOption,
   MenuOption,
@@ -39,17 +38,20 @@ export const createContextMenuItems = (actions: MenuOption[]) => {
   });
 };
 
-export const contextMenuActions = (element: Node): React.ReactElement[] => {
+export const graphActionContext = (graph: Graph, connectorSource?: Node) => ({
+  'topology-context-actions': { element: graph, connectorSource },
+});
+
+export const groupActionContext = (element: Node, connectorSource?: Node) => ({
+  'topology-context-actions': { element, connectorSource },
+});
+
+export const contextMenuActions = (element: Node) => {
   const resource = getResource(element);
   const { csvName } = element.getData()?.data ?? {};
-  const context = {
+  return {
     'topology-actions': element,
     ...(resource ? { [referenceFor(resource)]: resource } : {}),
     ...(csvName ? { 'csv-actions': { csvName, resource } } : {}),
   };
-  return [
-    <ActionServiceProvider key="topology" context={context}>
-      {({ options, loaded }) => loaded && createContextMenuItems(options)}
-    </ActionServiceProvider>,
-  ];
 };

--- a/frontend/packages/topology/src/components/graph-view/components/componentFactory.ts
+++ b/frontend/packages/topology/src/components/graph-view/components/componentFactory.ts
@@ -9,7 +9,7 @@ import {
   DragObjectWithType,
   ComponentFactory,
 } from '@patternfly/react-topology';
-import { contextMenuActions } from '../../../actions';
+import { contextMenuActions, graphActionContext, groupActionContext } from '../../../actions';
 import {
   TYPE_WORKLOAD,
   TYPE_CONNECTS_TO,
@@ -33,7 +33,6 @@ import {
 import { AggregateEdge, ConnectsTo, CreateConnector, TrafficConnector } from './edges';
 import GraphComponent from './GraphComponent';
 import { Application } from './groups';
-import { graphContextMenu, groupContextMenu } from './nodeContextMenu';
 import { WorkloadNode } from './nodes';
 
 import './ContextMenu.scss';
@@ -42,7 +41,7 @@ export const componentFactory: ComponentFactory = (kind, type) => {
   switch (type) {
     case TYPE_APPLICATION_GROUP:
       return withDndDrop(applicationGroupDropTargetSpec)(
-        withSelection({ controlled: true })(withContextMenu(groupContextMenu)(Application)),
+        withSelection({ controlled: true })(withContextMenu(groupActionContext)(Application)),
       );
     case TYPE_WORKLOAD:
       return withCreateConnector(
@@ -78,7 +77,7 @@ export const componentFactory: ComponentFactory = (kind, type) => {
           return withDndDrop(graphDropTargetSpec)(
             withPanZoom()(
               withSelection({ controlled: true })(
-                withContextMenu(graphContextMenu)(GraphComponent),
+                withContextMenu(graphActionContext)(GraphComponent),
               ),
             ),
           );

--- a/frontend/packages/topology/src/components/graph-view/components/componentUtils.ts
+++ b/frontend/packages/topology/src/components/graph-view/components/componentUtils.ts
@@ -14,7 +14,6 @@ import {
   DragSpecOperationType,
   CREATE_CONNECTOR_DROP_TYPE,
   CREATE_CONNECTOR_OPERATION,
-  withContextMenu as withTopologyContextMenu,
   isGraph,
   withDndDrop,
   DragEvent,
@@ -24,9 +23,10 @@ import i18next from 'i18next';
 import { action } from 'mobx';
 import { errorModal } from '@console/internal/components/modals';
 import { K8sResourceKind } from '@console/internal/module/k8s';
+import { ActionContext } from '@console/shared';
 import { createConnection, moveNodeToGroup } from '../../../utils';
 import { isWorkloadRegroupable, graphContextMenu, groupContextMenu } from './nodeContextMenu';
-
+import withTopologyContextMenu from './withTopologyContextMenu';
 import './GraphComponent.scss';
 
 const MOVE_CONNECTOR_DROP_TYPE = '#moveConnector#';
@@ -319,7 +319,7 @@ const withNoDrop = () => {
   return withDndDrop<any, any, {}, NodeComponentProps>(noDropTargetSpec);
 };
 
-const withContextMenu = <E extends GraphElement>(actions: (element: E) => React.ReactElement[]) => {
+const withContextMenu = <E extends GraphElement>(actions: (element: E) => ActionContext) => {
   return withTopologyContextMenu(
     actions,
     document.getElementById('popper-container'),

--- a/frontend/packages/topology/src/components/graph-view/components/withTopologyContextMenu.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/withTopologyContextMenu.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import {
+  GraphElement as TopologyElement,
+  ElementContext,
+  ContextMenu,
+} from '@patternfly/react-topology';
+import { observer } from 'mobx-react';
+import { ActionContext, ActionServiceProvider } from '@console/shared';
+import { createContextMenuItems } from '../../../actions';
+
+type Reference = React.ComponentProps<typeof ContextMenu>['reference'];
+
+export interface WithContextMenuProps {
+  onContextMenu: (e: React.MouseEvent) => void;
+  contextMenuOpen: boolean;
+}
+
+const withContextMenu = <E extends TopologyElement>(
+  actionContext: (element: E) => ActionContext,
+  container?: Element | null | undefined | (() => Element),
+  className?: string,
+  atPoint: boolean = true,
+) => <P extends WithContextMenuProps>(WrappedComponent: React.ComponentType<P>) => {
+  const Component: React.FC<Omit<P, keyof WithContextMenuProps>> = (props) => {
+    const element = React.useContext(ElementContext);
+    const [reference, setReference] = React.useState<Reference | null>(null);
+    const onContextMenu = React.useCallback((e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setReference(
+        atPoint
+          ? {
+              x: e.pageX,
+              y: e.pageY,
+            }
+          : e.currentTarget,
+      );
+    }, []);
+
+    return (
+      <>
+        <WrappedComponent
+          {...(props as any)}
+          onContextMenu={onContextMenu}
+          contextMenuOpen={!!reference}
+        />
+        <ActionServiceProvider key="topology" context={actionContext(element as E)}>
+          {({ options, loaded }) =>
+            reference && loaded ? (
+              <ContextMenu
+                reference={reference}
+                container={container}
+                className={className}
+                open
+                onRequestClose={() => setReference(null)}
+              >
+                {createContextMenuItems(options)}
+              </ContextMenu>
+            ) : null
+          }
+        </ActionServiceProvider>
+      </>
+    );
+  };
+  Component.displayName = `withContextMenu(${WrappedComponent.displayName ||
+    WrappedComponent.name})`;
+  return observer(Component);
+};
+
+export default withContextMenu;

--- a/frontend/packages/topology/src/components/graph-view/components/withTopologyContextMenu.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/withTopologyContextMenu.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import {
-  GraphElement as TopologyElement,
-  ElementContext,
-  ContextMenu,
-} from '@patternfly/react-topology';
+import { GraphElement, ElementContext, ContextMenu } from '@patternfly/react-topology';
 import { observer } from 'mobx-react';
 import { ActionContext, ActionServiceProvider } from '@console/shared';
 import { createContextMenuItems } from '../../../actions';
@@ -15,7 +11,7 @@ export interface WithContextMenuProps {
   contextMenuOpen: boolean;
 }
 
-const withContextMenu = <E extends TopologyElement>(
+const withContextMenu = <E extends GraphElement>(
   actionContext: (element: E) => ActionContext,
   container?: Element | null | undefined | (() => Element),
   className?: string,
@@ -44,21 +40,23 @@ const withContextMenu = <E extends TopologyElement>(
           onContextMenu={onContextMenu}
           contextMenuOpen={!!reference}
         />
-        <ActionServiceProvider key="topology" context={actionContext(element as E)}>
-          {({ options, loaded }) =>
-            reference && loaded ? (
-              <ContextMenu
-                reference={reference}
-                container={container}
-                className={className}
-                open
-                onRequestClose={() => setReference(null)}
-              >
-                {createContextMenuItems(options)}
-              </ContextMenu>
-            ) : null
-          }
-        </ActionServiceProvider>
+        {reference ? (
+          <ActionServiceProvider context={actionContext(element as E)}>
+            {({ options, loaded }) =>
+              loaded ? (
+                <ContextMenu
+                  reference={reference}
+                  container={container}
+                  className={className}
+                  open
+                  onRequestClose={() => setReference(null)}
+                >
+                  {createContextMenuItems(options)}
+                </ContextMenu>
+              ) : null
+            }
+          </ActionServiceProvider>
+        ) : null}
       </>
     );
   };


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/OCPBUGSM-37007

Problem: ContextMenu always opens downward even when there is no space on viewport. Problem was that we were sending only one element(and this element had all the menu items) in array for the ContextMenu component.

Solution: This PR creates a HOC based on the PF/react-topology `withContextMenu` HOC. The difference is that it Wraps ContextMenu with ActionServiceProvider. Now, the ActionProvider context is passed to HOC instead of passing menu items in componentFactory for ContextMenu.

Screenshot:
![Kapture 2022-03-08 at 12 59 25](https://user-images.githubusercontent.com/9278015/157189613-2e830cb8-1c08-4d49-abe6-55a0ac6f52fb.gif)

