### PR TITLE
Bug 2103224:Update the side nav perspective selection so it has the correct background and border color when in dark mode

### DIFF
--- a/frontend/public/components/nav/NavHeader.scss
+++ b/frontend/public/components/nav/NavHeader.scss
@@ -5,6 +5,11 @@
   border-bottom: 1px solid var(--pf-global--BackgroundColor--dark-200);
   padding: 0.6rem var(--pf-global--spacer--sm);
 
+  :where(.pf-theme-dark) & {
+    // Match --pf-c-nav__item--before--BorderColor
+    border-bottom-color: var(--pf-global--BorderColor--100);
+  }
+
   @media screen and (min-width: $pf-global--breakpoint--xl) {
     padding-left: var(--pf-global--spacer--md);
     padding-right: var(--pf-global--spacer--md);
@@ -16,12 +21,22 @@
 
   .pf-c-dropdown {
     --pf-c-dropdown__menu-item--PaddingLeft: 7px;
-
     width: 100%;
     cursor: pointer;
 
     &.pf-m-expanded {
-      --pf-c-dropdown__toggle--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
+      .pf-c-dropdown__toggle {
+        background-color: var(--pf-global--BackgroundColor--dark-200);
+        :where(.pf-theme-dark) & {
+          background-color: var(--pf-global--BackgroundColor--dark-300);
+        }
+      }
+    }
+  }
+
+  .pf-c-dropdown__toggle {
+    :where(.pf-theme-dark) & {
+      background-color: var(--pf-c-page__sidebar--BackgroundColor);
     }
   }
 


### PR DESCRIPTION
The select field should have the same default background color and bottom border as the `pf-c-nav__list` and set opened background color to match.
fixes https://bugzilla.redhat.com/show_bug.cgi?id=2103224
cc @spadgett 

before
<img width="428" alt="select-incorrect" src="https://user-images.githubusercontent.com/1874151/177575963-dde628eb-b02c-4ecb-99f6-02644236f554.png">
<img width="439" alt="select-incorrect-open" src="https://user-images.githubusercontent.com/1874151/177575989-894dbbc1-db31-4ab6-9026-c48bc0da280c.png">

---

after
<img width="416" alt="select-correct" src="https://user-images.githubusercontent.com/1874151/177576082-c87f9546-e128-4260-950e-3cddcc4e6103.png">
<img width="427" alt="select-correct-open" src="https://user-images.githubusercontent.com/1874151/177576099-6f3dbcac-c39e-481d-bd59-071d7d549d96.png">

