### PR TITLE
Bug 2075592: add z-index to ocs-drawer to make box-shadow visible

### DIFF
--- a/frontend/packages/console-shared/src/components/drawer/Drawer.scss
+++ b/frontend/packages/console-shared/src/components/drawer/Drawer.scss
@@ -7,6 +7,7 @@
   box-shadow: var(--pf-global--BoxShadow--sm-top);
   display: flex;
   flex-direction: column;
+  z-index: var(--pf-global--ZIndex--xs);
 
   &__drag-handle {
     width: 100%;


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGSM-43313

**Descriptions:**
- add `z-index: var(--pf-global--ZIndex--xs);` to `.ocs-drawer` to make `box-shadow` visible.

**Screenshot:**
![image](https://user-images.githubusercontent.com/2561818/164244059-2ccc0a4e-1421-4197-9e31-4a353a9431d7.png)
