### PR TITLE
Bug 2105344:  correct usePodActionsProvider and apply it

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -194,7 +194,7 @@
         "version": "v1",
         "kind": "Pod"
       },
-      "provider": { "$codeRef": "actions.useCronJobActionsProvider" }
+      "provider": { "$codeRef": "actions.usePodActionsProvider" }
     }
   },
   {

--- a/frontend/packages/console-app/src/actions/providers/index.ts
+++ b/frontend/packages/console-app/src/actions/providers/index.ts
@@ -5,3 +5,4 @@ export * from './job-provider';
 export * from './service-binding-provider';
 export * from './replicaset-provider';
 export * from './replication-controllers-provider';
+export * from './pod-provider';

--- a/frontend/packages/console-app/src/actions/providers/pod-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/pod-provider.ts
@@ -2,14 +2,16 @@ import * as React from 'react';
 import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { getCommonResourceActions } from '../creators/common-factory';
+import { usePDBActions } from '../creators/pdb-factory';
 
 export const usePodActionsProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
+  const [pdbActions] = usePDBActions(kindObj, resource);
 
-  const actions = React.useMemo(() => getCommonResourceActions(kindObj, resource), [
-    kindObj,
-    resource,
-  ]);
+  const actions = React.useMemo(
+    () => [...pdbActions, ...getCommonResourceActions(kindObj, resource)],
+    [kindObj, pdbActions, resource],
+  );
 
   return [actions, !inFlight, undefined];
 };


### PR DESCRIPTION
Because `usePodActionsProvider` was not in use when @cyril-ui-developer implemented PDBs in https://github.com/openshift/console/pull/10445, `usePodActionsProvider` was not updated to include PDBs.