### PR TITLE
Gherkin for Builds v2 in Dev Console - Topology

### DIFF
--- a/frontend/packages/shipwright-plugin/integration-tests/features/shipwright-build-in-topology.feature
+++ b/frontend/packages/shipwright-plugin/integration-tests/features/shipwright-build-in-topology.feature
@@ -1,0 +1,71 @@
+@shipwright @odc-5387
+Feature: Shipwright build in topolgy
+              As a user, I want check my Shipwright Build in topology.
+
+        Background:
+            Given user has installed OpenShift Pipelines Operator
+              And user is at developer perspective
+              And user has created or selected namespace "aut-shipwright-build-details"
+              And user has installed Shipwright Operator
+              And user is at Add page
+              And user has created shipwright builds
+
+
+        @smoke @to-do
+        Scenario Outline: Sidebar for workload with shipwright build: SWB-02-TC01
+            Given user has created workload using yaml "<workload_yaml>"
+              And user is at the Topology page
+             When user clicks on workload "<workload_name>"
+              And user clicks on Resource tab
+             Then user will see Shipwright BuildRuns
+
+        Examples:
+                  | workload_yaml                                                    | workload_name               |
+                  | testData/builds/201-full-openshift-deployment-example.yaml       | sw-deployment-example       |
+                  | testData/builds/202-full-openshift-deploymentconfig-example.yaml | sw-deploymentconfig-example |
+                  | testData/builds/203-full-openshift-knative-service-example.yaml  | sw-knative-service-example  |
+
+
+        @regression @to-do
+        Scenario Outline: Shipwright build decorator in topology: SWB-02-TC02
+            Given user has created workload "<workload_name>"
+              And user is at the Topology page
+             When user clicks on build decorator for workload "<workload_name>"
+             Then user will see "Shipwright Builds" tab
+
+        Examples:
+                  | workload_name               |
+                  | sw-deployment-example       |
+                  | sw-deploymentconfig-example |
+                  | sw-knative-service-example  |
+
+
+        @regression @to-do
+        Scenario Outline: Check Shipwright buildrun from topology: SWB-02-TC03
+            Given user has created workload using yaml "<workload_yaml>"
+              And user is at Shipwright Builds details page for build "<build_name>"
+             When user selects "Start Build" from the action menu
+              And user navigates to Topology page
+             Then user will see build running for "<workload_yaml>"
+
+        Examples:
+                  | build_name                        | workload_name               |
+                  | sw-deployment-example-build       | sw-deployment-example       |
+                  | sw-deploymentconfig-example-build | sw-deploymentconfig-example |
+                  | sw-knative-service-example-build  | sw-knative-service-example  |
+
+
+        @regression @to-do
+        Scenario Outline: View logs for shipwright buildrun: SWB-02-TC04
+            Given user has created workload "<workload_name>"
+              And user is at the Topology page
+             When user clicks on workload "<workload_name>"
+              And user clicks on Resource tab
+              And user clicks on View logs button for build run
+             Then user will see Shipwright BuildRuns logs
+
+        Examples:
+                  | workload_name               |
+                  | sw-deployment-example       |
+                  | sw-deploymentconfig-example |
+                  | sw-knative-service-example  |

--- a/frontend/packages/shipwright-plugin/integration-tests/testData/workload/201-full-openshift-deployment-example.yaml
+++ b/frontend/packages/shipwright-plugin/integration-tests/testData/workload/201-full-openshift-deployment-example.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sw-deployment-example
+  labels:
+    app.kubernetes.io/part-of: sw-deployment-app
+  annotations:
+    image.openshift.io/triggers: >-
+      [{"from":{"kind":"ImageStreamTag","name":"sw-deployment-example:latest","namespace":"build-examples"},"fieldPath":"spec.template.spec.containers[?(@.name==\"container\")].image","pause":"false"}]
+spec:
+  selector:
+    matchLabels:
+      app: sw-deployment-example
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: sw-deployment-example
+    spec:
+      containers:
+        - name: container
+          image: >-
+            image-registry.openshift-image-registry.svc:5000/build-examples/sw-deployment-example:latest
+---
+apiVersion: shipwright.io/v1alpha1
+kind: Build
+metadata:
+  name: sw-deployment-example-build
+spec:
+  source:
+    url: https://github.com/shipwright-io/sample-nodejs
+    contextDir: source-build
+  strategy:
+    name: buildpacks-v3
+    kind: BuildStrategy
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/sw-deployment-example
+---
+apiVersion: shipwright.io/v1alpha1
+kind: BuildRun
+metadata:
+  generateName: sw-deployment-example-buildrun-
+spec:
+  buildRef:
+    name: sw-deployment-example-build
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sw-deployment-example-service
+  labels:
+    app.kubernetes.io/component: sw-deployment-example
+spec:
+  ports:
+    - name: 8080-tcp
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: sw-deployment-example
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: sw-deployment-example-route
+  labels:
+    app.kubernetes.io/component: sw-deployment-example
+spec:
+  to:
+    kind: Service
+    name: sw-deployment-example-service
+    weight: 100
+  port:
+    targetPort: 8080-tcp

--- a/frontend/packages/shipwright-plugin/integration-tests/testData/workload/202-full-openshift-deploymentconfig-example.yaml
+++ b/frontend/packages/shipwright-plugin/integration-tests/testData/workload/202-full-openshift-deploymentconfig-example.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: sw-deploymentconfig-example
+  labels:
+    app.kubernetes.io/part-of: sw-deploymentconfig-app
+spec:
+  selector:
+    app: sw-deploymentconfig-example
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: sw-deploymentconfig-example
+    spec:
+      containers:
+        - name: container
+          image: >-
+            image-registry.openshift-image-registry.svc:5000/build-examples/sw-deploymentconfig-example:latest
+  triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - container
+        from:
+          kind: ImageStreamTag
+          name: 'sw-deploymentconfig-example:latest'
+---
+apiVersion: shipwright.io/v1alpha1
+kind: Build
+metadata:
+  name: sw-deploymentconfig-example-build
+spec:
+  source:
+    url: https://github.com/shipwright-io/sample-nodejs
+    contextDir: source-build
+  strategy:
+    name: buildpacks-v3
+    kind: BuildStrategy
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/sw-deploymentconfig-example
+---
+apiVersion: shipwright.io/v1alpha1
+kind: BuildRun
+metadata:
+  generateName: sw-deploymentconfig-example-buildrun-
+spec:
+  buildRef:
+    name: sw-deploymentconfig-example-build
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sw-deploymentconfig-example-service
+  labels:
+    app.kubernetes.io/component: sw-deploymentconfig-example
+spec:
+  ports:
+    - name: 8080-tcp
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: sw-deploymentconfig-example
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: sw-deploymentconfig-example-route
+  labels:
+    app.kubernetes.io/component: sw-deploymentconfig-example
+spec:
+  to:
+    kind: Service
+    name: sw-deploymentconfig-example-service
+    weight: 100
+  port:
+    targetPort: 8080-tcp

--- a/frontend/packages/shipwright-plugin/integration-tests/testData/workload/203-full-openshift-knative-service-example.yaml
+++ b/frontend/packages/shipwright-plugin/integration-tests/testData/workload/203-full-openshift-knative-service-example.yaml
@@ -1,0 +1,41 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: sw-knative-service-example
+  labels:
+    app.kubernetes.io/part-of: sw-knative-service-app
+  annotations:
+    image.openshift.io/triggers: >-
+      [{"from":{"kind":"ImageStreamTag","name":"sw-knative-service-example:latest","namespace":"build-examples"},"fieldPath":"spec.template.spec.containers[?(@.name==\"container\")].image","pause":"false"}]
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: sw-knative-service-example
+    spec:
+      containers:
+        - name: container
+          image: >-
+            image-registry.openshift-image-registry.svc:5000/build-examples/sw-knative-service-example:latest
+---
+apiVersion: shipwright.io/v1alpha1
+kind: Build
+metadata:
+  name: sw-knative-service-example-build
+spec:
+  source:
+    url: https://github.com/shipwright-io/sample-nodejs
+    contextDir: source-build
+  strategy:
+    name: buildpacks-v3
+    kind: BuildStrategy
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/sw-knative-service-example
+---
+apiVersion: shipwright.io/v1alpha1
+kind: BuildRun
+metadata:
+  generateName: sw-knative-service-example-buildrun-
+spec:
+  buildRef:
+    name: sw-knative-service-example-build


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-5387
Story: https://issues.redhat.com/browse/ODC-6757

Acceptance criteria:

- The lower left hand decorator of a that node should provide the status of the latest Build Run, similar to Builds v1 and Pipeline / PipelineRuns.
- Clicking on the Build decorator should navigate to the BuildRun logs page
- When the D/DC node is selected, the Resources tab should have a *BuildRun*s section.
    - The Build should be shown as the first item in the BuildRuns section
        - The user should be able to click on that Build link to navigate directly to the Build page
        - The user should have an option to "Start Build"
    - Additionally, BuildRuns should be shown as additional rows , each with a View logs link 

**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]
