### PR TITLE
capture telemetry for helmChartRepo creation to detect scope

### DIFF
--- a/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/CreateHelmChartRepository.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/CreateHelmChartRepository.tsx
@@ -7,6 +7,7 @@ import { history } from '@console/internal/components/utils';
 import { modelFor, referenceFor } from '@console/internal/module/k8s';
 import { useActiveNamespace } from '@console/shared/src';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 import { safeJSToYAML } from '@console/shared/src/utils/yaml';
 import { ProjectHelmChartRepositoryModel } from '../../../models';
 import { HelmChartRepositoryData, HelmChartRepositoryType } from '../../../types/helm-types';
@@ -27,6 +28,7 @@ const CreateHelmChartRepository: React.FC<CreateHelmChartRepositoryProps> = ({
 }) => {
   const { t } = useTranslation();
   const [namespace] = useActiveNamespace();
+  const fireTelemetryEvent = useTelemetry();
 
   const initialValues = React.useRef({
     editorType: EditorType.Form,
@@ -77,6 +79,12 @@ const CreateHelmChartRepository: React.FC<CreateHelmChartRepositoryProps> = ({
 
     return resourceCall
       .then(() => {
+        fireTelemetryEvent('Helm Chart Repository', {
+          helmChartRepositoryScope:
+            values.formData?.scope === ProjectHelmChartRepositoryModel.kind
+              ? 'namespace'
+              : 'cluster',
+        });
         actions.setStatus({
           submitError: '',
           submitSuccess: t('helm-plugin~{{hcr}} has been created', {


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-6717

**Description:**
capture telemetry for helmChartRepo creation to detect scope

**Screenshots/Gif:**

- namespace scoped

<img width="1419" alt="image" src="https://user-images.githubusercontent.com/5129024/180802461-1c93e9e0-2b85-47d4-a168-46aafa76586d.png">


- cluster scoped

<img width="1461" alt="image" src="https://user-images.githubusercontent.com/5129024/180802708-b39f8e98-4503-4bf9-b855-5bf20cdcd90b.png">

![HCR-2](https://user-images.githubusercontent.com/5129024/180803987-72fb06c5-8e73-4094-83d8-5b2889ea6b48.gif)

**Tests:**

to verify it locally run bridge as below

`./bin/bridge -listen "http://0.0.0.0:9000/" -user-settings-location configmap --telemetry=DEBUG=true`

on chrome make sure log level `verbose` is selected if testing in debug mode

![image](https://user-images.githubusercontent.com/5129024/181462431-4a6c5b28-c7e0-4dd1-8082-335fe18b8b0a.png)


**Browser conformance:**

- [x]  Chrome
- [ ]  Firefox
- [ ]  Safari
- [ ]  Edge
