### PR TITLE
Gherkin and automation of topology usability improvements

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/global.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/global.ts
@@ -38,6 +38,7 @@ export enum operators {
   CrunchyPostgresforKubernetes = 'Crunchy Postgres for Kubernetes',
   QuayContainerSecurity = 'Quay Container Security',
   ShipwrightOperator = 'Shipwright Operator',
+  RedisOperator = 'Redis Operator',
 }
 
 export enum authenticationType {

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -188,6 +188,9 @@ export const catalogPO = {
       AddHostButton: '#root_ingress_hosts_add-btn',
     },
   },
+  operatorBacked: {
+    name: '#root_metadata_name',
+  },
   s2I: {
     gitRepoUrl: '[data-test-id="git-form-input-url"]',
     builderImageVersion: '#form-dropdown-image-tag-field',

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/operators-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/operators-po.ts
@@ -44,6 +44,7 @@ export const operatorsPO = {
       '[data-test="container-security-operator-redhat-operators-openshift-marketplace"]',
     shipwrightOperator:
       '[data-test="shipwright-operator-community-operators-openshift-marketplace"]',
+    redisOperatorCard: '[data-test="redis-operator-community-operators-openshift-marketplace"]',
   },
   subscription: {
     logo: 'h1.co-clusterserviceversion-logo__name__clusterserviceversion',

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
@@ -31,6 +31,18 @@ export const catalogPage = {
       .get('form h1')
       .eq(0)
       .should('have.text', pageTitle.InstallHelmCharts),
+  verifySelectOperatorBackedCard: (cardName: string) => {
+    cy.byTestID(`OperatorBackedService-${cardName}`)
+      .first()
+      .click();
+  },
+  verifyCreateOperatorBackedPage: (title: string) =>
+    detailsPage.titleShouldContain(`Create ${title}`),
+  enterOperatorBackedName: (OperatorBackedName: string) =>
+    cy
+      .get(catalogPO.operatorBacked.name)
+      .clear()
+      .type(OperatorBackedName),
   clickButtonOnCatalogPageSidePane: () => {
     catalogPage.verifyDialog();
     cy.get(catalogPO.sidePane.instantiateTemplate).click({ force: true });

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/createOperatorBacked.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/createOperatorBacked.ts
@@ -1,0 +1,35 @@
+import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
+import { addOptions, pageTitle } from '../../constants';
+import { formPO } from '../../pageObjects';
+import { addPage, catalogPage } from '../add-flow';
+
+export const createOperatorBacked = (
+  operatorName: string = 'nodejs-ex-git',
+  name: string = 'test123',
+) => {
+  addPage.selectCardFromOptions(addOptions.OperatorBacked);
+  detailsPage.titleShouldContain(pageTitle.OperatorBacked);
+  catalogPage.isCardsDisplayed();
+  catalogPage.search(operatorName);
+  catalogPage.verifySelectOperatorBackedCard(operatorName);
+  catalogPage.verifyDialog();
+  catalogPage.clickButtonOnCatalogPageSidePane();
+  catalogPage.verifyCreateOperatorBackedPage(operatorName);
+  catalogPage.enterOperatorBackedName(name);
+  cy.get('[data-test="create-dynamic-form"]')
+    .click()
+    .then(() => {
+      cy.get('.co-m-loader').should('not.exist');
+      cy.get('body').then(($body) => {
+        if ($body.find(formPO.errorAlert).length !== 0) {
+          cy.get(formPO.errorAlert)
+            .find('.co-pre-line')
+            .then(($ele) => {
+              cy.log($ele.text());
+            });
+        } else {
+          cy.log(`Operator Backed Worload : "${name}" is created`);
+        }
+      });
+    });
+};

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/index.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/index.ts
@@ -4,3 +4,4 @@ export * from './createHelmRelease';
 export * from './installOperatorOnCluster';
 export * from './createChannel';
 export * from './knativeSubscriptions';
+export * from './createOperatorBacked';

--- a/frontend/packages/dev-console/integration-tests/support/pages/operators-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/operators-page.ts
@@ -176,6 +176,11 @@ export const operatorsPage = {
         cy.get(operatorsPO.operatorHub.shipwrightOperator).click();
         break;
       }
+      case 'Redis Operator':
+      case operators.RedisOperator: {
+        cy.get(operatorsPO.operatorHub.redisOperatorCard).click();
+        break;
+      }
       default: {
         throw new Error('operator is not available');
       }

--- a/frontend/packages/topology/integration-tests/features/topology/topology-chart-area-visual.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-chart-area-visual.feature
@@ -101,12 +101,24 @@ Feature: Topology chart area
              Then user is able to see context menu options like Edit Application Grouping, Edit Pod Count, Pause Rollouts, Add Health Checks, Add Horizontal Pod Autoscaler, Add Storage, Edit Update Strategy, Edit Labels, Edit Annotations, Edit Deployment, Delete Deployment
 
 
-        @regression @manual
-        Scenario: Zoom In in topology: T-06-TC10
+        @regression @odc-4944 @manual
+        Scenario: Zoom In to 50% in topology: T-06-TC10
             Given user has created a workload named "nodejs-ex-git"
               And user is at the Topology page
-             When user clicks on Zoom In option
-             Then user sees the chart area is zoomed
+             When user clicks on Zoom In option to zoom to 50% scale
+             Then user can see the chart area is zoomed
+              And user can see all labels & decorators are hidden
+              And label are shown when hovering over the node
+
+
+        @regression @odc-4944 @manual
+        Scenario: Zoom In to 30% in topology: T-06-TC11
+            Given user has created a workload named "nodejs-ex-git"
+              And user is at the Topology page
+             When user clicks on Zoom In option to zoom to 30% scale
+             Then user can see the chart area is zoomed
+              And user can see all labels, decorators, pod rings & icons are hidden
+              And user can see background of node as white
 
 
         @regression @manual
@@ -181,7 +193,7 @@ Feature: Topology chart area
               And user clicks on Create button
               And user hovers on Add to Project and clicks on "Operator Backed"
               And user selects Postgres and clicks on Create
-              And user fills the "Operator Backed" form and clicks Create
+              And user fills the "Operator Backed" form with yaml at "test-data/postgres-operator-backed.yaml" and clicks Create
               And user hovers on Add to Project and clicks on "Helm Charts"
               And user selects Nodejs and clicks on Install Helm Charts
               And user fills the "Helm Chart" form and clicks Create
@@ -388,3 +400,53 @@ Feature: Topology chart area
               And user selects Bindable service as "kafka-instance-ex1"
               And user clicks on Save
              Then user will see error "Service binding already exists. Select a different service to connect to."
+
+
+        @regression @odc-4944 @manual
+        Scenario: Status on Service binding in topology: T-06-TC32
+            Given user has installed Service Binding operator
+              And user has installed Redis Operator
+              And user has installed Crunchy Postgres for Kubernetes operator
+              And user is at developer perspective
+              And user is at Topology page chart view
+              And user has created a deployment workload named "node-j"
+              And user has created a operator backed service of "Redis" operator named "redis-standalone"
+              And user has created a operator backed service "hippo" from yaml "test-data/hippo-postgres-cluster.yaml"
+              And user has created service binding connnector "test-connector1" between "node-j" and "redis-standalone"
+              And user has created service binding connnector "test-connector2" between "node-j" and "hippo"
+             When user clicks on service binding connector for "hippo"
+              And user clicks on service binding connector for "redis-standalone"
+             Then user will see black colored connector for "hippo"
+              And user can see "Connected" in Status section on service binding connnector topology sidebar
+              And user will see red colored connector for "redis-standalone"
+              And user can see "Error" in Status section on service binding connnector topology sidebar
+
+
+        @regression @odc-4944
+        Scenario: Connected status on Service binding details page: T-06-TC33
+            Given user has created namespace "aut-connected-sb"
+              And user has installed Service Binding operator
+              And user has installed Crunchy Postgres for Kubernetes operator
+              And user is at developer perspective
+              And user is at Topology page chart view
+              And user has created a deployment workload named "node-ej"
+              And user has created a operator backed service "hippo" from yaml "test-data/hippo-postgres-cluster.yaml"
+              And user has created service binding connnector "test-connector2" between "node-ej" and "hippo"
+             When user clicks on service binding connector
+              And user clicks on the service binding name "test-connector2" at the sidebar
+             Then user will see "Connected" Status on Service binding details page
+
+
+        @regression @odc-4944
+        Scenario: Error status on Service binding details page: T-06-TC34
+            Given user has created namespace "aut-error-sb"
+              And user has installed Service Binding operator
+              And user has installed Redis Operator
+              And user is at developer perspective
+              And user is at Topology page chart view
+              And user has created a deployment workload named "node-ej"
+              And user has created a operator backed service of "Redis" operator named "redis-standalone-test"
+              And user has created service binding connnector "test-connector3" between "node-ej" and "redis-standalone-test"
+             When user clicks on service binding connector
+              And user clicks on the service binding name "test-connector3" at the sidebar
+             Then user will see "Error" Status on Service binding details page

--- a/frontend/packages/topology/integration-tests/support/page-objects/chart-area-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/chart-area-po.ts
@@ -39,7 +39,7 @@ export const chartAreaPO = {
   channelName: '[data-test-id="channel-name"]',
   saveChanges: '[data-test="save-changes"]',
   yamlEditor: 'div.monaco-scrollable-element.editor-scrollable.vs-dark',
-  yamlView: '[data-test="yaml-view-input"]',
+  yamlView: '[data-test="import-yaml"]',
   dangerAlert: '[aria-label="Danger Alert"]',
   infoAlert: '[aria-label="Info Alert"]',
   contentScrollable: '#content-scrollable',

--- a/frontend/packages/topology/integration-tests/support/pages/functions/chart-functions.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/functions/chart-functions.ts
@@ -1,4 +1,10 @@
-import { app, gitPage, yamlEditor } from '@console/dev-console/integration-tests/support/pages';
+import { devNavigationMenu } from '@console/dev-console/integration-tests/support/constants';
+import {
+  app,
+  gitPage,
+  navigateTo,
+  yamlEditor,
+} from '@console/dev-console/integration-tests/support/pages';
 import { chartAreaPO } from '../../page-objects/chart-area-po';
 import { topologyPO } from '../../page-objects/topology-po';
 import { topologyHelper, topologyPage } from '../topology';
@@ -15,7 +21,7 @@ export const verifyMultipleWorkloadInTopologyPage = (workloadNames: string[]) =>
   }
 };
 
-export const createWorkloadUsingOptions = (optionName: string) => {
+export const createWorkloadUsingOptions = (optionName: string, optionalData?: string) => {
   switch (optionName) {
     case 'Go Sample':
       gitPage.verifyValidatedMessage(
@@ -70,9 +76,11 @@ export const createWorkloadUsingOptions = (optionName: string) => {
         .clear();
 
       // eslint-disable-next-line no-case-declarations
-      const yamlLocation = 'support/test-data/postgres-operator-backed.yaml';
+      const yamlLocation = `support/${optionalData}`;
       yamlEditor.setEditorContent(yamlLocation);
       cy.get(chartAreaPO.saveChanges).click();
+      cy.get('[aria-label="Breadcrumb"]').should('contain', 'PostgresCluster details');
+      navigateTo(devNavigationMenu.Topology);
       break;
 
     case 'Helm Chart':

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -398,3 +398,26 @@ export const topologyListPage = {
     cy.get(id).click({ force: true });
   },
 };
+
+export const createServiceBindingConnect = (
+  bindingName: string = 'testing',
+  senderNode: string,
+  recieverNode: string,
+) => {
+  topologyPage.rightClickOnNode(senderNode);
+  cy.byTestActionID('Create Service Binding')
+    .should('be.visible')
+    .click();
+  cy.get('#form-input-name-field')
+    .should('be.visible')
+    .clear()
+    .type(bindingName);
+  cy.get('#form-ns-dropdown-service-field')
+    .should('be.visible')
+    .click();
+  cy.get(`#${recieverNode}-link`)
+    .should('be.visible')
+    .click();
+  cy.get('#confirm-action').click();
+  cy.get('[data-test-id="edge-handler"]', { timeout: 10000 }).should('be.visible');
+};

--- a/frontend/packages/topology/integration-tests/support/test-data/hippo-postgres-cluster.yaml
+++ b/frontend/packages/topology/integration-tests/support/test-data/hippo-postgres-cluster.yaml
@@ -1,0 +1,38 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: hippo
+spec:
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-ha:centos8-13.4-0
+  postgresVersion: 13
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.33-2
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi
+      - name: repo2
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi
+  proxy:
+    pgBouncer:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-2


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-4944
Story: https://issues.redhat.com/browse/ODC-6500
Acceptance criteria:

-  SBR
    - Provide a visual indicator so that users know if there is an error with a SBR in topology
    - In Topology side panel, include status
    - In Details of Topology side panel, show the error
    - Show a status badge on the SB details page
    - Show a Status field in the right column of the SB details page
-  Remove the following features from topology view
    - Consumption mode can be removed, thus MODE in general is not needed
    - Layout 2 option, thus no layout options are needed
-  Topology should render differently based on zoom level ( actual percentages to be defined during development )
    - When zoomed to 50% scale, all labels & decorators will be hidden. Label are shown when hovering over the node
    - When zoomed to 30% scale, all labels, decorators, pod rings & icons will be hidden. Node shape remains the same, and background is either white, yellow or red. Background color is determined based on aggregate status of pods, alerts, builds and pipelines. Tooltip is available showing node name as well as the "things" which are attributing to the warning/error status.

**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]

**Fix**: https://issues.redhat.com/browse/ODC-6501


**Test Setup**:


Cluster should be running on local

Check the TAGS in frontend/packages/topology/integration-tests/cypress.json file be: ""@topology and @[odc-4944](https://issues.redhat.com//browse/odc-4944) and (@smoke or @regression or @pre-condition) and not (@manual or @to-do or @un-verified or @broken-test)"",


Command to execute:

Run a cluster locally and execute the command `yarn run dev` and then `npm run test-cypress-topology` simultaneously

Execute the topology-chart-area-visual.feature file

**Browser**
Chrome 99

**Test Execution Screenshot:**


