### PR TITLE
frontend: Use fuzzysort over fuzzysearch in ListDropdown

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -163,6 +163,7 @@
     "focus-trap-react": "^6.0.0",
     "formik": "2.0.3",
     "fuzzysearch": "1.0.x",
+    "fuzzysort": "2.0.1",
     "gherkin-lint": "^4.1.3",
     "git-url-parse": "^11.4.0",
     "graphql": "^14.0.0",

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -287,14 +287,13 @@ class Dropdown_ extends DropdownMixin {
     if (autocompleteFilter && !_.isEmpty(autocompleteText)) {
       if (weightedSort) {
         // Use fuzzysort
-        let totalItems = _.map(items, (item) => item.props);
+        const totalItems = _.map(items, (item) => item.props);
         const result = autocompleteFilter(autocompleteText, totalItems);
-        totalItems = {};
-        _.forEach(result, (item) => {
+        items = result.reduce((acc, item) => {
           const key = `${item.obj.name}-${item.obj.kind}`;
-          totalItems[key] = items[key];
-        });
-        items = totalItems;
+          acc[key] = items[key];
+          return acc;
+        }, {});
       } else {
         // Use fuzzysearch
         items = _.pickBy(items, (item, key) => autocompleteFilter(autocompleteText, item, key));

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -285,18 +285,13 @@ class Dropdown_ extends DropdownMixin {
   applyTextFilter_(autocompleteText, items) {
     const { autocompleteFilter } = this.props;
     if (autocompleteFilter && !_.isEmpty(autocompleteText)) {
-      const newItems = [];
       let totalItems = _.map(items, (item) => item.props);
-      totalItems = autocompleteFilter(autocompleteText, totalItems);
-      _.map(totalItems, (filterItem) => {
-        _.some(items, (item) => {
-          if (item.props.name === filterItem.target) {
-            newItems.push(item);
-            return true;
-          }
-        });
-      });
-      items = newItems;
+      const result = autocompleteFilter(autocompleteText, totalItems);
+      totalItems = [];
+      _.forEach(result, (filterItem) =>
+        totalItems.push(items[`${filterItem.obj.name}-${filterItem.obj.kind}`]),
+      );
+      items = totalItems;
     }
     this.setState({ autocompleteText, items });
   }

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -285,7 +285,18 @@ class Dropdown_ extends DropdownMixin {
   applyTextFilter_(autocompleteText, items) {
     const { autocompleteFilter } = this.props;
     if (autocompleteFilter && !_.isEmpty(autocompleteText)) {
-      items = _.pickBy(items, (item, key) => autocompleteFilter(autocompleteText, item, key));
+      const newItems = [];
+      let totalItems = _.map(items, (item) => item.props);
+      totalItems = autocompleteFilter(autocompleteText, totalItems);
+      _.map(totalItems, (filterItem) => {
+        _.some(items, (item) => {
+          if (item.props.name === filterItem.target) {
+            newItems.push(item);
+            return true;
+          }
+        });
+      });
+      items = newItems;
     }
     this.setState({ autocompleteText, items });
   }

--- a/frontend/public/components/utils/list-dropdown.jsx
+++ b/frontend/public/components/utils/list-dropdown.jsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as fuzzy from 'fuzzysort';
+import fuzzysort from 'fuzzysort';
 import * as PropTypes from 'prop-types';
 import { Alert } from '@patternfly/react-core';
 import { useFlag } from '@console/shared/src/hooks/flag';
@@ -32,7 +32,7 @@ class ListDropdownWithTranslation extends React.Component {
 
     this.state.title = props.loaded ? props.placeholder : <LoadingInline />;
 
-    this.autocompleteFilter = (text, item) => fuzzy.go(text, item, { key: 'name' });
+    this.autocompleteFilter = (text, item) => fuzzysort.go(text, item, { key: 'name' });
     // Pass both the resource name and the resource kind to onChange()
     this.onChange = (key) => {
       if (_.find(this.props.actionItems, { actionKey: key })) {

--- a/frontend/public/components/utils/list-dropdown.jsx
+++ b/frontend/public/components/utils/list-dropdown.jsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as fuzzy from 'fuzzysearch';
+import * as fuzzy from 'fuzzysort';
 import * as PropTypes from 'prop-types';
 import { Alert } from '@patternfly/react-core';
 import { useFlag } from '@console/shared/src/hooks/flag';
@@ -32,7 +32,7 @@ class ListDropdownWithTranslation extends React.Component {
 
     this.state.title = props.loaded ? props.placeholder : <LoadingInline />;
 
-    this.autocompleteFilter = (text, item) => fuzzy(text, item.props.name);
+    this.autocompleteFilter = (text, item) => fuzzy.go(text, item, { key: 'name' });
     // Pass both the resource name and the resource kind to onChange()
     this.onChange = (key) => {
       if (_.find(this.props.actionItems, { actionKey: key })) {

--- a/frontend/public/components/utils/list-dropdown.jsx
+++ b/frontend/public/components/utils/list-dropdown.jsx
@@ -141,6 +141,7 @@ class ListDropdownWithTranslation extends React.Component {
       <Dropdown
         actionItems={this.props.actionItems}
         autocompleteFilter={this.autocompleteFilter}
+        weightedSort={true}
         autocompletePlaceholder={placeholder}
         items={items}
         selectedKey={selectedKey}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9274,6 +9274,11 @@ fuzzysearch@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fuzzysearch/-/fuzzysearch-1.0.3.tgz#dffc80f6d6b04223f2226aa79dd194231096d008"
 
+fuzzysort@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fuzzysort/-/fuzzysort-2.0.1.tgz#e1bf6abbcfeefd1191900a5f56527aa0508d6934"
+  integrity sha512-SlgbPAq0eQ6JQ1h3l4MNeGH/t9DHKH8GGM0RD/6RhmJrNnSoWt3oIVaiQm9g9BPB+wAhRMeMqlUTbhbd7+Ufcg==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"


### PR DESCRIPTION
Updated the code to use fuzzysort over fuzzysearch in ListDropdown
to give a weighted sort.

Fixes: #11114

Signed-off-by: nik-redhat <nladha@redhat.com>