### PR TITLE
Bug 2066159: Modified to renderNull only if extension is resolved for workload

### DIFF
--- a/frontend/packages/topology/src/components/workload/build-tab-section.tsx
+++ b/frontend/packages/topology/src/components/workload/build-tab-section.tsx
@@ -39,10 +39,10 @@ const BuildTabSection: React.FC<{ element: GraphElement; renderNull: () => null 
   }, []);
 
   React.useEffect(() => {
-    if (!buildAdapter) {
+    if (!buildAdapter && extensionsResolved) {
       renderNull();
     }
-  }, [buildAdapter, renderNull]);
+  }, [buildAdapter, renderNull, extensionsResolved]);
 
   return buildAdapter ? (
     <TopologySideBarTabSection>

--- a/frontend/packages/topology/src/components/workload/network-tab-section.tsx
+++ b/frontend/packages/topology/src/components/workload/network-tab-section.tsx
@@ -27,10 +27,10 @@ const NetworkTabSection: React.FC<{ element: GraphElement; renderNull: () => nul
   );
 
   React.useEffect(() => {
-    if (!networkAdapter) {
+    if (!networkAdapter && extensionsLoaded) {
       renderNull();
     }
-  }, [networkAdapter, renderNull]);
+  }, [networkAdapter, renderNull, extensionsLoaded]);
 
   return networkAdapter ? (
     <TopologySideBarTabSection>

--- a/frontend/packages/topology/src/components/workload/pods-tab-section.tsx
+++ b/frontend/packages/topology/src/components/workload/pods-tab-section.tsx
@@ -37,10 +37,10 @@ const PodsTabSection: React.FC<{ element: GraphElement; renderNull: () => null }
   }, []);
 
   React.useEffect(() => {
-    if (!podAdapter) {
+    if (!podAdapter && podAdapterExtensionResolved) {
       renderNull();
     }
-  }, [podAdapter, renderNull]);
+  }, [podAdapter, renderNull, podAdapterExtensionResolved]);
 
   return podAdapter ? (
     <TopologySideBarTabSection>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-42132

**Analysis / Root cause**: 
renderNull was called without checking whether extension is resolved or not

**Solution Description**: 
At the time of calling renderNull check whether extension is resolved or not.

**Screen shots / Gifs for design review**: 
<img width="968" alt="image" src="https://user-images.githubusercontent.com/102503482/163945190-3e16ee21-8e54-40bf-8fb3-0eea4b96d1ca.png">


**Unit test coverage report**: 
NA

**Test setup:**
1) Install a Jenkins Helm chart
2) Click on deployment config

**Browser conformance**: 
- [ x ] Chrome
- [ x ] Firefox
- [ x ] Safari
