### PR TITLE
Bug 2099654: Fix endless re-render loop when associatedDeployment is not defined

### DIFF
--- a/frontend/packages/console-shared/src/hooks/usePodsWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/usePodsWatcher.ts
@@ -7,6 +7,11 @@ import { getPodsDataForResource, getResourcesToWatchForPods } from '../utils';
 import { useDebounceCallback } from './debounce';
 import { useDeepCompareMemoize } from './deep-compare-memoize';
 
+/**
+ * Watches for all Pods for a kind and namespace.
+ * Kind and namespace is used from the given `resource` and can be overridden
+ * with the `kind` and `namespace` parameters.
+ */
 export const usePodsWatcher = (
   resource: K8sResourceKind,
   kind?: string,
@@ -15,12 +20,12 @@ export const usePodsWatcher = (
   const [loaded, setLoaded] = useSafetyFirst<boolean>(false);
   const [loadError, setLoadError] = useSafetyFirst<string>('');
   const [podData, setPodData] = useSafetyFirst<PodRCData>(undefined);
-  const watchKind = kind || resource.kind;
-  const watchNS = namespace || resource.metadata.namespace;
-  const watchedResources = React.useMemo(() => getResourcesToWatchForPods(watchKind, watchNS), [
-    watchKind,
-    watchNS,
-  ]);
+  const watchKind = kind || resource?.kind;
+  const watchNS = namespace || resource?.metadata.namespace;
+  const watchedResources = React.useMemo(
+    () => (watchKind ? getResourcesToWatchForPods(watchKind, watchNS) : {}),
+    [watchKind, watchNS],
+  );
 
   const resources = useK8sWatchResources(watchedResources);
 

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
@@ -57,8 +57,11 @@ const EventSink: React.FC<EventSinkProps> = ({
   const isKafkaConnectionLinkPresent =
     element.getSourceEdges()?.filter((edge: Edge) => edge.getType() === TYPE_KAFKA_CONNECTION_LINK)
       .length > 0;
-  const { revisions, associatedDeployment = {} } = resources;
-  const revisionIds = revisions?.map((revision) => revision.metadata.uid);
+  const { revisions, associatedDeployment } = resources;
+  const revisionIds = React.useMemo(() => revisions?.map((revision) => revision.metadata.uid), [
+    revisions,
+  ]);
+
   const { loaded, loadError, pods } = usePodsForRevisions(revisionIds, resource.metadata.namespace);
   const controller = useVisualizationController();
   const detailsLevel = controller.getGraph().getDetailsLevel();
@@ -70,8 +73,8 @@ const EventSink: React.FC<EventSinkProps> = ({
     loaded: loadedDeployment,
   } = usePodsWatcher(
     associatedDeployment,
-    associatedDeployment.kind ?? DeploymentModel.kind,
-    associatedDeployment.metadata?.namespace || resource.metadata?.namespace,
+    associatedDeployment?.kind ?? DeploymentModel.kind,
+    associatedDeployment?.metadata?.namespace || resource.metadata?.namespace,
   );
 
   const isKafkaSink = referenceFor(resource) === referenceForModel(KafkaSinkModel);

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-resource-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-resource-tab-sections.tsx
@@ -73,7 +73,7 @@ export const useKnativeSidepanelEventSinkSection: DetailsTabSectionExtensionHook
 
 export const usePodsForEventSink = (resource: K8sResourceKind, data) => {
   const { t } = useTranslation();
-  const { revisions, associatedDeployment = {} } = data;
+  const { revisions, associatedDeployment } = data;
   const { pods, loaded, loadError } = usePodsForRevisions(
     revisions?.map((r) => r.metadata.uid) ?? '',
     resource.metadata.namespace,
@@ -120,7 +120,7 @@ export const usePodsForEventSink = (resource: K8sResourceKind, data) => {
 };
 
 export const usePodsForEventSource = (resource: K8sResourceKind, data) => {
-  const { associatedDeployment = {} } = data;
+  const { associatedDeployment } = data;
   const {
     podData: podsDeployment,
     loadError: loadErrorDeployment,
@@ -133,7 +133,7 @@ export const usePodsForEventSource = (resource: K8sResourceKind, data) => {
 
   return React.useMemo(
     () =>
-      Object.keys(associatedDeployment).length === 0
+      !associatedDeployment || Object.keys(associatedDeployment).length === 0
         ? null
         : {
             pods: podsDeployment?.pods ?? [],


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2099654

**Analysis / Root cause**: 
The endless rerender happens because `EventSink` sets `associatedDeployment` to a empty object `= {}` when its not defined.

https://github.com/openshift/console/blob/e9ceaf5d255eee6bac40e0733d6e635151345b0d/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx#L60-L75

On each rerender this object doesn't match the old instance and triggers the updateResources call in usePodsWatcher:

https://github.com/openshift/console/blob/e9ceaf5d255eee6bac40e0733d6e635151345b0d/frontend/packages/console-shared/src/hooks/usePodsWatcher.ts#L49-L51

And then we have an endless re-render loop...

**Solution Description**: 
1. Don't set `associatedDeployment` to a empty object `= {}`, just keep it undefined
2. Make the rest of the code save if the `associatedDeployment` is null or undefined.
3. Don't watch anything in `usePodsWatcher` if NO resource AND NO kind is defined.
4. Add useMemo for `const revisionIds` in `EventSink` because the revision.map creates a new array every render and breaks the `const donutStatus` `useMemo`

Highlight updates in React dev tools before:

https://user-images.githubusercontent.com/139310/175125694-9e716992-48f6-47bc-9ff6-4c352eb870b2.mp4

Highlight updates in React dev tools with this PR:

https://user-images.githubusercontent.com/139310/175125705-ef66dba3-6180-409e-8c51-1cf9d824c0bf.mp4

**Unit test coverage report**: 
Untouched

**Test setup:**
1. Install Serverless and Camel K operator
3. Create required eventing resources
4. Open the developer perspective
5. Navigate to Add > Event Sinks and search for HTTP
6. Select "HTTP Sink" and press "Create Event Sink"
7. Enter any URL and press Create
8. Navigate to the topology graph, open the react dev tools (browser extension)
9. Select the React Components tab and enable "Highlight updates when component render."

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
