### PR TITLE
Bug 2090457: openshift-debug-node- namespaces do not get deleted for…

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeTerminal.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeTerminal.tsx
@@ -138,6 +138,10 @@ const NodeTerminal: React.FC<NodeTerminalProps> = ({ obj: node }) => {
         console.warn('Could not delete node terminal debug namespace.', e);
       }
     };
+    const closeTab = (event) => {
+      event.preventDefault();
+      deleteNamespace(namespace.metadata.name);
+    };
     const createDebugPod = async () => {
       try {
         namespace = await k8sCreate(NamespaceModel, {
@@ -174,10 +178,10 @@ const NodeTerminal: React.FC<NodeTerminalProps> = ({ obj: node }) => {
       }
     };
     createDebugPod();
-    window.addEventListener('beforeunload', deleteNamespace);
+    window.addEventListener('beforeunload', closeTab);
     return () => {
       deleteNamespace(namespace.metadata.name);
-      window.removeEventListener('beforeunload', deleteNamespace);
+      window.removeEventListener('beforeunload', closeTab);
     };
   }, [nodeName]);
 


### PR DESCRIPTION
… debug terminals launched via console

Makes sure the pod/project is deleted after launching a terminal session from the console and closing the browser window without navigating anywhere else.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2090457