### PR TITLE
Bug 2041389: Fix explore-type-sidebar path resolving

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -416,6 +416,7 @@ let updateSwaggerInterval;
  * then poll swagger definitions every 5 minutes to ensure they stay up to date.
  */
 const updateSwaggerDefinitionContinual = () => {
+  console.log('here continual fetching');
   fetchSwagger().catch((e) => {
     // eslint-disable-next-line no-console
     console.error('Could not fetch OpenAPI after application start:', e);

--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -80,10 +80,13 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
 
   const getNextPath = (nextName) => {
     const nextLongPath = [...resolvePath(currentPath), 'properties', nextName];
+    const hasRef = _.has(_.get(allDefinitions, nextLongPath), ['items', '$ref']);
     // check if reference exists in the next definition
-    const reference = _.has(_.get(allDefinitions, nextLongPath), '$ref')
-      ? getRef(_.get(allDefinitions, currentPath))
-      : null;
+    const reference =
+      _.has(_.get(allDefinitions, nextLongPath), '$ref') ||
+      _.has(_.get(allDefinitions, nextLongPath), ['items', '$ref'])
+        ? getRef(_.get(allDefinitions, currentPath))
+        : null;
     return reference ? [reference, 'properties', nextName] : nextLongPath;
   };
 

--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -43,9 +43,12 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
   const currentPath = currentSelection
     ? currentSelection.path
     : [kindObj ? getDefinitionKey(kindObj, allDefinitions) : 'custom-schema'];
+  const ref = _.get(allDefinitions, currentPath).$ref
+    ? getRef(_.get(allDefinitions, currentPath))
+    : null;
   const currentDefinition: SwaggerDefinition = _.get(
     allDefinitions,
-    getRef(_.get(allDefinitions, currentPath)) || currentPath,
+    ref || currentPath,
   );
   const currentProperties =
     _.get(currentDefinition, 'properties') || _.get(currentDefinition, 'items.properties');
@@ -84,9 +87,11 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
   // - Inline property declartions
   // - Inline property declartions for array items
   const getDrilldownPath = (name: string): string[] => {
-    const path = kindObj
-      ? getSwaggerPath(allDefinitions, currentPath, name, true)
-      : [...currentPath, 'properties', name];
+    const reference = _.has(_.get(allDefinitions, [...currentPath, 'properties', name]), '$ref')
+      ? getRef(_.get(allDefinitions, currentPath))
+      : null;
+    const resolvedPath = reference ? [reference] : [...currentPath, 'properties', name];
+    const path = kindObj ? resolvedPath : [...currentPath, 'properties', name];
     // Only allow drilldown if the reference has additional properties to explore.
     const child = _.get(allDefinitions, path) as SwaggerDefinition;
     return _.has(child, 'properties') || _.has(child, 'items.properties') ? path : null;

--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -43,7 +43,10 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
   const currentPath = currentSelection
     ? currentSelection.path
     : [kindObj ? getDefinitionKey(kindObj, allDefinitions) : 'custom-schema'];
-  const currentDefinition: SwaggerDefinition = _.get(allDefinitions, currentPath);
+  const currentDefinition: SwaggerDefinition = _.get(
+    allDefinitions,
+    getRef(_.get(allDefinitions, currentPath)) || currentPath,
+  );
   const currentProperties =
     _.get(currentDefinition, 'properties') || _.get(currentDefinition, 'items.properties');
 


### PR DESCRIPTION
Fixes path resolving in YAML sidebar navigation.

The issue was, that references(`$ref`) in k8s/openapi was not followed. The created path looked like: `io.k8s.api.apps.v1.Deployment, properties, spec, properties, selector, ...` instead of being correctly resolved on the way: `io.k8s.api.apps.v1.DeploymentSpec, properties, selector, ...`. 


Signed-off-by: Pavel Kratochvil <pakratoc@redhat.com>