### PR TITLE
Bug 2086417: Fix start pipeline default value for GIT REVISION field

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/__tests__/pipeline-template-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/__tests__/pipeline-template-utils.spec.ts
@@ -604,6 +604,34 @@ describe('getPipelineParams', () => {
     ).toEqual([{ name: 'GIT_REPO', default: 'https://github.com/owner/repo' }]);
   });
 
+  it('should contain empty string in GIT_REVISION param when gitRef is undefined or null', () => {
+    expect(
+      getPipelineParams(
+        [{ name: 'GIT_REVISION', default: '' }],
+        'name',
+        'namespace',
+        'gitUrl',
+        undefined, // git ref
+        'gitDir',
+        'dockerfilePath',
+        'tag',
+      ),
+    ).toEqual([{ name: 'GIT_REVISION', default: '' }]);
+
+    expect(
+      getPipelineParams(
+        [{ name: 'GIT_REVISION', default: '' }],
+        'name',
+        'namespace',
+        'gitUrl',
+        null, // git ref
+        'gitDir',
+        'dockerfilePath',
+        'tag',
+      ),
+    ).toEqual([{ name: 'GIT_REVISION', default: '' }]);
+  });
+
   it('should return empty object if params is invalid or not an array', () => {
     expect(
       getPipelineParams(

--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils.ts
@@ -51,7 +51,7 @@ export const getPipelineParams = (
       case 'GIT_REPO':
         return { ...param, default: gitUrl };
       case 'GIT_REVISION':
-        return { ...param, default: gitRef };
+        return { ...param, default: gitRef || '' };
       case 'PATH_CONTEXT':
         return { ...param, default: gitDir.replace(/^\//, '') || param.default };
       case 'IMAGE_NAME':


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://bugzilla.redhat.com/show_bug.cgi?id=2086417

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

In start pipeline modal, Git Revision field is marked as required field for pipeline created via add flow. `gitref` is set as undefined so default values is not set in the pipeline

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Set empty string as default value to make the GIT Revision field as a non required field in start pipeline modal.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
Before:

![image](https://user-images.githubusercontent.com/9964343/168537083-9903d291-59d6-4f82-8846-ac97950dbfc0.png)

After:
![image](https://user-images.githubusercontent.com/9964343/168537021-1cbf41e6-80ec-4a8a-ac35-db8c8e72527b.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

    ✓ should contain empty string in GIT_REVISION param when gitRef is undefined or null
    
**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge