### PR TITLE
Bug 2064454: return process data as array for list true in firehose as done in hooks

### DIFF
--- a/frontend/public/components/utils/__tests__/firehose.spec.tsx
+++ b/frontend/public/components/utils/__tests__/firehose.spec.tsx
@@ -850,12 +850,12 @@ describe('Firehose', () => {
     // pods 'resource' object (with data, loaded, etc.) object
     expect(propsChildA.pods).toEqual(propsChildB.pods);
     expect(propsChildA.pods).not.toBe(propsChildB.pods); // Could be the same?
-    expect(propsChildA.pods.data).toBe(propsChildB.pods.data);
+    expect(propsChildA.pods.data).toEqual(propsChildB.pods.data);
     expect(propsChildA.pods.data[0]).toBe(propsChildB.pods.data[0]);
 
     expect(propsChildA.resources.pods).toEqual(propsChildB.resources.pods);
     expect(propsChildA.resources.pods).not.toBe(propsChildB.resources.pods); // Could be the same?
-    expect(propsChildA.resources.pods.data).toBe(propsChildB.resources.pods.data);
+    expect(propsChildA.resources.pods.data).toEqual(propsChildB.resources.pods.data);
     expect(propsChildA.resources.pods.data[0]).toBe(propsChildB.resources.pods.data[0]);
 
     // pod 'resource' object (with data, loaded, etc.) object

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -41,14 +41,12 @@ export const processReduxId = ({ k8s }, props) => {
   const selected = k8s.getIn([reduxID, 'selected']);
 
   if (data) {
-    if (!data[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL]) {
-      data[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = data.toArray().map((a) => {
-        if (!a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL]) {
-          a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = a.toJSON();
-        }
-        return a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL];
-      });
-    }
+    data[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = data.toArray().map((a) => {
+      if (!a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL]) {
+        a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = a.toJSON();
+      }
+      return a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL];
+    });
     data = data[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL];
   }
 


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=2069621,  https://bugzilla.redhat.com/show_bug.cgi?id=2064454

**Description:**

git import flow from the developer perspective in 4.9 nightly builds with this PR change https://github.com/openshift/console/pull/11184

**Solution:** 
return process data as array for `isList: true` in firehose as well as done in hooks