### PR TITLE
[WIP]Upgrade @types/react-redux to v7.1.24

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -256,7 +256,7 @@
     "@types/react-dom": "16.8.4",
     "@types/react-helmet": "5.x",
     "@types/react-jsonschema-form": "^1.3.8",
-    "@types/react-redux": "6.0.2",
+    "@types/react-redux": "7.1.24",
     "@types/react-router-dom": "5.1.2",
     "@types/react-transition-group": "2.x",
     "@types/react-virtualized": "9.x",

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/footer.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/footer.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';

--- a/frontend/packages/ceph-storage-plugin/src/components/disk-inventory/ocs-disks-list.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/disk-inventory/ocs-disks-list.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import * as _ from 'lodash';
 import * as cx from 'classnames';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import {
   Table,

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { match as RouterMatch } from 'react-router';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch } from 'react-redux';
 import {
   Wizard,

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { match as RouterMatch } from 'react-router';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { Alert, Button } from '@patternfly/react-core';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { history, LoadingBox } from '@console/internal/components/utils';

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/external-mode/install.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/external-mode/install.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import * as _ from 'lodash';
 import { match } from 'react-router';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch } from 'react-redux';
 import {
   ButtonBar,

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/internal-mode/install-wizard.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/internal-mode/install-wizard.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { match as RouteMatch } from 'react-router';

--- a/frontend/packages/console-app/src/components/cloud-shell/ExecuteCommand.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/ExecuteCommand.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { useCloudShellCommandDispatch } from '../../redux/actions/cloud-shell-dispatchers';
 import { getCloudShellCommand } from '../../redux/reducers/cloud-shell-selectors';

--- a/frontend/packages/console-app/src/components/detect-cluster/cluster.ts
+++ b/frontend/packages/console-app/src/components/detect-cluster/cluster.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
 import { setActiveCluster } from '@console/dynamic-plugin-sdk/src/app/core/actions';
 import { LAST_CLUSTER_USER_SETTINGS_KEY, HUB_CLUSTER_NAME } from '@console/shared/src/constants';

--- a/frontend/packages/console-app/src/components/detect-namespace/__tests__/namespace.spec.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/__tests__/namespace.spec.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { k8sGet } from '@console/dynamic-plugin-sdk/src/utils/k8s';

--- a/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { setActiveNamespace as setActiveNamespaceForStore } from '@console/internal/actions/ui';

--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -3,9 +3,6 @@ import { sortable } from '@patternfly/react-table';
 import i18next from 'i18next';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector, connect } from 'react-redux';
 import { NodeMetrics, setNodeMetrics } from '@console/internal/actions/ui';
 import { coFetchJSON } from '@console/internal/co-fetch';

--- a/frontend/packages/console-app/src/components/tour/tour-context.ts
+++ b/frontend/packages/console-app/src/components/tour/tour-context.ts
@@ -9,8 +9,6 @@ import {
   useCallback,
 } from 'react';
 import { pick, union, isEqual } from 'lodash';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';

--- a/frontend/packages/console-app/src/redux/actions/cloud-shell-dispatchers.ts
+++ b/frontend/packages/console-app/src/redux/actions/cloud-shell-dispatchers.ts
@@ -1,6 +1,4 @@
 import { useCallback } from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
 import { setCloudShellCommand } from './cloud-shell-actions';
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/useReduxStore.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/useReduxStore.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useStore } from 'react-redux';
 import { applyMiddleware, combineReducers, createStore, compose, Store } from 'redux';
 import thunk from 'redux-thunk';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/flags.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/flags.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector } from 'react-redux';
 import { FeatureSubStore } from '../app/features';
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/k8s-watch-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/k8s-watch-types.ts
@@ -1,4 +1,4 @@
-import { Dispatch } from 'react-redux';
+import { Dispatch } from 'redux';
 import { K8sModel } from '../../../api/common-types';
 import { SDKStoreState } from '../../../app/redux-types';
 import { WatchK8sResource } from '../../../extensions/console-types';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sModel.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sModel.ts
@@ -1,7 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { K8sModel } from '../../../api/common-types';
+import { SDKStoreState } from '../../../app/redux-types';
 import {
   UseK8sModel,
   K8sResourceKindReference,
@@ -33,6 +32,6 @@ export const getK8sModel = (
  * ```
  */
 export const useK8sModel: UseK8sModel = (k8sGroupVersionKind) => [
-  useSelector(({ k8s }) => getK8sModel(k8s, k8sGroupVersionKind)),
-  useSelector(({ k8s }) => k8s.getIn(['RESOURCES', 'inFlight']) ?? false),
+  useSelector<SDKStoreState, K8sModel>(({ k8s }) => getK8sModel(k8s, k8sGroupVersionKind)),
+  useSelector<SDKStoreState, boolean>(({ k8s }) => k8s.getIn(['RESOURCES', 'inFlight']) ?? false),
 ];

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sModels.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sModels.ts
@@ -1,6 +1,7 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { Map as ImmutableMap } from 'immutable';
 import { useSelector } from 'react-redux';
+import { K8sModel } from '../../../api/common-types';
+import { SDKStoreState } from '../../../app/redux-types';
 import { UseK8sModels } from '../../../extensions/console-types';
 
 /**
@@ -16,6 +17,8 @@ import { UseK8sModels } from '../../../extensions/console-types';
  * ```
  */
 export const useK8sModels: UseK8sModels = () => [
-  useSelector(({ k8s }) => k8s.getIn(['RESOURCES', 'models']))?.toJS() ?? {},
-  useSelector(({ k8s }) => k8s.getIn(['RESOURCES', 'inFlight'])) ?? false,
+  useSelector<SDKStoreState, ImmutableMap<string, K8sModel>>(({ k8s }) =>
+    k8s.getIn(['RESOURCES', 'models']),
+  )?.toJS() ?? {},
+  useSelector<SDKStoreState, boolean>(({ k8s }) => k8s.getIn(['RESOURCES', 'inFlight'])) ?? false,
 ];

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { Map as ImmutableMap } from 'immutable';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector, useDispatch } from 'react-redux';
 import { getActiveCluster } from '../../../app/core/reducers/coreSelectors';
 import * as k8sActions from '../../../app/k8s/actions/k8s';
@@ -29,7 +27,7 @@ import { useModelsLoaded } from './useModelsLoaded';
  * ```
  */
 export const useK8sWatchResource: UseK8sWatchResource = (initResource) => {
-  const cluster = useSelector((state) => getActiveCluster(state));
+  const cluster = useSelector<SDKStoreState, string>((state) => getActiveCluster(state));
   const resource = useDeepCompareMemoize(initResource, true);
   const modelsLoaded = useModelsLoaded();
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { Map as ImmutableMap } from 'immutable';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { Map as ImmutableMap, Iterable } from 'immutable';
 import { useSelector, useDispatch } from 'react-redux';
 import { createSelectorCreator, defaultMemoize } from 'reselect';
 import { K8sModel } from '../../../api/common-types';
@@ -50,7 +48,7 @@ export const useK8sWatchResources: UseK8sWatchResources = (initResources) => {
   const prevK8sModels = usePrevious(allK8sModels);
   const prevResources = usePrevious(resources);
 
-  const k8sModelsRef = React.useRef<ImmutableMap<string, K8sModel>>(ImmutableMap());
+  const k8sModelsRef = React.useRef<Iterable<string, K8sModel>>(Iterable(ImmutableMap()));
 
   if (
     prevResources !== resources ||

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useModelsLoaded.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useModelsLoaded.ts
@@ -1,16 +1,15 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { Map as ImmutableMap } from 'immutable';
 import { useSelector } from 'react-redux';
 import { K8sModel } from '../../../api/common-types';
 import { OpenShiftReduxRootState } from './k8s-watch-types';
 
 export const useModelsLoaded = (): boolean => {
   const ref = React.useRef(false);
-  const k8sModels = useSelector<OpenShiftReduxRootState, K8sModel>(({ k8s }) =>
-    k8s.getIn(['RESOURCES', 'models']),
+  const k8sModels = useSelector<OpenShiftReduxRootState, ImmutableMap<string, K8sModel>>(
+    ({ k8s }) => k8s.getIn(['RESOURCES', 'models']),
   );
-  const inFlight = useSelector<OpenShiftReduxRootState, K8sModel>(({ k8s }) =>
+  const inFlight = useSelector<OpenShiftReduxRootState, boolean>(({ k8s }) =>
     k8s.getIn(['RESOURCES', 'inFlight']),
   );
 

--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/prometheus-hook.ts
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/prometheus-hook.ts
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { createSelectorCreator, defaultMemoize } from 'reselect';
 import {

--- a/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
@@ -1,7 +1,4 @@
 import { act } from 'react-dom/test-utils';
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector } from 'react-redux';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ConfigMapKind } from '@console/internal/module/k8s';

--- a/frontend/packages/console-shared/src/hooks/redux-selectors.ts
+++ b/frontend/packages/console-shared/src/hooks/redux-selectors.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 
 export const useActiveNamespace = (): string => {

--- a/frontend/packages/console-shared/src/hooks/useDashboardResources.ts
+++ b/frontend/packages/console-shared/src/hooks/useDashboardResources.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
 import {
   RequestMap,

--- a/frontend/packages/console-shared/src/hooks/useLocation.ts
+++ b/frontend/packages/console-shared/src/hooks/useLocation.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { RootState } from '@console/internal/redux';
 

--- a/frontend/packages/console-shared/src/hooks/useNotificationAlerts.ts
+++ b/frontend/packages/console-shared/src/hooks/useNotificationAlerts.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector } from 'react-redux';
 import { HIDE_USER_WORKLOAD_NOTIFICATIONS_USER_SETTINGS_KEY } from '@console/app/src/consts';
 import { Alert } from '@console/dynamic-plugin-sdk';

--- a/frontend/packages/console-shared/src/hooks/useTabbedTableBreadcrumb.ts
+++ b/frontend/packages/console-shared/src/hooks/useTabbedTableBreadcrumb.ts
@@ -1,8 +1,5 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector } from 'react-redux';
 import { match as RMatch } from 'react-router-dom';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';

--- a/frontend/packages/console-shared/src/hooks/useUserSettings.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettings.ts
@@ -1,7 +1,4 @@
 import * as React from 'react';
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector } from 'react-redux';
 import { getImpersonate, getUser } from '@console/dynamic-plugin-sdk';
 import { UseUserSettings } from '@console/dynamic-plugin-sdk/src/api/internal-types';

--- a/frontend/packages/console-shared/src/hooks/useUtilizationDuration.ts
+++ b/frontend/packages/console-shared/src/hooks/useUtilizationDuration.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector, useDispatch } from 'react-redux';
 import { UseUtilizationDuration } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 import * as UIActions from '@console/internal/actions/ui';

--- a/frontend/packages/console-shared/src/hooks/version.ts
+++ b/frontend/packages/console-shared/src/hooks/version.ts
@@ -1,6 +1,4 @@
 import { useEffect, useState } from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ClusterVersionModel } from '@console/internal/models';

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlerts.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlerts.tsx
@@ -3,9 +3,6 @@ import { Table, TableHeader, TableBody, SortByDirection } from '@patternfly/reac
 import * as _ from 'lodash';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch, connect } from 'react-redux';
 import { match as RMatch } from 'react-router-dom';
 import { RowFilter as RowFilterExt } from '@console/dynamic-plugin-sdk';

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlertsRulesDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlertsRulesDetailsPage.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch } from 'react-redux';
 import { match as RMatch } from 'react-router';
 import { alertingLoaded, alertingSetRules } from '@console/internal/actions/observe';

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceAlert.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceAlert.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import { Switch } from '@patternfly/react-core';
 import * as _ from 'lodash';
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch } from 'react-redux';
 import { alertingSetRules } from '@console/internal/actions/observe';
 import { coFetchJSON } from '@console/internal/co-fetch';

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector, useDispatch } from 'react-redux';
 import { getUser } from '@console/dynamic-plugin-sdk';
 import { alertingSetRules } from '@console/internal/actions/observe';

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/__tests__/MonitoringAlerts.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/__tests__/MonitoringAlerts.spec.tsx
@@ -22,14 +22,10 @@ describe('MonitoringAlerts', () => {
     filters: Map({}),
     listSorts: Map({}),
   };
-  // FIXME upgrading redux types is causing many errors at this time
-  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-  // @ts-ignore
+
   const spySelector = jest.spyOn(redux, 'useSelector');
   spySelector.mockReturnValue({ monitoring: { devRules: [] } });
-  // FIXME upgrading redux types is causing many errors at this time
-  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-  // @ts-ignore
+
   const spyDispatch = jest.spyOn(redux, 'useDispatch');
   spyDispatch.mockReturnValue(() => {});
 

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/monitoring-alerts-utils.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/monitoring-alerts-utils.tsx
@@ -2,9 +2,6 @@ import * as React from 'react';
 import { SortByDirection } from '@patternfly/react-table';
 import i18next from 'i18next';
 import * as _ from 'lodash';
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
 import {

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { Card, CardBody, CardHeader, CardTitle, CardActions } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { dashboardsSetEndTime, dashboardsSetTimespan } from '@console/internal/actions/observe';

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboardGraph.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboardGraph.spec.tsx
@@ -7,9 +7,6 @@ import { monitoringDashboardQueries } from '../../queries';
 import { MonitoringDashboardGraph, GraphTypes } from '../MonitoringDashboardGraph';
 
 describe('Monitoring Dashboard graph', () => {
-  // FIXME upgrading redux types is causing many errors at this time
-  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-  // @ts-ignore
   const spyDispatch = jest.spyOn(redux, 'useDispatch');
   spyDispatch.mockReturnValue(() => {});
   let monitoringDashboardGraphProps: React.ComponentProps<typeof MonitoringDashboardGraph>;

--- a/frontend/packages/dev-console/src/components/monitoring/metrics/MetricsQueryInput.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/metrics/MetricsQueryInput.tsx
@@ -3,9 +3,6 @@ import { Button } from '@patternfly/react-core';
 import * as fuzzy from 'fuzzysearch';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector, useDispatch } from 'react-redux';
 import {
   queryBrowserRunQueries,

--- a/frontend/packages/dev-console/src/components/monitoring/metrics/QueryInput.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/metrics/QueryInput.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import * as fuzzy from 'fuzzysearch';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
 import { queryBrowserPatchQuery, queryBrowserRunQueries } from '@console/internal/actions/observe';
 import { RootState } from '@console/internal/redux';

--- a/frontend/packages/dev-console/src/components/monitoring/metrics/__tests__/MetricsQueryInput.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/metrics/__tests__/MetricsQueryInput.spec.tsx
@@ -7,14 +7,8 @@ import MetricsQueryInput from '../MetricsQueryInput';
 import { QueryInput } from '../QueryInput';
 
 describe('Metrics Query Input', () => {
-  // FIXME upgrading redux types is causing many errors at this time
-  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-  // @ts-ignore
   const spySelector = jest.spyOn(redux, 'useSelector');
   spySelector.mockReturnValue({ queryBrowser: { queries: [] } });
-  // FIXME upgrading redux types is causing many errors at this time
-  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-  // @ts-ignore
   const spyDispatch = jest.spyOn(redux, 'useDispatch');
   spyDispatch.mockReturnValue(() => {});
   it('should render Dropdown with default title', () => {

--- a/frontend/packages/dev-console/src/utils/__tests__/usePerspectiveDetection.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/usePerspectiveDetection.spec.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { testHook } from '../../../../../__tests__/utils/hooks-utils';
 import { usePerspectiveDetection } from '../perspective';

--- a/frontend/packages/dev-console/src/utils/perspective.tsx
+++ b/frontend/packages/dev-console/src/utils/perspective.tsx
@@ -1,6 +1,4 @@
 import { CodeIcon } from '@patternfly/react-icons';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { Perspective, ResolvedExtension } from '@console/dynamic-plugin-sdk';
 import { getFlagsObject, flagPending } from '@console/internal/reducers/features';

--- a/frontend/packages/gitops-plugin/src/components/utils/useDefaultSecret.tsx
+++ b/frontend/packages/gitops-plugin/src/components/utils/useDefaultSecret.tsx
@@ -1,7 +1,4 @@
 import * as _ from 'lodash';
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector } from 'react-redux';
 import { userStateToProps } from '@console/internal/reducers/ui';
 

--- a/frontend/packages/knative-plugin/src/components/add/EventSink.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSink.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { Formik } from 'formik';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { Perspective, isPerspective, useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { k8sCreateResource } from '@console/dynamic-plugin-sdk/src/utils/k8s';

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSink.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSink.spec.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { Formik } from 'formik';
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector } from 'react-redux';
 import { mockKameletSink, mockNormalizedSink } from '../__mocks__/Kamelet-data';
 import EventSink from '../EventSink';

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/advanced-tab/cloud-init/Cloudinit.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/advanced-tab/cloud-init/Cloudinit.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import yamlParser from 'js-yaml';
 import { isEmpty, isEqual } from 'lodash';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { RootStateOrAny, useDispatch, useSelector } from 'react-redux';
 import useCloudinitValidations from '../../../../../hooks/use-cloudinit-validations';
 import useSSHKeys from '../../../../../hooks/use-ssh-keys';

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/advanced-tab/sysprep/SysprepFileField.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/advanced-tab/sysprep/SysprepFileField.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { FileUpload, Text, TextVariants } from '@patternfly/react-core';
 import { isEmpty } from 'lodash';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
 import xml from 'xml2js';
 import { SysprepActions, SysprepActionsNames } from '../../../../../redux/actions/sysprep-actions';

--- a/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHForm/SSHFormKey/SSHFormKey.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHForm/SSHFormKey/SSHFormKey.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { Button, FileUpload, Flex, FlexItem } from '@patternfly/react-core';
 import { isEmpty } from 'lodash';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
 import sshpk from 'sshpk';
 import useSSHKeys from '../../../../hooks/use-ssh-keys';

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-cloudinit-validations.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-cloudinit-validations.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
 import { vmWizardInternalActions } from '../components/create-vm-wizard/redux/internal-actions';
 import { InternalActionType } from '../components/create-vm-wizard/redux/types';

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-namespace.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-namespace.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { getActiveNamespace } from '@console/internal/actions/ui';
 import { ALL_NAMESPACES_KEY } from '../constants';

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-ssh-selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-ssh-selectors.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { RootStateOrAny, useDispatch, useSelector } from 'react-redux';
 import { sshActions, SSHActionsNames } from '../components/ssh-service/redux/actions';
 

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-ssh-service.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-ssh-service.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ServiceModel } from '@console/internal/models';

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-v2v-config-map.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-v2v-config-map.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { isEmpty } from 'lodash';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
 import { VIRTIO_WIN_IMAGE } from '../constants/vm/constants';
 import { getVmwareConfigMap } from '../k8s/requests/v2v/v2vvmware-configmap';

--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
@@ -5,8 +5,6 @@ import * as classNames from 'classnames';
 import { Map as ImmutableMap, Set as ImmutableSet, fromJS } from 'immutable';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { match, Link } from 'react-router-dom';
 import { getUser } from '@console/dynamic-plugin-sdk';

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -4,8 +4,6 @@ import * as classNames from 'classnames';
 import { JSONSchema7 } from 'json-schema';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
 import { useHistory, match } from 'react-router-dom';
 import { ListPageBody } from '@console/dynamic-plugin-sdk';

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/useShowOperandsInAllNamespaces.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/useShowOperandsInAllNamespaces.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector, useDispatch } from 'react-redux';
 import * as UIActions from '@console/internal/actions/ui';
 import { RootState } from '@console/internal/redux';

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/triggered-by/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/triggered-by/hooks.ts
@@ -1,7 +1,5 @@
 import { merge } from 'lodash';
 // FIXME react-redux types are 6.x while react-redux is 7.x
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector } from 'react-redux';
 import { getUser } from '@console/dynamic-plugin-sdk';
 import { KebabAction, Kebab } from '@console/internal/components/utils';

--- a/frontend/packages/topology/src/components/side-bar/components/SideBarBody.tsx
+++ b/frontend/packages/topology/src/components/side-bar/components/SideBarBody.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector, useDispatch } from 'react-redux';
 import * as UIActions from '@console/internal/actions/ui';
 import { SimpleTabNav, Tab } from '@console/internal/components/utils';

--- a/frontend/packages/topology/src/utils/useOverviewMetrics.ts
+++ b/frontend/packages/topology/src/utils/useOverviewMetrics.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { RootState } from '@console/internal/redux';
 

--- a/frontend/public/components/factory/list-page.tsx
+++ b/frontend/public/components/factory/list-page.tsx
@@ -1,8 +1,6 @@
 import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { connect, useDispatch } from 'react-redux';
 import { Link, match as RMatch } from 'react-router-dom';
 import { Button, TextInput, TextInputProps } from '@patternfly/react-core';

--- a/frontend/public/components/factory/table-data-hook.ts
+++ b/frontend/public/components/factory/table-data-hook.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { createSelectorCreator, defaultMemoize } from 'reselect';
 import { SortByDirection } from '@patternfly/react-table';

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -1,7 +1,5 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
 import { match as RMatch } from 'react-router-dom';
 import {

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { useLocation } from 'react-router-dom';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch } from 'react-redux';
 import {
   Badge,

--- a/frontend/public/components/modals/delete-namespace-modal.tsx
+++ b/frontend/public/components/modals/delete-namespace-modal.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@console/internal/redux';
 import { k8sKill, K8sKind, K8sResourceKind } from '@console/internal/module/k8s';

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -12,8 +12,6 @@ import { sortable } from '@patternfly/react-table';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
 import { Link, Redirect, Route, Switch } from 'react-router-dom';
 import {

--- a/frontend/public/components/monitoring/dashboards/custom-time-range-modal.tsx
+++ b/frontend/public/components/monitoring/dashboards/custom-time-range-modal.tsx
@@ -1,8 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
 
 import { DatePicker, TimePicker } from '@patternfly/react-core';

--- a/frontend/public/components/monitoring/dashboards/graph.tsx
+++ b/frontend/public/components/monitoring/dashboards/graph.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
 
 import { dashboardsSetEndTime, dashboardsSetTimespan } from '../../../actions/observe';

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -15,8 +15,6 @@ import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
 import { Link } from 'react-router-dom';

--- a/frontend/public/components/monitoring/dashboards/timespan-dropdown.tsx
+++ b/frontend/public/components/monitoring/dashboards/timespan-dropdown.tsx
@@ -2,8 +2,6 @@ import * as _ from 'lodash';
 import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
 
 import { dashboardsSetEndTime, dashboardsSetTimespan } from '../../../actions/observe';

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -29,8 +29,6 @@ import {
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
 
 import { PrometheusEndpoint } from '@console/dynamic-plugin-sdk/src/api/common-types';

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -27,8 +27,6 @@ import {
 } from '@patternfly/react-core';
 import { ChartLineIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
 import { VictoryPortal } from 'victory-core';
 

--- a/frontend/public/components/monitoring/silence-form.tsx
+++ b/frontend/public/components/monitoring/silence-form.tsx
@@ -4,8 +4,6 @@ import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { Trans, useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector } from 'react-redux';
 import { getUser } from '@console/dynamic-plugin-sdk';
 

--- a/frontend/public/components/monitoring/targets.tsx
+++ b/frontend/public/components/monitoring/targets.tsx
@@ -4,8 +4,6 @@ import { sortable } from '@patternfly/react-table';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector } from 'react-redux';
 import { Link, Route, RouteComponentProps, Switch, withRouter } from 'react-router-dom';
 

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -14,9 +14,6 @@ import {
 } from '@patternfly/react-core';
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';

--- a/frontend/public/components/nav/NavHeader.tsx
+++ b/frontend/public/components/nav/NavHeader.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch } from 'react-redux';
 import { Dropdown, DropdownItem, DropdownToggle, Title } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -2,8 +2,6 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { connect, useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
 import {

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch, connect } from 'react-redux';
 import { sortable } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -1,7 +1,4 @@
 import * as React from 'react';
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { sortable } from '@patternfly/react-table';

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import {

--- a/frontend/public/components/utils/resource-log.tsx
+++ b/frontend/public/components/utils/resource-log.tsx
@@ -1,7 +1,4 @@
 import * as React from 'react';
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector } from 'react-redux';
 import { Base64 } from 'js-base64';
 import {

--- a/frontend/public/components/utils/service-level.tsx
+++ b/frontend/public/components/utils/service-level.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { Alert, Label, Skeleton } from '@patternfly/react-core';
 import { NotificationEntry, NotificationTypes } from '@console/patternfly';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import * as UIActions from '@console/internal/actions/ui';

--- a/frontend/public/components/utils/timestamp.tsx
+++ b/frontend/public/components/utils/timestamp.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { Tooltip } from '@patternfly/react-core';
 import * as classNames from 'classnames';

--- a/frontend/public/module/k8s/k8s-models.ts
+++ b/frontend/public/module/k8s/k8s-models.ts
@@ -1,7 +1,5 @@
 import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash-es';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useSelector } from 'react-redux';
 
 import { K8sResourceKindReference, K8sKind, getModelExtensionMetadata } from './index';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2667,7 +2667,7 @@
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
 
-"@types/hoist-non-react-statics@^3.3.1":
+"@types/hoist-non-react-statics@^3.3.0", "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
   integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
@@ -2887,11 +2887,14 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-redux@6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-6.0.2.tgz#10069b53db8e0920fd8656e068dcf10c53c9ad2a"
+"@types/react-redux@7.1.24":
+  version "7.1.24"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.24.tgz#6caaff1603aba17b27d20f8ad073e4c077e975c0"
+  integrity sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==
   dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
     "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
 
 "@types/react-router-dom@5.1.2":


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-6493

Due to out-of-sync @types/react-redux version few imports such as `useSelector` from `react-redux` was showing errors. So `ts-ignore` was used and also because of that `@typescript-eslint/ban-ts-ignore` rule was disabled for these lines. This PR:

- Upgrades  @types/react-redux to v7.1.24
- Removes `ts-ignore` and enables `@typescript-eslint/ban-ts-ignore`
- Refactors code according to the upgraded version
