### PR TITLE
Bug 2068594:  fix Cluster Dashboard Details Card test

### DIFF
--- a/frontend/integration-tests/tests/dashboards/cluster-dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/dashboards/cluster-dashboard.scenario.ts
@@ -1,3 +1,5 @@
+import { $, browser, ExpectedConditions as until } from 'protractor';
+import { waitForNone } from '@console/internal-integration-tests/protractor.conf';
 import * as dashboardView from '@console/shared/src/test-views/dashboard-shared.view';
 import * as clusterDashboardView from '../../views/dashboard.view';
 import * as sideNavView from '../../views/sidenav.view';
@@ -28,12 +30,14 @@ describe('Cluster Dashboard', () => {
         'Service Level Agreement (SLA)',
         'Update channel',
       ];
+      await browser.wait(until.presenceOf($('[data-test-id="sla-text"]')), 7000);
       const items = clusterDashboardView.detailsCardList.$$('dt');
       const values = clusterDashboardView.detailsCardList.$$('dd');
       expect(items.count()).toBe(expectedItems.length);
       expect(values.count()).toBe(expectedItems.length);
-      expectedItems.forEach((label: string, i: number) => {
+      expectedItems.forEach(async (label: string, i: number) => {
         expect(items.get(i).getText()).toBe(label);
+        await browser.wait(waitForNone(dashboardView.loaders));
         const text = values.get(i).getText();
         expect(text).not.toBe('');
         // `Update Channel` is expected to be `Not available` in CI.

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
@@ -182,7 +182,7 @@ export const DetailsCard = withDashboardResources(
                   </DetailItem>
 
                   <ServiceLevel clusterID={clusterID}>
-                    <DetailItem title={useServiceLevelTitle()} error={false} isLoading={false}>
+                    <DetailItem title={useServiceLevelTitle()}>
                       {/* Service Level handles loading and error state */}
                       <ServiceLevelText clusterID={clusterID} />
                     </DetailItem>

--- a/frontend/public/components/utils/service-level.tsx
+++ b/frontend/public/components/utils/service-level.tsx
@@ -247,7 +247,7 @@ export const ServiceLevelText: React.FC<ServiceLevelTextProps> = ({ clusterID, i
     );
   }
   return (
-    <>
+    <div data-test-id="sla-text">
       <div className="co-select-to-copy">
         {levelText}
         <div>
@@ -262,7 +262,7 @@ export const ServiceLevelText: React.FC<ServiceLevelTextProps> = ({ clusterID, i
           />
         </div>
       ) : null}
-    </>
+    </div>
   );
 };
 export const useServiceLevelTitle = (): string => {


### PR DESCRIPTION
The test was failing at a high rate because it can take several seconds for `<ServiceLevelText>` to render, and 'Cluster API address' and 'Provider' values can take several seconds time to load as well.