### PR TITLE
Bug 2060924: Fix  alert from showing an object

### DIFF
--- a/frontend/public/components/debug-terminal.tsx
+++ b/frontend/public/components/debug-terminal.tsx
@@ -99,6 +99,7 @@ const DebugTerminalInner: React.FC<DebugTerminalInnerProps> = ({ debugPod, initi
 export const DebugTerminal: React.FC<DebugTerminalProps> = ({ podData, containerName }) => {
   const [errorMessage, setErrorMessage] = React.useState('');
   const [generatedDebugPodName, setGeneratedDebugPodName] = React.useState('');
+  const { t } = useTranslation();
   const podNamespace = podData?.metadata.namespace;
   const podContainerName = containerName || podData?.spec.containers[0].name;
   const debugPodName = `${podData?.metadata.name}-debug-`;
@@ -153,7 +154,7 @@ export const DebugTerminal: React.FC<DebugTerminalProps> = ({ podData, container
 
   if (generatedDebugPodName) {
     if (err) {
-      return <DebugTerminalError error={err} />;
+      return <DebugTerminalError error={err.message || t('public~The debug pod failed.')} />;
     }
     if (loaded) {
       return <DebugTerminalInner initialContainer={containerName} debugPod={debugPod} />;


### PR DESCRIPTION
The `useK8sWatchResource` call returns an err that can be an object.  The error object was being passed indirectly into an `Alert` resource as its title.  This was causing the error.

I have added a check to prevent an object from being passed to the `Alert`.

I am not sure why the nginx image is not correctly connecting via the UI as it does connect with the command line debug tool.  But that is for another issue.