### PR TITLE
Bug 2070020: create correct apiversion: group/version for creating custom resource key for Resource Dropdown

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
@@ -112,7 +112,10 @@ export const EventSource: React.FC<Props> = ({
       apiVersion: sinkApiVersion,
       kind: sinkKind,
       name: sinkName,
-      key: craftResourceKey(sinkName, { kind: sinkKind, apiVersion: sinkGroupVersionKind }),
+      key: craftResourceKey(sinkName, {
+        kind: sinkKind,
+        apiVersion: `${sinkGroup}/${sinkVersion}`,
+      }),
       uri: '',
     },
     type: sourceKind,


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGSM-42690

Root Cause: While reading the data from `contextSource` param, API version was read incorrectly creating an invalid key for resource dropdown

Screenshot:
<img width="917" alt="Screenshot 2022-03-30 at 3 34 14 PM" src="https://user-images.githubusercontent.com/9278015/160842698-655ff710-0786-49d2-8585-66d170453f09.png">
