### PR TITLE
Bug 2071719:  remove `.pf-c-button.pf-m-link` override

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -115,10 +115,6 @@ form.pf-c-form {
   text-align: left; // override default .pf-c-button text centering
 }
 
-.pf-c-button.pf-m-link {
-  white-space: normal; // override default .pf-c-button to enable wrapping
-}
-
 .pf-c-button.pf-m-link--align-left {
   --pf-c-button--PaddingLeft: 0;
 }


### PR DESCRIPTION
This rule was added in https://github.com/openshift/console/pull/2666 in order to allow the pencil icon to wrap independently of the text prior to https://github.com/patternfly/patternfly/pull/3470.  Now that the issue has been addressed upstream, this override is no longer needed.

Note this change could impact other instances where `isInline`/`.pf-m-inline` is not in use on link buttons, but after searching through the code, I don't see any such instances where the change should pose an issue, but could have overlooked one or more.