### PR TITLE
Bug 2073329: fix pipelineruns name in repository details page

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryDetailsPage.tsx
@@ -32,7 +32,7 @@ const RepositoryDetailsPage: React.FC<DetailsPageProps> = (props) => {
         navFactory.editYaml(),
         {
           href: 'Runs',
-          name: t('pipelines-plugin~Pipeline Runs'),
+          name: t('pipelines-plugin~PipelineRuns'),
           component: RepositoryPipelineRunListPage,
         },
       ]}


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2073329

**Screenshot:**
![Screenshot from 2022-04-14 01-31-56](https://user-images.githubusercontent.com/22490998/163260783-97a3d9e2-15b5-4bec-bafe-6ecd070c6864.png)

/kind bug