### PR TITLE
Gherkin Scripts and Automation for Web-Terminal | Dev Console

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/web-terminal/web-terminal-adminuser.feature
+++ b/frontend/packages/dev-console/integration-tests/features/web-terminal/web-terminal-adminuser.feature
@@ -5,6 +5,7 @@ Feature: Web Terminal for Admin user
 
         Background:
             Given user has logged in as admin user
+              # Error while installing WTO operator because of DWO https://issues.redhat.com/browse/WTO-127
               And user has installed Web Terminal operator
 
         @smoke @to-do
@@ -14,3 +15,16 @@ Feature: Web Terminal for Admin user
              Then user will see the terminal window
              Then user will see the terminal instance for namespace "openshift-terminal"
               And user ID obtained by API should match with user id in yaml editor for "openshift-terminal" namespace
+
+        @regression @odc-6463
+        Scenario Outline: User is able to open and close multiple terminals in the cloudshell: WT-02-TC02
+            Given  user can see terminal icon on masthead
+             When  user clicks on the Web Terminal icon on the Masthead
+              And  user opens <number_of_terminals> additional web terminal tabs
+              And  user closed "<closed_terminal>" web terminal tab
+             Then  user is able see <open_terminals> web terminal tabs
+
+        Examples:
+                  | number_of_terminals | closed_terminal | open_terminals |
+                  | 3                   | 2nd             | 3              |
+                  

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/operators-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/operators-po.ts
@@ -63,6 +63,7 @@ export const operatorsPO = {
     uninstall: '[data-test-id="operator-uninstall-btn"]',
   },
   alertDialog: '[role="dialog"]',
+  warningAlert: '[aria-label="Warning Alert"]',
   uninstallPopup: {
     uninstall: '#confirm-action',
   },

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/web-terminal-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/web-terminal-po.ts
@@ -1,0 +1,6 @@
+export const webTerminalPO = {
+  webTerminalIcon: '[data-tour-id="tour-cloud-shell-button"]',
+  addTerminalIcon: '[data-test="add-terminal-icon"]',
+  closeTerminalIcon: '[data-test="close-terminal-icon"]',
+  tabsList: '[data-test="multi-tab-terminal"] ul',
+};

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/addTerminalTabs.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/addTerminalTabs.ts
@@ -1,0 +1,14 @@
+import { webTerminalPO } from '../../pageObjects/web-terminal-po';
+
+export const addTerminals = (n: number) => {
+  for (let i = 0; i < n; i++) {
+    cy.get(webTerminalPO.addTerminalIcon).click();
+  }
+};
+
+export const closeTerminal = (x: string) => {
+  const n = x.substring(0, 1);
+  cy.get(webTerminalPO.closeTerminalIcon)
+    .eq(Number(n) - 1)
+    .click();
+};

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/checkTerminalIcon.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/checkTerminalIcon.ts
@@ -1,0 +1,16 @@
+import { webTerminalPO } from '../../pageObjects/web-terminal-po';
+
+export const checkTerminalIcon = (tries: number = 10) => {
+  if (tries < 1) {
+    return;
+  }
+  cy.get('body').then(($body) => {
+    if ($body.find(webTerminalPO.webTerminalIcon).length === 0) {
+      cy.reload();
+      cy.wait(10000); // wait is for body to render after reload
+      checkTerminalIcon(tries - 1);
+    } else {
+      cy.log('Found');
+    }
+  });
+};

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/common/operators.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/common/operators.ts
@@ -1,24 +1,10 @@
 import { Given } from 'cypress-cucumber-preprocessor/steps';
-import { operatorsPO } from '@console/dev-console/integration-tests/support/pageObjects';
-import { operators, switchPerspective } from '../../constants';
-import { perspective, operatorsPage, installOperator, verifyAndInstallOperator } from '../../pages';
+import { operators } from '../../constants';
+import { verifyAndInstallOperator } from '../../pages';
+import { verifyAndInstallWebTerminalOperator } from '../../pages/functions/installOperatorOnCluster';
 
 Given('user has installed Web Terminal operator', () => {
-  perspective.switchTo(switchPerspective.Administrator);
-  operatorsPage.navigateToInstallOperatorsPage();
-  cy.get(operatorsPO.installOperators.search)
-    .should('be.visible')
-    .clear()
-    .type(operators.WebTerminalOperator);
-  cy.get('body', {
-    timeout: 50000,
-  }).then(($ele) => {
-    if ($ele.find(operatorsPO.installOperators.noOperatorsFound)) {
-      installOperator(operators.WebTerminalOperator);
-    } else {
-      cy.log('Serverless operator is installed in cluster');
-    }
-  });
+  verifyAndInstallWebTerminalOperator();
 });
 
 Given('user has installed OpenShift Serverless Operator', () => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/web-terminal/web-terminal-adminuser.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/web-terminal/web-terminal-adminuser.ts
@@ -1,0 +1,35 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { nav } from '@console/cypress-integration-tests/views/nav';
+import { switchPerspective } from '../../constants';
+import { webTerminalPO } from '../../pageObjects/web-terminal-po';
+import { perspective } from '../../pages';
+import { addTerminals, closeTerminal } from '../../pages/functions/addTerminalTabs';
+import { checkTerminalIcon } from '../../pages/functions/checkTerminalIcon';
+
+Given('user has logged in as admin user', () => {
+  perspective.switchTo(switchPerspective.Administrator);
+  nav.sidenav.switcher.shouldHaveText(switchPerspective.Administrator);
+});
+
+Given('user can see terminal icon on masthead', () => {
+  checkTerminalIcon();
+  cy.get(webTerminalPO.webTerminalIcon).should('be.visible');
+});
+
+When('user clicks on the Web Terminal icon on the Masthead', () => {
+  cy.get(webTerminalPO.webTerminalIcon).click();
+});
+
+When('user opens {int} additional web terminal tabs', (n: number) => {
+  addTerminals(n);
+});
+
+When('user closed {string} web terminal tab', (n: string) => {
+  closeTerminal(n);
+});
+
+Then('user is able see {int} web terminal tabs', (n: number) => {
+  cy.get(webTerminalPO.tabsList).then(($el) => {
+    expect($el.prop('children').length).toEqual(n + 1);
+  });
+});


### PR DESCRIPTION
**Description:**
<!-- PR description-->
- Gherkin script for opening and closing feature of web terminal tabs.
- Automation of opening and closing web terminal tabs.

**Jira Id:** 
- Epic: [ODC-6463](https://issues.redhat.com/browse/ODC-6463)
- Stories:
     - [ODC-6502](https://issues.redhat.com/browse/ODC-6502)
     - [ODC-6641](https://issues.redhat.com/browse/ODC-6641)

<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
**Pre-conditions/setup:**
    
Web Terminal Operator has to be pre-installed on cluster v4.11
    https://issues.redhat.com/browse/WTO-127
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.11-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p dev-console
```
**Screen shots**:
<!--   -->
<img width="1726" alt="image" src="https://user-images.githubusercontent.com/65410551/164390206-d0e8bcbb-1d5d-45cc-9df5-93202b740765.png">


**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge