### PR TITLE
Bug 2058051: SDK - add error prop to ResourceYAMLEditor

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -141,6 +141,7 @@ export { useFlag } from '../utils/flags';
  * @param {ResourceYAMLEditorProps['header']} header - Add a header on top of the YAML editor
  * @param {ResourceYAMLEditorProps['onSave']} onSave - Callback for the Save button.
  * Passing it will override the default update performed on the resource by the editor
+ * @param {ResourceYAMLEditorProps['error']} error - Error message to display in the editor
  */
 export const ResourceYAMLEditor: React.FC<ResourceYAMLEditorProps> = require('@console/internal/components/AsyncResourceYAMLEditor')
   .AsyncResourceYAMLEditor;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -589,5 +589,6 @@ export type SelfSubjectAccessReviewKind = {
 export type ResourceYAMLEditorProps = {
   initialResource: string | { [key: string]: any };
   header?: string;
+  error?: string;
   onSave?: (content: string) => void;
 };

--- a/frontend/public/components/droppable-edit-yaml.tsx
+++ b/frontend/public/components/droppable-edit-yaml.tsx
@@ -36,8 +36,16 @@ type DroppableEditYAMLProps = ResourceYAMLEditorProps & {
 export const ResourceYAMLEditor: React.FC<ResourceYAMLEditorProps> = ({
   initialResource,
   header,
+  error,
   onSave,
-}) => <DroppableEditYAML initialResource={initialResource} header={header} onSave={onSave} />;
+}) => (
+  <DroppableEditYAML
+    initialResource={initialResource}
+    header={header}
+    onSave={onSave}
+    error={error}
+  />
+);
 
 export const DroppableEditYAML = withDragDropContext<DroppableEditYAMLProps>(
   class DroppableEditYAML extends React.Component<DroppableEditYAMLProps, DroppableEditYAMLState> {
@@ -109,7 +117,7 @@ export const DroppableEditYAML = withDragDropContext<DroppableEditYAMLProps>(
     }
 
     render() {
-      const { allowMultiple, initialResource } = this.props;
+      const { allowMultiple, initialResource, error } = this.props;
       const { errors, fileUpload } = this.state;
       return (
         <EditYAMLComponent
@@ -117,7 +125,7 @@ export const DroppableEditYAML = withDragDropContext<DroppableEditYAMLProps>(
           allowMultiple={allowMultiple}
           obj={initialResource}
           fileUpload={fileUpload}
-          error={errors.join('\n')}
+          error={[error, ...errors].filter((e) => e).join('\n')}
           onDrop={this.handleFileDrop}
           clearFileUpload={this.clearFileUpload}
         />


### PR DESCRIPTION
For consumers that implement a custom `onSave`, we need to expose a custom error prop.