### PR TITLE
Bug 2084489: Create VM from template that has sourceRef - will now reflect sourceRef at yaml

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/storage-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/storage-tab-initial-state.ts
@@ -314,20 +314,22 @@ export const getNewProvisionSourceStorage = (state: any, id: string): VMWizardSt
     const [pvcs] = iGetCommonData(state, id, VMWizardProps.pvcs);
     const iBaseImage = iGetLoadedCommonData(state, id, VMWizardProps.openshiftCNVBaseImages)
       ?.valueSeq()
-      .find((iPVC) => iGetName(iPVC) === pvcName);
-
-    const dsBaseImage = findDataSourcePVC(dataSources, pvcs, pvcName, pvcNamespace);
+      ?.find((iPVC) => iGetName(iPVC) === pvcName);
+    const { dsBaseImage, dataSource } = findDataSourcePVC(dataSources, pvcs, pvcName, pvcNamespace);
     const image = dsBaseImage || iBaseImage;
     const pvcSize = iGetIn(image, ['spec', `resources`, `requests`, `storage`]);
 
-    return getBaseImageStorage(
-      iGetName(image),
-      iGetNamespace(image),
-      pvcSize,
-      diskBus,
-      accessMode,
-      volumeMode,
-    );
+    return {
+      ...getBaseImageStorage(
+        iGetName(image),
+        iGetNamespace(image),
+        pvcSize,
+        diskBus,
+        accessMode,
+        volumeMode,
+      ),
+      sourceRef: dataSource,
+    };
   }
   if (provisionSource === ProvisionSource.DISK && !iUserTemplate) {
     const iOldSourceStorage = iGetProvisionSourceStorage(state, id);

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/main-actions/create-vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/main-actions/create-vm.ts
@@ -5,6 +5,10 @@ import {
 } from '../../../../k8s/enhancedK8sMethods/k8sMethodsUtils';
 import { ResultsWrapper } from '../../../../k8s/enhancedK8sMethods/types';
 import { createVM as _createVM, createVMTemplate } from '../../../../k8s/requests/vm/create/create';
+import {
+  SourceRefActions,
+  SourceRefActionsNames,
+} from '../../../../redux/actions/sourceRef-actions';
 import { SysprepActions, SysprepActionsNames } from '../../../../redux/actions/sysprep-actions';
 import { immutableListToJS } from '../../../../utils/immutable';
 import { createOrDeleteSSHService } from '../../../ssh-service/SSHForm/ssh-form-utils';
@@ -13,7 +17,11 @@ import { iGetNetworks } from '../../selectors/immutable/networks';
 import { iGetCommonData, iGetLoadedCommonData } from '../../selectors/immutable/selectors';
 import { iGetStorages } from '../../selectors/immutable/storage';
 import { iGetVmSettings } from '../../selectors/immutable/vm-settings';
-import { getEnableSSHService, getSysprepData } from '../../selectors/immutable/wizard-selectors';
+import {
+  getEnableSSHService,
+  getSysprepData,
+  getSourceRefData,
+} from '../../selectors/immutable/wizard-selectors';
 import { iGetHardwareField } from '../../tabs/advanced-tab/hardware-devices/selectors';
 import {
   AUTOUNATTEND,
@@ -40,6 +48,7 @@ export const createVMAction = (id: string) => (dispatch, getState) => {
 
   const enableSSHService = getEnableSSHService(state);
   const sysprepData = getSysprepData(state);
+  const sourceRef = getSourceRefData(state);
   const enhancedK8sMethods = new EnhancedK8sMethods();
 
   const importProviders = iGetImportProviders(state, id).toJS() as ImportProvidersSettings;
@@ -73,6 +82,7 @@ export const createVMAction = (id: string) => (dispatch, getState) => {
     sysprepData,
     gpus,
     hostDevices,
+    sourceRef,
   };
 
   const create = isCreateTemplate ? createVMTemplate : _createVM;
@@ -89,6 +99,9 @@ export const createVMAction = (id: string) => (dispatch, getState) => {
       if (sysprepData?.[AUTOUNATTEND] || sysprepData?.[UNATTEND]) {
         createSysprepConfigMap(vm, sysprepData);
         dispatch(SysprepActions[SysprepActionsNames.clearValues]());
+      }
+      if (sourceRef) {
+        dispatch(SourceRefActions[SourceRefActionsNames.clearValues]());
       }
       dispatch(
         vmWizardInternalActions[InternalActionType.SetResults](id, tabState, isValid, false, false),

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/prefill-vm-template-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/prefill-vm-template-state-update.ts
@@ -6,6 +6,10 @@ import { ProvisionSource } from '../../../../constants/vm/provision-source';
 import { CloudInitDataHelper } from '../../../../k8s/wrapper/vm/cloud-init-data-helper';
 import { DiskWrapper } from '../../../../k8s/wrapper/vm/disk-wrapper';
 import { VolumeWrapper } from '../../../../k8s/wrapper/vm/volume-wrapper';
+import {
+  SourceRefActions,
+  SourceRefActionsNames,
+} from '../../../../redux/actions/sourceRef-actions';
 import { getName } from '../../../../selectors';
 import { isCustomFlavor, toUIFlavor } from '../../../../selectors/vm-like/flavor';
 import {
@@ -257,9 +261,12 @@ export const prefillVmTemplateUpdater = ({ id, dispatch, getState }: UpdateOptio
     }
     storagesUpdate.unshift(...templateStorages);
   } else {
+    dispatch(SourceRefActions[SourceRefActionsNames.clearValues]());
     const newSourceStorage = getNewProvisionSourceStorage(state, id);
     if (newSourceStorage) {
       storagesUpdate.unshift({ ...newSourceStorage, id: getNextStorageID() });
+      newSourceStorage?.sourceRef &&
+        dispatch(SourceRefActions[SourceRefActionsNames.updateValue](newSourceStorage?.sourceRef));
     }
   }
 

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/storage-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/storage-tab-state-update.ts
@@ -12,6 +12,10 @@ import { winToolsContainerNames } from '../../../../constants/vm/wintools';
 import { DataVolumeWrapper } from '../../../../k8s/wrapper/vm/data-volume-wrapper';
 import { DiskWrapper } from '../../../../k8s/wrapper/vm/disk-wrapper';
 import { VolumeWrapper } from '../../../../k8s/wrapper/vm/volume-wrapper';
+import {
+  SourceRefActions,
+  SourceRefActionsNames,
+} from '../../../../redux/actions/sourceRef-actions';
 import { ValidationErrorType } from '../../../../selectors';
 import {
   getDataVolumeAccessModes,
@@ -79,7 +83,11 @@ export const prefillInitialDiskUpdater = ({ id, prevState, dispatch, getState }:
   const oldSourceStorage: VMWizardStorage = iOldSourceStorage && iOldSourceStorage.toJSON();
 
   // Depends on OPERATING_SYSTEM CLONE_COMMON_BASE_DISK_IMAGE PROVISION_SOURCE_TYPE FLAVOR USER_TEMPLATE and WORKLOAD_PROFILE
+  dispatch(SourceRefActions[SourceRefActionsNames.clearValues]());
   const newSourceStorage = getNewProvisionSourceStorage(state, id);
+  if (newSourceStorage?.sourceRef) {
+    dispatch(SourceRefActions[SourceRefActionsNames.updateValue](newSourceStorage?.sourceRef));
+  }
   const oldType =
     (oldSourceStorage &&
       StorageUISource.fromTypes(

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/vm-settings-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/vm-settings-tab-state-update.ts
@@ -181,7 +181,8 @@ const baseImageUpdater = ({ id, prevState, dispatch, getState }: UpdateOptions) 
       iGetAnnotation(iBaseImage, CDI_UPLOAD_POD_ANNOTATION) === CDI_PVC_PHASE_RUNNING;
 
     if (!iBaseImage) {
-      iBaseImage = findDataSourcePVC(dataSources, pvcs, pvcName, pvcNamespace);
+      const { dsBaseImage } = findDataSourcePVC(dataSources, pvcs, pvcName, pvcNamespace);
+      iBaseImage = dsBaseImage;
     }
   }
 

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/immutable/wizard-selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/immutable/wizard-selectors.ts
@@ -1,4 +1,5 @@
 import { isCustomFlavor } from '../../../../selectors/vm-like/flavor';
+import { DataSourceKind } from '../../../../types';
 import { iGet, iGetIn } from '../../../../utils/immutable';
 import { getStringEnumValues } from '../../../../utils/types';
 import { SysprepData } from '../../tabs/advanced-tab/sysprep/utils/sysprep-utils';
@@ -54,6 +55,9 @@ export const getSSHTempKey = (state): string =>
   state?.plugins?.kubevirt?.authorizedSSHKeys?.tempSSHKey;
 
 export const getSysprepData = (state): SysprepData => state?.plugins?.kubevirt?.sysprep;
+
+export const getSourceRefData = (state): DataSourceKind =>
+  state?.plugins?.kubevirt?.sourceRef?.value;
 
 export const getStepsMetadata = (state, wizardID: string): VMWizardTabsMetadata => {
   const stepData = iGetCreateVMWizardTabs(state, wizardID);

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os.tsx
@@ -13,7 +13,7 @@ import {
   getFlavors,
   getWorkloadProfiles,
 } from '../../../../selectors/vm-template/combined-dependent';
-import { OperatingSystemRecord } from '../../../../types';
+import { OperatingSystemRecord, OperationSystemField } from '../../../../types';
 import {
   iGet,
   iGetIsLoaded,
@@ -138,11 +138,11 @@ export const OS: React.FC<OSProps> = React.memo(
         const baseImageFoundInCluster =
           loadedBaseImages?.find(
             (pvc) => iGetName(pvc) === pvcName && iGetNamespace(pvc) === pvcNamespace,
-          ) || findDataSourcePVC(dataSourcesData, pvcsData, pvcName, pvcNamespace);
+          ) || findDataSourcePVC(dataSourcesData, pvcsData, pvcName, pvcNamespace)?.dsBaseImage;
         const isBaseImageUploading =
           iGetAnnotation(baseImageFoundInCluster, CDI_UPLOAD_POD_ANNOTATION) ===
           CDI_PVC_PHASE_RUNNING;
-        const osField: any = {
+        const osField: OperationSystemField = {
           id: operatingSystem.id,
           name: operatingSystem.name,
           baseImageFoundInCluster,
@@ -194,7 +194,20 @@ export const OS: React.FC<OSProps> = React.memo(
         return osField;
       },
     );
-    const baseImage = operatingSystemBaseImages.find((image) => image.id === os);
+    const [baseImage, setBaseImage] = React.useState<OperationSystemField>();
+
+    React.useEffect(() => {
+      const osImage = operatingSystemBaseImages.find((image) => image.id === os);
+      const { dsBaseImage: matchingDataSourcePVC } = findDataSourcePVC(
+        dataSources,
+        pvcs,
+        osImage?.pvcName,
+        osImage?.pvcNamespace,
+      );
+      if (osImage && dataSources && pvcs && !baseImage) {
+        setBaseImage({ ...osImage, pvcName: iGetName(matchingDataSourcePVC) || osImage.pvcName });
+      }
+    }, [baseImage, dataSources, operatingSystemBaseImages, os, pvcs]);
 
     const numOfMountedDisks = cloneBaseDiskImage + mountWindowsGuestTools; // using boolean addition operator to count true
     const mountedDisksHelpMsg = numOfMountedDisks > 0 && (

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
@@ -377,4 +377,5 @@ export type VMWizardStorage = {
     devicePath?: string;
     fileName?: string;
   };
+  sourceRef?: DataSourceKind;
 };

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/utils/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/utils/utils.ts
@@ -51,5 +51,6 @@ export const findDataSourcePVC = (
       iGetName(iPVC) === dataSource?.spec?.source?.pvc?.name &&
       iGetNamespace(iPVC) === dataSource?.spec?.source?.pvc?.namespace,
   );
-  return dsBaseImage;
+
+  return { dsBaseImage, dataSource: dsBaseImage && dataSource };
 };

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/create.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/create.ts
@@ -122,6 +122,7 @@ export const createVM = async (params: CreateVMParams) => {
     openshiftFlag,
     isProviderImport,
     sysprepData,
+    sourceRef,
   } = params;
   const { k8sCreate, k8sWrapperCreate, getActualState } = enhancedK8sMethods;
 
@@ -185,6 +186,10 @@ export const createVM = async (params: CreateVMParams) => {
       disk: sysprepDisk(),
       volume: sysprepVolume(vmWrapper),
     });
+  }
+
+  if (sourceRef) {
+    vmWrapper.removePVC();
   }
 
   initializeCommonVMMetadata(combinedSimpleSettings, vmWrapper);

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/initialize-vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/initialize-vm.ts
@@ -25,7 +25,7 @@ import { VolumeWrapper } from '../../../wrapper/vm/volume-wrapper';
 import { CreateVMParams } from './types';
 
 const initializeStorage = (params: CreateVMParams, vm: VMWrapper) => {
-  const { vmSettings, storages, isTemplate } = params;
+  const { vmSettings, storages, isTemplate, sourceRef } = params;
   const settings = asSimpleSettings(vmSettings);
 
   const resolvedStorages = storages.map((storage) => {
@@ -55,6 +55,14 @@ const initializeStorage = (params: CreateVMParams, vm: VMWrapper) => {
         volumeWrapper.setCloudInitNoCloud({
           userData: ['#cloud-config', volumeWrapper.getCloudInitNoCloud().userData].join('\n'),
         });
+    }
+
+    if (
+      sourceRef &&
+      dataVolumeWrapper &&
+      sourceRef?.spec?.source?.pvc?.name === dataVolumeWrapper?.getPersistentVolumeClaimName()
+    ) {
+      dataVolumeWrapper.setSourceRef(sourceRef);
     }
 
     return {

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/types.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../../components/create-vm-wizard/redux/initial-state/types';
 import { SysprepData } from '../../../../components/create-vm-wizard/tabs/advanced-tab/sysprep/utils/sysprep-utils';
 import { VMWizardNetwork, VMWizardStorage } from '../../../../components/create-vm-wizard/types';
+import { DataSourceKind } from '../../../../types';
 import { V1GPU, V1HostDevice } from '../../../../types/api';
 import { ITemplate } from '../../../../types/template';
 import { EnhancedK8sMethods } from '../../../enhancedK8sMethods/enhancedK8sMethods';
@@ -25,6 +26,7 @@ export type CreateVMParams = {
   sysprepData: SysprepData;
   gpus: V1GPU;
   hostDevices: V1HostDevice;
+  sourceRef: DataSourceKind;
 };
 
 export type DefaultVMLikeEntityParams = {

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/data-volume-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/data-volume-wrapper.ts
@@ -13,6 +13,7 @@ import {
   getDataVolumeStorageSize,
   getDataVolumeVolumeMode,
 } from '../../../selectors/dv/selectors';
+import { DataSourceKind } from '../../../types';
 import { V1alpha1DataVolume } from '../../../types/api';
 import { compareOwnerReference } from '../../../utils';
 import { K8sResourceObjectWithTypePropertyWrapper } from '../common/k8s-resource-object-with-type-property-wrapper';
@@ -35,7 +36,11 @@ export class DataVolumeWrapper extends K8sResourceObjectWithTypePropertyWrapper<
   }
 
   init(
-    data: K8sInitAddon & { size?: string | number; unit?: string; storageClassName?: string } = {},
+    data: K8sInitAddon & {
+      size?: string | number;
+      unit?: string;
+      storageClassName?: string;
+    } = {},
   ) {
     super.init(data);
     const { size, unit, storageClassName } = data;
@@ -84,6 +89,16 @@ export class DataVolumeWrapper extends K8sResourceObjectWithTypePropertyWrapper<
   getAccessModesEnum = () => {
     const accessModes = this.getAccessModes();
     return accessModes ? accessModes.map((mode) => AccessMode.fromString(mode)) : accessModes;
+  };
+
+  setSourceRef = (sourceRef: DataSourceKind) => {
+    delete this.data.spec.pvc;
+    this.data.spec.sourceRef = {
+      kind: sourceRef?.kind,
+      name: sourceRef?.metadata?.name,
+      namespace: sourceRef?.metadata?.namespace,
+    };
+    return this;
   };
 
   setPVCSize = (value: string | number, unit = 'Gi') => {

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/vm-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/vm-wrapper.ts
@@ -266,6 +266,17 @@ export class VMWrapper extends K8sResourceWrapper<VMKind, VMWrapper> implements 
     this.ensureStorageConsistency();
     return this;
   };
+  removePVC = () => {
+    this.ensureDataVolumeTemplates();
+    this.data.spec.dataVolumeTemplates = this.getDataVolumeTemplates().map((dataVolume) => {
+      if (dataVolume.spec.source.pvc) {
+        const { source, ...specWithoutPVC } = dataVolume.spec;
+        return { ...dataVolume, spec: specWithoutPVC };
+      }
+      return dataVolume;
+    }) as V1DataVolumeTemplateSpec[];
+    return this;
+  };
   removeInterface = (interfaceName: string) => {
     this.ensurePath('spec.template.spec.domain.devices', {});
     this.data.spec.template.spec.domain.devices.interfaces = this.getNetworkInterfaces().filter(

--- a/frontend/packages/kubevirt-plugin/src/redux/actions/sourceRef-actions.ts
+++ b/frontend/packages/kubevirt-plugin/src/redux/actions/sourceRef-actions.ts
@@ -1,0 +1,27 @@
+import { DataSourceKind } from '../../types';
+
+export enum SourceRefActionsNames {
+  updateValue = 'UPDATE_VALUES',
+  clearValues = 'CLEAR_VALUES',
+}
+
+type SourceRefActionsType = (
+  val?: DataSourceKind,
+) => {
+  type: string;
+  payload?: DataSourceKind;
+};
+
+type SourceRefActions = {
+  [key in SourceRefActionsNames]: SourceRefActionsType;
+};
+
+export const SourceRefActions: SourceRefActions = {
+  [SourceRefActionsNames.updateValue]: (val: DataSourceKind) => ({
+    type: SourceRefActionsNames.updateValue,
+    payload: val,
+  }),
+  [SourceRefActionsNames.clearValues]: () => ({
+    type: SourceRefActionsNames.clearValues,
+  }),
+};

--- a/frontend/packages/kubevirt-plugin/src/redux/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/redux/index.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
 import createVmWizardReducers from '../components/create-vm-wizard/redux/reducers';
 import authorizedSSHKeysReducer from '../components/ssh-service/redux/reducer';
+import sourceRefReducer from './reducers/sourceRef-reducer';
 import sysprepReducer from './reducers/sysprep-reducer';
 import v2vConfigMapReducer from './reducers/v2v-config-map-reducer';
 
@@ -9,4 +10,5 @@ export default combineReducers({
   authorizedSSHKeys: authorizedSSHKeysReducer,
   v2vConfigMap: v2vConfigMapReducer,
   sysprep: sysprepReducer,
+  sourceRef: sourceRefReducer,
 });

--- a/frontend/packages/kubevirt-plugin/src/redux/reducers/sourceRef-reducer.ts
+++ b/frontend/packages/kubevirt-plugin/src/redux/reducers/sourceRef-reducer.ts
@@ -1,0 +1,16 @@
+import { SourceRefActionsNames } from '../actions/sourceRef-actions';
+
+const initialState = { value: null };
+
+const sourceRefReducer = (state = initialState, { type, payload }) => {
+  switch (type) {
+    case SourceRefActionsNames.updateValue:
+      return { ...state, value: payload };
+    case SourceRefActionsNames.clearValues:
+      return { ...initialState };
+    default:
+      return state;
+  }
+};
+
+export default sourceRefReducer;

--- a/frontend/packages/kubevirt-plugin/src/statuses/template/template-source-status.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/template/template-source-status.ts
@@ -71,6 +71,7 @@ export const getTemplateSourceStatus: GetTemplateSourceStatus = ({
           provider: RED_HAT,
           isReady: matchedDataSourceDataVolume?.status?.phase === 'Succeeded',
           pvc: matchedDataSourcePVC,
+          sourceRef: matchedDataSource,
           dataVolume: matchedDataSourceDataVolume,
           isCDRom: isCDRom(matchedDataSourceDataVolume, matchedDataSourcePVC),
           addedOn: getCreationTimestamp(matchedDataSourceDataVolume),

--- a/frontend/packages/kubevirt-plugin/src/statuses/template/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/template/types.ts
@@ -25,6 +25,7 @@ export type TemplateSourceStatusError = {
   alert?: boolean;
   dataVolume?: V1alpha1DataVolume;
   pvc?: PersistentVolumeClaimKind;
+  sourceRef?: DataSourceKind;
 };
 
 export type TemplateSourceStatusBundle = {
@@ -38,6 +39,7 @@ export type TemplateSourceStatusBundle = {
   container?: string;
   dvTemplate?: V1alpha1DataVolume;
   pxe?: string;
+  sourceRef?: DataSourceKind;
   addedOn: string;
 };
 

--- a/frontend/packages/kubevirt-plugin/src/types/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/types.ts
@@ -1,3 +1,6 @@
+import * as React from 'react';
+import { Map as ImmutableMap } from 'immutable';
+import { PersistentVolumeClaimKind } from '@console/internal/module/k8s';
 import { DeviceType } from '../constants';
 import { V1Disk } from './api';
 import { V1NetworkInterface } from './vm';
@@ -18,4 +21,15 @@ export type OperatingSystemRecord = {
   baseImageName?: string;
   baseImageNamespace?: string;
   baseImageRecomendedSize?: any;
+};
+
+export type OperationSystemField = {
+  id: string;
+  name: string;
+  baseImageFoundInCluster: ImmutableMap<string, PersistentVolumeClaimKind>;
+  message: string;
+  longMessage?: string | React.ReactElement<any, any>;
+  checkboxDescription: string;
+  pvcName?: string;
+  pvcNamespace?: string;
 };


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

** Adding to 4.10 branch **

Creating VM from a template that has sourceRef as boot source, was placing the PVC of sourceRef in the YAML instead of the sourceRef object, now, creating from a template that has sourceRef will reflect the sourceRef object in the new created VM YAML.

Original PR: https://github.com/openshift/console/pull/11457

![image](https://user-images.githubusercontent.com/14824964/168062355-53a4cd55-6066-436a-b975-392faff532b1.png)


