### PR TITLE
Bug 2112481: Fix visual inconsistencies across synched editor forms

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -375,6 +375,7 @@
   "The value of maxUnavailable = 0 might not protect your pods from disruption": "The value of maxUnavailable = 0 might not protect your pods from disruption",
   "Create {{label}}": "Create {{label}}",
   "Edit {{label}}": "Edit {{label}}",
+  "{helpText}": "{helpText}",
   "Create PodDiscruptionBudget": "Create PodDiscruptionBudget",
   "No PodDisruptionBudgets": "No PodDisruptionBudgets",
   "Quick Starts": "Quick Starts",

--- a/frontend/packages/console-app/src/components/network-policies/create-network-policy.tsx
+++ b/frontend/packages/console-app/src/components/network-policies/create-network-policy.tsx
@@ -85,7 +85,6 @@ export const CreateNetworkPolicy: React.FC<{
         className="create-network-policy__page-heading"
         title={t('console-app~Create NetworkPolicy')}
         helpText={helpText}
-        detail
       />
       <SyncedEditor
         context={{

--- a/frontend/packages/console-app/src/components/pdb/PDBFormPage.tsx
+++ b/frontend/packages/console-app/src/components/pdb/PDBFormPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import { CreateYAML } from '@console/internal/components/create-yaml';
 import { PageHeading, LoadingBox } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
@@ -95,9 +95,14 @@ export const PDBFormPage: React.FC<{
         <LoadingBox />
       ) : (
         <>
-          <PageHeading title={title}>
-            <span className="help-block">{helpText}</span>
-          </PageHeading>
+          <PageHeading
+            title={title}
+            helpText={
+              <Trans t={t} ns="console-app">
+                {helpText}
+              </Trans>
+            }
+          />
 
           <SyncedEditor
             context={{

--- a/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.scss
@@ -19,9 +19,10 @@
 
   &--inline {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
 
     > .pf-c-form__group-label {
+      padding-bottom: 0;
       margin-right: var(--pf-global--spacer--md);
     }
 

--- a/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.scss
@@ -2,9 +2,19 @@
 
 .ocs-synced-editor-field {
   &__editor-toggle {
-    padding-top: var(--pf-global--spacer--sm);
     border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
     border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+    margin-left: -$pf-global-gutter;
+    margin-right: -$pf-global-gutter;
+    padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--lg);
+    @media (min-width: $pf-global--breakpoint--xl) {
+      margin-left: -$pf-global-gutter--md;
+      margin-right: -$pf-global-gutter--md;
+    }
+    @media (min-width: $pf-global--breakpoint--xl) {
+      padding-left: $pf-global-gutter--md;
+      padding-right: $pf-global-gutter--md;
+    }
 
     &.margin {
       margin: var(--pf-global--spacer--md) 0;

--- a/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.scss
@@ -1,19 +1,34 @@
 @import '~@patternfly/patternfly/sass-utilities/all';
+@import '../../../../../public/style/vars';
 
 .osc-yaml-editor {
   display: flex;
   flex: 1 0 auto;
   flex-direction: row;
+  margin-right: -$pf-global-gutter;
+  @media (max-width: $pf-global--breakpoint--md) {
+    margin-left: -$pf-global-gutter;
+    margin-top: -$pf-global-gutter--md;
+  }
+  @media (min-width: $pf-global--breakpoint--xl) {
+    margin-right: -$pf-global-gutter--md;
+  }
 
   &__editor {
     display: flex;
     flex: 1 0 auto;
     flex-direction: column;
+    @media (min-width: $pf-global--breakpoint--md) {
+      margin-right: $pf-global-gutter;
+    }
+    @media (min-width: $pf-global--breakpoint--xl) {
+      margin-right: $pf-global-gutter--md;
+    }
   }
   &__sidebar {
     display: flex;
     flex: 1 0 0;
-    margin-left: 20px;
+    margin-top: -$pf-global-gutter--md;
     @media screen and (max-width: $pf-global--breakpoint--lg) {
       display: none;
     }

--- a/frontend/packages/console-shared/src/components/synced-editor/styles.scss
+++ b/frontend/packages/console-shared/src/components/synced-editor/styles.scss
@@ -2,7 +2,8 @@
 
 .co-synced-editor__editor-toggle {
   border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
-  padding: 8px $pf-global-gutter;
+  border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+  padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--lg);
   @media (min-width: $pf-global--breakpoint--xl) {
     padding-left: $pf-global-gutter--md;
     padding-right: $pf-global-gutter--md;
@@ -10,6 +11,7 @@
 }
 
 .co-synced-editor__editor-toggle-label {
+  font-size: $font-size-base - 1; // match --pf-c-form__label--FontSize that's used for the osc-yaml-editor
   margin-bottom: 0;
 }
 

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
@@ -147,6 +147,7 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
             yamlContext={{ name: 'yamlData', editor: yamlEditor }}
             lastViewUserSettingKey={LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY}
             prune={prune}
+            noMargin
           />
         )}
       </FormBody>

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
@@ -132,7 +132,6 @@ export const CreateOperand: React.FC<CreateOperandProps> = ({
         title={t('olm~Create {{item}}', { item: model.label })}
         badge={getBadgeFromType(model.badge)}
         helpText={helpText}
-        detail
       />
       <SyncedEditor
         context={{

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.scss
@@ -1,15 +1,9 @@
 .opp-pipeline-builder-form {
-  margin-top: var(--pf-global--spacer--md);
   height: 100%;
   &__content {
     display: flex;
     flex-grow: 1;
   }
-  &__grid {
-    padding-left: var(--pf-global--spacer--lg);
-    padding-right: var(--pf-global--spacer--lg);
-  }
-
   &__short-section {
     max-width: 400px;
   }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -199,7 +199,11 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
             <PipelineBuilderHeader namespace={namespace} />
             <FlexForm className="opp-pipeline-builder-form" onSubmit={handleSubmit}>
               <div className="opp-pipeline-builder-form__content">
-                <FormBody flexLayout disablePaneBody className="opp-pipeline-builder-form__grid">
+                <FormBody
+                  flexLayout
+                  disablePaneBody
+                  className="co-m-pane__body co-m-pane__body--no-top-margin"
+                >
                   <PipelineQuickSearch
                     namespace={namespace}
                     viewContainer={contentRef.current}
@@ -210,6 +214,7 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
                     taskGroup={taskGroup}
                   />
                   <SyncedEditorField
+                    noMargin
                     name="editorType"
                     formContext={{
                       name: 'formData',

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -42,7 +42,7 @@ body,
   height: 100%;
 
   &__body {
-    flex: 1 1 700px;
+    flex: 1 1 auto;
   }
 
   &__close-button {
@@ -54,7 +54,7 @@ body,
   &__sidebar {
     position: relative;
     @media (min-width: $screen-md-min) {
-      flex: 1 0 300px;
+      flex: 1 0 auto;
       overflow-y: auto;
     }
 


### PR DESCRIPTION
Some screens with forms that allow for editing via Form or YAML editor do not follow the page visual design (Note YAML only forms are all correct). These page elements should follow the PatternFly page design where the borders extend to adjacent UI elements (Side nav bar, edge of screen, etc) Example below. And there are two separate components used that enable synced editing, but they have visual inconsistencies. Alignment, font-size, spacing. These were also addressed.


The following page forms have space gaps between elements.
Edit BuildConfig
Create Deployment
Create ConfigMap
Install Helm chart
Create Pipeline Builder
Create Route


**PatternFly page example showing correct border panel connections.**

<img width="1749" alt="Screen Shot 2022-07-29 at 6 40 55 PM" src="https://user-images.githubusercontent.com/1874151/181854497-eb58139b-2ab3-4b00-9244-83b762ea4e98.png">

---

**Before**
<img width="1308" alt="deploy-with-bug-errors" src="https://user-images.githubusercontent.com/1874151/181853623-b617df9c-d881-47c8-8350-0fc9f88a9ab8.png">


**After**
<img width="1290" alt="Screen Shot 2022-07-29 at 6 42 47 PM" src="https://user-images.githubusercontent.com/1874151/181854633-82970c48-6c20-44d1-b78f-5db48ad7121e.png">


---

**Before**
<img width="1278" alt="pipe-before" src="https://user-images.githubusercontent.com/1874151/181852760-4f4fd0f4-3dc2-45b9-b85b-37a0f7af2cf4.png">

**After**
<img width="1243" alt="pipe-after1" src="https://user-images.githubusercontent.com/1874151/181854367-f68c1adc-c885-4f05-bc35-6d9379a6db9b.png">


---

**Before**
<img width="1271" alt="bc-before" src="https://user-images.githubusercontent.com/1874151/181852801-0ce026f4-df3d-4a20-b497-4b3e25c40381.png">

**After**
<img width="1276" alt="bc-after" src="https://user-images.githubusercontent.com/1874151/181852809-1253f636-d95c-49df-8514-d39f4f1d2872.png">

---

**Before**
<img width="1275" alt="helm-before" src="https://user-images.githubusercontent.com/1874151/181852915-1b1ca956-e710-46c1-8a0f-64da5d65c67a.png">

**After**
<img width="1296" alt="helm-after" src="https://user-images.githubusercontent.com/1874151/181852920-58b598b7-7fa8-44ae-9272-9163c9766435.png">

---

**Before**
<img width="1272" alt="cm-before" src="https://user-images.githubusercontent.com/1874151/181852944-8c1bb215-e367-4b40-b32d-6367f89e6511.png">

**After**
<img width="1299" alt="cm-after" src="https://user-images.githubusercontent.com/1874151/181852952-c8a98035-8e19-4088-9ab5-3cadd2c9f52d.png">

---

Also the Create PodDisruptionBudget was missing a top horizontal border and help text had inconsistent spacing. 

**Before**
<img width="1278" alt="pdb-before" src="https://user-images.githubusercontent.com/1874151/181852965-e3e59527-41d8-4e1a-a0f0-2c95a8e26087.png">

**After**
<img width="1277" alt="pdb-after" src="https://user-images.githubusercontent.com/1874151/181852974-22a94ac7-f491-4877-b067-dde3aab0f0c0.png">





