### PR TITLE
Bug 2054735: Change learn more link in virtualization -> migration tool

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/migration-tool/MigrationToolContent.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/migration-tool/MigrationToolContent.tsx
@@ -69,7 +69,7 @@ const MigrationTool: React.FC<MigrationToolProps> = ({
           >
             <ExternalLink
               text={t('kubevirt-plugin~Learn more')}
-              href="https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/2.0/"
+              href="https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/"
             />
           </Alert>
         )}


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

Change learn more migration tool link according to https://bugzilla.redhat.com/show_bug.cgi?id=2054735

