### PR TITLE
Bug 2099358: Fix application group background colors

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/components/groups/Application.scss
+++ b/frontend/packages/topology/src/components/graph-view/components/groups/Application.scss
@@ -2,12 +2,27 @@
 @import '../../../topology-utils';
 
 .odc-application-group {
+  cursor: pointer;
+
+  .odc-m-drag-active & {
+    pointer-events: none;
+  }
+
+  .pf-topology__group__background {
+    fill: $group-node-fill-color;
+    fill-opacity: $group-node-fill-opacity;
+  }
+
   &.is-filtered .pf-topology__group__background {
     stroke: $filtered-stroke-color;
   }
   &.pf-m-highlight .pf-topology__group__background {
     fill: $pf-color-black-150;
     stroke: $interactive-stroke-color;
+  }
+  &.pf-m-selected .pf-topology__group__background {
+    stroke: $selected-stroke-color;
+    fill: $selected-fill-color;
   }
 }
 .odc-m-drag-active,


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2099358

**Analysis / Root cause**: 
Application group backgrounds did not change on select when the group was hovered. They also did not have the pointer cursor indicating the group is selectable. In light theme, the background was the same as the graph so at low zoom scales it was hard to see the groupings.

**Solution Description**: 
Update the background color of the groups and use opacity to stagger the group background colors which makes it easier to distinguish groups and groups within groups. Add a pointer cursor on the application groups so the user can see that the groups are selectable (and gives an indication of hover when the group is selected since there is no other hover indication when selected).

**Screen shots / Gifs for design review**: 

### Default

Dark theme before
![image](https://user-images.githubusercontent.com/11633780/175301109-02e0e0f9-475e-441b-8144-3c7148b683ea.png)

Dark theme after:  Background color updated
![image](https://user-images.githubusercontent.com/11633780/175301457-a6f70991-ee1e-4ba0-a21b-5f36104c7ccd.png)

Light theme before
![image](https://user-images.githubusercontent.com/11633780/175301749-bbd0fd1b-d5f5-40d9-bbc7-abc7ea343b28.png)

Light theme after: Background color updated
![image](https://user-images.githubusercontent.com/11633780/175301834-6bf309c8-b6ad-4e8c-ba2a-b8f128b94235.png)

## Selected

Dark theme before
![image](https://user-images.githubusercontent.com/11633780/175301187-1c911af0-24f1-4c0f-bbe7-88bcc7097800.png)

Dark theme after:  Background color updated
![image](https://user-images.githubusercontent.com/11633780/175301553-3dd29ee7-beee-4901-91c0-81d56046f168.png)

 Light theme before
![image](https://user-images.githubusercontent.com/11633780/175311286-f37c3ab9-af91-481f-905c-fa92babe2448.png)

Light theme after: Background color updated
![image](https://user-images.githubusercontent.com/11633780/175311727-6f009487-d7db-4754-962b-b622b03c3c3d.png)

## Hovered

Dark theme before
![image](https://user-images.githubusercontent.com/11633780/175317596-503fa282-fc62-46dd-80b4-c3612ba63385.png)

Dark theme after: Background color updated, add pointer cursor
![image](https://user-images.githubusercontent.com/11633780/175318495-5de3ad05-e68a-4ca1-bd7b-721df0eb34fc.png)

Light theme before
![image](https://user-images.githubusercontent.com/11633780/175318149-49e2529b-a9bf-451e-b088-9a0d6b6aee3b.png)

Light theme after: pointer cursor added
![image](https://user-images.githubusercontent.com/11633780/175317939-157ee081-05b9-4250-9b83-4bb758b6a985.png)


## Selected and Hovered

Dark theme before
![image](https://user-images.githubusercontent.com/11633780/175301292-736d9605-4775-4f7f-b6d9-524ec1bc0d73.png)

Dark theme after:  Background color updated and pointer cursor added, keep selection treatments
![image](https://user-images.githubusercontent.com/11633780/175301651-23c0156b-fc4a-49a2-b047-31bfdf6d52ac.png)

Light theme before
![image](https://user-images.githubusercontent.com/11633780/175315538-244ad4a8-a653-43b4-b29c-6914506d471f.png)

Light theme after Add pointer cursor, keep border selection treatment
![image](https://user-images.githubusercontent.com/11633780/175315835-242143a5-f28a-4f6b-8b87-daf766d0e8db.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge