### PR TITLE
[release-4.10] Bug 2100431: Improve SLA test stability by not fetching subscription two times (at the same time)

### DIFF
--- a/frontend/public/components/utils/service-level.tsx
+++ b/frontend/public/components/utils/service-level.tsx
@@ -164,8 +164,10 @@ const useLoadServiceLevel = (): [boolean, boolean, (clusterID: string) => void] 
 
   return [loadingSecret, loadingServiceLevel, loadServiceLevel];
 };
+
 const useGetServiceLevel = (
   clusterIDParam: string,
+  loadServiceLevelIfNeeded: boolean,
 ): {
   level: string;
   daysRemaining: number | null;
@@ -184,7 +186,12 @@ const useGetServiceLevel = (
   const [loadingSecret, loadingServiceLevel, loadServiceLevel] = useLoadServiceLevel();
 
   React.useEffect(() => {
-    if (clusterID !== clusterIDParam && !loadingSecret && !loadingServiceLevel) {
+    if (
+      clusterID !== clusterIDParam &&
+      !loadingSecret &&
+      !loadingServiceLevel &&
+      loadServiceLevelIfNeeded
+    ) {
       loadServiceLevel(clusterIDParam);
     }
     // only on clusterID change
@@ -205,7 +212,10 @@ export const ServiceLevel: React.FC<{ clusterID: string; children: React.ReactNo
   clusterID,
   children,
 }) => {
-  const { hasSecretAccess, loadingSecret, loadingServiceLevel } = useGetServiceLevel(clusterID);
+  const { hasSecretAccess, loadingSecret, loadingServiceLevel } = useGetServiceLevel(
+    clusterID,
+    false,
+  );
 
   if (!showServiceLevel(clusterID)) {
     return null;
@@ -214,18 +224,20 @@ export const ServiceLevel: React.FC<{ clusterID: string; children: React.ReactNo
     return null;
   }
   if (!loadingSecret && loadingServiceLevel) {
-    return <Skeleton />;
+    return <Skeleton width="100%" />;
   }
 
   return <>{children}</>;
 };
+
 type ServiceLevelTextProps = {
   clusterID?: string;
   inline?: boolean;
 };
+
 export const ServiceLevelText: React.FC<ServiceLevelTextProps> = ({ clusterID, inline }) => {
   const { t } = useTranslation();
-  const { level, daysRemaining } = useGetServiceLevel(clusterID);
+  const { level, daysRemaining } = useGetServiceLevel(clusterID, false);
   const levelText = (
     <>
       {useServiceLevelText(level)}
@@ -265,13 +277,14 @@ export const ServiceLevelText: React.FC<ServiceLevelTextProps> = ({ clusterID, i
     </>
   );
 };
+
 export const useServiceLevelTitle = (): string => {
   const { t } = useTranslation();
   return t('public~Service Level Agreement (SLA)');
 };
 
 export const useShowServiceLevelNotifications = (clusterID: string): boolean => {
-  const { level } = useGetServiceLevel(clusterID);
+  const { level } = useGetServiceLevel(clusterID, true);
   return level && (level === 'Eval' || level === 'None');
 };
 
@@ -280,7 +293,7 @@ export const ServiceLevelNotification: React.FC<{
   toggleNotificationDrawer: () => void;
 }> = ({ clusterID, toggleNotificationDrawer }) => {
   const { t } = useTranslation();
-  const { level, daysRemaining, trialDateEnd } = useGetServiceLevel(clusterID);
+  const { level, daysRemaining, trialDateEnd } = useGetServiceLevel(clusterID, false);
   const showServiceLevelNotification = useShowServiceLevelNotifications(clusterID);
 
   if (!showServiceLevelNotification) {


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2100431 - A backport of #11701

**Analysis / Root cause**: 
SLA was fetched two times at the same time. This might confuse our e2e tests. The UI is flickering.

**Solution Description**: 
Fetch subscription only when `useGetServiceLevel` was called from `useShowServiceLevelNotifications`. `useShowServiceLevelNotifications` was used in the ConnectedNotificationDrawer, which was always rendered in app.jsx.

So it is not needed to call the API again from the components `ServiceLevelNotification` and `ServiceLevelText`.

**Screenrecording**: 

SLA API calls before:

https://user-images.githubusercontent.com/139310/175283568-373dc69e-070c-43a1-8cde-07106afcd46c.mp4

SLA API calls with this PR:

**TODO: waiting on a cluster bot instance**

**Unit test coverage report**: 
Untouched

**Test setup:**
1. Open the network inspector and filter for `api/accounts_mgmt`
2. Reload the console
3. Check that the information from the SLA are still displayed correctly

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
