### PR TITLE
[Dark Theme]: fix Topology empty state to support dark theme

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -283,8 +283,10 @@ ul.pf-c-tree-view__list {
   font-size: $font-size-base !important;
 }
 
-.pf-topology-content {
-  background-color: var(--pf-global--BackgroundColor--200);
+.odc-topology {
+  .pf-topology-content {
+    background-color: var(--pf-global--BackgroundColor--200);
+  }
 }
 
 .pfext-quick-start-footer {


### PR DESCRIPTION
**Story:** https://issues.redhat.com/browse/ODC-6654

**Description:**
Override `pf-topology-content` `background-color` with `--pf-global--BackgroundColor--200`.

**Before:**
![Screenshot 2022-04-25 at 10 32 01 PM](https://user-images.githubusercontent.com/2561818/165137910-740df694-aef7-4e2c-b2e9-6fff24af550e.png)

**After:**
![image](https://user-images.githubusercontent.com/2561818/165137610-e8b8628f-588a-468e-bf33-f3e13fa80162.png)
