### PR TITLE
Bug 2075117: Added inline-flex styling for searchbar filter div

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogToolbar.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogToolbar.tsx
@@ -61,7 +61,7 @@ const CatalogToolbar = React.forwardRef<HTMLInputElement, CatalogToolbarProps>(
       <div className="co-catalog-page__header">
         <div className="co-catalog-page__heading text-capitalize">{title}</div>
         <div className="co-catalog-page__filter">
-          <div ref={inputRef}>
+          <div ref={inputRef} className="co-catalog-page__searchfilter">
             <SearchInput
               className="co-catalog-page__input"
               data-test="search-catalog"

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -306,6 +306,10 @@ $catalog-tile-width: $co-m-catalog-tile-width;
     flex: 0 0 220px;
     margin: 0 $pf-global-gutter 0 0;
   }
+
+  &__searchfilter {
+    display: inline-flex;
+  }
 }
 
 .co-catalog-page__overlay.pf-c-modal-box {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-43273

**Analysis / Root cause**: 
CSS styling is modified to change in other place and that affects this issue since both the places are using same classname.

**Solution Description**: 
Added a custom class to add inline-flex styling

**Screen shots / Gifs for design review**: 
-----BEFORE CHANGES-------
<img width="836" alt="image" src="https://user-images.githubusercontent.com/102503482/164423457-614cbd6f-9e34-4028-b2e9-220c0ce7ac81.png">

-----AFTER CHANGES--------
<img width="830" alt="image" src="https://user-images.githubusercontent.com/102503482/164423299-8920ff49-6bf7-4407-87b6-b56e392b6cf3.png">


**Unit test coverage report**: 
NA

**Test setup:**
1. Switch to developer perspective
2. Navigate to Add > Developer Catalog > All Services

**Browser conformance**: 
- [ x ] Chrome
- [ x ] Firefox
- [ x ] Safari
