### PR TITLE
Bug 2109673: Align Console plugin SDK package dependencies with generated code

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
@@ -70,7 +70,12 @@ export const getCorePackage: GetPackageDefinition = (
     ...commonManifestFields,
     dependencies: {
       ...parseSharedModuleDeps(rootPackage, missingDepCallback),
-      ...parseDeps(rootPackage, ['typesafe-actions', 'whatwg-fetch'], missingDepCallback),
+      ...parseDeps(
+        rootPackage,
+        ['classnames', 'immutable', 'reselect', 'typesafe-actions', 'whatwg-fetch'],
+        missingDepCallback,
+      ),
+      ...parseDepsAs(rootPackage, { 'lodash-es': 'lodash' }, missingDepCallback),
     },
   },
   filesToCopy: {
@@ -90,7 +95,10 @@ export const getInternalPackage: GetPackageDefinition = (
     version: sdkPackage.version,
     main: 'lib/lib-internal.js',
     ...commonManifestFields,
-    dependencies: parseSharedModuleDeps(rootPackage, missingDepCallback),
+    dependencies: {
+      ...parseSharedModuleDeps(rootPackage, missingDepCallback),
+      ...parseDeps(rootPackage, ['immutable'], missingDepCallback),
+    },
   },
   filesToCopy: {
     ...commonFiles,


### PR DESCRIPTION
This PR aligns `dependencies` of the following Console plugin SDK packages with what's actually used within their generated `dist/<pkg>/lib` code (excluding type-only dependencies):

- `@openshift-console/dynamic-plugin-sdk` :arrow_right: add `classnames`, `immutable`, `reselect`, `lodash`
- `@openshift-console/dynamic-plugin-sdk-internal` :arrow_right: add `immutable`

This also excludes `@patternfly/react-icons` and `@patternfly/react-tokens` which are pulled in via `@patternfly/react-core`.