### PR TITLE
Bug 2066782: Attached disk keeps in loading status when add disk to a power off VM by non-privileged user

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
@@ -127,7 +127,7 @@ export const DiskSimpleRow: React.FC<VMDiskSimpleRowProps> = ({
   const dimensify = dimensifyRow(columnClasses);
 
   const isSizeLoading = size === undefined;
-  const isStorageClassLoading = size === undefined;
+  const isStorageClassLoading = storageClass === undefined;
   const pvcName = disk?.persistentVolumeClaimWrapper?.getName();
   const pvcNamespace = disk?.persistentVolumeClaimWrapper?.getNamespace();
   const pvcLink = pvcName && pvcNamespace && (

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/combined-disk.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/combined-disk.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import { FirehoseResult } from '@console/internal/components/utils';
-import { K8sResourceKind } from '@console/internal/module/k8s/types';
+import { K8sResourceKind, PersistentVolumeClaimKind } from '@console/internal/module/k8s/types';
 import { StorageUISource } from '../../../components/modals/disk-modal/storage-ui-source';
 import { AccessMode, DiskType, VolumeMode, VolumeType } from '../../../constants/vm/storage';
 import { DataVolumeModel } from '../../../models';
@@ -262,7 +262,7 @@ export class CombinedDiskFactory {
   static initializeFromVMLikeEntity = (
     vmLikeEntity: VMGenericLikeEntityKind,
     datavolumes?: FirehoseResult<V1alpha1DataVolume[]>,
-    pvcs?: FirehoseResult,
+    pvcs?: PersistentVolumeClaimKind[],
   ) => {
     const vmiLikeWrapper = asVMILikeWrapper(vmLikeEntity);
 
@@ -271,9 +271,9 @@ export class CombinedDiskFactory {
       volumes: vmiLikeWrapper?.getVolumes() || [],
       dataVolumeTemplates: getDataVolumeTemplates(asVM(vmLikeEntity)),
       dataVolumes: getLoadedData(datavolumes, []),
-      pvcs: getLoadedData(pvcs),
+      pvcs: pvcs || [],
       dataVolumesLoading: !isLoaded(datavolumes),
-      pvcsLoading: !isLoaded(pvcs),
+      pvcsLoading: true,
       namespace: getNamespace(vmLikeEntity),
     });
   };


### PR DESCRIPTION
a non privileged user can not watch PVC resources where he is not project-admin,
since disk modal allows only PVCs from same namespace as VM, we can get the PVC data needed from only PVC on same namespace as the VM

before:
<img width="1370" alt="image (2)" src="https://user-images.githubusercontent.com/67270715/169091695-b01c71b7-2574-45f4-9cc8-241dae4273e9.png">


after:

https://user-images.githubusercontent.com/67270715/169091370-72a86e23-76eb-4a96-92c8-f58a8ae25e86.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>