### PR TITLE
Bug 2084438: Change Ping source spec.jsonData (deprecated) field to spec.data

### DIFF
--- a/frontend/packages/knative-plugin/integration-tests/support/testData/createPingSource.yaml
+++ b/frontend/packages/knative-plugin/integration-tests/support/testData/createPingSource.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     openshift.io/generated-by: OpenShiftWebConsole
 spec:
-  jsonData: Message
+  data: Message
   schedule: '* * * * *'
   sink:
     ref:

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/PingSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/PingSourceSection.tsx
@@ -16,7 +16,7 @@ const PingSourceSection: React.FC<PingSourceSectionProps> = ({ title, fullWidth 
     <FormSection title={title} extraMargin fullWidth={fullWidth}>
       <InputField
         type={TextInputTypes.text}
-        name={`formData.data.${EventSources.PingSource}.jsonData`}
+        name={`formData.data.${EventSources.PingSource}.data`}
         label={t('knative-plugin~Data')}
         helpText={t('knative-plugin~The data posted to the target function')}
       />

--- a/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
@@ -81,7 +81,7 @@ describe('Create knative Utils', () => {
   });
 
   it('expect getEventSourceData should return data for builtin Sources', () => {
-    expect(getEventSourceData(EventSources.PingSource).jsonData).toBeDefined();
+    expect(getEventSourceData(EventSources.PingSource).data).toBeDefined();
     expect(getEventSourceData(EventSources.PingSource).schedule).toBeDefined();
 
     expect(getEventSourceData(EventSources.SinkBinding).subject).toBeDefined();
@@ -243,7 +243,7 @@ describe('sanitizeSourceToForm always returns valid Event Source', () => {
       uri: '',
     },
     type: 'PingSource',
-    data: { PingSource: { jsonData: '', schedule: '' } },
+    data: { PingSource: { data: '', schedule: '' } },
   };
 
   it('expect an empty form to return a EventSource data with updated properties', () => {

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
@@ -349,7 +349,7 @@ export const deploymentKnativeData: K8sResourceKind = {
 
 const eventSourceData = {
   [EventSources.PingSource]: {
-    jsonData: '',
+    data: '',
     schedule: '* * * * *',
   },
   [EventSources.ApiServerSource]: {

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -151,7 +151,7 @@ export const getCatalogEventSourceResource = (
 export const getEventSourceData = (source: string) => {
   const eventSourceData = {
     [EventSources.PingSource]: {
-      jsonData: '',
+      data: '',
       schedule: '',
     },
     [EventSources.SinkBinding]: {


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGSM-44200

**Descriptions:**
- Change Ping source spec.jsonData (deprecated) field to spec.data