### PR TITLE
Bug 2100356: remove Condition tab and create option if the crd is not available

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -176,6 +176,17 @@
     "type": "console.flag/model",
     "properties": {
       "model": {
+        "group": "tekton.dev",
+        "version": "v1alpha1",
+        "kind": "Condition"
+      },
+      "flag": "OPENSHIFT_PIPELINE_CONDITION"
+    }
+  },
+  {
+    "type": "console.flag/model",
+    "properties": {
+      "model": {
         "group": "pipelinesascode.tekton.dev",
         "version": "v1alpha1",
         "kind": "Repository"
@@ -225,6 +236,9 @@
         "kind": "Condition"
       },
       "component": { "$codeRef": "pipelinesComponent.PipelineConditionDetailsPage" }
+    },
+    "flags": {
+      "required": ["OPENSHIFT_PIPELINE_CONDITION"]
     }
   },
   {
@@ -379,6 +393,9 @@
         "kind": "Condition"
       },
       "component": { "$codeRef": "pipelinesComponent.ConditionListPage" }
+    },
+    "flags": {
+      "required": ["OPENSHIFT_PIPELINE_CONDITION"]
     }
   },
   {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines-lists/PipelinesListsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines-lists/PipelinesListsPage.tsx
@@ -17,7 +17,7 @@ import {
   SecondaryButtonAction,
   useFlag,
 } from '@console/shared';
-import { FLAG_OPENSHIFT_PIPELINE_AS_CODE } from '../../const';
+import { FLAG_OPENSHIFT_PIPELINE_AS_CODE, FLAG_OPENSHIFT_PIPELINE_CONDITION } from '../../const';
 import {
   PipelineModel,
   PipelineResourceModel,
@@ -40,6 +40,7 @@ interface PipelinesListPageProps {
 const PipelinesListPage: React.FC<PipelinesListPageProps> = ({ match }) => {
   const { t } = useTranslation();
   const isRepositoryEnabled = useFlag(FLAG_OPENSHIFT_PIPELINE_AS_CODE);
+  const isConditionsEnabled = useFlag(FLAG_OPENSHIFT_PIPELINE_CONDITION);
   const {
     params: { ns: namespace },
   } = match;
@@ -62,7 +63,7 @@ const PipelinesListPage: React.FC<PipelinesListPageProps> = ({ match }) => {
     },
     pipelineRun: { model: PipelineRunModel },
     pipelineResource: { model: PipelineResourceModel },
-    condition: { model: ConditionModel },
+    ...(isConditionsEnabled ? { condition: { model: ConditionModel } } : {}),
     ...(isRepositoryEnabled
       ? {
           repository: {
@@ -90,17 +91,21 @@ const PipelinesListPage: React.FC<PipelinesListPageProps> = ({ match }) => {
       component: PipelineResourcesListPage,
       pageData: { showTitle, hideBadge },
     },
-    {
-      href: 'conditions',
-      name: t(ConditionModel.labelPluralKey),
-      component: DefaultPage,
-      pageData: {
-        kind: referenceForModel(ConditionModel),
-        canCreate,
-        namespace,
-        showTitle,
-      },
-    },
+    ...(isConditionsEnabled
+      ? [
+          {
+            href: 'conditions',
+            name: t(ConditionModel.labelPluralKey),
+            component: DefaultPage,
+            pageData: {
+              kind: referenceForModel(ConditionModel),
+              canCreate,
+              namespace,
+              showTitle,
+            },
+          },
+        ]
+      : []),
     ...(isRepositoryEnabled
       ? [
           {

--- a/frontend/packages/pipelines-plugin/src/const.ts
+++ b/frontend/packages/pipelines-plugin/src/const.ts
@@ -1,5 +1,6 @@
 export const FLAG_OPENSHIFT_PIPELINE = 'OPENSHIFT_PIPELINE';
 export const FLAG_OPENSHIFT_PIPELINE_AS_CODE = 'OPENSHIFT_PIPELINE_AS_CODE';
+export const FLAG_OPENSHIFT_PIPELINE_CONDITION = 'OPENSHIFT_PIPELINE_CONDITION';
 export const CLUSTER_PIPELINE_NS = 'openshift';
 export const PIPELINE_RUNTIME_LABEL = 'pipeline.openshift.io/runtime';
 export const PIPELINE_RUNTIME_VERSION_LABEL = 'pipeline.openshift.io/runtime-version';


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2100356

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

 Deprecated `Conditions` has been removed. Existing pipelines using Conditions will need to be updated. 
 Ref: https://github.com/tektoncd/pipeline/releases/tag/v0.37.0

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Feature flagged `Condition` CRD, to show/hide based on the availability of the CRD.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
**With OSP 1.7.1 installed:**

<img width="1791" alt="image" src="https://user-images.githubusercontent.com/9964343/175250167-19ca0423-bd8a-46e9-9d02-5a9f30fe70c4.png">

**With Tekton V.37 installed**:

<img width="1789" alt="image" src="https://user-images.githubusercontent.com/9964343/175250258-eb0e764d-8f82-4240-ab36-577dafb1ad25.png">



**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
To install tekton v.37 use this following command
```
kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.37.0/release.yaml
```
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge