### PR TITLE
[release-4.10] Bug 2100345: fix clone vm error creating DV

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/clone-vm-modal/clone-vm-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/clone-vm-modal/clone-vm-modal.tsx
@@ -1,3 +1,5 @@
+import './_clone-vm-modal.scss';
+
 import * as React from 'react';
 import {
   Checkbox,
@@ -29,13 +31,13 @@ import { K8sResourceKind, PersistentVolumeClaimKind } from '@console/internal/mo
 import { cloneVM } from '../../../k8s/requests/vm/clone';
 import { DataVolumeModel, VirtualMachineModel } from '../../../models';
 import { kubevirtReferenceForModel } from '../../../models/kubevirtReferenceForModel';
-import { getName, getNamespace, ValidationErrorType, getDescription } from '../../../selectors';
+import { getDescription, getName, getNamespace, ValidationErrorType } from '../../../selectors';
 import { getVolumes, isVMExpectedRunning } from '../../../selectors/vm/selectors';
 import {
   getVolumeDataVolumeName,
   getVolumePersistentVolumeClaimName,
 } from '../../../selectors/vm/volume';
-import { VMKind, VMIKind } from '../../../types';
+import { VMIKind, VMKind } from '../../../types';
 import { V1alpha1DataVolume } from '../../../types/api';
 import { getLoadedData, getLoadError, prefixedID } from '../../../utils';
 import { COULD_NOT_LOAD_DATA } from '../../../utils/strings';
@@ -43,8 +45,6 @@ import { validateVmLikeEntityName } from '../../../utils/validations/vm';
 import { Errors } from '../../errors/errors';
 import { ModalFooter } from '../modal/modal-footer';
 import { ConfigurationSummary } from './configuration-summary';
-
-import './_clone-vm-modal.scss';
 
 export const CloneVMModal = withHandlePromise<CloneVMModalProps>((props) => {
   const {
@@ -221,7 +221,6 @@ export const CloneVMModal = withHandlePromise<CloneVMModalProps>((props) => {
               id={asId('configuration-summary')}
               vm={vm}
               persistentVolumeClaims={persistentVolumeClaimsData}
-              dataVolumes={dataVolumesData}
             />
           </FormGroup>
         </Form>
@@ -260,7 +259,9 @@ const CloneVMModalFirehose: React.FC<CloneVMModalFirehoseProps> = (props) => {
   const [namespace, setNamespace] = React.useState(vmNamespace);
 
   const requestsDataVolumes = !!getVolumes(vm).find(getVolumeDataVolumeName);
-  const requestsPVCs = !!getVolumes(vm).find(getVolumePersistentVolumeClaimName);
+  const requestsPVCs =
+    !!getVolumes(vm).find(getVolumePersistentVolumeClaimName) ||
+    !!getVolumes(vm).find(getVolumeDataVolumeName);
 
   const resources: FirehoseResource[] = [
     {

--- a/frontend/packages/kubevirt-plugin/src/k8s/helpers/vm-clone.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/helpers/vm-clone.ts
@@ -9,7 +9,6 @@ import { getName, getNamespace } from '../../selectors';
 import {
   getDataVolumeAccessModes,
   getDataVolumeStorageClassName,
-  getDataVolumeStorageSize,
   getDataVolumeVolumeMode,
 } from '../../selectors/dv/selectors';
 import {
@@ -194,7 +193,7 @@ export class VMClone {
                 volumeMode: getDataVolumeVolumeMode(dataVolume),
                 resources: {
                   requests: {
-                    storage: getDataVolumeStorageSize(dataVolume),
+                    storage: pvcSize,
                   },
                 },
                 storageClassName: getDataVolumeStorageClassName(dataVolume),


### PR DESCRIPTION
When to clone a VM with a disk created with DataVolume and given setting via `pvc` property we get incorrect size for the PVC we try to clone (we get the DV size instead of the PVC owned by the DV size)
### before:

https://user-images.githubusercontent.com/67270715/176452008-1f29fb0a-310d-4e26-97a2-fd5be7f5d975.mp4

### after:

https://user-images.githubusercontent.com/67270715/176452062-07c644f4-ed57-41b5-a9f4-a84f859fb551.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>