### PR TITLE
[Dark Theme]: fix mutilStream logs and pod logs viewer and console header to support dark theme

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/MultiStreamLogs.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/MultiStreamLogs.scss
@@ -27,7 +27,7 @@
     flex: 1;
     flex-direction: column;
     background-color: var(--pf-global--palette--black-1000);
-    color: var(--pf-global--BackgroundColor--100);
+    color: var(--pf-global--Color--light-100);
     font-family: Menlo, Monaco, 'Courier New', monospace;
     overflow-y: scroll;
     position: relative;
@@ -39,7 +39,7 @@
   &__taskName {
     background-color: var(--pf-global--BackgroundColor--dark-300);
     padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--md);
-    color: var(--pf-global--BackgroundColor--100);
+    color: var(--pf-global--Color--light-100);
   }
   &__taskName__loading-indicator {
     margin-left: var(--pf-global--spacer--sm);

--- a/frontend/public/components/utils/_log-window.scss
+++ b/frontend/public/components/utils/_log-window.scss
@@ -1,5 +1,13 @@
-$color-log-window-header-bg: $pf-color-black-900;
-$color-log-window-text: $pf-color-black-150;
+$color-log-window-header-bg: var(--pf-global--BackgroundColor--dark-300);
+$color-log-window-text: var(--pf-global--Color--light-100);
+
+.pf-c-log-viewer {
+  &.pf-m-dark {
+    .pf-c-log-viewer__main {
+      background-color: var(--pf-global--palette--black-1000);
+    }
+  }
+}
 
 .log-window__header {
   color: $color-log-window-text;

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -152,6 +152,10 @@ form.pf-c-form {
     flex-direction: column;
     height: 100%;
   }
+
+  .pf-c-page__header {
+    background-color: var(--pf-global--palette--black-1000);
+  }
 }
 
 // specificity targeting form elements to override --pf-global--FontSize--md


### PR DESCRIPTION
**Story:** https://issues.redhat.com/browse/ODC-6638

**Descriptions:**
- override `pf-c-page__header` background color with `--pf-global--palette--black-1000`
- use `--pf-global--BackgroundColor--dark-200` for logs container
- use `--pf-global--BackgroundColor--dark-300` for log header

**Screenshots:**
**Console header**
**Before**
![image](https://user-images.githubusercontent.com/2561818/163944546-dc28fb5d-82e3-4432-a084-0f5113799e50.png)

![image](https://user-images.githubusercontent.com/2561818/163944644-d0ce77d7-444d-4402-b623-dd32a9ebcf97.png)

**After**
![image](https://user-images.githubusercontent.com/2561818/163944788-bf7d8dc9-91e4-4749-b258-429f2204954f.png)

![image](https://user-images.githubusercontent.com/2561818/163944834-fc9404d3-c883-4ce7-abe8-b9a0c5688d5b.png)

**Logs viewer**
**Before**
![image](https://user-images.githubusercontent.com/2561818/163945028-d07434e4-3d6f-48d7-b1de-5ad12a8b3bd2.png)

![image](https://user-images.githubusercontent.com/2561818/163945128-92bfa2ca-7624-4629-bd4c-c4798264f472.png)

**After**
![image](https://user-images.githubusercontent.com/2561818/163945329-af500967-aed2-4ff8-ae16-0e5bd8c5388d.png)

![image](https://user-images.githubusercontent.com/2561818/163945274-8635de49-ae25-42b2-9483-1b80ea5461c5.png)

cc: @sg00dwin @mattnolting 