### PR TITLE
Monitoring: Add "fade out" horizontal gradient to Metrics page table

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -47,6 +47,38 @@
   }
 }
 
+.horizontal-scroll {
+  overflow-x: auto;
+  padding-left: var(--pf-global--spacer--md);
+  padding-right: var(--pf-global--spacer--md);
+
+  &:before, &:after {
+    bottom: 0;
+    content: '';
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    width: var(--pf-global--spacer--md);
+    z-index: 1;
+  }
+  &:before {
+    background: linear-gradient(
+      to right,
+      var(--pf-global--BackgroundColor--100),
+      rgba(255, 255, 255, 0)
+    );
+    left: 0;
+  }
+  &:after {
+    background: linear-gradient(
+      to left,
+      var(--pf-global--BackgroundColor--100),
+      rgba(255, 255, 255, 0)
+    );
+    right: 0;
+  }
+}
+
 .monitoring-dashboards__card {
   height: calc(100% - 20px);
   margin: 0 0 20px 0;
@@ -127,25 +159,9 @@
 .monitoring-dashboards__legend-wrap {
   $legend-content-height: 65px;
   height: $legend-content-height + 10px; // Add space for the horizontal scrollbar
-  overflow-x: auto;
-  padding-right: var(--pf-global--spacer--lg);
   padding-top: 1px;
   svg {
     max-height: $legend-content-height; // Required for Chrome to prevent vertical scrolling
-  }
-  &:after {
-    background: linear-gradient(
-      to left,
-      var(--pf-global--BackgroundColor--100),
-      rgba(255, 255, 255, 0)
-    );
-    content: '';
-    height: $legend-content-height;
-    pointer-events: none;
-    position: absolute;
-    right: 0;
-    top: 0;
-    width: var(--pf-global--spacer--lg);
   }
 }
 
@@ -453,22 +469,15 @@ $monitoring-line-height: 18px;
   }
 
   tr > :first-child {
-    width: 40px;
     padding-top: 0;
     padding-bottom: 0;
+    padding-left: 0;
     vertical-align: middle;
   }
 }
 
-.query-browser__table-cell {
-  @include co-break-word;
-  min-width: 120px;
-  --pf-c-table-cell--PaddingRight: 0;
-  --pf-c-table__sort-indicator--MarginLeft: 4px;
-}
-
 .query-browser__table-wrapper {
-  overflow-x: auto;
+  position: relative;
   width: 100%;
 
   table {

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -423,19 +423,16 @@ export const QueryTable: React.FC<QueryTableProps> = ({ index, namespace }) => {
     );
   }
 
-  const cellProps = {
-    props: { className: 'query-browser__table-cell' },
-    transforms: [sortable, wrappable],
-  };
+  const transforms = [sortable, wrappable];
 
   const buttonCell = (labels) => ({ title: <SeriesButton index={index} labels={labels} /> });
 
   let columns, rows;
   if (data.resultType === 'scalar') {
-    columns = ['', { title: t('public~Value'), ...cellProps }];
+    columns = ['', { title: t('public~Value'), transforms }];
     rows = [[buttonCell({}), _.get(result, '[1]')]];
   } else if (data.resultType === 'string') {
-    columns = [{ title: t('public~Value'), ...cellProps }];
+    columns = [{ title: t('public~Value'), transforms }];
     rows = [[result?.[1]]];
   } else {
     const allLabelKeys = _.uniq(_.flatMap(result, ({ metric }) => Object.keys(metric))).sort();
@@ -444,9 +441,9 @@ export const QueryTable: React.FC<QueryTableProps> = ({ index, namespace }) => {
       '',
       ...allLabelKeys.map((k) => ({
         title: <span>{k === '__name__' ? t('public~Name') : k}</span>,
-        ...cellProps,
+        transforms,
       })),
-      { title: t('public~Value'), ...cellProps },
+      { title: t('public~Value'), transforms },
     ];
 
     let rowMapper;
@@ -496,18 +493,20 @@ export const QueryTable: React.FC<QueryTableProps> = ({ index, namespace }) => {
   return (
     <>
       <div className="query-browser__table-wrapper">
-        <Table
-          aria-label={t('public~query results table')}
-          cells={columns}
-          gridBreakPoint={TableGridBreakpoint.none}
-          onSort={onSort}
-          rows={tableRows}
-          sortBy={sortBy}
-          variant={TableVariant.compact}
-        >
-          <TableHeader />
-          <TableBody />
-        </Table>
+        <div className="horizontal-scroll">
+          <Table
+            aria-label={t('public~query results table')}
+            cells={columns}
+            gridBreakPoint={TableGridBreakpoint.none}
+            onSort={onSort}
+            rows={tableRows}
+            sortBy={sortBy}
+            variant={TableVariant.compact}
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
+        </div>
       </div>
       <TablePagination
         itemCount={rows.length}

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -297,7 +297,7 @@ const LegendContainer = ({ children }: { children?: React.ReactNode }) => {
   const width = children?.[0]?.[0]?.props?.width ?? '100%';
   return (
     <foreignObject height={75} width="100%" y={245}>
-      <div className="monitoring-dashboards__legend-wrap">
+      <div className="monitoring-dashboards__legend-wrap horizontal-scroll">
         <svg width={width}>{children}</svg>
       </div>
     </foreignObject>


### PR DESCRIPTION
The table can have many columns, so it sometimes requires horizontal
scrolling. This adds a gradient "fade out" to both the left and right
sides of the table. The left and right padding on the table are equal in
size to the gradient, so when not scrolling the gradient is not visible.

Changes the dashboard graphs to use the same style (they already had a
gradient on the right side).

Removes the `query-browser__table-cell` CSS class. This class was
beneficial before, but with more recent changes to the default table
styles the benefit is now questionable and it's better to use the
default styles when possible.

FYI @thile01

![screenshot](https://user-images.githubusercontent.com/460802/167761631-f86a2f6f-826e-417f-afbc-41e5d04494be.png)

![screenshot](https://user-images.githubusercontent.com/460802/167761206-78bb55b8-cf85-4792-bb64-739625558e5e.png)