### PR TITLE
Bug 2109469: Fix create-namespace e2e test: cleanup useServiceLevelTitle hook usage

### DIFF
--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -36,6 +36,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) =>
   }, [t]);
   const clusterVersion = useClusterVersion();
   const canUpgrade = useCanClusterUpgrade();
+  const serviceLevelTitle = useServiceLevelTitle();
 
   const clusterID = getClusterID(clusterVersion);
   const channel: string = clusterVersion?.spec?.channel;
@@ -97,7 +98,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) =>
             clusterID={clusterID}
             loading={
               <>
-                <TextListItem component="dt">{useServiceLevelTitle()}</TextListItem>
+                <TextListItem component="dt">{serviceLevelTitle}</TextListItem>
                 <TextListItem component="dd">
                   <ServiceLevelLoading />
                 </TextListItem>
@@ -105,7 +106,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) =>
             }
           >
             <>
-              <TextListItem component="dt">{useServiceLevelTitle()}</TextListItem>
+              <TextListItem component="dt">{serviceLevelTitle}</TextListItem>
               <TextListItem component="dd" className="co-select-to-copy">
                 <ServiceLevelText inline clusterID={clusterID} />
               </TextListItem>

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -1076,10 +1076,14 @@ export const ClusterVersionDetailsTable: React.FC<ClusterVersionDetailsTableProp
   const imageParts = desiredImage.split('@');
   const releaseNotes = showReleaseNotes();
   const status = getClusterUpdateStatus(cv);
+
+  const { t } = useTranslation();
   const canUpgrade = useCanClusterUpgrade();
   const [machineConfigPools] = useK8sWatchResource<MachineConfigPoolKind[]>(
     MachineConfigPoolsResource,
   );
+  const serviceLevelTitle = useServiceLevelTitle();
+
   const desiredVersion = getDesiredClusterVersion(cv);
   const updateStartedTime = getStartedTimeForCVDesiredVersion(cv, desiredVersion);
   const workerMachineConfigPool = getMCPByName(machineConfigPools, NodeTypes.worker);
@@ -1092,7 +1096,6 @@ export const ClusterVersionDetailsTable: React.FC<ClusterVersionDetailsTableProp
       .then(() => removeQueryArgument('showChannels'))
       .catch(_.noop);
   }
-  const { t } = useTranslation();
 
   return (
     <>
@@ -1204,7 +1207,7 @@ export const ClusterVersionDetailsTable: React.FC<ClusterVersionDetailsTableProp
               clusterID={clusterID}
               loading={
                 <>
-                  <dt>{useServiceLevelTitle()}</dt>
+                  <dt>{serviceLevelTitle}</dt>
                   <dd>
                     <ServiceLevelLoading />
                   </dd>
@@ -1212,7 +1215,7 @@ export const ClusterVersionDetailsTable: React.FC<ClusterVersionDetailsTableProp
               }
             >
               <>
-                <dt>{useServiceLevelTitle()}</dt>
+                <dt>{serviceLevelTitle}</dt>
                 <dd>
                   <ServiceLevelText clusterID={clusterID} />
                 </dd>

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
@@ -128,6 +128,7 @@ export const DetailsCard = withDashboardResources(
       };
       fetchK8sVersion();
     }, [openshiftFlag, watchK8sResource, stopWatchK8sResource]);
+    const serviceLevelTitle = useServiceLevelTitle();
 
     const clusterID = getClusterID(clusterVersionData);
     const openShiftVersion = getOpenShiftVersion(clusterVersionData);
@@ -212,12 +213,12 @@ export const DetailsCard = withDashboardResources(
                   <ServiceLevel
                     clusterID={clusterID}
                     loading={
-                      <OverviewDetailItem title={useServiceLevelTitle()}>
+                      <OverviewDetailItem title={serviceLevelTitle}>
                         <ServiceLevelLoading />
                       </OverviewDetailItem>
                     }
                   >
-                    <OverviewDetailItem title={useServiceLevelTitle()}>
+                    <OverviewDetailItem title={serviceLevelTitle}>
                       {/* Service Level handles loading and error state */}
                       <ServiceLevelText clusterID={clusterID} />
                     </OverviewDetailItem>


### PR DESCRIPTION
This is a follow-up on #11809

Based on the 4.11 backport https://github.com/openshift/console/pull/11826#pullrequestreview-1037215986 I have extracted the `useServiceLevelTitle` hook and call it before the JSX tree is build.

/cc @spadgett 
/assign @spadgett 