### PR TITLE
Bug 2074465: Fix default branch param in pipeline import from git flow

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils.ts
@@ -51,7 +51,7 @@ export const getPipelineParams = (
       case 'GIT_REPO':
         return { ...param, default: gitUrl };
       case 'GIT_REVISION':
-        return { ...param, default: gitRef || 'master' };
+        return { ...param, default: gitRef || '' };
       case 'PATH_CONTEXT':
         return { ...param, default: gitDir.replace(/^\//, '') || param.default };
       case 'IMAGE_NAME':

--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils.ts
@@ -44,14 +44,14 @@ export const getPipelineParams = (
   dockerfilePath: string,
   tag: string,
 ) => {
-  return params.map((param) => {
+  return (params || []).map((param) => {
     switch (param.name) {
       case 'APP_NAME':
         return { ...param, default: name };
       case 'GIT_REPO':
         return { ...param, default: gitUrl };
       case 'GIT_REVISION':
-        return { ...param, default: gitRef || '' };
+        return { ...param, default: gitRef };
       case 'PATH_CONTEXT':
         return { ...param, default: gitDir.replace(/^\//, '') || param.default };
       case 'IMAGE_NAME':


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGSM-43202

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

GIT_REVISION param in pipeline defaults to `master` branch, so it fails for repositories that has only `main` branch and no master branch.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Set the GIT_REVISION to empty string so the git-clone task automatically fetches the repository's remote default branch.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

<img width="1460" alt="image" src="https://user-images.githubusercontent.com/9964343/163103543-11128997-9606-49e7-9437-dbddd7efbd31.png">


**Unit test coverage report**: 
<!-- Attach test coverage report -->
```
  getPipelineParams
    ✓ should contain the application name in APP_NAME param if app name is passed
    ✓ should contain the repository url in GIT_REPO param if repo is passed
    ✓ should return empty object if params is invalid or not an array (1ms)
    ✓ should contain empty string in GIT_REVISION param when gitRef is not passed
    ✓ should contain the branch name in GIT_REVISION param when gitRef is passed
    ✓ should contain the context directory path in PATH_CONTEXT param if git directory is passed
    ✓ should contain the image url in  IMAGE_NAME param if image name param is passed
    ✓ should contain the docker path in  DOCKERFILE param if it is passed (1ms)
    ✓ should contain the tag in VERSION param if it is passed
    ✓ should return params that are passed
```

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Steps to Reproduce:
1. Import from Git in Dev perspective
2. Provide https://github.com/siamaksade/todo-demo-app
3. Select checkbox to add pipeline
4. Create


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


