### PR TITLE
Bug 2070731: details switch label is not clickable on add page

### DIFF
--- a/frontend/packages/dev-console/src/components/add/AddPageLayout.scss
+++ b/frontend/packages/dev-console/src/components/add/AddPageLayout.scss
@@ -1,3 +1,5 @@
+@import '../../../../../public/style/vars';
+
 .odc-add-page-layout {
   // Fix missing white background color above the header.
   .ocs-page-layout__title {
@@ -39,8 +41,10 @@
         display: flex;
       }
       &__text {
-        margin-left: var(--pf-global--spacer--xs);
-        vertical-align: middle;
+        // Used font-size-base variable instead of --pf-global--FontSize--sm, which is getting calculated to 13px instead of 14px
+        font-size: $font-size-base;
+        font-weight: normal;
+        align-items: center;    
       }
     }
   }

--- a/frontend/packages/dev-console/src/components/add/AddPageLayout.tsx
+++ b/frontend/packages/dev-console/src/components/add/AddPageLayout.tsx
@@ -88,17 +88,14 @@ const AddPageLayout: React.FC<AddPageLayoutProps> = ({ title, hintBlock: additio
                       setShowDetails(checked);
                     }}
                     data-test="switch"
+                    label={switchText}
+                    labelOff={switchText}
+                    className="odc-add-page-layout__hint-block__details-switch__text"
                   />
                 </Tooltip>
               ) : (
                 <Skeleton shape="circle" width="24px" />
               )}
-              <span
-                className="odc-add-page-layout__hint-block__details-switch__text"
-                data-test="label"
-              >
-                {extensionsLoaded ? switchText : <Skeleton height="100%" width="64px" />}
-              </span>
             </div>
           </div>
           <TopologyQuickSearch

--- a/frontend/packages/dev-console/src/components/add/__tests__/AddPageLayout.spec.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/AddPageLayout.spec.tsx
@@ -99,7 +99,9 @@ describe('AddPageLayout', () => {
       expect(
         wrapper
           .find(PageLayout)
-          .shallow()
+          .dive()
+          .find(Switch)
+          .dive()
           .text()
           .includes('Details on'),
       ).toBe(true);
@@ -113,7 +115,9 @@ describe('AddPageLayout', () => {
       expect(
         wrapper
           .find(PageLayout)
-          .shallow()
+          .dive()
+          .find(Switch)
+          .dive()
           .text()
           .includes('Details off'),
       ).toBe(true);


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2070731

**Analysis / Root cause**: 
Switch label was not added as part of switch component. It was added as span outside. 

**Solution Description**: 
Added switch text as part of switch component by using  label and labeloff props of switch component.

**Screen shots / Gifs for design review**:
----BEFORE CHANGES------- 
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/102503482/162679409-1c18d1ac-d689-4bdc-9f87-5ed38e3caf2e.png">

-----AFTER CHANGES--------
<img width="1420" alt="image" src="https://user-images.githubusercontent.com/102503482/162679032-ae87453e-9f5f-4784-a28f-6a966c1fbe75.png">

**NOTE:** 

1) From the above screenshots, the space between switch and label was very less before and when we do any changes to switch then switch boundary was covering the label. So I kept the default spacing is provided in Patternfly.

2) Before we had tick mark inside the switch if we turn on the switch, that was coming because we were using switch without label. Now since we started using the switch with label, when we turn on the switch the tick mark will not be there. Details of the switch component: https://www.patternfly.org/v4/components/switch/

**Unit test coverage report**: 
NA

**Test setup:**
Login to developer console, go to +Add, click on Details on/off text.

**Browser conformance**: 
- [ x ] Chrome
- [ x ] Firefox
- [ x ] Safari
