### PR TITLE
Bug 2075189: Fix failed module resoltion errors in console sdk

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
@@ -68,7 +68,10 @@ export const getCorePackage: GetPackageDefinition = (
     version: sdkPackage.version,
     main: 'lib/lib-core.js',
     ...commonManifestFields,
-    dependencies: parseSharedModuleDeps(rootPackage, missingDepCallback),
+    dependencies: {
+      ...parseSharedModuleDeps(rootPackage, missingDepCallback),
+      ...parseDeps(rootPackage, ['typesafe-actions', 'whatwg-fetch'], missingDepCallback),
+    },
   },
   filesToCopy: {
     ...commonFiles,

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-utils.ts
@@ -13,6 +13,8 @@ import { Extension } from '../../types';
 import { k8sBasePath } from './k8s';
 import { getReferenceForModel } from './k8s-ref';
 import { WSFactory, WSOptions } from './ws-factory';
+// eslint-disable-next-line
+const staticModels = require('@console/internal/models');
 
 const getK8sAPIPath = ({ apiGroup = 'core', apiVersion }: K8sModel): string => {
   const isLegacy = apiGroup === 'core' && apiVersion === 'v1';
@@ -212,7 +214,7 @@ let k8sModels;
 const getK8sModels = () => {
   if (!k8sModels) {
     // TODO this was migrated from console and is only used for the fallback API discovery and can likely be removed
-    k8sModels = modelsToMap([]);
+    k8sModels = modelsToMap(_.values(staticModels));
 
     const hasModel = (model: K8sModel) => k8sModels.has(modelKey(model));
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-utils.ts
@@ -1,6 +1,5 @@
 import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash';
-import * as staticModels from '@console/internal/models';
 import {
   K8sModel,
   MatchExpression,
@@ -212,7 +211,8 @@ let k8sModels;
 
 const getK8sModels = () => {
   if (!k8sModels) {
-    k8sModels = modelsToMap(_.values(staticModels));
+    // TODO this was migrated from console and is only used for the fallback API discovery and can likely be removed
+    k8sModels = modelsToMap([]);
 
     const hasModel = (model: K8sModel) => k8sModels.has(modelKey(model));
 


### PR DESCRIPTION
This is not the final cleanup of the console SDK logic. We will track that as part of https://issues.redhat.com/browse/HAC-557.

See slack thread here discussing the issue: https://coreos.slack.com/archives/C011BL0FEKZ/p1649788666821279

This fix will:
1. Remove the static model import in the API discovery logic. This is only consumed via: `allModels` and is only used by API discovery via this reducer: https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/src/app/k8s/reducers/k8s.ts#L116
2. The console does not use our default API discovery implementation. It is overriden here:  https://github.com/openshift/console/blob/master/frontend/public/components/app.jsx#L506
3. ~The `typesafe-actions` is used by multiple reducers, however it was being pulled into `dynamic-core-api.ts` via the export for `useK8sWatchResrouce(s)`.  A quick search revealed the console/plugins pull this hook in directly, and it should not be necessary to expose here. For example: `export { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource';` and `export { useK8sWatchResources } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources';`.~
4. ~`whatwg-fetch` was pulled in via the export for `export { consoleFetch, consoleFetchJSON, consoleFetchText } from '../utils/fetch';`. A quick search revealed console/plugins also go directly to the utils folder for these utilities.~

EDIT: @vojtechszocs pointed out that 3 and 4 could be solved by updating our `package-definitions.ts` script to look for `typesafe-actions` and `whatwg-fetch` and ensure they are present in the core package.json. This is a safer change temporarily and should unblock the kubevirt team.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2075189