### PR TITLE
Bug 2079944: Fix crash and allow users to link a Pod with bindable services

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -103,6 +103,19 @@
     "type": "console.action/resource-provider",
     "properties": {
       "model": {
+        "version": "v1",
+        "kind": "Pod"
+      },
+      "provider": { "$codeRef": "actions.useCreateServiceBindingProvider" }
+    },
+    "flags": {
+      "required": ["ALLOW_SERVICE_BINDING"]
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
         "group": "apps",
         "version": "v1",
         "kind": "Deployment"

--- a/frontend/packages/topology/src/operators/actions/__tests__/serviceBindings.spec.ts
+++ b/frontend/packages/topology/src/operators/actions/__tests__/serviceBindings.spec.ts
@@ -1,0 +1,92 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { createServiceBindingResource } from '../serviceBindings';
+
+describe('createServiceBindingResource', () => {
+  it('creates the right ServiceBinding for a Deployment', () => {
+    const source: K8sResourceKind = {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        namespace: 'source-namespace',
+        name: 'source-deployment',
+      },
+    };
+    const target: K8sResourceKind = {
+      apiVersion: 'rhoas.redhat.com/v1alpha1',
+      kind: 'KafkaConnection',
+      metadata: {
+        namespace: 'target-namespace',
+        name: 'target-kafkaconnection',
+      },
+    };
+    const serviceBindingName = 'deployment-to-kafka';
+    const actualServiceBinding = createServiceBindingResource(source, target, serviceBindingName);
+    const expectedServiceBinding = {
+      apiVersion: 'binding.operators.coreos.com/v1alpha1',
+      kind: 'ServiceBinding',
+      metadata: { name: 'deployment-to-kafka', namespace: 'source-namespace' },
+      spec: {
+        application: {
+          group: 'apps',
+          name: 'source-deployment',
+          resource: 'deployments',
+          version: 'v1',
+        },
+        detectBindingResources: true,
+        services: [
+          {
+            group: 'rhoas.redhat.com',
+            kind: 'KafkaConnection',
+            name: 'target-kafkaconnection',
+            version: 'v1alpha1',
+          },
+        ],
+      },
+    };
+    expect(actualServiceBinding).toEqual(expectedServiceBinding);
+  });
+
+  it('creates the right ServiceBinding for a Pod', () => {
+    const source: K8sResourceKind = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: {
+        namespace: 'source-namespace',
+        name: 'source-pod',
+      },
+    };
+    const target: K8sResourceKind = {
+      apiVersion: 'rhoas.redhat.com/v1alpha1',
+      kind: 'KafkaConnection',
+      metadata: {
+        namespace: 'target-namespace',
+        name: 'target-kafkaconnection',
+      },
+    };
+    const serviceBindingName = 'deployment-to-kafka';
+    const actualServiceBinding = createServiceBindingResource(source, target, serviceBindingName);
+    const expectedServiceBinding = {
+      apiVersion: 'binding.operators.coreos.com/v1alpha1',
+      kind: 'ServiceBinding',
+      metadata: { name: 'deployment-to-kafka', namespace: 'source-namespace' },
+      spec: {
+        application: {
+          group: 'core',
+          name: 'source-pod',
+          resource: 'pods',
+          version: 'v1',
+        },
+        detectBindingResources: true,
+        services: [
+          {
+            group: 'rhoas.redhat.com',
+            kind: 'KafkaConnection',
+            name: 'target-kafkaconnection',
+            version: 'v1alpha1',
+          },
+        ],
+      },
+    };
+    expect(actualServiceBinding).toEqual(expectedServiceBinding);
+  });
+});

--- a/frontend/packages/topology/src/operators/actions/serviceBindings.ts
+++ b/frontend/packages/topology/src/operators/actions/serviceBindings.ts
@@ -1,7 +1,7 @@
 import { Node } from '@patternfly/react-topology';
-import * as _ from 'lodash';
 import { serviceBindingModal } from '@console/app/src/components/modals/service-binding';
 import {
+  K8sResourceCommon,
   k8sCreate,
   K8sResourceKind,
   modelFor,
@@ -11,6 +11,87 @@ import {
 import { ServiceBindingModel } from '../../models';
 import { TYPE_OPERATOR_BACKED_SERVICE } from '../components/const';
 
+type ServiceBinding = K8sResourceCommon & {
+  spec: {
+    application: {
+      group: string;
+      version: string;
+      resource: string;
+      name: string;
+    };
+    services: {
+      group: string;
+      version: string;
+      kind: string;
+      name: string;
+    }[];
+    bindAsFiles?: boolean;
+    detectBindingResources?: boolean;
+  };
+};
+
+/**
+ * Extract the first part of a kubernetes apiVersion.
+ *
+ * For example 'apps' for Deployments (kind: Deployment, apiVersion: apps/v1)
+ * and 'core' for Pods (kind: Pod, apiVersion: v1)
+ */
+const getGroup = (resource: K8sResourceCommon): string =>
+  resource.apiVersion.includes('/')
+    ? resource.apiVersion.substring(0, resource.apiVersion.indexOf('/'))
+    : 'core';
+
+/**
+ * Extract the second part of a kubernetes apiVersion.
+ *
+ * For example 'v1' for Deployments (kind: Deployment, apiVersion: apps/v1)
+ * and Pods (kind: Pod, apiVersion: v1)
+ */
+const getVersion = (resource: K8sResourceCommon): string =>
+  resource.apiVersion.includes('/')
+    ? resource.apiVersion.substring(resource.apiVersion.indexOf('/') + 1)
+    : resource.apiVersion;
+
+/**
+ * Extracts the resource plural based on the registered models.
+ *
+ * For example 'deployments', 'pods', etc.
+ */
+const getResourcePlural = (resource: K8sResourceCommon): string =>
+  modelFor(referenceFor(resource)).plural;
+
+export const createServiceBindingResource = (
+  source: K8sResourceKind,
+  target: K8sResourceKind,
+  serviceBindingName: string,
+): ServiceBinding => {
+  return {
+    apiVersion: apiVersionForModel(ServiceBindingModel),
+    kind: ServiceBindingModel.kind,
+    metadata: {
+      name: serviceBindingName,
+      namespace: source.metadata.namespace,
+    },
+    spec: {
+      application: {
+        group: getGroup(source),
+        version: getVersion(source),
+        resource: getResourcePlural(source),
+        name: source.metadata.name,
+      },
+      services: [
+        {
+          group: getGroup(target),
+          version: getVersion(target),
+          kind: target.kind,
+          name: target.metadata.name,
+        },
+      ],
+      detectBindingResources: true,
+    },
+  };
+};
+
 export const createServiceBinding = (
   source: K8sResourceKind,
   target: K8sResourceKind,
@@ -19,38 +100,7 @@ export const createServiceBinding = (
   if (!source || !target || source === target) {
     return Promise.reject();
   }
-
-  const targetName = target.metadata.name;
-  const { namespace, name: sourceName } = source.metadata;
-  const sourceGroup = _.split(source.apiVersion, '/');
-  const targetGroup = _.split(target.apiVersion, '/');
-
-  const serviceBinding = {
-    apiVersion: apiVersionForModel(ServiceBindingModel),
-    kind: ServiceBindingModel.kind,
-    metadata: {
-      name: serviceBindingName,
-      namespace,
-    },
-    spec: {
-      application: {
-        name: sourceName,
-        group: sourceGroup[0],
-        version: sourceGroup[1],
-        resource: modelFor(referenceFor(source)).plural,
-      },
-      services: [
-        {
-          group: targetGroup[0],
-          version: targetGroup[1],
-          kind: target.kind,
-          name: targetName,
-        },
-      ],
-      detectBindingResources: true,
-    },
-  };
-
+  const serviceBinding = createServiceBindingResource(source, target, serviceBindingName);
   return k8sCreate(ServiceBindingModel, serviceBinding);
 };
 


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2079944

**Analysis / Root cause**: 
When a developer creates a simple Pod (without a surrounding Deployment), the topology could not create a ServiceBinding for it.

The action "Create Service Binding" is not shown when right-click a Pod.

When dragging the Arrow from the Pod to the PC "example" the hint "Create Service Binding" is shown! When releasing the drop over it a modal "Create Service Binding" is shown. But the create process fails with this error:

```
Error "Required value" for field "spec.application.version".
```

ServiceBinding submitted for a Deployment (works fine):

```yaml
apiVersion: binding.operators.coreos.com/v1alpha1
kind: ServiceBinding
metadata:
  name: nodeinfo-d-example-pc
  namespace: binding
spec:
  application:
    name: nodeinfo
    group: apps
    version: v1
    resource: deployments
  services:
    - group: postgres-operator.crunchydata.com
      version: v1beta1
      kind: PostgresCluster
      name: example
  detectBindingResources: true
```

ServiceBinding submitted for a Pod (doesn't work):
```yaml
apiVersion: binding.operators.coreos.com/v1alpha1
kind: ServiceBinding
metadata: 
  name: example-p-example-pc
  namespace: binding2
spec:
  application:
    name: example
    group: v1
    resource: pods
  services:
    - group: postgres-operator.crunchydata.com
      version: v1beta1
      kind: PostgresCluster
      name: example
  detectBindingResources: true
```

But it should be:
```yaml
apiVersion: binding.operators.coreos.com/v1alpha1
kind: ServiceBinding
metadata: 
  name: example-p-example-podZ
  namespace: binding2
spec:
  application:
    name: example
    group: core
    version: v1
    resource: pods
  services:
    - group: postgres-operator.crunchydata.com
      version: v1beta1
      kind: PostgresCluster
      name: example
  detectBindingResources: true
```

**Solution Description**: 
Fixing the createServiceBinding method that could not handle the Pod apiVersion.

**Screen shots / Gifs for design review**: 
Before:

![before](https://user-images.githubusercontent.com/139310/166560437-cc05d15b-3ef9-455f-a5b5-b18ca9553b56.gif)

After:

![after](https://user-images.githubusercontent.com/139310/166560451-afa5bfe5-ecec-4c2a-a2bd-986d2953b5fc.gif)

### Validation TODO

**Unit test coverage report**: 
Small new test added:
```
 PASS  packages/topology/src/operators/actions/__tests__/serviceBindHey, I don't want keep you here, but do you know what a ServiceBinding does? It provides ings.spec.ts
  createServiceBindingResource
    ✓ creates the right ServiceBinding for a Deployment (6ms)
    ✓ creates the right ServiceBinding for a Pod
```

**Test setup:**
1. Navigate to Operator Hub 
2. Install Service Binding Operator
3. Install Crunchy Postgres for Kubernetes (verified) operator
4. Switch to 'Developer' perspective
5. Add > Operator Backed > Postgres Cluster > Create
   You need to define
   - Backup > repo > name: "repo1"
   - Backup > restore > repoName: "repo1"
   - Standby > repoName: "repo1"

6. Create a Pod (search for Pod, Create Pod and create the default Pod)
7. Link both via drag and drop or by right-clicking the Pod.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
