### PR TITLE
Bug 2061918: Topology sidebar broken issue is fixed

### DIFF
--- a/frontend/packages/topology/src/components/side-bar/TopologySideBar.tsx
+++ b/frontend/packages/topology/src/components/side-bar/TopologySideBar.tsx
@@ -30,14 +30,16 @@ const TopologySideBar: React.FC<TopologySideBarProps> = ({ children, onClose }) 
       onResize={handleResizeCallback}
     >
       <PFTopologySideBar resizable className="pf-topology-side-bar-resizable">
-        <div className="co-sidebar-dismiss clearfix">
-          <CloseButton
-            onClick={onClose}
-            dataTestID="sidebar-close-button"
-            additionalClassName="co-close-button--float-right co-sidebar-dismiss__close-button"
-          />
+        <div className="pf-topology-side-bar__body">
+          <div className="co-sidebar-dismiss clearfix">
+            <CloseButton
+              onClick={onClose}
+              dataTestID="sidebar-close-button"
+              additionalClassName="co-close-button--float-right co-sidebar-dismiss__close-button"
+            />
+          </div>
+          {children}
         </div>
-        {children}
       </PFTopologySideBar>
     </DrawerPanelContent>
   );

--- a/frontend/packages/topology/src/components/side-bar/TopologySideBar.tsx
+++ b/frontend/packages/topology/src/components/side-bar/TopologySideBar.tsx
@@ -29,17 +29,18 @@ const TopologySideBar: React.FC<TopologySideBarProps> = ({ children, onClose }) 
       defaultSize={`${sideBarSizeLoaded ? sideBarSize : DEFAULT_SIDE_BAR_SIZE}px`}
       onResize={handleResizeCallback}
     >
-      <PFTopologySideBar resizable className="pf-topology-side-bar-resizable">
-        <div className="pf-topology-side-bar__body">
-          <div className="co-sidebar-dismiss clearfix">
-            <CloseButton
-              onClick={onClose}
-              dataTestID="sidebar-close-button"
-              additionalClassName="co-close-button--float-right co-sidebar-dismiss__close-button"
-            />
-          </div>
-          {children}
+      <PFTopologySideBar
+        resizable
+        className="pf-topology-side-bar-resizable pf-topology-side-bar__body"
+      >
+        <div className="co-sidebar-dismiss clearfix">
+          <CloseButton
+            onClick={onClose}
+            dataTestID="sidebar-close-button"
+            additionalClassName="co-close-button--float-right co-sidebar-dismiss__close-button"
+          />
         </div>
+        {children}
       </PFTopologySideBar>
     </DrawerPanelContent>
   );


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2061918

**Analysis / Root cause**: 
In the latest changes in Patternfly, outer div component is removed, which causes 2 div to sit beside.

**Solution Description**: 
Wrapped close button div and the resource details div under a div with same class used before in patternfly.

**Screen shots / Gifs for design review**: 
-------BEFORE CHANGES----------
<img width="873" alt="image" src="https://user-images.githubusercontent.com/102503482/162134694-a0491af7-e2b9-4b15-8fec-73dc4721c0e9.png">

------AFTER CHANGES--------
<img width="862" alt="image" src="https://user-images.githubusercontent.com/102503482/162134536-e56eb07c-86a9-4761-9469-339646ec2af9.png">

**Unit test coverage report**: 
NA

**Test setup:**
Click on any resource in the topology to open the side panel to verify.

**Browser conformance**: 
- [ x ] Chrome
- [ x ] Firefox
- [ x ] Safari
