### PR TITLE
GitOps-1941 fixed dark theme color issue

### DIFF
--- a/frontend/packages/gitops-plugin/src/components/details/GitOpsDetails.scss
+++ b/frontend/packages/gitops-plugin/src/components/details/GitOpsDetails.scss
@@ -70,6 +70,7 @@
   }
   &__author-sha {
     align-items: center;
+    color: var(--pf-global--Color--200);
     display: flex;
     margin-bottom: var(--pf-global--spacer--xs);
   }
@@ -84,10 +85,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    color: var(--pf-global--palette--black-600);
-    :where(.pf-theme-dark) & {
-      color: var(--pf-global--palette--black-100) !important;
-    }
   }
   &__sha {
     background-color: inherit;

--- a/frontend/packages/gitops-plugin/src/components/details/GitOpsDetails.scss
+++ b/frontend/packages/gitops-plugin/src/components/details/GitOpsDetails.scss
@@ -70,7 +70,6 @@
   }
   &__author-sha {
     align-items: center;
-    color: var(--pf-global--palette--black-600);
     display: flex;
     margin-bottom: var(--pf-global--spacer--xs);
   }
@@ -85,6 +84,10 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    color: var(--pf-global--palette--black-600);
+    :where(.pf-theme-dark) & {
+      color: var(--pf-global--palette--black-100) !important;
+    }
   }
   &__sha {
     background-color: inherit;

--- a/frontend/packages/gitops-plugin/src/components/list/GitOpsTableRow.scss
+++ b/frontend/packages/gitops-plugin/src/components/list/GitOpsTableRow.scss
@@ -3,6 +3,9 @@
 }
 .gop-gitops-lastDeploymentTime {
   color: var(--pf-global--palette--black-600);
+  :where(.pf-theme-dark) & {
+    color: var(--pf-global--palette--black-100) !important;
+  }
 }
 .gop-gitops-tooltip-text {
   color: white;

--- a/frontend/packages/gitops-plugin/src/components/list/GitOpsTableRow.scss
+++ b/frontend/packages/gitops-plugin/src/components/list/GitOpsTableRow.scss
@@ -2,10 +2,7 @@
   max-width: '100px';
 }
 .gop-gitops-lastDeploymentTime {
-  color: var(--pf-global--palette--black-600);
-  :where(.pf-theme-dark) & {
-    color: var(--pf-global--palette--black-100) !important;
-  }
+  color: var(--pf-global--Color--200);
 }
 .gop-gitops-tooltip-text {
   color: white;


### PR DESCRIPTION
This PR is for Story [GITOPS-1941](https://issues.redhat.com/browse/GITOPS-1941), to fix Dark theme issues in GitOps pages.

Screenshots:
<img width="1142" alt="Screen Shot 2022-05-02 at 4 12 33 PM" src="https://user-images.githubusercontent.com/26255262/166318772-5c0cb0d1-7ff6-404d-8432-770b24e50773.png">
<img width="366" alt="Screen Shot 2022-05-02 at 4 12 24 PM" src="https://user-images.githubusercontent.com/26255262/166318789-63cd0c94-acbc-424b-aed8-2c6183f06102.png">
