### PR TITLE
Remove now unused function getPrometheusExpressionBrowserURL

### DIFF
--- a/frontend/__tests__/components/graphs/prometheus-graph.spec.tsx
+++ b/frontend/__tests__/components/graphs/prometheus-graph.spec.tsx
@@ -11,7 +11,6 @@ import { history } from '@console/internal/components/utils/router';
 import {
   PrometheusGraph,
   PrometheusGraphLink,
-  getPrometheusExpressionBrowserURL,
 } from '@console/internal/components/graphs/prometheus-graph';
 import store from '@console/internal/redux';
 
@@ -99,14 +98,4 @@ describe('<PrometheusGraphLink />', () => {
     expect(wrapper.find(Link).exists()).toBe(true);
     expect(wrapper.find(Link).props().to).toEqual('/monitoring/query-browser?query0=test');
   });
-});
-
-describe('getPrometheusExpressionBrowserURL()', () => {
-  const url = getPrometheusExpressionBrowserURL('https://mock.prometheus.url', [
-    'test-query-1',
-    'test-query-2',
-  ]);
-  expect(url).toBe(
-    'https://mock.prometheus.url/graph?g0.range_input=1h&g0.expr=test-query-1&g0.tab=0&g1.range_input=1h&g1.expr=test-query-2&g1.tab=0',
-  );
 });

--- a/frontend/public/components/graphs/prometheus-graph.tsx
+++ b/frontend/public/components/graphs/prometheus-graph.tsx
@@ -10,19 +10,6 @@ import { featureReducerName } from '../../reducers/features';
 import { getActiveNamespace } from '../../reducers/ui';
 import { RootState } from '../../redux';
 
-export const getPrometheusExpressionBrowserURL = (url, queries): string => {
-  if (!url || _.isEmpty(queries)) {
-    return null;
-  }
-  const params = new URLSearchParams();
-  _.each(queries, (query, i) => {
-    params.set(`g${i}.range_input`, '1h');
-    params.set(`g${i}.expr`, query);
-    params.set(`g${i}.tab`, '0');
-  });
-  return `${url}/graph?${params.toString()}`;
-};
-
 const mapStateToProps = (state: RootState) => ({
   canAccessMonitoring:
     !!state[featureReducerName].get(FLAGS.CAN_GET_NS) && !!window.SERVER_FLAGS.prometheusBaseURL,

--- a/frontend/public/components/graphs/prometheus-graph.tsx
+++ b/frontend/public/components/graphs/prometheus-graph.tsx
@@ -16,7 +16,7 @@ const mapStateToProps = (state: RootState) => ({
   namespace: getActiveNamespace(state),
 });
 
-export const PrometheusGraphLink_: React.FC<PrometheusGraphLinkProps> = ({
+const PrometheusGraphLink_: React.FC<PrometheusGraphLinkProps> = ({
   canAccessMonitoring,
   children,
   query,


### PR DESCRIPTION
The Prometheus UI was removed, so we will no longer be linking to it.

Also stops this file from exporting `PrometheusGraphLink_` (only export `PrometheusGraphLink`).