### PR TITLE
Bug 2065804: Fix Web Terminal availability check to verify operator is installed

### DIFF
--- a/pkg/terminal/proxy.go
+++ b/pkg/terminal/proxy.go
@@ -222,12 +222,15 @@ func (p *Proxy) HandleTerminalInstalledNamespace(w http.ResponseWriter, r *http.
 		return
 	}
 
-	operatorNamespace, err := getWebTerminalNamespace(subscription)
+	operatorNamespace, found, err := getWebTerminalNamespace(subscription)
 	if err != nil {
 		klog.Errorf("Failed to get the namespace of the web terminal subscription: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
+	} else if !found {
+		klog.Error("Web Terminal Operator is not installed")
+		w.WriteHeader(http.StatusServiceUnavailable)
 	}
 
 	w.Write([]byte(operatorNamespace))


### PR DESCRIPTION
### Description
The fix for https://bugzilla.redhat.com/show_bug.cgi?id=2006329 introduced a regression by changing the backend check for a Web Terminal Operator subscription to work via a list instead of get operation. For a get, if the object does not exist, the API returns a not found error, whereas for a list, the response is an empty list.

The backend /api/terminal/available/ endpoint would still check for the "not found" error and assume its absence meant the terminal was installed, despite the list having zero items.

Since the backend also checks that relevant webhooks are installed in the cluster, in most cases this issue is hidden and does not occur. However, since these webhooks are installed by a dependency of the Web Terminal Operator (the DevWorkspace Operator), it's possible for the Web Terminal button to show up in the UI incorrectly if the DevWorkspace Operator is installed but the Web Terminal Operator is not.

### Testing instructions
1. Install DevWorkspace Operator (but _not_ Web Terminal Operator) via OperatorHub
2. Refresh Console webpage and check:
    * Browser requests to `/api/terminal/available` return 503 service unavailable
    * Web Terminal button is not shown in top-right

Bugzilla link: https://bugzilla.redhat.com/show_bug.cgi?id=2065804

/cherrypick release-4.8
/cherrypick release-4.9
/cherrypick release-4.10
