### PR TITLE
Bug 2068490: change 'kubectl' to 'oc' to fix descriptors test

### DIFF
--- a/frontend/packages/integration-tests-cypress/support/index.ts
+++ b/frontend/packages/integration-tests-cypress/support/index.ts
@@ -87,6 +87,6 @@ export const create = (obj) => {
     `${obj.metadata.name}.${obj.kind.toLowerCase()}.json`,
   ].join('/');
   cy.writeFile(filename, JSON.stringify(obj));
-  cy.exec(`kubectl create -f ${filename}`);
+  cy.exec(`oc create -f ${filename}`);
   cy.exec(`rm ${filename}`);
 };

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.spec.ts
@@ -21,8 +21,9 @@ describe('Using OLM descriptor components', () => {
   });
 
   after(() => {
-    cy.exec(`kubectl delete crd ${testCRD.metadata.name}`);
-    cy.exec(`kubectl delete -n ${testName} clusterserviceversion ${testCSV.metadata.name}`);
+    cy.exec(`oc delete crd ${testCRD.metadata.name}`);
+    cy.exec(`oc delete -n ${testName} clusterserviceversion ${testCSV.metadata.name}`);
+    cy.deleteProject(testName);
     cy.logout();
   });
 


### PR DESCRIPTION
The descriptors test is using `kubectl` to create and delete test CRD, CSV, and CR resources before and after the test runs.  In debugging locally, I see the test CSV is failing to create with the following error in the browser's console.

```
Stderr: error: error validating "/go/src/github.com/openshift/console/frontend/gui_test_screenshots/olm-descriptors-test.app.json": error validating data: [ValidationError(App.spec): unknown field "boolean...
```

Changing `kubectl` to `oc` in the creation (and deletion for consistency) of the resources appears to resolve the bug and the test runs successfully.