### PR TITLE
Sort catalog filters and other enhancements

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogFilters.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogFilters.tsx
@@ -5,7 +5,12 @@ import {
   FilterSidePanelCategoryItem,
 } from '@patternfly/react-catalog-view-extension';
 import * as _ from 'lodash';
-import { CatalogFilterCounts, CatalogFilters } from '../utils/types';
+import {
+  CatalogFilter,
+  CatalogFilterCounts,
+  CatalogFilterItem,
+  CatalogFilters,
+} from '../utils/types';
 
 type CatalogFiltersProps = {
   activeFilters: CatalogFilters;
@@ -26,12 +31,12 @@ const CatalogFilters: React.FC<CatalogFiltersProps> = ({
 }) => {
   const sortedActiveFilters = Object.keys(activeFilters)
     .sort()
-    .reduce((acc, groupName) => {
+    .reduce<CatalogFilters>((acc, groupName) => {
       acc[groupName] = activeFilters[groupName];
       return acc;
     }, {});
 
-  const renderFilterItem = (filter, filterName, groupName) => {
+  const renderFilterItem = (filter: CatalogFilterItem, filterName: string, groupName: string) => {
     const { label, active } = filter;
     const count = filterGroupCounts[groupName]?.[filterName] ?? 0;
     // TODO remove when adopting https://github.com/patternfly/patternfly-react/issues/5139
@@ -54,10 +59,10 @@ const CatalogFilters: React.FC<CatalogFiltersProps> = ({
     );
   };
 
-  const renderFilterGroup = (filterGroup, groupName) => {
+  const renderFilterGroup = (filterGroup: CatalogFilter, groupName: string) => {
     const filterGroupKeys = Object.keys(filterGroup);
     if (filterGroupKeys.length > 1) {
-      const sortedFilterGroup = filterGroupKeys.sort().reduce((acc, filterName) => {
+      const sortedFilterGroup = filterGroupKeys.sort().reduce<CatalogFilter>((acc, filterName) => {
         acc[filterName] = filterGroup[filterName];
         return acc;
       }, {});

--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogFilters.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogFilters.tsx
@@ -24,6 +24,13 @@ const CatalogFilters: React.FC<CatalogFiltersProps> = ({
   onFilterChange,
   onShowAllToggle,
 }) => {
+  const sortedActiveFilters = Object.keys(activeFilters)
+    .sort()
+    .reduce((acc, groupName) => {
+      acc[groupName] = activeFilters[groupName];
+      return acc;
+    }, {});
+
   const renderFilterItem = (filter, filterName, groupName) => {
     const { label, active } = filter;
     const count = filterGroupCounts[groupName]?.[filterName] ?? 0;
@@ -47,24 +54,35 @@ const CatalogFilters: React.FC<CatalogFiltersProps> = ({
     );
   };
 
-  const renderFilterGroup = (filterGroup, groupName) =>
-    Object.keys(filterGroup).length > 1 ? (
-      <FilterSidePanelCategory
-        key={groupName}
-        title={filterGroupNameMap[groupName] || groupName}
-        onShowAllToggle={() => onShowAllToggle(groupName)}
-        showAll={filterGroupsShowAll[groupName] ?? false}
-        data-test-group-name={groupName}
-      >
-        {_.map(filterGroup, (filter, filterName) =>
-          renderFilterItem(filter, filterName, groupName),
-        )}
-      </FilterSidePanelCategory>
-    ) : null;
+  const renderFilterGroup = (filterGroup, groupName) => {
+    const filterGroupKeys = Object.keys(filterGroup);
+    if (filterGroupKeys.length > 1) {
+      const sortedFilterGroup = filterGroupKeys.sort().reduce((acc, filterName) => {
+        acc[filterName] = filterGroup[filterName];
+        return acc;
+      }, {});
+      return (
+        <FilterSidePanelCategory
+          key={groupName}
+          title={filterGroupNameMap[groupName] || groupName}
+          onShowAllToggle={() => onShowAllToggle(groupName)}
+          showAll={filterGroupsShowAll[groupName] ?? false}
+          data-test-group-name={groupName}
+        >
+          {_.map(sortedFilterGroup, (filter, filterName) =>
+            renderFilterItem(filter, filterName, groupName),
+          )}
+        </FilterSidePanelCategory>
+      );
+    }
+    return null;
+  };
 
   return (
     <FilterSidePanel>
-      {_.map(activeFilters, (filterGroup, groupName) => renderFilterGroup(filterGroup, groupName))}
+      {_.map(sortedActiveFilters, (filterGroup, groupName) =>
+        renderFilterGroup(filterGroup, groupName),
+      )}
     </FilterSidePanel>
   );
 };

--- a/frontend/packages/console-shared/src/components/catalog/service/CatalogServiceProvider.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/service/CatalogServiceProvider.tsx
@@ -36,7 +36,7 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
   const [extItemsMap, setExtItemsMap] = React.useState<{ [uid: string]: CatalogItem[] }>({});
   const [extItemsErrorMap, setItemsErrorMap] = React.useState<{ [uid: string]: Error }>({});
   const [metadataProviderMap, setMetadataProviderMap] = React.useState<{
-    [type: string]: CatalogItemMetadataProviderFunction[];
+    [type: string]: { [id: string]: CatalogItemMetadataProviderFunction };
   }>({});
 
   const loaded =
@@ -79,8 +79,11 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
     setItemsErrorMap((prev) => ({ ...prev, [uid]: error }));
   }, []);
 
-  const onMetadataValueResolved = React.useCallback((provider, type) => {
-    setMetadataProviderMap((prev) => ({ ...prev, [type]: [...(prev?.[type] ?? []), provider] }));
+  const onMetadataValueResolved = React.useCallback((provider, uid, type) => {
+    setMetadataProviderMap((prev) => ({
+      ...prev,
+      [type]: { ...(prev?.[type] ?? {}), [uid]: provider },
+    }));
   }, []);
 
   const searchCatalog = React.useCallback(
@@ -148,7 +151,9 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
             id={extension.uid}
             useValue={extension.properties.provider}
             options={defaultOptions}
-            onValueResolved={(value) => onMetadataValueResolved(value, extension.properties.type)}
+            onValueResolved={(value, uid) =>
+              onMetadataValueResolved(value, uid, extension.properties.type)
+            }
           />
         ))}
       {children(catalogService)}

--- a/frontend/packages/console-shared/src/components/catalog/utils/__tests__/catalog-utils.spec.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/utils/__tests__/catalog-utils.spec.tsx
@@ -34,10 +34,10 @@ describe('catalog-utils#applyCatalogItemMetadata', () => {
       },
     ];
     const metadataProviderMap: {
-      [type: string]: CatalogItemMetadataProviderFunction[];
+      [type: string]: { [id: string]: CatalogItemMetadataProviderFunction };
     } = {
-      type1: [
-        () => ({
+      type1: {
+        '@console/dev-console[49]': () => ({
           tags: ['foo', 'bar'],
           attributes: {
             foo: 'bar',
@@ -51,7 +51,7 @@ describe('catalog-utils#applyCatalogItemMetadata', () => {
             },
           ],
         }),
-      ],
+      },
     };
 
     const result = applyCatalogItemMetadata(catalogItems, metadataProviderMap);

--- a/frontend/packages/console-shared/src/components/catalog/utils/catalog-utils.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/utils/catalog-utils.tsx
@@ -94,11 +94,11 @@ export const customPropertyPresent = (
 export const applyCatalogItemMetadata = (
   catalogItems: CatalogItem[],
   metadataProviderMap: {
-    [type: string]: CatalogItemMetadataProviderFunction[];
+    [type: string]: { [id: string]: CatalogItemMetadataProviderFunction };
   },
 ) =>
   catalogItems.map((item) => {
-    const metadataProviders = metadataProviderMap[item.type];
+    const metadataProviders = Object.values(metadataProviderMap[item.type] ?? {});
     if (metadataProviders?.length) {
       const metadata = metadataProviders
         .map((metadataProvider) => metadataProvider(item))

--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -285,7 +285,7 @@
       ]
     },
     "flags": {
-      "required": ["OPENSHIFT"]
+      "required": ["ALLOW_SERVICE_BINDING"]
     }
   },
   {
@@ -296,7 +296,7 @@
       "provider": { "$codeRef": "catalog.bindableItemMetadataProvider" }
     },
     "flags": {
-      "required": ["OPENSHIFT"]
+      "required": ["ALLOW_SERVICE_BINDING"]
     }
   },
   {

--- a/frontend/packages/dev-console/src/components/catalog/providers/useBindableItemMetadataProvider.ts
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useBindableItemMetadataProvider.ts
@@ -5,25 +5,18 @@ import {
   CatalogItemMetadataProviderFunction,
   ExtensionHook,
 } from '@console/dynamic-plugin-sdk';
-import { fetchBindableServices } from '../../topology/bindable-services/fetch-bindable-services-utils';
+import { getGroupVersionKindForModel } from '@console/dynamic-plugin-sdk/src/lib-core';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { BindableServicesModel } from '../../topology/bindable-services/models';
+import { BindableServiceGVK, BindableServicesKind } from '../../topology/bindable-services/types';
 
 const useBindableItemMetadataProvider: ExtensionHook<CatalogItemMetadataProviderFunction> = () => {
-  const [bindableServices, setBindableServices] = React.useState([]);
-  const [loaded, setLoaded] = React.useState(false);
-  const [error, setError] = React.useState(null);
+  const [bindableKindsRes, loaded, error] = useK8sWatchResource<BindableServicesKind>({
+    groupVersionKind: getGroupVersionKindForModel(BindableServicesModel),
+    name: 'bindable-kinds',
+  });
 
-  React.useEffect(() => {
-    fetchBindableServices()
-      .then((resp) => {
-        setBindableServices(resp);
-        setLoaded(true);
-      })
-      .catch((e) => {
-        setBindableServices([]);
-        setLoaded(true);
-        setError(e);
-      });
-  }, []);
+  const bindableServices: BindableServiceGVK[] = bindableKindsRes?.status ?? [];
 
   const [t] = useTranslation();
 


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-6491

This PR adds the fix for sorting catalog filters alphabetically and 
uses useK8sWatchResource instead of k8sGet for fetching the bindable-services.

**Screenshots:**
<img width="1784" alt="Screenshot 2022-03-08 at 11 13 24 PM" src="https://user-images.githubusercontent.com/20724543/157407728-a191931a-4039-4da8-a440-ee8d947733ad.png">

<img width="1784" alt="Screenshot 2022-03-08 at 11 13 40 PM" src="https://user-images.githubusercontent.com/20724543/157407734-eda2f729-8015-4f1a-aeed-1e4ae1b46448.png">

<img width="1784" alt="Screenshot 2022-03-09 at 4 12 08 PM" src="https://user-images.githubusercontent.com/20724543/157429633-a3538fdf-b13d-47da-aad0-a377ce20e29c.png">
<img width="1784" alt="Screenshot 2022-03-09 at 4 19 34 PM" src="https://user-images.githubusercontent.com/20724543/157429643-249f3c82-2565-4208-8c01-6f53a9ee91f3.png">


/kind feature