### PR TITLE
CONSOLE-3081: Include pf charts dark theme css file in app.jsx to ensure they are loaded last

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -53,7 +53,9 @@ import { Page, SkipToContent, AlertVariant } from '@patternfly/react-core'; // P
 import '../vendor.scss';
 import '../style.scss';
 import '@patternfly/quickstarts/dist/quickstarts.min.css';
-import '@patternfly/patternfly/patternfly-theme-dark.css'; // load dark theme here as MiniCssExtractPlugin ignores load order of sass and dark theme must load after all other css
+// load dark theme here as MiniCssExtractPlugin ignores load order of sass and dark theme must load after all other css
+import '@patternfly/patternfly/patternfly-theme-dark.css';
+import '@patternfly/patternfly/patternfly-charts-theme-dark.css';
 
 const breakpointMD = 1200;
 const NOTIFICATION_DRAWER_BREAKPOINT = 1800;


### PR DESCRIPTION
The latest PatternFly charts updated for dark theme support are pulled in, but its `@patternfly/patternfly/patternfly-charts-theme-dark.css` needs to be imported after all other css is loaded, so it is included in `app.jsx`
Similar to https://github.com/openshift/console/pull/11370

**before**
<img width="1326" alt="overview-broke" src="https://user-images.githubusercontent.com/1874151/169335801-019d25c2-ba74-41da-9400-a4adcc691c08.png">
<img width="1077" alt="routes-bad" src="https://user-images.githubusercontent.com/1874151/169335922-268c5a77-2cf6-4b96-9ca2-79d7ea985fe2.png">

**after**
<img width="1305" alt="overview-good" src="https://user-images.githubusercontent.com/1874151/169335959-9ac63e7d-6549-428d-882e-fa96d48bdb0a.png">
<img width="1025" alt="routes-good" src="https://user-images.githubusercontent.com/1874151/169335975-04f1222f-b896-4299-818f-cf01e027044a.png">

