### PR TITLE
CONSOLE-3244: Make status.HostIP for Pods visible in the OCP Web Console

### DIFF
--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -742,6 +742,7 @@ export const PodDetailsList: React.FC<PodDetailsListProps> = ({ pod }) => {
           : t('public~Not configured')}
       </DetailsItem>
       <DetailsItem label={t('public~Pod IP')} obj={pod} path="status.podIP" />
+      <DetailsItem label={t('public~Host IP')} obj={pod} path="status.hostIP" />
       <DetailsItem label={t('public~Node')} obj={pod} path="spec.nodeName" hideEmpty>
         <NodeLink name={pod.spec.nodeName} />
       </DetailsItem>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1314,6 +1314,7 @@
   "To troubleshoot, view logs and events, then debug in terminal.": "To troubleshoot, view logs and events, then debug in terminal.",
   "Debug container {{name}}": "Debug container {{name}}",
   "Restart policy": "Restart policy",
+  "Host IP": "Host IP",
   "Image pull secret": "Image pull secret",
   "Pod details": "Pod details",
   "Init containers": "Init containers",


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/CONSOLE-3244

Adds Host IP field to Pods details page.