### PR TITLE
Bug 2073176: Fix key/value pair removal issue in configmap form yaml switcher

### DIFF
--- a/frontend/public/components/configmaps/ConfigMapForm.tsx
+++ b/frontend/public/components/configmaps/ConfigMapForm.tsx
@@ -39,12 +39,14 @@ const ConfigmapForm: React.FC<ConfigMapProps> = ({
       configMapYaml.metadata.namespace = namespace;
     }
     const configmap: ConfigMap =
-      values.editorType === EditorType.Form ? getConfigmapData(values) : configMapYaml;
+      values.editorType === EditorType.Form
+        ? getConfigmapData(values, configMapYaml)
+        : configMapYaml;
     if (isCreateFlow) {
       resourceCall = k8sCreateResource({ model: ConfigMapModel, data: configmap });
     } else {
       const editConfigMapData = _.cloneDeep(configMap);
-      editConfigMapData.metadata.name = configmap?.metadata?.name;
+      editConfigMapData.metadata = configmap?.metadata;
       editConfigMapData.data = configmap.data;
       editConfigMapData.binaryData = configmap.binaryData;
       editConfigMapData.immutable = configmap.immutable;

--- a/frontend/public/components/configmaps/__tests__/configmap-utils.spec.ts
+++ b/frontend/public/components/configmaps/__tests__/configmap-utils.spec.ts
@@ -175,9 +175,23 @@ describe('configmap-utils', () => {
       expect(yamlData).toBe(defaultConfigMapYaml);
     });
 
-    it('should convert the object from yaml to formData', () => {
+    it('should convert the object from formData to yaml', () => {
       const yamlData = sanitizeToYaml(getInitialConfigMapFormData(sampleConfigMap, ''), null);
       expect(yamlData).toBe(sampleConfigMapYaml);
+    });
+
+    it('should set data or binary data to empty object if they are removed from formData', () => {
+      const configMapFormData = getInitialConfigMapFormData(
+        {
+          ...sampleConfigMap,
+          data: {},
+          binaryData: {},
+        },
+        '',
+      );
+      const yamlData = safeYAMLToJS(sanitizeToYaml(configMapFormData, null));
+      expect(yamlData.data).toEqual({});
+      expect(yamlData.binaryData).toEqual({});
     });
 
     it('should convert the binaryData value to base64 format when switched to yamlview', () => {

--- a/frontend/public/components/configmaps/configmap-utils.ts
+++ b/frontend/public/components/configmaps/configmap-utils.ts
@@ -106,7 +106,7 @@ export const getConfigmapFormData = (
   };
 };
 
-export const getConfigmapData = (values: FormikValues): ConfigMap => {
+export const getConfigmapData = (values: FormikValues, existingConfigMap: ConfigMap): ConfigMap => {
   const { name, namespace, immutable, data, binaryData } = values.formData;
 
   const dataMap = data.reduce((acc, { key, value }) => {
@@ -127,7 +127,9 @@ export const getConfigmapData = (values: FormikValues): ConfigMap => {
   }, {});
 
   return _.merge({}, initialConfigmapData, {
+    ...existingConfigMap,
     metadata: {
+      ...existingConfigMap?.metadata,
       name,
       namespace,
     },
@@ -136,11 +138,8 @@ export const getConfigmapData = (values: FormikValues): ConfigMap => {
     binaryData: binaryDataMap ?? {},
   });
 };
-export const sanitizeToYaml = (formData: ConfigMapFormData, configMap: ConfigMap): string => {
-  let configmapObj = getConfigmapData({ formData });
-  if (configMap) {
-    configmapObj = _.merge({}, configMap, configmapObj);
-  }
+export const sanitizeToYaml = (formData: ConfigMapFormData, configMap?: ConfigMap): string => {
+  const configmapObj = getConfigmapData({ formData }, configMap);
   return safeJSToYAML(configmapObj, 'yamlData', {
     skipInvalid: true,
   });


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://bugzilla.redhat.com/show_bug.cgi?id=2073176

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

After removing data in the form view, switching back to the yaml view continues to show the removed values.

SantizeToYaml method was merging the  previous `yamlData` with `formData` to preserve extra fields like metadata, which caused this issue. 

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Removed merging formData with old yaml values and  using only the metadata information from `yamlData` so that all the fields will be in sync between form/yaml view.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->


https://user-images.githubusercontent.com/9964343/163147245-dbf96cb6-ed5a-42db-b188-f0151e836ee5.mov


**Unit test coverage report**: 
<!-- Attach test coverage report -->

```
      ✓ should set data or binary data to empty object if they are removed from formData (2ms)
```

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Steps to Reproduce:

1. create or edit a configmap
2. go to the form view
3. enter a key and value for data and binary data
4. switch to yaml view and observe the values are present (unnecessary step)
5. switch to form view
6. remove the data values by clicking the `- remove key/value` option
7. switch to yaml view




**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc: @christianvogt 