### PR TITLE
Bug 2070720: Fix Filter Dropdown & Label Selection State Management

### DIFF
--- a/frontend/public/components/useLabelSelectionFix.ts
+++ b/frontend/public/components/useLabelSelectionFix.ts
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import useMirroredLocalState, { UseMirroredLocalStateReturn } from './useMirroredLocalState';
+import { setOrRemoveQueryArgument } from './utils';
+
+/**
+ * Handles a state management hack-fix around the label filters auto complete field.
+ * Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2070720
+ * TODO: Refactor FilterToolbar to use proper state management: https://issues.redhat.com/browse/CONSOLE-3147
+ *
+ * This is a hack fix due to the violation in state management in FilterToolbar. This hook should
+ * be deleted once proper React state management has been implemented.
+ */
+const useLabelSelectorFix = (
+  params: URLSearchParams,
+  labelFilterQueryArgumentKey: string,
+): UseMirroredLocalStateReturn<string[]> => {
+  const syncSearchParams = React.useCallback(
+    (values: string[]) => {
+      setOrRemoveQueryArgument(labelFilterQueryArgumentKey, values.join(','));
+    },
+    [labelFilterQueryArgumentKey],
+  );
+
+  const labelFilters = params.get(labelFilterQueryArgumentKey)?.split(',') ?? [];
+
+  return useMirroredLocalState<string[]>({
+    externalState: labelFilters,
+    externalChangeHandler: syncSearchParams,
+    defaultState: [],
+  });
+};
+
+export default useLabelSelectorFix;

--- a/frontend/public/components/useMirroredLocalState.ts
+++ b/frontend/public/components/useMirroredLocalState.ts
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+
+export type UseMirroredLocalStateReturn<S> = [S, (state: S) => void, boolean];
+
+/**
+ * DO NOT USE -- proper state management in React is Top-Down state management.
+ * Syncs an external data point with a local data point. Used to fix the ToolbarFilter poor state
+ * management issue.
+ */
+const useMirroredLocalState = <S>({
+  externalState,
+  externalChangeHandler,
+  defaultState,
+}: {
+  externalState: S;
+  externalChangeHandler: (state: S) => void;
+  defaultState: S;
+}): UseMirroredLocalStateReturn<S> => {
+  const [localState, setLocalState] = React.useState<S>(null);
+
+  const onExternalChange = React.useCallback(
+    (state: S) => {
+      setLocalState(state);
+      externalChangeHandler(state);
+    },
+    [externalChangeHandler],
+  );
+
+  React.useEffect(() => {
+    if (localState === null) {
+      // We don't have local data, fresh mount
+      if (_.isEmpty(externalState)) {
+        // No url params, use defaults
+        onExternalChange(defaultState);
+      } else {
+        // We have url params, routed here with params
+        setLocalState(externalState);
+      }
+    } else {
+      // We have local data so we have been initialized
+      if (!_.isEqual(externalState, localState)) {
+        // They are not equal, so we need to figure out who is right
+        if (_.isEmpty(externalState)) {
+          // Params are empty, so this means the component was not re-mounted but we lost params
+          onExternalChange(localState);
+        } else {
+          // Params are not empty -- this is a conflict of source of truth
+          // Possible reason would be a local code re-route on this page, accept URL as source of truth
+          setLocalState(externalState);
+        }
+      }
+    }
+  }, [localState, externalState, onExternalChange, defaultState]);
+
+  return [localState ?? defaultState, onExternalChange, localState !== null];
+};
+
+export default useMirroredLocalState;

--- a/frontend/public/components/useRowFilterFix.ts
+++ b/frontend/public/components/useRowFilterFix.ts
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import useMirroredLocalState, { UseMirroredLocalStateReturn } from './useMirroredLocalState';
+import { setOrRemoveQueryArgument } from './utils';
+
+/**
+ * Handles a state management hack-fix around the row filters dropdown.
+ * Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2070720
+ * TODO: Refactor FilterToolbar to use proper state management: https://issues.redhat.com/browse/CONSOLE-3147
+ *
+ * This is a hack fix due to the violation in state management in FilterToolbar. This hook should
+ * be deleted once proper React state management has been implemented.
+ */
+const useRowFilterFix = (
+  params: URLSearchParams,
+  filters: { [key: string]: string[] },
+  filterKeys: { [key: string]: string },
+  defaultSelections: string[],
+): UseMirroredLocalStateReturn<string[]> => {
+  const syncRowFilterParams = React.useCallback(
+    (selected) => {
+      _.forIn(filters, (value, key) => {
+        const recognized = _.filter(selected, (item) => value.includes(item));
+        setOrRemoveQueryArgument(filterKeys[key], recognized.join(','));
+      });
+    },
+    [filters, filterKeys],
+  );
+
+  const selectedRowFilters = _.flatMap(filterKeys, (f) => params.get(f)?.split(',') ?? []);
+
+  return useMirroredLocalState<string[]>({
+    externalChangeHandler: syncRowFilterParams,
+    externalState: selectedRowFilters,
+    defaultState: defaultSelections,
+  });
+};
+
+export default useRowFilterFix;


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2070720
Followup Refactor: https://issues.redhat.com/browse/CONSOLE-3147

### The Issue

React principles were violated during the writing of `FilterToolbar`. Source of truth MUST be within React & in a single location and then propagated back down the tree aligning all hooks and components on the same source of truth.

Whereas, in the case of `FilterToolbar`, the source of truth of the filters was held in the URL params & in an external data / hooks / redux. This data was never re-shared with this component and it continued to derive the filter state based on the URL.

When the URL was updated to exclude the filter settings (local react-router re-route -- in this case the main navigation), React diffs the component tree to make as few mutations as possible for performance. It detected the same components and thus kept them around with their current state. Since the filters were not provided and only derived from the URL... we had a break in data logic -- URL filters were reset but local state storage were not. This caused the discrepancy the bug noted.

### The Fix

A hacky hook was put in place for the "Filters" dropdown & then during testing one was needed for the "Label filter" selections as well. These hooks serve to use the same "mirror local state" which will match up the URL and the local state in all various load and execution states. This is a hack to allow us to backport this fix without having to refactor every usage of the `FilterToolbar`.

### Animation

Before

https://user-images.githubusercontent.com/8126518/166466751-c6e98d43-2d74-4ab4-bd99-d53d5cfce21e.mov



After

https://user-images.githubusercontent.com/8126518/166466771-cd948a9e-117f-48aa-9af5-756201abc75e.mov

