### PR TITLE
Bug 2105909, Bug 2105328: Fix create-namespace e2e test, ESOCKET timeout issue, and a11y violations to unblock CI

### DIFF
--- a/frontend/.yarnrc
+++ b/frontend/.yarnrc
@@ -3,3 +3,4 @@
 
 
 yarn-path ".yarn/releases/yarn-1.22.15.js"
+network-timeout "600000"

--- a/frontend/packages/integration-tests-cypress/tests/crud/other-routes.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/other-routes.spec.ts
@@ -131,7 +131,7 @@ describe('Visiting other routes', () => {
       if (route.waitFor) {
         route.waitFor();
       }
-      cy.testA11y(`${route} page`);
+      cy.testA11y(`route ${route.path.replace(/\//g, ' ')}`);
     });
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
@@ -31,6 +31,12 @@ describe('Create namespace from install operators', () => {
     cy.byTestID(operatorSelector).click();
     cy.byLegacyTestID('operator-install-btn').click({ force: true });
 
+    // 3scale 2.11 supports only installation mode 'A specific namespace',
+    // so it was automatically selected.
+    // But starting with 2.12 it also supports 'All namespaces'.
+    // So it is required to select this radio option to specify the namespace.
+    cy.byTestID('A specific namespace on the cluster-radio-input').click();
+
     // configure operator install ("^=Create_"" will match "Create_Namespace" and "Create_Project")
     cy.byTestID('dropdown-selectbox')
       .click()

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   Alert,
   AboutModal as PfAboutModal,
-  Skeleton,
   TextContent,
   TextList,
   TextListItem,
@@ -11,7 +10,13 @@ import { Link } from 'react-router-dom';
 import { Trans, useTranslation } from 'react-i18next';
 import { useClusterVersion, BlueArrowCircleUpIcon, useCanClusterUpgrade } from '@console/shared';
 import { getBrandingDetails } from './masthead';
-import { ReleaseNotesLink, ServiceLevel, useServiceLevelTitle, ServiceLevelText } from './utils';
+import {
+  ReleaseNotesLink,
+  ServiceLevel,
+  useServiceLevelTitle,
+  ServiceLevelText,
+  ServiceLevelLoading,
+} from './utils';
 import { k8sVersion } from '../module/status';
 import {
   getClusterID,
@@ -92,9 +97,9 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) =>
             clusterID={clusterID}
             loading={
               <>
-                <TextListItem component="dt" />
+                <TextListItem component="dt">{useServiceLevelTitle()}</TextListItem>
                 <TextListItem component="dd">
-                  <Skeleton />
+                  <ServiceLevelLoading />
                 </TextListItem>
               </>
             }

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   Alert,
   AboutModal as PfAboutModal,
+  Skeleton,
   TextContent,
   TextList,
   TextListItem,
@@ -87,7 +88,17 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) =>
             {window.SERVER_FLAGS.kubeAPIServerURL}
           </TextListItem>
 
-          <ServiceLevel clusterID={clusterID}>
+          <ServiceLevel
+            clusterID={clusterID}
+            loading={
+              <>
+                <TextListItem component="dt" />
+                <TextListItem component="dd">
+                  <Skeleton />
+                </TextListItem>
+              </>
+            }
+          >
             <>
               <TextListItem component="dt">{useServiceLevelTitle()}</TextListItem>
               <TextListItem component="dd" className="co-select-to-copy">

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -14,7 +14,6 @@ import {
   Progress,
   ProgressSize,
   ProgressVariant,
-  Skeleton,
   Text,
   TextContent,
   TextVariants,
@@ -126,7 +125,12 @@ import {
 import { useFlag } from '@console/shared/src/hooks/flag';
 import { FLAGS } from '@console/shared/src/constants';
 
-import { ServiceLevel, useServiceLevelTitle, ServiceLevelText } from '../utils/service-level';
+import {
+  ServiceLevel,
+  useServiceLevelTitle,
+  ServiceLevelText,
+  ServiceLevelLoading,
+} from '../utils/service-level';
 import { hasAvailableUpdates, hasNotRecommendedUpdates } from '../../module/k8s/cluster-settings';
 
 const cancelUpdate = (cv: ClusterVersionKind) => {
@@ -1205,9 +1209,9 @@ export const ClusterVersionDetailsTable: React.FC<ClusterVersionDetailsTableProp
               clusterID={clusterID}
               loading={
                 <>
-                  <dt></dt>
+                  <dt>{useServiceLevelTitle()}</dt>
                   <dd>
-                    <Skeleton />
+                    <ServiceLevelLoading />
                   </dd>
                 </>
               }

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -14,6 +14,7 @@ import {
   Progress,
   ProgressSize,
   ProgressVariant,
+  Skeleton,
   Text,
   TextContent,
   TextVariants,
@@ -1200,7 +1201,17 @@ export const ClusterVersionDetailsTable: React.FC<ClusterVersionDetailsTableProp
                 </dd>
               </>
             )}
-            <ServiceLevel clusterID={clusterID}>
+            <ServiceLevel
+              clusterID={clusterID}
+              loading={
+                <>
+                  <dt></dt>
+                  <dd>
+                    <Skeleton />
+                  </dd>
+                </>
+              }
+            >
               <>
                 <dt>{useServiceLevelTitle()}</dt>
                 <dd>

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
@@ -1,13 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  Card,
-  CardBody,
-  CardHeader,
-  CardTitle,
-  CardActions,
-  Skeleton,
-} from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, CardTitle, CardActions } from '@patternfly/react-core';
 import { InProgressIcon } from '@patternfly/react-icons';
 import {
   BlueArrowCircleUpIcon,
@@ -30,7 +23,12 @@ import { OverviewDetailItem } from '@openshift-console/plugin-shared/src';
 
 import { DashboardItemProps, withDashboardResources } from '../../with-dashboard-resources';
 import { ClusterVersionModel } from '../../../../models';
-import { ServiceLevel, useServiceLevelTitle, ServiceLevelText } from '../../../utils/service-level';
+import {
+  ServiceLevel,
+  useServiceLevelTitle,
+  ServiceLevelText,
+  ServiceLevelLoading,
+} from '../../../utils/service-level';
 import {
   referenceForModel,
   getOpenShiftVersion,
@@ -214,8 +212,8 @@ export const DetailsCard = withDashboardResources(
                   <ServiceLevel
                     clusterID={clusterID}
                     loading={
-                      <OverviewDetailItem title={''}>
-                        <Skeleton />
+                      <OverviewDetailItem title={useServiceLevelTitle()}>
+                        <ServiceLevelLoading />
                       </OverviewDetailItem>
                     }
                   >

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
@@ -1,4 +1,13 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  CardTitle,
+  CardActions,
+  Skeleton,
+} from '@patternfly/react-core';
 import { InProgressIcon } from '@patternfly/react-icons';
 import {
   BlueArrowCircleUpIcon,
@@ -16,10 +25,8 @@ import {
   WatchK8sResource,
   OverviewDetailItem as OverviewDetailItemType,
 } from '@console/dynamic-plugin-sdk';
-import { Card, CardBody, CardHeader, CardTitle, CardActions } from '@patternfly/react-core';
 import DetailsBody from '@console/shared/src/components/dashboard/details-card/DetailsBody';
 import { OverviewDetailItem } from '@openshift-console/plugin-shared/src';
-import { useTranslation } from 'react-i18next';
 
 import { DashboardItemProps, withDashboardResources } from '../../with-dashboard-resources';
 import { ClusterVersionModel } from '../../../../models';
@@ -204,7 +211,14 @@ export const DetailsCard = withDashboardResources(
                     <ClusterVersion cv={clusterVersionData} />
                   </OverviewDetailItem>
 
-                  <ServiceLevel clusterID={clusterID}>
+                  <ServiceLevel
+                    clusterID={clusterID}
+                    loading={
+                      <OverviewDetailItem title={''}>
+                        <Skeleton />
+                      </OverviewDetailItem>
+                    }
+                  >
                     <OverviewDetailItem title={useServiceLevelTitle()}>
                       {/* Service Level handles loading and error state */}
                       <ServiceLevelText clusterID={clusterID} />

--- a/frontend/public/components/utils/service-level.tsx
+++ b/frontend/public/components/utils/service-level.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, Label } from '@patternfly/react-core';
+import { Alert, Label, Skeleton } from '@patternfly/react-core';
 import { NotificationEntry, NotificationTypes } from '@console/patternfly';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
@@ -199,6 +199,11 @@ const useGetServiceLevel = (
     loadingSecret,
     loadingServiceLevel,
   };
+};
+
+export const ServiceLevelLoading: React.FC = () => {
+  const { t } = useTranslation();
+  return <Skeleton screenreaderText={t('public~Loading')} />;
 };
 
 export const ServiceLevel: React.FC<{

--- a/frontend/public/components/utils/service-level.tsx
+++ b/frontend/public/components/utils/service-level.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, Skeleton, Label } from '@patternfly/react-core';
+import { Alert, Label } from '@patternfly/react-core';
 import { NotificationEntry, NotificationTypes } from '@console/patternfly';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
@@ -201,10 +201,11 @@ const useGetServiceLevel = (
   };
 };
 
-export const ServiceLevel: React.FC<{ clusterID: string; children: React.ReactNode }> = ({
-  clusterID,
-  children,
-}) => {
+export const ServiceLevel: React.FC<{
+  clusterID: string;
+  loading: React.ReactNode;
+  children: React.ReactNode;
+}> = ({ clusterID, loading, children }) => {
   const { hasSecretAccess, loadingSecret, loadingServiceLevel } = useGetServiceLevel(clusterID);
 
   if (!showServiceLevel(clusterID)) {
@@ -214,7 +215,7 @@ export const ServiceLevel: React.FC<{ clusterID: string; children: React.ReactNo
     return null;
   }
   if (!loadingSecret && loadingServiceLevel) {
-    return <Skeleton />;
+    return <>{loading}</>;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2105909
https://bugzilla.redhat.com/show_bug.cgi?id=2105328

## Change 1: 3scale create-namespace.spec.ts issue

3scale 2.11 supports only installation mode 'A specific namespace', so it was automatically selected. But starting with 2.12 it also supports 'All namespaces'.

For example:
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console/11798/pull-ci-openshift-console-release-4.10-e2e-gcp-console/1545505724312850432
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console/11798/pull-ci-openshift-console-release-4.10-e2e-gcp-console/1545549888563974144
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console/11798/pull-ci-openshift-console-release-4.10-e2e-gcp-console/1545684305693380608

See also:
https://search.ci.openshift.org/?search=before+all%60+hook+we+are+skipping+the+remaining+tests+in+the+current+suite%3A+%60Using+OLM+descriptor+compon&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

It is now required to select this radio option to specify the namespace. If the operator version supports only 'A specific namespace' this click has no effect because it is already selected.

## Change 2: Log more information when an a11y issue was detected

We had different a11y issues in the past, but it was sometimes difficult to understand the root cause.

Just added some more log statements to a11y.ts. The table was visible in the logs, but sometimes its helpful to see more infos also in the cypress UI.

Before:

![before-a11y-log](https://user-images.githubusercontent.com/139310/178505737-899c7469-099d-4b1a-98c9-433802af8328.png)

After:

![after-a11y-log](https://user-images.githubusercontent.com/139310/178505757-b3808457-61c7-4adc-b9e6-388ae756dca6.png)

## Change 3: A11y issue while the SLA infos are not fetched

Similar to #11804 by @rhamilto. But I tried to fix the a11y issue (invalid HTML definition list content) instead of waiting until the Skeleton isn't shown anymore.

The YAML was renredered like this before:

```html
<dl>
  <dt>title</dt>
  <dd>content</dd>
  <dt>title</dt>
  <dd>content</dd>
  <div class="pf-skeleton" />
  <dt>title</dt>
  <dd>content</dd>
</dl>  
```

Now it renders:

```html
<dl>
  <dt>title</dt>
  <dd>content</dd>
  <dt>title</dt>
  <dd>content</dd>
  <dt></dt>  <!-- no title in this case -->
  <dd><div class="pf-skeleton" /></dd>
  <dt>title</dt>
  <dd>content</dd>
</dl>  
```

This is maybe not perfect, but better then before. The UI looks also better in my opinion:

| UI | before | after |
|---|---|---|
| Admin dashboard | ![before-sla-loading](https://user-images.githubusercontent.com/139310/178507317-ba50de1f-1d0f-4ffa-b864-062cab1343f3.png) | ![after-sla-loading](https://user-images.githubusercontent.com/139310/178507326-5ed73614-dc15-446b-a0cd-d51e001439ee.png) |
| Cluster settings | ![cluster-settings-before](https://user-images.githubusercontent.com/139310/178507401-6686af9c-9ccb-4398-8113-62027e80a7fc.png) | ![cluster-settings-after](https://user-images.githubusercontent.com/139310/178507415-5d2a7e55-475a-4b8c-89e2-78018f544bb5.png) |
| About dialog | ![about-modal-before](https://user-images.githubusercontent.com/139310/178507462-8d6521ea-8549-43ec-9aed-47dc4040d1d4.png) | ![about-modal-after](https://user-images.githubusercontent.com/139310/178507475-23b3493c-6103-48a2-9d7d-5b7eafa47cd5.png) |

### Change 4: Fix yarn install network timeout

Thanks to #11804 by @rhamilto, just added `network-timeout "600000"` to `frontend/.yarnrc`
