### PR TITLE
CONSOLE-3179: Improve control over shared modules provided by Console to dynamic plugins

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/__tests__/shared-modules-init.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/__tests__/shared-modules-init.spec.ts
@@ -3,10 +3,6 @@ import { initSharedPluginModules } from '../shared-modules-init';
 import { getEntryModuleMocks } from '../utils/test-utils';
 
 describe('initSharedPluginModules', () => {
-  const expectSameValues = (arr1: string[], arr2: string[]) => {
-    expect(new Set(arr1)).toEqual(new Set(arr2));
-  };
-
   it('is consistent with sharedPluginModules definition', () => {
     const [, entryModule] = getEntryModuleMocks({});
 
@@ -14,7 +10,9 @@ describe('initSharedPluginModules', () => {
 
     expect(entryModule.init).toHaveBeenCalledTimes(1);
 
-    expectSameValues(Object.keys(entryModule.init.mock.calls[0][0]), sharedPluginModules);
+    expect(new Set(Object.keys(entryModule.init.mock.calls[0][0]))).toEqual(
+      new Set(sharedPluginModules),
+    );
   });
 
   it('supports plugins built with an older version of plugin SDK', () => {
@@ -26,6 +24,8 @@ describe('initSharedPluginModules', () => {
     expect(entryModule.override).toHaveBeenCalledTimes(1);
     expect(entryModule.init).not.toHaveBeenCalled();
 
-    expectSameValues(Object.keys(entryModule.override.mock.calls[0][0]), sharedPluginModules);
+    expect(new Set(Object.keys(entryModule.override.mock.calls[0][0]))).toEqual(
+      new Set(sharedPluginModules),
+    );
   });
 });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules.ts
@@ -1,3 +1,23 @@
+type SharedModuleMetadata = Partial<{
+  /**
+   * If `true`, only a single version of the module can be loaded at runtime.
+   *
+   * @default true
+   */
+  singleton: boolean;
+
+  /**
+   * If `true`, plugins will provide their own fallback version of the module.
+   *
+   * The fallback module will be loaded when a matching module is not found within
+   * the Console shared scope object. If the given module is declared as singleton
+   * and is already loaded, the fallback module will not load.
+   *
+   * @default false
+   */
+  allowFallback: boolean;
+}>;
+
 /**
  * Modules shared between the Console application and its dynamic plugins.
  */
@@ -15,4 +35,26 @@ export const sharedPluginModules = [
   'react-redux',
   'redux',
   'redux-thunk',
-];
+] as const;
+
+/**
+ * Metadata associated with the shared modules.
+ */
+export const sharedPluginModulesMetadata: Record<
+  typeof sharedPluginModules[number],
+  SharedModuleMetadata
+> = {
+  '@openshift-console/dynamic-plugin-sdk': {},
+  '@openshift-console/dynamic-plugin-sdk-internal': {},
+  '@patternfly/react-core': {},
+  '@patternfly/react-table': {},
+  '@patternfly/quickstarts': {},
+  react: {},
+  'react-helmet': { singleton: false, allowFallback: true },
+  'react-i18next': {},
+  'react-router': {},
+  'react-router-dom': {},
+  'react-redux': {},
+  redux: {},
+  'redux-thunk': {},
+};


### PR DESCRIPTION
Fixes [CONSOLE-3179](https://issues.redhat.com/browse/CONSOLE-3179)

All shared modules provided by Console to its dynamic plugins currently have the same configuration:
- `singleton: true` means there can be only a single version of the module loaded at runtime
- `import: false` means plugins will not attempt to bring their own fallback version of the module

This PR allows for better control over shared modules via the `sharedPluginModulesMetadata` object.

Additionally, `react-helmet` module metadata has been updated to `{ singleton: false, allowFallback: true }`.