### PR TITLE
Bug 2071691: Update and scope our breadcrumb padding rule so it doesn't effect a pure implementation

### DIFF
--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -96,7 +96,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
   return (
     <>
       {!_.isEmpty(breadcrumbs) && (
-        <Breadcrumb className="pf-c-breadcrumb--no-padding-top co-break-word">
+        <Breadcrumb className="co-breadcrumb co-break-word">
           {breadcrumbs.map((crumb, i) => {
             const isLast = i === breadcrumbs.length - 1;
             return (

--- a/frontend/public/components/utils/details-item.tsx
+++ b/frontend/public/components/utils/details-item.tsx
@@ -22,7 +22,7 @@ export const PropertyPath: React.FC<{ kind: string; path: string | string[] }> =
 }) => {
   const pathArray: string[] = _.toPath(path);
   return (
-    <Breadcrumb className="pf-c-breadcrumb--no-padding-top">
+    <Breadcrumb className="co-breadcrumb">
       <BreadcrumbItem>{kind}</BreadcrumbItem>
       {pathArray.map((property, i) => {
         const isLast = i === pathArray.length - 1;

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -53,7 +53,7 @@ export const ResourceItemDeleting = () => {
 };
 
 export const BreadCrumbs: React.SFC<BreadCrumbsProps> = ({ breadcrumbs }) => (
-  <Breadcrumb>
+  <Breadcrumb className="co-breadcrumb">
     {breadcrumbs.map((crumb, i, { length }) => {
       const isLast = i === length - 1;
 
@@ -136,86 +136,92 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
   const showHeading = props.icon || kind || resourceTitle || resourceStatus || badge || showActions;
   const showBreadcrumbs = breadcrumbs || (breadcrumbsFor && !_.isEmpty(data));
   return (
-    <div
-      className={classNames(
-        'co-m-nav-title',
-        { 'co-m-nav-title--detail': detail },
-        { 'co-m-nav-title--logo': props.icon },
-        { 'co-m-nav-title--breadcrumbs': showBreadcrumbs },
-        className,
-      )}
-      style={style}
-    >
+    <>
       {showBreadcrumbs && (
-        <Split style={{ alignItems: 'baseline' }}>
-          <SplitItem isFilled>
-            <BreadCrumbs breadcrumbs={breadcrumbs || breadcrumbsFor(data)} />
-          </SplitItem>
-          {badge && (
-            <SplitItem>{<span className="co-m-pane__heading-badge">{badge}</span>}</SplitItem>
-          )}
-        </Split>
+        <div className="pf-c-page__main-breadcrumb">
+          <Split style={{ alignItems: 'baseline' }}>
+            <SplitItem isFilled>
+              <BreadCrumbs breadcrumbs={breadcrumbs || breadcrumbsFor(data)} />
+            </SplitItem>
+            {badge && (
+              <SplitItem>{<span className="co-m-pane__heading-badge">{badge}</span>}</SplitItem>
+            )}
+          </Split>
+        </div>
       )}
-      {showHeading && (
-        <Text
-          component={TextVariants.h1}
-          className={classNames('co-m-pane__heading', {
-            'co-m-pane__heading--baseline': link,
-            'co-m-pane__heading--center': centerText,
-            'co-m-pane__heading--logo': props.icon,
-            'co-m-pane__heading--with-help-text': helpText,
-          })}
-        >
-          {props.icon ? (
-            <props.icon obj={data} />
-          ) : (
-            <div className="co-m-pane__name co-resource-item">
-              {kind && <ResourceIcon kind={kind} className="co-m-resource-icon--lg" />}{' '}
-              <span data-test-id="resource-title" className="co-resource-item__resource-name">
-                {resourceTitle}
-                {data?.metadata?.namespace && data?.metadata?.ownerReferences?.length && (
-                  <ManagedByOperatorLink obj={data} />
+      <div
+        className={classNames(
+          'co-m-nav-title',
+          { 'co-m-nav-title--detail': detail },
+          { 'co-m-nav-title--logo': props.icon },
+          { 'co-m-nav-title--breadcrumbs': showBreadcrumbs },
+          className,
+        )}
+        style={style}
+      >
+        {showHeading && (
+          <Text
+            component={TextVariants.h1}
+            className={classNames('co-m-pane__heading', {
+              'co-m-pane__heading--baseline': link,
+              'co-m-pane__heading--center': centerText,
+              'co-m-pane__heading--logo': props.icon,
+              'co-m-pane__heading--with-help-text': helpText,
+            })}
+          >
+            {props.icon ? (
+              <props.icon obj={data} />
+            ) : (
+              <div className="co-m-pane__name co-resource-item">
+                {kind && <ResourceIcon kind={kind} className="co-m-resource-icon--lg" />}{' '}
+                <span data-test-id="resource-title" className="co-resource-item__resource-name">
+                  {resourceTitle}
+                  {data?.metadata?.namespace && data?.metadata?.ownerReferences?.length && (
+                    <ManagedByOperatorLink obj={data} />
+                  )}
+                </span>
+                {resourceStatus && (
+                  <ResourceStatus additionalClassNames="hidden-xs">
+                    <Status status={resourceStatus} />
+                  </ResourceStatus>
                 )}
-              </span>
-              {resourceStatus && (
-                <ResourceStatus additionalClassNames="hidden-xs">
-                  <Status status={resourceStatus} />
-                </ResourceStatus>
-              )}
-            </div>
-          )}
-          {!breadcrumbsFor && !breadcrumbs && badge && (
-            <span className="co-m-pane__heading-badge">{badge}</span>
-          )}
-          {link && <div className="co-m-pane__heading-link">{link}</div>}
-          {showActions && (
-            <div className="co-actions" data-test-id="details-actions">
-              {hasButtonActions && (
-                <ActionButtons actionButtons={buttonActions.map((a) => a(kindObj, data))} />
-              )}
-              {hasMenuActions && (
-                <ActionsMenu
-                  actions={
-                    _.isFunction(menuActions)
-                      ? menuActions(kindObj, data, extraResources, customData)
-                      : menuActions.map((a) => a(kindObj, data, extraResources, customData))
-                  }
-                />
-              )}
-              {_.isFunction(customActionMenu) ? customActionMenu(kindObj, data) : customActionMenu}
-            </div>
-          )}
-        </Text>
-      )}
-      {helpText && (
-        <TextContent>
-          <Text component={TextVariants.p} className="help-block co-m-pane__heading-help-text">
-            {helpText}
+              </div>
+            )}
+            {!breadcrumbsFor && !breadcrumbs && badge && (
+              <span className="co-m-pane__heading-badge">{badge}</span>
+            )}
+            {link && <div className="co-m-pane__heading-link">{link}</div>}
+            {showActions && (
+              <div className="co-actions" data-test-id="details-actions">
+                {hasButtonActions && (
+                  <ActionButtons actionButtons={buttonActions.map((a) => a(kindObj, data))} />
+                )}
+                {hasMenuActions && (
+                  <ActionsMenu
+                    actions={
+                      _.isFunction(menuActions)
+                        ? menuActions(kindObj, data, extraResources, customData)
+                        : menuActions.map((a) => a(kindObj, data, extraResources, customData))
+                    }
+                  />
+                )}
+                {_.isFunction(customActionMenu)
+                  ? customActionMenu(kindObj, data)
+                  : customActionMenu}
+              </div>
+            )}
           </Text>
-        </TextContent>
-      )}
-      {props.children}
-    </div>
+        )}
+        {helpText && (
+          <TextContent>
+            <Text component={TextVariants.p} className="help-block co-m-pane__heading-help-text">
+              {helpText}
+            </Text>
+          </TextContent>
+        )}
+        {props.children}
+      </div>
+    </>
   );
 });
 

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -1,5 +1,9 @@
 $co-external-link-padding-right: 15px;
 
+.co-breadcrumb {
+  padding-bottom: var(--pf-global--spacer--sm);
+}
+
 dl.co-inline {
   dd {
     margin-bottom: 1em;

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -71,15 +71,6 @@ form.pf-c-form {
   font-family: var(--pf-global--FontFamily--sans-serif);
 }
 
-.pf-c-breadcrumb {
-  padding-bottom: 12px;
-  padding-top: 25px;
-
-  &--no-padding-top {
-    padding-top: 0;
-  }
-}
-
 .pf-c-button--align-right {
   margin-left: auto !important;
 }


### PR DESCRIPTION
Move override rule to `.co-breadcrumb` 
Wrap breadcrumbs and badge row with `pf-c-page__main-breadcrumb` which sets top and side margins
and remove `pf-c-breadcrumb--no-padding-top` that is no longer needed since PF `<BreadCrumb>` has no padding.

**After**
<img width="1082" alt="Screen Shot 2022-04-12 at 1 45 36 PM" src="https://user-images.githubusercontent.com/1874151/163048834-bca4972f-85fb-4721-ac86-96d0ab9994a7.png">
<img width="483" alt="Screen Shot 2022-04-12 at 1 45 18 PM" src="https://user-images.githubusercontent.com/1874151/163048917-11379510-be2e-43fa-a547-b63018252f6d.png">


