### PR TITLE
Bug 2096374: Improve SLA stability by not fetching the subscription twice at the same time

### DIFF
--- a/frontend/public/components/utils/service-level.tsx
+++ b/frontend/public/components/utils/service-level.tsx
@@ -164,8 +164,10 @@ const useLoadServiceLevel = (): [boolean, boolean, (clusterID: string) => void] 
 
   return [loadingSecret, loadingServiceLevel, loadServiceLevel];
 };
+
 const useGetServiceLevel = (
   clusterIDParam: string,
+  loadServiceLevelIfNeeded: boolean,
 ): {
   level: string;
   daysRemaining: number | null;
@@ -184,7 +186,12 @@ const useGetServiceLevel = (
   const [loadingSecret, loadingServiceLevel, loadServiceLevel] = useLoadServiceLevel();
 
   React.useEffect(() => {
-    if (clusterID !== clusterIDParam && !loadingSecret && !loadingServiceLevel) {
+    if (
+      clusterID !== clusterIDParam &&
+      !loadingSecret &&
+      !loadingServiceLevel &&
+      loadServiceLevelIfNeeded
+    ) {
       loadServiceLevel(clusterIDParam);
     }
     // only on clusterID change
@@ -211,7 +218,10 @@ export const ServiceLevel: React.FC<{
   loading: React.ReactNode;
   children: React.ReactNode;
 }> = ({ clusterID, loading, children }) => {
-  const { hasSecretAccess, loadingSecret, loadingServiceLevel } = useGetServiceLevel(clusterID);
+  const { hasSecretAccess, loadingSecret, loadingServiceLevel } = useGetServiceLevel(
+    clusterID,
+    false,
+  );
 
   if (!showServiceLevel(clusterID)) {
     return null;
@@ -225,13 +235,15 @@ export const ServiceLevel: React.FC<{
 
   return <>{children}</>;
 };
+
 type ServiceLevelTextProps = {
   clusterID?: string;
   inline?: boolean;
 };
+
 export const ServiceLevelText: React.FC<ServiceLevelTextProps> = ({ clusterID, inline }) => {
   const { t } = useTranslation();
-  const { level, daysRemaining } = useGetServiceLevel(clusterID);
+  const { level, daysRemaining } = useGetServiceLevel(clusterID, false);
   const levelText = (
     <>
       {useServiceLevelText(level)}
@@ -271,13 +283,14 @@ export const ServiceLevelText: React.FC<ServiceLevelTextProps> = ({ clusterID, i
     </div>
   );
 };
+
 export const useServiceLevelTitle = (): string => {
   const { t } = useTranslation();
   return t('public~Service Level Agreement (SLA)');
 };
 
 export const useShowServiceLevelNotifications = (clusterID: string): boolean => {
-  const { level } = useGetServiceLevel(clusterID);
+  const { level } = useGetServiceLevel(clusterID, true);
   return level && (level === 'Eval' || level === 'None');
 };
 
@@ -286,7 +299,7 @@ export const ServiceLevelNotification: React.FC<{
   toggleNotificationDrawer: () => void;
 }> = ({ clusterID, toggleNotificationDrawer }) => {
   const { t } = useTranslation();
-  const { level, daysRemaining, trialDateEnd } = useGetServiceLevel(clusterID);
+  const { level, daysRemaining, trialDateEnd } = useGetServiceLevel(clusterID, false);
   const showServiceLevelNotification = useShowServiceLevelNotifications(clusterID);
 
   if (!showServiceLevelNotification) {


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2096374

**Analysis / Root cause**: 
SLA was fetched two times at the same time. This might confuse our e2e tests. The UI is flickering.

**Solution Description**: 
Fetch subscription only when `useGetServiceLevel` was called from `useShowServiceLevelNotifications`. `useShowServiceLevelNotifications` was used in the ConnectedNotificationDrawer, which was always rendered in app.jsx.

So it is not needed to call the API again from the components `ServiceLevelNotification` and `ServiceLevelText`.

**Screenrecording**: 

SLA API calls before:

https://user-images.githubusercontent.com/139310/175275581-2de30d67-08ce-4175-8c2b-4a9784cceeb8.mp4

SLA API calls with this PR:

https://user-images.githubusercontent.com/139310/175298429-a605416f-ec56-4a46-b143-dc51ac5915e5.mp4

Hmmm, got a 403, but that's not related to this error. Does PR based clusters doesn't have a valid SLA? :thinking: 

**Unit test coverage report**: 
Untouched

**Test setup:**
1. Open the network inspector and filter for `api/accounts_mgmt`
2. Reload the console
3. Check that the information from the SLA are still displayed correctly

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
