### PR TITLE
CONSOLE-3179: Add deprecation note for react-helmet

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -10,12 +10,12 @@ other plugins, each plugin must declare its dependencies using [semantic version
 ranges.
 
 ## Related Documentation
-*[Extension Documentation](./docs/console-extensions.md)* - Detailed documentation of every available console extension point.
 
-*[API Documentation](./docs/api.md)* - Detailed documentation of hooks, components, and other APIs provided by this package. 
+_[Extension Documentation](./docs/console-extensions.md)_ - Detailed documentation of every available console extension point.
 
-*[OpenShift Console Dynamic Plugins feature page](https://github.com/openshift/enhancements/blob/master/enhancements/console/dynamic-plugins.md)* - A high level overview of dynamic plugins in relation to OLM operators and cluster administration.
+_[API Documentation](./docs/api.md)_ - Detailed documentation of hooks, components, and other APIs provided by this package.
 
+_[OpenShift Console Dynamic Plugins feature page](https://github.com/openshift/enhancements/blob/master/enhancements/console/dynamic-plugins.md)_ - A high level overview of dynamic plugins in relation to OLM operators and cluster administration.
 
 Example project structure:
 
@@ -30,30 +30,31 @@ dynamic-demo-plugin/
 
 ## SDK packages
 
-| Package Name | Description |
-| --- | --- |
-| `@openshift-console/dynamic-plugin-sdk` | Provides core APIs, types and utilities used by dynamic plugins at runtime. |
-| `@openshift-console/dynamic-plugin-sdk-webpack` | Provides webpack plugin `ConsoleRemotePlugin` used to build all dynamic plugin assets. |
-| `@openshift-console/dynamic-plugin-sdk-internal` | Internal package exposing additional code. |
-| `@openshift-console/plugin-shared` | Provides reusable components and utility functions to build OCP dynamic plugins. Compatible with multiple versions of OpenShift Console. |
+| Package Name                                     | Description                                                                                                                              |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `@openshift-console/dynamic-plugin-sdk`          | Provides core APIs, types and utilities used by dynamic plugins at runtime.                                                              |
+| `@openshift-console/dynamic-plugin-sdk-webpack`  | Provides webpack plugin `ConsoleRemotePlugin` used to build all dynamic plugin assets.                                                   |
+| `@openshift-console/dynamic-plugin-sdk-internal` | Internal package exposing additional code.                                                                                               |
+| `@openshift-console/plugin-shared`               | Provides reusable components and utility functions to build OCP dynamic plugins. Compatible with multiple versions of OpenShift Console. |
 
 ## OpenShift Console Versions vs SDK Versions
 
 Not all NPM packages are fully compatible with all versions of the Console. This table will help align compatible versions of the SDK Packages to versions of the OpenShift Console.
 
-| Console Version | SDK Package | Last Package Version |
-| --- | --- | --- |
-| 4.12.x | `@openshift-console/dynamic-plugin-sdk` | Latest |
-|  | `@openshift-console/dynamic-plugin-sdk-webpack` | Latest |
-| 4.11.x | `@openshift-console/dynamic-plugin-sdk` | 0.0.12 |
-|  | `@openshift-console/dynamic-plugin-sdk-webpack` | 0.0.7 |
-| 4.10.x **[Tech]** | `@openshift-console/dynamic-plugin-sdk` | 0.0.3 |
-|  | `@openshift-console/dynamic-plugin-sdk-webpack` | 0.0.6 |
-| 4.9.x **[Dev]** | `@openshift-console/dynamic-plugin-sdk` | 0.0.0-alpha18 |
+| Console Version   | SDK Package                                     | Last Package Version |
+| ----------------- | ----------------------------------------------- | -------------------- |
+| 4.12.x            | `@openshift-console/dynamic-plugin-sdk`         | Latest               |
+|                   | `@openshift-console/dynamic-plugin-sdk-webpack` | Latest               |
+| 4.11.x            | `@openshift-console/dynamic-plugin-sdk`         | 0.0.12               |
+|                   | `@openshift-console/dynamic-plugin-sdk-webpack` | 0.0.7                |
+| 4.10.x **[Tech]** | `@openshift-console/dynamic-plugin-sdk`         | 0.0.3                |
+|                   | `@openshift-console/dynamic-plugin-sdk-webpack` | 0.0.6                |
+| 4.9.x **[Dev]**   | `@openshift-console/dynamic-plugin-sdk`         | 0.0.0-alpha18        |
 
 Notes
-* **[Tech]** - Release 4.10 was Tech Preview for the SDK packages
-* **[Dev]** - Release 4.9 was Dev Preview for the SDK packages
+
+- **[Tech]** - Release 4.10 was Tech Preview for the SDK packages
+- **[Dev]** - Release 4.9 was Dev Preview for the SDK packages
 
 ## `package.json`
 
@@ -245,3 +246,9 @@ yarn publish dist/<pkg> --no-git-tag-version --new-version <version>
 ```
 
 If the given package doesn't exist in npm registry, add `--access public` to `yarn publish` command.
+
+## Future Deprecations in Shared Plugin Dependencies
+
+Certain packages are currently in the shared plugin dependencies that will be removed in the future. Plugin authors will need to manually add these items to their configurations or chose other options:
+
+_- react-helmet_


### PR DESCRIPTION
Adds deprecation note for react-helmet in the for dynamic plugins readme page.  

This is only the first part to add a note saying it will be deprecated.  There is no code change for this issue.

https://issues.redhat.com/browse/CONSOLE-3179

@vojtechszocs 