### PR TITLE
Bug 2039477: Add a workaround to show the PF validation status also when the input field is autofilled.

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/InputField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/InputField.scss
@@ -1,0 +1,51 @@
+// This is a workaround because the Chrome browser automatically sets a
+// background color and remove the background image when the input field
+// is autofilled.
+// https://bugzilla.redhat.com/show_bug.cgi?id=2039477
+.oc-inputfield {
+  // Required by the position: absolute below.
+  position: relative;
+
+  // Disable the standard icon
+  .pf-c-form-control.pf-m-success, .pf-c-form-control.pf-m-warning, .pf-c-form-control[aria-invalid=true] {
+    background-image: none;
+  }
+
+  // Add an overlay icon that also work with browser autofill 'background colors'
+  &__validation-icon.pf-c-form-control {
+    // Align the icon on the right side
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    // We need pf-c-form-control to get the form control variables below.
+    // But we need to unset the form-control background and border for the icon.
+    background-color: transparent;
+    border: 0 transparent;
+
+    &.success {
+      width: var(--pf-c-form-control--success--PaddingRight);
+      background-image: var(--pf-c-form-control--success--BackgroundUrl);
+      background-position: var(--pf-c-form-control--success--BackgroundPosition);
+      background-size: var(--pf-c-form-control--success--BackgroundSize);
+      border-bottom: var(--pf-c-form-control--success--BorderBottomWidth) transparent;
+      padding-bottom: var(--pf-c-form-control--success--PaddingBottom);
+    }
+    &.warning {
+      width: var(--pf-c-form-control--warning--PaddingRight);
+      background-image: var(--pf-c-form-control--warning--BackgroundUrl);
+      background-position: var(--pf-c-form-control--warning--BackgroundPosition);
+      background-size: var(--pf-c-form-control--warning--BackgroundSize);
+      border-bottom: var(--pf-c-form-control--warning--BorderBottomWidth) transparent;
+      padding-bottom: var(--pf-c-form-control--warning--PaddingBottom);
+    }
+    &.error {
+      width: var(--pf-c-form-control--invalid--PaddingRight);
+      background-image: var(--pf-c-form-control--invalid--BackgroundUrl);
+      background-position: var(--pf-c-form-control--invalid--BackgroundPosition);
+      background-size: var(--pf-c-form-control--invalid--BackgroundSize);
+      border-bottom-width: var(--pf-c-form-control--invalid--BorderBottomWidth) transparent;
+      padding-bottom: var(--pf-c-form-control--invalid--PaddingBottom);
+    }
+  }
+}

--- a/frontend/packages/console-shared/src/components/formik-fields/InputField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/InputField.tsx
@@ -1,14 +1,29 @@
 import * as React from 'react';
-import { TextInput, TextInputTypes } from '@patternfly/react-core';
+import { TextInput, TextInputTypes, ValidatedOptions } from '@patternfly/react-core';
 import BaseInputField from './BaseInputField';
 import { BaseInputFieldProps } from './field-types';
+
+import './InputField.scss';
 
 const InputField: React.FC<BaseInputFieldProps> = (
   { type = TextInputTypes.text, ...baseProps },
   ref,
 ) => (
   <BaseInputField type={type} {...baseProps}>
-    {(props) => <TextInput ref={ref} {...props} />}
+    {(props) => (
+      <div className="oc-inputfield">
+        <TextInput ref={ref} {...props} />
+        {props.validated && props.validated !== ValidatedOptions.default ? (
+          <div
+            // pf-c-form-control is needed to load the right PatternFly variables.
+            className={`pf-c-form-control oc-inputfield__validation-icon ${props.validated}`}
+            // The BaseInputField will show an description (helper-text) below
+            // the input field that describes the validation error.
+            aria-hidden="true"
+          />
+        ) : null}
+      </div>
+    )}
   </BaseInputField>
 );
 

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -167,17 +167,6 @@ form.pf-c-form {
   }
 }
 
-@-webkit-keyframes autofill-success {
-  to {
-    background: var(--pf-c-form-control--success--Background);
-  }
-}
-@-webkit-keyframes autofill-invalid {
-  to {
-    background: var(--pf-c-form-control--invalid--Background);
-  }
-}
-
 // specificity targeting form elements to override --pf-global--FontSize--md
 .pf-c-page,
 .modal-dialog {
@@ -198,18 +187,6 @@ form.pf-c-form {
   .pf-c-form-control.pf-m-success,
   .pf-c-form-control[aria-invalid='true'] {
     --pf-global--FontSize--md: #{$font-size-base};
-  }
-
-  .pf-c-form-control {
-    &:-webkit-autofill {
-      -webkit-animation-fill-mode: both;
-      &.pf-m-success {
-        -webkit-animation-name: autofill-success;
-      }
-      &[aria-invalid='true'] {
-        -webkit-animation-name: autofill-invalid;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2039477

**Analysis / Root cause**: 
Some browsers, at least Chrome / Chromium / WebKit browsers automatically apply some custom CSS rules if the user autofills a field. In earlier versions of chrome this could be overridden, and we had a workaround in `_overrides.scss`, but this workaround doesn't work anymore.

The problem was logged by @jeff-phillips-18 in PF https://github.com/patternfly/patternfly/issues/2702, but there was no update that solves this issue in a generic way.

You can reproduce the issue with this "pure HTML example": https://codesandbox.io/s/autofill-background-issues-2wrejy?file=/src/styles.css

![pure-html-example](https://user-images.githubusercontent.com/139310/159033174-7bf97b73-97bc-4f0d-892e-791908392b68.gif)

**Solution Description**: 
Replaced the CSS overrides with an overlaying div element that shows the icon on another layer.

**Screen shots / Gifs for design review**: 


**Unit test coverage report**: 
Untouched

**Test setup:**
Search for fields that can be auto-filled and compare the new UI with the old UI.

Best of all, there is no visual difference other than the icon now showing up in the chrome browser.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
