### PR TITLE
Bug 2081671: SSH Service for vmi with any name

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHForm/ssh-form-utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHForm/ssh-form-utils.ts
@@ -24,6 +24,7 @@ export const inputValidation = {
 
 export const PORT = 22000;
 export const TARGET_PORT = 22;
+export const VM_NAME_SERVICE_SELECTOR = 'vm.kubevirt.io/name';
 
 export const getCloudInitValues = (vm: VMKind | VMIKind, field: string) => {
   const volume = vm?.spec?.template?.spec?.volumes?.find(({ name }) => name === CLOUDINIT_DISK);
@@ -38,6 +39,7 @@ export const getCloudInitValues = (vm: VMKind | VMIKind, field: string) => {
 export const createOrDeleteSSHService = async (
   virtualMachine: VMKind | VMIKind,
   enableSSHService: boolean,
+  sshServiceName?: string,
 ) => {
   const metadata = virtualMachine?.metadata;
   const createOrDelete = enableSSHService ? k8sCreate : k8sKill;
@@ -46,7 +48,7 @@ export const createOrDeleteSSHService = async (
       kind: ServiceModel.kind,
       apiVersion: ServiceModel.apiVersion,
       metadata: {
-        name: `${metadata?.name}-ssh-service`,
+        name: sshServiceName ?? `${metadata?.name}-ssh-service`,
         namespace: metadata?.namespace,
         ownerReferences: [buildOwnerReference(virtualMachine, { blockOwnerDeletion: false })],
       },
@@ -65,7 +67,7 @@ export const createOrDeleteSSHService = async (
             ),
           ),
           'kubevirt.io/domain': metadata?.name,
-          'vm.kubevirt.io/name': metadata?.name,
+          [VM_NAME_SERVICE_SELECTOR]: metadata?.name,
         },
       },
     });

--- a/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHModal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHModal.tsx
@@ -8,7 +8,6 @@ import {
   ModalTitle,
 } from '@console/internal/components/factory';
 import { ResourceLink } from '@console/internal/components/utils';
-import useSSHService from '../../hooks/use-ssh-service';
 import { VirtualMachineModel } from '../../models';
 import { VMIKind, VMKind } from '../../types';
 import { ModalFooter } from '../modals/modal/modal-footer';
@@ -19,11 +18,16 @@ import './ssh-modal.scss';
 
 type SSHModalProps = ModalComponentProps & {
   vm: VMIKind | VMKind;
+
+  sshServices: {
+    running: boolean;
+    port: number;
+    serviceName: string;
+  };
 };
 
-const SSHModal: React.FC<SSHModalProps> = ({ vm, close }) => {
+const SSHModal: React.FC<SSHModalProps> = ({ vm, sshServices, close }) => {
   const { t } = useTranslation();
-  const { sshServices } = useSSHService(vm);
   const [isEnabled, setEnabled] = React.useState<boolean>(sshServices?.running);
 
   return (
@@ -61,7 +65,7 @@ const SSHModal: React.FC<SSHModalProps> = ({ vm, close }) => {
       </ModalBody>
       <ModalFooter
         onSubmit={() => {
-          createOrDeleteSSHService(vm, isEnabled);
+          createOrDeleteSSHService(vm, isEnabled, sshServices?.serviceName);
           close();
         }}
         onCancel={close}

--- a/frontend/packages/kubevirt-plugin/src/components/ssh-service/redux/actions.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/ssh-service/redux/actions.ts
@@ -14,6 +14,7 @@ type SSHActionsObject = (
   val?: string | boolean,
   port?: number | string,
   machineName?: string,
+  serviceName?: string,
 ) => {
   type: string;
   payload: string | boolean | null | undefined | { [key: string]: any };
@@ -30,9 +31,10 @@ export const sshActions: SSHActions = {
     isRunning: boolean,
     port: number | string,
     machineName: string,
+    serviceName: string,
   ) => ({
     type: SSHActionsNames.updateSSHServices,
-    payload: { machineName, isRunning, port },
+    payload: { machineName, isRunning, port, serviceName },
   }),
   [SSHActionsNames.showRestoreKeyButton]: (value: boolean) => ({
     type: SSHActionsNames.showRestoreKeyButton,

--- a/frontend/packages/kubevirt-plugin/src/components/ssh-service/redux/reducer.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/ssh-service/redux/reducer.ts
@@ -20,7 +20,11 @@ const authorizedSSHKeysReducer = (state = initialState, { type, payload }) => {
         ...state,
         sshServices: {
           ...state.sshServices,
-          [payload?.machineName]: { running: payload?.isRunning, port: payload?.port },
+          [payload?.machineName]: {
+            running: payload?.isRunning,
+            port: payload?.port,
+            serviceName: payload?.serviceName,
+          },
         },
       };
     case SSHActionsNames.showRestoreKeyButton:

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -162,8 +162,8 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
   const ipAddrs = getVmiIpAddresses(vmi);
   const workloadProfile = vmiLikeWrapper?.getWorkloadProfile();
 
-  const { sshServices } = useSSHService(vm);
-  const { command, user } = useSSHCommand(vm);
+  const { sshServices } = useSSHService(vmi);
+  const { command, user } = useSSHCommand(sshServices, vm || vmi);
   const vmiReady = isVMIReady(vmi);
   const sshServicesRunning = sshServices?.running;
 
@@ -263,17 +263,18 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
       >
         {vmiReady ? (
           <>
-            <span data-test="details-item-user-credentials-user-name">
-              {t('kubevirt-plugin~user: {{user}}', { user })}
-            </span>
-            <ClipboardCopy
-              isReadOnly
-              data-test="SSHDetailsPage-command"
-              className="SSHDetailsPage-clipboard-command"
-            >
-              {sshServicesRunning ? command : `ssh ${user}@`}
-            </ClipboardCopy>
-            {!sshServicesRunning && (
+            <div data-test="details-item-user-credentials-user-name">
+              {user && t('kubevirt-plugin~user: {{user}}', { user })}
+            </div>
+            {sshServicesRunning ? (
+              <ClipboardCopy
+                isReadOnly
+                data-test="SSHDetailsPage-command"
+                className="SSHDetailsPage-clipboard-command"
+              >
+                {command}
+              </ClipboardCopy>
+            ) : (
               <span className="kubevirt-menu-actions__secondary-title">
                 {t('kubevirt-plugin~Requires SSH service')}
               </span>
@@ -289,7 +290,7 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
         dataTest="ssh-access-details-item"
         idValue={prefixedID(id, 'ssh-access')}
         canEdit={vmiReady}
-        onEditClick={() => SSHModal({ vm })}
+        onEditClick={() => SSHModal({ vm: vm || vmi, sshServices })}
       >
         <span data-test="details-item-ssh-access-port">
           {vmiReady ? (

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-ssh-selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-ssh-selectors.ts
@@ -12,7 +12,7 @@ export type SSHState = {
   tempSSHKey: string | null;
   isValidSSHKey: boolean;
   updateSSHKeyInGlobalNamespaceSecret: boolean;
-  sshServices: { [key: string]: { running: boolean; port: number } };
+  sshServices: { [key: string]: { running: boolean; port: number; serviceName: string } };
 };
 
 export type useSSHSelectorsResult = SSHState & {


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2081671

Do not get ssh service for a particular vmi using the name `{vmi.metadata.name}-ssh-service` but find the service for that particular virtual machine that use the port 22.
With this fix, we should be able to connect an ssh service with any name

without ssh service
![Screenshot from 2022-05-09 18-09-28](https://user-images.githubusercontent.com/29160323/167451762-7b8f20bc-f725-4381-8be4-9d1fdded4bb6.png)

with ssh service
![Screenshot from 2022-05-09 18-09-21](https://user-images.githubusercontent.com/29160323/167451767-ee9af8ca-a1f5-4205-b989-50d13d24a300.png)
