### PR TITLE
Bug 2066754: Don't delete core Cypress reports

### DIFF
--- a/frontend/packages/dev-console/integration-tests/package.json
+++ b/frontend/packages/dev-console/integration-tests/package.json
@@ -13,7 +13,7 @@
     "cypress-generate": "../../../node_modules/.bin/marge -o ../../../gui_test_screenshots/ -f cypress-report -t 'OpenShift DevConsole Cypress Test Results' -p 'OpenShift Cypress Test Results' --showPassed false --assetsDir ../../../gui_test_screenshots/cypress/assets ../../../gui_test_screenshots/cypress.json",
     "test-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless --spec \"features/e2e/add-flow-ci.feature\";",
     "test-headless-all": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless",
-    "test-cypress-headless": "yarn run clean-reports && yarn run test-headless && yarn run cypress-merge && yarn run cypress-generate",
-    "test-cypress-nightly": "yarn run clean-reports && yarn run test-headless-all && yarn run cypress-merge && yarn run cypress-generate"
+    "test-cypress-headless": "yarn run test-headless && yarn run cypress-merge && yarn run cypress-generate",
+    "test-cypress-nightly": "yarn run test-headless-all && yarn run cypress-merge && yarn run cypress-generate"
   }
 }


### PR DESCRIPTION
The dev-console tests were calling `yarn run clean-reports` when they started. This deleted the reports from the core Cypress tests in CI, which run first.

@jrichter1 I don't believe this will cause any problems for the dev-console tests since each CI run will have an empty gui_test_screenshots directory. (You might need to run `yarn run clean-reports` between runs locally, however.)

/assign @rhamilto 
