### PR TITLE
Bug 2063732: Workloads - StatefulSets : I18n misses

### DIFF
--- a/frontend/public/components/modals/configure-count-modal.tsx
+++ b/frontend/public/components/modals/configure-count-modal.tsx
@@ -47,15 +47,18 @@ export const ConfigureCountModal = withHandlePromise((props: ConfigureCountModal
     );
   };
 
+  const messageVariablesSafe = { ...messageVariables };
   if (labelKey) {
-    messageVariables.resourceKinds = t(labelKey, titleVariables);
+    messageVariablesSafe.resourceKinds = t(labelKey, titleVariables);
   }
 
   return (
     <form onSubmit={submit} name="form" className="modal-content ">
       <ModalTitle>{titleKey ? t(titleKey, titleVariables) : title}</ModalTitle>
       <ModalBody>
-        <p className="modal-paragraph">{messageKey ? t(messageKey, messageVariables) : message}</p>
+        <p className="modal-paragraph">
+          {messageKey ? t(messageKey, messageVariablesSafe) : message}
+        </p>
         <NumberSpinner
           value={value}
           onChange={(e: any) => setValue(e.target.value)}

--- a/frontend/public/components/modals/configure-count-modal.tsx
+++ b/frontend/public/components/modals/configure-count-modal.tsx
@@ -12,6 +12,7 @@ export const ConfigureCountModal = withHandlePromise((props: ConfigureCountModal
     buttonTextKey,
     buttonTextVariables,
     defaultValue,
+    labelKey,
     path,
     resource,
     resourceKind,
@@ -45,6 +46,10 @@ export const ConfigureCountModal = withHandlePromise((props: ConfigureCountModal
       },
     );
   };
+
+  if (labelKey) {
+    messageVariables.resourceKinds = t(labelKey, titleVariables);
+  }
 
   return (
     <form onSubmit={submit} name="form" className="modal-content ">
@@ -81,6 +86,7 @@ export const configureReplicaCountModal = (props) => {
         // t('public~Edit Pod count')
         titleKey: 'public~Edit Pod count',
         // t('public~{{resourceKinds}} maintain the desired number of healthy pods.', {resourceKind: props.resourceKind.labelPlural})
+        labelKey: props.resourceKind.labelPluralKey,
         messageKey: 'public~{{resourceKinds}} maintain the desired number of healthy pods.',
         messageVariables: { resourceKinds: props.resourceKind.labelPlural },
         path: '/spec/replicas',
@@ -122,6 +128,7 @@ export type ConfigureCountModalProps = {
   buttonTextKey?: string;
   buttonTextVariables?: { [key: string]: any };
   defaultValue: number;
+  labelKey?: string;
   path: string;
   resource: K8sResourceKind;
   resourceKind: K8sKind;

--- a/frontend/public/components/modals/configure-count-modal.tsx
+++ b/frontend/public/components/modals/configure-count-modal.tsx
@@ -88,8 +88,8 @@ export const configureReplicaCountModal = (props) => {
         defaultValue: 0,
         // t('public~Edit Pod count')
         titleKey: 'public~Edit Pod count',
-        // t('public~{{resourceKinds}} maintain the desired number of healthy pods.', {resourceKind: props.resourceKind.labelPlural})
         labelKey: props.resourceKind.labelPluralKey,
+        // t('public~{{resourceKinds}} maintain the desired number of healthy pods.', {resourceKind: props.resourceKind.labelPlural})
         messageKey: 'public~{{resourceKinds}} maintain the desired number of healthy pods.',
         messageVariables: { resourceKinds: props.resourceKind.labelPlural },
         path: '/spec/replicas',


### PR DESCRIPTION
Translates "StatefulSets" to the selected UI language in the "Edit Pod Count" modal.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2063732