### PR TITLE
Bug 2084292: Add useDashboardResources hook

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
@@ -16,6 +16,7 @@ import {
   UseActiveNamespace,
   VirtualizedGridProps,
   LazyActionMenuProps,
+  UseDashboardResources,
 } from './internal-types';
 
 export const ActivityItem: React.FC<ActivityItemProps> = require('@console/shared/src/components/dashboard/activity-card/ActivityItem')
@@ -54,3 +55,5 @@ export const useUtilizationDuration: UseUtilizationDuration = require('@console/
 export const useActiveNamespace: UseActiveNamespace = require('@console/shared/src/hooks/useActiveNamespace')
   .useActiveNamespace;
 export const ServicesList = require('@console/internal/components/service').ServicesList;
+export const useDashboardResources: UseDashboardResources = require('@console/shared/src/hooks/useDashboardResources')
+  .useDashboardResources;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
@@ -1,14 +1,15 @@
+import { Map as ImmutableMap } from 'immutable';
 import {
-  K8sResourceCommon,
   FirehoseResult,
-  PrometheusResponse,
   HealthState,
-  StatusGroupMapper,
-  QueryParams,
-  TopConsumerPopoverProps,
+  K8sResourceCommon,
   LIMIT_STATE,
+  PrometheusResponse,
+  QueryParams,
+  StatusGroupMapper,
+  TopConsumerPopoverProps,
 } from '../extensions/console-types';
-import { K8sModel, Alert } from './common-types';
+import { Alert, K8sModel } from './common-types';
 
 type WithClassNameProps<R = {}> = R & {
   className?: string;
@@ -228,3 +229,39 @@ export enum ActionMenuVariant {
   KEBAB = 'plain',
   DROPDOWN = 'default',
 }
+
+type Request<R> = {
+  active: boolean;
+  timeout: NodeJS.Timer;
+  inFlight: boolean;
+  data: R;
+  error: any;
+};
+
+export type RequestMap<R> = ImmutableMap<string, Request<R>>;
+
+export type Fetch = (url: string) => Promise<any>;
+export type WatchURLProps = {
+  url: string;
+  fetch?: Fetch;
+};
+
+export type WatchPrometheusQueryProps = {
+  query: string;
+  namespace?: string;
+  timespan?: number;
+};
+
+export type UseDashboardResources = ({
+  prometheusQueries,
+  urls,
+  notificationAlertLabelSelectors,
+}: {
+  prometheusQueries?: WatchPrometheusQueryProps[];
+  urls?: WatchURLProps[];
+  notificationAlertLabelSelectors?: { [k: string]: string };
+}) => {
+  urlResults: RequestMap<any>;
+  prometheusResults: RequestMap<PrometheusResponse>;
+  notificationAlerts: { alerts: Alert[]; loaded: boolean; loadError: Error };
+};

--- a/frontend/packages/console-shared/src/hooks/useDashboardResources.ts
+++ b/frontend/packages/console-shared/src/hooks/useDashboardResources.ts
@@ -1,0 +1,57 @@
+import * as React from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  RequestMap,
+  UseDashboardResources,
+} from '@console/dynamic-plugin-sdk/src/api/internal-types';
+import {
+  stopWatchPrometheusQuery,
+  stopWatchURL,
+  watchPrometheusQuery,
+  watchURL,
+} from '@console/internal/actions/dashboards';
+import { PrometheusResponse } from '@console/internal/components/graphs';
+import { RESULTS_TYPE } from '@console/internal/reducers/dashboards';
+import { useNotificationAlerts } from './useNotificationAlerts';
+
+export const useDashboardResources: UseDashboardResources = ({
+  prometheusQueries,
+  urls,
+  notificationAlertLabelSelectors,
+}) => {
+  const [alerts, alertsLoaded, alertsLoadError] = useNotificationAlerts(
+    notificationAlertLabelSelectors,
+  );
+
+  const dispatch = useDispatch();
+  React.useEffect(() => {
+    prometheusQueries?.forEach((query) =>
+      dispatch(watchPrometheusQuery(query.query, null, query.timespan)),
+    );
+    urls?.forEach((url) => dispatch(watchURL(url?.url)));
+
+    return () => {
+      prometheusQueries?.forEach((query) => {
+        dispatch(stopWatchPrometheusQuery(query.query, query.timespan));
+      });
+      urls?.forEach((url) => dispatch(stopWatchURL(url?.url)));
+    };
+  }, [dispatch, prometheusQueries, urls]);
+
+  const urlResults = useSelector((state) => state.dashboards.get(RESULTS_TYPE.URL));
+  const prometheusResults = useSelector(
+    (state) => state.dashboards.get(RESULTS_TYPE.PROMETHEUS) as RequestMap<PrometheusResponse>,
+  );
+
+  return {
+    urlResults,
+    prometheusResults,
+    notificationAlerts: {
+      alerts,
+      loaded: alertsLoaded,
+      loadError: alertsLoadError,
+    },
+  };
+};

--- a/frontend/public/actions/dashboards.ts
+++ b/frontend/public/actions/dashboards.ts
@@ -3,11 +3,12 @@ import { Dispatch } from 'react-redux';
 
 import { coFetchJSON } from '../co-fetch';
 import { k8sBasePath } from '../module/k8s/k8s';
-import { isWatchActive, RESULTS_TYPE, RequestMap } from '../reducers/dashboards';
+import { isWatchActive, RESULTS_TYPE } from '../reducers/dashboards';
 import { RootState } from '../redux';
 import { getPrometheusURL, PrometheusEndpoint } from '../components/graphs/helpers';
 import { PrometheusResponse } from '../components/graphs';
 import { URL_POLL_DEFAULT_DELAY } from '../components/utils/url-poll-hook';
+import { Fetch, RequestMap } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 
 export enum ActionType {
   StopWatch = 'stopWatch',
@@ -134,8 +135,6 @@ export type WatchPrometheusQueryAction = (
 ) => ThunkAction;
 export type StopWatchURLAction = (url: string) => void;
 export type StopWatchPrometheusAction = (query: string, timespan?: number) => void;
-
-export type Fetch = (url: string) => Promise<any>;
 
 type FetchPeriodically = (
   dispatch: Dispatch,

--- a/frontend/public/components/dashboard/with-dashboard-resources.tsx
+++ b/frontend/public/components/dashboard/with-dashboard-resources.tsx
@@ -2,10 +2,9 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 
-import { RESULTS_TYPE, RequestMap } from '../../reducers/dashboards';
+import { RESULTS_TYPE } from '../../reducers/dashboards';
 import { NotificationAlerts } from '../../reducers/observe';
 import {
-  Fetch,
   StopWatchPrometheusAction,
   stopWatchPrometheusQuery,
   stopWatchURL,
@@ -20,6 +19,7 @@ import { RootState } from '../../redux';
 import { Firehose, FirehoseResource, FirehoseResult } from '../utils';
 import { K8sResourceKind, AppliedClusterResourceQuotaKind } from '../../module/k8s';
 import { PrometheusResponse } from '../graphs';
+import { Fetch, RequestMap } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 
 const mapDispatchToProps: DispatchToProps = (dispatch) => ({
   watchURL: (url, fetch) => dispatch(watchURL(url, fetch)),

--- a/frontend/public/reducers/dashboards.ts
+++ b/frontend/public/reducers/dashboards.ts
@@ -1,5 +1,6 @@
 import { ActionType, DashboardsAction } from '../actions/dashboards';
-import { Map as ImmutableMap, fromJS } from 'immutable';
+import { fromJS, Map as ImmutableMap } from 'immutable';
+import { RequestMap } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 
 export enum RESULTS_TYPE {
   PROMETHEUS = 'PROMETHEUS',
@@ -11,16 +12,6 @@ export const defaults = {
   [RESULTS_TYPE.PROMETHEUS]: fromJS({}),
   [RESULTS_TYPE.URL]: fromJS({}),
 };
-
-type Request<R> = {
-  active: boolean;
-  timeout: NodeJS.Timer;
-  inFlight: boolean;
-  data: R;
-  error: any;
-};
-
-export type RequestMap<R> = ImmutableMap<string, Request<R>>;
 
 export type DashboardsState = ImmutableMap<string, RequestMap<any>>;
 


### PR DESCRIPTION
This PR adds the `useDashboardResources` hook and exposes it via the internal SDK to provide access to resources required for overview cards such as the status and activity cards.