### PR TITLE
CONSOLE-3090: [Dark Theme]  This is to reassign the correct blue and orange heading colors that are used in the getting started sections on both Admin and Dev console

### DIFF
--- a/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
@@ -55,9 +55,9 @@ export const DeveloperFeaturesGettingStartedCard: React.FC = () => {
   return (
     <GettingStartedCard
       id="developer-features"
-      icon={<FlagIcon color="var(--pf-global--palette--orange-300)" aria-hidden="true" />}
+      icon={<FlagIcon color="var(--co-global--palette--orange-400)" aria-hidden="true" />}
       title={t('devconsole~Explore new developer features')}
-      titleColor={'var(--co-global--palette--orange-700)'}
+      titleColor={'var(--co-global--palette--orange-400)'}
       description={t(
         'devconsole~Explore new features and resources within the developer perspective.',
       )}

--- a/frontend/packages/dev-console/src/components/add/SampleGettingStartedCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/SampleGettingStartedCard.tsx
@@ -83,9 +83,9 @@ export const SampleGettingStartedCard: React.FC<SampleGettingStartedCardProps> =
         return (
           <GettingStartedCard
             id="samples"
-            icon={<CatalogIcon color="var(--co-global--palette--blue-600)" aria-hidden="true" />}
+            icon={<CatalogIcon color="var(--co-global--palette--blue-400)" aria-hidden="true" />}
             title={t('devconsole~Create applications using samples')}
-            titleColor={'var(--co-global--palette--blue-600)'}
+            titleColor={'var(--co-global--palette--blue-400)'}
             description={t(
               'devconsole~Choose a code sample to get started creating an application with.',
             )}

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/FeatureHighlightsCard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/FeatureHighlightsCard.tsx
@@ -46,10 +46,10 @@ export const FeatureHighlightsCard: React.FC = () => {
     <GettingStartedCard
       id="feature-highlights"
       icon={
-        <i className="fas fa-blog" color="var(--co-global--palette--blue-600)" aria-hidden="true" />
+        <i className="fas fa-blog" color="var(--co-global--palette--blue-400)" aria-hidden="true" />
       }
       title={t('kubevirt-plugin~Feature highlights')}
-      titleColor={'var(--co-global--palette--blue-600)'}
+      titleColor={'var(--co-global--palette--blue-400)'}
       description={t(
         'kubevirt-plugin~Read about the latest information and key virtualization features on the Virtualization highlights.',
       )}

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/RecommendedOperatorsCard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/getting-started-card/RecommendedOperatorsCard.tsx
@@ -42,7 +42,7 @@ export const RecommendedOperatorsCard: React.FC = () => {
         />
       }
       title={t('kubevirt-plugin~Recommended Operators')}
-      titleColor={'var(--co-global--palette--blue-600)'}
+      titleColor={'var(--co-global--palette--blue-400)'}
       description={t(
         'kubevirt-plugin~Ease operational complexity with virtualization by using Operators.',
       )}

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
@@ -34,9 +34,9 @@ export const ClusterSetupGettingStartedCard: React.FC = () => {
   return (
     <GettingStartedCard
       id="cluster-setup"
-      icon={<ClipboardCheckIcon color="var(--co-global--palette--blue-600)" aria-hidden="true" />}
+      icon={<ClipboardCheckIcon color="var(--co-global--palette--blue-400)" aria-hidden="true" />}
       title={t('public~Set up your cluster')}
-      titleColor={'var(--co-global--palette--blue-600)'}
+      titleColor={'var(--co-global--palette--blue-400)'}
       description={t('public~Finish setting up your cluster with recommended configurations.')}
       links={links}
       moreLink={moreLink}

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
@@ -38,9 +38,9 @@ export const ExploreAdminFeaturesGettingStartedCard: React.FC = () => {
   return (
     <GettingStartedCard
       id="admin-features"
-      icon={<FlagIcon color="var(--co-global--palette--orange-700)" aria-hidden="true" />}
+      icon={<FlagIcon color="var(--co-global--palette--orange-400)" aria-hidden="true" />}
       title={t('public~Explore new admin features')}
-      titleColor={'var(--co-global--palette--orange-700)'}
+      titleColor={'var(--co-global--palette--orange-400)'}
       description={t('public~Explore new features and resources within the admin perspective.')}
       links={links}
       moreLink={moreLink}

--- a/frontend/public/style/_theme-dark.scss
+++ b/frontend/public/style/_theme-dark.scss
@@ -1,19 +1,19 @@
 :root {
-  --co-global--palette--blue-600: var(--pf-global--palette--blue-600);
+  --co-global--palette--blue-400: var(--pf-global--palette--blue-400);
   --co-global--palette--purple-600: var(--pf-global--palette--purple-600);
-  --co-global--palette--orange-700: var(--pf-global--palette--orange-700);
+  --co-global--palette--orange-400: var(--pf-global--palette--orange-400);
   --co-global--palette--purple-700: var(--pf-global--palette--purple-700);
 
   // dark
-  --co-global--dark--palette--blue-600: var(--pf-global--palette--blue-200);
+  --co-global--dark--palette--blue-400: var(--pf-global--palette--blue-200);
   --co-global--dark--palette--purple-600: var(--pf-global--palette--purple-200);
-  --co-global--dark--palette--orange-700: var(--pf-global--palette--orange-200);
+  --co-global--dark--palette--orange-400: var(--pf-global--palette--orange-200);
   --co-global--dark--palette--purple-700: var(--pf-global--palette--purple-200);
 }
 
 :root:where(.pf-theme-dark) {
-  --co-global--palette--blue-600: var(--co-global--dark--palette--blue-600);
+  --co-global--palette--blue-400: var(--co-global--dark--palette--blue-400);
   --co-global--palette--purple-600: var(--co-global--dark--palette--purple-600);
-  --pf-global--palette--orange-700: var(--co-global--dark--palette--orange-700);
+  --co-global--palette--orange-400: var(--co-global--dark--palette--orange-400);
   --co-global--palette--purple-700: var(--co-global--dark--palette--purple-600);
 }


### PR DESCRIPTION
These were previously updated in https://github.com/openshift/console/pull/11151, but inadvertently assigned to darker shade css properties. Note the purple vars are correct.
This only effects the light theme colors. Dark theme are assigned the correct color variables.

**Before**
<img width="1315" alt="adm-gs-light-before" src="https://user-images.githubusercontent.com/1874151/164800044-ae845a5d-4b77-414c-9134-b02b42227808.png">
<img width="1314" alt="dev-gs-light-before" src="https://user-images.githubusercontent.com/1874151/164800055-f9385fbb-ced0-4c9f-a4d2-be6f72ec02f7.png">


**After**
<img width="1314" alt="adm-gs-light" src="https://user-images.githubusercontent.com/1874151/164800070-fe74039d-fe97-4f0f-bb05-6d91a418d4bc.png">
<img width="1302" alt="dev-gs-light" src="https://user-images.githubusercontent.com/1874151/164800078-25e13457-f9fe-4993-bf46-38fab7b6dd72.png">

**Dark**
<img width="1312" alt="adm-gs-dark" src="https://user-images.githubusercontent.com/1874151/164800267-a46df142-10fa-4671-a397-c990a874d108.png">
<img width="1312" alt="dev-gs-dark" src="https://user-images.githubusercontent.com/1874151/164800279-263e83e9-632f-4d35-bf33-1717efe0abf6.png">


