### PR TITLE
[release-4.10] Bug 2095637: Disable update channel validation as well

### DIFF
--- a/frontend/integration-tests/tests/dashboards/cluster-dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/dashboards/cluster-dashboard.scenario.ts
@@ -29,7 +29,10 @@ describe('Cluster Dashboard', () => {
         // Underlating issue is a `504 Gateway Timeout` error.
         // See also https://bugzilla.redhat.com/show_bug.cgi?id=2096374
         // 'Service Level Agreement (SLA)',
-        'Update channel',
+
+        // We need to disable everything after the SLA validation because
+        // of the index based implementation.
+        // 'Update channel',
       ];
       const items = clusterDashboardView.detailsCardList.$$('dt');
       const values = clusterDashboardView.detailsCardList.$$('dd');


### PR DESCRIPTION
E2e tests fail after #11710 got merged and the SLA API is available again.

See also https://prow.ci.openshift.org/?repo=openshift%2Fconsole&job=pull-ci-openshift-console-release-4.10-e2e-gcp-console
