### PR TITLE
Bug 2112146: Update pod YAML sample for restricted pod security admission policy

### DIFF
--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -379,11 +379,20 @@ metadata:
   labels:
     app: httpd
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: httpd
       image: image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest
       ports:
         - containerPort: 8080
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
 `,
   )
   .setIn(


### PR DESCRIPTION
The sample pod template should set security context values allowed by
the `restricted` policy level for the pod security admission controller,
which will be enabled by default in OpenShift.

https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted

cc @jerolimov 