### PR TITLE
Bug 2087546: Expose getting started card resources

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/loader/QuickStartsLoader.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/loader/QuickStartsLoader.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react';
 import { QuickStart, isDisabledQuickStart, getDisabledQuickStarts } from '@patternfly/quickstarts';
+import { QuickStartsLoaderProps } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { referenceForModel } from '@console/internal/module/k8s/k8s';
 import { QuickStartModel } from '../../../models';
 import QuickStartPermissionChecker from './QuickStartPermissionChecker';
-
-type QuickStartsLoaderProps = {
-  children: (quickStarts: QuickStart[], loaded: boolean) => React.ReactNode;
-};
 
 const QuickStartsLoader: React.FC<QuickStartsLoaderProps> = ({ children }) => {
   const [quickStarts, quickStartsLoaded] = useK8sWatchResource<QuickStart[]>({

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
@@ -17,6 +17,8 @@ import {
   VirtualizedGridProps,
   LazyActionMenuProps,
   UseDashboardResources,
+  UseUserSettings,
+  QuickStartsLoaderProps,
 } from './internal-types';
 
 export const ActivityItem: React.FC<ActivityItemProps> = require('@console/shared/src/components/dashboard/activity-card/ActivityItem')
@@ -49,6 +51,8 @@ export const VirtualizedGrid: React.FC<VirtualizedGridProps> = require('@console
   .default;
 export const LazyActionMenu: React.FC<LazyActionMenuProps> = require('@console/shared/src/components/actions/LazyActionMenu')
   .default;
+export const QuickStartsLoader: React.FC<QuickStartsLoaderProps> = require('@console/app/src/components/quick-starts/loader/QuickStartsLoader')
+  .default;
 
 export const useUtilizationDuration: UseUtilizationDuration = require('@console/shared/src/hooks/useUtilizationDuration')
   .useUtilizationDuration;
@@ -57,3 +61,5 @@ export const useActiveNamespace: UseActiveNamespace = require('@console/shared/s
 export const ServicesList = require('@console/internal/components/service').ServicesList;
 export const useDashboardResources: UseDashboardResources = require('@console/shared/src/hooks/useDashboardResources')
   .useDashboardResources;
+export const useUserSettings: UseUserSettings = require('@console/shared/src/hooks/useUserSettings')
+  .useUserSettings;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { QuickStart } from '@patternfly/quickstarts';
 import { Map as ImmutableMap } from 'immutable';
 import {
   FirehoseResult,
@@ -264,4 +266,18 @@ export type UseDashboardResources = ({
   urlResults: RequestMap<any>;
   prometheusResults: RequestMap<PrometheusResponse>;
   notificationAlerts: { alerts: Alert[]; loaded: boolean; loadError: Error };
+};
+
+export type UseUserSettings = <T>(
+  key: string,
+  defaultValue?: T,
+  sync?: boolean,
+) => [T, React.Dispatch<React.SetStateAction<T>>, boolean];
+
+export type QuickStartsLoaderProps = {
+  children: (quickStarts: QuickStart[], loaded: boolean) => React.ReactNode;
+};
+
+export type QuickStartsSectionWrapperProps = {
+  children: React.ReactElement[];
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules-init.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules-init.ts
@@ -10,6 +10,7 @@ const modules: SharedModuleResolution = {
     require('@console/dynamic-plugin-sdk/src/lib-internal'),
   '@patternfly/react-core': async () => () => require('@patternfly/react-core'),
   '@patternfly/react-table': async () => () => require('@patternfly/react-table'),
+  '@patternfly/quickstarts': async () => () => require('@patternfly/quickstarts'),
   react: async () => () => require('react'),
   'react-helmet': async () => () => require('react-helmet'),
   'react-i18next': async () => () => require('react-i18next'),

--- a/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules.ts
@@ -6,6 +6,7 @@ export const sharedPluginModules = [
   '@openshift-console/dynamic-plugin-sdk-internal',
   '@patternfly/react-core',
   '@patternfly/react-table',
+  '@patternfly/quickstarts',
   'react',
   'react-helmet',
   'react-i18next',

--- a/frontend/packages/console-shared/src/hooks/useUserSettings.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettings.ts
@@ -4,6 +4,7 @@ import * as React from 'react';
 // @ts-ignore
 import { useSelector } from 'react-redux';
 import { getImpersonate, getUser } from '@console/dynamic-plugin-sdk';
+import { UseUserSettings } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ConfigMapModel } from '@console/internal/models';
 import { K8sResourceKind } from '@console/internal/module/k8s';
@@ -35,12 +36,8 @@ const useCounterRef = (initialValue: number = 0): [boolean, () => void, () => vo
   return [counterRef.current !== initialValue, increment, decrement];
 };
 
-export const useUserSettings = <T>(
-  key: string,
-  defaultValue?: T,
-  sync: boolean = false,
-): [T, React.Dispatch<React.SetStateAction<T>>, boolean] => {
-  // Mount status for safty state updates
+export const useUserSettings: UseUserSettings = <T>(key, defaultValue, sync = false) => {
+  // Mount status for safety state updates
   const mounted = React.useRef(true);
   React.useEffect(() => () => (mounted.current = false), []);
 


### PR DESCRIPTION
Access to the console instance of `QuickStartContextProvider` is required in order to add the quick start section to the cluster overview. This PR adds access to that via a wrapper component as well as access to the `QuickStartsLoaderProps` component and `useUserSettings` hook to allow hiding of the getting started card.