### PR TITLE
Bug 2080387: Pass contextSource to TopologyApplicationActionProvider

### DIFF
--- a/frontend/packages/dev-console/src/actions/providers.ts
+++ b/frontend/packages/dev-console/src/actions/providers.ts
@@ -208,20 +208,24 @@ export const useTopologyApplicationActionProvider: TopologyActionProvider = ({
     if (element.getType() === TYPE_APPLICATION_GROUP) {
       if (inFlight) return [[], !inFlight, undefined];
       const path = connectorSource ? '' : 'add-to-application';
+      const sourceObj = connectorSource?.getData()?.resource;
+      const sourceReference = sourceObj
+        ? `${referenceFor(sourceObj)}/${sourceObj?.metadata?.name}`
+        : undefined;
       const actions = [
         ...(connectorSource ? [] : [DeleteApplicationAction(appData, kindObj)]),
-        AddActions.FromGit(namespace, application, undefined, path, !isImportResourceAccess),
+        AddActions.FromGit(namespace, application, sourceReference, path, !isImportResourceAccess),
         AddActions.ContainerImage(
           namespace,
           application,
-          undefined,
+          sourceReference,
           path,
           !isCatalogImageResourceAccess,
         ),
         AddActions.UploadJarFile(
           namespace,
           application,
-          undefined,
+          sourceReference,
           path,
           !isCatalogImageResourceAccess,
         ),


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGSM-43829

**Descriptions:**

**Analysis / Root cause:**
- we were passing an undefined value for `contextSource` to the Application action provider because that visual connector does not get created when we create a node in the context of the application and already a present node in Topology.

**Solution:**
- Pass the contextSource to the TopologyApplicationActionProvider

**GIF:**
![Kapture 2022-05-31 at 21 13 43](https://user-images.githubusercontent.com/2561818/171215390-8929e3d8-b699-4fa2-810d-f1bfddb20e55.gif)
