### PR TITLE
[release-4.9] Bug 2084028: Improve Firehose cache, fix broken import

### DIFF
--- a/frontend/public/components/utils/__tests__/firehose.spec.tsx
+++ b/frontend/public/components/utils/__tests__/firehose.spec.tsx
@@ -1049,10 +1049,10 @@ describe('Firehose together with useK8sWatchResources', () => {
     expect(lastFirehoseChildProps.pod.data).toEqual(lastUseResourcesHookResult.pod.data);
 
     // And they also should return the same instance for lists
-    expect(lastFirehoseChildProps.pods.data).not.toBe(lastUseResourcesHookResult.pods.data); // Could be the same!
-    expect(lastFirehoseChildProps.pods.data[0]).not.toBe(lastUseResourcesHookResult.pods.data[0]); // Should be the same!!!
-    expect(lastFirehoseChildProps.pods.data[1]).not.toBe(lastUseResourcesHookResult.pods.data[1]); // Should be the same!!!
-    expect(lastFirehoseChildProps.pods.data[2]).not.toBe(lastUseResourcesHookResult.pods.data[2]); // Should be the same!!!
+    expect(lastFirehoseChildProps.pods.data).toBe(lastUseResourcesHookResult.pods.data);
+    expect(lastFirehoseChildProps.pods.data[0]).toBe(lastUseResourcesHookResult.pods.data[0]);
+    expect(lastFirehoseChildProps.pods.data[1]).toBe(lastUseResourcesHookResult.pods.data[1]);
+    expect(lastFirehoseChildProps.pods.data[2]).toBe(lastUseResourcesHookResult.pods.data[2]);
 
     // And they also should return the same instance for single items
     expect(lastFirehoseChildProps.pod.data).not.toBe(lastUseResourcesHookResult.pod.data); // Should be the same, or?
@@ -1137,10 +1137,10 @@ describe('Firehose together with useK8sWatchResources', () => {
     expect(lastFirehoseChildProps.pod.data).toEqual(lastUseResourcesHookResult.pod.data);
 
     // And they also should return the same instance for lists
-    expect(lastFirehoseChildProps.pods.data).not.toBe(lastUseResourcesHookResult.pods.data); // Could be the same!
-    expect(lastFirehoseChildProps.pods.data[0]).not.toBe(lastUseResourcesHookResult.pods.data[0]); // Should be the same!!!
-    expect(lastFirehoseChildProps.pods.data[1]).not.toBe(lastUseResourcesHookResult.pods.data[1]); // Should be the same!!!
-    expect(lastFirehoseChildProps.pods.data[2]).not.toBe(lastUseResourcesHookResult.pods.data[2]); // Should be the same!!!
+    expect(lastFirehoseChildProps.pods.data).toBe(lastUseResourcesHookResult.pods.data);
+    expect(lastFirehoseChildProps.pods.data[0]).toBe(lastUseResourcesHookResult.pods.data[0]);
+    expect(lastFirehoseChildProps.pods.data[1]).toBe(lastUseResourcesHookResult.pods.data[1]);
+    expect(lastFirehoseChildProps.pods.data[2]).toBe(lastUseResourcesHookResult.pods.data[2]);
 
     // And they also should return the same instance for single items
     expect(lastFirehoseChildProps.pod.data).not.toBe(lastUseResourcesHookResult.pod.data); // Should be the same, or?

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -10,7 +10,7 @@ import * as k8sActions from '../../actions/k8s';
 import {
   INTERNAL_REDUX_IMMUTABLE_TOARRAY_CACHE_SYMBOL,
   INTERNAL_REDUX_IMMUTABLE_TOJSON_CACHE_SYMBOL,
-} from '@console/dynamic-plugin-sdk';
+} from './k8s-watch-hook';
 
 const shallowMapEquals = (a, b) => {
   if (a === b || (a.size === 0 && b.size === 0)) {


### PR DESCRIPTION
Fix imports that are wrongly changed with backport PR #11476

Reverts this change in backport PR #11476:

![image](https://user-images.githubusercontent.com/139310/169983952-9599a371-763e-4415-9c86-48e2d711ac2d.png)

The result is that the cache symbol is `undefined`. It looks like the caching still works fine, but in theory, this could reopen the bug #11256. The specific issue when importing an application is fixed in #11476

---

`yarn build` on release-4.9

![image](https://user-images.githubusercontent.com/139310/169980011-b695c3d3-cb32-4ae7-ab2d-0d3538e77baa.png)

`yarn dev-once` on release-4.9

![image](https://user-images.githubusercontent.com/139310/169981013-2e77092f-f5d6-46b1-91ac-70d1074cae8e.png)

`yarn build` with this PR

![image](https://user-images.githubusercontent.com/139310/169978781-d4102f48-a841-4c13-808b-b4d457814833.png)

`yarn dev-once` with this PR

![image](https://user-images.githubusercontent.com/139310/169977691-c675f462-9ad8-4319-a6d8-658a983c4112.png)
