### PR TITLE
SDK - 'reselect' missing dep reselect

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/package.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/package.json
@@ -21,6 +21,7 @@
     "@types/fs-extra": "9.x",
     "ejs": "3.x",
     "fs-extra": "9.x",
+    "reselect": "4.x",
     "ts-json-schema-generator": "0.91.0",
     "tsutils": "3.x",
     "typescript": "4.2.x",


### PR DESCRIPTION
`reselect` used [here](https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources.ts#L6)

@vojtechszocs 