### PR TITLE
Bug 2107469: Fix service-binding modal sub-title text when the target is available

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -195,6 +195,7 @@
   "No bindable services available": "No bindable services available",
   "To create a Service binding, first create a bindable service.": "To create a Service binding, first create a bindable service.",
   "Select Service": "Select Service",
+  "Connect <1>{{sourceName}}</1> to service <3>{{targetName}}</3>.": "Connect <1>{{sourceName}}</1> to service <3>{{targetName}}</3>.",
   "Select a service to connect to.": "Select a service to connect to.",
   "Create": "Create",
   "Required": "Required",

--- a/frontend/packages/console-app/src/components/modals/service-binding/CreateServiceBindingForm.tsx
+++ b/frontend/packages/console-app/src/components/modals/service-binding/CreateServiceBindingForm.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { TextInputTypes, Title } from '@patternfly/react-core';
 import { FormikProps, FormikValues } from 'formik';
 import * as _ from 'lodash';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 import {
   ModalTitle,
@@ -30,12 +30,24 @@ const CreateServiceBindingForm: React.FC<FormikProps<FormikValues> &
   errors,
 }) => {
   const { t } = useTranslation();
+
+  const sourceName = source.metadata.name;
+  const targetName = target?.metadata?.name;
+
+  const title = target ? (
+    <Trans t={t} ns="console-app">
+      Connect <b>{{ sourceName }}</b> to service <b>{{ targetName }}</b>.
+    </Trans>
+  ) : (
+    t('console-app~Select a service to connect to.')
+  );
+
   return (
     <form onSubmit={handleSubmit} className="modal-content">
       <ModalTitle>{t('console-app~Create Service Binding')}</ModalTitle>
       <ModalBody>
         <Title headingLevel="h2" size="md" className="co-m-form-row">
-          {t('console-app~Select a service to connect to.')}
+          {title}
         </Title>
         <FormSection fullWidth>
           <InputField


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGSM-46859

This PR adds a fix to change the service binding modal sub-title text from `Select a service to connect to.` to `Connect <sourceName> to service <targetName>.` when target is already known.


https://user-images.githubusercontent.com/20724543/181743038-6ed7fd52-3e27-468b-a28d-bd70a8c391aa.mov

<img width="599" alt="Screenshot 2022-07-29 at 4 13 37 PM" src="https://user-images.githubusercontent.com/20724543/181743047-7de630ff-27a5-4fd9-82ff-c1e23df2eac9.png">


/kind bug


