### PR TITLE
Bug 2067298: Remove `modelsLoaded` conditional rendering from ModelStatusBox

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/model-status-box.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/model-status-box.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ErrorPage404 } from '@console/internal/components/error';
-import { LoadingBox } from '@console/internal/components/utils';
 import { GroupVersionKind, kindForReference } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 
@@ -11,10 +10,8 @@ type ModelStatusBoxProps = {
 
 const ModelStatusBox: React.FC<ModelStatusBoxProps> = ({ groupVersionKind, children }) => {
   const { t } = useTranslation();
-  const [model, modelsLoading] = useK8sModel(groupVersionKind);
-  return modelsLoading ? (
-    <LoadingBox />
-  ) : model ? (
+  const [model] = useK8sModel(groupVersionKind);
+  return model ? (
     <>{children}</>
   ) : (
     <ErrorPage404


### PR DESCRIPTION
Conditionally rendering ModelStatusBox children caused those children to be remounted on every API discovery poll when the k8s resources "inFlight" redux state cycled. The operand creation form is wrapped in this component and was being reset to its initial state on every remount.