### PR TITLE
[release-4.7] Bug 2105914: Fix create-namespace e2e test with updated 3scale operator

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
@@ -29,6 +29,12 @@ describe('Create namespace from install operators', () => {
     cy.byTestID(operatorSelector).click();
     cy.byLegacyTestID('operator-install-btn').click({ force: true });
 
+    // 3scale 2.11 supports only installation mode 'A specific namespace',
+    // so it was automatically selected.
+    // But starting with 2.12 it also supports 'All namespaces'.
+    // So it is required to select this radio option to specify the namespace.
+    cy.byTestID('A specific namespace on the cluster-radio-input').click();
+
     // configure operator install
     cy.byTestID('Select a Namespace-radio-input').check();
     cy.byTestID('dropdown-selectbox')


### PR DESCRIPTION
Backport ticket https://bugzilla.redhat.com/show_bug.cgi?id=2105914

Backport of #11809

See also https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-console-release-4.7-e2e-gcp-console
