### PR TITLE
CONSOLE-3081: updated skeleton color definitions, updated sidebar shadow

### DIFF
--- a/frontend/packages/console-shared/src/styles/skeleton-screen.scss
+++ b/frontend/packages/console-shared/src/styles/skeleton-screen.scss
@@ -1,17 +1,5 @@
-:root {
-  --os-skeleton--Color: var(--pf-global--palette--black-150);
-  --os-skeleton--Color--300: var(--pf-global--palette--black-300);
-}
-
-[class^="skeleton"] {
-  .pf-theme-dark & {
-    --os-skeleton--Color: var(--pf-global--palette--black-600);
-    --os-skeleton--Color--300: var(--pf-global--palette--black-700)
-  }
-}
-
-$skeleton-color: var(--os-skeleton--Color);
-$skeleton-color--300: var(--os-skeleton--Color--300);
+$skeleton-color: var(--co-skeleton--Color);
+$skeleton-color--300: var(--co-skeleton--Color--300);
 
 $skeleton-animation: loading-skeleton 1s ease-out .15s infinite alternate;
 $skeleton-bone-height-1line: 24px;

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -181,10 +181,11 @@ form.pf-c-form {
   }
 }
 
+:where(:root:not(.pf-theme-dark)) .pf-c-page {
+  --pf-c-page__sidebar--BoxShadow: none;
+}
+
 .pf-c-page__sidebar {
-  @media screen and (min-width: $pf-global--breakpoint--xl) {
-    --pf-c-page__sidebar--BoxShadow: none;
-  }
 
   // Perspective switcher
   &.pf-m-dark .pf-c-dropdown {

--- a/frontend/public/style/_theme-dark.scss
+++ b/frontend/public/style/_theme-dark.scss
@@ -1,19 +1,33 @@
 :root {
+  // Co Palette
   --co-global--palette--blue-400: var(--pf-global--palette--blue-400);
   --co-global--palette--purple-600: var(--pf-global--palette--purple-600);
   --co-global--palette--orange-400: var(--pf-global--palette--orange-400);
   --co-global--palette--purple-700: var(--pf-global--palette--purple-700);
 
-  // dark
+  // Co Palette Dark
   --co-global--dark--palette--blue-400: var(--pf-global--palette--blue-200);
   --co-global--dark--palette--purple-600: var(--pf-global--palette--purple-200);
   --co-global--dark--palette--orange-400: var(--pf-global--palette--orange-200);
   --co-global--dark--palette--purple-700: var(--pf-global--palette--purple-200);
+
+  // Skeleton
+  --co-skeleton--Color: var(--pf-global--palette--black-150);
+  --co-skeleton--Color--300: var(--pf-global--palette--black-300);
+
+  // Skeleton dark
+  --co-skeleton--dark--Color: var(--pf-global--palette--black-600);
+  --co-skeleton--dark--Color--300: var(--pf-global--palette--black-700)
 }
 
 :root:where(.pf-theme-dark) {
+  // Co palette updates
   --co-global--palette--blue-400: var(--co-global--dark--palette--blue-400);
   --co-global--palette--purple-600: var(--co-global--dark--palette--purple-600);
   --co-global--palette--orange-400: var(--co-global--dark--palette--orange-400);
   --co-global--palette--purple-700: var(--co-global--dark--palette--purple-600);
+
+  // Skeleton
+  --co-skeleton--Color: var(--co-skeleton--dark--Color);
+  --co-skeleton--Color--300: var(--co-skeleton--dark--Color--300);
 }


### PR DESCRIPTION
This PR moves the skeleton color definitions to the theme file and adds a conditional wrapper to the sidebar box shadow, resets the `box shadow` to `none` only on light mode.

Before:

![Screen Shot 2022-04-27 at 10 01 39 AM](https://user-images.githubusercontent.com/5385435/165537924-c85c972d-5a16-453a-a32a-792388ede2ff.png)

After:

![Screen Shot 2022-04-27 at 10 02 05 AM](https://user-images.githubusercontent.com/5385435/165538056-6ef2bb7f-895b-47c9-bf16-8bcfcf671bc4.png)

Drop shadow before:

![Screen Shot 2022-04-27 at 10 02 31 AM](https://user-images.githubusercontent.com/5385435/165538342-9102f24c-9324-400b-9621-98d89ce53572.png)

Drop shadow after:
![Screen Shot 2022-04-27 at 10 02 39 AM](https://user-images.githubusercontent.com/5385435/165538368-708f8a1e-3aab-4261-9c0a-f05fe4cabd60.png)

