### PR TITLE
CONSOLE-3081: Integrate dark theme - fix(borders): convert #ccc, #ddd, $pf-color-black-300, $color-row-filter-border to var(--pf-global--BorderColor--100)

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system.scss
@@ -1,16 +1,16 @@
 .odf-create-storage-system__header {
-    border-bottom: var(--pf-global--BorderWidth--sm) solid #ddd;
+    border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
     padding-right: var(--pf-global--spacer--lg);
     padding-left: var(--pf-global--spacer--lg);
     padding-bottom: var(--pf-global--spacer--sm);
   }
 
   .odf-create-storage-system__breadcrumb {
-    // _overrides.scss modifies the default padding for pf breadcrumbs to be padding-top: 25px 
+    // _overrides.scss modifies the default padding for pf breadcrumbs to be padding-top: 25px
     // Adjusting it since it takes a lot of space on thecreate system page
     padding-top: var(--pf-global--spacer--sm);
   }
-  
+
   .odf-create-storage-system-footer__alert {
     margin: 0 var(--pf-global--spacer--md);
   }

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.scss
@@ -18,5 +18,5 @@
   // no pf class for 0.3rem
   padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--xl) 0.3rem
     var(--pf-global--spacer--xl);
-  border-bottom: var(--pf-global--BorderWidth--sm) solid #ddd;
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
 }

--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
@@ -16,7 +16,7 @@
 }
 
 .co-activity-card__ongoing-title {
-  border-bottom: solid 1px $pf-color-black-300;
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   padding: 0.2rem var(--pf-c-card--child--PaddingRight) 0.2rem var(--pf-c-card--child--PaddingLeft);
 }
 
@@ -71,7 +71,7 @@
 }
 
 .co-activity-card__recent-title {
-  border-bottom: solid 1px $pf-color-black-300;
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;

--- a/frontend/packages/console-shared/src/components/dashboard/inventory-card/inventory-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/inventory-card/inventory-card.scss
@@ -39,7 +39,7 @@
 }
 
 .co-inventory-card__accordion.pf-c-accordion {
-  border-bottom: 1px solid $pf-color-black-300;
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   box-shadow: none;
   padding: 0;
 

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
@@ -2,7 +2,7 @@
 @import '../../../styles/skeleton-screen';
 
 .co-status-card__alerts-body {
-  border-top: 1px solid $pf-color-black-300;
+  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   max-height: 19rem;
   min-height: 6rem;
   overflow-x: hidden;

--- a/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.scss
@@ -3,8 +3,8 @@
 .ocs-synced-editor-field {
   &__editor-toggle {
     padding-top: var(--pf-global--spacer--sm);
-    border-bottom: 1px solid #ddd;
-    border-top: 1px solid #ddd;
+    border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+    border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
 
     &.margin {
       margin: var(--pf-global--spacer--md) 0;

--- a/frontend/packages/console-shared/src/components/synced-editor/styles.scss
+++ b/frontend/packages/console-shared/src/components/synced-editor/styles.scss
@@ -2,7 +2,7 @@
 
 .co-synced-editor__editor-toggle {
   padding: 8px 30px;
-  border-bottom: 1px solid #ddd;
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   & label {
     margin: 0;
   }

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/top-consumers-card/top-consumers-card.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/top-consumers-card/top-consumers-card.scss
@@ -5,7 +5,7 @@
 }
 
 .kv-top-consumers-card__header {
-  border-bottom: 1px solid $pf-color-black-300;
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
 }
 
 .kv-top-consumers-card__dropdown {
@@ -20,7 +20,7 @@ div.kv-top-consumers-card__body {
 }
 
 .kv-top-consumers-card__top-grid {
-  border-bottom: 1px solid $pf-color-black-300;
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
 }
 
 .kv-top-consumers-card__progress-chart--title {
@@ -30,7 +30,7 @@ div.kv-top-consumers-card__body {
 
 .kv-top-consumers-card__card-grid-item {
   &:not(:last-child) {
-    border-right: 1px solid $pf-color-black-300;
+    border-right: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   }
 }
 
@@ -56,7 +56,7 @@ div.kv-top-consumers-card__body {
   justify-content: space-between;
   color: var(--pf-global--Color--200);
   font-size: var(--pf-global--FontSize--sm);
-  border-bottom: 1px solid $pf-color-black-300;
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   padding-left: var(--pf-c-card--child--PaddingLeft);
   padding-right: var(--pf-c-card--child--PaddingRight);
   padding-top: var(--pf-global--spacer--md);

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/vm-environment.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/vm-environment.scss
@@ -1,4 +1,4 @@
 .environment-buttons {
-    border-top: 1px solid #ddd;
-    padding-top: var(--pf-global--spacer--lg);
-  }
+  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+  padding-top: var(--pf-global--spacer--lg);
+}

--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -103,7 +103,7 @@ $co-affinity-row-margin: 15px;
 }
 
 .co-catalog-install-modal .modal-header .co-clusterserviceversion-logo__icon {
-  border: 1px solid #ddd;
+  border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
 }
 
 .co-catalog-details {
@@ -141,7 +141,7 @@ $co-affinity-row-margin: 15px;
 }
 
 .co-create-operand__header {
-  border-bottom: 1px solid #ddd;
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   padding: 0 15px 10px;
   @media (min-width: $screen-sm-min) {
     padding: 0 30px 15px;

--- a/frontend/public/components/_edit-yaml.scss
+++ b/frontend/public/components/_edit-yaml.scss
@@ -17,7 +17,7 @@
 
 .yaml-editor__buttons {
   background: white;
-  border-top: 1px solid #ddd;
+  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   padding: 20px $pf-global-gutter;
   margin-top: auto;
   z-index: 10;
@@ -28,7 +28,7 @@
 }
 
 .yaml-editor__header {
-  border-bottom: 1px solid #ddd;
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   padding: 20px $pf-global-gutter;
   @media(min-width: $pf-global--breakpoint--xl) {
     padding-left: $pf-global-gutter--md;

--- a/frontend/public/components/_environment.scss
+++ b/frontend/public/components/_environment.scss
@@ -1,4 +1,4 @@
 .environment-buttons {
-  border-top: 1px solid #ddd;
+  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   padding-top: 20px;
 }

--- a/frontend/public/components/_image-stream.scss
+++ b/frontend/public/components/_image-stream.scss
@@ -43,7 +43,7 @@
 }
 
 .co-images-stream-tag-timeline__line {
-  border: 2px solid $pf-color-black-300;
+  border: var(--pf-global--BorderWidth--md) solid var(--pf-global--BorderColor--100);
   left: 14px;
   position: relative;
 }

--- a/frontend/public/components/_row-filter.scss
+++ b/frontend/public/components/_row-filter.scss
@@ -26,7 +26,7 @@ $color-row-filter-border--active: $pf-color-blue-300;
   margin-bottom: $pf-global--spacer--xl;
   // use pseudo element for border so .row-filter__box-es can overlaps
   &::before {
-    border: 1px solid $color-row-filter-border;
+    border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
     bottom: calc(var(--pf-global--spacer--xl) - 1px);
     content: '';
     left: $pf-global-gutter;
@@ -46,12 +46,12 @@ $color-row-filter-border--active: $pf-color-blue-300;
   &,
   &:focus,
   &:hover {
-    border: 1px solid $color-row-filter-border;
+    border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
     color: inherit;
     text-decoration: none;
   }
   &:focus {
-    border-color: darken($color-row-filter-border, 40%);
+    border-color: var(--pf-global--BorderColor--200);
     border-style: dotted;
     z-index: 2;
   }
@@ -80,7 +80,7 @@ $color-row-filter-border--active: $pf-color-blue-300;
 .row-filter__number-bubble {
   background: $pf-color-white;
   border-radius: 4px;
-  border: 1px solid $color-row-filter-border;
+  border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   display: inline-block;
   line-height: 16px;
   margin-right: 6px;

--- a/frontend/public/components/secrets/_create-secret.scss
+++ b/frontend/public/components/secrets/_create-secret.scss
@@ -17,7 +17,7 @@
 }
 
 .co-create-secret__form-entry-wrapper + .co-create-secret__form-entry-wrapper {
-  border-top: 1px solid #ccc;
+  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor—100);
   padding-top: 10px;
 }
 

--- a/frontend/public/components/sidebars/_resource-sidebar.scss
+++ b/frontend/public/components/sidebars/_resource-sidebar.scss
@@ -1,5 +1,5 @@
 .co-resource-sidebar-item {
-  border-top: 1px solid #ccc;
+  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor—100);
   padding: ($line-height-computed * 0.5) 0 $line-height-computed;
 
   &:first-child {

--- a/frontend/public/components/utils/_copy-to-clipboard.scss
+++ b/frontend/public/components/utils/_copy-to-clipboard.scss
@@ -32,7 +32,7 @@
   --pf-c-button--PaddingRight: 16px;
   --pf-c-button--PaddingBottom: 11px;
   --pf-c-button--PaddingLeft: 16px;
-  --pf-c-button--BorderColor: #ccc;
+  --pf-c-button--BorderColor: var(--pf-global--BorderColor—100);
   --pf-c-button--BorderRadius: 0;
   --pf-c-button--hover--BorderWidth: 1px;
   --pf-c-button--LineHeight: 20px;

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -3,7 +3,7 @@
 }
 
 .co-add-remove-form__entry + .co-add-remove-form__entry {
-  border-top: 1px solid #ccc;
+  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor—100);
   padding-top: 10px;
 }
 

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -60,10 +60,10 @@ body,
 
     &--bordered {
       @media (max-width: $screen-sm-max) {
-        border-top: 1px solid #ccc;
+        border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor—100);
       }
       @media (min-width: $screen-md-min) {
-        border-left: 1px solid #ccc;
+        border-left: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor—100);
       }
     }
   }


### PR DESCRIPTION
For: https://issues.redhat.com/browse/CONSOLE-3081
fix(borders): convert #ccc, #ddd, $pf-color-black-300, $color-row-filter-border to var(--pf-global--BorderColor--100)
This pr converts `#ddd`, `#ccc`, `$pf-color-black-300`, `$color-row-filter-border`

Color shifts are described here: https://codepen.io/bobcatTaco/pen/NWwVYzq#ccc-ddd-black-300

![Screen Shot 2022-03-08 at 2 34 10 PM](https://user-images.githubusercontent.com/5385435/157311687-f7947cbf-31ee-48ea-aafb-2fe963b37425.png)

