### PR TITLE
[release-4.10] Bug 2052662: Fix null reference

### DIFF
--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/mappers.ts
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/mappers.ts
@@ -40,7 +40,7 @@ type Metrics = {
 
 export const mapMetrics = (response: PrometheusResponse): Metrics => {
   const values: Metrics = {};
-  for (let i = 0; i < response.data.result.length; i++) {
+  for (let i = 0; i < response?.data.result.length; i++) {
     const value = response.data?.result?.[i]?.value?.[1];
     if (_.isNil(value)) {
       return null;


### PR DESCRIPTION
`mapMetrics()` should return empty `values` when an error occured

Signed-off-by: Pavel Kratochvil <pakratoc@redhat.com>