### PR TITLE
Bug 2094240: Update workload-pause.tsx to fix inconsistency between buttons in the notification and kebab action dropdown. 

### DIFF
--- a/frontend/public/components/utils/workload-pause.tsx
+++ b/frontend/public/components/utils/workload-pause.tsx
@@ -44,7 +44,9 @@ export const WorkloadPausedAlert = ({ model, obj }) => {
             togglePaused(model, obj).catch((err) => errorModal({ error: err.message }))
           }
         >
-          {t('public~Resume rollouts')}
+          {obj.kind === 'MachineConfigPool'
+            ? t('public~Resume updates')
+            : t('public~Resume rollouts')}
         </AlertActionLink>
       }
     >


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2094240
The Resume rollout in the [MachineConfigPools] > MachineConfigPool details page is inconsistent with the Resume updates button appeared in the kebab action dropdown menu.