### PR TITLE
[release-4.9] Bug 2082610: correct ChannelDocLink url

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -82,6 +82,7 @@ import {
   Firehose,
   FirehoseResource,
   HorizontalNav,
+  isUpstream,
   openshiftHelpBase,
   ReleaseNotesLink,
   ResourceLink,
@@ -381,10 +382,13 @@ export const CurrentVersionHeader: React.FC<CurrentVersionProps> = ({ cv }) => {
 };
 
 export const ChannelDocLink: React.FC<{}> = () => {
+  const upgradeLink = isUpstream()
+    ? `${openshiftHelpBase}updating/understanding-upgrade-channels-release.html#understanding-upgrade-channels_understanding-upgrade-channels-releases`
+    : `${openshiftHelpBase}html/updating_clusters/understanding-upgrade-channels-releases#understanding-upgrade-channels_understanding-upgrade-channels-releases`;
   const { t } = useTranslation();
   return (
     <ExternalLink
-      href={`${openshiftHelpBase}updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor`}
+      href={upgradeLink}
       text={t('public~Learn more about OpenShift update channels')}
     />
   );

--- a/frontend/public/components/utils/documentation.tsx
+++ b/frontend/public/components/utils/documentation.tsx
@@ -2,6 +2,8 @@
 export const openshiftHelpBase =
   window.SERVER_FLAGS.documentationBaseURL || 'https://docs.okd.io/latest/';
 
+export const isUpstream = () => window.SERVER_FLAGS.branding === 'okd';
+
 export const getNetworkPolicyDocLink = (openshiftFlag: boolean) => {
   return openshiftFlag
     ? `${openshiftHelpBase}networking/network_policy/about-network-policy.html`


### PR DESCRIPTION
Manual back port of https://github.com/openshift/console/pull/11225 due to merge conflicts, unnecessary changes for 4.9.