### PR TITLE
Bug 2064744: Remove duplicate app label on debug terminal

### DIFF
--- a/frontend/public/components/debug-terminal.tsx
+++ b/frontend/public/components/debug-terminal.tsx
@@ -19,6 +19,7 @@ const getDebugPod = (debugPodName: string, podToDebug: PodKind, containerName: s
   delete debugPod.metadata.uid;
   delete debugPod.metadata.managedFields;
   delete debugPod.metadata.name;
+  delete debugPod.metadata.labels;
   debugPod.metadata.generateName = debugPodName;
   debugPod.metadata.annotations['debug.openshift.io/source-container'] = containerName;
   debugPod.metadata.annotations[


### PR DESCRIPTION
If a workload has a label app property in the pod definition, that needs to be removed when the debug terminal is copied or else the debug pod immediately fails and terminates.

This fix explicitly deletes the app field.