### PR TITLE
CONSOLE-3081: Adjust pf-c-card background color, when on dark theme, so that it is discernible.

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -226,6 +226,11 @@ form.pf-c-form {
   }
 }
 
+// Remove when upstream issue is addressed. https://github.com/patternfly/patternfly/issues/4889
+.pf-theme-dark .pf-c-card  {
+  --pf-c-card--BackgroundColor: var(--pf-global--BackgroundColor--dark-300);
+}
+
 .table {
   margin-bottom: 0;
   &--layout-fixed {


### PR DESCRIPTION
Upstream issue opened https://github.com/patternfly/patternfly/issues/4889

**Before and After**

<img width="1354" alt="Screen Shot 2022-06-09 at 3 43 54 PM" src="https://user-images.githubusercontent.com/1874151/172931630-6a1d4dde-22df-49f1-89bb-69e112d6feb8.png">
<img width="1351" alt="Screen Shot 2022-06-09 at 3 45 42 PM" src="https://user-images.githubusercontent.com/1874151/172931667-91dfac20-b0ca-40d9-987c-b5b3c93e2cf4.png">

----

<img width="1177" alt="Screen Shot 2022-06-09 at 3 43 11 PM" src="https://user-images.githubusercontent.com/1874151/172931925-ee4af6df-a25d-480a-8f66-2c722cae1c65.png">

<img width="1165" alt="Screen Shot 2022-06-09 at 3 09 24 PM" src="https://user-images.githubusercontent.com/1874151/172931939-81d3c4b0-ec79-4cdc-85de-c41e0557d413.png">

----
<img width="1068" alt="os-dark-card2" src="https://user-images.githubusercontent.com/1874151/172932461-2e672336-682c-4605-a455-f515971f303a.png">
<img width="935" alt="Screen Shot 2022-06-09 at 2 37 22 PM" src="https://user-images.githubusercontent.com/1874151/172932483-3e6bda0d-383d-45d4-83b8-efda3aae92ad.png">

