### PR TITLE
Bug 2042852: Topology toolbars are unaligned to other toolbars

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/TopologyControlBar.scss
+++ b/frontend/packages/topology/src/components/graph-view/TopologyControlBar.scss
@@ -1,0 +1,5 @@
+.pf-topology-control-bar {
+  &.odc-topology-control-bar {
+    left: var(--pf-global--spacer--sm);
+  }
+}

--- a/frontend/packages/topology/src/components/graph-view/TopologyControlBar.tsx
+++ b/frontend/packages/topology/src/components/graph-view/TopologyControlBar.tsx
@@ -9,6 +9,8 @@ import {
 } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
 
+import './TopologyControlBar.scss';
+
 interface ControlBarProps {
   visualization: Visualization;
   isDisabled: boolean;
@@ -17,7 +19,7 @@ interface ControlBarProps {
 const TopologyControlBar: React.FC<ControlBarProps> = observer(({ visualization, isDisabled }) => {
   const { t } = useTranslation();
   return (
-    <span className="pf-topology-control-bar">
+    <span className="pf-topology-control-bar odc-topology-control-bar">
       <PfTopologyControlBar
         controlButtons={[
           ...createTopologyControlButtons({

--- a/frontend/packages/topology/src/components/list-view/TopologyListView.scss
+++ b/frontend/packages/topology/src/components/list-view/TopologyListView.scss
@@ -25,6 +25,10 @@
     }
   }
 
+  .pf-c-data-list {
+    --pf-c-data-list__item-row--PaddingLeft: calc(var(--pf-c-data-list__item-row--xl--PaddingLeft) - var(--pf-global--spacer--sm));
+  }
+
   &__sidebar {
     background-color: var(--pf-global--BackgroundColor--100);
     bottom: 0;

--- a/frontend/packages/topology/src/filters/TopologyFilterBar.scss
+++ b/frontend/packages/topology/src/filters/TopologyFilterBar.scss
@@ -2,11 +2,11 @@
 
 .odc-topology-filter-bar {
   background-color: var(--pf-global--BackgroundColor--100);
-  padding: 6px $pf-global-gutter;
+  padding: 6px 0;
 
-  @media (min-width: $pf-global--breakpoint--xl) {
-    padding-left: $pf-global-gutter--md;
-    padding-right: $pf-global-gutter--md;
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    padding-left: var(--pf-global--spacer--sm); 
+    padding-right: var(--pf-global--spacer--sm)
   }
 
   &__kiali-link {

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -85,6 +85,13 @@ $dropdown-background--hover: $pf-color-black-200; // pf-c-dropdown__menu-item--h
   }
 }
 
+.co-namespace-bar--no-project {
+  padding-left: var(--pf-global--spacer--sm);
+  @media screen and (max-width: $pf-global--breakpoint--xl) {
+    margin-left: -0.5rem;
+  }
+}
+
 .co-namespace-selector {
   margin-right: 20px;
   max-width: 60%;

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -1149,7 +1149,9 @@ export const NamespaceBar = ({ hideProjects = false, children, disabled, onNames
     k8s.hasIn(['RESOURCES', 'models', ProjectModel.kind]),
   );
   return (
-    <div className="co-namespace-bar">
+    <div
+      className={classNames('co-namespace-bar', { 'co-namespace-bar--no-project': hideProjects })}
+    >
       {hideProjects ? (
         <div className="co-namespace-bar__items" data-test-id="namespace-bar-dropdown">
           {children}


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGSM-39613

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Due to the latest changes in the Patterfly classes, the alignment of the topology toolbars in admin and dev perspective got messed up in `4.10`, when the `Gitops Primer` plugin was installed. This issue wasn't present in `4.8` and `4.9`.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Adjusted the Patternfly classes so that the toolbars get aligned.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
*Developer Perspective*
![left-alignment](https://user-images.githubusercontent.com/47265560/157402909-cf780933-6d9f-4d05-ad27-ef2855ccb6be.png)
![right-alignment](https://user-images.githubusercontent.com/47265560/157402991-71449e09-3f54-41c4-97e5-e9d2791fd4b9.png)

*Admin Perspective*
![admin-left-alignment](https://user-images.githubusercontent.com/47265560/157403149-f5d4bbf5-950c-47ef-9b39-a39d66058587.png)
![admin-right-alignment](https://user-images.githubusercontent.com/47265560/157403172-f4c39a3d-367a-466c-99b6-969c17eb62c2.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup is required to test this PR, mention the details -->
1. Install Primer operator to see also the export button
2. For admin perspective: Switch perspective, navigate to projects, select a project and switch to the workload tab
3. For dev perspective: Switch perspective, select a project and navigate to topology


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge