### PR TITLE
Bug 2055492: The default YAML on vm wizard is not latest

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/models/templates/vm-template-yaml.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/templates/vm-template-yaml.ts
@@ -10,10 +10,10 @@ metadata:
   name: vm-template-example
   labels:
     template.kubevirt.io/type: vm
-    os.template.kubevirt.io/fedora31: 'true'
+    os.template.kubevirt.io/fedora35: 'true'
     workload.template.kubevirt.io/server: 'true'
   annotations:
-    name.os.template.kubevirt.io/fedora31: Fedora 31
+    name.os.template.kubevirt.io/fedora35: Fedora 35
     description: VM template example
 objects:
   - apiVersion: kubevirt.io/v1
@@ -46,6 +46,7 @@ objects:
               interfaces:
                 - masquerade: {}
                   name: default
+                  model: virtio
               networkInterfaceMultiqueue: true
               rng: {}
             resources:
@@ -58,7 +59,7 @@ objects:
           volumes:
             - name: containerdisk
               containerDisk:
-                image: 'quay.io/kubevirt/fedora-cloud-container-disk-demo:latest'
+                image: 'quay.io/containerdisks/fedora:35'
             - cloudInitNoCloud:
                 userData: |-
                   #cloud-config

--- a/frontend/packages/kubevirt-plugin/src/models/templates/vm-yaml.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/templates/vm-yaml.ts
@@ -10,10 +10,10 @@ metadata:
   name: vm-example
   labels:
     app: vm-example
-    os.template.kubevirt.io/fedora31: 'true'
+    os.template.kubevirt.io/fedora35: 'true'
     workload.template.kubevirt.io/server: 'true'
   annotations:
-    name.os.template.kubevirt.io/fedora31: Fedora 31
+    name.os.template.kubevirt.io/fedora35: Fedora 35
     description: VM example
 spec:
   running: false
@@ -22,7 +22,7 @@ spec:
       labels:
         kubevirt.io/domain: vm-example
         vm.kubevirt.io/name: vm-example
-        os.template.kubevirt.io/fedora31: 'true'
+        os.template.kubevirt.io/fedora35: 'true'
         workload.template.kubevirt.io/server: 'true'
     spec:
       domain:
@@ -42,6 +42,7 @@ spec:
           interfaces:
             - masquerade: {}
               name: default
+              model: virtio
           networkInterfaceMultiqueue: true
           rng: {}
         resources:
@@ -54,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
         - containerDisk:
-            image: 'quay.io/kubevirt/fedora-cloud-container-disk-demo:latest'
+            image: 'quay.io/containerdisks/fedora:35'
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-


### PR DESCRIPTION
updating the YAML file example to create a VM and create Template
- updating to use Fedora 35 instead of Fedora 31
- Adding model property to network interface
- changing to get image from `quay.io/containerdisks/fedora:35`

before:

https://user-images.githubusercontent.com/67270715/168632427-03b84eb0-cf44-4d8f-adc6-e747a6ff27ac.mp4

after:

https://user-images.githubusercontent.com/67270715/168635763-c9c33b17-4587-420c-a8fe-5c5649426cf7.mp4

@yaacov please review

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>