### PR TITLE
Bug 2062524: fixes uri case for event sink

### DIFF
--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -245,7 +245,7 @@
   "Unable to create kafka connector as bootstrapServerHost or secret is not available in target resource.": "Unable to create kafka connector as bootstrapServerHost or secret is not available in target resource.",
   "Knative Services": "Knative Services",
   "All Revisions are autoscaled to 0.": "All Revisions are autoscaled to 0.",
-  "Output Target": "Output Target",
   "No output target found for this resource.": "No output target found for this resource.",
+  "Output Target": "Output Target",
   "Domain mappings": "Domain mappings"
 }

--- a/frontend/packages/knative-plugin/src/topology/sidebar/__tests__/__mocks__/event-sink-data.ts
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/__tests__/__mocks__/event-sink-data.ts
@@ -1,0 +1,84 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
+export const eventSinkKamelet: K8sResourceKind = {
+  apiVersion: 'camel.apache.org/v1alpha1',
+  kind: 'KameletBinding',
+  metadata: {
+    annotations: {
+      'camel.apache.org/kamelet.icon':
+        'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pg0KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE2LjAuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPg0KPCFET0NUWVBFIHN2ZyBQVUJMSUMgIi0vL1czQy8vRFREIFNWRyAxLjEvL0VOIiAiaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkIj4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCINCgkgd2lkdGg9IjUxMnB4IiBoZWlnaHQ9IjUxMnB4IiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgNTEyIDUxMjsiIHhtbDpzcGFjZT0icHJlc2VydmUiPg0KPGc+DQoJPHBhdGggZD0iTTQ0OCwwSDY0QzQ2LjMyOCwwLDMyLDE0LjMxMywzMiwzMnY0NDhjMCwxNy42ODgsMTQuMzI4LDMyLDMyLDMyaDM4NGMxNy42ODgsMCwzMi0xNC4zMTIsMzItMzJWMzINCgkJQzQ4MCwxNC4zMTMsNDY1LjY4OCwwLDQ0OCwweiBNNjQsNDgwVjEyOGg4MHY2NEg5NnYxNmg0OHY0OEg5NnYxNmg0OHY0OEg5NnYxNmg0OHY0OEg5NnYxNmg0OHY4MEg2NHogTTQ0OCw0ODBIMTYwdi04MGgyNTZ2LTE2DQoJCUgxNjB2LTQ4aDI1NnYtMTZIMTYwdi00OGgyNTZ2LTE2SDE2MHYtNDhoMjU2di0xNkgxNjB2LTY0aDI4OFY0ODB6Ii8+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8L3N2Zz4NCg==',
+    },
+    creationTimestamp: '2022-03-10T04:09:58Z',
+    generation: 1,
+    managedFields: [
+      {
+        apiVersion: 'camel.apache.org/v1alpha1',
+        fieldsType: 'FieldsV1',
+        fieldsV1: {
+          'f:spec': {
+            '.': {},
+            'f:sink': {
+              '.': {},
+              'f:ref': { '.': {}, 'f:apiVersion': {}, 'f:kind': {}, 'f:name': {} },
+            },
+            'f:source': {
+              '.': {},
+              'f:ref': { '.': {}, 'f:apiVersion': {}, 'f:kind': {}, 'f:name': {} },
+            },
+          },
+        },
+        manager: 'Mozilla',
+        operation: 'Update',
+        time: '2022-03-10T04:09:58Z',
+      },
+      {
+        apiVersion: 'camel.apache.org/v1alpha1',
+        fieldsType: 'FieldsV1',
+        fieldsV1: {
+          'f:metadata': { 'f:annotations': { '.': {}, 'f:camel.apache.org/kamelet.icon': {} } },
+        },
+        manager: 'kamel',
+        operation: 'Update',
+        time: '2022-03-10T04:09:58Z',
+      },
+      {
+        apiVersion: 'camel.apache.org/v1alpha1',
+        fieldsType: 'FieldsV1',
+        fieldsV1: {
+          'f:status': {
+            '.': {},
+            'f:conditions': {},
+            'f:phase': {},
+            'f:replicas': {},
+            'f:selector': {},
+          },
+        },
+        manager: 'kamel',
+        operation: 'Update',
+        subresource: 'status',
+        time: '2022-03-10T04:11:13Z',
+      },
+    ],
+    name: 'log-sink-binding',
+    namespace: 'jai-test',
+    resourceVersion: '49188',
+    uid: 'ef3daae8-3a43-45b1-be6c-4170983f26ab',
+  },
+  spec: {
+    sink: { ref: { apiVersion: 'camel.apache.org/v1alpha1', kind: 'Kamelet', name: 'log-sink' } },
+    source: { ref: { apiVersion: 'messaging.knative.dev/v1', kind: 'Channel', name: 'channel' } },
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2022-03-10T04:11:13Z',
+        lastUpdateTime: '2022-03-10T04:11:13Z',
+        status: 'True',
+        type: 'Ready',
+      },
+    ],
+    phase: 'Ready',
+    replicas: 1,
+    selector: 'camel.apache.org/integration=log-sink-binding',
+  },
+};

--- a/frontend/packages/knative-plugin/src/topology/sidebar/__tests__/knative-resource-tab-sections.spec.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/__tests__/knative-resource-tab-sections.spec.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { configure, render, screen } from '@testing-library/react';
+import * as _ from 'lodash';
+import { EventSinkOutputTargetSection } from '../knative-resource-tab-sections';
+import { eventSinkKamelet } from './__mocks__/event-sink-data';
+
+configure({ testIdAttribute: 'data-test' });
+
+describe('EventSinkOutputTargetSection', () => {
+  it('should show message no output resources foung if none exists', () => {
+    const mockEventSink = _.omit(eventSinkKamelet, 'spec.source');
+    render(<EventSinkOutputTargetSection resource={mockEventSink} />);
+    screen.getByTestId('event-sink-text');
+    expect(screen.queryByTestId('event-sink-sb-res')).toBeNull();
+    expect(screen.queryByTestId('event-sink-target-uri')).toBeNull();
+  });
+
+  it('should show ResourceLink as output resource if source is ref', () => {
+    render(<EventSinkOutputTargetSection resource={eventSinkKamelet} />);
+    screen.getByTestId('event-sink-sb-res');
+    expect(screen.queryByTestId('event-sink-text')).toBeNull();
+    expect(screen.queryByTestId('event-sink-target-uri')).toBeNull();
+  });
+
+  it('should show ExternalLink as output resource if source is uri', () => {
+    const mockEventSink = _.omit(eventSinkKamelet, 'spec.source.ref');
+    mockEventSink.spec.source.uri = 'http://abc.com';
+    render(<EventSinkOutputTargetSection resource={mockEventSink} />);
+    screen.getByTestId('event-sink-target-uri');
+    expect(screen.queryByTestId('event-sink-text')).toBeNull();
+    expect(screen.queryByTestId('event-sink-sb-res')).toBeNull();
+  });
+});

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-resource-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-resource-tab-sections.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
-import { SidebarSectionHeading, ResourceLink } from '@console/internal/components/utils';
+import {
+  SidebarSectionHeading,
+  ResourceLink,
+  ExternalLink,
+} from '@console/internal/components/utils';
 import { K8sResourceKind, referenceFor, PodKind, podPhase } from '@console/internal/module/k8s';
 import { AllPodStatus } from '@console/shared/src';
 import TopologySideBarTabSection from '@console/topology/src/components/side-bar/TopologySideBarTabSection';
@@ -14,27 +18,43 @@ export const EventSinkOutputTargetSection: React.FC<{ resource: K8sResourceKind 
 }) => {
   const { t } = useTranslation();
   const target = resource?.spec?.source?.ref;
-  const reference = referenceFor(target);
+  const reference = target && referenceFor(target);
+  const sinkUri = resource?.spec?.source?.uri;
+
+  if (!reference && !sinkUri) {
+    return (
+      <span data-test="event-sink-text" className="text-muted">
+        {t('knative-plugin~No output target found for this resource.')}
+      </span>
+    );
+  }
+
   return (
     <>
       <SidebarSectionHeading text={t('knative-plugin~Output Target')} />
-      {target ? (
-        <ul className="list-group">
-          <li className="list-group-item">
-            {target && (
-              <ResourceLink
-                kind={reference}
-                name={target.name}
-                namespace={resource.metadata.namespace}
+      <ul className="list-group">
+        <li className="list-group-item">
+          {reference ? (
+            <ResourceLink
+              kind={reference}
+              name={target.name}
+              namespace={resource.metadata.namespace}
+              dataTest="event-sink-sb-res"
+            />
+          ) : (
+            <>
+              <span data-test="event-sink-target-uri" className="text-muted">
+                {t('knative-plugin~Target URI:')}{' '}
+              </span>
+              <ExternalLink
+                href={sinkUri}
+                additionalClassName="co-external-link--block"
+                text={sinkUri}
               />
-            )}
-          </li>
-        </ul>
-      ) : (
-        <span className="text-muted">
-          {t('knative-plugin~No output target found for this resource.')}
-        </span>
-      )}
+            </>
+          )}
+        </li>
+      </ul>
     </>
   );
 };


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2062524

**Analysis / Root cause**: 
Topology crashes on click of Event sink node if the resource is created source to Uri over ref

**Solution Description**: 
fixes uri case for event sink
- check for uri as well in source
- visualise uri in sidebar resource

**Screen shots / Gifs for design review**: 

<img width="884" alt="image" src="https://user-images.githubusercontent.com/5129024/157590589-ac8a48fb-3484-4a5d-b343-a1b0e6fd4c4d.png">

**Test setup**: 
1. Install Serverless operator and create CR for knativeServing/knativeEventing
2. Install Camel K operator
3. Create a Channel
4. Create resource KameletBinding from YAML(provided below)
5. Go to topology and click on the event sink node

```
apiVersion: camel.apache.org/v1alpha1
kind: KameletBinding
metadata:
  name: log-sink-binding
spec:
  source:
    uri: http://dummy.com/
  sink:
    ref:
      kind: Kamelet
      apiVersion: camel.apache.org/v1alpha1
      name: log-sink
```
**Tests**: 

<img width="826" alt="image" src="https://user-images.githubusercontent.com/5129024/157590780-9d22472e-c266-4cd2-9670-40b05c2ff4b3.png">


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge