### PR TITLE
Bug 2075149: Fix translation of flag-enabled extensions

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/utils/useTranslatedExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/utils/useTranslatedExtensions.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { TFunction } from 'i18next';
 import { Extension, LoadedExtension } from '@console/dynamic-plugin-sdk/src/types';
 import { isTranslatableString, translateExtensionDeep } from './extension-i18n';
 import useTranslationExt from './useTranslationExt';
@@ -16,36 +15,36 @@ const useTranslatedExtensions = <E extends Extension>(
   extensions: LoadedExtension<E>[],
 ): typeof extensions => {
   const { t } = useTranslationExt();
-  // TODO: Drop ref and start using useEffect when we are not mutating extensions
-  const lastTRef = React.useRef<TFunction>(null);
 
-  if (t !== lastTRef.current) {
-    extensions.forEach((e) => {
-      const UID = e.uid;
-      translateExtensionDeep(
-        e,
-        (value, path): value is string => {
-          let translatableString = value;
-          if (translationKeyMap[UID]?.[path]) {
-            translatableString = translationKeyMap[UID][path];
-          }
-          return isTranslatableString(translatableString);
-        },
-        (value, key, obj, path) => {
-          if (!translationKeyMap[UID]) {
-            translationKeyMap[UID] = {};
-          }
-          if (!translationKeyMap[UID][path]) {
-            translationKeyMap[UID][path] = value;
-          }
-          // TODO: Fix mutation of extension - mirrors work done in translateExtension
-          // @see translateExtension()
-          obj[key] = t(translationKeyMap[UID][path]);
-        },
-      );
-    });
-    lastTRef.current = t;
-  }
+  React.useMemo(
+    // Mutate "extensions" parameter only if changed (i.e. a flag-enabled or translations changed)
+    () =>
+      extensions.forEach((e) => {
+        const UID = e.uid;
+        translateExtensionDeep(
+          e,
+          (value, path): value is string => {
+            let translatableString = value;
+            if (translationKeyMap[UID]?.[path]) {
+              translatableString = translationKeyMap[UID][path];
+            }
+            return isTranslatableString(translatableString);
+          },
+          (value, key, obj, path) => {
+            if (!translationKeyMap[UID]) {
+              translationKeyMap[UID] = {};
+            }
+            if (!translationKeyMap[UID][path]) {
+              translationKeyMap[UID][path] = value;
+            }
+            // TODO: Fix mutation of extension - mirrors work done in translateExtension
+            // @see translateExtension()
+            obj[key] = t(translationKeyMap[UID][path]);
+          },
+        );
+      }),
+    [t, extensions],
+  );
 
   return extensions;
 };


### PR DESCRIPTION
Issue: When list of extensions changes, i.e. enabled by an asynchronous flag, they are not translated.

This fix triggers passing through the extensions property tree for both cases - either translations are changed or list of extensions are changed.

Follow-up for https://github.com/openshift/console/pull/11278