### PR TITLE
Bug 2100103: Can't delete rootdisk in customization wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/main-actions/create-vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/main-actions/create-vm.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../../k8s/enhancedK8sMethods/k8sMethodsUtils';
 import { ResultsWrapper } from '../../../../k8s/enhancedK8sMethods/types';
 import { createVM as _createVM, createVMTemplate } from '../../../../k8s/requests/vm/create/create';
+import { DiskActions, DiskActionsNames } from '../../../../redux/actions/diskActions';
 import {
   SourceRefActions,
   SourceRefActionsNames,
@@ -19,8 +20,8 @@ import { iGetStorages } from '../../selectors/immutable/storage';
 import { iGetVmSettings } from '../../selectors/immutable/vm-settings';
 import {
   getEnableSSHService,
-  getSysprepData,
   getSourceRefData,
+  getSysprepData,
 } from '../../selectors/immutable/wizard-selectors';
 import { iGetHardwareField } from '../../tabs/advanced-tab/hardware-devices/selectors';
 import {
@@ -103,6 +104,7 @@ export const createVMAction = (id: string) => (dispatch, getState) => {
       if (sourceRef) {
         dispatch(SourceRefActions[SourceRefActionsNames.clearValues]());
       }
+      dispatch(DiskActions[DiskActionsNames.setInitialRootdisk]());
       dispatch(
         vmWizardInternalActions[InternalActionType.SetResults](id, tabState, isValid, false, false),
       );

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/main-actions/dispose-wizard.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/main-actions/dispose-wizard.ts
@@ -1,3 +1,4 @@
+import { DiskActions, DiskActionsNames } from '../../../../redux/actions/diskActions';
 import { getProviders } from '../../provider-definitions';
 import { ChangedCommonDataProp } from '../../types';
 import { vmWizardInternalActions } from '../internal-actions';
@@ -16,5 +17,6 @@ export const disposeWizard = (id: string) => (dispatch, getState) => {
 
   getProviders().forEach((provider) => provider.cleanup && provider.cleanup(options));
 
+  dispatch(DiskActions[DiskActionsNames.setInitialRootdisk]());
   dispatch(vmWizardInternalActions[InternalActionType.Dispose](id));
 };

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/storage-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/storage-tab-state-update.ts
@@ -12,6 +12,7 @@ import { winToolsContainerNames } from '../../../../constants/vm/wintools';
 import { DataVolumeWrapper } from '../../../../k8s/wrapper/vm/data-volume-wrapper';
 import { DiskWrapper } from '../../../../k8s/wrapper/vm/disk-wrapper';
 import { VolumeWrapper } from '../../../../k8s/wrapper/vm/volume-wrapper';
+import { DiskActions, DiskActionsNames } from '../../../../redux/actions/diskActions';
 import {
   SourceRefActions,
   SourceRefActionsNames,
@@ -132,12 +133,16 @@ export const prefillInitialDiskUpdater = ({ id, prevState, dispatch, getState }:
         VMWizardProps.storageClassConfigMap,
       );
       const idResolver = getNextIDResolver(getStorages(state, id));
-      dispatch(
-        vmWizardInternalActions[InternalActionType.UpdateStorage](id, {
-          id: oldSourceStorage ? oldSourceStorage.id : idResolver(),
-          ...newSourceStorage,
-        }),
-      );
+      if (state?.plugins?.kubevirt?.disk?.removeRootdisk) {
+        dispatch(
+          vmWizardInternalActions[InternalActionType.UpdateStorage](id, {
+            id: oldSourceStorage ? oldSourceStorage.id : idResolver(),
+            ...newSourceStorage,
+          }),
+        );
+        dispatch(DiskActions[DiskActionsNames.removeRootdisk]());
+      }
+
       if (newSourceStorage.disk.cdrom && !additionalStorage) {
         const emptyDisk = {
           id: idResolver(),

--- a/frontend/packages/kubevirt-plugin/src/redux/actions/diskActions.ts
+++ b/frontend/packages/kubevirt-plugin/src/redux/actions/diskActions.ts
@@ -1,0 +1,25 @@
+export enum DiskActionsNames {
+  removeRootdisk = 'REMOVE_ROOTDISK',
+  setInitialRootdisk = 'SET_INITIAL_ROOTDISK',
+}
+
+type DiskActionsType = (val?: {
+  [key: string]: string;
+}) => {
+  type: string;
+  payload?: { [key: string]: string };
+};
+
+type DiskActions = {
+  [key in DiskActionsNames]: DiskActionsType;
+};
+
+export const DiskActions: DiskActions = {
+  [DiskActionsNames.removeRootdisk]: (val: { [key: string]: string }) => ({
+    type: DiskActionsNames.removeRootdisk,
+    payload: val,
+  }),
+  [DiskActionsNames.setInitialRootdisk]: () => ({
+    type: DiskActionsNames.setInitialRootdisk,
+  }),
+};

--- a/frontend/packages/kubevirt-plugin/src/redux/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/redux/index.ts
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 import createVmWizardReducers from '../components/create-vm-wizard/redux/reducers';
 import authorizedSSHKeysReducer from '../components/ssh-service/redux/reducer';
 import sourceRefReducer from './reducers/sourceRef-reducer';
+import diskReducer from './reducers/storage-new-reducer-delete-rootdisk';
 import sysprepReducer from './reducers/sysprep-reducer';
 import v2vConfigMapReducer from './reducers/v2v-config-map-reducer';
 
@@ -11,4 +12,5 @@ export default combineReducers({
   v2vConfigMap: v2vConfigMapReducer,
   sysprep: sysprepReducer,
   sourceRef: sourceRefReducer,
+  disk: diskReducer,
 });

--- a/frontend/packages/kubevirt-plugin/src/redux/reducers/storage-new-reducer-delete-rootdisk.ts
+++ b/frontend/packages/kubevirt-plugin/src/redux/reducers/storage-new-reducer-delete-rootdisk.ts
@@ -1,0 +1,16 @@
+import { DiskActionsNames } from '../actions/diskActions';
+
+const initialState = { removeRootdisk: true };
+
+const diskReducer = (state = initialState, { type }) => {
+  switch (type) {
+    case DiskActionsNames.removeRootdisk:
+      return { ...state, removeRootdisk: false };
+    case DiskActionsNames.setInitialRootdisk:
+      return { ...initialState };
+    default:
+      return state;
+  }
+};
+
+export default diskReducer;


### PR DESCRIPTION
When trying to delete rootdisk, we have an updater that create rootdisk again, applying a flag to redux store so we can signle when is rootdisk created at first iteration and reset to flag after create vm is successful/ create vm is cancelled

before:

https://user-images.githubusercontent.com/67270715/181292369-6c14204f-2e26-4bcc-a12a-dd8838bd6477.mp4

after:

https://user-images.githubusercontent.com/67270715/181288910-b92c471f-9b4b-48ea-bedc-ffb7c0f4938d.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>