### PR TITLE
Bug 2097000: fix visualisation of kafka connection along with kafka sink

### DIFF
--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -1672,7 +1672,7 @@
     "type": "console.topology/data/factory",
     "properties": {
       "id": "knative-kafka-sink-topology-data-factory",
-      "priority": "99",
+      "priority": "500",
       "resources": {
         "kafkasinks": {
           "model": {
@@ -1683,6 +1683,7 @@
           "opts": { "isList": true, "optional": true, "namespaced": true }
         }
       },
+      "workloadKeys": ["kafkasinks"],
       "getDataModel": {
         "$codeRef": "topology.getKafkaSinkKnativeTopologyData"
       }

--- a/frontend/packages/rhoas-plugin/console-extensions.json
+++ b/frontend/packages/rhoas-plugin/console-extensions.json
@@ -129,7 +129,8 @@
           },
           "opts": {
             "isList": true,
-            "optional": true
+            "optional": true,
+            "namespaced": true
           }
         }
       },


### PR DESCRIPTION
**Fixes:**  https://bugzilla.redhat.com/show_bug.cgi?id=2097000

**Screenshot:**

Before:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/5129024/174050806-c27f0bbb-1f85-4c56-b12a-fbfedd17289f.png">

After:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/5129024/174051229-de61e1b5-02a3-4307-8279-e8ceac2115fa.png">


**Test setup:**
- Install servereless operator and create CRs for knativeServing, knativeEventing, and knativeKafka
- Install RHOAS operator
- Create a kafkaConnection in Topology
- Create a KafkaSink in Topology

