### PR TITLE
Bug 2094152: Filter alerts in virtualization overview status card

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
@@ -13,6 +13,7 @@ import {
   getAlertMessage,
   getAlertDescription,
   getAlertTime,
+  getAlertSummary,
 } from './alert-utils';
 
 const CriticalIcon = () => <RedExclamationCircleIcon title="Critical" />;
@@ -63,7 +64,7 @@ const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {
     <StatusItem
       Icon={getSeverityIcon(getAlertSeverity(alert))}
       timestamp={getAlertTime(alert)}
-      message={getAlertDescription(alert) || getAlertMessage(alert)}
+      message={getAlertDescription(alert) || getAlertMessage(alert) || getAlertSummary(alert)}
     >
       {text && action ? (
         <Button variant={ButtonVariant.link} onClick={() => action(alert)} isInline>

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/alert-utils.ts
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/alert-utils.ts
@@ -6,6 +6,7 @@ export const getAlertMessage = (alert: Alert) =>
   alert && alert.annotations ? alert.annotations.message : null;
 export const getAlertDescription = (alert: Alert) =>
   alert && alert.annotations ? alert.annotations.description : null;
+export const getAlertSummary = (alert: Alert) => alert?.annotations?.summary || null;
 export const getAlertTime = (alert: Alert) => (alert ? alert.activeAt : null);
 export const getAlertName = (alert: Alert) =>
   alert && alert.labels ? alert.labels.alertname : null;

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/HighPriorityAlerts.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/HighPriorityAlerts.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import { Alert } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import {
-  Alert as ConsoleAlert,
-  AlertSeverity,
-} from '@console/internal/components/monitoring/types';
+import { AlertSeverity } from '@console/internal/components/monitoring/types';
 import { ExternalLink } from '@console/internal/components/utils';
 import useFilteredAlerts from '../../hooks/useFilteredAlerts';
 
@@ -50,7 +47,7 @@ const AlertTitle = ({ alert }) => {
 };
 
 const HighPriorityAlerts: React.FC = () => {
-  const filteredAlerts: ConsoleAlert[] = useFilteredAlerts(isKubeVirtHighPriorityAlert);
+  const [filteredAlerts] = useFilteredAlerts(isKubeVirtHighPriorityAlert);
 
   return (
     <div className="kv-high-priority-alerts">

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/status-card/VirtOverviewDashboardAlerts.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/status-card/VirtOverviewDashboardAlerts.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { alertURL } from '@console/internal/components/monitoring/utils';
+import AlertItem from '@console/shared/src/components/dashboard/status-card/AlertItem';
+import AlertsBody from '@console/shared/src/components/dashboard/status-card/AlertsBody';
+import useFilteredAlerts from '../../../hooks/useFilteredAlerts';
+
+const OPERATOR_LABEL_KEY = 'kubernetes_operator_part_of';
+const isKubeVirtAlert = (alert) => alert?.labels?.[OPERATOR_LABEL_KEY] === 'kubevirt';
+
+const VirtualizationOverviewDashboardAlerts: React.FC = () => {
+  const [alerts, , loadError] = useFilteredAlerts(isKubeVirtAlert);
+
+  return (
+    <AlertsBody error={!_.isEmpty(loadError)}>
+      {alerts.map((alert) => (
+        <AlertItem key={alertURL(alert, alert.rule.id)} alert={alert} />
+      ))}
+    </AlertsBody>
+  );
+};
+
+export default VirtualizationOverviewDashboardAlerts;

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/status-card/VirtOverviewStatusCard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/status-card/VirtOverviewStatusCard.tsx
@@ -21,7 +21,6 @@ import {
   isResolvedDashboardsOverviewHealthURLSubsystem,
 } from '@console/dynamic-plugin-sdk';
 import { URLHealthItem } from '@console/internal/components/dashboard/dashboards-page/cluster-dashboard/health-item';
-import { DashboardAlerts } from '@console/internal/components/dashboard/dashboards-page/cluster-dashboard/status-card';
 import { FirehoseResource } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import {
@@ -35,6 +34,7 @@ import HealthBody from '@console/shared/src/components/dashboard/status-card/Hea
 import HealthItem from '@console/shared/src/components/dashboard/status-card/HealthItem';
 import { NetworkAddonsConfigModel } from '../../../models';
 import { StorageHealthItem } from './StorageHealthItem';
+import VirtualizationOverviewDashboardAlerts from './VirtOverviewDashboardAlerts';
 
 export const NetworkAddonsConfigResource: FirehoseResource = {
   kind: referenceForModel(NetworkAddonsConfigModel),
@@ -139,7 +139,7 @@ export const VirtOverviewStatusCard = connect<VirtOverviewStatusCardProps>(mapSt
             })}
           </Gallery>
         </HealthBody>
-        <DashboardAlerts />
+        <VirtualizationOverviewDashboardAlerts />
       </Card>
     );
   },

--- a/frontend/packages/kubevirt-plugin/src/hooks/useFilteredAlerts.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/useFilteredAlerts.ts
@@ -1,12 +1,17 @@
 import * as React from 'react';
+import { Alert } from '@console/dynamic-plugin-sdk';
+import { Alert as ConsoleAlert } from '@console/internal/components/monitoring/types';
 import { useNotificationAlerts } from '@console/shared/src/hooks/useNotificationAlerts';
-import { Alert } from 'public/components/monitoring/types';
 
-export type UseFilteredAlerts = (filter: any) => Alert[];
+export type UseFilteredAlerts = (filter: any) => [Alert[], boolean, Error];
 
 const useFilteredAlerts: UseFilteredAlerts = (filter) => {
-  const [alerts] = useNotificationAlerts();
-  return React.useMemo(() => alerts?.filter((alert) => filter(alert)), [alerts, filter]);
+  const [alerts, loaded, loadError] = useNotificationAlerts();
+  const filteredAlerts: ConsoleAlert[] = React.useMemo(
+    () => alerts?.filter((alert) => filter(alert)),
+    [alerts, filter],
+  );
+  return [filteredAlerts, loaded, loadError];
 };
 
 export default useFilteredAlerts;


### PR DESCRIPTION
This PR filters the alerts displayed in the virtualization overview status card to only those that related to KubeVirt.

Screenshot:
![Selection_106](https://user-images.githubusercontent.com/8544299/172283710-75080988-fef9-4719-8442-7d3a22571641.png)

