### PR TITLE
Bug 2099763: update icons for eventSource and eventSink

### DIFF
--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -451,7 +451,7 @@
       "href": "/catalog/ns/:namespace?catalogType=EventSource&provider=[\"Red+Hat\"]",
       "label": "%knative-plugin~Event Source%",
       "description": "%knative-plugin~Create an Event source to register interest in a class of events from a particular system%",
-      "icon": { "$codeRef": "icons.eventSourceIcon" }
+      "icon": { "$codeRef": "icons.eventSourceIconSVG" }
     }
   },
   {
@@ -497,7 +497,7 @@
       "href": "/catalog/ns/:namespace?catalogType=EventSink",
       "label": "%knative-plugin~Event Sink%",
       "description": "%knative-plugin~Create an Event sink to receive incoming events from a particular source%",
-      "icon": { "$codeRef": "icons.eventSinkIcon" }
+      "icon": { "$codeRef": "icons.eventSinkIconSVG" }
     }
   },
   {

--- a/frontend/packages/knative-plugin/src/actions/add-event-sink.tsx
+++ b/frontend/packages/knative-plugin/src/actions/add-event-sink.tsx
@@ -1,8 +1,9 @@
+import * as React from 'react';
 import i18next from 'i18next';
 import { QUERY_PROPERTIES } from '@console/dev-console/src/const';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { UNASSIGNED_KEY } from '@console/topology/src/const';
-import { eventSinkIcon } from '../utils/icons';
+import { EventSinkIcon, eventIconStyle } from '../utils/icons';
 
 export const EVENT_SINK_ADD_CONNECTOR_ACTION = 'event-sink-add-connector-action';
 
@@ -22,7 +23,7 @@ export const AddEventSinkAction = (
   return {
     id: 'event-sink-add',
     label: i18next.t('knative-plugin~Event Sink'),
-    icon: eventSinkIcon,
+    icon: <EventSinkIcon style={eventIconStyle} />,
     cta: {
       href: `${pageUrl}?${params.toString()}`,
     },

--- a/frontend/packages/knative-plugin/src/actions/add-event-source.tsx
+++ b/frontend/packages/knative-plugin/src/actions/add-event-source.tsx
@@ -1,8 +1,9 @@
+import * as React from 'react';
 import i18next from 'i18next';
 import { QUERY_PROPERTIES } from '@console/dev-console/src/const';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { UNASSIGNED_KEY } from '@console/topology/src/const';
-import { eventSourceIcon } from '../utils/icons';
+import { EventSourceIcon, eventIconStyle } from '../utils/icons';
 
 export const AddEventSourceAction = (
   namespace: string,
@@ -20,7 +21,7 @@ export const AddEventSourceAction = (
   return {
     id: 'event-source-add',
     label: i18next.t('knative-plugin~Event Source'),
-    icon: eventSourceIcon,
+    icon: <EventSourceIcon style={eventIconStyle} />,
     cta: {
       href: `${pageUrl}?${params.toString()}`,
     },

--- a/frontend/packages/knative-plugin/src/const.ts
+++ b/frontend/packages/knative-plugin/src/const.ts
@@ -39,3 +39,4 @@ export const EVENT_SOURCE_API_SERVER_KIND = 'ApiServerSource';
 export const EVENT_SOURCE_CONTAINER_KIND = 'ContainerSource';
 export const EVENT_SOURCE_PING_KIND = 'PingSource';
 export const EVENT_SOURCE_CRONJOB_KIND = 'CronJobSource';
+export const EVENT_SINK_KAFKA_KIND = 'KafkaSink';

--- a/frontend/packages/knative-plugin/src/imgs/event-sink.svg
+++ b/frontend/packages/knative-plugin/src/imgs/event-sink.svg
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 48 48"
+   style="enable-background:new 0 0 48 48;"
+   xml:space="preserve"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs59" />
+<g
+   id="layer1" /><g
+   id="layer2"><g
+     id="g54"
+     transform="matrix(0.83450041,0,0,0.83450041,0.01958465,4.0325038)">
+	<g
+   id="g24">
+		<defs
+   id="defs5">
+			<path
+   id="SVGID_1_"
+   d="m 22.6,15.4 v 4.4 H 5.5 c -0.1,0 -0.3,0 -0.4,0.1 C 5,19.9 5,20.1 5,20.2 v 2.3 c 0,0.1 0,0.3 0.1,0.4 0.1,0 0.2,0.1 0.4,0.1 h 17.1 v 4.4 c 0,0.7 0.4,0.8 0.9,0.4 l 4.6,-5.5 c 0.6,-0.6 0.6,-1.1 0,-1.7 L 23.5,15 C 23,14.5 22.6,14.7 22.6,15.4 Z" />
+		</defs>
+		<use
+   xlink:href="#SVGID_1_"
+   style="clip-rule:evenodd;overflow:visible;fill-rule:evenodd"
+   id="use7"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+		<clipPath
+   id="SVGID_00000153686767603803014330000008432418958077573286_">
+			<use
+   xlink:href="#SVGID_1_"
+   style="overflow:visible"
+   id="use9"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+		</clipPath>
+		<g
+   clip-path="url(#SVGID_00000153686767603803014330000008432418958077573286_)"
+   id="g22">
+			<defs
+   id="defs13">
+				
+					<rect
+   id="SVGID_00000065038216947270348640000007913041585346537631_"
+   x="-761.40002"
+   y="-325.70001"
+   transform="matrix(0.7071,-0.7071,0.7071,0.7071,-165.4445,119.5037)"
+   width="1645.9"
+   height="1170.4" />
+			</defs>
+			<use
+   xlink:href="#SVGID_00000065038216947270348640000007913041585346537631_"
+   style="overflow:visible"
+   id="use15"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+			<clipPath
+   id="SVGID_00000092419341826936213990000017663793735483835285_">
+				<use
+   xlink:href="#SVGID_00000065038216947270348640000007913041585346537631_"
+   style="overflow:visible"
+   id="use17"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+			</clipPath>
+			<polygon
+   points="20.1,10.8 30.6,21.3 20.1,31.8 2,21.3 "
+   clip-path="url(#SVGID_00000092419341826936213990000017663793735483835285_)"
+   id="polygon20" />
+		</g>
+	</g>
+	<g
+   id="g46">
+		<defs
+   id="defs27">
+			<path
+   id="SVGID_00000100383862757635835300000008544962276497267859_"
+   d="m 17.6,27.7 v 4.4 H 0.5 c -0.1,0 -0.3,0 -0.4,0.1 C 0,32.3 0,32.5 0,32.6 v 2.3 c 0,0.1 0,0.3 0.1,0.4 0.1,0.1 0.2,0.1 0.4,0.1 h 17.1 v 4.4 c 0,0.7 0.4,0.8 0.9,0.4 l 4.6,-5.5 c 0.6,-0.6 0.6,-1.1 0,-1.7 L 18.5,27.5 C 18,26.9 17.6,27.1 17.6,27.7 Z" />
+		</defs>
+		
+			<use
+   xlink:href="#SVGID_00000100383862757635835300000008544962276497267859_"
+   style="clip-rule:evenodd;overflow:visible;fill-rule:evenodd"
+   id="use29"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+		<clipPath
+   id="SVGID_00000107559171352424902800000015842758297990970045_">
+			<use
+   xlink:href="#SVGID_00000100383862757635835300000008544962276497267859_"
+   style="overflow:visible"
+   id="use31"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+		</clipPath>
+		<g
+   clip-path="url(#SVGID_00000107559171352424902800000015842758297990970045_)"
+   id="g44">
+			<defs
+   id="defs35">
+				
+					<rect
+   id="SVGID_00000006691629812589118440000017543570273826496154_"
+   x="-766.40002"
+   y="-313.39999"
+   transform="matrix(0.7071,-0.7071,0.7071,0.7071,-175.6596,119.6215)"
+   width="1645.9"
+   height="1170.4" />
+			</defs>
+			<use
+   xlink:href="#SVGID_00000006691629812589118440000017543570273826496154_"
+   style="overflow:visible"
+   id="use37"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+			<clipPath
+   id="SVGID_00000036936571345607443920000009552654329235352713_">
+				<use
+   xlink:href="#SVGID_00000006691629812589118440000017543570273826496154_"
+   style="overflow:visible"
+   id="use39"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+			</clipPath>
+			<polygon
+   points="15.1,23.2 25.6,33.7 15.1,44.2 -3,33.7 "
+   clip-path="url(#SVGID_00000036936571345607443920000009552654329235352713_)"
+   id="polygon42" />
+		</g>
+	</g>
+	<g
+   id="g50">
+		<path
+   class="st4"
+   d="M 28.8,4.8 C 20.2,4.8 13,10.4 10.5,18.1 h 3.3 c 2.3,-6 8.2,-10.3 15,-10.3 8.9,0 16.1,7.2 16.1,16.1 0,8.9 -7.2,16.1 -16.1,16.1 -2.3,0 -4.5,-0.5 -6.5,-1.4 L 20.2,41 c 2.6,1.3 5.5,2 8.6,2 C 39.4,43.2 48,34.6 48,24 48,13.4 39.4,4.8 28.8,4.8 Z"
+   id="path48" />
+	</g>
+	<path
+   class="st4"
+   d="m 12.7,24.4 h -3 c 0,2.2 0.5,4.4 1.2,6.3 h 3.3 c -0.9,-1.9 -1.4,-4.1 -1.5,-6.3 z"
+   id="path52" />
+</g></g>
+</svg>

--- a/frontend/packages/knative-plugin/src/imgs/event-source.svg
+++ b/frontend/packages/knative-plugin/src/imgs/event-source.svg
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 48 48"
+   style="enable-background:new 0 0 48 48;"
+   xml:space="preserve"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs118" />
+<g
+   id="layer3" /><g
+   id="layer4"><a
+     id="a401"
+     transform="matrix(0.82890056,0,0,0.82890056,6.7181284,8.0905591)"><g
+       id="g113">
+	<g
+   id="g83">
+		<defs
+   id="defs64">
+			<path
+   id="SVGID_1_"
+   d="M 45.3,26.2 42,29.5 29.2,16.6 c -0.1,-0.1 -0.2,-0.2 -0.4,-0.2 -0.1,0 -0.3,0.1 -0.4,0.2 l -1.7,1.7 c -0.1,0.1 -0.2,0.2 -0.2,0.4 0,0.1 0.1,0.3 0.2,0.4 l 12.8,12.8 -3.3,3.3 c -0.5,0.5 -0.3,0.9 0.4,0.9 l 7.6,-0.6 c 0.9,0 1.3,-0.4 1.3,-1.3 l 0.6,-7.6 c 0.1,-0.7 -0.3,-0.9 -0.8,-0.4 z" />
+		</defs>
+		<use
+   xlink:href="#SVGID_1_"
+   style="clip-rule:evenodd;overflow:visible;fill-rule:evenodd"
+   id="use66"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+		<clipPath
+   id="SVGID_00000169529502274305501380000012786890020970890167_">
+			<use
+   xlink:href="#SVGID_1_"
+   style="overflow:visible"
+   id="use68"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+		</clipPath>
+		<g
+   clip-path="url(#SVGID_00000169529502274305501380000012786890020970890167_)"
+   id="g81">
+			<defs
+   id="defs72">
+				<rect
+   id="SVGID_00000023999172388563319280000000930733870357485454_"
+   x="-979.79999"
+   y="-381.60001"
+   width="1743"
+   height="1239.5" />
+			</defs>
+			<use
+   xlink:href="#SVGID_00000023999172388563319280000000930733870357485454_"
+   style="overflow:visible"
+   id="use74"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+			<clipPath
+   id="SVGID_00000021825206980038039580000012636863102742748820_">
+				<use
+   xlink:href="#SVGID_00000023999172388563319280000000930733870357485454_"
+   style="overflow:visible"
+   id="use76"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+			</clipPath>
+			<polygon
+   points="31.1,36.6 25.4,15.2 46.8,20.9 46.8,36.6 "
+   clip-path="url(#SVGID_00000021825206980038039580000012636863102742748820_)"
+   id="polygon79" />
+		</g>
+	</g>
+	<g
+   id="g105">
+		<defs
+   id="defs86">
+			<path
+   id="SVGID_00000132797996050601758740000001996864769455682988_"
+   d="M 41.1,38.1 37.8,41.4 25,28.6 c -0.1,-0.1 -0.2,-0.2 -0.4,-0.2 -0.2,0 -0.3,0.1 -0.4,0.2 l -1.7,1.7 c -0.1,0.1 -0.2,0.2 -0.2,0.4 0,0.1 0.1,0.3 0.2,0.4 L 35.3,43.9 32,47.2 c -0.5,0.5 -0.3,0.9 0.4,0.9 L 40,47.5 c 0.9,0 1.3,-0.4 1.3,-1.3 l 0.6,-7.6 c 0.1,-0.8 -0.3,-1 -0.8,-0.5 z" />
+		</defs>
+		
+			<use
+   xlink:href="#SVGID_00000132797996050601758740000001996864769455682988_"
+   style="clip-rule:evenodd;overflow:visible;fill-rule:evenodd"
+   id="use88"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+		<clipPath
+   id="SVGID_00000070806848333203157840000018088651999689357239_">
+			<use
+   xlink:href="#SVGID_00000132797996050601758740000001996864769455682988_"
+   style="overflow:visible"
+   id="use90"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+		</clipPath>
+		<g
+   clip-path="url(#SVGID_00000070806848333203157840000018088651999689357239_)"
+   id="g103">
+			<defs
+   id="defs94">
+				<rect
+   id="SVGID_00000034795737241456181990000002702895336249809838_"
+   x="-984"
+   y="-369.70001"
+   width="1743"
+   height="1239.5" />
+			</defs>
+			<use
+   xlink:href="#SVGID_00000034795737241456181990000002702895336249809838_"
+   style="overflow:visible"
+   id="use96"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+			<clipPath
+   id="SVGID_00000145757618844522193150000002123630661411659963_">
+				<use
+   xlink:href="#SVGID_00000034795737241456181990000002702895336249809838_"
+   style="overflow:visible"
+   id="use98"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+			</clipPath>
+			<polygon
+   points="26.9,48.6 21.2,27.2 42.6,32.8 42.6,48.6 "
+   clip-path="url(#SVGID_00000145757618844522193150000002123630661411659963_)"
+   id="polygon101" />
+		</g>
+	</g>
+	<path
+   class="st4"
+   d="M 20.8,35 C 12,35 4.8,27.9 4.8,19 4.8,10.1 12,3 20.8,3 c 8.8,0 16,7.1 16,16 0,0.5 0,1 -0.1,1.5 l 2.7,2.7 c 0.3,-1.3 0.5,-2.7 0.5,-4.2 0,-10.5 -8.5,-19 -19,-19 -10.5,0 -19,8.5 -19,19 0,10.5 8.5,19 19,19 1.7,0 3.3,-0.2 4.9,-0.6 L 23.2,34.8 C 22.3,34.9 21.6,35 20.8,35 Z"
+   id="path107" />
+	<g
+   id="g111">
+		<path
+   class="st4"
+   d="m 33.4,28.7 c -0.7,0.9 -1.5,1.8 -2.4,2.5 l 2.2,2.2 c 0.9,-0.8 1.7,-1.6 2.4,-2.5 z"
+   id="path109" />
+	</g>
+</g></a></g></svg>

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { SignInAltIcon } from '@patternfly/react-icons';
 import {
   Node,
   observer,
@@ -20,6 +19,7 @@ import { PodSet } from '@console/topology/src/components/graph-view';
 import { BaseNode } from '@console/topology/src/components/graph-view/components/nodes';
 import { KafkaSinkModel } from '../../../models';
 import { getEventSourceIcon } from '../../../utils/get-knative-icon';
+import { EventSinkIcon } from '../../../utils/icons';
 import { usePodsForRevisions } from '../../../utils/usePodsForRevisions';
 import { TYPE_EVENT_SINK_LINK, TYPE_KAFKA_CONNECTION_LINK } from '../../const';
 import EventSinkTargetAnchor from '../anchors/EventSinkTargetAnchor';
@@ -101,7 +101,7 @@ const EventSink: React.FC<EventSinkProps> = ({
       kind={data.kind}
       element={element}
       dragNodeRef={groupRefs}
-      labelIcon={<SignInAltIcon />}
+      labelIcon={<EventSinkIcon />}
       {...rest}
     >
       {donutStatus && !isKafkaSink && (

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { SignOutAltIcon } from '@patternfly/react-icons';
 import {
   Node,
   observer,
@@ -12,6 +11,7 @@ import {
 } from '@patternfly/react-topology';
 import { BaseNode } from '@console/topology/src/components/graph-view/components/nodes';
 import { getEventSourceIcon } from '../../../utils/get-knative-icon';
+import { EventSourceIcon } from '../../../utils/icons';
 import { TYPE_KAFKA_CONNECTION_LINK } from '../../const';
 
 import './EventSource.scss';
@@ -40,7 +40,7 @@ const EventSource: React.FC<EventSourceProps> = ({ element, onShowCreateConnecto
       onShowCreateConnector={isKafkaConnectionLinkPresent && onShowCreateConnector}
       kind={data.kind}
       element={element}
-      labelIcon={<SignOutAltIcon />}
+      labelIcon={<EventSourceIcon />}
       {...rest}
     >
       {typeof getEventSourceIcon(data.kind, resources.obj) === 'string' ? (

--- a/frontend/packages/knative-plugin/src/topology/listView/NoStatusListViewNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/listView/NoStatusListViewNode.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { SignOutAltIcon } from '@patternfly/react-icons';
 import {
   TopologyListViewNode,
   TypedResourceBadgeCell,
 } from '@console/topology/src/components/list-view';
 import { OdcBaseNode } from '@console/topology/src/elements';
 import { getResourceKind } from '@console/topology/src/utils';
+import { EventSourceIcon, eventIconStyle } from '../../utils/icons';
 import { NodeType } from '../topology-types';
 
 interface NoStatusListViewNodeProps {
@@ -17,7 +17,11 @@ interface NoStatusListViewNodeProps {
 const NoStatusListViewNode: React.FC<NoStatusListViewNodeProps> = (props) => {
   const kind = getResourceKind(props.item);
   const badgeCell = (
-    <TypedResourceBadgeCell key="type-icon" kind={kind} typeIcon={<SignOutAltIcon />} />
+    <TypedResourceBadgeCell
+      key="type-icon"
+      kind={kind}
+      typeIcon={<EventSourceIcon style={eventIconStyle} />}
+    />
   );
   return (
     <TopologyListViewNode

--- a/frontend/packages/knative-plugin/src/utils/get-knative-icon.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-icon.ts
@@ -10,6 +10,7 @@ import {
   EVENT_SOURCE_API_SERVER_KIND,
   EVENT_SOURCE_CONTAINER_KIND,
   EVENT_SOURCE_PING_KIND,
+  EVENT_SINK_KAFKA_KIND,
 } from '../const';
 import * as apiServerSourceImg from '../imgs/logos/apiserversource.svg';
 import * as camelSourceImg from '../imgs/logos/camelsource.svg';
@@ -18,7 +19,7 @@ import * as kafkaSourceImg from '../imgs/logos/kafkasource.svg';
 import * as pingSourceImg from '../imgs/logos/pingsource.svg';
 import * as sinkBindingSourceImg from '../imgs/logos/sinkbindingsource.svg';
 import { TYPE_EVENT_SINK } from '../topology/const';
-import { eventSinkIcon, eventSourceIcon } from './icons';
+import { eventSinkIconSVG, eventSourceIconSVG } from './icons';
 
 const getEventSourceIconFromKind = (kind: string, nodeType?: string): React.ReactNode | string => {
   switch (kindForReference(kind)) {
@@ -34,8 +35,10 @@ const getEventSourceIconFromKind = (kind: string, nodeType?: string): React.Reac
       return kafkaSourceImg;
     case EVENT_SOURCE_SINK_BINDING_KIND:
       return sinkBindingSourceImg;
+    case EVENT_SINK_KAFKA_KIND:
+      return eventSinkIconSVG;
     default:
-      return nodeType === TYPE_EVENT_SINK ? eventSinkIcon : eventSourceIcon;
+      return nodeType === TYPE_EVENT_SINK ? eventSinkIconSVG : eventSourceIconSVG;
   }
 };
 

--- a/frontend/packages/knative-plugin/src/utils/icons.tsx
+++ b/frontend/packages/knative-plugin/src/utils/icons.tsx
@@ -1,9 +1,22 @@
 import * as React from 'react';
-import { SignInAltIcon, SignOutAltIcon } from '@patternfly/react-icons';
 import * as channelIcon from '../imgs/channel.svg';
+import * as eventSinkIcon from '../imgs/event-sink.svg';
+import * as eventSourceIcon from '../imgs/event-source.svg';
 
-export const eventSourceIcon = <SignOutAltIcon />;
+export const eventIconStyle: React.CSSProperties = {
+  width: '1em',
+  height: '1em',
+};
+export const eventSourceIconSVG = eventSourceIcon;
 
-export const eventSinkIcon = <SignInAltIcon />;
+export const eventSinkIconSVG = eventSinkIcon;
 
 export const channelIconSVG = channelIcon;
+
+export const EventSinkIcon: React.FC<{ style?: React.CSSProperties }> = ({ style }) => (
+  <img src={eventSinkIcon} style={style} alt="Event Sink logo" />
+);
+
+export const EventSourceIcon: React.FC<{ style?: React.CSSProperties }> = ({ style }) => (
+  <img src={eventSourceIcon} style={style} alt="Event Source logo" />
+);

--- a/frontend/packages/topology/src/components/graph-view/components/ContextMenu.scss
+++ b/frontend/packages/topology/src/components/graph-view/components/ContextMenu.scss
@@ -8,10 +8,8 @@
   }
 }
 
-:root:where(.pf-theme-dark) .odc-topology-context-menu {
-  .pf-c-dropdown__menu-item-icon {
+:root:where(.pf-theme-dark) .pf-c-dropdown__menu-item-icon {
     img {
       filter: brightness(1.5) invert(1) hue-rotate(180deg) saturate(4);
     }
-  }
 }


### PR DESCRIPTION
**Tracks:**
 https://bugzilla.redhat.com/show_bug.cgi?id=2099763
 https://issues.redhat.com/browse/ODC-6643

**Descriptions:**

Update the Event Sink and Event Source icons based on https://issues.redhat.com/browse/DTUX-1212 

Screenshots:

<img width="1789" alt="image" src="https://user-images.githubusercontent.com/5129024/174631136-c2c1a8cb-c876-4022-a36a-a5d3a3077cab.png">

<img width="1786" alt="image" src="https://user-images.githubusercontent.com/5129024/174631263-0b6f041f-9d03-43b7-8f8f-10b42af08e8f.png">

<img width="764" alt="image" src="https://user-images.githubusercontent.com/5129024/174632254-b389f59f-05b3-4b33-bf16-e9df1fe88ddc.png">

