### PR TITLE
CONSOLE-3090: [Dark Theme] Several dark theme fixes. Includes borders, hr, disabled form element, row hover, hint blocks

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/multi-utilization-item.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/multi-utilization-item.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { DataPoint } from '@console/internal/components/graphs';
 import { Humanize } from '@console/internal/components/utils';
+import { Divider } from '@patternfly/react-core';
 import { AreaChart } from './area-chart';
 
 export const MultilineUtilizationItem: React.FC<MultilineUtilizationItemProps> = React.memo(
@@ -40,7 +41,7 @@ export const MultilineUtilizationItem: React.FC<MultilineUtilizationItemProps> =
           </div>
         </div>
         <div className="co-utilization-card__item-chart">{chart}</div>
-        <hr style={{ border: '1px lightgray solid', margin: '0px' }} />
+        <Divider />
       </div>
     );
   },

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/utilization-item.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/utilization-item.tsx
@@ -10,6 +10,7 @@ import {
   RedExclamationCircleIcon,
 } from '@console/shared/src/components/status';
 import { TopConsumerPopoverProps } from '@console/dynamic-plugin-sdk';
+import { Divider } from '@patternfly/react-core';
 import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
 import { global_danger_color_100 as dangerColor } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
 import { AreaChart } from './area-chart';
@@ -194,7 +195,7 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
           )}
         </div>
         <div className="co-utilization-card__item-chart">{chart}</div>
-        <hr style={{ border: '1px lightgray solid', margin: '0px' }} />
+        <Divider />
       </div>
     );
   },

--- a/frontend/packages/console-shared/src/components/dynamic-form/templates.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/templates.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Alert, FormHelperText } from '@patternfly/react-core';
+import { Button, Alert, Divider, FormHelperText } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { ArrayFieldTemplateProps, FieldTemplateProps, ObjectFieldTemplateProps } from '@rjsf/core';
 import { getUiOptions, getSchemaType } from '@rjsf/core/dist/cjs/utils';
@@ -127,7 +127,7 @@ export const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
       {_.map(items ?? [], (item) => {
         return (
           <div className="co-dynamic-form__array-field-group-item" key={item.key}>
-            {item.index > 0 && <hr />}
+            {item.index > 0 && <Divider className="co-divider" />}
             {item.hasRemove && (
               <div className="row co-dynamic-form__array-field-group-remove">
                 <Button

--- a/frontend/packages/console-shared/src/components/shortcuts/Shortcut.tsx
+++ b/frontend/packages/console-shared/src/components/shortcuts/Shortcut.tsx
@@ -20,7 +20,7 @@ interface ShortcutProps {
 
 export const ShortcutCommand: React.FC = ({ children }) => (
   <span className="ocs-shortcut__command">
-    <kbd>{children}</kbd>
+    <kbd className="co-kbd">{children}</kbd>
   </span>
 );
 

--- a/frontend/packages/dev-console/src/components/projects/ProjectListPage.scss
+++ b/frontend/packages/dev-console/src/components/projects/ProjectListPage.scss
@@ -1,9 +1,4 @@
 .odc-project-list-page {
   background-color: var(--pf-global--BackgroundColor--light-100);
   flex: 1;
-  &__section-border {
-    margin-top: 30px;
-    margin-bottom: 30px;
-    border-bottom: 0.8px solid #ccc;
-  }
 }

--- a/frontend/packages/dev-console/src/components/projects/ProjectListPage.tsx
+++ b/frontend/packages/dev-console/src/components/projects/ProjectListPage.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Divider } from '@patternfly/react-core';
 import { ListPage } from '@console/internal/components/factory';
 import { ProjectsTable } from '@console/internal/components/namespace';
 import { PageHeading } from '@console/internal/components/utils';
@@ -21,7 +22,7 @@ const ProjectListPage: React.FC<ProjectListPageProps> = ({
     <PageHeading title={title} badge={badge}>
       {children}
     </PageHeading>
-    <hr className="odc-project-list-page__section-border" />
+    <Divider className="co-divider" />
     <ListPage
       {...listPageProps}
       showTitle={false}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarHeader.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarHeader.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Divider } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { ActionsMenu } from '@console/internal/components/utils';
 import { TaskKind } from '../../../../types';
@@ -42,7 +43,7 @@ const TaskSidebarHeader: React.FC<TaskSidebarHeaderProps> = ({ removeThisTask, t
       <div className="opp-task-sidebar-header__shortcuts clearfix">
         <TaskSidebarShortcuts />
       </div>
-      <hr />
+      <Divider className="co-divider" />
     </div>
   );
 };

--- a/frontend/packages/rhoas-plugin/src/components/service-table/ServiceInstanceFilter.tsx
+++ b/frontend/packages/rhoas-plugin/src/components/service-table/ServiceInstanceFilter.tsx
@@ -34,8 +34,10 @@ const ServiceInstanceFilter: React.FC<ServiceInstanceFilterProps> = ({
                 placeholder={`${t('rhoas-plugin~Search by name')}...`}
                 className="co-text-filter"
               />
-              <span className="form-control-feedback form-control-feedback--keyboard-hint">
-                <kbd>{KEYBOARD_SHORTCUTS.focusFilterInput}</kbd>
+              <span className="co-text-filter-feedback">
+                <kbd className="co-kbd co-kbd__filter-input">
+                  {KEYBOARD_SHORTCUTS.focusFilterInput}
+                </kbd>
               </span>
             </div>
           </ToolbarItem>

--- a/frontend/public/components/RBAC/_rbac.scss
+++ b/frontend/public/components/RBAC/_rbac.scss
@@ -22,8 +22,7 @@
 }
 
 .resource-separator {
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin: var(--pf-global--spacer--sm) 0;
 }
 
 .edit-rule {
@@ -41,13 +40,8 @@
   }
 
   .rbac-minor {
-    margin-top: 10px;
-    margin-bottom: 20px;
-    color: #ccc;
-  }
-  .rbac-major {
-    color: #ccc;
-    margin: 30px 0;
+    margin-bottom: var(--pf-global--spacer--md);
+    margin-top: var(--pf-global--spacer--sm);
   }
   .newspaper-columns {
     columns: 3 auto;

--- a/frontend/public/components/RBAC/edit-rule.jsx
+++ b/frontend/public/components/RBAC/edit-rule.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
-import { ActionGroup, Button } from '@patternfly/react-core';
+import { ActionGroup, Button, Divider } from '@patternfly/react-core';
 
 import { k8sGet, k8sUpdate } from '../../module/k8s';
 import { RoleModel, ClusterRoleModel } from '../../models';
@@ -83,8 +83,8 @@ const RadioButton = ({ name, value, label, text, onChange, activeValue }) => (
   </div>
 );
 
-const HRMinor = () => <hr className="rbac-minor" />;
-const HRMajor = () => <hr className="rbac-major" />;
+const HRMinor = () => <Divider className="co-divider rbac-minor" />;
+const HRMajor = () => <Divider className="co-divider" />;
 
 const stateToProps = (state) => {
   const resourceMap = state.k8s.get('RESOURCES');

--- a/frontend/public/components/RBAC/rules.jsx
+++ b/frontend/public/components/RBAC/rules.jsx
@@ -2,6 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import { connect } from 'react-redux';
 
+import { Divider } from '@patternfly/react-core';
 import { k8sPatch } from '../../module/k8s';
 import { RoleModel, ClusterRoleModel } from '../../models';
 import { Kebab, EmptyBox, ResourceIcon } from '../utils';
@@ -96,7 +97,7 @@ const Resources = connect(({ k8s }) => ({ allModels: k8s.getIn(['RESOURCES', 'mo
 
     if (nonResourceURLs && nonResourceURLs.length) {
       if (allResources.length) {
-        allResources.push(<hr key="hr" className="resource-separator" />);
+        allResources.push(<Divider key="hr" className="co-divider resource-separator" />);
       }
       let URLs = [];
       _.each(nonResourceURLs.sort(), (r) => {

--- a/frontend/public/components/_deploy-image.scss
+++ b/frontend/public/components/_deploy-image.scss
@@ -10,8 +10,8 @@
 }
 
 .co-image-name-results {
-  border-bottom: 1px solid $pf-color-black-200;
-  border-top: 1px solid $pf-color-black-200;
+  border-bottom: 1px solid var(--pf-global--BorderColor--300);
+  border-top: 1px solid var(--pf-global--BorderColor--300);
   margin: 30px 0;
   padding: 30px 0;
 

--- a/frontend/public/components/_detail-table.scss
+++ b/frontend/public/components/_detail-table.scss
@@ -17,7 +17,7 @@
 
   &,
   &__section {
-    border-color: $pf-color-black-200;
+    border-color: var(--pf-global--BorderColor--300);
     border-style: solid;
   }
 

--- a/frontend/public/components/_image-stream.scss
+++ b/frontend/public/components/_image-stream.scss
@@ -19,7 +19,7 @@
 
 .co-images-stream-tag-timeline__circle-icon,
 .co-images-stream-tag-timeline__square-icon {
-  color: $pf-color-black-300;
+  color: var(--pf-global--BorderColor--100);
   left: 8px;
   position: relative;
 }

--- a/frontend/public/components/cluster-settings/_cluster-settings.scss
+++ b/frontend/public/components/cluster-settings/_cluster-settings.scss
@@ -210,7 +210,7 @@ $co-channel-height: 60px;
 
   &,
   &__section {
-    border-color: $pf-color-black-200;
+    border-color: var(--pf-global--BorderColor--300);
     border-style: solid;
   }
 
@@ -257,7 +257,7 @@ $co-channel-height: 60px;
     margin: 0 0 var(--pf-global--spacer--lg) 0;
 
     &--divided {
-      border-top: 1px solid $pf-color-black-200;
+      border-top: 1px solid var(--pf-global--BorderColor--300);
       padding-top: var(--pf-global--spacer--lg);
 
       // only add border and padding to first instance

--- a/frontend/public/components/command-line-tools.tsx
+++ b/frontend/public/components/command-line-tools.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
+import { Divider } from '@patternfly/react-core';
 
 import { FLAGS } from '@console/shared';
 import { ExternalLink, Firehose, FirehoseResult } from './utils';
@@ -20,7 +21,7 @@ export const CommandLineTools: React.FC<CommandLineToolsProps> = ({ obj }) => {
     const defaultLinkText = `Download ${displayName}`;
     return (
       <React.Fragment key={tool.metadata.uid}>
-        <hr />
+        <Divider className="co-divider" />
         <h2 className="co-section-heading" data-test-id={displayName}>
           {displayName}
         </h2>
@@ -57,7 +58,7 @@ export const CommandLineTools: React.FC<CommandLineToolsProps> = ({ obj }) => {
         </h1>
         {window.SERVER_FLAGS.requestTokenURL && (
           <>
-            <hr />
+            <Divider className="co-divider" />
             <ExternalLink
               href={window.SERVER_FLAGS.requestTokenURL}
               text={t('public~Copy login command')}

--- a/frontend/public/components/container.tsx
+++ b/frontend/public/components/container.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Trans, useTranslation } from 'react-i18next';
-import { CodeBlock, CodeBlockCode } from '@patternfly/react-core';
+import { CodeBlock, CodeBlockCode, Divider } from '@patternfly/react-core';
 import { Status } from '@console/shared';
 import {
   ContainerLifecycle,
@@ -366,7 +366,7 @@ export const ContainerDetailsList: React.FC<ContainerDetailsListProps> = (props)
         </div>
       </div>
 
-      <hr />
+      <Divider className="co-divider" />
 
       <div className="row">
         <div className="col-lg-4">

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -640,7 +640,7 @@ export const EditYAML_ = connect(stateToProps)(
                     allowMultiple ? (
                       <Trans ns="public">
                         Drag and drop YAML or JSON files into the editor, or manually enter files
-                        and use <kbd>---</kbd> to separate each definition.
+                        and use <kbd className="co-kbd">---</kbd> to separate each definition.
                       </Trans>
                     ) : (
                       t(

--- a/frontend/public/components/factory/list-page.tsx
+++ b/frontend/public/components/factory/list-page.tsx
@@ -76,8 +76,8 @@ export const TextFilter: React.FC<TextFilterProps> = (props) => {
         tabIndex={0}
         type="text"
       />
-      <span className="form-control-feedback form-control-feedback--keyboard-hint">
-        <kbd>{KEYBOARD_SHORTCUTS.focusFilterInput}</kbd>
+      <span className="co-text-filter-feedback">
+        <kbd className="co-kbd co-kbd__filter-input">{KEYBOARD_SHORTCUTS.focusFilterInput}</kbd>
       </span>
     </div>
   );

--- a/frontend/public/components/graphs/_graphs.scss
+++ b/frontend/public/components/graphs/_graphs.scss
@@ -40,7 +40,7 @@
 }
 
 .graph-title {
-  color: black;
+  color: var(--pf-global--Color--100);
   line-height: 1.4; // so descenders don't clip
   margin: 0 0 10px 0;
   overflow: hidden;

--- a/frontend/public/components/instantiate-template.tsx
+++ b/frontend/public/components/instantiate-template.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';
 import * as classNames from 'classnames';
-import { ActionGroup, Button } from '@patternfly/react-core';
+import { ActionGroup, Button, Divider } from '@patternfly/react-core';
 /* eslint-disable import/named */
 import { useTranslation, withTranslation, WithTranslation } from 'react-i18next';
 
@@ -45,7 +45,7 @@ const TemplateResourceDetails: React.FC<TemplateResourceDetailsProps> = ({ templ
 
   return (
     <>
-      <hr />
+      <Divider className="co-divider" />
       <p>The following resources will be created:</p>
       <ul>
         {resources.map((kind: string) => (

--- a/frontend/public/components/utils/_disabled.scss
+++ b/frontend/public/components/utils/_disabled.scss
@@ -1,16 +1,15 @@
 .co-disabled {
-  position: relative;
+  color: var(--pf-global--disabled-color--100);
   height: 100%;
   overflow: hidden;
+  position: relative;
 }
 
 .co-disabled::before {
-  background-color: #fff;
   bottom: 0;
   content: '';
   cursor: not-allowed;
   left: 0;
-  opacity: 0.4;
   overflow: hidden;
   position: absolute;
   right: 0;

--- a/frontend/public/components/utils/_hint-block.scss
+++ b/frontend/public/components/utils/_hint-block.scss
@@ -1,6 +1,11 @@
 .co-hint-block {
-  background-color: var(--pf-global--BackgroundColor--400);
-  border: 1px solid var(--pf-global--BorderColor--300);
+  background-color: var(--pf-global--palette--blue-50);
+  border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--palette--blue-100);
   color: var(--pf-global--Color--100);
   padding: var(--pf-global--spacer--lg);
+
+  :where(.pf-theme-dark) & {
+    background-color: var(--pf-global--BackgroundColor--400);
+    border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
+  }
 }

--- a/frontend/public/components/utils/_name-value-editor.scss
+++ b/frontend/public/components/utils/_name-value-editor.scss
@@ -32,7 +32,7 @@ $drag-column-width: 28px;
 }
 
 .pairs-list__row-dragging {
-  background-color: $pf-color-black-200;
+  background-color: var(--pf-global--BorderColor--300);
   border: 1px dashed $pf-color-black-300;
   border-radius: 4px;
   height: 28px;

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -4,6 +4,11 @@ $co-external-link-padding-right: 15px;
   padding-bottom: var(--pf-global--spacer--sm);
 }
 
+.co-divider {
+  margin-bottom: var(--pf-global--spacer--lg);
+  margin-top: var(--pf-global--spacer--lg);
+}
+
 dl.co-inline {
   dd {
     margin-bottom: 1em;
@@ -530,10 +535,6 @@ dl.co-inline {
     position: relative;
     vertical-align: middle;
   }
-}
-
-.co-m-row:hover {
-  background-color: $color-co-m-row-hover;
 }
 
 .co-m-loader {

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -38,6 +38,18 @@
   margin-left: 20px;
 }
 
+.co-kbd {
+  border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+  border-radius: 3px;
+  color: var(--pf-global--Color--200);
+  font-size: var(--pf-global--FontSize--sm);
+  padding: 1px 3px;
+}
+
+.co-kbd__filter-input {
+  border-color: var(--pf-global--BorderColor--300);
+}
+
 .co-label--plain {
   font-weight: var(--pf-global--FontWeight--normal);
   margin-bottom: 0px;
@@ -59,16 +71,20 @@
   }
 }
 
-.co-text-filter:focus + .form-control-feedback--keyboard-hint {
+.co-text-filter:focus + .co-text-filter-feedback {
   display: none;
 }
 
-.co-text-filter {
-  min-width: 270px;
-}
-
-.form-control-feedback--keyboard-hint {
-  top: 1px;
+.co-text-filter-feedback {
+  display: block;
+  height: 29px;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  top: 5px;
+  width: 29px;
+  z-index: 2;
 }
 
 .has-feedback .pf-c-form-control {

--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -49,7 +49,6 @@ $co-m-catalog-tile-width: 260px;
 // == Colors
 
 $color-alertmanager-dark: $pf-color-orange-600;
-$color-co-m-row-hover: #fafafa;
 $color-application-dark: $pf-color-green-500;
 $color-configmap-dark: $pf-color-purple-600;
 $color-container-dark: $pf-color-blue-300;

--- a/frontend/public/style/ancillary/_bootstrap-residual.scss
+++ b/frontend/public/style/ancillary/_bootstrap-residual.scss
@@ -1,18 +1,4 @@
 // Residual css rules within codebase that pertain to Bootstrap
-
-.form-control-feedback {
-  position: absolute;
-  top: 0;
-  right: 0;
-  z-index: 2;
-  display: block;
-  width: 29px;
-  height: 29px;
-  line-height: 29px;
-  text-align: center;
-  pointer-events: none;
-}
-
 .form-group {
   margin-bottom: $form-group-margin-bottom;
 }
@@ -26,23 +12,6 @@
   margin-top: 5px;
   margin-bottom: 10px;
   color: lighten($text-color, 25%); // lighten the text some for contrast
-}
-
-
-hr {
-  margin-top: 23px;
-  margin-bottom: 23px;
-  border: 0;
-  border-top: 1px solid #f1f1f1;
-}
-
-kbd {
-  padding: 2px 4px;
-  font-size: 90%;
-  color: #72767b;
-  background-color: rgba(0,0,0,0);
-  border-radius: 3px;
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
 }
 
 label {


### PR DESCRIPTION
**Change notes with before and after screenshots.**
cc @vikram-raj @mattnolting 

Changed borders using `$pf-color-black-200` to `var(--pf-global--BorderColor--300)`, (both assigned to `#f0f0f0` at light theme) and supports dark theme.

<img width="835" alt="cluster-before" src="https://user-images.githubusercontent.com/1874151/162278026-b98f853f-e2b3-476e-8b6d-a69268486b4a.png">
<img width="833" alt="cluster-after" src="https://user-images.githubusercontent.com/1874151/162278034-a3380b28-e1e5-4861-a722-194612b98813.png">
--
<img width="867" alt="sub-before" src="https://user-images.githubusercontent.com/1874151/162278054-3647e891-0c71-4616-9587-c1fa9764d79e.png">
<img width="832" alt="sub-after" src="https://user-images.githubusercontent.com/1874151/162278067-f1a9e830-da0e-4e6c-b931-e06b2940b0a0.png">
--
<img width="830" alt="ms-before" src="https://user-images.githubusercontent.com/1874151/162278149-ddb18f3d-2d55-428b-8236-c847f492ad9b.png">
<img width="826" alt="ms-after" src="https://user-images.githubusercontent.com/1874151/162278162-d5d37d8f-563e-42f9-98c8-a65a1d41e377.png">


---
Changed borders using `$pf-color-black-300` to `var(--pf-global--BorderColor--100)`, (both assigned to `#d2d2d2` at light theme) and supports dark theme.
<img width="484" alt="history-before" src="https://user-images.githubusercontent.com/1874151/162277898-7bbe15aa-0ac7-4cbd-8cc9-4e64147b9e9c.png">
<img width="561" alt="history-after" src="https://user-images.githubusercontent.com/1874151/162277905-9791c9e9-5d69-4f42-8820-dda4741f22c2.png">


---
Class `.form-control-feedback` becomes `.co-text-filter-feedback`, which is a sibling to `co-text-filter` and used in filter input fields to wrap `<kbd` shortcut. Now supports dark theme.
<img width="317" alt="search-before" src="https://user-images.githubusercontent.com/1874151/162277757-81208f3d-5aa7-4f66-81a7-766a9775c610.png">

<img width="311" alt="search-after" src="https://user-images.githubusercontent.com/1874151/162277787-95923959-d76e-42d9-8c1f-afc850ae0eb8.png">


---
Scoped generic `kbd` rules to `.co-kbd` and applied class to stand alone keyboard shortcut elements. 
<img width="403" alt="shortcuts-before" src="https://user-images.githubusercontent.com/1874151/162277590-4ac7e9d5-3d97-4ff3-8ea9-a47e7b84a66e.png">

<img width="399" alt="shortcuts-after" src="https://user-images.githubusercontent.com/1874151/162277608-b31be3ef-5952-4e98-807e-06a68fd6b8c2.png">


---
Updated `.co-disabled` form field class to variable supporting dark theme
<img width="422" alt="disabled-before" src="https://user-images.githubusercontent.com/1874151/162277072-3481088b-4fed-45cb-ad8e-e3cd8b568078.png">

<img width="427" alt="disabled-after" src="https://user-images.githubusercontent.com/1874151/162277081-22624bb8-a9e7-4d0e-a6fc-2811728e2540.png">


---
Update (previously updated incorrectly) custom hint block class to match light and dark theme variables used with `pf-hint-block`
before
<img width="675" alt="hint-before" src="https://user-images.githubusercontent.com/1874151/162277226-93811145-9015-4bd3-9f04-6e79a117e3f0.png">

after
<img width="674" alt="hint-after" src="https://user-images.githubusercontent.com/1874151/162277239-8cee735c-25b5-4d3a-ac00-1a4b69e9023d.png">
<img width="679" alt="Screen Shot 2022-04-07 at 3 01 38 PM" src="https://user-images.githubusercontent.com/1874151/162277408-e68afa1f-8947-4460-92d2-933f5acd746d.png">



---
Updated `hr` variables that support dark theme
<img width="940" alt="hr-before" src="https://user-images.githubusercontent.com/1874151/162277003-cf3b7a9d-d857-404b-a02d-9ad4ffc1ade7.png">
<img width="1085" alt="hr-after" src="https://user-images.githubusercontent.com/1874151/162277024-d4917219-355a-4312-902e-1ebb86c1ac83.png">

<img width="918" alt="hr2-before" src="https://user-images.githubusercontent.com/1874151/162329507-39029ef1-c89e-488f-aea8-6d3725b91e94.png">

<img width="1087" alt="hr2-after" src="https://user-images.githubusercontent.com/1874151/162329514-9e05ed57-7afc-45b2-a054-afc1cff1c5e9.png">


---
Removed un needed `.co-m-row:hover` styling.
<img width="1086" alt="row-hover-befoer" src="https://user-images.githubusercontent.com/1874151/162276945-8682c581-6125-49ba-b17a-0b4d96f9551f.png">
<img width="1082" alt="row-hover-after" src="https://user-images.githubusercontent.com/1874151/162276963-d057f822-feed-46b8-bdab-d5f312b51e4f.png">

---
Corrected graph title to support dark theme version
<img width="435" alt="resource-title-before" src="https://user-images.githubusercontent.com/1874151/163264307-099fe138-733b-4f5a-a7bd-135cdc83b7da.png">

<img width="621" alt="resource-title-after" src="https://user-images.githubusercontent.com/1874151/163264325-d531c097-0fe3-4336-9576-b603047fe926.png">

