### PR TITLE
Bug 2067246: Removing SSH service selectors to minimum required

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHForm/ssh-form-utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHForm/ssh-form-utils.ts
@@ -59,12 +59,6 @@ export const createOrDeleteSSHService = async (
         ],
         type: 'NodePort',
         selector: {
-          ...Object.fromEntries(
-            Object.entries(metadata?.labels).filter(
-              ([objectKey]) => !objectKey.startsWith('vm') && !objectKey.startsWith('app'),
-            ),
-          ),
-          'kubevirt.io/domain': metadata?.name,
           'vm.kubevirt.io/name': metadata?.name,
         },
       },


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

SSH service was getting selectors from VM labels, once VM flavor changed to custom some labels were removed on VM but not on ssh service and caused a client cant to connect using ssh.

Removed all selectors except one, which is the minimum required.


