### PR TITLE
Bug 2066418:  correct ChannelDocLink url

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -13,6 +13,9 @@ import {
   Progress,
   ProgressSize,
   ProgressVariant,
+  Text,
+  TextContent,
+  TextVariants,
   Tooltip,
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
@@ -389,8 +392,8 @@ export const CurrentVersionHeader: React.FC<CurrentVersionProps> = ({ cv }) => {
 
 export const ChannelDocLink: React.FC<{}> = () => {
   const upgradeLink = isUpstream()
-    ? `${openshiftHelpBase}updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor`
-    : `${openshiftHelpBase}html/updating_clusters/updating-cluster-between-minor#understanding-upgrade-channels_updating-cluster-between-minor`;
+    ? `${openshiftHelpBase}updating/understanding-upgrade-channels-release.html#understanding-upgrade-channels_understanding-upgrade-channels-releases`
+    : `${openshiftHelpBase}html/updating_clusters/understanding-upgrade-channels-releases#understanding-upgrade-channels_understanding-upgrade-channels-releases`;
   const { t } = useTranslation();
   return (
     <ExternalLink
@@ -406,12 +409,16 @@ const ChannelHeader: React.FC<{}> = () => {
     <>
       {t('public~Channel')}
       <FieldLevelHelp>
-        <p>
-          {t(
-            'public~Channels help to control the pace of updates and recommend the appropriate release versions. Update channels are tied to a minor version of OpenShift Container Platform, for example 4.5.',
-          )}
-        </p>
-        <ChannelDocLink />
+        <TextContent>
+          <Text component={TextVariants.p}>
+            {t(
+              'public~Channels help to control the pace of updates and recommend the appropriate release versions. Update channels are tied to a minor version of OpenShift Container Platform, for example 4.5.',
+            )}
+          </Text>
+          <Text component={TextVariants.p}>
+            <ChannelDocLink />
+          </Text>
+        </TextContent>
       </FieldLevelHelp>
     </>
   );

--- a/frontend/public/components/modals/cluster-channel-modal.tsx
+++ b/frontend/public/components/modals/cluster-channel-modal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
-import { TextInput } from '@patternfly/react-core';
+import { Text, TextContent, TextInput, TextVariants } from '@patternfly/react-core';
 import * as semver from 'semver';
 
 import { ChannelDocLink } from '../cluster-settings/cluster-settings';
@@ -43,18 +43,20 @@ const ClusterChannelModal = withHandlePromise((props: ClusterChannelModalProps) 
         {channelsExist ? t('public~Select channel') : t('public~Input channel')}
       </ModalTitle>
       <ModalBody>
-        <p>
-          {channelsExist
-            ? t(
-                'public~The current version is available in the channels listed in the dropdown below. Select a channel that reflects the desired version. Critical security updates will be delivered to any vulnerable channels.',
-              )
-            : t(
-                'public~Input a channel that reflects the desired version. To verify if the version exists in a channel, save and check the update status. Critical security updates will be delivered to any vulnerable channels.',
-              )}
-        </p>
-        <p>
-          <ChannelDocLink />
-        </p>
+        <TextContent>
+          <Text component={TextVariants.p}>
+            {channelsExist
+              ? t(
+                  'public~The current version is available in the channels listed in the dropdown below. Select a channel that reflects the desired version. Critical security updates will be delivered to any vulnerable channels.',
+                )
+              : t(
+                  'public~Input a channel that reflects the desired version. To verify if the version exists in a channel, save and check the update status. Critical security updates will be delivered to any vulnerable channels.',
+                )}
+          </Text>
+          <Text component={TextVariants.p} className="pf-u-mb-md">
+            <ChannelDocLink />
+          </Text>
+        </TextContent>
         <div className="form-group">
           <label htmlFor="channel">{t('public~Channel')}</label>
           {channelsExist ? (


### PR DESCRIPTION
Bonus:  improve layout of text around ChannelDocLink instances.  cc: @megan-hall 

<img width="425" alt="Screen Shot 2022-03-22 at 11 18 42 AM" src="https://user-images.githubusercontent.com/895728/159517637-1456213e-abb4-4b3d-9310-0ca20cd3c48b.png">
<img width="642" alt="Screen Shot 2022-03-22 at 11 18 47 AM" src="https://user-images.githubusercontent.com/895728/159517638-daf0d181-0fc1-47c2-b967-07b739b9ba19.png">