### PR TITLE
Bug 2072883: Fix dashboard graph width tracking

### DIFF
--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -552,12 +552,12 @@ const Card: React.FC<CardProps> = React.memo(({ panel }) => {
 
   const panelClassModifier = getPanelClassModifier(panel);
 
-  const handleZoom = (timeRange: number, endTime: number) => {
+  const handleZoom = React.useCallback((timeRange: number, endTime: number) => {
     setQueryArguments({
       endTime: endTime.toString(),
       timeRange: timeRange.toString(),
     });
-  };
+  }, []);
 
   return (
     <div

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -351,7 +351,7 @@ const Graph: React.FC<GraphProps> = React.memo(
     _.each(allSeries, (series, i) => {
       _.each(series, ([metric, values]) => {
         // Ignore any disabled series
-        data.push(_.some(disabledSeries[i], (s) => _.isEqual(s, metric)) ? null : values);
+        data.push(_.some(disabledSeries?.[i], (s) => _.isEqual(s, metric)) ? null : values);
         if (formatSeriesTitle) {
           const name = formatSeriesTitle(metric, i);
           legendData.push({ name });
@@ -633,7 +633,7 @@ const getMaxSamplesForSpan = (span: number) =>
 const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   defaultSamples,
   defaultTimespan = parsePrometheusDuration('30m'),
-  disabledSeries = [],
+  disabledSeries,
   disableZoom,
   filterLabels,
   fixedEndTime,

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -920,48 +920,46 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
           </div>
         </div>
       )}
-      {error && <Error error={error} />}
-      {isGraphDataEmpty && !updating && <GraphEmpty />}
-      {!isGraphDataEmpty && (
-        <div
-          className={classNames('graph-wrapper graph-wrapper--query-browser', {
-            'graph-wrapper--query-browser--with-legend': showLegend && !!formatSeriesTitle,
-          })}
-        >
-          <div ref={containerRef} style={{ width: '100%' }}>
-            {width > 0 && (
-              <>
-                {disableZoom ? (
-                  <Graph
-                    allSeries={graphData}
-                    disabledSeries={disabledSeries}
-                    fixedXDomain={xDomain}
-                    formatSeriesTitle={formatSeriesTitle}
-                    isStack={canStack && isStacked}
-                    showLegend={showLegend}
-                    span={span}
-                    units={units}
-                    width={width}
-                  />
-                ) : (
-                  <ZoomableGraph
-                    allSeries={graphData}
-                    disabledSeries={disabledSeries}
-                    fixedXDomain={xDomain}
-                    formatSeriesTitle={formatSeriesTitle}
-                    isStack={canStack && isStacked}
-                    onZoom={zoomableGraphOnZoom}
-                    showLegend={showLegend}
-                    span={span}
-                    units={units}
-                    width={width}
-                  />
-                )}
-              </>
-            )}
-          </div>
+      <div
+        className={classNames('graph-wrapper graph-wrapper--query-browser', {
+          'graph-wrapper--query-browser--with-legend': showLegend && !!formatSeriesTitle,
+        })}
+      >
+        <div ref={containerRef} style={{ width: '100%' }}>
+          {error && <Error error={error} />}
+          {isGraphDataEmpty && !updating && <GraphEmpty />}
+          {!isGraphDataEmpty && width > 0 && (
+            <>
+              {disableZoom ? (
+                <Graph
+                  allSeries={graphData}
+                  disabledSeries={disabledSeries}
+                  fixedXDomain={xDomain}
+                  formatSeriesTitle={formatSeriesTitle}
+                  isStack={canStack && isStacked}
+                  showLegend={showLegend}
+                  span={span}
+                  units={units}
+                  width={width}
+                />
+              ) : (
+                <ZoomableGraph
+                  allSeries={graphData}
+                  disabledSeries={disabledSeries}
+                  fixedXDomain={xDomain}
+                  formatSeriesTitle={formatSeriesTitle}
+                  isStack={canStack && isStacked}
+                  onZoom={zoomableGraphOnZoom}
+                  showLegend={showLegend}
+                  span={span}
+                  units={units}
+                  width={width}
+                />
+              )}
+            </>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
We should keep tracking the value of `width` when the graph is removed
due to an error or no data state.

Also prevents a couple of cases where unnecessary re-renders could be triggered.