### PR TITLE
Bug 2092137: Search doesn't show all entries when name filter is cleared

### DIFF
--- a/frontend/public/components/factory/ListPage/filter-hook.ts
+++ b/frontend/public/components/factory/ListPage/filter-hook.ts
@@ -26,7 +26,7 @@ export const useListPageFilter: UseListPageFilter = (data, rowFilters, staticFil
   React.useEffect(() => {
     const params = new URLSearchParams(location.search);
     const name = params.get('name');
-    if (name && name !== filter?.name?.selected?.[0]) {
+    if (!_.isNil(name) && name !== filter?.name?.selected?.[0]) {
       setFilter((state) => ({ ...state, name: { selected: [name] } }));
     }
   }, [filter, location]);

--- a/frontend/public/components/factory/list-page.tsx
+++ b/frontend/public/components/factory/list-page.tsx
@@ -129,7 +129,7 @@ export const ListPageWrapper: React.FC<ListPageWrapperProps> = (props) => {
   const memoizedIds = useDeepCompareMemoize(reduxIDs);
 
   React.useEffect(() => {
-    if (nameFilter) {
+    if (!_.isNil(nameFilter)) {
       memoizedIds.forEach((id) => dispatch(filterList(id, 'name', { selected: [nameFilter] })));
     }
   }, [dispatch, nameFilter, memoizedIds]);


### PR DESCRIPTION
Makes sure that when the user clears the name filter on the Search page all of the resources are shown again

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2092137