### PR TITLE
CONSOLE-3081: updated --pf-global--BorderColor—100 to --pf-global--BorderColor--100

### DIFF
--- a/frontend/public/components/secrets/_create-secret.scss
+++ b/frontend/public/components/secrets/_create-secret.scss
@@ -17,7 +17,7 @@
 }
 
 .co-create-secret__form-entry-wrapper + .co-create-secret__form-entry-wrapper {
-  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor—100);
+  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   padding-top: 10px;
 }
 

--- a/frontend/public/components/sidebars/_resource-sidebar.scss
+++ b/frontend/public/components/sidebars/_resource-sidebar.scss
@@ -1,5 +1,5 @@
 .co-resource-sidebar-item {
-  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor—100);
+  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   padding: ($line-height-computed * 0.5) 0 $line-height-computed;
 
   &:first-child {

--- a/frontend/public/components/utils/_copy-to-clipboard.scss
+++ b/frontend/public/components/utils/_copy-to-clipboard.scss
@@ -32,7 +32,7 @@
   --pf-c-button--PaddingRight: 16px;
   --pf-c-button--PaddingBottom: 11px;
   --pf-c-button--PaddingLeft: 16px;
-  --pf-c-button--BorderColor: var(--pf-global--BorderColor—100);
+  --pf-c-button--BorderColor: var(--pf-global--BorderColor--100);
   --pf-c-button--BorderRadius: 0;
   --pf-c-button--hover--BorderWidth: 1px;
   --pf-c-button--LineHeight: 20px;

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -3,7 +3,7 @@
 }
 
 .co-add-remove-form__entry + .co-add-remove-form__entry {
-  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor—100);
+  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   padding-top: 10px;
 }
 

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -60,10 +60,10 @@ body,
 
     &--bordered {
       @media (max-width: $screen-sm-max) {
-        border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor—100);
+        border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
       }
       @media (min-width: $screen-md-min) {
-        border-left: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor—100);
+        border-left: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
       }
     }
   }


### PR DESCRIPTION
For: https://issues.redhat.com/browse/CONSOLE-3081

Some `--pf-global--BorderColor--100` contained an em dash rather than double dashes.

Related to: https://github.com/openshift/console/pull/11154

> https://github.com/openshift/console/pull/11154#issuecomment-1079077622