### PR TITLE
Bug 2108638: SDK - expose useLastNamespace

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
@@ -20,6 +20,7 @@ import {
   UseUserSettings,
   QuickStartsLoaderProps,
   UseURLPoll,
+  UseLastNamespace,
 } from './internal-types';
 
 export const ActivityItem: React.FC<ActivityItemProps> = require('@console/shared/src/components/dashboard/activity-card/ActivityItem')
@@ -66,3 +67,6 @@ export const useUserSettings: UseUserSettings = require('@console/shared/src/hoo
   .useUserSettings;
 export const useURLPoll: UseURLPoll = require('@console/internal/components/utils/url-poll-hook')
   .useURLPoll;
+export const useLastNamespace: UseLastNamespace = require('@console/app/src/components/detect-namespace/useLastNamespace')
+  .useLastNamespace;
+

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
@@ -178,6 +178,12 @@ export type Options = {
 
 export type UseActiveNamespace = () => [string, (ns: string) => void];
 
+export type UseLastNamespace = () => [
+  string,
+  React.Dispatch<React.SetStateAction<string>>,
+  boolean,
+];
+
 export type VirtualizedGridProps = {
   items: VirtualizedGridItem[] | VirtualizedGridGroupedItems;
   renderCell: VirtualizedGridRenderCell;


### PR DESCRIPTION
@vojtechszocs 

Hei guys, don't know exactly how to test this change.
But should work :D 

Why do we need to expose this hook? 
Sometimes to create a link (like vm/template lists links) we need to know which is the last namespace used. 
This logic is used also to create the links for the side menu

There is also a function [here](https://github.com/openshift/console/blob/master/frontend/public/components/utils/breadcrumbs.ts#L7) that we can expose instead if you want. But the hook seems to have more functionality