### PR TITLE
[release-4.9] Bug 2065549: Change the tekton hub api endpoint to use v1 api

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/catalog/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/const.ts
@@ -1,1 +1,1 @@
-export const TEKTON_HUB_API_ENDPOINT = 'https://api.hub.tekton.dev';
+export const TEKTON_HUB_API_ENDPOINT = 'https://api.hub.tekton.dev/v1';


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/openshift/console/pull/11186

Description:

Change the tekton hub endpoints to use the latest `v1` Apis

/assign @jerolimov 
/cc @sanketpathak 