### PR TITLE
Bug 2086542: Fix that Service Binding could not be created via drag and drop

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/components/componentUtils.ts
+++ b/frontend/packages/topology/src/components/graph-view/components/componentUtils.ts
@@ -195,7 +195,7 @@ const nodeDropTargetSpec: DropTargetSpec<
     if (isEdge(item)) {
       return canDropEdgeOnNode(monitor.getOperation()?.type, item as Edge, props.element);
     }
-    if (item === props.element) {
+    if (!props.element || item === props.element) {
       return false;
     }
     return !props.element.getTargetEdges().find((e) => e.getSource() === item);

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/BindableNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/BindableNode.tsx
@@ -27,12 +27,12 @@ const BindableNode: React.FC<BindableNodeProps> = ({
   selected,
   onSelect,
   tooltipLabel,
-  ...props
+  ...rest
 }) => {
   const spec = React.useMemo(() => getRelationshipProvider(), []);
   const { width, height } = element.getBounds();
   const iconRadius = Math.min(width, height) * 0.25;
-  const [dndDropProps, dndDropRef] = useDndDrop(spec, { element, ...props });
+  const [dndDropProps, dndDropRef] = useDndDrop(spec, { element, ...rest });
   const resourceObj = getTopologyResourceObject(element.getData());
   const resourceModel = modelFor(referenceFor(resourceObj));
   const iconData = element.getData()?.data?.icon || openshiftImg;
@@ -48,7 +48,7 @@ const BindableNode: React.FC<BindableNodeProps> = ({
       innerRadius={iconRadius}
       selected={selected}
       element={element}
-      {...props}
+      {...rest}
       dndDropRef={dndDropRef}
       {...dndDropProps}
     />

--- a/frontend/packages/topology/src/operators/components/OperatorBackedService.tsx
+++ b/frontend/packages/topology/src/operators/components/OperatorBackedService.tsx
@@ -47,7 +47,7 @@ export const obsDropTargetSpec = (
     if (isEdge(item)) {
       return canDropEdgeOnNode(monitor.getOperation()?.type, item, props.element);
     }
-    if (item === props.element) {
+    if (!props.element || item === props.element) {
       return false;
     }
     return !props.element.getTargetEdges().find((e) => e.getSource() === item);
@@ -80,7 +80,7 @@ const OperatorBackedService: React.FC<OperatorBackedServiceProps> = ({
   ...rest
 }) => {
   const spec = React.useMemo(() => obsDropTargetSpec(serviceBinding), [serviceBinding]);
-  const [dndDropProps, dndDropRef] = useDndDrop(spec, rest as any);
+  const [dndDropProps, dndDropRef] = useDndDrop(spec, { element, ...rest });
   const resourceObj = getResource(element);
   const resourceModel = resourceObj ? modelFor(referenceFor(resourceObj)) : null;
   const editAccess = useAccessReview({

--- a/frontend/packages/topology/src/utils/relationship-provider-utils.ts
+++ b/frontend/packages/topology/src/utils/relationship-provider-utils.ts
@@ -57,7 +57,7 @@ export const getRelationshipProvider = (): DropTargetSpec<
       if (isEdge(item)) {
         return canDropEdgeOnNode(monitor.getOperation()?.type, item, props.element);
       }
-      if (item === props.element) {
+      if (!props.element || item === props.element) {
         return false;
       }
       const relationshipExtension = getRelExtension(monitor, props);


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2086542

**Analysis / Root cause**: 
NPE when drag and drop a Deployment or Pod over a service bindable. The `element` not passed to `useDndDrop` in `OperatorBackedService.tsx`.

**Solution Description**: 
Pass `element` to `useDndDrop` and add null checks for element if its missing for any other reason.

**Screen shots / Gifs for design review**: 
Before:
https://user-images.githubusercontent.com/139310/168912480-e7c331bb-1262-4558-adc1-57fe2f3540a4.mp4

After:
https://user-images.githubusercontent.com/139310/168912532-1a2253af-f940-4a24-821d-6cdb07255eb5.mp4

**Unit test coverage report**: 
Unchanged

**Test setup:**
Drag the handle from deployment workload and drop it on the bindable service.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
