### PR TITLE
fix the quick search style to support dark theme

### DIFF
--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.scss
@@ -1,4 +1,5 @@
 .ocs-quick-search-bar {
+  background: var(--pf-global--BackgroundColor--400) !important;
   &:hover {
     cursor: move;
   }

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.scss
@@ -20,10 +20,10 @@
       }
     }
     &--highlight {
-      background: var(--pf-global--active-color--200) !important;
+      background-color: var(--pf-global--BackgroundColor--200) !important;
     }
     &:hover {
-      background: var(--pf-global--active-color--200);
+      background-color: var(--pf-global--BackgroundColor--200);
     }
   }
   &__item-row {


### PR DESCRIPTION
Epic:
https://issues.redhat.com/browse/ODC-5990

Story:
https://issues.redhat.com/browse/ODC-6516

Description:
Fix style for quick search to support dark theme.

Screens:

**Topology**
![Screenshot from 2022-03-30 11-19-29](https://user-images.githubusercontent.com/38663217/160760910-3c6a862a-28b2-4f2b-a74e-1095a9cf90f7.png)
![Screenshot from 2022-03-30 11-20-09](https://user-images.githubusercontent.com/38663217/160760969-5068144e-48ec-4590-861b-e7ed9deec95f.png)

**Pipelines**
![Screenshot from 2022-03-30 11-19-01](https://user-images.githubusercontent.com/38663217/160761051-9429033c-af65-48c8-bfa8-70b0c269ca62.png)
![Screenshot from 2022-03-30 11-19-12](https://user-images.githubusercontent.com/38663217/160761076-fe83ada4-ee0d-4b29-b8bd-e7b119e275ba.png)

Tests:
NA

Browser conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge