### PR TITLE
Bug 2110927: Remove zero from edit yaml page and clear errors when the user press the save button

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -118,6 +118,7 @@ export const EditYAML_ = connect(stateToProps)(
           }
           return models.get(referenceFor(obj)) || models.get(obj.kind);
         }
+
         async createResources(objs) {
           const results = [];
           for (const obj of objs) {
@@ -137,11 +138,16 @@ export const EditYAML_ = connect(stateToProps)(
           return Promise.resolve(results);
         }
 
+        /** @param {() => void} callback */
+        clearErrors(callback) {
+          this.setState({ errors: [] }, callback);
+        }
+
         handleError(error, success = null) {
           this.setState((prevState) => {
-            const errors = prevState.errors || [];
+            let errors = prevState.errors || [];
             if (!_.isEmpty(error)) {
-              errors.push(error);
+              errors = [...errors, error];
             }
             return {
               errors,
@@ -392,91 +398,94 @@ export const EditYAML_ = connect(stateToProps)(
         }
 
         save() {
-          const { onSave, t } = this.props;
-          const { owner } = this.state;
-          let obj;
+          this.clearErrors(() => {
+            const { onSave, t } = this.props;
+            const { owner } = this.state;
+            let obj;
 
-          if (onSave) {
-            onSave(this.getEditor().getValue());
-            return;
-          }
-
-          try {
-            obj = safeLoad(this.getEditor().getValue());
-          } catch (e) {
-            this.handleError(t('public~Error parsing YAML: {{e}}', { e }));
-            return;
-          }
-
-          const error = this.validate(obj);
-          if (error) {
-            this.handleError(error);
-            return;
-          }
-
-          const { namespace: newNamespace, name: newName } = obj.metadata;
-
-          if (!this.props.create && this.props.obj) {
-            const { namespace, name } = this.props.obj.metadata;
-
-            if (name !== newName) {
-              this.handleError(
-                t(
-                  'public~Cannot change resource name (original: "{{name}}", updated: "{{newName}}").',
-                  { name, newName },
-                ),
-              );
-              return;
-            }
-            if (namespace !== newNamespace) {
-              this.handleError(
-                t(
-                  'public~Cannot change resource namespace (original: "{{namespace}}", updated: "{{newNamespace}}").',
-                  { namespace, newNamespace },
-                ),
-              );
-              return;
-            }
-            if (this.props.obj.kind !== obj.kind) {
-              this.handleError(
-                t(
-                  'public~Cannot change resource kind (original: "{{original}}", updated: "{{updated}}").',
-                  { original: this.props.obj.kind, updated: obj.kind },
-                ),
-              );
+            if (onSave) {
+              onSave(this.getEditor().getValue());
               return;
             }
 
-            const apiGroup = groupVersionFor(this.props.obj.apiVersion).group;
-            const newAPIGroup = groupVersionFor(obj.apiVersion).group;
-            if (apiGroup !== newAPIGroup) {
-              this.handleError(
-                t(
-                  'public~Cannot change API group (original: "{{apiGroup}}", updated: "{{newAPIGroup}}").',
-                  { apiGroup, newAPIGroup },
-                ),
-              );
+            try {
+              obj = safeLoad(this.getEditor().getValue());
+            } catch (e) {
+              this.handleError(t('public~Error parsing YAML: {{e}}', { e }));
               return;
             }
 
-            if (owner) {
-              managedResourceSaveModal({
-                kind: obj.kind,
-                resource: obj,
-                onSubmit: () => this.updateYAML(obj, this.getModel(obj), newNamespace, newName),
-                owner,
-              });
+            const error = this.validate(obj);
+            if (error) {
+              this.handleError(error);
               return;
             }
-          }
-          this.updateYAML(obj, this.getModel(obj), newNamespace, newName);
+
+            const { namespace: newNamespace, name: newName } = obj.metadata;
+
+            if (!this.props.create && this.props.obj) {
+              const { namespace, name } = this.props.obj.metadata;
+
+              if (name !== newName) {
+                this.handleError(
+                  t(
+                    'public~Cannot change resource name (original: "{{name}}", updated: "{{newName}}").',
+                    { name, newName },
+                  ),
+                );
+                return;
+              }
+              if (namespace !== newNamespace) {
+                this.handleError(
+                  t(
+                    'public~Cannot change resource namespace (original: "{{namespace}}", updated: "{{newNamespace}}").',
+                    { namespace, newNamespace },
+                  ),
+                );
+                return;
+              }
+              if (this.props.obj.kind !== obj.kind) {
+                this.handleError(
+                  t(
+                    'public~Cannot change resource kind (original: "{{original}}", updated: "{{updated}}").',
+                    { original: this.props.obj.kind, updated: obj.kind },
+                  ),
+                );
+                return;
+              }
+
+              const apiGroup = groupVersionFor(this.props.obj.apiVersion).group;
+              const newAPIGroup = groupVersionFor(obj.apiVersion).group;
+              if (apiGroup !== newAPIGroup) {
+                this.handleError(
+                  t(
+                    'public~Cannot change API group (original: "{{apiGroup}}", updated: "{{newAPIGroup}}").',
+                    { apiGroup, newAPIGroup },
+                  ),
+                );
+                return;
+              }
+
+              if (owner) {
+                managedResourceSaveModal({
+                  kind: obj.kind,
+                  resource: obj,
+                  onSubmit: () => this.updateYAML(obj, this.getModel(obj), newNamespace, newName),
+                  owner,
+                });
+                return;
+              }
+            }
+            this.updateYAML(obj, this.getModel(obj), newNamespace, newName);
+          });
         }
 
         saveAll() {
-          const { t } = this.props;
-          let objs;
-          let hasErrors = false;
-          this.setState({ errors: null }, () => {
+          this.clearErrors(() => {
+            const { t } = this.props;
+            let objs;
+            let hasErrors = false;
+
             try {
               objs = safeLoadAll(this.getEditor().getValue()).filter((obj) => obj);
             } catch (e) {
@@ -679,7 +688,7 @@ export const EditYAML_ = connect(stateToProps)(
                       />
                       <div className="yaml-editor__buttons" ref={(r) => (this.buttons = r)}>
                         {customAlerts}
-                        {errors?.length && (
+                        {errors?.length > 0 && (
                           <Alert
                             isInline
                             className="co-alert co-alert--scrollable"


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2110927

**Analysis / Root cause**: 
1. The `error?.length` check added in #11863 shows a zero if the error array is defined but empty.
2. It also just appends the error to the error array without removing them.

**Solution Description**: 
1. Add `> 0` check to the length. Also, create a new errors array if the error was set.
2. Clear all errors when the Save button is pressed similar to `saveAll`

**Screen shots / Gifs for design review**: 
Before:

https://user-images.githubusercontent.com/139310/180963886-b70d66df-c2d3-4bf0-9d22-3a3213a143b3.mp4

After:

https://user-images.githubusercontent.com/139310/180963851-d8e76614-823e-49dd-9060-b3bcd86b57c6.mp4

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
Open any edit yaml page.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
/cc @debsmita1 