### PR TITLE
[release-4.8] Bug 2088756: Improve Firehose cache, so that it does not return unexpected data also if isList differs on two concurrent calls

### DIFF
--- a/frontend/public/components/utils/__tests__/firehose.data.tsx
+++ b/frontend/public/components/utils/__tests__/firehose.data.tsx
@@ -7,7 +7,7 @@ export const podData = {
   kind: 'Pod',
   metadata: {
     name: 'my-pod',
-    namespace: 'default',
+    namespace: 'my-namespace',
     resourceVersion: '123',
   },
 };
@@ -20,7 +20,7 @@ export const podList = {
     kind: 'Pod',
     metadata: {
       name,
-      namespace: 'default',
+      namespace: 'my-namespace',
       resourceVersion: '123',
     },
   })),

--- a/frontend/public/components/utils/__tests__/firehose.spec.tsx
+++ b/frontend/public/components/utils/__tests__/firehose.spec.tsx
@@ -170,7 +170,7 @@ describe('processReduxId', () => {
     // And it could not be the same because optional parameter could change!
     expect(firstTime).not.toBe(secondTime);
     // But at least the data should be the same
-    expect(firstTime.data).not.toBe(secondTime.data); // TODO
+    expect(firstTime.data).toBe(secondTime.data);
   });
 
   it('should return different data for isList true and false, but same data when calling multiple times', () => {});
@@ -914,10 +914,10 @@ describe('Firehose', () => {
     expect(propsChildA.resources.pods.data[0]).toBe(propsChildB.resources.pods.data[0]);
 
     // pod 'resource' object (with data, loaded, etc.) object
-    expect(propsChildA.pod).not.toBe(propsChildB.pod); // Should be the same?
-    expect(propsChildA.data).not.toBe(propsChildB.pod.data); // Should be the same?
-    expect(propsChildA.resources.pod).not.toBe(propsChildB.resources.pod); // Should be the same?
-    expect(propsChildA.resources.pod.data).not.toBe(propsChildB.resources.pod.data); // Should be the same?
+    expect(propsChildA.pod).not.toBe(propsChildB.pod); // Could be the same?
+    expect(propsChildA.data).toBe(propsChildB.data);
+    expect(propsChildA.resources.pod).not.toBe(propsChildB.resources.pod); // Could be the same?
+    expect(propsChildA.resources.pod.data).toBe(propsChildB.resources.pod.data);
   });
 });
 
@@ -1070,7 +1070,7 @@ describe('Firehose together with useK8sWatchResources', () => {
     expect(lastFirehoseChildProps.pod.data).toEqual(lastUseResourcesHookResult.pod.data);
 
     // And they also should return the same instance for lists
-    expect(lastFirehoseChildProps.pods.data).not.toBe(lastUseResourcesHookResult.pods.data); // Could be the same!
+    expect(lastFirehoseChildProps.pods.data).toBe(lastUseResourcesHookResult.pods.data);
     expect(lastFirehoseChildProps.pods.data[0]).toBe(lastUseResourcesHookResult.pods.data[0]);
     expect(lastFirehoseChildProps.pods.data[1]).toBe(lastUseResourcesHookResult.pods.data[1]);
     expect(lastFirehoseChildProps.pods.data[2]).toBe(lastUseResourcesHookResult.pods.data[2]);
@@ -1155,7 +1155,7 @@ describe('Firehose together with useK8sWatchResources', () => {
     expect(lastFirehoseChildProps.pod.data).toEqual(lastUseResourcesHookResult.pod.data);
 
     // And they also should return the same instance for lists
-    expect(lastFirehoseChildProps.pods.data).not.toBe(lastUseResourcesHookResult.pods.data); // Could be the same!
+    expect(lastFirehoseChildProps.pods.data).toBe(lastUseResourcesHookResult.pods.data);
     expect(lastFirehoseChildProps.pods.data[0]).toBe(lastUseResourcesHookResult.pods.data[0]);
     expect(lastFirehoseChildProps.pods.data[1]).toBe(lastUseResourcesHookResult.pods.data[1]);
     expect(lastFirehoseChildProps.pods.data[2]).toBe(lastUseResourcesHookResult.pods.data[2]);
@@ -1245,15 +1245,23 @@ describe('Firehose together with useK8sWatchResources', () => {
       expect(lastUseResourcesHookResult.pods).toEqual({
         loaded: true,
         loadError: '',
-        data: ['my-pod1', 'my-pod2', 'my-pod3'].map((name) => ({
-          apiVersion: 'v1',
-          kind: 'Pod',
-          metadata: {
-            name,
-            namespace: 'my-namespace',
-            resourceVersion: '123',
+        data: {
+          '(my-namespace)-my-pod1': {
+            apiVersion: 'v1',
+            kind: 'Pod',
+            metadata: { name: 'my-pod1', namespace: 'my-namespace', resourceVersion: '123' },
           },
-        })),
+          '(my-namespace)-my-pod2': {
+            apiVersion: 'v1',
+            kind: 'Pod',
+            metadata: { name: 'my-pod2', namespace: 'my-namespace', resourceVersion: '123' },
+          },
+          '(my-namespace)-my-pod3': {
+            apiVersion: 'v1',
+            kind: 'Pod',
+            metadata: { name: 'my-pod3', namespace: 'my-namespace', resourceVersion: '123' },
+          },
+        },
       });
     });
 
@@ -1337,23 +1345,15 @@ describe('Firehose together with useK8sWatchResources', () => {
       // and should return an array.
       expect(lastFirehoseChildProps.pods).toEqual({
         kind: 'Pod',
-        data: {
-          '(my-namespace)-my-pod1': {
-            apiVersion: 'v1',
-            kind: 'Pod',
-            metadata: { name: 'my-pod1', namespace: 'my-namespace', resourceVersion: '123' },
+        data: ['my-pod1', 'my-pod2', 'my-pod3'].map((name) => ({
+          apiVersion: 'v1',
+          kind: 'Pod',
+          metadata: {
+            name,
+            namespace: 'my-namespace',
+            resourceVersion: '123',
           },
-          '(my-namespace)-my-pod2': {
-            apiVersion: 'v1',
-            kind: 'Pod',
-            metadata: { name: 'my-pod2', namespace: 'my-namespace', resourceVersion: '123' },
-          },
-          '(my-namespace)-my-pod3': {
-            apiVersion: 'v1',
-            kind: 'Pod',
-            metadata: { name: 'my-pod3', namespace: 'my-namespace', resourceVersion: '123' },
-          },
-        },
+        })),
         loaded: true,
         loadError: '',
         filters: {},

--- a/frontend/public/components/utils/__tests__/firehose.spec.tsx
+++ b/frontend/public/components/utils/__tests__/firehose.spec.tsx
@@ -4,12 +4,14 @@ import { combineReducers, createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { act } from 'react-dom/test-utils';
+import { WatchK8sResources } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { receivedResources } from '../../../actions/k8s';
 import k8sReducers from '../../../reducers/k8s';
 import UIReducers from '../../../reducers/ui';
 import { thunk } from '../../../redux';
 import { k8sList, k8sGet, k8sWatch } from '../../../module/k8s/resource';
 import { processReduxId, Firehose } from '../firehose';
+import { useK8sWatchResources } from '../k8s-watch-hook';
 import { PodModel, podData, podList, firehoseChildPropsWithoutModels } from './firehose.data';
 
 // Mock network calls
@@ -23,16 +25,12 @@ const k8sListMock = k8sList as jest.Mock;
 const k8sGetMock = k8sGet as jest.Mock;
 const k8sWatchMock = k8sWatch as jest.Mock;
 
+let namespaceNameIndex = 0;
+const createUniqueNamespaceName = () => `test-namespace-${namespaceNameIndex++}`;
+
 // Redux wrapper
 let store;
 const Wrapper: React.FC = ({ children }) => <Provider store={store}>{children}</Provider>;
-
-// Object under test
-const resourceUpdate = jest.fn();
-const Child: React.FC = (props) => {
-  resourceUpdate(props);
-  return null;
-};
 
 describe('processReduxId', () => {
   const k8s = ImmutableMap({
@@ -44,7 +42,7 @@ describe('processReduxId', () => {
             kind: 'Pod',
             metadata: {
               name,
-              namespace: 'default',
+              namespace: 'my-namespace',
               resourceVersion: '123',
             },
           }),
@@ -57,7 +55,7 @@ describe('processReduxId', () => {
         kind: 'Pod',
         metadata: {
           name: 'my-pod',
-          namespace: 'default',
+          namespace: 'my-namespace',
           resourceVersion: '123',
         },
       }),
@@ -107,17 +105,17 @@ describe('processReduxId', () => {
         {
           apiVersion: 'v1',
           kind: 'Pod',
-          metadata: { name: 'my-pod1', namespace: 'default', resourceVersion: '123' },
+          metadata: { name: 'my-pod1', namespace: 'my-namespace', resourceVersion: '123' },
         },
         {
           apiVersion: 'v1',
           kind: 'Pod',
-          metadata: { name: 'my-pod2', namespace: 'default', resourceVersion: '123' },
+          metadata: { name: 'my-pod2', namespace: 'my-namespace', resourceVersion: '123' },
         },
         {
           apiVersion: 'v1',
           kind: 'Pod',
-          metadata: { name: 'my-pod3', namespace: 'default', resourceVersion: '123' },
+          metadata: { name: 'my-pod3', namespace: 'my-namespace', resourceVersion: '123' },
         },
       ],
       filters: {},
@@ -126,6 +124,21 @@ describe('processReduxId', () => {
       optional: undefined,
       selected: undefined,
     });
+  });
+
+  it('should return the same object twice when calling it twice for a list', () => {
+    const props = {
+      reduxID: 'Pods',
+      kind: 'Pod',
+      isList: true,
+    };
+    const firstTime = processReduxId({ k8s }, props);
+    const secondTime = processReduxId({ k8s }, props);
+    // Exact JSON is tested above.
+    // It returns always a new result object
+    expect(firstTime).not.toBe(secondTime);
+    // But at least the data should be the same
+    expect(firstTime.data).toBe(secondTime.data);
   });
 
   it('should return an Firehose object with data when extract a single item', () => {
@@ -138,14 +151,39 @@ describe('processReduxId', () => {
       data: {
         apiVersion: 'v1',
         kind: 'Pod',
-        metadata: { name: 'my-pod', namespace: 'default', resourceVersion: '123' },
+        metadata: { name: 'my-pod', namespace: 'my-namespace', resourceVersion: '123' },
       },
       optional: undefined,
     });
   });
+
+  it('should return the same object twice when calling it twice for a single item', () => {
+    const props = {
+      reduxID: 'Pods~~~my-pod',
+      kind: 'Pod',
+      isList: false,
+    };
+    const firstTime = processReduxId({ k8s }, props);
+    const secondTime = processReduxId({ k8s }, props);
+    // Exact JSON is tested above.
+    // It returns always a new result object
+    // And it could not be the same because optional parameter could change!
+    expect(firstTime).not.toBe(secondTime);
+    // But at least the data should be the same
+    expect(firstTime.data).not.toBe(secondTime.data); // TODO
+  });
+
+  it('should return different data for isList true and false, but same data when calling multiple times', () => {});
 });
 
 describe('Firehose', () => {
+  // Object under test
+  const resourceUpdate = jest.fn();
+  const Child: React.FC = (props) => {
+    resourceUpdate(props);
+    return null;
+  };
+
   let container: HTMLDivElement;
 
   beforeEach(() => {
@@ -287,7 +325,7 @@ describe('Firehose', () => {
         kind: 'Pod',
         metadata: {
           name,
-          namespace: 'default',
+          namespace: 'my-namespace',
           resourceVersion: '123',
         },
       })),
@@ -376,7 +414,7 @@ describe('Firehose', () => {
         kind: 'Pod',
         metadata: {
           name: 'my-pod',
-          namespace: 'default',
+          namespace: 'my-namespace',
           resourceVersion: '123',
         },
       },
@@ -667,7 +705,7 @@ describe('Firehose', () => {
         kind: 'Pod',
         metadata: {
           name,
-          namespace: 'default',
+          namespace: 'my-namespace',
           resourceVersion: '123',
         },
       })),
@@ -683,7 +721,7 @@ describe('Firehose', () => {
         kind: 'Pod',
         metadata: {
           name: 'my-pod',
-          namespace: 'default',
+          namespace: 'my-namespace',
           resourceVersion: '123',
         },
       },
@@ -815,7 +853,7 @@ describe('Firehose', () => {
         kind: 'Pod',
         metadata: {
           name,
-          namespace: 'default',
+          namespace: 'my-namespace',
           resourceVersion: '123',
         },
       })),
@@ -831,7 +869,7 @@ describe('Firehose', () => {
         kind: 'Pod',
         metadata: {
           name: 'my-pod',
-          namespace: 'default',
+          namespace: 'my-namespace',
           resourceVersion: '123',
         },
       },
@@ -880,5 +918,676 @@ describe('Firehose', () => {
     expect(propsChildA.data).not.toBe(propsChildB.pod.data); // Should be the same?
     expect(propsChildA.resources.pod).not.toBe(propsChildB.resources.pod); // Should be the same?
     expect(propsChildA.resources.pod.data).not.toBe(propsChildB.resources.pod.data); // Should be the same?
+  });
+});
+
+describe('Firehose together with useK8sWatchResources', () => {
+  // Objects under test
+  const firehoseUpdate = jest.fn();
+  const Child: React.FC = (props) => {
+    firehoseUpdate(props);
+    return null;
+  };
+
+  const resourcesUpdate = jest.fn();
+  const WatchResources: React.FC<{ initResources: WatchK8sResources<{}> }> = ({
+    initResources,
+  }) => {
+    resourcesUpdate(useK8sWatchResources(initResources));
+    return null;
+  };
+
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    // Init k8s redux store with just one model
+    store = createStore(
+      combineReducers({ k8s: k8sReducers, UI: UIReducers }),
+      {},
+      applyMiddleware(thunk),
+    );
+    store.dispatch(
+      receivedResources({
+        models: [PodModel],
+        adminResources: [],
+        allResources: [],
+        configResources: [],
+        namespacedSet: null,
+        safeResources: [],
+        groupVersionMap: {},
+      }),
+    );
+
+    jest.useFakeTimers();
+    jest.resetAllMocks();
+
+    k8sListMock.mockReturnValue(Promise.resolve(podList));
+    k8sGetMock.mockReturnValue(Promise.resolve(podData));
+    const wsMock = {
+      onclose: () => wsMock,
+      ondestroy: () => wsMock,
+      onbulkmessage: () => wsMock,
+      destroy: () => wsMock,
+    };
+    k8sWatchMock.mockReturnValue(wsMock);
+  });
+
+  afterEach(async () => {
+    // Ensure that there is no timer left which triggers a rerendering
+    await act(async () => jest.runAllTimers());
+
+    document.body.removeChild(container);
+    container = null;
+
+    // Ensure that there is no unexpected api calls
+    expect(k8sListMock).toHaveBeenCalledTimes(0);
+    expect(k8sGetMock).toHaveBeenCalledTimes(0);
+    // The 4.10 version expects that k8sWatch was NOT called, but in earlier versions it was called.
+    // But instead of adding / changing all tests we accept that it was called.
+    // expect(k8sWatchMock).toHaveBeenCalledTimes(0);
+    expect(firehoseUpdate).toHaveBeenCalledTimes(0);
+    expect(resourcesUpdate).toHaveBeenCalledTimes(0);
+
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('should fetch data just once and return the same data for both (Firehose first)', async () => {
+    const namespace = createUniqueNamespaceName();
+    const resources = [
+      {
+        prop: 'pods',
+        kind: 'Pod',
+        isList: true,
+        namespace,
+      },
+      {
+        prop: 'pod',
+        kind: 'Pod',
+        namespace,
+        name: 'my-pod',
+      },
+    ];
+    const initResources: WatchK8sResources<{}> = {
+      pods: {
+        kind: 'Pod',
+        namespace,
+        isList: true,
+      },
+      pod: {
+        kind: 'Pod',
+        namespace,
+        name: 'my-pod',
+      },
+    };
+
+    render(
+      <Wrapper>
+        <Firehose resources={resources}>
+          <Child />
+        </Firehose>
+        <WatchResources initResources={initResources} />
+      </Wrapper>,
+      container,
+    );
+
+    // Finish API calls
+    await act(async () => jest.runAllTimers());
+
+    // Assert that API calls are just triggered once
+    expect(k8sListMock).toHaveBeenCalledTimes(1);
+    expect(k8sListMock.mock.calls[0]).toEqual([PodModel, { limit: 250, ns: namespace }, true, {}]);
+    k8sListMock.mockClear();
+
+    expect(k8sGetMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetMock.mock.calls[0]).toEqual([PodModel, 'my-pod', namespace, null, {}]);
+    k8sGetMock.mockClear();
+
+    // Components was rendered the right amount of time (loaded: false, loaded: true)
+    expect(firehoseUpdate).toHaveBeenCalledTimes(3);
+    expect(resourcesUpdate).toHaveBeenCalledTimes(3);
+    const lastFirehoseChildProps = firehoseUpdate.mock.calls[2][0];
+    const lastUseResourcesHookResult = resourcesUpdate.mock.calls[2][0];
+    firehoseUpdate.mockClear();
+    resourcesUpdate.mockClear();
+
+    // Tests earlier checks the exact format, we focus here on comparing the data instances
+    expect(lastFirehoseChildProps.pods).toBeTruthy();
+    expect(lastFirehoseChildProps.pod).toBeTruthy();
+    expect(lastUseResourcesHookResult.pods).toBeTruthy();
+    expect(lastUseResourcesHookResult.pod).toBeTruthy();
+
+    // Result objects looks different for list (not a requirement, but the status quo)
+    expect(lastFirehoseChildProps.pods).not.toEqual(lastUseResourcesHookResult.pods);
+    // but is the same for single items at the moment (also not a requirement, but the status quo)
+    expect(lastFirehoseChildProps.pod).toEqual(lastUseResourcesHookResult.pod);
+    expect(lastFirehoseChildProps.pod).not.toBe(lastUseResourcesHookResult.pod);
+
+    // The data should be the same!
+    expect(lastFirehoseChildProps.pods.data).toEqual(lastUseResourcesHookResult.pods.data);
+    expect(lastFirehoseChildProps.pod.data).toEqual(lastUseResourcesHookResult.pod.data);
+
+    // And they also should return the same instance for lists
+    expect(lastFirehoseChildProps.pods.data).not.toBe(lastUseResourcesHookResult.pods.data); // Could be the same!
+    expect(lastFirehoseChildProps.pods.data[0]).toBe(lastUseResourcesHookResult.pods.data[0]);
+    expect(lastFirehoseChildProps.pods.data[1]).toBe(lastUseResourcesHookResult.pods.data[1]);
+    expect(lastFirehoseChildProps.pods.data[2]).toBe(lastUseResourcesHookResult.pods.data[2]);
+
+    // And they also should return the same instance for single items
+    expect(lastFirehoseChildProps.pod.data).not.toBe(lastUseResourcesHookResult.pod.data); // Should be the same, or?
+  });
+
+  it('should fetch data just once and return the same data for both (useK8sWatchResources first)', async () => {
+    const namespace = createUniqueNamespaceName();
+    const initResources: WatchK8sResources<{}> = {
+      pods: {
+        kind: 'Pod',
+        namespace,
+        isList: true,
+      },
+      pod: {
+        kind: 'Pod',
+        namespace,
+        name: 'my-pod',
+      },
+    };
+    const resources = [
+      {
+        prop: 'pods',
+        kind: 'Pod',
+        isList: true,
+        namespace,
+      },
+      {
+        prop: 'pod',
+        kind: 'Pod',
+        namespace,
+        name: 'my-pod',
+      },
+    ];
+
+    render(
+      <Wrapper>
+        <WatchResources initResources={initResources} />
+        <Firehose resources={resources}>
+          <Child />
+        </Firehose>
+      </Wrapper>,
+      container,
+    );
+
+    // Finish API calls
+    await act(async () => jest.runAllTimers());
+
+    // Assert that API calls are just triggered once
+    expect(k8sListMock).toHaveBeenCalledTimes(1);
+    expect(k8sListMock.mock.calls[0]).toEqual([PodModel, { limit: 250, ns: namespace }, true, {}]);
+    k8sListMock.mockClear();
+
+    expect(k8sGetMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetMock.mock.calls[0]).toEqual([PodModel, 'my-pod', namespace, null, {}]);
+    k8sGetMock.mockClear();
+
+    // Components was rendered the right amount of time (loaded: false, loaded: true)
+    expect(firehoseUpdate).toHaveBeenCalledTimes(3);
+    expect(resourcesUpdate).toHaveBeenCalledTimes(4);
+    const lastFirehoseChildProps = firehoseUpdate.mock.calls[2][0];
+    const lastUseResourcesHookResult = resourcesUpdate.mock.calls[3][0];
+    firehoseUpdate.mockClear();
+    resourcesUpdate.mockClear();
+
+    // Tests earlier checks the exact format, we focus here on comparing the data instances
+    expect(lastFirehoseChildProps.pods).toBeTruthy();
+    expect(lastFirehoseChildProps.pod).toBeTruthy();
+    expect(lastUseResourcesHookResult.pods).toBeTruthy();
+    expect(lastUseResourcesHookResult.pod).toBeTruthy();
+
+    // Result objects looks different for list (not a requirement, but the status quo)
+    expect(lastFirehoseChildProps.pods).not.toEqual(lastUseResourcesHookResult.pods);
+    // but is the same for single items at the moment (also not a requirement, but the status quo)
+    expect(lastFirehoseChildProps.pod).toEqual(lastUseResourcesHookResult.pod);
+    expect(lastFirehoseChildProps.pod).not.toBe(lastUseResourcesHookResult.pod);
+
+    // The data should be the same!
+    expect(lastFirehoseChildProps.pods.data).toEqual(lastUseResourcesHookResult.pods.data);
+    expect(lastFirehoseChildProps.pod.data).toEqual(lastUseResourcesHookResult.pod.data);
+
+    // And they also should return the same instance for lists
+    expect(lastFirehoseChildProps.pods.data).not.toBe(lastUseResourcesHookResult.pods.data); // Could be the same!
+    expect(lastFirehoseChildProps.pods.data[0]).toBe(lastUseResourcesHookResult.pods.data[0]);
+    expect(lastFirehoseChildProps.pods.data[1]).toBe(lastUseResourcesHookResult.pods.data[1]);
+    expect(lastFirehoseChildProps.pods.data[2]).toBe(lastUseResourcesHookResult.pods.data[2]);
+
+    // And they also should return the same instance for single items
+    expect(lastFirehoseChildProps.pod.data).not.toBe(lastUseResourcesHookResult.pod.data); // Should be the same, or?
+  });
+
+  // Regression test for "Git import page crashes after load" on 4.9
+  // https://bugzilla.redhat.com/show_bug.cgi?id=2069621
+  describe('regression test for bug #2069621', () => {
+    // This reproduce the original issue
+    it('should return an array for Firehose isList=true even when useK8sWatchResources isList=false is called without a name (Firehose first)', async () => {
+      const namespace = createUniqueNamespaceName();
+      const resources = [
+        {
+          prop: 'pods',
+          kind: 'Pod',
+          isList: true,
+          namespace,
+        },
+      ];
+      const initResources: WatchK8sResources<{}> = {
+        pods: {
+          kind: 'Pod',
+          namespace,
+          name: '', // Should not be supported by the API, but this happens sometimes
+          isList: false,
+          optional: true,
+        },
+      };
+
+      render(
+        <Wrapper>
+          <Firehose resources={resources}>
+            <Child />
+          </Firehose>
+          <WatchResources initResources={initResources} />
+        </Wrapper>,
+        container,
+      );
+
+      // Finish API calls
+      await act(async () => jest.runAllTimers());
+
+      // Assert that API calls are just triggered once
+      expect(k8sListMock).toHaveBeenCalledTimes(1);
+      expect(k8sListMock.mock.calls[0]).toEqual([
+        PodModel,
+        { limit: 250, ns: namespace },
+        true,
+        {},
+      ]);
+      k8sListMock.mockClear();
+
+      // Components was rendered the right amount of time (loaded: false, loaded: true)
+      expect(firehoseUpdate).toHaveBeenCalledTimes(2);
+      const lastFirehoseChildProps = firehoseUpdate.mock.calls[1][0];
+      firehoseUpdate.mockClear();
+
+      expect(resourcesUpdate).toHaveBeenCalledTimes(2);
+      const lastUseResourcesHookResult = resourcesUpdate.mock.calls[1][0];
+      resourcesUpdate.mockClear();
+
+      // But the Firehose call defines isList correctly and should still work
+      // and should return an array.
+      expect(lastFirehoseChildProps.pods).toEqual({
+        kind: 'Pod',
+        data: ['my-pod1', 'my-pod2', 'my-pod3'].map((name) => ({
+          apiVersion: 'v1',
+          kind: 'Pod',
+          metadata: {
+            name,
+            namespace: 'my-namespace',
+            resourceVersion: '123',
+          },
+        })),
+        loaded: true,
+        loadError: '',
+        filters: {},
+        selected: null,
+        optional: undefined,
+      });
+
+      // The hook should not return any data because the name is missing!
+      // Instead it returns the internal redux state of the list above as object.
+      expect(lastUseResourcesHookResult.pods).toEqual({
+        loaded: true,
+        loadError: '',
+        data: ['my-pod1', 'my-pod2', 'my-pod3'].map((name) => ({
+          apiVersion: 'v1',
+          kind: 'Pod',
+          metadata: {
+            name,
+            namespace: 'my-namespace',
+            resourceVersion: '123',
+          },
+        })),
+      });
+    });
+
+    // And this 3 cases tests against other call orders / isList=true/false combinations...
+    it('should return an array for Firehose isList=true even when useK8sWatchResources isList=false is called without a name (useK8sWatchResources first)', async () => {
+      const namespace = createUniqueNamespaceName();
+      const initResources: WatchK8sResources<{}> = {
+        pods: {
+          kind: 'Pod',
+          namespace,
+          name: '', // Should not be supported by the API, but this happens sometimes
+          isList: false,
+          optional: true,
+        },
+      };
+      const resources = [
+        {
+          prop: 'pods',
+          kind: 'Pod',
+          isList: true,
+          namespace,
+        },
+      ];
+
+      render(
+        <Wrapper>
+          <WatchResources initResources={initResources} />
+          <Firehose resources={resources}>
+            <Child />
+          </Firehose>
+        </Wrapper>,
+        container,
+      );
+
+      // Finish API calls
+      await act(async () => jest.runAllTimers());
+
+      // Assert that API calls are just triggered once
+      expect(k8sListMock).toHaveBeenCalledTimes(1);
+      expect(k8sListMock.mock.calls[0]).toEqual([
+        PodModel,
+        { limit: 250, ns: namespace },
+        true,
+        {},
+      ]);
+      k8sListMock.mockClear();
+
+      // Components was rendered the right amount of time (loaded: false, loaded: true)
+      expect(resourcesUpdate).toHaveBeenCalledTimes(3);
+      const lastUseResourcesHookResult = resourcesUpdate.mock.calls[2][0];
+      resourcesUpdate.mockClear();
+
+      expect(firehoseUpdate).toHaveBeenCalledTimes(2);
+      const lastFirehoseChildProps = firehoseUpdate.mock.calls[1][0];
+      firehoseUpdate.mockClear();
+
+      // The hook could not return any data because the name is missing.
+      expect(lastUseResourcesHookResult.pods).toEqual({
+        loaded: true,
+        loadError: '',
+        data: {
+          '(my-namespace)-my-pod1': {
+            apiVersion: 'v1',
+            kind: 'Pod',
+            metadata: { name: 'my-pod1', namespace: 'my-namespace', resourceVersion: '123' },
+          },
+          '(my-namespace)-my-pod2': {
+            apiVersion: 'v1',
+            kind: 'Pod',
+            metadata: { name: 'my-pod2', namespace: 'my-namespace', resourceVersion: '123' },
+          },
+          '(my-namespace)-my-pod3': {
+            apiVersion: 'v1',
+            kind: 'Pod',
+            metadata: { name: 'my-pod3', namespace: 'my-namespace', resourceVersion: '123' },
+          },
+        },
+      });
+
+      // But the Firehose call defines isList correctly and should still work
+      // and should return an array.
+      expect(lastFirehoseChildProps.pods).toEqual({
+        kind: 'Pod',
+        data: {
+          '(my-namespace)-my-pod1': {
+            apiVersion: 'v1',
+            kind: 'Pod',
+            metadata: { name: 'my-pod1', namespace: 'my-namespace', resourceVersion: '123' },
+          },
+          '(my-namespace)-my-pod2': {
+            apiVersion: 'v1',
+            kind: 'Pod',
+            metadata: { name: 'my-pod2', namespace: 'my-namespace', resourceVersion: '123' },
+          },
+          '(my-namespace)-my-pod3': {
+            apiVersion: 'v1',
+            kind: 'Pod',
+            metadata: { name: 'my-pod3', namespace: 'my-namespace', resourceVersion: '123' },
+          },
+        },
+        loaded: true,
+        loadError: '',
+        filters: {},
+        selected: null,
+        optional: undefined,
+      });
+    });
+
+    // FIXME crashs
+    it.skip('should return an array for useK8sWatchResources isList=true even when Firehose isList=false is called without a name (Firehose first)', async () => {
+      // Without a name the k8sGet API is called, but it returns a list anyway.
+      k8sGetMock.mockReturnValue(Promise.resolve(podList));
+
+      const resources = [
+        {
+          prop: 'pods',
+          kind: 'Pod',
+          isList: false,
+          namespace: 'my-namespace',
+          name: '',
+        },
+      ];
+      const initResources: WatchK8sResources<{}> = {
+        pods: {
+          kind: 'Pod',
+          namespace: 'my-namespace',
+          isList: true,
+        },
+      };
+
+      render(
+        <Wrapper>
+          <Firehose resources={resources}>
+            <Child />
+          </Firehose>
+          <WatchResources initResources={initResources} />
+        </Wrapper>,
+        container,
+      );
+
+      // Finish API calls
+      await act(async () => jest.runAllTimers());
+
+      // Assert that API calls are just triggered once
+      expect(k8sGetMock).toHaveBeenCalledTimes(1);
+      expect(k8sGetMock.mock.calls[0]).toEqual([
+        PodModel,
+        '', // Without a name above this calls the get api, but it still returns a list.
+        'my-namespace',
+        null,
+        {},
+      ]);
+      k8sGetMock.mockClear();
+
+      // Components was rendered the right amount of time (loaded: false, loaded: true)
+      expect(firehoseUpdate).toHaveBeenCalledTimes(2);
+      const lastFirehoseChildProps = firehoseUpdate.mock.calls[1][0];
+      firehoseUpdate.mockClear();
+
+      expect(resourcesUpdate).toHaveBeenCalledTimes(2);
+      const lastUseResourcesHookResult = resourcesUpdate.mock.calls[1][0];
+      resourcesUpdate.mockClear();
+
+      // The Firehose call defines isList=false, so it returns the full API response.
+      expect(lastFirehoseChildProps.pods).toEqual({
+        data: {
+          apiVersion: 'v1',
+          items: [
+            {
+              apiVersion: 'v1',
+              kind: 'Pod',
+              metadata: { name: 'my-pod1', namespace: 'my-namespace', resourceVersion: '123' },
+            },
+            {
+              apiVersion: 'v1',
+              kind: 'Pod',
+              metadata: { name: 'my-pod2', namespace: 'my-namespace', resourceVersion: '123' },
+            },
+            {
+              apiVersion: 'v1',
+              kind: 'Pod',
+              metadata: { name: 'my-pod3', namespace: 'my-namespace', resourceVersion: '123' },
+            },
+          ],
+          kind: 'PodList',
+          metadata: { resourceVersion: '123' },
+        },
+        loaded: true,
+        loadError: '',
+        optional: undefined,
+      });
+
+      // But the hook defines isList=true and converts it automatically to an array.
+      // At the moment it doesn't extract the 'values' key.
+      expect(lastUseResourcesHookResult.pods).toEqual({
+        loaded: true,
+        loadError: '',
+        data: [
+          'v1',
+          'PodList',
+          [
+            {
+              apiVersion: 'v1',
+              kind: 'Pod',
+              metadata: { name: 'my-pod1', namespace: 'my-namespace', resourceVersion: '123' },
+            },
+            {
+              apiVersion: 'v1',
+              kind: 'Pod',
+              metadata: { name: 'my-pod2', namespace: 'my-namespace', resourceVersion: '123' },
+            },
+            {
+              apiVersion: 'v1',
+              kind: 'Pod',
+              metadata: { name: 'my-pod3', namespace: 'my-namespace', resourceVersion: '123' },
+            },
+          ],
+          { resourceVersion: '123' },
+        ],
+      });
+    });
+
+    // FIXME crashs
+    it.skip('should return an array for useK8sWatchResources isList=true even when Firehose isList=false is called without a name (useK8sWatchResources first)', async () => {
+      // Without a name the k8sGet API is called, but it returns a list anyway.
+      k8sGetMock.mockReturnValue(Promise.resolve(podList));
+
+      const initResources: WatchK8sResources<{}> = {
+        pods: {
+          kind: 'Pod',
+          namespace: 'my-namespace',
+          isList: true,
+          optional: true,
+        },
+      };
+      const resources = [
+        {
+          prop: 'pods',
+          kind: 'Pod',
+          isList: false,
+          namespace: 'my-namespace',
+          name: '',
+        },
+      ];
+
+      render(
+        <Wrapper>
+          <WatchResources initResources={initResources} />
+          <Firehose resources={resources}>
+            <Child />
+          </Firehose>
+        </Wrapper>,
+        container,
+      );
+
+      // Finish API calls
+      await act(async () => jest.runAllTimers());
+
+      expect(k8sGetMock).toHaveBeenCalledTimes(1);
+      expect(k8sGetMock.mock.calls[0]).toEqual([
+        PodModel,
+        '', // Without a name above this calls the get api, but it still returns a list.
+        'my-namespace',
+        null,
+        {},
+      ]);
+      k8sGetMock.mockClear();
+
+      // Components was rendered the right amount of time (loaded: false, loaded: true)
+      expect(resourcesUpdate).toHaveBeenCalledTimes(3);
+      const lastUseResourcesHookResult = resourcesUpdate.mock.calls[2][0];
+      resourcesUpdate.mockClear();
+
+      expect(firehoseUpdate).toHaveBeenCalledTimes(2);
+      const lastFirehoseChildProps = firehoseUpdate.mock.calls[1][0];
+      firehoseUpdate.mockClear();
+
+      // The hook could not return any data because the name is missing.
+      expect(lastUseResourcesHookResult.pods).toEqual({
+        data: [
+          'v1',
+          'PodList',
+          [
+            {
+              apiVersion: 'v1',
+              kind: 'Pod',
+              metadata: { name: 'my-pod1', namespace: 'my-namespace', resourceVersion: '123' },
+            },
+            {
+              apiVersion: 'v1',
+              kind: 'Pod',
+              metadata: { name: 'my-pod2', namespace: 'my-namespace', resourceVersion: '123' },
+            },
+            {
+              apiVersion: 'v1',
+              kind: 'Pod',
+              metadata: { name: 'my-pod3', namespace: 'my-namespace', resourceVersion: '123' },
+            },
+          ],
+          { resourceVersion: '123' },
+        ],
+        loadError: '',
+        loaded: true,
+      });
+
+      // But Firehose can return a pod when  call defines isList correctly and should still work
+      // and should get an array.
+      expect(lastFirehoseChildProps.pods).toEqual({
+        data: {
+          apiVersion: 'v1',
+          items: [
+            {
+              apiVersion: 'v1',
+              kind: 'Pod',
+              metadata: { name: 'my-pod1', namespace: 'my-namespace', resourceVersion: '123' },
+            },
+            {
+              apiVersion: 'v1',
+              kind: 'Pod',
+              metadata: { name: 'my-pod2', namespace: 'my-namespace', resourceVersion: '123' },
+            },
+            {
+              apiVersion: 'v1',
+              kind: 'Pod',
+              metadata: { name: 'my-pod3', namespace: 'my-namespace', resourceVersion: '123' },
+            },
+          ],
+          kind: 'PodList',
+          metadata: { resourceVersion: '123' },
+        },
+        loaded: true,
+        loadError: '',
+        optional: undefined,
+      });
+    });
   });
 });

--- a/frontend/public/components/utils/__tests__/k8s-watch-hook.spec.tsx
+++ b/frontend/public/components/utils/__tests__/k8s-watch-hook.spec.tsx
@@ -101,7 +101,7 @@ describe('getReduxData', () => {
     expect(firstTime).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
     expect(secondTime).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
     // The array instance should be the same
-    expect(firstTime).not.toBe(secondTime); // TODO???
+    expect(firstTime).toBe(secondTime);
     expect(firstTime[0]).toBe(secondTime[0]);
     expect(firstTime[1]).toBe(secondTime[1]);
     expect(firstTime[2]).toBe(secondTime[2]);
@@ -146,7 +146,7 @@ describe('getReduxData', () => {
     expect(noListSecondTime).toEqual({ a: { a: 1 }, b: { b: 2 }, c: { c: 3 } });
 
     // Contains the same (cached) data for both calls
-    expect(listFirstTime).not.toBe(listSecondTime); // BUT THIS COULD BE THE SAME
+    expect(listFirstTime).toBe(listSecondTime);
     expect(noListFirstTime).toBe(noListSecondTime);
   });
 });

--- a/frontend/public/components/utils/__tests__/k8s-watch-hook.spec.tsx
+++ b/frontend/public/components/utils/__tests__/k8s-watch-hook.spec.tsx
@@ -127,4 +127,26 @@ describe('getReduxData', () => {
     // Except for the changed object obviously
     expect(firstTime[2]).not.toBe(secondTime[2]);
   });
+
+  it('should return different data for isList true and false, but same data when calling multiple times', () => {
+    const immutableData = ImmutableMap({
+      a: ImmutableMap({ a: 1 }),
+      b: ImmutableMap({ b: 2 }),
+      c: ImmutableMap({ c: 3 }),
+    });
+    const listFirstTime = getReduxData(immutableData, { kind: 'Pod', isList: true });
+    const noListFirstTime = getReduxData(immutableData, { kind: 'Pod', isList: false });
+    const listSecondTime = getReduxData(immutableData, { kind: 'Pod', isList: true });
+    const noListSecondTime = getReduxData(immutableData, { kind: 'Pod', isList: false });
+
+    // Contains the right data
+    expect(listFirstTime).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
+    expect(noListFirstTime).toEqual({ a: { a: 1 }, b: { b: 2 }, c: { c: 3 } });
+    expect(listSecondTime).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
+    expect(noListSecondTime).toEqual({ a: { a: 1 }, b: { b: 2 }, c: { c: 3 } });
+
+    // Contains the same (cached) data for both calls
+    expect(listFirstTime).not.toBe(listSecondTime); // BUT THIS COULD BE THE SAME
+    expect(noListFirstTime).toBe(noListSecondTime);
+  });
 });

--- a/frontend/public/components/utils/__tests__/useK8sWatchResource.data.tsx
+++ b/frontend/public/components/utils/__tests__/useK8sWatchResource.data.tsx
@@ -5,7 +5,7 @@ export const podData = {
   kind: 'Pod',
   metadata: {
     name: 'my-pod',
-    namespace: 'default',
+    namespace: 'my-namespace',
     resourceVersion: '123',
   },
 };
@@ -18,7 +18,7 @@ export const podList = {
     kind: 'Pod',
     metadata: {
       name,
-      namespace: 'default',
+      namespace: 'my-namespace',
       resourceVersion: '123',
     },
   })),

--- a/frontend/public/components/utils/__tests__/useK8sWatchResources.data.tsx
+++ b/frontend/public/components/utils/__tests__/useK8sWatchResources.data.tsx
@@ -5,7 +5,7 @@ export const podData = {
   kind: 'Pod',
   metadata: {
     name: 'my-pod',
-    namespace: 'default',
+    namespace: 'my-namespace',
     resourceVersion: '123',
   },
 };
@@ -18,7 +18,7 @@ export const podList = {
     kind: 'Pod',
     metadata: {
       name,
-      namespace: 'default',
+      namespace: 'my-namespace',
       resourceVersion: '123',
     },
   })),

--- a/frontend/public/components/utils/__tests__/useK8sWatchResources.spec.tsx
+++ b/frontend/public/components/utils/__tests__/useK8sWatchResources.spec.tsx
@@ -491,8 +491,7 @@ describe('useK8sWatchResource', () => {
     const itemsWatcher1 = resourceUpdate.mock.calls[4][0].pods.data;
     const itemsWatcher2 = resourceUpdate.mock.calls[5][0].pods.data;
     expect(itemsWatcher1).toEqual(itemsWatcher2);
-    // Unluckly the data are not the same at the moment
-    expect(itemsWatcher1).not.toBe(itemsWatcher2);
+    expect(itemsWatcher1).toBe(itemsWatcher2);
 
     resourceUpdate.mockClear();
   });

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -7,7 +7,10 @@ import { Map as ImmutableMap } from 'immutable';
 import { inject } from './inject';
 import { makeReduxID, makeQuery } from './k8s-watcher';
 import * as k8sActions from '../../actions/k8s';
-import { INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL } from './k8s-watch-hook';
+import {
+  INTERNAL_REDUX_IMMUTABLE_TOARRAY_CACHE_SYMBOL,
+  INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL,
+} from './k8s-watch-hook';
 
 const shallowMapEquals = (a, b) => {
   if (a === b || (a.size === 0 && b.size === 0)) {
@@ -28,28 +31,33 @@ export const processReduxId = ({ k8s }, props) => {
 
   if (!isList) {
     let stuff = k8s.get(reduxID);
-    if (stuff) {
-      stuff = stuff.toJS();
-      // TODO: To cache also single resources we need to remove this attribute.
-      stuff.optional = props.optional;
+    if (!stuff) {
+      return {};
     }
-    return stuff || {};
+    if (!stuff[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL]) {
+      stuff[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = stuff.toJSON();
+    }
+    stuff = stuff[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL];
+    return { ...stuff, optional: props.optional };
   }
 
   let data = k8s.getIn([reduxID, 'data']);
   const _filters = k8s.getIn([reduxID, 'filters']);
   const selected = k8s.getIn([reduxID, 'selected']);
 
-  if (data) {
-    if (!data[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL]) {
-      data[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = data.toArray().map((a) => {
-        if (!a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL]) {
-          a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = a.toJSON();
+  if (data && data.toArray) {
+    if (!data[INTERNAL_REDUX_IMMUTABLE_TOARRAY_CACHE_SYMBOL]) {
+      data[INTERNAL_REDUX_IMMUTABLE_TOARRAY_CACHE_SYMBOL] = data.toArray().map((a) => {
+        if (a.toJSON) {
+          if (!a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL]) {
+            a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = a.toJSON();
+          }
+          return a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL];
         }
-        return a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL];
+        return a;
       });
     }
-    data = data[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL];
+    data = data[INTERNAL_REDUX_IMMUTABLE_TOARRAY_CACHE_SYMBOL];
   }
 
   return {

--- a/frontend/public/components/utils/k8s-watch-hook.ts
+++ b/frontend/public/components/utils/k8s-watch-hook.ts
@@ -59,20 +59,30 @@ const getIDAndDispatch: GetIDAndDispatch = (resource, k8sModel) => {
   return { id, dispatch };
 };
 
-export const INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL = Symbol('_cachedToJSResult');
+export const INTERNAL_REDUX_IMMUTABLE_TOARRAY_CACHE_SYMBOL = Symbol('_cachedToArrayResult');
+export const INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL = Symbol('_cachedToJSONResult');
 
 export const getReduxData = (immutableData, resource: WatchK8sResource) => {
   if (!immutableData) {
     return null;
   }
-  if (resource.isList) {
-    return immutableData.toArray().map((a) => {
-      if (!a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL]) {
-        a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = a.toJSON();
-      }
-      return a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL];
-    });
-  } else if (immutableData.toJSON) {
+  if (resource.isList && immutableData.toArray) {
+    if (!immutableData[INTERNAL_REDUX_IMMUTABLE_TOARRAY_CACHE_SYMBOL]) {
+      immutableData[INTERNAL_REDUX_IMMUTABLE_TOARRAY_CACHE_SYMBOL] = immutableData
+        .toArray()
+        .map((a) => {
+          if (a.toJSON) {
+            if (!a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL]) {
+              a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = a.toJSON();
+            }
+            return a[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL];
+          }
+          return a;
+        });
+    }
+    return immutableData[INTERNAL_REDUX_IMMUTABLE_TOARRAY_CACHE_SYMBOL];
+  }
+  if (immutableData.toJSON) {
     if (!immutableData[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL]) {
       immutableData[INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL] = immutableData.toJSON();
     }


### PR DESCRIPTION
Manual cherry-pick of #11476

* Doesn't include the "4.9 only" revert because it was only applied as hot fix on 4.9.
* Doesn't include the last commit because SourceSecretSelector.tsx doesn't use a watcher in 4.8.