### PR TITLE
Bug 2070000: Add high priority alerts to overview

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -693,6 +693,7 @@
   "Migration Toolkit for Virtualization": "Migration Toolkit for Virtualization",
   "Recommended Operators": "Recommended Operators",
   "Ease operational complexity with virtualization by using Operators.": "Ease operational complexity with virtualization by using Operators.",
+  "Runbook": "Runbook",
   "VM statuses": "VM statuses",
   "Permissions": "Permissions",
   "Task": "Task",

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/HighPriorityAlerts.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/HighPriorityAlerts.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { Alert } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import {
+  Alert as ConsoleAlert,
+  AlertSeverity,
+} from '@console/internal/components/monitoring/types';
+import { ExternalLink } from '@console/internal/components/utils';
+import useFilteredAlerts from '../../hooks/useFilteredAlerts';
+
+import './high-priority-alerts.scss';
+
+const OPERATOR_LABEL_KEY = 'kubernetes_operator_part_of';
+const isKubeVirtAlert = (alert) => alert?.labels?.[OPERATOR_LABEL_KEY] === 'kubevirt';
+const isHighPriorityAlert = (alert) => alert?.labels?.['priority'] === 'high';
+const isKubeVirtHighPriorityAlert = (alert) => isKubeVirtAlert(alert) && isHighPriorityAlert(alert);
+
+enum AlertVariant {
+  Warning = 'warning',
+  Danger = 'danger',
+  Info = 'info',
+  Default = 'default',
+}
+
+const asAlertVariant = (severity: AlertSeverity) => {
+  switch (severity) {
+    case AlertSeverity.Warning:
+      return AlertVariant.Warning;
+    case AlertSeverity.Critical:
+      return AlertVariant.Danger;
+    case AlertSeverity.Info:
+      return AlertVariant.Info;
+    case AlertSeverity.None:
+    default:
+      return AlertVariant.Default;
+  }
+};
+
+const AlertTitle = ({ alert }) => {
+  const { t } = useTranslation();
+  const message = alert?.annotations?.message || alert?.annotations?.summary;
+  const runbookURL = alert?.annotations?.runbook_url;
+
+  return (
+    <>
+      {message}{' '}
+      {runbookURL && <ExternalLink href={runbookURL} text={t('kubevirt-plugin~Runbook')} />}
+    </>
+  );
+};
+
+const HighPriorityAlerts: React.FC = () => {
+  const filteredAlerts: ConsoleAlert[] = useFilteredAlerts(isKubeVirtHighPriorityAlert);
+
+  return (
+    <div className="kv-high-priority-alerts">
+      {filteredAlerts.map((alert) => {
+        const severity = alert?.labels?.severity as AlertSeverity;
+        return (
+          <Alert
+            isInline
+            variant={asAlertVariant(severity)}
+            title={<AlertTitle alert={alert} />}
+            className="kv-high-priority-alerts__alert"
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default HighPriorityAlerts;

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/VirtualizationOverviewPage.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/VirtualizationOverviewPage.tsx
@@ -8,6 +8,7 @@ import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
 import DashboardGrid from '@console/shared/src/components/dashboard/DashboardGrid';
 import { KUBEVIRT_QUICK_START_USER_SETTINGS_KEY } from './getting-started-card/const';
 import { GettingStartedContainerCard } from './getting-started-card/GettingStartedContainerCard';
+import HighPriorityAlerts from './HighPriorityAlerts';
 import { VirtOverviewInventoryCard } from './inventory-card/VirtOverviewInventoryCard';
 import { VirtOverviewPermissionsCard } from './permissions-card/VirtOverviewPermissionsCard';
 import { RunningVMsPerTemplateCard } from './running-vms-per-template-card/RunningVMsPerTemplateCard';
@@ -32,7 +33,9 @@ export const WrappedVirtualizationOverviewPage: React.FC = () => {
       <Helmet>
         <title>Virtualization Overview</title>
       </Helmet>
-      <PageHeading title={title} detail badge={badge} />
+      <PageHeading title={title} detail badge={badge}>
+        <HighPriorityAlerts />
+      </PageHeading>
       <Dashboard>
         <GettingStartedContainerCard />
         <DashboardGrid leftCards={leftCards} mainCards={mainCards} rightCards={rightCards} />

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/high-priority-alerts.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/high-priority-alerts.scss
@@ -1,0 +1,10 @@
+.kv-high-priority-alerts {
+  margin-bottom: var(--pf-global--spacer--sm);
+}
+
+.kv-high-priority-alerts__alert {
+  margin-bottom: var(--pf-global--spacer--sm);
+  &:last-child{
+    margin-bottom: 0;
+  }
+}

--- a/frontend/packages/kubevirt-plugin/src/hooks/useFilteredAlerts.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/useFilteredAlerts.ts
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { useNotificationAlerts } from '@console/shared/src/hooks/useNotificationAlerts';
+import { Alert } from 'public/components/monitoring/types';
+
+export type UseFilteredAlerts = (filter: any) => Alert[];
+
+const useFilteredAlerts: UseFilteredAlerts = (filter) => {
+  const [alerts] = useNotificationAlerts();
+  return React.useMemo(() => alerts?.filter((alert) => filter(alert)), [alerts, filter]);
+};
+
+export default useFilteredAlerts;


### PR DESCRIPTION
This PR adds high priority kubevirt-related alerts to the virtualization overview page. The alerts will be color-coded based on the value of the alert's severity label.

Screenshot:
![Selection_096](https://user-images.githubusercontent.com/8544299/171206962-c6ec33a8-75b0-467b-a623-983155ba0162.png)


