### PR TITLE
Bug 2100159: [dark theme] Fix build pending icon color in topology sidebar

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/Status.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/Status.tsx
@@ -34,7 +34,7 @@ const Status: React.FC<StatusProps> = ({
       return <StatusIconAndText {...statusProps} icon={<HourglassStartIcon />} />;
 
     case 'Pending':
-      return <StatusIconAndText {...statusProps} icon={<HourglassHalfIcon color="inherit" />} />;
+      return <StatusIconAndText {...statusProps} icon={<HourglassHalfIcon />} />;
 
     case 'Planning':
       return <StatusIconAndText {...statusProps} icon={<ClipboardListIcon />} />;


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2100159

**Analysis / Root cause**: 
There was just one icon with `color="inherit"` in our complete project, with this attribute the icon ignores the theme color.

**Solution Description**: 
Removed this color attribute to show the icon in the right color.

**Screen shots / Gifs for design review**: 
I have done this screenshot with the new state while testing this. In reality the wrong color is only shown for the pending state!

Before:
<img width="438" alt="light-before" src="https://user-images.githubusercontent.com/139310/175411374-6affb181-70d7-49e8-9174-656180238dd4.png">

<img width="435" alt="dark-before" src="https://user-images.githubusercontent.com/139310/175411403-03a1d0df-14c9-4334-a861-a027772375cc.png">

With this PR:
<img width="418" alt="dark-after" src="https://user-images.githubusercontent.com/139310/175411340-e54444f8-09f5-4e49-a13a-604fcc06d420.png">

<img width="425" alt="light-after" src="https://user-images.githubusercontent.com/139310/175411363-bf8288aa-ab67-43c1-a0e3-31ccf8c002c4.png">

**Unit test coverage report**: 
Untouched

**Test setup:**
1. Import from git (s2i)
2. Switch to topology and open the deployment
3. Checkout the build status icons, click on start to trigger a new build

Only the pending state was wrong, it was shown really short between new and in progress.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
/cc @divyanshiGupta
