### PR TITLE
Gherkin for pipeline builder to support local tektonhub instances

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
@@ -330,3 +330,13 @@ Feature: Create the pipeline from builder page
               And user clicks Add task button under Tasks section
               And user types 'git'
              Then user will see Task, clusterTask only
+
+
+        @regression @manual @odc-6236
+        Scenario: Pipeline builder to support local Tekton Hub instances : P-02-TC21
+            Given user has setup tektonhub instance
+            # Refer to document https://docs.google.com/document/d/1HImc2DdtFKMWgk5dTm8Ib-I3wgnVXxdHxzX8Cn0jrZA/edit?usp=sharing for setting up tektonhub insance
+              And user is at Pipeline Builder page
+             When user clicks on Add task button under Tasks section
+              And user searches a tasks that is available in the local tektonhub instance
+             Then user will see the intended community task


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-6236
Story: https://issues.redhat.com/browse/ODC-6511

Acceptance criteria:

- Cluster admin can modify the default Tekton Hub API endpoint to point to their local Tekton Hub 

**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]

