### PR TITLE
Bug 2079690: Fix operand affinity form field

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/common-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/common-types.ts
@@ -82,7 +82,6 @@ export type MatchExpression = {
   key: string;
   operator: Operator | string;
   values?: string[];
-  value?: string;
 };
 
 export type MatchLabels = {

--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -120,7 +120,7 @@
   "An error occurred": "An error occurred",
   "Key": "Key",
   "Operator": "Operator",
-  "Value": "Value",
+  "Values": "Values",
   "Add expression": "Add expression",
   "CPU cores": "CPU cores",
   "Memory": "Memory",

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/match-expressions.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/match-expressions.tsx
@@ -3,15 +3,16 @@ import { Button } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { Dropdown } from '@console/internal/components/utils';
-import { MatchExpression } from '@console/internal/module/k8s';
+import { MatchExpression, Operator } from '@console/internal/module/k8s';
 
+const UNARY_OPERATORS = [Operator.Exists, Operator.DoesNotExist];
 const ALL_OPERATORS: MatchExpression['operator'][] = [
-  'DoesNotExist',
-  'Equals',
-  'Exists',
-  'In',
-  'NotEqual',
-  'NotIn',
+  Operator.DoesNotExist,
+  Operator.Equals,
+  Operator.Exists,
+  Operator.In,
+  Operator.NotEqual,
+  Operator.NotIn,
 ];
 
 const MatchExpression: React.FC<MatchExpressionProps> = ({
@@ -20,6 +21,7 @@ const MatchExpression: React.FC<MatchExpressionProps> = ({
   allowedOperators = ALL_OPERATORS,
   onClickRemove = () => {},
 }) => {
+  const { key, operator, values } = expression;
   const { t } = useTranslation();
   return (
     <div className="row key-operator-value__row">
@@ -30,7 +32,7 @@ const MatchExpression: React.FC<MatchExpressionProps> = ({
         <input
           type="text"
           className="pf-c-form-control"
-          value={expression.key}
+          value={expression.key ?? ''}
           onChange={(e) => onChange({ ...expression, key: e.target.value })}
         />
       </div>
@@ -41,23 +43,27 @@ const MatchExpression: React.FC<MatchExpressionProps> = ({
         <Dropdown
           dropDownClassName="dropdown--full-width"
           items={allowedOperators.reduce((acc, o) => ({ ...acc, [o]: o }), {})}
-          onChange={(operator: MatchExpression['operator']) =>
-            onChange({ ...expression, operator })
-          }
+          onChange={(newOperator: Operator) => onChange({ key, operator: newOperator, values: [] })}
           selectedKey={expression.operator}
           title={expression.operator}
         />
       </div>
       <div className="col-md-3 col-xs-5 key-operator-value__value-field key-operator-value__value-field--stacked">
         <div className="key-operator-value__heading hidden-md hidden-lg text-secondary text-uppercase">
-          {t('olm~Value')}
+          {t('olm~Values')}
         </div>
         <input
           className="pf-c-form-control"
           type="text"
-          value={expression?.value}
-          onChange={(e) => onChange({ ...expression, value: e?.target?.value })}
-          readOnly={['Exists', 'DoesNotExist'].includes(expression.operator)}
+          value={values?.join(',') ?? ''}
+          onChange={(e) =>
+            onChange({
+              key,
+              operator,
+              values: e.target?.value?.split(',')?.map((v) => v.trim()) ?? [],
+            })
+          }
+          disabled={UNARY_OPERATORS.includes(operator as Operator)}
         />
       </div>
       <div className="col-xs-1 key-operator-value__action key-operator-value__action--stacked">
@@ -91,14 +97,14 @@ export const MatchExpressions: React.FC<MatchExpressionsProps> = ({
     onChange(matchExpressions.filter((_exp, i) => i !== index));
 
   const addExpression = (): void =>
-    onChange([...matchExpressions, { key: '', operator: 'Exists' }]);
+    onChange([...matchExpressions, { key: '', operator: Operator.Exists, values: [] }]);
 
   return (
     <>
       <div className="row key-operator-value__heading hidden-sm hidden-xs">
         <div className="col-md-4 text-secondary text-uppercase">{t('olm~Key')}</div>
         <div className="col-md-3 text-secondary text-uppercase">{t('olm~Operator')}</div>
-        <div className="col-md-3 text-secondary text-uppercase">{t('olm~Value')}</div>
+        <div className="col-md-3 text-secondary text-uppercase">{t('olm~Values')}</div>
       </div>
       {matchExpressions.map((expression, index) => (
         // Have to use array index in the key bc any other unique id whould have to use editable fields.


### PR DESCRIPTION
The MatchExpression API does not have a `value` property. Update the form field to only use `values` property and appropriately update underlying data.