### PR TITLE
Bug 2071599:  fix bug where RoleBindings are not displaying in ClusterRole > RoleBindings

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -188,14 +188,13 @@ const RoleBindingsTableHeader = () => {
 };
 RoleBindingsTableHeader.displayName = 'RoleBindingsTableHeader';
 
-export const BindingName = ({ binding }) => {
+export const BindingName = ({ binding }) => (
   <ResourceLink
     kind={bindingKind(binding)}
     name={binding.metadata.name}
     namespace={binding.metadata.namespace}
-    className="co-resource-item__resource-name"
-  />;
-};
+  />
+);
 
 export const BindingKebab = connect(null, {
   startImpersonate: UIActions.startImpersonate,
@@ -221,12 +220,7 @@ const RoleBindingsTableRow = ({ obj: binding }) => {
   return (
     <>
       <TableData className={tableColumnClasses[0]}>
-        <ResourceLink
-          kind={bindingKind(binding)}
-          name={binding.metadata.name}
-          namespace={binding.metadata.namespace}
-          className="co-resource-item__resource-name"
-        />
+        <BindingName binding={binding} />
       </TableData>
       <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <RoleLink binding={binding} />
@@ -267,12 +261,12 @@ export const BindingsList = (props) => {
   const { t } = useTranslation();
   return (
     <Table
-      {...props}
       aria-label={t('public~RoleBindings')}
       EmptyMsg={EmptyMsg}
       Header={RoleBindingsTableHeader}
       Row={RoleBindingsTableRow}
       virtualize
+      {...props}
     />
   );
 };

--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -8,8 +8,8 @@ import { useTranslation, withTranslation } from 'react-i18next';
 import i18next from 'i18next';
 // import { Button } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
-import { flatten as bindingsFlatten } from './bindings';
-import { BindingName, BindingsList, RulesList } from './index';
+import { BindingName, BindingsList, flatten as bindingsFlatten } from './bindings';
+import { RulesList } from './rules';
 import { DetailsPage, MultiListPage, TextFilter, Table, TableData } from '../factory';
 import {
   Kebab,
@@ -208,7 +208,7 @@ const BindingsListComponent = (props) => {
   };
   BindingsTableHeader.displayName = 'BindingsTableHeader';
 
-  return <BindingsList {...props} Header={BindingsTableHeader} Row={BindingsTableRow} virtualize />;
+  return <BindingsList {...props} Header={BindingsTableHeader} Row={BindingsTableRow} />;
 };
 
 export const BindingsForRolePage = (props) => {
@@ -234,7 +234,11 @@ export const BindingsForRolePage = (props) => {
         }/rolebindings/~new?rolekind=${kind}&rolename=${name}${ns ? `&namespace=${ns}` : ''}`,
       }}
       ListComponent={BindingsListComponent}
-      staticFilters={[{ 'role-binding-roleRef-name': name }, { 'role-binding-roleRef-kind': kind }]}
+      staticFilters={[
+        // Some bindings have a name that needs to be decoded (e.g., `system%3Aimage-builder`)
+        { 'role-binding-roleRef-name': decodeURIComponent(name) },
+        { 'role-binding-roleRef-kind': kind },
+      ]}
       resources={resources}
       textFilter="role-binding"
       filterLabel={t('public~by role or subject')}


### PR DESCRIPTION
The bug occurs because the colon in the binding name is URL encoded (e.g., `system%3Aimage-builder`) and needs to be decoded in order for the filter to return the correct bindings.

Bonus fixes:
* fix bug where `BindingsListComponent` was rendering `BindingsList` with the incorrect `Header` and `Row`
* fix bug where `BindingName` wasn't returning anything and use it in order to DRY up code

After:
<img width="1280" alt="Screen Shot 2022-04-05 at 2 23 28 PM" src="https://user-images.githubusercontent.com/895728/161830912-336e1d8b-6173-47d6-9505-7b2caf2317a1.png">
