### PR TITLE
[release-4.11] Bug 2109887: remove redundant model check to prevent tab reloading

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/model-status-box.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/model-status-box.tsx
@@ -10,17 +10,22 @@ type ModelStatusBoxProps = {
 
 const ModelStatusBox: React.FC<ModelStatusBoxProps> = ({ groupVersionKind, children }) => {
   const { t } = useTranslation();
-  const [model] = useK8sModel(groupVersionKind);
-  return model ? (
-    <>{children}</>
-  ) : (
-    <ErrorPage404
-      message={t(
-        "olm~The server doesn't have a resource type {{kind}}. Try refreshing the page if it was recently added.",
-        { kind: kindForReference(groupVersionKind) },
-      )}
-    />
-  );
+  const [model, inFlight] = useK8sModel(groupVersionKind);
+
+  if (!model && inFlight) {
+    return null;
+  }
+  if (!model) {
+    return (
+      <ErrorPage404
+        message={t(
+          "olm~The server doesn't have a resource type {{kind}}. Try refreshing the page if it was recently added.",
+          { kind: kindForReference(groupVersionKind) },
+        )}
+      />
+    );
+  }
+  return <>{children}</>;
 };
 
 export default ModelStatusBox;

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -595,7 +595,7 @@ export const ProvidedAPIPage: React.FC<ProvidedAPIPageProps> = (props) => {
 
   const [staticData, filteredData, onFilterChange] = useListPageFilter(resources);
 
-  return inFlight ? null : (
+  return (
     <ModelStatusBox groupVersionKind={apiGroupVersionKind}>
       <ListPageHeader title={showTitle ? `${label}s` : undefined}>
         {managesAllNamespaces && (


### PR DESCRIPTION
since ModelStatusBox is already checking for the model