### PR TITLE
Bug 2099528: Restore spacing between/below modal body content

### DIFF
--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -39,6 +39,9 @@
 .modal-body-content {
   height: 100%;
   padding: 0 var(--pf-global--spacer--xl) var(--pf-global--spacer--xl);
+  p {
+    margin-bottom: var(--pf-c-content--MarginBottom);
+  }
 }
 
 .modal-content {

--- a/frontend/public/components/modals/delete-modal.tsx
+++ b/frontend/public/components/modals/delete-modal.tsx
@@ -66,7 +66,7 @@ const DeleteModal = withHandlePromise((props: DeleteModalProps & HandlePromisePr
 
   const { kind, resource, message, errorMessage } = props;
   return (
-    <form onSubmit={submit} name="form" className="modal-content ">
+    <form onSubmit={submit} name="form" className="modal-content">
       <ModalTitle>
         <YellowExclamationTriangleIcon className="co-icon-space-r" />{' '}
         {t('public~Delete {{kind}}?', {

--- a/frontend/public/components/modals/delete-namespace-modal.tsx
+++ b/frontend/public/components/modals/delete-namespace-modal.tsx
@@ -67,7 +67,7 @@ export const DeleteNamespaceModal: React.FC<DeleteNamespaceModalProps> = ({
   };
 
   return (
-    <form onSubmit={onSubmit} name="form" className="modal-content ">
+    <form onSubmit={onSubmit} name="form" className="modal-content">
       <ModalTitle className="modal-header">
         <YellowExclamationTriangleIcon className="co-icon-space-r" />{' '}
         {t('public~Delete {{label}}?', { label: t(kind.labelKey) })}

--- a/frontend/public/components/modals/managed-resource-save-modal.tsx
+++ b/frontend/public/components/modals/managed-resource-save-modal.tsx
@@ -17,7 +17,7 @@ const ManagedResourceSaveModal: React.SFC<ManagedResourceSaveModalProps> = (prop
   const { owner, resource } = props;
   const { t } = useTranslation();
   return (
-    <form onSubmit={submit} name="form" className="modal-content ">
+    <form onSubmit={submit} name="form" className="modal-content">
       <ModalTitle>
         <YellowExclamationTriangleIcon className="co-icon-space-r" /> {t('public~Managed resource')}
       </ModalTitle>


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2099528

**Analysis / Root cause**: 
#10649 removes global spacing below paragraphs and #11404 restores some of them on different pages, but it was still missing on the modals.

**Solution Description**: 
Restore/Add spacing specific for modals.

**Screen shots / Gifs for design review**: 
Before:
<img width="641" alt="image" src="https://user-images.githubusercontent.com/139310/175402699-64cee6c0-1297-4831-97d4-f82ebf58075d.png">

With this change:
<img width="647" alt="image" src="https://user-images.githubusercontent.com/139310/175402807-92ce324e-51f3-4b33-8ddc-a678caa5d423.png">

**Unit test coverage report**: 
Unchanged

**Test setup:**
Open any (?) delete (?) modal, for example "Delete Project"

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
