### PR TITLE
Bug 2096350: fix bug where Cluster update modal errors weren't displa…

### DIFF
--- a/frontend/public/components/modals/cluster-update-modal.tsx
+++ b/frontend/public/components/modals/cluster-update-modal.tsx
@@ -63,7 +63,7 @@ const ClusterUpdateModal = withHandlePromise((props: ClusterUpdateModalProps) =>
     isList: true,
     kind: referenceForModel(MachineConfigPoolModel),
   });
-  const [error, setError] = React.useState(errorMessage);
+  const [error, setError] = React.useState('');
   const [machineConfigPoolsToPause, setMachineConfigPoolsToPause] = React.useState<string[]>([]);
   const [upgradeType, setUpgradeType] = React.useState<upgradeTypes>(upgradeTypes.Full);
   const [includeNotRecommended, setIncludeNotRecommended] = React.useState(false);
@@ -321,7 +321,7 @@ const ClusterUpdateModal = withHandlePromise((props: ClusterUpdateModalProps) =>
         </div>
       </ModalBody>
       <ModalSubmitFooter
-        errorMessage={error}
+        errorMessage={errorMessage || error}
         inProgress={inProgress}
         submitText={t('public~Update')}
         cancelText={t('public~Cancel')}


### PR DESCRIPTION
…ying

This regression was introduced in 4.7 when the modal was refactored and should be back ported to 4.7

Before:

https://user-images.githubusercontent.com/895728/175565437-10ed9277-81be-4ea8-8559-6ae7537484a3.mov

After:

https://user-images.githubusercontent.com/895728/175565471-fb320bf6-c098-4eab-90c7-541c09837df4.mov

