### PR TITLE
CONSOLE-3153: Expose timestamp component as part of the dynamic plugin sdk API

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -58,6 +58,7 @@
 56. [`ResourceYAMLEditor`](#resourceyamleditor)
 57. [`ResourceEventStream`](#resourceeventstream)
 58. [`usePrometheusPoll`](#useprometheuspoll)
+59. [`Timestamp`](#timestamp)
 
 ---
 
@@ -1363,5 +1364,27 @@ React hook to poll Prometheus for a single query.
 ### Returns
 
 A tuple containing the query response, a boolean flag indicating whether the response has completed, and any errors encountered during the request or post-processing of the request
+
+
+---
+
+## `Timestamp`
+
+### Summary
+
+A component to render timestamp.<br/>The timestamps are synchronized between invidual instances of the Timestamp component.<br/>The provided timestamp is formatted according to user locale.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `timestamp` | the timestamp to render. Format is expected to be ISO 8601 (used by Kubernetes), epoch timestamp, or an instance of a Date. |
+| `simple` | render simple version of the component omitting icon and tooltip. |
+| `omitSuffix` | formats the date ommiting the suffix. |
+| `className` | additional class name for the component. |
+
 
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -22,6 +22,7 @@ import {
   ResourceYAMLEditorProps,
   ResourceEventStreamProps,
   UsePrometheusPoll,
+  TimestampProps,
 } from '../extensions/console-types';
 import { StatusPopupSectionProps, StatusPopupItemProps } from '../extensions/dashboard-types';
 
@@ -238,3 +239,16 @@ export const usePrometheusPoll: UsePrometheusPoll = (options) => {
   // unify order with the rest of API
   return [result[0], !result[2], result[1]];
 };
+
+/**
+ * A component to render timestamp.
+ * The timestamps are synchronized between invidual instances of the Timestamp component.
+ * The provided timestamp is formatted according to user locale.
+ *
+ * @param {TimestampProps['timestamp']} timestamp - the timestamp to render. Format is expected to be ISO 8601 (used by Kubernetes), epoch timestamp, or an instance of a Date.
+ * @param {TimestampProps['simple']} simple - render simple version of the component omitting icon and tooltip.
+ * @param {TimestampProps['omitSuffix']} omitSuffix - formats the date ommiting the suffix.
+ * @param {TimestampProps['className']} className - additional class name for the component.
+ */
+export const Timestamp: React.FC<TimestampProps> = require('@console/internal/components/utils/timestamp')
+  .Timestamp;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -618,3 +618,10 @@ export type ResourceYAMLEditorProps = {
 export type ResourceEventStreamProps = {
   resource: K8sResourceCommon;
 };
+
+export type TimestampProps = {
+  timestamp: string | number | Date;
+  simple?: boolean;
+  omitSuffix?: boolean;
+  className?: string;
+};

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -76,14 +76,15 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
     critical: 'insights-plugin~critical',
   };
 
-  const lastRefreshTime = parseInt(lastGatherResponse?.data?.result?.[0]?.value?.[1] || '0', 10);
+  const lastRefreshTime =
+    parseInt(lastGatherResponse?.data?.result?.[0]?.value?.[1] || '0', 10) * 1000;
 
   return errorUpload(conditions) ? (
     <ErrorState />
   ) : (
     <Stack hasGutter>
       <StackItem>
-        {t('insights-plugin~Last refresh')}: <Timestamp timestamp={lastRefreshTime} isUnix simple />
+        {t('insights-plugin~Last refresh')}: <Timestamp timestamp={lastRefreshTime} simple />
       </StackItem>
       <StackItem className="text-muted">
         {t(

--- a/frontend/public/components/utils/timestamp.tsx
+++ b/frontend/public/components/utils/timestamp.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
-import { connect } from 'react-redux';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useSelector } from 'react-redux';
 import { Tooltip } from '@patternfly/react-core';
 import * as classNames from 'classnames';
 import { GlobeAmericasIcon } from '@patternfly/react-icons';
+import { TimestampProps } from '@console/dynamic-plugin-sdk';
 
 import * as dateTime from './datetime';
 
@@ -27,17 +30,16 @@ const timestampFor = (mdate: Date, now: Date, omitSuffix: boolean) => {
 
 const nowStateToProps = ({ UI }) => ({ now: UI.get('lastTick') });
 
-export const Timestamp = connect(nowStateToProps)((props: TimestampProps) => {
+export const Timestamp = (props: TimestampProps) => {
+  const now = useSelector(nowStateToProps);
   // Check for null. If props.timestamp is null, it returns incorrect date and time of Wed Dec 31 1969 19:00:00 GMT-0500 (Eastern Standard Time)
   if (!props.timestamp) {
     return <div className="co-timestamp">-</div>;
   }
 
-  const mdate = props.isUnix
-    ? new Date((props.timestamp as number) * 1000)
-    : new Date(props.timestamp);
+  const mdate = new Date(props.timestamp);
 
-  const timestamp = timestampFor(mdate, new Date(props.now), props.omitSuffix);
+  const timestamp = timestampFor(mdate, new Date(now), props.omitSuffix);
 
   if (!dateTime.isValid(mdate)) {
     return <div className="co-timestamp">-</div>;
@@ -61,15 +63,6 @@ export const Timestamp = connect(nowStateToProps)((props: TimestampProps) => {
       </Tooltip>
     </div>
   );
-});
-
-export type TimestampProps = {
-  timestamp: string | number;
-  isUnix?: boolean;
-  now: number;
-  simple?: boolean;
-  omitSuffix?: boolean;
-  className?: string;
 };
 
 Timestamp.displayName = 'Timestamp';


### PR DESCRIPTION
The PR exposes Timestamp component as a part of the SDK API.
The Timestamp uses redux to sync all Timestamp component instances at the same time so it is a good candidate for the SDK API package