### PR TITLE
Bug 2077943: If there is a service with multiple ports, and the route uses 8080, when editing the 8080 port isn't replaced, but a random port gets replaced and 8080 still stays

### DIFF
--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -386,7 +386,8 @@ export const createOrUpdateDeployImageResources = async (
     }
     if (!_.isEmpty(ports)) {
       const originalService = appResources?.service?.data;
-      const service = createService(formData, undefined, originalService);
+      const originalRoute = appResources?.route?.data;
+      const service = createService(formData, undefined, originalService, originalRoute);
       const request =
         verb === 'update'
           ? !_.isEmpty(originalService)

--- a/frontend/packages/dev-console/src/utils/__tests__/shared-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/shared-submit-utils.spec.ts
@@ -51,6 +51,33 @@ describe('Shared submit utils', () => {
         ]),
       );
     });
+
+    it('While editing, the new custom route port must replace the current route port from services', () => {
+      const mockData: GitImportFormData = _.cloneDeep(mockFormData);
+
+      mockData.build.strategy = 'Source';
+      mockData.git.url = 'https://github.com/nodeshift-blog-examples/react-web-app';
+      mockData.image.ports = [
+        { containerPort: 8080, protocol: 'TCP' },
+        { containerPort: 8081, protocol: 'TCP' },
+        { containerPort: 8082, protocol: 'TCP' },
+      ];
+      mockData.route.unknownTargetPort = '8080';
+      let serviceObj = createService(mockData);
+
+      mockData.route.unknownTargetPort = '3000';
+      serviceObj = createService(mockData);
+
+      const { ports } = serviceObj.spec;
+
+      expect(ports).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            port: 8080,
+          }),
+        ]),
+      );
+    });
   });
 
   describe('Create Route', () => {

--- a/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
+++ b/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
@@ -27,6 +27,7 @@ export const createService = (
   formData: DeployImageFormData | GitImportFormData | UploadJarFormData,
   imageStreamData?: K8sResourceKind,
   originalService?: K8sResourceKind,
+  originalRoute?: K8sResourceKind,
 ): K8sResourceKind => {
   const {
     project: { name: namespace },
@@ -76,7 +77,12 @@ export const createService = (
     !ports.some((port) => unknownTargetPort === port.containerPort.toString())
   ) {
     const port = { containerPort: _.toInteger(unknownTargetPort), protocol: 'TCP' };
+    const existingRouteTargetPort = originalRoute?.spec?.port?.targetPort;
     ports = [...ports.filter((p) => p.containerPort !== defaultUnknownPort), port];
+
+    if (existingRouteTargetPort) {
+      ports = [...ports.filter((p) => p.containerPort !== existingRouteTargetPort), port];
+    }
   }
 
   const newService: any = {


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGSM-43566

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
If there is a service with multiple ports, and the route uses 8080, when editing the 8080 port isn't replaced, but a random port gets replaced and 8080 still stays

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Specifying a condition in the `createService` function, which will identify the current route `targetPort` and replace that port from the service ports, whenever a new targetPort is added in the `Edit Application Form`.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
https://user-images.githubusercontent.com/47265560/167483004-80d71cc6-c16e-4b02-a135-014cf30b9274.mp4

**Unit test coverage report**: 
<!-- Attach test coverage report -->
```
Test Suites: 99 passed, 99 total
Tests:       602 passed, 602 total
Snapshots:   4 passed, 4 total
Time:        216.232s
Ran all test suites matching /packages\/dev-console|shared-submit-utils.spec.ts/i.
Done in 220.97s.
```
**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Switch to the developer perspective and create a fresh namespace if needed
2. Navigate to Add > Git repository > Import from Git
3. Enter Git URL (https://github.com/nodeshift-blog-examples/react-web-app), name (test-app) and set port to 8080.
5. Open the Service YAML and expose 8081 and 8082 also.
4. Come to the Topology page and right-click on the app and select Edit test-app. The Edit form will open.
5. Change the Target Port (8080) to 3000 and save.


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge