### PR TITLE
Bug 2089221: Could not de-select a Git Secret in add and edit forms

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -400,6 +400,7 @@
   "Try sample": "Try sample",
   "Source Secret": "Source Secret",
   "Secret with credentials for pulling your source code.": "Secret with credentials for pulling your source code.",
+  "No Secret": "No Secret",
   "docker.io/openshift/hello-openshift or quay.io/<username>/<image-name>": "docker.io/openshift/hello-openshift or quay.io/<username>/<image-name>",
   "To deploy an Image from a private repository, you must <2>create an Image pull secret</2> with your Image registry credentials.": "To deploy an Image from a private repository, you must <2>create an Image pull secret</2> with your Image registry credentials.",
   "Secret {{newImageSecret}} was created.": "Secret {{newImageSecret}} was created.",

--- a/frontend/packages/dev-console/src/components/import/git/SourceSecretSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/SourceSecretSelector.tsx
@@ -11,6 +11,7 @@ import SourceSecretDropdown from '../../dropdown/SourceSecretDropdown';
 import { secretModalLauncher } from '../CreateSecretModal';
 
 const CREATE_SOURCE_SECRET = 'create-source-secret';
+const CLEAR_SOURCE_SECRET = 'clear-source-secret';
 
 const SourceSecretSelector: React.FC<{
   formContextField?: string;
@@ -45,6 +46,9 @@ const SourceSecretSelector: React.FC<{
         save: handleSave,
         secretType: SecretTypeAbstraction.source,
       });
+    } else if (key === CLEAR_SOURCE_SECRET) {
+      setFieldValue(`${fieldPrefix}git.secret`, '');
+      setFieldValue(`${fieldPrefix}git.secretResource`, {});
     } else {
       setFieldValue(`${fieldPrefix}git.secret`, key);
     }
@@ -73,6 +77,10 @@ const SourceSecretSelector: React.FC<{
             {
               actionTitle: t('devconsole~Create new Secret'),
               actionKey: CREATE_SOURCE_SECRET,
+            },
+            {
+              actionTitle: t('devconsole~No Secret'),
+              actionKey: CLEAR_SOURCE_SECRET,
             },
           ]}
           selectedKey={secret}

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -143,9 +143,14 @@ export const mergeData = (originalResource: K8sResourceKind, newResource: K8sRes
   if (mergedData.spec?.triggers) {
     mergedData.spec.triggers = newResource.spec.triggers;
   }
+  if (!newResource.spec?.source?.sourceSecret) {
+    delete mergedData?.spec?.source?.sourceSecret;
+  }
+
   if (mergedData.spec?.template?.spec?.hasOwnProperty('volumes')) {
     mergedData.spec.template.spec.volumes = originalResource.spec?.template?.spec?.volumes;
   }
+
   return mergedData;
 };
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGSM-44541

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
As a user, I want to have an option to de-select the Git Secret in the add and edit forms. But the dropdown that shows all possibles Secrets has no option to do this.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Added a field in the dropdown signifying `Clear Selection`. This will clear the field.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
https://user-images.githubusercontent.com/47265560/171229410-df458321-9d04-4f43-9411-ac07fb1fc0c8.mp4

**Unit test coverage report**: 
<!-- Attach test coverage report -->
Not changed

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Navigate to "Development" perspective, Add, "Import from Git"
2. Enter a git URL (public or private doesn't matter)
3. Open the advanced Git options
4. Select "Source secret" and create a Secret if needed
5. Try to de-select it

After creating the Deployment
6. Right click the Deployment, choice "Edit <deployment-name>"
7. Open the advanced Git options
8. Try to de-select it (same issue)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge