### PR TITLE
Bug 2084287: Fix NPE when consuming CSVs with missing informations

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -1111,16 +1111,20 @@ export const ClusterServiceVersionDetails: React.FC<ClusterServiceVersionDetails
               </dd>
               <dt>{t('olm~Status reason')}</dt>
               <dd>{status ? status.message : t('olm~Unknown')}</dd>
-              <dt>{t('olm~Operator Deployments')}</dt>
-              {spec.install.spec.deployments.map(({ name }) => (
-                <dd key={name}>
-                  <ResourceLink
-                    name={name}
-                    kind="Deployment"
-                    namespace={operatorNamespaceFor(props.obj)}
-                  />
-                </dd>
-              ))}
+              {!_.isEmpty(spec.install.spec?.deployments) && (
+                <>
+                  <dt>{t('olm~Operator Deployments')}</dt>
+                  {spec.install.spec.deployments.map(({ name }) => (
+                    <dd key={name}>
+                      <ResourceLink
+                        name={name}
+                        kind="Deployment"
+                        namespace={operatorNamespaceFor(props.obj)}
+                      />
+                    </dd>
+                  ))}
+                </>
+              )}
               {!_.isEmpty(permissions) && (
                 <>
                   <dt>{t('olm~Operator ServiceAccounts')}</dt>

--- a/frontend/packages/operator-lifecycle-manager/src/types.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/types.ts
@@ -118,7 +118,7 @@ export type ClusterServiceVersionKind = {
   spec: {
     install: {
       strategy: 'Deployment';
-      spec: {
+      spec?: {
         permissions: {
           serviceAccountName: string;
           rules: { apiGroups: string[]; resources: string[]; verbs: string[] }[];
@@ -129,7 +129,7 @@ export type ClusterServiceVersionKind = {
     customresourcedefinitions?: { owned?: CRDDescription[]; required?: CRDDescription[] };
     apiservicedefinitions?: { owned?: APIServiceDefinition[]; required?: APIServiceDefinition[] };
     replaces?: string;
-    installModes: { type: InstallModeType; supported: boolean }[];
+    installModes?: { type: InstallModeType; supported: boolean }[];
     displayName?: string;
     description?: string;
     provider?: { name: string };

--- a/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersions.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersions.tsx
@@ -10,7 +10,7 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { getImageForCSVIcon } from '@console/shared';
 import { providedAPIsForCSV, referenceForProvidedAPI } from '../components';
 import { ClusterServiceVersionModel } from '../models';
-import { ClusterServiceVersionKind } from '../types';
+import { ProvidedAPI, ClusterServiceVersionKind } from '../types';
 
 type ExpandCollapseDescriptionProps = {
   children: React.ReactNode;
@@ -43,10 +43,10 @@ const normalizeClusterServiceVersions = (
   const formatTileDescription = (csvDescription: string): string =>
     `## ${t('olm~Operator description')}\n${csvDescription}`;
 
-  const operatorProvidedAPIs: CatalogItem[] = _.flatten(
-    clusterServiceVersions.map((csv) => providedAPIsForCSV(csv).map((desc) => ({ ...desc, csv }))),
-  )
-    .reduce(
+  const operatorProvidedAPIs: CatalogItem[] = _.flatten<
+    ProvidedAPI & { csv: ClusterServiceVersionKind }
+  >(clusterServiceVersions.map((csv) => providedAPIsForCSV(csv).map((desc) => ({ ...desc, csv }))))
+    .reduce<(ProvidedAPI & { csv: ClusterServiceVersionKind })[]>(
       (all, cur) =>
         all.find((v) => referenceForProvidedAPI(v) === referenceForProvidedAPI(cur))
           ? all
@@ -57,7 +57,7 @@ const normalizeClusterServiceVersions = (
       const { creationTimestamp } = desc.csv.metadata;
       const uid = `${desc.csv.metadata.uid}-${desc.displayName}`;
       const { description } = desc;
-      const provider = desc.csv.spec.provider.name;
+      const provider = desc.csv.spec.provider?.name;
       const operatorName = desc.csv.spec.displayName;
       const supportUrl =
         desc.csv.metadata.annotations?.['marketplace.openshift.io/support-workflow'];


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2084287

**Analysis / Root cause**: 
I don't know which operator has incomplete data and let `packages/operator-lifecycle-manager/src/utils/useClusterServiceVersions.tsx` crash, but I could reproduce this with this CSV:

```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: ClusterServiceVersion
metadata:
  name: minimal-csv
  namespace: christoph
spec:
  apiservicedefinitions:
    owned:
      - group: A
        kind: A
        name: A
        version: v1
  customresourcedefinitions:
    owned:
      - kind: B
        name: B
        version: v1
  displayName: My minimal CSV
  install:
    strategy: ''
```

Provider was already defined as optional:

https://github.com/openshift/console/blob/09d13c91326e70c402e49c5dd6dddb7628faff7d/frontend/packages/operator-lifecycle-manager/src/types.ts#L135

Found another crash in the Operator Detail page with this CSV.

**Solution Description**: 
Marked non-existing values as optional as it is not guaranteed as you can see above.

Fixed two NPE.

**Screen shots / Gifs for design review**: 
UI is unchanged.

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Apply the CSV yaml from above.
2. Open the Admin perspective > Installed Operator > Operator detail page
3. Open the Developer perspective > Add > Catalog or Topology page

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge