### PR TITLE
[Release-4.9]-Bug 2021595: Key value field is not getting updated under Environment Tab in OpenShift Web Console

### DIFF
--- a/frontend/public/components/utils/value-from-pair.jsx
+++ b/frontend/public/components/utils/value-from-pair.jsx
@@ -40,7 +40,7 @@ const getKeys = (keyMap) => {
 
 export const NameKeyDropdownPair = ({
   name,
-  key,
+  keyValue,
   configMaps,
   secrets,
   serviceAccounts,
@@ -74,7 +74,7 @@ export const NameKeyDropdownPair = ({
   const saItems = {};
   const nameAutocompleteFilter = (text, item) => fuzzy(text, item.props.name);
   const keyAutocompleteFilter = (text, item) => fuzzy(text, item);
-  const keyTitle = _.isEmpty(key) ? t('public~Select a key') : key;
+  const keyTitle = _.isEmpty(keyValue) ? t('public~Select a key') : keyValue;
   const cmRefProperty = isKeyRef ? 'configMapKeyRef' : 'configMapRef';
   const secretRefProperty = isKeyRef ? 'secretKeyRef' : 'secretRef';
   const serviceAccountRefProperty = isKeyRef ? 'serviceAccountKeyRef' : 'serviceAccountRef';
@@ -142,7 +142,7 @@ export const NameKeyDropdownPair = ({
           autocompleteFilter={keyAutocompleteFilter}
           autocompletePlaceholder={t('public~Key')}
           items={itemKeys}
-          selectedKey={key}
+          selectedKey={keyValue}
           title={keyTitle}
           onChange={(val) => onChange({ [refProperty]: { name, key: val } })}
         />
@@ -193,7 +193,7 @@ const ConfigMapSecretKeyRef = ({
   }
   return (
     <NameKeyDropdownPair
-      key={key}
+      keyValue={key}
       name={name}
       configMaps={configMaps}
       secrets={secrets}
@@ -240,7 +240,7 @@ const ConfigMapSecretRef = ({
   }
   return (
     <NameKeyDropdownPair
-      key={key}
+      keyValue={key}
       name={name}
       configMaps={configMaps}
       secrets={secrets}


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2021595

Using the setup from the bug, the values are now displayed correctly in 4.9. 

This bug was fixed in 4.8 and also in 4.10.

<img width="925" alt="Screen Shot 2022-03-11 at 4 13 12 PM" src="https://user-images.githubusercontent.com/35978579/157968123-a5db7bcf-1eec-4291-9e70-9c37bd3506b3.png">
