### PR TITLE
Gherkin for service binding enhancement- discoverability

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-operator-backed.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-operator-backed.feature
@@ -43,3 +43,25 @@ Feature: Create workload from Operator Backed file
               And user clicks create button in Create Jaeger page
              Then user will be redirected to Topology page
               And user is able to see "jaeger-all-in-one-inmemory1" in Topology page
+
+
+        @regression @to-do @odc-6467
+        Scenario: Bindable resource in Operator Backed: A-08-TC05
+            Given user has installed Service Binding operator
+              And user has installed Crunchy Postgres for Kubernetes operator
+              And user has created or selected namespace "aut-service-binding"
+              And user is at OperatorBacked page
+             When user enters "Postgres Cluster" in Filter by keyword
+             Then user will see "Bindable" label associated with "Postgres Cluster" card
+              And user will see "Bindable" label in "Postgres Cluster" sidebar
+
+
+        @regression @to-do @odc-6467
+        Scenario: Bindable filter for service binding in Operator Backed: A-08-TC06
+            Given user has installed Service Binding operator
+              And user has installed Crunchy Postgres for Kubernetes operator
+              And user has created or selected namespace "aut-service-binding"
+              And user is at OperatorBacked page
+             When user selects Bindable checkbox under Service Binding
+             Then user will see Bindable cards
+              And user can see infotip associated with the Service Binding filter

--- a/frontend/packages/dev-console/integration-tests/features/addFlow/quick-search-add.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/quick-search-add.feature
@@ -55,3 +55,13 @@ Feature: Provide quick search in Add page
               And user clicks on "Create Application"
               And user clicks on Create button in the Import from Git page
              Then user is taken to the Topology page with "devfile-sample-git" workload created
+
+
+        @regression @to-do @odc-6467
+        Scenario: Bindable resource in Quick Add: A-11-TC07
+            Given user has installed Service Binding operator
+              And user has installed Crunchy Postgres for Kubernetes operator
+              And user is at Add page
+             When user clicks Add to project button
+              And user enters "crunchy" in Add to project search bar
+             Then user will see "Bindable" label associated with "Postgres Cluster"


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-6467
Story: https://issues.redhat.com/browse/ODC-6512

Acceptance criteria:

- All operator backed services which support service binding features will have a "label" on the catalog tile for easy discoverability
- We provide a filter ( at what level ? main catalog or operator backed service ) allowing the user to find all offerings that support the service binding features.
- All operator backed services which support service binding features will have an indicator on the side panel for easy discoverability


**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]

