### PR TITLE
Bug 2106805: Enable running specific spec files with headless test-cypress

### DIFF
--- a/frontend/packages/dev-console/integration-tests/package.json
+++ b/frontend/packages/dev-console/integration-tests/package.json
@@ -11,9 +11,9 @@
     "clean-reports": "rm -rf ../../../gui_test_screenshots",
     "cypress-merge": "../../../node_modules/.bin/mochawesome-merge ../../../gui_test_screenshots/cypress_report*.json > ../../../gui_test_screenshots/cypress.json",
     "cypress-generate": "../../../node_modules/.bin/marge -o ../../../gui_test_screenshots/ -f cypress-report -t 'OpenShift DevConsole Cypress Test Results' -p 'OpenShift Cypress Test Results' --showPassed false --assetsDir ../../../gui_test_screenshots/cypress/assets ../../../gui_test_screenshots/cypress.json",
-    "test-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless --spec \"features/e2e/add-flow-ci.feature\";",
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless --spec \"features/e2e/add-flow-ci.feature\"",
     "test-headless-all": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless",
-    "test-cypress-headless": "yarn run test-headless && yarn run cypress-merge && yarn run cypress-generate",
-    "test-cypress-nightly": "yarn run test-headless-all && yarn run cypress-merge && yarn run cypress-generate"
+    "test-cypress-nightly": "yarn run test-headless-all && yarn run cypress-merge && yarn run cypress-generate",
+    "posttest-cypress-headless": "yarn run cypress-merge && yarn run cypress-generate"
   }
 }

--- a/frontend/packages/helm-plugin/integration-tests/package.json
+++ b/frontend/packages/helm-plugin/integration-tests/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless --spec \"features/helm-release.feature\";",
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless --spec \"features/helm-release.feature\"",
     "test-cypress-headless-all": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless"
   }
 }

--- a/frontend/packages/knative-plugin/integration-tests/package.json
+++ b/frontend/packages/knative-plugin/integration-tests/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless --spec \"features/e2e/knative-ci.feature\";",
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless --spec \"features/e2e/knative-ci.feature\"",
     "test-cypress-headless-all": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless"
   }
 }

--- a/frontend/packages/pipelines-plugin/integration-tests/package.json
+++ b/frontend/packages/pipelines-plugin/integration-tests/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless cypress:cli,cypress:server:specs --spec \"features/e2e/pipeline-ci.feature\";",
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless cypress:cli,cypress:server:specs --spec \"features/e2e/pipeline-ci.feature\"",
     "test-cypress-headless-all": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless cypress:cli,cypress:server:specs --spec \"features/pipelines/*.feature\";"
   }
 }

--- a/frontend/packages/topology/integration-tests/package.json
+++ b/frontend/packages/topology/integration-tests/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless cypress:cli,cypress:server:specs --spec \"features/*/topology-ci.feature\";",
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless cypress:cli,cypress:server:specs --spec \"features/*/topology-ci.feature\"",
     "test-cypress-headless-all": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless cypress:cli,cypress:server:specs"
   }
 }


### PR DESCRIPTION
fixes the `-s` flag for test-cypress script not overriding the `--spec` flag for the npm scripts