### PR TITLE
Bug 2081674: Added onSubmit for create a project function for Dev perspective

### DIFF
--- a/frontend/public/components/start-guide.tsx
+++ b/frontend/public/components/start-guide.tsx
@@ -6,15 +6,21 @@ import { Button } from '@patternfly/react-core';
 import { useTranslation, Trans } from 'react-i18next';
 
 import { FLAGS } from '@console/shared/src/constants';
+import { useActiveNamespace } from '@console/shared';
+import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { createProjectMessageStateToProps } from '../reducers/ui';
 import { Disabled, HintBlock, ExternalLink, openshiftHelpBase, LinkifyExternal } from './utils';
 import { connectToFlags } from '../reducers/connectToFlags';
 import { ProjectModel } from '../models';
-import { createProjectModal } from './modals/create-namespace-modal';
+import { createProjectModal } from './modals';
+import { K8sResourceKind } from '../module/k8s/types';
 
 export const OpenShiftGettingStarted = connect(createProjectMessageStateToProps)(
   ({ canCreateProject = true, createProjectMessage }: OpenShiftGettingStartedProps) => {
     const { t } = useTranslation();
+    const [, setActiveNamespace] = useActiveNamespace();
+    const [perspective] = useActivePerspective();
+
     return (
       <>
         {canCreateProject ? (
@@ -50,7 +56,20 @@ export const OpenShiftGettingStarted = connect(createProjectMessageStateToProps)
           </Trans>
         </p>
         {canCreateProject && (
-          <Button variant="link" onClick={() => createProjectModal({ blocking: true })}>
+          <Button
+            variant="link"
+            onClick={() =>
+              createProjectModal({
+                blocking: true,
+                onSubmit:
+                  perspective !== 'admin'
+                    ? (project: K8sResourceKind) => {
+                        setActiveNamespace(project.metadata?.name);
+                      }
+                    : undefined,
+              })
+            }
+          >
             {t('public~Create a new project')}
           </Button>
         )}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-43933

**Analysis / Root cause**: 
onSubmit function was not passed and history.push was getting called to project details page.

**Solution Description**: 
Added onSubmit function to stay in the same page where project will be created. This change is made only for developer perspective. 

**Screen shots / Gifs for design review**: 
-----BEFORE----

https://bugzilla-attachments.redhat.com/attachment.cgi?id=1876984

---AFTER-----

https://user-images.githubusercontent.com/102503482/177311602-348d7242-d5e0-4e5b-9931-d4f1f0b8a551.mov


**Unit test coverage report**: 
NA

**Test setup:**
1. Login with a developer user (limited access, this means the developer perspective should be opened automatically and the user can not see any other project)
2. Navigate to the add page and click on "Create a new project"
3. Create a new project with the modal

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge