### PR TITLE
Bug 2100666: Use BuildConfig form also when pressing create

### DIFF
--- a/frontend/packages/dev-console/src/components/buildconfig/BuildConfigForm.tsx
+++ b/frontend/packages/dev-console/src/components/buildconfig/BuildConfigForm.tsx
@@ -40,16 +40,19 @@ const BuildConfigForm: React.FC<FormikProps<BuildConfigFormikValues> & {
   const { t } = useTranslation();
   const [activeNamespace] = useActiveNamespace();
 
-  const namespace = watchedBuildConfig?.metadata?.namespace || activeNamespace;
+  const isNew =
+    !watchedBuildConfig?.metadata?.name || watchedBuildConfig?.metadata?.name === '~new';
+  const isStale =
+    !isNew && watchedBuildConfig?.metadata?.resourceVersion !== values.resourceVersion;
 
-  const isStale = watchedBuildConfig?.metadata?.resourceVersion !== values.resourceVersion;
+  const namespace = watchedBuildConfig?.metadata?.namespace || activeNamespace;
 
   const formEditor = <BuildConfigFormEditor namespace={namespace} />;
   const yamlEditor = (
     <YAMLEditorField
       name="yamlData"
       model={BuildConfigModel}
-      showSamples={!watchedBuildConfig}
+      showSamples={isNew}
       onSave={handleSubmit}
     />
   );
@@ -97,14 +100,14 @@ const BuildConfigForm: React.FC<FormikProps<BuildConfigFormikValues> & {
         />
       </FormBody>
       <FormFooter
-        handleReset={onReload}
+        handleReset={isNew ? null : onReload}
         errorMessage={status?.submitError}
         successMessage={status?.submitSuccess}
         showAlert={isStale}
         infoTitle={t('devconsole~This object has been updated.')}
         infoMessage={t('devconsole~Click reload to see the new version.')}
         isSubmitting={isSubmitting}
-        submitLabel={t('devconsole~Save')}
+        submitLabel={isNew ? t('devconsole~Create') : t('devconsole~Save')}
         disableSubmit={
           (values.editorType === EditorType.YAML ? !dirty : !dirty || !_.isEmpty(errors)) ||
           isSubmitting

--- a/frontend/packages/dev-console/src/components/buildconfig/EditBuildConfig.tsx
+++ b/frontend/packages/dev-console/src/components/buildconfig/EditBuildConfig.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Formik, FormikHelpers } from 'formik';
 import { useTranslation } from 'react-i18next';
-import { history } from '@console/internal/components/utils';
+import { history, resourcePathFromModel } from '@console/internal/components/utils';
 import { k8sCreate, k8sUpdate } from '@console/internal/module/k8s';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
 import { safeJSToYAML, safeYAMLToJS } from '@console/shared/src/utils/yaml';
@@ -64,24 +64,13 @@ const EditBuildConfig: React.FC<EditBuildConfigProps> = ({
         ? await k8sCreate<BuildConfig>(BuildConfigModel, changedBuildConfig)
         : await k8sUpdate<BuildConfig>(BuildConfigModel, changedBuildConfig, namespace, name);
 
-      helpers.setFieldValue(
-        'yamlData',
-        safeJSToYAML(updatedBuildConfig, '', { skipInvalid: true }),
-        false,
+      history.push(
+        resourcePathFromModel(
+          BuildConfigModel,
+          updatedBuildConfig.metadata.name,
+          updatedBuildConfig.metadata.namespace,
+        ),
       );
-      helpers.setFieldValue('resourceVersion', updatedBuildConfig.metadata.resourceVersion, true);
-      helpers.setStatus({
-        submitSuccess: t('devconsole~{{name}} has been updated to version {{resVersion}}', {
-          name: updatedBuildConfig.metadata.name,
-          resVersion: updatedBuildConfig.metadata.resourceVersion,
-        }),
-        submitError: '',
-      });
-      if (isNew) {
-        history.replace(
-          history.location.pathname.replace('~new', updatedBuildConfig.metadata.name),
-        );
-      }
     } catch (err) {
       helpers.setStatus({ submitSuccess: '', submitError: err.message });
     }

--- a/frontend/packages/dev-console/src/components/buildconfig/form-utils/validation.ts
+++ b/frontend/packages/dev-console/src/components/buildconfig/form-utils/validation.ts
@@ -6,26 +6,35 @@ import { BuildConfigFormikValues } from './types';
 const nameSchema = () => yup.string().required(i18n.t('devconsole~Required'));
 
 const sourceSchema = () =>
-  yup.object({
-    git: yup.object().when('type', {
-      is: 'git',
-      then: yup.object({
-        git: yup.object({
-          url: yup.string().required(i18n.t('devconsole~Required')),
-          ref: yup.string(),
-          dir: yup.string(),
+  yup
+    .object({
+      type: yup
+        .string()
+        .required(i18n.t('devconsole~Required'))
+        .oneOf(['git', 'dockerfile', 'binary']),
+      git: yup.object().when('type', {
+        is: 'git',
+        then: yup.object({
+          git: yup.object({
+            url: yup.string().required(i18n.t('devconsole~Required')),
+            ref: yup.string(),
+            dir: yup.string(),
+          }),
         }),
       }),
-    }),
-    dockerfile: yup.string().when('type', {
-      is: 'dockerfile',
-      then: yup.string(),
-    }),
-  });
+      dockerfile: yup.string().when('type', {
+        is: 'dockerfile',
+        then: yup.string(),
+      }),
+    })
+    .required(i18n.t('devconsole~Required'));
 
-const imageSchema = () =>
+const imageSchema = (allowedTypes: string[]) =>
   yup.object({
-    type: yup.string().required(i18n.t('devconsole~Required')),
+    type: yup
+      .string()
+      .required(i18n.t('devconsole~Required'))
+      .oneOf(allowedTypes),
     imageStreamTag: yup.object().when('type', {
       is: 'imageStreamTag',
       then: yup.object({
@@ -48,8 +57,8 @@ const imageSchema = () =>
 
 const imagesSchema = () =>
   yup.object({
-    buildFrom: imageSchema(),
-    pushTo: imageSchema(),
+    buildFrom: imageSchema(['imageStreamTag', 'imageStreamImage', 'dockerImage']),
+    pushTo: imageSchema(['none', 'imageStreamTag', 'imageStreamImage', 'dockerImage']),
   });
 
 const environmentVariablesSchema = () => yup.array();

--- a/frontend/packages/dev-console/src/components/buildconfig/sections/ImagesSection.tsx
+++ b/frontend/packages/dev-console/src/components/buildconfig/sections/ImagesSection.tsx
@@ -33,7 +33,8 @@ const ImageOption: React.FC<{
   fallbackTitle: string;
   items: Record<string, string>;
   dataTest: string;
-}> = ({ fieldPrefix, label, fallbackTitle, items, dataTest }) => {
+  required?: boolean;
+}> = ({ fieldPrefix, label, fallbackTitle, items, dataTest, required }) => {
   const { t } = useTranslation();
   const [{ value: type }] = useField<ImageOptionType>(`${fieldPrefix}.type`);
 
@@ -45,6 +46,7 @@ const ImageOption: React.FC<{
         items={items}
         title={items[type] || fallbackTitle}
         dataTest={`${dataTest} type`}
+        required={required}
       />
 
       {type === 'imageStreamTag' ? (
@@ -111,6 +113,7 @@ const ImagesSection: React.FC<{}> = () => {
         fallbackTitle={t('devconsole~Please select')}
         items={buildFromItems}
         dataTest="build-from"
+        required
       />
       <ImageOption
         fieldPrefix="formData.images.pushTo"

--- a/frontend/packages/dev-console/src/components/builds/BuildsTabListPage.tsx
+++ b/frontend/packages/dev-console/src/components/builds/BuildsTabListPage.tsx
@@ -64,7 +64,7 @@ const BuildsTabListPage: React.FC<BuildsTabListPageProps> = ({ match }) => {
   if (namespace) {
     menuActions.buildConfig = {
       label: t('devconsole~BuildConfig'),
-      onSelection: () => `/k8s/ns/${namespace}/buildconfigs/~new`,
+      onSelection: () => `/k8s/ns/${namespace}/buildconfigs/~new/form`,
     };
   }
   if (buildConfigComponent) {

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { match as Rmatch } from 'react-router-dom';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { useTranslation } from 'react-i18next';
 import { K8sResourceKind, K8sResourceKindReference, referenceFor } from '../module/k8s';
 import { startBuild } from '../module/k8s/builds';
 import { DetailsPage, ListPage, Table, TableData, RowFunctionArgs } from './factory';
@@ -213,6 +214,12 @@ export const BuildConfigsPage: React.FC<BuildConfigsPageProps> = (props) => {
       items: allStrategies,
     },
   ];
+
+  const namespace = props.match.params.ns;
+  const createProps = {
+    to: `/k8s/ns/${namespace || 'default'}/buildconfigs/~new/form`,
+  };
+
   return (
     <ListPage
       {...props}
@@ -220,6 +227,7 @@ export const BuildConfigsPage: React.FC<BuildConfigsPageProps> = (props) => {
       kind={BuildConfigsReference}
       ListComponent={BuildConfigsList}
       canCreate={props.canCreate ?? true}
+      createProps={createProps}
       filterLabel={props.filterLabel}
       rowFilters={filters}
     />
@@ -232,6 +240,7 @@ export type BuildConfigsDetailsProps = {
 };
 
 export type BuildConfigsPageProps = {
+  match: Rmatch<{ ns?: string }>;
   canCreate?: boolean;
   filterLabel?: string;
   mock?: boolean;


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2100666

**Analysis / Root cause**: 
BuildConfig form was only used for edit flow before.

**Solution Description**: 
Set the right URL as `createProps` similar to Deployments, DeploymentConfigs, etc.

Redirects now to the details page when the user presses "Create".

Updated the form required fields and yup validation to ensure that the user enters all required data.

**Recording**

https://user-images.githubusercontent.com/139310/181357312-ec730cdb-bdf1-4f5b-8ec8-29acc3e50c4d.mp4

**Test setup:**
1. Switch to dev perspective
2. Navigate to build
3. Click on create
4. Opens a YAML editor to create a BuildConfig in admin and dev perspective

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
