### PR TITLE
Bug 2088248: Create HANA VM does not use values from customized HANA templates

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
@@ -6,6 +6,7 @@ import { K8sKind, TemplateKind } from '@console/internal/module/k8s';
 import { VMWizardMode, VMWizardName } from '../../constants/vm';
 import { CustomizeSourceFunction } from '../../hooks/use-customize-source-modal';
 import { SupportModalFunction } from '../../hooks/use-support-modal';
+import { VMTemplateWrapper } from '../../k8s/wrapper/vm/vm-template-wrapper';
 import { VirtualMachineModel } from '../../models';
 import { getNamespace } from '../../selectors';
 import { isCommonTemplate } from '../../selectors/vm-template/basic';
@@ -48,6 +49,7 @@ const newTemplateFromCommon: MenuAction = (kind, vmTemplate, { namespace }) => (
     template: vmTemplate.variants[0],
   }),
   accessReview: asAccessReview(kind, vmTemplate, 'patch'),
+  isDisabled: new VMTemplateWrapper(vmTemplate.variants[0]).getWorkloadProfile() === 'saphana',
 });
 
 const vmTemplateCreateVMAction: MenuAction = (


### PR DESCRIPTION
disabling the option the create new template from SAP HANA template,
applying same logic from https://github.com/openshift/console/pull/11011, to master branch

### before:
![Screenshot (49)](https://user-images.githubusercontent.com/67270715/169305253-df768638-d6f0-4a5e-9c77-d2f1b69f2c6e.png)

### after:
![Screenshot (50)](https://user-images.githubusercontent.com/67270715/169305303-b44dd890-b75f-43b7-b75c-d1c227b277ba.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>