### PR TITLE
Bug 2083149:  fix bug where "Update blocked" label incorrectly displa…

### DIFF
--- a/frontend/public/components/modals/cluster-more-updates-modal.tsx
+++ b/frontend/public/components/modals/cluster-more-updates-modal.tsx
@@ -28,13 +28,14 @@ export const ClusterMoreUpdatesModal: React.FC<ClusterMoreUpdatesModalProps> = (
   const availableUpdates = getSortedUpdates(cv);
   const moreAvailableUpdates = availableUpdates.slice(1).reverse();
   const releaseNotes = showReleaseNotes();
+  const clusterUpgradeableFalse = !!getConditionUpgradeableFalse(cv);
   const { t } = useTranslation();
 
   return (
     <div className="modal-content">
       <ModalTitle>{t('public~Other available paths')}</ModalTitle>
       <ModalBody>
-        {!!getConditionUpgradeableFalse(cv) && <ClusterNotUpgradeableAlert cv={cv} />}
+        {clusterUpgradeableFalse && <ClusterNotUpgradeableAlert cv={cv} />}
         <table className="table">
           <thead>
             <tr>
@@ -48,9 +49,10 @@ export const ClusterMoreUpdatesModal: React.FC<ClusterMoreUpdatesModalProps> = (
                 <tr key={update.version}>
                   <td>
                     {update.version}
-                    {isMinorVersionNewer(getLastCompletedUpdate(cv), update.version) && (
-                      <UpdateBlockedLabel />
-                    )}
+                    {clusterUpgradeableFalse &&
+                      isMinorVersionNewer(getLastCompletedUpdate(cv), update.version) && (
+                        <UpdateBlockedLabel />
+                      )}
                   </td>
                   {releaseNotes && (
                     <td>


### PR DESCRIPTION
…ys on new minor versions in the "Other available paths" modal

After:

https://user-images.githubusercontent.com/895728/167418740-0d9da257-c76f-4f92-991c-90172f976df2.mov
