### PR TITLE
Automation of Pipeline-Workspaces | Pipeline-Plugin

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-workspaces.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-workspaces.feature
@@ -3,7 +3,7 @@ Feature: Workspaces
               As a user, I want to add or remove secrets details to pipeline
 
         Background:
-            Given user has created or selected namespace "aut-pipelines-workpsaces"
+            Given user has created or selected namespace "aut-pipelines-workspaces"
               And user is at pipelines page
 
 
@@ -34,11 +34,11 @@ Feature: Workspaces
               And user will see "Empty Directory" in the Workspace Resources section of Pipeline Run Details page
 
 
-        @to-do
+        @regression
         Scenario: Start the pipeline with ConfigMap: P-10-TC04
-            Given user created config map from "configMap-test-motd.yaml"
+            Given user created Config Map using yaml "configMap-test-motd.yaml"
               And user created pipeline run using yaml "pipelineRun-using-optional-workspaces-in-when-expressions.yaml"
-             When user opens pipeline run details page for "optional-workspace-when-"
+             When user is at PipelineRun Details Page of "optional-workspace-when-"
               And user selects "rerun" option from action menu for pipeline run "optional-workspace-when-"
              Then user will see Config Map Workspace "test-motd" mentioned in the Workspace Resources section of Pipeline Run Details page
 

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineBuilder-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineBuilder-page.ts
@@ -173,6 +173,7 @@ export const pipelineBuilderPage = {
     taskName: string = 'git-clone',
     workspaceName: string = 'git',
   ) => {
+    cy.byTestID('form-view-input').check();
     pipelineBuilderPage.enterPipelineName(pipelineName);
     pipelineBuilderPage.selectTask(taskName);
     pipelineBuilderPage.clickOnAddWorkSpace();

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelines-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelines-page.ts
@@ -282,7 +282,7 @@ export const startPipelineInPipelinesPage = {
   },
 
   selectSecret: (secret: string) => {
-    cy.selectByDropDownText(pipelinesPO.startPipeline.workspaces.secret, secret);
+    cy.selectByAutoCompleteDropDownText(pipelinesPO.startPipeline.workspaces.secret, secret);
   },
 
   selectPVC: (pvc: string) => {

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-workspaces.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-workspaces.ts
@@ -89,8 +89,10 @@ Then(
 );
 
 Given('user created Config Map using yaml {string}', (yamlFile: string) => {
-  const yamlFileName = `testData/pipelines-workspaces/${yamlFile}`;
-  cy.exec(`oc apply -f ${yamlFileName} -n ${Cypress.env('NAMESPACE')}`);
+  const yamlFileName = `testData/pipelines-workspaces/using-optional-workspaces-in-when-expressions-pipelineRun/${yamlFile}`;
+  cy.exec(`oc apply -f ${yamlFileName} -n ${Cypress.env('NAMESPACE')}`, {
+    failOnNonZeroExit: false,
+  });
 });
 
 Given('user created pipeline {string} with workspace', (pipelineName: string) => {
@@ -102,12 +104,16 @@ Given('user created pipeline {string} with workspace', (pipelineName: string) =>
 
 Given('user created Secret using yaml {string}', (yamlFile: string) => {
   const yamlFileName = `testData/pipelines-workspaces/${yamlFile}`;
-  cy.exec(`oc apply -f ${yamlFileName} -n ${Cypress.env('NAMESPACE')}`);
+  cy.exec(`oc apply -f ${yamlFileName} -n ${Cypress.env('NAMESPACE')}`, {
+    failOnNonZeroExit: false,
+  });
 });
 
 Given('user created PVC using yaml {string}', (yamlFile: string) => {
   const yamlFileName = `testData/pipelines-workspaces/${yamlFile}`;
-  cy.exec(`oc apply -f ${yamlFileName} -n ${Cypress.env('NAMESPACE')}`);
+  cy.exec(`oc apply -f ${yamlFileName} -n ${Cypress.env('NAMESPACE')}`, {
+    failOnNonZeroExit: false,
+  });
 });
 
 When('user selects {string} from Config Map dropdown', (ConfigMapValue: string) => {
@@ -147,5 +153,28 @@ Then(
   (pvc: string) => {
     pipelineRunDetailsPage.verifyWorkspacesSection();
     cy.get(`[data-test-id^="${pvc}"]`).should('be.visible');
+  },
+);
+
+Given('user created pipeline run using yaml {string}', (yamlFile: string) => {
+  const yamlFileName = `testData/pipelines-workspaces/using-optional-workspaces-in-when-expressions-pipelineRun/${yamlFile}`;
+  cy.byTestID('import-yaml').click();
+  yamlEditor.isLoaded();
+  pipelinesPage.clearYAMLEditor();
+  pipelinesPage.setEditorContent(yamlFileName);
+  cy.byTestID('save-changes').click();
+});
+
+When('user is at PipelineRun Details Page of {string}', (pipelineRunName: string) => {
+  cy.contains('PipelineRun details').should('be.visible');
+  cy.byLegacyTestID('resource-title').should('include.text', pipelineRunName);
+});
+
+When(
+  'user selects "rerun" option from action menu for pipeline run {string}',
+  (pipelineRunName: string) => {
+    cy.byLegacyTestID('resource-title').should('include.text', pipelineRunName);
+    cy.byLegacyTestID('actions-menu-button').click();
+    cy.get('[data-test-action="Rerun"]').click();
   },
 );


### PR DESCRIPTION
**Description:**
Automation of pipeline-workspaces | pipeline-plugin

**Jira Id:** [ODC-6631](https://issues.redhat.com/browse/ODC-6631)
<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p pipelines
```

**Screen shots**:
![image](https://user-images.githubusercontent.com/65410551/163096537-8f7a8bf0-3bca-486c-8b38-1e602ef54aa7.png)



**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge