### PR TITLE
(chore) Do not extract not existing yarn archive

### DIFF
--- a/Dockerfile.product
+++ b/Dockerfile.product
@@ -16,8 +16,6 @@ FROM rhscl/nodejs-8-rhel7 AS nodebuilder
 ADD . .
 
 USER 0
-# extract the yarn dependencies that must be provided in the dist-git lookaside cache
-RUN tar fx yarn-offline.tar
 
 # bootstrap yarn so we can install and run the other tools.
 RUN container-entrypoint npm install ./artifacts/yarn-v1.22.19.tar.gz


### PR DESCRIPTION
Follow-up of https://github.com/openshift/console/pull/11786

Resulting build: https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2083175