### PR TITLE
Bug 2095687: fix issue with debugcontainer for build logs

### DIFF
--- a/frontend/public/components/utils/resource-log.tsx
+++ b/frontend/public/components/utils/resource-log.tsx
@@ -129,6 +129,9 @@ const FooterButton = ({ setStatus, linesBehind, className }) => {
   );
 };
 const showDebugAction = (pod: PodKind, containerName: string) => {
+  if (!containerName) {
+    return false;
+  }
   const containerStatus = pod?.status?.containerStatuses?.find((c) => c.name === containerName);
   if (pod?.status?.phase === 'Succeeded' || pod?.status?.phase === 'Pending') {
     return false;
@@ -145,7 +148,7 @@ const showDebugAction = (pod: PodKind, containerName: string) => {
     return false;
   }
 
-  return !containerStatus?.state?.running || !containerStatus.ready;
+  return !containerStatus?.state?.running || !containerStatus?.ready;
 };
 
 // Component for log stream controls


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=2095687

**Description:** Debug Container was shown in scenarios where container was not preset, added check and should be shown only if the container exists

**Screenshots/gif:**

Build Logs should now show Debug Container if the container doesn't exist

![buildLogDC](https://user-images.githubusercontent.com/5129024/173030701-3bece0c2-d65e-426f-b607-1ee6aa86b626.gif)


Should show Debug Container for a valid scenario like crash loop backoff

![podLogDC](https://user-images.githubusercontent.com/5129024/173031031-7be1477a-f4e9-4964-b4bb-4c0a6c905a7b.gif)

To reproduce the above create a Deployment with an image [quay.io/redhat-appstudio-qe/quarkus:7dd062e2e8cb4ba599185e48d628b65a](http://quay.io/redhat-appstudio-qe/quarkus:7dd062e2e8cb4ba599185e48d628b65a)
