### PR TITLE
CONSOLE-3186: Add shared-plugin to the SDK Packages tables docs

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -35,6 +35,7 @@ dynamic-demo-plugin/
 | `@openshift-console/dynamic-plugin-sdk` | Provides core APIs, types and utilities used by dynamic plugins at runtime. |
 | `@openshift-console/dynamic-plugin-sdk-webpack` | Provides webpack plugin `ConsoleRemotePlugin` used to build all dynamic plugin assets. |
 | `@openshift-console/dynamic-plugin-sdk-internal` | Internal package exposing additional code. |
+| `@openshift-console/plugin-shared` | Provides reusable components and utility functions to build OCP dynamic plugins. Compatible with multiple versions of OpenShift Console. |
 
 ## OpenShift Console Versions vs SDK Versions
 


### PR DESCRIPTION
Addresses: https://issues.redhat.com/browse/CONSOLE-3186

Documents the purpose of the '@openshift-console/plugin-shared' package in the SDK packages docs.