### PR TITLE
Bug 2089405: fix topology build decorator color

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.scss
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.scss
@@ -1,0 +1,14 @@
+.dps-icons {
+  &__green-check-icon {
+    fill: var(--pf-global--palette--green-500) !important;
+  }
+  &__red-exclamation-icon {
+    fill: var(--pf-global--danger-color--100) !important;
+  }
+  &__yellow-exclamation-icon {
+    fill: var(--pf-global--warning-color--100) !important;
+  }
+  &__blue-info-icon {
+    fill: var(--pf-global--palette--blue-300) !important;
+  }
+}

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.tsx
@@ -5,10 +5,9 @@ import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
 } from '@patternfly/react-icons';
-import { global_danger_color_100 as dangerColor } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
-import { global_palette_blue_300 as blueInfoColor } from '@patternfly/react-tokens/dist/js/global_palette_blue_300';
-import { global_palette_green_500 as okColor } from '@patternfly/react-tokens/dist/js/global_palette_green_500';
-import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
+import * as classNames from 'classnames';
+
+import './icons.scss';
 
 export type ColoredIconProps = {
   className?: string;
@@ -20,8 +19,7 @@ export const GreenCheckCircleIcon: React.FC<ColoredIconProps> = ({ className, ti
   <CheckCircleIcon
     data-test="success-icon"
     size={size}
-    color={okColor.value}
-    className={className}
+    className={classNames('dps-icons__green-check-icon', className)}
     title={title}
   />
 );
@@ -33,8 +31,7 @@ export const RedExclamationCircleIcon: React.FC<ColoredIconProps> = ({
 }) => (
   <ExclamationCircleIcon
     size={size}
-    color={dangerColor.value}
-    className={className}
+    className={classNames('dps-icons__red-exclamation-icon', className)}
     title={title}
   />
 );
@@ -46,12 +43,11 @@ export const YellowExclamationTriangleIcon: React.FC<ColoredIconProps> = ({
 }) => (
   <ExclamationTriangleIcon
     size={size}
-    color={warningColor.value}
-    className={className}
+    className={classNames('dps-icons__yellow-exclamation-icon', className)}
     title={title}
   />
 );
 
 export const BlueInfoCircleIcon: React.FC<ColoredIconProps> = ({ className, title }) => (
-  <InfoCircleIcon color={blueInfoColor.value} className={className} title={title} />
+  <InfoCircleIcon className={classNames('dps-icons__blue-info-icon', className)} title={title} />
 );


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2089405

**Root analysis:**
The Icon's fill color was not overriding the pf node decorator's fill color

**Solution description:**
Added custom classnames

**Screenshots:**
![Screenshot from 2022-06-17 00-21-22](https://user-images.githubusercontent.com/22490998/174144099-5b3e56c4-bba8-46ed-8410-849f8b7f7a45.png)
![Screenshot from 2022-06-17 00-21-00](https://user-images.githubusercontent.com/22490998/174144107-0ea05cfe-7abb-408f-aa5f-7483a33bb545.png)


/kind bug