### PR TITLE
Automation of pipeline-task-runs-display | pipelines-plugin

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipeline-task-runs-display.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipeline-task-runs-display.feature
@@ -6,11 +6,11 @@ Feature: Display task runs page
             Given user has created or selected namespace "aut-pipelines"
               And user is at pipelines page
 
-
+ 
         @smoke
         Scenario: Task runs tab: P-05-TC01
-            Given pipeline run is displayed for "pipeline-tasks-one" with resource
-             When user clicks on pipeline "pipeline-tasks-one"
+            Given pipeline run is displayed for "pipe-one" with resource
+             When user clicks on pipeline "pipe-one"
               And user clicks on Pipeline Runs tab
               And user clicks on a Pipeline Run
               And user clicks on Task Runs tab
@@ -18,37 +18,37 @@ Feature: Display task runs page
               And user can see Name, Task, Pod, Status and Started columns
 
 
-        @regression @to-do
+        @regression
         Scenario: Options in kebab menu of task runs: P-05-TC02
-            Given user is at PipelineRuns tab with pipeline runs
-              And user clicks on a Pipeline Run
+            Given user is at PipelineRuns tab with pipeline runs for pipeline "pipe-one"
+             When user clicks on Pipeline Run for "pipe-one"
               And user clicks on TaskRuns tab
               And user clicks kebab menu of a task run
              Then user can see kebab menu option Delete TaskRun
 
 
-        @regression @to-do
+        @regression
         Scenario: Task Runs Details page for passed task runs: P-05-TC03
-            Given user is at pipeline details page with pipeline runs
+            Given user is at pipeline details page with pipeline runs "pipe-one"
              When user clicks on pipeline runs tab
-              And user clicks on a pipeline run
+              And user clicks on Pipeline Run for "pipe-one"
               And user clicks on Task Runs tab
-              And user clicks on a Succeeded task run
+              And user clicks on task run "pipe-one"
              Then user is redirected to Task Run Details tab
-              And user can see "Details", "Log", "YAML" and "Events" tab
-              And user can see Status and Pods in "Details" tab
+              And user can see Details, Log, YAML and Events tab
+              And user can see Status and Pods in Details tab
 
 
-        @regression @to-do
+        @regression
         Scenario: Task Runs Details page for failed task runs: P-05-TC04
-            Given user is at pipeline details page with pipeline runs
-             When user clicks on pipeline runs tab
-              And user clicks on a pipeline run
+            Given user is at pipeline details page with pipeline runs for failed task run in "aut-pipelines" namespace
+             When user clicks on pipeline runs tab for pipeline "new-pipeline-failed-task"
+              And user clicks on Pipeline Run "pipeline-runs-failed-task"
               And user clicks on Task Runs tab
-              And user clicks on a Failed task run
+              And user clicks on task run "pipeline-runs-failed-task"
              Then user is redirected to Task Run Details tab
-              And user can see "Details", "Log", "YAML" and "Events" tab
-              And user can see Status, Message and Log snippet in "Details" tab
+              And user can see Details, Log, YAML and Events tab
+              And user can see Status, Message and Log snippet in Details tab
 
 
         @regression @manual
@@ -69,18 +69,13 @@ Feature: Display task runs page
                   | pipe-wp-t5    | VolumeClaimTemplate   | VolumeClaimTemplate | VolumeClaimTemplate |
 
 
-        @regression @to-do
+        @regression
         Scenario: Task Run results on Task Run details page for passed task run: P-05-TC06
-            Given pipeline run with passed task run is displayed for "pipeline-tasks-one"
-              And user is on Task Run details page of passed task run
+            Given pipeline run with passed task run is displayed for "aut-pipelines" namespace
+             When user clicks on pipeline runs tab for pipeline "pipeline-taskrun-results"
+              And user clicks on Pipeline Run "pipeline-runs-taskrun-results"
+              And user clicks on Task Runs tab
+              And user clicks on task run "pipeline-runs-taskrun-results"
+             Then user is redirected to Task Run Details tab
              When user scrolls to the Task Run results section
              Then user can see Name and Value column under Task Run results
-
-
-        @regression @to-do
-        Scenario: Task Run results on Task Run details page for failed task run: P-05-TC07
-            Given pipeline run with failed task run is displayed for "pipeline-tasks-one"
-            # user can use yaml content "sum-and-multiply-pipeline/sum-and-multiply-pipeline.yaml"
-              And user is on Task Run details page of failed task run
-             When user scrolls to the Task Run results section
-             Then user can see message "No Task Run results available due to failure."

--- a/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
@@ -211,6 +211,15 @@ export const pipelineRunDetailsPO = {
       started: '[data-label="Started"]',
     },
   },
+  taskRunsDetails: {
+    columnNames: {
+      details: '[data-test-id="horizontal-link-public~Details"]',
+      YAML: '[data-test-id="horizontal-link-public~YAML"]',
+      logs: '[data-test-id="horizontal-link-Logs"]',
+      events: '[data-test-id="horizontal-link-public~Events"]',
+    },
+    status: '.odc-taskrun-details__status',
+  },
 };
 
 export const pipelineRunsPO = {

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-task-runs-display.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-task-runs-display.ts
@@ -1,9 +1,17 @@
 import { When, Then, Given } from 'cypress-cucumber-preprocessor/steps';
+import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
 import { modal } from '@console/cypress-integration-tests/views/modal';
-import { devNavigationMenu } from '@console/dev-console/integration-tests/support/constants';
+import {
+  devNavigationMenu,
+  pageTitle,
+} from '@console/dev-console/integration-tests/support/constants';
 import { navigateTo } from '@console/dev-console/integration-tests/support/pages';
 import { pipelineActions } from '../../constants';
-import { pipelineRunDetailsPO, pipelinesPO } from '../../page-objects/pipelines-po';
+import {
+  pipelineRunDetailsPO,
+  pipelinesPO,
+  pipelineDetailsPO,
+} from '../../page-objects/pipelines-po';
 import { pipelinesPage, startPipelineInPipelinesPage } from '../../pages';
 import { pipelineDetailsPage } from '../../pages/pipelines/pipelineDetails-page';
 import { pipelineRunDetailsPage } from '../../pages/pipelines/pipelineRun-details-page';
@@ -78,4 +86,115 @@ Given(
 Given('user is at Task Runs tab of pipeline run with all kind of Workspaces', () => {
   // pipelinesPage.selectPipelineRun(pipelineName);
   pipelineRunDetailsPage.selectTab('TaskRuns');
+});
+
+Given(
+  'user is at PipelineRuns tab with pipeline runs for pipeline {string}',
+  (pipelineName: string) => {
+    detailsPage.titleShouldContain(pageTitle.Pipelines);
+    pipelinesPage.selectPipeline(pipelineName);
+    cy.get(pipelineDetailsPO.pipelineRunsTab).click();
+  },
+);
+
+When('user clicks on Pipeline Run for {string}', (pipelineName: string) => {
+  cy.get(`[data-test-id^="${pipelineName}"]`).click();
+});
+
+When('user clicks kebab menu of a task run', () => {
+  cy.get(pipelinesPO.pipelinesTable.kebabMenu).click();
+});
+
+When('user clicks on TaskRuns tab', () => {
+  cy.get(pipelineRunDetailsPO.taskRunsTab).click();
+});
+
+Then('user can see kebab menu option Delete TaskRun', () => {
+  cy.get('[data-test-action="Delete TaskRun"]').should('be.visible');
+});
+
+Then('user can see Status and Pods in Details tab', () => {
+  cy.contains('.co-resource-item', 'Pod').should('be.visible');
+  cy.byTestID('status-text').should('be.visible');
+});
+
+Then('user can see Details, Log, YAML and Events tab', () => {
+  cy.get(pipelineRunDetailsPO.taskRunsDetails.columnNames.details).should('be.visible');
+  cy.get(pipelineRunDetailsPO.taskRunsDetails.columnNames.logs).should('be.visible');
+  cy.get(pipelineRunDetailsPO.taskRunsDetails.columnNames.YAML).should('be.visible');
+  cy.get(pipelineRunDetailsPO.taskRunsDetails.columnNames.events).should('be.visible');
+});
+
+Then('user is redirected to Task Run Details tab', () => {
+  cy.get('.pf-c-breadcrumb').should('include.text', 'TaskRun details');
+});
+
+When('user clicks on task run {string}', (pipelineRunsName: string) => {
+  cy.get(`[data-test-id^="${pipelineRunsName}-"]`)
+    .eq(0)
+    .click();
+});
+
+Given('user is at pipeline details page with pipeline runs {string}', (pipelineName: string) => {
+  detailsPage.titleShouldContain(pageTitle.Pipelines);
+  pipelinesPage.selectPipeline(pipelineName);
+  cy.get('.pf-c-breadcrumb').should('include.text', 'Pipeline details');
+});
+
+When('user clicks on pipeline runs tab', () => {
+  cy.get(pipelineDetailsPO.pipelineRunsTab).click();
+});
+
+Given(
+  'user is at pipeline details page with pipeline runs for failed task run in {string} namespace',
+  (namespace: string) => {
+    cy.exec(
+      `oc apply -f testData/pipelines-workspaces/sum-and-multiply-pipeline/pipeline-failed-task.yaml -n ${namespace}`,
+    );
+  },
+);
+
+Then('user can see Status, Message and Log snippet in Details tab', () => {
+  cy.get(pipelineRunDetailsPO.taskRunsDetails.status)
+    .contains('Status')
+    .should('be.visible');
+  cy.get(pipelineRunDetailsPO.taskRunsDetails.status)
+    .contains('Message')
+    .should('be.visible');
+  cy.get(pipelineRunDetailsPO.taskRunsDetails.status)
+    .contains('Log snippet')
+    .should('be.visible');
+});
+
+Given(
+  'pipeline run with passed task run is displayed for {string} namespace',
+  (namespace: string) => {
+    cy.exec(
+      `oc apply -f testData/pipelines-workspaces/sum-and-multiply-pipeline/passed-task-run-results.yaml -n ${namespace}`,
+    );
+  },
+);
+
+When('user scrolls to the Task Run results section', () => {
+  cy.get('[data-test-section-heading="TaskRun results"]');
+});
+
+When('user clicks on pipeline runs tab for pipeline {string}', (pipelineName: string) => {
+  cy.get(`[data-test-id^="${pipelineName}"]`)
+    .eq(0)
+    .click();
+  pipelineDetailsPage.selectTab('Pipeline Runs');
+});
+
+When('user clicks on Pipeline Run {string}', (pipelineRunsName: string) => {
+  cy.get(`[data-test-id^="${pipelineRunsName}"]`).click();
+});
+
+Then('user can see Name and Value column under Task Run results', () => {
+  cy.get('[role="grid"]')
+    .contains('Name')
+    .should('be.visible');
+  cy.get('[role="grid"]')
+    .contains('Value')
+    .should('be.visible');
 });

--- a/frontend/packages/pipelines-plugin/integration-tests/testData/pipelines-workspaces/sum-and-multiply-pipeline/passed-task-run-results.yaml
+++ b/frontend/packages/pipelines-plugin/integration-tests/testData/pipelines-workspaces/sum-and-multiply-pipeline/passed-task-run-results.yaml
@@ -1,0 +1,59 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: multiply
+  annotations:
+    description: |
+      A simple task that multiplies the two provided integers
+spec:
+  params:
+    - name: a
+      type: string
+      default: "1"
+      description: The first integer
+    - name: b
+      type: string
+      default: "1"
+      description: The second integer
+  results:
+    - name: product
+      description: The product of the two provided integers
+  steps:
+    - name: product
+      image: bash:latest
+      script: |
+        #!/usr/bin/env bash
+        echo -n $(( "$(params.a)" * "$(params.b)" )) | tee $(results.product.path)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline-taskrun-results
+spec:
+  params: []
+  resources: []
+  workspaces: []
+  tasks:
+    - name: multiply
+      taskRef:
+        kind: Task
+        name: multiply
+      params:
+        - name: a
+          value: '1'
+        - name: b
+          value: '1'
+  finally: []
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipeline-runs-taskrun-results
+spec:
+  pipelineRef:
+    name: pipeline-taskrun-results
+  params:
+    - name: first
+      value: "2"
+    - name: second
+      value: "10"

--- a/frontend/packages/pipelines-plugin/integration-tests/testData/pipelines-workspaces/sum-and-multiply-pipeline/pipeline-failed-task.yaml
+++ b/frontend/packages/pipelines-plugin/integration-tests/testData/pipelines-workspaces/sum-and-multiply-pipeline/pipeline-failed-task.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: multiply
+  annotations:
+    description: |
+      A simple task that multiplies the two provided integers
+spec:
+  params:
+    - name: a
+      type: string
+      default: "1"
+      description: The first integer
+    - name: b
+      type: string
+      default: "1"
+      description: The second integer
+  results:
+    - name: product
+      description: The product of the two provided integers
+  steps:
+    - name: product
+      image: bash:latest
+      script: |
+        #!/usr/bin/env bash
+        echo "some-error-occured"
+        exit 1
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: new-pipeline-failed-task
+spec:
+  params: []
+  resources: []
+  workspaces: []
+  tasks:
+    - name: multiply
+      taskRef:
+        kind: Task
+        name: multiply
+      params:
+        - name: a
+          value: '1'
+        - name: b
+          value: '1'
+  finally: []
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipeline-runs-failed-task
+spec:
+  pipelineRef:
+    name: new-pipeline-failed-task
+  params:
+    - name: first
+      value: "2"
+    - name: second
+      value: "10"


### PR DESCRIPTION
**Description:**
<!-- PR description-->
- Automation of event-tab-in-pipeline-run feature file.

**Jira Id:** [ODC-6608](https://issues.redhat.com/browse/ODC-6608)
<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example: 
```
export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p pipelines

```

**Screen shots**:
<!--   -->
<img width="1725" alt="image" src="https://user-images.githubusercontent.com/39815871/161979506-719b8a71-05d7-454d-a755-ea473a28ebc3.png">



**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge