### PR TITLE
CONSOLE-3091: Remove orphaned code along with consolidating some code to use PF instead of Bootstrap

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/details/CatalogDetailsPanel.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/details/CatalogDetailsPanel.tsx
@@ -29,67 +29,65 @@ const CatalogDetailsPanel: React.FC<CatalogDetailsPanelProps> = ({ item }) => {
   return (
     <div className="modal-body modal-body-border">
       <div className="modal-body-content">
-        <div className="modal-body-inner-shadow-covers">
-          <div className="co-catalog-page__overlay-body">
-            <PropertiesSidePanel>
-              {details?.properties?.map((property) => (
-                <PropertyItem
-                  key={property.label}
-                  label={property.label}
-                  value={property.value || notAvailable}
-                />
-              ))}
-              {!customPropertyPresent(details, providerLabel) && (
-                <PropertyItem label={providerLabel} value={provider || notAvailable} />
-              )}
-              {!customPropertyPresent(details, createdAtLabel) && (
-                <PropertyItem label={createdAtLabel} value={created || notAvailable} />
-              )}
-              {!customPropertyPresent(details, supportLabel) && (
-                <PropertyItem
-                  label={supportLabel}
-                  value={
-                    supportUrl ? (
-                      <ExternalLink href={supportUrl} text={t('console-shared~Get support')} />
-                    ) : (
-                      notAvailable
-                    )
-                  }
-                />
-              )}
-              {!customPropertyPresent(details, documentationLabel) && (
-                <PropertyItem
-                  label={documentationLabel}
-                  value={
-                    documentationUrl ? (
-                      <ExternalLink
-                        href={documentationUrl}
-                        text={t('console-shared~Refer documentation')}
-                      />
-                    ) : (
-                      notAvailable
-                    )
-                  }
-                />
-              )}
-            </PropertiesSidePanel>
-            {(details?.descriptions?.length || description) && (
-              <div className="co-catalog-page__overlay-description">
-                <Stack hasGutter>
-                  {!details?.descriptions?.[0]?.label && (
-                    <SectionHeading text={t('console-shared~Description')} />
-                  )}
-                  {!details?.descriptions?.length && description && <p>{description}</p>}
-                  {details?.descriptions?.map((desc, index) => (
-                    <StackItem key={index}>
-                      {desc.label && <SectionHeading text={desc.label} />}
-                      {desc.value}
-                    </StackItem>
-                  ))}
-                </Stack>
-              </div>
+        <div className="co-catalog-page__overlay-body">
+          <PropertiesSidePanel>
+            {details?.properties?.map((property) => (
+              <PropertyItem
+                key={property.label}
+                label={property.label}
+                value={property.value || notAvailable}
+              />
+            ))}
+            {!customPropertyPresent(details, providerLabel) && (
+              <PropertyItem label={providerLabel} value={provider || notAvailable} />
             )}
-          </div>
+            {!customPropertyPresent(details, createdAtLabel) && (
+              <PropertyItem label={createdAtLabel} value={created || notAvailable} />
+            )}
+            {!customPropertyPresent(details, supportLabel) && (
+              <PropertyItem
+                label={supportLabel}
+                value={
+                  supportUrl ? (
+                    <ExternalLink href={supportUrl} text={t('console-shared~Get support')} />
+                  ) : (
+                    notAvailable
+                  )
+                }
+              />
+            )}
+            {!customPropertyPresent(details, documentationLabel) && (
+              <PropertyItem
+                label={documentationLabel}
+                value={
+                  documentationUrl ? (
+                    <ExternalLink
+                      href={documentationUrl}
+                      text={t('console-shared~Refer documentation')}
+                    />
+                  ) : (
+                    notAvailable
+                  )
+                }
+              />
+            )}
+          </PropertiesSidePanel>
+          {(details?.descriptions?.length || description) && (
+            <div className="co-catalog-page__overlay-description">
+              <Stack hasGutter>
+                {!details?.descriptions?.[0]?.label && (
+                  <SectionHeading text={t('console-shared~Description')} />
+                )}
+                {!details?.descriptions?.length && description && <p>{description}</p>}
+                {details?.descriptions?.map((desc, index) => (
+                  <StackItem key={index}>
+                    {desc.label && <SectionHeading text={desc.label} />}
+                    {desc.value}
+                  </StackItem>
+                ))}
+              </Stack>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/packages/dev-console/integration-tests/support/pages/modal.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/modal.ts
@@ -8,7 +8,7 @@ export const editLabels = {
       .type(labelName)
       .type('{enter}'),
   numberOfLabels: () => {
-    return cy.get('tags-input span.tag-item__content');
+    return cy.get('tags-input span.tag-item-content');
   },
   removeLabel: (labelName: string) => {
     cy.get('tags-input span.tag-item')

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/repositoryDetails-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/repositoryDetails-page.ts
@@ -52,7 +52,7 @@ export const repositoryDetailsPage = {
     const labelArr = label.split('=');
     cy.byTestID('label-list').within(() => {
       cy.byTestID('label-key').should('contain.text', labelArr[0]);
-      cy.get('.co-m-label__value').should('contain.text', labelArr[1]);
+      cy.get('.co-label__value').should('contain.text', labelArr[1]);
     });
   },
 

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -21,7 +21,7 @@ $dropdown-background--hover: $pf-color-black-200; // pf-c-dropdown__menu-item--h
 }
 
 .dropdown__disabled {
-  color: $dropdown-link-disabled-color;
+  color: var(--pf-global--disabled-color--100);
   cursor: not-allowed;
 }
 
@@ -180,7 +180,7 @@ $dropdown-background--hover: $pf-color-black-200; // pf-c-dropdown__menu-item--h
   li {
     &:not(.co-namespace-selector__divider):hover {
       background-color: var(--pf-global--BackgroundColor--200);
-      color: $dropdown-link-hover-color;
+      color: var(--pf-global--Color--100);
       position: relative;
     }
     > a {

--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -61,18 +61,6 @@
   width: auto !important;
 }
 
-.co-search-input.pf-c-form-control {
-  --pf-c-form-control--Width: 100%;
-  --pf-c-form-control--PaddingTop: 3px;
-  --pf-c-form-control--PaddingRight: 9px;
-  --pf-c-form-control--PaddingBottom: 3px;
-  --pf-c-form-control--PaddingLeft: 9px;
-
-  align-items: center;
-  display: flex;
-  height: auto; // allow tags to wrap
-}
-
 .co-type-selector {
   .pf-c-select__menu {
     min-width: 290px;

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -236,11 +236,6 @@ $catalog-tile-width: $co-m-catalog-tile-width;
       --pf-c-modal-box__body--last-child--PaddingBottom: 0 !important;
     }
 
-    .modal-body-inner-shadow-covers {
-      padding-left: 0 !important;
-      padding-right: 0 !important;
-    }
-
     h1 {
       white-space: normal;
     }

--- a/frontend/public/components/monitoring/labels.tsx
+++ b/frontend/public/components/monitoring/labels.tsx
@@ -1,13 +1,13 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Label as PfLabel } from '@patternfly/react-core';
+import { Label as PfLabel, LabelGroup as PfLabelGroup } from '@patternfly/react-core';
 
 export const Label = ({ k, v }) => (
-  <PfLabel className="co-label co-m-label--expand" key={k}>
-    <span className="co-m-label__key">{k}</span>
-    <span className="co-m-label__eq">=</span>
-    <span className="co-m-label__value">{v}</span>
+  <PfLabel className="co-label" key={k}>
+    <span className="co-label__key">{k}</span>
+    <span className="co-label__eq">=</span>
+    <span className="co-label__value">{v}</span>
   </PfLabel>
 );
 
@@ -18,9 +18,11 @@ export const Labels = ({ kind, labels }) => {
     <div className="text-muted">{t('public~No labels')}</div>
   ) : (
     <div className={`co-text-${kind}`}>
-      {_.map(labels, (v, k) => (
-        <Label key={k} k={k} v={v} />
-      ))}
+      <PfLabelGroup className="co-label-group" numLabels={20}>
+        {_.map(labels, (v, k) => (
+          <Label key={k} k={k} v={v} />
+        ))}
+      </PfLabelGroup>
     </div>
   );
 };

--- a/frontend/public/components/utils/_details-item.scss
+++ b/frontend/public/components/utils/_details-item.scss
@@ -26,7 +26,4 @@
 
 .details-item__value--labels {
   padding: var(--pf-global--spacer--xs);
-  .co-m-label {
-    margin: 2px;
-  }
 }

--- a/frontend/public/components/utils/_label.scss
+++ b/frontend/public/components/utils/_label.scss
@@ -1,36 +1,5 @@
-.co-m-label {
-  background-color: $pf-color-black-150;
-  border: 1px solid $pf-color-black-200;
-  border-radius: 12px;
-  display: inline-flex;
-  line-height: $co-m-label-line-height;
-  margin: 0 2px 2px 0;
-  max-width: 100%;
-  padding: 0 8px;
-
-  &__key,
-  &__value {
-    max-width: 60px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-}
-
-.co-m-label-list:hover .co-m-label,
-.co-m-label--expand {
-  .co-m-label__key,
-  .co-m-label__value {
-    max-width: 100%;
-  }
-}
-
 .co-label.pf-c-label {
   --pf-c-label__text--MaxWidth: 100%;
-}
-
-.co-label-group {
-  max-width: 100%;
 }
 
 .co-label,
@@ -40,9 +9,12 @@
   min-width: 0;
 }
 
+.co-label-group {
+  max-width: 100%;
+}
+
 .co-label__key,
 .co-label__value {
-  max-width: 60px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -52,157 +24,25 @@ tags-input {
   min-width: 100%;
 }
 
-tags-input:focus,
-tags-input .host:focus {
-  outline: none;
-}
-
-tags-input .host {
-  margin-bottom: 5px;
-  margin-top: 5px;
-  position: relative;
-}
-tags-input .host:active {
-  outline: none;
-}
-
 tags-input .tags {
   align-content: flex-start;
-  background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
-  border-radius: $input-border-radius; // Note: This has no effect on <select>s in some browsers, due to the limited stylability of <select>s in CSS.
-  color: $input-color;
-  cursor: text;
   display: flex;
   flex-wrap: wrap;
   gap: var(--pf-global--spacer--xs);
-  line-height: $co-m-label-line-height;
-
-  > span {
-    display: contents;
-  }
-}
-
-.modal-body tags-input .tags {
-  margin-bottom: $pf-global-gutter;
   min-height: 120px;
 
-  .tag-item {
-    background-color: rgba(235, 235, 235, 0.5); // enable scroll-shadows to be seen
+  > span {
+    display: contents; // enable truncation in the edit labels modal
   }
-}
-
-tags-input .tags.focused,
-tags-input .tags:focus {
-  border-color: #66afe9;
-  outline: none;
-}
-
-tags-input .tags .tag-item {
-  @extend .co-m-label;
-  word-break: break-all; // required for Firefox, Edge
-}
-
-tags-input .tags .tag-list {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-tags-input .tags .tag-item.selected {
-  border: solid 1px;
-}
-
-tags-input .tags .tag-item .remove-button {
-  border: none;
-  background: none;
-  color: #585858;
-  cursor: pointer;
-  font-size: 16px;
-  margin: 0 0 0 2px;
-  padding: 0;
-  vertical-align: middle;
-}
-
-tags-input .tags .tag-item .remove-button:active {
-  color: var(--pf-global--palette--white);
-}
-
-tags-input .remove-button:active,
-tags-input .remove-button:hover {
-  text-decoration: none;
 }
 
 tags-input .tags .input {
   background: transparent;
   border: 1px solid transparent;
-  line-height: $co-m-label-line-height;
+  flex-grow: 1;
   outline: none;
-  padding: 0;
-  // Since iOS phone text input size is larger, remove border and margin and increase line-height
-  @supports (-webkit-overflow-scrolling: touch) {
-    // Target mobile Safari
-    @media (max-width: $pf-global--breakpoint--sm-max) {
-      // Target phones
-      border: 0;
-      line-height: 24px;
-      margin-bottom: 0;
-      margin-top: 0;
-    }
-  }
 }
 
 tags-input .tags .input.invalid-tag {
-  color: $pf-color-red-200;
-}
-
-tags-input .tags .input::-ms-clear {
-  display: none;
-}
-
-tags-input.ng-invalid .tags {
-  border-color: $pf-color-red-200;
-}
-
-tags-input .autocomplete {
-  background-color: var(--pf-global--BackgroundColor--100);
-  border: 1px solid rgba(0, 0, 0, 0.2);
-  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-  margin-top: 5px;
-  position: absolute;
-  padding: 5px 0;
-  width: 100%;
-  z-index: 999;
-}
-
-tags-input .autocomplete .suggestion-list {
-  margin: 0;
-  padding: 0;
-  list-style-type: none;
-}
-
-tags-input .autocomplete .suggestion-item {
-  background-color: var(--pf-global--BackgroundColor--100);
-  color: black;
-  cursor: pointer;
-  font: 16px 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  overflow: hidden;
-  padding: 5px 10px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-tags-input .autocomplete .suggestion-item.selected {
-  background-color: #0097cf;
-  color: white;
-}
-
-tags-input .autocomplete .suggestion-item.selected em {
-  background-color: #0097cf;
-  color: white;
-}
-
-tags-input .autocomplete .suggestion-item em {
-  background-color: var(--pf-global--BackgroundColor--100);
-  color: black;
-  font: normal bold 16px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  color: var(--pf-global--danger-color--100);
 }

--- a/frontend/public/components/utils/selector-input.jsx
+++ b/frontend/public/components/utils/selector-input.jsx
@@ -144,7 +144,7 @@ export class SelectorInput extends React.Component {
     };
 
     return (
-      <div className="co-search-input pf-c-form-control">
+      <div className="pf-c-form-control">
         <tags-input>
           <TagsInput
             ref={this.setRef}

--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -37,7 +37,6 @@ $pf-global-gutter--md: 1.5rem; // Matches --pf-global--gutter--md
 
 // == Custom variables
 
-$co-m-label-line-height: 20px;
 $pf-header-icon-fontsize: 16px; // Patternfly 4 default
 // Manually set because our default font size is different than PF 4
 $co-side-nav-font-size: $font-size-base; // Matches PF 4 --pf-c-nav__subnav__link--FontSize

--- a/frontend/public/style/ancillary/_bootstrap-residual.scss
+++ b/frontend/public/style/ancillary/_bootstrap-residual.scss
@@ -11,7 +11,7 @@
   display: block; // account for any element using help-block
   margin-top: 5px;
   margin-bottom: 10px;
-  color: lighten($text-color, 25%); // lighten the text some for contrast
+  color: var(--pf-global--Color--100); // matches --pf-c-helper-text__item-text--Color and picks up dark theme variable
 }
 
 label {
@@ -63,7 +63,7 @@ label {
   &.disabled,
   fieldset[disabled] & {
     label {
-      cursor: $cursor-disabled;
+      cursor: not-allowed;
     }
   }
 
@@ -103,7 +103,7 @@ label {
   // These are used directly on <label>s
   &.disabled,
   fieldset[disabled] & {
-    cursor: $cursor-disabled;
+    cursor: not-allowed;
   }
 }
 .radio-inline + .radio-inline,
@@ -127,8 +127,7 @@ label {
     > tr {
       > th,
       > td {
-        padding: $table-cell-padding;
-        line-height: $line-height-base;
+        padding: var(--pf-global--spacer--sm); // matches --pf-c-table--m-compact--cell--Padding
         vertical-align: top;
         border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
       }

--- a/frontend/public/style/ancillary/_bootstrap-variables.scss
+++ b/frontend/public/style/ancillary/_bootstrap-variables.scss
@@ -2,34 +2,6 @@
 // Variables
 // --------------------------------------------------
 
-//== Colors
-
-$gray-base:              #000 !default;
-$gray-dark:              lighten($gray-base, 20%) !default;   // #333
-$gray:                   lighten($gray-base, 33.5%) !default; // #555
-$gray-light:             lighten($gray-base, 46.7%) !default; // #777
-$gray-lighter:           lighten($gray-base, 93.5%) !default; // #eee
-
-$brand-primary:         darken(#428bca, 6.5%) !default; // #337ab7
-$brand-success:         #5cb85c !default;
-$brand-info:            #5bc0de !default;
-$brand-warning:         #f0ad4e !default;
-$brand-danger:          #d9534f !default;
-
-//== Scaffolding
-
-//** Background color for `<body>`.
-$body-bg:               #fff !default;
-//** Global text color on `<body>`.
-$text-color:            $gray-dark !default;
-
-//** Global textual link color.
-$link-color:            $brand-primary !default;
-//** Link hover color set via `darken()` function.
-$link-hover-color:      darken($link-color, 15%) !default;
-//** Link hover decoration.
-$link-hover-decoration: underline !default;
-
 //== Typography
 
 $font-size-base:          14px !default;
@@ -43,58 +15,13 @@ $line-height-computed:    floor(($font-size-base * $line-height-base)) !default;
 
 //== Components
 
-$padding-base-vertical:     6px !default;
-$padding-base-horizontal:   12px !default;
-
-$padding-large-vertical:    10px !default;
-$padding-large-horizontal:  16px !default;
-
-$padding-small-vertical:    5px !default;
-$padding-small-horizontal:  10px !default;
-
 $line-height-large:         1.3333333 !default; // extra decimals for Win 8.1 Chrome
 $line-height-small:         1.5 !default;
 
-$border-radius-base:        4px !default;
-$border-radius-large:       6px !default;
-$border-radius-small:       3px !default;
-
-//** Global color for active items (e.g., navs or dropdowns).
-$component-active-color:    #fff !default;
-//** Global background color for active items (e.g., navs or dropdowns).
-$component-active-bg:       $brand-primary !default;
-
-//== Tables
-
-//** Padding for `<th>`s and `<td>`s.
-$table-cell-padding:            8px !default;
-
-//** Border color for table and cell borders.
-$table-border-color:            #ddd !default;
-
 //== Forms
-
-//** Text color for `<input>`s
-$input-color:                    $gray !default;
-
-// TODO: Rename `$input-border-radius` to `$input-border-radius-base` in v4
-//** Default `.form-control` border radius
-// This has no effect on `<select>`s in some browsers, due to the limited stylability of `<select>`s in CSS.
-$input-border-radius:            $border-radius-base !default;
 
 //** `.form-group` margin
 $form-group-margin-bottom:       15px !default;
-
-//** Disabled cursor for form controls and buttons.
-$cursor-disabled:                not-allowed !default;
-
-//== Dropdowns
-
-//** Hover color for dropdown links.
-$dropdown-link-hover-color:      darken($gray-dark, 5%) !default;
-
-//** Disabled dropdown menu item background color.
-$dropdown-link-disabled-color:   $gray-light !default;
 
 //-- Z-index master list
 $zindex-navbar:            1000 !default;
@@ -128,15 +55,3 @@ $screen-lg-min:              $screen-lg !default;
 $screen-xs-max:              ($screen-sm-min - 1) !default;
 $screen-sm-max:              ($screen-md-min - 1) !default;
 $screen-md-max:              ($screen-lg-min - 1) !default;
-
-//== Grid system
-
-//** Number of columns in the grid.
-$grid-columns:              12 !default;
-
-//== List group
-
-//** Background color on `.list-group-item`
-$list-group-bg:                 #fff !default;
-//** `.list-group-item` border color
-$list-group-border:             #ddd !default;


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/CONSOLE-3091
Effected areas largely center around labels and modals. 
Also extracted Bootstrap variables and css

- Removed unused classes. eg. tags-input * .  Searched each bootstrap variable to see which could be easily replaced &/or removed.
- Switched the monitoring labels.tsx to use the `co-label*` rules that was missed in the earlier conversion from the custom to PF Label component, so all `co-m-label*` rules are removed. And wrapped it in `PfLabelGroup` so it gets the right spacing.

- The `co-search-input` was no longer doing anything so removed it.
- The custom modal scroll shadows were removed in an earlier pr by MNolting, which missed removing them from the Operator hub install modal, so I yanked that and reassigned the `&--accommodate-dropdown` padding-bottom to the `modal-body-content`.  Which only effects the edit taints and tolerations modals, so I checked those and increased the padding slightly since the those styles where added back when using the older PF version where dropdown items had less padding.
- The `tag-item__content` to`tag-item-content` change was [missed in this pr change](https://github.com/openshift/console/commit/206ffaed47896bb7cdad5ed5c8887d58de3b808c#diff-3a97196d178fd88488bd5f864af7997880e887d398fae4daf839b13585acf1cfR136).

- Switched our old .table  cell padding to match the --pf-c-table--m-compact--cell--Padding