### PR TITLE
Bug 2080260: Update OLM pages to use details and list page extensions for operands when they exist

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useResourceDetailsPage.ts
+++ b/frontend/packages/console-shared/src/hooks/useResourceDetailsPage.ts
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { useResourceDetailsPages } from './useResourceDetailsPages';
+
+export const useResourceDetailsPage = (key: string) => {
+  const detailsPages = useResourceDetailsPages();
+  return React.useMemo(() => detailsPages.get(key), [detailsPages, key]);
+};

--- a/frontend/packages/console-shared/src/hooks/useResourceDetailsPages.tsx
+++ b/frontend/packages/console-shared/src/hooks/useResourceDetailsPages.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import {
+  ResourceDetailsPage as DynamicResourceDetailsPage,
+  isResourceDetailsPage as isDynamicResourceDetailsPage,
+} from '@console/dynamic-plugin-sdk/src';
+import { getResourceDetailsPages } from '@console/internal/components/resource-pages';
+import { isResourceDetailsPage, ResourceDetailsPage, useExtensions } from '@console/plugin-sdk/src';
+
+export const useResourceDetailsPages = () => {
+  const resourceDetailsPageExtensions = useExtensions<ResourceDetailsPage>(isResourceDetailsPage);
+  const dynamicResourceDetailsPageExtensions = useExtensions<DynamicResourceDetailsPage>(
+    isDynamicResourceDetailsPage,
+  );
+  return React.useMemo(
+    () =>
+      getResourceDetailsPages(resourceDetailsPageExtensions, dynamicResourceDetailsPageExtensions),
+    [resourceDetailsPageExtensions, dynamicResourceDetailsPageExtensions],
+  );
+};

--- a/frontend/packages/console-shared/src/hooks/useResourceListPage.ts
+++ b/frontend/packages/console-shared/src/hooks/useResourceListPage.ts
@@ -1,0 +1,7 @@
+import { useMemo } from 'react';
+import { useResourceListPages } from './useResourceListPages';
+
+export const useResourceListPage = (key: string) => {
+  const listPages = useResourceListPages();
+  return useMemo(() => listPages.get(key), [listPages, key]);
+};

--- a/frontend/packages/console-shared/src/hooks/useResourceListPages.tsx
+++ b/frontend/packages/console-shared/src/hooks/useResourceListPages.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import {
+  ResourceListPage as DynamicResourceListPage,
+  isResourceListPage as isDynamicResourceListPage,
+} from '@console/dynamic-plugin-sdk/src';
+import { getResourceListPages } from '@console/internal/components/resource-pages';
+import { isResourceListPage, ResourceListPage, useExtensions } from '@console/plugin-sdk/src';
+
+export const useResourceListPages = () => {
+  const resourceListPageExtensions = useExtensions<ResourceListPage>(isResourceListPage);
+  const dynamicResourceListPageExtensions = useExtensions<DynamicResourceListPage>(
+    isDynamicResourceListPage,
+  );
+  return React.useMemo(
+    () => getResourceListPages(resourceListPageExtensions, dynamicResourceListPageExtensions),
+    [resourceListPageExtensions, dynamicResourceListPageExtensions],
+  );
+};

--- a/frontend/packages/container-security/src/plugin.ts
+++ b/frontend/packages/container-security/src/plugin.ts
@@ -1,5 +1,4 @@
 import { referenceForModel } from '@console/internal/module/k8s';
-import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
 import {
   Plugin,
   ModelDefinition,
@@ -56,32 +55,6 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Resource/Details',
     properties: {
       model: ImageManifestVulnModel,
-      loader: () =>
-        import(
-          './components/image-manifest-vuln' /* webpackChunkName: "container-security" */
-        ).then((m) => m.ImageManifestVulnDetailsPage),
-    },
-  },
-  {
-    type: 'Page/Route',
-    properties: {
-      exact: false,
-      path: `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/${referenceForModel(
-        ImageManifestVulnModel,
-      )}/:name`,
-      loader: () =>
-        import(
-          './components/image-manifest-vuln' /* webpackChunkName: "container-security" */
-        ).then((m) => m.ImageManifestVulnDetailsPage),
-    },
-  },
-  {
-    type: 'Page/Route',
-    properties: {
-      exact: false,
-      path: `/k8s/ns/:ns/${referenceForModel(
-        ClusterServiceVersionModel,
-      )}/:appName/${referenceForModel(ImageManifestVulnModel)}/:name`,
       loader: () =>
         import(
           './components/image-manifest-vuln' /* webpackChunkName: "container-security" */

--- a/frontend/packages/dev-console/src/components/builds/BuildsTabListPage.tsx
+++ b/frontend/packages/dev-console/src/components/builds/BuildsTabListPage.tsx
@@ -2,33 +2,17 @@ import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import { useTranslation, Trans } from 'react-i18next';
 import { match as Rmatch } from 'react-router-dom';
-import {
-  ResourceListPage as DynamicResourceListPage,
-  isResourceListPage as isDynamicResourceListPage,
-} from '@console/dynamic-plugin-sdk';
-import { getResourceListPages } from '@console/internal/components/resource-pages';
 import { withStartGuide } from '@console/internal/components/start-guide';
 import { Page, AsyncComponent } from '@console/internal/components/utils';
-import { useExtensions, isResourceListPage, ResourceListPage } from '@console/plugin-sdk';
 import { useFlag, MenuActions, MultiTabListPage, getBadgeFromType } from '@console/shared';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
+import { useResourceListPages } from '@console/shared/src/hooks/useResourceListPages';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import CreateProjectListPage from '../projects/CreateProjectListPage';
 
 interface BuildsTabListPageProps {
   match: Rmatch<{ ns?: string }>;
 }
-
-const useResourceListPages = () => {
-  const resourceListPageExtensions = useExtensions<ResourceListPage>(isResourceListPage);
-  const dynamicResourceListPageExtensions = useExtensions<DynamicResourceListPage>(
-    isDynamicResourceListPage,
-  );
-  return React.useMemo(
-    () => getResourceListPages(resourceListPageExtensions, dynamicResourceListPageExtensions),
-    [resourceListPageExtensions, dynamicResourceListPageExtensions],
-  );
-};
 
 /**
  * We might add a generic extension for multi tab list pages in the future.

--- a/frontend/packages/integration-tests-cypress/views/list-page.ts
+++ b/frontend/packages/integration-tests-cypress/views/list-page.ts
@@ -2,7 +2,10 @@ import * as yamlEditor from './yaml-editor';
 
 export const listPage = {
   titleShouldHaveText: (title: string) =>
-    cy.byLegacyTestID('resource-title').should('have.text', title),
+    cy
+      .byLegacyTestID('resource-title')
+      .contains(title)
+      .should('exist'),
   clickCreateYAMLdropdownButton: () => {
     cy.byTestID('item-create')
       .click()

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
@@ -9,9 +9,11 @@ const testOperator = {
 
 const testOperand: TestOperandProps = {
   name: 'ServiceBinding',
+  group: 'binding.operators.coreos.com',
+  version: 'v1alpha1',
   kind: 'ServiceBinding',
-  tabName: 'Service Binding',
-  exampleName: `example-servicebinding`,
+  createActionID: 'list-page-create-dropdown-item-servicebindings.binding.operators.coreos.com',
+  exampleName: 'example-servicebinding',
 };
 
 describe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
@@ -41,7 +43,7 @@ describe(`Globally installing "${testOperator.name}" operator in ${GlobalInstall
     cy.byLegacyTestID('resource-summary').should('exist');
 
     operator.createOperand(testOperator.name, testOperand);
-    cy.byTestOperandLink(testOperand.exampleName).should('exist');
+    cy.byTestID(testOperand.exampleName).should('exist');
     operator.operandShouldExist(testOperator.name, testOperand);
 
     operator.deleteOperand(testOperator.name, testOperand);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -12,8 +12,10 @@ const testOperator = {
 
 const testOperand: TestOperandProps = {
   name: '3scale Backend Schema',
+  group: 'capabilities.3scale.net',
+  version: 'v1beta1',
   kind: 'Backend',
-  tabName: '3scale Backend',
+  createActionID: 'list-page-create-dropdown-item-backends.capabilities.3scale.net',
   exampleName: `backend1-sample`,
 };
 
@@ -71,7 +73,7 @@ describe(`Installing "${testOperator.name}" operator in test namespace`, () => {
     });
 
     operator.createOperand(testOperator.name, testOperand, testOperator.installedNamespace);
-    cy.byTestOperandLink(testOperand.exampleName).should('exist');
+    cy.byTestID(testOperand.exampleName).should('exist');
     operator.operandShouldExist(testOperator.name, testOperand, testOperator.installedNamespace);
 
     operator.deleteOperand(testOperator.name, testOperand, testOperator.installedNamespace);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-uninstall.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-uninstall.spec.ts
@@ -4,6 +4,7 @@ import { modal } from '../../../integration-tests-cypress/views/modal';
 import { nav } from '../../../integration-tests-cypress/views/nav';
 import { operator, TestOperandProps } from '../views/operator.view';
 
+// TODO Update to valid operator. This is deprecated.
 const testOperator = {
   name: 'Red Hat CodeReady Workspaces',
   operatorHubCardTestID: 'codeready-workspaces-redhat-operators-openshift-marketplace',
@@ -12,8 +13,10 @@ const testOperator = {
 
 const testOperand: TestOperandProps = {
   name: 'CodeReady Workspaces Cluster',
+  group: 'org.eclipse.che',
+  version: 'v1',
   kind: 'CheCluster',
-  tabName: 'CodeReady Workspaces Cluster',
+  createActionID: '', // TODO Define a real selector here when we re-enable this test case
   exampleName: `codeready-workspaces`,
   deleteURL: '/api/kubernetes/apis/org.eclipse.che/*/namespaces/*/checlusters/codeready-workspaces',
 };
@@ -49,7 +52,7 @@ xdescribe(`Testing uninstall of ${testOperator.name} Operator`, () => {
     );
     operator.installedSucceeded(testOperator.name);
     operator.createOperand(testOperator.name, testOperand, testOperator.installedNamespace);
-    cy.byTestOperandLink(testOperand.exampleName).should('exist');
+    cy.byTestID(testOperand.exampleName).should('exist');
     operator.operandShouldExist(testOperator.name, testOperand, testOperator.installedNamespace);
   });
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
 import { useHistory, match } from 'react-router-dom';
-import { ListPageBody } from '@console/dynamic-plugin-sdk';
+import { ListPageBody, K8sModel } from '@console/dynamic-plugin-sdk';
 import { getResources } from '@console/internal/actions/k8s';
 import { Conditions } from '@console/internal/components/conditions';
 import { ErrorPage404 } from '@console/internal/components/error';
@@ -40,6 +40,7 @@ import {
   Timestamp,
   navFactory,
   ResourceLink,
+  AsyncComponent,
 } from '@console/internal/components/utils';
 import {
   useK8sWatchResources,
@@ -73,6 +74,8 @@ import { Status, SuccessStatus } from '@console/shared';
 import ErrorAlert from '@console/shared/src/components/alerts/error';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { useK8sModels } from '@console/shared/src/hooks/useK8sModels';
+import { useResourceDetailsPage } from '@console/shared/src/hooks/useResourceDetailsPage';
+import { useResourceListPage } from '@console/shared/src/hooks/useResourceListPage';
 import { ClusterServiceVersionModel } from '../../models';
 import { ClusterServiceVersionKind, ProvidedAPI } from '../../types';
 import { DescriptorDetailsItem, DescriptorDetailsItemList } from '../descriptors';
@@ -552,7 +555,7 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
   );
 };
 
-export const ProvidedAPIPage: React.FC<ProvidedAPIPageProps> = (props) => {
+const DefaultProvidedAPIPage: React.FC<ProvidedAPIPageProps> = (props) => {
   const { t } = useTranslation();
   const [showOperandsInAllNamespaces] = useShowOperandsInAllNamespaces();
 
@@ -625,6 +628,14 @@ export const ProvidedAPIPage: React.FC<ProvidedAPIPageProps> = (props) => {
       </ListPageBody>
     </ModelStatusBox>
   );
+};
+
+export const ProvidedAPIPage = (props: ProvidedAPIPageProps) => {
+  const resourceListPage = useResourceListPage(props.kind);
+  if (resourceListPage) {
+    return <AsyncComponent {...props} loader={resourceListPage} />;
+  }
+  return <DefaultProvidedAPIPage {...props} />;
 };
 
 const OperandDetailsSection: React.FC = ({ children }) => (
@@ -784,7 +795,7 @@ const ResourcesTab = (resourceProps) => (
   <Resources {...resourceProps} clusterServiceVersion={resourceProps.csv} />
 );
 
-export const OperandDetailsPage = (props: OperandDetailsPageProps) => {
+const DefaultOperandDetailsPage = (props: OperandDetailsPageProps) => {
   const { t } = useTranslation();
   const [model] = useK8sModel(props.match.params.plural);
   const actionExtensions = useExtensions<ClusterServiceVersionAction>(
@@ -850,6 +861,14 @@ export const OperandDetailsPage = (props: OperandDetailsPageProps) => {
   );
 };
 
+export const OperandDetailsPage = (props: OperandDetailsPageProps) => {
+  const resourceDetailsPage = useResourceDetailsPage(props.match.params.plural);
+  if (resourceDetailsPage) {
+    return <AsyncComponent {...props} loader={resourceDetailsPage} />;
+  }
+  return <DefaultOperandDetailsPage {...props} />;
+};
+
 type OperandStatusType = {
   type: string;
   value: string;
@@ -898,6 +917,10 @@ export type ProvidedAPIPageProps = {
   hideLabelFilter?: boolean;
   hideNameLabelFilters?: boolean;
   hideColumnManagement?: boolean;
+  match?: match<{
+    ns: string;
+    plural: string;
+  }>;
 };
 
 type PodStatusesProps = {
@@ -923,6 +946,8 @@ export type OperandDetailsPageProps = {
     plural: string;
   }>;
 };
+
+type DefaultOperandDetailsPage = OperandDetailsPageProps & { model: K8sModel };
 
 export type OperandesourceDetailsProps = {
   csv?: { data: ClusterServiceVersionKind };
@@ -958,6 +983,9 @@ type GetK8sWatchResources = {
 OperandList.displayName = 'OperandList';
 OperandDetails.displayName = 'OperandDetails';
 ProvidedAPIsPage.displayName = 'ProvidedAPIsPage';
+DefaultProvidedAPIPage.displayName = 'DefaultProvidedAPIPage';
+ProvidedAPIPage.displayName = 'ProvidedAPIPage';
+DefaultOperandDetailsPage.displayName = 'DefaultOperandDetailsPage';
 OperandDetailsPage.displayName = 'OperandDetailsPage';
 OperandTableRow.displayName = 'OperandTableRow';
 OperandDetailsSection.displayName = 'OperandDetailsSection';

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
-import { useHistory, match } from 'react-router-dom';
+import { useHistory, match as routerMatch } from 'react-router-dom';
 import { ListPageBody, K8sModel } from '@console/dynamic-plugin-sdk';
 import { getResources } from '@console/internal/actions/k8s';
 import { Conditions } from '@console/internal/components/conditions';
@@ -84,7 +84,6 @@ import { DescriptorType, StatusCapability, StatusDescriptor } from '../descripto
 import { isMainStatusDescriptor } from '../descriptors/utils';
 import { providedAPIsForCSV, referenceForProvidedAPI } from '../index';
 import { Resources } from '../k8s-resource';
-import ModelStatusBox from '../model-status-box';
 import { csvNameFromWindow, OperandLink } from './operand-link';
 import { ShowOperandsInAllNamespacesRadioGroup } from './ShowOperandsInAllNamespacesRadioGroup';
 import { useShowOperandsInAllNamespaces } from './useShowOperandsInAllNamespaces';
@@ -555,7 +554,7 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
   );
 };
 
-const DefaultProvidedAPIPage: React.FC<ProvidedAPIPageProps> = (props) => {
+const DefaultProvidedAPIPage: React.FC<DefaultProvidedAPIPageProps> = (props) => {
   const { t } = useTranslation();
   const [showOperandsInAllNamespaces] = useShowOperandsInAllNamespaces();
 
@@ -569,37 +568,21 @@ const DefaultProvidedAPIPage: React.FC<ProvidedAPIPageProps> = (props) => {
     hideColumnManagement = false,
   } = props;
   const createPath = `/k8s/ns/${csv.metadata.namespace}/${ClusterServiceVersionModel.plural}/${csv.metadata.name}/${apiGroupVersionKind}/~new`;
-  const [model, inFlight] = useK8sModel(apiGroupVersionKind);
-  const [apiRefreshed, setAPIRefreshed] = React.useState(false);
-  const dispatch = useDispatch();
 
-  // Refresh API definitions if model is missing and the definitions have not already been refreshed.
-  const apiMightBeOutdated = !inFlight && !model;
-  React.useEffect(() => {
-    if (!apiRefreshed && apiMightBeOutdated) {
-      dispatch(getResources());
-      setAPIRefreshed(true);
-    }
-  }, [dispatch, apiRefreshed, apiMightBeOutdated]);
-
-  const { apiGroup: group, apiVersion: version, kind, namespaced, label } = model ?? {};
+  const { apiGroup: group, apiVersion: version, kind, namespaced, label } = props.k8sModel;
   const managesAllNamespaces = namespaced && hasAllNamespaces(csv);
   const listAllNamespaces = managesAllNamespaces && showOperandsInAllNamespaces;
-  const [resources, loaded, loadError] = useK8sWatchResource<K8sResourceKind[]>(
-    model
-      ? {
-          groupVersionKind: { group, version, kind },
-          isList: true,
-          namespaced,
-          ...(!listAllNamespaces && namespaced && namespace ? { namespace } : {}),
-        }
-      : {},
-  );
+  const [resources, loaded, loadError] = useK8sWatchResource<K8sResourceKind[]>({
+    groupVersionKind: { group, version, kind },
+    isList: true,
+    namespaced,
+    ...(!listAllNamespaces && namespaced && namespace ? { namespace } : {}),
+  });
 
   const [staticData, filteredData, onFilterChange] = useListPageFilter(resources);
 
   return (
-    <ModelStatusBox groupVersionKind={apiGroupVersionKind}>
+    <>
       <ListPageHeader title={showTitle ? `${label}s` : undefined}>
         {managesAllNamespaces && (
           <div className="co-operator-details__toggle-value pf-u-ml-xl-on-md">
@@ -626,21 +609,47 @@ const DefaultProvidedAPIPage: React.FC<ProvidedAPIPageProps> = (props) => {
           showNamespace={listAllNamespaces}
         />
       </ListPageBody>
-    </ModelStatusBox>
+    </>
   );
 };
 
 export const ProvidedAPIPage = (props: ProvidedAPIPageProps) => {
   const resourceListPage = useResourceListPage(props.kind);
-  if (resourceListPage) {
-    return <AsyncComponent {...props} loader={resourceListPage} />;
-  }
-  return <DefaultProvidedAPIPage {...props} />;
-};
+  const [k8sModel, inFlight] = useK8sModel(props.kind);
+  const [apiRefreshed, setAPIRefreshed] = React.useState(false);
+  const dispatch = useDispatch();
 
-const OperandDetailsSection: React.FC = ({ children }) => (
-  <div className="co-operand-details__section co-operand-details__section--info">{children}</div>
-);
+  // Refresh API definitions if model is missing and the definitions have not already been refreshed.
+  const apiMightBeOutdated = !inFlight && !k8sModel;
+  React.useEffect(() => {
+    if (!apiRefreshed && apiMightBeOutdated) {
+      dispatch(getResources());
+      setAPIRefreshed(true);
+    }
+  }, [dispatch, apiRefreshed, apiMightBeOutdated]);
+
+  if (inFlight && !k8sModel) {
+    return null;
+  }
+
+  if (!k8sModel) {
+    return <ErrorPage404 />;
+  }
+
+  const { apiGroup: group, apiVersion: version, kind } = k8sModel;
+
+  return resourceListPage ? (
+    <AsyncComponent
+      {...props}
+      model={{ group, version, kind }}
+      kind={props.kind}
+      namespace={props.match.params.ns}
+      loader={resourceListPage}
+    />
+  ) : (
+    <DefaultProvidedAPIPage {...props} k8sModel={k8sModel} />
+  );
+};
 
 const PodStatuses: React.FC<PodStatusesProps> = ({ kindObj, obj, podStatusDescriptors, schema }) =>
   podStatusDescriptors?.length > 0 ? (
@@ -795,34 +804,33 @@ const ResourcesTab = (resourceProps) => (
   <Resources {...resourceProps} clusterServiceVersion={resourceProps.csv} />
 );
 
-const DefaultOperandDetailsPage = (props: OperandDetailsPageProps) => {
+const DefaultOperandDetailsPage = ({ match, k8sModel }: DefaultOperandDetailsPageProps) => {
   const { t } = useTranslation();
-  const [model] = useK8sModel(props.match.params.plural);
   const actionExtensions = useExtensions<ClusterServiceVersionAction>(
     isClusterServiceVersionAction,
   );
   const menuActions = React.useMemo(
-    () => getOperandActions(props.match.params.plural, actionExtensions),
-    [props.match.params.plural, actionExtensions],
+    () => getOperandActions(match.params.plural, actionExtensions),
+    [match.params.plural, actionExtensions],
   );
 
-  return model ? (
+  return (
     <DetailsPage
-      match={props.match}
-      name={props.match.params.name}
-      kind={props.match.params.plural}
-      namespace={props.match.params.ns}
+      match={match}
+      name={match.params.name}
+      kind={match.params.plural}
+      namespace={match.params.ns}
       resources={[
         {
           kind: referenceForModel(ClusterServiceVersionModel),
-          name: props.match.params.appName,
-          namespace: props.match.params.ns,
+          name: match.params.appName,
+          namespace: match.params.ns,
           isList: false,
           prop: 'csv',
         },
         {
           kind: CustomResourceDefinitionModel.kind,
-          name: nameForModel(model),
+          name: nameForModel(k8sModel),
           isList: false,
           prop: 'crd',
         },
@@ -832,20 +840,20 @@ const DefaultOperandDetailsPage = (props: OperandDetailsPageProps) => {
       breadcrumbsFor={() => [
         {
           name: t('olm~Installed Operators'),
-          path: `/k8s/ns/${props.match.params.ns}/${ClusterServiceVersionModel.plural}`,
+          path: `/k8s/ns/${match.params.ns}/${ClusterServiceVersionModel.plural}`,
         },
         {
-          name: props.match.params.appName,
-          path: props.match.url.slice(0, props.match.url.lastIndexOf('/')),
+          name: match.params.appName,
+          path: match.url.slice(0, match.url.lastIndexOf('/')),
         },
         {
-          name: t('olm~{{item}} details', { item: kindForReference(props.match.params.plural) }), // Use url param in case model doesn't exist
-          path: `${props.match.url}`,
+          name: t('olm~{{item}} details', { item: kindForReference(match.params.plural) }), // Use url param in case model doesn't exist
+          path: `${match.url}`,
         },
       ]}
       pages={[
         navFactory.details((detailsProps) => (
-          <OperandDetails {...detailsProps} appName={props.match.params.appName} />
+          <OperandDetails {...detailsProps} appName={match.params.appName} />
         )),
         navFactory.editYaml(),
         {
@@ -856,17 +864,33 @@ const DefaultOperandDetailsPage = (props: OperandDetailsPageProps) => {
         navFactory.events(ResourceEventStream),
       ]}
     />
-  ) : (
-    <ErrorPage404 />
   );
 };
 
 export const OperandDetailsPage = (props: OperandDetailsPageProps) => {
   const resourceDetailsPage = useResourceDetailsPage(props.match.params.plural);
-  if (resourceDetailsPage) {
-    return <AsyncComponent {...props} loader={resourceDetailsPage} />;
+  const [k8sModel, inFlight] = useK8sModel(props.match.params.plural);
+  if (inFlight && !k8sModel) {
+    return null;
   }
-  return <DefaultOperandDetailsPage {...props} />;
+
+  if (!k8sModel) {
+    return <ErrorPage404 />;
+  }
+
+  const { apiVersion: version, apiGroup: group, kind } = k8sModel;
+  return resourceDetailsPage ? (
+    <AsyncComponent
+      {...props}
+      model={{ group, version, kind }}
+      namespace={props.match.params.ns}
+      kind={props.match.params.plural} // TODO remove when static plugins are no longer supported
+      name={props.match.params.name} // TODO remove when static plugins are no longer supported
+      loader={resourceDetailsPage}
+    />
+  ) : (
+    <DefaultOperandDetailsPage {...props} k8sModel={k8sModel} />
+  );
 };
 
 type OperandStatusType = {
@@ -917,11 +941,13 @@ export type ProvidedAPIPageProps = {
   hideLabelFilter?: boolean;
   hideNameLabelFilters?: boolean;
   hideColumnManagement?: boolean;
-  match?: match<{
+  match?: routerMatch<{
     ns: string;
     plural: string;
   }>;
 };
+
+type DefaultProvidedAPIPageProps = ProvidedAPIPageProps & { k8sModel: K8sModel };
 
 type PodStatusesProps = {
   kindObj: K8sKind;
@@ -939,7 +965,7 @@ export type OperandDetailsProps = {
 };
 
 export type OperandDetailsPageProps = {
-  match: match<{
+  match: routerMatch<{
     name: string;
     ns: string;
     appName: string;
@@ -947,14 +973,14 @@ export type OperandDetailsPageProps = {
   }>;
 };
 
-type DefaultOperandDetailsPage = OperandDetailsPageProps & { model: K8sModel };
+type DefaultOperandDetailsPageProps = OperandDetailsPageProps & { k8sModel: K8sModel };
 
-export type OperandesourceDetailsProps = {
+export type OperandResourceDetailsProps = {
   csv?: { data: ClusterServiceVersionKind };
   gvk: GroupVersionKind;
   name: string;
   namespace: string;
-  match: match<{ appName: string }>;
+  match: routerMatch<{ appName: string }>;
 };
 
 type Header = {
@@ -988,5 +1014,4 @@ ProvidedAPIPage.displayName = 'ProvidedAPIPage';
 DefaultOperandDetailsPage.displayName = 'DefaultOperandDetailsPage';
 OperandDetailsPage.displayName = 'OperandDetailsPage';
 OperandTableRow.displayName = 'OperandTableRow';
-OperandDetailsSection.displayName = 'OperandDetailsSection';
 PodStatuses.displayName = 'PodStatuses';

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-link.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-link.tsx
@@ -34,6 +34,7 @@ export const OperandLink: React.FC<OperandLinkProps> = (props) => {
         className="co-resource-item__resource-name"
         onClick={props.onClick}
         data-test-operand-link={name}
+        data-test={name}
       >
         {name}
       </Link>

--- a/frontend/packages/operator-lifecycle-manager/src/components/topology/sidebar/TopologyOperatorBackedResources.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/topology/sidebar/TopologyOperatorBackedResources.tsx
@@ -146,7 +146,12 @@ const TopologyOperatorBackedResources: React.FC<TopologyOperatorBackedResourcesP
         {t('olm~Managed by')}{' '}
         <span className="co-resource-item">
           <ResourceIcon kind={kind} />
-          <Link to={link} className="co-resource-item__resource-name" data-test-operand-link={name}>
+          <Link
+            to={link}
+            className="co-resource-item__resource-name"
+            data-test-operand-link={name}
+            data-test={name}
+          >
             {name}
           </Link>
         </span>

--- a/frontend/public/components/factory/ListPage/ListPageCreate.tsx
+++ b/frontend/public/components/factory/ListPage/ListPageCreate.tsx
@@ -76,7 +76,12 @@ export const ListPageCreateDropdown: React.FC<ListPageCreateDropdownProps> = ({
           </DropdownToggle>
         }
         dropdownItems={Object.keys(items).map((key) => (
-          <DropdownItem key={key} component="button" onClick={() => onClick(key)}>
+          <DropdownItem
+            key={key}
+            data-test={`list-page-create-dropdown-item-${key}`}
+            component="button"
+            onClick={() => onClick(key)}
+          >
             {items[key]}
           </DropdownItem>
         ))}

--- a/frontend/public/components/resource-list.tsx
+++ b/frontend/public/components/resource-list.tsx
@@ -83,7 +83,7 @@ export const ResourceListPage = connectToPlural(
 
 export const ResourceDetailsPage = connectToPlural((props: ResourceDetailsPageProps) => {
   const detailsPageExtensions = useExtensions<ResourceDetailsPageExt>(isResourceDetailsPage);
-  const dynamicResourceListPageExtensions = useExtensions<DynamicResourceDetailsPage>(
+  const dynamicResourceDetailsPageExtensions = useExtensions<DynamicResourceDetailsPage>(
     isDynamicResourceDetailsPage,
   );
   const { name, ns, kindObj, kindsInFlight } = allParams(props);
@@ -101,8 +101,8 @@ export const ResourceDetailsPage = connectToPlural((props: ResourceDetailsPagePr
       ? referenceForModel(kindObj)
       : null;
   const componentLoader =
-    getResourceDetailsPages(detailsPageExtensions, dynamicResourceListPageExtensions).get(ref) ||
-    getResourceDetailsPages(detailsPageExtensions, dynamicResourceListPageExtensions).get(
+    getResourceDetailsPages(detailsPageExtensions, dynamicResourceDetailsPageExtensions).get(ref) ||
+    getResourceDetailsPages(detailsPageExtensions, dynamicResourceDetailsPageExtensions).get(
       referenceForExtensionModel({
         group: kindObj.apiGroup,
         kind: kindObj.kind,

--- a/frontend/public/components/utils/managed-by.tsx
+++ b/frontend/public/components/utils/managed-by.tsx
@@ -37,6 +37,7 @@ export const ManagedByOperatorResourceLink: React.SFC<ManagerLinkProps> = ({
             to={ownerIsCSV ? link : `${link}/${ownerGroupVersionKind}/${owner.name}`}
             className="co-resource-item__resource-name"
             data-test-operand-link={owner.name}
+            data-test={owner.name}
           >
             {owner.name}
           </Link>

--- a/frontend/public/components/utils/resource-link.tsx
+++ b/frontend/public/components/utils/resource-link.tsx
@@ -104,13 +104,17 @@ export const ResourceLink: React.FC<ResourceLinkProps> = ({
           title={title}
           className="co-resource-item__resource-name"
           data-test-id={value}
-          data-test={dataTest}
+          data-test={dataTest ?? value}
           onClick={onClick}
         >
           {value}
         </Link>
       ) : (
-        <span className="co-resource-item__resource-name" data-test-id={value} data-test={dataTest}>
+        <span
+          className="co-resource-item__resource-name"
+          data-test-id={value}
+          data-test={dataTest ?? value}
+        >
           {value}
         </span>
       )}


### PR DESCRIPTION
- Update the CSV details page to load and render list and details page extensions for the operands it manages
- Remove container security route extensions that collide with olm create-operand routes