### PR TITLE
Bug 2091603: move terminal tick & add phase handlers

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellExec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellExec.tsx
@@ -19,8 +19,6 @@ import {
 import ExecuteCommand from './ExecuteCommand';
 import Terminal, { ImperativeTerminalType } from './Terminal';
 import TerminalLoadingBox from './TerminalLoadingBox';
-import useActivityTick, { TICK_INTERVAL } from './useActivityTick';
-
 import './CloudShellExec.scss';
 
 // pod exec WS protocol is FD prefixed, base64 encoded data (sometimes json stringified)
@@ -37,7 +35,6 @@ type Props = {
   namespace: string;
   shcommand?: string[];
   workspaceModel: K8sKind;
-  isActiveTab?: boolean;
 };
 
 type StateProps = {
@@ -65,7 +62,6 @@ const CloudShellExec: React.FC<CloudShellExecProps> = ({
   flags,
   impersonate,
   workspaceModel,
-  isActiveTab = false,
   onActivate,
 }) => {
   const fireTelemetryEvent = useTelemetry();
@@ -76,26 +72,6 @@ const CloudShellExec: React.FC<CloudShellExecProps> = ({
   const ws = React.useRef<WSFactory>();
   const terminal = React.useRef<ImperativeTerminalType>();
   const { t } = useTranslation();
-
-  const tick = useActivityTick(workspaceName, namespace);
-
-  React.useEffect(() => {
-    let startTime;
-    let tickReq;
-    const handleTick = (timestamp) => {
-      if ((!startTime || timestamp - startTime >= TICK_INTERVAL) && isActiveTab) {
-        startTime = timestamp;
-        tick();
-      }
-      tickReq = window.requestAnimationFrame(handleTick);
-    };
-
-    tickReq = window.requestAnimationFrame(handleTick);
-
-    return () => {
-      window.cancelAnimationFrame(tickReq);
-    };
-  }, [isActiveTab, tick]);
 
   const onData = (data: string): void => {
     ws.current?.send(`0${Base64.encode(data)}`);

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.tsx
@@ -13,7 +13,12 @@ import {
 } from '@console/shared';
 import { FLAG_V1ALPHA2DEVWORKSPACE } from '../../consts';
 import { v1alpha1WorkspaceModel, WorkspaceModel } from '../../models';
-import { TerminalInitData, initTerminal, startWorkspace } from './cloud-shell-utils';
+import {
+  TerminalInitData,
+  initTerminal,
+  startWorkspace,
+  CLOUD_SHELL_PHASE,
+} from './cloud-shell-utils';
 import CloudshellExec from './CloudShellExec';
 import { CLOUD_SHELL_NAMESPACE, CLOUD_SHELL_NAMESPACE_CONFIG_STORAGE_KEY } from './const';
 import CloudShellAdminSetup from './setup/CloudShellAdminSetup';
@@ -30,7 +35,9 @@ type StateProps = {
 
 type Props = {
   onCancel?: () => void;
-  isActiveTab?: boolean;
+  terminalNumber?: number;
+  setWorkspaceName?: (name: string, terminalNumber: number) => void;
+  setWorkspaceNamespace?: (namespace: string, terminalNumber: number) => void;
 };
 
 type CloudShellTerminalProps = StateProps & Props;
@@ -40,8 +47,10 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
   user,
   onCancel,
   userSettingState: namespace,
-  isActiveTab = false,
   setUserSettingState: setNamespace,
+  terminalNumber,
+  setWorkspaceName,
+  setWorkspaceNamespace,
 }) => {
   const [operatorNamespace, namespaceLoadError] = useCloudShellNamespace();
   const [initData, setInitData] = React.useState<TerminalInitData>();
@@ -64,6 +73,16 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
   const workspaceName = workspace?.metadata?.name;
   const workspaceNamespace = workspace?.metadata?.namespace;
   const workspaceId = workspace?.metadata?.uid;
+
+  terminalNumber &&
+    workspaceName &&
+    setWorkspaceName &&
+    setWorkspaceName(workspaceName, terminalNumber);
+
+  terminalNumber &&
+    workspaceNamespace &&
+    setWorkspaceNamespace &&
+    setWorkspaceNamespace(workspaceNamespace, terminalNumber);
 
   const username = user?.metadata?.name;
 
@@ -120,17 +139,15 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
   // initialize the terminal once it is Running
   React.useEffect(() => {
     let unmounted = false;
+    const defaultError = t('console-app~Failed to connect to your OpenShift command line terminal');
 
-    if (workspacePhase === 'Running') {
+    if (workspacePhase === CLOUD_SHELL_PHASE.RUNNING) {
       initTerminal(username, workspaceName, workspaceNamespace)
         .then((res: TerminalInitData) => {
           if (!unmounted) setInitData(res);
         })
         .catch((e) => {
           if (!unmounted) {
-            const defaultError = t(
-              'console-app~Failed to connect to your OpenShift command line terminal',
-            );
             if (e?.response?.headers?.get('Content-Type')?.startsWith('text/plain')) {
               // eslint-disable-next-line promise/no-nesting
               e.response
@@ -147,11 +164,18 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
           }
         });
     }
+    if (workspacePhase === CLOUD_SHELL_PHASE.FAILED) {
+      setInitError(defaultError);
+    }
+
+    if (workspacePhase === CLOUD_SHELL_PHASE.STARTING) {
+      setInitError(null);
+    }
 
     return () => {
       unmounted = true;
     };
-  }, [username, workspaceName, workspaceNamespace, workspacePhase, t]);
+  }, [username, workspaceName, workspaceNamespace, workspacePhase, t, terminalNumber]);
 
   // failed to load the workspace
   if (loadError) {
@@ -195,7 +219,6 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
         podname={initData.pod}
         shcommand={initData.cmd || []}
         workspaceModel={workspaceModel}
-        isActiveTab={isActiveTab}
       />
     );
   }

--- a/frontend/packages/console-app/src/components/cloud-shell/MultiTabbedTerminal.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/MultiTabbedTerminal.tsx
@@ -4,8 +4,9 @@ import { CloseIcon, PlusIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 import { Tabs } from '../tabs';
+import { sendActivityTick } from './cloud-shell-utils';
 import CloudShellTerminal from './CloudShellTerminal';
-
+import { TICK_INTERVAL } from './useActivityTick';
 import './MultiTabbedTerminal.scss';
 
 const MAX_TERMINAL_TABS = 8;
@@ -17,8 +18,32 @@ interface MultiTabbedTerminalProps {
 export const MultiTabbedTerminal: React.FC<MultiTabbedTerminalProps> = ({ onClose }) => {
   const [terminalTabs, setTerminalTabs] = React.useState<number[]>([1]);
   const [activeTabKey, setActiveTabKey] = React.useState<number>(1);
+  const [tickNamespace, setTickNamespace] = React.useState<string>(null);
+  const [tickWorkspace, setTickWorkspace] = React.useState<string>(null);
   const { t } = useTranslation();
   const fireTelemetryEvent = useTelemetry();
+
+  const tick = React.useCallback(() => {
+    return tickNamespace && tickWorkspace && sendActivityTick(tickWorkspace, tickNamespace);
+  }, [tickWorkspace, tickNamespace]);
+
+  React.useEffect(() => {
+    let startTime;
+    let tickReq;
+    const handleTick = (timestamp) => {
+      if (!startTime || timestamp - startTime >= TICK_INTERVAL) {
+        startTime = timestamp;
+        tick();
+      }
+      tickReq = window.requestAnimationFrame(handleTick);
+    };
+
+    tickReq = window.requestAnimationFrame(handleTick);
+
+    return () => {
+      window.cancelAnimationFrame(tickReq);
+    };
+  }, [tick]);
 
   const addNewTerminal = () => {
     if (terminalTabs.length < MAX_TERMINAL_TABS) {
@@ -39,6 +64,14 @@ export const MultiTabbedTerminal: React.FC<MultiTabbedTerminalProps> = ({ onClos
     }
     tabs.splice(tabIndex, 1);
     setTerminalTabs(tabs);
+  };
+
+  const getWorkspaceNamespace = (namespace: string, terminal: number) => {
+    terminal === activeTabKey && namespace !== tickNamespace && setTickNamespace(namespace);
+  };
+
+  const getWorkspaceName = (name: string, terminal: number) => {
+    terminal === activeTabKey && name !== tickWorkspace && setTickWorkspace(name);
   };
 
   return (
@@ -81,7 +114,11 @@ export const MultiTabbedTerminal: React.FC<MultiTabbedTerminalProps> = ({ onClos
             </div>
           }
         >
-          <CloudShellTerminal isActiveTab={activeTabKey === terminalNumber} />
+          <CloudShellTerminal
+            terminalNumber={terminalNumber}
+            setWorkspaceName={getWorkspaceName}
+            setWorkspaceNamespace={getWorkspaceNamespace}
+          />
         </Tab>
       ))}
       {terminalTabs.length < MAX_TERMINAL_TABS && (

--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellExec.spec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellExec.spec.tsx
@@ -4,12 +4,6 @@ import { FLAGS } from '@console/shared';
 import { WorkspaceModel } from '../../../models';
 import { InternalCloudShellExec, CloudShellExecProps } from '../CloudShellExec';
 import TerminalLoadingBox from '../TerminalLoadingBox';
-import useActivityTick from '../useActivityTick';
-
-Object.defineProperty(window, 'requestAnimationFrame', {
-  writable: true,
-  value: (callback) => callback(),
-});
 
 jest.mock('@console/shared', () => {
   const originalModule = (jest as any).requireActual('@console/shared');
@@ -18,10 +12,6 @@ jest.mock('@console/shared', () => {
     useTelemetry: () => {},
   };
 });
-
-jest.mock('../useActivityTick', () => ({
-  default: jest.fn(),
-}));
 
 const workspace = 'test1';
 const namespace = 'namespace1';
@@ -37,30 +27,9 @@ const cloudShellExecProps: CloudShellExecProps = {
   flags: { [FLAGS.OPENSHIFT]: true },
 };
 
-beforeEach(() => {
-  jest.useFakeTimers();
-
-  let count = 0;
-  jest
-    .spyOn(window, 'requestAnimationFrame')
-    .mockImplementation((cb) => setTimeout(() => cb(100 * ++count), 100));
-});
-
-afterEach(() => {
-  (window.requestAnimationFrame as any).mockRestore();
-  jest.clearAllTimers();
-});
-
 describe('CloudShellExec', () => {
-  it('should call requestAnimationFrame and useActivityTick On Mount', () => {
-    jest.useFakeTimers();
-    (useActivityTick as jest.Mock).mockImplementation((w, n) => {
-      return [w, n];
-    });
-    const wrapper = mount(<InternalCloudShellExec {...cloudShellExecProps} isActiveTab />);
+  it('should TerminalLoadingBox On Mount', () => {
+    const wrapper = mount(<InternalCloudShellExec {...cloudShellExecProps} />);
     expect(wrapper.find(TerminalLoadingBox).exists()).toBe(true);
-    expect(requestAnimationFrame).toHaveBeenCalled();
-    expect(useActivityTick).toHaveBeenCalledTimes(1);
-    expect(useActivityTick).toHaveBeenCalledWith(workspace, namespace);
   });
 });

--- a/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
@@ -54,6 +54,12 @@ export const CLOUD_SHELL_PROTECTED_NAMESPACE = 'openshift-terminal';
 
 export const createCloudShellResourceName = () => `terminal-${getRandomChars(6)}`;
 
+export enum CLOUD_SHELL_PHASE {
+  STARTING = 'Starting',
+  FAILED = 'Failed',
+  RUNNING = 'Running',
+}
+
 const v1alpha1DevworkspaceComponent = [
   {
     plugin: {
@@ -148,7 +154,12 @@ export const initTerminal = (
 };
 
 export const sendActivityTick = (workspaceName: string, namespace: string): void => {
-  coFetch(`/api/terminal/proxy/${namespace}/${workspaceName}/activity/tick`, { method: 'POST' });
+  coFetch(`/api/terminal/proxy/${namespace}/${workspaceName}/activity/tick`, {
+    method: 'POST',
+  }).catch((e) =>
+    // eslint-disable-next-line no-console
+    console.error(e),
+  );
 };
 
 export const checkTerminalAvailable = () => coFetch('/api/terminal/available');


### PR DESCRIPTION
# Addresses
https://bugzilla.redhat.com/show_bug.cgi?id=2091603
https://bugzilla.redhat.com/show_bug.cgi?id=2094857

# Issue
When switching between terminal tabs, an individual tab reconnects and websocket connection issue is thrown.
 
# Fixes
1. Moves web terminal sendTick to MultiTabTrminal level
2. Adds handler for phases "starting" & "failed
 
# Screenshots
![move-terminal-tick](https://user-images.githubusercontent.com/24852534/172619934-ee59918c-e1e1-4ee4-b7aa-35e9964f666c.gif)

# Steps to Test
1. Spin up a cluster bot with this PR and login
2. Install web terminal Operator
3. Refresh once operator is successfully installed and then start web terminal by clicking on  masthead. 
4. Once Terminal loads create 2-3 tabs and run commands individually.
5. Switch between tabs. The tab content should not change and tab should not disconnect when switching away.(check that last command is there in the tab)
6. Open chrome network tab . Check for `tick` network calls happening every 60 seconds. (The response in the starting may fail but call must happen)
7. Clear console network tab and go offline for 4 minutes. When return to the page, only 1 tick call should happen(i.e tick call happens only when user in online on page)

# Browser conformance
Chrome
