### PR TITLE
[release-4.10] Bug 2094211: Change Ping source spec.jsonData (deprecated) field to spec.data

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/event-sources/PingSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/PingSourceSection.tsx
@@ -16,7 +16,7 @@ const PingSourceSection: React.FC<PingSourceSectionProps> = ({ title, fullWidth 
     <FormSection title={title} extraMargin fullWidth={fullWidth}>
       <InputField
         type={TextInputTypes.text}
-        name={`formData.data.${EventSources.PingSource}.jsonData`}
+        name={`formData.data.${EventSources.PingSource}.data`}
         label={t('knative-plugin~Data')}
         helpText={t('knative-plugin~The data posted to the target function')}
       />

--- a/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
@@ -87,7 +87,7 @@ describe('Create knative Utils', () => {
   });
 
   it('expect getEventSourceData should return data for builtin Sources', () => {
-    expect(getEventSourceData(EventSources.PingSource).jsonData).toBeDefined();
+    expect(getEventSourceData(EventSources.PingSource).data).toBeDefined();
     expect(getEventSourceData(EventSources.PingSource).schedule).toBeDefined();
 
     expect(getEventSourceData(EventSources.CronJobSource).data).toBeDefined();
@@ -252,7 +252,7 @@ describe('sanitizeSourceToForm always returns valid Event Source', () => {
       uri: '',
     },
     type: 'PingSource',
-    data: { PingSource: { jsonData: '', schedule: '' } },
+    data: { PingSource: { data: '', schedule: '' } },
   };
 
   it('expect an empty form to return a EventSource data with updated properties', () => {

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
@@ -352,7 +352,7 @@ const eventSourceData = {
     schedule: '* * * * *',
   },
   [EventSources.PingSource]: {
-    jsonData: '',
+    data: '',
     schedule: '* * * * *',
   },
   [EventSources.ApiServerSource]: {

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -154,7 +154,7 @@ export const getEventSourceData = (source: string) => {
       schedule: '',
     },
     [EventSources.PingSource]: {
-      jsonData: '',
+      data: '',
       schedule: '',
     },
     [EventSources.SinkBinding]: {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/console/pull/11548