### PR TITLE
[release-4.10] Bug 2100974: Restore spacing between/below modal body content

### DIFF
--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -29,6 +29,9 @@
 
 .modal-body-content {
   height: 100%;
+  p {
+    margin-bottom: var(--pf-c-content--MarginBottom);
+  }
 }
 
 .modal-body-inner-shadow-covers {

--- a/frontend/public/components/modals/delete-modal.tsx
+++ b/frontend/public/components/modals/delete-modal.tsx
@@ -66,7 +66,7 @@ const DeleteModal = withHandlePromise((props: DeleteModalProps & HandlePromisePr
 
   const { kind, resource, message, errorMessage } = props;
   return (
-    <form onSubmit={submit} name="form" className="modal-content ">
+    <form onSubmit={submit} name="form" className="modal-content">
       <ModalTitle>
         <YellowExclamationTriangleIcon className="co-icon-space-r" />{' '}
         {t('public~Delete {{kind}}?', {

--- a/frontend/public/components/modals/delete-namespace-modal.tsx
+++ b/frontend/public/components/modals/delete-namespace-modal.tsx
@@ -67,7 +67,7 @@ export const DeleteNamespaceModal: React.FC<DeleteNamespaceModalProps> = ({
   };
 
   return (
-    <form onSubmit={onSubmit} name="form" className="modal-content ">
+    <form onSubmit={onSubmit} name="form" className="modal-content">
       <ModalTitle className="modal-header">
         <YellowExclamationTriangleIcon className="co-icon-space-r" />{' '}
         {t('public~Delete {{label}}?', { label: t(kind.labelKey) })}

--- a/frontend/public/components/modals/managed-resource-save-modal.tsx
+++ b/frontend/public/components/modals/managed-resource-save-modal.tsx
@@ -17,7 +17,7 @@ const ManagedResourceSaveModal: React.SFC<ManagedResourceSaveModalProps> = (prop
   const { owner, resource } = props;
   const { t } = useTranslation();
   return (
-    <form onSubmit={submit} name="form" className="modal-content ">
+    <form onSubmit={submit} name="form" className="modal-content">
       <ModalTitle>
         <YellowExclamationTriangleIcon className="co-icon-space-r" /> {t('public~Managed resource')}
       </ModalTitle>


### PR DESCRIPTION
Manual backport of #11755

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2100974

**Analysis / Root cause**: 
#10649 removes global spacing below paragraphs and #11404 restores some of them on different pages, but it was still missing on the modals.

**Solution Description**: 
Restore/Add spacing specific for modals.

**Screen shots / Gifs for design review**: 
Before:
<img width="646" alt="image" src="https://user-images.githubusercontent.com/139310/175666246-dfb57673-59b9-4ad8-94ca-44ef8bcd467e.png">

With this change:
<img width="648" alt="Screenshot 2022-06-24 at 22 31 09" src="https://user-images.githubusercontent.com/139310/175663293-9ad99422-c60b-4b9b-b260-2f4df721e1c9.png">

**Unit test coverage report**: 
Unchanged

**Test setup:**
Open any (?) delete (?) modal, for example "Delete Project"

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
