### PR TITLE
CONSOLE-3081: swapped labels out for details view and modal

### DIFF
--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -51,7 +51,7 @@ export const clickTab = async (name: string) => {
   await navTabFor(name).click();
 };
 
-export const labelsForRow = (name: string) => rowForName(name).$$('.co-m-label');
+export const labelsForRow = (name: string) => rowForName(name).$$('.co-label');
 export const textFilter = $('[data-test-id="item-filter"]');
 export const actions = Object.freeze({
   labels: 'Edit labels',

--- a/frontend/integration-tests/views/monitoring.view.ts
+++ b/frontend/integration-tests/views/monitoring.view.ts
@@ -6,7 +6,7 @@ import { firstElementByTestID } from '../protractor.conf';
 
 export const wait = async (condition) => await browser.wait(condition, 20000);
 
-export const labels = $$('.co-m-label');
+export const labels = $$('.co-label');
 export const saveButton = $('button[type=submit]');
 
 // YAML form

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.spec.ts
@@ -145,7 +145,7 @@ describe('Using OLM descriptor components', () => {
   it('pre-populates Labels field', () => {
     getOperandFormFieldElement(LABELS_FIELD_ID).should('exist');
     getOperandFormFieldLabel(LABELS_FIELD_ID).should('have.text', 'Labels');
-    cy.get(`#${LABELS_FIELD_ID}_field .tag-item__content`).should(
+    cy.get(`#${LABELS_FIELD_ID}_field .tag-item-content`).should(
       'have.text',
       `automatedTestName=${testName}`,
     );

--- a/frontend/public/components/modals/create-namespace-modal.jsx
+++ b/frontend/public/components/modals/create-namespace-modal.jsx
@@ -231,7 +231,7 @@ const CreateNamespaceModalWithTranslation = connect(
                 </label>
                 <div className="modal-body__field">
                   <SelectorInput
-                    labelClassName="co-text-namespace"
+                    labelClassName="co-m-namespace"
                     onChange={this.onLabels}
                     tags={[]}
                   />

--- a/frontend/public/components/modals/labels-modal.jsx
+++ b/frontend/public/components/modals/labels-modal.jsx
@@ -77,7 +77,7 @@ const BaseLabelsModal = withHandlePromise((props) => {
             <SelectorInput
               onChange={(l) => setLabels(l)}
               tags={labels}
-              labelClassName={labelClassName || `co-text-${kind.id}`}
+              labelClassName={labelClassName || `co-m-${kind.id}`}
               autoFocus
             />
           </div>
@@ -114,7 +114,7 @@ export const podSelectorModal = createModalLauncher((props) => {
       messageVariables={{
         kind: props.kind.labelKey ? t(props.kind.labelKey) : props.kind.label.toLowerCase(),
       }}
-      labelClassName="co-text-pod"
+      labelClassName="co-m-pod"
       {...props}
     />
   );

--- a/frontend/public/components/monitoring/alert-manager-config.tsx
+++ b/frontend/public/components/monitoring/alert-manager-config.tsx
@@ -10,6 +10,8 @@ import {
   EmptyState,
   EmptyStateBody,
   EmptyStateVariant,
+  Label as PfLabel,
+  LabelGroup as PfLabelGroup,
   Title,
 } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
@@ -196,21 +198,19 @@ const RoutingLabel: React.FC<RoutingLabelProps> = ({ labels }) => {
   const list = _.map(labels, (value, key) => {
     count++;
     return key === 'default' ? (
-      <span key="default" className="co-m-label__value">
-        {t('public~All (default receiver)')}
-      </span>
+      <span key="default">{t('public~All (default receiver)')}</span>
     ) : (
-      <React.Fragment key={`label-${key}-${value}`}>
-        <span className="co-m-label__key">{key}</span>
-        <span className="co-m-label__eq">=</span>
-        <span className="co-m-label__value">{value}</span>
+      <PfLabel className="co-label" key={`label-${key}-${value}`}>
+        <span className="co-label__key">{key}</span>
+        <span className="co-label__eq">=</span>
+        <span className="co-label__value">{value}</span>
         {count < _.size(labels) && <>,&nbsp;</>}
-      </React.Fragment>
+      </PfLabel>
     );
   });
   return (
     <div>
-      <div className="co-m-label co-m-label--expand">{list}</div>
+      <PfLabelGroup className="co-label-group">{list}</PfLabelGroup>
     </div>
   );
 };

--- a/frontend/public/components/monitoring/labels.tsx
+++ b/frontend/public/components/monitoring/labels.tsx
@@ -1,13 +1,14 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Label as PfLabel } from '@patternfly/react-core';
 
 export const Label = ({ k, v }) => (
-  <div className="co-m-label co-m-label--expand" key={k}>
+  <PfLabel className="co-label co-m-label--expand" key={k}>
     <span className="co-m-label__key">{k}</span>
     <span className="co-m-label__eq">=</span>
     <span className="co-m-label__value">{v}</span>
-  </div>
+  </PfLabel>
 );
 
 export const Labels = ({ kind, labels }) => {

--- a/frontend/public/components/overview/_overview.scss
+++ b/frontend/public/components/overview/_overview.scss
@@ -86,19 +86,17 @@ $overview-sidebar-width: 550px;
 .resource-overview__body {
   display: flex;
   flex-wrap: wrap;
+  gap: var(--pf-global--spacer--lg);
 }
 
-.resource-overview__details {
-  width: 50%;
+.resource-overview__details,
+.resource-overview__summary {
+  flex: 1;
+  min-width: 200px;
 }
 
 .resource-overview__pod-counts {
   width: 100%;
-}
-
-.resource-overview__summary {
-  padding-right: 10px;
-  width: 50%;
 }
 
 .sidebar__section-heading {

--- a/frontend/public/components/utils/_label.scss
+++ b/frontend/public/components/utils/_label.scss
@@ -25,6 +25,29 @@
   }
 }
 
+.co-label.pf-c-label {
+  --pf-c-label__text--MaxWidth: 100%;
+}
+
+.co-label-group {
+  max-width: 100%;
+}
+
+.co-label,
+.co-label-group > *,
+.co-label-group li,
+.co-label-group ul {
+  min-width: 0;
+}
+
+.co-label__key,
+.co-label__value {
+  max-width: 60px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 tags-input {
   min-width: 100%;
 }
@@ -44,11 +67,19 @@ tags-input .host:active {
 }
 
 tags-input .tags {
+  align-content: flex-start;
   background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
   border-radius: $input-border-radius; // Note: This has no effect on <select>s in some browsers, due to the limited stylability of <select>s in CSS.
   color: $input-color;
   cursor: text;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pf-global--spacer--xs);
   line-height: $co-m-label-line-height;
+
+  > span {
+    display: contents;
+  }
 }
 
 .modal-body tags-input .tags {

--- a/frontend/public/components/utils/label-list.tsx
+++ b/frontend/public/components/utils/label-list.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
+import { Label as PfLabel, LabelGroup as PfLabelGroup } from '@patternfly/react-core';
+
 /* eslint-disable import/named */
 import { withTranslation, WithTranslation } from 'react-i18next';
 /* eslint-enable import/named */
@@ -9,18 +11,21 @@ import { K8sResourceKindReference, kindForReference } from '../../module/k8s';
 
 export const Label: React.SFC<LabelProps> = ({ kind, name, value, expand }) => {
   const href = `/search?kind=${kind}&q=${value ? encodeURIComponent(`${name}=${value}`) : name}`;
-  const klass = classNames('co-m-label', { 'co-m-label--expand': expand });
+  const kindOf = `co-m-${kindForReference(kind.toLowerCase())}`;
+  const klass = classNames(kindOf, { 'co-m-expand': expand }, 'co-label');
 
   return (
-    <Link className={`co-text-${kindForReference(kind.toLowerCase())}`} to={href}>
-      <div className={klass}>
-        <span className="co-m-label__key" data-test="label-key">
-          {name}
-        </span>
-        {value && <span className="co-m-label__eq">=</span>}
-        {value && <span className="co-m-label__value">{value}</span>}
-      </div>
-    </Link>
+    <>
+      <PfLabel className={klass} isTruncated>
+        <Link className="pf-c-label__content" to={href}>
+          <span className="co-label__key" data-test="label-key">
+            {name}
+          </span>
+          {value && <span className="co-label__eq">=</span>}
+          {value && <span className="co-label__value">{value}</span>}
+        </Link>
+      </PfLabel>
+    </>
   );
 };
 
@@ -31,22 +36,27 @@ class TranslatedLabelList extends React.Component<LabelListProps> {
 
   render() {
     const { labels, kind, t, expand = true } = this.props;
-    let list = _.map(labels, (label, key) => (
+    const list = _.map(labels, (label, key) => (
       <Label key={key} kind={kind} name={key} value={label} expand={expand} />
     ));
 
-    if (_.isEmpty(list)) {
-      list = [
-        <div className="text-muted" key="0">
-          {t('public~No labels')}
-        </div>,
-      ];
-    }
-
     return (
-      <div className="co-m-label-list" data-test="label-list">
-        {list}
-      </div>
+      <>
+        {_.isEmpty(list) ? (
+          <div className="text-muted" key="0">
+            {t('public~No labels')}
+          </div>
+        ) : (
+          <PfLabelGroup
+            className="co-label-group"
+            defaultIsOpen={true}
+            numLabels={20}
+            data-test="label-list"
+          >
+            {list}
+          </PfLabelGroup>
+        )}
+      </>
     );
   }
 }

--- a/frontend/public/components/utils/selector-input.jsx
+++ b/frontend/public/components/utils/selector-input.jsx
@@ -2,6 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
 import * as TagsInput from 'react-tagsinput';
+import { Label as PfLabel } from '@patternfly/react-core';
 
 import { split, selectorFromString } from '../../module/k8s/selector';
 import * as k8sSelectorRequirement from '../../module/k8s/selector-requirement';
@@ -131,13 +132,14 @@ export class SelectorInput extends React.Component {
 
     const renderTag = ({ tag, key, onRemove, getTagDisplayValue }) => {
       return (
-        <span className={classNames('tag-item', this.props.labelClassName)} key={key}>
-          <span className="tag-item__content">{getTagDisplayValue(tag)}</span>
-          &nbsp;
-          <a className="remove-button" onClick={() => onRemove(key)}>
-            ×
-          </a>
-        </span>
+        <PfLabel
+          className={classNames('co-label tag-item-content', this.props.labelClassName)}
+          key={key}
+          onClose={() => onRemove(key)}
+          isTruncated
+        >
+          {getTagDisplayValue(tag)}
+        </PfLabel>
       );
     };
 

--- a/frontend/public/style/_base.scss
+++ b/frontend/public/style/_base.scss
@@ -2,7 +2,7 @@
 // Please DO NOT add rules of this type.
 
 dd {
-  margin-bottom: 20px;
+  margin-bottom: var(--pf-global--spacer--lg);
 }
 
 dd:last-child {

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -185,7 +185,6 @@ dl.co-inline {
 .co-m-pane__details {
   line-height: 1.66;
   // TODO: refactor so <dl>s have margin-bottom by default
-  margin-bottom: 20px;
   min-width: 0; // enable break-word
   white-space: normal; // override inheritence from co-detail-table
   .co-detail-table__row & {

--- a/frontend/public/style/_text.scss
+++ b/frontend/public/style/_text.scss
@@ -1,3 +1,6 @@
+
+@import '~@patternfly/patternfly/components/Label/label.scss';
+
 $kinds: (
   alert: $color-alert-dark,
   alertmanager: $color-alertmanager-dark,
@@ -28,13 +31,52 @@ $kinds: (
   silence: $color-alert-dark,
 );
 
+$kindsToModifier: (
+  alert: 'blue',
+  alertmanager: 'orange',
+  alertrule: 'purple',
+  clusterserviceversion: 'blue',
+  configmap: 'purple',
+  daemonset: 'blue',
+  deployment: 'blue',
+  deploymentconfig: 'blue',
+  ingress: 'purple',
+  job: 'blue',
+  machine: 'purple',
+  machineautoscaler: 'purple',
+  machineconfig: 'purple',
+  machineconfigpool: 'purple',
+  machinedeployment: 'purple',
+  machineset: 'purple',
+  metricstarget: 'blue',
+  namespace: 'green',
+  node: 'purple',
+  pod: 'cyan',
+  project: 'green',
+  replicaset: 'blue',
+  replicationcontroller: 'blue',
+  secret: 'orange',
+  service: 'green',
+  serviceaccount: 'purple' ,
+  servicemonitor: 'green',
+  silence: 'blue',
+);
+
 @each $kind, $color in $kinds {
-  .co-text-#{$kind} {
+  .co-text-#{$kind}:where(:not([class*='co-m-'])) {
     color: $color;
 
     &:link, &:visited, &:hover, &:active {
       color: $color;
       text-decoration: none;
+    }
+  }
+}
+
+@each $kind, $color in $kindsToModifier {
+  .co-label {
+    &.co-m-#{$kind} {
+      @extend .pf-m-#{$color};
     }
   }
 }


### PR DESCRIPTION
Current light

![labels-light-current](https://user-images.githubusercontent.com/5385435/164273950-341aa15f-bbdb-4f0c-ae4c-465a0b7ba95a.png)

Current dark

![labels-dark-current](https://user-images.githubusercontent.com/5385435/164274012-9b7ae045-ee4e-422b-8268-15f6de81a3d2.png)

Updated light

![labels-light-update](https://user-images.githubusercontent.com/5385435/164274037-6ef4a1c7-7a2a-4281-829b-ed58fb7b0b26.png)

Updated dark

![labels-dark-update](https://user-images.githubusercontent.com/5385435/164274049-4a66fefe-cfdd-46b5-be16-b2ba196473b3.png)

This PR also contains a layout shift for details tab

Original

![original](https://user-images.githubusercontent.com/5385435/164310992-afff7c2b-21ac-4fc9-9496-b1365733992b.gif)

Update

![update](https://user-images.githubusercontent.com/5385435/164311011-048eba29-f4db-4acf-b4f5-dd0e5561211e.gif)

