### PR TITLE
Bug 2077150: Required parent class added so that margin spacing for breadcrumbs is applied.

### DIFF
--- a/frontend/packages/gitops-plugin/src/components/details/GitOpsDetailsPageHeading.tsx
+++ b/frontend/packages/gitops-plugin/src/components/details/GitOpsDetailsPageHeading.tsx
@@ -30,19 +30,23 @@ const GitOpsDetailsPageHeading: React.FC<GitOpsDetailsPageHeadingProps> = ({
   ];
 
   return (
-    <div className="gop-gitops-details-page-heading co-m-nav-title co-m-nav-title--breadcrumbs">
-      <BreadCrumbs breadcrumbs={breadcrumbs} />
-      <h1 className="co-m-pane__heading" style={{ marginRight: 'var(--pf-global--spacer--sm)' }}>
-        <div className="co-m-pane__name co-resource-item">
-          <span className="co-resource-item__resource-name">{appName}</span>
-        </div>
-        {badge && <span className="co-m-pane__heading-badge">{badge}</span>}
-      </h1>
-      <ExternalLink href={manifestURL} additionalClassName={'co-break-all'}>
-        {routeDecoratorIcon(manifestURL, 12, t)}&nbsp;
-        {manifestURL}&nbsp;
-      </ExternalLink>
-    </div>
+    <>
+      <div className="pf-c-page__main-breadcrumb">
+        <BreadCrumbs breadcrumbs={breadcrumbs} />
+      </div>
+      <div className="gop-gitops-details-page-heading co-m-nav-title co-m-nav-title--breadcrumbs">
+        <h1 className="co-m-pane__heading" style={{ marginRight: 'var(--pf-global--spacer--sm)' }}>
+          <div className="co-m-pane__name co-resource-item">
+            <span className="co-resource-item__resource-name">{appName}</span>
+          </div>
+          {badge && <span className="co-m-pane__heading-badge">{badge}</span>}
+        </h1>
+        <ExternalLink href={manifestURL} additionalClassName={'co-break-all'}>
+          {routeDecoratorIcon(manifestURL, 12, t)}&nbsp;
+          {manifestURL}&nbsp;
+        </ExternalLink>
+      </div>
+    </>
   );
 };
 

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -7,8 +7,6 @@ import {
   CodeBlock,
   CodeBlockCode,
   Popover,
-  Split,
-  SplitItem,
 } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import * as React from 'react';
@@ -691,7 +689,7 @@ const AlertsDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
         loaded={alerts?.loaded}
         loadError={alerts?.loadError}
       >
-        <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
+        <div className="pf-c-page__main-breadcrumb">
           <BreadCrumbs
             breadcrumbs={[
               {
@@ -701,6 +699,8 @@ const AlertsDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
               { name: t('public~Alert details'), path: undefined },
             ]}
           />
+        </div>
+        <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
           <h1 className="co-m-pane__heading">
             <div data-test="resource-title" className="co-resource-item">
               <MonitoringResourceIcon className="co-m-resource-icon--lg" resource={AlertResource} />
@@ -937,7 +937,7 @@ const AlertRulesDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
         <title>{t('public~{{name}} details', { name: rule?.name || RuleResource.label })}</title>
       </Helmet>
       <StatusBox data={rule} label={RuleResource.label} loaded={loaded} loadError={loadError}>
-        <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
+        <div className="pf-c-page__main-breadcrumb">
           <BreadCrumbs
             breadcrumbs={[
               {
@@ -949,6 +949,8 @@ const AlertRulesDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
               { name: t('public~Alerting rule details'), path: undefined },
             ]}
           />
+        </div>
+        <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
           <h1 className="co-m-pane__heading">
             <div data-test="resource-title" className="co-resource-item">
               <MonitoringResourceIcon className="co-m-resource-icon--lg" resource={RuleResource} />
@@ -1128,7 +1130,7 @@ const SilencesDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
         loaded={silences?.loaded}
         loadError={silences?.loadError}
       >
-        <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
+        <div className="pf-c-page__main-breadcrumb">
           <BreadCrumbs
             breadcrumbs={[
               {
@@ -1141,6 +1143,8 @@ const SilencesDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
               { name: t('public~Silence details'), path: undefined },
             ]}
           />
+        </div>
+        <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
           <h1 className="co-m-pane__heading">
             <div data-test="resource-title" className="co-resource-item">
               <MonitoringResourceIcon
@@ -1702,23 +1706,21 @@ const AlertingPage: React.FC<{ match: any }> = ({ match }) => {
 
   return (
     <>
+      {isAlertmanager && (
+        <div className="pf-c-page__main-breadcrumb">
+          <BreadCrumbs
+            breadcrumbs={breadcrumbsForGlobalConfig(
+              'Alertmanager',
+              '/monitoring/alertmanagerconfig',
+            )}
+          />
+        </div>
+      )}
       <div
         className={classNames('co-m-nav-title', 'co-m-nav-title--detail', {
           'co-m-nav-title--breadcrumbs': isAlertmanager,
         })}
       >
-        {isAlertmanager && (
-          <Split style={{ alignItems: 'baseline' }}>
-            <SplitItem isFilled>
-              <BreadCrumbs
-                breadcrumbs={breadcrumbsForGlobalConfig(
-                  'Alertmanager',
-                  '/monitoring/alertmanagerconfig',
-                )}
-              />
-            </SplitItem>
-          </Split>
-        )}
         <h1 className="co-m-pane__heading">
           <div className="co-m-pane__name co-resource-item">
             <span className="co-resource-item__resource-name" data-test-id="resource-title">

--- a/frontend/public/components/monitoring/targets.tsx
+++ b/frontend/public/components/monitoring/targets.tsx
@@ -103,13 +103,15 @@ const Details = withRouter<DetailsProps>(({ loaded, loadError, match, targets })
       <Helmet>
         <title>{t('public~Target details')}</title>
       </Helmet>
-      <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
+      <div className="pf-c-page__main-breadcrumb">
         <BreadCrumbs
           breadcrumbs={[
             { name: t('public~Targets'), path: '/monitoring/targets' },
             { name: t('public~Target details'), path: undefined },
           ]}
         />
+      </div>
+      <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
         <h1 className="co-m-pane__heading">
           <div className="co-resource-item">{scrapeUrl}</div>
         </h1>


### PR DESCRIPTION
A few pages include the `<Breadcrumbs>` component independently so they were not nested within `<div class="pf-c-page__main-breadcrumb">` which sets top and side margins

A followup that was missed in https://github.com/openshift/console/pull/11321 Update and scope our breadcrumb padding rule so it doesn't effect a pure implementation

before and after
<img width="496" alt="ar-before" src="https://user-images.githubusercontent.com/1874151/165166824-11655498-07ce-4bc1-a827-bf5e32e07092.png">
<img width="557" alt="ar-after" src="https://user-images.githubusercontent.com/1874151/165166841-db17c314-09a3-4228-842c-ce2c37cac928.png">

---

<img width="484" alt="target-before" src="https://user-images.githubusercontent.com/1874151/165166864-7266aace-27a2-41c0-8f25-261c24545d9d.png">
<img width="524" alt="target-after" src="https://user-images.githubusercontent.com/1874151/165166889-250923da-9cbc-426b-9ad2-e675e531bece.png">

--- 

<img width="506" alt="alertmgr-before" src="https://user-images.githubusercontent.com/1874151/165166919-ada01903-b382-4cf0-a309-06bfcfab18ae.png">
<img width="523" alt="alertmgr-after" src="https://user-images.githubusercontent.com/1874151/165166939-8493845f-1f66-4918-bc89-0eb3c55c27c9.png">


