### PR TITLE
[release-4.10] Bug 2089589: add debounce to tektonhub versions api call to avoid many calls

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/PipelineQuickSearchDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/PipelineQuickSearchDetails.tsx
@@ -14,6 +14,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons';
+import { debounce } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { ExternalLink } from '@console/internal/components/utils';
 import { handleCta } from '@console/shared';
@@ -54,20 +55,26 @@ const PipelineQuickSearchDetails: React.FC<QuickSearchDetailsRendererProps> = ({
     resetVersions();
     let mounted = true;
     if (isTektonHubTaskWithoutVersions(selectedItem)) {
-      getTektonHubTaskVersions(selectedItem.data.id)
-        .then((itemVersions = []) => {
-          if (mounted) {
-            setVersions([...itemVersions]);
+      const debouncedLoadVersions = debounce(async () => {
+        if (mounted) {
+          try {
+            const itemVersions = await getTektonHubTaskVersions(selectedItem?.data?.id);
+
             selectedItem.attributes.versions = itemVersions;
-            setHasInstalledVersion(isOneVersionInstalled(selectedItem));
+
+            if (mounted) {
+              setVersions([...itemVersions]);
+              setHasInstalledVersion(isOneVersionInstalled(selectedItem));
+            }
+          } catch (err) {
+            if (mounted) {
+              resetVersions();
+            }
+            console.log('failed to fetch versions:', err); // eslint-disable-line no-console
           }
-        })
-        .catch((err) => {
-          if (mounted) {
-            resetVersions();
-          }
-          console.log('failed to fetch versions:', err); // eslint-disable-line no-console
-        });
+        }
+      }, 10);
+      debouncedLoadVersions();
     }
 
     return () => (mounted = false);
@@ -104,7 +111,7 @@ const PipelineQuickSearchDetails: React.FC<QuickSearchDetailsRendererProps> = ({
           <Split hasGutter>
             <SplitItem>
               <Button
-                isDisabled={versions.length === 0}
+                isDisabled={isTektonHubTaskWithoutVersions(selectedItem)}
                 data-test="task-cta"
                 variant={ButtonVariant.primary}
                 className="opp-quick-search-details__form-button"


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://bugzilla.redhat.com/show_bug.cgi?id=2089589

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

In pipeline builder, when the users types a task name quickly eg: "buildah" then there are equal amount of API calls per keystroke.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Added a debounce in version fetch method, so the API calls will not be made frequently.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->


https://user-images.githubusercontent.com/9964343/166722058-d91958f2-7c08-4e26-b2cb-a01cf67967ad.mov



**Unit test coverage report**: 
<!-- Attach test coverage report -->

     CTA button tests
      ✓ Add button should be disabled if the versions is not available (89ms)
      ✓ Add button should be enabled if the versions is not available in the user created task (79ms)

    Fetching Versions API
      ✓ should not call the versions API multiple times for the same task (30ms)
      ✓ should call the versions API multiple times for different task (52ms)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
