### PR TITLE
Automation of event-sources-installation | knative-plugin

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/add.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/add.ts
@@ -74,8 +74,8 @@ export enum builderImages {
 }
 
 export enum eventSourceCards {
-  ApiServerSource = 'Api Server Source',
-  ContainerSource = 'Container Source',
-  PingSource = 'Ping Source',
-  SinkBinding = 'Sink Binding',
+  ApiServerSource = 'ApiServerSource',
+  ContainerSource = 'ContainerSource',
+  PingSource = 'PingSource',
+  SinkBinding = 'SinkBinding',
 }

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -225,7 +225,10 @@ export const containerImagePO = {
 };
 
 export const eventSourcePO = {
-  search: '[placeholder="Filter by type..."]',
+  search: '[placeholder="Filter by keyword..."]',
+  yamlView: '#form-radiobutton-editorType-yaml-field',
+  formView: '#form-radiobutton-editorType-form-field',
+  addButton: 'a[role="button"]',
   apiServerSource: {
     apiServerSourceSection: '[data-test~="ApiServerSource"][data-test~="section"]',
     apiVersion: '[data-test=pairs-list-name]',
@@ -271,6 +274,15 @@ export const eventSourcePO = {
     environmentVariableName: '[data-test="pairs-list-name"]',
     environmentVariableValue: '[data-test="pairs-list-name"]',
     addMoreRow: '[data-test="add-button"]',
+  },
+  createPingSource: {
+    data: '#form-input-formData-data-PingSource-jsonData-field',
+    schedule: '#form-input-formData-data-PingSource-schedule-field',
+    name: '#form-input-formData-name-field',
+    resourceToggleButton: '[id="form-radiobutton-formData-sinkType-resource-field"]',
+    resourceDropDownField: '[id="form-ns-dropdown-formData-sink-key-field"]',
+    resourceDropDownItem: '[data-test="dropdown-menu-item-link"]',
+    resourceSearch: '[placeholder="Select resource"]',
   },
 };
 

--- a/frontend/packages/knative-plugin/integration-tests/cypress.json
+++ b/frontend/packages/knative-plugin/integration-tests/cypress.json
@@ -19,7 +19,7 @@
   "screenshotsFolder": "../../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../../gui_test_screenshots/cypress/videos",
   "env": {
-    "TAGS": "(@knative or @knative-admin) and (@pre-condition or @smoke or @regression) and not (@manual or @to-do or @un-verified or @broken-test)",
+    "TAGS": "(@knative or @knative-admin or @knative-camelk or @knative-eventing) and (@pre-condition or @smoke or @regression) and not (@manual or @to-do or @un-verified or @broken-test)",
     "NAMESPACE": "aut-knative"
   },
   "retries": {

--- a/frontend/packages/knative-plugin/integration-tests/features/eventing/event-sources-installation-view.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/eventing/event-sources-installation-view.feature
@@ -4,9 +4,8 @@ Feature: Event Sources Installation View
 
 
         Background:
-            Given user has installed Red Hat Integration - Camel K Operator
-
-
+            Given user has created or selected namespace "aut-eventsources"
+            
         @regression @manual
         Scenario: Install Event Source from Developer Catalog Page using YAML View: KF-01-TC01
             Given user is at Add page
@@ -21,7 +20,7 @@ Feature: Event Sources Installation View
               And Topology page have the Event Source created
 
 
-        @smoke @to-do
+        @smoke
         Scenario: Install Event Source from Add Page using Form View: KF-01-TC02
             Given user is at Add page
               And user has created "hello-openshift" knative service
@@ -34,15 +33,15 @@ Feature: Event Sources Installation View
               And user selects "hello-openshift" as a resource
               And user clicks on the Create button
              Then user will be redirected to Topology page
-              And Topology page have the Event Source created
+              And Topology page have the "ping-source" Event Source created
 
 
-        @regression @to-do
+        @regression
         Scenario: Switch from YAML to Form view: KF-01-TC03
-            Given user is at the Create Event Source page
+            Given user is at the Ping Source Create page
              When user selects the YAML View
               And user does some valid changes in the yaml for Event Source
-              And user selects the Form view
+              And user selects Form view
              Then user will see that the data hasn't lost
 
 

--- a/frontend/packages/knative-plugin/integration-tests/support/pageObjects/global-po.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/pageObjects/global-po.ts
@@ -1,6 +1,7 @@
 export const eventingPO = {
   createEventDropDownMenu: '[data-test-id="dropdown-button"]',
   createEventSource: '[data-test-dropdown-menu="eventSource"]',
+  yamlEditor: 'div.monaco-scrollable-element.editor-scrollable.vs-dark',
   pingSource: {
     create: '[data-test="EventSource-PingSource"]',
     dataField: '[id="form-input-formData-data-PingSource-jsonData-field"]',

--- a/frontend/packages/knative-plugin/integration-tests/support/pages/dev-perspective/eventing-page.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/pages/dev-perspective/eventing-page.ts
@@ -1,0 +1,17 @@
+import { yamlEditor } from '@console/dev-console/integration-tests/support/pages';
+import { eventingPO } from '../../pageObjects/global-po';
+
+export const createEventPage = {
+  clearYAMLEditor: () => {
+    cy.get(eventingPO.yamlEditor)
+      .click()
+      .focused()
+      .type('{ctrl}a')
+      .clear();
+  },
+  setYAMLContent: (yamlLocation: string) => {
+    cy.readFile(yamlLocation).then((str) => {
+      yamlEditor.setEditorContent(str);
+    });
+  },
+};

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/eventing/event-sources-installation-view.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/eventing/event-sources-installation-view.ts
@@ -1,0 +1,103 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import * as yamlEditor from '@console/cypress-integration-tests/views/yaml-editor';
+import {
+  resourceTypes,
+  devNavigationMenu,
+  addOptions,
+} from '@console/dev-console/integration-tests/support/constants';
+import { eventSourcePO } from '@console/dev-console/integration-tests/support/pageObjects/add-flow-po';
+import {
+  createGitWorkloadIfNotExistsOnTopologyPage,
+  addPage,
+  navigateTo,
+  createForm,
+  eventSourcesPage,
+} from '@console/dev-console/integration-tests/support/pages';
+import { topologyPage } from '@console/topology/integration-tests/support/pages/topology/topology-page';
+import { createEventPage } from '../../pages/dev-perspective/eventing-page';
+
+Given('user has created {string} knative service', (knativeServiceName: string) => {
+  createGitWorkloadIfNotExistsOnTopologyPage(
+    'https://github.com/sclorg/nodejs-ex.git',
+    knativeServiceName,
+    resourceTypes.knativeService,
+  );
+});
+
+When('user clicks on the Ping Source Event Source card', () => {
+  cy.log('Ping Source Event Source created');
+  eventSourcesPage.search('Ping Source');
+  eventSourcesPage.clickEventSourceType('PingSource');
+});
+
+When('user clicks on the Event Source card on the Add page', () => {
+  navigateTo(devNavigationMenu.Add);
+  addPage.selectCardFromOptions(addOptions.EventSource);
+});
+
+When('user clicks on the Create Event Source button on side bar', () => {
+  cy.get(eventSourcePO.addButton)
+    .contains('Create Event Source')
+    .click({ force: true });
+});
+
+When('user selects Form view', () => {
+  cy.get(eventSourcePO.formView).click();
+});
+
+When('user enters {string} in Schedule field', (scheduleField: string) => {
+  cy.get(eventSourcePO.createPingSource.schedule).type(scheduleField);
+});
+
+When('user selects Resource radio button', () => {
+  cy.get(eventSourcePO.createPingSource.resourceToggleButton).click();
+});
+
+When('user selects {string} as a resource', (resourceName: string) => {
+  cy.get(eventSourcePO.createPingSource.resourceDropDownField).click();
+  cy.get(eventSourcePO.createPingSource.resourceSearch).type(resourceName);
+  cy.get(eventSourcePO.createPingSource.resourceDropDownItem)
+    .eq(0)
+    .click({ force: true });
+});
+
+When('user clicks on the Create button', () => {
+  createForm.clickSave();
+});
+
+Then('user will be redirected to Topology page', () => {
+  topologyPage.verifyTopologyPage();
+});
+
+Then('Topology page have the {string} Event Source created', (componentName: string) => {
+  topologyPage.verifyWorkloadInTopologyPage(componentName);
+});
+
+Given('user is at the Ping Source Create page', () => {
+  navigateTo(devNavigationMenu.Add);
+  addPage.selectCardFromOptions(addOptions.EventSource);
+  eventSourcesPage.search('Ping Source');
+  eventSourcesPage.clickEventSourceType('PingSource');
+  cy.get(eventSourcePO.addButton)
+    .contains('Create Event Source')
+    .click({ force: true });
+});
+
+When('user selects the YAML View', () => {
+  cy.get(eventSourcePO.yamlView).click();
+});
+
+When('user does some valid changes in the yaml for Event Source', () => {
+  yamlEditor.isLoaded();
+  createEventPage.clearYAMLEditor();
+  const yamlLocation = '../integration-tests/support/testData/createPingSource.yaml';
+  cy.readFile(yamlLocation).then((str) => {
+    yamlEditor.setEditorContent(str);
+  });
+});
+
+Then("user will see that the data hasn't lost", () => {
+  cy.get(eventSourcePO.createPingSource.data).should('have.value', 'Message');
+  cy.get(eventSourcePO.createPingSource.schedule).should('have.value', '* * * * *');
+  cy.get(eventSourcePO.createPingSource.name).should('have.value', 'ping-source-resource-event');
+});

--- a/frontend/packages/knative-plugin/integration-tests/support/testData/createPingSource.yaml
+++ b/frontend/packages/knative-plugin/integration-tests/support/testData/createPingSource.yaml
@@ -1,0 +1,21 @@
+apiVersion: sources.knative.dev/v1
+kind: PingSource
+metadata:
+  name: ping-source-resource-event
+  namespace: aut-knative
+  labels:
+    app: ping-source
+    app.kubernetes.io/instance: ping-source
+    app.kubernetes.io/component: ping-source
+    app.kubernetes.io/name: ping-source
+    app.kubernetes.io/part-of: nodejs-ex-git-app
+  annotations:
+    openshift.io/generated-by: OpenShiftWebConsole
+spec:
+  jsonData: Message
+  schedule: '* * * * *'
+  sink:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: nodejs-ex-git


### PR DESCRIPTION
**Description:**
<!-- PR description-->
- Automation of event-sources-installation feature file.

**Jira Id:** 

- [ODC-6663](https://issues.redhat.com/browse/ODC-6663) - event-sources-installation

<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example: 
```
export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p knative

```

**Screen shots**:
<!--   -->
![image](https://user-images.githubusercontent.com/39815871/166896849-60b7add6-13d3-461c-85f1-8705f5a2a5ba.png)



**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge