### PR TITLE
CONSOLE-3072: Cluster overview page changes for HyperShift provisioned clusters

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
@@ -7,6 +7,7 @@ import {
   getInfrastructurePlatform,
   isSingleNode,
   useFlag,
+  useCanClusterUpgrade,
 } from '@console/shared';
 import { Card, CardBody, CardHeader, CardTitle, CardActions } from '@patternfly/react-core';
 import DetailsBody from '@console/shared/src/components/dashboard/details-card/DetailsBody';
@@ -31,7 +32,7 @@ import {
   getOCMLink,
 } from '../../../../module/k8s';
 import { flagPending } from '../../../../reducers/features';
-import { ExternalLink, useAccessReview, LoadingInline } from '../../../utils';
+import { ExternalLink, LoadingInline } from '../../../utils';
 import { Link } from 'react-router-dom';
 import { useK8sWatchResource } from '../../../utils/k8s-watch-hook';
 import { ClusterDashboardContext } from './context';
@@ -40,14 +41,8 @@ const ClusterVersion: React.FC<ClusterVersionProps> = ({ cv }) => {
   const { t } = useTranslation();
   const desiredVersion = getDesiredClusterVersion(cv);
   const lastVersion = getLastCompletedUpdate(cv);
+  const canUpgrade = useCanClusterUpgrade();
   const status = getClusterUpdateStatus(cv);
-  const clusterVersionIsEditable =
-    useAccessReview({
-      group: ClusterVersionModel.apiGroup,
-      resource: ClusterVersionModel.plural,
-      verb: 'patch',
-      name: 'version',
-    }) && window.SERVER_FLAGS.branding !== 'dedicated';
 
   switch (status) {
     case ClusterUpdateStatus.Updating:
@@ -66,7 +61,7 @@ const ClusterVersion: React.FC<ClusterVersionProps> = ({ cv }) => {
       return (
         <>
           <span className="co-select-to-copy">{desiredVersion}</span>
-          {clusterVersionIsEditable && (
+          {canUpgrade && (
             <div>
               <Link to="/settings/cluster?showVersions">
                 <BlueArrowCircleUpIcon className="co-icon-space-r" />

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-getting-started-card.spec.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-getting-started-card.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { GettingStartedCard } from '@console/shared/src/components/getting-started';
+import { useCanClusterUpgrade } from '@console/shared';
 
 import { ClusterSetupGettingStartedCard } from '../cluster-setup-getting-started-card';
 import { useIdentityProviderLink } from '../cluster-setup-identity-provider-link';
@@ -9,6 +10,10 @@ import { useAlertReceiverLink } from '../cluster-setup-alert-receiver-link';
 jest.mock('react', () => ({
   ...require.requireActual('react'),
   useLayoutEffect: require.requireActual('react').useEffect,
+}));
+
+jest.mock('@console/shared/src/hooks/useCanClusterUpgrade', () => ({
+  useCanClusterUpgrade: jest.fn(),
 }));
 
 jest.mock('../cluster-setup-identity-provider-link', () => ({
@@ -33,11 +38,13 @@ jest.mock(
     },
 );
 
+const useCanClusterUpgradeMock = useCanClusterUpgrade as jest.Mock;
 const useIdentityProviderLinkMock = useIdentityProviderLink as jest.Mock;
 const useAlertReceiverLinkMock = useAlertReceiverLink as jest.Mock;
 
 describe('ClusterSetupGettingStartedCard', () => {
   it('should render links if hooks provide them', () => {
+    useCanClusterUpgradeMock.mockReturnValue(true);
     useIdentityProviderLinkMock.mockReturnValue({
       id: 'identity-providers',
       title: 'Add identity providers',

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ClipboardCheckIcon } from '@patternfly/react-icons';
 
+import { useCanClusterUpgrade } from '@console/shared';
+
 import {
   GettingStartedCard,
   GettingStartedLink,
@@ -13,10 +15,12 @@ import { useAlertReceiverLink } from './cluster-setup-alert-receiver-link';
 export const ClusterSetupGettingStartedCard: React.FC = () => {
   const { t } = useTranslation();
 
+  const canUpgrade = useCanClusterUpgrade();
+
   const identityProviderLink = useIdentityProviderLink();
   const alertReceiverLink = useAlertReceiverLink();
 
-  const links = [identityProviderLink, alertReceiverLink].filter(Boolean);
+  const links = [canUpgrade && identityProviderLink, alertReceiverLink].filter(Boolean);
 
   if (links.length === 0) {
     return null;

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -40,7 +40,12 @@ import {
   CardTitle,
   CardActions,
 } from '@patternfly/react-core';
-import { BlueArrowCircleUpIcon, FLAGS, getInfrastructurePlatform } from '@console/shared';
+import {
+  BlueArrowCircleUpIcon,
+  FLAGS,
+  getInfrastructurePlatform,
+  useCanClusterUpgrade,
+} from '@console/shared';
 
 import AlertsBody from '@console/shared/src/components/dashboard/status-card/AlertsBody';
 import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
@@ -66,7 +71,6 @@ import {
 import { useK8sWatchResource } from '../../../utils/k8s-watch-hook';
 import { useFlag } from '@console/shared/src/hooks/flag';
 import { ClusterDashboardContext } from './context';
-import { useAccessReview } from '../../../utils';
 import { useNotificationAlerts } from '@console/shared/src/hooks/useNotificationAlerts';
 
 const filterSubsystems = (
@@ -110,21 +114,10 @@ export const DashboardAlerts: React.FC<DashboardAlertsProps> = ({ labelSelector 
   const [cv, cvLoaded] = useK8sWatchResource<ClusterVersionKind>(
     hasCVResource ? cvResource : ({} as WatchK8sResource),
   );
-
-  const clusterVersionIsEditable =
-    useAccessReview({
-      group: ClusterVersionModel.apiGroup,
-      resource: ClusterVersionModel.plural,
-      verb: 'patch',
-      name: 'version',
-    }) && window.SERVER_FLAGS.branding !== 'dedicated';
+  const canUpgrade = useCanClusterUpgrade();
 
   const showClusterUpdate =
-    hasCVResource &&
-    cvLoaded &&
-    hasAvailableUpdates(cv) &&
-    clusterVersionIsEditable &&
-    !labelSelector;
+    canUpgrade && hasCVResource && cvLoaded && hasAvailableUpdates(cv) && !labelSelector;
   return (
     <AlertsBody error={!_.isEmpty(loadError)}>
       {showClusterUpdate && (


### PR DESCRIPTION
Story: https://issues.redhat.com/browse/CONSOLE-3072

If the cluster is provisioned by HyperShift dont render:
- `Update cluster` link in the Details Card
- `Update cluster` link in the Status Card
- `Add identity provider` link in the `Getting started resources`

Before:
<img width="1574" alt="Screenshot 2022-04-25 at 13 29 49" src="https://user-images.githubusercontent.com/1668218/165081100-90e0cbc1-9f6b-48fb-a6c0-47181ea9d012.png">

After:
<img width="1579" alt="Screenshot 2022-04-25 at 13 26 27" src="https://user-images.githubusercontent.com/1668218/165081113-89b7df4d-ef0b-4269-8553-14ad4561ddf3.png">

Setup / Testing
It's based on the SERVER_FLAG `controlPlaneTopology` being set to `External` is really the driving factor here; this can be done in one of two ways:

Locally via a Bridge Variable, `export BRIDGE_CONTROL_PLANE_TOPOLOGY_MODE="External"`
Locally / OnCluster via modifying the `window.SERVER_FLAGS.controlPlaneTopology` to `External` in the dev tools

/assign @andrewballantyne @rhamilto 
