### PR TITLE
Bug 2022611: Remove BlockPools tab in external mode

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/odf-system-dashboard.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/odf-system-dashboard.tsx
@@ -14,7 +14,7 @@ import { default as OCSOverview, BLOCK_FILE, OBJECT } from './ocs-system-dashboa
 import { BlockPoolListPage } from '../block-pool/block-pool-list-page';
 import { CEPH_STORAGE_NAMESPACE } from '../../constants';
 import { CephBlockPoolModel } from '../../models';
-import { MCG_FLAG, CEPH_FLAG } from '../../features';
+import { MCG_FLAG, CEPH_FLAG, OCS_INDEPENDENT_FLAG } from '../../features';
 
 type ODFSystemDashboardPageProps = Omit<DashboardsPageProps, 'match'> & {
   match: Match<{ systemName: string }>;
@@ -42,9 +42,11 @@ const ODFSystemDashboard: React.FC<ODFSystemDashboardPageProps> = ({
     },
   ]);
 
+  const isExternal = useFlag(OCS_INDEPENDENT_FLAG);
+
   React.useEffect(() => {
     const isBlockPoolAdded = pages.find((page) => page.href === blockPoolRef);
-    if (isCephAvailable && !isBlockPoolAdded) {
+    if (isCephAvailable && !isBlockPoolAdded && !isExternal) {
       setPages([
         ...pages,
         {
@@ -54,7 +56,10 @@ const ODFSystemDashboard: React.FC<ODFSystemDashboardPageProps> = ({
         },
       ]);
     }
-  }, [isCephAvailable, pages, t]);
+    if (isBlockPoolAdded && isExternal) {
+      setPages((p) => p.filter((page) => page.href !== blockPoolRef));
+    }
+  }, [isExternal, isCephAvailable, pages, t]);
 
   const breadcrumbs = [
     {


### PR DESCRIPTION
Remove BlockPools tab when running in external mode.

Signed-off-by: Pranshu Srivastava <rexagod@gmail.com>
***
<details>
<summary>Screenshot</summary>

#### For external mode.
![Screenshot from 2022-06-17 23-40-05](https://user-images.githubusercontent.com/33557095/174355959-df099bd8-da0e-4c0b-9df7-55b9fc42cfd4.png)

#### For internal mode.
![image](https://user-images.githubusercontent.com/33557095/174406401-a6a808fd-9eaf-413a-91e6-e2e12bce5189.png)

</details>