### PR TITLE
Bug 2110525: Clear the error when switching between the Form and YAML editor

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
@@ -47,7 +47,7 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
   const { t } = useTranslation();
   const [field] = useField(name);
 
-  const { values, setFieldValue } = useFormikContext<FormikValues>();
+  const { values, setFieldValue, setStatus } = useFormikContext<FormikValues>();
 
   const formData = _.get(values, formContext.name);
   const yamlData: string = _.get(values, yamlContext.name);
@@ -133,6 +133,7 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
       default:
         break;
     }
+    setStatus({ submitError: '' });
   };
 
   React.useEffect(() => {


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-6026

**Descriptions:**
- clear the formik`submitError` value when switching between the Form and YAML editor

**GIF:**
![Kapture 2022-07-25 at 19 46 29](https://user-images.githubusercontent.com/2561818/180798896-3e6c85b6-a1f3-4f3c-961e-08da161c37af.gif)
