### PR TITLE
Bug 2109511: fix failed PipelineRun log texts color in light mode

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.scss
@@ -23,7 +23,7 @@
   &__logtext {
     position: relative;
     background: var(--pf-global--palette--black-1000); // pod log background color
-    color: var(--pf-global--Color--100);
+    color: var(--pf-global--palette--black-100);
     height: 100%;
     padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--md);
   }


### PR DESCRIPTION
Fix: https://bugzilla.redhat.com/show_bug.cgi?id=2109511

**Before:**
![image (7)](https://user-images.githubusercontent.com/2561818/180224409-784eb534-7f57-4220-9a3e-2c2707223ecc.png)

**After:**
<img width="1501" alt="image" src="https://user-images.githubusercontent.com/2561818/180224638-ebf780d5-3194-4849-a3a3-757ec87d7438.png">
