### PR TITLE
[release-4.10] Bug 2105911: Fix create-namespace e2e test with updated 3scale operator

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
@@ -31,6 +31,12 @@ describe('Create namespace from install operators', () => {
     cy.byTestID(operatorSelector).click();
     cy.byLegacyTestID('operator-install-btn').click({ force: true });
 
+    // 3scale 2.11 supports only installation mode 'A specific namespace',
+    // so it was automatically selected.
+    // But starting with 2.12 it also supports 'All namespaces'.
+    // So it is required to select this radio option to specify the namespace.
+    cy.byTestID('A specific namespace on the cluster-radio-input').click();
+
     // configure operator install ("^=Create_"" will match "Create_Namespace" and "Create_Project")
     cy.byTestID('dropdown-selectbox')
       .click()

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
@@ -2,7 +2,7 @@ import { checkErrors, testName } from '../../../integration-tests-cypress/suppor
 import { modal } from '../../../integration-tests-cypress/views/modal';
 import { nav } from '../../../integration-tests-cypress/views/nav';
 
-describe.skip('Create namespace from install operators', () => {
+describe('Create namespace from install operators', () => {
   before(() => {
     cy.login();
     cy.visit('/');


### PR DESCRIPTION
Backport ticket: https://bugzilla.redhat.com/show_bug.cgi?id=2105911

Backport of #11809

See also https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-console-release-4.10-e2e-gcp-console

Current build history

<img width="998" alt="image" src="https://user-images.githubusercontent.com/139310/178132423-bc40d8f8-1374-40d3-8ee5-1f931a17323c.png">
