### PR TITLE
Bug 2093600: Added create call before delete call

### DIFF
--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
@@ -86,11 +86,11 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({
     if (updateRoles.length > 0) {
       roleBindingRequests.push(...sendRoleBindingRequest(Verb.Patch, updateRoles, roleBinding));
     }
-    if (removeRoles.length > 0) {
-      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Remove, removeRoles, roleBinding));
-    }
     if (newRoles.length > 0) {
       roleBindingRequests.push(...sendRoleBindingRequest(Verb.Create, newRoles, roleBinding));
+    }
+    if (removeRoles.length > 0) {
+      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Remove, removeRoles, roleBinding));
     }
 
     return Promise.all(roleBindingRequests)


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-45093

**Analysis / Root cause**: 
Delete call promise was called before create.

**Solution Description**: 
Added create call before delete call

**Screen shots / Gifs for design review**: 

---BEFORE---

https://bugzilla.redhat.com/attachment.cgi?id=1886710

----AFTER----

<img width="843" alt="Screenshot 2022-06-14 at 5 37 36 PM" src="https://user-images.githubusercontent.com/102503482/173575758-dd0d4f3d-ddcd-4337-b552-23151b768c77.png">


**Unit test coverage report**: 
NA

**Test setup:**
1. Switch to "Developer" perspective
2. Navigate to project > Project acccess
3. Add a new "user1" + "View" permission and save it.
4. Reload it
5. Open your browser network inspector!
6. Update the "user1" permission to "Edit" and save it.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge