### PR TITLE
Bug 2013461: Import deployment from Git with s2i expose always port 8080 (Service and Pod template, not Route) if another Route port is selected by the user

### DIFF
--- a/frontend/packages/dev-console/src/utils/__tests__/shared-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/shared-submit-utils.spec.ts
@@ -33,6 +33,24 @@ describe('Shared submit utils', () => {
       const serviceObj = createService(mockDeployImageData);
       expect(serviceObj).toMatchSnapshot();
     });
+
+    it('should expose only the custom port as TargetPort when it is set', () => {
+      const mockData: GitImportFormData = _.cloneDeep(mockFormData);
+
+      mockData.build.strategy = 'Source';
+      mockData.git.url = 'https://github.com/nodeshift-blog-examples/react-web-app';
+      mockData.route.unknownTargetPort = '3000';
+      const serviceObj = createService(mockData);
+      const { ports } = serviceObj.spec;
+
+      expect(ports).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            port: 8080,
+          }),
+        ]),
+      );
+    });
   });
 
   describe('Create Route', () => {

--- a/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
+++ b/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
@@ -76,7 +76,7 @@ export const createService = (
     !ports.some((port) => unknownTargetPort === port.containerPort.toString())
   ) {
     const port = { containerPort: _.toInteger(unknownTargetPort), protocol: 'TCP' };
-    ports = [...ports, port];
+    ports = [...ports.filter((p) => p.containerPort !== defaultUnknownPort), port];
   }
 
   const newService: any = {


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGSM-36101

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
When the user imports a git repository and builds it with s2i it automatically creates a service and exposes 8080 independent from the user "Route" "Target port" configuration.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Added check before submitting, which prevents 8080 port to be exposed alongside, when there is a different port mentioned in the Target Port field. But when the field is left blank, 8080 port is exposed.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
https://user-images.githubusercontent.com/47265560/163876325-78bf1c3c-794b-43cd-a733-e31ac0d5d650.mp4


**Unit test coverage report**: 
<!-- Attach test coverage report -->
Unchanged

**Test setup:**
<!-- If any setup is required to test this PR, mention the details -->
1. Switch to the developer perspective and create a fresh namespace if needed
2. Navigate to Add > Git repository > Import from Git
3. Enter Git URL which uses another port than 8080, for example, https://github.com/nodeshift-blog-examples/react-web-app (which uses 3000)

Scenario 1:
"Target port" shows the placeholder 8080
 "Create" the Deployment without additional changes

Scenario 2:
Click into the "Target port" field, enter "3000" and press "Create 3000"
"Create" the Deployment without additional changes



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge