### PR TITLE
Bug 2069181: Fix disabling community tasks in pipeline builder issue

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/catalog/__tests__/catalog-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/__tests__/catalog-utils.spec.ts
@@ -90,5 +90,16 @@ describe('catalog-utils', () => {
         expect(tektonHubTasksEnabled).toBe(false);
       });
     });
+
+    it('If the api call is not loaded then it should return false', () => {
+      testHook(() => {
+        (useK8sGet as jest.Mock).mockReturnValue([
+          tektonHubIntegrationConfigs[IntegrationTypes.ENABLED],
+          false,
+        ]);
+        const tektonHubTasksEnabled = useTektonHubIntegration();
+        expect(tektonHubTasksEnabled).toBe(false);
+      });
+    });
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/catalog/catalog-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/catalog-utils.ts
@@ -16,11 +16,15 @@ export const useTektonHubIntegration = () => {
     TektonConfigModel,
     'config',
   );
+  if (!configLoaded) {
+    return false;
+  }
+  // return false only if TEKTON_HUB_INTEGRATION_KEY value is set to 'false'
   if (config && configLoaded && !configLoadErr) {
     const devconsoleIntegrationEnabled = config.spec?.hub?.params?.find(
       (p) => p.name === TEKTON_HUB_INTEGRATION_KEY,
     );
-    return devconsoleIntegrationEnabled ? devconsoleIntegrationEnabled.value : true;
+    return devconsoleIntegrationEnabled?.value?.toLowerCase() !== 'false';
   }
   return true;
 };

--- a/frontend/packages/pipelines-plugin/src/test-data/tekon-config-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/tekon-config-data.ts
@@ -114,7 +114,7 @@ export const tektonHubIntegrationConfigs: TekonHubIntegrationConfigs = {
     spec: {
       ...sampleTektonConfig.spec,
       hub: {
-        params: [{ name: TEKTON_HUB_INTEGRATION_KEY, value: true }],
+        params: [{ name: TEKTON_HUB_INTEGRATION_KEY, value: 'true' }],
       },
     },
   },
@@ -123,7 +123,7 @@ export const tektonHubIntegrationConfigs: TekonHubIntegrationConfigs = {
     spec: {
       ...sampleTektonConfig.spec,
       hub: {
-        params: [{ name: TEKTON_HUB_INTEGRATION_KEY, value: false }],
+        params: [{ name: TEKTON_HUB_INTEGRATION_KEY, value: 'false' }],
       },
     },
   },


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGSM-42596

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

1. Tekton hub integration param value is a string but considered as boolean in the code.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Update checks to handle strings and awaiting till the k8s call to complete to avoid the initial load of all resources.


**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/9964343/160409079-a90da78f-15a1-4bfc-84bc-e546f73efccf.mov


**Unit test coverage report**: 
<!-- Attach test coverage report -->

Updated the tests
  ✓ If the api call is not loaded then it should return false (1ms)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

1. Use a clusterbot in the PR and Install OSP 1.7.0 from the custom catalogsource
2. Set the TektonConfig (config) CR to have the following object in the spec

```
  hub:
    params:
    - name: enable-devconsole-integration
      value: "false"

```

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge