### PR TITLE
Gherkin for "Cancelled" and "Stopped" status of pipeline run

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-runs.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-runs.feature
@@ -146,13 +146,14 @@ Feature: Pipeline Runs
              Then user is able to see expanded logs page
 
 
-        @regression
+        @regression @odc-4793
         Scenario: kebab menu options in pipeline Runs page: P-07-TC14
-            Given pipeline run is displayed for "pipeline-aaa" without resource
-             When user selects the Pipeline Run for "pipeline-aaa"
-              And user navigates to pipelineRuns page
-              And user selects the kebab menu in pipeline Runs page for pipeline "pipeline-aaa"
-             Then user is able to see kebab menu options Rerun, Delete Pipeline Run
+            Given user creates pipeline using git named "pipeline-aaa"
+              And user is at the Pipeline Details page of pipeline "pipeline-aaa"
+            #  When user starts the pipeline from start pipeline modal
+             When user starts the pipeline "pipeline-aaa" in Pipeline Details page
+              And user clicks Actions menu on the top right corner of the page
+             Then user is able to see Actions menu options "Stop", "Cancel", "Rerun", "Delete PipelineRun" in pipeline run page
 
 
         @regression
@@ -355,3 +356,21 @@ Feature: Pipeline Runs
               And user navigates to pipelineRun parameters tab
               And user is able to see parameters of pipelineRun
               And user is able to see name "testName" and value "testValue" parameters value of pipelineRun
+
+
+        @regression @odc-4793
+        Scenario: Status for the cancelled pipeline: P-07-TC34
+            Given user creates pipeline using git named "pipeline-cancel"
+              And user is at the Pipeline Details page of pipeline "pipeline-cancel"
+             When user starts the pipeline "pipeline-cancel" in Pipeline Details page
+              And user selects option "Cancel" from Actions menu drop down
+             Then status displays as "Cancelled" in pipeline run details page
+
+
+        @regression @odc-4793
+        Scenario: Status for the stopped pipeline: P-07-TC35
+            Given user creates pipeline using git named "pipeline-stop"
+              And user is at the Pipeline Details page of pipeline "pipeline-stop"
+             When user starts the pipeline "pipeline-stop" in Pipeline Details page
+              And user selects option "Stop" from Actions menu drop down
+             Then status displays as "Cancelled" in pipeline run details page

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-runs.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-runs.ts
@@ -23,6 +23,7 @@ import {
   pipelineRunsPO,
   pipelinesPO,
   pipelineDetailsPO,
+  triggerTemplateDetailsPO,
 } from '../../page-objects/pipelines-po';
 import {
   pipelinesPage,
@@ -236,7 +237,9 @@ When('user selects Rerun option from the Actions menu', () => {
 });
 
 Then('status displays as {string} in pipeline run details page', (pipelineStatus: string) => {
-  cy.get(pipelineRunsPO.pipelineRunsTable.status).should('contain.text', pipelineStatus);
+  cy.get(pipelineRunsPO.pipelineRunsTable.status).should('contain.text', pipelineStatus, {
+    timeout: 10000,
+  });
 });
 
 Then('user will be redirected to Pipeline Run Details page', () => {
@@ -339,6 +342,18 @@ Then('Last Run status of the workload displays as {string} in topology page', (s
 When('user clicks Actions menu on the top right corner of the page', () => {
   actionsDropdownMenu.clickActionMenu();
 });
+
+When(
+  'user is able to see Actions menu options {string}, {string}, {string}, {string} in pipeline run page',
+  (el1, el2, el3, el4: string) => {
+    cy.byLegacyTestID('breadcrumb-link-0').contains('PipelineRun');
+    cy.byLegacyTestID('action-items')
+      .should('contain', el1)
+      .and('contain', el2)
+      .and('contain', el3)
+      .and('contain', el4);
+  },
+);
 
 When('user clicks Last Run value of the pipeline {string}', (pipelineName: string) => {
   pipelinesPage.selectPipelineRun(pipelineName);
@@ -620,3 +635,32 @@ Then(
     cy.byTestID('value').should('have.value', paramValue);
   },
 );
+
+When('user creates pipeline using git named {string}', (pipelineName: string) => {
+  navigateTo(devNavigationMenu.Add);
+  addPage.selectCardFromOptions(addOptions.ImportFromGit);
+  gitPage.enterGitUrl('https://github.com/sclorg/golang-ex');
+  devFilePage.verifyValidatedMessage('https://github.com/sclorg/golang-ex');
+  gitPage.selectAddPipeline();
+  gitPage.enterWorkloadName(pipelineName);
+  gitPage.clickCreate();
+  topologyPage.verifyTopologyPage();
+});
+
+When('user is at the Pipeline Details page of pipeline {string}', (pipelineName: string) => {
+  navigateTo(devNavigationMenu.Pipelines);
+  pipelinesPage.search(pipelineName);
+  cy.byLegacyTestID(pipelineName).click();
+  pipelineDetailsPage.verifyTitle(pipelineName);
+});
+
+When('user starts the pipeline {string} in Pipeline Details page', (pipelineName: string) => {
+  pipelineDetailsPage.verifyTitle(pipelineName);
+  cy.get(triggerTemplateDetailsPO.detailsTab)
+    .should('be.visible')
+    .click();
+  cy.byLegacyTestID('breadcrumb-link-0').click();
+  pipelinesPage.selectActionForPipeline(pipelineName, pipelineActions.Start);
+  modal.modalTitleShouldContain('Start Pipeline');
+  startPipelineInPipelinesPage.clickStart();
+});


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-4793
Story: https://issues.redhat.com/browse/ODC-6736

Acceptance criteria:

- Users should be able to Stop a Running PipelineRun -> the code should use StoppedRunFinally
- Users should be able to Cancel a PipelineRun which is Stopped or Running-> the code should use CancelledRunFinally 

**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]

**Fix**: https://issues.redhat.com/browse/ODC-6736


**Test Setup**:

Check the TAGS in frontend/packages/pipelines/integration-tests/cypress.json file be: ""@pipelines and @[odc-4793](https://issues.redhat.com//browse/odc-4793) and not (@manual or @to-do or @un-verified or @broken-test)",",

Command to execute:

Run a cluster locally and execute the command `npm run test-cypress-pipelines` simultaneously

Execute the pipelines-runs.feature file

**Browser**
Chrome 103

**Test Execution Screenshot:**
![Uploading Screenshot from 2022-08-27 04-08-45.png…]()
