### PR TITLE
Console 3155: Display Operator logos on a white background on dark them to prevent visual issues and consistency

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/CatalogTile.scss
+++ b/frontend/packages/console-shared/src/components/catalog/CatalogTile.scss
@@ -1,4 +1,12 @@
+@import '../../../../../public/style/mixin/catalog-logo-background';
+
 .odc-catalog-tile {
+  .catalog-tile-pf-icon {
+    @include catalog-logo-background();
+    max-width: 100px;
+    height: 40px;
+  }
+
   > .catalog-tile-pf-body {
     display: flex;
     flex-direction: column;

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.scss
@@ -1,3 +1,5 @@
+@import '../../../../../public/style/mixin/catalog-logo-background';
+
 .ocs-quick-search-list {
   height: 100%;
   display: flex;
@@ -33,8 +35,11 @@
     align-items: center;
   }
   &__item-icon {
+    @include catalog-logo-background();
+    display: flex;
+    height: 30px;
+    justify-content: center;
     width: 30px;
-    text-align: center;
   }
   &__item-name {
     font-size: var(--pf-global--FontSize--md);

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.tsx
@@ -56,7 +56,7 @@ const QuickSearchList: React.FC<QuickSearchListProps> = ({
     const { iconImg, iconClass } = getIconProps(item);
     return (
       <img
-        className="ocs-quick-search-list__item-icon"
+        className="ocs-quick-search-list__item-icon-img"
         src={iconClass ? getImageForIconClass(iconClass) : iconImg}
         alt={`${item.name} icon`}
       />

--- a/frontend/packages/dev-console/src/components/import/devfile/DevfileInfo.tsx
+++ b/frontend/packages/dev-console/src/components/import/devfile/DevfileInfo.tsx
@@ -19,12 +19,16 @@ const DevfileInfo: React.FC<DevfileInfoProps> = ({ devfileSample }) => {
     <div>
       <div className="co-catalog-item-details">
         {iconUrl ? (
-          <img
-            className="co-catalog-item-icon__img co-catalog-item-icon__img--large"
-            src={iconUrl}
-            alt={displayName}
-            aria-hidden
-          />
+          <div className="co-catalog-item-icon">
+            <span className="co-catalog-item-icon__bg">
+              <img
+                className="co-catalog-item-icon__img co-catalog-item-icon__img--large"
+                src={iconUrl}
+                alt={displayName}
+                aria-hidden
+              />
+            </span>
+          </div>
         ) : (
           <LayerGroupIcon size="xl" />
         )}

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartMetaDescription.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartMetaDescription.tsx
@@ -18,12 +18,14 @@ const HelmChartMetaDescription: React.FC<HelmChartMetaDescriptionProps> = ({ cha
     <div style={{ marginBottom: '30px' }}>
       <div className="co-clusterserviceversion-logo">
         <div className="co-clusterserviceversion-logo__icon">
-          <img
-            className="co-catalog-item-icon__img co-catalog-item-icon__img--large"
-            src={imgSrc}
-            alt={displayName}
-            aria-hidden
-          />
+          <span className="co-catalog-item-icon__bg">
+            <img
+              className="co-catalog-item-icon__img co-catalog-item-icon__img--large"
+              src={imgSrc}
+              alt={displayName}
+              aria-hidden
+            />
+          </span>
         </div>
         <div className="co-clusterserviceversion-logo__name">
           <h1 className="co-clusterserviceversion-logo__name__clusterserviceversion">

--- a/frontend/packages/knative-plugin/src/components/add/KnEventMetaDescription.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/KnEventMetaDescription.tsx
@@ -19,12 +19,14 @@ const KnEventMetaDescription: React.FC<KnEventMetaDescriptionProps> = ({ normali
     <div className="kn-event-metadata-description__container">
       <div className="co-clusterserviceversion-logo">
         <div className="co-clusterserviceversion-logo__icon">
-          <img
-            className="co-catalog-item-icon__img co-catalog-item-icon__img--large"
-            src={iconUrl}
-            alt={name}
-            aria-hidden
-          />
+          <span className="co-catalog-item-icon__bg">
+            <img
+              className="co-catalog-item-icon__img co-catalog-item-icon__img--large"
+              src={iconUrl}
+              alt={name}
+              aria-hidden
+            />
+          </span>
         </div>
         <div className="co-clusterserviceversion-logo__name">
           <h1 className="co-clusterserviceversion-logo__name__clusterserviceversion">{name}</h1>

--- a/frontend/packages/operator-lifecycle-manager/src/components/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/index.tsx
@@ -115,12 +115,14 @@ export const ClusterServiceVersionLogo: React.FC<ClusterServiceVersionLogoProps>
   return (
     <div className="co-clusterserviceversion-logo">
       <div className="co-clusterserviceversion-logo__icon">
-        <img
-          className="co-catalog-item-icon__img co-catalog-item-icon__img--large"
-          src={imgSrc}
-          alt={displayName}
-          aria-hidden
-        />
+        <span className="co-catalog-item-icon__bg">
+          <img
+            className="co-catalog-item-icon__img co-catalog-item-icon__img--large"
+            src={imgSrc}
+            alt={displayName}
+            aria-hidden
+          />
+        </span>
       </div>
       <div className="co-clusterserviceversion-logo__name">
         <h1 className="co-clusterserviceversion-logo__name__clusterserviceversion">

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -362,14 +362,7 @@ const OperatorHubTile: React.FC<OperatorHubTileProps> = ({ item, onClick }) => {
   const badges = item?.catalogSourceDisplayName
     ? [<Badge text={item.catalogSourceDisplayName} />]
     : [];
-  const icon = (
-    <img
-      className="catalog-tile-pf-icon catalog-tile-pf-icon--align-top"
-      loading="lazy"
-      src={imgUrl}
-      alt=""
-    />
-  );
+  const icon = <img className="co-catalog--logo" loading="lazy" src={imgUrl} alt="" />;
 
   return (
     <CatalogTile

--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -1,5 +1,6 @@
 // OpenShift variables
 @import '../../../public/style/vars';
+@import '../../../public/style/mixin/catalog-logo-background';
 
 $co-affinity-row-margin: 15px;
 
@@ -27,16 +28,6 @@ $co-affinity-row-margin: 15px;
 }
 
 .co-clusterserviceversion-link {
-  .co-clusterserviceversion-logo {
-    flex-direction: column;
-    @media (min-width: $screen-xs-min) and (max-width: $screen-xs-max),
-      (min-width: $screen-md-min) {
-      flex-direction: row;
-    }
-  }
-}
-
-.co-clusterserviceversion-link {
   &:focus,
   &:hover {
     text-decoration: none;
@@ -48,18 +39,17 @@ $co-affinity-row-margin: 15px;
 }
 
 .co-clusterserviceversion-logo {
+  align-items: flex-start;
   display: flex;
 }
 
 .co-clusterserviceversion-logo__icon {
+  @include catalog-logo-background();
   align-items: center;
-  background: var(--pf-global--BackgroundColor--100);
   display: flex;
   flex: 0 0 auto;
-  height: 40px;
   justify-content: center;
   margin: 0 15px 5px 0;
-  width: 40px;
 }
 
 .co-clusterserviceversion-logo__name {

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -45,6 +45,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
 }
 
 .co-catalog-item-details {
+  align-items: flex-start;
   display: flex;
   margin: 0 0 10px;
 
@@ -74,7 +75,14 @@ $catalog-tile-width: $co-m-catalog-tile-width;
 }
 
 .co-catalog-item-icon {
-  padding-right: 10px;
+  @include catalog-logo-background();
+  margin-right: 15px;
+
+  &__bg {
+    align-items: center;
+    display: flex;
+    min-height: 40px;
+  }
 
   &__icon {
     font-size: $catalog-item-icon-size-sm;
@@ -87,6 +95,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
   &__img {
     max-height: $catalog-item-icon-size-sm;
     max-width: $catalog-item-icon-size-sm;
+    width: 100%; // prevent image size collapse to 0
 
     &[src$='.svg'] {
       width: $catalog-item-icon-size-sm;

--- a/frontend/public/components/catalog/catalog-item-icon.tsx
+++ b/frontend/public/components/catalog/catalog-item-icon.tsx
@@ -238,26 +238,28 @@ export const ImageStreamIcon: React.FC<ImageStreamIconProps> = ({ tag, iconSize 
   const iconClass = getImageStreamIcon(tag);
   const iconClassImg = getImageForIconClass(iconClass);
   return (
-    <span className="co-catalog-item-icon" aria-hidden>
-      {iconClassImg ? (
-        <img
-          className={classNames(
-            'co-catalog-item-icon__img',
-            iconSize && `co-catalog-item-icon__img--${iconSize}`,
-          )}
-          src={iconClassImg}
-          alt={t('public~Icon')}
-        />
-      ) : (
-        <span
-          className={classNames(
-            'co-catalog-item-icon__icon',
-            iconSize && `co-catalog-item-icon__icon--${iconSize}`,
-            normalizeIconClass(iconClass),
-          )}
-        />
-      )}
-    </span>
+    <div className="co-catalog-item-icon">
+      <span className="co-catalog-item-icon__bg" aria-hidden>
+        {iconClassImg ? (
+          <img
+            className={classNames(
+              'co-catalog-item-icon__img',
+              iconSize && `co-catalog-item-icon__img--${iconSize}`,
+            )}
+            src={iconClassImg}
+            alt={t('public~Icon')}
+          />
+        ) : (
+          <span
+            className={classNames(
+              'co-catalog-item-icon__icon',
+              iconSize && `co-catalog-item-icon__icon--${iconSize}`,
+              normalizeIconClass(iconClass),
+            )}
+          />
+        )}
+      </span>
+    </div>
   );
 };
 

--- a/frontend/public/components/instantiate-template.tsx
+++ b/frontend/public/components/instantiate-template.tsx
@@ -71,24 +71,26 @@ const TemplateInfo: React.FC<TemplateInfoProps> = ({ template }) => {
   return (
     <div className="co-catalog-item-info">
       <div className="co-catalog-item-details">
-        <span className="co-catalog-item-icon">
-          {imgURL ? (
-            <img
-              className="co-catalog-item-icon__img co-catalog-item-icon__img--large"
-              src={imgURL}
-              alt={displayName}
-              aria-hidden
-            />
-          ) : (
-            <span
-              className={classNames(
-                'co-catalog-item-icon__icon co-catalog-item-icon__icon--large',
-                normalizeIconClass(iconClass),
-              )}
-              aria-hidden
-            />
-          )}
-        </span>
+        <div className="co-catalog-item-icon">
+          <span className="co-catalog-item-icon__bg">
+            {imgURL ? (
+              <img
+                className="co-catalog-item-icon__img co-catalog-item-icon__img--large"
+                src={imgURL}
+                alt={displayName}
+                aria-hidden
+              />
+            ) : (
+              <span
+                className={classNames(
+                  'co-catalog-item-icon__icon co-catalog-item-icon__icon--large',
+                  normalizeIconClass(iconClass),
+                )}
+                aria-hidden
+              />
+            )}
+          </span>
+        </div>
         <div>
           <h2 className="co-section-heading co-catalog-item-details__name">{displayName}</h2>
           {!_.isEmpty(tags) && (

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -15,6 +15,7 @@
 @import 'style/mixin/prefix';
 @import 'style/mixin/truncate';
 @import 'style/mixin/line-clamp';
+@import 'style/mixin/catalog-logo-background';
 
 // Ancillary Styles to support removing Bootstrap
 @import 'style/ancillary/bootstrap';

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -4,14 +4,46 @@ form.pf-c-form {
   --pf-c-form__helper-text--Color: var(--pf-global--Color--200);
 }
 
-// Positions the img in OperatorHub that are nested with <span class="catalog-tile-pf-icon"><img ...>
-.catalog-tile-pf-icon--align-top {
-  vertical-align: top;
-}
-
 // Until Patternfly-React-Extensions is updated: https://github.com/patternfly/patternfly-react/issues/1146
 .catalog-tile-pf-title {
   @include co-break-word;
+}
+
+.co-catalog-tile {
+  .catalog-tile-pf-icon {
+    font-size: unset !important;
+  }
+  .co-catalog--logo {
+    height: 100%;
+    max-width: 80px;
+    min-width: auto;
+    object-fit: contain;
+    width: 100%;
+  }
+  .catalog-tile-pf-icon {
+    @include catalog-logo-background(var(--pf-global--spacer--sm));
+    height: 50px;
+    margin-bottom: calc(-1 * var(--pf-global--spacer--sm)); // Cancels bottom padding
+    margin-left: calc(-1 * var(--pf-global--spacer--sm)); // Align logo with left edge
+    margin-top: calc(-1 * var(--pf-global--spacer--sm)); // Align logo with top edge
+    max-width: 100%;
+    min-width: 50px; // prevent collapsed state before img loads
+    :where(.pf-theme-dark) & {
+      margin-left: 0;
+      margin-top: 0;
+    }
+  }
+}
+
+.catalog-item-header-pf-icon  {
+  @include catalog-logo-background(var(--pf-global--spacer--sm));
+}
+
+.co-catalog-page__overlay-header {
+  .catalog-item-header-pf-icon {
+    max-width: 80px;
+    width: auto;
+  }
 }
 
 // Override to remove accordion left border and prevent overlap https://bugzilla.redhat.com/show_bug.cgi?id=1942193

--- a/frontend/public/style/mixin/_catalog-logo-background.scss
+++ b/frontend/public/style/mixin/_catalog-logo-background.scss
@@ -1,0 +1,5 @@
+@mixin catalog-logo-background($padding: var(--pf-global--spacer--xs)) {
+  padding: $padding;
+  border-radius: var(--pf-global--BorderRadius--sm);
+  background: var(--pf-global--palette--white);
+}


### PR DESCRIPTION
Addresses: https://issues.redhat.com/browse/CONSOLE-3155

Effected screens
```
/operatorhub/ns/default
/operatorhub/ns/default?details-item=...
/operatorhub/subscribe?pkg=...
/k8s/all-namespaces/operators.coreos.com~v1alpha1~ClusterServiceVersion
/catalog/ns/default
/catalog/source-to-image?imagestream=...
/catalog/instantiate-template?template=...
/topology/ns/EMPTY_PROJECT quick search (start building your application)
```

<img width="1792" alt="Screen Shot 2022-05-12 at 3 41 16 PM" src="https://user-images.githubusercontent.com/1874151/168162698-155e7f12-5979-4c01-b41c-87e0fe32f1d4.png">
<img width="1792" alt="Screen Shot 2022-05-12 at 3 40 35 PM" src="https://user-images.githubusercontent.com/1874151/168162701-4cc78752-c194-4171-bbfb-f99b0f639bce.png">
<img width="1792" alt="Screen Shot 2022-05-12 at 3 39 58 PM" src="https://user-images.githubusercontent.com/1874151/168162704-a1b637f3-78f0-4350-a9f6-8a772c6aaedd.png">
<img width="1792" alt="Screen Shot 2022-05-12 at 3 39 04 PM" src="https://user-images.githubusercontent.com/1874151/168162708-ed754b2c-31ac-4d99-b905-617b2bfa7e69.png">
<img width="1792" alt="Screen Shot 2022-05-12 at 3 38 33 PM" src="https://user-images.githubusercontent.com/1874151/168162712-7fca0e60-942d-414a-884b-593ee1f0627f.png">
<img width="1792" alt="Screen Shot 2022-05-12 at 3 37 37 PM" src="https://user-images.githubusercontent.com/1874151/168162715-5cfe886f-688d-4914-b80b-1dc8f192943d.png">
