### PR TITLE
Hide Upgrade Cluster Alert in About Modal When Externally Managed

### DIFF
--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useCanClusterUpgrade';
 export * from './formik-validation-fix';
 export * from './deep-compare-memoize';
 export * from './document-listener';

--- a/frontend/packages/console-shared/src/hooks/useCanClusterUpgrade.ts
+++ b/frontend/packages/console-shared/src/hooks/useCanClusterUpgrade.ts
@@ -1,0 +1,21 @@
+import { useAccessReviewAllowed } from '@console/dynamic-plugin-sdk';
+import { ClusterVersionModel } from '@console/internal/models';
+import { ClusterVersionKind, hasAvailableUpdates } from '@console/internal/module/k8s';
+
+export const isClusterExternallyManaged = (): boolean => {
+  return window.SERVER_FLAGS.controlPlaneTopology === 'External';
+};
+
+export const useCanClusterUpgrade = (clusterVersion: ClusterVersionKind): boolean => {
+  const hasPermissionsToUpdate = useAccessReviewAllowed({
+    group: ClusterVersionModel.apiGroup,
+    resource: ClusterVersionModel.plural,
+    verb: 'patch',
+    name: 'version',
+  });
+  const notExternallyManaged = !isClusterExternallyManaged();
+  const bandingNotDedicated = window.SERVER_FLAGS.branding !== 'dedicated';
+  const canPerformUpgrade = hasPermissionsToUpdate && bandingNotDedicated && notExternallyManaged;
+
+  return hasAvailableUpdates(clusterVersion) && canPerformUpgrade;
+};

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -8,23 +8,15 @@ import {
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { Trans, useTranslation } from 'react-i18next';
-import { useClusterVersion, BlueArrowCircleUpIcon } from '@console/shared';
+import { useClusterVersion, BlueArrowCircleUpIcon, useCanClusterUpgrade } from '@console/shared';
 import { getBrandingDetails } from './masthead';
-import {
-  ReleaseNotesLink,
-  ServiceLevel,
-  useServiceLevelTitle,
-  ServiceLevelText,
-  useAccessReview,
-} from './utils';
-import { ClusterVersionModel } from '../models';
+import { ReleaseNotesLink, ServiceLevel, useServiceLevelTitle, ServiceLevelText } from './utils';
 import { k8sVersion } from '../module/status';
 import {
   getClusterID,
   getCurrentVersion,
   getK8sGitVersion,
   getOpenShiftVersion,
-  hasAvailableUpdates,
 } from '../module/k8s/cluster-settings';
 
 const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) => {
@@ -36,21 +28,15 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) =>
       .catch(() => setKubernetesVersion(t('public~unknown')));
   }, [t]);
   const clusterVersion = useClusterVersion();
+  const canUpgrade = useCanClusterUpgrade(clusterVersion);
 
   const clusterID = getClusterID(clusterVersion);
   const channel: string = clusterVersion?.spec?.channel;
   const openshiftVersion = getOpenShiftVersion(clusterVersion);
-  const clusterVersionIsEditable =
-    useAccessReview({
-      group: ClusterVersionModel.apiGroup,
-      resource: ClusterVersionModel.plural,
-      verb: 'patch',
-      name: 'version',
-    }) && window.SERVER_FLAGS.branding !== 'dedicated';
 
   return (
     <>
-      {clusterVersion && hasAvailableUpdates(clusterVersion) && clusterVersionIsEditable && (
+      {canUpgrade && (
         <Alert
           className="co-alert co-about-modal__alert"
           title={


### PR DESCRIPTION
## What

https://issues.redhat.com/browse/CONSOLE-3088

When a cluster is being managed by an external factor, in this case HyperShift, we do not want to allow the user to access the upgrade window. This PR strives to hide the about modal's upgrade link.

## Before Screenshot

![Screen Shot 2022-04-13 at 4 58 56 PM](https://user-images.githubusercontent.com/8126518/163271522-05cdd980-6860-4eb7-9a1c-b9e33dd88328.png)


## After Screenshot

![Screen Shot 2022-04-13 at 4 58 42 PM](https://user-images.githubusercontent.com/8126518/163271520-8dba0ab3-eb83-47d7-89f2-8785c255ce2d.png)

## Setup / Testing

It's based on the SERVER_FLAG `controlPlaneTopology` being set to `External` is really the driving factor here; this can be done in one of two ways:

- Locally via a Bridge Variable, `export BRIDGE_CONTROL_PLANE_TOPOLOGY_MODE="External"`
- Locally / OnCluster via modifying the `window.SERVER_FLAGS.controlPlaneTopology` to `External` in the dev tools

This was tested using a 4.10.3 cluster set on the `candidate-4.10` upgrade channel using 4.11 frontend code.

## Followup testing points

- [ ] I'd like to investigate trying to set up a 4.11 cluster and configure an upgrade path to test it more properly from that front, but I'm unsure if the UI will behave as expected ([slack convo](https://coreos.slack.com/archives/C6A3NV5J9/p1649693734845359?thread_ts=1649692406.072849&cid=C6A3NV5J9))