### PR TITLE
Bug 2095231: Fix default sidebar for resources like Kafka sink, Kafka connection 

### DIFF
--- a/frontend/packages/topology/src/components/side-bar/providers/SideBarTabHookResolver.tsx
+++ b/frontend/packages/topology/src/components/side-bar/providers/SideBarTabHookResolver.tsx
@@ -73,7 +73,7 @@ const TabBarTabHookResolver: React.FC<TabBarTabHookResolverProps> = ({
   );
 
   const [tabs, tabsLoaded] = React.useMemo(() => {
-    if (Object.keys(resolvedTabSections).length === 0) return [[], false];
+    if (Object.keys(resolvedTabSections).length === 0) return [[], true];
 
     const resolvedTabs: Tab[] = tabExtensions.reduce((acc, { id: tabId, label }) => {
       if (!resolvedTabSections[tabId]) {


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=2095231

**Description:** Default sidebar was not shown for the resources which don't contribute like Kafka sink, Kafka connection etc

**Screenshots:**

**Before:**

<img width="1789" alt="image" src="https://user-images.githubusercontent.com/5129024/172880202-95eb2d3e-b4e3-42b0-ae8e-a1d5800c3892.png">

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/5129024/172880306-971ad4a5-6ee5-4a68-91ab-2416a8a18376.png">


**After:**

<img width="1791" alt="image" src="https://user-images.githubusercontent.com/5129024/172879750-2d029dee-920b-4143-b47f-1e1a250519e5.png">

<img width="1787" alt="image" src="https://user-images.githubusercontent.com/5129024/172879852-f5e7e204-a5d5-41a9-acb8-5294d19db823.png">
