### PR TITLE
Bug 2064553: Remove reference to deprecated `v2v-vmware` ConfigMap

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/constants/v2v.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/v2v.ts
@@ -5,9 +5,9 @@ export const V2VVMWARE_DEPLOYMENT_NAME = 'v2v-vmware';
 export const CONVERSION_BASE_NAME = 'kubevirt-v2v-conversion';
 export const CONVERSION_GENERATE_NAME = `${CONVERSION_BASE_NAME}-`;
 
-export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES = ['v2v-vmware', 'virtio-win'];
+export const KUBEVIRT_VIRTIO_WIN_CONFIG_MAP_NAME = 'virtio-win';
 // Different releases, different locations. Respect the order when resolving. Otherwise the configMap name/namespace is considered as well-known.
-export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES = [
+export const KUBEVIRT_VIRTIO_WIN_CONFIG_MAP_NAMESPACES = [
   'openshift-cnv',
   'kubevirt-hyperconverged',
 ];

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/v2vvmware-configmap-validator.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/v2vvmware-configmap-validator.ts
@@ -4,8 +4,8 @@ import { VMImportProvider } from '../../../components/create-vm-wizard/types';
 import {
   V2VConfigMapAttribute,
   V2VProviderErrorSpecialUIMessageRequest,
-  VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES,
-  VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES,
+  KUBEVIRT_VIRTIO_WIN_CONFIG_MAP_NAME,
+  KUBEVIRT_VIRTIO_WIN_CONFIG_MAP_NAMESPACES,
 } from '../../../constants/v2v';
 import {
   getKubevirtV2vConversionContainerImage,
@@ -17,9 +17,9 @@ import { K8sDetailError } from '../../enhancedK8sMethods/errors';
 export const validateV2VConfigMap = (configMap: ConfigMapKind, providerType: VMImportProvider) => {
   if (!configMap) {
     return new K8sDetailError({
-      title: `${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES} ConfigMap missing`,
-      message: `${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES} ConfigMap cannot be found in any of the following namespaces: ${joinGrammaticallyListOfItems(
-        VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES,
+      title: `${KUBEVIRT_VIRTIO_WIN_CONFIG_MAP_NAME} ConfigMap missing`,
+      message: `${KUBEVIRT_VIRTIO_WIN_CONFIG_MAP_NAME} ConfigMap cannot be found in any of the following namespaces: ${joinGrammaticallyListOfItems(
+        KUBEVIRT_VIRTIO_WIN_CONFIG_MAP_NAMESPACES,
         'or',
       )}. Please see ${
         V2VProviderErrorSpecialUIMessageRequest.supplyDoclink
@@ -50,7 +50,7 @@ export const validateV2VConfigMap = (configMap: ConfigMapKind, providerType: VMI
   if (requiredImagesMissing.length > 0) {
     return new K8sDetailError({
       title: `Image configuration missing`,
-      message: `The following images are missing in a ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES} ConfigMap: ${joinGrammaticallyListOfItems(
+      message: `The following images are missing in a ${KUBEVIRT_VIRTIO_WIN_CONFIG_MAP_NAME} ConfigMap: ${joinGrammaticallyListOfItems(
         requiredImagesMissing,
       )}. Please see ${
         V2VProviderErrorSpecialUIMessageRequest.supplyDoclink

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/v2vvmware-configmap.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/v2vvmware-configmap.ts
@@ -1,8 +1,8 @@
 import { ConfigMapModel } from '@console/internal/models';
 import { k8sGet } from '@console/internal/module/k8s';
 import {
-  VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES,
-  VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES,
+  KUBEVIRT_VIRTIO_WIN_CONFIG_MAP_NAME,
+  KUBEVIRT_VIRTIO_WIN_CONFIG_MAP_NAMESPACES,
 } from '../../../constants/v2v';
 
 const { info } = console;
@@ -10,22 +10,24 @@ const { info } = console;
 export const getVmwareConfigMap = async () => {
   let lastErr;
   // query namespaces sequentially to respect order
-  for (const namespace of VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES) {
-    for (const configMapName of VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMES) {
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        const configMap = await k8sGet(ConfigMapModel, configMapName, namespace);
+  for (const namespace of KUBEVIRT_VIRTIO_WIN_CONFIG_MAP_NAMESPACES) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const configMap = await k8sGet(
+        ConfigMapModel,
+        KUBEVIRT_VIRTIO_WIN_CONFIG_MAP_NAME,
+        namespace,
+      );
 
-        if (configMap) {
-          return configMap;
-        }
-      } catch (e) {
-        lastErr = e;
-        info(
-          `The ${configMapName} can not be found in the ${namespace} namespace.  Another namespace will be queried, if any left. Error: `,
-          e,
-        );
+      if (configMap) {
+        return configMap;
       }
+    } catch (e) {
+      lastErr = e;
+      info(
+        `The ${KUBEVIRT_VIRTIO_WIN_CONFIG_MAP_NAME} can not be found in the ${namespace} namespace.  Another namespace will be queried, if any left. Error: `,
+        e,
+      );
     }
   }
 


### PR DESCRIPTION
In CNV 4.10, along we the deprecation of vm-import-operator (in favor of Migration Toolkit for Virtualization), the `v2v-vmware` as been deprecated as well in favor of the new `virtio-win` ConfigMap, which provides the virtio-win image for Windows VirtualMachines.
This PR removes reference to the deprecated ConfigMap, now that CNV 4.10 has been released and the transition period is over.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2064553

Signed-off-by: orenc1 <ocohen@redhat.com>