### PR TITLE
CONSOLE-3071: update Cluster Settings and ClusterVersion Details page…

### DIFF
--- a/frontend/__tests__/components/cluster-settings.spec.tsx
+++ b/frontend/__tests__/components/cluster-settings.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { shallow, mount, ShallowWrapper } from 'enzyme';
 import * as utils from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { useCanClusterUpgrade } from '@console/shared/src/hooks/useCanClusterUpgrade';
 import {
   clusterVersionProps,
   clusterVersionUpgradeableFalseProps,
@@ -48,6 +49,10 @@ jest.mock('react-redux', () => {
     useDispatch: jest.fn(),
   };
 });
+
+jest.mock('@console/shared/src/hooks/useCanClusterUpgrade', () => ({
+  useCanClusterUpgrade: jest.fn(),
+}));
 
 describe('Cluster Settings page', () => {
   let wrapper: ShallowWrapper<any>;
@@ -141,17 +146,11 @@ describe('Cluster Settings page', () => {
 describe('Cluster Version Details Table page', () => {
   let wrapper: ShallowWrapper<any>;
   let cv;
-  let spyUseAccessReview;
 
   beforeEach(() => {
-    spyUseAccessReview = jest.spyOn(utils, 'useAccessReview');
-    spyUseAccessReview.mockReturnValue(true);
     cv = clusterVersionProps;
     wrapper = shallow(<ClusterVersionDetailsTable obj={cv} autoscalers={[]} />);
-  });
-
-  afterEach(() => {
-    spyUseAccessReview.mockReset();
+    (useCanClusterUpgrade as jest.Mock).mockReturnValueOnce([[], true]);
   });
 
   it('should render ClusterVersionDetailsTable component', () => {
@@ -221,6 +220,7 @@ describe('ClusterSettingsAlerts while ClusterVersion Upgradeable=False', () => {
     cv = clusterVersionUpgradeableFalseProps;
     wrapper = shallow(
       <ClusterSettingsAlerts
+        canUpgrade={true}
         cv={cv}
         machineConfigPools={[]}
         status={ClusterUpdateStatus.UpToDate}
@@ -252,6 +252,7 @@ describe('ClusterSettingsAlerts while cluster is up to date or has available upd
     cv = clusterVersionProps;
     wrapper = shallow(
       <ClusterSettingsAlerts
+        canUpgrade={true}
         cv={cv}
         machineConfigPools={machineConfigPoolsWithPausedWorkerProps.items}
         status={ClusterUpdateStatus.UpToDate}
@@ -318,7 +319,7 @@ describe('Current Channel', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = mount(<CurrentChannel cv={clusterVersionProps} clusterVersionIsEditable={true} />);
+    wrapper = mount(<CurrentChannel cv={clusterVersionProps} canUpgrade={true} />);
   });
 
   it('should accept props', () => {
@@ -338,7 +339,7 @@ describe('Update Link', () => {
     spyUseAccessReview = jest.spyOn(utils, 'useAccessReview');
     spyUseAccessReview.mockReturnValue(true);
     cv = clusterVersionProps;
-    wrapper = shallow(<UpdateLink cv={cv} clusterVersionIsEditable={true} />);
+    wrapper = shallow(<UpdateLink cv={cv} canUpgrade={true} />);
   });
 
   afterEach(() => {
@@ -405,18 +406,12 @@ describe('Updates Graph', () => {
 describe('Cluster Version Details Table page while updating', () => {
   let wrapper: ShallowWrapper<any>;
   let cv;
-  let spyUseAccessReview;
 
   beforeEach(() => {
-    spyUseAccessReview = jest.spyOn(utils, 'useAccessReview');
-    spyUseAccessReview.mockReturnValue(true);
     cv = clusterVersionUpdatingProps;
     wrapper = shallow(<ClusterVersionDetailsTable obj={cv} autoscalers={[]} />);
     (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
-  });
-
-  afterEach(() => {
-    spyUseAccessReview.mockReset();
+    (useCanClusterUpgrade as jest.Mock).mockReturnValueOnce([[], true]);
   });
 
   it('should render ClusterVersionDetailsTable component', () => {
@@ -499,18 +494,12 @@ describe('Update In Progress while updating', () => {
 describe('Cluster Version Details Table page once updated', () => {
   let wrapper: ShallowWrapper<any>;
   let cv;
-  let spyUseAccessReview;
 
   beforeEach(() => {
-    spyUseAccessReview = jest.spyOn(utils, 'useAccessReview');
-    spyUseAccessReview.mockReturnValue(true);
     cv = clusterVersionUpdatedProps;
     wrapper = shallow(<ClusterVersionDetailsTable obj={cv} autoscalers={[]} />);
     (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
-  });
-
-  afterEach(() => {
-    spyUseAccessReview.mockReset();
+    (useCanClusterUpgrade as jest.Mock).mockReturnValueOnce([[], true]);
   });
 
   it('should render ClusterVersionDetailsTable component', () => {
@@ -533,7 +522,7 @@ describe('Update Link once updated', () => {
 
   beforeEach(() => {
     cv = clusterVersionUpdatedProps;
-    wrapper = shallow(<UpdateLink cv={cv} clusterVersionIsEditable={true} />);
+    wrapper = shallow(<UpdateLink cv={cv} canUpgrade={true} />);
   });
 
   it('should render an empty Update Link component', () => {

--- a/frontend/packages/console-shared/src/hooks/useCanClusterUpgrade.ts
+++ b/frontend/packages/console-shared/src/hooks/useCanClusterUpgrade.ts
@@ -1,12 +1,11 @@
 import { useAccessReviewAllowed } from '@console/dynamic-plugin-sdk';
 import { ClusterVersionModel } from '@console/internal/models';
-import { ClusterVersionKind, hasAvailableUpdates } from '@console/internal/module/k8s';
 
 export const isClusterExternallyManaged = (): boolean => {
   return window.SERVER_FLAGS.controlPlaneTopology === 'External';
 };
 
-export const useCanClusterUpgrade = (clusterVersion: ClusterVersionKind): boolean => {
+export const useCanClusterUpgrade = (): boolean => {
   const hasPermissionsToUpdate = useAccessReviewAllowed({
     group: ClusterVersionModel.apiGroup,
     resource: ClusterVersionModel.plural,
@@ -14,8 +13,8 @@ export const useCanClusterUpgrade = (clusterVersion: ClusterVersionKind): boolea
     name: 'version',
   });
   const notExternallyManaged = !isClusterExternallyManaged();
-  const bandingNotDedicated = window.SERVER_FLAGS.branding !== 'dedicated';
-  const canPerformUpgrade = hasPermissionsToUpdate && bandingNotDedicated && notExternallyManaged;
+  const brandingNotDedicated = window.SERVER_FLAGS.branding !== 'dedicated';
+  const canPerformUpgrade = hasPermissionsToUpdate && brandingNotDedicated && notExternallyManaged;
 
-  return hasAvailableUpdates(clusterVersion) && canPerformUpgrade;
+  return canPerformUpgrade;
 };

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -17,6 +17,7 @@ import {
   getCurrentVersion,
   getK8sGitVersion,
   getOpenShiftVersion,
+  hasAvailableUpdates,
 } from '../module/k8s/cluster-settings';
 
 const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) => {
@@ -28,7 +29,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) =>
       .catch(() => setKubernetesVersion(t('public~unknown')));
   }, [t]);
   const clusterVersion = useClusterVersion();
-  const canUpgrade = useCanClusterUpgrade(clusterVersion);
+  const canUpgrade = useCanClusterUpgrade();
 
   const clusterID = getClusterID(clusterVersion);
   const channel: string = clusterVersion?.spec?.channel;
@@ -36,7 +37,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) =>
 
   return (
     <>
-      {canUpgrade && (
+      {canUpgrade && hasAvailableUpdates(clusterVersion) && (
         <Alert
           className="co-alert co-about-modal__alert"
           title={

--- a/frontend/public/components/cluster-settings/cluster-version.tsx
+++ b/frontend/public/components/cluster-settings/cluster-version.tsx
@@ -1,24 +1,33 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
+import { useCanClusterUpgrade } from '@console/shared';
 
 import { ClusterVersionModel } from '../../models';
 import { DetailsPage } from '../factory';
 import { Conditions } from '../conditions';
 import { ClusterVersionKind, K8sResourceKindReference, referenceForModel } from '../../module/k8s';
-import { navFactory, ResourceSummary, SectionHeading, UpstreamConfigDetailsItem } from '../utils';
+import {
+  editYamlComponent,
+  navFactory,
+  ResourceSummary,
+  SectionHeading,
+  UpstreamConfigDetailsItem,
+  viewYamlComponent,
+} from '../utils';
 import { breadcrumbsForGlobalConfig } from './global-config';
 
 const clusterVersionReference: K8sResourceKindReference = referenceForModel(ClusterVersionModel);
 
 const ClusterVersionDetails: React.FC<ClusterVersionDetailsProps> = ({ obj }) => {
-  const conditions = _.get(obj, 'status.conditions', []);
   const { t } = useTranslation();
+  const canUpgrade = useCanClusterUpgrade();
+  const conditions = _.get(obj, 'status.conditions', []);
   return (
     <>
       <div className="co-m-pane__body">
         <SectionHeading text={t('public~ClusterVersion details')} />
-        <ResourceSummary resource={obj}>
+        <ResourceSummary resource={obj} canUpdateResource={canUpgrade}>
           <UpstreamConfigDetailsItem resource={obj} />
         </ResourceSummary>
       </div>
@@ -30,14 +39,20 @@ const ClusterVersionDetails: React.FC<ClusterVersionDetailsProps> = ({ obj }) =>
   );
 };
 
-export const ClusterVersionDetailsPage: React.FC<ClusterVersionDetailsPageProps> = (props) => (
-  <DetailsPage
-    {...props}
-    kind={clusterVersionReference}
-    pages={[navFactory.details(ClusterVersionDetails), navFactory.editYaml()]}
-    breadcrumbsFor={() => breadcrumbsForGlobalConfig(ClusterVersionModel.label, props.match.url)}
-  />
-);
+export const ClusterVersionDetailsPage: React.FC<ClusterVersionDetailsPageProps> = (props) => {
+  const canUpgrade = useCanClusterUpgrade();
+  return (
+    <DetailsPage
+      {...props}
+      kind={clusterVersionReference}
+      pages={[
+        navFactory.details(ClusterVersionDetails),
+        navFactory.editYaml(canUpgrade ? editYamlComponent : viewYamlComponent),
+      ]}
+      breadcrumbsFor={() => breadcrumbsForGlobalConfig(ClusterVersionModel.label, props.match.url)}
+    />
+  );
+};
 
 type ClusterVersionDetailsProps = {
   obj: ClusterVersionKind;

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -35,7 +35,7 @@ import {
 } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { useExtensions, HorizontalNavTab, isHorizontalNavTab } from '@console/plugin-sdk/src';
 
-const editYamlComponent = (props) => (
+export const editYamlComponent = (props) => (
   <AsyncComponent loader={() => import('../edit-yaml').then((c) => c.EditYAML)} obj={props.obj} />
 );
 export const viewYamlComponent = (props) => (

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -142,6 +142,7 @@
   "This cluster should not be updated to the next minor version.": "This cluster should not be updated to the next minor version.",
   "View ClusterOperators": "View ClusterOperators",
   "View installed Operators": "View installed Operators",
+  "Control plane is hosted.": "Control plane is hosted.",
   "This cluster is not currently requesting update notifications. To request update recommendations, configure a channel.": "This cluster is not currently requesting update notifications. To request update recommendations, configure a channel.",
   "Version {{version}} not found in channel {{channel}}. To request update recommendations, configure a channel that supports your version.": "Version {{version}} not found in channel {{channel}}. To request update recommendations, configure a channel that supports your version.",
   "{{resource}} updates are paused.": "{{resource}} updates are paused.",


### PR DESCRIPTION
…s for HyperShift Provisioned Clusters

After:

https://user-images.githubusercontent.com/895728/164299260-b1b36440-d5fd-4371-bb62-8e2f64de466a.mov

### Setup / Testing

It's based on the SERVER_FLAG `controlPlaneTopology` being set to `External` is really the driving factor here; this can be done in one of two ways:

* Locally via a Bridge Variable, `export BRIDGE_CONTROL_PLANE_TOPOLOGY_MODE="External"`
* Locally / OnCluster via modifying the `window.SERVER_FLAGS.controlPlaneTopology` to `External` in the dev tools

### TODOs

- [x] get final copy for the alert