### PR TITLE
Bug 2083729: Fix Filter Dropdown State Management

### DIFF
--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -36,6 +36,8 @@ import { createColumnManagementModal } from './modals';
 import { useDebounceCallback, useDeepCompareMemoize } from '@console/shared/src';
 import { TextFilter } from './factory';
 import { filterList } from '@console/dynamic-plugin-sdk/src/app/k8s/actions/k8s';
+import useRowFilterFix from './useRowFilterFix';
+import useLabelSelectionFix from './useLabelSelectionFix';
 
 /**
  * Housing both the row filter and name/label filter in the same file.
@@ -106,7 +108,6 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
     ? `${uniqueFilterName}-${labelFilter}`
     : labelFilter;
   const params = new URLSearchParams(location.search);
-  const labelFilters = params.get(labelFilterQueryArgumentKey)?.split(',') ?? [];
   const [filterType, setFilterType] = React.useState(FilterType.NAME);
   const [isOpen, setOpen] = React.useState(false);
   const [nameInputText, setNameInputText] = React.useState(
@@ -165,11 +166,15 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
       ),
     [generatedRowFilters],
   );
-
-  // Parse selected row filters from url query params
-  const selectedRowFilters = React.useMemo(
-    () => _.flatMap(filterKeys, (f) => params.get(f)?.split(',') ?? []),
-    [filterKeys, params],
+  const [selectedRowFilters, onRowFilterSearchParamChange, rowFiltersInitialized] = useRowFilterFix(
+    params,
+    filters,
+    filterKeys,
+    defaultSelections,
+  );
+  const [labelSelection, onLabelSelectionChange, labelSelectionInitialized] = useLabelSelectionFix(
+    params,
+    labelFilterQueryArgumentKey,
   );
 
   // Map row filters to select groups
@@ -211,18 +216,9 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
     });
   };
 
-  const setRowFilterQueryParameters = (selected: string[]) => {
-    if (!_.isEmpty(selectedRowFilters) || !_.isEmpty(selected)) {
-      _.forIn(filters, (value, key) => {
-        const recognized = _.filter(selected, (item) => value.includes(item));
-        setOrRemoveQueryArgument(filterKeys[key], recognized.join(','));
-      });
-    }
-  };
-
   const updateRowFilterSelected = (id: string[]) => {
     const selectedNew = _.xor(selectedRowFilters, id);
-    setRowFilterQueryParameters(selectedNew);
+    onRowFilterSearchParamChange(selectedNew);
     applyRowFilter(selectedNew);
   };
 
@@ -236,7 +232,7 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
 
   const applyLabelFilters = (values: string[]) => {
     setLabelInputText('');
-    setOrRemoveQueryArgument(labelFilterQueryArgumentKey, values.join(','));
+    onLabelSelectionChange(values);
     applyFilters(labelFilter, { all: values });
   };
 
@@ -265,18 +261,26 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
   // Run once on mount to apply filters from query params
   React.useEffect(() => {
     if (!hideNameLabelFilters || !hideLabelFilter) {
-      applyFilters(labelFilter, { all: labelFilters });
+      applyFilters(labelFilter, { all: labelSelection });
     }
     if (!hideNameLabelFilters) {
       applyFilters(textFilter, { selected: [nameInputText] });
     }
-    if (_.isEmpty(selectedRowFilters)) {
-      updateRowFilterSelected(defaultSelections);
-    } else {
-      applyRowFilter(selectedRowFilters);
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  /**
+   * Initialize any external data filters based on the hack-fix data when they are finished init
+   * TODO: Remove during https://issues.redhat.com/browse/CONSOLE-3147
+   */
+  React.useEffect(() => {
+    if (rowFiltersInitialized && labelSelectionInitialized) {
+      applyFilters(labelFilter, { all: labelSelection });
+      applyRowFilter(selectedRowFilters);
+    }
+    // Trigger the update only when we are initialized to sync the url params with the data
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rowFiltersInitialized, labelSelectionInitialized]);
 
   return (
     <Toolbar
@@ -343,10 +347,10 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
                 setLabelInputText('');
                 applyLabelFilters([]);
               }}
-              chips={labelFilters}
+              chips={labelSelection}
               deleteChip={(f, chip: string) => {
                 setLabelInputText('');
-                applyLabelFilters(_.difference(labelFilters, [chip]));
+                applyLabelFilters(_.difference(labelSelection, [chip]));
               }}
               categoryName={t('public~Label')}
             >
@@ -371,7 +375,7 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
                     <AutocompleteInput
                       className="co-text-node"
                       onSuggestionSelect={(selected) => {
-                        applyLabelFilters(_.uniq([...labelFilters, selected]));
+                        applyLabelFilters(_.uniq([...labelSelection, selected]));
                       }}
                       showSuggestions
                       textValue={labelInputText}

--- a/frontend/public/components/useLabelSelectionFix.ts
+++ b/frontend/public/components/useLabelSelectionFix.ts
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import useMirroredLocalState, { UseMirroredLocalStateReturn } from './useMirroredLocalState';
+import { setOrRemoveQueryArgument } from './utils';
+
+/**
+ * Handles a state management hack-fix around the label filters auto complete field.
+ * Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2070720
+ * TODO: Refactor FilterToolbar to use proper state management: https://issues.redhat.com/browse/CONSOLE-3147
+ *
+ * This is a hack fix due to the violation in state management in FilterToolbar. This hook should
+ * be deleted once proper React state management has been implemented.
+ */
+const useLabelSelectorFix = (
+  params: URLSearchParams,
+  labelFilterQueryArgumentKey: string,
+): UseMirroredLocalStateReturn<string[]> => {
+  const syncSearchParams = React.useCallback(
+    (values: string[]) => {
+      setOrRemoveQueryArgument(labelFilterQueryArgumentKey, values.join(','));
+    },
+    [labelFilterQueryArgumentKey],
+  );
+
+  const labelFilters = params.get(labelFilterQueryArgumentKey)?.split(',') ?? [];
+
+  return useMirroredLocalState<string[]>({
+    externalState: labelFilters,
+    externalChangeHandler: syncSearchParams,
+    defaultState: [],
+  });
+};
+
+export default useLabelSelectorFix;

--- a/frontend/public/components/useMirroredLocalState.ts
+++ b/frontend/public/components/useMirroredLocalState.ts
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+
+export type UseMirroredLocalStateReturn<S> = [S, (state: S) => void, boolean];
+
+/**
+ * DO NOT USE -- proper state management in React is Top-Down state management.
+ * Syncs an external data point with a local data point. Used to fix the ToolbarFilter poor state
+ * management issue.
+ */
+const useMirroredLocalState = <S>({
+  externalState,
+  externalChangeHandler,
+  defaultState,
+}: {
+  externalState: S;
+  externalChangeHandler: (state: S) => void;
+  defaultState: S;
+}): UseMirroredLocalStateReturn<S> => {
+  const [localState, setLocalState] = React.useState<S>(null);
+
+  const onExternalChange = React.useCallback(
+    (state: S) => {
+      setLocalState(state);
+      externalChangeHandler(state);
+    },
+    [externalChangeHandler],
+  );
+
+  React.useEffect(() => {
+    if (localState === null) {
+      // We don't have local data, fresh mount
+      if (_.isEmpty(externalState)) {
+        // No url params, use defaults
+        onExternalChange(defaultState);
+      } else {
+        // We have url params, routed here with params
+        setLocalState(externalState);
+      }
+    } else {
+      // We have local data so we have been initialized
+      if (!_.isEqual(externalState, localState)) {
+        // They are not equal, so we need to figure out who is right
+        if (_.isEmpty(externalState)) {
+          // Params are empty, so this means the component was not re-mounted but we lost params
+          onExternalChange(localState);
+        } else {
+          // Params are not empty -- this is a conflict of source of truth
+          // Possible reason would be a local code re-route on this page, accept URL as source of truth
+          setLocalState(externalState);
+        }
+      }
+    }
+  }, [localState, externalState, onExternalChange, defaultState]);
+
+  return [localState ?? defaultState, onExternalChange, localState !== null];
+};
+
+export default useMirroredLocalState;

--- a/frontend/public/components/useRowFilterFix.ts
+++ b/frontend/public/components/useRowFilterFix.ts
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import useMirroredLocalState, { UseMirroredLocalStateReturn } from './useMirroredLocalState';
+import { setOrRemoveQueryArgument } from './utils';
+
+/**
+ * Handles a state management hack-fix around the row filters dropdown.
+ * Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2070720
+ * TODO: Refactor FilterToolbar to use proper state management: https://issues.redhat.com/browse/CONSOLE-3147
+ *
+ * This is a hack fix due to the violation in state management in FilterToolbar. This hook should
+ * be deleted once proper React state management has been implemented.
+ */
+const useRowFilterFix = (
+  params: URLSearchParams,
+  filters: { [key: string]: string[] },
+  filterKeys: { [key: string]: string },
+  defaultSelections: string[],
+): UseMirroredLocalStateReturn<string[]> => {
+  const syncRowFilterParams = React.useCallback(
+    (selected) => {
+      _.forIn(filters, (value, key) => {
+        const recognized = _.filter(selected, (item) => value.includes(item));
+        setOrRemoveQueryArgument(filterKeys[key], recognized.join(','));
+      });
+    },
+    [filters, filterKeys],
+  );
+
+  const selectedRowFilters = _.flatMap(filterKeys, (f) => params.get(f)?.split(',') ?? []);
+
+  return useMirroredLocalState<string[]>({
+    externalChangeHandler: syncRowFilterParams,
+    externalState: selectedRowFilters,
+    defaultState: defaultSelections,
+  });
+};
+
+export default useRowFilterFix;


### PR DESCRIPTION
Manual cherry pick of https://github.com/openshift/console/pull/11428.
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2083729

Appears the conflict was structural rendering and nothing really around my logic. Although it looks like the code is a little less organized/structured than the 4.11 version.

Tested against a 4.10 cluster and appears the fix is equiv to the one I applied to 4.11.