### PR TITLE
Add Cancel option and update the stop status for the PipelineRun

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/Status.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/Status.tsx
@@ -70,6 +70,7 @@ const Status: React.FC<StatusProps> = ({
     case 'Deleting':
     case 'Expired':
     case 'Not Ready':
+    case 'Cancelling':
     case 'Terminating':
       return <StatusIconAndText {...statusProps} icon={<BanIcon />} />;
 

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-runs.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-runs.feature
@@ -336,7 +336,7 @@ Feature: Pipeline Runs
               And user navigates to pipelineRun logs tab
              Then user is able to see log snippet for failure of "build-image" task
 
-        @regression
+        @regression @odc-4793
         Scenario: Pipeline Run details page with Parameters tab and no parameters: P-07-TC34
             Given pipeline run is displayed for "pipeline-run-no-parameters" without resource
               And user is at pipelines page
@@ -346,7 +346,7 @@ Feature: Pipeline Runs
               And user navigates to pipelineRun parameters tab
               And user is able to see No parameters are associated with this PipelineRun
 
-        @regression
+        @regression @odc-4793
         Scenario: Pipeline Run with parameters: P-07-TC35
             Given pipeline run is displayed for "pipeline-run-parameters" with parameters
               And user is at pipelines page

--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -406,6 +406,8 @@
   "Edit Pipeline": "Edit Pipeline",
   "Start last run": "Start last run",
   "Stop": "Stop",
+  "Let the running tasks complete, then execute finally tasks": "Let the running tasks complete, then execute finally tasks",
+  "Interrupt any executing non finally tasks, then execute finally tasks": "Interrupt any executing non finally tasks, then execute finally tasks",
   "Succeeded": "Succeeded",
   "Failed": "Failed",
   "PipelineRun failed to start": "PipelineRun failed to start",

--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -414,6 +414,7 @@
   "Running": "Running",
   "Skipped": "Skipped",
   "Cancelled": "Cancelled",
+  "Cancelling": "Cancelling",
   "Pending": "Pending",
   "PipelineRun not started yet": "PipelineRun not started yet",
   "Other": "Other"

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/pipelineRunLogSnippet.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/pipelineRunLogSnippet.ts
@@ -31,7 +31,7 @@ export const getPLRLogSnippet = (pipelineRun: PipelineRunKind): CombinedErrorDet
   );
   const isKnownReason = (reason: string): boolean => {
     // known reasons https://tekton.dev/vault/pipelines-v0.21.0/pipelineruns/#monitoring-execution-status
-    return ['PipelineRunCancelled', 'PipelineRunTimeout'].includes(reason);
+    return ['StoppedRunFinally', 'CancelledRunFinally', 'PipelineRunTimeout'].includes(reason);
   };
 
   // We're intentionally looking at the first failure because we have to start somewhere - they have the YAML still

--- a/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
@@ -765,7 +765,7 @@ export const pipelineTestData: PipelineTestData = {
           pipelineSpec: pipelineSpec[PipelineExampleNames.COMPLEX_PIPELINE],
           conditions: [
             {
-              reason: 'StoppedRunFinally',
+              reason: 'Cancelled',
               status: 'False',
               type: 'Succeeded',
             },
@@ -841,7 +841,7 @@ export const pipelineTestData: PipelineTestData = {
           pipelineSpec: pipelineSpec[PipelineExampleNames.COMPLEX_PIPELINE],
           conditions: [
             {
-              reason: 'StoppedRunFinally',
+              reason: 'Cancelled',
               status: 'False',
               type: 'Succeeded',
             },
@@ -1047,7 +1047,7 @@ export const pipelineTestData: PipelineTestData = {
           pipelineSpec: pipelineSpec[PipelineExampleNames.COMPLEX_PIPELINE],
           conditions: [
             {
-              reason: 'StoppedRunFinally',
+              reason: 'Cancelled',
               status: 'False',
               type: 'Succeeded',
             },

--- a/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
@@ -16,7 +16,8 @@ export enum DataState {
   FAILED_BUT_COMPLETE = 'Completed But Failed',
   SKIPPED = 'Skipped',
   PIPELINE_RUN_PENDING = 'PipelineRunPending',
-  PIPELINE_RUN_CANCELLED = 'PipelineRunCancelled',
+  PIPELINE_RUN_CANCELLED = 'StoppedRunFinally',
+  PIPELINE_RUN_STOPPED = 'CancelledRunFinally',
 }
 
 export enum PipelineExampleNames {
@@ -625,6 +626,41 @@ export const pipelineTestData: PipelineTestData = {
         },
       },
 
+      [DataState.PIPELINE_RUN_STOPPED]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'simple-pipeline-p1bun0',
+          namespace: 'tekton-pipelines',
+          creationTimestamp: '2020-10-29T09:58:19Z',
+          labels: { [TektonResourceLabel.pipeline]: 'simple-pipeline' },
+        },
+        spec: {
+          pipelineRef: { name: 'simple-pipeline' },
+          resources: [
+            { name: 'source-repo', resourceRef: { name: 'mapit-git' } },
+            {
+              name: 'web-image',
+              resourceRef: { name: 'mapit-image' },
+            },
+          ],
+          status: 'CancelledRunFinally',
+        },
+        status: {
+          pipelineSpec: pipelineSpec[PipelineExampleNames.SIMPLE_PIPELINE],
+          completionTime: '2019-10-29T11:57:53Z',
+          conditions: [
+            {
+              lastTransitionTime: '2019-09-12T20:38:01Z',
+              message: 'All Tasks have completed executing',
+              reason: 'Succeeded',
+              status: 'True',
+              type: 'Succeeded',
+            },
+          ],
+        },
+      },
+
       [DataState.PIPELINE_RUN_CANCELLED]: {
         apiVersion: 'tekton.dev/v1alpha1',
         kind: 'PipelineRun',
@@ -643,7 +679,7 @@ export const pipelineTestData: PipelineTestData = {
               resourceRef: { name: 'mapit-image' },
             },
           ],
-          status: 'PipelineRunCancelled',
+          status: 'StoppedRunFinally',
         },
         status: {
           pipelineSpec: pipelineSpec[PipelineExampleNames.SIMPLE_PIPELINE],
@@ -723,13 +759,13 @@ export const pipelineTestData: PipelineTestData = {
             { name: 'app-git', resourceRef: { name: 'mapit-git' } },
             { name: 'app-image', resourceRef: { name: 'mapit-image' } },
           ],
-          status: 'PipelineRunCancelled',
+          status: 'StoppedRunFinally',
         },
         status: {
           pipelineSpec: pipelineSpec[PipelineExampleNames.COMPLEX_PIPELINE],
           conditions: [
             {
-              reason: 'PipelineRunCancelled',
+              reason: 'StoppedRunFinally',
               status: 'False',
               type: 'Succeeded',
             },
@@ -799,13 +835,13 @@ export const pipelineTestData: PipelineTestData = {
             { name: 'app-git', resourceRef: { name: 'mapit-git' } },
             { name: 'app-image', resourceRef: { name: 'mapit-image' } },
           ],
-          status: 'PipelineRunCancelled',
+          status: 'StoppedRunFinally',
         },
         status: {
           pipelineSpec: pipelineSpec[PipelineExampleNames.COMPLEX_PIPELINE],
           conditions: [
             {
-              reason: 'PipelineRunCancelled',
+              reason: 'StoppedRunFinally',
               status: 'False',
               type: 'Succeeded',
             },
@@ -1005,13 +1041,13 @@ export const pipelineTestData: PipelineTestData = {
             { name: 'app-git', resourceRef: { name: 'mapit-git' } },
             { name: 'app-image', resourceRef: { name: 'mapit-image' } },
           ],
-          status: 'PipelineRunCancelled',
+          status: 'StoppedRunFinally',
         },
         status: {
           pipelineSpec: pipelineSpec[PipelineExampleNames.COMPLEX_PIPELINE],
           conditions: [
             {
-              reason: 'PipelineRunCancelled',
+              reason: 'StoppedRunFinally',
               status: 'False',
               type: 'Succeeded',
             },

--- a/frontend/packages/pipelines-plugin/src/types/computedStatus.ts
+++ b/frontend/packages/pipelines-plugin/src/types/computedStatus.ts
@@ -1,4 +1,5 @@
 export enum ComputedStatus {
+  Cancelling = 'Cancelling',
   Succeeded = 'Succeeded',
   Failed = 'Failed',
   Running = 'Running',

--- a/frontend/packages/pipelines-plugin/src/types/pipelineRun.ts
+++ b/frontend/packages/pipelines-plugin/src/types/pipelineRun.ts
@@ -149,7 +149,7 @@ export type PipelineRunKind = K8sResourceCommon & {
     serviceAccountName?: string;
     timeout?: string;
     // Only used in a single case - cancelling a pipeline; should not be copied between PLRs
-    status?: 'PipelineRunCancelled' | 'PipelineRunPending';
+    status?: 'StoppedRunFinally' | 'PipelineRunPending' | 'CancelledRunFinally';
   };
   status?: PipelineRunStatus;
 };

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-actions.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-actions.spec.ts
@@ -6,6 +6,7 @@ import {
   reRunPipelineRun,
   startPipeline,
   getPipelineKebabActions,
+  cancelPipelineRunFinally,
 } from '../pipeline-actions';
 
 const samplePipeline = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipeline;
@@ -67,6 +68,44 @@ describe('PipelineAction testing stopPipelineRun create correct labels and callb
     expect(stopAction.labelKey).toBe(`${i18nNS}~Stop`);
     expect(stopAction.callback).not.toBeNull();
     expect(stopAction.hidden).not.toBeFalsy();
+  });
+});
+
+describe('PipelineAction testing cancelPipelineRunFinally create correct labels and callbacks', () => {
+  it('expect label to be "Cancel" with hidden flag as false when latest Run is running', () => {
+    const cancelAction = cancelPipelineRunFinally(PipelineRunModel, {
+      ...samplePipelineRun,
+      status: {
+        conditions: [
+          {
+            ...samplePipelineRun.status.conditions[0],
+            status: 'Unknown',
+          },
+        ],
+      },
+    });
+    expect(cancelAction.labelKey).toBe(`${i18nNS}~Cancel`);
+    expect(cancelAction.callback).not.toBeNull();
+    expect(cancelAction.hidden).toBeFalsy();
+  });
+
+  it('expect label to be "Cancel" with hidden flag as true when latest Run is not running', () => {
+    const cancelAction = cancelPipelineRunFinally(PipelineRunModel, samplePipelineRun);
+    expect(cancelAction.labelKey).toBe(`${i18nNS}~Cancel`);
+    expect(cancelAction.callback).not.toBeNull();
+    expect(cancelAction.hidden).not.toBeFalsy();
+  });
+
+  it('"Cancel" action should be present for the Stopped latest Run', () => {
+    const cancelAction = cancelPipelineRunFinally(PipelineRunModel, {
+      ...samplePipelineRun,
+      spec: {
+        status: 'StoppedRunFinally',
+      },
+    });
+    expect(cancelAction.labelKey).toBe(`${i18nNS}~Cancel`);
+    expect(cancelAction.callback).not.toBeNull();
+    expect(cancelAction.hidden).not.toBeFalsy();
   });
 });
 

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-actions.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-actions.spec.ts
@@ -73,17 +73,9 @@ describe('PipelineAction testing stopPipelineRun create correct labels and callb
 
 describe('PipelineAction testing cancelPipelineRunFinally create correct labels and callbacks', () => {
   it('expect label to be "Cancel" with hidden flag as false when latest Run is running', () => {
-    const cancelAction = cancelPipelineRunFinally(PipelineRunModel, {
-      ...samplePipelineRun,
-      status: {
-        conditions: [
-          {
-            ...samplePipelineRun.status.conditions[0],
-            status: 'Unknown',
-          },
-        ],
-      },
-    });
+    const pipelineRun =
+      pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipelineRuns[DataState.IN_PROGRESS];
+    const cancelAction = cancelPipelineRunFinally(PipelineRunModel, pipelineRun);
     expect(cancelAction.labelKey).toBe(`${i18nNS}~Cancel`);
     expect(cancelAction.callback).not.toBeNull();
     expect(cancelAction.hidden).toBeFalsy();

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
@@ -23,6 +23,7 @@ import {
   getResourceModelFromTaskKind,
   getResourceModelFromBindingKind,
   shouldHidePipelineRunStop,
+  shouldHidePipelineRunCancel,
 } from '../pipeline-augment';
 import { testData } from './pipeline-augment-test-data';
 
@@ -235,6 +236,30 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
           DataState.SUCCESS
         ];
       expect(shouldHidePipelineRunStop(pipelineRun)).toEqual(true);
+    });
+
+    it('should hide the pipelinerun cancel action ', () => {
+      const pipelineRun =
+        pipelineTestData[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].pipelineRuns[
+          DataState.SUCCESS
+        ];
+      expect(shouldHidePipelineRunCancel(pipelineRun)).toEqual(true);
+    });
+
+    it('should not hide the pipelinerun cancel action ', () => {
+      const pipelineRun =
+        pipelineTestData[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].pipelineRuns[
+          DataState.IN_PROGRESS
+        ];
+      expect(shouldHidePipelineRunCancel(pipelineRun)).toEqual(false);
+    });
+
+    it('should hide the pipelinerun cancel action ', () => {
+      const pipelineRun =
+        pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipelineRuns[
+          DataState.PIPELINE_RUN_STOPPED
+        ];
+      expect(shouldHidePipelineRunCancel(pipelineRun)).toEqual(true);
     });
   });
 

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-filter-reducer.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-filter-reducer.spec.ts
@@ -34,7 +34,12 @@ const mockPipelineRuns = [
   { status: { conditions: [{ status: 'Unknown', type: 'Succeeded' }] } },
   {
     status: {
-      conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'PipelineRunCancelled' }],
+      conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'StoppedRunFinally' }],
+    },
+  },
+  {
+    status: {
+      conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'CancelledRunFinally' }],
     },
   },
   {
@@ -120,12 +125,16 @@ describe('Check PipelineRun Status | Filter Reducer applied to the following:', 
     const reducerOutput = pipelineRunStatus(mockPipelineRuns[8]);
     expect(reducerOutput).toBe('Running');
   });
-  it('Pipelinerun with first element of condition array with type as "Succeeded" & status as "Unknown"', () => {
+  it('Pipelinerun with first element of condition array with type as "Succeeded" & status as "Unknown" & reason as "StoppedRunFinally"', () => {
     const reducerOutput = pipelineRunStatus(mockPipelineRuns[9]);
     expect(reducerOutput).toBe('Cancelled');
   });
-  it('Pipelinerun with first element of condition array with type as "Succeeded" & status as "Unknown"', () => {
+  it('Pipelinerun with first element of condition array with type as "Succeeded" & status as "Unknown" & reason as "CancelledRunFinally"', () => {
     const reducerOutput = pipelineRunStatus(mockPipelineRuns[10]);
+    expect(reducerOutput).toBe('Cancelled');
+  });
+  it('Pipelinerun with first element of condition array with type as "Succeeded" & status as "Unknown"', () => {
+    const reducerOutput = pipelineRunStatus(mockPipelineRuns[11]);
     expect(reducerOutput).toBe('Cancelled');
   });
   it('Pipelinerun with first element of condition array with type as "Succeeded" & Failing condition', () => {

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
@@ -168,6 +168,8 @@ export const getRunStatusColor = (status: string): StatusMessage => {
       return { message: i18next.t('pipelines-plugin~Skipped'), pftoken: skippedColor };
     case ComputedStatus.Cancelled:
       return { message: i18next.t('pipelines-plugin~Cancelled'), pftoken: cancelledColor };
+    case ComputedStatus.Cancelling:
+      return { message: i18next.t('pipelines-plugin~Cancelling'), pftoken: cancelledColor };
     case ComputedStatus.Idle:
     case ComputedStatus.Pending:
       return { message: i18next.t('pipelines-plugin~Pending'), pftoken: pendingColor };

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
@@ -320,3 +320,10 @@ export const shouldHidePipelineRunStop = (pipelineRun: PipelineRunKind): boolean
     (countRunningTasks(pipelineRun) > 0 ||
       pipelineRunFilterReducer(pipelineRun) === ComputedStatus.Running)
   );
+
+export const shouldHidePipelineRunCancel = (pipelineRun: PipelineRunKind): boolean =>
+  !(
+    pipelineRun &&
+    countRunningTasks(pipelineRun) > 0 &&
+    pipelineRunFilterReducer(pipelineRun) !== ComputedStatus.Cancelled
+  );

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-filter-reducer.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-filter-reducer.ts
@@ -3,7 +3,8 @@ import * as _ from 'lodash';
 import { ComputedStatus } from '../types';
 
 export enum SucceedConditionReason {
-  PipelineRunCancelled = 'PipelineRunCancelled',
+  PipelineRunCancelled = 'StoppedRunFinally',
+  PipelineRunStopped = 'CancelledRunFinally',
   TaskRunCancelled = 'TaskRunCancelled',
   Cancelled = 'Cancelled',
   PipelineRunStopping = 'PipelineRunStopping',
@@ -36,6 +37,7 @@ export const pipelineRunStatus = (pipelineRun): ComputedStatus => {
       case SucceedConditionReason.PipelineRunCancelled:
       case SucceedConditionReason.TaskRunCancelled:
       case SucceedConditionReason.Cancelled:
+      case SucceedConditionReason.PipelineRunStopped:
         return ComputedStatus.Cancelled;
       case SucceedConditionReason.PipelineRunStopping:
       case SucceedConditionReason.TaskRunStopping:

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-filter-reducer.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-filter-reducer.ts
@@ -21,6 +21,18 @@ export const pipelineRunStatus = (pipelineRun): ComputedStatus => {
   if (conditions.length === 0) return null;
 
   const succeedCondition = conditions.find((c) => c.type === 'Succeeded');
+  const cancelledCondition = conditions.find((c) => c.reason === 'Cancelled');
+
+  if (
+    [
+      SucceedConditionReason.PipelineRunStopped,
+      SucceedConditionReason.PipelineRunCancelled,
+    ].includes(pipelineRun.spec?.status) &&
+    !cancelledCondition
+  ) {
+    return ComputedStatus.Cancelling;
+  }
+
   if (!succeedCondition || !succeedCondition.status) {
     return null;
   }
@@ -74,6 +86,8 @@ export const pipelineRunStatusTitle = (pipelineRun): string => {
       return i18next.t('pipelines-plugin~Running');
     case ComputedStatus.Skipped:
       return i18next.t('pipelines-plugin~Skipped');
+    case ComputedStatus.Cancelling:
+      return i18next.t('pipelines-plugin~Cancelling');
     default:
       return status;
   }


### PR DESCRIPTION
**Story:** https://issues.redhat.com/browse/ODC-6705

**Descriptions:**
- Add a new PipelineRun action menu `Cancel`.
- Update the Stop PipelineRun status from `PipelineRunCancelled` to `StoppedRunFinally`.

**Screenshots:**
<img width="1504" alt="image" src="https://user-images.githubusercontent.com/2561818/182563129-149ee8d4-6c1a-4202-a996-0d5e54c9e358.png">

<img width="816" alt="image" src="https://user-images.githubusercontent.com/2561818/182563825-a62157af-5c20-4497-9cd9-3514b1cc77fc.png">

<img width="909" alt="image" src="https://user-images.githubusercontent.com/2561818/182563892-afce4070-96b9-459f-a204-cdd1cbd58895.png">

**Status Cancelling**

![Kapture 2022-08-03 at 21 03 57](https://user-images.githubusercontent.com/2561818/182650908-c3b2bd2a-d24b-422d-9e99-075bf3c14403.gif)


**Test setup**
- Required Red Hat Openshift Pipelines 1.8.0 operator.
- To install it navigate to https://artifacts.ospqa.com/builds/1.8.0/285588-4.11/ (VPN required)
- Apply image-content-source-policy.yaml then catalog-source.yaml
- Red Hat Openshift Pipelines 1.8.0 will be available in the cluster Operatorhub. 