### PR TITLE
Bug 2076544: Added margin-bottom for the paragraph component

### DIFF
--- a/frontend/packages/console-app/src/components/network-policies/_create-network-policy.scss
+++ b/frontend/packages/console-app/src/components/network-policies/_create-network-policy.scss
@@ -50,3 +50,7 @@
 .co-create-networkpolicy__selector-preview button.pf-c-tree-view__node[role="treeitem"] > .pf-c-tree-view__node-container {
   cursor: default;
 }
+
+.co-create-networkpolicy__paragraph {
+  margin-bottom: var(--pf-c-content--MarginBottom);
+}

--- a/frontend/packages/console-app/src/components/network-policies/network-policy-conditional-selector.tsx
+++ b/frontend/packages/console-app/src/components/network-policies/network-policy-conditional-selector.tsx
@@ -51,12 +51,12 @@ export const NetworkPolicyConditionalSelector: React.FunctionComponent<NetworkPo
         <label>{title}</label>
       </span>
       <div className="help-block">
-        <p>{helpText}</p>
+        <p className="co-create-networkpolicy__paragraph">{helpText}</p>
       </div>
       {isVisible ? (
         <>
           <div className="help-block">
-            <p>{secondHelpText}</p>
+            <p className="co-create-networkpolicy__paragraph">{secondHelpText}</p>
           </div>
           <NameValueEditorComponent
             nameValuePairs={values.length > 0 ? values : [['', '']]}

--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.scss
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.scss
@@ -2,4 +2,8 @@
   &__body {
     padding: 0 var(--pf-global--spacer--lg) var(--pf-global--spacer--lg);
   }
+
+  &__paragraph {
+    margin-bottom: var(--pf-c-content--MarginBottom);
+  }
 }

--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
@@ -94,7 +94,7 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
       />
       <Form onSubmit={!viewOnly ? handleSubmit : undefined}>
         <div className="odc-add-health-checks__body">
-          <p>
+          <p className="odc-add-health-checks__paragraph">
             <Trans t={t} ns="devconsole">
               Health checks for{' '}
               <ResourceLink
@@ -106,7 +106,7 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
               />
             </Trans>
           </p>
-          <p>
+          <p className="odc-add-health-checks__paragraph">
             {t('devconsole~Container')} &nbsp;
             {_.size(containers) > 1 ? (
               <ContainerDropdown

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.scss
@@ -27,6 +27,10 @@ $overview-sidebar-width: 550px;
     margin-bottom: var(--pf-global--spacer--md);
   }
 
+  &__paragraph {
+    margin-bottom: var(--pf-c-content--MarginBottom);
+  }
+
   h2 {
     margin: 0 0 var(--pf-global--spacer--sm) 0;
   }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
@@ -96,7 +96,7 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
         {params.length > 0 && (
           <div>
             <h2>{t('pipelines-plugin~Parameters')}</h2>
-            <p className="co-help-text">
+            <p className="co-help-text opp-task-sidebar__paragraph">
               <Trans ns="pipelines-plugin">
                 Use this format when you reference variables in this form:{' '}
                 <code className="co-code">$(</code>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarWhenExpression.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarWhenExpression.tsx
@@ -27,7 +27,7 @@ const TaskSidebarWhenExpression: React.FC<TaskSidebarWhenExpressionProps> = (pro
   return (
     <div className="opp-task-sidebar-when-expression">
       <h2>{t('pipelines-plugin~When expressions')}</h2>
-      <p className="co-help-text">
+      <p className="co-help-text opp-task-sidebar__paragraph">
         {field.value?.length > 0 ? (
           <Trans ns="pipelines-plugin">
             Use this format when you reference variables in this form:{' '}

--- a/frontend/public/components/cluster-settings/_cluster-settings.scss
+++ b/frontend/public/components/cluster-settings/_cluster-settings.scss
@@ -280,3 +280,7 @@ $co-channel-height: 60px;
 .co-update-status {
   padding-bottom: 5px;
 }
+
+.co-cluster-paragraph {
+  margin-bottom: var(--pf-c-content--MarginBottom);
+}

--- a/frontend/public/components/cluster-settings/global-config.tsx
+++ b/frontend/public/components/cluster-settings/global-config.tsx
@@ -169,7 +169,7 @@ const GlobalConfigPage_: React.FC<GlobalConfigPageProps & GlobalConfigPageExtens
     <div className="co-m-pane__body">
       {!loading && (
         <>
-          <p className="co-help-text">
+          <p className="co-help-text co-cluster-paragraph">
             {t('public~Edit the following resources to manage the configuration of your cluster.')}
           </p>
           <div className="co-m-pane__filter-row">

--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -134,3 +134,7 @@
     margin-bottom: 24px;
   }
 }
+
+.modal-paragraph {
+  margin-bottom: var(--pf-c-content--MarginBottom);
+}

--- a/frontend/public/components/modals/add-secret-to-workload.tsx
+++ b/frontend/public/components/modals/add-secret-to-workload.tsx
@@ -184,7 +184,7 @@ export class AddSecretToWorkloadModalWithTrans extends React.Component<
       >
         <ModalTitle>{t('public~Add secret to workload')}</ModalTitle>
         <ModalBody>
-          <p>
+          <p className="modal-paragraph">
             <Trans t={t} ns="public">
               Add all values from <ResourceIcon kind="Secret" />
               {{ secretName }} to a workload as environment variables or a volume.

--- a/frontend/public/components/modals/configure-count-modal.tsx
+++ b/frontend/public/components/modals/configure-count-modal.tsx
@@ -50,7 +50,7 @@ export const ConfigureCountModal = withHandlePromise((props: ConfigureCountModal
     <form onSubmit={submit} name="form" className="modal-content ">
       <ModalTitle>{titleKey ? t(titleKey, titleVariables) : title}</ModalTitle>
       <ModalBody>
-        <p>{messageKey ? t(messageKey, messageVariables) : message}</p>
+        <p className="modal-paragraph">{messageKey ? t(messageKey, messageVariables) : message}</p>
         <NumberSpinner
           value={value}
           onChange={(e: any) => setValue(e.target.value)}

--- a/frontend/public/components/modals/configure-update-strategy-modal.tsx
+++ b/frontend/public/components/modals/configure-update-strategy-modal.tsx
@@ -44,7 +44,7 @@ export const ConfigureUpdateStrategy: React.FC<ConfigureUpdateStrategyProps> = (
             autoFocus={props.strategyType === 'RollingUpdate'}
           >
             <div className="co-m-radio-desc">
-              <p className="text-muted">
+              <p className="text-muted modal-paragraph">
                 {t(
                   'public~Execute a smooth roll out of the new revision, based on the settings below',
                 )}

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -286,6 +286,10 @@ $monitoring-line-height: 18px;
       padding-top: 26px;
     }
   }
+
+  &__paragraph {
+    margin-bottom: var(--pf-c-content--MarginBottom);
+  }
 }
 
 .monitoring-state-icon--pending {

--- a/frontend/public/components/monitoring/silence-form.tsx
+++ b/frontend/public/components/monitoring/silence-form.tsx
@@ -268,7 +268,7 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => 
 
           <div className="co-m-pane__body-group">
             <SectionHeading text={t('public~Alert labels')} />
-            <p className="co-help-text">
+            <p className="co-help-text monitoring-silence-alert__paragraph">
               <Trans t={t} ns="public">
                 Alerts with labels that match these selectors will be silenced instead of firing.
                 Label values can be matched exactly or with a{' '}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-43396

**Analysis / Root cause**: 
PatternFly removed a generic rule for the paragraph component. It was adding margin-bottom by default before now it is not.

**Solution Description**: 
Added margin-bottom styling for paragraph component. Not kept the class in global level, added class for the component levels.

**Screen shots / Gifs for design review**: 

Changed in 8 screens, attached all the screenshots below with the steps to the page

1) Administrator -> workloads -> secrets -> secret details -> Add secret to workload 

--------BEFORE----------

<img width="1284" alt="Add secret to workload" src="https://user-images.githubusercontent.com/102503482/165468601-90a88523-ba6b-4e36-b454-cc50108af052.png">

--------AFTER-----------
<img width="607" alt="Add secret to workload" src="https://user-images.githubusercontent.com/102503482/165468704-4ed5d54f-0122-4d61-bb0b-c57fd4875b6f.png">

==========================================

2) Administrator -> Observe -> Alerting -> Silence -> Create silence

--------BEFORE----------

<img width="1486" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/102503482/165468786-0d76bb7d-88c4-4261-ae0b-71a97ea5459f.png">

--------AFTER-----------

<img width="1114" alt="Create silence" src="https://user-images.githubusercontent.com/102503482/165468812-1731ea12-afe9-4b06-8e62-bbf9dc49d394.png">

==========================================

3) Administrator -> Administation -> Cluster Settings -> Configuration

--------AFTER-----------

<img width="731" alt="Cluster Settings" src="https://user-images.githubusercontent.com/102503482/165468883-f4b430ef-9787-4959-b8c8-06d59904acb7.png">

--------BEFORE----------

<img width="991" alt="Cluster Settings" src="https://user-images.githubusercontent.com/102503482/165468862-3013c0a1-2cca-49bb-a5af-0ccc71f00748.png">

===========================================

4) Administrator -> Networking -> NetworkPolicies -> Create NetworkPolicy

--------BEFORE----------

<img width="1162" alt="Create NetworkPolicy" src="https://user-images.githubusercontent.com/102503482/165468941-781bfe36-0cff-4b87-a4b7-42f863770b66.png">

--------AFTER-----------

<img width="739" alt="Pasted Graphic 12" src="https://user-images.githubusercontent.com/102503482/165468965-12ca454f-ca94-47cd-9285-6a0240d045c7.png">

===========================================

5) Developer -> Topology -> Topology Side Bar -> Actions -> Edit Pod Count

--------BEFORE----------

<img width="1336" alt="Pasted Graphic 5" src="https://user-images.githubusercontent.com/102503482/165469020-71bb3995-f86e-4662-993e-f6c4f9fb3255.png">

--------AFTER-----------

<img width="612" alt="Edit Pod count" src="https://user-images.githubusercontent.com/102503482/165469037-f7ed9d58-d8d0-436d-97dc-664489e99b3d.png">

===========================================

6) Developer -> Topology -> Topology Sidebar -> Add health checks

--------BEFORE----------

<img width="1073" alt="Pasted Graphic 6" src="https://user-images.githubusercontent.com/102503482/165469091-9985aca1-8eef-44e3-9f9b-c982b060f5c8.png">

--------AFTER-----------

<img width="747" alt="Health checks for O devfile-sample-git" src="https://user-images.githubusercontent.com/102503482/165469115-1e6948dd-36c3-4710-b241-4639af2faf93.png">

===========================================

7) Developer -> Topology -> Topology Side Bar -> Actions -> Edit update strategy

--------BEFORE----------

<img width="1214" alt="Edit update strategy" src="https://user-images.githubusercontent.com/102503482/165469186-e47c3b70-a8ed-4284-adf2-423100b7e8f5.png">

--------AFTER-----------

<img width="591" alt="Edit update strategy" src="https://user-images.githubusercontent.com/102503482/165469218-bd64a1e4-dbfa-4ac8-b385-707ca9d28e38.png">

===========================================

8) Developer -> pipelines -> create pipelines -> click on task to open side bar 

--------BEFORE----------

<img width="1727" alt="Pasted Graphic 8" src="https://user-images.githubusercontent.com/102503482/165469318-976ac410-365d-439f-9616-887060718a45.png">

--------AFTER-----------

<img width="635" alt="CT buildah" src="https://user-images.githubusercontent.com/102503482/165469340-f0f36ffc-2926-4df8-b296-9530678ca4b4.png">

<img width="535" alt="Workspaces" src="https://user-images.githubusercontent.com/102503482/165469368-3dfb0e8f-6aa4-476a-80fb-8ec36798eff9.png">

================================================================

**Unit test coverage report**: 
NA

**Test setup:**
All 8 points added in the screenshot section

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge