### PR TITLE
Bug 2092414: Display only running VMs in Virtualization Overview chart

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/inventory-card/VirtOverviewInventoryCard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/inventory-card/VirtOverviewInventoryCard.tsx
@@ -13,7 +13,7 @@ import { TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_LABEL } from '../../../constants';
 import { VirtualMachineModel } from '../../../models';
 import { kubevirtReferenceForModel } from '../../../models/kubevirtReferenceForModel';
 import { ResourcesSection } from './ResourcesSection';
-import { VmStatusesSection } from './VmStatusesSection';
+import { VMStatusesSection } from './VMStatusesSection';
 
 import './virt-overview-inventory-card.scss';
 
@@ -119,7 +119,7 @@ export const InventoryCard: React.FC<DashboardItemProps> = ({
             </div>
           </GridItem>
           <GridItem span={8}>
-            <VmStatusesSection
+            <VMStatusesSection
               vms={(resources?.vms?.data as K8sResourceKind[]) ?? []}
               vmsLoaded={resources?.vms?.loaded}
             />

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/running-vms-per-template-card/RunningVMsChartLegendLabel.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/running-vms-per-template-card/RunningVMsChartLegendLabel.tsx
@@ -15,15 +15,16 @@ type RunningVMsChartLegendLabelProps = {
 };
 
 export const RunningVMsChartLegendLabel: React.FC<RunningVMsChartLegendLabelProps> = ({ item }) => {
-  const iconStyle = { color: item.color };
-  // const linkPath = `/k8s/ns/${item.namespace}/kubevirt.io~v1~VirtualMachine?labels=vm.kubevirt.io/template=${item.name}`
-  const linkPath = `/k8s/ns/${item.namespace}/virtualmachinetemplates/${item.name}`;
+  const iconStyle = { color: item?.color };
+  const linkPath = item?.namespace
+    ? `/k8s/ns/${item.namespace}/virtualmachinetemplates/${item?.name}`
+    : null;
 
   return (
     <>
       <i className="fas fa-square kv-running-vms-card__legend-label--color" style={iconStyle} />
-      <span className="kv-running-vms-card__legend-label--count">{item.vmCount}</span>{' '}
-      <Link to={linkPath}>{item.name}</Link>
+      <span className="kv-running-vms-card__legend-label--count">{item?.vmCount}</span>{' '}
+      {linkPath ? <Link to={linkPath}>{item?.name}</Link> : <span>{item?.name}</span>}
     </>
   );
 };

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/utils.ts
@@ -1,0 +1,39 @@
+import { getVmStatusFromPrintable, VMStatus } from '../../constants/vm/vm-status';
+import { isVM, isVMI } from '../../selectors/check-type';
+import { getVMStatus } from '../../statuses/vm/vm-status';
+
+export const UNKNOWN = 'Unknown';
+
+export const getPrintableVMStatus = (vmLike) => {
+  let status = UNKNOWN;
+  if (isVM(vmLike)) {
+    status = vmLike?.status?.printableStatus || UNKNOWN;
+  } else if (isVMI(vmLike)) {
+    status = vmLike?.status?.phase || UNKNOWN;
+  }
+  return status;
+};
+
+export const getVMStatusFromBundle = (vmLike, statusResources): VMStatus => {
+  const resources = {
+    vm: vmLike,
+    vmi: undefined,
+    pods: statusResources.pods,
+    pvcs: statusResources.pvcs,
+    dvs: statusResources.dvs,
+    migrations: statusResources.migrations,
+  };
+  return getVMStatus(resources)?.status || VMStatus.UNKNOWN;
+};
+
+export const getVmStatus = (vmLike, statusResources, printableVMStatusFlag): VMStatus => {
+  const vmStatus: VMStatus = printableVMStatusFlag
+    ? getVmStatusFromPrintable(getPrintableVMStatus(vmLike))
+    : getVMStatusFromBundle(vmLike, statusResources);
+  return vmStatus || VMStatus.UNKNOWN;
+};
+
+export const getVMStatusString = (vmLike, statusResources, printableVMStatusFlag) => {
+  const vmStatus: VMStatus = getVmStatus(vmLike, statusResources, printableVMStatusFlag);
+  return vmStatus?.toSimpleSortString() || UNKNOWN;
+};

--- a/frontend/packages/kubevirt-plugin/src/hooks/useRunningVMsPerTemplateChartData.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/useRunningVMsPerTemplateChartData.ts
@@ -1,0 +1,97 @@
+import { useTranslation } from 'react-i18next';
+import { TemplateKind } from '@console/internal/module/k8s';
+import { useFlag } from '@console/shared';
+import { RunningVMsChartLegendLabelItem } from '../components/virtualization-overview/running-vms-per-template-card/RunningVMsChartLegendLabel';
+import { getColorList } from '../components/virtualization-overview/running-vms-per-template-card/utils';
+import { getVmStatus } from '../components/virtualization-overview/utils';
+import { useVmStatusResources } from '../components/vm-status/use-vm-status-resources';
+import { LABEL_USED_TEMPLATE_NAME } from '../constants';
+import { VMStatus } from '../constants/vm/vm-status';
+import { FLAG_KUBEVIRT_HAS_PRINTABLESTATUS } from '../flags/const';
+import { getName, getNamespace } from '../selectors';
+import { VMKind } from '../types';
+import { useRunningVMsPerTemplateResources } from './use-running-vms-per-template-resources';
+
+const getTemplateNS = (templateName, templates) => {
+  const template = templates.find((temp) => getName(temp) === templateName);
+  return template ? getNamespace(template) : null;
+};
+
+const getTemplateToVMCountMap = (loaded, runningVMs, templates, t) => {
+  const templateToVMCountMap = new Map();
+  const numVMs = runningVMs?.length || 0;
+
+  if (loaded) {
+    runningVMs.forEach((vm) => {
+      const labels = vm?.metadata?.labels;
+      const template = labels?.[LABEL_USED_TEMPLATE_NAME] || t('kubevirt-plugin~Other');
+      const value = templateToVMCountMap.has(template)
+        ? templateToVMCountMap.get(template).vmCount + 1
+        : 1;
+      templateToVMCountMap.set(template, { vmCount: value });
+    });
+  }
+
+  const numTemplates = templateToVMCountMap.size;
+  const colorListIter = getColorList(numTemplates).values();
+
+  for (const key of templateToVMCountMap.keys()) {
+    const templateChartData = templateToVMCountMap.get(key);
+    const additionalData = {
+      percentage: numVMs ? Math.round((templateChartData.vmCount / numVMs) * 100) : 0,
+      color: colorListIter.next().value,
+      namespace: getTemplateNS(key, templates),
+    };
+    templateToVMCountMap.set(key, { ...templateChartData, ...additionalData });
+  }
+
+  return templateToVMCountMap;
+};
+
+const getChartData = (templateToVMCountMap) => {
+  const chartData = [];
+  templateToVMCountMap.forEach((data, templateName) => {
+    chartData.push({
+      x: templateName,
+      y: data.percentage,
+      fill: data.color,
+    });
+  });
+  return chartData;
+};
+
+const getLegendItems = (templateToVMCountMap): RunningVMsChartLegendLabelItem[] => {
+  const legendItems = [];
+  templateToVMCountMap.forEach((data, templateName) => {
+    legendItems.push({
+      name: templateName,
+      vmCount: data.vmCount,
+      color: data.color,
+      namespace: data.namespace,
+    });
+  });
+  return legendItems;
+};
+
+export const useRunningVMsPerTemplateChartData = (): [any[], any[], number] => {
+  const { t } = useTranslation();
+  const resources = useRunningVMsPerTemplateResources();
+  const printableStatusAvailable = useFlag(FLAG_KUBEVIRT_HAS_PRINTABLESTATUS);
+  const statusResources = useVmStatusResources(undefined);
+
+  const loaded = resources?.loaded;
+  const vms: VMKind[] = loaded ? resources?.vms : [];
+  const templates: TemplateKind[] = loaded ? resources?.templates : [];
+
+  const runningVMs = vms?.filter(
+    (vm) => getVmStatus(vm, statusResources, printableStatusAvailable) === VMStatus.RUNNING,
+  );
+
+  const templateToVMCountMap = getTemplateToVMCountMap(loaded, runningVMs, templates, t);
+
+  const chartData = getChartData(templateToVMCountMap);
+  const legendItems = getLegendItems(templateToVMCountMap);
+  const numRunningVMs = runningVMs?.length || 0;
+
+  return [chartData, legendItems, numRunningVMs];
+};


### PR DESCRIPTION
This PR fixes a bug in the Running VMs per Template card on the Virtualization Overview page wherein VMs that did not possess the `vm.kubevirt.io/template` label had no label in the table and the label on hover in the graph was incorrect.

Screenshot:
![Selection_105](https://user-images.githubusercontent.com/8544299/172227841-a9a7c260-c091-4dbe-bb12-eeaa7b0a6704.png)
 