### PR TITLE
Topology-toolbar-filter feature

### DIFF
--- a/frontend/packages/topology/integration-tests/features/topology/topology-toolbar-filter.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-toolbar-filter.feature
@@ -8,9 +8,11 @@ Feature: Topology Toolbar Filter Group
               And user is at Add page
 
 
-        @regression @to-do
+        @regression
         Scenario: Topology filter by resource: T-13-TC01
-            Given user has created workload "nodejs-ex-git-dc" with resource type "Deployment Config"
+            Given user has created workload "nodejs-ex-git-d" with resource type "Deployment"
+              And user is at Add page
+              And user has created workload "nodejs-ex-git-dc" with resource type "Deployment Config"
              When user clicks on List view button
               And user clicks the filter by resource on top
              Then user will see Deployment and DeploymentConfig options with 1 associated with it

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -272,6 +272,16 @@ export const topologyPO = {
     nodejsDevfiles: '[data-test="item-name-Basic Node.js-Devfiles"]',
     nodejsSamples: '[data-test="item-name-Basic Node.js-Samples"]',
   },
+  toolbarFilterPO: {
+    deployment: '[data-test="Deployment"]',
+    deploymentConfig: '[data-test="DeploymentConfig"]',
+    deploymentSpan: '[data-test="Deployment"] span',
+    deploymentConfigSpan: '[data-test="DeploymentConfig"] span',
+    deploymentCheckbox: '[data-test="Deployment"] input',
+    deploymentConfigCheckbox: '[data-test="DeploymentConfig"] input',
+    deploymentApp: '#nodejs-ex-git-app-Deployment',
+    deploymentConfigApp: '#nodejs-ex-git-app-DeploymentConfig',
+  },
 };
 
 export const typeOfWorkload = (workload: string) => {

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/topology-filters.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/topology-filters.ts
@@ -38,3 +38,26 @@ When('user unchecks the Expand', () => {
 Then('user will see the Knative Services checkbox is disabled', () => {
   topologyPage.verifyExpandDisabled();
 });
+
+Then('user will see Deployment and DeploymentConfig options with 1 associated with it', () => {
+  cy.get(topologyPO.toolbarFilterPO.deployment).should('be.visible');
+  cy.get(topologyPO.toolbarFilterPO.deploymentConfig).should('be.visible');
+  cy.get(topologyPO.toolbarFilterPO.deploymentSpan).contains('Deployment (1)');
+  cy.get(topologyPO.toolbarFilterPO.deploymentConfigSpan).contains('DeploymentConfig (1)');
+});
+
+Then('user clicks on Deployment checkbox to see only the deployment type workload', () => {
+  cy.get(topologyPO.toolbarFilterPO.deploymentCheckbox).check();
+  cy.get(topologyPO.toolbarFilterPO.deploymentApp).should('be.visible');
+  cy.get(topologyPO.toolbarFilterPO.deploymentConfigApp).should('not.exist');
+});
+
+Then(
+  'user clicks on DeploymentConfig checkbox to see only the deploymentconfig type workload',
+  () => {
+    cy.get(topologyPO.toolbarFilterPO.deploymentCheckbox).uncheck();
+    cy.get(topologyPO.toolbarFilterPO.deploymentConfigCheckbox).check();
+    cy.get(topologyPO.toolbarFilterPO.deploymentConfigApp).should('be.visible');
+    cy.get(topologyPO.toolbarFilterPO.deploymentApp).should('not.exist');
+  },
+);


### PR DESCRIPTION
**Description:**
<!-- PR description-->
- Topology-toolbar-filter feature | Topology-automation

**Jira Id:**
     - [ODC-6675](https://issues.redhat.com/browse/ODC-6675)

<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.11-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p topology
```
**Screen shots**:
<!--   -->
Topology-toolbar-filter.feature
<img width="1727" alt="image" src="https://user-images.githubusercontent.com/65410551/169223135-fad2b5e2-f489-4da4-a30a-8d65d757c31a.png">


**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge