### PR TITLE
use incluster tekton hub Api endpoint in pipeline builder

### DIFF
--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -318,6 +318,8 @@
   "{{taskLabel}} details": "{{taskLabel}} details",
   "TektonConfig": "TektonConfig",
   "TektonConfigs": "TektonConfigs",
+  "TektonHub": "TektonHub",
+  "TektonHubs": "TektonHubs",
   "Pipeline {{status}}": "Pipeline {{status}}",
   "Pipeline status is {{status}}. View logs.": "Pipeline status is {{status}}. View logs.",
   "Pipeline not started. Start pipeline.": "Pipeline not started. Start pipeline.",

--- a/frontend/packages/pipelines-plugin/src/components/catalog/apis/__tests__/tektonHub.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/apis/__tests__/tektonHub.spec.ts
@@ -1,12 +1,22 @@
+import { act } from 'react-dom/test-utils';
 import { setUtilsConfig } from '@console/dynamic-plugin-sdk/src/app/configSetup';
 import { appInternalFetch } from '@console/internal/co-fetch';
+import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
+import { testHook } from '../../../../../../../__tests__/utils/hooks-utils';
 import { sampleTektonHubCatalogItem } from '../../../../test-data/catalog-item-data';
+import { sampleTektonHubCR } from '../../../../test-data/tektonhub-data';
 import {
   TektonHubTaskVersion,
   getApiResponse,
   getHubUIPath,
   TEKTON_HUB_ENDPOINT,
+  useInclusterTektonHubURLs,
+  TEKTON_HUB_API_ENDPOINT,
 } from '../tektonHub';
+
+jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
+  useK8sGet: jest.fn(),
+}));
 
 const emptyHeaders = new Headers();
 const apiResults = ({
@@ -92,5 +102,87 @@ describe('getHubUIPath', () => {
 
   it('should return custom path url if the baseurl param is passed as a second argument', () => {
     expect(getHubUIPath('test-path', 'https://hub-ui.com')).toBe(`https://hub-ui.com/test-path`);
+  });
+});
+
+describe('useInClusterTektonHubURLs:', () => {
+  it('should return public tekton hub endpoint incase of hub CR not found', async () => {
+    (useK8sGet as jest.Mock).mockReturnValue([
+      null,
+      true,
+      'error fetching tektonhubs.operator.tekton.dev "hub" not found',
+    ]);
+    const { result } = testHook(() => useInclusterTektonHubURLs());
+    expect(result.current).toEqual({
+      loaded: true,
+      apiURL: TEKTON_HUB_API_ENDPOINT,
+      uiURL: TEKTON_HUB_ENDPOINT,
+    });
+  });
+
+  it('should return public tekton hub endpoint when hub is installed and if status field missing', async () => {
+    const sampleHubWithoutApiURL = {
+      ...sampleTektonHubCR,
+      status: null,
+    };
+    (useK8sGet as jest.Mock).mockReturnValue([sampleHubWithoutApiURL, true, '']);
+    const { result } = testHook(() => useInclusterTektonHubURLs());
+    expect(result.current).toEqual({
+      loaded: true,
+      apiURL: TEKTON_HUB_API_ENDPOINT,
+      uiURL: TEKTON_HUB_ENDPOINT,
+    });
+  });
+
+  it('should return public tekton hub endpoint when hub is installed but urls are missing', async () => {
+    const sampleHubWithoutApiURL = {
+      ...sampleTektonHubCR,
+      status: {
+        ...sampleTektonHubCR.status,
+        apiUrl: '',
+        uiUrl: '',
+      },
+    };
+    (useK8sGet as jest.Mock).mockReturnValue([sampleHubWithoutApiURL, true, '']);
+    const { result } = testHook(() => useInclusterTektonHubURLs());
+    expect(result.current).toEqual({
+      loaded: true,
+      apiURL: TEKTON_HUB_API_ENDPOINT,
+      uiURL: TEKTON_HUB_ENDPOINT,
+    });
+  });
+
+  it('should return incluster tekton hub endpoint when hub is installed', async () => {
+    (useK8sGet as jest.Mock).mockReturnValue([sampleTektonHubCR, true, '']);
+    const { result } = testHook(() => useInclusterTektonHubURLs());
+    expect(result.current).toEqual({
+      loaded: true,
+      apiURL: sampleTektonHubCR.status.apiUrl,
+      uiURL: sampleTektonHubCR.status.uiUrl,
+    });
+  });
+
+  it('should return the apiUrl and uiUrl when the api call the hub has urls in the status', async () => {
+    const sampleHubWithoutApiURL = {
+      ...sampleTektonHubCR,
+      status: null,
+    };
+    (useK8sGet as jest.Mock).mockReturnValue([sampleHubWithoutApiURL, true, '']);
+    const { result, rerender } = testHook(() => useInclusterTektonHubURLs());
+    expect(result.current).toEqual({
+      loaded: true,
+      apiURL: TEKTON_HUB_API_ENDPOINT,
+      uiURL: TEKTON_HUB_ENDPOINT,
+    });
+
+    (useK8sGet as jest.Mock).mockReturnValue([sampleTektonHubCR, true, '']);
+    act(() => {
+      rerender();
+    });
+    expect(result.current).toEqual({
+      loaded: true,
+      apiURL: sampleTektonHubCR.status.apiUrl,
+      uiURL: sampleTektonHubCR.status.uiUrl,
+    });
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/catalog/apis/__tests__/tektonHub.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/apis/__tests__/tektonHub.spec.ts
@@ -89,4 +89,8 @@ describe('getHubUIPath', () => {
     expect(getHubUIPath('test')).not.toBeNull();
     expect(getHubUIPath('test-path')).toBe(`${TEKTON_HUB_ENDPOINT}/test-path`);
   });
+
+  it('should return custom path url if the baseurl param is passed as a second argument', () => {
+    expect(getHubUIPath('test-path', 'https://hub-ui.com')).toBe(`https://hub-ui.com/test-path`);
+  });
 });

--- a/frontend/packages/pipelines-plugin/src/components/catalog/apis/tektonHub.ts
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/apis/tektonHub.ts
@@ -1,7 +1,7 @@
 import { coFetch } from '@console/internal/co-fetch';
 import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
-import { K8sResourceKind } from '@console/internal/module/k8s';
 import { TektonHubModel } from '../../../models';
+import { TektonHub } from '../../../types/hub';
 import useApiResponse, { ApiResult } from '../hooks/useApiResponse';
 
 export type TektonHubItem = {
@@ -60,7 +60,7 @@ export const getHubUIPath = (path: string = '', baseURL: string = TEKTON_HUB_END
 export const getApiResponse = async (url: string) => (await coFetch(url)).json();
 
 export const useInclusterTektonHubURLs = () => {
-  const [hub, loaded] = useK8sGet<K8sResourceKind>(TektonHubModel, 'hub');
+  const [hub, loaded] = useK8sGet<TektonHub>(TektonHubModel, 'hub');
   // check in-cluster hub exists, if yes use incluster hub instance api url and ui url
   return {
     loaded,

--- a/frontend/packages/pipelines-plugin/src/components/catalog/apis/tektonHub.ts
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/apis/tektonHub.ts
@@ -1,4 +1,7 @@
 import { coFetch } from '@console/internal/co-fetch';
+import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { TektonHubModel } from '../../../models';
 import useApiResponse, { ApiResult } from '../hooks/useApiResponse';
 
 export type TektonHubItem = {
@@ -42,29 +45,47 @@ export type TektonHubTask = {
   tags: TektonHubTag[];
   rating: number;
 };
-
-export const TEKTON_HUB_API_ENDPOINT = 'https://api.hub.tekton.dev/v1';
+export const TEKTON_HUB_API_VERSION = 'v1';
+export const TEKTON_HUB_API_ENDPOINT = 'https://api.hub.tekton.dev';
 export const TEKTON_HUB_ENDPOINT = `https://hub.tekton.dev`;
 export const TEKTON_HUB_INTEGRATION_KEY = 'enable-devconsole-integration';
 
-export const getHubUIPath = (path: string = ''): string => {
+export const getHubUIPath = (path: string = '', baseURL: string = TEKTON_HUB_ENDPOINT): string => {
   if (!path) {
     return null;
   }
-  return path ? `${TEKTON_HUB_ENDPOINT}/${path}` : TEKTON_HUB_ENDPOINT;
+  return `${baseURL}/${path}`;
 };
 
 export const getApiResponse = async (url: string) => (await coFetch(url)).json();
 
-export const useTektonHubResources = (hasPermission: boolean): ApiResult<TektonHubTask[]> => {
-  return useApiResponse<TektonHubTask>(`${TEKTON_HUB_API_ENDPOINT}/resources`, hasPermission);
+export const useInclusterTektonHubURLs = () => {
+  const [hub, loaded] = useK8sGet<K8sResourceKind>(TektonHubModel, 'hub');
+  // check in-cluster hub exists, if yes use incluster hub instance api url and ui url
+  return {
+    loaded,
+    apiURL: hub?.status?.apiUrl || TEKTON_HUB_API_ENDPOINT,
+    uiURL: hub?.status?.uiUrl || TEKTON_HUB_ENDPOINT,
+  };
+};
+
+export const useTektonHubResources = (
+  baseURL,
+  hasPermission: boolean,
+): ApiResult<TektonHubTask[]> => {
+  return useApiResponse<TektonHubTask>(
+    `${baseURL}/${TEKTON_HUB_API_VERSION}/resources`,
+    hasPermission,
+  );
 };
 
 export const getTektonHubTaskVersions = async (
   resourceId: string,
+  baseURL?: string,
 ): Promise<TektonHubTaskVersion[]> => {
+  const API_BASE_URL = baseURL || TEKTON_HUB_API_ENDPOINT;
   const response = await getApiResponse(
-    `${TEKTON_HUB_API_ENDPOINT}/resource/${resourceId}/versions`,
+    `${API_BASE_URL}/${TEKTON_HUB_API_VERSION}/resource/${resourceId}/versions`,
   );
   return response?.data?.versions ?? [];
 };

--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/PipelineQuickSearchDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/PipelineQuickSearchDetails.tsx
@@ -54,7 +54,7 @@ const PipelineQuickSearchDetails: React.FC<QuickSearchDetailsRendererProps> = ({
     resetVersions();
     let mounted = true;
     if (isTektonHubTaskWithoutVersions(selectedItem)) {
-      getTektonHubTaskVersions(selectedItem.data.id)
+      getTektonHubTaskVersions(selectedItem.data.id, selectedItem.attributes.apiURL)
         .then((itemVersions = []) => {
           if (mounted) {
             setVersions([...itemVersions]);
@@ -85,7 +85,7 @@ const PipelineQuickSearchDetails: React.FC<QuickSearchDetailsRendererProps> = ({
     [selectedVersion, versions],
   );
 
-  const hubLink = getHubUIPath(loadedVersion?.hubURLPath);
+  const hubLink = getHubUIPath(loadedVersion?.hubURLPath, selectedItem.attributes.uiURL);
 
   return (
     <div className="opp-quick-search-details">

--- a/frontend/packages/pipelines-plugin/src/models/pipelines.ts
+++ b/frontend/packages/pipelines-plugin/src/models/pipelines.ts
@@ -237,3 +237,20 @@ export const TektonConfigModel: K8sKind = {
   labelPlural: 'TektonConfigs',
   crd: true,
 };
+
+export const TektonHubModel: K8sKind = {
+  apiGroup: 'operator.tekton.dev',
+  apiVersion: 'v1alpha1',
+  label: 'TektonHub',
+  // t('pipelines-plugin~TektonHub')
+  labelKey: 'pipelines-plugin~TektonHub',
+  // t('pipelines-plugin~TektonHubs')
+  labelPluralKey: 'pipelines-plugin~TektonHubs',
+  plural: 'tektonhubs',
+  abbr: 'TH',
+  namespaced: false,
+  kind: 'TektonHub',
+  id: 'tektonhub',
+  labelPlural: 'TektonHubs',
+  crd: true,
+};

--- a/frontend/packages/pipelines-plugin/src/test-data/tektonhub-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/tektonhub-data.ts
@@ -1,0 +1,87 @@
+import { TektonHub } from '../types/hub';
+
+export const sampleTektonHubCR: TektonHub = {
+  apiVersion: 'operator.tekton.dev/v1alpha1',
+  kind: 'TektonHub',
+  metadata: {
+    creationTimestamp: '2022-04-14T09:56:29Z',
+    name: 'hub',
+    resourceVersion: '91182',
+    uid: '247a09d7-3de3-4e21-92ec-238b99d97c2b',
+  },
+  spec: {
+    api: {
+      hubConfigUrl: 'https://raw.githubusercontent.com/karthikjeeyar/hub/main/config.yaml',
+      secret: 'tekton-hub-api',
+    },
+    db: {
+      secret: 'tekton-hub-db',
+    },
+    targetNamespace: 'karthik',
+  },
+  status: {
+    apiUrl: 'https://tekton-hub-api.devcluster.openshift.com',
+    authUrl: 'https://tekton-hub-auth.devcluster.openshift.com',
+    conditions: [
+      {
+        lastTransitionTime: '2022-04-14T10:00:00Z',
+        status: 'True',
+        type: 'ApiDependenciesInstalled',
+      },
+      {
+        lastTransitionTime: '2022-04-14T09:59:45Z',
+        status: 'True',
+        type: 'ApiInstallSetAvailable',
+      },
+      {
+        lastTransitionTime: '2022-04-14T09:59:04Z',
+        status: 'True',
+        type: 'DatabasebMigrationDone',
+      },
+      {
+        lastTransitionTime: '2022-04-14T09:57:52Z',
+        status: 'True',
+        type: 'DbDependenciesInstalled',
+      },
+      {
+        lastTransitionTime: '2022-04-14T09:58:43Z',
+        status: 'True',
+        type: 'DbInstallSetAvailable',
+      },
+      {
+        lastTransitionTime: '2022-04-14T10:00:00Z',
+        status: 'True',
+        type: 'PostReconciler',
+      },
+      {
+        lastTransitionTime: '2022-04-14T09:57:52Z',
+        status: 'True',
+        type: 'PreReconciler',
+      },
+      {
+        lastTransitionTime: '2022-04-14T10:00:00Z',
+        status: 'True',
+        type: 'Ready',
+      },
+      {
+        lastTransitionTime: '2022-04-14T09:59:45Z',
+        status: 'True',
+        type: 'UiDependenciesInstalled',
+      },
+      {
+        lastTransitionTime: '2022-04-14T10:00:00Z',
+        status: 'True',
+        type: 'UiInstallSetAvailable',
+      },
+    ],
+    hubInstallerSets: {
+      ApiInstallerSet: 'tekton-hub-api-w6m9z',
+      DbInstallerSet: 'tekton-hub-db-8mzw8',
+      DbMigrationInstallerSet: 'tekton-hub-db-migration-zkn9p',
+      UiInstallerSet: 'tekton-hub-ui-fjbbb',
+    },
+    observedGeneration: 1,
+    uiUrl: 'https://tekton-hub-ui.devcluster.openshift.com',
+    version: 'v1.7.1',
+  },
+};

--- a/frontend/packages/pipelines-plugin/src/types/hub.ts
+++ b/frontend/packages/pipelines-plugin/src/types/hub.ts
@@ -1,0 +1,29 @@
+import { K8sResourceCommon } from 'packages/console-dynamic-plugin-sdk/src';
+import { Condition } from './pipelineRun';
+
+export type TektonHub = K8sResourceCommon & {
+  spec: {
+    api: {
+      hubConfigUrl: string;
+      secret: string;
+    };
+    db: {
+      secret: string;
+    };
+    targetNamespace: string;
+  };
+  status: {
+    apiUrl: string;
+    uiUrl: string;
+    authUrl: string;
+    conditions: Condition[];
+    hubInstallerSets: {
+      ApiInstallerSet: string;
+      DbInstallerSet: string;
+      DbMigrationInstallerSet: string;
+      UiInstallerSet: string;
+    };
+    observedGeneration: number;
+    version: string;
+  };
+};


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6136

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Pipeline builder only supports public tektonhub endpoint and as part of this ticket we need to support incluster tekton hub.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Read the tektonHub (hub) CR to get the API, UI urls and use them to populate the tasks in pipeline builder. If the In cluster tekton hub is not installed then fallback to public endpoint.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

API call is made to in-cluster tektonhub url 
 ie. `https://tekton-hub-api-karthik.apps.13apr22.devcluster.openshift.com/v1/resources` 

<img width="1764" alt="Screenshot 2022-04-13 at 8 09 56 PM" src="https://user-images.githubusercontent.com/9964343/163217413-30166341-824d-4eb3-b498-b9915865b8ab.png">


**Unit test coverage report**: 
<!-- Attach test coverage report -->
```
    ✓ should return custom path url if the baseurl param is passed as a second argument (1ms)
    
 useInClusterTektonHubURLs:
    ✓ should return public tekton hub endpoint incase of hub CR not found (11ms)
    ✓ should return public tekton hub endpoint when hub is installed and if status field missing (2ms)
    ✓ should return public tekton hub endpoint when hub is installed but urls are missing (1ms)
    ✓ should return incluster tekton hub endpoint when hub is installed (1ms)
    ✓ should return the apiUrl and uiUrl when the api call the hub has urls in the status (1ms)
 ```


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Install OSP 1.7.0 from custom catalogsource -> https://artifacts.ospqa.com/builds/1.7.0
2. Follow the tektonhub docs to install incluster tektonhub 
    https://github.com/tektoncd/operator/blob/main/docs/TektonHub.md

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

@siamaksade @serenamarie125 