### PR TITLE
Bug 2024708: Don't use lodash startCase on default operand field labels

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/utils.ts
+++ b/frontend/packages/console-shared/src/components/dynamic-form/utils.ts
@@ -18,7 +18,7 @@ export const useSchemaLabel = (schema: JSONSchema7, uiSchema: UiSchema, defaultL
   const options = getUiOptions(uiSchema ?? {});
   const showLabel = options?.label ?? true;
   const label = (options?.title || schema?.title) as string;
-  return [showLabel, label || _.startCase(defaultLabel)] as [boolean, string];
+  return [showLabel, label || defaultLabel] as [boolean, string];
 };
 
 export const useSchemaDescription = (

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.spec.ts
@@ -156,9 +156,9 @@ describe('Using OLM descriptor components', () => {
     cy.get(`#${FIELD_GROUP_ID}_accordion-toggle`)
       .should('exist')
       .click();
-    cy.get(`[for="${FIELD_GROUP_ID}_itemOne"]`).should('have.text', 'Item One');
+    cy.get(`[for="${FIELD_GROUP_ID}_itemOne"]`).should('have.text', 'itemOne');
     cy.get(`#${FIELD_GROUP_ID}_itemOne`).should('have.value', testCR.spec.fieldGroup.itemOne);
-    cy.get(`[for="${FIELD_GROUP_ID}_itemTwo"]`).should('have.text', 'Item Two');
+    cy.get(`[for="${FIELD_GROUP_ID}_itemTwo"]`).should('have.text', 'itemTwo');
     cy.get(`#${FIELD_GROUP_ID}_itemTwo`).should('have.value', testCR.spec.fieldGroup.itemTwo);
   });
 


### PR DESCRIPTION
Remove lodash startCase from fallback operand form field labels. The fallback label is the field name from the schema, which should be displayed as-is.