### PR TITLE
Bug 2111686: [OKD/nanokube] Fix NPE when project or build status is not defined

### DIFF
--- a/frontend/packages/console-shared/src/components/namespace/filters.ts
+++ b/frontend/packages/console-shared/src/components/namespace/filters.ts
@@ -19,8 +19,7 @@ export const requesterFilter = (filter, obj): boolean => {
     return true;
   }
 
-  const annotations = obj.metadata?.annotations;
-  const requester = annotations ? annotations['openshift.io/requester'] : undefined;
+  const requester = obj.metadata?.annotations?.['openshift.io/requester'];
   if (filter.selected.includes(REQUESTER_FILTER.ME) && isCurrentUser(requester)) {
     return true;
   }

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -422,7 +422,7 @@ const BuildsTableRow: React.FC<RowFunctionArgs<K8sResourceKind>> = ({ obj }) => 
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
-        <Status status={obj.status.phase} />
+        <Status status={obj.status?.phase} />
       </TableData>
       <TableData className={tableColumnClasses[3]}>
         <Timestamp timestamp={obj.metadata.creationTimestamp} />

--- a/frontend/public/components/dashboard/project-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/status-card.tsx
@@ -45,7 +45,7 @@ export const StatusCard: React.FC = () => {
           <HealthBody>
             <Gallery className="co-overview-status__health" hasGutter>
               <div className="co-status-card__health-item" data-test="project-status">
-                <Status status={obj.status.phase} className="co-icon-and-text--lg" />
+                <Status status={obj.status?.phase} className="co-icon-and-text--lg" />
               </div>
               {subsystem && (
                 <ResourceHealthItem subsystem={subsystem.properties} namespace={namespace} />

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -116,7 +116,7 @@ const getFilters = () => [
     type: 'requester',
     reducer: (namespace) => {
       const name = namespace.metadata?.name;
-      const requester = namespace.metadata?.annotations['openshift.io/requester'];
+      const requester = namespace.metadata?.annotations?.['openshift.io/requester'];
       if (isCurrentUser(requester)) {
         return REQUESTER_FILTER.ME;
       }
@@ -143,7 +143,7 @@ export const deleteModal = (kind, ns) => {
 
   if (ns.metadata.name === 'default') {
     tooltip = `${kind.label} default cannot be deleted`;
-  } else if (ns.status.phase === 'Terminating') {
+  } else if (ns.status?.phase === 'Terminating') {
     tooltip = `${kind.label} is already terminating`;
   } else {
     callback = () => deleteNamespaceModal({ kind, resource: ns });
@@ -348,7 +348,7 @@ const NamespacesTableRow = ({ obj: ns, customData: { tableColumns } }) => {
         columns={columns}
         columnID={namespaceColumnInfo.status.id}
       >
-        <Status status={ns.status.phase} />
+        <Status status={ns.status?.phase} />
       </TableData>
       <TableData
         className={classNames(namespaceColumnInfo.requester.classes, 'co-break-word')}
@@ -671,7 +671,7 @@ const ProjectTableRow = ({ obj: project, customData = {} }) => {
         columns={columns}
         columnID={namespaceColumnInfo.status.id}
       >
-        <Status status={project.status.phase} />
+        <Status status={project.status?.phase} />
       </TableData>
       <TableData
         className={classNames(namespaceColumnInfo.requester.classes, 'co-break-word')}
@@ -1029,7 +1029,7 @@ export const NamespaceSummary = ({ ns }) => {
       <div className="col-sm-6 col-xs-12">
         <dl className="co-m-pane__details">
           <DetailsItem label={t('public~Status')} obj={ns} path="status.phase">
-            <Status status={ns.status.phase} />
+            <Status status={ns.status?.phase} />
           </DetailsItem>
           <PullSecret namespace={ns} canViewSecrets={canListSecrets} />
           <dt>{t('public~NetworkPolicies')}</dt>


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2111686

**Analysis / Root cause**: 
While working on a new test-env feature of the backend in the HACk week, we run the console UI against a nanokube cluster and found some NPE errors.

**Solution Description**: 
Just added some optional chaining to code areas that crash when running the console UI against the nanokube cluster.

**Screen shots / Gifs for design review**: 
No UI change

**Unit test coverage report**: 
No test change

**Test setup:**
1. Clone and build https://github.com/RedHatInsights/nanokube

```
export KUBEBUILDER_ASSETS=`~/go/bin/setup-envtest use 1.21 -p path`
./nanokube
```
2. Run our console web UI against this cluster!

```
# do not call   ./contrib/oc-environment.sh   !!
export BRIDGE_USER_AUTH="disabled"
export BRIDGE_K8S_MODE="off-cluster"
export BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT="http://127.0.0.1:8090/"
export BRIDGE_K8S_AUTH="bearer-token"
export BRIDGE_K8S_AUTH_BEARER_TOKEN="ignored-by-proxy"
./bin/bridge
```

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
/cc @debsmita1 