### PR TITLE
Fix Forge security issue

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -311,6 +311,7 @@
     "mock-socket": "^9.0.3",
     "monaco-editor-core": "0.20.0",
     "monaco-editor-webpack-plugin": "^1.9.0",
+    "node-forge": "^1.3.0",
     "null-loader": "^3.0.0",
     "prettier": "1.19.1",
     "protractor": "^5.4.4",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -13448,10 +13448,10 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+node-forge@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
+  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
 
 node-gettext@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Resolves:
node-forge: Signature verification leniency in checking `digestAlgorithm`
     structure can lead to signature forgery (CVE-2022-24771)
node-forge: Signature verification failing to check tailing garbage bytes
     can lead to signature forgery (CVE-2022-24772)
node-forge: Signature verification leniency in checking `DigestInfo`
     structure (CVE-2022-24773)

Signed-off-by: Timothy Asir Jeyasingh <tjeyasin@redhat.com>