### PR TITLE
Bug 2078769: Added translations for filter group names

### DIFF
--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content.tsx
@@ -128,12 +128,13 @@ const VolumeSnapshotContentTable: React.FC = (props) => {
 };
 
 const VolumeSnapshotContentPage: React.FC = (props) => {
+  const { t } = useTranslation();
   return (
     <ListPage
       {...props}
       kind={referenceForModel(VolumeSnapshotContentModel)}
       ListComponent={VolumeSnapshotContentTable}
-      rowFilters={snapshotStatusFilters}
+      rowFilters={snapshotStatusFilters(t)}
       canCreate
     />
   );

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
@@ -186,6 +186,7 @@ const VolumeSnapshotTable: React.FC<VolumeSnapshotTableProps> = (props) => {
 };
 
 const VolumeSnapshotPage: React.FC<VolumeSnapshotPageProps> = (props) => {
+  const { t } = useTranslation();
   const canListVSC = useFlag(FLAGS.CAN_LIST_VSC);
   const namespace = props.namespace || props.match?.params?.ns || 'all-namespaces';
   const createProps = {
@@ -198,7 +199,7 @@ const VolumeSnapshotPage: React.FC<VolumeSnapshotPageProps> = (props) => {
       {...props}
       kind={referenceForModel(VolumeSnapshotModel)}
       ListComponent={VolumeSnapshotTable}
-      rowFilters={snapshotStatusFilters}
+      rowFilters={snapshotStatusFilters(t)}
       canCreate
       createProps={createProps}
       customData={{ disableItems: { 'Snapshot Content': !canListVSC } }}
@@ -229,13 +230,14 @@ const FilteredSnapshotTable: React.FC<FilteredSnapshotTable> = (props) => {
 };
 
 export const VolumeSnapshotPVCPage: React.FC<VolumeSnapshotPVCPage> = (props) => {
+  const { t } = useTranslation();
   const canListVSC = useFlag(FLAGS.CAN_LIST_VSC);
   return (
     <ListPage
       {...props}
       kind={referenceForModel(VolumeSnapshotModel)}
       ListComponent={FilteredSnapshotTable}
-      rowFilters={snapshotStatusFilters}
+      rowFilters={snapshotStatusFilters(t)}
       customData={{
         pvc: props.obj,
         disableItems: { Source: true, 'Snapshot Content': !canListVSC },

--- a/frontend/packages/console-app/src/status/snapshot.ts
+++ b/frontend/packages/console-app/src/status/snapshot.ts
@@ -1,3 +1,5 @@
+import { TFunction } from 'i18next';
+import { RowFilter } from '@console/internal/components/filter-toolbar';
 import { VolumeSnapshotStatus } from '@console/internal/module/k8s';
 
 export const volumeSnapshotStatus = ({ status }: { status?: VolumeSnapshotStatus }) => {
@@ -6,15 +8,17 @@ export const volumeSnapshotStatus = ({ status }: { status?: VolumeSnapshotStatus
   return readyToUse ? 'Ready' : isError ? 'Error' : 'Pending';
 };
 
-export const snapshotStatusFilters = [
-  {
-    filterGroupName: 'Status',
-    type: 'snapshot-status',
-    reducer: volumeSnapshotStatus,
-    items: [
-      { id: 'Ready', title: 'Ready' },
-      { id: 'Pending', title: 'Pending' },
-      { id: 'Error', title: 'Error' },
-    ],
-  },
-];
+export const snapshotStatusFilters = (t: TFunction): RowFilter[] => {
+  return [
+    {
+      filterGroupName: t('console-app~Status'),
+      type: 'snapshot-status',
+      reducer: volumeSnapshotStatus,
+      items: [
+        { id: 'Ready', title: 'Ready' },
+        { id: 'Pending', title: 'Pending' },
+        { id: 'Error', title: 'Error' },
+      ],
+    },
+  ];
+};

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
@@ -137,7 +137,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace }) => {
       EmptyMsg={emptyState}
       queryArg="rowFilter-helm-release-status"
       textFilter="name"
-      rowFilters={helmReleasesRowFilters}
+      rowFilters={helmReleasesRowFilters(t)}
       sortBy="name"
       sortOrder={SortByDirection.asc}
       rowFilterReducer={filterHelmReleasesByStatus}

--- a/frontend/packages/helm-plugin/src/utils/helm-utils.ts
+++ b/frontend/packages/helm-plugin/src/utils/helm-utils.ts
@@ -47,17 +47,19 @@ export const releaseStatusReducer = (release: HelmRelease) => {
   return release.info.status;
 };
 
-export const helmReleasesRowFilters: RowFilter[] = [
-  {
-    filterGroupName: 'Status',
-    type: 'helm-release-status',
-    reducer: releaseStatusReducer,
-    items: SelectedReleaseStatuses.map((status) => ({
-      id: status,
-      title: HelmReleaseStatusLabels[status],
-    })),
-  },
-];
+export const helmReleasesRowFilters = (t: TFunction): RowFilter[] => {
+  return [
+    {
+      filterGroupName: t('helm-plugin~Status'),
+      type: 'helm-release-status',
+      reducer: releaseStatusReducer,
+      items: SelectedReleaseStatuses.map((status) => ({
+        id: status,
+        title: HelmReleaseStatusLabels[status],
+      })),
+    },
+  ];
+};
 
 export const filterHelmReleasesByStatus = (releases: HelmRelease[], filter: string | string[]) => {
   return releases.filter((release: HelmRelease) => {

--- a/frontend/packages/knative-plugin/src/components/eventing/channels-list/ChannelListPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/eventing/channels-list/ChannelListPage.tsx
@@ -43,7 +43,7 @@ const ChannelListPage: React.FC<React.ComponentProps<typeof MultiListPage>> = (p
   const channelRowFilter = React.useMemo<RowFilter<K8sResourceCommon>[]>(
     () => [
       {
-        filterGroupName: 'Type',
+        filterGroupName: t('knative-plugin~Type'),
         type: 'event-source-type',
         items: eventSourceChannels.map(({ id, label }) => ({ id, title: label })),
         reducer: getModelId,
@@ -51,7 +51,7 @@ const ChannelListPage: React.FC<React.ComponentProps<typeof MultiListPage>> = (p
           !filter.selected?.length || filter.selected?.includes(getModelId(obj)),
       },
     ],
-    [eventSourceChannels, getModelId],
+    [eventSourceChannels, getModelId, t],
   );
   return (
     <MultiListPage

--- a/frontend/packages/knative-plugin/src/components/eventing/eventsource-list/EventSourceListPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/eventing/eventsource-list/EventSourceListPage.tsx
@@ -54,7 +54,7 @@ const EventSourceListPage: React.FC<React.ComponentProps<typeof MultiListPage>> 
   const eventSourceRowFilters = React.useMemo<RowFilter<K8sResourceCommon>[]>(
     () => [
       {
-        filterGroupName: 'Type',
+        filterGroupName: t('knative-plugin~Type'),
         type: 'event-source-type',
         items: sourcesModel.map(({ id, label }) => ({ id, title: label })),
         reducer: getModelId,
@@ -62,7 +62,7 @@ const EventSourceListPage: React.FC<React.ComponentProps<typeof MultiListPage>> 
           !filter.selected?.length || filter.selected?.includes(getModelId(obj)),
       },
     ],
-    [sourcesModel, getModelId],
+    [t, sourcesModel, getModelId],
   );
   return (
     <MultiListPage

--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -734,6 +734,7 @@
   "The following information regarding how the disks are partitioned is provided by the guest agent.": "The following information regarding how the disks are partitioned is provided by the guest agent.",
   "The following hot-plugged disks will be removed from the virtual machine": "The following hot-plugged disks will be removed from the virtual machine",
   "<0>{diskList}</0>": "<0>{diskList}</0>",
+  "Disk Type": "Disk Type",
   "VM Disks List": "VM Disks List",
   "Content": "Content",
   "Drive": "Drive",

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/table-filters.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/table-filters.ts
@@ -1,3 +1,4 @@
+import { TFunction } from 'i18next';
 import { RowFilter } from '@console/dynamic-plugin-sdk';
 import { DiskType } from '../../constants/vm/storage';
 
@@ -6,18 +7,20 @@ const typeReducer = (obj) => {
   return diskType.getValue();
 };
 
-export const diskSourceFilter: RowFilter = {
-  filterGroupName: 'Disk Type',
-  type: 'disk-types',
-  reducer: typeReducer,
-  items: DiskType.getAll().map((diskType) => ({
-    id: diskType.getValue(),
-    title: diskType.toString(),
-  })),
-  filter: (disks, obj) => {
-    const diskType = typeReducer(obj);
-    return (
-      !disks.selected.length || disks.selected.includes(diskType) || disks.all?.includes(diskType)
-    );
-  },
+export const diskSourceFilter = (t: TFunction): RowFilter => {
+  return {
+    filterGroupName: t('kubevirt-plugin~Disk Type'),
+    type: 'disk-type',
+    reducer: typeReducer,
+    items: DiskType.getAll().map((diskType) => ({
+      id: diskType.getValue(),
+      title: diskType.toString(),
+    })),
+    filter: (disks, obj) => {
+      const diskType = typeReducer(obj);
+      return (
+        !disks.selected.length || disks.selected.includes(diskType) || disks.all?.includes(diskType)
+      );
+    },
+  };
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -238,7 +238,7 @@ export const VMDisks: React.FC<VMDisksProps> = ({ obj: vmLikeEntity, vmi, pvcs }
         onClick: createFn,
         id: 'add-disk',
       }}
-      rowFilters={[diskSourceFilter]}
+      rowFilters={[diskSourceFilter(t)]}
       customData={{
         vmLikeEntity,
         vmi,

--- a/frontend/packages/kubevirt-plugin/src/components/vms/table-filters.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/table-filters.ts
@@ -1,3 +1,4 @@
+import { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import { RowFilter } from '@console/dynamic-plugin-sdk';
 import {
@@ -6,41 +7,45 @@ import {
 } from '../../constants/vm/vm-status';
 import { VMStatusBundle } from '../../statuses/vm/types';
 
-export const vmStatusFilter: RowFilter = {
-  filterGroupName: 'Status',
-  type: 'vm-status',
-  reducer: (obj) => {
-    return ((obj?.metadata as any)?.vmStatusBundle as VMStatusBundle)?.status?.getSimpleLabel();
-  },
-  items: VM_STATUS_SIMPLE_LABELS.map((status) => ({
-    id: status,
-    title: status,
-  })),
-  filter: (statuses, obj) => {
-    const status = ((obj?.metadata as any)
-      ?.vmStatusBundle as VMStatusBundle)?.status.getSimpleLabel();
-    return (
-      statuses.selected?.length === 0 ||
-      statuses.selected?.includes(status) ||
-      !_.includes(statuses.all, status)
-    );
-  },
+export const vmStatusFilter = (t: TFunction): RowFilter => {
+  return {
+    filterGroupName: t('kubevirt-plugin~Status'),
+    type: 'vm-status',
+    reducer: (obj) => {
+      return ((obj?.metadata as any)?.vmStatusBundle as VMStatusBundle)?.status?.getSimpleLabel();
+    },
+    items: VM_STATUS_SIMPLE_LABELS.map((status) => ({
+      id: status,
+      title: status,
+    })),
+    filter: (statuses, obj) => {
+      const status = ((obj?.metadata as any)
+        ?.vmStatusBundle as VMStatusBundle)?.status.getSimpleLabel();
+      return (
+        statuses.selected?.length === 0 ||
+        statuses.selected?.includes(status) ||
+        !_.includes(statuses.all, status)
+      );
+    },
+  };
 };
 
-export const vmStatusFilterNew: RowFilter = {
-  filterGroupName: 'Status',
-  type: 'vm-status',
-  reducer: (obj) => getVmStatusLabelFromPrintable(obj?.metadata?.status),
-  items: VM_STATUS_SIMPLE_LABELS.map((status) => ({
-    id: status,
-    title: status,
-  })),
-  filter: (statuses, obj) => {
-    const status = getVmStatusLabelFromPrintable(obj?.metadata?.status);
-    return (
-      statuses.selected?.length === 0 ||
-      statuses.selected?.includes(status) ||
-      !_.includes(statuses?.all, status)
-    );
-  },
+export const vmStatusFilterNew = (t: TFunction): RowFilter => {
+  return {
+    filterGroupName: t('kubevirt-plugin~Status'),
+    type: 'vm-status',
+    reducer: (obj) => getVmStatusLabelFromPrintable(obj?.metadata?.status),
+    items: VM_STATUS_SIMPLE_LABELS.map((status) => ({
+      id: status,
+      title: status,
+    })),
+    filter: (statuses, obj) => {
+      const status = getVmStatusLabelFromPrintable(obj?.metadata?.status);
+      return (
+        statuses.selected?.length === 0 ||
+        statuses.selected?.includes(status) ||
+        !_.includes(statuses?.all, status)
+      );
+    },
+  };
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-page-new.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-page-new.tsx
@@ -355,7 +355,7 @@ export const VirtualMachinesPage: React.FC<VirtualMachinesPageProps> = (props) =
       createButtonText={t('kubevirt-plugin~Create virtual machine')}
       title={VirtualMachineModel.labelPlural}
       showTitle={showTitle}
-      rowFilters={[vmStatusFilterNew]}
+      rowFilters={[vmStatusFilterNew(t)]}
       ListComponent={VMList}
       resources={resources}
       flatten={flatten}

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -446,7 +446,7 @@ export const VirtualMachinesPage: React.FC<VirtualMachinesPageProps> = (props) =
       createButtonText={t('kubevirt-plugin~Create virtual machine')}
       title={VirtualMachineModel.labelPlural}
       showTitle={showTitle}
-      rowFilters={[vmStatusFilter]}
+      rowFilters={[vmStatusFilter(t)]}
       ListComponent={VMList}
       resources={resources}
       flatten={flatten}

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/table-filters.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/table-filters.ts
@@ -65,7 +65,7 @@ export const getHostFilterStatus = (bundle: BareMetalHostBundle): string => {
 };
 
 export const hostStatusFilter = (t: TFunction): RowFilter<BareMetalHostBundle> => ({
-  filterGroupName: 'Status',
+  filterGroupName: t('metal3-plugin~Status'),
   type: 'host-status',
   reducer: getHostFilterStatus,
   items: _.map(hostStatesToFilterMap, ({ title }, id) => ({ id, title: t(title) })),

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/table-filters.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/table-filters.ts
@@ -33,7 +33,7 @@ export const getBareMetalNodeFilterStatus = (bundle: BareMetalNodeListBundle): s
     : _.findKey(statesToFilterMap, ({ states }) => states.includes(bundle.status.status));
 
 export const bareMetalNodeStatusFilter = (t: TFunction): RowFilter<BareMetalNodeListBundle> => ({
-  filterGroupName: 'Status',
+  filterGroupName: t('metal3-plugin~Status'),
   type: 'bare-metal-node-status',
   reducer: getBareMetalNodeFilterStatus,
   items: _.map(statesToFilterMap, ({ titleKey }, id) => ({ id, title: t(titleKey) })),

--- a/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
@@ -185,7 +185,7 @@ export const Resources: React.FC<ResourcesProps> = (props) => {
       rowFilters={[
         {
           type: 'clusterserviceversion-resource-kind',
-          filterGroupName: 'Kind',
+          filterGroupName: t('olm~Kind'),
           reducer: ({ kind }) => kindForReference(kind),
           items: firehoseResources.map(({ kind }) => ({
             id: kindForReference(kind),

--- a/frontend/packages/pipelines-plugin/src/components/pipeline-resources/list-page/PipelineResourcesListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipeline-resources/list-page/PipelineResourcesListPage.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
+import { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { ListPage } from '@console/internal/components/factory';
+import { RowFilter } from '@console/internal/components/filter-toolbar';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineResourceModel } from '../../../models';
 import { usePipelineTechPreviewBadge } from '../../../utils/hooks';
@@ -13,40 +16,42 @@ import {
 } from '../../../utils/pipeline-utils';
 import PipelineResourcesList from './PipelineResourcesList';
 
-const pipelineResourceFilters = [
-  {
-    filterGroupName: 'Type',
-    type: 'pipelineresource-type',
-    reducer: pipelineResourceFilterReducer,
-    items: [
-      {
-        id: PipelineResourceListFilterId.Git,
-        title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.Git],
-      },
-      {
-        id: PipelineResourceListFilterId.PullRequest,
-        title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.PullRequest],
-      },
-      {
-        id: PipelineResourceListFilterId.Image,
-        title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.Image],
-      },
-      {
-        id: PipelineResourceListFilterId.Cluster,
-        title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.Cluster],
-      },
-      {
-        id: PipelineResourceListFilterId.Storage,
-        title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.Storage],
-      },
-      {
-        id: PipelineResourceListFilterId.CloudEvent,
-        title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.CloudEvent],
-      },
-    ],
-    filter: pipelineResourceTypeFilter,
-  },
-];
+const pipelineResourceFilters = (t: TFunction): RowFilter[] => {
+  return [
+    {
+      filterGroupName: t('pipelines-plugin~Type'),
+      type: 'pipelineresource-type',
+      reducer: pipelineResourceFilterReducer,
+      items: [
+        {
+          id: PipelineResourceListFilterId.Git,
+          title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.Git],
+        },
+        {
+          id: PipelineResourceListFilterId.PullRequest,
+          title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.PullRequest],
+        },
+        {
+          id: PipelineResourceListFilterId.Image,
+          title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.Image],
+        },
+        {
+          id: PipelineResourceListFilterId.Cluster,
+          title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.Cluster],
+        },
+        {
+          id: PipelineResourceListFilterId.Storage,
+          title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.Storage],
+        },
+        {
+          id: PipelineResourceListFilterId.CloudEvent,
+          title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.CloudEvent],
+        },
+      ],
+      filter: pipelineResourceTypeFilter,
+    },
+  ];
+};
 
 interface PipelineResourcesListPageProps {
   hideBadge?: boolean;
@@ -57,6 +62,7 @@ const PipelineResourcesListPage: React.FC<Omit<
   'canCreate' | 'kind' | 'ListComponent' | 'rowFilters'
 > &
   PipelineResourcesListPageProps> = (props) => {
+  const { t } = useTranslation();
   const badge = usePipelineTechPreviewBadge(props.namespace);
   return (
     <ListPage
@@ -64,7 +70,7 @@ const PipelineResourcesListPage: React.FC<Omit<
       canCreate={false}
       kind={referenceForModel(PipelineResourceModel)}
       ListComponent={PipelineResourcesList}
-      rowFilters={pipelineResourceFilters}
+      rowFilters={pipelineResourceFilters(t)}
       badge={props.hideBadge ? null : badge}
     />
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsResourceList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsResourceList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../models';
@@ -16,6 +17,7 @@ const PipelineRunsResourceList: React.FC<Omit<
   'kind' | 'ListComponent' | 'rowFilters'
 > &
   PipelineRunsResourceListProps> = (props) => {
+  const { t } = useTranslation();
   const badge = usePipelineTechPreviewBadge(props.namespace);
   return (
     <ListPage
@@ -23,7 +25,7 @@ const PipelineRunsResourceList: React.FC<Omit<
       canCreate={props.canCreate ?? true}
       kind={referenceForModel(PipelineRunModel)}
       ListComponent={PipelineRunsList}
-      rowFilters={runFilters}
+      rowFilters={runFilters(t)}
       badge={props.hideBadge ? null : badge}
     />
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesResourceList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesResourceList.tsx
@@ -29,7 +29,7 @@ const PipelinesResourceList: React.FC<PipelinesResourceListProps> = (props) => {
       kind: referenceForModel(PipelineModel),
       namespace,
       prop: PipelineModel.id,
-      filters: { ...filters, name: nameFilter },
+      filters: { ...filters(t), name: nameFilter },
       selector,
       name,
     },

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineRuns.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineRuns.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
+import { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { ListPage } from '@console/internal/components/factory';
+import { RowFilter } from '@console/internal/components/filter-toolbar';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../../models';
 import {
@@ -10,39 +13,38 @@ import { ListFilterId, ListFilterLabels } from '../../../utils/pipeline-utils';
 import PipelineRunsList from '../../pipelineruns/list-page/PipelineRunList';
 import { PipelineDetailsTabProps } from './types';
 
-export const runFilters = [
-  {
-    filterGroupName: 'Status',
-    type: 'pipelinerun-status',
-    selected: [
-      ListFilterId.Succeeded,
-      ListFilterId.Running,
-      ListFilterId.Failed,
-      ListFilterId.Cancelled,
-    ],
-    reducer: pipelineRunFilterReducer,
-    items: [
-      { id: ListFilterId.Succeeded, title: ListFilterLabels[ListFilterId.Succeeded] },
-      { id: ListFilterId.Running, title: ListFilterLabels[ListFilterId.Running] },
-      { id: ListFilterId.Failed, title: ListFilterLabels[ListFilterId.Failed] },
-      { id: ListFilterId.Cancelled, title: ListFilterLabels[ListFilterId.Cancelled] },
-    ],
-    filter: pipelineRunStatusFilter,
-  },
-];
+export const runFilters = (t: TFunction): RowFilter[] => {
+  return [
+    {
+      filterGroupName: t('pipelines-plugin~Status'),
+      type: 'pipelinerun-status',
+      reducer: pipelineRunFilterReducer,
+      items: [
+        { id: ListFilterId.Succeeded, title: ListFilterLabels[ListFilterId.Succeeded] },
+        { id: ListFilterId.Running, title: ListFilterLabels[ListFilterId.Running] },
+        { id: ListFilterId.Failed, title: ListFilterLabels[ListFilterId.Failed] },
+        { id: ListFilterId.Cancelled, title: ListFilterLabels[ListFilterId.Cancelled] },
+      ],
+      filter: pipelineRunStatusFilter,
+    },
+  ];
+};
 
-const PipelineRuns: React.FC<PipelineDetailsTabProps> = ({ obj }) => (
-  <ListPage
-    showTitle={false}
-    canCreate={false}
-    kind={referenceForModel(PipelineRunModel)}
-    namespace={obj.metadata.namespace}
-    selector={{
-      matchLabels: { 'tekton.dev/pipeline': obj.metadata.name },
-    }}
-    ListComponent={PipelineRunsList}
-    rowFilters={runFilters}
-  />
-);
+const PipelineRuns: React.FC<PipelineDetailsTabProps> = ({ obj }) => {
+  const { t } = useTranslation();
+  return (
+    <ListPage
+      showTitle={false}
+      canCreate={false}
+      kind={referenceForModel(PipelineRunModel)}
+      namespace={obj.metadata.namespace}
+      selector={{
+        matchLabels: { 'tekton.dev/pipeline': obj.metadata.name },
+      }}
+      ListComponent={PipelineRunsList}
+      rowFilters={runFilters(t)}
+    />
+  );
+};
 
 export default PipelineRuns;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRuns.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRuns.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { TFunction } from 'i18next';
 import * as _ from 'lodash';
+import { RowFilter } from '@console/internal/components/filter-toolbar';
 import { inject } from '@console/internal/components/utils';
 import { K8sKind } from '@console/internal/module/k8s';
 import { augmentRunsToData, PropPipelineData, KeyedRuns } from '../../../utils/pipeline-augment';
@@ -12,21 +14,23 @@ import { ListFilterId, ListFilterLabels } from '../../../utils/pipeline-utils';
 interface ListPipelineData extends K8sKind {
   data: PropPipelineData[];
 }
-export const filters = [
-  {
-    filterGroupName: 'Status',
-    type: 'pipeline-status',
-    reducer: pipelineFilterReducer,
-    items: [
-      { id: ListFilterId.Succeeded, title: ListFilterLabels[ListFilterId.Succeeded] },
-      { id: ListFilterId.Running, title: ListFilterLabels[ListFilterId.Running] },
-      { id: ListFilterId.Failed, title: ListFilterLabels[ListFilterId.Failed] },
-      { id: ListFilterId.Cancelled, title: ListFilterLabels[ListFilterId.Cancelled] },
-      { id: ListFilterId.Other, title: ListFilterLabels[ListFilterId.Other] },
-    ],
-    filter: pipelineStatusFilter,
-  },
-];
+export const filters = (t: TFunction): RowFilter[] => {
+  return [
+    {
+      filterGroupName: t('pipelines-plugin~Status'),
+      type: 'pipeline-status',
+      reducer: pipelineFilterReducer,
+      items: [
+        { id: ListFilterId.Succeeded, title: ListFilterLabels[ListFilterId.Succeeded] },
+        { id: ListFilterId.Running, title: ListFilterLabels[ListFilterId.Running] },
+        { id: ListFilterId.Failed, title: ListFilterLabels[ListFilterId.Failed] },
+        { id: ListFilterId.Cancelled, title: ListFilterLabels[ListFilterId.Cancelled] },
+        { id: ListFilterId.Other, title: ListFilterLabels[ListFilterId.Other] },
+      ],
+      filter: pipelineStatusFilter,
+    },
+  ];
+};
 
 export type PipelineAugmentRunsProps = {
   data?: PropPipelineData[];

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRunsWrapper.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRunsWrapper.tsx
@@ -36,7 +36,7 @@ const PipelineAugmentRunsWrapper: React.FC<PipelineAugmentRunsWrapperProps> = (p
           flatten={(_resources) => _.get(_resources, ['pipeline', 'data'], {})}
           kinds={['Pipeline']}
           ListComponent={PipelineList}
-          rowFilters={filters}
+          rowFilters={filters(t)}
           hideNameLabelFilters={props.hideNameLabelFilters}
         />
       </PipelineAugmentRuns>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelinesList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelinesList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { match as Rmatch } from 'react-router-dom';
 import { Firehose } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
@@ -15,13 +16,14 @@ const PipelinesList: React.FC<PipelinesListProps> = ({
     params: { ns: namespace },
   },
 }) => {
+  const { t } = useTranslation();
   const resources = [
     {
       isList: true,
       kind: referenceForModel(PipelineModel),
       namespace,
       prop: PipelineModel.id,
-      filters: { ...filters },
+      filters: { ...filters(t) },
     },
   ];
   return (

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunListPage.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../models';
@@ -11,18 +12,21 @@ export interface RepositoryPipelineRunListPageProps {
   obj: RepositoryKind;
 }
 
-const RepositoryPipelineRunListPage: React.FC<RepositoryPipelineRunListPageProps> = ({ obj }) => (
-  <ListPage
-    showTitle={false}
-    canCreate={false}
-    kind={referenceForModel(PipelineRunModel)}
-    namespace={obj.metadata.namespace}
-    selector={{
-      matchLabels: { [RepositoryLabels[RepositoryFields.REPOSITORY]]: obj.metadata.name },
-    }}
-    ListComponent={RunList}
-    rowFilters={runFilters}
-  />
-);
+const RepositoryPipelineRunListPage: React.FC<RepositoryPipelineRunListPageProps> = ({ obj }) => {
+  const { t } = useTranslation();
+  return (
+    <ListPage
+      showTitle={false}
+      canCreate={false}
+      kind={referenceForModel(PipelineRunModel)}
+      namespace={obj.metadata.namespace}
+      selector={{
+        matchLabels: { [RepositoryLabels[RepositoryFields.REPOSITORY]]: obj.metadata.name },
+      }}
+      ListComponent={RunList}
+      rowFilters={runFilters(t)}
+    />
+  );
+};
 
 export default RepositoryPipelineRunListPage;

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsListPage.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { ListPage } from '@console/internal/components/factory';
 import { getURLSearchParams } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
@@ -17,6 +18,7 @@ const TaskRunsListPage: React.FC<Omit<
   'canCreate' | 'kind' | 'ListComponent' | 'rowFilters'
 > &
   TaskRunsListPageProps> = ({ hideBadge, showPipelineColumn = true, namespace, ...props }) => {
+  const { t } = useTranslation();
   const searchParams = getURLSearchParams();
   const kind = searchParams?.kind;
   const badge = usePipelineTechPreviewBadge(namespace);
@@ -33,7 +35,7 @@ const TaskRunsListPage: React.FC<Omit<
       canCreate={kind?.includes(referenceForModel(TaskRunModel)) ?? false}
       kind={referenceForModel(TaskRunModel)}
       ListComponent={TaskRunsList}
-      rowFilters={taskRunFilters}
+      rowFilters={taskRunFilters(t)}
       badge={hideBadge ? null : badge}
       namespace={namespace}
     />

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -245,13 +245,10 @@ const SecretsPage = (props) => {
 
   const filters = [
     {
-      filterGroupName: 'Type',
+      filterGroupName: t('public~Type'),
       type: 'secret-type',
       reducer: secretTypeFilterReducer,
-      items: secretTypeFilterValues.map((filterValue) => ({
-        id: filterValue.id,
-        title: filterValue.title,
-      })),
+      items: secretTypeFilterValues,
     },
   ];
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-43639

**Analysis / Root cause**: 
Filter group names are not translated.

**Solution Description**: 
Added translation for the filter group names

**Screen shots / Gifs for design review**: 

-------Volume snapshot content-------
<img width="514" alt="pcontent X Pending" src="https://user-images.githubusercontent.com/102503482/170942062-aedee6e6-aabc-4b59-8596-b77f1ae9f306.png">

<img width="516" alt="Staatuus" src="https://user-images.githubusercontent.com/102503482/170942086-90b758bf-4f95-40f1-95d7-6f23ca36f264.png">

----Helm release----
<img width="405" alt="Heelm Reeleeaasees" src="https://user-images.githubusercontent.com/102503482/170942375-381969cc-57cd-4f89-bfc3-a4416e6e20bb.png">

<img width="415" alt="Pasted Graphic 21" src="https://user-images.githubusercontent.com/102503482/170942407-39f5d62c-fccc-4fca-8144-947c3c81d23d.png">

----Eventing resource-----
<img width="397" alt="EEveentiing" src="https://user-images.githubusercontent.com/102503482/170942462-0e1f5c53-c4ee-42ec-8f80-f49bffd95778.png">

<img width="444" alt="EEveentiing" src="https://user-images.githubusercontent.com/102503482/170942484-ef89b471-3b2c-4548-8cdf-71e353108f66.png">

----Eventing channel----
<img width="616" alt="EEveentiing" src="https://user-images.githubusercontent.com/102503482/170942566-a4574c2c-974e-488a-8a14-99c5b6167a77.png">

<img width="642" alt="EEveentiing" src="https://user-images.githubusercontent.com/102503482/170942587-5fc278ae-44db-4ace-8222-e21ab9b67cd1.png">

---Operators---
<img width="747" alt="Pasted Graphic 26" src="https://user-images.githubusercontent.com/102503482/170942671-0585aae9-4c5f-4d89-8ae6-e45780c9f82e.png">

<img width="733" alt="Pasted Graphic 27" src="https://user-images.githubusercontent.com/102503482/170942708-16ea1cef-0974-47d1-8109-6e47732d8fac.png">

----Operator resources----
<img width="610" alt="Deployment" src="https://user-images.githubusercontent.com/102503482/170942787-b61989c4-a7aa-4cee-ac44-bb2b384f2b5a.png">

<img width="632" alt="Deployment" src="https://user-images.githubusercontent.com/102503482/170942820-18529cb9-0f51-449c-aaf5-1787702ddc96.png">

----Pipelines----
<img width="357" alt="Seeaarch" src="https://user-images.githubusercontent.com/102503482/170943171-6cd47bb4-c3aa-4b5b-927a-0655ecf9d0d1.png">

<img width="350" alt="Naamee" src="https://user-images.githubusercontent.com/102503482/170942907-120db218-661a-4fb3-9f3e-718167ccb84c.png">

----Pipeline runs---
<img width="389" alt="Pipeeliinees" src="https://user-images.githubusercontent.com/102503482/170942960-ceb005ef-4caa-4349-a1a5-232ec80b98b1.png">

<img width="382" alt="Naamee" src="https://user-images.githubusercontent.com/102503482/170942982-827ff693-c8d1-4338-9e9d-39b2e245bb5a.png">

----Pipeline resources----
<img width="598" alt="Pasted Graphic 34" src="https://user-images.githubusercontent.com/102503482/170943020-4d126011-7fa7-4bd1-8c74-4988df36f6a3.png">

<img width="591" alt="Pasted Graphic 35" src="https://user-images.githubusercontent.com/102503482/170943037-14e97d17-f3f9-4855-b01a-487850eb8819.png">

----Secrets----
<img width="382" alt="Seecreets" src="https://user-images.githubusercontent.com/102503482/170943078-15ae6470-74fa-44c7-879c-90a414024c86.png">

<img width="394" alt="Seecreets" src="https://user-images.githubusercontent.com/102503482/170943088-1cf085da-c2d4-4c31-9f8b-86057b81dd3d.png">


**Unit test coverage report**: 
NA

**Test setup:**
In below pages, changes are made
1) Pipelines
2) Pipelineruns
3) Pipeline resources 
4) Secrets
5) Helm
6) Operators
7) Operator resources
8) Event Source
9) Event channel
10) Volume snapshot content
11) VM's (Tested by installing Virtualization operator, but to attach screenshot I am not able to install that operator now)
12) Volume Snapshot (Not able to test this since I not able to create one)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge