### PR TITLE
Bug 2021297: Implement dynamic plugin dependency resolution

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -137,6 +137,7 @@ func main() {
 	fProjectAccessClusterRoles := fs.String("project-access-cluster-roles", "", "The list of Cluster Roles assignable for the project access page. (JSON as string)")
 	fManagedClusterConfigs := fs.String("managed-clusters", "", "List of managed cluster configurations. (JSON as string)")
 	fControlPlaneTopology := fs.String("control-plane-topology-mode", "", "Defines the topology mode of the control/infra nodes (External | HighlyAvailable | SingleReplica)")
+	fReleaseVersion := fs.String("release-version", "", "Defines the release version of the cluster")
 
 	if err := serverconfig.Parse(fs, os.Args[1:], "BRIDGE"); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -266,6 +267,7 @@ func main() {
 		K8sProxyConfigs:           make(map[string]*proxy.Config),
 		K8sClients:                make(map[string]*http.Client),
 		Telemetry:                 telemetryFlags,
+		ReleaseVersion:            *fReleaseVersion,
 	}
 
 	managedClusterConfigs := []serverconfig.ManagedClusterConfig{}

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -11,21 +11,21 @@
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
       "source.organizeImports": false,
-      "source.sortImports": false    
+      "source.sortImports": false
     }
   },
   "[typescript]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
       "source.organizeImports": false,
-      "source.sortImports": false    
+      "source.sortImports": false
     }
   },
   "[typescriptreact]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
       "source.organizeImports": false,
-      "source.sortImports": false    
+      "source.sortImports": false
     }
   },
   "[json]": {
@@ -86,7 +86,11 @@
   },
   "cucumberautocomplete.steps": ["./packages/*/integration-tests/support/step-definitions/*/*.ts"],
   "cucumberautocomplete.strictGherkinCompletion": true,
-  "editor.quickSuggestions": true
+  "editor.quickSuggestions": {
+    "comments": "on",
+    "strings": "on",
+    "other": "on"
+  }
   // TODO support prettier + stylelint
   // "prettier.stylelintIntegration": true,
   // "css.validate": false,

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -35,6 +35,7 @@ declare interface Window {
     prometheusBaseURL: string;
     prometheusTenancyBaseURL: string;
     quickStarts: string;
+    releaseVersion: string;
     requestTokenURL: string;
     inactivityTimeout: number;
     statuspageID: string;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-dependencies.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-dependencies.spec.ts
@@ -1,0 +1,197 @@
+import * as _ from 'lodash';
+import * as pluginSubscriptionServiceModule from '@console/plugin-sdk/src/api/pluginSubscriptionService';
+import { LoadedDynamicPluginInfo, NotLoadedDynamicPluginInfo } from '@console/plugin-sdk/src/store';
+import { ConsolePluginManifestJSON } from '../../schema/plugin-manifest';
+import { getPluginManifest } from '../../utils/test-utils';
+import {
+  resolvePluginDependencies,
+  getStateForTestPurposes,
+  resetStateAndEnvForTestPurposes,
+} from '../plugin-dependencies';
+import { getPluginID } from '../plugin-utils';
+
+type DynamicPluginListener = Parameters<
+  typeof pluginSubscriptionServiceModule.subscribeToDynamicPlugins
+>[0];
+
+const subscribeToDynamicPlugins = jest.spyOn(
+  pluginSubscriptionServiceModule,
+  'subscribeToDynamicPlugins',
+);
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  resetStateAndEnvForTestPurposes();
+});
+
+describe('resolvePluginDependencies', () => {
+  const getLoadedDynamicPluginInfo = (
+    manifest: ConsolePluginManifestJSON,
+  ): LoadedDynamicPluginInfo => ({
+    status: 'Loaded',
+    pluginID: getPluginID(manifest),
+    metadata: _.pick(manifest, 'name', 'version', 'dependencies'),
+    enabled: true,
+  });
+
+  const getPendingDynamicPluginInfo = (
+    manifest: ConsolePluginManifestJSON,
+  ): NotLoadedDynamicPluginInfo => ({
+    status: 'Pending',
+    pluginName: manifest.name,
+  });
+
+  const getFailedDynamicPluginInfo = (
+    manifest: ConsolePluginManifestJSON,
+  ): NotLoadedDynamicPluginInfo => ({
+    status: 'Failed',
+    pluginName: manifest.name,
+  });
+
+  it('throws an error if Console plugin API dependency is not met', async () => {
+    const manifest = getPluginManifest('Test', '1.2.3');
+    manifest.dependencies = { '@console/pluginAPI': '~4.12' };
+
+    try {
+      await resolvePluginDependencies(manifest, ['Test', 'Foo', 'Bar'], '4.11.1');
+    } catch (e) {
+      expect(e.message).toEqual(
+        'Unmet dependency @console/pluginAPI: required ~4.12, current 4.11.1',
+      );
+      expect(subscribeToDynamicPlugins).not.toHaveBeenCalled();
+      expect(getStateForTestPurposes().unsubListenerMap.size).toBe(0);
+    }
+
+    expect.assertions(3);
+  });
+
+  it('completes if there are no required plugins', async () => {
+    const manifest = getPluginManifest('Test', '1.2.3');
+    manifest.dependencies = { '@console/pluginAPI': '*' };
+
+    await resolvePluginDependencies(manifest, ['Test', 'Foo', 'Bar'], '4.11.1');
+
+    expect(subscribeToDynamicPlugins).not.toHaveBeenCalled();
+    expect(getStateForTestPurposes().unsubListenerMap.size).toBe(0);
+  });
+
+  it('throws an error if some of the required plugins are not available', async () => {
+    const manifest = getPluginManifest('Test', '1.2.3');
+    manifest.dependencies = { '@console/pluginAPI': '*', Foo: '*', Bar: '*' };
+
+    try {
+      await resolvePluginDependencies(manifest, ['Test'], '4.11.1');
+    } catch (e) {
+      expect(e.message).toEqual('Dependent plugins are not available: Bar, Foo');
+      expect(subscribeToDynamicPlugins).not.toHaveBeenCalled();
+      expect(getStateForTestPurposes().unsubListenerMap.size).toBe(0);
+    }
+
+    expect.assertions(3);
+  });
+
+  it('subscribes to changes in dynamic plugin information', async () => {
+    const manifest = getPluginManifest('Test', '1.2.3');
+    manifest.dependencies = { '@console/pluginAPI': '*', Foo: '*', Bar: '*' };
+
+    subscribeToDynamicPlugins.mockImplementation((listener: DynamicPluginListener) => {
+      listener([
+        getPendingDynamicPluginInfo(getPluginManifest('Foo', '1.0.0')),
+        getPendingDynamicPluginInfo(getPluginManifest('Bar', '1.0.0')),
+      ]);
+    });
+
+    await Promise.race([
+      resolvePluginDependencies(manifest, ['Test', 'Foo', 'Bar'], '4.11.1'),
+      Promise.resolve(), // avoid dependency resolution Promise timeout
+    ]);
+
+    expect(subscribeToDynamicPlugins).toHaveBeenCalledTimes(1);
+    expect(getStateForTestPurposes().unsubListenerMap.size).toBe(1);
+    expect(getStateForTestPurposes().unsubListenerMap.has('Test@1.2.3')).toBe(true);
+
+    try {
+      await resolvePluginDependencies(manifest, ['Test', 'Foo', 'Bar'], '4.11.1');
+    } catch (e) {
+      expect(e.message).toEqual(
+        'Dependency resolution for plugin Test@1.2.3 is already in progress',
+      );
+      expect(subscribeToDynamicPlugins).toHaveBeenCalledTimes(1);
+      expect(getStateForTestPurposes().unsubListenerMap.size).toBe(1);
+      expect(getStateForTestPurposes().unsubListenerMap.has('Test@1.2.3')).toBe(true);
+    }
+
+    expect.assertions(7);
+  });
+
+  it('completes when all required plugins are loaded successfully', async () => {
+    const manifest = getPluginManifest('Test', '1.2.3');
+    manifest.dependencies = { '@console/pluginAPI': '*', Foo: '*', Bar: '*' };
+
+    subscribeToDynamicPlugins.mockImplementation((listener: DynamicPluginListener) => {
+      listener([
+        getLoadedDynamicPluginInfo(getPluginManifest('Foo', '1.0.0')),
+        getLoadedDynamicPluginInfo(getPluginManifest('Bar', '1.0.0')),
+      ]);
+    });
+
+    await resolvePluginDependencies(manifest, ['Test', 'Foo', 'Bar'], '4.11.1');
+
+    expect(subscribeToDynamicPlugins).toHaveBeenCalledTimes(1);
+    expect(getStateForTestPurposes().unsubListenerMap.size).toBe(0);
+  });
+
+  it('throws an error if some of the required plugins fail to load successfully', async () => {
+    const manifest = getPluginManifest('Test', '1.2.3');
+    manifest.dependencies = { '@console/pluginAPI': '*', Foo: '*', Bar: '*', Baz: '*' };
+
+    subscribeToDynamicPlugins.mockImplementation((listener: DynamicPluginListener) => {
+      listener([
+        getLoadedDynamicPluginInfo(getPluginManifest('Foo', '1.0.0')),
+        getFailedDynamicPluginInfo(getPluginManifest('Bar', '1.0.0')),
+        getFailedDynamicPluginInfo(getPluginManifest('Baz', '1.0.0')),
+      ]);
+    });
+
+    try {
+      await resolvePluginDependencies(manifest, ['Test', 'Foo', 'Bar', 'Baz'], '4.11.1');
+    } catch (e) {
+      expect(e.message).toEqual('Dependent plugins failed to load: Bar, Baz');
+      expect(subscribeToDynamicPlugins).toHaveBeenCalledTimes(1);
+      expect(getStateForTestPurposes().unsubListenerMap.size).toBe(0);
+    }
+
+    expect.assertions(3);
+  });
+
+  it('throws an error if some of the required plugin dependencies are not met', async () => {
+    const manifest = getPluginManifest('Test', '1.2.3');
+    manifest.dependencies = {
+      '@console/pluginAPI': '*',
+      Foo: '^1.0.0',
+      Bar: '~1.1.1',
+      Baz: '=1.1.1',
+    };
+
+    subscribeToDynamicPlugins.mockImplementation((listener: DynamicPluginListener) => {
+      listener([
+        getLoadedDynamicPluginInfo(getPluginManifest('Foo', '1.0.0')),
+        getLoadedDynamicPluginInfo(getPluginManifest('Bar', '1.1.0')),
+        getLoadedDynamicPluginInfo(getPluginManifest('Baz', '1.1.2')),
+      ]);
+    });
+
+    try {
+      await resolvePluginDependencies(manifest, ['Test', 'Foo', 'Bar', 'Baz'], '4.11.1');
+    } catch (e) {
+      expect(e.message).toEqual(
+        'Unmet dependency Bar: required ~1.1.1, current 1.1.0\n' +
+          'Unmet dependency Baz: required =1.1.1, current 1.1.2',
+      );
+      expect(subscribeToDynamicPlugins).toHaveBeenCalledTimes(1);
+      expect(getStateForTestPurposes().unsubListenerMap.size).toBe(0);
+    }
+
+    expect.assertions(3);
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-utils.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-utils.spec.ts
@@ -1,0 +1,8 @@
+import { getPluginManifest } from '../../utils/test-utils';
+import { getPluginID } from '../plugin-utils';
+
+describe('getPluginID', () => {
+  it('returns a string formatted as {name}@{version}', () => {
+    expect(getPluginID(getPluginManifest('Test', '1.2.3'))).toBe('Test@1.2.3');
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-dependencies.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-dependencies.ts
@@ -1,0 +1,123 @@
+import * as _ from 'lodash';
+import * as semver from 'semver';
+import { subscribeToDynamicPlugins } from '@console/plugin-sdk/src/api/pluginSubscriptionService';
+import { ConsolePluginManifestJSON } from '../schema/plugin-manifest';
+import { getPluginID } from './plugin-utils';
+
+const unsubListenerMap = new Map<string, VoidFunction>();
+
+const cleanupListener = (pluginID: string) => {
+  if (unsubListenerMap.has(pluginID)) {
+    unsubListenerMap.get(pluginID)();
+    unsubListenerMap.delete(pluginID);
+  }
+};
+
+const formatPluginNames = (values: string[]) =>
+  values.sort((a, b) => a.localeCompare(b)).join(', ');
+
+export const resolvePluginDependencies = (
+  manifest: ConsolePluginManifestJSON,
+  allowedPluginNames: string[],
+  consolePluginAPIVersion: string,
+) => {
+  const { dependencies } = manifest;
+  const pluginID = getPluginID(manifest);
+
+  if (unsubListenerMap.has(pluginID)) {
+    throw new Error(`Dependency resolution for plugin ${pluginID} is already in progress`);
+  }
+
+  // Ensure compatibility with current Console plugin API
+  const pluginAPIDepName = '@console/pluginAPI';
+
+  if (!semver.satisfies(consolePluginAPIVersion, dependencies[pluginAPIDepName])) {
+    throw new Error(
+      `Unmet dependency ${pluginAPIDepName}: required ${dependencies[pluginAPIDepName]}, current ${consolePluginAPIVersion}`,
+    );
+  }
+
+  // Ensure compatibility with other dynamic plugins
+  const requiredPluginNames = _.difference(Object.keys(dependencies), [pluginAPIDepName]);
+  const unavailablePluginNames = _.difference(requiredPluginNames, allowedPluginNames);
+
+  if (requiredPluginNames.length === 0) {
+    return Promise.resolve();
+  }
+
+  if (unavailablePluginNames.length > 0) {
+    throw new Error(
+      `Dependent plugins are not available: ${formatPluginNames(unavailablePluginNames)}`,
+    );
+  }
+
+  // Wait for all dependent plugins to be loaded before resolving the Promise.
+  // If some of them fail to load successfully, the Promise will be rejected.
+  return new Promise<void>((resolve, reject) => {
+    let promiseSettled = false;
+
+    const resolvePromise = () => {
+      promiseSettled = true;
+      cleanupListener(pluginID);
+      resolve();
+    };
+
+    const rejectPromise = (reason) => {
+      promiseSettled = true;
+      cleanupListener(pluginID);
+      reject(reason);
+    };
+
+    const unsubListener = subscribeToDynamicPlugins((entries) => {
+      const loadedPlugins = entries.reduce<Record<string, string>>((acc, e) => {
+        if (e.status === 'Loaded' && requiredPluginNames.includes(e.metadata.name)) {
+          acc[e.metadata.name] = e.metadata.version;
+        }
+        return acc;
+      }, {});
+
+      const failedPluginNames = entries.reduce<string[]>((acc, e) => {
+        if (e.status === 'Failed' && requiredPluginNames.includes(e.pluginName)) {
+          acc.push(e.pluginName);
+        }
+        return acc;
+      }, []);
+
+      if (failedPluginNames.length > 0) {
+        rejectPromise(
+          new Error(`Dependent plugins failed to load: ${formatPluginNames(failedPluginNames)}`),
+        );
+      } else if (_.isEqual(requiredPluginNames, Object.keys(loadedPlugins))) {
+        const unmetDependencyErrors: string[] = [];
+
+        requiredPluginNames.forEach((pluginName) => {
+          if (!semver.satisfies(loadedPlugins[pluginName], dependencies[pluginName])) {
+            unmetDependencyErrors.push(
+              `Unmet dependency ${pluginName}: required ${dependencies[pluginName]}, current ${loadedPlugins[pluginName]}`,
+            );
+          }
+        });
+
+        if (unmetDependencyErrors.length > 0) {
+          rejectPromise(new Error(unmetDependencyErrors.join('\n')));
+        } else {
+          resolvePromise();
+        }
+      }
+    });
+
+    // subscribeToDynamicPlugins immediately invokes the provided listener,
+    // which may cause the dependency resolution Promise to be settled already
+    if (!promiseSettled) {
+      unsubListenerMap.set(pluginID, unsubListener);
+    }
+  });
+};
+
+export const getStateForTestPurposes = () => ({
+  unsubListenerMap,
+});
+
+export const resetStateAndEnvForTestPurposes = () => {
+  unsubListenerMap.clear();
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-loader.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-loader.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 
 import * as _ from 'lodash';
+import * as semver from 'semver';
 import { PluginStore } from '@console/plugin-sdk/src/store';
 import { resolveEncodedCodeRefs } from '../coderefs/coderef-resolver';
 import { remoteEntryFile } from '../constants';
@@ -125,8 +126,8 @@ export const loadAndEnablePlugin = async (
 
     await resolvePluginDependencies(
       manifest,
+      semver.valid(window.SERVER_FLAGS.releaseVersion),
       pluginStore.getAllowedDynamicPluginNames(),
-      window.SERVER_FLAGS.releaseVersion,
     );
 
     const pluginID = await loadDynamicPlugin(url, manifest);

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-utils.ts
@@ -1,0 +1,3 @@
+import { ConsolePluginManifestJSON } from '../schema/plugin-manifest';
+
+export const getPluginID = (m: ConsolePluginManifestJSON) => `${m.name}@${m.version}`;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/schema/plugin-package.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/schema/plugin-package.ts
@@ -17,7 +17,10 @@ export type ConsolePluginMetadata = {
   description?: string;
   /** Specific modules exposed through the plugin's remote entry. */
   exposedModules?: { [moduleName: string]: string };
-  /** Plugin API and other plugins required for this plugin to work. */
+  /**
+   * Plugin API and other plugins required for this plugin to work.
+   * Values must be valid semver ranges or `*` representing any version.
+   */
   dependencies: {
     '@console/pluginAPI': string;
     [pluginName: string]: string;

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -110,6 +110,7 @@ type jsGlobals struct {
 	Clusters                   []string                   `json:"clusters"`
 	ControlPlaneTopology       string                     `json:"controlPlaneTopology"`
 	Telemetry                  serverconfig.MultiKeyValue `json:"telemetry"`
+	ReleaseVersion             string                     `json:"releaseVersion"`
 }
 
 type Server struct {
@@ -132,6 +133,7 @@ type Server struct {
 	StatuspageID         string
 	LoadTestFactor       int
 	InactivityTimeout    int
+	ReleaseVersion       string
 	// Map that contains list of enabled plugins and their endpoints.
 	EnabledConsolePlugins serverconfig.MultiKeyValue
 	I18nNamespaces        []string
@@ -711,6 +713,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		ProjectAccessClusterRoles:  s.ProjectAccessClusterRoles,
 		Clusters:                   clusters,
 		Telemetry:                  s.Telemetry,
+		ReleaseVersion:             s.ReleaseVersion,
 	}
 
 	localAuther := s.getLocalAuther()

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -209,6 +209,10 @@ func addClusterInfo(fs *flag.FlagSet, clusterInfo *ClusterInfo) {
 	if clusterInfo.ControlPlaneTopology != "" {
 		fs.Set("control-plane-topology-mode", string(clusterInfo.ControlPlaneTopology))
 	}
+
+	if clusterInfo.ReleaseVersion != "" {
+		fs.Set("release-version", string(clusterInfo.ReleaseVersion))
+	}
 }
 
 func addAuth(fs *flag.FlagSet, auth *Auth) {

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -69,6 +69,7 @@ type ClusterInfo struct {
 	ConsoleBasePath      string                `yaml:"consoleBasePath,omitempty"`
 	MasterPublicURL      string                `yaml:"masterPublicURL,omitempty"`
 	ControlPlaneTopology configv1.TopologyMode `yaml:"controlPlaneTopology,omitempty"`
+	ReleaseVersion       string                `yaml:"releaseVersion,omitempty"`
 }
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".


### PR DESCRIPTION
Related Console operator PR: openshift/console-operator#659

Dynamic plugins declare their dependencies via `consolePlugin.dependencies` object in their `package.json` file.

There are currently two kinds of dependencies:
- `@console/pluginAPI` (required) - dependency on OpenShift Console application
- `<plugin-name>` (optional) - dependency on another plugin with the given name

Dependency values must be valid [semver](https://semver.org/) ranges or `*` representing any version.

For example:
```json
"dependencies": {
  "@console/pluginAPI": "~4.11.0",
  "foo": "^1.0.0",
  "bar": "=1.2.3"
},
```
indicates that the given plugin depends on:
- OpenShift Console (release) version matching `>=4.11.0 <4.12.0`
- `foo` plugin version matching `>=1.0.0 <2.0.0`
- `bar` plugin version that is strictly `1.2.3`

Console `loadAndEnablePlugin` function's async operation flow has been modified as following:
1. fetch & validate the manifest (`plugin-manifest.json`)
2. resolve dependencies :star: (added by this PR)
3. load & process the entry script (`plugin-entry.js`)
