### PR TITLE
Bug 2106648: When creating a namespace with labels, the labels text b…

### DIFF
--- a/frontend/public/components/utils/_selector-input.scss
+++ b/frontend/public/components/utils/_selector-input.scss
@@ -1,0 +1,5 @@
+.co-selector-input {
+  input {
+    width: 100% !important;
+  }
+}

--- a/frontend/public/components/utils/selector-input.jsx
+++ b/frontend/public/components/utils/selector-input.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import * as TagsInput from 'react-tagsinput';
 import { Label as PfLabel } from '@patternfly/react-core';
+import './_selector-input.scss';
 
 import { split, selectorFromString } from '../../module/k8s/selector';
 import * as k8sSelectorRequirement from '../../module/k8s/selector-requirement';
@@ -148,7 +149,7 @@ export class SelectorInput extends React.Component {
         <tags-input>
           <TagsInput
             ref={this.setRef}
-            className="tags"
+            className="tags co-selector-input"
             value={tags}
             addKeys={addKeys}
             removeKeys={removeKeys}


### PR DESCRIPTION
…ox trims the text

Prevents label text from being cut off when creating a namespace

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2106648