### PR TITLE
Bug 2074767: change metrics queries based on metrics level configurations

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-metrics.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-metrics.ts
@@ -27,7 +27,7 @@ Then(
 );
 
 Then(
-  'user can see Pipeline success ratio, Number of Pipeline Runs, Pipeline Run duration, Task Run duration graphs',
+  'user can see Pipeline success ratio, Number of Pipeline Runs graphs for default metrics level',
   () => {
     cy.get(pipelineDetailsPO.metrics.graphTitle)
       .eq(0)
@@ -35,12 +35,6 @@ Then(
     cy.get(pipelineDetailsPO.metrics.graphTitle)
       .eq(1)
       .should('contain.text', pipelineDetailsText.metrics.graphs.numberOfPipelineRuns);
-    cy.get(pipelineDetailsPO.metrics.graphTitle)
-      .eq(2)
-      .should('contain.text', pipelineDetailsText.metrics.graphs.pipelineRunDuration);
-    cy.get(pipelineDetailsPO.metrics.graphTitle)
-      .eq(3)
-      .should('contain.text', pipelineDetailsText.metrics.graphs.taskRunDuration);
   },
 );
 

--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -262,6 +262,7 @@
   "PipelineRun Duration": "PipelineRun Duration",
   "TaskRun Duration": "TaskRun Duration",
   "Start your pipeline to view pipeline metrics.": "Start your pipeline to view pipeline metrics.",
+  "Administrators can try <2>this quick start</2> to configure their metrics level to pipelinerun and taskrun. The pipelinerun and taskrun metrics level collects large volume of metrics over time in unbounded cardinality which may lead to metrics unreliability.": "Administrators can try <2>this quick start</2> to configure their metrics level to pipelinerun and taskrun. The pipelinerun and taskrun metrics level collects large volume of metrics over time in unbounded cardinality which may lead to metrics unreliability.",
   "Refresh Interval": "Refresh Interval",
   "Time Range": "Time Range",
   "Pipeline run count chart": "Pipeline run count chart",

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/PipelineDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/PipelineDetailsPage.tsx
@@ -20,9 +20,8 @@ import {
 } from './detail-page-tabs';
 import { PipelineDetailsTabProps } from './detail-page-tabs/types';
 import { useDevPipelinesBreadcrumbsFor, useLatestPipelineRun } from './hooks';
-import { MetricsQueryPrefix } from './pipeline-metrics/pipeline-metrics-utils';
 import PipelineMetrics from './pipeline-metrics/PipelineMetrics';
-import { isGAVersionInstalled, usePipelineOperatorVersion } from './utils/pipeline-operator';
+import { usePipelineMetricsLevel } from './utils/pipeline-operator';
 import { usePipelineTriggerTemplateNames } from './utils/triggers';
 
 const PipelineDetailsPage: React.FC<DetailsPageProps> = (props) => {
@@ -32,12 +31,8 @@ const PipelineDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const breadcrumbsFor = useDevPipelinesBreadcrumbsFor(kindObj, match);
   const [, pipelineLoaded, pipelineError] = useK8sGet<PipelineKind>(PipelineModel, name, namespace);
   const latestPipelineRun = useLatestPipelineRun(name, namespace);
-  const pipelineOperator = usePipelineOperatorVersion(namespace);
   const badge = usePipelineTechPreviewBadge(namespace);
-  const queryPrefix =
-    pipelineOperator && !isGAVersionInstalled(pipelineOperator)
-      ? MetricsQueryPrefix.TEKTON
-      : MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER;
+  const { hasUpdatePermission, queryPrefix, metricsLevel } = usePipelineMetricsLevel(namespace);
 
   const augmentedMenuActions: KebabAction[] = useMenuActionsWithUserAnnotation(
     getPipelineKebabActions(latestPipelineRun, templateNames.length > 0),
@@ -50,7 +45,7 @@ const PipelineDetailsPage: React.FC<DetailsPageProps> = (props) => {
       {...props}
       badge={badge}
       menuActions={augmentedMenuActions}
-      customData={{ templateNames, queryPrefix }}
+      customData={{ templateNames, queryPrefix, metricsLevel, hasUpdatePermission }}
       breadcrumbsFor={() => breadcrumbsFor}
       pages={[
         navFactory.details(PipelineDetails),

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/__tests__/pipelineDetailsPage.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/__tests__/pipelineDetailsPage.spec.tsx
@@ -1,22 +1,31 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
+import { act } from '@testing-library/react';
+import { mount, ReactWrapper } from 'enzyme';
 import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
 import { SemVer } from 'semver';
+import * as sdkUtils from '@console/dynamic-plugin-sdk';
 import useActivePerspective from '@console/dynamic-plugin-sdk/src/perspective/useActivePerspective';
 import { ErrorPage404 } from '@console/internal/components/error';
 import { DetailsPage } from '@console/internal/components/factory/';
-import { LoadingBox } from '@console/internal/components/utils';
+import { history, LoadingBox } from '@console/internal/components/utils';
 import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
 import { referenceForModel } from '@console/internal/module/k8s';
 import store from '@console/internal/redux';
 import { PipelineModel } from '../../../models';
 import { pipelineTestData, PipelineExampleNames } from '../../../test-data/pipeline-data';
+import {
+  sampleTektonConfig,
+  sampleTektonConfigMetrics,
+} from '../../../test-data/tekon-config-data';
 import { PipelineRunKind } from '../../../types';
 import { getPipelineKebabActions } from '../../../utils/pipeline-actions';
 import * as utils from '../../pipelineruns/triggered-by';
+import { PipelineMetricsLevel } from '../const';
 import * as hookUtils from '../hooks';
 import { MetricsQueryPrefix } from '../pipeline-metrics/pipeline-metrics-utils';
 import PipelineDetailsPage from '../PipelineDetailsPage';
+import * as configUtils from '../utils/pipeline-config';
 import * as operatorUtils from '../utils/pipeline-operator';
 import * as triggerUtils from '../utils/triggers';
 
@@ -25,6 +34,8 @@ const breadCrumbs = jest.spyOn(hookUtils, 'usePipelinesBreadcrumbsFor');
 const templateNames = jest.spyOn(triggerUtils, 'usePipelineTriggerTemplateNames');
 const latestPipelineRun = jest.spyOn(hookUtils, 'useLatestPipelineRun');
 const operatorVersion = jest.spyOn(operatorUtils, 'usePipelineOperatorVersion');
+const spyUseAccessReview = jest.spyOn(sdkUtils, 'useAccessReview');
+const spyPipelineConfig = jest.spyOn(configUtils, 'usePipelineConfig');
 
 const useActivePerspectiveMock = useActivePerspective as jest.Mock;
 
@@ -34,6 +45,11 @@ jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
 
 jest.mock('@console/dynamic-plugin-sdk/src/perspective/useActivePerspective', () => ({
   default: jest.fn(),
+}));
+
+jest.mock('@console/internal/components/utils/firehose', () => ({
+  ...require.requireActual('@console/internal/components/utils/firehose'),
+  Firehose: ({ children }) => children,
 }));
 
 type PipelineDetailsPageProps = React.ComponentProps<typeof PipelineDetailsPage>;
@@ -64,84 +80,73 @@ describe('PipelineDetailsPage:', () => {
     latestPipelineRun.mockReturnValue(null);
     (useK8sGet as jest.Mock).mockReturnValue([mockData.pipeline, true, null]);
     useActivePerspectiveMock.mockClear();
+    ((operatorVersion as unknown) as jest.Mock).mockReturnValue(new SemVer('1.6.2'));
+    spyPipelineConfig.mockReturnValue([sampleTektonConfig]);
+    spyUseAccessReview.mockReturnValue([true]);
   });
+  const renderPipelineDetailsPage = async () => {
+    let wrapper: ReactWrapper;
+    await act(
+      async () =>
+        (wrapper = mount(
+          <Router history={history}>
+            <Provider store={store}>
+              <PipelineDetailsPage {...PipelineDetailsPageProps} />
+            </Provider>
+          </Router>,
+        )),
+    );
+    return wrapper;
+  };
 
-  it('should render the Details Page if the pipeline is loaded and available', () => {
+  it('should render the Details Page if the pipeline is loaded and available', async () => {
     (useK8sGet as jest.Mock).mockReturnValue([mockData.pipeline, true, null]);
     useActivePerspectiveMock.mockReturnValue(['dev', () => {}]);
-    const wrapper = mount(
-      <Provider store={store}>
-        <PipelineDetailsPage {...PipelineDetailsPageProps} />
-      </Provider>,
-    );
+    const wrapper: ReactWrapper = await renderPipelineDetailsPage();
     expect(wrapper.find(DetailsPage).exists()).toBe(true);
   });
 
-  it('should render the loading box if the pipeline is not loaded yet', () => {
+  it('should render the loading box if the pipeline is not loaded yet', async () => {
     (useK8sGet as jest.Mock).mockReturnValue([[], false, null]);
-    const wrapper = mount(
-      <Provider store={store}>
-        <PipelineDetailsPage {...PipelineDetailsPageProps} />
-      </Provider>,
-    );
+    const wrapper: ReactWrapper = await renderPipelineDetailsPage();
     expect(wrapper.find(LoadingBox).exists()).toBe(true);
   });
 
-  it('should render the ErrorPage404 if the pipeline is not found', () => {
+  it('should render the ErrorPage404 if the pipeline is not found', async () => {
     (useK8sGet as jest.Mock).mockReturnValue([[], true, { response: { status: 404 } }]);
-    const wrapper = mount(
-      <Provider store={store}>
-        <PipelineDetailsPage {...PipelineDetailsPageProps} />
-      </Provider>,
-    );
+    const wrapper: ReactWrapper = await renderPipelineDetailsPage();
     expect(wrapper.find(ErrorPage404).exists()).toBe(true);
   });
 
-  it('should have the latest metrics endpoint as default queryPrefix', () => {
+  it('should have the latest metrics endpoint as default queryPrefix', async () => {
     (useK8sGet as jest.Mock).mockReturnValue([mockData.pipeline, true, null]);
-    const wrapper = mount(
-      <Provider store={store}>
-        <PipelineDetailsPage {...PipelineDetailsPageProps} />
-      </Provider>,
-    );
+    const wrapper: ReactWrapper = await renderPipelineDetailsPage();
     expect(wrapper.find(DetailsPage).props().customData.queryPrefix).toBe(
       MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
     );
   });
 
-  it('should use the new metrics endpoint if the pipeline operator is greater than 1.4.0', () => {
+  it('should use the new metrics endpoint if the pipeline operator is greater than 1.4.0', async () => {
     (useK8sGet as jest.Mock).mockReturnValue([mockData.pipeline, true, null]);
     ((operatorVersion as unknown) as jest.Mock).mockReturnValue(new SemVer('1.8.0'));
-    const wrapper = mount(
-      <Provider store={store}>
-        <PipelineDetailsPage {...PipelineDetailsPageProps} />
-      </Provider>,
-    );
+    const wrapper: ReactWrapper = await renderPipelineDetailsPage();
     expect(wrapper.find(DetailsPage).props().customData.queryPrefix).toBe(
       MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
     );
   });
 
-  it('should use the old metrics endpoint if the pipeline operator is less than 1.4.0', () => {
+  it('should use the old metrics endpoint if the pipeline operator is less than 1.4.0', async () => {
     (useK8sGet as jest.Mock).mockReturnValue([mockData.pipeline, true, null]);
     ((operatorVersion as unknown) as jest.Mock).mockReturnValue(new SemVer('1.2.1'));
-    const wrapper = mount(
-      <Provider store={store}>
-        <PipelineDetailsPage {...PipelineDetailsPageProps} />
-      </Provider>,
-    );
+    const wrapper: ReactWrapper = await renderPipelineDetailsPage();
     expect(wrapper.find(DetailsPage).props().customData.queryPrefix).toBe(
       MetricsQueryPrefix.TEKTON,
     );
   });
 
-  it('should not contain Start last run menu item if the pipeline run is not present', () => {
+  it('should not contain Start last run menu item if the pipeline run is not present', async () => {
     menuActions.mockReturnValue(getPipelineKebabActions(null, false));
-    const wrapper = mount(
-      <Provider store={store}>
-        <PipelineDetailsPage {...PipelineDetailsPageProps} />
-      </Provider>,
-    );
+    const wrapper: ReactWrapper = await renderPipelineDetailsPage();
     const menuItems: any = wrapper.find(DetailsPage).props().menuActions;
     const startLastRun = menuItems.find(
       (menu) =>
@@ -150,13 +155,9 @@ describe('PipelineDetailsPage:', () => {
     expect(startLastRun).toBeUndefined();
   });
 
-  it('should contain Start last run menu item if the pipeline run is present', () => {
+  it('should contain Start last run menu item if the pipeline run is present', async () => {
     menuActions.mockReturnValue(getPipelineKebabActions(pipelineRuns[0], false));
-    const wrapper = mount(
-      <Provider store={store}>
-        <PipelineDetailsPage {...PipelineDetailsPageProps} />
-      </Provider>,
-    );
+    const wrapper: ReactWrapper = await renderPipelineDetailsPage();
 
     const menuItems: any = wrapper.find(DetailsPage).props().menuActions;
     const startLastRun = menuItems.find(
@@ -164,5 +165,30 @@ describe('PipelineDetailsPage:', () => {
         menu(PipelineModel, mockData.pipeline).labelKey === 'pipelines-plugin~Start last run',
     );
     expect(startLastRun).toBeDefined();
+  });
+
+  describe('Pipeline Details page Metrics Tab:', () => {
+    test('It should contain metrics tab if the user has view permission in the openshift pipelines namespace', async () => {
+      const wrapper: ReactWrapper = await renderPipelineDetailsPage();
+      const tabs = wrapper.find(DetailsPage).props().pages;
+      const metricsTab = tabs.find((t) => t.name === 'Metrics');
+
+      expect(tabs).toHaveLength(6);
+      expect(metricsTab).toBeDefined();
+    });
+
+    test('It should contain metrics tab if the user has permission and osp 1.5.2 is installed', async () => {
+      spyUseAccessReview.mockReturnValue([true]);
+      ((operatorVersion as unknown) as jest.Mock).mockReturnValue(new SemVer('1.5.2'));
+      spyPipelineConfig.mockReturnValue([
+        sampleTektonConfigMetrics[PipelineMetricsLevel.UNSIMPLIFIED_METRICS_LEVEL],
+      ]);
+      const wrapper: ReactWrapper = await renderPipelineDetailsPage();
+      const tabs = wrapper.find(DetailsPage).props().pages;
+      const metricsTab = tabs.find((t) => t.name === 'Metrics');
+
+      expect(tabs).toHaveLength(6);
+      expect(metricsTab).toBeDefined();
+    });
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
@@ -53,6 +53,7 @@ export const SecretAnnotationType = {
 
 export const PIPELINE_GA_VERSION = '1.4.0';
 export const TRIGGERS_GA_VERSION = '1.6.0';
+export const PIPELINE_UNSIMPLIFIED_METRICS_VERSION = '1.5.2';
 export const PIPELINE_SERVICE_ACCOUNT = 'pipeline';
 export const PIPELINE_RUN_AUTO_START_FAILED = `bridge/pipeline-run-auto-start-failed`;
 
@@ -66,3 +67,11 @@ export const DEFAULT_SAMPLES = 60;
 export const preferredNameAnnotation = 'pipeline.openshift.io/preferredName';
 
 export const PIPELINE_NAMESPACE = 'openshift-pipelines';
+export const PIPELINE_CONFIG_NAME = 'config';
+
+export enum PipelineMetricsLevel {
+  PIPELINE_TASK_LEVEL = 'pipeline/task',
+  PIPELINERUN_TASKRUN_LEVEL = 'pipelinerun/taskrun',
+  UNSUPPORTED_LEVEL = 'unsupported',
+  UNSIMPLIFIED_METRICS_LEVEL = 'unsimplified',
+}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/PipelineRuns.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/PipelineRuns.spec.tsx
@@ -15,6 +15,8 @@ const pipelineRunProps: React.ComponentProps<typeof PipelineRuns> = {
   customData: {
     templateNames: [],
     queryPrefix: '',
+    metricsLevel: '',
+    hasUpdatePermission: true,
   },
 };
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/types.ts
@@ -6,5 +6,7 @@ export type PipelineDetailsTabProps = {
   customData: {
     templateNames: RouteTemplate[];
     queryPrefix: string;
+    metricsLevel: string;
+    hasUpdatePermission: boolean;
   };
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/hooks.ts
@@ -15,8 +15,8 @@ import { PipelineRunModel } from '../../models';
 import { PipelineRunKind } from '../../types';
 import { getLatestRun } from '../../utils/pipeline-augment';
 import { pipelinesTab } from '../../utils/pipeline-utils';
-import { DEFAULT_SAMPLES, PIPELINE_NAMESPACE, TektonResourceLabel } from './const';
-import { metricQueries, PipelineQuery } from './pipeline-metrics/pipeline-metrics-utils';
+import { DEFAULT_SAMPLES, TektonResourceLabel } from './const';
+import { metricsQueries, PipelineQuery } from './pipeline-metrics/pipeline-metrics-utils';
 
 type Match = RMatch<{ url: string }>;
 
@@ -76,15 +76,24 @@ export const usePipelinePVC = (
   return [!PVCError && PVC.length > 0 ? PVC[0] : null, PVCLoaded];
 };
 
-export const usePipelineSuccessRatioPoll = ({ delay, namespace, name, timespan, queryPrefix }) => {
+export const usePipelineSuccessRatioPoll = ({
+  delay,
+  namespace,
+  name,
+  timespan,
+  queryPrefix,
+  metricsLevel,
+}) => {
+  const queries = metricsQueries(queryPrefix)[metricsLevel];
+
   return useURLPoll<PrometheusResponse>(
     getPrometheusURL({
       endpoint: PrometheusEndpoint.QUERY_RANGE,
-      query: metricQueries(queryPrefix)[PipelineQuery.PIPELINE_SUCCESS_RATIO]({ name, namespace }),
+      query: queries[PipelineQuery.PIPELINE_SUCCESS_RATIO]({ name, namespace }),
       samples: 1,
       endTime: Date.now(),
       timespan,
-      namespace: PIPELINE_NAMESPACE,
+      namespace,
     }),
     delay,
     namespace,
@@ -92,18 +101,27 @@ export const usePipelineSuccessRatioPoll = ({ delay, namespace, name, timespan, 
   );
 };
 
-export const usePipelineRunTaskRunPoll = ({ delay, namespace, name, timespan, queryPrefix }) => {
+export const usePipelineRunTaskRunPoll = ({
+  delay,
+  namespace,
+  name,
+  timespan,
+  queryPrefix,
+  metricsLevel,
+}) => {
+  const queries = metricsQueries(queryPrefix)[metricsLevel];
+
   return useURLPoll<PrometheusResponse>(
     getPrometheusURL({
       endpoint: PrometheusEndpoint.QUERY_RANGE,
-      query: metricQueries(queryPrefix)[PipelineQuery.PIPELINE_RUN_TASK_RUN_DURATION]({
+      query: queries[PipelineQuery.PIPELINE_RUN_TASK_RUN_DURATION]({
         name,
         namespace,
       }),
       samples: DEFAULT_SAMPLES,
       endTime: Date.now(),
       timespan,
-      namespace: PIPELINE_NAMESPACE,
+      namespace,
     }),
     delay,
     namespace,
@@ -117,15 +135,21 @@ export const usePipelineRunDurationPoll = ({
   name,
   timespan,
   queryPrefix,
+  metricsLevel,
 }): any => {
+  const queries = metricsQueries(queryPrefix)[metricsLevel];
+
   return useURLPoll<PrometheusResponse>(
     getPrometheusURL({
       endpoint: PrometheusEndpoint.QUERY_RANGE,
-      query: metricQueries(queryPrefix)[PipelineQuery.PIPELINE_RUN_DURATION]({ name, namespace }),
+      query: queries[PipelineQuery.PIPELINE_RUN_DURATION]({
+        name,
+        namespace,
+      }),
       samples: DEFAULT_SAMPLES,
       endTime: Date.now(),
       timespan,
-      namespace: PIPELINE_NAMESPACE,
+      namespace,
     }),
     delay,
     namespace,
@@ -133,15 +157,24 @@ export const usePipelineRunDurationPoll = ({
   );
 };
 
-export const usePipelineRunPoll = ({ delay, namespace, name, timespan, queryPrefix }) => {
+export const usePipelineRunPoll = ({
+  delay,
+  namespace,
+  name,
+  timespan,
+  queryPrefix,
+  metricsLevel,
+}) => {
+  const queries = metricsQueries(queryPrefix)[metricsLevel];
+
   return useURLPoll<PrometheusResponse>(
     getPrometheusURL({
       endpoint: PrometheusEndpoint.QUERY_RANGE,
-      query: metricQueries(queryPrefix)[PipelineQuery.NUMBER_OF_PIPELINE_RUNS]({ name, namespace }),
+      query: queries[PipelineQuery.NUMBER_OF_PIPELINE_RUNS]({ name, namespace }),
       samples: DEFAULT_SAMPLES,
       endTime: Date.now(),
       timespan,
-      namespace: PIPELINE_NAMESPACE,
+      namespace,
     }),
     delay,
     namespace,

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetricsQuickstart.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetricsQuickstart.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { QuickStartContextValues, QuickStartContext } from '@patternfly/quickstarts';
+import { Alert } from '@patternfly/react-core';
+import { Trans } from 'react-i18next';
+import { Link, useLocation } from 'react-router-dom';
+import QuickStartsLoader from '@console/app/src/components/quick-starts/loader/QuickStartsLoader';
+import { isModifiedEvent } from '@console/shared/src';
+
+type PipelineMetricsQuickstartInfoProps = {
+  onClick: (event: React.MouseEvent<HTMLElement>) => void;
+  to: { pathname: string; search: string };
+};
+
+export const PipelineMetricsQuickstartInfo: React.FC<PipelineMetricsQuickstartInfoProps> = ({
+  onClick,
+  to,
+}) => (
+  <Trans ns="pipelines-plugin">
+    Administrators can try{' '}
+    <Link to={to} onClick={onClick}>
+      this quick start
+    </Link>{' '}
+    to configure their metrics level to pipelinerun and taskrun. The pipelinerun and taskrun metrics
+    level collects large volume of metrics over time in unbounded cardinality which may lead to
+    metrics unreliability.
+  </Trans>
+);
+
+const PipelineMetricsQuickstart: React.FC = () => {
+  const PIPELINE_METRICS_CONFIGURATION_QUICKSTART = 'configure-pipeline-metrics';
+  const { pathname, search } = useLocation();
+  const { setActiveQuickStart } = React.useContext<QuickStartContextValues>(QuickStartContext);
+  const queryParams = new URLSearchParams(search);
+  queryParams.set('quickstart', PIPELINE_METRICS_CONFIGURATION_QUICKSTART);
+
+  const to = {
+    pathname,
+    search: `?${queryParams.toString()}`,
+  };
+
+  return (
+    <QuickStartsLoader>
+      {(quickStarts, loaded) => {
+        const handleOnClick = (event: React.MouseEvent<HTMLElement>) => {
+          if (isModifiedEvent(event)) {
+            return;
+          }
+          setActiveQuickStart(PIPELINE_METRICS_CONFIGURATION_QUICKSTART);
+        };
+
+        const isPipelineMetricsQSAvailable =
+          loaded &&
+          quickStarts?.length > 0 &&
+          !!quickStarts.find(
+            (qs) => qs.metadata.name === PIPELINE_METRICS_CONFIGURATION_QUICKSTART,
+          );
+
+        return (
+          <>
+            {isPipelineMetricsQSAvailable && (
+              <Alert
+                variant="info"
+                isInline
+                title="Pipeline metrics configuration defaults to pipeline and task level"
+              >
+                <PipelineMetricsQuickstartInfo
+                  data-test-id="pipeline-metrics-quickstart-link"
+                  to={to}
+                  onClick={handleOnClick}
+                />
+              </Alert>
+            )}
+          </>
+        );
+      }}
+    </QuickStartsLoader>
+  );
+};
+
+export default PipelineMetricsQuickstart;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunCount.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunCount.tsx
@@ -25,6 +25,7 @@ const PipelineRunCount: React.FC<PipelineMetricsGraphProps> = ({
   loaded = true,
   onLoad: onInitialLoad,
   queryPrefix,
+  metricsLevel,
 }) => {
   const {
     metadata: { name, namespace },
@@ -36,6 +37,7 @@ const PipelineRunCount: React.FC<PipelineMetricsGraphProps> = ({
     timespan,
     delay: interval,
     queryPrefix,
+    metricsLevel,
   });
   const pipelineRunResultData = pipelineRunResult?.data?.result ?? [];
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunDurationGraph.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunDurationGraph.tsx
@@ -20,6 +20,7 @@ const PipelineRunDurationGraph: React.FC<PipelineMetricsGraphProps> = ({
   loaded = true,
   onLoad: onInitialLoad,
   queryPrefix,
+  metricsLevel,
 }) => {
   const {
     metadata: { name, namespace },
@@ -31,6 +32,7 @@ const PipelineRunDurationGraph: React.FC<PipelineMetricsGraphProps> = ({
     timespan,
     delay: interval,
     queryPrefix,
+    metricsLevel,
   });
   const pipelineRunDurationData = runData?.data?.result ?? [];
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunTaskRunGraph.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunTaskRunGraph.tsx
@@ -31,6 +31,7 @@ const PipelineRunTaskRunGraph: React.FC<PipelineMetricsGraphProps> = ({
   loaded = true,
   onLoad: onInitialLoad,
   queryPrefix,
+  metricsLevel,
 }) => {
   const {
     metadata: { name, namespace },
@@ -44,6 +45,7 @@ const PipelineRunTaskRunGraph: React.FC<PipelineMetricsGraphProps> = ({
     timespan,
     delay: interval,
     queryPrefix,
+    metricsLevel,
   });
 
   const taskNameMap = pipeline.spec.tasks

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineSuccessRatioDonut.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineSuccessRatioDonut.tsx
@@ -25,6 +25,7 @@ const PipelineSuccessRatioDonut: React.FC<PipelineMetricsGraphProps> = ({
   loaded = true,
   onLoad: onInitialLoad,
   queryPrefix,
+  metricsLevel,
 }) => {
   const {
     metadata: { name, namespace },
@@ -36,6 +37,7 @@ const PipelineSuccessRatioDonut: React.FC<PipelineMetricsGraphProps> = ({
     timespan,
     delay: interval,
     queryPrefix,
+    metricsLevel,
   });
   const pipelineSuccessData = runData?.data?.result ?? [];
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineMetrics.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineMetrics.spec.tsx
@@ -6,10 +6,12 @@ import {
   PipelineExampleNames,
   pipelineTestData,
 } from '../../../../test-data/pipeline-data';
+import { PipelineMetricsLevel } from '../../const';
 import * as hookUtils from '../../hooks';
 import { MetricsQueryPrefix } from '../pipeline-metrics-utils';
 import PipelineMetrics from '../PipelineMetrics';
 import PipelineMetricsEmptyState from '../PipelineMetricsEmptyState';
+import PipelineMetricsQuickstart from '../PipelineMetricsQuickstart';
 import PipelineMetricsRefreshDropdown from '../PipelineMetricsRefreshDropdown';
 import PipelineMetricsTimeRangeDropdown from '../PipelineMetricsTimeRangeDropdown';
 import PipelineRunCount from '../PipelineRunCount';
@@ -37,6 +39,8 @@ describe('Pipeline Metrics', () => {
       customData: {
         templateNames: [],
         queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
+        metricsLevel: PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL,
+        hasUpdatePermission: true,
       },
     };
   });
@@ -60,5 +64,85 @@ describe('Pipeline Metrics', () => {
     expect(pipelineMetricsWrapper.find(PipelineRunCount).exists()).toBe(true);
     expect(pipelineMetricsWrapper.find(PipelineRunDurationGraph).exists()).toBe(true);
     expect(pipelineMetricsWrapper.find(PipelineRunTaskRunGraph).exists()).toBe(true);
+  });
+
+  it('Should render only success ratio and number of pipeline runs charts if the metrics level is set to pipeline /task (default) level', () => {
+    latestPipelineRunSpy.mockReturnValue(pipelineRun);
+    const pipelineMetricsWrapper = shallow(<PipelineMetrics {...PipelineMetricsProps} />);
+    pipelineMetricsWrapper
+      .setProps({
+        customData: { metricsLevel: PipelineMetricsLevel.PIPELINE_TASK_LEVEL },
+      })
+      .update();
+    expect(pipelineMetricsWrapper.find(PipelineMetricsEmptyState).exists()).toBe(false);
+    expect(pipelineMetricsWrapper.find(Card)).toHaveLength(2);
+
+    expect(pipelineMetricsWrapper.find(PipelineMetricsTimeRangeDropdown).exists()).toBe(true);
+    expect(pipelineMetricsWrapper.find(PipelineMetricsRefreshDropdown).exists()).toBe(true);
+
+    expect(pipelineMetricsWrapper.find(PipelineSuccessRatioDonut).exists()).toBe(true);
+    expect(pipelineMetricsWrapper.find(PipelineRunCount).exists()).toBe(true);
+    expect(pipelineMetricsWrapper.find(PipelineRunDurationGraph).exists()).toBe(false);
+    expect(pipelineMetricsWrapper.find(PipelineRunTaskRunGraph).exists()).toBe(false);
+  });
+
+  it('Should contain quickstart link if the metrics level is set to pipeline /task (default) level', () => {
+    latestPipelineRunSpy.mockReturnValue(pipelineRun);
+    const pipelineMetricsWrapper = shallow(<PipelineMetrics {...PipelineMetricsProps} />);
+    pipelineMetricsWrapper
+      .setProps({
+        customData: {
+          metricsLevel: PipelineMetricsLevel.PIPELINE_TASK_LEVEL,
+          hasUpdatePermission: true,
+        },
+      })
+      .update();
+
+    expect(pipelineMetricsWrapper.find(PipelineMetricsQuickstart).exists()).toBe(true);
+  });
+
+  it('Should contain quickstart link if the user has update permission', () => {
+    latestPipelineRunSpy.mockReturnValue(pipelineRun);
+    const pipelineMetricsWrapper = shallow(<PipelineMetrics {...PipelineMetricsProps} />);
+    pipelineMetricsWrapper
+      .setProps({
+        customData: {
+          metricsLevel: PipelineMetricsLevel.PIPELINE_TASK_LEVEL,
+          hasUpdatePermission: true,
+        },
+      })
+      .update();
+
+    expect(pipelineMetricsWrapper.find(PipelineMetricsQuickstart).exists()).toBe(true);
+  });
+
+  it('Should not contain quickstart link if the user does not have update permission', () => {
+    latestPipelineRunSpy.mockReturnValue(pipelineRun);
+    const pipelineMetricsWrapper = shallow(<PipelineMetrics {...PipelineMetricsProps} />);
+    pipelineMetricsWrapper
+      .setProps({
+        customData: {
+          metricsLevel: PipelineMetricsLevel.PIPELINE_TASK_LEVEL,
+          hasUpdatePermission: false,
+        },
+      })
+      .update();
+
+    expect(pipelineMetricsWrapper.find(PipelineMetricsQuickstart).exists()).toBe(false);
+  });
+
+  it('Should not contain quickstart link if the metrics level is set to pipelinerun /taskrun level', () => {
+    latestPipelineRunSpy.mockReturnValue(pipelineRun);
+    const pipelineMetricsWrapper = shallow(<PipelineMetrics {...PipelineMetricsProps} />);
+    pipelineMetricsWrapper
+      .setProps({
+        customData: {
+          metricsLevel: PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL,
+          hasUpdatePermission: true,
+        },
+      })
+      .update();
+
+    expect(pipelineMetricsWrapper.find(PipelineMetricsQuickstart).exists()).toBe(false);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineRunCount.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineRunCount.spec.tsx
@@ -5,7 +5,7 @@ import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
 import { LoadingInline } from '@console/internal/components/utils';
 import { parsePrometheusDuration } from '@console/internal/components/utils/datetime';
 import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
-import { DEFAULT_REFRESH_INTERVAL } from '../../const';
+import { DEFAULT_REFRESH_INTERVAL, PipelineMetricsLevel } from '../../const';
 import * as hookUtils from '../../hooks';
 import { TimeSeriesChart } from '../charts/TimeSeriesChart';
 import { MetricsQueryPrefix } from '../pipeline-metrics-utils';
@@ -30,6 +30,7 @@ describe('Pipeline Run Count Graph', () => {
       timespan: DEFAULT_PROMETHEUS_TIMESPAN,
       interval: parsePrometheusDuration(DEFAULT_REFRESH_INTERVAL),
       queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
+      metricsLevel: PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL,
     };
   });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineRunDuration.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineRunDuration.spec.tsx
@@ -6,7 +6,7 @@ import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
 import { LoadingInline } from '@console/internal/components/utils';
 import { parsePrometheusDuration } from '@console/internal/components/utils/datetime';
 import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
-import { DEFAULT_REFRESH_INTERVAL } from '../../const';
+import { DEFAULT_REFRESH_INTERVAL, PipelineMetricsLevel } from '../../const';
 import * as hookUtils from '../../hooks';
 import { LineChart } from '../charts/lineChart';
 import { MetricsQueryPrefix } from '../pipeline-metrics-utils';
@@ -31,6 +31,7 @@ describe('Pipeline Run Duration Graph', () => {
       timespan: DEFAULT_PROMETHEUS_TIMESPAN,
       interval: parsePrometheusDuration(DEFAULT_REFRESH_INTERVAL),
       queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
+      metricsLevel: PipelineMetricsLevel.PIPELINE_TASK_LEVEL,
     };
   });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineRunTaskRunGraph.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineRunTaskRunGraph.spec.tsx
@@ -6,7 +6,7 @@ import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
 import { LoadingInline } from '@console/internal/components/utils';
 import { parsePrometheusDuration } from '@console/internal/components/utils/datetime';
 import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
-import { DEFAULT_REFRESH_INTERVAL } from '../../const';
+import { DEFAULT_REFRESH_INTERVAL, PipelineMetricsLevel } from '../../const';
 import * as hookUtils from '../../hooks';
 import { LineChart } from '../charts/lineChart';
 import { MetricsQueryPrefix } from '../pipeline-metrics-utils';
@@ -31,6 +31,7 @@ describe('TaskRun Duration Graph', () => {
       timespan: DEFAULT_PROMETHEUS_TIMESPAN,
       interval: parsePrometheusDuration(DEFAULT_REFRESH_INTERVAL),
       queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
+      metricsLevel: PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL,
     };
   });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineSuccessRatioDonut.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineSuccessRatioDonut.spec.tsx
@@ -6,7 +6,7 @@ import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
 import { LoadingInline } from '@console/internal/components/utils';
 import { parsePrometheusDuration } from '@console/internal/components/utils/datetime';
 import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
-import { DEFAULT_REFRESH_INTERVAL } from '../../const';
+import { DEFAULT_REFRESH_INTERVAL, PipelineMetricsLevel } from '../../const';
 import * as hookUtils from '../../hooks';
 import SuccessRatioDonut from '../charts/successRatioDonut';
 import { TimeSeriesChart } from '../charts/TimeSeriesChart';
@@ -32,6 +32,7 @@ describe('Pipeline Success Ratio Graph', () => {
       timespan: DEFAULT_PROMETHEUS_TIMESPAN,
       interval: parsePrometheusDuration(DEFAULT_REFRESH_INTERVAL),
       queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
+      metricsLevel: PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL,
     };
   });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/pipeline-metrics-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/pipeline-metrics-utils.ts
@@ -11,6 +11,7 @@ import {
   parsePrometheusDuration,
 } from '@console/internal/components/utils/datetime';
 import { PipelineKind } from '../../../types';
+import { PipelineMetricsLevel } from '../const';
 
 export interface GraphData {
   chartName: string;
@@ -20,6 +21,7 @@ export interface PipelineMetricsGraphProps {
   pipeline: PipelineKind;
   timespan: number;
   queryPrefix: string;
+  metricsLevel: string;
   interval: number;
   width?: number;
 
@@ -37,19 +39,46 @@ export enum MetricsQueryPrefix {
   TEKTON = 'tekton',
   TEKTON_PIPELINES_CONTROLLER = 'tekton_pipelines_controller',
 }
-export const metricQueries = (prefix: string = MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER) => ({
-  [PipelineQuery.NUMBER_OF_PIPELINE_RUNS]: _.template(
-    `sum(count by (pipelinerun) (${prefix}_pipelinerun_duration_seconds_count{pipeline="<%= name %>",exported_namespace="<%= namespace %>"}))`,
-  ),
-  [PipelineQuery.PIPELINE_RUN_TASK_RUN_DURATION]: _.template(
-    `sum(${prefix}_pipelinerun_taskrun_duration_seconds_sum{pipeline="<%= name %>",exported_namespace="<%= namespace %>"})  by (pipelinerun, task)`,
-  ),
-  [PipelineQuery.PIPELINE_RUN_DURATION]: _.template(
-    `sum(${prefix}_pipelinerun_duration_seconds_sum{pipeline="<%= name %>",exported_namespace="<%= namespace %>"})  by (pipelinerun)`,
-  ),
-  [PipelineQuery.PIPELINE_SUCCESS_RATIO]: _.template(
-    `count(sort_desc(${prefix}_pipelinerun_duration_seconds_count{pipeline="<%= name %>",exported_namespace="<%= namespace %>"})) by (status)`,
-  ),
+
+export const metricsQueries = (
+  prefix: string = MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
+) => ({
+  [PipelineMetricsLevel.PIPELINE_TASK_LEVEL]: {
+    [PipelineQuery.PIPELINE_SUCCESS_RATIO]: _.template(
+      `${prefix}_pipelinerun_duration_seconds_count{pipeline="<%= name %>",namespace="<%= namespace %>"}`,
+    ),
+    [PipelineQuery.NUMBER_OF_PIPELINE_RUNS]: _.template(
+      `sum(${prefix}_pipelinerun_duration_seconds_count{pipeline="<%= name %>",namespace="<%= namespace %>"})`,
+    ),
+  },
+  [PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL]: {
+    [PipelineQuery.NUMBER_OF_PIPELINE_RUNS]: _.template(
+      `sum(count by (pipelinerun) (${prefix}_pipelinerun_duration_seconds{pipeline="<%= name %>",namespace="<%= namespace %>"}))`,
+    ),
+    [PipelineQuery.PIPELINE_RUN_TASK_RUN_DURATION]: _.template(
+      `sum(${prefix}_pipelinerun_taskrun_duration_seconds{pipeline="<%= name %>",namespace="<%= namespace %>"})  by (pipelinerun, task)`,
+    ),
+    [PipelineQuery.PIPELINE_RUN_DURATION]: _.template(
+      `sum(${prefix}_pipelinerun_duration_seconds{pipeline="<%= name %>",namespace="<%= namespace %>"})  by (pipelinerun)`,
+    ),
+    [PipelineQuery.PIPELINE_SUCCESS_RATIO]: _.template(
+      `count(sort_desc(${prefix}_pipelinerun_duration_seconds{pipeline="<%= name %>",namespace="<%= namespace %>"})) by(status)`,
+    ),
+  },
+  [PipelineMetricsLevel.UNSIMPLIFIED_METRICS_LEVEL]: {
+    [PipelineQuery.NUMBER_OF_PIPELINE_RUNS]: _.template(
+      `sum(count by (pipelinerun) (${prefix}_pipelinerun_duration_seconds_count{pipeline="<%= name %>",exported_namespace="<%= namespace %>"}))`,
+    ),
+    [PipelineQuery.PIPELINE_RUN_TASK_RUN_DURATION]: _.template(
+      `sum(${prefix}_pipelinerun_taskrun_duration_seconds_sum{pipeline="<%= name %>",exported_namespace="<%= namespace %>"})  by (pipelinerun, task)`,
+    ),
+    [PipelineQuery.PIPELINE_RUN_DURATION]: _.template(
+      `sum(${prefix}_pipelinerun_duration_seconds_sum{pipeline="<%= name %>",exported_namespace="<%= namespace %>"})  by (pipelinerun)`,
+    ),
+    [PipelineQuery.PIPELINE_SUCCESS_RATIO]: _.template(
+      `count(sort_desc(${prefix}_pipelinerun_duration_seconds_count{pipeline="<%= name %>",exported_namespace="<%= namespace %>"})) by(status)`,
+    ),
+  },
 });
 
 const formatPositiveValue = (v: number): string =>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/utils/__tests__/pipeline-config.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/utils/__tests__/pipeline-config.spec.ts
@@ -1,0 +1,35 @@
+import { sampleTektonConfigMetrics } from '../../../../test-data/tekon-config-data';
+import { PipelineMetricsLevel } from '../../const';
+import { getPipelineMetricsLevel } from '../pipeline-config';
+
+describe('getPipelineMetricsLevel', () => {
+  it('should return unsupported level for the invalid configuration combinations', () => {
+    expect(
+      getPipelineMetricsLevel(sampleTektonConfigMetrics[PipelineMetricsLevel.UNSUPPORTED_LEVEL]),
+    ).toBe(PipelineMetricsLevel.UNSUPPORTED_LEVEL);
+  });
+
+  it('should return unsupported level if the config is not passed', () => {
+    expect(getPipelineMetricsLevel(null)).toBe(PipelineMetricsLevel.UNSUPPORTED_LEVEL);
+    expect(getPipelineMetricsLevel(undefined)).toBe(PipelineMetricsLevel.UNSUPPORTED_LEVEL);
+  });
+
+  it('should return unsupported level for null or invalid values', () => {
+    expect(getPipelineMetricsLevel(null)).toBe(PipelineMetricsLevel.UNSUPPORTED_LEVEL);
+    expect(getPipelineMetricsLevel(undefined)).toBe(PipelineMetricsLevel.UNSUPPORTED_LEVEL);
+  });
+
+  it('should return pipeline/task level for the pipeline task default configuration', () => {
+    expect(
+      getPipelineMetricsLevel(sampleTektonConfigMetrics[PipelineMetricsLevel.PIPELINE_TASK_LEVEL]),
+    ).toBe(PipelineMetricsLevel.PIPELINE_TASK_LEVEL);
+  });
+
+  it('should return pipelinerun/taskrun level for the pipelinerun/taskrun and lastvalue as duration type', () => {
+    expect(
+      getPipelineMetricsLevel(
+        sampleTektonConfigMetrics[PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL],
+      ),
+    ).toBe(PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL);
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/utils/__tests__/pipeline-operator.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/utils/__tests__/pipeline-operator.spec.ts
@@ -1,9 +1,13 @@
 import { SemVer } from 'semver';
-import { k8sList } from '@console/internal/module/k8s';
+import { k8sList } from '@console/dynamic-plugin-sdk/src/utils/k8s';
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
-import { getPipelineOperatorVersion, isGAVersionInstalled } from '../pipeline-operator';
+import {
+  getPipelineOperatorVersion,
+  isGAVersionInstalled,
+  isSimplifiedMetricsInstalled,
+} from '../pipeline-operator';
 
-jest.mock('@console/internal/module/k8s', () => ({
+jest.mock('@console/dynamic-plugin-sdk/src/utils/k8s', () => ({
   k8sList: jest.fn(),
 }));
 
@@ -24,6 +28,25 @@ describe('isGAVersionInstalled', () => {
 
   it('should return true if the installed operator is above 1.4.0', () => {
     expect(isGAVersionInstalled(new SemVer('1.5.1'))).toBe(true);
+  });
+});
+
+describe('isSimplifiedMetricsInstalled', () => {
+  it('should return false if the operator is not identified', () => {
+    expect(isSimplifiedMetricsInstalled(null)).toBe(false);
+  });
+
+  it('should return false if the installed operator is less than or equal to 1.5.2', () => {
+    expect(isSimplifiedMetricsInstalled(new SemVer('1.3.1'))).toBe(false);
+    expect(isSimplifiedMetricsInstalled(new SemVer('1.4.1'))).toBe(false);
+    expect(isSimplifiedMetricsInstalled(new SemVer('1.5.1'))).toBe(false);
+    expect(isSimplifiedMetricsInstalled(new SemVer('1.5.2'))).toBe(false);
+  });
+
+  it('should return true if the installed operator is above 1.5.2', () => {
+    expect(isSimplifiedMetricsInstalled(new SemVer('1.6.2'))).toBe(true);
+    expect(isSimplifiedMetricsInstalled(new SemVer('1.7.0'))).toBe(true);
+    expect(isSimplifiedMetricsInstalled(new SemVer('1.8.0'))).toBe(true);
   });
 });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/utils/pipeline-config.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/utils/pipeline-config.ts
@@ -1,0 +1,31 @@
+import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
+import { TektonConfigModel } from '@console/pipelines-plugin/src/models';
+import { TektonConfig, MetricsLevel, LevelTypes, DurationTypes } from '../../../types';
+import { PipelineMetricsLevel, PIPELINE_CONFIG_NAME } from '../const';
+
+export const usePipelineConfig = () =>
+  useK8sGet<TektonConfig>(TektonConfigModel, PIPELINE_CONFIG_NAME);
+
+export const getPipelineMetricsLevel = (config: TektonConfig): string => {
+  if (!config) {
+    return PipelineMetricsLevel.UNSUPPORTED_LEVEL;
+  }
+  const { pipeline } = config.spec;
+  if (
+    pipeline[MetricsLevel.METRICS_PIPELINERUN_DURATION_TYPE] === DurationTypes.HISTOGRAM &&
+    pipeline[MetricsLevel.METRICS_TASKRUN_DURATION_TYPE] === DurationTypes.HISTOGRAM &&
+    pipeline[MetricsLevel.METRICS_PIPELINERUN_LEVEL] === LevelTypes.PIPELINE &&
+    pipeline[MetricsLevel.METRICS_TASKRUN_LEVEL] === LevelTypes.TASK
+  ) {
+    return PipelineMetricsLevel.PIPELINE_TASK_LEVEL;
+  }
+  if (
+    pipeline[MetricsLevel.METRICS_PIPELINERUN_DURATION_TYPE] === DurationTypes.LASTVALUE &&
+    pipeline[MetricsLevel.METRICS_TASKRUN_DURATION_TYPE] === DurationTypes.LASTVALUE &&
+    pipeline[MetricsLevel.METRICS_PIPELINERUN_LEVEL] === LevelTypes.PIPELINERUN &&
+    pipeline[MetricsLevel.METRICS_TASKRUN_LEVEL] === LevelTypes.TASKRUN
+  ) {
+    return PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL;
+  }
+  return PipelineMetricsLevel.UNSUPPORTED_LEVEL;
+};

--- a/frontend/packages/pipelines-plugin/src/types/coreTekton.ts
+++ b/frontend/packages/pipelines-plugin/src/types/coreTekton.ts
@@ -1,3 +1,5 @@
+import { K8sResourceCommon } from '@console/dynamic-plugin-sdk/src';
+
 export type ResourceTarget = 'inputs' | 'outputs';
 
 export type TektonParam = {
@@ -56,4 +58,94 @@ export type TektonWorkspace = {
 export type TektonResultsRun = {
   name: string;
   value: string;
+};
+
+export interface Addon {
+  enablePipelinesAsCode: boolean;
+  params: Param[];
+}
+
+export interface Param {
+  name: string;
+  value: string;
+}
+
+export interface Dashboard {
+  readonly: boolean;
+}
+
+export enum MetricsLevel {
+  METRICS_PIPELINERUN_DURATION_TYPE = 'metrics.pipelinerun.duration-type',
+  METRICS_PIPELINERUN_LEVEL = 'metrics.pipelinerun.level',
+  METRICS_TASKRUN_DURATION_TYPE = 'metrics.taskrun.duration-type',
+  METRICS_TASKRUN_LEVEL = 'metrics.taskrun.level',
+}
+
+export enum LevelTypes {
+  PIPELINE = 'pipeline',
+  PIPELINERUN = 'pipelinerun',
+  TASK = 'task',
+  TASKRUN = 'taskrun',
+}
+
+export enum DurationTypes {
+  HISTOGRAM = 'histogram',
+  LASTVALUE = 'lastvalue',
+  NAMESPACE = 'namespace',
+}
+
+export interface Pipeline {
+  'default-service-account': string;
+  'disable-affinity-assistant': boolean;
+  'disable-creds-init': boolean;
+  'enable-api-fields': string;
+  'enable-custom-tasks': boolean;
+  'enable-tekton-oci-bundles': boolean;
+  [MetricsLevel.METRICS_PIPELINERUN_DURATION_TYPE]: DurationTypes;
+  [MetricsLevel.METRICS_PIPELINERUN_LEVEL]: LevelTypes;
+  [MetricsLevel.METRICS_TASKRUN_DURATION_TYPE]: DurationTypes;
+  [MetricsLevel.METRICS_TASKRUN_LEVEL]: LevelTypes;
+  params: Param[];
+  'require-git-ssh-secret-known-hosts': boolean;
+  'running-in-environment-with-injected-sidecars': boolean;
+  'scope-when-expressions-to-task': boolean;
+}
+
+export interface Pruner {
+  keep: number;
+  resources: string[];
+  schedule: string;
+}
+
+export interface Trigger {
+  'default-service-account': string;
+  'enable-api-fields': string;
+}
+
+export interface Spec {
+  addon: Addon;
+  config: {};
+  dashboard: Dashboard;
+  hub: {};
+  params: Param[];
+  pipeline: Pipeline;
+  profile: string;
+  pruner: Pruner;
+  targetNamespace: string;
+  trigger: Trigger;
+}
+
+export interface Status {
+  conditions: TektonConfigCondition[];
+}
+
+export interface TektonConfigCondition {
+  lastTransitionTime: string;
+  status: string;
+  type: string;
+}
+
+export type TektonConfig = K8sResourceCommon & {
+  spec: Spec;
+  status: Status;
 };


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
 https://bugzilla.redhat.com/show_bug.cgi?id=2074767


**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
 Metrics page uses that pipelinerun/taskrun level metrics (histogram values) but with OSP 1.6.x and higher, the metrics level is set to pipeline/task and pipelinerun and taskrun histogram values are not supported.
 
 Ref: https://github.com/tektoncd/pipeline/blob/main/docs/metrics.md 

---

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Choose different query set based on the metrics level configuration.

1. Show top 2 charts for the default pipeline/task metrics level and histogram type
2. Show all 4 charts for the pipelinerun/taskrun metrics level and lastvalue type
3. ~Hide metrics tab if the user don't have view access in openshift-pipelines (TBD)~ - Adding `honorLabels` to pipeline Service Monitor gets us the metric results and its fixed by operator team
4. Add Quickstart link to guide the users to change the metrics level configurations.

**Note: This solution works for both kubeadmin/non-kubeadmin users**

---
**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

Default pipeline metrics level **pipeline/task** with QS link for kubeadmin/ns-admins:

![image (4)](https://user-images.githubusercontent.com/9964343/170243777-1f6fda31-2302-4bdf-b559-38a054fe1ff6.png)

Default pipeline metrics level view for consoledeveloper/non-admins (without QS):

![image (5)](https://user-images.githubusercontent.com/9964343/170244045-e8ed1067-1ea9-4843-8d43-38cb1ae89e08.png)

Pipeline Metrics level set to **pipelinerun/taskrun**:

![image](https://user-images.githubusercontent.com/9964343/170243463-6876ea72-744e-4f65-bbd8-49abf16129dc.png)

Quickstart to guide the user to change metrics level:
![image](https://user-images.githubusercontent.com/9964343/170244432-f726719a-3672-4ef0-b4fa-6d718441463f.png)

**Unit test coverage report**: 
<!-- Attach test coverage report -->
```
  Pipeline Details page:

  Pipeline Details page Metrics Tab:
    ✓ It should contain metrics tab if the user has view permission in the openshift pipelines namespace (16ms)
    ✓ It should not contain metrics tab if the user does not have view access to openshift-pipelines namespace (14ms)
    ✓ It should contain metrics tab if the user has permission and osp 1.5.2 is installed (16ms)

    PipelineMetrics.spec.tsx:
      ✓ Should render only success ratio and number of pipeline runs charts if the metrics level is set to pipeline /task (default) level (13ms)
     ✓ Should contain quickstart link if the metrics level is set to pipeline /task (default) level (2ms)
     ✓ Should contain quickstart link if the user has update permission (2ms)
     ✓ Should not contain quickstart link if the user does not have update permission (1ms)
     ✓ Should not contain quickstart link if the metrics level is set to pipelinerun /taskrun level (2ms)


   pipeline-operator.spec.ts: 
    isSimplifiedVersionInstalled:
      ✓ should return false if the operator is not identified
      ✓ should return false if the installed operator is less than or equal to 1.5.2 (1ms)
      ✓ should return true if the installed operator is above 1.5.2

   pipeline-config.spec.ts:

     getPipelineMetricsLevel:
      ✓ should return unsupported level for the invalid configuration combinations (2ms)
      ✓ should return unsupported level if the config is not passed (2ms)
      ✓ should return unsupported level for null or invalid values
      ✓ should return pipeline/task level for the pipeline task default configuration
      ✓ should return pipelinerun/taskrun level for the pipelinerun/taskrun and lastvalue as duration type (1ms)
```


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

Prerequisite:

1. Add ConsoleQuickstart should be added to the cluster, use this [yaml](https://github.com/tektoncd/operator/blob/main/cmd/openshift/operator/kodata/tekton-addon/optional/quickstarts/configure-pipeline-metrics-quickstart-yaml) 
2. Add `honorLabels: true` in the pipeline service monitor like it is mentioned in this [operator PR](https://github.com/tektoncd/operator/pull/799) 
3. Add a workload from Git Import flow with Add pipeline options selected.
4. Visit the pipeline details page.


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge