### PR TITLE
Automation of pipeline-runs | pipelines-plugin 

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-runs.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-runs.feature
@@ -216,22 +216,22 @@ Feature: Pipeline Runs
               And existing pipeline runs contains the old pipeline graph
 
 
-        @regression @to-do
+        @regression
         Scenario: Display failure details on pipeline run details: P-07-TC22
             Given user is at pipeline page in developer perspective
               And a failed pipeline is present
-             When user goes to failed pipeline run
+             When user goes to failed pipeline run of pipeline "golang-ex"
               And user opens pipeline run details
              Then user can see status as Failure
               And user can view failure message under Message heading
               And user can see Log snippet to get know what taskruns failed
 
 
-        @regression @to-do
+        @regression
         Scenario: Display failure details of pipeline run in topology sidebar: P-07-TC23
-            Given user is at Topology page
-              And a node with an associated pipeline that has failed is present
-             When user opens sidebar of the node
+            Given user is at the Topology page
+              And a node with an associated pipeline "golang-ex" is present
+             When user opens sidebar of the node "golang-ex"
               And user scrolls down to pipeline runs section
              Then user will see the pipeline run name with failed status
               And user will see failure message below pipeline runs
@@ -289,11 +289,11 @@ Feature: Pipeline Runs
               And user can see failed task before finally task
 
 
-        @regression @to-do
+        @regression
         Scenario: Pipeline Run results on Pipeline Run details page for passed pipeline run: P-07-TC29
             #Run oc apply -f ../../testData/pipelines-workspaces/sum-three-pipeline.yaml
-            Given user has passed pipeline run for pipeline "sum-three-pipeline"
-              And user is on Pipeline Run details page
+            Given user has passed pipeline run
+              And user is on Pipeline Run details page of "sum-three-pipeline-run" pipeline run
              When user scrolls to the Pipeline Run results section
              Then user can see Name and Value column under Pipeline Run results
 

--- a/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
@@ -108,6 +108,7 @@ export const pipelineDetailsPO = {
       createdAt: '[data-test="Created at"]',
       owner: '[data-test="Owner"]',
       tasks: '.odc-dynamic-resource-link-list--addSpaceBelow dl dt',
+      list: '.odc-dynamic-resource-link-list',
     },
     fieldValues: {
       name: '[data-test-selector="details-item-value__Name"]',
@@ -120,6 +121,7 @@ export const pipelineDetailsPO = {
     },
     sections: {
       triggerTemplates: '.odc-trigger-template-list',
+
       tasks: '.odc-dynamic-resource-link-list--addSpaceBelow',
     },
   },
@@ -181,8 +183,10 @@ export const pipelineRunDetailsPO = {
   yamlTab: '[data-test-id$="YAML"]',
   detailsTab: '[data-test-id$="Details"]',
   taskRunsTab: '[data-test-id="horizontal-link-TaskRuns"]',
+  pipelineRunsResults: '[data-test-section-heading="PipelineRun results"]',
   eventsTab: '[data-test-id$="Events"]',
   pipelineRunStatus: '[data-test="resource-status"]',
+  statusMessage: '.odc-pipeline-run-details__customDetails',
   details: {
     pipelineLink: '[data-test-id="git-pipeline-events"]',
     sectionTitle: '[data-test-section-heading="PipelineRun details"]',
@@ -231,6 +235,7 @@ export const pipelineRunsPO = {
     table: 'div[role="grid"]',
     pipelineRunName: 'tr td:nth-child(1)',
     status: '[data-test="status-text"]',
+    resultTable: '[role="grid"]',
   },
 };
 

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -75,6 +75,10 @@ export const topologyPO = {
     applicationGroupingsTitle: '.overview__sidebar-pane-head.resource-overview__heading',
     applicationGroupingsSidepane: 'overview__sidebar-pane resource-overview',
     resourcesTabApplicationGroupings: '.co-m-horizontal-nav__menu-item',
+    pipelineRunsDetails: '.sidebar__section-heading',
+    pipelineRunsLogSnippet: '.ocs-log-snippet__log-snippet',
+    pipelineRunsStatus: '.ocs-log-snippet__status-message',
+    pipelineRunsLinks: 'a.sidebar__section-view-all',
     detailsTab: {
       labels: '[data-test="label-list"]',
       annotations: '[data-test="edit-annotations"]',


### PR DESCRIPTION
**Description:**
<!-- PR description-->
- Automation of pipeline-runs feature file.

**Jira Id:** [ODC-6630](https://issues.redhat.com/browse/ODC-6630)
<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example: 
```
export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p pipelines

```

**Screen shots**:
<!--   -->
![image](https://user-images.githubusercontent.com/39815871/163103547-37439d8e-d442-4109-946e-f511c8477c8c.png)




**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge