### PR TITLE
Bug 2093601: allow project access page to update the settings twice

### DIFF
--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
@@ -4,7 +4,6 @@ import * as _ from 'lodash';
 import Helmet from 'react-helmet';
 import { useTranslation, Trans } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import {
   history,
   LoadingBox,
@@ -24,7 +23,7 @@ import {
   getRolesWithMultipleSubjects,
 } from './project-access-form-submit-utils';
 import { getUserRoleBindings, Roles } from './project-access-form-utils';
-import { Verb, UserRoleBinding, roleBinding } from './project-access-form-utils-types';
+import { Verb, UserRoleBinding } from './project-access-form-utils-types';
 import { validationSchema } from './project-access-form-validation-utils';
 import ProjectAccessForm from './ProjectAccessForm';
 
@@ -57,7 +56,6 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({
 
   const initialValues = {
     projectAccess: roleBindings.loaded && userRoleBindings,
-    namespace,
   };
 
   const handleSubmit = (values, actions) => {
@@ -81,16 +79,15 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({
     }
     updateRoles.push(...updateRolesWithMultipleSubjects);
     const roleBindingRequests = [];
-    roleBinding.metadata.namespace = namespace;
 
     if (updateRoles.length > 0) {
-      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Patch, updateRoles, roleBinding));
+      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Patch, updateRoles, namespace));
     }
     if (newRoles.length > 0) {
-      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Create, newRoles, roleBinding));
+      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Create, newRoles, namespace));
     }
     if (removeRoles.length > 0) {
-      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Remove, removeRoles, roleBinding));
+      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Remove, removeRoles, namespace));
     }
 
     return Promise.all(roleBindingRequests)
@@ -118,11 +115,9 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({
           {
             "Project access allows you to add or remove a user's access to the project. More advanced management of role-based access control appear in "
           }
-          <Link to={`/k8s/ns/${getActiveNamespace()}/${RoleModel.plural}`}>Roles</Link> and{' '}
-          <Link to={`/k8s/ns/${getActiveNamespace()}/${RoleBindingModel.plural}`}>
-            Role Bindings
-          </Link>
-          . For more information, see the{' '}
+          <Link to={`/k8s/ns/${namespace}/${RoleModel.plural}`}>Roles</Link> and{' '}
+          <Link to={`/k8s/ns/${namespace}/${RoleBindingModel.plural}`}>Role Bindings</Link>. For
+          more information, see the{' '}
           <ExternalLink href={rbacLink}>role-based access control documentation</ExternalLink>.
         </Trans>
       </PageHeading>

--- a/frontend/packages/dev-console/src/components/project-access/project-access-form-utils-types.ts
+++ b/frontend/packages/dev-console/src/components/project-access/project-access-form-utils-types.ts
@@ -23,18 +23,3 @@ export type RoleBinding = K8sResourceCommon & {
   roleRef: SubjectType;
   subjects?: SubjectType[];
 };
-
-export const roleBinding: RoleBinding = {
-  apiVersion: 'rbac.authorization.k8s.io/v1',
-  kind: 'RoleBinding',
-  metadata: {
-    name: '',
-    namespace: '',
-  },
-  roleRef: {
-    apiGroup: 'rbac.authorization.k8s.io',
-    kind: 'ClusterRole',
-    name: '',
-  },
-  subjects: [],
-};

--- a/frontend/packages/dev-console/src/components/project-access/project-access-form-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/project-access/project-access-form-validation-utils.ts
@@ -2,7 +2,6 @@ import * as yup from 'yup';
 import i18n from '@console/internal/i18n';
 
 export const validationSchema = yup.object().shape({
-  namespace: yup.string().required(i18n.t('devconsole~Required')),
   projectAccess: yup.array().of(
     yup.object().shape({
       subject: yup.object().shape({ name: yup.string().required(i18n.t('devconsole~Required')) }),


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2093601

**Root analysis:**
The submit button was disabled because when the form is updated after being saved the validation schema returns namespace required error

**Solution description:**
Removed namespace from the validation schema

**GIF:**
![pa](https://user-images.githubusercontent.com/22490998/173888031-a1955cee-7ef1-46d9-abcd-d0f48377790e.gif)

/kind bug