### PR TITLE
Add React-Router Docs to our Extension docs

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/pages.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/pages.ts
@@ -28,7 +28,12 @@ type RoutePageProperties = {
   exact?: boolean;
 };
 
-/** Adds new page to Console router. */
+/**
+ * Adds new page to Console router.
+ *
+ * Under the hood we use React Router.
+ * See https://v5.reactrouter.com/
+ */
 export type RoutePage = ExtensionDeclaration<'console.page/route', RoutePageProperties>;
 
 /** Adds new resource list page to Console router. */
@@ -58,7 +63,12 @@ export type ResourceTabPage = ExtensionDeclaration<
   }
 >;
 
-/** Adds new standalone page (rendered outside the common page layout) to Console router. */
+/**
+ * Adds new standalone page (rendered outside the common page layout) to Console router.
+ *
+ * Under the hood we use React Router.
+ * See https://v5.reactrouter.com/
+ */
 export type StandaloneRoutePage = ExtensionDeclaration<
   'console.page/route/standalone',
   Omit<RoutePageProperties, 'perspective'>


### PR DESCRIPTION
https://issues.redhat.com/browse/CONSOLE-3161

Add React Router doc link to the generated output for routes.

[Generated output](https://gist.github.com/andrewballantyne/f8eccdcd85f3443c9805825d898c12ff#consolepageroute)
![image](https://user-images.githubusercontent.com/8126518/170279633-57f9641b-4cfc-42ea-b180-74036b917081.png)
![image](https://user-images.githubusercontent.com/8126518/170279851-4f03a109-512d-43b1-98ee-a199644383e0.png)

Note: today it is just the first line of each summary