### PR TITLE
Bug 2093593: Updated selected strategy file as devfile when devfile is selected

### DIFF
--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -10,7 +10,7 @@ import AdvancedSection from './advanced/AdvancedSection';
 import AppSection from './app/AppSection';
 import DevfileStrategySection from './devfile/DevfileStrategySection';
 import GitSection from './git/GitSection';
-import { GitImportFormProps } from './import-types';
+import { GitImportFormProps, ImportTypes } from './import-types';
 import ImportStrategySection from './ImportStrategySection';
 import ResourceSection from './section/ResourceSection';
 
@@ -34,7 +34,7 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
     git: { validated, gitType },
   } = values;
   const showFullForm =
-    importType === 'devfile' ||
+    importType === ImportTypes.devfile ||
     (validated !== ValidatedOptions.default && gitType !== GitProvider.INVALID);
 
   return (
@@ -52,7 +52,7 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
         />
         {showFullForm && (
           <>
-            {importType === 'devfile' ? (
+            {importType === ImportTypes.devfile ? (
               <DevfileStrategySection />
             ) : (
               <ImportStrategySection builderImages={builderImages} />
@@ -61,13 +61,14 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
               project={values.project}
               noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
             />
-            {values.import.selectedStrategy.type !== ImportStrategy.DEVFILE && (
-              <>
-                <ResourceSection />
-                <PipelineSection builderImages={builderImages} />
-                <AdvancedSection values={values} />
-              </>
-            )}
+            {importType !== ImportTypes.devfile &&
+              values.import.selectedStrategy.type !== ImportStrategy.DEVFILE && (
+                <>
+                  <ResourceSection />
+                  <PipelineSection builderImages={builderImages} />
+                  <AdvancedSection values={values} />
+                </>
+              )}
           </>
         )}
       </FormBody>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-45090

**Analysis / Root cause**: 
import type was not considered while rendering other components

**Solution Description**: 
Added import type as a condition 

**Screen shots / Gifs for design review**: 
-----Before----

https://user-images.githubusercontent.com/102503482/174065535-ab0bad08-c7da-4d5e-95f7-a60c50f5bfeb.mov


-----After------


https://user-images.githubusercontent.com/102503482/174065556-88c68cfc-a489-45c3-8514-b4b79a4264c9.mov


**Unit test coverage report**: 
NA

**Test setup:**
1. Navigate to the Add page > All services
2. Select Devfiles as type
3. Select the "Basic Node.js" example and press Create

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge