### PR TITLE
Fix namespace and backing store table to show pre selected values.

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/bucket-class/backingstore-table.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/bucket-class/backingstore-table.tsx
@@ -92,7 +92,7 @@ const BackingStoreTable: React.FC<BackingStoreTableProps> = (props) => {
   const memoizedData = useDeepCompareMemoize(data, true);
   const memoizedPreSelected = useDeepCompareMemoize(preSelected, true);
   React.useEffect(() => {
-    if (!_.isEmpty(memoizedPreSelected) && selectedRows.size === 0) {
+    if (!_.isEmpty(memoizedPreSelected) && selectedRows.size === 0 && !_.isEmpty(memoizedData)) {
       const preSelectedRows = memoizedData.filter((item) =>
         memoizedPreSelected.includes(getUID(item)),
       );

--- a/frontend/packages/ceph-storage-plugin/src/components/namespace-store/namespace-store-table.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/namespace-store/namespace-store-table.tsx
@@ -84,7 +84,7 @@ const NamespaceStoreTable: React.FC<NamespaceStoreTableProps> = (props) => {
   );
   const memoizedData = useDeepCompareMemoize(data, true);
   React.useEffect(() => {
-    if (!_.isEmpty(preSelected) && selectedRows.size === 0) {
+    if (!_.isEmpty(preSelected) && selectedRows.size === 0 && !_.isEmpty(memoizedData)) {
       const preSelectedRows = memoizedData.filter((item) => preSelected.includes(getUID(item)));
       updateSelectedRows(preSelectedRows);
     }


### PR DESCRIPTION
The values get overwritten by empty array, which does not populate with
the preselected value in the edit bucket class modal.

before: 
![before-checkbox](https://user-images.githubusercontent.com/24807435/158553986-1f4d6236-98e3-4ade-88ab-41c38b86d355.png)

![ns-multi](https://user-images.githubusercontent.com/24807435/158743300-c2347f6f-323e-4482-be1a-6fe95626b02a.png)


after:
![after-checkbox](https://user-images.githubusercontent.com/24807435/158553976-935785d8-4846-43c6-a1a1-671743ce917d.png)
![ns-multi-after](https://user-images.githubusercontent.com/24807435/158743306-22f6fbe3-859c-4714-ac88-6ad71a65f211.png)


The editing modal successfully changes the custom resource as well

<details><summary>Before</summary>

<p>

```yaml
apiVersion: noobaa.io/v1alpha1
kind: BucketClass
metadata:
  resourceVersion: '217683'
  name: test-bc-ns-multi
  uid: 459ffae5-706b-4945-b19b-29b15129c31b
  creationTimestamp: '2022-03-16T04:24:35Z'
  generation: 4
  managedFields:
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:spec':
          .: {}
          'f:namespacePolicy':
            .: {}
            'f:multi':
              .: {}
              'f:readResources': {}
              'f:writeResource': {}
            'f:type': {}
      manager: Mozilla
      operation: Update
      time: '2022-03-16T04:24:35Z'
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:finalizers':
            .: {}
            'v:"noobaa.io/finalizer"': {}
          'f:labels':
            .: {}
            'f:app': {}
      manager: noobaa-operator
      operation: Update
      time: '2022-03-16T04:24:35Z'
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:status':
          .: {}
          'f:conditions': {}
          'f:phase': {}
      manager: noobaa-operator
      operation: Update
      subresource: status
      time: '2022-03-16T04:24:35Z'
  namespace: openshift-storage
  finalizers:
    - noobaa.io/finalizer
  labels:
    app: noobaa
spec:
  namespacePolicy:
    multi:
      readResources:
        - test-ns-2
      writeResource: test-ns-2
    type: Multi
status:
  conditions:
    - lastHeartbeatTime: '2022-03-16T04:24:35Z'
      lastTransitionTime: '2022-03-16T04:24:35Z'
      message: NooBaa NamespaceStore "test-ns-2" is not yet ready
      reason: TemporaryError
      status: 'False'
      type: Available
    - lastHeartbeatTime: '2022-03-16T04:24:35Z'
      lastTransitionTime: '2022-03-16T04:24:35Z'
      message: NooBaa NamespaceStore "test-ns-2" is not yet ready
      reason: TemporaryError
      status: 'True'
      type: Progressing
    - lastHeartbeatTime: '2022-03-16T04:24:35Z'
      lastTransitionTime: '2022-03-16T04:24:35Z'
      message: NooBaa NamespaceStore "test-ns-2" is not yet ready
      reason: TemporaryError
      status: 'False'
      type: Degraded
    - lastHeartbeatTime: '2022-03-16T04:24:35Z'
      lastTransitionTime: '2022-03-16T04:24:35Z'
      message: NooBaa NamespaceStore "test-ns-2" is not yet ready
      reason: TemporaryError
      status: 'False'
      type: Upgradeable
  phase: Verifying
```
</p>

</details>

<details><summary> After </summary> 
<p>

```yaml
apiVersion: noobaa.io/v1alpha1
kind: BucketClass
metadata:
  resourceVersion: '218643'
  name: test-bc-ns-multi
  uid: 459ffae5-706b-4945-b19b-29b15129c31b
  creationTimestamp: '2022-03-16T04:24:35Z'
  generation: 5
  managedFields:
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:spec':
          .: {}
          'f:namespacePolicy':
            .: {}
            'f:multi':
              .: {}
              'f:readResources': {}
              'f:writeResource': {}
            'f:type': {}
      manager: Mozilla
      operation: Update
      time: '2022-03-16T04:24:35Z'
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:finalizers':
            .: {}
            'v:"noobaa.io/finalizer"': {}
          'f:labels':
            .: {}
            'f:app': {}
      manager: noobaa-operator
      operation: Update
      time: '2022-03-16T04:24:35Z'
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:status':
          .: {}
          'f:conditions': {}
          'f:phase': {}
      manager: noobaa-operator
      operation: Update
      subresource: status
      time: '2022-03-16T04:24:35Z'
  namespace: openshift-storage
  finalizers:
    - noobaa.io/finalizer
  labels:
    app: noobaa
spec:
  namespacePolicy:
    multi:
      readResources:
        - test-ns-2
        - test-ns-store
      writeResource: test-ns-2
    type: Multi
status:
  conditions:
    - lastHeartbeatTime: '2022-03-16T04:24:35Z'
      lastTransitionTime: '2022-03-16T04:24:35Z'
      message: NooBaa NamespaceStore "test-ns-2" is not yet ready
      reason: TemporaryError
      status: 'False'
      type: Available
    - lastHeartbeatTime: '2022-03-16T04:24:35Z'
      lastTransitionTime: '2022-03-16T04:24:35Z'
      message: NooBaa NamespaceStore "test-ns-2" is not yet ready
      reason: TemporaryError
      status: 'True'
      type: Progressing
    - lastHeartbeatTime: '2022-03-16T04:24:35Z'
      lastTransitionTime: '2022-03-16T04:24:35Z'
      message: NooBaa NamespaceStore "test-ns-2" is not yet ready
      reason: TemporaryError
      status: 'False'
      type: Degraded
    - lastHeartbeatTime: '2022-03-16T04:24:35Z'
      lastTransitionTime: '2022-03-16T04:24:35Z'
      message: NooBaa NamespaceStore "test-ns-2" is not yet ready
      reason: TemporaryError
      status: 'False'
      type: Upgradeable
  phase: Verifying
```

</p>
</details>


Fixes: https://issues.redhat.com/browse/RHSTOR-1797