### PR TITLE
Bug 2071617: Stop disabling extensions with non-existing `disallowed` flags

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
@@ -169,7 +169,7 @@ describe('isExtensionInUse', () => {
 
   it('returns true only for the right combination of flag values', () => {
     // Generate all possible combinations (i.e. variations with repetition)
-    const allFlagCombos = Combinatorics.baseN([true, false, undefined], 4)
+    const allFlagCombos = Combinatorics.baseN([true, false], 4)
       .toArray()
       .map<ReturnType<typeof flags>>((combination) =>
         flags(combination[0], combination[1], combination[2], combination[3]),
@@ -188,6 +188,12 @@ describe('isExtensionInUse', () => {
     failFlagCombos.forEach((combo) => {
       expect(isExtensionInUse(gatedExtension, combo)).toBe(false);
     });
+
+    // When the flag value is undefined, having the flag in `required` array should put the extension out of use
+    expect(isExtensionInUse(gatedExtension, flags(undefined, undefined, false, false))).toBe(false);
+
+    // When the flag value is undefined, having the flag in `disallowed` array should keep the extension in use
+    expect(isExtensionInUse(gatedExtension, flags(true, true, undefined, undefined))).toBe(true);
   });
 });
 

--- a/frontend/packages/console-plugin-sdk/src/store.ts
+++ b/frontend/packages/console-plugin-sdk/src/store.ts
@@ -24,8 +24,7 @@ export const augmentExtension = <E extends Extension>(
   });
 
 export const isExtensionInUse = (e: Extension, flags: FlagsObject): boolean =>
-  e.flags.required.every((f) => flags[f] === true) &&
-  e.flags.disallowed.every((f) => flags[f] === false);
+  e.flags.required.every((f) => flags[f]) && e.flags.disallowed.every((f) => !flags[f]);
 
 export const getGatingFlagNames = (extensions: Extension[]): string[] =>
   _.uniq([


### PR DESCRIPTION
As of now, If flags in `disallowed` do not exist e.g. `"disallowed": ["KUBEVIRT_DYNAMIC"]`, the extension is disabled.

The extension should only be disabled if the flag exists and it is set to `true`.