### PR TITLE
Bug 2084504: can not silence platform alert from developer console

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.tsx
@@ -35,6 +35,8 @@ const durations = {
   '1d': '1 day',
 };
 
+const externalLabelFilter = ({ name }: { name: string }) => name !== 'prometheus';
+
 const SilenceDurationDropDown: React.FC<SilenceDurationDropDownProps> = ({
   rule,
   silenceInProgress,
@@ -54,7 +56,7 @@ const SilenceDurationDropDown: React.FC<SilenceDurationDropDownProps> = ({
       value: rule.name,
     },
     ...ruleMatchers,
-  ];
+  ].filter(externalLabelFilter);
 
   const setDuration = (duration: string) => {
     const startsAt = new Date();


### PR DESCRIPTION
Exclude the external label when creating a silence from the dev perspective

Fixes: https://bugzilla.redhat.com/show_bug.cgi\?id\=2084504