### PR TITLE
Filter out global configs when cluster is externally managed

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useCanClusterUpgrade.ts
+++ b/frontend/packages/console-shared/src/hooks/useCanClusterUpgrade.ts
@@ -1,12 +1,11 @@
 import { useAccessReviewAllowed } from '@console/dynamic-plugin-sdk';
 import { ClusterVersionModel } from '@console/internal/models';
-import { ClusterVersionKind, hasAvailableUpdates } from '@console/internal/module/k8s';
 
 export const isClusterExternallyManaged = (): boolean => {
   return window.SERVER_FLAGS.controlPlaneTopology === 'External';
 };
 
-export const useCanClusterUpgrade = (clusterVersion: ClusterVersionKind): boolean => {
+export const useCanClusterUpgrade = (): boolean => {
   const hasPermissionsToUpdate = useAccessReviewAllowed({
     group: ClusterVersionModel.apiGroup,
     resource: ClusterVersionModel.plural,
@@ -14,8 +13,8 @@ export const useCanClusterUpgrade = (clusterVersion: ClusterVersionKind): boolea
     name: 'version',
   });
   const notExternallyManaged = !isClusterExternallyManaged();
-  const bandingNotDedicated = window.SERVER_FLAGS.branding !== 'dedicated';
-  const canPerformUpgrade = hasPermissionsToUpdate && bandingNotDedicated && notExternallyManaged;
+  const brandingNotDedicated = window.SERVER_FLAGS.branding !== 'dedicated';
+  const canPerformUpgrade = hasPermissionsToUpdate && brandingNotDedicated && notExternallyManaged;
 
-  return hasAvailableUpdates(clusterVersion) && canPerformUpgrade;
+  return canPerformUpgrade;
 };

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -17,6 +17,7 @@ import {
   getCurrentVersion,
   getK8sGitVersion,
   getOpenShiftVersion,
+  hasAvailableUpdates,
 } from '../module/k8s/cluster-settings';
 
 const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) => {
@@ -28,7 +29,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) =>
       .catch(() => setKubernetesVersion(t('public~unknown')));
   }, [t]);
   const clusterVersion = useClusterVersion();
-  const canUpgrade = useCanClusterUpgrade(clusterVersion);
+  const canUpgrade = useCanClusterUpgrade();
 
   const clusterID = getClusterID(clusterVersion);
   const channel: string = clusterVersion?.spec?.channel;
@@ -36,7 +37,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) =>
 
   return (
     <>
-      {canUpgrade && (
+      {canUpgrade && hasAvailableUpdates(clusterVersion) && (
         <Alert
           className="co-alert co-about-modal__alert"
           title={

--- a/frontend/public/components/cluster-settings/filterNonUpgradableResources.ts
+++ b/frontend/public/components/cluster-settings/filterNonUpgradableResources.ts
@@ -1,0 +1,73 @@
+import { K8sGroupVersionKind, K8sModel } from '@console/dynamic-plugin-sdk';
+import { MachineConfigModel } from '@console/internal/models';
+
+const resourcesToOmit: K8sGroupVersionKind[] = [
+  {
+    group: MachineConfigModel.apiGroup,
+    version: MachineConfigModel.apiVersion,
+    kind: MachineConfigModel.kind,
+  },
+  {
+    group: 'machineconfiguration.openshift.io',
+    version: 'v1',
+    kind: 'KubeletConfig',
+  },
+  {
+    group: 'machineconfiguration.openshift.io',
+    version: 'v1',
+    kind: 'ContainerRuntimeConfig',
+  },
+  {
+    group: 'config.openshift.io',
+    version: 'v1',
+    kind: 'APIServer',
+  },
+  {
+    group: 'config.openshift.io',
+    version: 'v1',
+    kind: 'Authentication',
+  },
+  {
+    group: 'config.openshift.io',
+    version: 'v1',
+    kind: 'OAuth',
+  },
+  {
+    group: 'config.openshift.io',
+    version: 'v1',
+    kind: 'FeatureGate',
+  },
+  {
+    group: 'config.openshift.io',
+    version: 'v1',
+    kind: 'Scheduler',
+  },
+  {
+    group: 'config.openshift.io',
+    version: 'v1',
+    kind: 'Network',
+  },
+  {
+    group: 'config.openshift.io',
+    version: 'v1',
+    kind: 'Proxy',
+  },
+  {
+    group: 'config.openshift.io',
+    version: 'v1',
+    kind: 'DNS',
+  },
+];
+
+const matchModel = (toMatchWith: K8sGroupVersionKind) => (model: K8sGroupVersionKind): boolean =>
+  model.group === toMatchWith.group &&
+  model.version === toMatchWith.version &&
+  model.kind === toMatchWith.kind;
+
+const filterNonUpgradableResources = (model: K8sModel): boolean => {
+  return !resourcesToOmit.find(
+    matchModel({ group: model.apiGroup, version: model.apiVersion, kind: model.kind }),
+  );
+};
+
+export default filterNonUpgradableResources;

--- a/frontend/public/components/cluster-settings/filterNonUpgradableResources.ts
+++ b/frontend/public/components/cluster-settings/filterNonUpgradableResources.ts
@@ -1,22 +1,6 @@
 import { K8sGroupVersionKind, K8sModel } from '@console/dynamic-plugin-sdk';
-import { MachineConfigModel } from '@console/internal/models';
 
 const resourcesToOmit: K8sGroupVersionKind[] = [
-  {
-    group: MachineConfigModel.apiGroup,
-    version: MachineConfigModel.apiVersion,
-    kind: MachineConfigModel.kind,
-  },
-  {
-    group: 'machineconfiguration.openshift.io',
-    version: 'v1',
-    kind: 'KubeletConfig',
-  },
-  {
-    group: 'machineconfiguration.openshift.io',
-    version: 'v1',
-    kind: 'ContainerRuntimeConfig',
-  },
   {
     group: 'config.openshift.io',
     version: 'v1',

--- a/frontend/public/components/cluster-settings/global-config.tsx
+++ b/frontend/public/components/cluster-settings/global-config.tsx
@@ -23,6 +23,8 @@ import {
   ClusterGlobalConfig,
   isClusterGlobalConfig,
 } from '@console/dynamic-plugin-sdk/src/extensions/cluster-settings';
+import { useCanClusterUpgrade } from '@console/shared';
+import filterNonUpgradableResources from './filterNonUpgradableResources';
 
 type ConfigDataType = { model: K8sKind; id: string; name: string; namespace: string };
 
@@ -210,9 +212,21 @@ const GlobalConfigPage_: React.FC<GlobalConfigPageProps & GlobalConfigPageExtens
   );
 };
 
-export const GlobalConfigPage = connect(stateToProps)((props) => {
+export const GlobalConfigPage = connect(stateToProps)(({ configResources, ...props }) => {
   const [resolvedExtensions] = useResolvedExtensions<ClusterGlobalConfig>(isClusterGlobalConfig);
-  return <GlobalConfigPage_ globalConfigs={resolvedExtensions} {...props} />;
+
+  const canClusterUpgrade = useCanClusterUpgrade();
+  const adjustedConfigResources = canClusterUpgrade
+    ? configResources
+    : configResources.filter(filterNonUpgradableResources);
+
+  return (
+    <GlobalConfigPage_
+      globalConfigs={resolvedExtensions}
+      configResources={adjustedConfigResources}
+      {...props}
+    />
+  );
 });
 
 type GlobalConfigPageExtensionProps = {


### PR DESCRIPTION
https://issues.redhat.com/browse/CONSOLE-3073

Filters out the Cluster Settings => Configuration tab of resources (ticket has the list, but if you want the full qualified list see [this code link](https://github.com/openshift/console/pull/11383/files#diff-7c47f35e3e3c03d9ee57e6e7cc8c2761391134973e0b0e7be363faa8ef0e7760R4)) that cannot be modified if the cluster is externally managed.

![image](https://user-images.githubusercontent.com/8126518/164560732-dc97a108-0a63-44ac-85dd-4619688372d2.png)

### Setup / Testing
It's based on the SERVER_FLAG controlPlaneTopology being set to External is really the driving factor here; this can be done in one of two ways:

- Locally via a Bridge Variable, `export BRIDGE_CONTROL_PLANE_TOPOLOGY_MODE="External"`
- Locally / OnCluster via modifying the `window.SERVER_FLAGS.controlPlaneTopology` to External in the dev tools