### PR TITLE
Bug 2096053: [Dark Theme]: Add white background to Builder Image icons in Git import flow

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/ItemSelectorField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/ItemSelectorField.scss
@@ -16,7 +16,7 @@
     display: inline-flex;
     flex-direction: column;
     flex-flow: wrap;
-    background: var(--pf-global--Color--light-200);
+    background: var(--pf-global--BackgroundColor--200);
     padding: 4px;
 
     &__scrollbar {

--- a/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/SelectorCard.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/SelectorCard.scss
@@ -7,8 +7,11 @@
   border: 0;
 
   &__icon {
-    height: 32px;
+    height: 36px;
     max-width: 100%;
+    padding: var(--pf-global--spacer--xs);
+    border-radius: var(--pf-global--BorderRadius--sm);
+    background: var(--pf-global--palette--white);
   }
 
   &__title {


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGSM-45397

**Descriptions:**
- Add white background to Builder Image icons in Git import flow

**Screenshots:**

### **Before**
<img width="1506" alt="image" src="https://user-images.githubusercontent.com/2561818/173227501-b15701e1-b8c8-4ceb-b2be-98cab9735647.png">

### **After:**
<img width="1498" alt="image" src="https://user-images.githubusercontent.com/2561818/173227525-d992c1f8-b843-408b-b549-c14aafe3d9d9.png">
