### PR TITLE
Bug 2083641: fixes apiversion for k8s svc and resource selection for sink for form yaml switcher

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/event-sources/form-fields/SinkResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/form-fields/SinkResources.tsx
@@ -37,10 +37,13 @@ const SinkResources: React.FC<SinkResourcesProps> = ({ namespace, isMoveSink }) 
       const modelData = valueObj?.props?.model;
       const name = valueObj?.props?.name;
       if (name && modelData) {
-        const { apiGroup = 'core', apiVersion, kind } = modelData;
+        const { apiGroup, apiVersion, kind } = modelData;
         setFieldValue('formData.sink.name', name);
         setFieldTouched('formData.sink.name', true);
-        setFieldValue('formData.sink.apiVersion', `${apiGroup}/${apiVersion}`);
+        setFieldValue(
+          'formData.sink.apiVersion',
+          apiGroup ? `${apiGroup}/${apiVersion}` : apiVersion,
+        );
         setFieldTouched('formData.sink.apiVersion', true);
         setFieldValue('formData.sink.kind', kind);
         setFieldTouched('formData.sink.kind', true);

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -29,6 +29,7 @@ import {
   KnEventCatalogMetaData,
   YamlFormSyncData,
 } from '../components/add/import-types';
+import { craftResourceKey } from '../components/pub-sub/pub-sub-utils';
 import { CAMEL_K_PROVIDER_ANNOTATION } from '../const';
 import { CamelKameletModel } from '../models';
 import { getEventSourceIcon } from './get-knative-icon';
@@ -358,6 +359,7 @@ export const sanitizeSourceToForm = (
 ) => {
   const specData = newFormData.spec;
   const appGroupName = newFormData.metadata?.labels?.['app.kubernetes.io/part-of'];
+  const sinkRef = specData?.sink?.ref;
   const formData = {
     ...formDataValues,
     application: {
@@ -373,12 +375,15 @@ export const sanitizeSourceToForm = (
       }),
     },
     name: newFormData.metadata?.name,
-    sinkType: specData?.sink?.ref ? SinkType.Resource : SinkType.Uri,
+    sinkType: sinkRef ? SinkType.Resource : SinkType.Uri,
     sink: {
-      apiVersion: specData?.sink?.ref?.apiVersion,
-      kind: specData?.sink?.ref?.kind,
-      name: specData?.sink?.ref?.name,
-      key: `${specData?.sink?.ref?.kind}-${specData?.sink?.ref?.name}`,
+      apiVersion: sinkRef?.apiVersion,
+      kind: sinkRef?.kind,
+      name: sinkRef?.name,
+      key: craftResourceKey(sinkRef?.name, {
+        kind: sinkRef?.kind,
+        apiVersion: sinkRef?.apiVersion,
+      }),
       uri: specData?.sink?.uri || '',
     },
     data: {


### PR DESCRIPTION
**Fixes:**
- https://bugzilla.redhat.com/show_bug.cgi?id=2083641
- https://bugzilla.redhat.com/show_bug.cgi?id=2083964

**Description:**
- the apiVersion for k8s svc has `core/v1` and should be `v1`
- Sink resource was not preselected in YAML/form switcher as the key for dropdown was not correct

**Solution:**
- apiVersion should be the same as in the actual sink resource and in the case of k8s svc will be just the version and group is not needed
- Added the correct key for the selected resource so that can be preselected with the form/YAML switcher

**Screenshots:**

**Before**

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/5129024/167786025-ed48cdd2-1839-4e8b-b79c-21b2587e145b.png">

**After**

<img width="1779" alt="image" src="https://user-images.githubusercontent.com/5129024/167786108-b6ac48e3-0809-49e9-9fee-9e6a3302734a.png">

