### PR TITLE
Automation for application and resource grouping | Topology

### DIFF
--- a/frontend/packages/topology/integration-tests/features/topology/resources-groupings.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/resources-groupings.feature
@@ -8,12 +8,12 @@ Feature: Resources Groupings in Topology
               And user has created or selected namespace "aut-topology"
 
 
-        @regression @to-do
+        @regression
         Scenario: Default state of Resources dropdown: T-03-TC01
-            Given user is at Topology page
+            Given user has created workload with resource type deployment
+              And user is at Topology page
              When user clicks on the Resources dropdown
              Then user sees that all the checkboxes are unchecked
-
 
         @regression @manual
         Scenario: Ability to show Deployment resource types in Topology graph and list view: T-03-TC02

--- a/frontend/packages/topology/integration-tests/features/topology/topology-application-grouping.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-application-grouping.feature
@@ -24,13 +24,13 @@ Feature: Application groupings in topology
              Then user can view Add to application and Delete application options
 
 
-        @regression @broken-test
+        @regression
         Scenario: Add to Application in Application grouping from Action menu: T-05-TC03
             Given user is at Topology page
              When user clicks on application groupings "nodejs-ex-git-app"
               And user clicks on Action menu
-              And user clicks "Add to Application" from action menu
-              And user clicks on "From Git"
+              And user hovers on Add to Application from action menu
+              And user clicks on Import From Git option
               And user fills the form with workload name "added-application-1" and clicks Create
              Then user can see "added-application-1" workload
 
@@ -38,7 +38,7 @@ Feature: Application groupings in topology
         Scenario: Delete application grouping from Action menu: T-05-TC04
             Given user is at Add page
               And user has created workload "nodejs-1" with resource type "Deployment" and application groupings "app2"
-             When user right clicks on Application "app2" to open Context Menu
+             When user right clicks on application "app2" to open Context Menu
               And user clicks on "Delete application" from context action menu
               And user enters the name "app2" in the Delete application modal and clicks on Delete button
              Then user will not see Application groupings "app2"

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -246,6 +246,12 @@ export const topologyPO = {
     },
     tickButton: '[data-test-id="check-icon"]',
   },
+  grouping: {
+    addToApplication: '[data-test-action="add-to-application"]',
+    importFromGitOption: '[data-test-action="Import from Git"]',
+    filterResources: '[data-test="filter-by-resource"]',
+    deploymentCheckbox: '[data-test="Deployment"]',
+  },
 };
 
 export const typeOfWorkload = (workload: string) => {

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/application-groupings.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/application-groupings.ts
@@ -1,13 +1,17 @@
-import { When, Then } from 'cypress-cucumber-preprocessor/steps';
-import { topologyHelper } from '@console/dev-console/integration-tests/support/pages';
+import { When, Then, Given } from 'cypress-cucumber-preprocessor/steps';
+import {
+  createGitWorkloadIfNotExistsOnTopologyPage,
+  topologyHelper,
+} from '@console/dev-console/integration-tests/support/pages';
 import { addToApplication } from '@console/topology/integration-tests/support/pages/topology/topology-actions-page';
 import {
   topologyPage,
   addGitWorkload,
 } from '@console/topology/integration-tests/support/pages/topology/topology-page';
 import { topologySidePane } from '@console/topology/integration-tests/support/pages/topology/topology-side-pane-page';
+import { topologyPO } from '../../page-objects/topology-po';
 
-When('user right clicks on Application {string} to open Context Menu', (appName: string) => {
+When('user right clicks on application {string} to open Context Menu', (appName: string) => {
   topologyPage.rightClickOnApplicationGroupings(appName);
 });
 
@@ -26,7 +30,7 @@ Then('user can see Actions dropdown menu', () => {
   topologySidePane.verifyActionsDropDown();
 });
 
-Then('user can view Add to Application and Delete Application options', () => {
+Then('user can view Add to application and Delete application options', () => {
   topologySidePane.verifyActionsOnApplication();
 });
 
@@ -62,3 +66,29 @@ Then(
     topologyPage.verifyApplicationGroupingSidepane();
   },
 );
+
+When('user hovers on Add to Application from action menu', () => {
+  cy.get(topologyPO.grouping.addToApplication).trigger('mouseover');
+});
+
+When('user clicks on Import From Git option', () => {
+  cy.get(topologyPO.grouping.importFromGitOption).click();
+});
+
+Given('user has created workload with resource type deployment', () => {
+  createGitWorkloadIfNotExistsOnTopologyPage(
+    'https://github.com/sclorg/nodejs-ex.git',
+    'ex-node-js',
+    'deployment',
+    'nodejs-ex-git-app',
+  );
+  topologyHelper.verifyWorkloadInTopologyPage('ex-node-js');
+});
+
+When('user clicks on the Resources dropdown', () => {
+  cy.get(topologyPO.grouping.filterResources).click();
+});
+
+Then('user sees that all the checkboxes are unchecked', () => {
+  cy.get(topologyPO.grouping.deploymentCheckbox).should('not.be.checked');
+});


### PR DESCRIPTION
**Description:**
<!-- PR description-->
- Automation for application and resource grouping feature files | Topology

**Jira Id:**
     - [ODC-6656](https://issues.redhat.com/browse/ODC-6656)
     - [ODC-6655](https://issues.redhat.com/browse/ODC-6655)
<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
**Pre-conditions/setup:**

<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->
**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.11-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p dev-console
```
**Screen shots**:
topology-application-grouping.feature
<img width="1419" alt="image" src="https://user-images.githubusercontent.com/65410551/165236223-f5b568d2-322f-4a84-b034-9e2e9ec64ce4.png">

resources-grouping.feature
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/65410551/165236344-9443b184-2961-4259-9aef-16f5acbf7af2.png">

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge