### PR TITLE
Bug 2040180: handle dashboards single column case

### DIFF
--- a/frontend/public/components/monitoring/dashboards/table.tsx
+++ b/frontend/public/components/monitoring/dashboards/table.tsx
@@ -39,6 +39,9 @@ const getColumns = (styles: ColumnStyle[]): AugmentedColumnStyle[] => {
 
     if (col.pattern.startsWith('Value #')) {
       valueColumns.push(col);
+    } else if (col.pattern === 'Value') {
+      // Set the column to use the first group pattern because the panel has a single target
+      valueColumns.push({ ...col, pattern: 'Value #A' });
     } else {
       labelColumns.push({
         ...col,

--- a/frontend/public/components/monitoring/dashboards/types.ts
+++ b/frontend/public/components/monitoring/dashboards/types.ts
@@ -50,10 +50,11 @@ export type Panel = {
   span: number;
   stack: boolean;
   styles?: ColumnStyle[];
-  targets: {
+  targets: Array<{
     expr: string;
     legendFormat?: string;
-  };
+    refId: string;
+  }>;
   title: string;
   transform?: string;
   type: string;


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2040180

Solution: Assign the correct pattern for a single target data so single column values are visible

Used [this ConfigMap](https://gist.github.com/jgbernalp/8eab7b9268a0e2b8bb2b168e40dfea01#file-custom-dashboard-config-map-yml) to create a custom dashboard with a single column value
