### PR TITLE
Bug 2064596: [Tekton Hub] show read more link in the task quick search details pane

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/PipelineQuickSearchDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/PipelineQuickSearchDetails.tsx
@@ -53,7 +53,7 @@ const PipelineQuickSearchDetails: React.FC<QuickSearchDetailsRendererProps> = ({
     [selectedVersion, versions],
   );
 
-  const hubURL = loadedVersion?.hubURL; // To-Do: test once API is up and if needed change
+  const hubURL = loadedVersion?.hubURLPath;
   const hubLink = hubURL && `${TEKTON_HUB_ENDPOINT}/${hubURL}`;
 
   return (

--- a/frontend/packages/pipelines-plugin/src/test-data/catalog-item-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/catalog-item-data.ts
@@ -115,7 +115,7 @@ export const sampleTasks: SampleTasks = {
       displayName: 'Ansible Runner',
       description: 'Task to run Ansible playbooks using Ansible Runner',
       minPipelinesVersion: '0.12.1',
-      hubURL: 'tekton/task/curl/0.1',
+      hubURLPath: 'tekton/task/curl/0.1',
       rawURL:
         'https://raw.githubusercontent.com/tektoncd/catalog/main/task/ansible-runner/0.1/ansible-runner.yaml',
       webURL:
@@ -250,9 +250,9 @@ export const sampleTektonHubCatalogItemWithHubURL: CatalogItem = {
   attributes: {
     installed: '',
     versions: [
-      { id: '1', hubURL: 'foo/bar/test' },
-      { id: '2', hubURL: 'foo/bar/test2' },
-      { id: '3', hubURL: 'foo/bar/test3' },
+      { id: '1', hubURLPath: 'foo/bar/test' },
+      { id: '2', hubURLPath: 'foo/bar/test2' },
+      { id: '3', hubURLPath: 'foo/bar/test3' },
     ],
   },
   data: {

--- a/frontend/packages/pipelines-plugin/src/types/tektonHub.ts
+++ b/frontend/packages/pipelines-plugin/src/types/tektonHub.ts
@@ -21,7 +21,7 @@ export type TektonHubLatestVersion = {
   minPipelinesVersion: string;
   rawURL: string;
   webURL: string;
-  hubURL: string;
+  hubURLPath: string;
   platforms: TektonHubPlatform[];
   updatedAt: string;
 };


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGSM-42003
https://bugzilla.redhat.com/show_bug.cgi?id=2064596
**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
     hubURL is used initially to during implementation, but later it was modified as hubURLPath in v1 Apis.
**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
   Change hubURL to `hubURLPath` to show the docs link.
**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
**Before:**
Without the fix Read more button will not appear.
<img width="847" alt="image" src="https://user-images.githubusercontent.com/9964343/158559688-85974927-8445-40a9-b23a-c8fdb5624a28.png">

**After**:
Read more link is present with the fix:
<img width="847" alt="image" src="https://user-images.githubusercontent.com/9964343/158559067-c70a114c-782b-4a2e-a73c-f85ac98b86bf.png">




**Unit test coverage report**: 
<!-- Attach test coverage report -->
No test changed.

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Go to  Pipeline builder -> search for tekton hub tasks
2. In details pane, read more link should be available and it should take you to the tekton hub documentation page.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge