### PR TITLE
Bug 2065840: Fix CronJob resource version to batch/v1

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -181,7 +181,7 @@
     "properties": {
       "model": {
         "group": "batch",
-        "version": "v1beta1",
+        "version": "v1",
         "kind": "CronJob"
       },
       "provider": { "$codeRef": "actions.useCronJobActionsProvider" }

--- a/frontend/packages/console-shared/src/utils/__tests__/test-resource-data.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/test-resource-data.ts
@@ -2080,7 +2080,7 @@ export const sampleJobs: FirehoseResult = {
         namespace: 'jeff-project',
         ownerReferences: [
           {
-            apiVersion: 'batch/v1beta1',
+            apiVersion: 'batch/v1',
             kind: 'CronJob',
             name: 'py-cron',
             uid: 'be644703-be4b-4ee5-9d86-fdeb9495569c',
@@ -2383,7 +2383,7 @@ export const sampleJobs: FirehoseResult = {
         namespace: 'jeff-project',
         ownerReferences: [
           {
-            apiVersion: 'batch/v1beta1',
+            apiVersion: 'batch/v1',
             kind: 'CronJob',
             name: 'py-cron',
             uid: 'be644703-be4b-4ee5-9d86-fdeb9495569c',
@@ -2462,7 +2462,7 @@ export const sampleCronJobs: FirehoseResult = {
   data: [
     {
       kind: 'CronJob',
-      apiVersion: 'batch/v1beta1',
+      apiVersion: 'batch/v1',
       metadata: {
         name: 'py-cron',
         namespace: 'jeff-project',
@@ -2476,7 +2476,7 @@ export const sampleCronJobs: FirehoseResult = {
           {
             manager: 'oc',
             operation: 'Update',
-            apiVersion: 'batch/v1beta1',
+            apiVersion: 'batch/v1',
             time: '2020-06-24T11:17:41Z',
             fieldsType: 'FieldsV1',
             fieldsV1: {
@@ -2549,7 +2549,7 @@ export const sampleCronJobs: FirehoseResult = {
           {
             manager: 'kube-controller-manager',
             operation: 'Update',
-            apiVersion: 'batch/v1beta1',
+            apiVersion: 'batch/v1',
             time: '2020-06-24T12:35:05Z',
             fieldsType: 'FieldsV1',
             fieldsV1: {

--- a/frontend/packages/dev-console/integration-tests/testData/yamls/create-cronjob.yaml
+++ b/frontend/packages/dev-console/integration-tests/testData/yamls/create-cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: example-cronjob

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -777,7 +777,7 @@ export const CronJobModel: K8sKind = {
   label: 'CronJob',
   // t('public~CronJob')
   labelKey: 'public~CronJob',
-  apiVersion: 'v1beta1',
+  apiVersion: 'v1',
   apiGroup: 'batch',
   plural: 'cronjobs',
   abbr: 'CJ',

--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -269,7 +269,7 @@ data:
   .setIn(
     [referenceForModel(k8sModels.CronJobModel), 'default'],
     `
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: example


### PR DESCRIPTION
Bumping last pieces of the old apiVersion of the CronJob resource, from `batch/v1beta1` to `batch/v1
/assign @rhamilto 