### PR TITLE
[release-4.11] Bug 2109052: Unset the overflow to display sub menu content

### DIFF
--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenu.scss
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenu.scss
@@ -1,0 +1,8 @@
+// This is a workaround fix for the PatternFly issue https://github.com/patternfly/patternfly/issues/4871
+// It is fixed in the latest release via PR https://github.com/patternfly/patternfly/pull/4892
+
+.ocs-action-menu.pf-c-menu.pf-m-flyout {
+  .pf-c-menu__content {
+    overflow: unset
+  }
+}

--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenu.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenu.tsx
@@ -6,6 +6,7 @@ import { checkAccess } from '@console/internal/components/utils';
 import { ActionMenuVariant, MenuOption } from '../types';
 import ActionMenuContent from './ActionMenuContent';
 import ActionMenuToggle from './ActionMenuToggle';
+import './ActionMenu.scss';
 
 type ActionMenuProps = {
   actions: Action[];
@@ -74,7 +75,7 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
   }, [actions, isKebabVariant, setVisible]);
 
   const menu = (
-    <Menu ref={menuRef} containsFlyout onSelect={hideMenu}>
+    <Menu className="ocs-action-menu" ref={menuRef} containsFlyout onSelect={hideMenu}>
       <MenuContent data-test-id="action-items" translate="no">
         <MenuList>
           <ActionMenuContent options={menuOptions} onClick={hideMenu} focusItem={menuOptions[0]} />


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-44811

**Analysis / Root cause**: 
This is due to the PatternFly changes. overflow styling was added to menu content.

**Solution Description**: 
Unset the overflow added to menu content.

**Screen shots / Gifs for design review**: 
----BEFORE-----
![Add-to-application-not-working](https://user-images.githubusercontent.com/102503482/179960352-a2ea6ec5-4a1e-4f45-9042-e326bdad130f.gif)

----AFTER------
![add-to-application-working](https://user-images.githubusercontent.com/102503482/179960325-6f5dcf00-9b7c-4716-bc19-e1b80f6f8d72.gif)


**Unit test coverage report**: 
NA

**Test setup:**
1. Create a workload and click on application grouping of the workload.
2. Click on Action dropdown and hover on Add to application.
3. Won't able to see the Add to application options.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge