### PR TITLE
ODC-6660: Render topology differently based on zoom level

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/components/devConsoleComponetFactory.ts
+++ b/frontend/packages/dev-console/src/components/topology/components/devConsoleComponetFactory.ts
@@ -1,11 +1,7 @@
 import * as React from 'react';
-import {
-  GraphElement,
-  withDragNode,
-  withSelection,
-  withCreateConnector,
-} from '@patternfly/react-topology';
+import { GraphElement, withDragNode, withSelection } from '@patternfly/react-topology';
 import { contextMenuActions } from '@console/topology/src/actions';
+import { withCreateConnector } from '@console/topology/src/behavior';
 import {
   createConnectorCallback,
   nodeDragSourceSpec,

--- a/frontend/packages/helm-plugin/src/topology/components/helmComponentFactory.ts
+++ b/frontend/packages/helm-plugin/src/topology/components/helmComponentFactory.ts
@@ -1,12 +1,7 @@
 import * as React from 'react';
-import {
-  GraphElement,
-  withDragNode,
-  withSelection,
-  withDndDrop,
-  withCreateConnector,
-} from '@patternfly/react-topology';
+import { GraphElement, withDragNode, withSelection, withDndDrop } from '@patternfly/react-topology';
 import { contextMenuActions } from '@console/topology/src/actions/contextMenuActions';
+import { withCreateConnector } from '@console/topology/src/behavior';
 import {
   WorkloadNode,
   createConnectorCallback,

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeService.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeService.tsx
@@ -5,12 +5,12 @@ import {
   WithSelectionProps,
   WithContextMenuProps,
   WithDndDropProps,
-  WithCreateConnectorProps,
   useDragNode,
 } from '@patternfly/react-topology';
 import classNames from 'classnames';
 import { useAccessReview } from '@console/internal/components/utils';
 import { modelFor, referenceFor } from '@console/internal/module/k8s';
+import { WithCreateConnectorProps } from '@console/topology/src/behavior';
 import { nodeDragSourceSpec, GroupNode } from '@console/topology/src/components/graph-view';
 import { getKindStringAndAbbreviation } from '@console/topology/src/components/graph-view/components/nodes/nodeUtils';
 import { getResource } from '@console/topology/src/utils';
@@ -30,7 +30,7 @@ export type KnativeServiceProps = {
   WithContextMenuProps &
   WithCreateConnectorProps;
 
-const KnativeService: React.FC<KnativeServiceProps> = (props) => {
+const KnativeService: React.FC<KnativeServiceProps> = ({ children, ...props }) => {
   const { element } = props;
   const { data } = element.getData();
   const resourceObj = getResource(props.element);
@@ -62,7 +62,9 @@ const KnativeService: React.FC<KnativeServiceProps> = (props) => {
         badgeClassName={badgeClassName}
         dragging={dragging}
         dragNodeRef={dragNodeRef}
-      />
+      >
+        {children}
+      </GroupNode>
     );
   }
 
@@ -77,7 +79,9 @@ const KnativeService: React.FC<KnativeServiceProps> = (props) => {
       dragSpec={dragSpec}
       regrouping={regrouping}
       dragNodeRef={dragNodeRef}
-    />
+    >
+      {children}
+    </KnativeServiceGroup>
   );
 };
 

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
@@ -12,15 +12,14 @@ import {
   useAnchor,
   useDragNode,
   Layer,
-  useHover,
   createSvgIdUrl,
   useCombineRefs,
-  WithCreateConnectorProps,
   NodeLabel,
 } from '@patternfly/react-topology';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
+import { WithCreateConnectorProps, useHover } from '@console/topology/src/behavior';
 import {
   NodeShadows,
   NODE_SHADOW_FILTER_ID,
@@ -74,11 +73,14 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
   dndDropRef,
   editAccess,
   tooltipLabel,
+  children,
   onHideCreateConnector,
   onShowCreateConnector,
+  createConnectorDrag,
 }) => {
   const { t } = useTranslation();
-  const [hover, hoverRef] = useHover();
+  const [hoverChange, setHoverChange] = React.useState<boolean>(false);
+  const [hover, hoverRef] = useHover(200, 200, [hoverChange]);
   const [innerHover, innerHoverRef] = useHover();
   const dragProps = React.useMemo(() => ({ element }), [element]);
   const [{ dragging: labelDragging, regrouping: labelRegrouping }, dragLabelRef] = useDragNode(
@@ -112,6 +114,12 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
       }
     }
   }, [editAccess, innerHover, onShowCreateConnector, onHideCreateConnector]);
+
+  React.useEffect(() => {
+    if (!createConnectorDrag) {
+      setHoverChange((prev) => !prev);
+    }
+  }, [createConnectorDrag]);
 
   const decorators = getNodeDecorators(
     element,
@@ -208,6 +216,7 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
             {element.getLabel()}
           </NodeLabel>
         )}
+        {children}
       </g>
     </Tooltip>
   );

--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
@@ -5,10 +5,10 @@ import {
   withTargetDrag,
   withSelection,
   withDndDrop,
-  withCreateConnector,
 } from '@patternfly/react-topology';
 import { ViewComponentFactory } from '@console/dynamic-plugin-sdk/src/extensions/topology-types';
 import { contextMenuActions } from '@console/topology/src/actions';
+import { withCreateConnector } from '@console/topology/src/behavior';
 import {
   NodeComponentProps,
   withContextMenu,

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
@@ -8,7 +8,6 @@ import {
   WithContextMenuProps,
   useCombineRefs,
   WithDragNodeProps,
-  WithCreateConnectorProps,
   Edge,
   useAnchor,
   AnchorEnd,
@@ -19,6 +18,7 @@ import {
 import { DeploymentModel } from '@console/internal/models';
 import { referenceForModel, referenceFor } from '@console/internal/module/k8s';
 import { usePodsWatcher } from '@console/shared';
+import { WithCreateConnectorProps } from '@console/topology/src/behavior';
 import { PodSet } from '@console/topology/src/components/graph-view';
 import { BaseNode } from '@console/topology/src/components/graph-view/components/nodes';
 import { KafkaSinkModel } from '../../../models';
@@ -45,6 +45,7 @@ const EventSink: React.FC<EventSinkProps> = ({
   dndDropRef,
   onShowCreateConnector,
   contextMenuOpen,
+  children,
   ...rest
 }) => {
   useAnchor(EventSinkTargetAnchor, AnchorEnd.target, TYPE_EVENT_SINK_LINK);
@@ -135,6 +136,7 @@ const EventSink: React.FC<EventSinkProps> = ({
           {getEventSourceIcon(data.kind, resources.obj, element.getType())}
         </foreignObject>
       )}
+      {children}
     </BaseNode>
   );
 };

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.tsx
@@ -26,7 +26,12 @@ export type EventSourceProps = {
   WithContextMenuProps &
   WithCreateConnectorProps;
 
-const EventSource: React.FC<EventSourceProps> = ({ element, onShowCreateConnector, children, ...rest }) => {
+const EventSource: React.FC<EventSourceProps> = ({
+  element,
+  onShowCreateConnector,
+  children,
+  ...rest
+}) => {
   const { data, resources } = element.getData();
   const { width, height } = element.getBounds();
   const size = Math.min(width, height);

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.tsx
@@ -7,9 +7,9 @@ import {
   WithDndDropProps,
   WithContextMenuProps,
   WithDragNodeProps,
-  WithCreateConnectorProps,
   Edge,
 } from '@patternfly/react-topology';
+import { WithCreateConnectorProps } from '@console/topology/src/behavior';
 import { BaseNode } from '@console/topology/src/components/graph-view/components/nodes';
 import { getEventSourceIcon } from '../../../utils/get-knative-icon';
 import { TYPE_KAFKA_CONNECTION_LINK } from '../../const';
@@ -26,7 +26,7 @@ export type EventSourceProps = {
   WithContextMenuProps &
   WithCreateConnectorProps;
 
-const EventSource: React.FC<EventSourceProps> = ({ element, onShowCreateConnector, ...rest }) => {
+const EventSource: React.FC<EventSourceProps> = ({ element, onShowCreateConnector, children, ...rest }) => {
   const { data, resources } = element.getData();
   const { width, height } = element.getBounds();
   const size = Math.min(width, height);
@@ -62,6 +62,7 @@ const EventSource: React.FC<EventSourceProps> = ({ element, onShowCreateConnecto
           {getEventSourceIcon(data.kind, resources.obj, element.getType())}
         </foreignObject>
       )}
+      {children}
     </BaseNode>
   );
 };

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
@@ -9,10 +9,10 @@ import {
   useAnchor,
   WithDragNodeProps,
   AnchorEnd,
-  WithCreateConnectorProps,
   RectAnchor,
 } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
+import { WithCreateConnectorProps } from '@console/topology/src/behavior';
 import { BaseNode } from '@console/topology/src/components/graph-view/components/nodes';
 import { TYPE_AGGREGATE_EDGE } from '@console/topology/src/const';
 import { getTopologyResourceObject } from '@console/topology/src/utils';
@@ -40,6 +40,7 @@ const EventingPubSubNode: React.FC<EventingPubSubNodeProps> = ({
   element,
   canDrop,
   dropTarget,
+  children,
   ...rest
 }) => {
   useAnchor(PubSubSourceAnchor, AnchorEnd.source);
@@ -79,6 +80,7 @@ const EventingPubSubNode: React.FC<EventingPubSubNodeProps> = ({
           height={width * 0.5}
           xlinkHref={eventPubSubImg}
         />
+        {children}
       </BaseNode>
     </Tooltip>
   );

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/SinkUriNode.scss
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/SinkUriNode.scss
@@ -8,17 +8,9 @@
     pointer-events: none;
   }
 
-  .pf-topology__node__background {
-    fill: var(--pf-global--BackgroundColor--light-100);
-  }
-
   &.is-filtered .pf-topology__node__background {
     stroke-width: 2px;
     stroke: $filtered-stroke-color;
-  }
-  &.pf-m-selected .pf-topology__node__background {
-    stroke-width: 2px;
-    stroke: $selected-stroke-color;
   }
   &.pf-m-highlight .pf-topology__node__background {
     stroke: $interactive-stroke-color;

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/SinkUriNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/SinkUriNode.tsx
@@ -8,6 +8,9 @@ import {
   WithSelectionProps,
   WithDndDropProps,
   WithContextMenuProps,
+  useHover,
+  useVisualizationController,
+  ScaleDetailsLevel,
 } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
 import { calculateRadius } from '@console/shared';
@@ -27,32 +30,47 @@ export type SinkUriNodeProps = {
   WithContextMenuProps;
 
 const DECORATOR_RADIUS = 13;
-const SinkUriNode: React.FC<SinkUriNodeProps> = ({ element, canDrop, dropTarget, ...rest }) => {
+const SinkUriNode: React.FC<SinkUriNodeProps> = ({
+  element,
+  canDrop,
+  dropTarget,
+  contextMenuOpen,
+  ...rest
+}) => {
   const { t } = useTranslation();
   const { width, height } = element.getDimensions();
+  const [hover, hoverRef] = useHover();
   const sinkData = element.getData().data;
   const size = Math.min(width, height);
   const { radius } = calculateRadius(size);
   const cx = width / 2;
   const cy = height / 2;
+  const controller = useVisualizationController();
+  const detailsLevel = controller.getGraph().getDetailsLevel();
+  const showDetails = hover || contextMenuOpen || detailsLevel !== ScaleDetailsLevel.low;
 
-  const decorators = sinkData.sinkUri
-    ? [
-        <Tooltip key="URI" content={t('knative-plugin~Open URI')} position={TooltipPosition.right}>
-          <Decorator
-            x={cx + radius - DECORATOR_RADIUS * 0.7}
-            y={cy - radius + DECORATOR_RADIUS * 0.7}
-            radius={DECORATOR_RADIUS}
-            href={sinkData.sinkUri}
-            external
+  const decorators =
+    sinkData.sinkUri && showDetails
+      ? [
+          <Tooltip
+            key="URI"
+            content={t('knative-plugin~Open URI')}
+            position={TooltipPosition.right}
           >
-            <g transform={`translate(-${DECORATOR_RADIUS / 2}, -${DECORATOR_RADIUS / 2})`}>
-              <ExternalLinkAltIcon style={{ fontSize: DECORATOR_RADIUS }} title="Open URL" />
-            </g>
-          </Decorator>
-        </Tooltip>,
-      ]
-    : undefined;
+            <Decorator
+              x={cx + radius - DECORATOR_RADIUS * 0.7}
+              y={cy - radius + DECORATOR_RADIUS * 0.7}
+              radius={DECORATOR_RADIUS}
+              href={sinkData.sinkUri}
+              external
+            >
+              <g transform={`translate(-${DECORATOR_RADIUS / 2}, -${DECORATOR_RADIUS / 2})`}>
+                <ExternalLinkAltIcon style={{ fontSize: DECORATOR_RADIUS }} title="Open URL" />
+              </g>
+            </Decorator>
+          </Tooltip>,
+        ]
+      : undefined;
 
   return (
     <Tooltip
@@ -63,6 +81,7 @@ const SinkUriNode: React.FC<SinkUriNodeProps> = ({ element, canDrop, dropTarget,
     >
       <BaseNode
         className="odc-sink-uri"
+        hoverRef={hoverRef}
         createConnectorAccessVerb="create"
         kind={sinkData.kind}
         element={element}

--- a/frontend/packages/kubevirt-plugin/src/topology/components/kubevirtComponentFactory.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/components/kubevirtComponentFactory.ts
@@ -1,12 +1,7 @@
 import * as React from 'react';
-import {
-  GraphElement,
-  withCreateConnector,
-  withDndDrop,
-  withDragNode,
-  withSelection,
-} from '@patternfly/react-topology';
+import { GraphElement, withDndDrop, withDragNode, withSelection } from '@patternfly/react-topology';
 import { contextMenuActions } from '@console/topology/src/actions';
+import { withCreateConnector } from '@console/topology/src/behavior';
 import {
   CreateConnector,
   createConnectorCallback,

--- a/frontend/packages/kubevirt-plugin/src/topology/components/nodes/VmNode.tsx
+++ b/frontend/packages/kubevirt-plugin/src/topology/components/nodes/VmNode.tsx
@@ -8,12 +8,12 @@ import {
   RectAnchor,
   useAnchor,
   WithContextMenuProps,
-  WithCreateConnectorProps,
   WithDndDropProps,
   WithDragNodeProps,
   WithSelectionProps,
 } from '@patternfly/react-topology';
 import * as classNames from 'classnames';
+import { WithCreateConnectorProps } from '@console/topology/src/behavior';
 import { BaseNode } from '@console/topology/src/components/graph-view';
 import { TopologyDataObject } from '@console/topology/src/topology-types';
 import { VMStatus } from '../../../constants/vm/vm-status';
@@ -40,7 +40,13 @@ const VM_STATUS_GAP = 7;
 const VM_STATUS_WIDTH = 7;
 const VM_STATUS_RADIUS = 7;
 
-const ObservedVmNode: React.FC<VmNodeProps> = ({ element, canDrop, dropTarget, ...rest }) => {
+const ObservedVmNode: React.FC<VmNodeProps> = ({
+  element,
+  canDrop,
+  dropTarget,
+  children,
+  ...rest
+}) => {
   useAnchor(RectAnchor);
   const { width, height } = element.getBounds();
   const vmData = element.getData().data;
@@ -139,6 +145,7 @@ const ObservedVmNode: React.FC<VmNodeProps> = ({ element, canDrop, dropTarget, .
             height={height - (VM_STATUS_GAP + VM_STATUS_WIDTH) * 2}
           />
           {imageComponent}
+          {children}
         </BaseNode>
       </Tooltip>
     </g>

--- a/frontend/packages/pipelines-plugin/src/topology/getPipelinesDataModelReconciler.ts
+++ b/frontend/packages/pipelines-plugin/src/topology/getPipelinesDataModelReconciler.ts
@@ -2,6 +2,7 @@ import { Model } from '@patternfly/react-topology';
 import { TopologyDataResources } from '@console/topology/src/topology-types';
 import { getTopologyResourceObject } from '@console/topology/src/utils';
 import { getPipelinesAndPipelineRunsForResource } from '../utils/pipeline-plugin-utils';
+import { getLatestPipelineRunStatus } from '../utils/pipeline-utils';
 
 export const getPipelinesDataModelReconciler = (
   model: Model,
@@ -19,6 +20,8 @@ export const getPipelinesDataModelReconciler = (
       if (pipelineData) {
         node.data.resources.pipelines = pipelineData.pipelines;
         node.data.resources.pipelineRuns = pipelineData.pipelineRuns;
+        const { status } = getLatestPipelineRunStatus(pipelineData.pipelineRuns);
+        node.data.resources.pipelineRunStatus = status;
       }
     }
   });

--- a/frontend/packages/rhoas-plugin/src/topology/components/rhoasComponentFactory.ts
+++ b/frontend/packages/rhoas-plugin/src/topology/components/rhoasComponentFactory.ts
@@ -1,11 +1,7 @@
 import * as React from 'react';
-import {
-  GraphElement,
-  withDragNode,
-  withSelection,
-  withCreateConnector,
-} from '@patternfly/react-topology';
+import { GraphElement, withDragNode, withSelection } from '@patternfly/react-topology';
 import { contextMenuActions } from '@console/topology/src/actions/contextMenuActions';
+import { withCreateConnector } from '@console/topology/src/behavior';
 import {
   createConnectorCallback,
   nodeDragSourceSpec,

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -270,8 +270,8 @@ export const topologyPage = {
   },
   getKnativeRevision: (serviceName: string) => {
     return cy
-      .get('[data-type="knative-service"]')
-      .find('[data-type="knative-revision"] g.odc-workload-node')
+      .get('[data-type="knative-revision"]')
+      .find('g.odc-workload-node')
       .contains(serviceName);
   },
   waitForKnativeRevision: () => {

--- a/frontend/packages/topology/src/behavior/index.ts
+++ b/frontend/packages/topology/src/behavior/index.ts
@@ -1,0 +1,2 @@
+export { default as useHover } from './useHover';
+export * from './withCreateConnector';

--- a/frontend/packages/topology/src/behavior/useHover.ts
+++ b/frontend/packages/topology/src/behavior/useHover.ts
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { useCallbackRef } from '@patternfly/react-topology';
+
+//
+// Local version of the @patternfly/react-topology useHover
+// Updated to provide the capability to reset the hover state based on a dependency change
+//
+
+const EMPTY: any[] = [];
+
+const useHover = <T extends Element>(
+  delayIn: number = 200,
+  delayOut: number = 200,
+  dependencies: any[] = EMPTY,
+): [boolean, (node: T) => (() => void) | undefined] => {
+  const [hover, setHover] = React.useState<boolean>(false);
+  const mountRef = React.useRef(true);
+
+  // need to ensure we do not start the unset timer on unmount
+  React.useEffect(
+    () => () => {
+      mountRef.current = false;
+    },
+    [],
+  );
+
+  React.useEffect(() => {
+    setHover(false);
+    // dynamic dependencies
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, dependencies);
+
+  // The unset handle needs to be referred by listeners in different closures.
+  const unsetHandle = React.useRef<number>();
+
+  const callbackRef = useCallbackRef(
+    React.useCallback(
+      (node: T) => {
+        if (node) {
+          // store locally instead of a ref because it only needs to be referred by inner closures
+          let delayHandle: any;
+
+          const delayedStateChange = (newState: boolean, delay: number) => {
+            clearTimeout(unsetHandle.current);
+            clearTimeout(delayHandle);
+
+            if (delay != null) {
+              delayHandle = window.setTimeout(() => {
+                clearTimeout(unsetHandle.current);
+                setHover(newState);
+              }, delay);
+            } else {
+              setHover(newState);
+            }
+          };
+
+          const onMouseEnter = () => {
+            delayedStateChange(true, delayIn);
+          };
+
+          const onMouseLeave = () => {
+            delayedStateChange(false, delayOut);
+          };
+
+          node.addEventListener('mouseenter', onMouseEnter);
+          node.addEventListener('mouseleave', onMouseLeave);
+
+          return () => {
+            node.removeEventListener('mouseenter', onMouseEnter);
+            node.removeEventListener('mouseleave', onMouseLeave);
+            clearTimeout(delayHandle);
+            if (mountRef.current) {
+              // Queue the unset in case reattaching to a new node in the same location.
+              // This can happen with layers. Rendering a node to a new layer will unmount the old node
+              // and remount a new node at the same location. This will prevent flickering and getting
+              // stuck in a hover state.
+              unsetHandle.current = window.setTimeout(() => {
+                if (mountRef.current) {
+                  setHover(false);
+                }
+              }, Math.max(delayIn, delayOut));
+            }
+          };
+        }
+        return undefined;
+      },
+      [delayIn, delayOut],
+    ),
+  );
+
+  return [hover, callbackRef];
+};
+
+export default useHover;

--- a/frontend/packages/topology/src/behavior/withCreateConnector.tsx
+++ b/frontend/packages/topology/src/behavior/withCreateConnector.tsx
@@ -1,0 +1,324 @@
+import * as React from 'react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/Topology/topology-components';
+import {
+  hullPath,
+  DefaultCreateConnector,
+  Point,
+  Layer,
+  ContextMenu,
+  ContextMenuItem,
+  AnchorEnd,
+  Graph,
+  GraphElement,
+  isGraph,
+  isNode,
+  LabelPosition,
+  Node,
+  DragEvent,
+  DragObjectWithType,
+  DragOperationWithType,
+  DragSourceMonitor,
+  DragSourceSpec,
+  DragSpecOperationType,
+  useDndDrag,
+  TOP_LAYER,
+  useCombineRefs,
+  useHover,
+} from '@patternfly/react-topology';
+import { observer } from 'mobx-react';
+
+//
+// Local version of the @patternfly/react-topology withCreateConnector
+// Updated to notify the wrapped component when the create connector is being dragged
+//
+
+export const CREATE_CONNECTOR_OPERATION = '#createconnector#';
+export const CREATE_CONNECTOR_DROP_TYPE = '#createConnector#';
+
+export interface ConnectorChoice {
+  label: string;
+}
+
+export interface CreateConnectorOptions {
+  handleAngle?: number;
+  handleAngleTop?: number;
+  handleLength?: number;
+  dragItem?: DragObjectWithType;
+  dragOperation?: DragOperationWithType;
+  hideConnectorMenu?: boolean;
+}
+
+interface ConnectorComponentProps {
+  startPoint: Point;
+  endPoint: Point;
+  hints: string[];
+  dragging: boolean;
+  hover?: boolean;
+}
+
+type CreateConnectorRenderer = React.ComponentType<ConnectorComponentProps>;
+
+type OnCreateResult = ConnectorChoice[] | void | undefined | null | React.ReactElement[];
+
+type CreateConnectorWidgetProps = {
+  element: Node;
+  onKeepAlive: (isAlive: boolean) => void;
+  onCreate: (
+    element: Node,
+    target: Node | Graph,
+    event: DragEvent,
+    dropHints?: string[] | undefined,
+    choice?: ConnectorChoice,
+  ) => Promise<OnCreateResult> | OnCreateResult;
+  ConnectorComponent: CreateConnectorRenderer;
+  contextMenuClass?: string;
+} & CreateConnectorOptions;
+
+interface CollectProps {
+  event?: DragEvent;
+  dragging: boolean;
+  hints?: string[] | undefined;
+}
+
+interface PromptData {
+  element: Node;
+  target: Node | Graph;
+  event: DragEvent;
+  choices: ConnectorChoice[] | React.ReactElement[];
+}
+
+const isReactElementArray = (
+  choices: ConnectorChoice[] | React.ReactElement[],
+): choices is React.ReactElement[] => React.isValidElement(choices[0]);
+
+const DEFAULT_HANDLE_ANGLE = Math.PI / 180;
+const DEFAULT_HANDLE_ANGLE_TOP = 1.5 * Math.PI;
+const DEFAULT_HANDLE_LENGTH = 32;
+
+const CreateConnectorWidget: React.FunctionComponent<CreateConnectorWidgetProps> = observer(
+  (props) => {
+    const {
+      element,
+      onKeepAlive,
+      onCreate,
+      ConnectorComponent,
+      handleAngle = DEFAULT_HANDLE_ANGLE,
+      handleAngleTop = DEFAULT_HANDLE_ANGLE_TOP,
+      handleLength = DEFAULT_HANDLE_LENGTH,
+      contextMenuClass,
+      dragItem,
+      dragOperation,
+      hideConnectorMenu,
+    } = props;
+    const [prompt, setPrompt] = React.useState<PromptData | null>(null);
+    const [active, setActive] = React.useState(false);
+    const hintsRef = React.useRef<string[] | undefined>();
+
+    const spec = React.useMemo(() => {
+      const dragSourceSpec: DragSourceSpec<
+        DragObjectWithType,
+        DragSpecOperationType<DragOperationWithType>,
+        GraphElement,
+        CollectProps,
+        CreateConnectorWidgetProps
+      > = {
+        item: dragItem || { type: CREATE_CONNECTOR_DROP_TYPE },
+        operation: dragOperation || { type: CREATE_CONNECTOR_OPERATION },
+        begin: (monitor: DragSourceMonitor, dragProps: any) => {
+          setActive(true);
+          return dragProps.element;
+        },
+        drag: (event: DragEvent, monitor: DragSourceMonitor, p: CreateConnectorWidgetProps) => {
+          p.element.raise();
+        },
+        end: async (
+          dropResult: GraphElement,
+          monitor: DragSourceMonitor,
+          dragProps: CreateConnectorWidgetProps,
+        ) => {
+          const event = monitor.getDragEvent();
+          if ((isNode(dropResult) || isGraph(dropResult)) && event) {
+            const choices = await dragProps.onCreate(
+              dragProps.element,
+              dropResult,
+              event,
+              monitor.getDropHints(),
+            );
+            if (choices && choices.length && !hideConnectorMenu) {
+              setPrompt({ element: dragProps.element, target: dropResult, event, choices });
+              return;
+            }
+          }
+          setActive(false);
+          dragProps.onKeepAlive(false);
+        },
+        collect: (monitor) => ({
+          dragging: !!monitor.getItem(),
+          event: monitor.isDragging() ? monitor.getDragEvent() : undefined,
+          hints: monitor.getDropHints(),
+        }),
+      };
+      return dragSourceSpec;
+    }, [setActive, dragItem, dragOperation, hideConnectorMenu]);
+    const [{ dragging, event, hints }, dragRef] = useDndDrag(spec, props);
+    const [hover, hoverRef] = useHover();
+    const refs = useCombineRefs(dragRef, hoverRef);
+
+    if (!active && dragging && !event) {
+      // another connector is dragging right now
+      return null;
+    }
+
+    if (dragging) {
+      // store the latest hints
+      hintsRef.current = hints;
+    }
+
+    const dragEvent = prompt ? prompt.event : event;
+
+    let startPoint: Point;
+    let endPoint: Point;
+
+    if (dragEvent) {
+      endPoint = new Point(dragEvent.x, dragEvent.y);
+      startPoint = element.getAnchor(AnchorEnd.source).getLocation(endPoint);
+    } else {
+      const bounds = element.getBounds();
+      const isRightLabel = element.getLabelPosition() === LabelPosition.right;
+      const referencePoint = isRightLabel
+        ? new Point(bounds.x + bounds.width / 2, bounds.y)
+        : new Point(
+            bounds.right(),
+            Math.tan(handleAngle) * (bounds.width / 2) + bounds.y + bounds.height / 2,
+          );
+      startPoint = element.getAnchor(AnchorEnd.source).getLocation(referencePoint);
+      endPoint = new Point(
+        Math.cos(isRightLabel ? handleAngleTop : handleAngle) * handleLength + startPoint.x,
+        Math.sin(isRightLabel ? handleAngleTop : handleAngle) * handleLength + startPoint.y,
+      );
+    }
+
+    // bring into the coordinate space of the element
+    element.translateFromParent(startPoint);
+    element.translateFromParent(endPoint);
+
+    const connector = (
+      <g
+        className={css(styles.topologyDefaultCreateConnector)}
+        ref={refs}
+        onMouseEnter={!active ? () => onKeepAlive(true) : undefined}
+        onMouseLeave={!active ? () => onKeepAlive(false) : undefined}
+      >
+        <ConnectorComponent
+          startPoint={startPoint}
+          endPoint={endPoint}
+          dragging={dragging}
+          hints={hintsRef.current || []}
+          hover={hover}
+        />
+        <path
+          d={hullPath(
+            [
+              [startPoint.x, startPoint.y],
+              [endPoint.x, endPoint.y],
+            ],
+            7,
+          )}
+          fillOpacity="0"
+        />
+      </g>
+    );
+
+    return (
+      <>
+        {active ? <Layer id={TOP_LAYER}>{connector}</Layer> : connector}
+        {prompt && (
+          <ContextMenu
+            reference={{ x: prompt.event.pageX, y: prompt.event.pageY }}
+            className={contextMenuClass}
+            open
+            onRequestClose={() => {
+              setActive(false);
+              onKeepAlive(false);
+            }}
+          >
+            {isReactElementArray(prompt.choices)
+              ? prompt.choices
+              : prompt.choices.map((c: ConnectorChoice) => (
+                  <ContextMenuItem
+                    key={c.label}
+                    onClick={() => {
+                      onCreate(prompt.element, prompt.target, prompt.event, hintsRef.current, c);
+                    }}
+                  >
+                    {c.label}
+                  </ContextMenuItem>
+                ))}
+          </ContextMenu>
+        )}
+      </>
+    );
+  },
+);
+
+interface ElementProps {
+  element: Node;
+}
+
+export interface WithCreateConnectorProps {
+  onShowCreateConnector: () => void;
+  onHideCreateConnector: () => void;
+  createConnectorDrag: boolean;
+}
+
+export const withCreateConnector = <P extends WithCreateConnectorProps & ElementProps>(
+  onCreate: React.ComponentProps<typeof CreateConnectorWidget>['onCreate'],
+  ConnectorComponent: CreateConnectorRenderer = DefaultCreateConnector,
+  contextMenuClass?: string,
+  options?: CreateConnectorOptions,
+) => (WrappedComponent: React.ComponentType<Partial<P>>) => {
+  const Component: React.FunctionComponent<Omit<P, keyof WithCreateConnectorProps>> = ({
+    children,
+    ...props
+  }) => {
+    const [show, setShow] = React.useState(false);
+    const [alive, setKeepAlive] = React.useState(false);
+    const onShowCreateConnector = React.useCallback(() => setShow(true), []);
+    const onHideCreateConnector = React.useCallback(() => setShow(false), []);
+    const onKeepAlive = React.useCallback(
+      (isAlive: boolean) => {
+        setKeepAlive((prev) => {
+          if (prev && !isAlive) {
+            onHideCreateConnector();
+          }
+          return isAlive;
+        });
+      },
+      [onHideCreateConnector],
+    );
+    return (
+      <WrappedComponent
+        {...(props as any)}
+        onShowCreateConnector={onShowCreateConnector}
+        onHideCreateConnector={onHideCreateConnector}
+        createConnectorDrag={alive}
+      >
+        {children}
+        {(show || alive) && (
+          <CreateConnectorWidget
+            {...options}
+            element={props.element}
+            onCreate={onCreate}
+            onKeepAlive={onKeepAlive}
+            ConnectorComponent={ConnectorComponent}
+            contextMenuClass={contextMenuClass}
+          />
+        )}
+      </WrappedComponent>
+    );
+  };
+  Component.displayName = `withCreateConnector(${WrappedComponent.displayName ||
+    WrappedComponent.name})`;
+  return observer(Component);
+};

--- a/frontend/packages/topology/src/components/graph-view/components/componentFactory.ts
+++ b/frontend/packages/topology/src/components/graph-view/components/componentFactory.ts
@@ -5,11 +5,11 @@ import {
   withTargetDrag,
   withSelection,
   withDndDrop,
-  withCreateConnector,
   DragObjectWithType,
   ComponentFactory,
 } from '@patternfly/react-topology';
 import { contextMenuActions, graphActionContext, groupActionContext } from '../../../actions';
+import { withCreateConnector } from '../../../behavior/withCreateConnector';
 import {
   TYPE_WORKLOAD,
   TYPE_CONNECTS_TO,

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/BaseNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/BaseNode.tsx
@@ -10,9 +10,7 @@ import {
   ScaleDetailsLevel,
   TOP_LAYER,
   useCombineRefs,
-  useHover,
   WithContextMenuProps,
-  WithCreateConnectorProps,
   WithDndDropProps,
   WithDragNodeProps,
   WithSelectionProps,
@@ -21,6 +19,8 @@ import classNames from 'classnames';
 import { useAccessReview } from '@console/internal/components/utils';
 import { K8sVerb, modelFor, referenceFor } from '@console/internal/module/k8s';
 import { RESOURCE_NAME_TRUNCATE_LENGTH } from '@console/shared';
+import useHover from '../../../../behavior/useHover';
+import { WithCreateConnectorProps } from '../../../../behavior/withCreateConnector';
 import { useSearchFilter } from '../../../../filters';
 import { useShowLabel } from '../../../../filters/useShowLabel';
 import { getTopologyResourceObject } from '../../../../utils/topology-utils';
@@ -71,9 +71,11 @@ const BaseNode: React.FC<BaseNodeProps> = ({
   onContextMenu,
   contextMenuOpen,
   createConnectorAccessVerb = 'patch',
+  createConnectorDrag,
   ...rest
 }) => {
-  const [hover, internalHoverRef] = useHover();
+  const [hoverChange, setHoverChange] = React.useState<boolean>(false);
+  const [hover, internalHoverRef] = useHover(200, 200, [hoverChange]);
   const nodeHoverRefs = useCombineRefs(internalHoverRef, hoverRef);
   const { width, height } = element.getDimensions();
   const cx = width / 2;
@@ -102,7 +104,11 @@ const BaseNode: React.FC<BaseNodeProps> = ({
         [`odc-resource-icon-${kindData.kindStr.toLowerCase()}`]: !kindData.kindColor,
       })
     : '';
-
+  React.useEffect(() => {
+    if (!createConnectorDrag) {
+      setHoverChange((prev) => !prev);
+    }
+  }, [createConnectorDrag]);
   return (
     <Layer id={hover || contextMenuOpen ? TOP_LAYER : DEFAULT_LAYER}>
       <g ref={nodeHoverRefs}>
@@ -113,7 +119,6 @@ const BaseNode: React.FC<BaseNodeProps> = ({
           truncateLength={RESOURCE_NAME_TRUNCATE_LENGTH}
           element={element}
           showLabel={showLabel}
-          scaleLabel={detailsLevel !== ScaleDetailsLevel.high}
           scaleNode={(hover || contextMenuOpen) && detailsLevel !== ScaleDetailsLevel.high}
           onShowCreateConnector={
             editAccess && detailsLevel !== ScaleDetailsLevel.low && onShowCreateConnector

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/BaseNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/BaseNode.tsx
@@ -111,7 +111,7 @@ const BaseNode: React.FC<BaseNodeProps> = ({
   }, [createConnectorDrag]);
   return (
     <Layer id={hover || contextMenuOpen ? TOP_LAYER : DEFAULT_LAYER}>
-      <g ref={nodeHoverRefs}>
+      <g ref={nodeHoverRefs} data-test-id={element.getLabel()}>
         <DefaultNode
           className={classNames('odc-base-node', className, {
             'is-filtered': filtered,

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/BindableNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/BindableNode.tsx
@@ -4,12 +4,12 @@ import {
   Node,
   useDndDrop,
   WithContextMenuProps,
-  WithCreateConnectorProps,
   WithDragNodeProps,
   WithSelectionProps,
 } from '@patternfly/react-topology';
 import * as openshiftImg from '@console/internal/imgs/logos/openshift.svg';
 import { modelFor, referenceFor, referenceForModel } from '@console/internal/module/k8s';
+import { WithCreateConnectorProps } from '@console/topology/src/behavior';
 import { getTopologyResourceObject } from '../../../../utils';
 import { getRelationshipProvider } from '../../../../utils/relationship-provider-utils';
 import BaseNode from './BaseNode';

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import {
   Node,
+  NodeStatus,
   observer,
   ScaleDetailsLevel,
+  useHover,
   useVisualizationController,
   WithContextMenuProps,
   WithCreateConnectorProps,
@@ -13,18 +15,129 @@ import {
 } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
-import { calculateRadius, PodRCData, usePodsWatcher } from '@console/shared';
+import { AlertSeverity } from '@console/internal/components/monitoring/types';
+import {
+  AllPodStatus,
+  calculateRadius,
+  getFiringAlerts,
+  getPodStatus,
+  getSeverityAlertType,
+  PodRCData,
+  useBuildConfigsWatcher,
+  usePodsWatcher,
+} from '@console/shared';
 import { getFilterById, SHOW_POD_COUNT_FILTER_ID, useDisplayFilters } from '../../../../filters';
-import { getTopologyResourceObject } from '../../../../utils/topology-utils';
+import { getResource, getTopologyResourceObject } from '../../../../utils/topology-utils';
 import BaseNode from './BaseNode';
 import { getNodeDecorators } from './decorators/getNodeDecorators';
 import PodSet, { podSetInnerRadius } from './PodSet';
 
 import './WorkloadNode.scss';
 
+const POD_STATUS_NORMAL = 1;
+const POD_STATUS_WARNING = 2;
+const POD_STATUS_DANGER = 3;
+
+const StatusSeverities = {
+  danger: [
+    'ContainerCannotRun',
+    'CrashLoopBackOff',
+    'Critical',
+    'ErrImagePull',
+    'Error',
+    'Failed',
+    'Failure',
+    'ImagePullBackOff',
+    'InstallCheckFailed',
+    'Lost',
+    'Rejected',
+    'UpgradeFailed',
+  ],
+  warning: [
+    'Cancelled',
+    'Deleting',
+    'Expired',
+    'Not Ready',
+    'Terminating',
+    'Warning',
+    'RequiresApproval',
+  ],
+  normal: [
+    'New',
+    'Pending',
+    'Planning',
+    'ContainerCreating',
+    'UpgradePending',
+    'In Progress',
+    'Installing',
+    'InstallReady',
+    'Replacing',
+    'Running',
+    'Updating',
+    'Upgrading',
+    'Accepted',
+    'Active',
+    'Bound',
+    'Complete',
+    'Completed',
+    'Created',
+    'Enabled',
+    'Succeeded',
+    'Ready',
+    'Up to date',
+    'Provisioned as node',
+    'Preferred',
+    'Connected',
+    'Info',
+    'Unknown',
+    'PipelineNotStarted',
+  ],
+};
+
+export const getNodePodStatus = (podStatus: AllPodStatus): number => {
+  switch (podStatus) {
+    case AllPodStatus.Failed:
+    case AllPodStatus.CrashLoopBackOff:
+      return POD_STATUS_DANGER;
+    case AllPodStatus.Warning:
+      return POD_STATUS_WARNING;
+    default:
+      return POD_STATUS_NORMAL;
+  }
+};
+
+export const getAggregateStatus = (
+  donutStatus: PodRCData,
+  alertSeverity: AlertSeverity,
+  buildStatus: string,
+  pipelineStatus: string,
+): NodeStatus => {
+  const worstPodStatus =
+    donutStatus?.pods?.reduce((acc, pod) => {
+      return Math.max(acc, getNodePodStatus(getPodStatus(pod)));
+    }, POD_STATUS_NORMAL) ?? NodeStatus.default;
+
+  if (
+    worstPodStatus === POD_STATUS_DANGER ||
+    alertSeverity === AlertSeverity.Critical ||
+    StatusSeverities.danger.includes(buildStatus) ||
+    StatusSeverities.danger.includes(pipelineStatus)
+  ) {
+    return NodeStatus.danger;
+  }
+  if (
+    worstPodStatus === POD_STATUS_WARNING ||
+    alertSeverity === AlertSeverity.Warning ||
+    StatusSeverities.warning.includes(buildStatus) ||
+    StatusSeverities.warning.includes(pipelineStatus)
+  ) {
+    return NodeStatus.warning;
+  }
+  return NodeStatus.default;
+};
+
 type WorkloadNodeProps = {
   element: Node;
-  hover?: boolean;
   dragging?: boolean;
   highlight?: boolean;
   canDrop?: boolean;
@@ -48,12 +161,14 @@ const WorkloadPodsNode: React.FC<WorkloadPodsNodeProps> = observer(function Work
   canDrop,
   dropTarget,
   dropTooltip,
+  contextMenuOpen,
   ...rest
 }) {
   const { t } = useTranslation();
   const { width, height } = element.getDimensions();
   const workloadData = element.getData().data;
   const filters = useDisplayFilters();
+  const [hover, hoverRef] = useHover();
   const size = Math.min(width, height);
   const { radius, decoratorRadius } = calculateRadius(size);
   const cx = width / 2;
@@ -64,11 +179,18 @@ const WorkloadPodsNode: React.FC<WorkloadPodsNodeProps> = observer(function Work
   const { decorators } = element.getGraph().getData();
   const controller = useVisualizationController();
   const detailsLevel = controller.getGraph().getDetailsLevel();
-  const nodeDecorators =
-    detailsLevel === ScaleDetailsLevel.high
-      ? getNodeDecorators(element, decorators, cx, cy, radius, decoratorRadius)
-      : null;
   const iconImageUrl = getImageForIconClass(workloadData.builderImage) ?? workloadData.builderImage;
+  const showDetails = hover || contextMenuOpen || detailsLevel !== ScaleDetailsLevel.low;
+  const nodeDecorators = showDetails
+    ? getNodeDecorators(element, decorators, cx, cy, radius, decoratorRadius)
+    : null;
+  const { monitoringAlerts } = workloadData;
+  const firingAlerts = getFiringAlerts(monitoringAlerts);
+  const severityAlertType = getSeverityAlertType(firingAlerts);
+  const resource = getResource(element);
+  const { buildConfigs } = useBuildConfigsWatcher(resource);
+  const buildStatus = buildConfigs?.[0]?.builds?.[0]?.status?.phase;
+  const pipelineStatus = element.getData()?.resources?.pipelineRunStatus ?? 'Unknown';
 
   return (
     <g className="odc-workload-node">
@@ -80,16 +202,22 @@ const WorkloadPodsNode: React.FC<WorkloadPodsNodeProps> = observer(function Work
       >
         <BaseNode
           className="odc-workload-node"
+          hoverRef={hoverRef}
           innerRadius={podSetInnerRadius(size, donutStatus)}
-          icon={!showPodCount ? iconImageUrl : undefined}
+          icon={showDetails && !showPodCount ? iconImageUrl : undefined}
           kind={workloadData.kind}
           element={element}
           dropTarget={dropTarget}
           canDrop={canDrop}
+          nodeStatus={
+            !showDetails &&
+            getAggregateStatus(donutStatus, severityAlertType, buildStatus, pipelineStatus)
+          }
           attachments={nodeDecorators}
+          contextMenuOpen={contextMenuOpen}
           {...rest}
         >
-          {donutStatus ? (
+          {donutStatus && showDetails ? (
             <PodSet size={size} x={cx} y={cy} data={donutStatus} showPodCount={showPodCount} />
           ) : null}
         </BaseNode>

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
@@ -8,7 +8,6 @@ import {
   useHover,
   useVisualizationController,
   WithContextMenuProps,
-  WithCreateConnectorProps,
   WithDndDropProps,
   WithDragNodeProps,
   WithSelectionProps,
@@ -26,6 +25,7 @@ import {
   useBuildConfigsWatcher,
   usePodsWatcher,
 } from '@console/shared';
+import { WithCreateConnectorProps } from '../../../../behavior/withCreateConnector';
 import { getFilterById, SHOW_POD_COUNT_FILTER_ID, useDisplayFilters } from '../../../../filters';
 import { getResource, getTopologyResourceObject } from '../../../../utils/topology-utils';
 import BaseNode from './BaseNode';
@@ -157,6 +157,7 @@ type WorkloadPodsNodeProps = WorkloadNodeProps & {
 const WorkloadPodsNode: React.FC<WorkloadPodsNodeProps> = observer(function WorkloadPodsNode({
   donutStatus,
   element,
+  children,
   urlAnchorRef,
   canDrop,
   dropTarget,
@@ -220,6 +221,7 @@ const WorkloadPodsNode: React.FC<WorkloadPodsNodeProps> = observer(function Work
           {donutStatus && showDetails ? (
             <PodSet size={size} x={cx} y={cy} data={donutStatus} showPodCount={showPodCount} />
           ) : null}
+          {children}
         </BaseNode>
       </Tooltip>
     </g>

--- a/frontend/packages/topology/src/filters/useShowLabel.tsx
+++ b/frontend/packages/topology/src/filters/useShowLabel.tsx
@@ -9,7 +9,7 @@ const useShowLabel = (hover: boolean): boolean => {
   const detailsLevel = controller.getGraph().getDetailsLevel();
   const showLabelsFilter = getFilterById(SHOW_LABELS_FILTER_ID, displayFilters);
 
-  return detailsLevel === ScaleDetailsLevel.high && (showLabelsFilter?.value || hover);
+  return hover || (detailsLevel === ScaleDetailsLevel.high && showLabelsFilter?.value);
 };
 
 export { useShowLabel };


### PR DESCRIPTION
**Fixes**: 
Implements [ODC-6660](https://issues.redhat.com/browse/ODC-6660)

**Analysis / Root cause**: 
As a user, I want the topology view to be less cluttered as I doom out showing only information that I can discern and still be able to get a feel for the status of my project.

**Solution Description**: 

- When zoomed to medium scale, all labels are hidden. Label are shown when hovering over the node.
- When zoomed to 30% scale, all labels, decorators, pod rings & icons will be hidden. Node shape remains the same, and background is either white, yellow or red. Background color is determined based on the worst status of pods, build, or alerts. When hovering over the node, it is scaled up to 1:1 scale so the entire node, label, and decorators are shown.

**Screen shots / Gifs for design review**: 
![console-zoom-details](https://user-images.githubusercontent.com/11633780/173403124-218fff14-b27e-4112-92d1-335a7902f5c1.gif)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge