### PR TITLE
Include ActionServiceProvider in dynamic-plugin-sdk

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -59,9 +59,10 @@
 57.  [`usePrometheusPoll`](#useprometheuspoll)
 58.  [`Timestamp`](#timestamp)
 59.  [`useModal`](#usemodal)
-60. [DEPRECATED] [`PerspectiveContext`](#perspectivecontext)
-61. [DEPRECATED] [`useAccessReviewAllowed`](#useaccessreviewallowed)
-62. [DEPRECATED] [`useSafetyFirst`](#usesafetyfirst)
+60.  [`ActionServiceProvider`](#actionserviceprovider)
+61. [DEPRECATED] [`PerspectiveContext`](#perspectivecontext)
+62. [DEPRECATED] [`useAccessReviewAllowed`](#useaccessreviewallowed)
+63. [DEPRECATED] [`useSafetyFirst`](#usesafetyfirst)
 
 ---
 
@@ -2034,6 +2035,45 @@ A hook to launch Modals.<br/><br/>```tsx<br/>const AppPage: React.FC = () => {<b
 
 
 
+
+
+
+---
+
+## `ActionServiceProvider`
+
+### Summary 
+
+Component that allows to receive contributions from other plugins for the `console.action/provider` extension type.<br/>See docs: https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md#consoleactionprovider
+
+
+
+### Example
+
+
+```tsx
+   const context: ActionContext = { 'a-context-id': { dataFromDynamicPlugin } };
+
+   ...
+
+   <ActionServiceProvider context={context}>
+       {({ actions, options, loaded }) =>
+         loaded && (
+           <ActionMenu actions={actions} options={options} variant={ActionMenuVariant.DROPDOWN} />
+         )
+       }
+   </ActionServiceProvider>
+```
+
+
+
+
+
+### Parameters
+
+| Parameter Name | Description |
+| -------------- | ----------- |
+| `context` | Object with contextId and optional plugin data |
 
 
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import * as React from 'react';
+import { ActionServiceProviderProps } from '../extensions/actions';
 import {
   HorizontalNavProps,
   UseResolvedExtensions,
@@ -351,7 +352,7 @@ export { default as ResourceStatus } from '../app/components/utils/resource-stat
  * @param {K8sResourceKindReference} [kind] - (optional) the kind of resource i.e. Pod, Deployment, Namespace
  * @param {K8sGroupVersionKind} [groupVersionKind] - (optional) object with group, version, and kind
  * @param {string} [className] -  (optional) class style for component
- * @example 
+ * @example
  * ```tsx
  * <ResourceIcon kind="Pod"/>
  * ```
@@ -645,3 +646,26 @@ export const Timestamp: React.FC<TimestampProps> = require('@console/internal/co
   .Timestamp;
 
 export { useModal } from '../app/modal-support/useModal';
+
+/**
+ * Component that allows to receive contributions from other plugins for the `console.action/provider` extension type.
+ * See docs: https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md#consoleactionprovider
+ *
+ * @param {ActionServiceProviderProps["context"]} context - Object with contextId and optional plugin data
+ * @example
+ * ```tsx
+ *    const context: ActionContext = { 'a-context-id': { dataFromDynamicPlugin } };
+ *
+ *    ...
+ *
+ *    <ActionServiceProvider context={context}>
+ *        {({ actions, options, loaded }) =>
+ *          loaded && (
+ *            <ActionMenu actions={actions} options={options} variant={ActionMenuVariant.DROPDOWN} />
+ *          )
+ *        }
+ *    </ActionServiceProvider>
+ * ```
+ */
+export const ActionServiceProvider: React.FC<ActionServiceProviderProps> = require('@console/shared/src/components/actions/ActionServiceProvider')
+  .default;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/actions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/actions.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ExtensionHook, ExtensionK8sKindVersionModel } from '../api/common-types';
+import { ActionContext } from '../api/internal-types';
 import { Extension, ExtensionDeclaration, CodeRef } from '../types';
 import { AccessReviewResourceAttributes } from './console-types';
 
@@ -125,4 +126,28 @@ export type Action = {
   insertAfter?: string | string[];
   /** Describes the access check to perform. */
   accessReview?: AccessReviewResourceAttributes;
+};
+
+export type GroupedMenuOption = ActionGroup['properties'] & {
+  children?: MenuOption[];
+};
+
+export type MenuOption = Action | GroupedMenuOption;
+
+export type ActionService = {
+  actions: Action[];
+  options: MenuOption[];
+  loaded: boolean;
+  error: any;
+};
+
+export enum MenuOptionType {
+  GROUP_MENU,
+  SUB_MENU,
+  ATOMIC_MENU,
+}
+
+export type ActionServiceProviderProps = {
+  context: ActionContext;
+  children: (service: ActionService) => React.ReactNode;
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { ButtonProps } from '@patternfly/react-core';
-import { TableGridBreakpoint, OnSelect, SortByDirection, ICell } from '@patternfly/react-table';
+import { ICell, OnSelect, SortByDirection, TableGridBreakpoint } from '@patternfly/react-table';
 import { RouteComponentProps } from 'react-router';
 import {
   ExtensionK8sGroupKindModel,
   K8sModel,
+  PrometheusEndpoint,
   PrometheusLabels,
   PrometheusValue,
   ResolvedExtension,
   Selector,
-  PrometheusEndpoint,
 } from '../api/common-types';
 import { Extension, ExtensionTypeGuard } from '../types';
 

--- a/frontend/packages/console-shared/src/components/actions/ActionServiceProvider.tsx
+++ b/frontend/packages/console-shared/src/components/actions/ActionServiceProvider.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { Action, ActionGroup, isActionGroup } from '@console/dynamic-plugin-sdk';
+import {
+  Action,
+  ActionGroup,
+  ActionService,
+  ActionServiceProviderProps,
+  isActionGroup,
+  MenuOption,
+} from '@console/dynamic-plugin-sdk';
 import { useExtensions } from '@console/plugin-sdk';
 import { useDeepCompareMemoize } from '../../hooks';
 import ActionsLoader from './loader/ActionsLoader';
-import { ActionContext, ActionService, MenuOption } from './types';
+import { ActionContext } from './types';
 import { createMenuOptions } from './utils';
-
-type ActionServiceProviderProps = {
-  context: ActionContext;
-  children: (service: ActionService) => React.ReactNode;
-};
 
 const ActionServiceProvider: React.FC<ActionServiceProviderProps> = ({ context, children }) => {
   const [contextMap, setContextMap] = React.useState<ActionContext>(context);

--- a/frontend/packages/console-shared/src/components/actions/__tests__/utils.spec.ts
+++ b/frontend/packages/console-shared/src/components/actions/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { MenuOptionType } from '../types';
+import { MenuOptionType } from '@console/dynamic-plugin-sdk';
 import { getMenuOptionType, createMenuOptions } from '../utils';
 import { mockActionGroups, mockActions, mockMenuOptions } from './utils-test-data';
 

--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenu.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenu.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Menu, MenuContent, MenuList, Popper } from '@patternfly/react-core';
 import * as _ from 'lodash';
-import { Action, useSafetyFirst } from '@console/dynamic-plugin-sdk';
+import { Action, MenuOption, useSafetyFirst } from '@console/dynamic-plugin-sdk';
 import { checkAccess } from '@console/internal/components/utils';
-import { ActionMenuVariant, MenuOption } from '../types';
+import { ActionMenuVariant } from '../types';
 import ActionMenuContent from './ActionMenuContent';
 import ActionMenuToggle from './ActionMenuToggle';
 

--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenuContent.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenuContent.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { Menu, MenuContent, MenuGroup, MenuItem, MenuList, Divider } from '@patternfly/react-core';
-import { Action } from '@console/dynamic-plugin-sdk';
+import { Action, GroupedMenuOption, MenuOption, MenuOptionType } from '@console/dynamic-plugin-sdk';
 import { orderExtensionBasedOnInsertBeforeAndAfter } from '../../../utils/order-extensions';
-import { GroupedMenuOption, MenuOption, MenuOptionType } from '../types';
 import { getMenuOptionType } from '../utils';
 import ActionMenuItem from './ActionMenuItem';
 

--- a/frontend/packages/console-shared/src/components/actions/types.ts
+++ b/frontend/packages/console-shared/src/components/actions/types.ts
@@ -1,25 +1,5 @@
-import { Action, ActionGroup } from '@console/dynamic-plugin-sdk';
 import { ActionContext as ActionContextType } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 
 export { ActionMenuVariant } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 
 export type ActionContext = ActionContextType;
-
-export type MenuOption = Action | GroupedMenuOption;
-
-export type GroupedMenuOption = ActionGroup['properties'] & {
-  children?: MenuOption[];
-};
-
-export enum MenuOptionType {
-  GROUP_MENU,
-  SUB_MENU,
-  ATOMIC_MENU,
-}
-
-export type ActionService = {
-  actions: Action[];
-  options: MenuOption[];
-  loaded: boolean;
-  error: any;
-};

--- a/frontend/packages/console-shared/src/components/actions/utils.ts
+++ b/frontend/packages/console-shared/src/components/actions/utils.ts
@@ -1,6 +1,11 @@
-import { Action, ActionGroup } from '@console/dynamic-plugin-sdk';
+import {
+  Action,
+  ActionGroup,
+  GroupedMenuOption,
+  MenuOption,
+  MenuOptionType,
+} from '@console/dynamic-plugin-sdk';
 import { LoadedExtension } from '@console/plugin-sdk';
-import { GroupedMenuOption, MenuOption, MenuOptionType } from './types';
 
 export const createMenuOptions = (
   actions: Action[],

--- a/frontend/packages/topology/src/actions/contextMenuActions.tsx
+++ b/frontend/packages/topology/src/actions/contextMenuActions.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import { Node, ContextSubMenuItem, ContextMenuItem, Graph } from '@patternfly/react-topology';
-import { Action } from '@console/dynamic-plugin-sdk/src';
-import { referenceFor } from '@console/internal/module/k8s';
 import {
-  getMenuOptionType,
+  Action,
   GroupedMenuOption,
   MenuOption,
   MenuOptionType,
-  orderExtensionBasedOnInsertBeforeAndAfter,
-} from '@console/shared';
+} from '@console/dynamic-plugin-sdk/src';
+import { referenceFor } from '@console/internal/module/k8s';
+import { getMenuOptionType, orderExtensionBasedOnInsertBeforeAndAfter } from '@console/shared';
 import ActionMenuItem from '@console/shared/src/components/actions/menu/ActionMenuItem';
 import { getResource } from '../utils';
 

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -294,6 +294,18 @@ $monitoring-line-height: 18px;
   margin-right: 10px;
 }
 
+.monitoring-alert-detail-toolbar.pf-c-toolbar  {
+  padding-top: 0;
+
+  .pf-c-toolbar__content{
+    padding: 0;
+  }
+
+  .co-section-heading{
+    margin: 0;
+  }
+}
+
 .monitoring-silence-alert {
   max-width: 950px;
 
@@ -496,9 +508,10 @@ $monitoring-line-height: 18px;
   padding: 10px 20px;
 }
 
-.query-browser__toggle-graph {
-  margin-bottom: 5px;
-  float: right;
+.query-browser__toggle-graph-container {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--pf-global--spacer--xs);
 }
 
 .query-browser__tooltip {

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -814,7 +814,9 @@ const QueryBrowserPage_: React.FC<{}> = () => {
       <div className="co-m-pane__body">
         <div className="row">
           <div className="col-xs-12">
-            <ToggleGraph />
+            <div className="query-browser__toggle-graph-container">
+              <ToggleGraph />
+            </div>
           </div>
         </div>
         <div className="row">


### PR DESCRIPTION
Exposes ActionServiceProvider to ease the consumption of action extensions. Using the ActionsServiceProvider includes an extension points to alerts toolbar.

https://user-images.githubusercontent.com/5461414/185861110-7acaf8ae-0ec3-4cb2-9ec6-fa09ab314d03.mov
