### PR TITLE
CONSOLE-3141: Hide 'Control Plane' section in the status card for External controlPlaneTopology

### DIFF
--- a/frontend/packages/console-app/src/plugin.tsx
+++ b/frontend/packages/console-app/src/plugin.tsx
@@ -114,7 +114,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         ).then((m) => m.default),
       // t('console-app~Control Plane status')
       popupTitle: '%console-app~Control Plane status%',
-      disallowedProviders: ['IBMCloud'],
+      disallowedControlPlaneTopology: ['External'],
     },
   },
   {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/dashboards.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/dashboards.ts
@@ -66,8 +66,8 @@ export type DashboardsOverviewHealthPrometheusSubsystem = ExtensionDeclaration<
     popupComponent?: CodeRef<React.ComponentType<PrometheusHealthPopupProps>>;
     /** The title of the popover. */
     popupTitle?: string;
-    /** Cloud providers which for which the subsystem should be hidden. */
-    disallowedProviders?: string[];
+    /** Control plane topology for which the subsystem should be hidden. */
+    disallowedControlPlaneTopology?: string[];
   }
 >;
 

--- a/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
@@ -80,10 +80,8 @@ namespace ExtensionProperties {
      */
     popupTitle?: string;
 
-    /**
-     * Cloud providers which for which the subsystem should be hidden.
-     */
-    disallowedProviders?: string[];
+    /** Control plane topology for which the subsystem should be hidden. */
+    disallowedControlPlaneTopology?: string[];
   }
 
   export interface DashboardsOverviewHealthResourceSubsystem<R extends ResourcesObject>

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -40,12 +40,7 @@ import {
   CardTitle,
   CardActions,
 } from '@patternfly/react-core';
-import {
-  BlueArrowCircleUpIcon,
-  FLAGS,
-  getInfrastructurePlatform,
-  useCanClusterUpgrade,
-} from '@console/shared';
+import { BlueArrowCircleUpIcon, FLAGS, useCanClusterUpgrade } from '@console/shared';
 
 import AlertsBody from '@console/shared/src/components/dashboard/status-card/AlertsBody';
 import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
@@ -70,7 +65,6 @@ import {
 } from './health-item';
 import { useK8sWatchResource } from '../../../utils/k8s-watch-hook';
 import { useFlag } from '@console/shared/src/hooks/flag';
-import { ClusterDashboardContext } from './context';
 import { useNotificationAlerts } from '@console/shared/src/hooks/useNotificationAlerts';
 
 const filterSubsystems = (
@@ -181,7 +175,6 @@ export const StatusCard = connect<StatusCardProps>(mapStateToProps)(({ k8sModels
       ),
     [subsystems],
   );
-  const { infrastructure, infrastructureLoaded } = React.useContext(ClusterDashboardContext);
   const { t } = useTranslation();
   const healthItems: { title: string; Component: React.ReactNode }[] = [];
   subsystems.forEach((subsystem) => {
@@ -197,11 +190,10 @@ export const StatusCard = connect<StatusCardProps>(mapStateToProps)(({ k8sModels
       isDashboardsOverviewHealthPrometheusSubsystem(subsystem) ||
       isResolvedDashboardsOverviewHealthPrometheusSubsystem(subsystem)
     ) {
-      const { disallowedProviders } = subsystem.properties;
+      const { disallowedControlPlaneTopology } = subsystem.properties;
       if (
-        disallowedProviders?.length &&
-        (!infrastructureLoaded ||
-          disallowedProviders.includes(getInfrastructurePlatform(infrastructure)))
+        disallowedControlPlaneTopology?.length &&
+        disallowedControlPlaneTopology.includes(window.SERVER_FLAGS.controlPlaneTopology)
       ) {
         return;
       }


### PR DESCRIPTION
Jira Story : https://issues.redhat.com/browse/CONSOLE-3141

We should be hiding the `Control Plane` section in the status card, if `controlPlaneTopology` is  `External`.

Before:
<img width="767" alt="Screenshot 2022-04-27 at 16 47 43" src="https://user-images.githubusercontent.com/1668218/165546988-2a9413cc-9394-4171-8bfa-b0ca331cbf6b.png">


After:
<img width="814" alt="Screenshot 2022-04-27 at 16 47 53" src="https://user-images.githubusercontent.com/1668218/165547042-73416522-4548-4cf3-96ed-c0fe8b8237bf.png">


Based on https://github.com/openshift/console/pull/11366#issuecomment-1104436134

/assign @andrewballantyne @csrwng 
