### PR TITLE
CONSOLE-3074: update notifications for HyperShift Provisioned Clusters

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useCanClusterUpgrade.ts
+++ b/frontend/packages/console-shared/src/hooks/useCanClusterUpgrade.ts
@@ -1,12 +1,11 @@
 import { useAccessReviewAllowed } from '@console/dynamic-plugin-sdk';
 import { ClusterVersionModel } from '@console/internal/models';
-import { ClusterVersionKind, hasAvailableUpdates } from '@console/internal/module/k8s';
 
 export const isClusterExternallyManaged = (): boolean => {
   return window.SERVER_FLAGS.controlPlaneTopology === 'External';
 };
 
-export const useCanClusterUpgrade = (clusterVersion: ClusterVersionKind): boolean => {
+export const useCanClusterUpgrade = (): boolean => {
   const hasPermissionsToUpdate = useAccessReviewAllowed({
     group: ClusterVersionModel.apiGroup,
     resource: ClusterVersionModel.plural,
@@ -14,8 +13,8 @@ export const useCanClusterUpgrade = (clusterVersion: ClusterVersionKind): boolea
     name: 'version',
   });
   const notExternallyManaged = !isClusterExternallyManaged();
-  const bandingNotDedicated = window.SERVER_FLAGS.branding !== 'dedicated';
-  const canPerformUpgrade = hasPermissionsToUpdate && bandingNotDedicated && notExternallyManaged;
+  const brandingNotDedicated = window.SERVER_FLAGS.branding !== 'dedicated';
+  const canPerformUpgrade = hasPermissionsToUpdate && brandingNotDedicated && notExternallyManaged;
 
-  return hasAvailableUpdates(clusterVersion) && canPerformUpgrade;
+  return canPerformUpgrade;
 };

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -17,6 +17,7 @@ import {
   getCurrentVersion,
   getK8sGitVersion,
   getOpenShiftVersion,
+  hasAvailableUpdates,
 } from '../module/k8s/cluster-settings';
 
 const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) => {
@@ -28,7 +29,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) =>
       .catch(() => setKubernetesVersion(t('public~unknown')));
   }, [t]);
   const clusterVersion = useClusterVersion();
-  const canUpgrade = useCanClusterUpgrade(clusterVersion);
+  const canUpgrade = useCanClusterUpgrade();
 
   const clusterID = getClusterID(clusterVersion);
   const channel: string = clusterVersion?.spec?.channel;
@@ -36,7 +37,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) =>
 
   return (
     <>
-      {canUpgrade && (
+      {canUpgrade && hasAvailableUpdates(clusterVersion) && (
         <Alert
           className="co-alert co-about-modal__alert"
           title={

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -34,7 +34,7 @@ import {
 } from '@console/internal/components/utils/service-level';
 import { getAlertsAndRules, alertURL } from '@console/internal/components/monitoring/utils';
 import { NotificationAlerts } from '@console/internal/reducers/observe';
-import { RedExclamationCircleIcon } from '@console/shared';
+import { RedExclamationCircleIcon, useCanClusterUpgrade } from '@console/shared';
 import {
   getAlertDescription,
   getAlertMessage,
@@ -68,8 +68,7 @@ import {
   getSortedUpdates,
   splitClusterVersionChannel,
 } from '../module/k8s';
-import { ClusterVersionModel } from '../models';
-import { useAccessReview, useAccessReview2 } from './utils/rbac';
+import { useAccessReview2 } from './utils/rbac';
 import { LinkifyExternal } from './utils';
 import { PrometheusEndpoint } from './graphs/helpers';
 import { LabelSelector } from '@console/internal/module/k8s/label-selector';
@@ -132,11 +131,11 @@ export const getAlertActions = (actionsExtensions: ResolvedExtension<AlertAction
 };
 
 const getUpdateNotificationEntries = (
+  canUpgrade: boolean,
   cv: ClusterVersionKind,
-  isEditable: boolean,
   toggleNotificationDrawer: () => void,
 ): React.ReactNode[] => {
-  if (!cv || !isEditable) {
+  if (!cv || !canUpgrade) {
     return [];
   }
   const updateData: ClusterUpdate[] = getSortedUpdates(cv);
@@ -285,16 +284,10 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
     alertActionExtensions,
   ]);
 
-  const clusterVersionIsEditable =
-    useAccessReview({
-      group: ClusterVersionModel.apiGroup,
-      resource: ClusterVersionModel.plural,
-      verb: 'patch',
-      name: 'version',
-    }) && window.SERVER_FLAGS.branding !== 'dedicated';
+  const canUpgrade = useCanClusterUpgrade();
   const updateList: React.ReactNode[] = getUpdateNotificationEntries(
+    canUpgrade,
     clusterVersion,
-    clusterVersionIsEditable,
     toggleNotificationDrawer,
   );
 


### PR DESCRIPTION
After:

<img width="2009" alt="Screen Shot 2022-04-20 at 2 15 48 PM" src="https://user-images.githubusercontent.com/895728/164296325-24186d47-7050-4b54-9c11-9c93108d3148.png">

Note this duplicates changes to `useCanClusterUpgrade` and the about modal from https://github.com/openshift/console/pull/11363.

### Setup / Testing

It's based on the SERVER_FLAG `controlPlaneTopology` being set to `External` is really the driving factor here; this can be done in one of two ways:

* Locally via a Bridge Variable, `export BRIDGE_CONTROL_PLANE_TOPOLOGY_MODE="External"`
* Locally / OnCluster via modifying the `window.SERVER_FLAGS.controlPlaneTopology` to `External` in the dev tools