### PR TITLE
Monitoring: Clean up imports and types

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -84,7 +84,8 @@
   margin: 0 0 20px 0;
 
   .co-dashboard-card__body--dashboard {
-    // Add extra padding to the right. X-axis times with AM/PM at certain screen widths can overflow the card otherwise.
+    // Add extra padding to the right. X-axis times with AM/PM at certain screen widths can overflow
+    // the card otherwise.
     padding: 10px 15px 10px 10px;
   }
 
@@ -264,7 +265,8 @@ $monitoring-line-height: 18px;
 }
 
 .monitoring-description {
-  // Limit to $num-lines lines of text. Truncate with an ellipsis in WebKit. Just overflow hidden for other browsers.
+  // Limit to $num-lines lines of text. Truncate with an ellipsis in WebKit. Just overflow hidden
+  // for other browsers.
   $num-lines: 2;
   display: -webkit-box;
   -webkit-box-orient: vertical;

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -1,4 +1,4 @@
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import i18next from 'i18next';
 import * as _ from 'lodash-es';
 import {

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -2,12 +2,31 @@ import * as classNames from 'classnames';
 import i18next from 'i18next';
 import * as _ from 'lodash-es';
 import {
+  AlertSeverity,
+  AlertStates,
+  BlueInfoCircleIcon,
+  GreenCheckCircleIcon,
+  PrometheusAlert,
+  PrometheusLabels,
+  RedExclamationCircleIcon,
+  ResourceStatus,
+  useActivePerspective,
+  YellowExclamationTriangleIcon,
+} from '@console/dynamic-plugin-sdk';
+import {
   Alert as PFAlert,
   Button,
   CodeBlock,
   CodeBlockCode,
   Popover,
 } from '@patternfly/react-core';
+import {
+  BanIcon,
+  BellIcon,
+  BellSlashIcon,
+  HourglassHalfIcon,
+  OutlinedBellIcon,
+} from '@patternfly/react-icons';
 import { sortable } from '@patternfly/react-table';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
@@ -16,21 +35,7 @@ import { useTranslation } from 'react-i18next';
 // @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
 import { Link, Redirect, Route, Switch } from 'react-router-dom';
-import {
-  BanIcon,
-  BellIcon,
-  BellSlashIcon,
-  HourglassHalfIcon,
-  OutlinedBellIcon,
-} from '@patternfly/react-icons';
 
-import { useActivePerspective, ResourceStatus } from '@console/dynamic-plugin-sdk';
-import {
-  BlueInfoCircleIcon,
-  GreenCheckCircleIcon,
-  RedExclamationCircleIcon,
-  YellowExclamationTriangleIcon,
-} from '@console/shared';
 import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { withFallback } from '@console/shared/src/components/error';
 import {
@@ -55,7 +60,6 @@ import { RootState } from '../../redux';
 import { RowFunctionArgs, Table, TableData, TableProps } from '../factory';
 import { FilterToolbar, RowFilter } from '../filter-toolbar';
 import { confirmModal } from '../modals';
-import { PrometheusLabels } from '../graphs';
 import { AlertmanagerYAMLEditorWrapper } from './alert-manager-yaml-editor';
 import { AlertmanagerConfigWrapper } from './alert-manager-config';
 import MonitoringDashboardsPage from './dashboards';
@@ -67,12 +71,9 @@ import { TargetsUI } from './targets';
 import {
   Alert,
   Alerts,
-  AlertSeverity,
   AlertSource,
-  AlertStates,
   ListPageProps,
   MonitoringResource,
-  PrometheusAlert,
   Rule,
   Silence,
   Silences,
@@ -161,15 +162,18 @@ const MonitoringResourceIcon: React.FC<MonitoringResourceIconProps> = ({ classNa
   </span>
 );
 
-const alertStateIcons = {
-  [AlertStates.Firing]: <BellIcon />,
-  [AlertStates.Pending]: <OutlinedBellIcon />,
-  [AlertStates.Silenced]: <BellSlashIcon className="text-muted" />,
-};
-
-const AlertStateIcon: React.FC<{ state: string }> = React.memo(
-  ({ state }) => alertStateIcons[state],
-);
+const AlertStateIcon: React.FC<{ state: string }> = React.memo(({ state }) => {
+  switch (state) {
+    case AlertStates.Firing:
+      return <BellIcon />;
+    case AlertStates.Pending:
+      return <OutlinedBellIcon />;
+    case AlertStates.Silenced:
+      return <BellSlashIcon className="text-muted" />;
+    default:
+      return null;
+  }
+});
 
 const getAlertStateKey = (state) => {
   switch (state) {
@@ -185,7 +189,7 @@ const getAlertStateKey = (state) => {
 };
 
 export const AlertState: React.FC<AlertStateProps> = React.memo(({ state }) => {
-  const icon = alertStateIcons[state];
+  const icon = <AlertStateIcon state={state} />;
 
   return icon ? (
     <>

--- a/frontend/public/components/monitoring/dashboards/custom-time-range-modal.tsx
+++ b/frontend/public/components/monitoring/dashboards/custom-time-range-modal.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
-
 import { DatePicker, TimePicker } from '@patternfly/react-core';
 
 import { dashboardsSetEndTime, dashboardsSetTimespan } from '../../../actions/observe';

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -1,4 +1,4 @@
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { PrometheusEndpoint, RedExclamationCircleIcon } from '@console/dynamic-plugin-sdk';
 import {

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -727,7 +727,8 @@ const MonitoringDashboardsPage: React.FC<MonitoringDashboardsPageProps> = ({ mat
         const allVariables = getAllVariables(boards, newBoard, namespace);
         dispatch(dashboardsPatchAllVariables(allVariables, activePerspective));
 
-        // Set time range and poll interval options to their defaults or from the query params if available
+        // Set time range and poll interval options to their defaults or from the query params if
+        // available
         if (refreshInterval) {
           dispatch(dashboardsSetPollInterval(_.toNumber(refreshInterval), activePerspective));
         }

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -1,4 +1,6 @@
+import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
+import { PrometheusEndpoint, RedExclamationCircleIcon } from '@console/dynamic-plugin-sdk';
 import {
   Button,
   Label,
@@ -20,10 +22,7 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
 import { Link } from 'react-router-dom';
-import * as classNames from 'classnames';
 
-import { PrometheusEndpoint } from '@console/dynamic-plugin-sdk/src/api/common-types';
-import { RedExclamationCircleIcon } from '@console/shared';
 import { ErrorBoundaryFallbackPage, withFallback } from '@console/shared/src/components/error';
 import ErrorAlert from '@console/shared/src/components/alerts/error';
 import Dashboard from '@console/shared/src/components/dashboard/Dashboard';

--- a/frontend/public/components/monitoring/dashboards/single-stat.tsx
+++ b/frontend/public/components/monitoring/dashboards/single-stat.tsx
@@ -1,13 +1,12 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import { PrometheusEndpoint, PrometheusResponse } from '@console/dynamic-plugin-sdk';
 import { Bullseye } from '@patternfly/react-core';
 
-import { PrometheusEndpoint } from '@console/dynamic-plugin-sdk/src/api/common-types';
 import ErrorAlert from '@console/shared/src/components/alerts/error';
 
 import { formatNumber } from '../format';
 import { Panel } from './types';
-import { PrometheusResponse } from '../../graphs';
 import { getPrometheusURL } from '../../graphs/helpers';
 import { LoadingInline, usePoll, useSafeFetch } from '../../utils';
 

--- a/frontend/public/components/monitoring/dashboards/table.tsx
+++ b/frontend/public/components/monitoring/dashboards/table.tsx
@@ -1,5 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import { PrometheusEndpoint, PrometheusResponse } from '@console/dynamic-plugin-sdk';
 import { PerPageOptions } from '@patternfly/react-core';
 import {
   ISortBy,
@@ -11,12 +12,10 @@ import {
   TableVariant,
 } from '@patternfly/react-table';
 
-import { PrometheusEndpoint } from '@console/dynamic-plugin-sdk/src/api/common-types';
 import ErrorAlert from '@console/shared/src/components/alerts/error';
 
 import { formatNumber } from '../format';
 import { ColumnStyle, Panel } from './types';
-import { PrometheusResponse } from '../../graphs';
 import { getPrometheusURL } from '../../graphs/helpers';
 import { EmptyBox, usePoll, useSafeFetch } from '../../utils';
 import TablePagination from '../table-pagination';

--- a/frontend/public/components/monitoring/dashboards/table.tsx
+++ b/frontend/public/components/monitoring/dashboards/table.tsx
@@ -1,5 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import { PerPageOptions } from '@patternfly/react-core';
 import {
   ISortBy,
   sortable,
@@ -54,7 +55,7 @@ const getColumns = (styles: ColumnStyle[]): AugmentedColumnStyle[] => {
   return [...labelColumns, ...valueColumns];
 };
 
-const paginationOptions = [5, 10, 20, 50, 100].map((n) => ({
+const perPageOptions: PerPageOptions[] = [5, 10, 20, 50, 100].map((n) => ({
   title: n.toString(),
   value: n,
 }));
@@ -184,9 +185,9 @@ const Table: React.FC<Props> = ({ panel, pollInterval, queries, namespace }) => 
       </div>
       <TablePagination
         itemCount={sortedData.length}
-        paginationOptions={paginationOptions}
         page={page}
         perPage={perPage}
+        perPageOptions={perPageOptions}
         setPage={setPage}
         setPerPage={setPerPage}
       />

--- a/frontend/public/components/monitoring/dashboards/useFetchDashboards.ts
+++ b/frontend/public/components/monitoring/dashboards/useFetchDashboards.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
+
 import { useSafeFetch } from '../../utils';
 import { useBoolean } from '../hooks/useBoolean';
 import { Board } from './types';

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -174,24 +174,24 @@ const MetricsDropdown: React.FC<{}> = () => {
     }
   };
 
-  let title: React.ReactNode = t('public~Insert metric at cursor');
+  let title: React.ReactElement = <>{t('public~Insert metric at cursor')}</>;
   if (error !== undefined) {
     const message =
       error?.response?.status === 403
         ? t('public~Access restricted.')
         : t('public~Failed to load metrics list.');
     title = (
-      <span>
+      <>
         <RedExclamationCircleIcon /> {message}
-      </span>
+      </>
     );
   } else if (items === undefined) {
     title = <LoadingInline />;
   } else if (_.isEmpty(items)) {
     title = (
-      <span>
+      <>
         <YellowExclamationTriangleIcon /> {t('public~No metrics found.')}
-      </span>
+      </>
     );
   }
 

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -168,7 +168,8 @@ const MetricsDropdown: React.FC<{}> = () => {
     if (target) {
       target.focus();
 
-      // Restore cursor position / currently selected text (use _.defer() to delay until after the input value is set)
+      // Restore cursor position / currently selected text (use _.defer() to delay until after the
+      // input value is set)
       _.defer(() => target.setSelectionRange(selection.start, selection.start + metric.length));
     }
   };
@@ -643,8 +644,8 @@ const QueryBrowserWrapper: React.FC<{}> = () => {
   }, [dispatch]);
 
   /* eslint-disable react-hooks/exhaustive-deps */
-  // Use React.useMemo() to prevent these two arrays being recreated on every render, which would trigger unnecessary
-  // re-renders of QueryBrowser, which can be quite slow
+  // Use React.useMemo() to prevent these two arrays being recreated on every render, which would
+  // trigger unnecessary re-renders of QueryBrowser, which can be quite slow
   const queriesMemoKey = JSON.stringify(_.map(queries, 'query'));
   const queryStrings = React.useMemo(() => _.map(queries, 'query'), [queriesMemoKey]);
   const disabledSeriesMemoKey = JSON.stringify(

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -1,4 +1,4 @@
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash-es';
 import {
   PrometheusData,

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -67,7 +67,7 @@ import {
 } from '../utils';
 import { setAllQueryArguments } from '../utils/router';
 import IntervalDropdown from './poll-interval-dropdown';
-import { colors, Error as QueryBrowserError, QueryBrowser } from './query-browser';
+import { colors, Error, QueryBrowser } from './query-browser';
 import TablePagination from './table-pagination';
 import { PrometheusAPIError } from './types';
 
@@ -395,7 +395,7 @@ export const QueryTable: React.FC<QueryTableProps> = ({ index, namespace }) => {
   if (error) {
     return (
       <div className="query-browser__table-message">
-        <QueryBrowserError error={error} title={t('public~Error loading values')} />
+        <Error error={error} title={t('public~Error loading values')} />
       </div>
     );
   }

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -1,6 +1,13 @@
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
 import {
+  PrometheusData,
+  PrometheusEndpoint,
+  PrometheusLabels,
+  RedExclamationCircleIcon,
+  YellowExclamationTriangleIcon,
+} from '@console/dynamic-plugin-sdk';
+import {
   ActionGroup,
   Button,
   EmptyState,
@@ -33,9 +40,7 @@ import { useTranslation } from 'react-i18next';
 // @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
 
-import { PrometheusEndpoint } from '@console/dynamic-plugin-sdk/src/api/common-types';
 import { withFallback } from '@console/shared/src/components/error';
-import { RedExclamationCircleIcon, YellowExclamationTriangleIcon } from '@console/shared';
 
 import {
   queryBrowserAddQuery,
@@ -53,7 +58,7 @@ import {
   toggleGraphs,
 } from '../../actions/observe';
 import { RootState } from '../../redux';
-import { PrometheusData, PrometheusLabels, PROMETHEUS_BASE_PATH } from '../graphs';
+import { PROMETHEUS_BASE_PATH } from '../graphs';
 import { getPrometheusURL } from '../graphs/helpers';
 import {
   ActionsMenu,

--- a/frontend/public/components/monitoring/poll-interval-dropdown.tsx
+++ b/frontend/public/components/monitoring/poll-interval-dropdown.tsx
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
+
 import { formatPrometheusDuration, parsePrometheusDuration } from '../utils/datetime';
 import { useBoolean } from './hooks/useBoolean';
 

--- a/frontend/public/components/monitoring/promql-expression-input.tsx
+++ b/frontend/public/components/monitoring/promql-expression-input.tsx
@@ -22,13 +22,13 @@ import {
   ViewPlugin,
   ViewUpdate,
 } from '@codemirror/view';
-import { YellowExclamationTriangleIcon } from '@console/shared';
+import { PrometheusEndpoint, YellowExclamationTriangleIcon } from '@console/dynamic-plugin-sdk';
 import CloseButton from '@console/shared/src/components/close-button';
 import { PromQLExtension } from 'codemirror-promql';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+
 import { PROMETHEUS_BASE_PATH } from '../graphs';
-import { PrometheusEndpoint } from '../graphs/helpers';
 import { useSafeFetch } from '../utils';
 import './_promql-expression-input.scss';
 

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -529,7 +529,8 @@ const maxStacks = 50;
 // so don't update unless the number of samples would change by at least this proportion
 const samplesLeeway = 0.2;
 
-// Minimum step (milliseconds between data samples) because tiny steps reduce performance for almost no benefit
+// Minimum step (milliseconds between data samples) because tiny steps reduce performance for almost
+// no benefit
 const minStep = 5 * 1000;
 
 // Don't allow zooming to less than this number of milliseconds

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -2,6 +2,13 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import {
+  PrometheusEndpoint,
+  PrometheusLabels,
+  PrometheusResponse,
+  PrometheusResult,
+  PrometheusValue,
+} from '@console/dynamic-plugin-sdk';
+import {
   Chart,
   ChartArea,
   ChartAxis,
@@ -32,7 +39,6 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { VictoryPortal } from 'victory-core';
 
-import { PrometheusEndpoint } from '@console/dynamic-plugin-sdk/src/api/common-types';
 import withFallback from '@console/shared/src/components/error/fallbacks/withFallback';
 
 import {
@@ -41,7 +47,6 @@ import {
   queryBrowserSetTimespan,
 } from '../../actions/observe';
 import { RootState } from '../../redux';
-import { PrometheusLabels, PrometheusResponse, PrometheusResult, PrometheusValue } from '../graphs';
 import { GraphEmpty } from '../graphs/graph-empty';
 import { getPrometheusURL } from '../graphs/helpers';
 import { queryBrowserTheme } from '../graphs/themes';

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -1,6 +1,6 @@
-import * as classNames from 'classnames';
-import * as React from 'react';
+import classNames from 'classnames';
 import * as _ from 'lodash-es';
+import * as React from 'react';
 import {
   PrometheusEndpoint,
   PrometheusLabels,

--- a/frontend/public/components/monitoring/table-pagination.tsx
+++ b/frontend/public/components/monitoring/table-pagination.tsx
@@ -1,13 +1,18 @@
-import { Pagination, PaginationVariant } from '@patternfly/react-core';
+import { Pagination, PaginationVariant, PerPageOptions } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 
-const defaultPaginationOptions = [10, 20, 50, 100, 200, 500].map((n) => ({
+const defaultPerPageOptions: PerPageOptions[] = [10, 20, 50, 100, 200, 500].map((n) => ({
   title: n.toString(),
   value: n,
 }));
 
-const LocalizedToggleTemplate = ({ firstIndex, lastIndex, itemCount, itemsTitle }) => {
+const LocalizedToggleTemplate: React.FC<LocalizedToggleTemplateProps> = ({
+  firstIndex,
+  itemCount,
+  itemsTitle,
+  lastIndex,
+}) => {
   const { t } = useTranslation();
   return (
     <Trans t={t} ns="public">
@@ -19,13 +24,13 @@ const LocalizedToggleTemplate = ({ firstIndex, lastIndex, itemCount, itemsTitle 
   );
 };
 
-const TablePagination = ({
+const TablePagination: React.FC<TablePaginationProps> = ({
   itemCount,
   page,
   perPage,
+  perPageOptions = defaultPerPageOptions,
   setPage,
   setPerPage,
-  paginationOptions = defaultPaginationOptions,
 }) => {
   const { t } = useTranslation();
   const onPerPageSelect = (e, v) => {
@@ -42,7 +47,7 @@ const TablePagination = ({
       onSetPage={(e, v) => setPage(v)}
       page={page}
       perPage={perPage}
-      perPageOptions={paginationOptions}
+      perPageOptions={perPageOptions}
       variant={PaginationVariant.bottom}
       toggleTemplate={LocalizedToggleTemplate}
       titles={{
@@ -61,6 +66,22 @@ const TablePagination = ({
       }}
     />
   );
+};
+
+type LocalizedToggleTemplateProps = {
+  firstIndex: number;
+  itemCount: number;
+  itemsTitle: string;
+  lastIndex: number;
+};
+
+type TablePaginationProps = {
+  itemCount: number;
+  page: number;
+  perPage: number;
+  perPageOptions?: PerPageOptions[];
+  setPage: (number) => void;
+  setPerPage: (number) => void;
 };
 
 export default TablePagination;

--- a/frontend/public/components/monitoring/targets.tsx
+++ b/frontend/public/components/monitoring/targets.tsx
@@ -1,4 +1,9 @@
 import * as _ from 'lodash-es';
+import {
+  GreenCheckCircleIcon,
+  PrometheusEndpoint,
+  RedExclamationCircleIcon,
+} from '@console/dynamic-plugin-sdk';
 import { Alert } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import * as React from 'react';
@@ -8,9 +13,6 @@ import { useTranslation } from 'react-i18next';
 // @ts-ignore
 import { useSelector } from 'react-redux';
 import { Link, Route, RouteComponentProps, Switch, withRouter } from 'react-router-dom';
-
-import { PrometheusEndpoint } from '@console/dynamic-plugin-sdk/src/api/common-types';
-import { GreenCheckCircleIcon, RedExclamationCircleIcon } from '@console/shared';
 
 import { NamespaceModel, ServiceModel, ServiceMonitorModel } from '../../models';
 import { K8sResourceKind, LabelSelector, referenceForModel } from '../../module/k8s';

--- a/frontend/public/components/monitoring/types.ts
+++ b/frontend/public/components/monitoring/types.ts
@@ -2,15 +2,13 @@ import {
   Alert,
   AlertSeverity,
   AlertStates,
-  PrometheusAlert,
   PrometheusLabels,
   PrometheusRule,
-  PrometheusValue,
   Rule,
   RuleStates,
   Silence,
   SilenceStates,
-} from '@console/dynamic-plugin-sdk/src/api/common-types';
+} from '@console/dynamic-plugin-sdk';
 
 import { RowFunctionArgs } from '../factory';
 import { RowFilter } from '../filter-toolbar';
@@ -25,11 +23,7 @@ export {
 // prettier 1.x doesn't support TS 3.8 syntax
 // eslint-disable-next-line prettier/prettier
 export type {
-  PrometheusAlert,
   Alert,
-  PrometheusRule,
-  PrometheusLabels,
-  PrometheusValue,
   Rule,
   Silence,
 }

--- a/frontend/public/components/monitoring/types.ts
+++ b/frontend/public/components/monitoring/types.ts
@@ -1,15 +1,14 @@
-import { APIError } from '@console/shared';
 import {
-  Silence,
-  PrometheusAlert,
   Alert,
-  PrometheusRule,
+  AlertSeverity,
+  AlertStates,
+  PrometheusAlert,
   PrometheusLabels,
+  PrometheusRule,
   PrometheusValue,
   Rule,
   RuleStates,
-  AlertStates,
-  AlertSeverity,
+  Silence,
   SilenceStates,
 } from '@console/dynamic-plugin-sdk/src/api/common-types';
 
@@ -72,13 +71,14 @@ type Group = {
 };
 
 export type PrometheusAPIError = {
-  response?: {
-    status: number;
-  };
-  json?: {
+  json: {
     error?: string;
   };
-} & APIError;
+  message?: string;
+  response: {
+    status: number;
+  };
+};
 
 export type PrometheusRulesResponse = {
   data: {

--- a/frontend/public/components/monitoring/utils.ts
+++ b/frontend/public/components/monitoring/utils.ts
@@ -1,20 +1,17 @@
 import * as _ from 'lodash-es';
 import { murmur3 } from 'murmurhash-js';
-
-import { PrometheusLabels } from '../graphs';
 import {
   Alert,
   AlertSeverity,
-  AlertSource,
   AlertStates,
-  MonitoringResource,
+  PrometheusLabels,
   PrometheusRule,
-  PrometheusRulesResponse,
   Rule,
   Silence,
   SilenceStates,
-  Target,
-} from './types';
+} from '@console/dynamic-plugin-sdk';
+
+import { AlertSource, MonitoringResource, PrometheusRulesResponse, Target } from './types';
 
 export const AlertResource: MonitoringResource = {
   kind: 'Alert',


### PR DESCRIPTION
This PR has a few refactoring changes that are both for the sake of general clean up and also begin moving the code to run more like a dynamic plugin.

- Add type definitions for table pagination 
- Rename `paginationOptions` to `perPageOptions` to match the name used by PatternFly
- Tighten up `PrometheusAPIError` type definition (the fields of `APIError` are not all found in `PrometheusAPIError`)
- Import components and types from `dynamic-plugin-sdk` whenever possible. This is preferable because it brings us closer to having the monitoring pages run as a plugin.
- Limit comment line length to 100 characters
- Change classNames import syntax to avoid TypeScript error