### PR TITLE
Bug 2037329: remove redundant model check to prevent tab reloading

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/model-status-box.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/model-status-box.tsx
@@ -10,17 +10,22 @@ type ModelStatusBoxProps = {
 
 const ModelStatusBox: React.FC<ModelStatusBoxProps> = ({ groupVersionKind, children }) => {
   const { t } = useTranslation();
-  const [model] = useK8sModel(groupVersionKind);
-  return model ? (
-    <>{children}</>
-  ) : (
-    <ErrorPage404
-      message={t(
-        "olm~The server doesn't have a resource type {{kind}}. Try refreshing the page if it was recently added.",
-        { kind: kindForReference(groupVersionKind) },
-      )}
-    />
-  );
+  const [model, inFlight] = useK8sModel(groupVersionKind);
+
+  if (!model && inFlight) {
+    return null;
+  }
+  if (!model) {
+    return (
+      <ErrorPage404
+        message={t(
+          "olm~The server doesn't have a resource type {{kind}}. Try refreshing the page if it was recently added.",
+          { kind: kindForReference(groupVersionKind) },
+        )}
+      />
+    );
+  }
+  return <>{children}</>;
 };
 
 export default ModelStatusBox;

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -595,7 +595,7 @@ export const ProvidedAPIPage: React.FC<ProvidedAPIPageProps> = (props) => {
 
   const [staticData, filteredData, onFilterChange] = useListPageFilter(resources);
 
-  return !model && inFlight ? null : (
+  return (
     <ModelStatusBox groupVersionKind={apiGroupVersionKind}>
       <ListPageHeader title={showTitle ? `${label}s` : undefined}>
         {managesAllNamespaces && (


### PR DESCRIPTION
and update `<ModelStatusBox>` to better capture the various states.

https://github.com/openshift/console/commit/9180214d0de0df33a184726154f9398ac25308fd#diff-bfafd33720c50cfb2fa606deb9ea6e529726657c3e9adbc4e259374e923a0c09R598 appears to have fixed this bug as well.  But `<ModelStatusBox>` is already checking for `model`, so there doesn't seem to be a need to do it before `<ModelStatusBox>` does.

This fix should be back ported to 4.10.