### PR TITLE
Bug 2091102: Name of workload get changed, when project and image stream gets changed on edit deployment page of the workload

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-deployment/EditDeployment.tsx
+++ b/frontend/packages/dev-console/src/components/edit-deployment/EditDeployment.tsx
@@ -39,7 +39,10 @@ const EditDeployment: React.FC<EditDeploymentProps> = ({ heading, resource, name
     yamlData: safeJSToYAML(resource, 'yamlData', {
       skipInvalid: true,
     }),
-    formData: convertDeploymentToEditForm(resource),
+    formData: {
+      ...convertDeploymentToEditForm(resource),
+      formType: isNew ? 'create' : 'edit',
+    },
     formReloadCount: 0,
   });
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGSM-44809

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Name of workload get changed, when project and image stream gets changed on edit deployment page of the workload.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Workload name doesn't have to be changed, when image stream name changed on edit deployment page, as name field is not changeable.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/47265560/175432164-ca6f6b35-26d7-4446-bc7c-92e5261d02c3.mp4

**Unit test coverage report**: 
<!-- Attach test coverage report -->
No Change

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Create a deployment workload
2. Select Edit Deployment option on workload
3. Verify initially name was same as workload name and field was not changeable.
4. Change the project to "openshift", image stream to "golang" or anything and tag to "latest"
5. Now check that the name also got changed to golang.


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge