### PR TITLE
Bug 2084453: - Edit PodDisruptionBudget page sometimes takes user to not synced YAML view

### DIFF
--- a/frontend/packages/console-app/src/components/pdb/PDBForm.tsx
+++ b/frontend/packages/console-app/src/components/pdb/PDBForm.tsx
@@ -29,7 +29,7 @@ import { FieldLevelHelp } from '@console/internal/components/utils/field-level-h
 import { k8sCreate } from '@console/internal/module/k8s';
 import { PodDisruptionBudgetModel } from '../../models';
 import AvailabilityRequirementPopover from './AvailabilityRequirementPopover';
-import { pdbToK8sResource, formValuesFromK8sResource, patchPDB } from './pdb-models';
+import { pdbToK8sResource, initialValuesFromK8sResource, patchPDB } from './pdb-models';
 import { PodDisruptionBudgetKind } from './types';
 
 const PDBForm: React.FC<PodDisruptionBudgetFormProps> = ({
@@ -38,8 +38,8 @@ const PDBForm: React.FC<PodDisruptionBudgetFormProps> = ({
   existingResource,
 }) => {
   const { t } = useTranslation();
-  const converted = formValuesFromK8sResource(formData);
-  const [formValues, setFormValues] = React.useState(converted);
+  const initialFormValues = initialValuesFromK8sResource(formData);
+  const [formValues, setFormValues] = React.useState(initialFormValues);
   const [error, setError] = React.useState('');
   const [inProgress, setInProgress] = React.useState(false);
   const [requirement, setRequirement] = React.useState('');
@@ -66,7 +66,7 @@ const PDBForm: React.FC<PodDisruptionBudgetFormProps> = ({
     requirement === 'Requirement' ? setDisabled(true) : setDisabled(false);
 
     if (!_.isEmpty(existingResource) && _.isEmpty(formValues.name)) {
-      onFormValuesChange(formValuesFromK8sResource(existingResource));
+      onFormValuesChange(initialValuesFromK8sResource(existingResource));
     }
   }, [existingResource, formValues, onFormValuesChange, requirement]);
 

--- a/frontend/packages/console-app/src/components/pdb/PDBFormPage.tsx
+++ b/frontend/packages/console-app/src/components/pdb/PDBFormPage.tsx
@@ -8,7 +8,7 @@ import { SyncedEditor } from '@console/shared/src/components/synced-editor';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
 import { safeJSToYAML } from '@console/shared/src/utils/yaml';
 import { PodDisruptionBudgetModel } from '../../models';
-import { pdbToK8sResource } from './pdb-models';
+import { pdbToK8sResource, mergeInitialYAMLWithExistingResource } from './pdb-models';
 import PDBForm from './PDBForm';
 import { PodDisruptionBudgetKind } from './types';
 import { getPDBResource } from './utils/get-pdb-resources';
@@ -69,17 +69,16 @@ export const PDBFormPage: React.FC<{
   const k8sObj = pdbToK8sResource(initialPDB);
 
   const YAMLEditor: React.FC<YAMLEditorProps> = ({ onChange, initialYAML = '' }) => {
+    const yamlData = mergeInitialYAMLWithExistingResource(initialYAML, existingResource);
+
     return (
       <CreateYAML
         hideHeader
         match={match}
         onChange={onChange}
-        template={
-          initialYAML ||
-          safeJSToYAML(existingResource, 'yamlData', {
-            skipInvalid: true,
-          })
-        }
+        template={safeJSToYAML(yamlData, 'yamlData', {
+          skipInvalid: true,
+        })}
         isCreate={!existingResource}
       />
     );

--- a/frontend/packages/console-app/src/components/pdb/pdb-models.ts
+++ b/frontend/packages/console-app/src/components/pdb/pdb-models.ts
@@ -1,6 +1,7 @@
 import i18next from 'i18next';
 import * as _ from 'lodash';
 import { Selector, k8sPatch, Patch } from '@console/internal/module/k8s';
+import { safeYAMLToJS } from '@console/shared/src/utils/yaml';
 import { PodDisruptionBudgetModel } from '../../models';
 import { PodDisruptionBudgetKind } from './types';
 
@@ -31,8 +32,8 @@ export const pdbToK8sResource = (
     },
     spec: {
       selector: {
-        matchLabels: from.selector.matchLabels,
-        matchExpressions: from.selector.matchExpressions,
+        matchLabels: from?.selector?.matchLabels,
+        matchExpressions: from?.selector?.matchExpressions,
       },
     },
   };
@@ -57,7 +58,7 @@ export const pdbToK8sResource = (
   return pdbRes;
 };
 
-export const formValuesFromK8sResource = (from: PodDisruptionBudgetKind): FormValues => {
+export const initialValuesFromK8sResource = (from: PodDisruptionBudgetKind): FormValues => {
   return {
     name: from?.metadata?.name || '',
     namespace: from?.metadata?.namespace || '',
@@ -140,6 +141,13 @@ export const patchPDB = (
 
   return k8sPatch(PodDisruptionBudgetModel, existingResource, patch);
 };
+
+export const mergeInitialYAMLWithExistingResource = (
+  initialYAML: string,
+  existingResource: PodDisruptionBudgetKind,
+): PodDisruptionBudgetKind =>
+  pdbToK8sResource(initialValuesFromK8sResource(safeYAMLToJS(initialYAML)), existingResource);
+
 export type FormValues = {
   name: string;
   namespace: string;

--- a/frontend/packages/console-shared/src/components/synced-editor/index.tsx
+++ b/frontend/packages/console-shared/src/components/synced-editor/index.tsx
@@ -63,7 +63,7 @@ export const SyncedEditor: React.FC<SyncedEditorProps> = ({
       .then((js) => {
         setSwitchError(undefined);
         handleFormDataChange(js);
-        setYAML('');
+        setYAML(safeJSToYAML(prune?.(formData) ?? formData, yaml, YAML_TO_JS_OPTIONS));
       })
       .catch((err) => setSwitchError(String(err)));
   };


### PR DESCRIPTION
A follow on [PR](https://github.com/openshift/console/pull/11494) to fix  a regression - 'Labels' value are truncated when switching between Form and YAML

### Before:
![Screen Shot 2022-07-18 at 1 15 14 PM](https://user-images.githubusercontent.com/15249132/179566597-a6fa2876-0a01-4249-824b-659974f4f1dc.png)
![Screen Shot 2022-07-18 at 1 15 23 PM](https://user-images.githubusercontent.com/15249132/179566601-844a929c-824d-4967-8938-4d8699f33231.png)

### After:
![Screen Shot 2022-07-18 at 1 13 36 PM](https://user-images.githubusercontent.com/15249132/179566676-06cd57f1-2a41-4898-95af-dd0e873548ce.png)
![Screen Shot 2022-07-18 at 1 13 45 PM](https://user-images.githubusercontent.com/15249132/179566678-90fff6d3-1918-4058-869c-ada6de9b25ae.png)
