### PR TITLE
Bug 2112999: Replace sum_irate with sum_rate for Deployments CPU graph

### DIFF
--- a/frontend/packages/console-shared/src/promql/resource-metrics.ts
+++ b/frontend/packages/console-shared/src/promql/resource-metrics.ts
@@ -39,7 +39,7 @@ const podControllerMetricsQueries = {
     "sum(container_memory_working_set_bytes{container!=''} * on(pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
   ),
   [ResourceUtilizationQuery.CPU]: _.template(
-    "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{} * on(pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
+    "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{} * on(pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
   ),
   [ResourceUtilizationQuery.FILESYSTEM]: _.template(
     "sum(pod:container_fs_usage_bytes:sum * on(pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",


### PR DESCRIPTION
In in OCP 4.8 the metric node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
is not available, what is available is the same metric but using
sum_rate instead. CMO replaced sum_rate with sum_irate in 4.9 through
an update on a transitive dependency. This bug was introduced by
cherry-picking a change for 4.9 that assumes sum_irate is available.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2112999