### PR TITLE
Automation of Service bindings | dev-console

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-operator-backed.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-operator-backed.feature
@@ -3,15 +3,15 @@ Feature: Create workload from Operator Backed file
               As a user, I want to create the application, component or service from Developer Catalog Operator backed file
 
         Background:
-            Given user has installed OpenShift Serverless Operator
-              And user is at developer perspective
+            Given user is at developer perspective
               And user is at Add page
 
 
 # Below scenario needs to be executed only once. Second time it throws error. So not recommended to execute in automation suite
         @regression @manual
         Scenario: Create the Knative Kafka workload from Operator Backed: A-08-TC01
-            Given user has not created kafka instance in "knative-eventing" namespace
+            Given user has installed OpenShift Serverless Operator
+              And user has not created kafka instance in "knative-eventing" namespace
               And user has created or selected namespace "knative-eventing"
               And user is at OperatorBacked page
              When user selects knative Kafka card
@@ -24,7 +24,8 @@ Feature: Create workload from Operator Backed file
 
         @smoke @manual
         Scenario: Perform cancel operation: A-08-TC02
-            Given user has created or selected namespace "knative-eventing"
+            Given user has installed OpenShift Serverless Operator
+              And user has created or selected namespace "knative-eventing"
               And user is at OperatorBacked page
              When user selects knative Serving card
               And user clicks Create button in side bar
@@ -45,7 +46,7 @@ Feature: Create workload from Operator Backed file
               And user is able to see "jaeger-all-in-one-inmemory1" in Topology page
 
 
-        @regression @to-do @odc-6467
+        @regression @odc-6467
         Scenario: Bindable resource in Operator Backed: A-08-TC05
             Given user has installed Service Binding operator
               And user has installed Crunchy Postgres for Kubernetes operator
@@ -56,7 +57,7 @@ Feature: Create workload from Operator Backed file
               And user will see "Bindable" label in "Postgres Cluster" sidebar
 
 
-        @regression @to-do @odc-6467
+        @regression @odc-6467
         Scenario: Bindable filter for service binding in Operator Backed: A-08-TC06
             Given user has installed Service Binding operator
               And user has installed Crunchy Postgres for Kubernetes operator

--- a/frontend/packages/dev-console/integration-tests/features/addFlow/quick-search-add.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/quick-search-add.feature
@@ -57,7 +57,7 @@ Feature: Provide quick search in Add page
              Then user is taken to the Topology page with "devfile-sample-git" workload created
 
 
-        @regression @to-do @odc-6467
+        @regression @odc-6467
         Scenario: Bindable resource in Quick Add: A-11-TC07
             Given user has installed Service Binding operator
               And user has installed Crunchy Postgres for Kubernetes operator

--- a/frontend/packages/dev-console/integration-tests/support/constants/global.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/global.ts
@@ -33,6 +33,7 @@ export enum operators {
   RedHatCodereadyWorkspaces = 'Red Hat CodeReady Workspaces',
   GitopsPrimer = 'gitops-primer',
   ServiceBinding = 'Service Binding Operator',
+  CrunchyPostgresforKubernetes = 'Crunchy Postgres for Kubernetes',
 }
 
 export enum authenticationType {

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -101,6 +101,8 @@ export const gitPO = {
 
 export const catalogPO = {
   search: 'input[placeholder="Filter by keyword..."]',
+  filterKeyword: 'input.pf-c-search-input__text-input',
+  templateTitle: '.catalog-tile-pf-title',
   card: '.pf-c-card',
   cardBadge: 'span.pf-c-badge',
   groupBy: '[data-test-id="dropdown-button"]',
@@ -112,6 +114,12 @@ export const catalogPO = {
   cardList: '[role="grid"]',
   cardHeader: '.pf-c-badge.pf-m-read',
   groupByMenu: 'pf-c-dropdown__menu',
+  catalogBatch: '.odc-catalog-badges',
+  batchLabel: '.odc-catalog-badges__label',
+  bindingFilterBindable: '[data-test="bindable-bindable"]',
+  filterInfoTip: '.co-field-level-help__icon',
+  filterInfoTipContent: '.pf-c-popover__content',
+  filterCheckBox: '[class="pf-c-check__input"]',
   chartRepositoryGroup: '[data-test-group-name="chartRepositoryTitle"]',
   catalogTypeLink: 'li.vertical-tabs-pf-tab.shown.text-capitalize.co-catalog-tab__empty',
   catalogTypes: {

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/operators-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/operators-po.ts
@@ -37,6 +37,8 @@ export const operatorsPO = {
     gitopsPrimer: '[data-test="gitops-primer-community-operators-openshift-marketplace"]',
     serviceBinding:
       '[data-test="rh-service-binding-operator-redhat-operators-openshift-marketplace"]',
+    CrunchyPostgresforKubernetes:
+      '[data-test="crunchy-postgres-operator-certified-operators-openshift-marketplace"]',
   },
   subscription: {
     logo: 'h1.co-clusterserviceversion-logo__name__clusterserviceversion',

--- a/frontend/packages/dev-console/integration-tests/support/pages/operators-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/operators-page.ts
@@ -157,6 +157,11 @@ export const operatorsPage = {
         cy.get(operatorsPO.operatorHub.serviceBinding).click();
         break;
       }
+      case 'Crunchy Postgres for Kubernetes':
+      case operators.CrunchyPostgresforKubernetes: {
+        cy.get(operatorsPO.operatorHub.CrunchyPostgresforKubernetes).click();
+        break;
+      }
       default: {
         throw new Error('operator is not available');
       }

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/quick-search-add.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/quick-search-add.ts
@@ -1,4 +1,6 @@
-import { When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { operators } from '@console/dev-console/integration-tests/support/constants/global';
+import { verifyAndInstallOperator } from '@console/dev-console/integration-tests/support/pages';
 import { catalogPO, gitPO, quickSearchAddPO, quickStartSidebarPO } from '../../pageObjects';
 import { devFilePage, gitPage, topologyPage } from '../../pages';
 import { addQuickSearch } from '../../pages/add-flow/add-quick-search';
@@ -20,6 +22,16 @@ When('user enters {string} in Add to project search bar', (node: string) => {
 When('user selects {string} option of {string}', (option: string, type: string) => {
   addQuickSearch.selectQuickOption(option, type);
 });
+
+Then(
+  'user will see {string} label associated with {string}',
+  (labelName: string, catalogName: string) => {
+    cy.get(`[data-test^="item-name-${catalogName}-Operator Backed"]`).click();
+    cy.get(catalogPO.catalogBatch)
+      .should('be.visible')
+      .contains(labelName);
+  },
+);
 
 When('user clicks on {string}', (buttonName: string) => {
   cy.log(buttonName, 'is clicked');
@@ -80,3 +92,11 @@ Then(
     topologyPage.verifyWorkloadInTopologyPage(workloadName);
   },
 );
+
+Given('user has installed Service Binding operator', () => {
+  verifyAndInstallOperator(operators.ServiceBinding);
+});
+
+Given('user has installed Crunchy Postgres for Kubernetes operator', () => {
+  verifyAndInstallOperator(operators.CrunchyPostgresforKubernetes);
+});


### PR DESCRIPTION
**Description:**
<!-- PR description-->
- Automation of Create workload from Operator Backed file (create-operator-backed.feature)
- Automation of Provide quick search in Add page (quick-search-add.feature)

Functionality PR : 
- https://github.com/openshift/console/pull/11313 (merged)

Gherkin Script PR :
-  https://github.com/openshift/console/pull/11326 (merged)

**Jira Id:** [ODC-6513](https://issues.redhat.com/browse/ODC-6513)

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example: 
```
export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p dev-console

```

**Screen shots**:
<!--   -->

quick-search-add.feature
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/39815871/163803814-7755049a-b0b4-45d7-bfa9-0472bcccf353.png">

create-operator-backed.feature

<img width="1727" alt="image" src="https://user-images.githubusercontent.com/39815871/163804372-77d7adca-a689-4d58-b63a-08463fa63800.png">


**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge