### PR TITLE
Bug 2089996: Don't rerun yarn install when running tests

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd frontend
-yarn install
+
+if [ ! -d node_modules ]; then
+  yarn install
+fi
 
 function generateReport {
   yarn run cypress-postreport

--- a/test-protractor.sh
+++ b/test-protractor.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
-
 set -exuo pipefail
-
 cd frontend
 
-yarn install
+if [ ! -d node_modules ]; then
+  yarn install
+fi
+
 if [ "${BRIDGE_E2E_BROWSER_NAME-}" == 'firefox' ]; then
- yarn run webdriver-update
+  yarn run webdriver-update
 else
- if [ -n "${CHROME_VERSION-}" ]; then
-  yarn run webdriver-update --versions.chrome="$CHROME_VERSION" --gecko=false
- else
-  yarn run webdriver-update --gecko=false
- fi
+  if [ -n "${CHROME_VERSION-}" ]; then
+    yarn run webdriver-update --versions.chrome="$CHROME_VERSION" --gecko=false
+  else
+    yarn run webdriver-update --gecko=false
+  fi
 fi
 
 if [ $# -gt 0 ] && [ -n "$1" ]; then


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2089996

**Analysis / Root cause**: 
Saw that our tests run `yarn install` multiple times and this takes 5-10 minutes per yarn install (incl. yarn generate)

**Solution Description**: 
Don't rerun `yarn install` if `node_modules` folder exist already

Compare build times of this job with others successfully jobs:

1. https://prow.ci.openshift.org/pr-history/?org=openshift&repo=console&pr=11517
2. https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-console-master-e2e-gcp-console