### PR TITLE
Bug 2043068: <x> available of <y> text disappears in Utilization item if x is 0

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -156,6 +156,9 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
       }
 
       humanAvailable = humanizeValue(max - current).string;
+      if (humanAvailable === '') {
+        humanAvailable = '0';
+      }
     }
 
     const chart = (

--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -145,9 +145,10 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
 
     let humanMax: string;
     let humanAvailable: string;
-    if (!_.isNil(current) && max) {
+    if (max) {
+      const currentUtilization = current ?? 0;
+      const percentage = (100 * currentUtilization) / max;
       humanMax = humanizeValue(max).string;
-      const percentage = (100 * current) / max;
 
       if (percentage >= 90) {
         chartStyle[0] = { data: { fill: chartStatusColors[AreaChartStatus.ERROR] } };
@@ -155,10 +156,7 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
         chartStyle[0] = { data: { fill: chartStatusColors[AreaChartStatus.WARNING] } };
       }
 
-      humanAvailable = humanizeValue(max - current).string;
-      if (humanAvailable === '') {
-        humanAvailable = '0';
-      }
+      humanAvailable = humanizeValue(max - currentUtilization).string;
     }
 
     const chart = (


### PR DESCRIPTION
Displays "<x> available of <y>" text even if x (current utilization) is 0. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2043068