### PR TITLE
[release-4.10] Bug 2080389: Link to documentation from the overview page goes to a missing link

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
@@ -22,8 +22,10 @@ export const ClusterSetupGettingStartedCard: React.FC = () => {
     return null;
   }
 
-  const moreLinkBaseURL = window.SERVER_FLAGS.documentationBaseURL || 'https://docs.okd.io/latest/';
-  const moreLinkURL = `${moreLinkBaseURL}post_installation_configuration/machine-configuration-tasks.html`;
+  const moreLinkURL = window.SERVER_FLAGS.documentationBaseURL
+    ? `${window.SERVER_FLAGS.documentationBaseURL}html/post-installation_configuration/post-install-machine-configuration-tasks`
+    : 'https://docs.okd.io/latest/post_installation_configuration/machine-configuration-tasks.html';
+
   const moreLink: GettingStartedLink = {
     id: 'machine-configuration',
     title: t('public~View all steps in documentation'),


### PR DESCRIPTION
manual backport of https://github.com/openshift/console/pull/11668/files

/assign @rhamilto 