### PR TITLE
Bug 2019877: The dashboard shows lots of events without a timestamp f…

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -47,7 +47,11 @@ export const getLastTime = (event) => {
   return event.lastTimestamp || lastObservedTime || event.eventTime;
 };
 export const sortEvents = (events) => {
-  return _.orderBy(events, [getLastTime, getFirstTime, 'name'], ['desc', 'desc', 'asc']);
+  return _.orderBy(
+    events,
+    [(event) => (event.lastTimestamp || event.eventTime ? getLastTime : ''), getFirstTime, 'name'],
+    ['desc', 'desc', 'asc'],
+  );
 };
 
 // Predicate function to filter by event "type" (normal, warning, or all)


### PR DESCRIPTION
…rom kube-apiserver, although they have timestamps

Displays the newest and most relevant events at the top with the correct timestamps. Events with no timestamps are now filtered to the bottom instead of the top.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2019877