### PR TITLE
Bug 2069914: fix casing of 'Red Hat Applications' so all links appear…

### DIFF
--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -275,7 +275,7 @@ class MastheadToolbarContents_ extends React.Component {
       window.SERVER_FLAGS.branding !== 'azure'
     ) {
       sections.push({
-        name: t('public~Red Hat applications'),
+        name: t('public~Red Hat Applications'),
         isSection: true,
         actions: [
           {

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -708,7 +708,7 @@
   "Learning Portal": "Learning Portal",
   "OpenShift Blog": "OpenShift Blog",
   "System status": "System status",
-  "Red Hat applications": "Red Hat applications",
+  "Red Hat Applications": "Red Hat Applications",
   "Quick Starts": "Quick Starts",
   "Documentation": "Documentation",
   "ACM Documentation": "ACM Documentation",


### PR DESCRIPTION
… in the same section

Before:
<img width="497" alt="Screen Shot 2022-03-31 at 9 40 22 AM" src="https://user-images.githubusercontent.com/895728/161068776-a244803a-615c-4e8f-907a-8ac353472f53.png">

After:
<img width="521" alt="Screen Shot 2022-03-31 at 9 39 47 AM" src="https://user-images.githubusercontent.com/895728/161068847-c36001b1-e812-4eed-9e78-72ce135d350b.png">

cc: @andybraren 