### PR TITLE
Bug 2029797: if linkTo is false, do not attempt to get path

### DIFF
--- a/frontend/public/components/utils/resource-link.tsx
+++ b/frontend/public/components/utils/resource-link.tsx
@@ -87,7 +87,7 @@ export const ResourceLink: React.FC<ResourceLinkProps> = ({
     return null;
   }
   const kindReference = groupVersionKind ? getReference(groupVersionKind) : kind;
-  const path = resourcePath(kindReference, name, namespace);
+  const path = linkTo ? resourcePath(kindReference, name, namespace) : undefined;
   const value = displayName ? displayName : name;
   const classes = classNames('co-resource-item', className, {
     'co-resource-item--inline': inline,
@@ -96,7 +96,7 @@ export const ResourceLink: React.FC<ResourceLinkProps> = ({
   return (
     <span className={classes}>
       {!hideIcon && <ResourceIcon kind={kindReference} />}
-      {path && linkTo ? (
+      {path ? (
         <Link
           to={path}
           title={title}


### PR DESCRIPTION
Note this fixes an error that is different than the one described in the bug report as I am unable to reproduce the error in the bug report.

After:

https://user-images.githubusercontent.com/895728/173391121-ac839993-d18f-4140-940b-bae3cebfd475.mov