### PR TITLE
Bug 2096394: Fix pf-c-card background color for Add page in Dark mode

### DIFF
--- a/frontend/packages/dev-console/src/components/add/AddPageLayout.scss
+++ b/frontend/packages/dev-console/src/components/add/AddPageLayout.scss
@@ -52,4 +52,8 @@
   &__additional-hint-block {
     padding-bottom: var(--pf-global--spacer--md);
   }
+
+  .pf-c-card {
+    --pf-c-card--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  }
 }


### PR DESCRIPTION
**Descriptions:**
- pf-c-card background color has been overridden in [PR](https://github.com/openshift/console/pull/11684) which affects the add page where we do not want to override it. This PR adds back the background color `--pf-global--BackgroundColor--100` for the pf-c-card for the add page.

**Screenshots:**
### **Before**
<img width="1501" alt="image" src="https://user-images.githubusercontent.com/2561818/173290671-01d49670-0d22-4c4f-bc29-77413a7f7549.png">


### **After:**
<img width="1501" alt="image" src="https://user-images.githubusercontent.com/2561818/173290460-6976e772-b554-4adc-9d1a-ced31a64943d.png">
