### PR TITLE
Bug 2062920: Remove the namespace dropdown set menu height to prevent unneccessary…

### DIFF
--- a/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.tsx
+++ b/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.tsx
@@ -333,7 +333,7 @@ const NamespaceMenu: React.FC<{
     >
       {/*
         //@ts-ignore */}
-      <MenuContent menuHeight="60vh" maxMenuHeight="60vh">
+      <MenuContent maxMenuHeight="60vh">
         <Filter
           filterRef={filterRef}
           onFilterChange={setFilterText}


### PR DESCRIPTION
… tall menu and allow menu to adapt to the number of projects

Fixes [bug 2062920](https://bugzilla.redhat.com/show_bug.cgi?id=2062920)

before/after
![menu-no-collapse](https://user-images.githubusercontent.com/1874151/175107606-7fa0c6fd-c2ca-444b-b2f2-aa2453a0aba3.gif)
![menu-collapse](https://user-images.githubusercontent.com/1874151/175107623-321d759c-7cd5-435e-b8a2-085a723ebc6f.gif)


