### PR TITLE
[release-4.8] Bug 2105913: Fix create-namespace e2e test with updated 3scale operator

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
@@ -31,6 +31,12 @@ describe('Create namespace from install operators', () => {
     cy.byTestID(operatorSelector).click();
     cy.byLegacyTestID('operator-install-btn').click({ force: true });
 
+    // 3scale 2.11 supports only installation mode 'A specific namespace',
+    // so it was automatically selected.
+    // But starting with 2.12 it also supports 'All namespaces'.
+    // So it is required to select this radio option to specify the namespace.
+    cy.byTestID('A specific namespace on the cluster-radio-input').click();
+
     // configure operator install
     cy.byTestID('dropdown-selectbox')
       .click()


### PR DESCRIPTION
Backport ticket https://bugzilla.redhat.com/show_bug.cgi?id=2105913

Backport of #11809

See also https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-console-release-4.8-e2e-gcp-console

Current build history

<img width="999" alt="image" src="https://user-images.githubusercontent.com/139310/178132506-93858c0d-6168-4259-925e-47875cf3c529.png">
