### PR TITLE
add data test ids for MultiTabTerminal

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellDrawer.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellDrawer.tsx
@@ -29,7 +29,7 @@ const CloudShellDrawer: React.FC<CloudShellDrawerProps> = ({ children, onClose }
     setExpanded(openState);
   };
   const header = (
-    <Flex style={{ flexGrow: 1 }}>
+    <Flex style={{ flexGrow: 1 }} data-test="cloudshell-drawer-header">
       <FlexItem className="co-cloud-shell-drawer__heading">
         {t('console-app~Command line terminal')}
       </FlexItem>
@@ -52,7 +52,11 @@ const CloudShellDrawer: React.FC<CloudShellDrawerProps> = ({ children, onClose }
           onClick={onMRButtonClick}
         />
         <Tooltip content={t('console-app~Close terminal')}>
-          <CloseButton ariaLabel={t('console-app~Close terminal')} onClick={onClose} />
+          <CloseButton
+            ariaLabel={t('console-app~Close terminal')}
+            onClick={onClose}
+            data-test="cloudshell-drawer-close-button"
+          />
         </Tooltip>
       </FlexItem>
     </Flex>

--- a/frontend/packages/console-app/src/components/cloud-shell/MultiTabbedTerminal.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/MultiTabbedTerminal.tsx
@@ -38,11 +38,12 @@ export const MultiTabbedTerminal: React.FC<MultiTabbedTerminalProps> = ({ onClos
   };
 
   return (
-    <Tabs activeKey={activeTabKey} isBox>
+    <Tabs activeKey={activeTabKey} isBox data-test="multi-tab-terminal">
       {terminalTabs.map((terminalNumber, tabIndex) => (
         <Tab
           translate="no"
           className="co-multi-tabbed-terminal__tab"
+          data-test="multi-tab-terminal-tab"
           eventKey={terminalNumber}
           key={terminalNumber}
           title={


### PR DESCRIPTION
Data test ids for multitab terminal

Added the following -> 
Drawer Header id `cloudshell-drawer-header`
Drawer close button `cloudshell-drawer-close-button`
MultiTab Terminal ul `multi-tab-terminal`
MultiTab Terminal Tab `multi-tab-terminal-tab`