### PR TITLE
E2E tests: wait for project list to load before creating

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -189,6 +189,11 @@ export const projectNameSpace = {
 
   selectOrCreateProject: (projectName: string) => {
     app.waitForLoad();
+    cy.url().then((url) => {
+      if (url.includes('add/all-namespaces')) {
+        cy.get('tr[data-test-rows="resource-row"]').should('have.length.at.least', 1);
+      }
+    });
     projectNameSpace.clickProjectDropdown();
     cy.byTestID('showSystemSwitch').check(); // Ensure that all projects are showing
     cy.byTestID('dropdown-menu-item-link').should('have.length.gt', 5);


### PR DESCRIPTION
Should fix the occasional hiccup when cypress tests get stuck trying to create a namespace.