### PR TITLE
Bug 2088304: Eliminate use of lookaside cache and move to Cachito

### DIFF
--- a/Dockerfile.product
+++ b/Dockerfile.product
@@ -16,11 +16,15 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-nodejs-openshift-4.10 AS 
 ADD . .
 
 USER 0
-# extract the yarn dependencies that must be provided in the dist-git lookaside cache
-RUN tar fx yarn-offline.tar
 
 # bootstrap yarn so we can install and run the other tools.
-RUN container-entrypoint npm install ./yarn-1.9.4.tgz
+RUN container-entrypoint npm install ./artifacts/yarn-v1.22.19.tar.gz
+
+COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
+
+# use dependencies provided by Cachito
+RUN cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem . \
+  && cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/frontend/{.npmrc,.yarnrc,yarn.lock} frontend/
 
 # prevent download of chromedriver, geckodriver, and the cypress binary as part of module installs
 ENV CHROMEDRIVER_SKIP_DOWNLOAD=true \

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "openshift-console",
+  "version": "0.0.0",
   "description": "OpenShift Web Console",
   "repository": "https://github.com/openshift/console",
   "license": "Apache-2.0",

--- a/frontend/packages/console-plugin-sdk/src/codegen/plugin-resolver.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/plugin-resolver.ts
@@ -68,8 +68,8 @@ export const getMonorepoRootDir = () => {
   return findUp.sync(
     (currentDir) => {
       return fs.existsSync(path.join(currentDir, 'package.json'))
-        ? readPkg.sync({ cwd: currentDir, normalize: true }).name === 'openshift-console' && 
-        currentDir
+        ? readPkg.sync({ cwd: currentDir, normalize: true }).name === 'openshift-console' &&
+            currentDir
         : undefined;
     },
     { cwd: __dirname, type: 'directory' },

--- a/frontend/packages/console-plugin-sdk/src/codegen/plugin-resolver.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/plugin-resolver.ts
@@ -68,7 +68,7 @@ export const getMonorepoRootDir = () => {
   return findUp.sync(
     (currentDir) => {
       return fs.existsSync(path.join(currentDir, 'package.json'))
-        ? readPkg.sync({ cwd: currentDir, normalize: true }).name === '' && currentDir
+        ? readPkg.sync({ cwd: currentDir, normalize: true }).name === 'openshift-console' && currentDir
         : undefined;
     },
     { cwd: __dirname, type: 'directory' },

--- a/frontend/packages/console-plugin-sdk/src/codegen/plugin-resolver.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/plugin-resolver.ts
@@ -68,7 +68,8 @@ export const getMonorepoRootDir = () => {
   return findUp.sync(
     (currentDir) => {
       return fs.existsSync(path.join(currentDir, 'package.json'))
-        ? readPkg.sync({ cwd: currentDir, normalize: true }).name === 'openshift-console' && currentDir
+        ? readPkg.sync({ cwd: currentDir, normalize: true }).name === 'openshift-console' && 
+        currentDir
         : undefined;
     },
     { cwd: __dirname, type: 'directory' },


### PR DESCRIPTION
[Legacy Container First Pipeline][1] will be deprecated on Jun 3, 2022. Images failing to migrate to the new source container workflow by this date will not have their sources shipped to customers and lose the compliance with legal requirements.

To move to the new source container workflow, we need to:
- Eliminate use of distgit lookaside cache, which is not supported by the new workflow.
- Use [Cachito][2] to track and provide npm dependencies.
- Use [fetch-artifacts-url.yaml][3] to fetch binaries artifacts during the build.

Due to a limitation in Cachito, we also need to give a pseudo name and version to the frontend package. AFAIK the version doesn't need to be unique for every build.
I am not familiar with the code base. Let me know if the change is legitimate.

[1]: https://docs.engineering.redhat.com/display/SP/Decommission+of+Legacy+Container+First+Pipeline
[2]: https://github.com/containerbuildsystem/cachito
[3]: https://osbs.readthedocs.io/en/osbs_ocp3/users.html#fetch-artifacts-url-yaml