### PR TITLE
Gherkin and Automation of e2e support for event sinks

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/add.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/add.ts
@@ -11,6 +11,7 @@ export enum addOptions {
   Channel = 'Channel',
   UploadJARFile = 'Upload JAR file',
   Broker = 'Broker',
+  EventSink = 'Event Sink',
 }
 
 export enum buildConfigOptions {
@@ -56,6 +57,7 @@ export enum catalogTypes {
   ServiceClass = 'Service Class',
   ManagedServices = 'Managed Services',
   EventSources = 'Event Sources',
+  EventSinks = 'Event Sinks',
 }
 
 export enum builderImages {

--- a/frontend/packages/dev-console/integration-tests/support/constants/pageTitle.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/pageTitle.ts
@@ -7,6 +7,7 @@ export const pageTitle = {
   PipelineBuilder: 'Pipeline builder',
   EventSource: 'Event Sources',
   CreateEventSource: 'Create Event Source',
+  EventSink: 'Event Sinks',
   upgradeHelmRelease: 'Upgrade Helm Release',
   Channel: 'Channel',
   Broker: 'Broker',

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -122,6 +122,7 @@ export const catalogPO = {
     serviceClass: '[data-test="kind-cluster-service-class"]',
     managedServices: '[data-test="kind-managed-service"]',
     eventSources: '[data-test="tab EventSource"]',
+    eventSinks: '[data-test="tab EventSink"]',
   },
   cards: {
     mariaDBTemplate: 'a[data-test="Template-MariaDB"] .catalog-tile-pf-title',
@@ -265,6 +266,10 @@ export const eventSourcePO = {
   },
 };
 
+export const eventSinkPO = {
+  search: '[placeholder="Filter by keyword..."]',
+};
+
 export const devFilePO = {
   form: '[data-test-id="import-devfile-form"]',
   formFields: {
@@ -280,7 +285,7 @@ export const devFilePO = {
 export const channelPO = {
   channelType: '[data-test-id="dropdown-button"]',
   channelName: '[data-test-id="channel-name"]',
-  appName: '#form-dropdown-application-name-field',
+  appName: '[data-test-id="application-form-app-input"]',
 };
 
 export const yamlPO = {

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
@@ -94,6 +94,13 @@ export const addPage = {
         detailsPage.titleShouldContain(pageTitle.Broker);
         cy.testA11y(pageTitle.Broker);
         break;
+      case 'Event Sink':
+      case addOptions.EventSink:
+        cy.byTestID('item knative-event-sink').click();
+        app.waitForLoad();
+        detailsPage.titleShouldContain(pageTitle.EventSink);
+        cy.testA11y(pageTitle.EventSink);
+        break;
       default:
         throw new Error(`Unable to find the "${card}" card on Add page`);
     }

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
@@ -73,6 +73,11 @@ export const catalogPage = {
         cy.get(catalogPO.catalogTypes.eventSources).click();
         break;
       }
+      case catalogTypes.EventSinks:
+      case 'Event Sinks': {
+        cy.get(catalogPO.catalogTypes.eventSinks).click();
+        break;
+      }
       default: {
         throw new Error('Card is not available in Catalog');
       }

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/event-sink-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/event-sink-page.ts
@@ -1,0 +1,30 @@
+import { eventSourceCards } from '../../constants';
+import { catalogPO, eventSinkPO } from '../../pageObjects';
+
+export const eventSinkPage = {
+  search: (type: string) => cy.get(eventSinkPO.search).type(type),
+  verifyEventSinkType: (eventSinkName: string) => {
+    cy.byTestID(`EventSink-${eventSinkName}`).should('be.visible');
+  },
+  clickEventSourceType: (eventSinkName: string | eventSourceCards) => {
+    cy.byTestID(`EventSink-${eventSinkName}`)
+      .should('be.visible')
+      .click();
+  },
+  clickCreateEventSinkOnSidePane: () => {
+    cy.get(catalogPO.sidePane.createApplication).click({ force: true });
+  },
+};
+export const createEventSinkPage = {
+  selectOutputTargetName: (outputTargetName: string) => {
+    cy.get('#form-ns-dropdown-formData-source-key-field')
+      .scrollIntoView()
+      .should('be.visible')
+      .click();
+    cy.get("[role='listbox']")
+      .find('li')
+      .contains(outputTargetName)
+      .should('be.visible')
+      .click();
+  },
+};

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/index.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/index.ts
@@ -2,6 +2,7 @@ export * from './add-page';
 export * from './catalog-page';
 export * from './container-image-page';
 export * from './dev-file-page';
+export * from './event-sink-page';
 export * from './event-source-page';
 export * from './git-page';
 export * from './yaml-page';

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/createBroker.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/createBroker.ts
@@ -3,14 +3,10 @@ import { devNavigationMenu } from '../../constants/global';
 import { addPage, gitPage } from '../add-flow';
 import { app, createForm, navigateTo } from '../app';
 
-export const createBroker = (
-  brokerName: string = 'broker-one',
-  appName: string = 'nodejs-ex-git-app',
-) => {
+export const createBroker = (brokerName: string = 'broker-one') => {
   navigateTo(devNavigationMenu.Add);
   addPage.selectCardFromOptions(addOptions.Broker);
   gitPage.enterWorkloadName(brokerName);
-  gitPage.enterAppName(appName);
   createForm.clickCreate().then(() => {
     app.waitForLoad();
     cy.log(`Broker "${brokerName}" is created`);

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/createChannel.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/createChannel.ts
@@ -3,15 +3,11 @@ import { devNavigationMenu } from '../../constants/global';
 import { addPage, channelPage } from '../add-flow';
 import { app, createForm, navigateTo } from '../app';
 
-export const createChannel = (
-  channelName: string = 'channel-one',
-  appName: string = 'nodejs-ex-git-app',
-) => {
+export const createChannel = (channelName: string = 'channel-one') => {
   navigateTo(devNavigationMenu.Add);
   addPage.selectCardFromOptions(addOptions.Channel);
   channelPage.selectChannelType();
   channelPage.enterChannelName(channelName);
-  channelPage.enterAppName(appName);
   createForm.clickCreate().then(() => {
     app.waitForLoad();
     cy.log(`Channel "${channelName}" is created`);

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/createEventSink.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/createEventSink.ts
@@ -1,0 +1,22 @@
+import { addOptions } from '../../constants/add';
+import { devNavigationMenu } from '../../constants/global';
+import { addPage, createEventSinkPage, eventSinkPage, gitPage } from '../add-flow';
+import { app, createForm, navigateTo } from '../app';
+
+export const createEventSink = (
+  cardName: string = 'Log Sink',
+  target: string,
+  eventSinkName: string = 'event-sink-one',
+) => {
+  navigateTo(devNavigationMenu.Add);
+  addPage.selectCardFromOptions(addOptions.EventSink);
+  eventSinkPage.search(cardName);
+  eventSinkPage.clickEventSourceType(cardName);
+  eventSinkPage.clickCreateEventSinkOnSidePane();
+  createEventSinkPage.selectOutputTargetName(target);
+  gitPage.enterWorkloadName(eventSinkName);
+  createForm.clickCreate().then(() => {
+    app.waitForLoad();
+    cy.log(`Event Sink "${eventSinkName}" is created`);
+  });
+};

--- a/frontend/packages/knative-plugin/integration-tests/features/eventing/create-event-sink.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/eventing/create-event-sink.feature
@@ -1,0 +1,81 @@
+@knative-eventing
+Feature: Create event sinks
+              As a user, I want to create event sinks
+
+        Background:
+            Given user has installed Red Hat Integration - Camel K Operator
+              And user has created or selected namespace "aut-event-sink"
+              And user has created channel "kn-channel"
+              And user is at Add page
+
+
+        @regression @odc-6390
+        Scenario: Create event sink from Add page: KES-01-TC01
+             When user clicks on Event Sink card
+              And user clicks on "Log Sink" card
+              And user clicks on Create Event Sink
+              And user selects Output Target as "kn-channel"
+              And user enters name as "event-sink-test1"
+              And user clicks on Create button
+             Then user will see "event-sink-test1" created in topology
+
+
+        @regression @odc-6390
+        Scenario: Create event sink from catalog page: KES-01-TC02
+            Given user is at catalog page
+             When user selects Types as Event Sinks
+              And user clicks on "Log Sink" card
+              And user clicks on Create Event Sink
+              And user selects Output Target as "kn-channel"
+              And user enters name as "event-sink-test2"
+              And user clicks on Create button
+             Then user will see "event-sink-test2" created in topology
+
+
+        @regression @odc-6390
+        Scenario: Create event sink with YAML view: KES-01-TC03
+             When user clicks on Event Sink card
+              And user clicks on "Log Sink" card
+              And user clicks on Create Event Sink
+              And user switches to YAML view
+              And user clicks on Create button
+             Then user will see "kamelet-log-sink" created in topology
+
+
+        @regression @odc-6390
+        Scenario: Create event sink from context menu: KES-01-TC04
+            Given user is at Topology page
+             When user right clicks in empty space of topology
+              And user selects "Event Sink" from Add to project
+              And user clicks on "Log Sink" card
+              And user clicks on Create Event Sink
+              And user selects Output Target as "kn-channel"
+              And user enters name as "event-sink-test3"
+              And user clicks on Create button
+             Then user will see "event-sink-test3" created in topology
+
+
+        @regression @manual @odc-6390
+        Scenario: Create event sink through drag and drop from Broker: KES-01-TC05
+            Given user created broker "test-broker"
+              And user is at Topology page
+             When user drags and drops connector to empty area in topology
+              And user selects "Event Sink" from context menu
+              And user clicks on "Log Sink" card
+              And user clicks on Create Event Sink
+              And user enters name as "event-sink-test10"
+              And user clicks on Create button
+             Then user will see "event-sink-test10" created in topology connected to broker "test-broker"
+
+
+        @regression @manual @odc-6390
+        Scenario: Create event sink through drag and drop from Broker: KES-01-TC06
+            Given user created channel "test-channel"
+              And user is at Topology page
+             When user drags and drops connector to empty area in topology
+              And user selects "Event Sink" from context menu
+              And user clicks on "Log Sink" card
+              And user clicks on Create Event Sink
+              And user enters name as "event-sink-test20"
+              And user clicks on Create button
+             Then user will see "event-sink-test20" created in topology connected to channel "test-channel"

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/common.ts
@@ -17,6 +17,7 @@ import {
   createGitWorkloadIfNotExistsOnTopologyPage,
   createEventSourcePage,
   verifyAndInstallKnativeOperator,
+  createChannel,
 } from '@console/dev-console/integration-tests/support/pages';
 
 Given('user is at developer perspective', () => {
@@ -131,4 +132,8 @@ Then('modal with {string} appears', (header: string) => {
 
 Given('user has installed OpenShift Serverless Operator', () => {
   verifyAndInstallKnativeOperator();
+});
+
+Given('user has created channel {string}', (channelName: string) => {
+  createChannel(channelName);
 });

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/eventing/create-event-sink.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/eventing/create-event-sink.ts
@@ -1,0 +1,78 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import {
+  devNavigationMenu,
+  addOptions,
+  catalogTypes,
+} from '@console/dev-console/integration-tests/support/constants';
+import { topologyPO } from '@console/dev-console/integration-tests/support/pageObjects';
+import {
+  addPage,
+  eventSinkPage,
+  navigateTo,
+  createForm,
+  gitPage,
+  catalogPage,
+  createEventSinkPage,
+} from '@console/dev-console/integration-tests/support/pages';
+import { topologyPage } from '@console/topology/integration-tests/support/pages/topology';
+
+When('user clicks on Event Sink card', () => {
+  navigateTo(devNavigationMenu.Add);
+  addPage.selectCardFromOptions(addOptions.EventSink);
+});
+
+When('user clicks on {string} card', (cardName: string) => {
+  eventSinkPage.search(cardName);
+  eventSinkPage.clickEventSourceType(cardName);
+});
+
+When('user clicks on Create Event Sink', () => {
+  eventSinkPage.clickCreateEventSinkOnSidePane();
+});
+
+When('user selects Output Target as {string}', (target: string) => {
+  createEventSinkPage.selectOutputTargetName(target);
+});
+
+When('user enters name as {string}', (name: string) => {
+  gitPage.enterComponentName(name);
+});
+
+When('user clicks on Create button', () => {
+  createForm.clickCreate();
+});
+
+Then('user will see {string} created in topology', (workloadName: string) => {
+  topologyPage.verifyWorkloadInTopologyPage(workloadName);
+});
+
+Given('user is at catalog page', () => {
+  navigateTo(devNavigationMenu.Add);
+  addPage.selectCardFromOptions(addOptions.DeveloperCatalog);
+});
+
+When('user selects Types as Event Sinks', () => {
+  catalogPage.selectCatalogType(catalogTypes.EventSinks);
+});
+
+When('user switches to YAML view', () => {
+  cy.get('[id="form-radiobutton-editorType-yaml-field"]')
+    .should('be.visible')
+    .click();
+});
+
+Given('user is at Topology page', () => {
+  navigateTo(devNavigationMenu.Topology);
+});
+
+When('user right clicks in empty space of topology', () => {
+  cy.get(topologyPO.graph.fitToScreen).should('be.visible');
+  cy.get('[data-id="odc-topology-graph"]').rightclick('topLeft');
+});
+
+When('user selects {string} from Add to project', (option: string) => {
+  cy.get(topologyPO.graph.contextMenuOptions.addToProject)
+    .focus()
+    .trigger('mouseover');
+  cy.byTestActionID(option).click({ force: true });
+});


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-6390
Story: https://issues.redhat.com/browse/ODC-6503

Acceptance criteria:

-  Add an Event Sink Catalog to the Console

    1. Include new tile on Add page which drills into the *Event Sink *catalog
    2. Include new Event Sink Catalog
    3. Include new catalog type in Dev Catalog, thus Event Sinks are shown in Developer catalog along with other items
    4. Provide side panel for Event Sinks, similar to Event Source experience
    5. Provide a form driven experience for Event Sinks by default, as we do for Event Sources
    6. Provide the ability to switch between YAML/Form in the Event Sink creation process
    7. Add to project menu in Topology should have an Event Sink option
-  Update Event Source flow to allow for an Event Sink as a valid target, both in form & topology D&D flows
-  Update Add Trigger flow to allow for Event Sink as valid subscriber, both in form & topology D&D flows
-  Update Add Subscription flow to allow for Event Sink as valid subscriber, both in form & topology D&D flows

**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]

**Fix**: https://issues.redhat.com/browse/ODC-6504


**Test Setup**:


Cluster should be running on local

Check the TAGS in frontend/packages/knative-plugin/integration-tests/cypress.json file be: ""(@knative or @knative-eventing) and (@pre-condition or @smoke or @regression) and not (@manual or @to-do or @un-verified or @broken-test)"",


Command to execute:

Run a cluster locally and execute the command `yarn run dev` and then `npm run test-cypress-knative` simultaneously

Execute the eventing/create-event-sink.feature file

**Browser**
Chrome 99

**Test Execution Screenshot:**


