### PR TITLE
Topology-connecting-workloads and editing app | Topology Automation

### DIFF
--- a/frontend/packages/topology/integration-tests/features/topology/topology-connecting-workloads.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-connecting-workloads.feature
@@ -4,6 +4,7 @@ Feature: Connecting nodes
 
         Background:
             Given user is at developer perspective
+              And user is at Add page
               And user has created or selected namespace "aut-tp-connect-workloads"
               And user has created workload "nodejs-ex-git" with resource type "Deployment"
               And user is at Add page

--- a/frontend/packages/topology/integration-tests/features/topology/topology-editing-app-node.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-editing-app-node.feature
@@ -23,20 +23,20 @@ Feature: Editing an application
                   | Deployment Config | dancer-ex-git-1 | app2                  |
 
 
-        @smoke @broken-test
+        @smoke
         Scenario: Editing a knative service: T-09-TC02
             Given user has installed OpenShift Serverless Operator
               And user is at Add page
-              And user has created or selected namespace "aut-topology-edit-resource"
+              And user has created or selected namespace "edit-knative-service"
               And user has created workload "nodejs-ex-git-kn" with resource type "Knative Service"
-             When user right clicks on the workload "nodejs-ex-git-kn" to open the Context Menu
+             When user right clicks on the knative workload "nodejs-ex-git-kn" to open the Context Menu
               And user clicks on "Edit nodejs-ex-git-kn" from context action menu
               And user edits application groupings to "new-app"
               And user saves the changes
              Then user can see application groupings updated to "new-app"
 
 
-        @smoke
+        @regression
         Scenario: Advanced image options in Edit deployment/deployment config form: T-09-TC03
             Given user has created workload "nodejs-advanced" with resource type "Deployment"
              When user right clicks on the workload "nodejs-advanced" to open the Context Menu
@@ -60,13 +60,14 @@ Feature: Editing an application
              Then user will be redirected to Topology with the updated resource limits
 
 
-        @smoke
+        @smoke @broken-test
         Scenario: Editing deployment using form view: T-09-TC05
             Given user has created workload "rolling-update" with resource type "Deployment"
              When user right clicks on the workload "rolling-update" to open the Context Menu
               And user clicks "Edit Deployment" from action menu
               And user selects "Rolling Update" Strategy type under Deployment Strategy
               And user enters value of Maximum number of unavailable Pods and Maximum number of surge Pods as "25%"
+            #2091102 : https://bugzilla.redhat.com/show_bug.cgi?id=2091102
               And user selects value of project, image stream and tag section under images as "openshift", "golang" and "latest" respectively
               And user enters NAME as "DEMO_GREETING" and VALUE as "Hello from the environment"
               And user clicks on Show advanced image options
@@ -78,7 +79,7 @@ Feature: Editing an application
              Then user will be redirected to Topology with the updated deployment
 
 
-        @smoke @broken-test
+        @regression
         Scenario Outline: Editing deployment config using form view: T-09-TC06
             Given user has created workload "recreate-update" with resource type "Deployment Config"
              When user right clicks on the workload "recreate-update" to open the Context Menu

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -25,6 +25,7 @@ export const topologyPO = {
     filterDropdown: '[id^=pf-select-toggle-id]',
     nodeContextMenu: '.pf-c-dropdown__menu-item',
     nodeLabel: 'g.pf-topology__node__label',
+    knativeNodeLabel: '.odc-base-node__label',
     groupLabel: 'g.pf-topology__group__label',
     selectNodeLabel: 'g.odc-base-node__label',
     knativeServiceNode: '[data-type="knative-service"]',
@@ -195,6 +196,7 @@ export const topologyPO = {
     enterReplica: 'input[id="form-number-spinner-formData-replicas-field"]',
     saveEdit: '[data-test-id="submit-button"]',
     selectSecret: '[id="form-ns-dropdown-formData-imagePullSecret-field"]',
+    dropdownSecret: '[data-test-id="dropdown-text-filter"]',
     timeout:
       'input[id="form-input-formData-deploymentStrategy-recreateParams-timeoutSeconds-field"]',
     deployImageCheckbox: 'input[name="formData.fromImageStreamTag"]',

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -205,6 +205,12 @@ export const topologyPage = {
       .should('be.visible')
       .contains(nodeName);
   },
+  getKnativeNode: (nodeName: string) => {
+    return cy
+      .get(topologyPO.graph.knativeNodeLabel)
+      .should('be.visible')
+      .contains(nodeName);
+  },
   getGroup: (groupName: string) => {
     return cy
       .get(topologyPO.graph.groupLabel)


### PR DESCRIPTION
**Description:**
<!-- PR description-->
- Automation for Topology-connecting-workloads and editing app

**Jira Id:**
     - [ODC-6667](https://issues.redhat.com/browse/ODC-6667)
     - [ODC-6668](https://issues.redhat.com/browse/ODC-6668)
<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.11-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p topology
```
**Screen shots**:
<!--   -->
topology-connecting-workload.feature
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/65410551/167283889-8dc8871f-1d37-48f5-86da-26e726da65a3.png">


topology-editing-app.feature
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/65410551/167283880-60039933-6dac-4b7a-a3d5-756667d69dd1.png">


**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge