### PR TITLE
Send activity tick by polling

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.tsx
@@ -30,6 +30,7 @@ type StateProps = {
 
 type Props = {
   onCancel?: () => void;
+  isActiveTab?: boolean;
 };
 
 type CloudShellTerminalProps = StateProps & Props;
@@ -39,6 +40,7 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
   user,
   onCancel,
   userSettingState: namespace,
+  isActiveTab = false,
   setUserSettingState: setNamespace,
 }) => {
   const [operatorNamespace, namespaceLoadError] = useCloudShellNamespace();
@@ -191,6 +193,7 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
         podname={initData.pod}
         shcommand={initData.cmd || []}
         workspaceModel={workspaceModel}
+        isActiveTab={isActiveTab}
       />
     );
   }

--- a/frontend/packages/console-app/src/components/cloud-shell/MultiTabbedTerminal.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/MultiTabbedTerminal.tsx
@@ -77,7 +77,7 @@ export const MultiTabbedTerminal: React.FC<MultiTabbedTerminalProps> = ({ onClos
             </div>
           }
         >
-          <CloudShellTerminal />
+          <CloudShellTerminal isActiveTab={activeTabKey === terminalNumber} />
         </Tab>
       ))}
       {terminalTabs.length < MAX_TERMINAL_TABS && (

--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellExec.spec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellExec.spec.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { FLAGS } from '@console/shared';
+import { WorkspaceModel } from '../../../models';
+import { InternalCloudShellExec, CloudShellExecProps } from '../CloudShellExec';
+import TerminalLoadingBox from '../TerminalLoadingBox';
+import useActivityTick from '../useActivityTick';
+
+Object.defineProperty(window, 'requestAnimationFrame', {
+  writable: true,
+  value: (callback) => callback(),
+});
+
+jest.mock('../useActivityTick', () => ({
+  default: jest.fn(),
+}));
+
+const workspace = 'test1';
+const namespace = 'namespace1';
+
+const cloudShellExecProps: CloudShellExecProps = {
+  workspaceName: workspace,
+  container: 'test1',
+  podname: 'testpod',
+  namespace,
+  workspaceModel: WorkspaceModel,
+  onActivate: () => {},
+  flags: { [FLAGS.OPENSHIFT]: true },
+};
+
+beforeEach(() => {
+  jest.useFakeTimers();
+
+  let count = 0;
+  jest
+    .spyOn(window, 'requestAnimationFrame')
+    .mockImplementation((cb) => setTimeout(() => cb(100 * ++count), 100));
+});
+
+afterEach(() => {
+  (window.requestAnimationFrame as any).mockRestore();
+  jest.clearAllTimers();
+});
+
+describe('CloudShellExec', () => {
+  it('should call requestAnimationFrame and useActivityTick On Mount', () => {
+    jest.useFakeTimers();
+    (useActivityTick as jest.Mock).mockImplementation((w, n) => {
+      return [w, n];
+    });
+    const wrapper = mount(<InternalCloudShellExec {...cloudShellExecProps} isActiveTab />);
+    expect(wrapper.find(TerminalLoadingBox).exists()).toBe(true);
+    expect(requestAnimationFrame).toHaveBeenCalled();
+    expect(useActivityTick).toHaveBeenCalledTimes(1);
+    expect(useActivityTick).toHaveBeenCalledWith(workspace, namespace);
+  });
+});

--- a/frontend/packages/console-app/src/components/cloud-shell/useActivityTick.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/useActivityTick.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { sendActivityTick } from './cloud-shell-utils';
 
 // 1 minute
-const TICK_INTERVAL = 60000;
+export const TICK_INTERVAL = 60000;
 
 const useActivityTick = (workspaceName: string, namespace: string) => {
   const lastTick = React.useRef<number>(0);


### PR DESCRIPTION
# Addresses
https://issues.redhat.com/browse/ODC-6644

Sends tick by polling even when drawer is minimised

# Screenshots
<img width="1792" alt="Screenshot 2022-04-25 at 8 14 09 PM" src="https://user-images.githubusercontent.com/24852534/165295273-da2d3a7a-e9e0-49d3-9811-aa26bd70aa9e.png">


<img width="497" alt="Screenshot 2022-04-25 at 8 15 09 PM" src="https://user-images.githubusercontent.com/24852534/165295229-819b98a4-8b85-47dd-a823-0100cc62d04d.png">
4.09 PM.png…]()

# Tests
no change

# Browser conformance

Chrome

