### PR TITLE
Bug 1951901: incorrect Worker nodes number calculated when nodes have…

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -26,7 +26,7 @@ import { NodeKind, referenceForModel } from '@console/internal/module/k8s';
 import {
   getName,
   getUID,
-  getNodeRole,
+  getNodeRoleMatch,
   getLabels,
   getNodeMachineNameAndNamespace,
   WithUserSettingsCompatibilityProps,
@@ -508,7 +508,7 @@ const NodesPage = connect<{}, MapDispatchToProps>(
       {
         filterGroupName: t('console-app~Role'),
         type: 'node-role',
-        reducer: getNodeRole,
+        isMatch: getNodeRoleMatch,
         items: [
           {
             id: 'master',

--- a/frontend/packages/console-shared/src/selectors/node.ts
+++ b/frontend/packages/console-shared/src/selectors/node.ts
@@ -22,6 +22,12 @@ export const getNodeRoles = (node: NodeKind): string[] => {
 export const getNodeRole = (node: NodeKind): string =>
   getNodeRoles(node).includes('master') ? 'master' : 'worker';
 
+export const getNodeRoleMatch = (node: NodeKind, role: string): boolean => {
+  const roles = getNodeRoles(node);
+
+  return roles.filter((elem) => elem === role).length > 0;
+};
+
 export const getNodeAddresses = (node: NodeKind): NodeAddress[] =>
   _.get(node, 'status.addresses', []);
 

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash-es';
 import * as fuzzy from 'fuzzysearch';
 import { nodeStatus, volumeSnapshotStatus } from '@console/app/src/status';
-import { getNodeRole, getLabelsAsString } from '@console/shared';
+import { getNodeRoles, getLabelsAsString } from '@console/shared';
 import { FilterValue, RowFilter } from '@console/dynamic-plugin-sdk';
 import { routeStatus } from '../routes';
 import { secretTypeFilterReducer } from '../secret';
@@ -146,8 +146,9 @@ export const tableFilters: FilterMap = {
     if (!roles || !roles.selected || !roles.selected.length) {
       return true;
     }
-    const role = getNodeRole(node);
-    return roles.selected.includes(role);
+
+    const roleList = getNodeRoles(node);
+    return roles.selected.filter((elem) => roleList.includes(elem)).length > 0;
   },
 
   'clusterserviceversion-resource-kind': (filters, resource) => {


### PR DESCRIPTION
… both master and worker role

Displays the correct number of worker nodes when a node acts as both master and worker.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1951901