### PR TITLE
Gherkin and automation for PAC bootstrap form

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-as-code.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-as-code.feature
@@ -132,3 +132,23 @@ Feature: Perform Actions on repository
         Examples:
                   | repository_name |
                   | test-repo       |
+
+
+        @regression @odc-6460
+        Scenario: Setup GitHub page: P-11-TC12
+            Given user is at Pipelines tab in admin page
+             When user clicks on Setup GitHub App button
+             Then user can see "GitHub application name", "See GitHub permissions" and "View all steps in documentation"
+
+
+        @regression @manual @odc-6460
+        #This test case is manual as it navigates to github in between the process
+        Scenario: Create and configure the GitHub Application to work with Pipelines as code: P-11-TC13
+            Given user is at Pipelines tab in admin page
+             When user clicks on Setup GitHub App button
+              And user enters GitHub application name as "pac-app123"
+              And user clicks on Setup button
+              And user confirms access in github
+              And user clicks Create GitHub App button in Create GitHub App page
+             Then user will be redirected to GitHub App details
+              And user will see App Name as "pac-app123", App Link as "https://github.com/apps/pac-app123" and Secret as "pipelines-as-code-secret" in "openshift-pipelines" namespace

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/task-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/task-page.ts
@@ -38,7 +38,7 @@ export const tasksPage = {
   openPipelinePage: () => {
     cy.get('[data-quickstart-id="qs-nav-pipelines"]')
       .eq(1)
-      .click();
+      .click({ force: true });
   },
   clickOnCreatePipeline: () => {
     cy.get('[data-test-id="dropdown-button"]').click();

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-as-code.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-as-code.ts
@@ -4,11 +4,13 @@ import { modal } from '@console/cypress-integration-tests/views/modal';
 import {
   devNavigationMenu,
   pageTitle,
+  switchPerspective,
 } from '@console/dev-console/integration-tests/support/constants';
 import { formPO } from '@console/dev-console/integration-tests/support/pageObjects';
 import {
   editAnnotations,
   navigateTo,
+  perspective,
   yamlEditor,
 } from '@console/dev-console/integration-tests/support/pages';
 import { pipelineActions, pipelineTabs, repositoryDetailsTabs } from '../../constants';
@@ -21,6 +23,7 @@ import {
   pipelineRunDetailsPage,
 } from '../../pages';
 import { actionsDropdownMenu, tableFunctions } from '../../pages/functions/common';
+import { tasksPage } from '../../pages/pipelines/task-page';
 
 Given('user has installed pipelines as code', () => {
   // Steps to install pipeline as code feature : https://gist.github.com/chmouel/272df2cfbeef5606ca36d29a9a2d2f96
@@ -270,4 +273,23 @@ Then('user should see commit message in tooltip', () => {
 
 Then('user clicks on Pipeline Runs tab', () => {
   cy.get(repositoryDetailsPO.pipelineRunsTab).click();
+});
+
+Given('user is at Pipelines tab in admin page', () => {
+  perspective.switchTo(switchPerspective.Administrator);
+  tasksPage.openPipelinePage();
+  tasksPage.togglePipelineSidebar();
+});
+
+When('user clicks on Setup GitHub App button', () => {
+  cy.byTestID('secondary-action')
+    .should('be.visible')
+    .click();
+});
+
+Then('user can see {string}, {string} and {string}', (el1, el2, el3: string) => {
+  cy.byTestID('form-setup-github-app')
+    .should('contain', el1)
+    .and('contain', el2)
+    .and('contain', el3);
 });

--- a/frontend/packages/pipelines-plugin/src/components/pac/PacAppForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pac/PacAppForm.tsx
@@ -30,7 +30,12 @@ const PacAppForm: React.FC<FormikProps<FormikValues>> = ({
     }
   };
   return (
-    <FlexForm action={PAC_GH_APP_NEW} onSubmit={submitFrom} method="post">
+    <FlexForm
+      action={PAC_GH_APP_NEW}
+      onSubmit={submitFrom}
+      method="post"
+      data-test="form-setup-github-app"
+    >
       <FormBody flexLayout>
         <FormSection>
           <FormGroup


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-6460
Story: https://issues.redhat.com/browse/ODC-6507
Acceptance criteria:

-  As an admin, I can follow a wizard-like experience to configure OpenShift and my git provider for pipeline as code

**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]

**Fix**: https://issues.redhat.com/browse/ODC-6508


**Test Setup**:


Cluster should be running on local

Check the TAGS in frontend/packages/pipelines/integration-tests/cypress.json file be: ""@pipelines and @[odc-6460](https://issues.redhat.com//browse/odc-6460) and not (@manual or @to-do or @un-verified or @broken-test)"",


Command to execute:

Run a cluster locally and execute the command `yarn run dev` and then `npm run test-cypress-pipelines` simultaneously

Execute the pipelines-as-code.feature file

**Browser**
Chrome 99

**Test Execution Screenshot:**


