### PR TITLE
Bug 2100669: Don't log usernames with the telemetry plugin

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -60,6 +60,7 @@ const breakpointMD = 1200;
 const NOTIFICATION_DRAWER_BREAKPOINT = 1800;
 // Edge lacks URLSearchParams
 import 'url-search-params-polyfill';
+import { withoutSensitiveInformations } from './utils/telemetry';
 import { graphQLReady } from '../graphql/client';
 
 initI18n();
@@ -284,7 +285,7 @@ const CaptureTelemetry = React.memo(function CaptureTelemetry() {
   // Also because some pages update the URL as the user enters a search term.
   const fireUrlChangeEvent = useDebounceCallback(fireTelemetryEvent);
   React.useEffect(() => {
-    fireUrlChangeEvent('page', history.location);
+    fireUrlChangeEvent('page', withoutSensitiveInformations(history.location));
 
     let { pathname, search } = history.location;
     const unlisten = history.listen((location) => {
@@ -292,7 +293,7 @@ const CaptureTelemetry = React.memo(function CaptureTelemetry() {
       if (pathname !== nextPathname || search !== nextSearch) {
         pathname = nextPathname;
         search = nextSearch;
-        fireUrlChangeEvent('page', location);
+        fireUrlChangeEvent('page', withoutSensitiveInformations(location));
       }
     });
     return () => unlisten();

--- a/frontend/public/components/utils/__tests__/telemetry.spec.ts
+++ b/frontend/public/components/utils/__tests__/telemetry.spec.ts
@@ -1,0 +1,42 @@
+import { withoutSensitiveInformations } from '../telemetry';
+
+describe('withoutSensitiveInformations', () => {
+  const createLocation = (pathname: string) => ({
+    pathname,
+    search: '',
+    state: null,
+    hash: '',
+    key: '',
+  });
+
+  it('should not touch urls does not match any special rule', () => {
+    expect(withoutSensitiveInformations(createLocation(''))).toEqual(createLocation(''));
+    expect(withoutSensitiveInformations(createLocation('/builds'))).toEqual(
+      createLocation('/builds'),
+    );
+    expect(
+      withoutSensitiveInformations(createLocation('/k8s/ns/christoph/buildconfigs/example/yaml/')),
+    ).toEqual(createLocation('/k8s/ns/christoph/buildconfigs/example/yaml/'));
+    expect(
+      withoutSensitiveInformations(createLocation('/k8s/cluster/user.openshift.io~v1~User')),
+    ).toEqual(createLocation('/k8s/cluster/user.openshift.io~v1~User'));
+  });
+
+  it('should remove username from the telemetry pathname', () => {
+    expect(
+      withoutSensitiveInformations(
+        createLocation('/k8s/cluster/user.openshift.io~v1~User/a-username'),
+      ),
+    ).toEqual(createLocation('/k8s/cluster/user.openshift.io~v1~User/removed-username'));
+    expect(
+      withoutSensitiveInformations(
+        createLocation('/k8s/cluster/user.openshift.io~v1~User/a-username/yaml'),
+      ),
+    ).toEqual(createLocation('/k8s/cluster/user.openshift.io~v1~User/removed-username/yaml'));
+    expect(
+      withoutSensitiveInformations(
+        createLocation('/k8s/cluster/user.openshift.io~v1~User/a-username/roles'),
+      ),
+    ).toEqual(createLocation('/k8s/cluster/user.openshift.io~v1~User/removed-username/roles'));
+  });
+});

--- a/frontend/public/components/utils/telemetry.ts
+++ b/frontend/public/components/utils/telemetry.ts
@@ -1,0 +1,21 @@
+import { Location } from 'history';
+
+/**
+ * Removes sensitive informations from the pathname.
+ *
+ * At the moment it just removes usernames from
+ * `/k8s/cluster/user.openshift.io~v1~User/a-user[...]`
+ */
+export const withoutSensitiveInformations = (location: Location): Location => {
+  let pathname = location.pathname;
+  if (pathname.startsWith('/k8s/cluster/user.openshift.io~v1~User/')) {
+    pathname = pathname.replace(/User\/[^/]+/, 'User/removed-username');
+  }
+  return {
+    pathname,
+    search: location.search,
+    state: location.state,
+    hash: location.hash,
+    key: location.key,
+  };
+};


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2100669

**Analysis / Root cause**: 
All paths are logged, if the admin navigates to user management > users > a user the URL contains the username.

**Solution Description**: 
For a specific path we now removes the username. It removes the username in all/most cases.

**Screen shots / Gifs for design review**: 
<img width="969" alt="image" src="https://user-images.githubusercontent.com/139310/175432709-074330ad-baed-4920-a0c3-fa81d05bdfb8.png">

**Unit test coverage report**: 
Added a small test for the new utils

**Test setup:**
1. Run the local bridge with `--telemetry=DEBUG=true`, for example:

bin/bridge -listen "http://0.0.0.0:9000/" -user-settings-location configmap --telemetry=DEBUG=true

2. Open the browser log and filter for 'console-telemetry-plugin'
3. Navigate to user management > users > a user

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
/cc @divyanshiGupta @invincibleJai 