### PR TITLE
Bug 2063153: Use link to the downstream doc for Sysprep info

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/advanced-tab/sysprep/SysprepInfo.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/advanced-tab/sysprep/SysprepInfo.tsx
@@ -12,7 +12,7 @@ const SysprepInfo: React.FC = () => {
           'kubevirt-plugin~Sysprep is an automation tool for Windows that automates Windows installation, setup, and custom software provisioning. An answer file is an XML-based file that contains setting definitions and values to use during Windows Setup',
         )}{' '}
         <ExternalLink
-          href="https://kubevirt.io/user-guide/virtual_machines/startup_scripts/#sysprep"
+          href="https://docs.openshift.com/container-platform/4.10/virt/virtual_machines/virt-automating-windows-sysprep.html"
           text={t('kubevirt-plugin~Learn more')}
         />
       </Text>


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2063153

**Solution Description:**
Use the link to the downstream sysprep info instead of the related kubevirt doc. Redirect to the downstream doc when clicking on _Learn more_ when customizing VM sysprep in the _Advanced_ step.

**Screen shots / Gifs for design review:**
Clicking on _Learn more_ in the _Advanced_ step of a VM creation:
![sysprep](https://user-images.githubusercontent.com/13417815/176540383-8003b89f-853d-449d-b474-9d33cf08f24b.png)
_Before:_
Redirecting to the kubevirt doc after clicking on _Learn more_:
![s_before](https://user-images.githubusercontent.com/13417815/176540347-f71d2d4f-323d-4248-86dd-bd4f363e9b7f.png)
_After:_
Redirecting to the new, downstream doc:
![s_after](https://user-images.githubusercontent.com/13417815/176540368-bbd54005-a36f-491d-a9a6-e591ba41a87c.png)

