### PR TITLE
Bug 2077138: fix {{execute}} regex for multiline executables in QuickStart

### DIFF
--- a/frontend/packages/console-shared/src/components/markdown-extensions/multiline-execute-extension.ts
+++ b/frontend/packages/console-shared/src/components/markdown-extensions/multiline-execute-extension.ts
@@ -11,7 +11,7 @@ const useMultilineExecuteCommandShowdownExtension = () => {
   return useMemo(
     () => ({
       type: 'lang',
-      regex: /```[\n]((.*?\n)+)```{{execute}}/g,
+      regex: /```[\n]\s*((((?!```).)*?\n)+)\s*```{{execute}}/g,
       replace: (
         text: string,
         group: string,

--- a/frontend/packages/console-shared/src/components/markdown-extensions/multiline-execute-extension.ts
+++ b/frontend/packages/console-shared/src/components/markdown-extensions/multiline-execute-extension.ts
@@ -45,7 +45,7 @@ const useMultilineExecuteCommandShowdownExtension = () => {
                 </div>
               </div>
               <div class="pf-c-code-block__content">
-                <pre class="pf-c-code-block__pre ocs-code-block__pre">
+                <pre class="pf-c-code-block__pre pfext-code-block__pre">
                   <code class="pf-c-code-block__code" 
                     ${MARKDOWN_SNIPPET_ID}="${groupType}">${group}</code>
                 </pre>


### PR DESCRIPTION
# Addresses
https://bugzilla.redhat.com/show_bug.cgi?id=2077138

# Issue
ConsoleQuickStart YAML does not support the {{copy}} or {{execute}} modifiers for multi-line code blocks if the blocks are indented as part of a list.

# Solution
Regex problem in {{execute}} quickstart block.
converts regex from `/```[\n]((.*?\n)+)```{{execute}}/g` to `/```[\n]\s*((((?!```).)*?\n)+)\s*```{{execute}}/g` 

# Screenshots
<img width="1242" alt="Screenshot 2022-05-31 at 10 11 56 PM" src="https://user-images.githubusercontent.com/24852534/171228944-851fff6a-5eac-474e-8f6b-45763fceb1c7.png">
<img width="417" alt="Screenshot 2022-05-31 at 10 12 02 PM" src="https://user-images.githubusercontent.com/24852534/171228972-f3c72990-6508-4401-8fb4-9c195a8eb2ef.png">


#Browser conformance
Chrome