### PR TITLE
CONSOLE-3181: Deprecate useAccessReviewAllowed and useSafetyFirst

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -1,70 +1,70 @@
 # OpenShift Console API
 
-1. [`useActivePerspective`](#useactiveperspective)
-2. [`PerspectiveContext`](#perspectivecontext)
-3. [`GreenCheckCircleIcon`](#greencheckcircleicon)
-4. [`RedExclamationCircleIcon`](#redexclamationcircleicon)
-5. [`YellowExclamationTriangleIcon`](#yellowexclamationtriangleicon)
-6. [`BlueInfoCircleIcon`](#blueinfocircleicon)
-7. [`ErrorStatus`](#errorstatus)
-8. [`InfoStatus`](#infostatus)
-9. [`ProgressStatus`](#progressstatus)
-10. [`SuccessStatus`](#successstatus)
-11. [`checkAccess`](#checkaccess)
-12. [`useAccessReview`](#useaccessreview)
-13. [`useAccessReviewAllowed`](#useaccessreviewallowed)
-14. [`useSafetyFirst`](#usesafetyfirst)
-15. [`useResolvedExtensions`](#useresolvedextensions)
-16. [`HorizontalNav`](#horizontalnav)
-17. [`VirtualizedTable`](#virtualizedtable)
-18. [`TableData`](#tabledata)
-19. [`useActiveColumns`](#useactivecolumns)
-20. [`ListPageHeader`](#listpageheader)
-21. [`ListPageCreate`](#listpagecreate)
-22. [`ListPageCreateLink`](#listpagecreatelink)
-23. [`ListPageCreateButton`](#listpagecreatebutton)
-24. [`ListPageCreateDropdown`](#listpagecreatedropdown)
-25. [`ListPageFilter`](#listpagefilter)
-26. [`useListPageFilter`](#uselistpagefilter)
-27. [`ResourceLink`](#resourcelink)
-28. [`useK8sModel`](#usek8smodel)
-29. [`useK8sModels`](#usek8smodels)
-30. [`useK8sWatchResource`](#usek8swatchresource)
-31. [`useK8sWatchResources`](#usek8swatchresources)
-32. [`consoleFetch`](#consolefetch)
-33. [`consoleFetchJSON`](#consolefetchjson)
-34. [`consoleFetchText`](#consolefetchtext)
-35. [`getConsoleRequestHeaders`](#getconsolerequestheaders)
-36. [`k8sGetResource`](#k8sgetresource)
-37. [`k8sCreateResource`](#k8screateresource)
-38. [`k8sUpdateResource`](#k8supdateresource)
-39. [`k8sPatchResource`](#k8spatchresource)
-40. [`k8sDeleteResource`](#k8sdeleteresource)
-41. [`k8sListResource`](#k8slistresource)
-42. [`k8sListResourceItems`](#k8slistresourceitems)
-43. [`getAPIVersionForModel`](#getapiversionformodel)
-44. [`getGroupVersionKindForResource`](#getgroupversionkindforresource)
-45. [`getGroupVersionKindForModel`](#getgroupversionkindformodel)
-46. [`StatusPopupSection`](#statuspopupsection)
-47. [`StatusPopupItem`](#statuspopupitem)
-48. [`Overview`](#overview)
-49. [`OverviewGrid`](#overviewgrid)
-50. [`InventoryItem`](#inventoryitem)
-51. [`InventoryItemTitle`](#inventoryitemtitle)
-52. [`InventoryItemBody`](#inventoryitembody)
-53. [`InventoryItemStatus`](#inventoryitemstatus)
-54. [`InventoryItemLoading`](#inventoryitemloading)
-55. [`useFlag`](#useflag)
-56. [`ResourceYAMLEditor`](#resourceyamleditor)
-57. [`ResourceEventStream`](#resourceeventstream)
-58. [`usePrometheusPoll`](#useprometheuspoll)
-59. [`Timestamp`](#timestamp)
+1.  [`useActivePerspective`](#useactiveperspective)
+2.  [`GreenCheckCircleIcon`](#greencheckcircleicon)
+3.  [`RedExclamationCircleIcon`](#redexclamationcircleicon)
+4.  [`YellowExclamationTriangleIcon`](#yellowexclamationtriangleicon)
+5.  [`BlueInfoCircleIcon`](#blueinfocircleicon)
+6.  [`ErrorStatus`](#errorstatus)
+7.  [`InfoStatus`](#infostatus)
+8.  [`ProgressStatus`](#progressstatus)
+9.  [`SuccessStatus`](#successstatus)
+10.  [`checkAccess`](#checkaccess)
+11.  [`useAccessReview`](#useaccessreview)
+12.  [`useResolvedExtensions`](#useresolvedextensions)
+13.  [`HorizontalNav`](#horizontalnav)
+14.  [`VirtualizedTable`](#virtualizedtable)
+15.  [`TableData`](#tabledata)
+16.  [`useActiveColumns`](#useactivecolumns)
+17.  [`ListPageHeader`](#listpageheader)
+18.  [`ListPageCreate`](#listpagecreate)
+19.  [`ListPageCreateLink`](#listpagecreatelink)
+20.  [`ListPageCreateButton`](#listpagecreatebutton)
+21.  [`ListPageCreateDropdown`](#listpagecreatedropdown)
+22.  [`ListPageFilter`](#listpagefilter)
+23.  [`useListPageFilter`](#uselistpagefilter)
+24.  [`ResourceLink`](#resourcelink)
+25.  [`useK8sModel`](#usek8smodel)
+26.  [`useK8sModels`](#usek8smodels)
+27.  [`useK8sWatchResource`](#usek8swatchresource)
+28.  [`useK8sWatchResources`](#usek8swatchresources)
+29.  [`consoleFetch`](#consolefetch)
+30.  [`consoleFetchJSON`](#consolefetchjson)
+31.  [`consoleFetchText`](#consolefetchtext)
+32.  [`getConsoleRequestHeaders`](#getconsolerequestheaders)
+33.  [`k8sGetResource`](#k8sgetresource)
+34.  [`k8sCreateResource`](#k8screateresource)
+35.  [`k8sUpdateResource`](#k8supdateresource)
+36.  [`k8sPatchResource`](#k8spatchresource)
+37.  [`k8sDeleteResource`](#k8sdeleteresource)
+38.  [`k8sListResource`](#k8slistresource)
+39.  [`k8sListResourceItems`](#k8slistresourceitems)
+40.  [`getAPIVersionForModel`](#getapiversionformodel)
+41.  [`getGroupVersionKindForResource`](#getgroupversionkindforresource)
+42.  [`getGroupVersionKindForModel`](#getgroupversionkindformodel)
+43.  [`StatusPopupSection`](#statuspopupsection)
+44.  [`StatusPopupItem`](#statuspopupitem)
+45.  [`Overview`](#overview)
+46.  [`OverviewGrid`](#overviewgrid)
+47.  [`InventoryItem`](#inventoryitem)
+48.  [`InventoryItemTitle`](#inventoryitemtitle)
+49.  [`InventoryItemBody`](#inventoryitembody)
+50.  [`InventoryItemStatus`](#inventoryitemstatus)
+51.  [`InventoryItemLoading`](#inventoryitemloading)
+52.  [`useFlag`](#useflag)
+53.  [`ResourceYAMLEditor`](#resourceyamleditor)
+54.  [`ResourceEventStream`](#resourceeventstream)
+55.  [`usePrometheusPoll`](#useprometheuspoll)
+56.  [`Timestamp`](#timestamp)
+57. [DEPRECATED] [`PerspectiveContext`](#perspectivecontext)
+58. [DEPRECATED] [`useAccessReviewAllowed`](#useaccessreviewallowed)
+59. [DEPRECATED] [`useSafetyFirst`](#usesafetyfirst)
 
 ---
 
 ## `useActivePerspective`
 
-### Summary
+### Summary 
 
 Hook that provides the currently active perspective and a callback for setting the active perspective
 
@@ -100,33 +100,9 @@ A tuple containing the current active perspective and setter callback.
 
 ---
 
-## `PerspectiveContext`
-
-### Summary
-
-Creates the perspective context
-
-
-
-
-### Parameters
-
-| Parameter Name | Description |
-| -------------- | ----------- |
-| `PerspectiveContextType` | object with active perspective and setter |
-
-
-
-### Returns
-
-React context
-
-
----
-
 ## `GreenCheckCircleIcon`
 
-### Summary
+### Summary 
 
 Component for displaying a green check mark circle icon
 
@@ -157,7 +133,7 @@ Component for displaying a green check mark circle icon
 
 ## `RedExclamationCircleIcon`
 
-### Summary
+### Summary 
 
 Component for displaying a red exclamation mark circle icon
 
@@ -188,7 +164,7 @@ Component for displaying a red exclamation mark circle icon
 
 ## `YellowExclamationTriangleIcon`
 
-### Summary
+### Summary 
 
 Component for displaying a yellow triangle exclamation icon
 
@@ -219,7 +195,7 @@ Component for displaying a yellow triangle exclamation icon
 
 ## `BlueInfoCircleIcon`
 
-### Summary
+### Summary 
 
 Component for displaying a blue info circle icon
 
@@ -250,7 +226,7 @@ Component for displaying a blue info circle icon
 
 ## `ErrorStatus`
 
-### Summary
+### Summary 
 
 Component for displaying an error status popover
 
@@ -283,7 +259,7 @@ Component for displaying an error status popover
 
 ## `InfoStatus`
 
-### Summary
+### Summary 
 
 Component for displaying an information status popover
 
@@ -316,7 +292,7 @@ Component for displaying an information status popover
 
 ## `ProgressStatus`
 
-### Summary
+### Summary 
 
 Component for displaying a progressing status popover
 
@@ -349,7 +325,7 @@ Component for displaying a progressing status popover
 
 ## `SuccessStatus`
 
-### Summary
+### Summary 
 
 Component for displaying a success status popover
 
@@ -382,7 +358,7 @@ Component for displaying a success status popover
 
 ## `checkAccess`
 
-### Summary
+### Summary 
 
 Provides information about user access to a given resource.
 
@@ -407,7 +383,7 @@ Object with resource access information.
 
 ## `useAccessReview`
 
-### Summary
+### Summary 
 
 Hook that provides information about user access to a given resource.
 
@@ -430,58 +406,9 @@ Array with isAllowed and loading values.
 
 ---
 
-## `useAccessReviewAllowed`
-
-### Summary
-
-Hook that provides allowed status about user access to a given resource.
-
-
-
-
-### Parameters
-
-| Parameter Name | Description |
-| -------------- | ----------- |
-| `resourceAttributes` | resource attributes for access review |
-| `impersonate` | impersonation details |
-
-
-
-### Returns
-
-The isAllowed boolean value.
-
-
----
-
-## `useSafetyFirst`
-
-### Summary
-
-Hook that ensures a safe asynchronnous setting of React state in case a given component could be unmounted.<br/>(https://github.com/facebook/react/issues/14113)
-
-
-
-
-### Parameters
-
-| Parameter Name | Description |
-| -------------- | ----------- |
-| `initialState` | initial state value |
-
-
-
-### Returns
-
-An array with a pair of state value and it's set function.
-
-
----
-
 ## `useResolvedExtensions`
 
-### Summary
+### Summary 
 
 React hook for consuming Console extensions with resolved `CodeRef` properties.<br/>This hook accepts the same argument(s) as `useExtensions` hook and returns an adapted list of extension instances, resolving all code references within each extension's properties.<br/>Initially, the hook returns an empty array. Once the resolution is complete, the React component is re-rendered with the hook returning an adapted list of extensions.<br/>When the list of matching extensions changes, the resolution is restarted. The hook will continue to return the previous result until the resolution completes.<br/>The hook's result elements are guaranteed to be referentially stable across re-renders.
 
@@ -516,7 +443,7 @@ Tuple containing a list of adapted extension instances with resolved code refere
 
 ## `HorizontalNav`
 
-### Summary
+### Summary 
 
 A component that creates a Navigation bar for a page.<br/><br/>- Routing is handled as part of the component.<br/>- `console.tab/horizontalNav` can be used to add additional content to any horizontal nav.
 
@@ -554,7 +481,7 @@ const HomePage: React.FC = (props) => {
 
 ## `VirtualizedTable`
 
-### Summary
+### Summary 
 
 A component for making virtualized tables
 
@@ -605,7 +532,7 @@ const MachineList: React.FC<MachineListProps> = (props) => {
 
 ## `TableData`
 
-### Summary
+### Summary 
 
 Component for displaying table data within a table row
 
@@ -647,7 +574,7 @@ const PodRow: React.FC<RowProps<K8sResourceCommon>> = ({ obj, activeColumnIDs })
 
 ## `useActiveColumns`
 
-### Summary
+### Summary 
 
 A hook that provides a list of user-selected active TableColumns.
 
@@ -690,7 +617,7 @@ A tuple containing the current user selected active columns (a subset of options
 
 ## `ListPageHeader`
 
-### Summary
+### Summary 
 
 Component for generating a page header
 
@@ -727,7 +654,7 @@ const exampleList: React.FC = () => {
 
 ## `ListPageCreate`
 
-### Summary
+### Summary 
 
 Component for adding a create button for a specific resource kind that automatically generates a link to the create YAML for this resource
 
@@ -764,7 +691,7 @@ const exampleList: React.FC<MyProps> = () => {
 
 ## `ListPageCreateLink`
 
-### Summary
+### Summary 
 
 Component for creating a stylized link
 
@@ -803,7 +730,7 @@ const exampleList: React.FC<MyProps> = () => {
 
 ## `ListPageCreateButton`
 
-### Summary
+### Summary 
 
 Component for creating button
 
@@ -841,7 +768,7 @@ const exampleList: React.FC<MyProps> = () => {
 
 ## `ListPageCreateDropdown`
 
-### Summary
+### Summary 
 
 Component for creating a dropdown wrapped with permissions check
 
@@ -885,7 +812,7 @@ const exampleList: React.FC<MyProps> = () => {
 
 ## `ListPageFilter`
 
-### Summary
+### Summary 
 
 Component that generates filter for list page
 
@@ -938,7 +865,7 @@ Component that generates filter for list page
 
 ## `useListPageFilter`
 
-### Summary
+### Summary 
 
 A hook that manages filter state for the ListPageFilter component.
 
@@ -989,7 +916,7 @@ A tuple containing the data filtered by all static filteres, the data filtered b
 
 ## `ResourceLink`
 
-### Summary
+### Summary 
 
 Component that creates a link to a specific resource type with an icon badge
 
@@ -1034,7 +961,7 @@ Component that creates a link to a specific resource type with an icon badge
 
 ## `useK8sModel`
 
-### Summary
+### Summary 
 
 Hook that retrieves the k8s model for provided K8sGroupVersionKind from redux.
 
@@ -1071,7 +998,7 @@ An array with the first item as k8s model and second item as inFlight status
 
 ## `useK8sModels`
 
-### Summary
+### Summary 
 
 Hook that retrieves all current k8s models from redux.
 
@@ -1102,7 +1029,7 @@ An array with the first item as the list of k8s model and second item as inFligh
 
 ## `useK8sWatchResource`
 
-### Summary
+### Summary 
 
 Hook that retrieves the k8s resource along with status for loaded and error.
 
@@ -1142,7 +1069,7 @@ An array with first item as resource(s), second item as loaded status and third 
 
 ## `useK8sWatchResources`
 
-### Summary
+### Summary 
 
 Hook that retrieves the k8s resources along with their respective status for loaded and error.
 
@@ -1184,7 +1111,7 @@ A map where keys are as provided in initResouces and value has three properties 
 
 ## `consoleFetch`
 
-### Summary
+### Summary 
 
 A custom wrapper around `fetch` that adds console specific headers and allows for retries and timeouts.<br/>It also validates the response status code and throws appropriate error or logs out the user if required.
 
@@ -1210,7 +1137,7 @@ A promise that resolves to the response
 
 ## `consoleFetchJSON`
 
-### Summary
+### Summary 
 
 A custom wrapper around `fetch` that adds console specific headers and allows for retries and timeouts.<br/>It also validates the response status code and throws appropriate error or logs out the user if required.<br/>It returns the response as a JSON object.<br/>Uses consoleFetch internally.
 
@@ -1238,7 +1165,7 @@ A promise that resolves to the response as JSON object.
 
 ## `consoleFetchText`
 
-### Summary
+### Summary 
 
 A custom wrapper around `fetch` that adds console specific headers and allows for retries and timeouts.<br/>It also validates the response status code and throws appropriate error or logs out the user if required.<br/>It returns the response as a text.<br/>Uses consoleFetch internally.
 
@@ -1265,7 +1192,7 @@ A promise that resolves to the response as text.
 
 ## `getConsoleRequestHeaders`
 
-### Summary
+### Summary 
 
 A function that creates impersonation and multicluster related headers for API requests using current redux state.
 
@@ -1289,7 +1216,7 @@ an object containing the appropriate impersonation and clustr requst headers, ba
 
 ## `k8sGetResource`
 
-### Summary
+### Summary 
 
 It fetches a resource from the cluster, based on the provided options.<br/>If the name is provided it returns one resource else it returns all the resources matching the model.
 
@@ -1319,7 +1246,7 @@ A promise that resolves to the response as JSON object with a resource if the na
 
 ## `k8sCreateResource`
 
-### Summary
+### Summary 
 
 It creates a resource in the cluster, based on the provided options.
 
@@ -1347,7 +1274,7 @@ A promise that resolves to the response of the resource created.<br/>In case of 
 
 ## `k8sUpdateResource`
 
-### Summary
+### Summary 
 
 It updates the entire resource in the cluster, based on provided options.<br/>When a client needs to replace an existing resource entirely, they can use k8sUpdate.<br/>Alternatively can use k8sPatch to perform the partial update.
 
@@ -1377,7 +1304,7 @@ A promise that resolves to the response of the resource updated.<br/>In case of 
 
 ## `k8sPatchResource`
 
-### Summary
+### Summary 
 
 It patches any resource in the cluster, based on provided options.<br/>When a client needs to perform the partial update, they can use k8sPatch.<br/>Alternatively can use k8sUpdate to replace an existing resource entirely.<br/>See more https://datatracker.ietf.org/doc/html/rfc6902
 
@@ -1406,7 +1333,7 @@ A promise that resolves to the response of the resource patched.<br/>In case of 
 
 ## `k8sDeleteResource`
 
-### Summary
+### Summary 
 
 It deletes resources from the cluster, based on the provided model, resource.<br/>The garbage collection works based on 'Foreground' | 'Background', can be configured with propagationPolicy property in provided model or passed in json.
 
@@ -1446,7 +1373,7 @@ A promise that resolves to the response of kind Status.<br/>In case of failure p
 
 ## `k8sListResource`
 
-### Summary
+### Summary 
 
 Lists the resources as an array in the cluster, based on provided options.
 
@@ -1473,7 +1400,7 @@ A promise that resolves to the response
 
 ## `k8sListResourceItems`
 
-### Summary
+### Summary 
 
 Same interface as {@link k8sListResource} but returns the sub items.
 
@@ -1486,7 +1413,7 @@ Same interface as {@link k8sListResource} but returns the sub items.
 
 ## `getAPIVersionForModel`
 
-### Summary
+### Summary 
 
 Provides apiVersion for a k8s model.
 
@@ -1510,7 +1437,7 @@ The apiVersion for the model i.e `group/version`.
 
 ## `getGroupVersionKindForResource`
 
-### Summary
+### Summary 
 
 Provides a group, version, and kind for a resource.
 
@@ -1534,7 +1461,7 @@ The group, version, kind for the provided resource.<br/>If the resource does not
 
 ## `getGroupVersionKindForModel`
 
-### Summary
+### Summary 
 
 Provides a group, version, and kind for a k8s model.
 
@@ -1558,7 +1485,7 @@ The group, version, kind for the provided model.<br/>If the model does not have 
 
 ## `StatusPopupSection`
 
-### Summary
+### Summary 
 
 Component that shows the status in a popup window. Helpful component for building `console.dashboards/overview/health/resource` extensions
 
@@ -1599,7 +1526,7 @@ Component that shows the status in a popup window. Helpful component for buildin
 
 ## `StatusPopupItem`
 
-### Summary
+### Summary 
 
 Status element used in status popup; used in `StatusPopupSection`
 
@@ -1640,7 +1567,7 @@ Status element used in status popup; used in `StatusPopupSection`
 
 ## `Overview`
 
-### Summary
+### Summary 
 
 Creates a wrapper component for a dashboard
 
@@ -1672,7 +1599,7 @@ Creates a wrapper component for a dashboard
 
 ## `OverviewGrid`
 
-### Summary
+### Summary 
 
 Creates a grid of card elements for a dashboard; used within `Overview`
 
@@ -1705,7 +1632,7 @@ Creates a grid of card elements for a dashboard; used within `Overview`
 
 ## `InventoryItem`
 
-### Summary
+### Summary 
 
 Creates an inventory card item
 
@@ -1741,7 +1668,7 @@ Creates an inventory card item
 
 ## `InventoryItemTitle`
 
-### Summary
+### Summary 
 
 Creates a title for an inventory card item; used within `InventoryItem`
 
@@ -1777,7 +1704,7 @@ Creates a title for an inventory card item; used within `InventoryItem`
 
 ## `InventoryItemBody`
 
-### Summary
+### Summary 
 
 Creates the body of an inventory card; used within `InventoryCard` and can be used with `InventoryTitle`
 
@@ -1814,7 +1741,7 @@ Creates the body of an inventory card; used within `InventoryCard` and can be us
 
 ## `InventoryItemStatus`
 
-### Summary
+### Summary 
 
 Creates a count and icon for an inventory card with optional link address; used within `InventoryItemBody`
 
@@ -1852,7 +1779,7 @@ Creates a count and icon for an inventory card with optional link address; used 
 
 ## `InventoryItemLoading`
 
-### Summary
+### Summary 
 
 Creates a skeleton container for when an inventory card is loading; used with `InventoryItem` and related components
 
@@ -1884,7 +1811,7 @@ return (
 
 ## `useFlag`
 
-### Summary
+### Summary 
 
 Hook that returns the given feature flag from FLAGS redux state.
 
@@ -1908,7 +1835,7 @@ the boolean value of the requested feature flag or undefined
 
 ## `ResourceYAMLEditor`
 
-### Summary
+### Summary 
 
 A lazy loaded YAML editor for Kubernetes resources with hover help and completion.<br/>The editor will handle updating the resource when the user clicks save unless an onSave handler is provided.<br/>It should be wrapped in a React.Suspense component.
 
@@ -1945,7 +1872,7 @@ A lazy loaded YAML editor for Kubernetes resources with hover help and completio
 
 ## `ResourceEventStream`
 
-### Summary
+### Summary 
 
 A component to show events related to a particular resource.
 
@@ -1975,7 +1902,7 @@ return <ResourceEventStream resource={resource} />
 
 ## `usePrometheusPoll`
 
-### Summary
+### Summary 
 
 Sets up a poll to Prometheus for a single query.
 
@@ -2006,7 +1933,7 @@ A tuple containing the query response, a boolean flag indicating whether the res
 
 ## `Timestamp`
 
-### Summary
+### Summary 
 
 A component to render timestamp.<br/>The timestamps are synchronized between invidual instances of the Timestamp component.<br/>The provided timestamp is formatted according to user locale.
 
@@ -2022,5 +1949,78 @@ A component to render timestamp.<br/>The timestamps are synchronized between inv
 | `omitSuffix` | formats the date ommiting the suffix. |
 | `className` | additional class name for the component. |
 
+
+
+---
+
+## `PerspectiveContext`
+
+### Summary [DEPRECATED]
+
+@deprecated - use the provided `usePerspectiveContext` instead<br/>Creates the perspective context
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `PerspectiveContextType` | object with active perspective and setter |
+
+
+
+### Returns
+
+React context
+
+
+---
+
+## `useAccessReviewAllowed`
+
+### Summary [DEPRECATED]
+
+@deprecated - Use useAccessReview from \@console/dynamic-plugin-sdk instead.<br/>Hook that provides allowed status about user access to a given resource.
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `resourceAttributes` | resource attributes for access review |
+| `impersonate` | impersonation details |
+
+
+
+### Returns
+
+The isAllowed boolean value.
+
+
+---
+
+## `useSafetyFirst`
+
+### Summary [DEPRECATED]
+
+@deprecated - This hook is not related to console functionality.<br/>Hook that ensures a safe asynchronnous setting of React state in case a given component could be unmounted.<br/>(https://github.com/facebook/react/issues/14113)
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `initialState` | initial state value |
+
+
+
+### Returns
+
+An array with a pair of state value and it's set function.
 
 

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/generate-doc.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/generate-doc.ts
@@ -108,11 +108,13 @@ const generateDoc = (comment: tsdoc.DocComment) => {
     description: renderDocNode(param.content),
   }));
   const returns = renderDocNode(comment.returnsBlock?.content);
+  const deprecated = renderDocNode(comment.deprecatedBlock);
   return {
     summary,
     example,
     parameters,
     returns,
+    deprecated,
   };
 };
 
@@ -188,7 +190,12 @@ const getAPIs = () => {
 };
 
 renderTemplate('scripts/templates/api.md.ejs', {
-  apis: getAPIs(),
+  apis: getAPIs().sort((a, b) => {
+    if (a.doc.deprecated !== b.doc.deprecated) {
+      return a.doc.deprecated ? 1 : -1;
+    }
+    return 1;
+  }),
   printComments: (docComments: string) => printJSDocComments([docComments]).replace(/\n/g, '<br/>'),
   removeNewLines: (comment: string) => comment.replace('\n', ''),
   toLowerCase: (str: string) => str.toLocaleLowerCase(),

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/templates/api.md.ejs
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/templates/api.md.ejs
@@ -1,8 +1,8 @@
 # OpenShift Console API
 
 <%# Table of contents _%>
-<% apis.map((api) => api.name).forEach((component, index) => { _%>
-<%- index + 1 %>. [`<%- component %>`](#<%- toLowerCase(component) %>)
+<% apis.forEach((api, index) => { _%>
+<%- index + 1 %>. <%- api.doc.deprecated ? '[DEPRECATED]' : '' %> [`<%- api.name %>`](#<%- toLowerCase(api.name) %>)
 <% }); _%>
 
 <%# Generate one section per extension type _%>
@@ -11,9 +11,9 @@
 
 ## `<%- api.name %>`
 
-### Summary
+### Summary <%- api.doc.deprecated ? '[DEPRECATED]' : '' %>
 
-<%- printComments(api.doc.summary) || '(not available)' %>
+<%- printComments((api.doc.deprecated ? api.doc.deprecated : '') + api.doc.summary) || '(not available)' %>
 
 <% if(api.doc.example) { %>
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/safety-first.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/safety-first.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 /**
+ * @deprecated - This hook is not related to console functionality.
  * Hook that ensures a safe asynchronnous setting of React state in case a given component could be unmounted.
  * (https://github.com/facebook/react/issues/14113)
  * @param initialState initial state value

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/utils/rbac.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/utils/rbac.tsx
@@ -142,6 +142,7 @@ export const useAccessReview = (
 };
 
 /**
+ * @deprecated - Use useAccessReview from \@console/dynamic-plugin-sdk instead.
  * Hook that provides allowed status about user access to a given resource.
  * @param resourceAttributes resource attributes for access review
  * @param impersonate impersonation details

--- a/frontend/public/components/utils/rbac.tsx
+++ b/frontend/public/components/utils/rbac.tsx
@@ -23,7 +23,7 @@ export const useAccessReview2 = (
   impersonate?: ImpersonateKind,
 ) => useAccReview(resourceAttributes, impersonate);
 
-/** @deprecated - Use useAccessReviewAllowed from \@console/dynamic-plugin-sdk instead. */
+/** @deprecated - Use useAccessReview from \@console/dynamic-plugin-sdk instead. */
 export const useAccessReview = (
   resourceAttributes: AccessReviewResourceAttributes,
   impersonate?: ImpersonateKind,


### PR DESCRIPTION
Deprecates useAccessReviewAllowed and useSafetyFirst.
Allows 'api.md' doc to generate deprecated tags and sorts deprecated items to bottom.