### PR TITLE
Automation of event-sources-sink-to-uri | knative-plugin

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -229,6 +229,7 @@ export const eventSourcePO = {
   yamlView: '#form-radiobutton-editorType-yaml-field',
   formView: '#form-radiobutton-editorType-form-field',
   addButton: 'a[role="button"]',
+  nodeHandler: '[data-test-id="base-node-handler"]',
   apiServerSource: {
     apiServerSourceSection: '[data-test~="ApiServerSource"][data-test~="section"]',
     apiVersion: '[data-test=pairs-list-name]',
@@ -283,6 +284,16 @@ export const eventSourcePO = {
     resourceDropDownField: '[id="form-ns-dropdown-formData-sink-key-field"]',
     resourceDropDownItem: '[data-test="dropdown-menu-item-link"]',
     resourceSearch: '[placeholder="Select resource"]',
+  },
+  createSinkBinding: {
+    resourceToggleButton: '[data-test="resource-view-input"]',
+    resourceDropDownField: '[id="form-ns-dropdown-formData-sink-key-field"]',
+    resourceDropDownItem: '[data-test="dropdown-menu-item-link"]',
+    resourceSearchField: '[data-test-id="dropdown-text-filter"]',
+    createButton: '[data-test=confirm-action]',
+    moveSinkButton: '[data-test-action="Move sink"]',
+    eventSourceNode: 'g.odc-event-source',
+    uriNode: 'g.odc-sink-uri',
   },
 };
 

--- a/frontend/packages/knative-plugin/integration-tests/features/eventing/event-sources-sink-to-uri.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/eventing/event-sources-sink-to-uri.feature
@@ -13,15 +13,15 @@ Feature: Event Sources can able sink to URI as well as Resource
         Scenario: Context Menu for URI: KE-03-TC01
             Given user has sinked event source "sink-binding" to URI "http://cluster.example.com/svc"
               And user is at Topology page
-             When user right clicks on URI "http://cluster.example.com/svc" to open context menu
+             When user right clicks on URI to open context menu
              Then user is able to see a context menu with option "Edit URI"
 
 
         @smoke
         Scenario: Update the URI for Sink Binding: KE-03-TC02
-            Given user has sinked event source "sink-binding" to URI "http://cluster.example.com/svc"
+            Given user has sinked event source "sink-binding" to URI
               And user is at Topology page
-             When user right clicks on URI "http://cluster.example.com/svc" to open context menu
+             When user right clicks on URI to open context menu
               And user selects "Edit URI" from context menu
               And user enters the uri as "http://cluster.example.com/svc-1" in "Edit URI" modal
               And user clicks on save
@@ -57,7 +57,7 @@ Feature: Event Sources can able sink to URI as well as Resource
               And user will see the associated Connections on the Resources tab
 
 
-        @to-do
+        @manual
         Scenario: Manually drag a Connector from URI to Knative Service: KE-03-TC06
             Given user has sinked an event source to URI
               And user has a Knative Service
@@ -66,9 +66,9 @@ Feature: Event Sources can able sink to URI as well as Resource
              Then user will see that Event Source is now connected to Knative Service
 
 
-        @regression @to-do
+        @regression
         Scenario: Move sink from URI to new Resource: KE-03-TC07
-            Given user has sinked an event source to URI
+            Given user has sinked event source "sink-binding" to URI
               And user is at Topology page
              When user right clicks on the event source
               And user clicks on the Move Sink option
@@ -77,19 +77,6 @@ Feature: Event Sources can able sink to URI as well as Resource
               And user clicks on Save button
              Then user will see that event source is now connected to new resource
               And user will see that the already existed URI will get vanished
-
-
-        @regression @to-do
-        Scenario: Move sink from URI to new URI: KE-03-TC08
-            Given user has sinked an event source to URI
-              And user is at Topology page
-             When user right clicks on the event source
-              And user clicks on the Move Sink option
-              And user selects sink to URI option
-              And user removes the privious URI
-              And user enters the URI
-              And user clicks on Save button
-             Then user will see that event source is now connected to new URI
 
 
         @regression @manual

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/eventing/actions-on-event-sources.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/eventing/actions-on-event-sources.ts
@@ -1,8 +1,9 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
 import { modal } from '@console/cypress-integration-tests/views/modal';
+import { devNavigationMenu } from '@console/dev-console/integration-tests/support/constants';
 import { nodeActions } from '@console/dev-console/integration-tests/support/constants/topology';
 import { topologyPO } from '@console/dev-console/integration-tests/support/pageObjects';
-import { app } from '@console/dev-console/integration-tests/support/pages/app';
+import { app, navigateTo } from '@console/dev-console/integration-tests/support/pages/app';
 import { moveSink } from '@console/dev-console/integration-tests/support/pages/modal';
 import {
   topologyPage,
@@ -26,7 +27,7 @@ When(
 When('user clicks on save', () => {
   modal.submit();
   modal.shouldBeClosed();
-  cy.reload();
+  navigateTo(devNavigationMenu.Topology);
 });
 
 When('user selects {string} from context menu', (option: string) => {

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/eventing/event-sources-sink-to-uri.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/eventing/event-sources-sink-to-uri.ts
@@ -1,7 +1,10 @@
 import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 import { modal } from '@console/cypress-integration-tests/views/modal';
+import { devNavigationMenu } from '@console/dev-console/integration-tests/support/constants/global';
+import { eventSourcePO } from '@console/dev-console/integration-tests/support/pageObjects';
 import {
   createEventSourcePage,
+  navigateTo,
   topologyPage,
   topologySidePane,
 } from '@console/dev-console/integration-tests/support/pages';
@@ -13,8 +16,10 @@ Given(
   },
 );
 
-When('user right clicks on URI {string} to open context menu', (uri: string) => {
-  cy.get(`[href="${uri}"]`).trigger('contextmenu', { force: true });
+When('user right clicks on URI to open context menu', () => {
+  cy.get(eventSourcePO.createSinkBinding.uriNode)
+    .find(eventSourcePO.nodeHandler)
+    .rightclick({ force: true });
 });
 
 Then('user is able to see a context menu with option {string}', (option: string) => {
@@ -37,3 +42,44 @@ Then(
     cy.get(`[href="${uri}"]`).should('be.visible');
   },
 );
+
+Given('user has sinked event source {string} to URI', (eventSourceName: string) => {
+  navigateTo(devNavigationMenu.Topology);
+  topologyPage.verifyWorkloadInTopologyPage(eventSourceName);
+});
+
+When('user right clicks on the event source', () => {
+  cy.get(eventSourcePO.createSinkBinding.eventSourceNode)
+    .find(eventSourcePO.nodeHandler)
+    .rightclick({ force: true });
+});
+
+When('user clicks on the Move Sink option', () => {
+  cy.get(eventSourcePO.createSinkBinding.moveSinkButton).click();
+});
+
+When('user selects sink to Resource option', () => {
+  cy.get(eventSourcePO.createSinkBinding.resourceToggleButton).click();
+});
+
+When('user selects the resource from Select Resource dropdown', () => {
+  cy.get(eventSourcePO.createSinkBinding.resourceDropDownField).click();
+  cy.get(eventSourcePO.createSinkBinding.resourceSearchField).type('kn-event');
+  cy.get(eventSourcePO.createSinkBinding.resourceDropDownItem)
+    .eq(0)
+    .click();
+});
+
+When('user clicks on Save button', () => {
+  cy.get(eventSourcePO.createSinkBinding.createButton).click();
+  modal.shouldBeClosed();
+});
+
+Then('user will see that event source is now connected to new resource', () => {
+  cy.get(eventSourcePO.createSinkBinding.eventSourceNode).click();
+  cy.byLegacyTestID('kn-event').should('be.visible');
+});
+
+Then('user will see that the already existed URI will get vanished', () => {
+  cy.get(eventSourcePO.createSinkBinding.uriNode, { timeout: 0 }).should('not.exist');
+});

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -24,6 +24,7 @@ export const topologyPO = {
     filterDropdown: '[id^=pf-select-toggle-id]',
     nodeLabel: 'g.pf-topology__node__label',
     groupLabel: 'g.pf-topology__group__label',
+    selectNodeLabel: 'g.odc-base-node__label',
     knativeServiceNode: '[data-type="knative-service"]',
     eventSourceNode: '[data-type="event-source-link"]',
     contextMenu: '#popper-container ul',

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -199,6 +199,12 @@ export const topologyPage = {
       .should('be.visible')
       .contains(nodeName);
   },
+  getNodeLabel: (nodeName: string) => {
+    return cy
+      .get(topologyPO.graph.selectNodeLabel)
+      .should('be.visible')
+      .contains(nodeName);
+  },
   getGroup: (groupName: string) => {
     return cy
       .get(topologyPO.graph.groupLabel)
@@ -226,6 +232,9 @@ export const topologyPage = {
   },
   clickOnNode: (nodeName: string) => {
     topologyPage.getNode(nodeName).click({ force: true });
+  },
+  clickOnNodeLabel: (nodeName: string) => {
+    topologyPage.getNodeLabel(nodeName).click({ force: true });
   },
   clickOnGroup: (groupName: string) => {
     topologyPage.getGroup(groupName).click({ force: true });


### PR DESCRIPTION
**Description:**
<!-- PR description-->
- Automation of event-sources-sink-to-uri feature file.

**Jira Id:** 

- [ODC-6665](https://issues.redhat.com/browse/ODC-6665) -  event-sources-sink-to-uri

<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example: 
```
export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p knative

```

**Screen shots**:
<!--   -->
![image](https://user-images.githubusercontent.com/39815871/167144984-0155a3c2-0623-413c-955e-93889ee6b19d.png)



**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge