### PR TITLE
CONSOLE-3162: Implement check for the new i18n annotation for dynamic plugins

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -123,6 +123,7 @@ func main() {
 	consolePluginsFlags := serverconfig.MultiKeyValue{}
 	fs.Var(&consolePluginsFlags, "plugins", "List of plugin entries that are enabled for the console. Each entry consist of plugin-name as a key and plugin-endpoint as a value.")
 	fPluginProxy := fs.String("plugin-proxy", "", "Defines various service types to which will console proxy plugins requests. (JSON as string)")
+	fI18NamespacesFlags := fs.String("i18n-namespaces", "", "List of namespaces separated by comma. Example --i18n-namespaces=plugin__acm,plugin__kubevirt")
 
 	telemetryFlags := serverconfig.MultiKeyValue{}
 	fs.Var(&telemetryFlags, "telemetry", "Telemetry configuration that can be used by console plugins. Each entry should be a key=value pair.")
@@ -229,6 +230,15 @@ func main() {
 		}
 	}
 
+	i18nNamespaces := strings.Split(*fI18NamespacesFlags, ",")
+	if *fI18NamespacesFlags != "" {
+		for _, str := range i18nNamespaces {
+			if str == "" {
+				bridge.FlagFatalf("i18n-namespaces", "list must contain name of i18n namespaces separated by comma")
+			}
+		}
+	}
+
 	srv := &server.Server{
 		PublicDir:                 *fPublicDir,
 		BaseURL:                   baseURL,
@@ -248,6 +258,7 @@ func main() {
 		DevCatalogCategories:      *fDevCatalogCategories,
 		UserSettingsLocation:      *fUserSettingsLocation,
 		EnabledConsolePlugins:     consolePluginsFlags,
+		I18nNamespaces:            i18nNamespaces,
 		PluginProxy:               *fPluginProxy,
 		QuickStarts:               *fQuickStarts,
 		AddPage:                   *fAddPage,

--- a/dynamic-demo-plugin/README.md
+++ b/dynamic-demo-plugin/README.md
@@ -153,6 +153,13 @@ conster Header: React.FC = () => {
 };
 ```
 
+The demo plugin contains `console.openshift.io/use-i18n` annotation, which
+indicates whether the `ConsolePlugin` contains localization resources.
+If the annotation is set to `"true"`, the localization resources from
+the i18n namespace named after the dynamic plugin, in this case `plugin__console-demo-plugin`,
+are loaded. If the annotation is set to any other value or is missing on the `ConsolePlugin`
+resource, localization resources are not loaded.
+
 For labels in `console-extensions.json`, you can use the format
 `%plugin__console-demo-plugin~My Label%`. Console will replace the value with
 the message for the current language from the `plugin__console-demo-plugin`

--- a/dynamic-demo-plugin/oc-manifest.yaml
+++ b/dynamic-demo-plugin/oc-manifest.yaml
@@ -79,6 +79,8 @@ apiVersion: console.openshift.io/v1alpha1
 kind: ConsolePlugin
 metadata:
   name: console-demo-plugin
+  annotations:
+    console.openshift.io/use-i18n: "true" 
 spec:
   displayName: 'OpenShift Console Demo Plugin'
   service:

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -45,6 +45,7 @@ declare interface Window {
     userSettingsLocation: string;
     addPage: string; // JSON encoded configuration
     consolePlugins: string[]; // Console dynamic plugins enabled on the cluster
+    i18nNamespaces: string[]; // Available i18n namespaces
     quickStarts: string;
     projectAccessClusterRoles: string;
     clusters: string[];

--- a/frontend/packages/console-plugin-sdk/src/store.ts
+++ b/frontend/packages/console-plugin-sdk/src/store.ts
@@ -51,6 +51,8 @@ export class PluginStore {
   // Extensions contributed by dynamic plugins which are currently in use
   private dynamicPluginExtensions: LoadedExtension[];
 
+  private i18nNamespaces: Set<string>;
+
   private readonly staticPlugins: StaticPlugin[];
 
   // Static plugins that were disabled by loading replacement dynamic plugins
@@ -66,7 +68,11 @@ export class PluginStore {
 
   private readonly listeners: VoidFunction[] = [];
 
-  constructor(staticPlugins: ActivePlugin[] = [], allowedDynamicPluginNames: string[] = []) {
+  constructor(
+    staticPlugins: ActivePlugin[] = [],
+    allowedDynamicPluginNames: string[] = [],
+    i18nNamespaces: string[] = [],
+  ) {
     this.staticPlugins = staticPlugins.map((plugin) => ({
       name: plugin.name,
       extensions: plugin.extensions.map((e, index) =>
@@ -77,6 +83,7 @@ export class PluginStore {
     }));
 
     this.allowedDynamicPluginNames = new Set(allowedDynamicPluginNames);
+    this.i18nNamespaces = new Set(i18nNamespaces);
     this.updateExtensions();
   }
 
@@ -86,6 +93,10 @@ export class PluginStore {
 
   getAllowedDynamicPluginNames() {
     return Array.from(this.allowedDynamicPluginNames);
+  }
+
+  getI18nNamespaces() {
+    return Array.from(this.i18nNamespaces);
   }
 
   subscribe(listener: VoidFunction): VoidFunction {

--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -54,7 +54,7 @@ export const init = () => {
         'public',
         'rhoas-plugin',
         'topology',
-        ...pluginStore.getAllowedDynamicPluginNames().map((name) => `plugin__${name}`),
+        ...pluginStore.getI18nNamespaces(),
       ],
       defaultNS: 'public',
       nsSeparator: '~',

--- a/frontend/public/plugins.ts
+++ b/frontend/public/plugins.ts
@@ -17,6 +17,10 @@ const getEnabledDynamicPluginNames = () => {
   return allPluginNames.filter((pluginName) => !disabledPluginNames.includes(pluginName));
 };
 
+const getI18nNamespaces = () => {
+  return window.SERVER_FLAGS.i18nNamespaces;
+};
+
 // The '@console/active-plugins' module is generated during a webpack build,
 // so we use dynamic require() instead of the usual static import statement.
 const activePlugins =
@@ -25,8 +29,9 @@ const activePlugins =
     : [];
 
 const dynamicPluginNames = getEnabledDynamicPluginNames();
+const i18nNamespaces = getI18nNamespaces();
 
-export const pluginStore = new PluginStore(activePlugins, dynamicPluginNames);
+export const pluginStore = new PluginStore(activePlugins, dynamicPluginNames, i18nNamespaces);
 
 if (process.env.NODE_ENV !== 'production') {
   // Expose Console plugin store for debugging

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -111,6 +111,7 @@ func SetFlagsFromConfig(fs *flag.FlagSet, config Config) (err error) {
 	addMonitoringInfo(fs, &config.MonitoringInfo)
 	addHelmConfig(fs, &config.Helm)
 	addPlugins(fs, config.Plugins)
+	addI18nNamespaces(fs, config.I18nNamespaces)
 	addManagedClusters(fs, config.ManagedClusterConfigFile)
 	err = addProxy(fs, &config.Proxy)
 	if err != nil {
@@ -334,6 +335,10 @@ func addTelemetry(fs *flag.FlagSet, telemetry MultiKeyValue) {
 	for key, value := range telemetry {
 		fs.Set("telemetry", fmt.Sprintf("%s=%s", key, value))
 	}
+}
+
+func addI18nNamespaces(fs *flag.FlagSet, i18nNamespaces []string) {
+	fs.Set("i18n-namespaces", strings.Join(i18nNamespaces, ","))
 }
 
 func addManagedClusters(fs *flag.FlagSet, fileName string) {

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -20,6 +20,7 @@ type Config struct {
 	Helm                     `yaml:"helm"`
 	MonitoringInfo           `yaml:"monitoringInfo,omitempty"`
 	Plugins                  MultiKeyValue `yaml:"plugins,omitempty"`
+	I18nNamespaces           []string      `yaml:"i18nNamespaces,omitempty"`
 	ManagedClusterConfigFile string        `yaml:"managedClusterConfigFile,omitempty"`
 	Proxy                    Proxy         `yaml:"proxy,omitempty"`
 	Telemetry                MultiKeyValue `yaml:"telemetry,omitempty"`


### PR DESCRIPTION
FollowUp of https://github.com/openshift/console-operator/pull/654 where console-operator should be checking for the new console.openshift.io/default-i18next-namespace annotation, update the console-config.yaml accordingly and redeploy the console server.
Console server will check for those i18n namespaces and put them into the `SERVER_FLAGS`. Only locales from these namespaces will get loaded.

/assign @spadgett @vojtechszocs 

Story: https://issues.redhat.com/browse/CONSOLE-3162