### PR TITLE
Bug 2070562: Base64 data value for java keystore secret changing auto…

### DIFF
--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -153,7 +153,7 @@ export const SecretFormWrapper = withTranslation()(
         inProgress: false,
         type: defaultSecretType,
         stringData: _.mapValues(_.get(props.obj, 'data'), (value) => {
-          return value ? Base64.decode(value) : '';
+          return value ? Base64.atob(value) : '';
         }),
         disableForm: false,
       };
@@ -194,7 +194,7 @@ export const SecretFormWrapper = withTranslation()(
       this.setState({ inProgress: true });
       const data = {
         ..._.mapValues(this.state.stringData, (value) => {
-          return Base64.encode(value);
+          return Base64.btoa(value);
         }),
         ...this.state?.base64StringData,
       };


### PR DESCRIPTION
…matically, when we edit it from the console and saving it without doing any changes

Prevents base64 data value of java keystore secret from being changed when no changes have been made.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2070562