### PR TITLE
Bug 2068115: Fixed the rendering of a Tab Extension when there is a version present

### DIFF
--- a/dynamic-demo-plugin/console-extensions.json
+++ b/dynamic-demo-plugin/console-extensions.json
@@ -187,6 +187,19 @@
     }
   },
   {
+    "type": "console.page/resource/tab",
+    "properties": {
+      "model": {
+        "group": "project.openshift.io",
+        "version": "v1",
+        "kind": "Project"
+      },
+      "name": "Demo Plugin",
+      "href": "/demo-plugin",
+      "component": { "$codeRef": "projectTabContent" }
+    }
+  },
+  {
     "type": "console.page/route",
     "properties": {
       "path": "/test-utility-consumer",

--- a/dynamic-demo-plugin/package.json
+++ b/dynamic-demo-plugin/package.json
@@ -54,6 +54,7 @@
       "K8sAPIConsumer": "./components/k8sConsumer/K8sAPIConsumer",
       "navPage": "./components/Nav",
       "listPage": "./components/ListPage",
+      "projectTabContent": "./components/ProjectTabExtensionContent",
       "clusterInventoryOverview": "./components/ClusterOverview/Inventory",
       "clusterOverview": "./utils/cluster-overview"
     },

--- a/dynamic-demo-plugin/src/components/ProjectTabExtensionContent.tsx
+++ b/dynamic-demo-plugin/src/components/ProjectTabExtensionContent.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router';
+import { PageSection } from '@patternfly/react-core';
+
+const ProjectTabExtensionContent: React.FC<RouteComponentProps> = () => {
+  return <PageSection>This is the demo plugin addition for the project model.</PageSection>;
+};
+
+export default ProjectTabExtensionContent;

--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -81,8 +81,8 @@
 "@openshift-console/dynamic-plugin-sdk@file:../frontend/packages/console-dynamic-plugin-sdk/dist/core":
   version "0.0.0-fixed"
   dependencies:
-    "@patternfly/react-core" "4.175.4"
-    "@patternfly/react-table" "4.44.4"
+    "@patternfly/react-core" "4.198.5"
+    "@patternfly/react-table" "4.67.5"
     react "^17.0.1"
     react-helmet "^6.1.0"
     react-i18next "^11.7.3"
@@ -105,14 +105,14 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-core@4.175.4":
-  version "4.175.4"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.175.4.tgz#1dae2a6b5eb58209a47bdc3bf457c47b68ccee54"
-  integrity sha512-bnQhvXKbprni5WhlbMI+nbYxwMR03bFZtUk+F7JiLM96uk/yCrPjUes6u8Pbgkh/HhsRYx8K1kx84WmC+MyD5w==
+"@patternfly/react-core@4.198.5":
+  version "4.198.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.198.5.tgz#0bbd5e449644a4667ea65ec6903ee4a690e3a10b"
+  integrity sha512-LMpOYgaCp6W8+2nT12D4/9+6RnIJufBPzn5xtr8/0+gvBe16VMlpBfb9msC5ibX28fWqSKzlEic1Ovn1vhUYFw==
   dependencies:
-    "@patternfly/react-icons" "^4.26.4"
-    "@patternfly/react-styles" "^4.25.4"
-    "@patternfly/react-tokens" "^4.27.4"
+    "@patternfly/react-icons" "^4.49.5"
+    "@patternfly/react-styles" "^4.48.5"
+    "@patternfly/react-tokens" "^4.50.5"
     focus-trap "6.2.2"
     react-dropzone "9.0.0"
     tippy.js "5.1.2"
@@ -131,14 +131,14 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-core@^4.175.4":
-  version "4.192.15"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.192.15.tgz#ee664054233add748321871a6c6f746b974b3e6a"
-  integrity sha512-nYNhuWeRegZ89WY4OKa4bX06DYsEDCmNYDEq8Jp9CHPVm/6UzmPmWA/Y5MTbLPZN6w2i0cvLHf2wQVrHSzwVvg==
+"@patternfly/react-core@^4.198.5":
+  version "4.198.19"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.198.19.tgz#14444b7421417eec43fb8a0f6163c34aa37c1c2e"
+  integrity sha512-f46CIKwWCJ1UNL50TXnvarYUhr2KtxNFw/kGYtG6QwrQwKXscZiXMMtW//0Q08cyhLB0vfxHOLbCKxVaVJ3R3w==
   dependencies:
-    "@patternfly/react-icons" "^4.43.15"
-    "@patternfly/react-styles" "^4.42.15"
-    "@patternfly/react-tokens" "^4.44.15"
+    "@patternfly/react-icons" "^4.49.19"
+    "@patternfly/react-styles" "^4.48.19"
+    "@patternfly/react-tokens" "^4.50.19"
     focus-trap "6.2.2"
     react-dropzone "9.0.0"
     tippy.js "5.1.2"
@@ -149,20 +149,20 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.19.8.tgz#376cfe136b3acef86fa28081c99e4e88bd13457c"
   integrity sha512-JBBcVntRLspe857JnGo8lFaZfy+WOR/IYe2E9W3Rknqm1T8WO6oXpeEnrr5r9bpYDFUa4ttcb/acuQXc1xypxg==
 
-"@patternfly/react-icons@^4.26.4", "@patternfly/react-icons@^4.43.15":
-  version "4.43.15"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.43.15.tgz#8dd696ba92867b1074eee6ef7c672833197f6046"
-  integrity sha512-b1fcPpIsQVJBGG1onpNTDiGqVJ60BVNy3qvzUu4Ea+lOwP83oIlhODtS792wx1B284a4wxP3uMc6uXCfdULD/w==
+"@patternfly/react-icons@^4.49.19", "@patternfly/react-icons@^4.49.5":
+  version "4.49.19"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.49.19.tgz#66f426570378213f6f717d4a39fadcbf57635d1e"
+  integrity sha512-Pr6JDDKWOnWChkifXKWglKEPo3Q+1CgiUTUrvk4ZbnD7mhq5e/TFxxInB9CPzi278bvnc2YlPyTjpaAcCN0yGw==
 
 "@patternfly/react-styles@^4.12.4", "@patternfly/react-styles@^4.18.8":
   version "4.18.8"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.18.8.tgz#92b314c41a8df27cf4c531ab60fc9daf11da8150"
   integrity sha512-136N/Whs0qXDtPpsh5JeNJld5BeFPsbmmcgI5LlMQ+P9dioddh24rTqaaOIea67tHiXUB7orxaqKpBBILXqcPQ==
 
-"@patternfly/react-styles@^4.25.4", "@patternfly/react-styles@^4.42.15":
-  version "4.42.15"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.42.15.tgz#749c1db42cb78f7b0ac276ba414812438d7c5e6b"
-  integrity sha512-7E6NmaB3b+OOAqIBlS7nJ74Plq+n76VVTH5zxCyUFkrbjo31TRArwLU2dlO/tZr77Z3MiUjGBcoLLEv0R6BZBg==
+"@patternfly/react-styles@^4.48.19", "@patternfly/react-styles@^4.48.5":
+  version "4.48.19"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.48.19.tgz#23bb4521a586275ed14d89c2c60fe8765e45b3bb"
+  integrity sha512-8+t8wqYGWkmyhxLty/kQXCY44rnW0y60nUMG7QKNzF1bAFJIpR8jKuVnHArM1h+MI9D53e8OVjKORH83hUAzJw==
 
 "@patternfly/react-table@4.31.7":
   version "4.31.7"
@@ -176,15 +176,15 @@
     lodash "^4.17.19"
     tslib "^2.0.0"
 
-"@patternfly/react-table@4.44.4":
-  version "4.44.4"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.44.4.tgz#38e11f15339324efe642a3f01139afe77af0845f"
-  integrity sha512-UV2kq4OV1v6Hv2TXvvsEApPwbAyD6zvurvl0/BZoqqEHTWVQedG0m1jUN9jFMTJiD4GTESvg6TAcSowGkJlTug==
+"@patternfly/react-table@4.67.5":
+  version "4.67.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.67.5.tgz#b476f460d82fcb966395c0c4a8d3753d549e9861"
+  integrity sha512-drb4hrPAnAI4wlPtqopotjK5pN6E0b0/o9CYfvIO2O+NeabRg8l3MqpxbKIG2bEwXPjmVCBDLQ/ut14loLNe+g==
   dependencies:
-    "@patternfly/react-core" "^4.175.4"
-    "@patternfly/react-icons" "^4.26.4"
-    "@patternfly/react-styles" "^4.25.4"
-    "@patternfly/react-tokens" "^4.27.4"
+    "@patternfly/react-core" "^4.198.5"
+    "@patternfly/react-icons" "^4.49.5"
+    "@patternfly/react-styles" "^4.48.5"
+    "@patternfly/react-tokens" "^4.50.5"
     lodash "^4.17.19"
     tslib "^2.0.0"
 
@@ -193,10 +193,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.20.8.tgz#8413af8516fdcdaea1da81912434eef4c9c7865a"
   integrity sha512-OFlgTknFBNAETWVYYoLdISJBjPMQ8e3tcLpWb3h/KgKk/Tn1NR+P7Pl1gQGvTL/9liBZfS/HKDD5+P8c70w+2Q==
 
-"@patternfly/react-tokens@^4.27.4", "@patternfly/react-tokens@^4.44.15":
-  version "4.44.15"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.44.15.tgz#8eca5b3b03d1c8fd88664ab45f7a7238f9b9b218"
-  integrity sha512-Xp82baZURMISkvpNaWNu3w4cMfc2NIsDYh9K5QpVMQ94vphQrAd54UoO5NQI574+/QY2IPGKWadfvix8324J0Q==
+"@patternfly/react-tokens@^4.50.19", "@patternfly/react-tokens@^4.50.5":
+  version "4.50.19"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.50.19.tgz#7619830e7ad70853e54819b37e196c85ed604f21"
+  integrity sha512-wbUPb8welJ8p+OjXrc0X3UYDj5JjN9xnfpYkZdAySpcFtk0BAn5Py6UEZCjKtw7XHHfCQ1zwKXpXDShcu/5KVQ==
 
 "@types/eslint-scope@^3.7.0":
   version "3.7.1"

--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -15,6 +15,7 @@ import {
   useResolvedExtensions,
   ResourceTabPage as DynamicResourceTabPage,
   isResourceTabPage as isDynamicResourceTabPage,
+  K8sModel,
 } from '@console/dynamic-plugin-sdk';
 import { withFallback } from '@console/shared/src/components/error/error-boundary';
 import {
@@ -32,7 +33,6 @@ import {
   K8sResourceKind,
   K8sKind,
   referenceForModel,
-  referenceFor,
   referenceForExtensionModel,
 } from '../../module/k8s';
 import { ErrorBoundaryFallback } from '../error';
@@ -64,7 +64,7 @@ export const DetailsPage = withFallback<DetailsPageProps>(({ pages = [], ...prop
   const resourceKeys = _.map(props.resources, 'prop');
   const [pluginBreadcrumbs, setPluginBreadcrumbs] = React.useState(undefined);
   const [model] = useK8sModel(props.kind);
-  const kindObj = props.kindObj ?? model;
+  const kindObj: K8sModel = props.kindObj ?? model;
   const renderAsyncComponent = (page: ResourceTabPage, cProps: PageComponentProps) => (
     <AsyncComponent loader={page.properties.loader} {...cProps} />
   );
@@ -80,7 +80,7 @@ export const DetailsPage = withFallback<DetailsPageProps>(({ pages = [], ...prop
         .filter(
           (p) =>
             referenceForModel(p.properties.model) ===
-            (kindObj ? referenceFor(kindObj) : props.kind),
+            (kindObj ? referenceForModel(kindObj) : props.kind),
         )
         .map((p) => ({
           href: p.properties.href,
@@ -92,7 +92,7 @@ export const DetailsPage = withFallback<DetailsPageProps>(({ pages = [], ...prop
           if (p.properties.model.version) {
             return (
               referenceForExtensionModel(p.properties.model) ===
-              (kindObj ? referenceFor(kindObj) : props.kind)
+              (kindObj ? referenceForModel(kindObj) : props.kind)
             );
           }
           return (


### PR DESCRIPTION
## Cause
We were using the wrong comparison method when a version was in play and thus we never had a string that could match the filter, so the extension tabs would always be omitted.

There was the same issue in the static plugin method, so I applied the same fix to it. 

## Changes

- Added a small example page to the dynamic demo plugin
- `referenceFor` takes a `K8sResourceCommon` we needed `referenceForModel` which takes a `K8sKind` (aka `K8sModel`)
    - Changed the dynamic extensions check to filter properly when a `version` is passed
    - Changed the static extensions to also do this check properly (since it checks the same object as the dynamic one)