### PR TITLE
Bug 2092408: Change icon in virtualization overview permissions card

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/permissions-card/VirtOverviewPermissionsCard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/permissions-card/VirtOverviewPermissionsCard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Card, CardBody, CardHeader, CardTitle, Flex, FlexItem } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { GreenCheckCircleIcon, RedExclamationCircleIcon } from '@console/shared';
+import { GreenCheckCircleIcon, YellowExclamationTriangleIcon } from '@console/shared';
 import { usePermissionsCardPermissions } from '../../../hooks/use-permissions-card-permissions';
 import { PermissionsCardPopover } from './PermissionsCardPopover';
 import { PermissionsCountItem } from './PermissionsCountItem';
@@ -39,7 +39,7 @@ export const VirtOverviewPermissionsCard: React.FC = () => {
             <FlexItem>
               <PermissionsCountItem
                 count={numNotAllowedCapabilities}
-                Icon={RedExclamationCircleIcon}
+                Icon={YellowExclamationTriangleIcon}
                 isLoading={permissionsLoading}
               />
             </FlexItem>


### PR DESCRIPTION
The red exclamation icon in the permissions card of the virtualization overview should be a yellow exclamation triangle icon. This PR switches the icons.

### Screenshots:

Before:
![Selection_099](https://user-images.githubusercontent.com/8544299/171414025-9dc1aecc-e087-4053-bb12-59cd5bf760ab.png)

After:
![Selection_098](https://user-images.githubusercontent.com/8544299/171414047-4bb1a1b2-693e-42f9-94be-336937388234.png)

