### PR TITLE
CONSOLE-3169: Publish console dynamic plugin extension and api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,3 +469,26 @@ We support the latest versions of the following browsers:
 - Firefox
 
 IE 11 and earlier is not supported.
+
+## Frontend Packages
+- [ceph-storage-plugin](./frontend/packages/ceph-storage-plugin/README.md)
+
+- [console-dynamic-plugin-sdk](./frontend/packages/console-dynamic-plugin-sdk/README.md)
+[[API]](./frontend/packages/console-dynamic-plugin-sdk/docs/api.md)
+[[Console Extensions]](./frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md)
+
+- [console-plugin-shared](./frontend/packages/console-plugin-shared/README.md)
+
+- [dev-console](./frontend/packages/dev-console/README.md)
+
+- [eslint-plugin-console](./frontend/packages/eslint-plugin-console/README.md)
+
+- [integration-tests-cypress](./frontend/packages/integration-tests-cypress/README.md)
+
+- [knative-plugin](./frontend/packages/knative-plugin/README.md)
+
+- operator-lifecycle-manager
+[[Descriptors README]](./frontend/packages/operator-lifecycle-manager/src/components/descriptors/README.md)
+[[Descriptors API Reference]](./frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md)
+
+- [rhoas-plugin](./frontend/packages/rhoas-plugin/README.md)

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -9,9 +9,13 @@ released, installed and upgraded independently from each other. To ensure compat
 other plugins, each plugin must declare its dependencies using [semantic version](https://semver.org/)
 ranges.
 
-See the
-[OpenShift Console Dynamic Plugins feature page](https://github.com/openshift/enhancements/blob/master/enhancements/console/dynamic-plugins.md)
-for a high level overview of dynamic plugins in relation to OLM operators and cluster administration.
+## Related Documentation
+*[Extension Documentation](./docs/console-extensions.md)* - Detailed documentation of every available console extension point.
+
+*[API Documentation](./docs/api.md)* - Detailed documentation of hooks, components, and other APIs provided by this package. 
+
+*[OpenShift Console Dynamic Plugins feature page](https://github.com/openshift/enhancements/blob/master/enhancements/console/dynamic-plugins.md)* - A high level overview of dynamic plugins in relation to OLM operators and cluster administration.
+
 
 Example project structure:
 

--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -1,0 +1,1367 @@
+# OpenShift Console API
+
+1. [`useActivePerspective`](#useactiveperspective)
+2. [`PerspectiveContext`](#perspectivecontext)
+3. [`GreenCheckCircleIcon`](#greencheckcircleicon)
+4. [`RedExclamationCircleIcon`](#redexclamationcircleicon)
+5. [`YellowExclamationTriangleIcon`](#yellowexclamationtriangleicon)
+6. [`BlueInfoCircleIcon`](#blueinfocircleicon)
+7. [`ErrorStatus`](#errorstatus)
+8. [`InfoStatus`](#infostatus)
+9. [`ProgressStatus`](#progressstatus)
+10. [`SuccessStatus`](#successstatus)
+11. [`checkAccess`](#checkaccess)
+12. [`useAccessReview`](#useaccessreview)
+13. [`useAccessReviewAllowed`](#useaccessreviewallowed)
+14. [`useSafetyFirst`](#usesafetyfirst)
+15. [`useResolvedExtensions`](#useresolvedextensions)
+16. [`HorizontalNav`](#horizontalnav)
+17. [`VirtualizedTable`](#virtualizedtable)
+18. [`TableData`](#tabledata)
+19. [`useActiveColumns`](#useactivecolumns)
+20. [`ListPageHeader`](#listpageheader)
+21. [`ListPageCreate`](#listpagecreate)
+22. [`ListPageCreateLink`](#listpagecreatelink)
+23. [`ListPageCreateButton`](#listpagecreatebutton)
+24. [`ListPageCreateDropdown`](#listpagecreatedropdown)
+25. [`ListPageFilter`](#listpagefilter)
+26. [`useListPageFilter`](#uselistpagefilter)
+27. [`ResourceLink`](#resourcelink)
+28. [`useK8sModel`](#usek8smodel)
+29. [`useK8sModels`](#usek8smodels)
+30. [`useK8sWatchResource`](#usek8swatchresource)
+31. [`useK8sWatchResources`](#usek8swatchresources)
+32. [`consoleFetch`](#consolefetch)
+33. [`consoleFetchJSON`](#consolefetchjson)
+34. [`consoleFetchText`](#consolefetchtext)
+35. [`getConsoleRequestHeaders`](#getconsolerequestheaders)
+36. [`k8sGetResource`](#k8sgetresource)
+37. [`k8sCreateResource`](#k8screateresource)
+38. [`k8sUpdateResource`](#k8supdateresource)
+39. [`k8sPatchResource`](#k8spatchresource)
+40. [`k8sDeleteResource`](#k8sdeleteresource)
+41. [`k8sListResource`](#k8slistresource)
+42. [`k8sListResourceItems`](#k8slistresourceitems)
+43. [`getAPIVersionForModel`](#getapiversionformodel)
+44. [`getGroupVersionKindForResource`](#getgroupversionkindforresource)
+45. [`getGroupVersionKindForModel`](#getgroupversionkindformodel)
+46. [`StatusPopupSection`](#statuspopupsection)
+47. [`StatusPopupItem`](#statuspopupitem)
+48. [`Overview`](#overview)
+49. [`OverviewGrid`](#overviewgrid)
+50. [`InventoryItem`](#inventoryitem)
+51. [`InventoryItemTitle`](#inventoryitemtitle)
+52. [`InventoryItemBody`](#inventoryitembody)
+53. [`InventoryItemStatus`](#inventoryitemstatus)
+54. [`InventoryItemLoading`](#inventoryitemloading)
+55. [`useFlag`](#useflag)
+56. [`ResourceYAMLEditor`](#resourceyamleditor)
+57. [`ResourceEventStream`](#resourceeventstream)
+58. [`usePrometheusPoll`](#useprometheuspoll)
+
+---
+
+## `useActivePerspective`
+
+### Summary
+
+Hook that provides the currently active perspective and a callback for setting the active perspective
+
+
+
+### Example
+
+
+```tsx
+const Component: React.FC = (props) => {
+   const [activePerspective, setActivePerspective] = useActivePerspective();
+   return <select
+     value={activePerspective}
+     onChange={(e) => setActivePerspective(e.target.value)}
+   >
+     {
+       // ...perspective options
+     }
+   </select>
+}
+```
+
+
+
+
+
+
+
+### Returns
+
+A tuple containing the current active perspective and setter callback.
+
+
+---
+
+## `PerspectiveContext`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-dynamic-plugin-sdk/src/perspective/perspective-context.ts)
+
+
+
+
+
+
+---
+
+## `GreenCheckCircleIcon`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.tsx)
+
+
+
+
+
+
+---
+
+## `RedExclamationCircleIcon`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.tsx)
+
+
+
+
+
+
+---
+
+## `YellowExclamationTriangleIcon`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.tsx)
+
+
+
+
+
+
+---
+
+## `BlueInfoCircleIcon`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.tsx)
+
+
+
+
+
+
+---
+
+## `ErrorStatus`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/statuses.tsx)
+
+
+
+
+
+
+---
+
+## `InfoStatus`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/statuses.tsx)
+
+
+
+
+
+
+---
+
+## `ProgressStatus`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/statuses.tsx)
+
+
+
+
+
+
+---
+
+## `SuccessStatus`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/statuses.tsx)
+
+
+
+
+
+
+---
+
+## `checkAccess`
+
+### Summary
+
+Provides information about user access to a given resource.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `resourceAttributes` | resource attributes for access review |
+| `impersonate` | impersonation details |
+
+
+
+### Returns
+
+Object with resource access information.
+
+
+---
+
+## `useAccessReview`
+
+### Summary
+
+Hook that provides information about user access to a given resource.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `resourceAttributes` | resource attributes for access review |
+| `impersonate` | impersonation details |
+
+
+
+### Returns
+
+Array with isAllowed and loading values.
+
+
+---
+
+## `useAccessReviewAllowed`
+
+### Summary
+
+Hook that provides allowed status about user access to a given resource.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `resourceAttributes` | resource attributes for access review |
+| `impersonate` | impersonation details |
+
+
+
+### Returns
+
+The isAllowed boolean value.
+
+
+---
+
+## `useSafetyFirst`
+
+### Summary
+
+Hook that ensures a safe asynchronnous setting of React state in case a given component could be unmounted.<br/>(https://github.com/facebook/react/issues/14113)
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `initialState` | initial state value |
+
+
+
+### Returns
+
+An array with a pair of state value and it's set function.
+
+
+---
+
+## `useResolvedExtensions`
+
+### Summary
+
+React hook for consuming Console extensions with resolved `CodeRef` properties.<br/>This hook accepts the same argument(s) as `useExtensions` hook and returns an adapted list of extension instances, resolving all code references within each extension's properties.<br/>Initially, the hook returns an empty array. Once the resolution is complete, the React component is re-rendered with the hook returning an adapted list of extensions.<br/>When the list of matching extensions changes, the resolution is restarted. The hook will continue to return the previous result until the resolution completes.<br/>The hook's result elements are guaranteed to be referentially stable across re-renders.
+
+
+
+### Example
+
+
+```ts
+const [navItemExtensions, navItemsResolved] = useResolvedExtensions<NavItem>(isNavItem);
+// process adapted extensions and render your component
+```
+
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `typeGuards` | A list of callbacks that each accept a dynamic plugin extension as an argument and return a boolean flag indicating whether or not the extension meets desired type constraints |
+
+
+
+### Returns
+
+Tuple containing a list of adapted extension instances with resolved code references, a boolean flag indicating whether the resolution is complete, and a list of errors detected during the resolution.
+
+
+---
+
+## `HorizontalNav`
+
+### Summary
+
+A component that creates a Navigation bar. It takes array of NavPage objects and renderes a NavBar.<br/>Routing is handled as part of the component.
+
+
+
+### Example
+
+
+```ts
+const HomePage: React.FC = (props) => {
+    const page = {
+      href: '/home',
+      name: 'Home',
+      component: () => <>Home</>
+    }
+    return <HorizontalNav match={props.match} pages={[page]} />
+}
+```
+
+
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `resource` | The resource associated with this Navigation, an object of K8sResourceCommon type |
+| `pages` | An array of page objects |
+| `match` | match object provided by React Router |
+
+
+
+---
+
+## `VirtualizedTable`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/public/components/factory/Table/VirtualizedTable.tsx)
+
+
+
+
+
+
+---
+
+## `TableData`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/public/components/factory/Table/VirtualizedTable.tsx)
+
+
+
+
+
+
+---
+
+## `useActiveColumns`
+
+### Summary
+
+A hook that provides a list of user-selected active TableColumns.
+
+
+
+### Example
+
+
+```tsx
+  // See implementation for more details on TableColumn type
+  const [activeColumns, userSettingsLoaded] = useActiveColumns({
+    columns,
+    showNamespaceOverride: false,
+    columnManagementID,
+  });
+  return userSettingsAreLoaded ? <VirtualizedTable columns={activeColumns} {...otherProps} /> : null
+```
+
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `options` | Which are passed as a key-value map |
+| `` |  options.columns - An array of all available TableColumns |
+| `` |  options.showNamespaceOverride - (optional) If true, a namespace column will be included, regardless of column management selections |
+| `` |  options.columnManagementID - (optional) A unique id used to persist and retrieve column management selections to and from user settings. Usually a 'group~verion~kind' string for a resource. |
+
+
+
+### Returns
+
+A tuple containing the current user selected active columns (a subset of options.columns), and a boolean flag indicating whether user settings have been loaded.
+
+
+---
+
+## `ListPageHeader`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/public/components/factory/ListPage/ListPageHeader.tsx)
+
+
+
+
+
+
+---
+
+## `ListPageCreate`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/public/components/factory/ListPage/ListPageCreate.tsx)
+
+
+
+
+
+
+---
+
+## `ListPageCreateLink`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/public/components/factory/ListPage/ListPageCreate.tsx)
+
+
+
+
+
+
+---
+
+## `ListPageCreateButton`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/public/components/factory/ListPage/ListPageCreate.tsx)
+
+
+
+
+
+
+---
+
+## `ListPageCreateDropdown`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/public/components/factory/ListPage/ListPageCreate.tsx)
+
+
+
+
+
+
+---
+
+## `ListPageFilter`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/public/components/factory/ListPage/ListPageFilter.tsx)
+
+
+
+
+
+
+---
+
+## `useListPageFilter`
+
+### Summary
+
+A hook that manages filter state for the ListPageFilter component.
+
+
+
+### Example
+
+
+```tsx
+  // See implementation for more details on RowFilter and FilterValue types
+  const [staticData, filteredData, onFilterChange] = useListPageFilter(
+    data,
+    rowFilters,
+    staticFilters,
+  );
+  // ListPageFilter updates filter state based on user interaction and resulting filtered data can be rendered in an independent component.
+  return (
+    <>
+      <ListPageHeader .../>
+      <ListPagBody>
+        <ListPageFilter data={staticData} onFilterChange={onFilterChange} />
+        <List data={filteredData} />
+      </ListPageBody>
+    </>
+  )
+```
+
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `data` | An array of data points |
+| `rowFilters` | (optional) An array of RowFilter elements that define the available filter options |
+| `staticFilters` | (optional) An array of FilterValue elements that are statically applied to the data |
+
+
+
+### Returns
+
+A tuple containing the data filtered by all static filteres, the data filtered by all static and row filters, and a callback that updates rowFilters
+
+
+---
+
+## `ResourceLink`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/public/components/utils/resource-link.tsx)
+
+
+
+
+
+
+---
+
+## `useK8sModel`
+
+### Summary
+
+Hook that retrieves the k8s model for provided K8sGroupVersionKind from redux.
+
+
+
+### Example
+
+
+```ts
+const Component: React.FC = () => {
+  const [model, inFlight] = useK8sModel({ group: 'app'; version: 'v1'; kind: 'Deployment' });
+  return ...
+}
+```
+
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `groupVersionKind` | group, version, kind of k8s resource {@link K8sGroupVersionKind} is preferred alternatively can pass reference for group, version, kind which is deprecated i.e `group~version~kind` {@link K8sResourceKindReference}. |
+
+
+
+### Returns
+
+An array with the first item as k8s model and second item as inFlight status
+
+
+---
+
+## `useK8sModels`
+
+### Summary
+
+Hook that retrieves all current k8s models from redux.
+
+
+
+### Example
+
+
+```ts
+const Component: React.FC = () => {
+  const [models, inFlight] = UseK8sModels();
+  return ...
+}
+```
+
+
+
+
+
+
+
+### Returns
+
+An array with the first item as the list of k8s model and second item as inFlight status
+
+
+---
+
+## `useK8sWatchResource`
+
+### Summary
+
+Hook that retrieves the k8s resource along with status for loaded and error.
+
+
+
+### Example
+
+
+```ts
+const Component: React.FC = () => {
+  const watchRes = {
+        ...
+      }
+  const [data, loaded, error] = UseK8sWatchResource(watchRes)
+  return ...
+}
+```
+
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `initResource` | options needed to watch for resource. |
+
+
+
+### Returns
+
+An array with first item as resource(s), second item as loaded status and third item as error state if any.
+
+
+---
+
+## `useK8sWatchResources`
+
+### Summary
+
+Hook that retrieves the k8s resources along with their respective status for loaded and error.
+
+
+
+### Example
+
+
+```ts
+const Component: React.FC = () => {
+  const watchResources = {
+        'deployment': {...},
+        'pod': {...}
+        ...
+      }
+  const {deployment, pod}  = UseK8sWatchResources(watchResources)
+  return ...
+}
+```
+
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `initResources` | resources need to be watched as key-value pair, wherein key will be unique to resource and value will be options needed to watch for the respective resource. |
+
+
+
+### Returns
+
+A map where keys are as provided in initResouces and value has three properties data, loaded and error.
+
+
+---
+
+## `consoleFetch`
+
+### Summary
+
+A custom wrapper around `fetch` that adds console specific headers and allows for retries and timeouts.<br/>It also validates the response status code and throws appropriate error or logs out the user if required.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `url` | The URL to fetch |
+| `options` | The options to pass to fetch |
+| `timeout` | The timeout in milliseconds |
+
+
+
+### Returns
+
+A promise that resolves to the response
+
+
+---
+
+## `consoleFetchJSON`
+
+### Summary
+
+A custom wrapper around `fetch` that adds console specific headers and allows for retries and timeouts.<br/>It also validates the response status code and throws appropriate error or logs out the user if required.<br/>It returns the response as a JSON object.<br/>Uses consoleFetch internally.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `url` | The URL to fetch |
+| `method` | The HTTP method to use. Defaults to GET |
+| `options` | The options to pass to fetch |
+| `timeout` | The timeout in milliseconds |
+| `cluster` | The name of the cluster to make the request to. Defaults to the active cluster the user has selected |
+
+
+
+### Returns
+
+A promise that resolves to the response as JSON object.
+
+
+---
+
+## `consoleFetchText`
+
+### Summary
+
+A custom wrapper around `fetch` that adds console specific headers and allows for retries and timeouts.<br/>It also validates the response status code and throws appropriate error or logs out the user if required.<br/>It returns the response as a text.<br/>Uses consoleFetch internally.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `url` | The URL to fetch |
+| `options` | The options to pass to fetch |
+| `timeout` | The timeout in milliseconds |
+| `cluster` | The name of the cluster to make the request to. Defaults to the active cluster the user has selected |
+
+
+
+### Returns
+
+A promise that resolves to the response as text.
+
+
+---
+
+## `getConsoleRequestHeaders`
+
+### Summary
+
+A function that creates impersonation and multicluster related headers for API requests using current redux state.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `targetCluster` | override the current active cluster with the provided targetCluster |
+
+
+
+### Returns
+
+an object containing the appropriate impersonation and clustr requst headers, based on redux state
+
+
+---
+
+## `k8sGetResource`
+
+### Summary
+
+It fetches a resource from the cluster, based on the provided options.<br/>If the name is provided it returns one resource else it returns all the resources matching the model.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `options` | Which are passed as key-value pairs in the map |
+| `` |  options.model - k8s model |
+| `` |  options.name - The name of the resource, if not provided then it'll look for all the resources matching the model. |
+| `` |  options.ns - The namespace to look into, should not be specified for cluster-scoped resources. |
+| `` |  options.path - Appends as subpath if provided |
+| `` |  options.queryParams - The query parameters to be included in the URL. |
+| `` |  options.requestInit - The fetch init object to use. This can have request headers, method, redirect, etc.See more https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.requestinit.html
+ |
+
+
+
+### Returns
+
+A promise that resolves to the response as JSON object with a resource if the name is provided<br/>else it returns all the resources matching the model. In case of failure, the promise gets rejected with HTTP error response.
+
+
+---
+
+## `k8sCreateResource`
+
+### Summary
+
+It creates a resource in the cluster, based on the provided options.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `options` | Which are passed as key-value pairs in the map |
+| `` |  options.model - k8s model |
+| `` |  options.data - payload for the resource to be created |
+| `` |  options.path - Appends as subpath if provided |
+| `` |  options.queryParams - The query parameters to be included in the URL. |
+
+
+
+### Returns
+
+A promise that resolves to the response of the resource created.<br/>In case of failure promise gets rejected with HTTP error response.
+
+
+---
+
+## `k8sUpdateResource`
+
+### Summary
+
+It updates the entire resource in the cluster, based on provided options.<br/>When a client needs to replace an existing resource entirely, they can use k8sUpdate.<br/>Alternatively can use k8sPatch to perform the partial update.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `options` | which are passed as key-value pair in the map |
+| `` |  options.model - k8s model |
+| `` |  options.data - payload for the k8s resource to be updated |
+| `` |  options.ns - namespace to look into, it should not be specified for cluster-scoped resources. |
+| `` |  options.name - resource name to be updated. |
+| `` |  options.path - Appends as subpath if provided |
+| `` |  options.queryParams - The query parameters to be included in the URL. |
+
+
+
+### Returns
+
+A promise that resolves to the response of the resource updated.<br/>In case of failure promise gets rejected with HTTP error response.
+
+
+---
+
+## `k8sPatchResource`
+
+### Summary
+
+It patches any resource in the cluster, based on provided options.<br/>When a client needs to perform the partial update, they can use k8sPatch.<br/>Alternatively can use k8sUpdate to replace an existing resource entirely.<br/>See more https://datatracker.ietf.org/doc/html/rfc6902
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `options` | Which are passed as key-value pairs in the map. |
+| `` |  options.model - k8s model |
+| `` |  options.resource - The resource to be patched. |
+| `` |  options.data - Only the data to be patched on existing resource with the operation, path, and value. |
+| `` |  options.path - Appends as subpath if provided. |
+| `` |  options.queryParams - The query parameters to be included in the URL. |
+
+
+
+### Returns
+
+A promise that resolves to the response of the resource patched.<br/>In case of failure promise gets rejected with HTTP error response.
+
+
+---
+
+## `k8sDeleteResource`
+
+### Summary
+
+It deletes resources from the cluster, based on the provided model, resource.<br/>The garbage collection works based on 'Foreground' | 'Background', can be configured with propagationPolicy property in provided model or passed in json.
+
+
+
+### Example
+
+
+{ kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy }
+
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `options` | which are passed as key-value pair in the map. |
+| `` |  options.model - k8s model |
+| `` |  options.resource - The resource to be deleted. |
+| `` |  options.path - Appends as subpath if provided |
+| `` |  options.queryParams - The query parameters to be included in the URL. |
+| `` |  options.requestInit - The fetch init object to use. This can have request headers, method, redirect, etc.See more https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.requestinit.html
+ |
+| `` |  options.json - Can control garbage collection of resources explicitly if provided else will default to model's "propagationPolicy". |
+
+
+
+### Returns
+
+A promise that resolves to the response of kind Status.<br/>In case of failure promise gets rejected with HTTP error response.
+
+
+---
+
+## `k8sListResource`
+
+### Summary
+
+It lists the resources as an array in the cluster, based on provided options.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `options` | Which are passed as key-value pairs in the map |
+| `` |  options.model - k8s model |
+| `` |  options.queryParams - The query parameters to be included in the URL and can pass label selector's as well with key "labelSelector". |
+| `` |  options.requestInit - The fetch init object to use. This can have request headers, method, redirect, etc.See more https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.requestinit.html
+ |
+
+
+
+### Returns
+
+A promise that resolves to the response
+
+
+---
+
+## `k8sListResourceItems`
+
+### Summary
+
+Same interface as {@link k8sListResource} but returns the sub items.
+
+
+
+
+
+
+---
+
+## `getAPIVersionForModel`
+
+### Summary
+
+Provides apiVersion for a k8s model.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `model` | k8s model |
+
+
+
+### Returns
+
+The apiVersion for the model i.e `group/version`.
+
+
+---
+
+## `getGroupVersionKindForResource`
+
+### Summary
+
+Provides a group, version, and kind for a resource.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `resource` | k8s resource |
+
+
+
+### Returns
+
+The group, version, kind for the provided resource.<br/>If the resource does not have an API group, group "core" will be returned.<br/>If the resource has an invalid apiVersion then it'll throw Error.
+
+
+---
+
+## `getGroupVersionKindForModel`
+
+### Summary
+
+Provides a group, version, and kind for a k8s model.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `model` | k8s model |
+
+
+
+### Returns
+
+The group, version, kind for the provided model.<br/>If the model does not have an apiGroup, group "core" will be returned.
+
+
+---
+
+## `StatusPopupSection`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-shared/src/components/dashboard/status-card/StatusPopup.tsx)
+
+
+
+
+
+
+---
+
+## `StatusPopupItem`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-shared/src/components/dashboard/status-card/StatusPopup.tsx)
+
+
+
+
+
+
+---
+
+## `Overview`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-shared/src/components/dashboard/Dashboard.tsx)
+
+
+
+
+
+
+---
+
+## `OverviewGrid`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-shared/src/components/dashboard/DashboardGrid.tsx)
+
+
+
+
+
+
+---
+
+## `InventoryItem`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryCard.tsx)
+
+
+
+
+
+
+---
+
+## `InventoryItemTitle`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryCard.tsx)
+
+
+
+
+
+
+---
+
+## `InventoryItemBody`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryCard.tsx)
+
+
+
+
+
+
+---
+
+## `InventoryItemStatus`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryCard.tsx)
+
+
+
+
+
+
+---
+
+## `InventoryItemLoading`
+
+### Summary
+
+[For more details please refer the implementation](https://github.com/openshift/console/tree/release-4.11/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryCard.tsx)
+
+
+
+
+
+
+---
+
+## `useFlag`
+
+### Summary
+
+Hook that returns the given feature flag from FLAGS redux state.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `flag` | The feature flag to return |
+
+
+
+### Returns
+
+the boolean value of the requested feature flag or undefined
+
+
+---
+
+## `ResourceYAMLEditor`
+
+### Summary
+
+A lazy loaded YAML editor for Kubernetes resources with hover help and completion.<br/>The editor will handle updating the resource when the user clicks save unless an onSave handler is provided.<br/>It should be wrapped in a React.Suspense component.
+
+
+
+### Example
+
+
+```tsx
+<React.Suspense fallback={<LoadingBox />}>
+  <ResourceYAMLEditor
+    initialResource={resource}
+    header="Create resource"
+    onSave={(content) => updateResource(content)}
+  />
+</React.Suspense>
+```
+
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `initialResource` | YAML/Object representing a resource to be shown by the editor.This prop is used only during the inital render
+ |
+| `header` | Add a header on top of the YAML editor |
+| `onSave` | Callback for the Save button.Passing it will override the default update performed on the resource by the editor
+ |
+
+
+
+---
+
+## `ResourceEventStream`
+
+### Summary
+
+A component to show events related to a particular resource.
+
+
+
+### Example
+
+
+```tsx
+const [resource, loaded, loadError] = useK8sWatchResource(clusterResource);
+return <ResourceEventStream resource={resource} />
+```
+
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `` |  {ResourceEventStreamProps['resource']} - An object whose related events should be shown. |
+
+
+
+---
+
+## `usePrometheusPoll`
+
+### Summary
+
+React hook to poll Prometheus for a single query.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `options` | Which is passed as a key-value map |
+| `` |  options.query - Prometheus query string. If empty or undefined, polling is not started. |
+| `` |  options.delay - polling delay interval (ms) |
+| `` |  options.endpoint - one of the PrometheusEndpoint (label, query, range, rules, targets) |
+| `` |  options.endTime - for QUERY_RANGE enpoint, end of the query range |
+| `` |  options.samples - for QUERY_RANGE enpoint |
+| `` |  options.timespan - for QUERY_RANGE enpoint |
+| `` |  options.namespace - a search param to append |
+| `` |  options.timeout - a search param to append |
+
+
+
+### Returns
+
+A tuple containing the query response, a boolean flag indicating whether the response has completed, and any errors encountered during the request or post-processing of the request
+
+

--- a/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md
@@ -1,0 +1,1308 @@
+# OpenShift Console Extension Types
+
+1.  [`console.action/filter`](#consoleactionfilter)
+2.  [`console.action/group`](#consoleactiongroup)
+3.  [`console.action/provider`](#consoleactionprovider)
+4.  [`console.action/resource-provider`](#consoleactionresource-provider)
+5.  [`console.alert-action`](#consolealert-action)
+6.  [`console.catalog/item-filter`](#consolecatalogitem-filter)
+7.  [`console.catalog/item-metadata`](#consolecatalogitem-metadata)
+8.  [`console.catalog/item-provider`](#consolecatalogitem-provider)
+9.  [`console.catalog/item-type`](#consolecatalogitem-type)
+10.  [`console.catalog/item-type-metadata`](#consolecatalogitem-type-metadata)
+11.  [`console.cluster-overview/inventory-item`](#consolecluster-overviewinventory-item)
+12.  [`console.cluster-overview/multiline-utilization-item`](#consolecluster-overviewmultiline-utilization-item)
+13.  [`console.cluster-overview/utilization-item`](#consolecluster-overviewutilization-item)
+14.  [`console.context-provider`](#consolecontext-provider)
+15.  [`console.dashboards/card`](#consoledashboardscard)
+16.  [`console.dashboards/overview/activity/resource`](#consoledashboardsoverviewactivityresource)
+17.  [`console.dashboards/overview/detail/item`](#consoledashboardsoverviewdetailitem)
+18.  [`console.dashboards/overview/health/operator`](#consoledashboardsoverviewhealthoperator)
+19.  [`console.dashboards/overview/health/prometheus`](#consoledashboardsoverviewhealthprometheus)
+20.  [`console.dashboards/overview/health/resource`](#consoledashboardsoverviewhealthresource)
+21.  [`console.dashboards/overview/health/url`](#consoledashboardsoverviewhealthurl)
+22.  [`console.dashboards/overview/inventory/item`](#consoledashboardsoverviewinventoryitem)
+23.  [`console.dashboards/overview/inventory/item/group`](#consoledashboardsoverviewinventoryitemgroup)
+24.  [`console.dashboards/overview/inventory/item/replacement`](#consoledashboardsoverviewinventoryitemreplacement)
+25.  [`console.dashboards/overview/prometheus/activity/resource`](#consoledashboardsoverviewprometheusactivityresource)
+26.  [`console.dashboards/project/overview/item`](#consoledashboardsprojectoverviewitem)
+27.  [`console.dashboards/tab`](#consoledashboardstab)
+28.  [`console.file-upload`](#consolefile-upload)
+29.  [`console.flag`](#consoleflag)
+30.  [`console.flag/hookProvider`](#consoleflaghookProvider)
+31.  [`console.flag/model`](#consoleflagmodel)
+32.  [`console.global-config`](#consoleglobal-config)
+33.  [`console.model-metadata`](#consolemodel-metadata)
+34.  [`console.navigation/href`](#consolenavigationhref)
+35.  [`console.navigation/resource-cluster`](#consolenavigationresource-cluster)
+36.  [`console.navigation/resource-ns`](#consolenavigationresource-ns)
+37.  [`console.navigation/section`](#consolenavigationsection)
+38.  [`console.navigation/separator`](#consolenavigationseparator)
+39.  [`console.page/resource/details`](#consolepageresourcedetails)
+40.  [`console.page/resource/list`](#consolepageresourcelist)
+41.  [`console.page/route`](#consolepageroute)
+42.  [`console.page/route/standalone`](#consolepageroutestandalone)
+43.  [`console.perspective`](#consoleperspective)
+44.  [`console.project-overview/inventory-item`](#consoleproject-overviewinventory-item)
+45.  [`console.project-overview/utilization-item`](#consoleproject-overviewutilization-item)
+46.  [`console.pvc/alert`](#consolepvcalert)
+47.  [`console.pvc/create-prop`](#consolepvccreate-prop)
+48.  [`console.pvc/delete`](#consolepvcdelete)
+49.  [`console.pvc/status`](#consolepvcstatus)
+50.  [`console.redux-reducer`](#consoleredux-reducer)
+51.  [`console.resource/create`](#consoleresourcecreate)
+52.  [`console.storage-provider`](#consolestorage-provider)
+53.  [`console.tab/horizontalNav`](#consoletabhorizontalNav)
+54.  [`console.telemetry/listener`](#consoletelemetrylistener)
+55.  [`console.topology/adapter/build`](#consoletopologyadapterbuild)
+56.  [`console.topology/adapter/network`](#consoletopologyadapternetwork)
+57.  [`console.topology/adapter/pod`](#consoletopologyadapterpod)
+58.  [`console.topology/component/factory`](#consoletopologycomponentfactory)
+59.  [`console.topology/create/connector`](#consoletopologycreateconnector)
+60.  [`console.topology/data/factory`](#consoletopologydatafactory)
+61.  [`console.topology/decorator/provider`](#consoletopologydecoratorprovider)
+62.  [`console.topology/details/resource-alert`](#consoletopologydetailsresource-alert)
+63.  [`console.topology/details/resource-link`](#consoletopologydetailsresource-link)
+64.  [`console.topology/details/tab`](#consoletopologydetailstab)
+65.  [`console.topology/details/tab-section`](#consoletopologydetailstab-section)
+66.  [`console.topology/display/filters`](#consoletopologydisplayfilters)
+67.  [`console.topology/relationship/provider`](#consoletopologyrelationshipprovider)
+68.  [`console.user-preference/group`](#consoleuser-preferencegroup)
+69.  [`console.user-preference/item`](#consoleuser-preferenceitem)
+70.  [`console.yaml-template`](#consoleyaml-template)
+71.  [`dev-console.add/action`](#dev-consoleaddaction)
+72.  [`dev-console.add/action-group`](#dev-consoleaddaction-group)
+73.  [`dev-console.import/environment`](#dev-consoleimportenvironment)
+74. [DEPRECATED] [`console.page/resource/tab`](#consolepageresourcetab)
+
+---
+
+## `console.action/filter`
+
+### Summary 
+
+ActionFilter can be used to filter an action
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `contextId` | `string` | no | The context ID helps to narrow the scope of contributed actions to a particular area of the application. Ex - topology, helm |
+| `filter` | `CodeRef<(scope: any, action: Action) => boolean>` | no | A function which will filter actions based on some conditions.<br/>scope: The scope in which actions should be provided for.<br/>Note: hook may be required if we want to remove the ModifyCount action from a deployment with HPA |
+
+---
+
+## `console.action/group`
+
+### Summary 
+
+ActionGroup contributes an action group that can also be a submenu
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | ID used to identify the action section. |
+| `label` | `string` | yes | The label to display in the UI.<br/>Required for submenus. |
+| `submenu` | `boolean` | yes | Whether this group should be displayed as submenu |
+| `insertBefore` | `string \| string[]` | yes | Insert this item before the item referenced here.<br/>For arrays, the first one found in order is used. |
+| `insertAfter` | `string \| string[]` | yes | Insert this item after the item referenced here.<br/>For arrays, the first one found in order is used.<br/>insertBefore takes precedence. |
+
+---
+
+## `console.action/provider`
+
+### Summary 
+
+ActionProvider contributes a hook that returns list of actions for specific context
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `contextId` | `string` | no | The context ID helps to narrow the scope of contributed actions to a particular area of the application. Ex - topology, helm |
+| `provider` | `CodeRef<ExtensionHook<Action[], any>>` | no | A react hook which returns actions for the given scope.<br/>If contextId = `resource` then the scope will always be a K8s resource object |
+
+---
+
+## `console.action/resource-provider`
+
+### Summary 
+
+ResourceActionProvider contributes a hook that returns list of actions for specific resource model
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `model` | `ExtensionK8sKindVersionModel` | no | The model for which this provider provides actions for. |
+| `provider` | `CodeRef<ExtensionHook<Action[], any>>` | no | A react hook which returns actions for the given resource model |
+
+---
+
+## `console.alert-action`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `alert` | `string` | no |  |
+| `text` | `string` | no |  |
+| `action` | `CodeRef<(alert: any) => void>` | no |  |
+
+---
+
+## `console.catalog/item-filter`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `catalogId` | `string \| string[]` | no | The unique identifier for the catalog this provider contributes to. |
+| `type` | `string` | no | Type ID for the catalog item type. |
+| `filter` | `CodeRef<(item: CatalogItem) => boolean>` | no | Filters items of a specific type. Value is a function that takes CatalogItem[] and returns a subset based on the filter criteria. |
+
+---
+
+## `console.catalog/item-metadata`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `catalogId` | `string \| string[]` | no | The unique identifier for the catalog this provider contributes to. |
+| `type` | `string` | no | Type ID for the catalog item type. |
+| `provider` | `CodeRef<ExtensionHook<CatalogItemMetadataProviderFunction, CatalogExtensionHookOptions>>` | no | A hook which returns a function that will be used to provide metadata to catalog items of a specific type. |
+
+---
+
+## `console.catalog/item-provider`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `catalogId` | `string \| string[]` | no | The unique identifier for the catalog this provider contributes to. |
+| `type` | `string` | no | Type ID for the catalog item type. |
+| `title` | `string` | no | Title for the catalog item provider |
+| `provider` | `CodeRef<ExtensionHook<CatalogItem<any>[], CatalogExtensionHookOptions>>` | no | Fetch items and normalize it for the catalog. Value is a react effect hook. |
+| `priority` | `number` | yes | Priority for this provider. Defaults to 0. Higher priority providers may override catalog<br/>items provided by other providers. |
+
+---
+
+## `console.catalog/item-type`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `type` | `string` | no | Type for the catalog item. |
+| `title` | `string` | no | Title for the catalog item. |
+| `catalogDescription` | `string \| CodeRef<React.ReactNode>` | yes | Description for the type specific catalog. |
+| `typeDescription` | `string` | yes | Description for the catalog item type. |
+| `filters` | `CatalogItemAttribute[]` | yes | Custom filters specific to the catalog item. |
+| `groupings` | `CatalogItemAttribute[]` | yes | Custom groupings specific to the catalog item. |
+
+---
+
+## `console.catalog/item-type-metadata`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `type` | `string` | no | Type for the catalog item. |
+| `filters` | `CatalogItemAttribute[]` | yes | Custom filters specific to the catalog item. |
+| `groupings` | `CatalogItemAttribute[]` | yes | Custom groupings specific to the catalog item. |
+
+---
+
+## `console.cluster-overview/inventory-item`
+
+### Summary 
+
+Adds a new inventory item into cluster overview page.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `component` | `CodeRef<React.ComponentType<{}>>` | no | The component to be rendered. |
+
+---
+
+## `console.cluster-overview/multiline-utilization-item`
+
+### Summary 
+
+Adds a new cluster overview multiline utilization item.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `title` | `string` | no | The title of the utilization item. |
+| `getUtilizationQueries` | `CodeRef<GetMultilineQueries>` | no | Prometheus utilization query. |
+| `humanize` | `CodeRef<Humanize>` | no | Convert prometheus data to human readable form. |
+| `TopConsumerPopovers` | `CodeRef<React.ComponentType<TopConsumerPopoverProps>[]>` | yes | Shows Top consumer popover instead of plain value |
+
+---
+
+## `console.cluster-overview/utilization-item`
+
+### Summary 
+
+Adds a new cluster overview utilization item.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `title` | `string` | no | The title of the utilization item. |
+| `getUtilizationQuery` | `CodeRef<GetQuery>` | no | Prometheus utilization query. |
+| `humanize` | `CodeRef<Humanize>` | no | Convert prometheus data to human readable form. |
+| `getTotalQuery` | `CodeRef<GetQuery>` | yes | Prometheus total query. |
+| `getRequestQuery` | `CodeRef<GetQuery>` | yes | Prometheus request query. |
+| `getLimitQuery` | `CodeRef<GetQuery>` | yes | Prometheus limit query. |
+| `TopConsumerPopover` | `CodeRef<React.ComponentType<TopConsumerPopoverProps>>` | yes | Shows Top consumer popover instead of plain value |
+
+---
+
+## `console.context-provider`
+
+### Summary 
+
+Adds new React context provider to Console application root.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `provider` | `CodeRef<Provider<T>>` | no | Context Provider component. |
+| `useValueHook` | `CodeRef<() => T>` | no | Hook for the Context value. |
+
+---
+
+## `console.dashboards/card`
+
+### Summary 
+
+Adds a new dashboard card.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `tab` | `string` | no | The id of the dashboard tab to which the card will be added. |
+| `position` | `'LEFT' \| 'RIGHT' \| 'MAIN'` | no | The grid position of the card on the dashboard. |
+| `component` | `CodeRef<React.ComponentType<{}>>` | no | Dashboard card component. |
+| `span` | `OverviewCardSpan` | yes | Card's vertical span in the column. Ignored for small screens, defaults to 12. |
+
+---
+
+## `console.dashboards/overview/activity/resource`
+
+### Summary 
+
+Adds an activity to the Activity Card of Overview Dashboard where the triggering of activity is based on watching a K8s resource.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `k8sResource` | `CodeRef<FirehoseResource & { isList: true; }>` | no | The utilization item to be replaced. |
+| `component` | `CodeRef<React.ComponentType<K8sActivityProps<T>>>` | no | The action component. |
+| `isActivity` | `CodeRef<(resource: T) => boolean>` | yes | Function which determines if the given resource represents the action. If not defined, every resource represents activity. |
+| `getTimestamp` | `CodeRef<(resource: T) => Date>` | yes | Timestamp for the given action, which will be used for ordering. |
+
+---
+
+## `console.dashboards/overview/detail/item`
+
+### Summary 
+
+Adds an item to the Details card of Overview Dashboard
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `component` | `CodeRef<React.ComponentType<{}>>` | no | The value, based on the DetailItem component |
+
+---
+
+## `console.dashboards/overview/health/operator`
+
+### Summary 
+
+Adds a health subsystem to the status card of Overview dashboard where the source of status is a K8s REST API.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `title` | `string` | no | Title of operators section in the popup. |
+| `resources` | `CodeRef<FirehoseResource[]>` | no | Kubernetes resources which will be fetched and passed to `healthHandler`. |
+| `getOperatorsWithStatuses` | `CodeRef<GetOperatorsWithStatuses<T>>` | yes | Resolves status for the operators. |
+| `operatorRowLoader` | `CodeRef<React.ComponentType<OperatorRowProps<T>>>` | yes | Loader for popup row component. |
+| `viewAllLink` | `string` | yes | Links to all resources page. If not provided then a list page of the first resource from resources prop is used. |
+
+---
+
+## `console.dashboards/overview/health/prometheus`
+
+### Summary 
+
+Adds a health subsystem to the status card of Overview dashboard where the source of status is Prometheus.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `title` | `string` | no | The display name of the subsystem. |
+| `queries` | `string[]` | no | The Prometheus queries |
+| `healthHandler` | `CodeRef<PrometheusHealthHandler>` | no | Resolve the subsystem's health. |
+| `additionalResource` | `CodeRef<FirehoseResource>` | yes | Additional resource which will be fetched and passed to `healthHandler`. |
+| `popupComponent` | `CodeRef<React.ComponentType<PrometheusHealthPopupProps>>` | yes | Loader for popup content. If defined, a health item will be represented as a link which opens popup with given content. |
+| `popupTitle` | `string` | yes | The title of the popover. |
+| `disallowedControlPlaneTopology` | `string[]` | yes | Control plane topology for which the subsystem should be hidden. |
+
+---
+
+## `console.dashboards/overview/health/resource`
+
+### Summary 
+
+Adds a health subsystem to the status card of Overview dashboard where the source of status is a K8s Resource.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `title` | `string` | no | The display name of the subsystem. |
+| `resources` | `CodeRef<WatchK8sResources<T>>` | no | Kubernetes resources which will be fetched and passed to `healthHandler`. |
+| `healthHandler` | `CodeRef<ResourceHealthHandler<T>>` | no | Resolve the subsystem's health. |
+| `popupComponent` | `CodeRef<WatchK8sResults<T>>` | yes | Loader for popup content. If defined, a health item will be represented as a link which opens popup with given content. |
+| `popupTitle` | `string` | yes | The title of the popover. |
+
+---
+
+## `console.dashboards/overview/health/url`
+
+### Summary 
+
+Adds a health subsystem to the status card of Overview dashboard where the source of status is a K8s REST API.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `title` | `string` | no | The display name of the subsystem. |
+| `url` | `string` | no | The URL to fetch data from. It will be prefixed with base k8s URL. |
+| `healthHandler` | `CodeRef<URLHealthHandler<T, K8sResourceCommon \| K8sResourceCommon[]>>` | no | Resolve the subsystem's health. |
+| `additionalResource` | `CodeRef<FirehoseResource>` | yes | Additional resource which will be fetched and passed to `healthHandler`. |
+| `popupComponent` | `CodeRef<React.ComponentType<{ healthResult?: T; healthResultError?: any; k8sResult?: FirehoseResult<R>; }>>` | yes | Loader for popup content. If defined, a health item will be represented as a link which opens popup with given content. |
+| `popupTitle` | `string` | yes | The title of the popover. |
+
+---
+
+## `console.dashboards/overview/inventory/item`
+
+### Summary 
+
+Adds a resource tile to the overview inventory card.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `model` | `CodeRef<T>` | no | The model for `resource` which will be fetched. Used to get the model's `label` or `abbr`. |
+| `mapper` | `CodeRef<StatusGroupMapper<T, R>>` | yes | Function which maps various statuses to groups. |
+| `additionalResources` | `CodeRef<WatchK8sResources<R>>` | yes | Additional resources which will be fetched and passed to the `mapper` function. |
+
+---
+
+## `console.dashboards/overview/inventory/item/group`
+
+### Summary 
+
+Adds an inventory status group.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | The id of the status group. |
+| `icon` | `CodeRef<React.ReactElement<any, string \| React.JSXElementConstructor<any>>>` | no | React component representing the status group icon. |
+
+---
+
+## `console.dashboards/overview/inventory/item/replacement`
+
+### Summary 
+
+Replaces an overview inventory card.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `model` | `CodeRef<T>` | no | The model for `resource` which will be fetched. Used to get the model's `label` or `abbr`. |
+| `mapper` | `CodeRef<StatusGroupMapper<T, R>>` | yes | Function which maps various statuses to groups. |
+| `additionalResources` | `CodeRef<WatchK8sResources<R>>` | yes | Additional resources which will be fetched and passed to the `mapper` function. |
+
+---
+
+## `console.dashboards/overview/prometheus/activity/resource`
+
+### Summary 
+
+Adds an activity to the Activity Card of Prometheus Overview Dashboard where the triggering of activity is based on watching a K8s resource.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `queries` | `string[]` | no | Queries to watch |
+| `component` | `CodeRef<React.ComponentType<PrometheusActivityProps>>` | no | The action component. |
+| `isActivity` | `CodeRef<(results: PrometheusResponse[]) => boolean>` | yes | Function which determines if the given resource represents the action. If not defined, every resource represents activity. |
+
+---
+
+## `console.dashboards/project/overview/item`
+
+### Summary 
+
+Adds a resource tile to the project overview inventory card.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `model` | `CodeRef<T>` | no | The model for `resource` which will be fetched. Used to get the model's `label` or `abbr`. |
+| `mapper` | `CodeRef<StatusGroupMapper<T, R>>` | yes | Function which maps various statuses to groups. |
+| `additionalResources` | `CodeRef<WatchK8sResources<R>>` | yes | Additional resources which will be fetched and passed to the `mapper` function. |
+
+---
+
+## `console.dashboards/tab`
+
+### Summary 
+
+Adds a new dashboard tab, placed after the Overview tab.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | A unique tab identifier, used as tab link `href` and when adding cards to this tab. |
+| `navSection` | `'home' \| 'storage'` | no | NavSection to which the tab belongs to |
+| `title` | `string` | no | The title of the tab. |
+
+---
+
+## `console.file-upload`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `fileExtensions` | `string[]` | no | Supported file extensions. |
+| `handler` | `CodeRef<FileUploadHandler>` | no | Function which handles the file drop action. |
+
+---
+
+## `console.flag`
+
+### Summary 
+
+Gives full control over Console feature flags.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `handler` | `CodeRef<FeatureFlagHandler>` | no | Used to set/unset arbitrary feature flags. |
+
+---
+
+## `console.flag/hookProvider`
+
+### Summary 
+
+Gives full control over Console feature flags with hook handlers.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `handler` | `CodeRef<FeatureFlagHandler>` | no | Used to set/unset arbitrary feature flags. |
+
+---
+
+## `console.flag/model`
+
+### Summary 
+
+Adds new Console feature flag driven by the presence of a CRD on the cluster.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `flag` | `string` | no | The name of the flag to set once the CRD is detected. |
+| `model` | `ExtensionK8sModel` | no | The model which refers to a `CustomResourceDefinition`. |
+
+---
+
+## `console.global-config`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | Unique identifier for the cluster config resource instance. |
+| `name` | `string` | no | The name of the cluster config resource instance. |
+| `model` | `ExtensionK8sModel` | no | The model which refers to a cluster config resource. |
+| `namespace` | `string` | no | The namespace of the cluster config resource instance. |
+
+---
+
+## `console.model-metadata`
+
+### Summary 
+
+Customize the display of models by overriding values retrieved and generated through API discovery.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `model` | `ExtensionK8sGroupModel` | no | The model to customize. May specify only a group, or optional version and kind. |
+| `badge` | `ModelBadge` | yes | Whether to consider this model reference as tech preview or dev preview. |
+| `color` | `string` | yes | The color to associate to this model. |
+| `label` | `string` | yes | Override the label. Requires `kind` be provided. |
+| `labelPlural` | `string` | yes | Override the plural label. Requires `kind` be provided. |
+| `abbr` | `string` | yes | Customize the abbreviation. Defaults to All uppercase chars in the kind up to 4 characters long. Requires `kind` be provided. |
+
+---
+
+## `console.navigation/href`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | A unique identifier for this item. |
+| `name` | `string` | no | The name of this item. |
+| `href` | `string` | no | The link href value. |
+| `perspective` | `string` | yes | The perspective ID to which this item belongs to. If not specified, contributes to the default perspective. |
+| `section` | `string` | yes | Navigation section to which this item belongs to. If not specified, render this item as a top level link. |
+| `dataAttributes` | `{ [key: string]: string; }` | yes | Adds data attributes to the DOM. |
+| `startsWith` | `string[]` | yes | Mark this item as active when the URL starts with one of these paths. |
+| `insertBefore` | `string \| string[]` | yes | Insert this item before the item referenced here. For arrays, the first one found in order is used. |
+| `insertAfter` | `string \| string[]` | yes | Insert this item after the item referenced here. For arrays, the first one found in order is used. `insertBefore` takes precedence. |
+| `namespaced` | `boolean` | yes | if true, adds /ns/active-namespace to the end |
+| `prefixNamespaced` | `boolean` | yes | if true, adds /k8s/ns/active-namespace to the begining |
+
+---
+
+## `console.navigation/resource-cluster`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | A unique identifier for this item. |
+| `model` | `ExtensionK8sModel` | no | The model for which this nav item links to. |
+| `perspective` | `string` | yes | The perspective ID to which this item belongs to. If not specified, contributes to the default perspective. |
+| `section` | `string` | yes | Navigation section to which this item belongs to. If not specified, render this item as a top level link. |
+| `dataAttributes` | `{ [key: string]: string; }` | yes | Adds data attributes to the DOM. |
+| `startsWith` | `string[]` | yes | Mark this item as active when the URL starts with one of these paths. |
+| `insertBefore` | `string \| string[]` | yes | Insert this item before the item referenced here. For arrays, the first one found in order is used. |
+| `insertAfter` | `string \| string[]` | yes | Insert this item after the item referenced here. For arrays, the first one found in order is used. `insertBefore` takes precedence. |
+| `name` | `string` | yes | Overrides the default name. If not supplied the name of the link will equal the plural value of the model. |
+
+---
+
+## `console.navigation/resource-ns`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | A unique identifier for this item. |
+| `model` | `ExtensionK8sModel` | no | The model for which this nav item links to. |
+| `perspective` | `string` | yes | The perspective ID to which this item belongs to. If not specified, contributes to the default perspective. |
+| `section` | `string` | yes | Navigation section to which this item belongs to. If not specified, render this item as a top level link. |
+| `dataAttributes` | `{ [key: string]: string; }` | yes | Adds data attributes to the DOM. |
+| `startsWith` | `string[]` | yes | Mark this item as active when the URL starts with one of these paths. |
+| `insertBefore` | `string \| string[]` | yes | Insert this item before the item referenced here. For arrays, the first one found in order is used. |
+| `insertAfter` | `string \| string[]` | yes | Insert this item after the item referenced here. For arrays, the first one found in order is used. `insertBefore` takes precedence. |
+| `name` | `string` | yes | Overrides the default name. If not supplied the name of the link will equal the plural value of the model. |
+
+---
+
+## `console.navigation/section`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | A unique identifier for this item. |
+| `perspective` | `string` | yes | The perspective ID to which this item belongs to. If not specified, contributes to the default perspective. |
+| `dataAttributes` | `{ [key: string]: string; }` | yes | Adds data attributes to the DOM. |
+| `insertBefore` | `string \| string[]` | yes | Insert this item before the item referenced here. For arrays, the first one found in order is used. |
+| `insertAfter` | `string \| string[]` | yes | Insert this item after the item referenced here. For arrays, the first one found in order is used. `insertBefore` takes precedence. |
+| `name` | `string` | yes | Name of this section. If not supplied, only a separator will be shown above the section. |
+
+---
+
+## `console.navigation/separator`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | A unique identifier for this item. |
+| `perspective` | `string` | yes | The perspective ID to which this item belongs to. If not specified, contributes to the default perspective. |
+| `section` | `string` | yes | Navigation section to which this item belongs to. If not specified, render this item as a top level link. |
+| `dataAttributes` | `{ [key: string]: string; }` | yes | Adds data attributes to the DOM. |
+| `insertBefore` | `string \| string[]` | yes | Insert this item before the item referenced here. For arrays, the first one found in order is used. |
+| `insertAfter` | `string \| string[]` | yes | Insert this item after the item referenced here. For arrays, the first one found in order is used. `insertBefore` takes precedence. |
+
+---
+
+## `console.page/resource/details`
+
+### Summary 
+
+Adds new resource details page to Console router.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `model` | `ExtensionK8sGroupKindModel` | no | The model for which this resource page links to. |
+| `component` | `CodeRef<React.ComponentType<{ match: match<{}>; namespace: string; model: ExtensionK8sModel; }>>` | no | The component to be rendered when the route matches. |
+
+---
+
+## `console.page/resource/list`
+
+### Summary 
+
+Adds new resource list page to Console router.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `model` | `ExtensionK8sGroupKindModel` | no | The model for which this resource page links to. |
+| `component` | `CodeRef<React.ComponentType<{ match: match<{}>; namespace: string; model: ExtensionK8sModel; }>>` | no | The component to be rendered when the route matches. |
+
+---
+
+## `console.page/route`
+
+### Summary 
+
+Adds new page to Console router.<br/><br/>Under the hood we use React Router.<br/>See https://v5.reactrouter.com/
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `component` | `CodeRef<React.ComponentType<RouteComponentProps<{}, StaticContext, any>>>` | no | The component to be rendered when the route matches. |
+| `path` | `string \| string[]` | no | Valid URL path or array of paths that `path-to-regexp@^1.7.0` understands. |
+| `perspective` | `string` | yes | The perspective to which this page belongs to. If not specified, contributes to all perspectives. |
+| `exact` | `boolean` | yes | When true, will only match if the path matches the `location.pathname` exactly. |
+
+---
+
+## `console.page/route/standalone`
+
+### Summary 
+
+Adds new standalone page (rendered outside the common page layout) to Console router.<br/><br/>Under the hood we use React Router.<br/>See https://v5.reactrouter.com/
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `component` | `CodeRef<React.ComponentType<RouteComponentProps<{}, StaticContext, any>>>` | no | The component to be rendered when the route matches. |
+| `path` | `string \| string[]` | no | Valid URL path or array of paths that `path-to-regexp@^1.7.0` understands. |
+| `exact` | `boolean` | yes | When true, will only match if the path matches the `location.pathname` exactly. |
+
+---
+
+## `console.perspective`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | The perspective identifier. |
+| `name` | `string` | no | The perspective display name. |
+| `icon` | `CodeRef<LazyComponent>` | no | The perspective display icon. |
+| `landingPageURL` | `CodeRef<(flags: { [key: string]: boolean; }, isFirstVisit: boolean) => string>` | no | The function to get perspective landing page URL. |
+| `importRedirectURL` | `CodeRef<(namespace: string) => string>` | no | The function to get redirect URL for import flow. |
+| `default` | `boolean` | yes | Whether the perspective is the default. There can only be one default. |
+| `defaultPins` | `ExtensionK8sModel[]` | yes | Default pinned resources on the nav |
+| `usePerspectiveDetection` | `CodeRef<() => [boolean, boolean]>` | yes | The hook to detect default perspective |
+
+---
+
+## `console.project-overview/inventory-item`
+
+### Summary 
+
+Adds a new inventory item into project overview page.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `component` | `CodeRef<React.ComponentType<{ projectName: string; }>>` | no | The component to be rendered. |
+
+---
+
+## `console.project-overview/utilization-item`
+
+### Summary 
+
+Adds a new project overview utilization item.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `title` | `string` | no | The title of the utilization item. |
+| `getUtilizationQuery` | `CodeRef<GetProjectQuery>` | no | Prometheus utilization query. |
+| `humanize` | `CodeRef<Humanize>` | no | Convert prometheus data to human readable form. |
+| `getTotalQuery` | `CodeRef<GetProjectQuery>` | yes | Prometheus total query. |
+| `getRequestQuery` | `CodeRef<GetProjectQuery>` | yes | Prometheus request query. |
+| `getLimitQuery` | `CodeRef<GetProjectQuery>` | yes | Prometheus limit query. |
+| `TopConsumerPopover` | `CodeRef<React.ComponentType<TopConsumerPopoverProps>>` | yes | Shows Top consumer popover instead of plain value |
+
+---
+
+## `console.pvc/alert`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `alert` | `CodeRef<React.ComponentType<{ pvc: K8sResourceCommon; }>>` | no | The alert component. |
+
+---
+
+## `console.pvc/create-prop`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `label` | `string` | no | Label for the create prop action. |
+| `path` | `string` | no | Path for the create prop action. |
+
+---
+
+## `console.pvc/delete`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `predicate` | `CodeRef<(pvc: K8sResourceCommon) => boolean>` | no | Predicate that tells whether to use the extension or not. |
+| `onPVCKill` | `CodeRef<(pvc: K8sResourceCommon) => Promise<void>>` | no | Method for the PVC delete operation. |
+| `alert` | `CodeRef<React.ComponentType<{ pvc: K8sResourceCommon; }>>` | no | Alert component to show additional information. |
+
+---
+
+## `console.pvc/status`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `priority` | `number` | no | Priority for the status component. Bigger value means higher priority. |
+| `status` | `CodeRef<React.ComponentType<{ pvc: K8sResourceCommon; }>>` | no | The status component. |
+| `predicate` | `CodeRef<(pvc: K8sResourceCommon) => boolean>` | no | Predicate that tells whether to render the status component or not. |
+
+---
+
+## `console.redux-reducer`
+
+### Summary 
+
+Adds new reducer to Console Redux store which operates on `plugins.<scope>` substate.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `scope` | `string` | no | The key to represent the reducer-managed substate within the Redux state object. |
+| `reducer` | `CodeRef<Reducer<any, AnyAction>>` | no | The reducer function, operating on the reducer-managed substate. |
+
+---
+
+## `console.resource/create`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `model` | `ExtensionK8sModel` | no | The model for which this create resource page will be rendered. |
+| `component` | `CodeRef<React.ComponentType<CreateResourceComponentProps>>` | no | The component to be rendered when the model matches |
+
+---
+
+## `console.storage-provider`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `name` | `string` | no |  |
+| `Component` | `CodeRef<React.ComponentType<Partial<RouteComponentProps<{}, StaticContext, any>>>>` | no |  |
+
+---
+
+## `console.tab/horizontalNav`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `model` | `ExtensionK8sKindVersionModel` | no | The model for which this provider show tab. |
+| `page` | `{ name: string; href: string; }` | no | The page to be show in horizontal tab. It takes tab name as name and href of the tab |
+| `component` | `CodeRef<React.ComponentType<PageComponentProps<K8sResourceCommon>>>` | no | The component to be rendered when the route matches. |
+
+---
+
+## `console.telemetry/listener`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `listener` | `CodeRef<TelemetryEventListener>` | no | Listen for telemetry events |
+
+---
+
+## `console.topology/adapter/build`
+
+### Summary 
+
+BuildAdapter contributes an adapter to adapt element to data that can be used by Build component
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `adapt` | `CodeRef<(element: GraphElement) => AdapterDataType<BuildConfigData> \| undefined>` | no |  |
+
+---
+
+## `console.topology/adapter/network`
+
+### Summary 
+
+NetworkAdpater contributes an adapter to adapt element to data that can be used by Networking component
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `adapt` | `CodeRef<(element: GraphElement) => NetworkAdapterType \| undefined>` | no |  |
+
+---
+
+## `console.topology/adapter/pod`
+
+### Summary 
+
+PodAdapter contributes an adapter to adapt element to data that can be used by Pod component
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `adapt` | `CodeRef<(element: GraphElement) => AdapterDataType<PodsAdapterDataType> \| undefined>` | no |  |
+
+---
+
+## `console.topology/component/factory`
+
+### Summary 
+
+Getter for a ViewComponentFactory
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `getFactory` | `CodeRef<ViewComponentFactory>` | no | Getter for a ViewComponentFactory |
+
+---
+
+## `console.topology/create/connector`
+
+### Summary 
+
+Getter for the create connector function
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `getCreateConnector` | `CodeRef<CreateConnectionGetter>` | no | Getter for the create connector function |
+
+---
+
+## `console.topology/data/factory`
+
+### Summary 
+
+Topology Data Model Factory Extension
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | Unique ID for the factory. |
+| `priority` | `number` | no | Priority for the factory |
+| `resources` | `WatchK8sResourcesGeneric` | yes | Resources to be fetched from useK8sWatchResources hook. |
+| `workloadKeys` | `string[]` | yes | Keys in resources containing workloads. |
+| `getDataModel` | `CodeRef<TopologyDataModelGetter>` | yes | Getter for the data model factory |
+| `isResourceDepicted` | `CodeRef<TopologyDataModelDepicted>` | yes | Getter for function to determine if a resource is depicted by this model factory |
+| `getDataModelReconciler` | `CodeRef<TopologyDataModelReconciler>` | yes | Getter for function to reconcile data model after all extensions' models have loaded |
+
+---
+
+## `console.topology/decorator/provider`
+
+### Summary 
+
+Topology Decorator Provider Extension
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no |  |
+| `priority` | `number` | no |  |
+| `quadrant` | `TopologyQuadrant` | no |  |
+| `decorator` | `CodeRef<TopologyDecoratorGetter>` | no |  |
+
+---
+
+## `console.topology/details/resource-alert`
+
+### Summary 
+
+DetailsResourceAlert contributes an alert for specific topology context or graph element.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | The ID of this alert. Used to save state if the alert shouldn't be shown after dismissed. |
+| `contentProvider` | `CodeRef<(element: GraphElement) => DetailsResourceAlertContent \| null>` | no | Hook to return the contents of the Alert. |
+
+---
+
+## `console.topology/details/resource-link`
+
+### Summary 
+
+DetailsResourceLink contributes a link for specific topology context or graph element.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `link` | `CodeRef<(element: GraphElement) => React.Component \| undefined>` | no | Return the resource link if provided, otherwise undefined.<br/>Use ResourceIcon and ResourceLink for styles. |
+| `priority` | `number` | yes | A higher priority factory will get the first chance to create the link. |
+
+---
+
+## `console.topology/details/tab`
+
+### Summary 
+
+DetailsTab contributes a tab for the topology details panel.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | A unique identifier for this details tab. |
+| `label` | `string` | no | The tab label to display in the UI. |
+| `insertBefore` | `string \| string[]` | yes | Insert this item before the item referenced here.<br/>For arrays, the first one found in order is used. |
+| `insertAfter` | `string \| string[]` | yes | Insert this item after the item referenced here.<br/>For arrays, the first one found in order is used.<br/>insertBefore takes precedence. |
+
+---
+
+## `console.topology/details/tab-section`
+
+### Summary 
+
+DetailsTabSection contributes a section for a specific tab in topology details panel.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | A unique identifier for this details tab section. |
+| `tab` | `string` | no | The parent tab ID that this section should contribute to. |
+| `provider` | `CodeRef<DetailsTabSectionExtensionHook>` | no | A hook that returns a component or null/undefined that will be rendered<br/>in the topology sidebar.<br/>SDK component: <Section title={<optional>}>... padded area </Section> |
+| `section` | `CodeRef<(element: GraphElement, renderNull?: () => null) => React.Component \| undefined>` | no | @deprecated Fallback if no provider is defined. renderNull is a no-op already. |
+| `insertBefore` | `string \| string[]` | yes | Insert this item before the item referenced here.<br/>For arrays, the first one found in order is used. |
+| `insertAfter` | `string \| string[]` | yes | Insert this item after the item referenced here.<br/>For arrays, the first one found in order is used.<br/>insertBefore takes precedence. |
+
+---
+
+## `console.topology/display/filters`
+
+### Summary 
+
+Topology Display Filters Extension
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `getTopologyFilters` | `CodeRef<() => TopologyDisplayOption[]>` | no |  |
+| `applyDisplayOptions` | `CodeRef<TopologyApplyDisplayOptions>` | no |  |
+
+---
+
+## `console.topology/relationship/provider`
+
+### Summary 
+
+Topology relationship provider connector extension
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `provides` | `CodeRef<RelationshipProviderProvides>` | no |  |
+| `tooltip` | `string` | no |  |
+| `create` | `CodeRef<RelationshipProviderCreate>` | no |  |
+| `priority` | `number` | no |  |
+
+---
+
+## `console.user-preference/group`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | ID used to identify the user preference group. |
+| `label` | `string` | no | The label of the user preference group |
+| `insertBefore` | `string` | yes | ID of user preference group before which this group should be placed |
+| `insertAfter` | `string` | yes | ID of user preference group after which this group should be placed |
+
+---
+
+## `console.user-preference/item`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | ID used to identify the user preference item and referenced in insertAfter and insertBefore to define the item order. |
+| `label` | `string` | no | The label of the user preference |
+| `description` | `string` | no | The description of the user preference. |
+| `field` | `UserPreferenceField` | no | The input field options used to render the values to set the user preference. |
+| `groupId` | `string` | yes | IDs used to identify the user preference groups the item would belong to. |
+| `insertBefore` | `string` | yes | ID of user preference item before which this item should be placed |
+| `insertAfter` | `string` | yes | ID of user preference item after which this item should be placed |
+
+---
+
+## `console.yaml-template`
+
+### Summary 
+
+YAML templates for editing resources via the yaml editor.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `model` | `ExtensionK8sModel` | no | Model associated with the template. |
+| `template` | `CodeRef<string>` | no | The YAML template. |
+| `name` | `string` | no | The name of the template. Use the name `default` to mark this as the default template. |
+
+---
+
+## `dev-console.add/action`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | ID used to identify the action. |
+| `label` | `string` | no | The label of the action |
+| `description` | `string` | no | The description of the action. |
+| `href` | `string` | no | The href to navigate to. |
+| `groupId` | `string` | yes | IDs used to identify the action groups the action would belong to. |
+| `icon` | `CodeRef<React.ReactNode>` | yes | The perspective display icon. |
+| `accessReview` | `AccessReviewResourceAttributes[]` | yes | Optional access review to control visibility / enablement of the action. |
+
+---
+
+## `dev-console.add/action-group`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `id` | `string` | no | ID used to identify the action group. |
+| `name` | `string` | no | The title of the action group |
+| `insertBefore` | `string` | yes | ID of action group before which this group should be placed |
+| `insertAfter` | `string` | yes | ID of action group after which this group should be placed |
+
+---
+
+## `dev-console.import/environment`
+
+### Summary 
+
+(not available)
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `imageStreamName` | `string` | no | Name of the image stream to provide custom environment variables for |
+| `imageStreamTags` | `string[]` | no | List of supported image stream tags |
+| `environments` | `ImageEnvironment[]` | no | List of environment variables |
+
+---
+
+## `console.page/resource/tab`
+
+### Summary [DEPRECATED]
+
+@deprecated - Use `console.tab/horizontalNav` instead<br/>Adds new resource tab page to Console router.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `model` | `ExtensionK8sGroupKindModel` | no | The model for which this resource page links to. |
+| `component` | `CodeRef<React.ComponentType<RouteComponentProps<{}, StaticContext, any>>>` | no | The component to be rendered when the route matches. |
+| `name` | `string` | no | The name of the tab. |
+| `href` | `string` | yes | The optional href for the tab link. If not provided, the first `path` is used. |
+| `exact` | `boolean` | yes | When true, will only match if the path matches the `location.pathname` exactly. |
+

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
@@ -75,7 +75,7 @@ export const getCorePackage: GetPackageDefinition = (
   },
   filesToCopy: {
     ...commonFiles,
-    'generated/doc': 'doc',
+    docs: 'docs',
   },
 });
 

--- a/test-frontend.sh
+++ b/test-frontend.sh
@@ -7,15 +7,19 @@ OPENSHIFT_CI=${OPENSHIFT_CI:=false}
 ARTIFACT_DIR=${ARTIFACT_DIR:=/tmp/artifacts}
 
 cd frontend
-yarn run lint
-if [ "$OPENSHIFT_CI" = true ]; then
-    JEST_SUITE_NAME="OpenShift Console Unit Tests" JEST_JUNIT_OUTPUT_DIR="$ARTIFACT_DIR" yarn run test --ci --maxWorkers=2 --reporters=default --reporters=jest-junit
-else
-    yarn run test
+
+# Fail fast if generated artifacts are out of sync
+
+if git status --short | grep 'yarn.lock' >/dev/null; then
+  printf "\n\nOUTDATED yarn.lock (COMMIT IT TO FIX!!!!!)\n"
+  git diff
+  exit 1
 fi
 
-if git status --short | grep 'yarn.lock' > /dev/null; then
-  printf "\n\nOUTDATED yarn.lock (COMMIT IT TO FIX!!!!!)\n"
+# Dynamic plugin SDK docs are generated as part of the build, check for changes
+GIT_STATUS="$(git status --short --untracked-files -- packages/console-dynamic-plugin-sdk/docs)"
+if [ -n "$GIT_STATUS" ]; then
+  echo "dynamic plugin sdk docs are not up to date. Run 'yarn generate-plugin-sdk-docs' then commit changes."
   git diff
   exit 1
 fi
@@ -23,7 +27,14 @@ fi
 yarn i18n
 GIT_STATUS="$(git status --short --untracked-files -- public/locales packages/**/locales)"
 if [ -n "$GIT_STATUS" ]; then
-  echo "i18n files are not up to date. Commit them to fix."
+  echo "i18n files are not up to date. Run 'yarn i18n' then commit changes."
   git diff
   exit 1
+fi
+
+yarn run lint
+if [ "$OPENSHIFT_CI" = true ]; then
+  JEST_SUITE_NAME="OpenShift Console Unit Tests" JEST_JUNIT_OUTPUT_DIR="$ARTIFACT_DIR" yarn run test --ci --maxWorkers=2 --reporters=default --reporters=jest-junit
+else
+  yarn run test
 fi


### PR DESCRIPTION
Manually publish dynamic plugin SDK API docs and add CI checks to ensure generated files stay up to date.

**`README.md`**
Update root README to provide easier navigation to package docs.

**`frontend/packages/console-dynamic-plugin-sdk/README.md`**
Update console dynamic plugin SDK README to provide easier navigation to API and Console Extension docs.

**`frontend/packages/console-dynamic-plugin-sdk/docs`**
Generate dynamic plugin docs in this dir so that they are not ignored by git and `/generated/` is not included in the GitHub Pages URL path.

**`frontend/packages/console-dynamic-plugin-sdk/scripts/generate-doc.ts`**
Refactor and simplify GitHub link generation logic

**`frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts`**
Update location of generated docs so that they are copied into dist

**`test-frontend.sh`**
Reorder the checks in this file so that the least time-consuming and compute-intensive steps come first, meaning we will fail faster.

https://issues.redhat.com/browse/CONSOLE-3169