### PR TITLE
Automation of Builder Page Pipelines

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
@@ -23,51 +23,51 @@ Feature: Create the pipeline from builder page
               And Create button is in disabled state
 
 
-        @regression @to-do
+        @regression
         Scenario Outline: Create a pipeline with series tasks: P-02-TC02
             Given user is at Pipeline Builder page
              When user enters pipeline name as "<pipeline_name>"
-              And user clicks on Add task
+              And user clicks Add task button under Tasks section
               And user searches "<cluster_task_name>" in quick search bar
-              And user clicks on "Add" in "<cluster_task_name>" task
+              And user clicks on Add in selected task
               And user adds another task "<cluster_task_name_1>" in series
               And user clicks Create button on Pipeline Builder page
              Then user will be redirected to Pipeline Details page with header name "<pipeline_name>"
 
         Examples:
                   | pipeline_name | cluster_task_name | cluster_task_name_1 |
-                  | p-one         | kn                | openshift-client    |
+                  | pipe-one      | kn                | openshift-client    |
 
 
-        @regression @to-do
+        @regression
         Scenario Outline: Create a pipeline with parallel tasks: P-02-TC03
             Given user is at Pipeline Builder page
              When user enters pipeline name as "<pipeline_name>"
-              And user clicks on Add task
+              And user clicks Add task button under Tasks section
               And user searches "<cluster_task_name>" in quick search bar
-              And user clicks on "Add" in "<cluster_task_name>" task
+              And user clicks on Add in selected task
               And user adds another task "<cluster_task_name_1>" in parallel
               And user clicks Create button on Pipeline Builder page
              Then user will be redirected to Pipeline Details page with header name "<pipeline_name>"
 
         Examples:
                   | pipeline_name | cluster_task_name | cluster_task_name_1 |
-                  | p-two         | kn                | openshift-client    |
+                  | pipe-two      | kn                | openshift-client    |
 
 
-        @smoke @to-do
+        @smoke
         Scenario Outline: Create a basic pipeline from pipeline builder page: P-02-TC04
             Given user is at Pipeline Builder page
              When user enters pipeline name as "<pipeline_name>"
-              And user clicks on Add task
+              And user clicks Add task button under Tasks section
               And user searches "<cluster_task_name>" in quick search bar
-              And user clicks on "Add" in "<cluster_task_name>" task
+              And user clicks on Add in selected task
               And user clicks Create button on Pipeline Builder page
              Then user will be redirected to Pipeline Details page with header name "<pipeline_name>"
 
         Examples:
                   | pipeline_name | cluster_task_name |
-                  | p-three-1     | kn                |
+                  | pipe-three    | kn                |
 
 
         @un-verified
@@ -91,13 +91,13 @@ Feature: Create the pipeline from builder page
                   # | p-cluster     | task-cluster           | Cluster       | cluster repo  |
 
 
-        @regression @to-do
+        @regression
         Scenario: Add Parameters to the pipeline in pipeline builder page: P-02-TC06
             Given user is at Pipeline Builder page
              When user enters pipeline name as "pipeline-params"
-              And user clicks on Add task
+              And user clicks Add task button under Tasks section
               And user searches "s2i-nodejs" in quick search bar
-              And user clicks on "Add" in "s2i-nodejs" task
+              And user clicks on Add in selected task
               And user adds the parameter details like Name, Description and Default Value
               And user clicks on Add workspace
               And user adds the Workspace name as "empty"
@@ -227,24 +227,20 @@ Feature: Create the pipeline from builder page
               And user sees "Add finally task" option below "git-clone" task
 
 
-        @regression @to-do
+        @regression
         Scenario: Create a pipeline with finally task node: P-02-TC15
             Given user is at Pipeline Builder page
-             When user enters pipeline name "pipeline-finally"
-              And user clicks on Add task
-              And user searches "openshift-client-v0-22-0" in quick search bar
-              And user clicks on Add in "openshift-client-v0-22-0" task
+             When user enters pipeline name as "pipeline-finally"
+              And user clicks Add task button under Tasks section
+              And user searches "openshift-client" in quick search bar
+              And user clicks on Add in selected task
               And user clicks on Add finally task
-              And user clicks on Add task
-              And user searches "tkn" in quick search bar
-              And user clicks on Add in "tkn" task
-              And user clicks on Add finally task again
-              And user selects "openshift-client" from Add task quick search
+              And user selects "tkn" from Add task quick search
               And user clicks on Add finally task again
               And user selects "kn" from Add task quick search
               And user clicks on Create
              Then user will be redirected to Pipeline Details page with header name "pipeline-finally"
-              And user is able to see finally tasks "tkn", "openshift-client" and "kn" mentioned under "Finally tasks" section in the Pipeline details page
+              And user is able to see finally tasks "tkn" and "kn" mentioned under "Finally tasks" section in the Pipeline details page
 
 
         @regression
@@ -278,12 +274,12 @@ Feature: Create the pipeline from builder page
               And user will see tooltip saying "When expression" while scrolling over diamond structure before conditional task
 
 
-        @regression @to-do
+        @regression
         Scenario: Code assistance for referencing params in the Pipeline Builder: P-02-TC18
             Given user is at Pipeline Builder page
-             When user clicks on Add task
+             When user clicks Add task button under Tasks section
               And user searches "git-clone" in quick search bar
-              And user clicks on Add in "git-clone" task
+              And user clicks on Add in selected task
               And user enters pipeline name as "pipeline-code-assistance"
               And user clicks on Add Parameter
               And user adds Name as "git-url"
@@ -291,7 +287,7 @@ Feature: Create the pipeline from builder page
               And user clicks on Add Workspace and add name as "git-workspace"
               And user clicks on "git-clone" task node
               And user enters url under Parameters section "$(params.git-url)"
-              And user adds workspace as "git-workspace"
+              And user adds "output" workspace as "git-workspace"
               And user clicks on Create
              Then user will be redirected to Pipeline Details page with header name "pipeline-code-assistance"
 
@@ -347,6 +343,6 @@ Feature: Create the pipeline from builder page
               And user clicks on Save button
               And user clicks on Pipeline tab in navigation menu
               And user clicks Create Pipeline button
-              And user clicks on Add task
+              And user clicks Add task button under Tasks section
               And user types 'git'
              Then user will see Task, clusterTask only

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/pipelines.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/pipelines.ts
@@ -7,7 +7,7 @@ import {
 } from '@console/dev-console/integration-tests/support/constants';
 import { app, navigateTo } from '@console/dev-console/integration-tests/support/pages';
 import { pipelineActions } from '../../constants';
-import { pipelineBuilderPO, pipelinesPO } from '../../page-objects';
+import { pipelinesPO } from '../../page-objects';
 import {
   pipelineRunDetailsPage,
   pipelineBuilderPage,
@@ -78,9 +78,6 @@ Given(
 
 When('user adds another task {string} in parallel', (taskName: string) => {
   pipelineBuilderPage.selectParallelTask(taskName);
-  pipelineBuilderPage.addResource('git resource');
-  pipelineBuilderPage.clickOnTask(taskName);
-  cy.get(pipelineBuilderPO.formView.sidePane.inputResource).select('git resource');
   pipelineBuilderPage.clickCreateButton();
 });
 

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
@@ -65,15 +65,6 @@ When('user selects {string} from Task drop down', (taskName: string) => {
   pipelineBuilderPage.selectTask(taskName);
 });
 
-When('user adds another task {string} in parallel', (taskName: string) => {
-  pipelineBuilderPage.selectParallelTask(taskName);
-  pipelineBuilderPage.addResource('git resource');
-  pipelineBuilderPage.clickOnTask(taskName);
-  cy.get(pipelineBuilderPO.formView.sidePane.inputResource).click();
-  cy.byTestDropDownMenu('git resource').click();
-  pipelineBuilderPage.clickCreateButton();
-});
-
 When('user clicks Create button on Pipeline Builder page', () => {
   pipelineBuilderPage.clickCreateButton();
 });
@@ -87,9 +78,6 @@ Then(
 
 When('user adds another task {string} in series', (taskName: string) => {
   pipelineBuilderPage.selectSeriesTask(taskName);
-  pipelineBuilderPage.addResource('git resource');
-  pipelineBuilderPage.clickOnTask(taskName);
-  cy.get(pipelineBuilderPO.formView.sidePane.inputResource).select('git resource');
   pipelineBuilderPage.clickCreateButton();
 });
 
@@ -223,11 +211,10 @@ And('user clicks on Create', () => {
 });
 
 And(
-  'user is able to see finally tasks {string}, {string} and {string} mentioned under "Finally tasks" section in the Pipeline details page',
-  (tkn: string, openshift: string, kn: string) => {
-    cy.get(`[data-test="finally-task-node ${tkn}"]`).should('be.visible');
-    cy.get(`[data-test="finally-task-node ${openshift}"]`).should('be.visible');
-    cy.get(`[data-test="finally-task-node ${kn}"]`).should('be.visible');
+  'user is able to see finally tasks {string} and {string} mentioned under "Finally tasks" section in the Pipeline details page',
+  (tkn: string, kn: string) => {
+    cy.get(`[data-test-id="${tkn}"]`).should('be.visible');
+    cy.get(`[data-test-id="${kn}"]`).should('be.visible');
   },
 );
 
@@ -410,10 +397,10 @@ And('user enters url under Parameters section {string}', (url: string) => {
   cy.get('[data-test="parameter url"] [data-test~="value"]').type(url);
 });
 
-And('user adds workspace as {string}', (workspace: string) => {
-  cy.get('[data-test~="workspaces"]')
+And('user adds {string} workspace as {string}', (workspace: string, wName: string) => {
+  cy.get(`[data-test="workspaces ${workspace}"]`)
     .scrollIntoView()
-    .select(workspace);
+    .select(wName);
 });
 
 Given('user has applied yaml {string}', (yamlFile: string) => {
@@ -540,5 +527,26 @@ When('user clicks on Install and add button', () => {
 });
 
 When('user clicks on Add button', () => {
+  cy.byTestID('task-cta').click();
+});
+
+When('user clicks on Add in selected task', () => {
+  cy.byTestID('task-cta').click();
+});
+
+When('user adds a task in series', () => {
+  cy.mouseHover(pipelineBuilderPO.formView.task);
+  cy.get(pipelineBuilderPO.formView.plusTaskIcon)
+    .first()
+    .click({ force: true });
+});
+
+When('user should see the Create button enabled after installation', () => {
+  cy.byLegacyTestID('submit-button').should('not.be.disabled');
+});
+
+When('user selects {string} from Add task quick search', (searchItem: string) => {
+  cy.get('[data-test="task-list"]').click();
+  cy.get(pipelineBuilderPO.formView.quickSearch).type(searchItem);
   cy.byTestID('task-cta').click();
 });


### PR DESCRIPTION
**Description:**
<!-- PR description-->
Automation on pipeline builder page

**Jira Id:** [ODC-6578](https://issues.redhat.com/browse/ODC-6578)
<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p pipelines
```

**Screen shots**:
<!--   -->
![image](https://user-images.githubusercontent.com/65410551/159008710-47f19430-3c66-4f4e-9f31-682f78a6000b.png)


**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge