### PR TITLE
Bug 2094833: Fix empty pipeline run template section for non-admin users

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/repository/__tests__/repository-form-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/repository/__tests__/repository-form-utils.spec.ts
@@ -209,4 +209,11 @@ describe('getPipelineRunTemplate', () => {
     const template = await getPipelineRunTemplate('nodejs', 'repo-name');
     expect(template).toEqual(expect.stringContaining('my-custom-template-string'));
   });
+
+  it('should return default template if there is an error while fetching', async () => {
+    /* eslint-disable-next-line prefer-promise-reject-errors */
+    k8sListResourceItemsMock.mockReturnValueOnce(Promise.reject({ message: '403' }));
+    const template = await getPipelineRunTemplate('nodejs', 'repo-name');
+    expect(template).toEqual(expect.stringContaining('name: repo-name'));
+  });
 });


### PR DESCRIPTION

**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://bugzilla.redhat.com/show_bug.cgi?id=2094833

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

Api call to fetch the template fails with forbidden error causing the error.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Added try/catch block to suppress the promise rejections and fallback template will be used in this case.

Before:
![image](https://user-images.githubusercontent.com/9964343/172615662-9e4cea8a-c509-4099-b6c8-d5f116e8377a.png)

After:

![image](https://user-images.githubusercontent.com/9964343/172615824-4a041b3d-cdf4-49ef-b9e2-4c7f3cdf9695.png)


**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
<!-- Attach test coverage report -->

  getPipelineRunTemplate

    ✓ should return default template if there is an error while fetching (5ms)
    
**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

1. Install OSP 1.8.0 (recommended) / OSP 1.7.0
2. Create a namespace user and give the rolebinding as outlined in this [doc](https://pipelinesascode.com/docs/install/installation/#rbac)https://pipelinesascode.com/docs/install/installation/#rbac
3. Log in as the newly created user and create Repository.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge