### PR TITLE
[release-4.10] Bug 2087932 - Creating VMs with YAML on Openshift Virtualization UI is missing labels flavor, os and workload

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/models/templates/vm-yaml.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/templates/vm-yaml.ts
@@ -12,6 +12,8 @@ metadata:
     app: vm-example
     os.template.kubevirt.io/fedora31: 'true'
     workload.template.kubevirt.io/server: 'true'
+    flavor.template.kubevirt.io/small: 'true'
+    vm.kubevirt.io/template: fedora-server-small
   annotations:
     name.os.template.kubevirt.io/fedora31: Fedora 31
     description: VM example
@@ -19,8 +21,14 @@ spec:
   running: false
   template:
     metadata:
+      annotations:
+        vm.kubevirt.io/flavor: small
+        vm.kubevirt.io/os: fedora
+        vm.kubevirt.io/workload: server
       labels:
+        flavor.template.kubevirt.io/small: 'true'
         kubevirt.io/domain: vm-example
+        kubevirt.io/size: small
         vm.kubevirt.io/name: vm-example
         os.template.kubevirt.io/fedora31: 'true'
         workload.template.kubevirt.io/server: 'true'


### PR DESCRIPTION
this PR is a manual backport to https://github.com/openshift/console/pull/11518

before:

![update-yaml-annotations-4 10-before](https://user-images.githubusercontent.com/67270715/169098665-64ceca3d-1b87-43d3-a228-657b985b329c.png)

after:

![update-yaml-annotations-4 10-after](https://user-images.githubusercontent.com/67270715/169098681-9ce60dad-9fda-4b70-9ba5-e92a214209ac.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>