### PR TITLE
Add toolbar extension point for alert detail view

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -292,6 +292,14 @@ $monitoring-line-height: 18px;
   margin-right: 10px;
 }
 
+.monitoring-alert-detail-toolbar.pf-c-toolbar  {
+  padding-top: 0;
+
+  .pf-c-toolbar__content{
+    padding: 0;
+  }
+}
+
 .monitoring-silence-alert {
   max-width: 950px;
 
@@ -494,9 +502,10 @@ $monitoring-line-height: 18px;
   padding: 10px 20px;
 }
 
-.query-browser__toggle-graph {
-  margin-bottom: 5px;
-  float: right;
+.query-browser__toggle-graph-container {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--pf-global--spacer--xs);
 }
 
 .query-browser__tooltip {

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -780,7 +780,9 @@ const QueryBrowserPage_: React.FC<{}> = () => {
       <div className="co-m-pane__body">
         <div className="row">
           <div className="col-xs-12">
-            <ToggleGraph />
+            <div className="query-browser__toggle-graph-container">
+              <ToggleGraph />
+            </div>
           </div>
         </div>
         <div className="row">


### PR DESCRIPTION
This will allow dynamic plugins to inject links in the top toolbar


https://user-images.githubusercontent.com/5461414/177584269-1dfde0e2-f28b-49c6-9222-bac1bc0540c9.mov

https://issues.redhat.com/browse/MON-2476
https://issues.redhat.com/browse/OU-44