### PR TITLE
Bug 2061918: Fixed topology sidebar scrolling issue

### DIFF
--- a/frontend/packages/topology/src/components/side-bar/TopologySideBar.tsx
+++ b/frontend/packages/topology/src/components/side-bar/TopologySideBar.tsx
@@ -30,14 +30,16 @@ const TopologySideBar: React.FC<TopologySideBarProps> = ({ children, onClose }) 
       onResize={handleResizeCallback}
     >
       <PFTopologySideBar resizable className="pf-topology-side-bar-resizable">
-        <div className="co-sidebar-dismiss clearfix">
-          <CloseButton
-            onClick={onClose}
-            dataTestID="sidebar-close-button"
-            additionalClassName="co-close-button--float-right co-sidebar-dismiss__close-button"
-          />
+        <div className="pf-topology-side-bar__body">
+          <div className="co-sidebar-dismiss clearfix">
+            <CloseButton
+              onClick={onClose}
+              dataTestID="sidebar-close-button"
+              additionalClassName="co-close-button--float-right co-sidebar-dismiss__close-button"
+            />
+          </div>
+          {children}
         </div>
-        {children}
       </PFTopologySideBar>
     </DrawerPanelContent>
   );


### PR DESCRIPTION
Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=2061918

Analysis / Root cause:
Due to the latest changes to fix the issue, the topology content also was able to scroll on scrolling side panel.

Solution Description:
Added the CSS styling in separate div instead of sending it to component as prop.

Screen shots / Gifs for design review:
-----BEFORE-----
https://user-images.githubusercontent.com/139310/164993324-d76747fc-e12d-49eb-b334-fe200e320dac.gif

----AFTER------
https://user-images.githubusercontent.com/139310/164993294-95ce44c9-fcd8-4156-913f-763ca2c5d066.gif

Unit test coverage report:
NA

Test setup:
Click on any resource in the topology to open the side panel to verify.

Browser conformance:

[x] Chrome
[x] Firefox
[x] Safari
[] Edge