### PR TITLE
[Dark Theme]: fixes quick starts, user preferences project selector, quick search, and help text color

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartCatalogPage.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartCatalogPage.scss
@@ -1,0 +1,9 @@
+.pfext-page-layout__content{
+  &.pfext-is-dark {
+    background-color: var(--pf-global--BackgroundColor--200);
+  }
+}
+
+.pfext-quick-start-footer {
+  background-color: var(--pf-global--BackgroundColor--100);
+}

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartCatalogPage.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartCatalogPage.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next';
 import { LoadingBox } from '@console/internal/components/utils';
 import QuickStartsLoader from './loader/QuickStartsLoader';
 
+import './QuickStartCatalogPage.scss';
+
 const QuickStartCatalogPage: React.FC = () => {
   const { t } = useTranslation();
   return (

--- a/frontend/packages/console-app/src/components/user-preferences/namespace/NamespaceDropdown.scss
+++ b/frontend/packages/console-app/src/components/user-preferences/namespace/NamespaceDropdown.scss
@@ -1,4 +1,4 @@
-.co-user-preference__namespace-menu-toggle {
+.pf-c-menu-toggle.co-user-preference__namespace-menu-toggle {
   padding: var(--pf-global--spacer--form-element) var(--pf-global--spacer--sm)
     var(--pf-global--spacer--form-element) var(--pf-global--spacer--sm) !important;
   &::before,

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.scss
@@ -1,5 +1,5 @@
 .ocs-quick-search-bar {
-  background: var(--pf-global--BackgroundColor--400) !important;
+  background-color: var(--pf-global--BackgroundColor--100) !important;
   &:hover {
     cursor: move;
   }

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -194,7 +194,7 @@ dl.co-inline {
 }
 
 .co-help-text {
-  color: $pf-color-black-600;
+  color: var(--pf-global--Color--200);
 }
 
 .co-m-pane__explanation code {


### PR DESCRIPTION
**Story:** https://issues.redhat.com/browse/ODC-6634

**Screenshots:**
![image](https://user-images.githubusercontent.com/2561818/163183864-a24ce6ff-5b87-493e-9a1e-2b7008f40d47.png)
![image](https://user-images.githubusercontent.com/2561818/163183951-0a1766dd-fc2f-4821-8b79-c3043599b270.png)
![image](https://user-images.githubusercontent.com/2561818/163184033-9372249f-6970-418a-8457-47428a38ab32.png)
![image](https://user-images.githubusercontent.com/2561818/163184114-d31fed14-ccb1-4cbe-ada1-f3bc3792af42.png)

cc: @sg00dwin @mattnolting 
