### PR TITLE
Bug 2100489: updated various modal layout

### DIFF
--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -30,6 +30,10 @@
   padding: 0;
   position: relative;
   -webkit-overflow-scrolling: touch;
+
+  .form-group p:not(:last-child) {
+    margin-bottom: var(--pf-c-content--MarginBottom);
+  }
 }
 
 .modal-body-border {
@@ -39,9 +43,6 @@
 .modal-body-content {
   height: 100%;
   padding: 0 var(--pf-global--spacer--xl) var(--pf-global--spacer--xl);
-  p {
-    margin-bottom: var(--pf-c-content--MarginBottom);
-  }
 }
 
 .modal-content {

--- a/frontend/public/components/modals/add-secret-to-workload.tsx
+++ b/frontend/public/components/modals/add-secret-to-workload.tsx
@@ -205,59 +205,63 @@ export class AddSecretToWorkloadModalWithTrans extends React.Component<
               autocompleteFilter={this.autocompleteFilter}
               autocompletePlaceholder={selectWorkloadPlaceholder}
               id="co-add-secret-to-workload__workload"
+              className="modal-body__field"
+              dropDownClassName="pf-m-full-width"
             />
           </div>
-          <fieldset>
-            <legend className="co-legend co-required">{t('public~Add secret as')}</legend>
-            <RadioInput
-              title={t('public~Environment variables')}
-              name="co-add-secret-to-workload__add-as"
-              id="co-add-secret-to-workload__envvars"
-              value="environment"
-              onChange={this.onAddAsChange}
-              checked={addAsEnvironment}
-            />
-            {addAsEnvironment && (
-              <div className="co-m-radio-desc">
-                <div className="form-group">
-                  <label htmlFor="co-add-secret-to-workload__prefix">{t('public~Prefix')}</label>
-                  <input
-                    className="pf-c-form-control"
-                    name="prefix"
-                    id="co-add-secret-to-workload__prefix"
-                    placeholder="(optional)"
-                    type="text"
-                    onChange={this.handleChange}
-                  />
+          <div className="form-group">
+            <fieldset>
+              <legend className="co-legend co-required">{t('public~Add secret as')}</legend>
+              <RadioInput
+                title={t('public~Environment variables')}
+                name="co-add-secret-to-workload__add-as"
+                id="co-add-secret-to-workload__envvars"
+                value="environment"
+                onChange={this.onAddAsChange}
+                checked={addAsEnvironment}
+              />
+              {addAsEnvironment && (
+                <div className="co-m-radio-desc">
+                  <div className="form-group">
+                    <label htmlFor="co-add-secret-to-workload__prefix">{t('public~Prefix')}</label>
+                    <input
+                      className="pf-c-form-control"
+                      name="prefix"
+                      id="co-add-secret-to-workload__prefix"
+                      placeholder="(optional)"
+                      type="text"
+                      onChange={this.handleChange}
+                    />
+                  </div>
                 </div>
-              </div>
-            )}
-            <RadioInput
-              title={t('public~Volume')}
-              name="co-add-secret-to-workload__add-as"
-              id="co-add-secret-to-workload__volume"
-              value="volume"
-              onChange={this.onAddAsChange}
-              checked={addAsVolume}
-            />
-            {addAsVolume && (
-              <div className="co-m-radio-desc">
-                <div className="form-group">
-                  <label htmlFor="co-add-secret-to-workload__mountpath" className="co-required">
-                    {t('public~Mount path')}
-                  </label>
-                  <input
-                    className="pf-c-form-control"
-                    name="mountPath"
-                    id="co-add-secret-to-workload__mountpath"
-                    type="text"
-                    onChange={this.handleChange}
-                    required
-                  />
+              )}
+              <RadioInput
+                title={t('public~Volume')}
+                name="co-add-secret-to-workload__add-as"
+                id="co-add-secret-to-workload__volume"
+                value="volume"
+                onChange={this.onAddAsChange}
+                checked={addAsVolume}
+              />
+              {addAsVolume && (
+                <div className="co-m-radio-desc">
+                  <div className="form-group">
+                    <label htmlFor="co-add-secret-to-workload__mountpath" className="co-required">
+                      {t('public~Mount path')}
+                    </label>
+                    <input
+                      className="pf-c-form-control"
+                      name="mountPath"
+                      id="co-add-secret-to-workload__mountpath"
+                      type="text"
+                      onChange={this.handleChange}
+                      required
+                    />
+                  </div>
                 </div>
-              </div>
-            )}
-          </fieldset>
+              )}
+            </fieldset>
+          </div>
         </ModalBody>
         <ModalSubmitFooter
           errorMessage={this.state.errorMessage}

--- a/frontend/public/components/modals/column-management-modal.tsx
+++ b/frontend/public/components/modals/column-management-modal.tsx
@@ -7,6 +7,8 @@ import {
   DataListItemRow,
   DataListCell,
   DataListItemCells,
+  Grid,
+  GridItem,
 } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { ColumnLayout, ManagedColumn } from '@console/dynamic-plugin-sdk';
@@ -111,10 +113,10 @@ export const ColumnManagementModal: React.FC<ColumnManagementModalProps &
     <form onSubmit={submit} name="form" className="modal-content">
       <ModalTitle className="modal-header">{t('public~Manage columns')}</ModalTitle>
       <ModalBody>
-        <div className="co-m-form-row">
-          <p>{t('public~Selected columns will appear in the table.')}</p>
-        </div>
-        <div className="co-m-form-row">
+        <div className="form-group">
+          <p className="modal-paragraph">
+            {t('public~Selected columns will appear in the table.')}
+          </p>
           <Alert
             className="co-alert"
             isInline
@@ -125,9 +127,9 @@ export const ColumnManagementModal: React.FC<ColumnManagementModalProps &
               t('public~The namespace column is only shown when in "All projects"')}
           </Alert>
         </div>
-        <div className="row co-m-form-row">
-          <div className="col-sm-12">
-            <span className="col-sm-6">
+        <div className="form-group">
+          <Grid hasGutter sm={6}>
+            <GridItem>
               <label className="control-label">
                 {t('public~Default {{resourceKind}} columns', { resourceKind: columnLayout.type })}
               </label>
@@ -146,8 +148,8 @@ export const ColumnManagementModal: React.FC<ColumnManagementModalProps &
                   />
                 ))}
               </DataList>
-            </span>
-            <span className="col-sm-6">
+            </GridItem>
+            <GridItem>
               <label className="control-label">{t('public~Additional columns')}</label>
               <DataList
                 aria-label={t('public~Additional column list')}
@@ -164,8 +166,8 @@ export const ColumnManagementModal: React.FC<ColumnManagementModalProps &
                   />
                 ))}
               </DataList>
-            </span>
-          </div>
+            </GridItem>
+          </Grid>
         </div>
       </ModalBody>
       <ModalSubmitFooter

--- a/frontend/public/components/modals/configure-cluster-upstream-modal.tsx
+++ b/frontend/public/components/modals/configure-cluster-upstream-modal.tsx
@@ -52,17 +52,19 @@ export const ConfigureClusterUpstreamModal = withHandlePromise(
       <form onSubmit={submit} name="form" className="modal-content modal-content--no-inner-scroll">
         <ModalTitle>{t('public~Edit upstream configuration')}</ModalTitle>
         <ModalBody>
-          <p>
-            {t(
-              'public~Select a configuration to receive updates. Updates can be configured to receive information from Red Hat or a custom update service.',
-            )}
-          </p>
-          <p>
-            <ExternalLink
-              href={updateLink}
-              text={t('public~Learn more about OpenShift local update services.')}
-            />
-          </p>
+          <div className="form-group">
+            <p>
+              {t(
+                'public~Select a configuration to receive updates. Updates can be configured to receive information from Red Hat or a custom update service.',
+              )}
+            </p>
+            <p>
+              <ExternalLink
+                href={updateLink}
+                text={t('public~Learn more about OpenShift local update services.')}
+              />
+            </p>
+          </div>
           <div className="form-group">
             <fieldset>
               <label>{t('public~Configuration')}</label>

--- a/frontend/public/components/modals/configure-count-modal.tsx
+++ b/frontend/public/components/modals/configure-count-modal.tsx
@@ -56,17 +56,19 @@ export const ConfigureCountModal = withHandlePromise((props: ConfigureCountModal
     <form onSubmit={submit} name="form" className="modal-content ">
       <ModalTitle>{titleKey ? t(titleKey, titleVariables) : title}</ModalTitle>
       <ModalBody>
-        <p className="modal-paragraph">
-          {messageKey ? t(messageKey, messageVariablesSafe) : message}
-        </p>
-        <NumberSpinner
-          value={value}
-          onChange={(e: any) => setValue(e.target.value)}
-          changeValueBy={(operation) => setValue(_.toInteger(value) + operation)}
-          autoFocus
-          required
-          min={0}
-        />
+        <div className="form-group">
+          <p>
+            {messageKey ? t(messageKey, messageVariablesSafe) : message}
+          </p>
+          <NumberSpinner
+            value={value}
+            onChange={(e: any) => setValue(e.target.value)}
+            changeValueBy={(operation) => setValue(_.toInteger(value) + operation)}
+            autoFocus
+            required
+            min={0}
+          />
+        </div>
       </ModalBody>
       <ModalSubmitFooter
         errorMessage={props.errorMessage}

--- a/frontend/public/components/modals/delete-modal.tsx
+++ b/frontend/public/components/modals/delete-modal.tsx
@@ -75,18 +75,22 @@ const DeleteModal = withHandlePromise((props: DeleteModalProps & HandlePromisePr
       </ModalTitle>
       <ModalBody className="modal-body">
         {message}
-        <div>
+        <div className="form-group">
           {_.has(resource.metadata, 'namespace') ? (
-            <Trans t={t} ns="public">
-              Are you sure you want to delete{' '}
-              <strong className="co-break-word">{{ resourceName: resource.metadata.name }}</strong>{' '}
-              in namespace <strong>{{ namespace: resource.metadata.namespace }}</strong>?
-            </Trans>
+            <p>
+              <Trans t={t} ns="public">
+                Are you sure you want to delete{' '}
+                <strong className="co-break-word">{{ resourceName: resource.metadata.name }}</strong>{' '}
+                in namespace <strong>{{ namespace: resource.metadata.namespace }}</strong>?
+              </Trans>
+            </p>
           ) : (
-            <Trans t={t} ns="public">
-              Are you sure you want to delete{' '}
-              <strong className="co-break-word">{{ resourceName: resource.metadata.name }}</strong>?
-            </Trans>
+            <p>
+              <Trans t={t} ns="public">
+                Are you sure you want to delete{' '}
+                <strong className="co-break-word">{{ resourceName: resource.metadata.name }}</strong>?
+              </Trans>
+            </p>
           )}
           {_.has(kind, 'propagationPolicy') && (
             <div className="checkbox">

--- a/frontend/public/components/modals/delete-namespace-modal.tsx
+++ b/frontend/public/components/modals/delete-namespace-modal.tsx
@@ -24,7 +24,6 @@ import {
 import { usePromiseHandler } from '@console/shared/src/hooks/promise-handler';
 import { getActiveNamespace } from '../../reducers/ui';
 import { setActiveNamespace } from '../../actions/ui';
-
 export const DeleteNamespaceModal: React.FC<DeleteNamespaceModalProps> = ({
   cancel,
   close,
@@ -73,30 +72,32 @@ export const DeleteNamespaceModal: React.FC<DeleteNamespaceModalProps> = ({
         {t('public~Delete {{label}}?', { label: t(kind.labelKey) })}
       </ModalTitle>
       <ModalBody>
-        <p>
-          <Trans t={t} ns="public">
-            This action cannot be undone. It will destroy all pods, services and other objects in
-            the namespace{' '}
-            <strong className="co-break-word">{{ name: resource.metadata.name }}</strong>.
-          </Trans>
-        </p>
-        <p>
-          <Trans t={t} ns="public">
-            Confirm deletion by typing{' '}
-            <strong className="co-break-word">{{ name: resource.metadata.name }}</strong> below:
-          </Trans>
-        </p>
-        <input
-          type="text"
-          data-test="project-name-input"
-          className="pf-c-form-control"
-          onKeyUp={onKeyUp}
-          placeholder={t('public~Enter name')}
-          aria-label={t('public~Enter the name of the {{label}} to delete', {
-            label: t(kind.labelKey),
-          })}
-          autoFocus={true}
-        />
+        <div className="form-group">
+          <p>
+            <Trans t={t} ns="public">
+              This action cannot be undone. It will destroy all pods, services and other objects in
+              the namespace{' '}
+              <strong className="co-break-word">{{ name: resource.metadata.name }}</strong>.
+            </Trans>
+          </p>
+          <p>
+            <Trans t={t} ns="public">
+              Confirm deletion by typing{' '}
+              <strong className="co-break-word">{{ name: resource.metadata.name }}</strong> below:
+            </Trans>
+          </p>
+          <input
+            type="text"
+            data-test="project-name-input"
+            className="pf-c-form-control"
+            onKeyUp={onKeyUp}
+            placeholder={t('public~Enter name')}
+            aria-label={t('public~Enter the name of the {{label}} to delete', {
+              label: t(kind.labelKey),
+            })}
+            autoFocus={true}
+          />
+        </div>
       </ModalBody>
       <ModalSubmitFooter
         submitText={t('public~Delete')}

--- a/frontend/public/components/modals/expand-pvc-modal.tsx
+++ b/frontend/public/components/modals/expand-pvc-modal.tsx
@@ -62,25 +62,27 @@ const ExpandPVCModal = withHandlePromise((props: ExpandPVCModalProps) => {
     <form onSubmit={submit} name="form" className="modal-content modal-content--no-inner-scroll">
       <ModalTitle>{t('public~Expand {{kind}}', { kind: kind.label })}</ModalTitle>
       <ModalBody>
-        <p>
-          <Trans t={t} ns="public">
-            Increase the capacity of PVC{' '}
-            <strong className="co-break-word">{{ resourceName: resource.metadata.name }}.</strong>{' '}
-            Note that capacity can't be less than the current PVC size. This can be a time-consuming
-            process.
-          </Trans>
-        </p>
-        <label className="control-label co-required">{t('public~Total size')}</label>
-        <RequestSizeInput
-          name={t('public~requestSize')}
-          required
-          onChange={handleRequestSizeInputChange}
-          defaultRequestSizeUnit={requestSizeUnit}
-          defaultRequestSizeValue={requestSizeValue}
-          dropdownUnits={dropdownUnits}
-          testID="pvc-expand-size-input"
-          minValue={defaultSize[0]}
-        />
+        <div className="form-group">
+          <p>
+            <Trans t={t} ns="public">
+              Increase the capacity of PVC{' '}
+              <strong className="co-break-word">{{ resourceName: resource.metadata.name }}.</strong>{' '}
+              Note that capacity can't be less than the current PVC size. This can be a
+              time-consuming process.
+            </Trans>
+          </p>
+          <label className="control-label co-required">{t('public~Total size')}</label>
+          <RequestSizeInput
+            name={t('public~requestSize')}
+            required
+            onChange={handleRequestSizeInputChange}
+            defaultRequestSizeUnit={requestSizeUnit}
+            defaultRequestSizeValue={requestSizeValue}
+            dropdownUnits={dropdownUnits}
+            testID="pvc-expand-size-input"
+            minValue={defaultSize[0]}
+          />
+        </div>
       </ModalBody>
       <ModalSubmitFooter
         errorMessage={errorMessage}

--- a/frontend/public/components/modals/labels-modal.jsx
+++ b/frontend/public/components/modals/labels-modal.jsx
@@ -57,11 +57,13 @@ const BaseLabelsModal = withHandlePromise((props) => {
       </ModalTitle>
       <ModalBody>
         <div className="form-group">
-          {messageKey
-            ? t(messageKey, messageVariables)
-            : t(
-                'public~Labels help you organize and select resources. Adding labels below will let you query for objects that have similar, overlapping or dissimilar labels.',
-              )}
+          <p>
+            {messageKey
+              ? t(messageKey, messageVariables)
+              : t(
+                  'public~Labels help you organize and select resources. Adding labels below will let you query for objects that have similar, overlapping or dissimilar labels.',
+                )}
+          </p>
         </div>
         <div className="form-group">
           <label htmlFor="tags-input" className="control-label">

--- a/frontend/public/components/modals/labels-modal.jsx
+++ b/frontend/public/components/modals/labels-modal.jsx
@@ -56,31 +56,27 @@ const BaseLabelsModal = withHandlePromise((props) => {
           : t('public~Edit labels')}
       </ModalTitle>
       <ModalBody>
-        <div className="row co-m-form-row">
-          <div className="col-sm-12">
-            {messageKey
-              ? t(messageKey, messageVariables)
-              : t(
-                  'public~Labels help you organize and select resources. Adding labels below will let you query for objects that have similar, overlapping or dissimilar labels.',
-                )}
-          </div>
+        <div className="form-group">
+          {messageKey
+            ? t(messageKey, messageVariables)
+            : t(
+                'public~Labels help you organize and select resources. Adding labels below will let you query for objects that have similar, overlapping or dissimilar labels.',
+              )}
         </div>
-        <div className="row co-m-form-row">
-          <div className="col-sm-12">
-            <label htmlFor="tags-input" className="control-label">
-              {descriptionKey
-                ? t('{{description}} for', { description: t(descriptionKey) })
-                : t('public~Labels for')}{' '}
-              <ResourceIcon kind={kind.crd ? referenceForModel(kind) : kind.kind} />{' '}
-              {resource.metadata.name}
-            </label>
-            <SelectorInput
-              onChange={(l) => setLabels(l)}
-              tags={labels}
-              labelClassName={labelClassName || `co-m-${kind.id}`}
-              autoFocus
-            />
-          </div>
+        <div className="form-group">
+          <label htmlFor="tags-input" className="control-label">
+            {descriptionKey
+              ? t('{{description}} for', { description: t(descriptionKey) })
+              : t('public~Labels for')}{' '}
+            <ResourceIcon kind={kind.crd ? referenceForModel(kind) : kind.kind} />{' '}
+            {resource.metadata.name}
+          </label>
+          <SelectorInput
+            onChange={(l) => setLabels(l)}
+            tags={labels}
+            labelClassName={labelClassName || `co-m-${kind.id}`}
+            autoFocus
+          />
         </div>
       </ModalBody>
       <ModalSubmitFooter

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -335,3 +335,10 @@ ul.pf-c-tree-view__list {
 .pf-c-skip-to-content {
   position: absolute !important;
 }
+
+.pf-c-dropdown {
+  &.pf-m-full-width,
+  &.pf-m-full-width > .pf-c-dropdown__toggle {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
closes https://bugzilla.redhat.com/show_bug.cgi?id=2100489

Updated delete modal

**Before**

![image](https://user-images.githubusercontent.com/5385435/175562139-8eb34505-107a-4122-8c35-e28b58dc23e4.png)

**After**

![Screen Shot 2022-06-23 at 3 39 38 PM](https://user-images.githubusercontent.com/5385435/175561418-25aa0347-3941-436f-92d7-0db7751541ef.png)

![Screen Shot 2022-06-23 at 4 03 34 PM](https://user-images.githubusercontent.com/5385435/175561454-7f09506f-74ec-4b98-97ce-c83f44771ae5.png)

Went through the modals, updated the those with either inconsistent markup and/or visual mistakes.

in [console/frontend/public/components/modals/](https://github.com/openshift/console/tree/master/frontend/public/components/modals)

add-secret-to-workload.tsx

**Before**

![Screen Shot 2022-06-24 at 8 17 31 AM](https://user-images.githubusercontent.com/5385435/175559687-fb76d5c1-c208-45db-93ab-698c2d9bbd27.png)

**After**

![Screen Shot 2022-06-24 at 8 29 10 AM](https://user-images.githubusercontent.com/5385435/175559745-af936732-4d5e-4c63-97c9-257e58ffb5d8.png)

add-users-modal.tsx - couldn’t initiate, code looks good
alert-routing-modal.tsx - couldn’t initiate, code looks good
cluster-channel-modal.tsx - previewed, looks good
cluster-more-updates-modal.tsx - couldn’t initiate, code looks good
cluster-update-modal.tsx - previewed, looks good

column-management-modal.tsx 

**Before**

![Screen Shot 2022-06-24 at 9 26 38 AM](https://user-images.githubusercontent.com/5385435/175559911-e89e308e-4026-424e-a12c-7d8e1204f1bd.png)

**After**

![Screen Shot 2022-06-24 at 9 26 45 AM](https://user-images.githubusercontent.com/5385435/175559937-aaf19f34-bd81-4e1b-b007-091a21e7b345.png)

configure-cluster-upstream-modal.jsx

**Before**

![Screen Shot 2022-06-24 at 10 47 29 AM](https://user-images.githubusercontent.com/5385435/175560244-c1707c02-c3cd-478c-ae8e-e066cae34812.png)

**After**

![Screen Shot 2022-06-24 at 9 12 47 AM](https://user-images.githubusercontent.com/5385435/175560222-ecb39ea6-2d16-4ddd-b9b9-99e3bb3074cd.png)

configure-count-modal.tsx

**Before**

![Edit Pod count](https://user-images.githubusercontent.com/5385435/175560347-21e90db1-7c3a-4141-981f-1efbc3db3b5b.png)

**After**

![Edit Pod count](https://user-images.githubusercontent.com/5385435/175560390-87b1e057-e4af-4ec4-b5a4-b04ff0e8b7a3.png)

create-machinę-autoscaler-modal.tsx - couldn’t initiate, code looks ok
configure-ns-pull-secret-modal.jsx - couldn’t initiate
confirm-modal.jsx - code looks good
delete-pvc-modal.tsx - previewed, code looks good
error-modal.tsx - couldn’t initiate, code looks ok

expand-pvc-modal.tsx

**Before**

![Expand Persistent VolumeClaim](https://user-images.githubusercontent.com/5385435/175560427-95d8d890-50b6-4112-a73a-4e6abf4c4c00.png)

**After**

![PVC size  This can be a time- consuming process](https://user-images.githubusercontent.com/5385435/175560497-774940f3-4d2a-40c0-a0cd-9df174b3c5cf.png)

Labels-modal.jsx

**Before**

![Edit labels](https://user-images.githubusercontent.com/5385435/175560541-f4355b01-1ab8-4caf-b18d-302b93c6db48.png)

**After** 

![Edit labels](https://user-images.githubusercontent.com/5385435/175560601-2e28c628-ed8c-429b-a43a-2c85de571d3a.png)

managed-resource-save-modal.tsx - couldn’t initiate, code looks ok
remove-user-modal.tsx - couldn’t initiate, code looks ok
remove-volume-modal.tsx  - couldn’t initiate, code looks good
rollback-modal.jsx - couldn’t initiate, code looks bad
tags.tsx - couldn’t initiate, code looks good
taints-modal.tsx - couldn’t initiate, code looks fine
tolertations-modal.tsx - couldn’t initiate, code looks fine

followup to 
