### PR TITLE
ODC-6670: Add --telemetry support to console backend (bridge)

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -124,6 +124,9 @@ func main() {
 	fs.Var(&consolePluginsFlags, "plugins", "List of plugin entries that are enabled for the console. Each entry consist of plugin-name as a key and plugin-endpoint as a value.")
 	fPluginProxy := fs.String("plugin-proxy", "", "Defines various service types to which will console proxy plugins requests. (JSON as string)")
 
+	telemetryFlags := serverconfig.MultiKeyValue{}
+	fs.Var(&telemetryFlags, "telemetry", "Telemetry configuration that can be used by console plugins. Each entry should be a key=value pair.")
+
 	fLoadTestFactor := fs.Int("load-test-factor", 0, "DEV ONLY. The factor used to multiply k8s API list responses for load testing purposes.")
 
 	fDevCatalogCategories := fs.String("developer-catalog-categories", "", "Allow catalog categories customization. (JSON as string)")
@@ -219,10 +222,9 @@ func main() {
 		klog.Infof("Setting user inactivity timout to %d seconds", *fInactivityTimeout)
 	}
 
-	consolePluginsMap := consolePluginsFlags.ToMap()
-	if len(consolePluginsMap) > 0 {
+	if len(consolePluginsFlags) > 0 {
 		klog.Infoln("The following console plugins are enabled:")
-		for pluginName := range consolePluginsMap {
+		for pluginName := range consolePluginsFlags {
 			klog.Infof(" - %s\n", pluginName)
 		}
 	}
@@ -245,13 +247,14 @@ func main() {
 		InactivityTimeout:         *fInactivityTimeout,
 		DevCatalogCategories:      *fDevCatalogCategories,
 		UserSettingsLocation:      *fUserSettingsLocation,
-		EnabledConsolePlugins:     consolePluginsMap,
+		EnabledConsolePlugins:     consolePluginsFlags,
 		PluginProxy:               *fPluginProxy,
 		QuickStarts:               *fQuickStarts,
 		AddPage:                   *fAddPage,
 		ProjectAccessClusterRoles: *fProjectAccessClusterRoles,
 		K8sProxyConfigs:           make(map[string]*proxy.Config),
 		K8sClients:                make(map[string]*http.Client),
+		Telemetry:                 telemetryFlags,
 	}
 
 	managedClusterConfigs := []serverconfig.ManagedClusterConfig{}

--- a/pkg/serverconfig/config_test.go
+++ b/pkg/serverconfig/config_test.go
@@ -1,12 +1,87 @@
 package serverconfig
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"math/rand"
 	"os"
+	"reflect"
 	"testing"
 )
+
+func TestMultiKeyValueSetter(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expected      MultiKeyValue
+		expectedError error
+	}{
+		{
+			name:          "Should ignore an empty string",
+			input:         "",
+			expected:      MultiKeyValue{},
+			expectedError: nil,
+		},
+		{
+			name:  "Should accept and split key=value pair",
+			input: "key=value",
+			expected: MultiKeyValue{
+				"key": "value",
+			},
+			expectedError: nil,
+		},
+		{
+			name:  "Should accept multiple comma-separated key=value pairs",
+			input: "key1=value1,key2=value2",
+			expected: MultiKeyValue{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expectedError: nil,
+		},
+		{
+			name:  "Should automatically trim spaces between key=value pairs",
+			input: "key1=value1, key2=value2, ",
+			expected: MultiKeyValue{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expectedError: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := MultiKeyValue{}
+			actualError := actual.Set(test.input)
+			if !reflect.DeepEqual(test.expected, actual) {
+				t.Errorf("Data does not match expectation:\n%v\nbut got\n%v", test.expected, actual)
+			}
+			if test.expectedError == nil && actualError != nil {
+				t.Errorf("Error does not match expectation:\n%v\nbut got\n%v", test.expectedError, actualError)
+			} else if test.expectedError != nil && (actualError == nil || test.expectedError.Error() != actualError.Error()) {
+				t.Errorf("Error does not match expectation:\n%v\nbut got\n%v", test.expectedError, actualError)
+			}
+		})
+	}
+}
+
+// Set is called multiple times when parsing the config file
+func TestCallingMultiKeyValueSetterMultipleTimes(t *testing.T) {
+	actual := MultiKeyValue{}
+	actual.Set("plugin-a=Service1")
+	actual.Set("plugin-b=Service2 ")
+	actual.Set("plugin-c=Service3, plugin-d=Service4, ")
+	expected := MultiKeyValue{
+		"plugin-a": "Service1",
+		"plugin-b": "Service2",
+		"plugin-c": "Service3",
+		"plugin-d": "Service4",
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Data does not match expectation:\n%v\nbut got\n%v", expected, actual)
+	}
+}
 
 func TestDefaultValue(t *testing.T) {
 	prefix := fmt.Sprintf("TEST_PREFIX_%d", rand.Int())
@@ -168,5 +243,82 @@ func TestCliArgumentsOverridesEnvVariablesAndParsedConfig(t *testing.T) {
 	// Value from config file
 	if *listen != "http://localhost:9000" {
 		t.Errorf("Unexpected value: actual %s, expected %s", *listen, "http://localhost:9000")
+	}
+}
+
+func TestSetFlagsFromConfig(t *testing.T) {
+	tests := []struct {
+		name               string
+		config             Config
+		expectedFlagValues map[string]string
+		expectedError      error
+	}{
+		{
+			name:               "Should fail for unsupported config files",
+			config:             Config{},
+			expectedFlagValues: map[string]string{},
+			expectedError:      errors.New("unsupported version (apiVersion: , kind: ), only console.openshift.io/v1 ConsoleConfig is supported"),
+		},
+		{
+			name: "Should consume an empty ConsoleConfig",
+			config: Config{
+				APIVersion: "console.openshift.io/v1",
+				Kind:       "ConsoleConfig",
+			},
+			expectedFlagValues: map[string]string{},
+			expectedError:      nil,
+		},
+		{
+			name: "Should apply plugins",
+			config: Config{
+				APIVersion: "console.openshift.io/v1",
+				Kind:       "ConsoleConfig",
+				Plugins: MultiKeyValue{
+					"plugin-a": "ServiceA",
+					"plugin-b": "ServiceB",
+				},
+			},
+			expectedFlagValues: map[string]string{
+				"plugins": "plugin-a=ServiceA, plugin-b=ServiceB",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Should apply telemetry configuration",
+			config: Config{
+				APIVersion: "console.openshift.io/v1",
+				Kind:       "ConsoleConfig",
+				Telemetry: MultiKeyValue{
+					"A_CONFIG_KEY":       "value1",
+					"ANOTHER_CONFIG_KEY": "value2",
+					"disabled":           "true",
+				},
+			},
+			expectedFlagValues: map[string]string{
+				"telemetry": "ANOTHER_CONFIG_KEY=value2, A_CONFIG_KEY=value1, disabled=true",
+			},
+			expectedError: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fs := &flag.FlagSet{}
+			fs.String("config", "", "")
+			fs.Var(&MultiKeyValue{}, "plugins", "")
+			fs.Var(&MultiKeyValue{}, "telemetry", "")
+
+			actualError := SetFlagsFromConfig(fs, test.config)
+			actual := make(map[string]string)
+			fs.Visit(func(f *flag.Flag) { actual[f.Name] = f.Value.String() })
+
+			if !reflect.DeepEqual(test.expectedFlagValues, actual) {
+				t.Errorf("FlagSet values does not match expectation:\n%v\nbut got\n%v", test.expectedFlagValues, actual)
+			}
+			if test.expectedError == nil && actualError != nil {
+				t.Errorf("Error does not match expectation:\n%v\nbut got\n%v", test.expectedError, actualError)
+			} else if test.expectedError != nil && (actualError == nil || test.expectedError.Error() != actualError.Error()) {
+				t.Errorf("Error does not match expectation:\n%v\nbut got\n%v", test.expectedError, actualError)
+			}
+		})
 	}
 }

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -19,9 +19,10 @@ type Config struct {
 	Providers                `yaml:"providers"`
 	Helm                     `yaml:"helm"`
 	MonitoringInfo           `yaml:"monitoringInfo,omitempty"`
-	Plugins                  map[string]string `yaml:"plugins,omitempty"`
-	ManagedClusterConfigFile string            `yaml:"managedClusterConfigFile,omitempty"`
-	Proxy                    Proxy             `yaml:"proxy,omitempty"`
+	Plugins                  MultiKeyValue `yaml:"plugins,omitempty"`
+	ManagedClusterConfigFile string        `yaml:"managedClusterConfigFile,omitempty"`
+	Proxy                    Proxy         `yaml:"proxy,omitempty"`
+	Telemetry                MultiKeyValue `yaml:"telemetry,omitempty"`
 }
 
 type Proxy struct {


### PR DESCRIPTION
**Implements**: 
https://issues.redhat.com/browse/ODC-6670

### Solution Description
:arrow_right: [Full Epic implementation documentation](https://docs.google.com/document/d/1PgQvB1TKwRH9Peezbr7Fu-raj-zU4iDFK9SJ6bZqxhs/edit)

To configure the new (separate PR) `telemetry-plugin` we need a generic mechanism to configure it. This PR adds a generic configuration option that provides a `string:string` map as `window.SERVER_FLAGS.telemetry`.

It adds all telemetry configuration from the `config.yaml` (used on a cluster) or from the cli arguments.

**Implementatio detail on MultiKeyValue and --plugins**
I reused and updated `serverconfig.MultiKeyValue` from ConsolePlugin support. Because `flag.Parse(args)` ignores multiple cli arguments with the same (flag) name, I changed the implementation so that it automatically splits parameters with a comma.

This doesn't work before:

```
./bin/bridge --plugins a=b --plugins c=d
```

This works now with this PR:

```
./bin/bridge --plugins a=b,c=d --telemetry seg=123,disabled=true
```

The `config.yaml` parse process with multiple plugins is **not affected** because it calls `flag.Set` already various times, which works like before (as long as no plugin name uses a comma).

See also:

https://github.com/golang/go/blob/128279e5034ca29bad4320eef81a8abd5b40ea7e/src/flag/flag.go#L1101-L1108

### Local test setup

`config.yaml` example:

```yaml
apiVersion: console.openshift.io/v1
kind: ConsoleConfig
telemetry:
  A_CONFIG_KEY: value1
  ANOTHER_CONFIG_KEY: value2
```

```bash
oc login ...
source ./contrib/oc-environment.sh 

./build-backend.sh
./bin/bridge --config ../config.yaml --telemetry seg=123,disabled=true

# or, I prefer:

~/go/bin/gow run github.com/openshift/console/cmd/bridge --config ../config.yaml --plugins a=b,c=d,a2=b2,c2=d2 --telemetry seg=123,disabled=true
```

To verify this values you can curl your local instance:

```bash
curl -s 'http://localhost:9000'  | grep SERVER_FLAGS | sed 's/.* = //;s/;$//' | jq
```

As you can see in this screenshot:

![image](https://user-images.githubusercontent.com/139310/169278030-0bff2248-dad7-4240-a096-d8defa4c15e3.png)

### Cluster bot verification

Test this together with https://github.com/openshift/console-operator/pull/653 on a cluster bot instance:

```
launch openshift/console-operator#653,openshift/console#11531
```

After that you can test this e2e with this oc patch and curl commands:

```
oc patch consoles.operator.openshift.io cluster --type=merge --patch='{"metadata":{"annotations":{"telemetry.console.openshift.io/A_CONFIG_KEY":"value1"}}}'

oc patch consoles.operator.openshift.io cluster --type=merge --patch='{"metadata":{"annotations":{"telemetry.console.openshift.io/ANOTHER_CONFIG_KEY":"value2"}}}'

oc patch consoles.operator.openshift.io cluster --type=merge --patch='{"metadata":{"annotations":{"telemetry.console.openshift.io/disabled":"true"}}}'
```

To check all annotations:

```
oc get consoles.operator.openshift.io cluster "-o=jsonpath={.metadata.annotations}" | sed 's/^map.\(.*\).$/\1/g' | xargs -n 1 echo
```

After applying annotations with tise `oc patch` commands you should see an updated SERVER_FLAGS when inspecting the console index.html. A new console pod will be started and this could take some seconds!

I have done this once:

![telemetry-backend-changes](https://user-images.githubusercontent.com/139310/169538945-e504665b-9b03-47f6-a080-552206c0ccd1.gif)
