### PR TITLE
[release-3.11] Bug 2089734: Eliminate use of lookaside cache and move to Cachito

### DIFF
--- a/Dockerfile.product
+++ b/Dockerfile.product
@@ -20,12 +20,17 @@ USER 0
 RUN tar fx yarn-offline.tar
 
 # bootstrap yarn so we can install and run the other tools.
-RUN container-entrypoint npm install ./yarn-1.9.4.tgz
+RUN container-entrypoint npm install ./artifacts/yarn-v1.22.19.tar.gz
+
+# use dependencies provided by Cachito
+COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
+RUN cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem . \
+  && cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/frontend/{.npmrc,.yarnrc,yarn.lock} frontend/
 
 # prevent download of chromedriver, sass binary, and node headers as part of module installs
 ENV CHROMEDRIVER_SKIP_DOWNLOAD=true \
     SKIP_SASS_BINARY_DOWNLOAD_FOR_CI=true \
-    NPM_CONFIG_TARBALL=$HOME/node-v8.9.4-headers.tar.gz
+    NPM_CONFIG_TARBALL=$HOME/artifacts/node-v8.9.4-headers.tar.gz
 
 # run the build
 RUN container-entrypoint ./build-frontend.sh

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6682,12 +6682,14 @@ mapbox-gl-function@^1.2.1:
 mapbox-gl-shaders@mapbox/mapbox-gl-shaders#de2ab007455aa2587c552694c68583f94c9f2747:
   version "1.0.0"
   resolved "https://codeload.github.com/mapbox/mapbox-gl-shaders/tar.gz/de2ab007455aa2587c552694c68583f94c9f2747"
+  integrity "sha512-EsGBaXdsEGmV/pcRlLcH9RyN4KgegS/sYAFseYR3auueT5lXA0DDY/GUgzVSSEGXSXCM0C/xJ1O10UM7O5JP+Q=="
   dependencies:
     brfs "^1.4.0"
 
 mapbox-gl-style-spec@mapbox/mapbox-gl-style-spec#83b1a3e5837d785af582efd5ed1a212f2df6a4ae:
   version "8.8.0"
   resolved "https://codeload.github.com/mapbox/mapbox-gl-style-spec/tar.gz/83b1a3e5837d785af582efd5ed1a212f2df6a4ae"
+  integrity "sha512-ua6GjNGpETd9guhdlWTWZSiIR0Akf68000Zq3TwyQJIMyNkmJ5NwrxnVG5fbcz35jPZLYzD6LbLnzaSiu9vHJA=="
   dependencies:
     csscolorparser "~1.0.2"
     jsonlint-lines-primitives "~1.6.0"


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/console/pull/11497.

Note in 3.11 yarn.lock, some dependencies come from github repositories. Due to a limitation of Cachito,  I have added explicit integrity key for those dependencies as a workaround. This workaround will not be needed once https://issues.redhat.com/browse/CLOUDBLD-10068 is done.