### PR TITLE
Remove namespaced and optional properties of k8s watch hooks

### DIFF
--- a/dynamic-demo-plugin/src/components/ListPage.tsx
+++ b/dynamic-demo-plugin/src/components/ListPage.tsx
@@ -89,7 +89,6 @@ const ListPage = () => {
       kind: 'Pod',
     },
     isList: true,
-    namespaced: true,
   });
 
   const [data, filteredData, onFilterChange] = useListPageFilter(pods, filters, {

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/use-fetch-csv.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/use-fetch-csv.tsx
@@ -30,7 +30,6 @@ export const useFetchCsv = (specName: string, namespace?: string): UseFetchCsvRe
   const [csv, csvLoaded, csvLoadError] = useK8sWatchResource<ClusterServiceVersionKind>({
     kind: referenceForModel(ClusterServiceVersionModel),
     name: csvName.current,
-    namespaced: true,
     namespace: csvNamespace.current,
     isList: false,
   });

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-storage-class-form/ocs-storage-class-form.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-storage-class-form/ocs-storage-class-form.tsx
@@ -477,7 +477,6 @@ export const StorageClassEncryptionKMSID: React.FC<ProvisionerProps> = ({
 
   const csiCMWatchResource: WatchK8sResource = {
     kind: ConfigMapModel.kind,
-    namespaced: true,
     isList: false,
     namespace: CEPH_STORAGE_NAMESPACE,
     name: KMSConfigMapCSIName,

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -202,7 +202,6 @@ const plugin: Plugin<ConsumedExtensions> = [
       resources: {
         ceph: {
           kind: referenceForModel(models.CephClusterModel),
-          namespaced: false,
           isList: true,
         },
       },

--- a/frontend/packages/ceph-storage-plugin/src/resources.ts
+++ b/frontend/packages/ceph-storage-plugin/src/resources.ts
@@ -31,7 +31,6 @@ export const cephClusterResource: FirehoseResource = {
 
 export const pvResource: WatchK8sResource = {
   kind: PersistentVolumeModel.kind,
-  namespaced: false,
   isList: true,
 };
 
@@ -43,7 +42,6 @@ export const pvcResource: FirehoseResource = {
 
 export const scResource: WatchK8sResource = {
   kind: StorageClassModel.kind,
-  namespaced: false,
   isList: true,
 };
 
@@ -62,7 +60,6 @@ export const subscriptionResource: FirehoseResource = {
 
 export const cephBlockPoolResource: WatchK8sResource = {
   kind: referenceForModel(CephBlockPoolModel),
-  namespaced: true,
   isList: true,
   namespace: CEPH_STORAGE_NAMESPACE,
 };
@@ -75,13 +72,11 @@ export const cephCapacityResource = {
 
 export const nodeResource: WatchK8sResource = {
   kind: NodeModel.kind,
-  namespaced: false,
   isList: true,
 };
 
 export const nodesDiscoveriesResource: WatchK8sResource = {
   kind: referenceForModel(LocalVolumeDiscoveryResult),
-  namespaced: false,
   isList: true,
 };
 

--- a/frontend/packages/console-app/src/components/pdb/PDBFormPage.tsx
+++ b/frontend/packages/console-app/src/components/pdb/PDBFormPage.tsx
@@ -39,7 +39,6 @@ export const PDBFormPage: React.FC<{
       version,
     },
     name,
-    namespaced: true,
     namespace: match.params.ns,
   });
 
@@ -50,7 +49,6 @@ export const PDBFormPage: React.FC<{
       version: PodDisruptionBudgetModel.apiVersion,
     },
     isList: true,
-    namespaced: true,
     namespace: match.params.ns,
   });
 

--- a/frontend/packages/console-app/src/components/pdb/PDBPage.tsx
+++ b/frontend/packages/console-app/src/components/pdb/PDBPage.tsx
@@ -22,7 +22,6 @@ export const PodDisruptionBudgetsPage: React.FC<PodDisruptionBudgetsPageProps> =
       version: PodDisruptionBudgetModel.apiVersion,
     },
     isList: true,
-    namespaced: true,
     namespace,
   });
 

--- a/frontend/packages/console-app/src/components/pdb/PodDisruptionBudgetField.tsx
+++ b/frontend/packages/console-app/src/components/pdb/PodDisruptionBudgetField.tsx
@@ -18,7 +18,6 @@ export const PodDisruptionBudgetField: React.FC<PodDisruptionBudgetFieldProps> =
       version: PodDisruptionBudgetModel.apiVersion,
     },
     isList: true,
-    namespaced: true,
     namespace: obj.metadata.namespace,
   });
   const pdb = getPDBResource(pdbResources, obj);

--- a/frontend/packages/console-app/src/components/user-preferences/namespace/NamespaceDropdown.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/namespace/NamespaceDropdown.tsx
@@ -46,7 +46,6 @@ const NamespaceDropdown: React.FC = () => {
   const [options, optionsLoaded, optionsLoadError] = useK8sWatchResource<K8sResourceKind[]>({
     kind: model?.kind,
     isList: true,
-    optional: true,
   });
   const [
     preferredNamespace,

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -176,10 +176,8 @@ export type WatchK8sResource = {
   namespace?: string;
   isList?: boolean;
   selector?: Selector;
-  namespaced?: boolean;
   limit?: number;
   fieldSelector?: string;
-  optional?: boolean;
   partialMetadata?: boolean;
   cluster?: string;
 };
@@ -198,6 +196,10 @@ export type WatchK8sResults<R extends ResourcesObject> = {
 
 export type WatchK8sResources<R extends ResourcesObject> = {
   [k in keyof R]: WatchK8sResource;
+};
+
+export type WatchK8sResourcesOptional<R extends ResourcesObject> = {
+  [k in keyof R]: WatchK8sResource & { optional?: boolean };
 };
 
 export type WatchK8sResourcesGeneric = {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/dashboards.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/dashboards.ts
@@ -9,6 +9,7 @@ import {
   WatchK8sResults,
   FirehoseResource,
   FirehoseResult,
+  WatchK8sResourcesOptional,
 } from './console-types';
 import {
   CardSpan,
@@ -302,5 +303,5 @@ type DashboardsOverviewInventoryItemProperties<
   /** Function which maps various statuses to groups. */
   mapper?: CodeRef<StatusGroupMapper<T, R>>;
   /** Additional resources which will be fetched and passed to the `mapper` function. */
-  additionalResources?: CodeRef<WatchK8sResources<R>>;
+  additionalResources?: CodeRef<WatchK8sResourcesOptional<R>>;
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource.ts
@@ -29,7 +29,7 @@ import { useModelsLoaded } from './useModelsLoaded';
  * ```
  */
 export const useK8sWatchResource: UseK8sWatchResource = (initResource) => {
-  const cluster = useSelector((state) => getActiveCluster(state));
+  const cluster = useSelector<SDKStoreState>(getActiveCluster);
   const resource = useDeepCompareMemoize(initResource, true);
   const modelsLoaded = useModelsLoaded();
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources.ts
@@ -39,7 +39,7 @@ import { usePrevious } from './usePrevious';
  * ```
  */
 export const useK8sWatchResources: UseK8sWatchResources = (initResources) => {
-  const cluster = useSelector((state: SDKStoreState) => getActiveCluster(state));
+  const cluster = useSelector<SDKStoreState>(getActiveCluster);
   const resources = useDeepCompareMemoize(initResources, true);
   const modelsLoaded = useModelsLoaded();
 

--- a/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
@@ -4,6 +4,7 @@ import {
   ResourcesObject,
   WatchK8sResults,
   GridPosition,
+  WatchK8sResourcesOptional,
 } from '@console/dynamic-plugin-sdk';
 import { PrometheusResponse } from '@console/internal/components/graphs';
 import {
@@ -158,7 +159,7 @@ namespace ExtensionProperties {
     mapper?: () => Promise<StatusGroupMapper>;
 
     /** Additional resources which will be fetched and passed to `mapper` function. */
-    additionalResources?: WatchK8sResources<any>;
+    additionalResources?: WatchK8sResourcesOptional<any>;
 
     /** Loader for the component which will be used when item is expanded. */
     expandedComponent?: LazyLoader<ExpandedComponentProps>;

--- a/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.tsx
+++ b/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.tsx
@@ -236,7 +236,6 @@ const NamespaceMenu: React.FC<{
   const [options, optionsLoaded] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     kind: isProjects ? ProjectModel.kind : NamespaceModel.kind,
-    optional: true,
   });
 
   const optionItems = React.useMemo(() => {

--- a/frontend/packages/console-shared/src/hooks/hpa-hooks.ts
+++ b/frontend/packages/console-shared/src/hooks/hpa-hooks.ts
@@ -18,7 +18,6 @@ export const useRelatedHPA = (
   const [hpas, loaded, error] = useK8sWatchResource<HorizontalPodAutoscalerKind[]>({
     kind: HorizontalPodAutoscalerModel.kind,
     namespace: workloadNamespace,
-    optional: true,
     isList: true,
   });
 

--- a/frontend/packages/console-shared/src/hooks/oauth.ts
+++ b/frontend/packages/console-shared/src/hooks/oauth.ts
@@ -17,7 +17,6 @@ export const useOAuthData = (canEdit: boolean) =>
       ? {
           kind: referenceForModel(OAuthModel),
           isList: false,
-          namespaced: false,
           name: 'cluster',
         }
       : null,

--- a/frontend/packages/container-security/src/plugin.ts
+++ b/frontend/packages/container-security/src/plugin.ts
@@ -95,7 +95,6 @@ const plugin: Plugin<ConsumedExtensions> = [
       resources: {
         imageManifestVuln: {
           kind: referenceForModel(ImageManifestVulnModel),
-          namespaced: true,
           isList: true,
         },
       },

--- a/frontend/packages/dev-console/src/components/guided-tour/GuidedTourText.tsx
+++ b/frontend/packages/dev-console/src/components/guided-tour/GuidedTourText.tsx
@@ -74,7 +74,6 @@ export const FinishTourText: React.FC = () => {
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     kind: referenceForModel(ConsoleLinkModel),
-    optional: true,
   });
   const { t } = useTranslation();
   const openshiftBlogLink =

--- a/frontend/packages/dev-console/src/components/import/git/SourceSecretSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/SourceSecretSelector.tsx
@@ -27,7 +27,6 @@ const SourceSecretSelector: React.FC<{
           kind: SecretModel.kind,
           namespace,
           name: secret,
-          optional: true,
           isList: false,
         }
       : null,

--- a/frontend/packages/dev-console/src/components/topology/bindable-services/bindable-service-resources.ts
+++ b/frontend/packages/dev-console/src/components/topology/bindable-services/bindable-service-resources.ts
@@ -1,12 +1,12 @@
 import {
   referenceForGroupVersionKind,
   referenceForModel,
-  WatchK8sResources,
+  WatchK8sResourcesOptional,
 } from '@console/internal/module/k8s';
 import { ServiceBindingModel } from '@console/service-binding-plugin/src/models';
 import { getBindableServicesList } from './fetch-bindable-services-utils';
 
-export const getBindableServiceResources = (namespace: string): WatchK8sResources<any> => {
+export const getBindableServiceResources = (namespace: string): WatchK8sResourcesOptional<any> => {
   const resources = {
     serviceBindingRequests: {
       namespace,

--- a/frontend/packages/gitops-plugin/src/components/details/GitOpsDetails.tsx
+++ b/frontend/packages/gitops-plugin/src/components/details/GitOpsDetails.tsx
@@ -37,7 +37,6 @@ const GitOpsDetails: React.FC<GitOpsDetailsProps> = ({ envs, appName, manifestUR
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     kind: referenceForModel(ConsoleLinkModel),
-    optional: true,
   });
   const argocdLink = _.find(
     consoleLinks,

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { WatchK8sResources } from '@console/dynamic-plugin-sdk';
+import { WatchK8sResources, WatchK8sResourcesOptional } from '@console/dynamic-plugin-sdk';
 import { FirehoseResource } from '@console/internal/components/utils';
 import { K8sResourceKind, PodKind, referenceForModel } from '@console/internal/module/k8s';
 import { KafkaConnectionModel } from '@console/rhoas-plugin/src/models';
@@ -311,7 +311,7 @@ export const knativeEventingTriggerResourceWatchers = (namespace: string) => {
 
 export const knativeCamelIntegrationsResourceWatchers = (
   namespace: string,
-): WatchK8sResources<any> => {
+): WatchK8sResourcesOptional<any> => {
   return {
     [CamelIntegrationModel.plural]: {
       isList: true,
@@ -363,7 +363,7 @@ export const strimziResourcesWatcher = (namespace: string): WatchK8sResources<an
 
 export const knativeCamelKameletBindingResourceWatchers = (
   namespace: string,
-): WatchK8sResources<any> => {
+): WatchK8sResourcesOptional<any> => {
   return {
     [CamelKameletBindingModel.plural]: {
       isList: true,
@@ -376,7 +376,7 @@ export const knativeCamelKameletBindingResourceWatchers = (
 
 export const knativeCamelDomainMappingResourceWatchers = (
   namespace: string,
-): WatchK8sResources<{ [key: string]: K8sResourceKind[] }> => {
+): WatchK8sResourcesOptional<{ [key: string]: K8sResourceKind[] }> => {
   return {
     [DomainMappingModel.plural]: {
       isList: true,

--- a/frontend/packages/knative-plugin/src/utils/useRoutesURL.ts
+++ b/frontend/packages/knative-plugin/src/utils/useRoutesURL.ts
@@ -19,7 +19,6 @@ export const useRoutesURL = (resource: K8sResourceKind): string => {
           isList: true,
           kind: referenceForModel(RouteModel),
           namespace,
-          optional: true,
         },
   );
 

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/cdi-upload-provider.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/cdi-upload-provider.tsx
@@ -11,7 +11,6 @@ import { CDI_UPLOAD_URL_BUILDER, UPLOAD_STATUS } from './consts';
 const resource: WatchK8sResource = {
   kind: kubevirtReferenceForModel(CDIConfigModel),
   isList: false,
-  namespaced: false,
   name: 'config',
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/pvc-delete-extension.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/pvc-delete-extension.tsx
@@ -23,7 +23,6 @@ export const killCDIBoundPVC = (pvc: PersistentVolumeClaimKind) =>
 export const PVCDeleteAlertExtension: React.FC<{ pvc: PersistentVolumeClaimKind }> = ({ pvc }) => {
   const templatesResource: WatchK8sResource = {
     isList: true,
-    optional: true,
     kind: TemplateModel.kind,
     namespace: TEMPLATE_VM_COMMON_NAMESPACE,
     selector: {

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
@@ -81,7 +81,6 @@ import './upload-pvc-form.scss';
 
 const templatesResource: WatchK8sResource = {
   isList: true,
-  optional: true,
   kind: TemplateModel.kind,
   namespace: TEMPLATE_VM_COMMON_NAMESPACE,
   selector: {
@@ -605,7 +604,6 @@ export const UploadPVCPage: React.FC<UploadPVCPageProps> = (props) => {
       ? {
           kind: StorageClassModel.kind,
           isList: true,
-          namespaced: false,
         }
       : null,
   );

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/import-providers-tab/providers/ovirt-import-provider/ovirt-provider-clusters-vms.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/import-providers-tab/providers/ovirt-import-provider/ovirt-provider-clusters-vms.tsx
@@ -69,7 +69,6 @@ const OvirtProviderClustersVMsConnected: React.FC<OvirtProviderClustersVMsConnec
         ? {
             kind: StorageClassModel.kind,
             isList: true,
-            namespaced: false,
           }
         : null,
     );

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/import-providers-tab/providers/vmware-import-provider/vmware-vms.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/import-providers-tab/providers/vmware-import-provider/vmware-vms.tsx
@@ -44,7 +44,6 @@ const VMWareVMsConnected: React.FC<VMWareVMsConnectedProps> = React.memo(
         ? {
             kind: StorageClassModel.kind,
             isList: true,
-            namespaced: false,
           }
         : null,
     );

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
@@ -92,7 +92,6 @@ export const VMSettingsTabComponent: React.FC<VMSettingsTabComponentProps> = ({
       ? {
           kind: StorageClassModel.kind,
           isList: true,
-          namespaced: false,
         }
       : null,
   );

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/boot-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/boot-source.tsx
@@ -37,7 +37,6 @@ export const BootSource: React.FC<BootSourceProps> = ({ template, state, dispatc
       ? {
           kind: StorageClassModel.kind,
           isList: true,
-          namespaced: false,
         }
       : null,
   );

--- a/frontend/packages/kubevirt-plugin/src/components/modals/add-template-source/add-template-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/add-template-source/add-template-source.tsx
@@ -112,7 +112,6 @@ export const AddTemplateSourceModal: React.FC<ModalComponentProps &
       ? {
           kind: StorageClassModel.kind,
           isList: true,
-          namespaced: false,
         }
       : null,
   );

--- a/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/delete-vm-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/delete-vm-modal.tsx
@@ -38,7 +38,6 @@ export const DeleteVMModal = withHandlePromise((props: DeleteVMModalProps) => {
   const snapshotResource: WatchK8sResource = {
     isList: true,
     kind: kubevirtReferenceForModel(VirtualMachineSnapshotModel),
-    namespaced: true,
     namespace: getNamespace(vm),
   };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/use-mapped-vm-restores.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/use-mapped-vm-restores.ts
@@ -12,7 +12,6 @@ export const useMappedVMRestores = (
   const restoreResource: WatchK8sResource = {
     isList: true,
     kind: kubevirtReferenceForModel(VirtualMachineRestoreModel),
-    namespaced: true,
     namespace,
   };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/vm-snapshots.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/vm-snapshots.tsx
@@ -102,7 +102,6 @@ export const VMSnapshotsPage: React.FC<VMTabProps> = ({ obj: vmLikeEntity, vmis:
   const snapshotResource: WatchK8sResource = {
     isList: true,
     kind: kubevirtReferenceForModel(VirtualMachineSnapshotModel),
-    namespaced: true,
     namespace,
   };
 

--- a/frontend/packages/local-storage-operator-plugin/src/resources.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/resources.ts
@@ -3,6 +3,5 @@ import { NodeModel } from '@console/internal/models';
 
 export const nodeResource: WatchK8sResource = {
   kind: NodeModel.kind,
-  namespaced: false,
   isList: true,
 };

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/DisksPage.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/DisksPage.tsx
@@ -14,7 +14,6 @@ import BareMetalHostDisks from '../baremetal-hosts/BareMetalHostDisks';
 const DisksPage: React.FC<PageComponentProps<NodeKind>> = ({ obj }) => {
   const [hosts, loaded, loadError] = useK8sWatchResource<BareMetalHostKind[]>({
     groupVersionKind: getGroupVersionKindForModel(BareMetalHostModel),
-    namespaced: true,
     isList: true,
   });
   let host: BareMetalHostKind;

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/dashboard/BareMetalNodeDashboard.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/dashboard/BareMetalNodeDashboard.tsx
@@ -45,7 +45,6 @@ const BareMetalNodeDashboard: React.FC<BareMetalNodeDetailsPageProps> = ({
 
   const [hosts, hostsLoaded] = useK8sWatchResource<BareMetalHostKind[]>({
     groupVersionKind: getGroupVersionKindForModel(BareMetalHostModel),
-    namespaced: true,
     isList: true,
   });
 

--- a/frontend/packages/metal3-plugin/src/components/modals/PowerOffHostModal.tsx
+++ b/frontend/packages/metal3-plugin/src/components/modals/PowerOffHostModal.tsx
@@ -174,7 +174,6 @@ const PowerOffHostModal = withHandlePromise<PowerOffHostModalProps & HandlePromi
   ({ host, nodeName, status, inProgress, errorMessage, handlePromise, close, cancel }) => {
     const [pods, loaded, loadError] = useK8sWatchResource<PodKind[]>({
       kind: PodModel.kind,
-      namespaced: false,
       isList: true,
       fieldSelector: `spec.nodeName=${nodeName}`,
     });

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -885,7 +885,6 @@ const InitializationResourceAlert: React.FC<InitializationResourceAlertProps> = 
   // Check if the CR is already present - only watches for the model in namespace
   const [customResource, customResourceLoaded] = useK8sWatchResource<K8sResourceCommon[]>({
     kind: referenceForModel(model),
-    namespaced: true,
     isList: true,
   });
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -413,7 +413,6 @@ const getK8sWatchResources = (
             isList: true,
             ...(namespace
               ? {
-                  namespaced: true,
                   namespace,
                 }
               : {}),
@@ -594,7 +593,6 @@ export const ProvidedAPIPage: React.FC<ProvidedAPIPageProps> = (props) => {
             kind: k8Kind,
             version,
           },
-          namespaced: true,
           namespace,
           isList: true,
         },
@@ -951,7 +949,6 @@ type GetK8sWatchResources = {
     kind: string;
     isList: boolean;
     namespace?: string;
-    namespaced?: boolean;
   };
 };
 // TODO(alecmerdler): Find Webpack loader/plugin to add `displayName` to React components automagically

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -72,7 +72,6 @@ const InstalledHintBlock: React.FC<OperatorHubItemDetailsHintBlockProps> = ({
     name: subscription?.status?.installedCSV,
     namespace: subscription?.metadata?.namespace,
     isList: false,
-    namespaced: true,
   });
   const nsPath = `/k8s/${namespace ? `ns/${namespace}` : 'all-namespaces'}`;
   const to = installedCSV
@@ -111,7 +110,6 @@ const InstallingHintBlock: React.FC<OperatorHubItemDetailsHintBlockProps> = ({
           name: subscription?.status?.installedCSV,
           namespace: subscription?.metadata?.namespace,
           isList: false,
-          namespaced: true,
         }
       : null,
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/hooks.ts
@@ -49,7 +49,6 @@ export const useLatestPipelineRun = (pipelineName: string, namespace: string): P
     selector: {
       matchLabels: { [TektonResourceLabel.pipeline]: pipelineName },
     },
-    optional: true,
     isList: true,
   };
   const [pipelineRun, pipelineRunLoaded, pipelineRunError] = useK8sWatchResource<PipelineRunKind[]>(
@@ -69,7 +68,6 @@ export const usePipelinePVC = (
     selector: {
       matchLabels: { [TektonResourceLabel.pipeline]: pipelineName },
     },
-    optional: true,
     isList: true,
   };
   const [PVC, PVCLoaded, PVCError] = useK8sWatchResource<PersistentVolumeClaimKind[]>(pvcResource);

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/hooks.ts
@@ -58,7 +58,6 @@ export const useFormikFetchAndSaveTasks = (namespace: string, validateForm: () =
     clusterTasks: {
       kind: referenceForModel(ClusterTaskModel),
       isList: true,
-      namespaced: false,
     },
   });
   const namespacedTaskData = namespacedTasks.loaded ? namespacedTasks.data : null;

--- a/frontend/packages/rhoas-plugin/src/catalog/providers/useRhoasCatalog.tsx
+++ b/frontend/packages/rhoas-plugin/src/catalog/providers/useRhoasCatalog.tsx
@@ -23,7 +23,6 @@ const useRhoasCatalog: ExtensionHook<CatalogItem[]> = ({
     isList: false,
     name: ServiceAccountCRName,
     namespace,
-    namespaced: true,
   });
 
   const loadedOrError = loaded || errorMsg;

--- a/frontend/packages/rhoas-plugin/src/components/service-list/ServiceListPage.tsx
+++ b/frontend/packages/rhoas-plugin/src/components/service-list/ServiceListPage.tsx
@@ -77,7 +77,6 @@ const ServiceListPage: React.FC = () => {
     name: ServicesRequestCRName,
     namespace: currentNamespace,
     isList: false,
-    optional: true,
   });
 
   const remoteKafkaInstances = watchedKafkaRequest?.status?.userKafkas || [];

--- a/frontend/packages/topology/src/components/export-app/export-app-context.ts
+++ b/frontend/packages/topology/src/components/export-app/export-app-context.ts
@@ -33,9 +33,7 @@ export const useExportAppFormToast = () => {
         groupVersionKind: groupVersionKind || getGroupVersionKindForModel(ExportModel),
         name,
         namespace: resNamespace,
-        namespaced: true,
         isList: false,
-        optional: true,
       };
       return acc;
     }, {} as Record<string, WatchK8sResource>);

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/EditDecorator.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/EditDecorator.tsx
@@ -21,7 +21,6 @@ const EditDecorator: React.FC<DefaultDecoratorProps> = ({ element, radius, x, y 
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     kind: referenceForModel(ConsoleLinkModel),
-    optional: true,
   });
   const { cheURL, cheIconURL } = getCheDecoratorData(consoleLinks);
   const workloadData = element.getData().data;

--- a/frontend/packages/topology/src/components/side-bar/TopologyEdgeResourcesPanel.tsx
+++ b/frontend/packages/topology/src/components/side-bar/TopologyEdgeResourcesPanel.tsx
@@ -22,7 +22,6 @@ const TopologyEdgeResourcesPanel: React.FC<TopologyEdgeResourcesPanelProps> = ({
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     kind: referenceForModel(ConsoleLinkModel),
-    optional: true,
   });
   const source = getResource(edge.getSource());
   const target = getResource(edge.getTarget());

--- a/frontend/packages/topology/src/data-transforms/ModelContext.ts
+++ b/frontend/packages/topology/src/data-transforms/ModelContext.ts
@@ -1,7 +1,7 @@
 import { createContext } from 'react';
 import { Model } from '@patternfly/react-topology';
 import { observable, computed } from 'mobx';
-import { WatchK8sResources } from '@console/dynamic-plugin-sdk';
+import { WatchK8sResourcesOptional } from '@console/dynamic-plugin-sdk';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import {
   TopologyDataModelDepicted,
@@ -18,7 +18,7 @@ import {
 
 export type ModelExtensionContext = {
   priority: number;
-  resources?: (namespace: string) => WatchK8sResources<any>;
+  resources?: (namespace: string) => WatchK8sResourcesOptional<any>;
   workloadKeys?: string[];
   dataModelGetter?: TopologyDataModelGetter;
   dataModelDepicter?: TopologyDataModelDepicted;
@@ -44,7 +44,7 @@ export class ExtensibleModel {
   public extensionsLoaded: boolean = false;
 
   @observable.ref
-  public watchedResources: WatchK8sResources<any> = {};
+  public watchedResources: WatchK8sResourcesOptional<any> = {};
 
   public onExtensionsLoaded: (extensibleModel: ExtensibleModel) => void;
 

--- a/frontend/packages/topology/src/data-transforms/transform-utils.ts
+++ b/frontend/packages/topology/src/data-transforms/transform-utils.ts
@@ -1,7 +1,7 @@
 import { EdgeModel, Model, NodeModel, NodeShape } from '@patternfly/react-topology';
 import i18next from 'i18next';
 import * as _ from 'lodash';
-import { WatchK8sResources } from '@console/dynamic-plugin-sdk';
+import { WatchK8sResourcesOptional } from '@console/dynamic-plugin-sdk';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import { HorizontalPodAutoscalerModel } from '@console/internal/models';
 import {
@@ -317,7 +317,7 @@ export const getWorkloadResources = (
   );
 };
 
-export const getBaseWatchedResources = (namespace: string): WatchK8sResources<any> => {
+export const getBaseWatchedResources = (namespace: string): WatchK8sResourcesOptional<any> => {
   return {
     deploymentConfigs: {
       isList: true,

--- a/frontend/packages/topology/src/extensions/topology.ts
+++ b/frontend/packages/topology/src/extensions/topology.ts
@@ -1,5 +1,5 @@
 import { TopologyQuadrant } from '@patternfly/react-topology';
-import { WatchK8sResources } from '@console/dynamic-plugin-sdk';
+import { WatchK8sResourcesOptional } from '@console/dynamic-plugin-sdk';
 import { CodeRef } from '@console/dynamic-plugin-sdk/src/types';
 import { Extension } from '@console/plugin-sdk/src/typings/base';
 import {
@@ -25,7 +25,7 @@ namespace ExtensionProperties {
     /** Priority for the factory */
     priority: number;
     /** Resources to be fetched from useK8sWatchResources hook. */
-    resources?: (namespace: string) => WatchK8sResources<any>;
+    resources?: (namespace: string) => WatchK8sResourcesOptional<any>;
     /** Keys in resources containing workloads. */
     workloadKeys?: string[];
     /** Getter for the data model factory */

--- a/frontend/packages/topology/src/filters/TopologyFilterBar.tsx
+++ b/frontend/packages/topology/src/filters/TopologyFilterBar.tsx
@@ -74,7 +74,6 @@ const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     kind: referenceForModel(ConsoleLinkModel),
-    optional: true,
   });
   const kialiLink = getNamespaceDashboardKialiLink(consoleLinks, namespace);
   const queryParams = useQueryParams();

--- a/frontend/packages/topology/src/operators/operatorResources.ts
+++ b/frontend/packages/topology/src/operators/operatorResources.ts
@@ -1,9 +1,9 @@
-import { WatchK8sResources } from '@console/dynamic-plugin-sdk';
+import { WatchK8sResourcesOptional } from '@console/dynamic-plugin-sdk';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src';
 import { ServiceBindingModel } from '@console/service-binding-plugin/src/models';
 
-export const getOperatorWatchedResources = (namespace: string): WatchK8sResources<any> => {
+export const getOperatorWatchedResources = (namespace: string): WatchK8sResourcesOptional<any> => {
   return {
     clusterServiceVersions: {
       isList: true,
@@ -14,7 +14,9 @@ export const getOperatorWatchedResources = (namespace: string): WatchK8sResource
   };
 };
 
-export const getServiceBindingWatchedResources = (namespace: string): WatchK8sResources<any> => {
+export const getServiceBindingWatchedResources = (
+  namespace: string,
+): WatchK8sResourcesOptional<any> => {
   return {
     serviceBindingRequests: {
       isList: true,

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
@@ -87,7 +87,6 @@ const ClusterVersion: React.FC<ClusterVersionProps> = ({ cv }) => {
 
 const clusterVersionResource: WatchK8sResource = {
   kind: referenceForModel(ClusterVersionModel),
-  namespaced: false,
   name: 'version',
   isList: false,
 };

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-alert-receiver-link.spec.ts
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-alert-receiver-link.spec.ts
@@ -130,7 +130,6 @@ describe('useAlertReceiverLink', () => {
     expect(useK8sWatchResourceMock).toHaveBeenCalledWith({
       kind: 'Secret',
       isList: false,
-      namespaced: true,
       namespace: 'openshift-monitoring',
       name: 'alertmanager-main',
     });

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-identity-provider-link.spec.ts
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-identity-provider-link.spec.ts
@@ -44,7 +44,6 @@ describe('useIdentityProviderLink', () => {
     expect(useK8sWatchResourceMock).toHaveBeenCalledWith({
       kind: 'config.openshift.io~v1~OAuth',
       isList: false,
-      namespaced: false,
       name: 'cluster',
     });
   });

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-alert-receiver-link.ts
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-alert-receiver-link.ts
@@ -25,7 +25,6 @@ const useAlertManagerConfigSecret = (watch: boolean) =>
       ? {
           kind: SecretModel.kind,
           isList: false,
-          namespaced: true,
           namespace: 'openshift-monitoring',
           name: 'alertmanager-main',
         }

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/inventory-card.tsx
@@ -25,7 +25,7 @@ import {
   isDashboardsOverviewInventoryItem as isDynamicDashboardsOverviewInventoryItem,
   isDashboardsOverviewInventoryItemReplacement as isDynamicDashboardsOverviewInventoryItemReplacement,
   ResolvedExtension,
-  WatchK8sResources,
+  WatchK8sResourcesOptional,
   ClusterOverviewInventoryItem,
   isClusterOverviewInventoryItem,
 } from '@console/dynamic-plugin-sdk';
@@ -195,6 +195,6 @@ type ClusterInventoryItemProps = DashboardItemProps & {
   model: K8sKind;
   mapperLoader?: () => Promise<StatusGroupMapper>;
   resolvedMapper?: StatusGroupMapper;
-  additionalResources?: WatchK8sResources<any>;
+  additionalResources?: WatchK8sResourcesOptional<any>;
   expandedComponent?: LazyLoader;
 };

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -96,7 +96,6 @@ const filterSubsystems = (
 
 const cvResource: WatchK8sResource = {
   kind: referenceForModel(ClusterVersionModel),
-  namespaced: false,
   name: 'version',
   isList: false,
 };

--- a/frontend/public/components/dashboard/project-dashboard/project-dashboard.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/project-dashboard.tsx
@@ -49,7 +49,6 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = ({ obj }) => {
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     kind: referenceForModel(ConsoleLinkModel),
-    optional: true,
   });
   const namespaceLinks = getNamespaceDashboardConsoleLinks(obj, consoleLinks);
   const context = {

--- a/frontend/public/components/nav/NavHeader.tsx
+++ b/frontend/public/components/nav/NavHeader.tsx
@@ -74,7 +74,6 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     kind: referenceForModel(ConsoleLinkModel),
-    optional: true,
   });
 
   const togglePerspectiveOpen = React.useCallback(() => {

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -1009,7 +1009,6 @@ export const PodsPage: React.FC<PodPageProps> = ({
   const [pods, loaded, loadError] = useK8sWatchResource<PodKind[]>({
     kind,
     isList: true,
-    namespaced: true,
     namespace,
     selector,
     fieldSelector,


### PR DESCRIPTION
`optional` property was kept only for easier migration from Firehose to hook. But hook actually does not do anything with it.

`namespaced` - if I checked correctly, hook does not actually do anything with this prop either. Whether the resource is namespaced or not, is derived from the k8s model.