### PR TITLE
Bug 2069632:  fix 'linkURL' for 'previous' logs

### DIFF
--- a/frontend/public/components/utils/resource-log.tsx
+++ b/frontend/public/components/utils/resource-log.tsx
@@ -391,7 +391,7 @@ export const ResourceLog: React.FC<ResourceLogProps> = ({
 
   const previousResourceStatus = usePrevious(resourceStatus);
   const previousTotalLineCount = usePrevious(totalLineCount);
-  const linkURL = getResourceLogURL(cluster, resource, containerName);
+  const linkURL = getResourceLogURL(cluster, resource, containerName, null, false, logType);
   const watchURL = getResourceLogURL(cluster, resource, containerName, null, true, logType);
   const [wrapLines, setWrapLines] = useUserSettings<boolean>(
     LOG_WRAP_LINES_USERSETTINGS_KEY,


### PR DESCRIPTION
Note this bug was introduced in [the initial implementation of past logs](https://github.com/openshift/console/pull/8896), so this will need to be back ported to 4.8.

And the bug affects the `Raw` link in the toolbar as well as the `open the raw file in another window` and  `download it` links that appear in the optional warning alert (all are highlighted in the screenshot below).

<img width="1364" alt="Screen Shot 2022-04-04 at 9 19 29 AM" src="https://user-images.githubusercontent.com/895728/161553130-16ebbd22-c26d-4917-873e-c3e51671905e.png">


