### PR TITLE
CONSOLE-3081: Integrate dark theme - fix borders updates #eee, #ededed, $table-border-color to `var(--pf-global--BorderColor--300)`

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -129,7 +129,7 @@ $co-affinity-row-margin: 15px;
 }
 
 .co-spec-descriptor--resource-requirements {
-  border: 1px solid #eee;
+  border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
   padding: 20px 0 20px 20px;
   margin-top: 5px;
 }
@@ -162,7 +162,7 @@ $co-affinity-row-margin: 15px;
 }
 
 .co-affinity-term {
-  border: 1px solid #eee;
+  border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
   display: flex;
   flex-direction: column;
   margin-bottom: 15px;
@@ -197,7 +197,7 @@ $co-affinity-row-margin: 15px;
 }
 
 .co-operand-field-group {
-  border: 1px solid #eee;
+  border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
   display: flex;
   flex-direction: column;
   margin-bottom: 15px;

--- a/frontend/public/components/_autocomplete.scss
+++ b/frontend/public/components/_autocomplete.scss
@@ -27,7 +27,7 @@
 }
 
 .co-suggestion-line {
-  border: 1px solid #ededed;
+  border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
   background-color: var(--pf-global--palette--black-150);
   border-radius: 12px;
   overflow: hidden;

--- a/frontend/public/components/_service.scss
+++ b/frontend/public/components/_service.scss
@@ -7,7 +7,7 @@
     // Collapse borders when multiple consecutive rows.
     margin-top: -1px;
     padding: 20px 0 5px 20px;
-    border: 1px solid #eee;
+    border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
 
     .ip-name {
       margin-bottom: 5px;

--- a/frontend/public/components/markdown-view.tsx
+++ b/frontend/public/components/markdown-view.tsx
@@ -220,7 +220,7 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
   }
   td,
   th {
-    border-bottom: 1px solid #ededed;
+    border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
     padding: 10px;
     vertical-align: top;
   }

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -508,7 +508,7 @@ dl.co-inline {
   &--bordered {
     .co-m-table-grid__body .row,
     .co-m-table-grid__head {
-      border-bottom: solid 1px #eee;
+      border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
     }
   }
   .co-m-table-grid {

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -30,7 +30,7 @@
 }
 
 .co-form-section__separator {
-  border-top: solid 1px #eee;
+  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
   margin: 30px 0;
 }
 

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -273,7 +273,7 @@ form.pf-c-form {
     border-bottom: 0;
   }
   tr:last-child {
-    border-bottom: 1px solid $table-border-color;
+    border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
   }
 }
 

--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -17,7 +17,7 @@ $fa-font-path: $consoleWebDistPath + '/';
 
 // PatternFly 4 font path.
 $pf-global--font-path: '~@patternfly/patternfly/assets/fonts';
-$table-border-color: $pf-color-black-200;
+$table-border-color: var(--pf-global--BorderColor--300);
 
 :root {
   --pf-global--FontSize--md: 14px; // Numerical value required, same as $font-size-base

--- a/frontend/public/style/ancillary/_bootstrap-residual.scss
+++ b/frontend/public/style/ancillary/_bootstrap-residual.scss
@@ -180,14 +180,14 @@ pre code {
         padding: $table-cell-padding;
         line-height: $line-height-base;
         vertical-align: top;
-        border-top: 1px solid $table-border-color;
+        border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
       }
     }
   }
   // Bottom align for column headings
   > thead > tr > th {
     vertical-align: bottom;
-    border-bottom: 2px solid $table-border-color;
+    border-bottom: var(--pf-global--BorderWidth--md) solid var(--pf-global--BorderColor--300);
   }
   // Remove top border from thead by default
   > caption + thead,


### PR DESCRIPTION
For: https://issues.redhat.com/browse/CONSOLE-3081
fix(borders): updates #eee, #ededed, $table-border-color to `var(--pf-global--BorderColor--300)`
This pr converts `#eee`, `#ededed`, `$pf-color-black-200`, `$table-border-color` to `var(--pf-global--BorderColor--300)`

Color shifts are described here: https://codepen.io/bobcatTaco/pen/NWwVYzq#eee-ededed

![Screen Shot 2022-03-08 at 2 34 53 PM](https://user-images.githubusercontent.com/5385435/157311770-4296aef4-db90-4a2e-a933-43a4943c4b52.png)

