### PR TITLE
Bug 2084635: Avoid using 'gp2' hardcoded storage class

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/VolumeClaimTemplateForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/VolumeClaimTemplateForm.tsx
@@ -22,7 +22,6 @@ interface VolumeClaimTemplateFormProps {
   initialSizeValue?: string;
   initialSizeUnit?: string;
   initialVolumeMode?: string;
-  initialStorageClass?: string;
 }
 
 interface RequestSize {
@@ -35,7 +34,6 @@ const VolumeClaimTemplateForm: React.FC<VolumeClaimTemplateFormProps> = ({
   initialSizeValue = '1',
   initialSizeUnit = 'Gi',
   initialVolumeMode = 'Filesystem',
-  initialStorageClass = 'gp2',
 }) => {
   const { t } = useTranslation();
   const [field] = useField(name);
@@ -49,7 +47,7 @@ const VolumeClaimTemplateForm: React.FC<VolumeClaimTemplateFormProps> = ({
   const [requestSizeValue, setRequestSizeValue] = React.useState(initialSizeValue);
   const [requestSizeUnit, setRequestSizeUnit] = React.useState(initialSizeUnit);
   const [storageProvisioner, setStorageProvisioner] = React.useState('');
-  const [storageClass, setStorageClass] = React.useState(initialStorageClass);
+  const [storageClass, setStorageClass] = React.useState('');
   useFormikValidationFix(field.value);
 
   const handleAccessMode: React.ReactEventHandler<HTMLInputElement> = (event) => {
@@ -138,8 +136,6 @@ const VolumeClaimTemplateForm: React.FC<VolumeClaimTemplateFormProps> = ({
             data-test="storageclass-dropdown"
             describedBy="storageclass-dropdown-help"
             required={false}
-            defaultClass={initialStorageClass}
-            valueFromAST
             name="storageClass"
           />
         </div>

--- a/frontend/public/components/utils/storage-class-dropdown.tsx
+++ b/frontend/public/components/utils/storage-class-dropdown.tsx
@@ -103,6 +103,13 @@ export class StorageClassDropdownInnerWithTranslation extends React.Component<
     this.setState(state);
   }
 
+  componentDidMount() {
+    const { defaultClass } = this.state;
+    if (defaultClass) {
+      this.onChange(defaultClass);
+    }
+  }
+
   componentDidUpdate() {
     const { defaultClass, selectedKey } = this.state;
     if (selectedKey) {


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2084635
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
- The VolumeClaimTemplateForm was using a hardcoded value `gp2` as the default storage class name, this caused issues when a storage class of that name did not exist on the cluster.
- If there are more than one storage class dropdown components mounted simultaneously, the `componentDidUpdate` method does not run for all components except the first, this results in having the initial value of `''` even when default value is set, and the onChange handler does not get called.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Avoid using a hardcoded value, instead let the StorageClassDropdown figure out initial value by using the `storageclass.kubernetes.io/is-default-class` annotation.
https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/

For the second issue, use `componentDidMount` method to call the onChange handler if defaultClass is set.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
(No UI changes)
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
Unchanged
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
