### PR TITLE
Bug 2089773: Added separate reducers for status and title for pipeline status

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunCustomDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunCustomDetails.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Status } from '@console/shared';
 import { PipelineRunKind } from '../../../types';
-import { pipelineRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
+import {
+  pipelineRunFilterReducer,
+  pipelineRunTitleFilterReducer,
+} from '../../../utils/pipeline-filter-reducer';
 import {
   convertBackingPipelineToPipelineResourceRefProps,
   getPipelineResourceLinks,
@@ -33,7 +36,7 @@ const PipelineRunCustomDetails: React.FC<PipelineRunCustomDetailsProps> = ({ pip
         <dd>
           <Status
             status={pipelineRunFilterReducer(pipelineRun)}
-            title={pipelineRunFilterReducer(pipelineRun)}
+            title={pipelineRunTitleFilterReducer(pipelineRun)}
           />
         </dd>
       </dl>

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
@@ -5,7 +5,10 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../../models';
 import { PipelineRunKind } from '../../../types';
 import { getPipelineRunKebabActions } from '../../../utils/pipeline-actions';
-import { pipelineRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
+import {
+  pipelineRunFilterReducer,
+  pipelineRunTitleFilterReducer,
+} from '../../../utils/pipeline-filter-reducer';
 import { pipelineRunDuration } from '../../../utils/pipeline-utils';
 import LinkedPipelineRunTaskStatus from '../status/LinkedPipelineRunTaskStatus';
 import PipelineRunStatus from '../status/PipelineRunStatus';
@@ -22,7 +25,7 @@ const PLRStatus: React.FC<PLRStatusProps> = ({ obj }) => {
   return (
     <PipelineRunStatus
       status={pipelineRunFilterReducer(obj)}
-      title={pipelineRunFilterReducer(obj)}
+      title={pipelineRunTitleFilterReducer(obj)}
       pipelineRun={obj}
     />
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineBars.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineBars.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
-import { PipelineRunKind } from '../../../types';
-import { runStatus, getRunStatusColor } from '../../../utils/pipeline-augment';
+import { ComputedStatus, PipelineRunKind } from '../../../types';
+import { getRunStatusColor } from '../../../utils/pipeline-augment';
 import HorizontalStackedBars from '../../charts/HorizontalStackedBars';
 import { useTaskStatus } from '../hooks/useTaskStatus';
 import TaskStatusToolTip from './TaskStatusTooltip';
@@ -18,10 +18,10 @@ export const PipelineBars: React.FC<PipelineBarProps> = ({ pipelinerun }) => {
       <HorizontalStackedBars
         height="1em"
         inline
-        values={Object.keys(runStatus).map((status) => ({
-          color: getRunStatusColor(runStatus[status]).pftoken.value,
+        values={Object.keys(ComputedStatus).map((status) => ({
+          color: getRunStatusColor(ComputedStatus[status]).pftoken.value,
           name: status,
-          size: taskStatus[runStatus[status]],
+          size: taskStatus[ComputedStatus[status]],
         }))}
       />
     </Tooltip>

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/TaskStatusTooltip.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/TaskStatusTooltip.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { TaskStatus, runStatus, getRunStatusColor } from '../../../utils/pipeline-augment';
+import { ComputedStatus } from '../../../types';
+import { TaskStatus, getRunStatusColor } from '../../../utils/pipeline-augment';
 import './TaskStatusTooltip.scss';
 
 interface TaskStatusToolTipProps {
@@ -9,7 +10,7 @@ interface TaskStatusToolTipProps {
 const TaskStatusToolTip: React.FC<TaskStatusToolTipProps> = ({ taskStatus }) => {
   return (
     <div className="odc-task-status-tooltip">
-      {Object.keys(runStatus).map((status) => {
+      {Object.keys(ComputedStatus).map((status) => {
         const { message, pftoken } = getRunStatusColor(status);
         return taskStatus[status] ? (
           <React.Fragment key={status}>
@@ -18,7 +19,8 @@ const TaskStatusToolTip: React.FC<TaskStatusToolTipProps> = ({ taskStatus }) => 
               style={{ background: pftoken.value }}
             />
             <div>
-              {status === runStatus.PipelineNotStarted || status === runStatus.FailedToStart
+              {status === ComputedStatus.PipelineNotStarted ||
+              status === ComputedStatus.FailedToStart
                 ? message
                 : `${taskStatus[status]} ${message}`}
             </div>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationStepList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationStepList.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
-import { getRunStatusColor, runStatus } from '../../../../utils/pipeline-augment';
+import { ComputedStatus } from '../../../../types';
+import { getRunStatusColor } from '../../../../utils/pipeline-augment';
 import { StepStatus } from './pipeline-step-utils';
 import { StatusIcon } from './StatusIcon';
 
@@ -23,7 +24,7 @@ const TooltipColoredStatusIcon = ({ status }) => {
 
   const icon = <StatusIcon status={status} {...sharedProps} />;
 
-  if (status === runStatus.Succeeded || status === runStatus.Failed) {
+  if (status === ComputedStatus.Succeeded || status === ComputedStatus.Failed) {
     // Succeeded and Failed icons have transparent centers shapes - in tooltips, this becomes an undesired black
     // This will simply wrap the icon and place a white backdrop
     return (
@@ -59,7 +60,7 @@ export const PipelineVisualizationStepList: React.FC<PipelineVisualizationStepLi
           {t('pipelines-plugin~Finally task')}
         </div>
       )}
-      {steps.map(({ duration, name, runStatus: status }) => {
+      {steps.map(({ duration, name, status }) => {
         return (
           <div
             className={classNames('odc-pipeline-visualization-step-list__step', {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
@@ -12,8 +12,14 @@ import {
 import { referenceForModel } from '@console/internal/module/k8s';
 import { SvgDropShadowFilter } from '@console/topology/src/components/svg';
 import { PipelineRunModel, TaskModel, ClusterTaskModel } from '../../../../models';
-import { TektonTaskSpec, PipelineTaskRef, TaskKind, WhenExpression } from '../../../../types';
-import { runStatus, getRunStatusColor } from '../../../../utils/pipeline-augment';
+import {
+  ComputedStatus,
+  TektonTaskSpec,
+  PipelineTaskRef,
+  TaskKind,
+  WhenExpression,
+} from '../../../../types';
+import { getRunStatusColor } from '../../../../utils/pipeline-augment';
 import { WHEN_EXPRESSSION_DIAMOND_SIZE } from '../../pipeline-topology/const';
 import WhenExpressionDecorator from '../../pipeline-topology/WhenExpressionDecorator';
 import { createStepStatus, StepStatus, TaskStatus } from './pipeline-step-utils';
@@ -78,15 +84,21 @@ export const PipelineVisualizationTask: React.FC<PipelineVisualizationTaskProp> 
 }) => {
   const taskStatus = task.status || {
     duration: '',
-    reason: runStatus.Idle,
+    reason: ComputedStatus.Idle,
   };
-  if (pipelineRunStatus === runStatus.Failed || pipelineRunStatus === runStatus.Cancelled) {
-    if (task.status?.reason === runStatus.Idle || task.status?.reason === runStatus.Pending) {
-      taskStatus.reason = runStatus.Cancelled;
+  if (
+    pipelineRunStatus === ComputedStatus.Failed ||
+    pipelineRunStatus === ComputedStatus.Cancelled
+  ) {
+    if (
+      task.status?.reason === ComputedStatus.Idle ||
+      task.status?.reason === ComputedStatus.Pending
+    ) {
+      taskStatus.reason = ComputedStatus.Cancelled;
     }
   }
   if (isSkipped) {
-    taskStatus.reason = runStatus.Skipped;
+    taskStatus.reason = ComputedStatus.Skipped;
   }
 
   const taskComponent = (
@@ -153,15 +165,15 @@ const TaskComponent: React.FC<TaskProps> = ({
     ? `${resourcePathFromModel(PipelineRunModel, pipelineRunName, namespace)}/logs/${name}`
     : undefined;
   const enableLogLink =
-    status?.reason !== runStatus.Idle &&
-    status?.reason !== runStatus.Pending &&
-    status?.reason !== runStatus.Cancelled &&
+    status?.reason !== ComputedStatus.Idle &&
+    status?.reason !== ComputedStatus.Pending &&
+    status?.reason !== ComputedStatus.Cancelled &&
     !!path;
   const hasWhenExpression = pipelineTask?.when?.length > 0;
   const hasRunAfter = pipelineTask?.runAfter?.length > 0;
   const taskStatusColor = status
     ? getRunStatusColor(status.reason).pftoken.value
-    : getRunStatusColor(runStatus.Cancelled).pftoken.value;
+    : getRunStatusColor(ComputedStatus.Cancelled).pftoken.value;
 
   const [hover, hoverRef] = useHover();
   const truncatedVisualName = React.useMemo(
@@ -213,8 +225,9 @@ const TaskComponent: React.FC<TaskProps> = ({
           >
             <g
               className={cx({
-                'fa-spin odc-pipeline-vis-task--icon-spin': status.reason === runStatus.Running,
-                'odc-pipeline-vis-task--icon-stop': status.reason !== runStatus.Running,
+                'fa-spin odc-pipeline-vis-task--icon-spin':
+                  status.reason === ComputedStatus.Running,
+                'odc-pipeline-vis-task--icon-stop': status.reason !== ComputedStatus.Running,
               })}
             >
               <StatusIcon status={status.reason} disableSpin />
@@ -296,7 +309,7 @@ const SvgTaskStatus: React.FC<SvgTaskStatusProps> = ({ steps, x, y, width }) => 
             y={y}
             width={stepWidth - gap}
             height={2}
-            fill={getRunStatusColor(step.runStatus).pftoken.value}
+            fill={getRunStatusColor(step.status).pftoken.value}
           />
         );
       })}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/StatusIcon.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/StatusIcon.tsx
@@ -9,7 +9,8 @@ import {
   SyncAltIcon,
 } from '@patternfly/react-icons';
 import * as cx from 'classnames';
-import { getRunStatusColor, runStatus } from '../../../../utils/pipeline-augment';
+import { ComputedStatus } from '../../../../types';
+import { getRunStatusColor } from '../../../../utils/pipeline-augment';
 
 interface StatusIconProps {
   status: string;
@@ -20,24 +21,24 @@ interface StatusIconProps {
 
 export const StatusIcon: React.FC<StatusIconProps> = ({ status, disableSpin, ...props }) => {
   switch (status) {
-    case runStatus['In Progress']:
-    case runStatus.Running:
+    case ComputedStatus['In Progress']:
+    case ComputedStatus.Running:
       return <SyncAltIcon {...props} className={cx({ 'fa-spin': !disableSpin })} />;
 
-    case runStatus.Succeeded:
+    case ComputedStatus.Succeeded:
       return <CheckCircleIcon {...props} />;
 
-    case runStatus.Failed:
+    case ComputedStatus.Failed:
       return <ExclamationCircleIcon {...props} />;
 
-    case runStatus.Idle:
-    case runStatus.Pending:
+    case ComputedStatus.Idle:
+    case ComputedStatus.Pending:
       return <HourglassHalfIcon {...props} />;
 
-    case runStatus.Cancelled:
+    case ComputedStatus.Cancelled:
       return <BanIcon {...props} />;
 
-    case runStatus.Skipped:
+    case ComputedStatus.Skipped:
       return <AngleDoubleRightIcon {...props} />;
 
     default:
@@ -51,7 +52,7 @@ export const ColoredStatusIcon: React.FC<StatusIconProps> = ({ status, ...others
       style={{
         color: status
           ? getRunStatusColor(status).pftoken.value
-          : getRunStatusColor(runStatus.Cancelled).pftoken.value,
+          : getRunStatusColor(ComputedStatus.Cancelled).pftoken.value,
       }}
     >
       <StatusIcon status={status} {...others} />

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/pipeline-step-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/pipeline-step-utils.ts
@@ -1,4 +1,4 @@
-import { runStatus } from '../../../../utils/pipeline-augment';
+import { ComputedStatus } from '../../../../types';
 import { calculateDuration } from '../../../../utils/pipeline-utils';
 
 enum TerminatedReasons {
@@ -17,7 +17,7 @@ export type TaskStatusStep = {
 };
 
 export type TaskStatus = {
-  reason: runStatus;
+  reason: ComputedStatus;
   duration?: string;
   steps?: TaskStatusStep[];
 };
@@ -48,32 +48,32 @@ const getMatchingStepDuration = (matchingStep?: TaskStatusStep) => {
 export type StepStatus = {
   duration: string | null;
   name: string;
-  runStatus: runStatus;
+  status: ComputedStatus;
 };
 
 export const createStepStatus = (step: { name: string }, status: TaskStatus): StepStatus => {
-  let stepRunStatus: runStatus = runStatus.PipelineNotStarted;
+  let stepRunStatus: ComputedStatus = ComputedStatus.PipelineNotStarted;
   let duration: string = null;
 
   if (!status || !status.reason) {
-    stepRunStatus = runStatus.Cancelled;
-  } else if (status.reason === runStatus['In Progress']) {
+    stepRunStatus = ComputedStatus.Cancelled;
+  } else if (status.reason === ComputedStatus['In Progress']) {
     // In progress, try to get granular statuses
     const matchingStep: TaskStatusStep = getMatchingStep(step, status);
 
     if (!matchingStep) {
-      stepRunStatus = runStatus.Pending;
+      stepRunStatus = ComputedStatus.Pending;
     } else if (matchingStep.terminated) {
       stepRunStatus =
         matchingStep.terminated.reason === TerminatedReasons.Completed
-          ? runStatus.Succeeded
-          : runStatus.Failed;
+          ? ComputedStatus.Succeeded
+          : ComputedStatus.Failed;
       duration = getMatchingStepDuration(matchingStep);
     } else if (matchingStep.running) {
-      stepRunStatus = runStatus['In Progress'];
+      stepRunStatus = ComputedStatus['In Progress'];
       duration = getMatchingStepDuration(matchingStep);
     } else if (matchingStep.waiting) {
-      stepRunStatus = runStatus.Pending;
+      stepRunStatus = ComputedStatus.Pending;
     }
   } else {
     // Not in progress, just use the run status reason
@@ -85,6 +85,6 @@ export const createStepStatus = (step: { name: string }, status: TaskStatus): St
   return {
     duration,
     name: step.name,
-    runStatus: stepRunStatus,
+    status: stepRunStatus,
   };
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
@@ -4,7 +4,10 @@ import { ResourceLink, Timestamp } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineModel, PipelineRunModel } from '../../../models';
 import { PipelineWithLatest } from '../../../types';
-import { pipelineFilterReducer } from '../../../utils/pipeline-filter-reducer';
+import {
+  pipelineFilterReducer,
+  pipelineTitleFilterReducer,
+} from '../../../utils/pipeline-filter-reducer';
 import LinkedPipelineRunTaskStatus from '../../pipelineruns/status/LinkedPipelineRunTaskStatus';
 import PipelineRunStatus from '../../pipelineruns/status/PipelineRunStatus';
 import { tableColumnClasses } from './pipeline-table';
@@ -21,7 +24,7 @@ const PipelineStatus: React.FC<PipelineStatusProps> = ({ obj }) => {
   return (
     <PipelineRunStatus
       status={pipelineFilterReducer(obj)}
-      title={pipelineFilterReducer(obj)}
+      title={pipelineTitleFilterReducer(obj)}
       pipelineRun={obj.latestRun}
     />
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/WhenExpressionDecorator.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/WhenExpressionDecorator.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
-import { runStatus } from '../../../utils/pipeline-augment';
+import { ComputedStatus } from '../../../types';
 import { NODE_HEIGHT } from './const';
 import { getWhenExpressionDiamondState } from './utils';
 
@@ -11,7 +11,7 @@ type WhenExpressionDecoratorProps = {
   height: number;
   leftOffset?: number;
   stroke?: string;
-  status: runStatus;
+  status: ComputedStatus;
   appendLine?: boolean;
   enableTooltip?: boolean;
   isFinallyTask: boolean;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/WhenExpressionDecorator.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/WhenExpressionDecorator.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import { chart_color_green_400 as successColor } from '@patternfly/react-tokens/dist/js/chart_color_green_400';
 import { shallow, ShallowWrapper } from 'enzyme';
-import { runStatus } from '../../../../utils/pipeline-augment';
+import { ComputedStatus } from '../../../../types';
 import WhenExpressionDecorator from '../WhenExpressionDecorator';
 
 type WhenExpressionDecoratorProps = React.ComponentProps<typeof WhenExpressionDecorator>;
@@ -15,7 +15,7 @@ describe('WhenExpressionDecorator', () => {
   const props: WhenExpressionDecoratorProps = {
     width: 10,
     height: 10,
-    status: runStatus.Failed,
+    status: ComputedStatus.Failed,
     isPipelineRun: true,
     isFinallyTask: false,
   };
@@ -64,28 +64,28 @@ describe('WhenExpressionDecorator', () => {
   });
 
   it('should contain the succeeded tooltip content if the task status is succeeded', () => {
-    wrapper.setProps({ enableTooltip: true, status: runStatus.Succeeded });
+    wrapper.setProps({ enableTooltip: true, status: ComputedStatus.Succeeded });
     const tooltip = wrapper.find(Tooltip);
     expect(tooltip.props().content).toEqual(whenExpressionContent('When expression was met'));
   });
 
   it('should contain the skipped tooltip content if the task status is skipped', () => {
-    wrapper.setProps({ enableTooltip: true, status: runStatus.Skipped });
+    wrapper.setProps({ enableTooltip: true, status: ComputedStatus.Skipped });
     const tooltip = wrapper.find(Tooltip);
     expect(tooltip.props().content).toEqual(whenExpressionContent('When expression was not met'));
   });
 
   it('should contain the default tooltip content for other task status', () => {
-    wrapper.setProps({ enableTooltip: true, status: runStatus.PipelineNotStarted });
+    wrapper.setProps({ enableTooltip: true, status: ComputedStatus.PipelineNotStarted });
 
     expect(wrapper.find(Tooltip).props().content).toEqual(whenExpressionContent('When expression'));
-    wrapper.setProps({ enableTooltip: true, status: runStatus.Failed });
+    wrapper.setProps({ enableTooltip: true, status: ComputedStatus.Failed });
     expect(wrapper.find(Tooltip).props().content).toEqual(
       whenExpressionContent('When expression was met'),
     );
-    wrapper.setProps({ enableTooltip: true, status: runStatus.Pending });
+    wrapper.setProps({ enableTooltip: true, status: ComputedStatus.Pending });
     expect(wrapper.find(Tooltip).props().content).toEqual(whenExpressionContent('When expression'));
-    wrapper.setProps({ enableTooltip: true, status: runStatus['In Progress'] });
+    wrapper.setProps({ enableTooltip: true, status: ComputedStatus['In Progress'] });
     expect(wrapper.find(Tooltip).props().content).toEqual(whenExpressionContent('When expression'));
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
@@ -2,7 +2,7 @@ import { chart_color_black_400 as skippedColor } from '@patternfly/react-tokens/
 import { chart_color_blue_300 as runningColor } from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
 import { chart_color_green_400 as successColor } from '@patternfly/react-tokens/dist/js/chart_color_green_400';
 import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
-import { runStatus } from '../../../../utils/pipeline-augment';
+import { ComputedStatus } from '../../../../types';
 import {
   getLastRegularTasks,
   getTopologyNodesEdges,
@@ -148,7 +148,7 @@ describe('hasWhenExpression', () => {
 describe('When expression decorator color', () => {
   it('should return grey color in pipeline details page', () => {
     const { diamondColor, tooltipContent } = getWhenExpressionDiamondState(
-      runStatus.Idle,
+      ComputedStatus.Idle,
       false,
       false,
     );
@@ -158,7 +158,7 @@ describe('When expression decorator color', () => {
 
   it('should return light-grey color in pipeline details page', () => {
     const { diamondColor, tooltipContent } = getWhenExpressionDiamondState(
-      runStatus.Idle,
+      ComputedStatus.Idle,
       false,
       true,
     );
@@ -168,7 +168,7 @@ describe('When expression decorator color', () => {
 
   it('should return green color for failed task status in pipeline-run details page', () => {
     const { diamondColor, tooltipContent } = getWhenExpressionDiamondState(
-      runStatus.Failed,
+      ComputedStatus.Failed,
       true,
       true,
     );
@@ -178,7 +178,7 @@ describe('When expression decorator color', () => {
 
   it('should return blue color for running task status in pipeline-run details page', () => {
     const { diamondColor, tooltipContent } = getWhenExpressionDiamondState(
-      runStatus.Running,
+      ComputedStatus.Running,
       true,
       true,
     );
@@ -188,7 +188,7 @@ describe('When expression decorator color', () => {
 
   it('should return black color for skipped status in pipeline-run details page', () => {
     const { diamondColor, tooltipContent } = getWhenExpressionDiamondState(
-      runStatus.Skipped,
+      ComputedStatus.Skipped,
       true,
       true,
     );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
@@ -2,8 +2,8 @@ import { chart_color_green_400 as successColor } from '@patternfly/react-tokens/
 import * as dagre from 'dagre';
 import * as _ from 'lodash';
 import i18n from '@console/internal/i18n';
-import { PipelineKind, PipelineRunKind, PipelineTask } from '../../../types';
-import { getRunStatusColor, runStatus } from '../../../utils/pipeline-augment';
+import { ComputedStatus, PipelineKind, PipelineRunKind, PipelineTask } from '../../../types';
+import { getRunStatusColor } from '../../../utils/pipeline-augment';
 import { getPipelineTasks, getFinallyTasksWithStatus } from '../../../utils/pipeline-utils';
 import { CheckTaskErrorMessage } from '../pipeline-builder/types';
 import {
@@ -359,13 +359,13 @@ export const getLayoutData = (layout: PipelineLayout): dagre.GraphLabel => {
 };
 
 export const getWhenExpressionDiamondState = (
-  status: runStatus,
+  status: ComputedStatus,
   isPipelineRun: boolean,
   isFinallyTask: boolean,
 ): DiamondStateType => {
   let diamondColor: string;
   if (isPipelineRun) {
-    if (status === runStatus.Failed) {
+    if (status === ComputedStatus.Failed) {
       diamondColor = successColor.value;
     } else {
       diamondColor = getRunStatusColor(status).pftoken.value;
@@ -378,11 +378,11 @@ export const getWhenExpressionDiamondState = (
 
   let tooltipContent: string;
   switch (status) {
-    case runStatus.Succeeded:
-    case runStatus.Failed:
+    case ComputedStatus.Succeeded:
+    case ComputedStatus.Failed:
       tooltipContent = i18n.t('pipelines-plugin~When expression was met');
       break;
-    case runStatus.Skipped:
+    case ComputedStatus.Skipped:
       tooltipContent = i18n.t('pipelines-plugin~When expression was not met');
       break;
     default:

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunRow.tsx
@@ -11,7 +11,10 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../models';
 import { PipelineRunKind } from '../../types';
 import { getPipelineRunKebabActions } from '../../utils/pipeline-actions';
-import { pipelineRunFilterReducer } from '../../utils/pipeline-filter-reducer';
+import {
+  pipelineRunFilterReducer,
+  pipelineRunTitleFilterReducer,
+} from '../../utils/pipeline-filter-reducer';
 import { pipelineRunDuration } from '../../utils/pipeline-utils';
 import LinkedPipelineRunTaskStatus from '../pipelineruns/status/LinkedPipelineRunTaskStatus';
 import PipelineRunStatus from '../pipelineruns/status/PipelineRunStatus';
@@ -34,7 +37,7 @@ const PLRStatus: React.FC<PLRStatusProps> = ({ obj }) => {
   return (
     <PipelineRunStatus
       status={pipelineRunFilterReducer(obj)}
-      title={pipelineRunFilterReducer(obj)}
+      title={pipelineRunTitleFilterReducer(obj)}
       pipelineRun={obj}
     />
   );

--- a/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoryRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoryRow.tsx
@@ -11,7 +11,10 @@ import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watc
 import { referenceFor, referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel, RepositoryModel } from '../../../models';
 import { PipelineRunKind } from '../../../types';
-import { pipelineRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
+import {
+  pipelineRunFilterReducer,
+  pipelineRunTitleFilterReducer,
+} from '../../../utils/pipeline-filter-reducer';
 import { pipelineRunDuration } from '../../../utils/pipeline-utils';
 import LinkedPipelineRunTaskStatus from '../../pipelineruns/status/LinkedPipelineRunTaskStatus';
 import PipelineRunStatus from '../../pipelineruns/status/PipelineRunStatus';
@@ -77,7 +80,7 @@ const RepositoryRow: React.FC<RowFunctionArgs<RepositoryKind>> = ({ obj }) => {
         {loaded ? (
           <PipelineRunStatus
             status={pipelineRunFilterReducer(latestRun)}
-            title={pipelineRunFilterReducer(latestRun)}
+            title={pipelineRunTitleFilterReducer(latestRun)}
             pipelineRun={latestRun}
           />
         ) : (

--- a/frontend/packages/pipelines-plugin/src/components/shared/results/ResultsList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/results/ResultsList.tsx
@@ -3,8 +3,7 @@ import { Bullseye, EmptyState, EmptyStateBody, EmptyStateVariant } from '@patter
 import { TableComposable, Thead, Tbody, Th, Td, Tr } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 import { SectionHeading } from '@console/internal/components/utils';
-import { TektonResultsRun } from '../../../types';
-import { runStatus } from '../../../utils/pipeline-augment';
+import { ComputedStatus, TektonResultsRun } from '../../../types';
 import { handleURLs } from '../../../utils/render-utils';
 
 export interface ResultsListProps {
@@ -31,7 +30,7 @@ const ResultsList: React.FC<ResultsListProps> = ({ results, resourceName, status
   return (
     <>
       <SectionHeading text={t('pipelines-plugin~{{resourceName}} results', { resourceName })} />
-      {status !== runStatus.Failed ? (
+      {status !== ComputedStatus.Failed ? (
         <TableComposable
           aria-label={t('pipelines-plugin~{{resourceName}} results', { resourceName })}
           {...reactPropFix}

--- a/frontend/packages/pipelines-plugin/src/components/shared/results/__tests__/ResultsList.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/results/__tests__/ResultsList.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { EmptyState } from '@patternfly/react-core';
 import { TableComposable } from '@patternfly/react-table';
 import { ShallowWrapper, shallow } from 'enzyme';
-import { runStatus } from '../../../../utils/pipeline-augment';
+import { ComputedStatus } from '../../../../types';
 import { taskRunWithResults } from '../../../taskruns/__tests__/taskrun-test-data';
 import ResultsList, { ResultsListProps } from '../ResultsList';
 
@@ -12,7 +12,7 @@ describe('ResultsList', () => {
 
   beforeEach(() => {
     resultsListProps = {
-      status: runStatus.Succeeded,
+      status: ComputedStatus.Succeeded,
       resourceName: 'TaskRun',
       results: taskRunWithResults.status.taskResults,
     };
@@ -25,7 +25,7 @@ describe('ResultsList', () => {
   });
   it('Should render an EmptyState instead', () => {
     resultsListProps = {
-      status: runStatus.Failed,
+      status: ComputedStatus.Failed,
       resourceName: 'TaskRun',
       results: taskRunWithResults.status.taskResults,
     };

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/TaskRunDetailsStatus.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/TaskRunDetailsStatus.tsx
@@ -4,7 +4,10 @@ import { ResourceLink } from '@console/internal/components/utils';
 import { PodModel } from '@console/internal/models';
 import { Status } from '@console/shared';
 import { TaskRunKind } from '../../types';
-import { taskRunFilterReducer } from '../../utils/pipeline-filter-reducer';
+import {
+  taskRunFilterReducer,
+  taskRunFilterTitleReducer,
+} from '../../utils/pipeline-filter-reducer';
 import RunDetailsErrorLog from '../pipelineruns/logs/RunDetailsErrorLog';
 import WorkspaceResourceLinkList from '../shared/workspaces/WorkspaceResourceLinkList';
 import { getTRLogSnippet } from './logs/taskRunLogSnippet';
@@ -21,7 +24,10 @@ const TaskRunDetailsStatus = ({ taskRun }) => {
       <dl>
         <dt>{t('pipelines-plugin~Status')}</dt>
         <dd>
-          <Status status={taskRunFilterReducer(taskRun)} title={taskRunFilterReducer(taskRun)} />
+          <Status
+            status={taskRunFilterReducer(taskRun)}
+            title={taskRunFilterTitleReducer(taskRun)}
+          />
         </dd>
       </dl>
       <RunDetailsErrorLog

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/status/TaskRunStatus.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/status/TaskRunStatus.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { resourcePathFromModel } from '@console/internal/components/utils';
 import { TaskRunModel } from '../../../models';
 import { TaskRunKind } from '../../../types';
-import { taskRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
+import { taskRunFilterTitleReducer } from '../../../utils/pipeline-filter-reducer';
 import PipelineResourceStatus from '../../pipelineruns/status/PipelineResourceStatus';
 import StatusPopoverContent from '../../pipelineruns/status/StatusPopoverContent';
 import { getTRLogSnippet } from '../logs/taskRunLogSnippet';
@@ -16,7 +16,7 @@ type TaskRunStatusProps = {
 const TaskRunStatus: React.FC<TaskRunStatusProps> = ({ status, taskRun }) => {
   const { t } = useTranslation();
   return (
-    <PipelineResourceStatus status={status} title={taskRunFilterReducer(taskRun)}>
+    <PipelineResourceStatus status={status} title={taskRunFilterTitleReducer(taskRun)}>
       <StatusPopoverContent
         logDetails={getTRLogSnippet(taskRun)}
         namespace={taskRun.metadata.namespace}

--- a/frontend/packages/pipelines-plugin/src/topology/build-decorators/PipelineBuildDecoratorTooltip.tsx
+++ b/frontend/packages/pipelines-plugin/src/topology/build-decorators/PipelineBuildDecoratorTooltip.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from 'react-i18next';
 import HorizontalStackedBars from '../../components/charts/HorizontalStackedBars';
 import { useTaskStatus } from '../../components/pipelineruns/hooks/useTaskStatus';
 import TaskStatusToolTip from '../../components/pipelineruns/status/TaskStatusTooltip';
-import { PipelineRunKind } from '../../types';
-import { getRunStatusColor, runStatus } from '../../utils/pipeline-augment';
+import { ComputedStatus, PipelineRunKind } from '../../types';
+import { getRunStatusColor } from '../../utils/pipeline-augment';
 
 import './PipelineBuildDecoratorTooltip.scss';
 
@@ -27,10 +27,10 @@ const PipelineBuildDecoratorTooltip: React.FC<PipelineBuildDecoratorTooltipProps
     <HorizontalStackedBars
       height="1em"
       inline
-      values={Object.keys(runStatus).map((rStatus) => ({
-        color: getRunStatusColor(runStatus[rStatus]).pftoken.value,
+      values={Object.keys(ComputedStatus).map((rStatus) => ({
+        color: getRunStatusColor(ComputedStatus[rStatus]).pftoken.value,
         name: rStatus,
-        size: taskStatus[runStatus[rStatus]],
+        size: taskStatus[ComputedStatus[rStatus]],
       }))}
     />
   );

--- a/frontend/packages/pipelines-plugin/src/types/computedStatus.ts
+++ b/frontend/packages/pipelines-plugin/src/types/computedStatus.ts
@@ -1,0 +1,13 @@
+export enum ComputedStatus {
+  Succeeded = 'Succeeded',
+  Failed = 'Failed',
+  Running = 'Running',
+  'In Progress' = 'In Progress',
+  FailedToStart = 'FailedToStart',
+  PipelineNotStarted = 'PipelineNotStarted',
+  Skipped = 'Skipped',
+  Cancelled = 'Cancelled',
+  Pending = 'Pending',
+  Idle = 'Idle',
+  Other = '-',
+}

--- a/frontend/packages/pipelines-plugin/src/types/index.ts
+++ b/frontend/packages/pipelines-plugin/src/types/index.ts
@@ -4,3 +4,4 @@ export * from './pipelineRun';
 export * from './pipelineResource';
 export * from './task';
 export * from './taskRun';
+export * from './computedStatus';

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
@@ -9,14 +9,13 @@ import {
   TriggerBindingModel,
 } from '../../models';
 import { pipelineTestData, DataState, PipelineExampleNames } from '../../test-data/pipeline-data';
-import { PipelineKind } from '../../types';
+import { ComputedStatus, PipelineKind } from '../../types';
 import {
   getResources,
   augmentRunsToData,
   getTaskStatus,
   TaskStatus,
   getRunStatusColor,
-  runStatus,
   getResourceModelFromTask,
   pipelineRefExists,
   getPipelineFromPipelineRun,
@@ -88,14 +87,14 @@ describe('PipelineAugment test correct data is augmented', () => {
   });
 });
 
-describe('PipelineAugment test getRunStatusColor handles all runStatus values', () => {
+describe('PipelineAugment test getRunStatusColor handles all ComputedStatus values', () => {
   it('expect all but PipelineNotStarted to produce a non-default result', () => {
-    // Verify that we cover colour states for all the runStatus values
+    // Verify that we cover colour states for all the ComputedStatus values
     const failCase = 'PipelineNotStarted';
-    const defaultCase = getRunStatusColor(runStatus[failCase]);
-    const allOtherStatuses = Object.keys(runStatus)
-      .filter((status) => status !== failCase)
-      .map((status) => runStatus[status]);
+    const defaultCase = getRunStatusColor(ComputedStatus[failCase]);
+    const allOtherStatuses = Object.keys(ComputedStatus)
+      .filter((status) => status !== failCase && ComputedStatus[status] !== ComputedStatus.Other)
+      .map((status) => ComputedStatus[status]);
 
     expect(allOtherStatuses).not.toHaveLength(0);
     allOtherStatuses.forEach((statusValue) => {
@@ -106,7 +105,7 @@ describe('PipelineAugment test getRunStatusColor handles all runStatus values', 
   });
 
   it('expect all status colors to return visible text to show as a descriptor of the colour', () => {
-    const runStates = Object.values(runStatus);
+    const runStates = Object.values(ComputedStatus);
 
     expect(runStates).not.toHaveLength(0);
     runStates.forEach((statusValue) => {

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
@@ -10,7 +10,7 @@ import { ContainerStatus } from '@console/internal/module/k8s';
 import { SecretAnnotationId } from '../../components/pipelines/const';
 import { PipelineRunModel } from '../../models';
 import { DataState, PipelineExampleNames, pipelineTestData } from '../../test-data/pipeline-data';
-import { runStatus } from '../pipeline-augment';
+import { ComputedStatus } from '../../types';
 import {
   getPipelineTasks,
   containerToLogSourceStatus,
@@ -78,7 +78,7 @@ describe('pipeline-utils ', () => {
   it('should expect getLatestPipelineRunStatus to return a non-started state if not provided with valid data', () => {
     const emptyState: LatestPipelineRunStatus = {
       latestPipelineRun: null,
-      status: runStatus.PipelineNotStarted,
+      status: ComputedStatus.PipelineNotStarted,
     };
     expect(getLatestPipelineRunStatus(null)).toEqual(emptyState);
     expect(getLatestPipelineRunStatus([])).toEqual(emptyState);
@@ -260,21 +260,21 @@ describe('pipeline-utils ', () => {
       ]);
     });
     const taskList = appendPipelineRunStatus(pipeline, pipelineRunWithoutStatus);
-    expect(taskList.filter((t) => t.status.reason === runStatus.Idle)).toHaveLength(2);
+    expect(taskList.filter((t) => t.status.reason === ComputedStatus.Idle)).toHaveLength(2);
   });
 
   it('should append pipelineRun running status for all the tasks', () => {
     const { pipeline, pipelineRuns } = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
     const pipelineRun = pipelineRuns[DataState.IN_PROGRESS];
     const taskList = appendPipelineRunStatus(pipeline, pipelineRun);
-    expect(taskList.filter((t) => t.status.reason === runStatus.Running)).toHaveLength(2);
+    expect(taskList.filter((t) => t.status.reason === ComputedStatus.Running)).toHaveLength(2);
   });
 
   it('should append pipelineRun pending status for all the tasks if taskruns are not present and pipelinerun status is PipelineRunPending', () => {
     const { pipeline, pipelineRuns } = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
     const pipelineRun = pipelineRuns[DataState.PIPELINE_RUN_PENDING];
     const taskList = appendPipelineRunStatus(pipeline, pipelineRun);
-    expect(taskList.filter((t) => t.status.reason === runStatus.Idle)).toHaveLength(
+    expect(taskList.filter((t) => t.status.reason === ComputedStatus.Idle)).toHaveLength(
       pipeline.spec.tasks.length,
     );
   });
@@ -283,7 +283,7 @@ describe('pipeline-utils ', () => {
     const { pipeline, pipelineRuns } = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
     const pipelineRun = pipelineRuns[DataState.PIPELINE_RUN_CANCELLED];
     const taskList = appendPipelineRunStatus(pipeline, pipelineRun);
-    expect(taskList.filter((t) => t.status.reason === runStatus.Cancelled)).toHaveLength(
+    expect(taskList.filter((t) => t.status.reason === ComputedStatus.Cancelled)).toHaveLength(
       pipeline.spec.tasks.length,
     );
   });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-44634

**Analysis / Root cause**: 
The status return value was compared with English string but due to translation added the status was not matching

**Solution Description**: 
Created separate reducers for status value and title.

**Screen shots / Gifs for design review**: 

---Pipeline---
<img width="770" alt="Pasted Graphic 49" src="https://user-images.githubusercontent.com/102503482/172770390-e1ab0955-ae25-4572-9a83-a7a925b4fde2.png">



---PipelineRun---
<img width="816" alt="Pasted Graphic 50" src="https://user-images.githubusercontent.com/102503482/172770426-731ce5d6-6bb3-4eda-9728-878f5533b7b8.png">



----Logs----
<img width="698" alt="0 s2i-nodejs" src="https://user-images.githubusercontent.com/102503482/172770447-d29877c9-56ef-4100-875f-8281b1fa6531.png">



---- Task Run---
<img width="1201" alt="Pasted Graphic 52" src="https://user-images.githubusercontent.com/102503482/172770475-95db0bec-8ec7-4e70-b684-f8a910a51626.png">



---onClick  of status taking to logs tab---

https://user-images.githubusercontent.com/102503482/172770656-742f5fb4-b31e-490d-99c1-d19f2b05793d.mov


NOTE: Before changes screenshots are attached in https://issues.redhat.com/browse/OCPBUGSM-44634

**Unit test coverage report**: 
NA

**Test setup:**
1. Install OpenShift Pipelines operator
2. Import a component and enable Pipelines support (or create a Pipeline manually)
3. Navigate to the Pipeline list and inspect the colors
4. Open another tab to switch the language
5. Refresh the Pipeline list browser tab.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge