### PR TITLE
Bug 2112862: Fix broken Namespace CRUD e2e test

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crud/namespace-crud.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/namespace-crud.spec.ts
@@ -65,7 +65,7 @@ describe('Namespace', () => {
       'List page to details page should change Project from "All Projects" to resource specific project',
     );
     listPage.filter.byName('kubernetes');
-    listPage.rows.countShouldBe(1);
+    listPage.rows.countShouldBeWithin(1, 3);
     listPage.rows.clickRowByName('kubernetes');
     detailsPage.isLoaded();
     projectDropdown.shouldContain(defaultProjectName);
@@ -74,7 +74,7 @@ describe('Namespace', () => {
     projectDropdown.shouldContain(allProjectsDropdownLabel);
     cy.log('Details page to list page via breadcrumb should change Project back to "All Projects"');
     listPage.filter.byName('kubernetes');
-    listPage.rows.countShouldBe(1);
+    listPage.rows.countShouldBeWithin(1, 3);
     listPage.rows.clickRowByName('kubernetes');
     detailsPage.isLoaded();
     projectDropdown.shouldContain(defaultProjectName);

--- a/frontend/packages/integration-tests-cypress/views/list-page.ts
+++ b/frontend/packages/integration-tests-cypress/views/list-page.ts
@@ -74,6 +74,9 @@ export const listPage = {
     countShouldBe: (count: number) => {
       cy.get(`[data-test-rows="resource-row"`).should('have.length', count);
     },
+    countShouldBeWithin: (min: number, max: number) => {
+      cy.get(`[data-test-rows="resource-row"`).should('have.length.within', min, max);
+    },
     clickFirstLinkInFirstRow: () => {
       cy.get(`[data-test-rows="resource-row"]`)
         .first()


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2112862

**Analysis / Root cause**: 
Test is broken because a filter for "kubernetes" in all projects matches two unexpected Services.

Test name:
Nav and breadcrumbs restores last selected "All Projects" when navigating from details to list view

Failure:

```
  1) Namespace
       Nav and breadcrumbs restores last selected "All Projects" when navigating from details to list view:
      AssertionError: Timed out retrying after 30000ms: Too many elements found. Found '3', expected '1'.
      + expected - actual
      -3
      +1
```

Broken job: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console/11905/pull-ci-openshift-console-master-e2e-gcp-console/1553985006299254784

![image](https://user-images.githubusercontent.com/139310/182132830-f0a7cc4f-ba5f-4356-b421-0cba93647ac1.png)

**Solution Description**: 
Change the assertions so that the search for a Service "kubernete" in all projects also accepts the two unexpected Services.

I don't dropped the assertion so that the test still asserts that the filter works and doesn't show "just all Services".

**Unit test coverage report**: 
Updated just the broken e2e test

**Test setup:**
It should pass the CI job

**Browser conformance**: 
not relevant
