### PR TITLE
[release-4.8] Bug 2079436: Pipeline metrics: use prometheus-tenancy API to get data

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
@@ -50,3 +50,5 @@ export const DEFAULT_SAMPLES = 60;
 
 // Annotation for referencing pipeline name in case of PipelineRun with no reference to a Pipeline (embedded pipeline)
 export const preferredNameAnnotation = 'pipeline.openshift.io/preferredName';
+
+export const PIPELINE_NAMESPACE = 'openshift-pipelines';

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/hooks.ts
@@ -18,7 +18,7 @@ import { PipelineRunModel } from '../../models';
 import { PipelineRunKind } from '../../types';
 import { getLatestRun } from '../../utils/pipeline-augment';
 import { pipelinesTab } from '../../utils/pipeline-utils';
-import { DEFAULT_SAMPLES, TektonResourceLabel } from './const';
+import { DEFAULT_SAMPLES, PIPELINE_NAMESPACE, TektonResourceLabel } from './const';
 
 type Match = RMatch<{ url: string }>;
 
@@ -73,6 +73,7 @@ export const usePipelineSuccessRatioPoll = ({ delay, namespace, name, timespan, 
       samples: 1,
       endTime: Date.now(),
       timespan,
+      namespace: PIPELINE_NAMESPACE,
     }),
     delay,
     namespace,
@@ -91,6 +92,7 @@ export const usePipelineRunTaskRunPoll = ({ delay, namespace, name, timespan, qu
       samples: DEFAULT_SAMPLES,
       endTime: Date.now(),
       timespan,
+      namespace: PIPELINE_NAMESPACE,
     }),
     delay,
     namespace,
@@ -112,6 +114,7 @@ export const usePipelineRunDurationPoll = ({
       samples: DEFAULT_SAMPLES,
       endTime: Date.now(),
       timespan,
+      namespace: PIPELINE_NAMESPACE,
     }),
     delay,
     namespace,
@@ -127,6 +130,7 @@ export const usePipelineRunPoll = ({ delay, namespace, name, timespan, queryPref
       samples: DEFAULT_SAMPLES,
       endTime: Date.now(),
       timespan,
+      namespace: PIPELINE_NAMESPACE,
     }),
     delay,
     namespace,


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/console/pull/11270