### PR TITLE
In-context-add-options feature | Topology

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/createGitWorkload.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/createGitWorkload.ts
@@ -49,7 +49,7 @@ export const createGitWorkloadIfNotExistsOnTopologyPage = (
     if ($body.find(topologyPO.emptyStateIcon).length) {
       cy.log(`Topology doesn't have workload "${componentName}", lets create it`);
       navigateTo(devNavigationMenu.Add);
-      createGitWorkload(gitUrl, componentName, resourceType);
+      createGitWorkload(gitUrl, componentName, resourceType, appName);
       topologyPage.verifyWorkloadInTopologyPage(componentName);
     } else {
       topologyPage.search(componentName);

--- a/frontend/packages/topology/integration-tests/features/topology/topology-in-context-add-options.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-in-context-add-options.feature
@@ -11,22 +11,23 @@ Feature: Add in context from the Developer Catalog
               And user is at Topology page
 
 
-        @smoke @to-do
+        @smoke
         Scenario: Add to Project in Context options: T-10-TC01
-             When user right clicks on graph
-              And user clicks on Add to Project
-             Then user can see in context options Samples, Import from Git, Container Image, From Catalog, Database, Operator Backed, Helm Chart, Event Source, Channel
+             When user right clicks on empty graph view
+              And user hovers on Add to Project
+             Then user can see in context options "Samples", "Import from Git", "Container Image", "From Catalog", "Database", "Operator Backed", "Helm Charts", "Event Source", "Channel"
 
 
-        @regression @to-do
+        @regression
         Scenario: Add to Application in Context: T-10-TC02
              When user right clicks on Application Grouping "aut-knative-demos"
-              And user clicks on Add to application
-             Then user can see in context options Import from Git, Container Image, Event Source, Channel
+              And user hovers on Add to application
+             Then user can see in context options "Import from Git", "Container Image", "Event Source", "Channel"
 
 
-        @regression @to-do
+        @regression
         Scenario: Delete application from the Context options: T-10-TC03
              When user right clicks on Application Grouping "aut-knative-demos"
               And user clicks on Delete application
+              And user enters the name "aut-knative-demos" in the Delete application modal and clicks on Delete button
              Then user won't be able to see the "aut-knative-demos" Application Groupings

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-add-options-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-add-options-po.ts
@@ -1,0 +1,3 @@
+export const topologyAddOptionsPO = (optionName: string) => {
+  return `[data-test-action="${optionName}"]`;
+};

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -1,3 +1,4 @@
+import { guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
 import {
   displayOptions,
   nodeActions,
@@ -239,6 +240,9 @@ export const topologyPage = {
       .click({ force: true });
   },
   verifyApplicationGroupingsDeleted: (appName: string) => {
+    cy.reload();
+    app.waitForLoad();
+    guidedTour.close();
     const id = `[data-id="group:${appName}"]`;
     cy.get(id, { timeout: 50000 }).should('not.exist');
   },

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/topology-add-options.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/topology-add-options.ts
@@ -1,0 +1,102 @@
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { operators } from '@console/dev-console/integration-tests/support/constants';
+import {
+  createGitWorkloadIfNotExistsOnTopologyPage,
+  projectNameSpace,
+  topologyHelper,
+  topologyPage,
+  verifyAndInstallOperator,
+} from '@console/dev-console/integration-tests/support/pages';
+import { topologyAddOptionsPO } from '../../page-objects/topology-add-options-po';
+
+Given('user has installed OpenShift Serverless Operator', () => {
+  verifyAndInstallOperator(operators.ServerlessOperator);
+});
+
+Given('user has created or selected namespace {string}', (projectName: string) => {
+  Cypress.env('NAMESPACE', projectName);
+  projectNameSpace.selectOrCreateProject(`${projectName}`);
+});
+
+Given(
+  'user has created {string} workload in {string} application',
+  (nodeName: string, appName: string) => {
+    createGitWorkloadIfNotExistsOnTopologyPage(
+      'https://github.com/sclorg/nodejs-ex.git',
+      nodeName,
+      'Deployment',
+      appName,
+    );
+    topologyHelper.verifyWorkloadInTopologyPage(nodeName);
+  },
+);
+
+When('user right clicks on empty graph view', () => {
+  cy.byLegacyTestID('topology').rightclick(10, 10);
+});
+
+When('user hovers on Add to Project', () => {
+  cy.get('.odc-topology-context-menu').trigger('mouseover');
+});
+
+Then(
+  'user can see in context options {string}, {string}, {string}, {string}, {string}, {string}, {string}, {string}, {string}',
+  (
+    s1: string,
+    s2: string,
+    s3: string,
+    s4: string,
+    s5: string,
+    s6: string,
+    s7: string,
+    s8: string,
+    s9: string,
+  ) => {
+    cy.get(topologyAddOptionsPO(s1)).should('be.visible');
+    cy.get(topologyAddOptionsPO(s2)).should('be.visible');
+    cy.get(topologyAddOptionsPO(s3)).should('be.visible');
+    cy.get(topologyAddOptionsPO(s4)).should('be.visible');
+    cy.get(topologyAddOptionsPO(s5)).should('be.visible');
+    cy.get(topologyAddOptionsPO(s6)).should('be.visible');
+    cy.get(topologyAddOptionsPO(s7)).should('be.visible');
+    cy.get(topologyAddOptionsPO(s8)).should('be.visible');
+    cy.get(topologyAddOptionsPO(s9)).should('be.visible');
+  },
+);
+
+When('user right clicks on Application Grouping {string}', (appName: string) => {
+  topologyPage.rightClickOnApplicationGroupings(appName);
+});
+
+When('user hovers on Add to application', () => {
+  cy.get('.odc-topology-context-menu')
+    .contains('Add to application')
+    .trigger('mouseover');
+});
+
+Then(
+  'user can see in context options {string}, {string}, {string}, {string}',
+  (s1: string, s2: string, s3: string, s4: string) => {
+    cy.get(topologyAddOptionsPO(s1)).should('be.visible');
+    cy.get(topologyAddOptionsPO(s2)).should('be.visible');
+    cy.get(topologyAddOptionsPO(s3)).should('be.visible');
+    cy.get(topologyAddOptionsPO(s4)).should('be.visible');
+  },
+);
+
+When('user clicks on Delete application', () => {
+  cy.get('.odc-topology-context-menu')
+    .contains('Delete application')
+    .click();
+});
+
+When(
+  'user enters the name {string} in the Delete application modal and clicks on Delete button',
+  (appName: string) => {
+    topologyPage.deleteApplication(appName);
+  },
+);
+
+Then("user won't be able to see the {string} Application Groupings", (appName: string) => {
+  topologyPage.verifyApplicationGroupingsDeleted(appName);
+});


### PR DESCRIPTION
**Description:**
<!-- PR description-->
- Topology-In-context-add-options feature | Topology-automation

**Jira Id:**
     - [ODC-6672](https://issues.redhat.com/browse/ODC-6672)

<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.11-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p topology
```
**Screen shots**:
<!--   -->
topology-context-add-options.feature
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/65410551/168549594-c896b16a-c898-433f-92c0-8b89f557eaef.png">

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge