### PR TITLE
Automation of event-tab-in-pipeline-run | pipelines-plugin

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/event-tab-in-pipeline-run-page.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/event-tab-in-pipeline-run-page.feature
@@ -6,26 +6,27 @@ Feature: Events tab in Pipeline run and Task run details pages
             Given user has created or selected namespace "aut-pipelines"
 
 
-        @regression @to-do
+        @regression
         Scenario: Events tab in pipeline run details page of administrator perspective: P-03-TC01
             Given user is at administrator perspective
-              And pipeline named "ex-pipeline_one" is available with pipeline run
+              And pipeline named "pipe-one" is available with pipeline run
              When user clicks on pipeline tab in navigation menu
               And user clicks on Pipelines
               And user goes to Pipeline Runs tab
-              And user opens pipeline run
+              And user clicks on pipeline run for pipeline "pipe-one"
               And user clicks on Events tab
              Then user can see events streaming for pipeline runs and all the associated task runs and pods
 
 
-        @regression @to-do
+
+        @regression
         Scenario: Events tab in task run details page of administrator perspective: P-03-TC02
             Given user is at administrator perspective
-              And task named "ex-task-two" is available with task run
+              And task named "ex-task-one" is available with task run
              When user clicks on pipeline tab in navigation menu
               And user clicks on Tasks
               And user goes to Task Runs tab
-              And user opens task run
+              And user opens task run for pipeline "new-pipeline-one"
               And user clicks on Events tab
              Then user can see events streaming for task runs and all associated pods
 
@@ -43,16 +44,15 @@ Feature: Events tab in Pipeline run and Task run details pages
              Then user can see events streaming for pipeline runs and all the associated task runs and pods
 
 
-        @regression @to-do
+        @regression
         Scenario: Events tab in task run details page of developer perspective: P-03-TC04
             Given user is at developer perspective
-              And task named "ex-task-one" is available with task run
+              And task named "ex-task-one" is available with task run for pipeline
              When user clicks on pipeline tab in navigation menu
-              And user clicks on available pipeline
+              And user clicks on available pipeline "new-pipeline-one"
               And user goes to Pipeline Runs tab
-              And user opens pipeline run
-              And user sees on Task Runs
+              And user opens pipeline run "new-pipeline-one"
               And user goes to Task Runs tab
-              And user opens task run
+              And user opens task run "new-pipeline-one"
               And user clicks on Events tab
              Then user can see events streaming for task runs and all associated pods

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineBuilder-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineBuilder-page.ts
@@ -163,7 +163,6 @@ export const pipelineBuilderPage = {
     pipelineBuilderPage.selectTask(taskName);
     pipelineBuilderPage.addResource(resourceName);
     pipelineBuilderPage.clickOnTask(taskName);
-    pipelineBuilderSidePane.selectInputResource(resourceName);
     pipelineBuilderPage.clickCreateButton();
     pipelineDetailsPage.verifyTitle(pipelineName);
   },

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/task-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/task-page.ts
@@ -1,0 +1,47 @@
+import * as yamlEditor from '@console/cypress-integration-tests/views/yaml-editor';
+import { pipelineBuilderPO } from '../../page-objects/pipelines-po';
+
+export const tasksPage = {
+  clickOnCreateTask: () => {
+    cy.get('[data-test-id="dropdown-button"]').click();
+    cy.byTestDropDownMenu('tasks').click();
+    yamlEditor.isLoaded();
+  },
+  clearYAMLEditor: () => {
+    cy.get(pipelineBuilderPO.yamlView.yamlEditor)
+      .click()
+      .focused()
+      .type('{ctrl}a')
+      .clear();
+  },
+  setEditorContent: (yamlLocation: string) => {
+    cy.readFile(yamlLocation).then((str) => {
+      yamlEditor.setEditorContent(str);
+    });
+  },
+  openTasksInPipelinesSidebar: () => {
+    cy.byTestID('nav')
+      .contains('Pipelines')
+      .click();
+    cy.byTestID('nav')
+      .contains('Tasks')
+      .click();
+  },
+  submitTaskYAML: () => {
+    cy.byTestID('save-changes').click();
+  },
+  togglePipelineSidebar: () => {
+    cy.byTestID('nav')
+      .contains('Pipelines')
+      .click();
+  },
+  openPipelinePage: () => {
+    cy.get('[data-quickstart-id="qs-nav-pipelines"]')
+      .eq(1)
+      .click();
+  },
+  clickOnCreatePipeline: () => {
+    cy.get('[data-test-id="dropdown-button"]').click();
+    cy.byTestDropDownMenu('pipeline').click();
+  },
+};

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/pipelines.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/pipelines.ts
@@ -25,6 +25,7 @@ When(
 
 Given('pipeline run is displayed for {string} with resource', (pipelineName: string) => {
   pipelinesPage.clickOnCreatePipeline();
+  cy.get('#form-radiobutton-editorType-form-field').click();
   pipelineBuilderPage.createPipelineWithGitResources(pipelineName);
   cy.byLegacyTestID('breadcrumb-link-0').click();
   pipelinesPage.search(pipelineName);

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/event-tab-in-pipeline-run-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/event-tab-in-pipeline-run-page.ts
@@ -1,8 +1,12 @@
-import { Then, When } from 'cypress-cucumber-preprocessor/steps';
-import { app } from '@console/dev-console/integration-tests/support/pages/app';
-import { pipelineDetailsPO } from '../../page-objects/pipelines-po';
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import * as yamlEditor from '@console/cypress-integration-tests/views/yaml-editor';
+import { switchPerspective } from '@console/dev-console/integration-tests/support/constants/global';
+import { app, perspective } from '@console/dev-console/integration-tests/support/pages/app';
+import { pipelineDetailsPO, pipelineBuilderPO } from '../../page-objects/pipelines-po';
+import { actionsDropdownMenu } from '../../pages/functions/common';
 import { pipelineRunDetailsPage } from '../../pages/pipelines/pipelineRun-details-page';
-import { pipelinesPage } from '../../pages/pipelines/pipelines-page';
+import { pipelinesPage, startPipelineInPipelinesPage } from '../../pages/pipelines/pipelines-page';
+import { tasksPage } from '../../pages/pipelines/task-page';
 
 When('user clicks on pipeline {string}', (pipelineName: string) => {
   pipelinesPage.selectPipeline(pipelineName);
@@ -12,8 +16,44 @@ When('user navigates to Pipeline Runs tab', () => {
   cy.get(pipelineDetailsPO.pipelineRunsTab).click();
 });
 
+Given('user is at administrator perspective', () => {
+  perspective.switchTo(switchPerspective.Administrator);
+});
+
+When('pipeline named {string} is available with pipeline run', (pipelineName: string) => {
+  tasksPage.togglePipelineSidebar();
+  tasksPage.openPipelinePage();
+  tasksPage.togglePipelineSidebar();
+  tasksPage.clickOnCreatePipeline();
+  cy.get(pipelineBuilderPO.formView.switchToFormView).click();
+  cy.get(pipelineBuilderPO.formView.name)
+    .clear()
+    .type(pipelineName);
+  cy.byTestID('task-list').click();
+  cy.get(pipelineBuilderPO.formView.quickSearch).type('kn');
+  cy.byTestID('task-cta').click();
+  cy.get(pipelineBuilderPO.create).click();
+  actionsDropdownMenu.selectAction('Start');
+});
+
+When('user clicks on pipeline tab in navigation menu', () => {
+  tasksPage.togglePipelineSidebar();
+});
+
+When('user clicks on Pipelines', () => {
+  tasksPage.openPipelinePage();
+});
+
+When('user goes to Pipeline Runs tab', () => {
+  cy.get(pipelineDetailsPO.pipelineRunsTab).click();
+});
+
 When('user clicks on pipeline run for pipeline {string}', (pipelineName: string) => {
   cy.get(`[data-test-id^="${pipelineName}-"]`).click();
+});
+
+When('user clicks on Events tab', () => {
+  cy.get(`[data-test-id="horizontal-link-public~Events"]`).click();
 });
 
 When('user clicks on Events tab in pipeline Runs page', () => {
@@ -27,3 +67,64 @@ Then(
     cy.get('[role="rowgroup"]').should('be.visible');
   },
 );
+
+When('task named {string} is available with task run', () => {
+  tasksPage.openTasksInPipelinesSidebar();
+  tasksPage.clickOnCreateTask();
+  tasksPage.clearYAMLEditor();
+  tasksPage.setEditorContent('testData/task-creation-with-yaml/new-task.yaml');
+  tasksPage.submitTaskYAML();
+  tasksPage.togglePipelineSidebar();
+  tasksPage.togglePipelineSidebar();
+  tasksPage.openPipelinePage();
+  cy.get('[data-test-id="dropdown-button"]').click();
+  cy.byTestDropDownMenu('pipeline').click();
+  startPipelineInPipelinesPage.selectView('YAML View');
+  yamlEditor.isLoaded();
+  pipelinesPage.clearYAMLEditor();
+  pipelinesPage.setEditorContent('testData/task-creation-with-yaml/create-pipeline-with-task.yaml');
+  cy.get(pipelineBuilderPO.create).click();
+  actionsDropdownMenu.selectAction('Start');
+  tasksPage.togglePipelineSidebar();
+});
+
+When('user clicks on Tasks', () => {
+  cy.byTestID('nav')
+    .contains('Tasks')
+    .click();
+});
+
+When('user goes to Task Runs tab', () => {
+  cy.get('[data-test-id="horizontal-link-TaskRuns"]').click();
+});
+
+When('user opens task run for pipeline {string}', (pipelineName: string) => {
+  cy.get(`[data-test-id^="${pipelineName}-"]`)
+    .eq(0)
+    .click();
+});
+
+When('user can see events streaming for task runs and all associated pods', () => {
+  app.waitForLoad();
+  cy.get('[role="rowgroup"]').should('be.visible');
+});
+
+When('task named {string} is available with task run for pipeline', () => {
+  app.waitForLoad();
+});
+
+When('user clicks on available pipeline {string}', (pipelineName: string) => {
+  cy.get(`[data-test-id^="${pipelineName}"]`)
+    .eq(0)
+    .click();
+});
+
+When('user opens pipeline run {string}', (pipelineName: string) => {
+  cy.get(`[data-test-id^="${pipelineName}-"]`).click();
+});
+
+When('user opens task run {string}', (pipelineName: string) => {
+  cy.get(`[data-test-id^="${pipelineName}-"]`)
+    .eq(0)
+    .click();
+});

--- a/frontend/packages/pipelines-plugin/integration-tests/testData/task-creation-with-yaml/create-pipeline-with-task.yaml
+++ b/frontend/packages/pipelines-plugin/integration-tests/testData/task-creation-with-yaml/create-pipeline-with-task.yaml
@@ -1,0 +1,17 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: new-pipeline-one
+spec:
+  params: []
+  resources: []
+  workspaces: []
+  tasks:
+    - name: ex-task-one
+      taskRef:
+        kind: Task
+        name: ex-task-one
+      params:
+        - name: appName2
+          value: appName2
+  finally: []

--- a/frontend/packages/pipelines-plugin/integration-tests/testData/task-creation-with-yaml/new-task.yaml
+++ b/frontend/packages/pipelines-plugin/integration-tests/testData/task-creation-with-yaml/new-task.yaml
@@ -1,0 +1,15 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: ex-task-one
+spec:
+  params:
+    - name: appName2
+      type: string
+  steps:
+    - image: registry.redhat.io/ubi7/ubi-minimal
+      command:
+        - /bin/bash
+        - '-c'
+        - echo
+        - $(inputs.params.appName)

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -275,6 +275,7 @@ const AdminNav: React.FC<AdminNavProps> = ({ pluginNavItems }) => {
         id="pipelines"
         title={t('public~Pipelines')}
         data-quickstart-id="qs-nav-pipelines"
+        data-test="nav-pipelines"
       />
 
       <NavSection


### PR DESCRIPTION
**Description:**
<!-- PR description-->
- Automation of event-tab-in-pipeline-run feature file.

**Jira Id:** [ODC-6579](https://issues.redhat.com/browse/ODC-6579)
<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example: 
```
export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p pipelines

```

**Screen shots**:
<!--   -->
![WhatsApp Image 2022-03-25 at 9 49 35 AM](https://user-images.githubusercontent.com/39815871/160055157-f4e3bac6-a2da-4b93-914e-6503f4cc248b.jpeg)


**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge