### PR TITLE
Bug 2074756: fix bug where ClusterRole > RoleBindings did not display…

### DIFF
--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -170,7 +170,11 @@ const BindingsTableRow = ({ obj: binding }) => {
       <TableData className={bindingsColumnClasses[1]}>{binding.subject.kind}</TableData>
       <TableData className={bindingsColumnClasses[2]}>{binding.subject.name}</TableData>
       <TableData className={bindingsColumnClasses[3]}>
-        {binding.namespace || t('public~All namespaces')}
+        {binding.metadata.namespace ? (
+          <ResourceLink kind="Namespace" name={binding.metadata.namespace} />
+        ) : (
+          t('public~All namespaces')
+        )}
       </TableData>
     </>
   );


### PR DESCRIPTION
… Namespace

Changes in https://github.com/openshift/console/pull/11285 that corrected the table being rendered on the ClusterRole > RoleBindings page revealed this bug; prior to the changes in #11285, the correct table wasn't rendering so the bug was never visible.

After:
<img width="1186" alt="Screen Shot 2022-04-18 at 9 14 52 AM" src="https://user-images.githubusercontent.com/895728/163813487-106f67db-8d0e-45d0-b927-231a8fe55b81.png">

