### PR TITLE
Bug 2079845: fix catalog filter group getting removed on keyword change

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogFilters.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogFilters.tsx
@@ -19,7 +19,6 @@ type CatalogFiltersProps = {
   filterGroupCounts: CatalogFilterCounts;
   filterGroupMap: { [key: string]: CatalogItemAttribute };
   filterGroupsShowAll: { [key: string]: boolean };
-  catalogItemsCount: number;
   onFilterChange: (filterType: string, id: string, value: boolean) => void;
   onShowAllToggle: (groupName: string) => void;
 };
@@ -29,7 +28,6 @@ const CatalogFilters: React.FC<CatalogFiltersProps> = ({
   filterGroupCounts,
   filterGroupMap,
   filterGroupsShowAll,
-  catalogItemsCount,
   onFilterChange,
   onShowAllToggle,
 }) => {
@@ -39,19 +37,6 @@ const CatalogFilters: React.FC<CatalogFiltersProps> = ({
       acc[groupName] = activeFilters[groupName];
       return acc;
     }, {});
-
-  const getFilterGroup = (filterGroup: CatalogFilter, groupName: string): CatalogFilter => {
-    const filterGroupKeys = Object.keys(filterGroup);
-
-    return filterGroupKeys.length > 0
-      ? _.omitBy(filterGroup, (filter, filterName) => {
-          const { label, active } = filter;
-          const count = filterGroupCounts[groupName]?.[filterName] ?? 0;
-          const showFilter = label && (active || (count > 0 && catalogItemsCount !== count));
-          return !showFilter;
-        })
-      : {};
-  };
 
   const renderFilterItem = (filter: CatalogFilterItem, filterName: string, groupName: string) => {
     const { label, active } = filter;
@@ -75,8 +60,7 @@ const CatalogFilters: React.FC<CatalogFiltersProps> = ({
   };
 
   const renderFilterGroup = (filterGroup: CatalogFilter, groupName: string) => {
-    const fg = getFilterGroup(filterGroup, groupName);
-    const filterGroupKeys = Object.keys(fg);
+    const filterGroupKeys = Object.keys(filterGroup);
     if (filterGroupKeys.length > 0) {
       const sortedFilterGroup = filterGroupKeys.sort().reduce<CatalogFilter>((acc, filterName) => {
         acc[filterName] = filterGroup[filterName];

--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogView.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogView.tsx
@@ -246,7 +246,6 @@ const CatalogView: React.FC<CatalogViewProps> = ({
               filterGroupCounts={filterGroupCounts}
               filterGroupMap={filterGroupMap}
               filterGroupsShowAll={filterGroupsShowAll}
-              catalogItemsCount={items.length}
               onShowAllToggle={handleShowAllToggle}
               onFilterChange={handleFilterChange}
             />


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=2079845


**Description:**

The issue is with filter group and filters showing up and hiding based on filter count if user types as in below

**Before:**

![filterGroupBefore](https://user-images.githubusercontent.com/5129024/167875287-4b4d921a-74b0-44c7-b72b-a983305cda27.gif)

**After:**

![CF3](https://user-images.githubusercontent.com/5129024/169309319-d73b173e-bb08-4b7e-8059-18e85b75dcd1.gif)


