### PR TITLE
Bug 2086546: [Dark Theme]: update Service binding connector color to support dark mode

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/components/edges/ServiceBinding.scss
+++ b/frontend/packages/topology/src/components/graph-view/components/edges/ServiceBinding.scss
@@ -1,3 +1,3 @@
 .odc-base-edge.odc-service-binding {
-  --edge--stroke: var(--pf-global--BackgroundColor--dark-200);
+  --edge--stroke: var(--pf-global--Color--300);
 }


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGSM-44323

**Descriptions:**
- Change the Service binding connector color from `--pf-global--BackgroundColor--dark-200` to `--pf-global--Color--300`

**Screenshots:**
**Before:**
![image](https://user-images.githubusercontent.com/2561818/170988742-26bdab69-00b6-4f95-a152-1bfadd5051d8.png)

**After:**
![image](https://user-images.githubusercontent.com/2561818/170988463-7b1c614d-db44-4dfa-8946-7ffa5484995f.png)
