### PR TITLE
Bug 2072807: Monitoring dashboards: Handle tables without `panel.styles` attribute

### DIFF
--- a/frontend/public/components/monitoring/dashboards/table.tsx
+++ b/frontend/public/components/monitoring/dashboards/table.tsx
@@ -115,6 +115,9 @@ const Table: React.FC<Props> = ({ panel, pollInterval, queries, namespace }) => 
   if (error) {
     return <ErrorAlert message={error} />;
   }
+  if (_.isEmpty(panel.styles)) {
+    return <ErrorAlert message={t('public~panel.styles attribute not found')} />;
+  }
   if (_.isEmpty(data)) {
     return <EmptyBox label={t('public~Data')} />;
   }

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -972,6 +972,7 @@
   "Dashboards": "Dashboards",
   "Inspect": "Inspect",
   "Metrics dashboards": "Metrics dashboards",
+  "panel.styles attribute not found": "panel.styles attribute not found",
   "query results table": "query results table",
   "Last {{count}} minute": "Last {{count}} minute",
   "Last {{count}} minute_plural": "Last {{count}} minutes",


### PR DESCRIPTION
Fixes `Cannot read properties of undefined (reading 'forEach')` JS
error.  Now, an error alert message is displayed instead.