### PR TITLE
Bug 2093047: Clean up duplicate entries in api.md

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -22,8 +22,6 @@ import {
   ResourceYAMLEditorProps,
   ResourceEventStreamProps,
   UsePrometheusPoll,
-  PrometheusPollProps,
-  PrometheusResponse,
 } from '../extensions/console-types';
 import { StatusPopupSectionProps, StatusPopupItemProps } from '../extensions/dashboard-types';
 
@@ -138,8 +136,6 @@ export const ResourceLink: React.FC<ResourceLinkProps> = require('@console/inter
   .ResourceLink;
 export { default as ResourceStatus } from '../app/components/utils/resource-status';
 
-export { checkAccess, useAccessReview, useAccessReviewAllowed } from '../app/components/utils/rbac';
-
 export {
   useK8sModel,
   useK8sModels,
@@ -222,14 +218,6 @@ export const ResourceYAMLEditor: React.FC<ResourceYAMLEditorProps> = require('@c
 export const ResourceEventStream: React.FC<ResourceEventStreamProps> = require('@console/internal/components/events')
   .WrappedResourceEventStream;
 
-const _usePrometheusPoll: (
-  props: PrometheusPollProps,
-) => [
-  PrometheusResponse,
-  unknown,
-  boolean,
-] = require('@console/internal/components/graphs/prometheus-poll-hook').usePrometheusPoll;
-
 /**
  * React hook to poll Prometheus for a single query.
  * @param options - Which is passed as a key-value map
@@ -243,8 +231,10 @@ const _usePrometheusPoll: (
  * @param options.timeout - a search param to append
  * @returns A tuple containing the query response, a boolean flag indicating whether the response has completed, and any errors encountered during the request or post-processing of the request
  */
-export const usePrometheusPoll: UsePrometheusPoll = (props) => {
-  const result = _usePrometheusPoll(props);
+export const usePrometheusPoll: UsePrometheusPoll = (options) => {
+  const result = require('@console/internal/components/graphs/prometheus-poll-hook').usePrometheusPoll(
+    options,
+  );
   // unify order with the rest of API
   return [result[0], !result[2], result[1]];
 };


### PR DESCRIPTION
Removed duplicate entries for `checkAccess`, `useCheckAccess`, `useAccessReviewAllowed` -- there were two imports to the same export in `dynamic-core-api.ts`.

Removed the underscore value `_usePrometheusPoll` which is a bug in our generation as it was not actually exported, just defined in the file. (this bug has not been fixed)

[api.md gist](https://gist.github.com/andrewballantyne/23a4cb2401f617e157dd3039807f20b9)