### PR TITLE
Remove sources file

### DIFF
--- a/sources
+++ b/sources
@@ -1,2 +1,0 @@
-401aa1438604b8e32306fa2bd4f8e211  node-v8.9.4-headers.tar.gz
-256a8e79051be698b697e423d3854353  yarn-offline.tar


### PR DESCRIPTION
Following up fe30ada847be26f0f6d578bf1c3904b7a91a1784, distgit lookaside
cache is not used anymore. `sources` file
also needs to be removed in order to turn off the alarm.