### PR TITLE
Bug 2057251: promql: Improve a few cluster-dashboard queries

### DIFF
--- a/frontend/packages/console-shared/src/promql/OWNERS
+++ b/frontend/packages/console-shared/src/promql/OWNERS
@@ -1,10 +1,12 @@
 reviewers:
   - jan--f
+  - jgbernalp
   - kyoto
   - simonpasquier
   - spadgett
 approvers:
   - jan--f
+  - jgbernalp
   - kyoto
   - simonpasquier
   - spadgett


### PR DESCRIPTION
Problem: Selected graphs in the cluster dashboard would sometimes
disappear periodically. This is caused by pods being rescheduled on a
different node. This causes some pod metrics to appear for two nodes
(due to how prometheus handles series staleness), which in turn causes
some queries to fail with a many-to-many, or "found duplicate series for
the match group" error.

Solution: Rewrite some queries so that they are resilient against this
scenario. This is achieved by ignoring labels that cause this
duplication (here the "node" label was the culprit). Additionally the
query "CPU_UTILIZATION" was rewritten to touch less samples by
introducing a label_rewrite, instead of joining two metrics via a third
metric.

Issues: https://bugzilla.redhat.com/show_bug.cgi?id=2057251

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>