### PR TITLE
Bug 2069760: Added divider to developer console navigation

### DIFF
--- a/frontend/public/components/nav/_perspective-nav.scss
+++ b/frontend/public/components/nav/_perspective-nav.scss
@@ -7,10 +7,13 @@
     }
   }
   .pf-c-nav__section.no-title {
-    border-bottom: 1px solid var(--pf-global--BackgroundColor--dark-200);
     --pf-c-nav__section--MarginTop: 0;
     .pf-c-nav__section-title {
       --pf-c-nav__section-title--PaddingBottom: 0;
     }
+  }
+  .pf-c-nav__section-divider {
+    padding-bottom: var(--pf-global--spacer--sm);
+    border-bottom: 1px solid var(--pf-global--BackgroundColor--dark-200);
   }
 }

--- a/frontend/public/components/nav/_perspective-nav.scss
+++ b/frontend/public/components/nav/_perspective-nav.scss
@@ -7,13 +7,14 @@
     }
   }
   .pf-c-nav__section.no-title {
+    border-bottom: 1px solid var(--pf-global--BackgroundColor--dark-200);
+    padding-bottom: var(--pf-global--spacer--sm);
     --pf-c-nav__section--MarginTop: 0;
     .pf-c-nav__section-title {
       --pf-c-nav__section-title--PaddingBottom: 0;
     }
-  }
-  .pf-c-nav__section-divider {
-    padding-bottom: var(--pf-global--spacer--sm);
-    border-bottom: 1px solid var(--pf-global--BackgroundColor--dark-200);
+    &:last-child {
+      border: none;
+    }
   }
 }

--- a/frontend/public/components/nav/_perspective-nav.scss
+++ b/frontend/public/components/nav/_perspective-nav.scss
@@ -7,6 +7,7 @@
     }
   }
   .pf-c-nav__section.no-title {
+    border-bottom: 1px solid var(--pf-global--BackgroundColor--dark-200);
     --pf-c-nav__section--MarginTop: 0;
     .pf-c-nav__section-title {
       --pf-c-nav__section-title--PaddingBottom: 0;

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -234,9 +234,11 @@ export const NavSection = connect(navSectionStateToProps)(
 
           if (isGrouped) {
             return (
-              <NavGroup title="" data-quickstart-id={dataQuickStartId} className="no-title">
-                {children}
-              </NavGroup>
+              <div className="pf-c-nav__section-divider">
+                <NavGroup title="" data-quickstart-id={dataQuickStartId} className="no-title">
+                  {children}
+                </NavGroup>
+              </div>
             );
           }
 

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -234,11 +234,9 @@ export const NavSection = connect(navSectionStateToProps)(
 
           if (isGrouped) {
             return (
-              <div className="pf-c-nav__section-divider">
-                <NavGroup title="" data-quickstart-id={dataQuickStartId} className="no-title">
-                  {children}
-                </NavGroup>
-              </div>
+              <NavGroup title="" data-quickstart-id={dataQuickStartId} className="no-title">
+                {children}
+              </NavGroup>
             );
           }
 


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2069760

**Analysis / Root cause**: 
It is due to changes in patternfly. We are using NavGroup component from patternfly. In the latest update, the title field they made it mandatory. 

--before-----
```
<h2 className={css(styles.navSectionTitle)} id={id}>
      {title}
 </h2>
```

---Now-----
```
{title && (
        <h2 className={css(styles.navSectionTitle)} id={id}>
          {title}
        </h2>
      )} 
```

We are passing null to title. Before if title is null also we used to get the divider but now since title is null, h2 was not getting rendered.

**Solution Description**: 
Modified below style for section class

```
.pf-c-nav__section.no-title {
    border-bottom: 1px solid var(--pf-global--BackgroundColor--dark-200);
    padding-bottom: var(--pf-global--spacer--sm);
    --pf-c-nav__section--MarginTop: 0;
    .pf-c-nav__section-title {
      --pf-c-nav__section-title--PaddingBottom: 0;
    }
    &:last-child {
      border: none;
    }
  }
```
File Name: frontend/public/components/nav/_perspective-nav.scss

**Screen shots / Gifs for design review**: 
----Before change-----
<img width="353" alt="image" src="https://user-images.githubusercontent.com/102503482/161717852-747ef9b5-78e7-4541-b1ae-2289a6e99b20.png">


---After changes-----
<img width="377" alt="image" src="https://user-images.githubusercontent.com/102503482/161717627-346680ce-9e81-4897-9e1b-fe13cb5f13d0.png">

**Unit test coverage report**: 
NA

**Test setup:**
-Login to ODC
-Navigate to Developer menu

**Browser conformance**: 
- [ x ] Chrome
- [ x ] Firefox
- [ x ] Safari
