### PR TITLE
Bug 2079214: Switch default modal scroll behavior from inner modal body scroll to entire modal scroll to prevent bug and have consistent display of dropdown menus.

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/add-capacity-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/add-capacity-modal.tsx
@@ -237,7 +237,7 @@ export const AddCapacityModal = (props: AddCapacityModalProps) => {
       {/** Modal is spanning across entire screen (for small screen sizes)
        * Wrapped components inside a <div> to fix it.
        */}
-      <div className="modal-content modal-content--no-inner-scroll">
+      <div className="modal-content">
         <ModalTitle>{t('ceph-storage-plugin~Add Capacity')}</ModalTitle>
         <ModalBody>
           <Trans t={t} ns="ceph-storage-plugin" values={{ name }}>

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/advanced-kms-modal/advanced-ibm-kms-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/advanced-kms-modal/advanced-ibm-kms-modal.tsx
@@ -38,7 +38,7 @@ export const AdvancedHpcsModal = withHandlePromise((props: AdvancedKMSModalProps
 
   return (
     <Form onSubmit={submit} key="advanced-ibm-kms-modal">
-      <div className="modal-content modal-content--no-inner-scroll">
+      <div className="modal-content">
         <ModalTitle>{t('ceph-storage-plugin~Key Management Service Advanced Settings')}</ModalTitle>
         <ModalBody>
           <FormGroup

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/attach-deployment-obc-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/attach-deployment-obc-modal.tsx
@@ -70,7 +70,7 @@ const AttachDeploymentToOBCModal = withHandlePromise((props: AttachDeploymentToO
   };
 
   return (
-    <form onSubmit={submit} name="form" className="modal-content modal-content--no-inner-scroll">
+    <form onSubmit={submit} name="form" className="modal-content">
       <ModalTitle>{t('ceph-storage-plugin~Attach OBC to a Deployment')}</ModalTitle>
       <ModalBody>
         <label htmlFor="dropdown-selectbox" className="control-label co-required">

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/block-pool-modal/create-block-pool-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/block-pool-modal/create-block-pool-modal.tsx
@@ -107,7 +107,7 @@ export const CreateBlockPoolModal = withHandlePromise((props: CreateBlockPoolMod
   };
 
   return (
-    <div className="modal-content modal-content--no-inner-scroll">
+    <div className="modal-content">
       <ModalTitle>{MODAL_TITLE}</ModalTitle>
       <ModalBody>
         <p>{MODAL_DESC}</p>

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/block-pool-modal/delete-block-pool-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/block-pool-modal/delete-block-pool-modal.tsx
@@ -101,7 +101,7 @@ const DeleteBlockPoolModal = withHandlePromise((props: DeleteBlockPoolModalProps
   const MODAL_TITLE = t('ceph-storage-plugin~Delete BlockPool');
 
   return (
-    <div className="modal-content modal-content--no-inner-scroll">
+    <div className="modal-content">
       <ModalTitle close={close}>
         <YellowExclamationTriangleIcon className="co-icon-space-r" /> {MODAL_TITLE}
       </ModalTitle>

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/block-pool-modal/update-block-pool-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/block-pool-modal/update-block-pool-modal.tsx
@@ -100,7 +100,7 @@ const UpdateBlockPoolModal = withHandlePromise((props: UpdateBlockPoolModalProps
   };
 
   return (
-    <div className="modal-content modal-content--no-inner-scroll">
+    <div className="modal-content">
       <ModalTitle close={close}>{MODAL_TITLE}</ModalTitle>
       {isLoaded && !loadError ? (
         <>

--- a/frontend/packages/console-app/src/components/modals/clone/clone-pvc-modal.tsx
+++ b/frontend/packages/console-app/src/components/modals/clone/clone-pvc-modal.tsx
@@ -118,7 +118,7 @@ const ClonePVCModal = withHandlePromise((props: ClonePVCModalProps) => {
 
   return (
     <Form onSubmit={submit}>
-      <div className="modal-content modal-content--no-inner-scroll">
+      <div className="modal-content">
         <ModalTitle>{t('console-app~Clone')}</ModalTitle>
         <ModalBody>
           <FormGroup

--- a/frontend/packages/console-app/src/components/modals/resource-limits/ResourceLimitsModal.tsx
+++ b/frontend/packages/console-app/src/components/modals/resource-limits/ResourceLimitsModal.tsx
@@ -24,7 +24,7 @@ const ResourceLimitsModal: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation();
   return (
-    <form className="modal-content modal-content--no-inner-scroll" onSubmit={handleSubmit}>
+    <form className="modal-content" onSubmit={handleSubmit}>
       <ModalTitle>{t('console-app~Edit resource limits')}</ModalTitle>
       <ModalBody>
         <ResourceLimitSection hideTitle />

--- a/frontend/packages/console-app/src/components/modals/restore-pvc/restore-pvc-modal.tsx
+++ b/frontend/packages/console-app/src/components/modals/restore-pvc/restore-pvc-modal.tsx
@@ -137,7 +137,7 @@ const RestorePVCModal = withHandlePromise<RestorePVCModalProps>(
       );
     };
     return (
-      <form onSubmit={submit} name="form" className="modal-content modal-content--no-inner-scroll">
+      <form onSubmit={submit} name="form" className="modal-content">
         <ModalTitle>{t('console-app~Restore as new PVC')}</ModalTitle>
         <ModalBody>
           <p>

--- a/frontend/packages/console-app/src/components/modals/service-binding/CreateServiceBindingForm.tsx
+++ b/frontend/packages/console-app/src/components/modals/service-binding/CreateServiceBindingForm.tsx
@@ -31,7 +31,7 @@ const CreateServiceBindingForm: React.FC<FormikProps<FormikValues> &
 }) => {
   const { t } = useTranslation();
   return (
-    <form onSubmit={handleSubmit} className="modal-content modal-content--no-inner-scroll">
+    <form onSubmit={handleSubmit} className="modal-content">
       <ModalTitle>{t('console-app~Create Service Binding')}</ModalTitle>
       <ModalBody>
         <Title headingLevel="h2" size="md" className="co-m-form-row">

--- a/frontend/packages/console-shared/src/components/modals/DeleteResourceModal.tsx
+++ b/frontend/packages/console-shared/src/components/modals/DeleteResourceModal.tsx
@@ -45,7 +45,7 @@ const DeleteResourceForm: React.FC<FormikProps<FormikValues> & DeleteResourceMod
   const isValid = values.resourceName === resourceName;
   const submitLabel = actionLabel || t(actionLabelKey);
   return (
-    <form onSubmit={handleSubmit} className="modal-content modal-content--no-inner-scroll">
+    <form onSubmit={handleSubmit} className="modal-content">
       <ModalTitle>
         <YellowExclamationTriangleIcon className="co-icon-space-r" /> {submitLabel} {resourceType}?
       </ModalTitle>

--- a/frontend/packages/knative-plugin/src/components/pub-sub/PubSubModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/PubSubModal.tsx
@@ -34,7 +34,7 @@ const PubSubModal: React.FC<Props> = ({
   const { t } = useTranslation();
   const dirty = values?.metadata?.name && values?.spec?.subscriber?.ref?.name;
   return (
-    <form className="modal-content modal-content--no-inner-scroll" onSubmit={handleSubmit}>
+    <form className="modal-content" onSubmit={handleSubmit}>
       <ModalTitle>{labelTitle}</ModalTitle>
       <ModalBody>
         <FormSection fullWidth>

--- a/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsubModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsubModal.tsx
@@ -59,7 +59,7 @@ const SinkPubsubModal: React.FC<Props> = ({
   const dirty = values?.ref?.name !== initialValues.ref.name;
 
   return (
-    <form className="modal-content modal-content--no-inner-scroll" onSubmit={handleSubmit}>
+    <form className="modal-content" onSubmit={handleSubmit}>
       <ModalTitle>{labelTitle}</ModalTitle>
       <ModalBody>
         <p>

--- a/frontend/packages/knative-plugin/src/components/sink-source/SinkSourceModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-source/SinkSourceModal.tsx
@@ -35,7 +35,7 @@ const SinkSourceModal: React.FC<Props> = ({
     values?.formData?.sink?.uri !== initialValues.formData.sink.uri;
 
   return (
-    <form className="modal-content modal-content--no-inner-scroll" onSubmit={handleSubmit}>
+    <form className="modal-content" onSubmit={handleSubmit}>
       <ModalTitle>{t('knative-plugin~Move sink')}</ModalTitle>
       <ModalBody>
         <p>

--- a/frontend/packages/knative-plugin/src/components/sink-uri/SinkUriModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-uri/SinkUriModal.tsx
@@ -29,7 +29,7 @@ const SinkUriModal: React.FC<Props> = ({
   const dirty = values?.uri !== initialValues.uri;
   return (
     <Form onSubmit={handleSubmit}>
-      <div className="modal-content modal-content--no-inner-scroll">
+      <div className="modal-content">
         <ModalTitle>{t('knative-plugin~Edit URI')}</ModalTitle>
         <ModalBody>
           <FormSection fullWidth>

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/edit-default-sources-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/edit-default-sources-modal.tsx
@@ -63,7 +63,7 @@ const EditDefaultSourcesModal: React.FC<EditDefaultSourcesModalProps> = ({
 
   return (
     <Form onSubmit={submit}>
-      <div className="modal-content modal-content--no-inner-scroll">
+      <div className="modal-content">
         <ModalTitle>{t('olm~Edit default sources')}</ModalTitle>
         <ModalBody>
           <FormGroup fieldId="enabled-default-sources" label={t('olm~Enabled default sources')}>

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/edit-registry-poll-interval-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/edit-registry-poll-interval-modal.tsx
@@ -47,7 +47,7 @@ const EditRegistryPollIntervalModal: React.FC<EditRegistryPollIntervalModalProps
 
   return (
     <Form onSubmit={submit} name="form">
-      <div className="modal-content modal-content--no-inner-scroll">
+      <div className="modal-content">
         <ModalTitle>{t('olm~Edit registry poll interval')}</ModalTitle>
         <ModalBody>
           <FormGroup label={t('olm~Registry poll interval')} fieldId="pollInterval_dropdown">

--- a/frontend/packages/topology/src/components/modals/EditApplicationModal.tsx
+++ b/frontend/packages/topology/src/components/modals/EditApplicationModal.tsx
@@ -43,7 +43,7 @@ const EditApplicationForm: React.FC<FormikProps<FormikValues> & EditApplicationF
   const { t } = useTranslation();
   const dirty = _.get(values, 'application.selectedKey') !== initialApplication;
   return (
-    <form onSubmit={handleSubmit} className="modal-content modal-content--no-inner-scroll">
+    <form onSubmit={handleSubmit} className="modal-content">
       <ModalTitle>{t('topology~Edit application grouping')}</ModalTitle>
       <ModalBody>
         <Title headingLevel="h2" size="md" className="co-m-form-row">

--- a/frontend/packages/topology/src/components/modals/MoveConnectionModal.tsx
+++ b/frontend/packages/topology/src/components/modals/MoveConnectionModal.tsx
@@ -82,7 +82,7 @@ const MoveConnectionForm: React.FC<FormikProps<FormikValues> &
 
   const sourceLabel = edge.getSource().getLabel();
   return (
-    <form onSubmit={handleSubmit} className="modal-content modal-content--no-inner-scroll">
+    <form onSubmit={handleSubmit} className="modal-content">
       <ModalTitle>{t('topology~Move connector')}</ModalTitle>
       <ModalBody>
         <Title headingLevel="h2" size="md" className="co-m-form-row">

--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -26,7 +26,6 @@
   flex: 1 1 auto;
   flex-direction: column;
   height: 100%;
-  overflow-y: auto;
   padding: 0;
   position: relative;
   -webkit-overflow-scrolling: touch;
@@ -52,32 +51,10 @@
   // Remove focus outline from opened modal
   outline: 0;
   position: relative;
-  @media(min-width: $pf-global--breakpoint--md) {
-    // Desktop only responsive max-height allows modal to adjust to content height and enable scroll shadows if needed.
-    max-height: calc(100vh - 60px);
-    // Dropdown workaround:  use when modal content can expand (taints, tolerations)
-    &--accommodate-dropdown .modal-body-inner-shadow-covers {
-      padding-bottom: 100px;
-    }
-    // Dropdown workaround: use when modal content is short and cannot expand
-    &--no-inner-scroll {
-      .modal-body {
-        overflow-y: visible !important;
-      }
-      .modal-body-inner-shadow-covers {
-        padding-bottom: var(--pf-global--spacer--lg);
-      }
-      .modal-footer {
-        padding-top: 0;
-      }
-    }
-  }
 }
 
-// setting a height on modal-dialog enables flex child height to shrink and become scrollable
 .modal-dialog {
-  margin: 10px;
-  margin-bottom: 0;
+  margin: var(--pf-global--spacer--md);
   max-width: calc(100% - var(--pf-global--spacer--xl));
   outline: 0;
   position: relative;
@@ -93,13 +70,6 @@
       // Manually set to match --pf-c-modal-box--m-lg--lg--MaxWidth because the PF variable is scoped to .pf-c-modal-box
       max-width: 70rem;
     }
-  }
-
-  @media(max-width: $screen-xs-max) and (orientation: portrait) {
-    height: calc(100% - 20px); // subtract height margin-top 10px + margin-bottom 10px
-  }
-  @media(max-width: $screen-xs-max) and (orientation: landscape) {
-    height: calc(100% - 60px); // At desktop, subtract margin-top 30px + margin-bottom 30px OR in the case of mobile landscape orientation, subtract the height of ios url control bar, since its height is not taken into account when the viewport height is calculated on initial page load. This causes the modal to extend below the viewport and hide modal-footer buttons.
   }
 }
 

--- a/frontend/public/components/modals/cluster-channel-modal.tsx
+++ b/frontend/public/components/modals/cluster-channel-modal.tsx
@@ -38,7 +38,7 @@ const ClusterChannelModal = withHandlePromise((props: ClusterChannelModalProps) 
   };
 
   return (
-    <form onSubmit={submit} name="form" className="modal-content modal-content--no-inner-scroll">
+    <form onSubmit={submit} name="form" className="modal-content">
       <ModalTitle>
         {channelsExist ? t('public~Select channel') : t('public~Input channel')}
       </ModalTitle>

--- a/frontend/public/components/modals/cluster-update-modal.tsx
+++ b/frontend/public/components/modals/cluster-update-modal.tsx
@@ -188,7 +188,7 @@ const ClusterUpdateModal = withHandlePromise((props: ClusterUpdateModalProps) =>
   const helpURL = getDocumentationURL(documentationURLs.updateUsingCustomMachineConfigPools);
 
   return (
-    <form onSubmit={submit} name="form" className="modal-content modal-content--no-inner-scroll">
+    <form onSubmit={submit} name="form" className="modal-content">
       <ModalTitle>{t('public~Update cluster')}</ModalTitle>
       <ModalBody>
         {clusterUpgradeableFalse && <ClusterNotUpgradeableAlert onCancel={cancel} cv={cv} />}

--- a/frontend/public/components/modals/configure-cluster-upstream-modal.tsx
+++ b/frontend/public/components/modals/configure-cluster-upstream-modal.tsx
@@ -52,7 +52,7 @@ export const ConfigureClusterUpstreamModal = withHandlePromise(
     const updateURL = getDocumentationURL(documentationURLs.updateService);
 
     return (
-      <form onSubmit={submit} name="form" className="modal-content modal-content--no-inner-scroll">
+      <form onSubmit={submit} name="form" className="modal-content">
         <ModalTitle>{t('public~Edit upstream configuration')}</ModalTitle>
         <ModalBody>
           <p>

--- a/frontend/public/components/modals/create-namespace-modal.jsx
+++ b/frontend/public/components/modals/create-namespace-modal.jsx
@@ -142,11 +142,7 @@ const CreateNamespaceModalWithTranslation = connect(
       const projectsURL = getDocumentationURL(documentationURLs.workingWithProjects);
 
       return (
-        <form
-          onSubmit={this._submit.bind(this)}
-          name="form"
-          className="modal-content modal-content--no-inner-scroll"
-        >
+        <form onSubmit={this._submit.bind(this)} name="form" className="modal-content">
           <ModalTitle>
             {createProject ? t('public~Create Project') : t('public~Create Namespace')}
           </ModalTitle>

--- a/frontend/public/components/modals/expand-pvc-modal.tsx
+++ b/frontend/public/components/modals/expand-pvc-modal.tsx
@@ -59,7 +59,7 @@ const ExpandPVCModal = withHandlePromise((props: ExpandPVCModalProps) => {
   };
 
   return (
-    <form onSubmit={submit} name="form" className="modal-content modal-content--no-inner-scroll">
+    <form onSubmit={submit} name="form" className="modal-content">
       <ModalTitle>{t('public~Expand {{kind}}', { kind: kind.label })}</ModalTitle>
       <ModalBody>
         <p>

--- a/frontend/public/components/modals/taints-modal.tsx
+++ b/frontend/public/components/modals/taints-modal.tsx
@@ -65,11 +65,7 @@ const TaintsModal = withHandlePromise((props: TaintsModalProps) => {
   const { errorMessage } = props;
 
   return (
-    <form
-      onSubmit={submit}
-      name="form"
-      className="modal-content modal-content--accommodate-dropdown taint-modal"
-    >
+    <form onSubmit={submit} name="form" className="modal-content taint-modal">
       <ModalTitle>{t('public~Edit taints')}</ModalTitle>
       <ModalBody>
         {_.isEmpty(taints) ? (

--- a/frontend/public/components/modals/tolerations-modal.tsx
+++ b/frontend/public/components/modals/tolerations-modal.tsx
@@ -103,11 +103,7 @@ const TolerationsModal = withHandlePromise((props: TolerationsModalProps) => {
   const { errorMessage } = props;
 
   return (
-    <form
-      onSubmit={submit}
-      name="form"
-      className="modal-content modal-content--accommodate-dropdown toleration-modal"
-    >
+    <form onSubmit={submit} name="form" className="modal-content toleration-modal">
       <ModalTitle>{t('public~Edit tolerations')}</ModalTitle>
       <ModalBody>
         {_.isEmpty(tolerations) ? (

--- a/frontend/public/components/monitoring/dashboards/custom-time-range-modal.tsx
+++ b/frontend/public/components/monitoring/dashboards/custom-time-range-modal.tsx
@@ -60,7 +60,7 @@ const CustomTimeRangeModal = ({ cancel, close, activePerspective }: CustomTimeRa
   };
 
   return (
-    <form onSubmit={submit} name="form" className="modal-content modal-content--no-inner-scroll">
+    <form onSubmit={submit} name="form" className="modal-content">
       <ModalTitle>{t('public~Custom time range')}</ModalTitle>
       <ModalBody>
         <div className="row co-m-form-row">


### PR DESCRIPTION
**TLDR;** Change the default modal scrolling behavior from inner content scroll  to scrolling of the entire modal view. Have consistent dropdown menu display behavior. And allow the modal at mobile sizes shrink based on its content size if less than viewport height, which matches PF behavior.
Fixes bug https://bugzilla.redhat.com/show_bug.cgi?id=2079214

Our custom modal component defaults to inner scrolling of the `modal-body` node activated by a `max-height: calc(100vh - 60px)`.  There is also an option, via `modal-content--no-inner-scroll`, added to allow `dropdown` menus to overlay the `modal-footer` and outside the modal if needed. But the combination of the two causes a bug when the modal content height exceeds the viewport height. https://bugzilla.redhat.com/show_bug.cgi?id=2079214

The PatternFly `<Modal>` overflow scroll behavior defaults to inner scrolling. But the PF `<Modal>` has conflicting aspects in that, dropdown menus are allowed to overlay outside the modal body. This can cause a bug where the menu items are inaccessible because the entire modal isn't scrollable in that scenario.  Upstream issue opened. https://github.com/patternfly/patternfly/issues/4957

So the question is should dropdown menus be contained within an inner modal scroll or can they overlay outside the content area and enable scrolling on the entire modal view itself? Based on the following, I made the choice to switch the default scrolling behavior from inner to entire modal and always overlay menus outside its body content container. 

1. The earlier decision to overlay dropdown menus outside the `modal-body` via `--no-inner-scroll` https://github.com/openshift/console/pull/1416
2. PF `<Modal>` displays dropdown menus outside of its modal content container.
3. Ideally if dropdown menus were contained with the `modal-body` inner scroll the dropdown should automatically switch the menu direction to up, when it is at the content bottom. Currently this functionally doesn't exist in the component.

Side note Bootstrap has both scroll options available. Entire modal  view scroll is the default behavior or inner scroll can be set optionally, in which case a dropdown menu at the content bottom switches direction to up. 


cc @jcaianirh @spadgett  

**Before bug fix**
<img width="1024" alt="cluster-bad" src="https://user-images.githubusercontent.com/1874151/178826213-52eb2edf-7a4c-4980-afe0-0ba196bcf112.png">

**After bug fix**
<img width="1025" alt="cluster-good" src="https://user-images.githubusercontent.com/1874151/178826226-bc3fc441-1bd2-4da5-8cbf-1bf26825f119.png">

**Dropdown inner scroll**
![tolerations-inner](https://user-images.githubusercontent.com/1874151/178853699-29df1890-6138-459f-892a-77a371517a86.gif)

---

**Dropdown entire scroll**
![tolerations-outer](https://user-images.githubusercontent.com/1874151/178853715-3f6f102c-7832-4aae-b7b0-a25e65cd1296.gif)

