### PR TITLE
 KafkaSink Visualization

### DIFF
--- a/dynamic-demo-plugin/src/components/ExtensionConsumer.tsx
+++ b/dynamic-demo-plugin/src/components/ExtensionConsumer.tsx
@@ -36,7 +36,9 @@ const ExtensionConsumer: React.FC = () => {
       }
     >
       <PageSection>
-        {extensions.map((ext) => (
+        {/* prevent integration test failure when a new console.flag/model extension is added.
+            Integration tests has 20 length hardcoded packages/integration-tests-cypress/tests/app/demo-dynamic-plugin.spec.ts */}
+        {extensions.slice(0, 20).map((ext) => (
           <Card key={ext.properties.flag}>
             <CardTitle>{ext.properties.flag}</CardTitle>
             <CardBody>

--- a/dynamic-demo-plugin/src/components/ExtensionConsumer.tsx
+++ b/dynamic-demo-plugin/src/components/ExtensionConsumer.tsx
@@ -36,9 +36,7 @@ const ExtensionConsumer: React.FC = () => {
       }
     >
       <PageSection>
-        {/* prevent integration test failure when a new console.flag/model extension is added.
-            Integration tests has 20 length hardcoded packages/integration-tests-cypress/tests/app/demo-dynamic-plugin.spec.ts */}
-        {extensions.slice(0, 20).map((ext) => (
+        {extensions.map((ext) => (
           <Card key={ext.properties.flag}>
             <CardTitle>{ext.properties.flag}</CardTitle>
             <CardBody>

--- a/frontend/packages/integration-tests-cypress/tests/app/demo-dynamic-plugin.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/demo-dynamic-plugin.spec.ts
@@ -170,7 +170,7 @@ describe('Demo dynamic plugin test', () => {
   it(`test Test Consumer nav item`, () => {
     nav.sidenav.clickNavLink(['Demo Plugin', 'Test Consumer']);
     cy.byTestID('test-consumer-title').should('contain', 'Extensions of type Console.flag/Model');
-    cy.get('.pf-c-card').should('have.length', 20);
+    cy.get('.pf-c-card').should('have.length', 21);
   });
 
   it(`test Test Utilities nav item`, () => {

--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -121,6 +121,17 @@
     }
   },
   {
+    "type": "console.flag/model",
+    "properties": {
+      "model": {
+        "group": "eventing.knative.dev",
+        "version": "v1alpha1",
+        "kind": "KafkaSink"
+      },
+      "flag": "FLAG_KAFKA_SINK"
+    }
+  },
+  {
     "type": "console.page/resource/list",
     "properties": {
       "model": {
@@ -1572,6 +1583,19 @@
     }
   },
   {
+    "type": "console.model-metadata",
+    "properties": {
+      "model": {
+        "group": "eventing.knative.dev",
+        "version": "v1alpha1",
+        "kind": "KafkaSink"
+      },
+      "label": "%knative-plugin~KafkaSink%",
+      "labelPlural": "%knative-plugin~KafkaSinks%",
+      "abbr": "KS"
+    }
+  },
+  {
     "type": "console.context-provider",
     "properties": {
       "provider": { "$codeRef": "eventingContext.EventingContextProvider" },
@@ -1616,6 +1640,40 @@
     },
     "flags": {
       "required": ["KNATIVE_SERVING", "KNATIVE_EVENTING"]
+    }
+  },
+  {
+    "type": "console.topology/data/factory",
+    "properties": {
+      "id": "knative-kafka-sink-topology-data-factory",
+      "priority": "99",
+      "resources": {
+        "kafkasinks": {
+          "model": {
+            "group": "eventing.knative.dev",
+            "version": "v1alpha1",
+            "kind": "KafkaSink"
+          },
+          "opts": { "isList": true, "optional": true, "namespaced": true }
+        }
+      },
+      "getDataModel": {
+        "$codeRef": "topology.getKafkaSinkKnativeTopologyData"
+      }
+    },
+    "flags": {
+      "required": ["FLAG_KAFKA_SINK"]
+    }
+  },
+  {
+    "type": "console.topology/component/factory",
+    "properties": {
+      "getFactory": {
+        "$codeRef": "topology.getKafkaSinkComponentFactory"
+      }
+    },
+    "flags": {
+      "required": ["FLAG_KAFKA_SINK"]
     }
   }
 ]

--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -65,6 +65,8 @@
   "Kamelets": "Kamelets",
   "IntegrationPlatform": "IntegrationPlatform",
   "IntegrationPlatforms": "IntegrationPlatforms",
+  "KafkaSink": "KafkaSink",
+  "KafkaSinks": "KafkaSinks",
   "Add Event Sink": "Add Event Sink",
   "Add Subscription": "Add Subscription",
   "Add Trigger": "Add Trigger",

--- a/frontend/packages/knative-plugin/src/actions/providers.ts
+++ b/frontend/packages/knative-plugin/src/actions/providers.ts
@@ -312,7 +312,12 @@ export const useKnativeEventSinkActionProvider = (element: Node) => {
   const actions = React.useMemo(() => {
     const type = element.getType();
     if ((type !== TYPE_EVENT_SINK && type !== TYPE_KAFKA_SINK) || !k8sModel) return undefined;
-    return k8sModel && resource ? getCommonResourceActions(k8sModel, resource) : undefined;
+    return k8sModel && resource
+      ? [
+          getModifyApplicationAction(k8sModel, resource),
+          ...getCommonResourceActions(k8sModel, resource),
+        ]
+      : undefined;
   }, [element, k8sModel, resource]);
 
   return React.useMemo(() => {

--- a/frontend/packages/knative-plugin/src/actions/providers.ts
+++ b/frontend/packages/knative-plugin/src/actions/providers.ts
@@ -27,6 +27,7 @@ import {
   TYPE_REVISION_TRAFFIC,
   TYPE_KAFKA_CONNECTION_LINK,
   TYPE_EVENT_SINK,
+  TYPE_KAFKA_SINK,
 } from '../topology/const';
 import { isEventingChannelResourceKind } from '../utils/fetch-dynamic-eventsources-utils';
 import { AddBrokerAction } from './add-broker';
@@ -310,7 +311,7 @@ export const useKnativeEventSinkActionProvider = (element: Node) => {
   const [k8sModel] = useK8sModel(referenceFor(resource));
   const actions = React.useMemo(() => {
     const type = element.getType();
-    if (type !== TYPE_EVENT_SINK || !k8sModel) return undefined;
+    if ((type !== TYPE_EVENT_SINK && type !== TYPE_KAFKA_SINK) || !k8sModel) return undefined;
     return k8sModel && resource ? getCommonResourceActions(k8sModel, resource) : undefined;
   }, [element, k8sModel, resource]);
 

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -262,3 +262,21 @@ export const CamelKameletModel: K8sKind = {
   crd: true,
   color: knativeEventingColor.value,
 };
+
+export const KafkaSinkModel: K8sKind = {
+  apiGroup: 'eventing.knative.dev',
+  apiVersion: 'v1alpha1',
+  kind: 'KafkaSink',
+  label: 'KafkaSink',
+  // t('knative-plugin~KafkaSink')
+  labelKey: 'knative-plugin~KafkaSink',
+  labelPlural: 'KafkaSinks',
+  // t('knative-plugin~KafkaSinks')
+  labelPluralKey: 'knative-plugin~KafkaSinks',
+  plural: 'kafkasinks',
+  id: 'kafkasink',
+  abbr: 'KS',
+  namespaced: true,
+  crd: true,
+  color: knativeEventingColor.value,
+};

--- a/frontend/packages/knative-plugin/src/topology/__tests__/data-transformer.spec.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/data-transformer.spec.ts
@@ -129,7 +129,7 @@ describe('knative data transformer ', () => {
       isKnativeResource(resource, graphData),
     );
     expect(workloadResources).toHaveLength(6);
-    expect(filteredResources).toHaveLength(3);
+    expect(filteredResources).toHaveLength(2);
   });
 
   it('Should delete all the specific models related to knative deployments if the build config is not present i.e. for resource created through deploy image form', async (done) => {

--- a/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
@@ -31,6 +31,7 @@ import {
   EventingTriggerModel,
   CamelKameletBindingModel,
   ConfigurationModel,
+  KafkaSinkModel,
 } from '../../models';
 import {
   RevisionKind,
@@ -837,7 +838,7 @@ export const sampleSourceKameletBinding: FirehoseResult = {
             'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNDAgMjQwIj48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImEiIHgxPSIuNjY3IiB4Mj0iLjQxNyIgeTE9Ii4xNjciIHkyPSIuNzUiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iIzM3YWVlMiIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzFlOTZjOCIvPjwvbGluZWFyR3JhZGllbnQ+PGxpbmVhckdyYWRpZW50IGlkPSJiIiB4MT0iLjY2IiB4Mj0iLjg1MSIgeTE9Ii40MzciIHkyPSIuODAyIj48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiNlZmY3ZmMiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNmZmYiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48Y2lyY2xlIGN4PSIxMjAiIGN5PSIxMjAiIHI9IjEyMCIgZmlsbD0idXJsKCNhKSIvPjxwYXRoIGZpbGw9IiNjOGRhZWEiIGQ9Ik05OCAxNzVjLTMuODg4IDAtMy4yMjctMS40NjgtNC41NjgtNS4xN0w4MiAxMzIuMjA3IDE3MCA4MCIvPjxwYXRoIGZpbGw9IiNhOWM5ZGQiIGQ9Ik05OCAxNzVjMyAwIDQuMzI1LTEuMzcyIDYtM2wxNi0xNS41NTgtMTkuOTU4LTEyLjAzNSIvPjxwYXRoIGZpbGw9InVybCgjYikiIGQ9Ik0xMDAuMDQgMTQ0LjQxbDQ4LjM2IDM1LjcyOWM1LjUxOSAzLjA0NSA5LjUwMSAxLjQ2OCAxMC44NzYtNS4xMjNsMTkuNjg1LTkyLjc2M2MyLjAxNS04LjA4LTMuMDgtMTEuNzQ2LTguMzYtOS4zNDlsLTExNS41OSA0NC41NzFjLTcuODkgMy4xNjUtNy44NDMgNy41NjctMS40MzggOS41MjhsMjkuNjYzIDkuMjU5IDY4LjY3My00My4zMjVjMy4yNDItMS45NjYgNi4yMTgtLjkxIDMuNzc2IDEuMjU4Ii8+PC9zdmc+',
         },
         resourceVersion: '267611',
-        name: 'overlayimage',
+        name: 'overlayimage-kb',
         uid: '3343caf6-f23f-420a-888e-e2c06aaaa843',
         creationTimestamp: '2020-11-17T07:06:51Z',
         generation: 3,
@@ -855,6 +856,44 @@ export const sampleSourceKameletBinding: FirehoseResult = {
             name: 'telegram-source',
           },
         },
+      },
+      status: {
+        conditions: [
+          {
+            lastTransitionTime: '2020-11-17T08:19:41Z',
+            lastUpdateTime: '2020-11-17T08:19:41Z',
+            status: 'True',
+            type: 'Ready',
+          },
+        ],
+        phase: 'Ready',
+      },
+    },
+  ],
+};
+
+export const sampleSourceKafkaSink: FirehoseResult = {
+  loaded: true,
+  loadError: '',
+  data: [
+    {
+      kind: KafkaSinkModel.kind,
+      apiVersion: `${KafkaSinkModel.apiGroup}/${KafkaSinkModel.apiVersion}`,
+      metadata: {
+        annotations: {
+          'camel.apache.org/kamelet.icon':
+            'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNDAgMjQwIj48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImEiIHgxPSIuNjY3IiB4Mj0iLjQxNyIgeTE9Ii4xNjciIHkyPSIuNzUiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iIzM3YWVlMiIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzFlOTZjOCIvPjwvbGluZWFyR3JhZGllbnQ+PGxpbmVhckdyYWRpZW50IGlkPSJiIiB4MT0iLjY2IiB4Mj0iLjg1MSIgeTE9Ii40MzciIHkyPSIuODAyIj48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiNlZmY3ZmMiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNmZmYiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48Y2lyY2xlIGN4PSIxMjAiIGN5PSIxMjAiIHI9IjEyMCIgZmlsbD0idXJsKCNhKSIvPjxwYXRoIGZpbGw9IiNjOGRhZWEiIGQ9Ik05OCAxNzVjLTMuODg4IDAtMy4yMjctMS40NjgtNC41NjgtNS4xN0w4MiAxMzIuMjA3IDE3MCA4MCIvPjxwYXRoIGZpbGw9IiNhOWM5ZGQiIGQ9Ik05OCAxNzVjMyAwIDQuMzI1LTEuMzcyIDYtM2wxNi0xNS41NTgtMTkuOTU4LTEyLjAzNSIvPjxwYXRoIGZpbGw9InVybCgjYikiIGQ9Ik0xMDAuMDQgMTQ0LjQxbDQ4LjM2IDM1LjcyOWM1LjUxOSAzLjA0NSA5LjUwMSAxLjQ2OCAxMC44NzYtNS4xMjNsMTkuNjg1LTkyLjc2M2MyLjAxNS04LjA4LTMuMDgtMTEuNzQ2LTguMzYtOS4zNDlsLTExNS41OSA0NC41NzFjLTcuODkgMy4xNjUtNy44NDMgNy41NjctMS40MzggOS41MjhsMjkuNjYzIDkuMjU5IDY4LjY3My00My4zMjVjMy4yNDItMS45NjYgNi4yMTgtLjkxIDMuNzc2IDEuMjU4Ii8+PC9zdmc+',
+        },
+        resourceVersion: '267611',
+        name: 'kafkasink-dummy',
+        uid: '3343caf6-dg43-420a-888e-e2c06aaaa843',
+        creationTimestamp: '2020-11-17T07:06:51Z',
+        generation: 3,
+        namespace: 'testproject3',
+      },
+      spec: {
+        topic: 'kafka-demo',
+        bootstrapServers: 'localhost:9092',
       },
       status: {
         conditions: [
@@ -1250,6 +1289,7 @@ export const MockKnativeResources: TopologyDataResources = {
   triggers: sampleTriggers,
   brokers: sampleBrokers,
   [CamelKameletBindingModel.plural]: sampleSourceKameletBinding,
+  [KafkaSinkModel.plural]: sampleSourceKafkaSink,
   [DomainMappingModel.plural]: sampleDomainMapping,
   [CamelKameletModel.plural]: sampleKamelets,
 };

--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
@@ -7,6 +7,7 @@ import {
   withDndDrop,
   withCreateConnector,
 } from '@patternfly/react-topology';
+import { ViewComponentFactory } from '@console/dynamic-plugin-sdk/src/extensions/topology-types';
 import { contextMenuActions } from '@console/topology/src/actions';
 import {
   NodeComponentProps,
@@ -31,6 +32,7 @@ import {
   TYPE_KAFKA_CONNECTION_LINK,
   TYPE_EVENT_SINK,
   TYPE_EVENT_SINK_LINK,
+  TYPE_KAFKA_SINK,
 } from '../const';
 import EventingPubSubLink from './edges/EventingPubSubLink';
 import EventSinkLink from './edges/EventSinkLink';
@@ -164,4 +166,15 @@ export const getKnativeComponentFactory = (
     default:
       return undefined;
   }
+};
+
+export const getKafkaSinkComponentFactory: ViewComponentFactory = (kind, type) => {
+  if (type === TYPE_KAFKA_SINK) {
+    return withEditReviewAccess('patch')(
+      withDragNode(nodeDragSourceSpec(type))(
+        withSelection({ controlled: true })(withContextMenu(contextMenuActions)(EventSink)),
+      ),
+    );
+  }
+  return undefined;
 };

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
@@ -18,6 +18,7 @@ import {
 } from '@patternfly/react-topology';
 import * as classNames from 'classnames';
 import { DeploymentModel } from '@console/internal/models';
+import { referenceForModel, referenceFor } from '@console/internal/module/k8s';
 import { usePodsWatcher } from '@console/shared';
 import {
   NodeShadows,
@@ -32,6 +33,7 @@ import {
   getFilterById,
   SHOW_LABELS_FILTER_ID,
 } from '@console/topology/src/filters';
+import { KafkaSinkModel } from '../../../models';
 import { getEventSourceIcon } from '../../../utils/get-knative-icon';
 import { usePodsForRevisions } from '../../../utils/usePodsForRevisions';
 import { TYPE_EVENT_SINK_LINK, TYPE_KAFKA_CONNECTION_LINK } from '../../const';
@@ -89,6 +91,8 @@ const EventSink: React.FC<EventSinkProps> = ({
     associatedDeployment.kind ?? DeploymentModel.kind,
     associatedDeployment.metadata?.namespace || resource.metadata?.namespace,
   );
+
+  const isKafkaSink = referenceFor(resource) === referenceForModel(KafkaSinkModel);
 
   const donutStatus = React.useMemo(() => {
     if (!revisionIds && loadedDeployment && !loadErrorDeployment) {
@@ -151,7 +155,9 @@ const EventSink: React.FC<EventSinkProps> = ({
         points={`${width / 2}, ${(height - size) / 2} ${width - (width - size) / 2},${height /
           2} ${width / 2},${height - (height - size) / 2} ${(width - size) / 2},${height / 2}`}
       />
-      {donutStatus && <PodSet size={size * 0.75} x={width / 2} y={height / 2} data={donutStatus} />}
+      {donutStatus && !isKafkaSink && (
+        <PodSet size={size * 0.75} x={width / 2} y={height / 2} data={donutStatus} />
+      )}
       <image
         x={width * 0.33}
         y={height * 0.33}

--- a/frontend/packages/knative-plugin/src/topology/const.ts
+++ b/frontend/packages/knative-plugin/src/topology/const.ts
@@ -2,6 +2,7 @@ import { DEFAULT_GROUP_PAD, GROUP_WIDTH } from '@console/topology/src/const';
 
 export const TYPE_EVENT_SOURCE = 'event-source';
 export const TYPE_EVENT_SINK = 'event-sink';
+export const TYPE_KAFKA_SINK = 'kafka-sink';
 export const TYPE_EVENT_SOURCE_KAFKA = 'event-source-kafka';
 export const TYPE_EVENT_SOURCE_LINK = 'event-source-link';
 export const TYPE_EVENT_SINK_LINK = 'event-sink-link';

--- a/frontend/packages/knative-plugin/src/topology/data-transformer.ts
+++ b/frontend/packages/knative-plugin/src/topology/data-transformer.ts
@@ -38,17 +38,37 @@ const addKnativeTopologyData = (
   addToTopologyDataModel(knativeResourceDataModel, graphModel);
 };
 
+const getKnativeTOpologyDataUtils = () => [
+  getKnativeServingRevisions,
+  getKnativeServingConfigurations,
+  getKnativeServingRoutes,
+  getKnativeServingServices,
+  getKnativeServingDomainMapping,
+];
+
+export const getKafkaSinkKnativeTopologyData = (
+  namespace: string,
+  resources: TopologyDataResources,
+): Promise<Model> => {
+  const knativeTopologyGraphModel: Model = { nodes: [], edges: [] };
+  const kafkaSinks = resources?.kafkasinks?.data ?? [];
+  const addTopologyData = (KnResources: K8sResourceKind[], type?: string) => {
+    addKnativeTopologyData(
+      knativeTopologyGraphModel,
+      KnResources,
+      type,
+      resources,
+      getKnativeTOpologyDataUtils(),
+    );
+  };
+  addTopologyData(kafkaSinks, NodeType.KafkaSink);
+  return Promise.resolve(knativeTopologyGraphModel);
+};
+
 export const getKnativeTopologyDataModel = (
   namespace: string,
   resources: TopologyDataResources,
 ): Promise<Model> => {
-  const utils = [
-    getKnativeServingRevisions,
-    getKnativeServingConfigurations,
-    getKnativeServingRoutes,
-    getKnativeServingServices,
-    getKnativeServingDomainMapping,
-  ];
   const eventSourceProps = getDynamicEventSourcesModelRefs();
   const channelResourceProps = getDynamicChannelModelRefs();
   const knativeTopologyGraphModel: Model = { nodes: [], edges: [] };
@@ -73,7 +93,13 @@ export const getKnativeTopologyDataModel = (
     resources,
   );
   const addTopologyData = (KnResources: K8sResourceKind[], type?: string) => {
-    addKnativeTopologyData(knativeTopologyGraphModel, KnResources, type, resources, utils);
+    addKnativeTopologyData(
+      knativeTopologyGraphModel,
+      KnResources,
+      type,
+      resources,
+      getKnativeTOpologyDataUtils(),
+    );
   };
 
   addTopologyData(knSvcResources, NodeType.KnService);
@@ -84,7 +110,7 @@ export const getKnativeTopologyDataModel = (
   addTopologyData(camelSourceKameletBindings, NodeType.EventSource);
   addTopologyData(camelSinkKameletBindings, NodeType.EventSink);
 
-  const revisionData = getRevisionsData(knRevResources, resources, utils);
+  const revisionData = getRevisionsData(knRevResources, resources, getKnativeTOpologyDataUtils());
 
   knativeTopologyGraphModel.nodes.forEach((n) => {
     if (n.type === NodeType.KnService) {

--- a/frontend/packages/knative-plugin/src/topology/data-transformer.ts
+++ b/frontend/packages/knative-plugin/src/topology/data-transformer.ts
@@ -38,7 +38,7 @@ const addKnativeTopologyData = (
   addToTopologyDataModel(knativeResourceDataModel, graphModel);
 };
 
-const getKnativeTOpologyDataUtils = () => [
+const getKnativeTopologyDataUtils = () => [
   getKnativeServingRevisions,
   getKnativeServingConfigurations,
   getKnativeServingRoutes,
@@ -58,7 +58,7 @@ export const getKafkaSinkKnativeTopologyData = (
       KnResources,
       type,
       resources,
-      getKnativeTOpologyDataUtils(),
+      getKnativeTopologyDataUtils(),
     );
   };
   addTopologyData(kafkaSinks, NodeType.KafkaSink);
@@ -98,7 +98,7 @@ export const getKnativeTopologyDataModel = (
       KnResources,
       type,
       resources,
-      getKnativeTOpologyDataUtils(),
+      getKnativeTopologyDataUtils(),
     );
   };
 
@@ -110,7 +110,7 @@ export const getKnativeTopologyDataModel = (
   addTopologyData(camelSourceKameletBindings, NodeType.EventSource);
   addTopologyData(camelSinkKameletBindings, NodeType.EventSink);
 
-  const revisionData = getRevisionsData(knRevResources, resources, getKnativeTOpologyDataUtils());
+  const revisionData = getRevisionsData(knRevResources, resources, getKnativeTopologyDataUtils());
 
   knativeTopologyGraphModel.nodes.forEach((n) => {
     if (n.type === NodeType.KnService) {

--- a/frontend/packages/knative-plugin/src/topology/index.ts
+++ b/frontend/packages/knative-plugin/src/topology/index.ts
@@ -7,3 +7,6 @@ export {
   providerProvidesServiceBinding,
   providerCreateServiceBinding,
 } from './relationship-provider';
+
+export { getKafkaSinkKnativeTopologyData } from './data-transformer';
+export { getKafkaSinkComponentFactory } from './components/knativeComponentFactory';

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -1159,6 +1159,7 @@ export const transformKnNodeData = (
   _.forEach(knResourcesData, (res) => {
     const item = createKnativeDeploymentItems(res, resources, utils);
     switch (type) {
+      case NodeType.KafkaSink:
       case NodeType.EventSink: {
         const data = createEventSinkTopologyNodeData(res, item, type);
         const itemData = getOwnedEventSinkData(res, data, resources);

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -491,7 +491,7 @@ export const getKnativeServiceData = (
   const configurations = getOwnedResources(resource, resources.configurations?.data);
   const revisions = getKnativeRevisionsData(resource, resources);
   const ksroutes = resources.ksroutes
-    ? getOwnedResources(resource, resources.ksroutes.data)
+    ? getOwnedResources(resource, resources.ksroutes?.data)
     : undefined;
   const eventSources = getSubscribedPubSubNodes(resource, resources);
   const overviewItem: KnativeItem = {
@@ -1060,11 +1060,11 @@ const getOwnedEventSourceData = (
 };
 
 const getOwnedEventSinkData = (resource: K8sResourceKind, data: TopologyDataObject, resources) => {
-  const ownedIntegrationData = getOwnedResources(resource, resources.integrations.data);
-  const ownedServiceData = getOwnedResources(ownedIntegrationData[0], resources.ksservices.data);
+  const ownedIntegrationData = getOwnedResources(resource, resources.integrations?.data);
+  const ownedServiceData = getOwnedResources(ownedIntegrationData[0], resources.ksservices?.data);
   const ownedDeploymentData = getOwnedResources(
     ownedIntegrationData[0],
-    resources.deployments.data,
+    resources.deployments?.data,
   );
   let knServiceData = {};
   if (ownedServiceData.length > 0) {

--- a/frontend/packages/knative-plugin/src/topology/topology-types.ts
+++ b/frontend/packages/knative-plugin/src/topology/topology-types.ts
@@ -12,6 +12,7 @@ export enum NodeType {
   SinkUri = 'sink-uri',
   EventSourceKafka = 'event-source-kafka',
   Kafka = 'knative-kafka',
+  KafkaSink = 'kafka-sink',
 }
 
 export enum EdgeType {

--- a/frontend/packages/topology/src/__tests__/topology-test-data.ts
+++ b/frontend/packages/topology/src/__tests__/topology-test-data.ts
@@ -1,6 +1,7 @@
 import { Model } from '@patternfly/react-topology';
 import { FirehoseResult } from '@console/internal/components/utils';
 import { EventKind } from '@console/internal/module/k8s';
+import { CamelKameletBindingModel, KafkaSinkModel } from '@console/knative-plugin';
 import { sampleDeployments } from '@console/shared/src/utils/__tests__/test-resource-data';
 import { NODE_HEIGHT, NODE_PADDING, NODE_WIDTH } from '../const';
 import { WorkloadModelProps } from '../data-transforms/transform-utils';
@@ -39,6 +40,8 @@ export const TEST_KINDS_MAP = {
   vmImports: 'VirtualMachineImport',
   brokers: 'Broker',
   triggers: 'Trigger',
+  [CamelKameletBindingModel.plural]: CamelKameletBindingModel.kind,
+  [KafkaSinkModel.kind]: KafkaSinkModel.kind,
 };
 
 export const resources: TopologyDataResources = {

--- a/frontend/packages/topology/src/components/side-bar/components/SideBarBody.tsx
+++ b/frontend/packages/topology/src/components/side-bar/components/SideBarBody.tsx
@@ -33,8 +33,9 @@ const SimpleTabNavWrapper: React.FC<{ tabs: Tab[] }> = ({ tabs }) => {
 };
 
 const SideBarBody: React.FC<{ element: GraphElement }> = ({ element }) => {
+  const uid = element.getId();
   return (
-    <SideBarTabLoader element={element}>
+    <SideBarTabLoader key={uid} element={element}>
       {(tabs, loaded) => (loaded ? <SimpleTabNavWrapper tabs={tabs} /> : null)}
     </SideBarTabLoader>
   );

--- a/frontend/packages/topology/src/utils/application-utils.ts
+++ b/frontend/packages/topology/src/utils/application-utils.ts
@@ -26,7 +26,9 @@ import {
   referenceFor,
 } from '@console/internal/module/k8s';
 import {
+  CamelKameletBindingModel,
   EventingBrokerModel,
+  KafkaSinkModel,
   ServiceModel as KnativeServiceModel,
 } from '@console/knative-plugin/src/models';
 import {
@@ -236,6 +238,10 @@ export const cleanUpWorkload = async (
       break;
     case KnativeServiceModel.kind:
       batchDeleteRequests(knativeDeleteModels, resourceData);
+      break;
+    case CamelKameletBindingModel.kind:
+    case KafkaSinkModel.kind:
+      deleteRequest(resourceModel, resource);
       break;
     default:
       break;


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-6628
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Missing visualization of kafka Sink
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Added support for Kafka sink in Topology view
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Kapture 2022-04-11 at 20 29 55](https://user-images.githubusercontent.com/9278015/163190270-6a9eca62-b5b8-4f55-93a7-f74c81d45b05.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Creation of Kafka Sink

- Install Serverless Operator
- Create KnativeKafka CR (KnativeEventing CR is required to create KF CR). 
- Expand Sink section on Form view and enable sink
- Install AMQ streams
- Create namespace kafka
- Create Kaka cluster (Kafka CR from AMQ streams) with default values (make note of name/ns for example- my-cluster-kafka-bootstrap.kafka.svc:9092)
- Create kafka topic as below
```
apiVersion: kafka.strimzi.io/v1beta2
kind: KafkaTopic
metadata:
  name: knative-demo-topic
  namespace: kafka
  labels:
    strimzi.io/cluster: my-cluster # kafka cluster name
spec:
  partitions: 3
  replicas: 1
  config:
    retention.ms: 7200000
    segment.bytes: 1073741824
```
- Create Kafka Sink
```
apiVersion: eventing.knative.dev/v1alpha1
kind: KafkaSink
metadata:
  name: my-kafka-sink
  namespace: kafka
spec:
  topic: knative-demo-topic # KafkaTopic name
  bootstrapServers:
   - my-cluster-kafka-bootstrap.kafka:9092 # Kafka cluster bootstrap server
 ```

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
