### PR TITLE
[Dark Theme]: fix quick search bar and  project selector in User Preferences page

### DIFF
--- a/frontend/packages/console-app/src/components/user-preferences/namespace/NamespaceDropdown.scss
+++ b/frontend/packages/console-app/src/components/user-preferences/namespace/NamespaceDropdown.scss
@@ -1,6 +1,7 @@
 .pf-c-menu-toggle.co-user-preference__namespace-menu-toggle {
   padding: var(--pf-global--spacer--form-element) var(--pf-global--spacer--sm)
     var(--pf-global--spacer--form-element) var(--pf-global--spacer--sm) !important;
+  background-color: var(--pf-global--BackgroundColor--400);
   &::before,
   &::after {
     border-width: var(--pf-global--BorderWidth--sm) !important;

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.scss
@@ -1,5 +1,7 @@
 .ocs-quick-search-bar {
-  background-color: var(--pf-global--BackgroundColor--100) !important;
+  &.pf-c-input-group {
+    background-color: var(--pf-global--BackgroundColor--400);
+  }
   &:hover {
     cursor: move;
   }


### PR DESCRIPTION
**fixes:** https://issues.redhat.com/browse/ODC-6634

**Screnshots:**
### Project selector
**Before:**
![image](https://user-images.githubusercontent.com/2561818/167088240-b470a939-f641-4fd3-abf0-823dd406ad59.png)

**After:**
![image](https://user-images.githubusercontent.com/2561818/167088363-1facab76-1579-4020-8fc1-90daf882352d.png)

### Quick Search
**Before:**
![image](https://user-images.githubusercontent.com/2561818/167088447-fbd8215b-fb1b-48ca-8891-ed4c617f556d.png)

![image](https://user-images.githubusercontent.com/2561818/167088728-0a00d080-24cf-47b9-affa-2370f53ed1d0.png)

**After:**
![image](https://user-images.githubusercontent.com/2561818/167088641-6c44b41d-b25b-4335-99a8-2fa7ae75866a.png)

![image](https://user-images.githubusercontent.com/2561818/167088802-d0ff6193-a0eb-4ed9-95df-87c70e6309b5.png)


