### PR TITLE
CONSOLE-3081: Adjust darkest purple resource color to one PF shade lighter for better contrast on dark theme.

### DIFF
--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -53,7 +53,7 @@ $color-application-dark: $pf-color-green-500;
 $color-configmap-dark: $pf-color-purple-600;
 $color-container-dark: $pf-color-blue-300;
 $color-error: $pf-color-red-100;
-$color-ingress-dark: $pf-color-purple-700;
+$color-ingress-dark: $pf-color-purple-600;
 $color-namespace-dark: $pf-color-green-600;
 $color-node-dark: $pf-color-purple-400;
 $color-pod-dark: $pf-color-cyan-300;


### PR DESCRIPTION
**Before and After**

<img width="637" alt="Screen Shot 2022-06-09 at 4 30 26 PM" src="https://user-images.githubusercontent.com/1874151/172938787-fbc37f3b-9334-4aa6-97b0-d1eda49c4657.png">
<img width="658" alt="Screen Shot 2022-06-09 at 4 15 13 PM" src="https://user-images.githubusercontent.com/1874151/172938808-dad78154-33d1-44cb-baae-2e71607f05fa.png">

---

<img width="380" alt="Screen Shot 2022-06-09 at 4 28 24 PM" src="https://user-images.githubusercontent.com/1874151/172938997-274088dd-a72d-4dc6-a98f-b480a3950a89.png">
<img width="378" alt="Screen Shot 2022-06-09 at 4 13 54 PM" src="https://user-images.githubusercontent.com/1874151/172939055-7f09177a-7e5a-4da9-a2d6-5cf713b04b90.png">



