### PR TITLE
Bug 2069654: Adding missing annotations to create VM from YAML

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/models/templates/vm-yaml.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/templates/vm-yaml.ts
@@ -11,6 +11,8 @@ metadata:
   labels:
     app: vm-example
     os.template.kubevirt.io/fedora35: 'true'
+    flavor.template.kubevirt.io/small: 'true'
+    vm.kubevirt.io/template: fedora-server-small
     workload.template.kubevirt.io/server: 'true'
   annotations:
     name.os.template.kubevirt.io/fedora35: Fedora 35
@@ -19,8 +21,14 @@ spec:
   running: false
   template:
     metadata:
+      annotations:
+        vm.kubevirt.io/flavor: small
+        vm.kubevirt.io/os: fedora
+        vm.kubevirt.io/workload: server
       labels:
+        flavor.template.kubevirt.io/small: 'true'
         kubevirt.io/domain: vm-example
+        kubevirt.io/size: small
         vm.kubevirt.io/name: vm-example
         os.template.kubevirt.io/fedora35: 'true'
         workload.template.kubevirt.io/server: 'true'


### PR DESCRIPTION
Adding missing annotation for `flavor` `os` and `workload`

demo:

https://user-images.githubusercontent.com/67270715/169011981-c86f99f8-5878-4d0f-8499-ee4ee160517b.mp4

YAML file example:
```
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  name: vm-example
  labels:
    app: vm-example
    os.template.kubevirt.io/fedora35: 'true'
    flavor.template.kubevirt.io/small: 'true'
    vm.kubevirt.io/template: fedora-server-small
    workload.template.kubevirt.io/server: 'true'
  annotations:
    name.os.template.kubevirt.io/fedora35: Fedora 35
    description: VM example
  namespace: default
spec:
  running: false
  template:
    metadata:
      annotations:
        vm.kubevirt.io/flavor: small
        vm.kubevirt.io/os: fedora
        vm.kubevirt.io/workload: server
      labels:
        flavor.template.kubevirt.io/small: 'true'
        kubevirt.io/domain: vm-example
        kubevirt.io/size: small
        vm.kubevirt.io/name: vm-example
        os.template.kubevirt.io/fedora35: 'true'
        workload.template.kubevirt.io/server: 'true'
    spec:
      domain:
        cpu:
          cores: 1
          sockets: 1
          threads: 1
        devices:
          disks:
            - bootOrder: 1
              disk:
                bus: virtio
              name: containerdisk
            - disk:
                bus: virtio
              name: cloudinitdisk
          interfaces:
            - masquerade: {}
              name: default
              model: virtio
          networkInterfaceMultiqueue: true
          rng: {}
        resources:
          requests:
            memory: 1G
      hostname: vm-example
      networks:
        - name: default
          pod: {}
      terminationGracePeriodSeconds: 0
      volumes:
        - containerDisk:
            image: 'quay.io/containerdisks/fedora:35'
          name: containerdisk
        - cloudInitNoCloud:
            userData: |-
              #cloud-config
              password: fedora
              chpasswd: { expire: False }
          name: cloudinitdisk
```

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>