### PR TITLE
Bug 2096394: Switch from overriding dark theme pf-c-card background to increasing its boxshadow.

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -228,7 +228,7 @@ form.pf-c-form {
 
 // Remove when upstream issue is addressed. https://github.com/patternfly/patternfly/issues/4889
 .pf-theme-dark .pf-c-card  {
-  --pf-c-card--BackgroundColor: var(--pf-global--BackgroundColor--dark-300);
+  --pf-c-card--BoxShadow: var(--pf-global--BoxShadow--md);
 }
 
 .table {


### PR DESCRIPTION
@vikram-raj 

Initially this pr https://github.com/openshift/console/pull/11684 changed `<Cards>` background color, so when they are  on the same background color they become more distinguishable. It ended up [causing another bug](https://bugzilla.redhat.com/show_bug.cgi?id=2096394), when cards contain PF `<List>` components, where the background colors differed. 

So this pr reverts 11684 and adjust only the `--pf-c-card--BoxShadow` from `sm` to `md` which makes it more distinguishable when on the same dark background color. And will make the pr (https://github.com/openshift/console/pull/11690) for https://bugzilla.redhat.com/show_bug.cgi?id=2096394 no longer required. 


Updated cards with boxshadow md
<img width="761" alt="Screen Shot 2022-06-14 at 2 04 43 PM" src="https://user-images.githubusercontent.com/1874151/173661565-2b3a22ae-5b25-467a-9e35-b04ec9ee2c3b.png">

<img width="1126" alt="Screen Shot 2022-06-14 at 2 05 24 PM" src="https://user-images.githubusercontent.com/1874151/173661549-e3add81e-179d-49a1-83d6-cd7e5b7b2fb9.png">

