### PR TITLE
Bug 2072999: Add params prop to HorizontalNav component

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.tsx
@@ -38,7 +38,7 @@ class PipelineRunLogsWithTranslation extends React.Component<
     const { obj, activeTask } = this.props;
     const taskRunFromYaml = _.get(obj, ['status', 'taskRuns'], {});
     const taskRuns = this.getSortedTaskRun(taskRunFromYaml);
-    const activeItem = this.getActiveTaskRun(taskRuns, activeTask);
+    const activeItem = this.getActiveTaskRun(obj, taskRuns, activeTask);
     this.setState({ activeItem });
   }
 
@@ -47,15 +47,18 @@ class PipelineRunLogsWithTranslation extends React.Component<
       const { obj, activeTask } = this.props;
       const taskRunFromYaml = _.get(obj, ['status', 'taskRuns'], {});
       const taskRuns = this.getSortedTaskRun(taskRunFromYaml);
-      const activeItem = this.getActiveTaskRun(taskRuns, activeTask);
+      const activeItem = this.getActiveTaskRun(obj, taskRuns, activeTask);
       this.state.navUntouched && this.setState({ activeItem });
     }
   }
 
-  getActiveTaskRun = (taskRuns: string[], activeTask: string): string =>
-    activeTask
-      ? taskRuns.find((taskRun) => taskRun.includes(activeTask))
-      : taskRuns[taskRuns.length - 1];
+  getActiveTaskRun = (obj: PipelineRunKind, taskRuns: string[], activeTask: string): string => {
+    const activeTaskRun: string = _.findKey(
+      obj?.status?.taskRuns,
+      (taskRun) => taskRun.pipelineTaskName === activeTask,
+    );
+    return activeTaskRun || taskRuns[taskRuns.length - 1];
+  };
 
   getSortedTaskRun = (taskRunFromYaml) => {
     const taskRuns = Object.keys(taskRunFromYaml).sort((a, b) => {

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -329,6 +329,7 @@ export const HorizontalNav = React.memo((props: HorizontalNavProps) => {
             {...extraResources}
             {...p.pageData}
             customData={props.customData}
+            params={params}
           />
         </ErrorBoundary>
       );


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=2072999

**Analysis / Root cause**: 
`params` prop is undefined for HorizontalNav `PipelineRunLogs` component

**Solution Description**: 
Add params prop to HorizontalNav component.

**Screenshots / GIF:**
![Kapture 2022-04-20 at 15 27 54](https://user-images.githubusercontent.com/2561818/164203294-592dc17c-ec98-4f1d-83e4-16ffc2b735f8.gif)



