### PR TITLE
CONSOLE-3081: [Dark theme] Updates hint block element

### DIFF
--- a/frontend/public/components/utils/_hint-block.scss
+++ b/frontend/public/components/utils/_hint-block.scss
@@ -1,5 +1,6 @@
 .co-hint-block {
-  background-color: $pf-color-blue-50;
-  color: $pf-color-blue-600;
-  padding: 10px 15px 10px;
+  background-color: var(--pf-global--BackgroundColor--400);
+  border: 1px solid var(--pf-global--BorderColor--300);
+  color: var(--pf-global--Color--100);
+  padding: var(--pf-global--spacer--lg);
 }


### PR DESCRIPTION
**Areas & elements addressed.**
Style hint elements`co-hint-block` with styles matching the PatternFly `<Hint>` component. So that it uses it's dark theme styles.

Dark and Light theme versions
<img width="691" alt="Screen Shot 2022-03-08 at 1 26 19 PM" src="https://user-images.githubusercontent.com/1874151/157301940-34d83561-644d-403b-a840-5e09eecaa099.png">