### PR TITLE
Bug 2080873: Fix crash when stored topology layout isn't supported anymore

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/layouts/layoutFactory.ts
+++ b/frontend/packages/topology/src/components/graph-view/layouts/layoutFactory.ts
@@ -3,8 +3,12 @@ import TopologyColaLayout from './TopologyColaLayout';
 
 const COLA_LAYOUT = 'Cola';
 
+const DEFAULT_LAYOUT = COLA_LAYOUT;
+
+const SUPPORTED_LAYOUTS = [COLA_LAYOUT];
+
 const layoutFactory: LayoutFactory = (type: string, graph: Graph): Layout | undefined => {
   return type === COLA_LAYOUT ? new TopologyColaLayout(graph, { layoutOnDrag: false }) : undefined;
 };
 
-export { layoutFactory, COLA_LAYOUT };
+export { COLA_LAYOUT, DEFAULT_LAYOUT, SUPPORTED_LAYOUTS, layoutFactory };


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2080873

**Analysis / Root cause**: 
We removed "Layout 2" (`COLAFORCE_LAYOUT`) with #11145 to simplify the topology UI. But for users that selected this Layout in 4.10 the topology view crashs.

**Solution Description**: 
Detect unsupported layouts and automatically set the "Layout 1" (cola layout) (via `DEFAULT_LAYOUT`) instead.

**Screen shots / Gifs for design review**: 
4.10:
![image](https://user-images.githubusercontent.com/139310/166437697-7c08cc98-76cb-4332-a5fd-2f2d8ecf398c.png)

4.11 master
![image](https://user-images.githubusercontent.com/139310/166437730-12792efc-7399-4d28-803a-4a8e6fbcbfff.png)

With this PR:
![image](https://user-images.githubusercontent.com/139310/166437757-89e32348-470c-4957-a1df-f45f8b322a51.png)

**Unit test coverage report**: 
Unchanged

**Test setup:**
In theory, update a cluster from 4.10 to 4.11...

Local development:
1. Checkout `branch-4.10`, build it, run it
2. Import an application, open the topology graph view and switch to Layout 2
3. Checkout `branch-4.11`, or master, build it, run it.
4. Re-open or refresh your browser and open the same namespace
In theory, update a cluster from 4.10 to 4.11...

Or setting the ConfigMap manually:
1. Search in the namespace "openshift-console-user-settings" for the user settings ConfigMap of your user.
2. Override this topology YAML (replace sidebar1 with your namespace):

```yaml
  devconsole.topology.layout: '{"sidebar1":{"nodes":[],"layout":"ColaForce"}}'
```

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
