### PR TITLE
Bug 2090457: openshift-debug-node- namespaces do not get deleted for …

### DIFF
--- a/frontend/public/components/debug-terminal.tsx
+++ b/frontend/public/components/debug-terminal.tsx
@@ -119,6 +119,10 @@ export const DebugTerminal: React.FC<DebugTerminalProps> = ({ podData, container
       }
     };
     let newDebugPod;
+    const closeTab = (event) => {
+      event.preventDefault();
+      deleteDebugPod(newDebugPod.metadata.name);
+    };
     const createDebugPod = async () => {
       try {
         newDebugPod = await k8sCreate(PodModel, podToCreate);
@@ -129,12 +133,12 @@ export const DebugTerminal: React.FC<DebugTerminalProps> = ({ podData, container
     };
     createDebugPod();
 
-    window.addEventListener('beforeunload', deleteDebugPod);
+    window.addEventListener('beforeunload', closeTab);
     return () => {
       if (newDebugPod) {
         deleteDebugPod(newDebugPod.metadata.name);
       }
-      window.removeEventListener('beforeunload', deleteDebugPod);
+      window.removeEventListener('beforeunload', closeTab);
     };
   }, [debugPodName, podNamespace, podToCreate]);
 


### PR DESCRIPTION
…debug terminals launched via console

Makes sure the pod/project is deleted after launching a terminal session from the console and closing the browser window without navigating anywhere else.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2090457