### PR TITLE
CONSOLE-3081: [Dark theme] Additional skeleton updates for dark theme

### DIFF
--- a/frontend/packages/console-shared/src/styles/skeleton-screen.scss
+++ b/frontend/packages/console-shared/src/styles/skeleton-screen.scss
@@ -1,14 +1,17 @@
 :root {
   --os-skeleton--Color: var(--pf-global--palette--black-150);
+  --os-skeleton--Color--300: var(--pf-global--palette--black-300);
 }
 
-[class^="loading-skeleton"] {
+[class^="skeleton"] {
   .pf-theme-dark & {
     --os-skeleton--Color: var(--pf-global--palette--black-600);
+    --os-skeleton--Color--300: var(--pf-global--palette--black-700)
   }
 }
 
 $skeleton-color: var(--os-skeleton--Color);
+$skeleton-color--300: var(--os-skeleton--Color--300);
 
 $skeleton-animation: loading-skeleton 1s ease-out .15s infinite alternate;
 $skeleton-bone-height-1line: 24px;
@@ -41,6 +44,9 @@ $skeleton-activity-size: auto;
   width: 100%;
   &::after {
     background-image: url('../images/skeleton-chart.svg');
+    .pf-theme-dark & {
+      opacity: .2;
+    }
     background-position: 0px bottom;
     background-repeat: no-repeat;
     background-size: cover;

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/inventory-card/virt-overview-inventory-card.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/inventory-card/virt-overview-inventory-card.scss
@@ -1,6 +1,6 @@
 @import '~@patternfly/patternfly/sass-utilities/colors';
-$skeleton-animation: loading-skeleton 1s ease-out .15s infinite alternate;
-$skeleton-color: #eaedf1;
+@import '../../../../../console-shared/src/styles/skeleton-screen.scss';
+
 
 .kv-inventory-card__body {
   padding: 0;

--- a/frontend/public/components/utils/_skeleton-screen.scss
+++ b/frontend/public/components/utils/_skeleton-screen.scss
@@ -1,23 +1,23 @@
 @import '~@console/shared/src/styles/skeleton-screen';
 
 $skeleton-detail-bone-height: $skeleton-bone-height-1line;
-$skeleton-detail-bone: linear-gradient(white $skeleton-detail-bone-height, transparent 0);
+$skeleton-detail-bone: linear-gradient($skeleton-color $skeleton-detail-bone-height, transparent 0);
 
-$skeleton-detail-position: 15px 35px; // declared out of alpha order to be reused
+$skeleton-detail-position: 0 35px; // declared out of alpha order to be reused
 
 $skeleton-detail-data-position: $skeleton-detail-position;
 $skeleton-detail-data-size: 200px $skeleton-detail-bone-height;
 
-$skeleton-detail-label: linear-gradient(white ($skeleton-detail-bone-height * 2), transparent 0);
+$skeleton-detail-label: linear-gradient($skeleton-color ($skeleton-detail-bone-height * 2), transparent 0);
 $skeleton-detail-label-position: $skeleton-detail-position;
 $skeleton-detail-label-size: 90% 75px;
 
-$skeleton-detail-name-position: 15px 15px;
+$skeleton-detail-name-position: 0 15px;
 $skeleton-detail-name-size: 80px 15px;
 
-$skeleton-detail-resource-position: 45px 35px;
+$skeleton-detail-resource-position: 30px 35px;
 $skeleton-detail-resource-size: 75%;
-$skeleton-detail-resource-icon: radial-gradient(circle 12px at center, white 100%, transparent 0);
+$skeleton-detail-resource-icon: radial-gradient(circle 12px at center, $skeleton-color 100%, transparent 0);
 $skeleton-detail-resource-icon-position: $skeleton-detail-position;
 $skeleton-detail-resource-icon-size: $skeleton-detail-bone-height $skeleton-detail-bone-height;
 
@@ -27,11 +27,11 @@ $skeleton-overview-tile-padding: 24px;
 
 $skeleton-overview-icon-size: 24px;
 $skeleton-overview-icon-position: 15px $skeleton-overview-tile-padding;
-$skeleton-overview-icon-bone: radial-gradient(circle 12px at center, white 100%, transparent 0);
+$skeleton-overview-icon-bone: radial-gradient(circle 12px at center, $skeleton-color 100%, transparent 0);
 
 $skeleton-overview-meta-height: 24px;
 $skeleton-overview-meta-position: 96% $skeleton-overview-tile-padding;
-$skeleton-overview-meta-bone: linear-gradient(white $skeleton-overview-meta-height, transparent 0);
+$skeleton-overview-meta-bone: linear-gradient($skeleton-color $skeleton-overview-meta-height, transparent 0);
 $skeleton-overview-meta-width: 75px;
 
 $skeleton-overview-tile-bone: linear-gradient(
@@ -42,23 +42,23 @@ $skeleton-overview-tile-bone: linear-gradient(
 $skeleton-overview-title-height: 24px;
 $skeleton-overview-title-position: 50px $skeleton-overview-tile-padding;
 $skeleton-overview-title-bone: linear-gradient(
-  white $skeleton-overview-title-height,
+  $skeleton-color $skeleton-overview-title-height,
   transparent 0
 );
 $skeleton-overview-title-width: 38%;
 
 $skeleton-tile-height: 240px; // height of catalog tiles
 $skeleton-tile-padding: 24px;
-$skeleton-tile-bone: linear-gradient($skeleton-color $skeleton-tile-height, transparent 0);
+$skeleton-tile-bone: linear-gradient($skeleton-color--300 $skeleton-tile-height, transparent 0);
 
-$skeleton-tile-logo-bone: radial-gradient(circle 20px at center, #fff 100%, transparent 0);
+$skeleton-tile-logo-bone: radial-gradient(circle 20px at center, $skeleton-color 100%, transparent 0);
 $skeleton-tile-logo-position: $skeleton-tile-padding $skeleton-tile-padding;
 $skeleton-tile-logo-size: 46px;
 
 $skeleton-tile-title-height: 32px;
 $skeleton-tile-title-position: $skeleton-tile-padding 75px;
 $skeleton-tile-title-width: 142px;
-$skeleton-tile-title-bone: linear-gradient(#fff $skeleton-tile-title-height, transparent 0);
+$skeleton-tile-title-bone: linear-gradient($skeleton-color $skeleton-tile-title-height, transparent 0);
 
 $skeleton-tile-desc-line-height: 14px;
 $skeleton-tile-desc-line-1-width: 168px;
@@ -69,7 +69,7 @@ $skeleton-tile-desc-line-3-width: 185px;
 $skeleton-tile-desc-line-3-position: $skeleton-tile-padding 172px;
 $skeleton-tile-desc-line-4-width: 125px;
 $skeleton-tile-desc-line-4-position: $skeleton-tile-padding 192px;
-$skeleton-tile-desc-line-bone: linear-gradient(#fff $skeleton-tile-desc-line-height, transparent 0);
+$skeleton-tile-desc-line-bone: linear-gradient($skeleton-color $skeleton-tile-desc-line-height, transparent 0);
 
 @keyframes loading-skeleton {
   0% {
@@ -193,7 +193,6 @@ $skeleton-tile-desc-line-bone: linear-gradient(#fff $skeleton-tile-desc-line-hei
 
 .skeleton-detail-view--tile {
   animation: $skeleton-animation;
-  background: $skeleton-color;
   height: 75px;
   opacity: 0;
   width: 95%;


### PR DESCRIPTION
More updated skeleton views
To make it easier to view, adjust page load speed via. Browser Developer tools > Network > Network throttling

@mattnolting @jerolimov @vikram-raj 

**Catalog** (dark and light)
<img width="1466" alt="cat-d" src="https://user-images.githubusercontent.com/1874151/157975660-b05b4720-fbaf-4c0e-857e-b18bbb08954e.png">
<img width="1468" alt="cat-l" src="https://user-images.githubusercontent.com/1874151/157975664-27335e70-8c4f-45fd-91ac-a999d5c1bc14.png">


----
**Resource details** (dark and light)
<img width="1477" alt="Screen Shot 2022-03-11 at 5 05 12 PM" src="https://user-images.githubusercontent.com/1874151/157977224-81a3a860-5928-4be1-b8b2-d7f2668b22e2.png">
<img width="1478" alt="Screen Shot 2022-03-11 at 5 06 43 PM" src="https://user-images.githubusercontent.com/1874151/157977604-273e1bb1-0628-49d3-a0a6-d44597b2d6d8.png">


----
**Overview info, status, events** (dark and light)
<img width="1042" alt="3cards-d" src="https://user-images.githubusercontent.com/1874151/157977867-9af5e7d9-cb49-48b5-8cd2-045b74428336.png">
<img width="1037" alt="3cards-l" src="https://user-images.githubusercontent.com/1874151/157977884-5de20c42-f1e9-4933-a0aa-a0f3f9679a9a.png">


----
**Overview chart** (dark and light)
<img width="508" alt="chart-d" src="https://user-images.githubusercontent.com/1874151/157975616-df88d5b3-b242-4273-9887-b894ee693545.png">
<img width="513" alt="chart-l" src="https://user-images.githubusercontent.com/1874151/157977654-3dfd8f8f-762c-45b6-804c-a0143fef30b3.png">
