### PR TITLE
Topology-Toolbar Filter Group Gherkin Design and Automation

### DIFF
--- a/frontend/packages/topology/integration-tests/features/topology/topology-display-filter.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-display-filter.feature
@@ -1,0 +1,58 @@
+@topology
+Feature: Topology Display Filter Group
+              As a user, I should be able to use the Display Filter Groups on Topology page
+
+        Background:
+            Given user is at developer perspective
+              And user has created or selected namespace "aut-display-filter"
+              And user is at Add page
+              
+              
+        @regression
+        Scenario: Topology display filter by expand option: T-18-TC01
+            Given user has created workload "nodejs-ex-git" with resource type "Deployment"
+              And user is at Topology page
+              And user is at Topology Graph view
+             When user clicks display options
+              And user disbales expand option
+             Then user will see the application_groupings checkbox will disable
+              And user will see workload in text view
+
+
+        @regression
+        Scenario: Topology display filter by application grouping option: T-18-TC02
+            Given user is at Topology page
+              And user is at Topology Graph view
+             When user clicks display options
+              And user enables expand option
+              And user unchecks the application grouping option
+             Then user will see workload in text view
+
+
+        @regression
+        Scenario: Topology display filter by pod count option: T-18-TC03
+            Given user is at Topology page
+              And user is at Topology Graph view
+             When user clicks display options
+              And user checks the application grouping option
+              And user checks the pod count option
+             Then user will able to see the pod count inside workload
+
+
+        @regression
+        Scenario: Topology display filter by labels option: T-18-TC04
+            Given user is at Topology page
+              And user is at Topology Graph view
+             When user clicks display options
+              And user unchecks the labels option
+             Then user will not able to see the labels on workload
+
+        @regression
+        Scenario: Topology display filter by expand option in list view: T-18-TC05
+            Given user is at Topology page
+              And user is at topology list view
+             When user clicks display options
+              And user disbales expand option
+             Then user will see the application_groupings checkbox will disable
+              And user will see deployment section is not visible
+              And user will see deployments in count view

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -282,6 +282,17 @@ export const topologyPO = {
     deploymentApp: '#nodejs-ex-git-app-Deployment',
     deploymentConfigApp: '#nodejs-ex-git-app-DeploymentConfig',
   },
+  displayFilter: {
+    display: '.odc-topology-filter-dropdown__select',
+    expandOption: '.odc-topology-filter-dropdown__expand-groups-switcher input',
+    applicationGroupingOption: '.odc-topology-filter-dropdown__expand-groups-label input',
+    unexpandedNode: '.odc-workload-node',
+    disabledClass: '.pf-m-disabled',
+    podLabelOptions: '.odc-topology-filter-dropdown__group input',
+    podRingText: '.pod-ring__center-text',
+    deploymentLabel: '#nodejs-ex-git-app-Deployment-label',
+    deployemntCount: '.odc-topology-list-view__group-resource-count',
+  },
 };
 
 export const typeOfWorkload = (workload: string) => {

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/topology-filters.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/topology-filters.ts
@@ -61,3 +61,69 @@ Then(
     cy.get(topologyPO.toolbarFilterPO.deploymentApp).should('not.exist');
   },
 );
+When('user clicks display options', () => {
+  cy.get(topologyPO.displayFilter.display).click();
+});
+
+When('user disbales expand option', () => {
+  // eslint-disable-next-line promise/catch-or-return
+  cy.get('body').then((el) => {
+    if (el.find(topologyPO.displayFilter.disabledClass).length === 0) {
+      cy.get(topologyPO.displayFilter.expandOption).click({ force: true });
+    }
+  });
+});
+
+When('user enables expand option', () => {
+  // eslint-disable-next-line promise/catch-or-return
+  cy.get('body').then((el) => {
+    if (el.find(topologyPO.displayFilter.disabledClass).length !== 0) {
+      cy.get(topologyPO.displayFilter.expandOption).click({ force: true });
+    }
+  });
+});
+
+When('user unchecks the application grouping option', () => {
+  cy.get(topologyPO.displayFilter.applicationGroupingOption).uncheck({ force: true });
+});
+
+When('user checks the application grouping option', () => {
+  cy.get(topologyPO.displayFilter.applicationGroupingOption).check({ force: true });
+});
+
+Then('user will see the application_groupings checkbox will disable', () => {
+  cy.get(topologyPO.displayFilter.applicationGroupingOption).should('be.disabled');
+});
+
+Then('user will see workload in text view', () => {
+  cy.get(topologyPO.displayFilter.unexpandedNode).should('not.exist');
+});
+
+When('user checks the pod count option', () => {
+  cy.get(topologyPO.displayFilter.podLabelOptions)
+    .eq(2)
+    .check();
+});
+
+Then('user will able to see the pod count inside workload', () => {
+  cy.get(topologyPO.displayFilter.podRingText).should('be.visible');
+});
+
+When('user unchecks the labels option', () => {
+  cy.get(topologyPO.displayFilter.podLabelOptions)
+    .eq(3)
+    .uncheck();
+});
+
+Then('user will not able to see the labels on workload', () => {
+  cy.get(topologyPO.graph.nodeLabel).should('not.exist');
+  cy.get(topologyPO.graph.groupLabel).should('not.exist');
+});
+
+Then('user will see deployment section is not visible', () => {
+  cy.get(topologyPO.displayFilter.deploymentLabel).should('not.exist');
+});
+
+Then('user will see deployments in count view', () => {
+  cy.get(topologyPO.displayFilter.deployemntCount).should('be.visible');
+});


### PR DESCRIPTION
**Description:**
<!-- PR description-->
- Topology-Toolbar Filter Group Gherkin Design and Automation

**Jira Id:**
     - [ODC-5821](https://issues.redhat.com/browse/ODC-5821) : Topology-Display-Options

<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.11-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p topology
```
**Screen shots**:
<!--   -->
topology-display-filter.feature

<img width="1417" alt="image" src="https://user-images.githubusercontent.com/65410551/171095592-a60fcaa1-1484-46f1-a909-979315a685b8.png">

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge