### PR TITLE
Bug 2096392: [Dark Theme]: Add white background to node icons in Topology in dark mode

### DIFF
--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
@@ -117,6 +117,12 @@ const EventSink: React.FC<EventSinkProps> = ({
       {donutStatus && showDetails && !isKafkaSink && (
         <PodSet size={size * 0.75} x={width / 2} y={height / 2} data={donutStatus} />
       )}
+      <circle
+        cx={width * 0.5}
+        cy={height * 0.5}
+        r={width * 0.25}
+        fill="var(--pf-global--palette--white)"
+      />
       {typeof getEventSourceIcon(data.kind, resources.obj) === 'string' ? (
         <image
           x={width * 0.33}

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.scss
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.scss
@@ -23,6 +23,7 @@
   &__svg-icon svg {
     width: 100%;
     height: 100%;
+    fill: var(--pf-topology__node__label__icon--Color);
   }
 }
 

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.tsx
@@ -48,6 +48,12 @@ const EventSource: React.FC<EventSourceProps> = ({
       labelIcon={<EventSourceIcon />}
       {...rest}
     >
+      <circle
+        cx={width * 0.5}
+        cy={height * 0.5}
+        r={width * 0.25 + 6}
+        fill="var(--pf-global--palette--white)"
+      />
       {typeof getEventSourceIcon(data.kind, resources.obj) === 'string' ? (
         <image
           x={width * 0.25}

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.scss
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.scss
@@ -47,3 +47,9 @@
     }
   }
 }
+
+:root:where(.pf-theme-dark) .odc-eventing-pubsub {
+  &--image {
+    filter: brightness(1.5) invert(1) hue-rotate(180deg) saturate(4);
+  }
+}

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
@@ -79,6 +79,7 @@ const EventingPubSubNode: React.FC<EventingPubSubNodeProps> = ({
           width={width * 0.8}
           height={width * 0.5}
           xlinkHref={eventPubSubImg}
+          className="odc-eventing-pubsub--image"
         />
         {children}
       </BaseNode>

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/BaseNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/BaseNode.tsx
@@ -133,13 +133,21 @@ const BaseNode: React.FC<BaseNodeProps> = ({
         >
           <g data-test-id="base-node-handler">
             {icon && showDetails && (
-              <image
-                x={cx - iconRadius}
-                y={cy - iconRadius}
-                width={iconRadius * 2}
-                height={iconRadius * 2}
-                xlinkHref={icon}
-              />
+              <>
+                <circle
+                  fill="var(--pf-global--palette--white)"
+                  cx={cx}
+                  cy={cy}
+                  r={innerRadius + 6}
+                />
+                <image
+                  x={cx - iconRadius}
+                  y={cy - iconRadius}
+                  width={iconRadius * 2}
+                  height={iconRadius * 2}
+                  xlinkHref={icon}
+                />
+              </>
             )}
             {showDetails && children}
           </g>


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=2096392

**Screenshots:**
### **Before**
![image (5)](https://user-images.githubusercontent.com/2561818/173415565-67a4bf90-fa99-431e-b7b4-483b7d6c1136.png)

### **After**
![image (6)](https://user-images.githubusercontent.com/2561818/173415680-bb3bb1a1-f60a-4d06-acd4-710e08e80a92.png)
