### PR TITLE
Bug 2074635: fix web terminal start

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
@@ -37,7 +37,7 @@ const useCloudShellWorkspace = (
   React.useEffect(() => {
     setNamespace(defaultNamespace);
     // a new namespace means we can start a new search
-    setNoNamespaceFound(false);
+    defaultNamespace && setNoNamespaceFound(false);
   }, [defaultNamespace, setNamespace, setNoNamespaceFound]);
 
   const [canListWorkspaces, loadingAccessReview] = useAccessReview2({


### PR DESCRIPTION
# Issue 
https://bugzilla.redhat.com/show_bug.cgi?id=2074635

# Problem
For developer users, web-terminal goes into a `loading` loop once the `devworkspace` CR is deleted

# Screenshots
![fix-terminal-start](https://user-images.githubusercontent.com/24852534/171210371-92481759-d762-4cf2-a0e4-14c233aedb3e.gif)

# Steps to verify

-  Spin a cluster using this PR `launch openshift/console#11597 gcp` (if not done already)
-  Install WebTerminal Operator from Operator Hub.
- Add a developer user.
- Logout and login using a developer user.
- As a developer user Start Web terminal by clicking on `masthead terminal icon`. 
- Select namespace and start terminal.
- Once terminal is UP, go to `Search` and search for `devworkspace` CR.
- Delete the `devworkspace` resource for the `namespace` which was used to initialise the terminal.

# Desired Outcome
The select namespace (Web Terminal setup screen) should show up again