### PR TITLE
Bug 2094558: MetalLB: Creating ip address pool and community CR throu…

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/templates.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/templates.tsx
@@ -115,7 +115,7 @@ export const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
 }) => {
   const { t } = useTranslation();
   const [, label] = useSchemaLabel(schema, uiSchema, title ?? 'Items');
-  const singularLabel = label.replace(/s$/, '');
+  // const singularLabel = label.replace(/s$/, '');
   return (
     <FieldSet
       defaultLabel={label}
@@ -137,7 +137,7 @@ export const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
                   variant="link"
                 >
                   <MinusCircleIcon className="co-icon-space-r" />
-                  {t('console-shared~Remove {{singularLabel}}', { singularLabel })}
+                  {t('console-shared~Remove {{singularLabel}}', { singularLabel: label })}
                 </Button>
               </div>
             )}
@@ -148,7 +148,7 @@ export const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
       <div className="row">
         <Button id={`${idSchema.$id}_add-btn`} type="button" onClick={onAddClick} variant="link">
           <PlusCircleIcon className="co-icon-space-r" />
-          {t('console-shared~Add {{singularLabel}}', { singularLabel })}
+          {t('console-shared~Add {{singularLabel}}', { singularLabel: label })}
         </Button>
       </div>
     </FieldSet>

--- a/frontend/packages/console-shared/src/components/dynamic-form/templates.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/templates.tsx
@@ -115,7 +115,6 @@ export const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
 }) => {
   const { t } = useTranslation();
   const [, label] = useSchemaLabel(schema, uiSchema, title ?? 'Items');
-  // const singularLabel = label.replace(/s$/, '');
   return (
     <FieldSet
       defaultLabel={label}


### PR DESCRIPTION
…gh webconsole the words like addresses and communities are truncated

This removes the truncation that occurs when creating IP address pools and communities in MetalLB.

However, I'm not sure that this is the intended solution. The previous code removed an 's' from the end of the item name to change it to singular form, but this does not work with any resources that don't end with a single -s prefix, hence the truncation bug. The current solution removes this functionality entirely but perhaps we want to keep the singular form.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2094558