### PR TITLE
Bug 2114488: Fix Monitoring Alert decorator icon color in Topology

### DIFF
--- a/frontend/packages/console-shared/src/components/alerts/AlertSeverityIcon.tsx
+++ b/frontend/packages/console-shared/src/components/alerts/AlertSeverityIcon.tsx
@@ -17,7 +17,7 @@ const AlertSeverityIcon: React.FC<AlertSeverityIconProps> = ({
         <ExclamationCircleIcon
           style={{
             fontSize,
-            color: 'var(--pf-global--danger-color--100)',
+            fill: 'var(--pf-global--danger-color--100)',
           }}
         />
       );
@@ -27,7 +27,7 @@ const AlertSeverityIcon: React.FC<AlertSeverityIconProps> = ({
         <ExclamationTriangleIcon
           style={{
             fontSize,
-            color: 'var(--pf-global--warning-color--100)',
+            fill: 'var(--pf-global--warning-color--100)',
           }}
         />
       );


### PR DESCRIPTION
**Fix:** https://bugzilla.redhat.com/show_bug.cgi?id=2114488

**Screeshots:**
![image (9)](https://user-images.githubusercontent.com/2561818/182686089-5b94e02f-831b-44c4-9dc0-5b7cdf5d606e.png)
![image (10)](https://user-images.githubusercontent.com/2561818/182686106-309036fa-43e8-42f7-b349-fb87d2af6d6c.png)
![image (11)](https://user-images.githubusercontent.com/2561818/182686112-a4106a28-b20f-49eb-8bc0-ac16478d85c6.png)
![image (12)](https://user-images.githubusercontent.com/2561818/182686117-66d36a69-058d-4ab1-99e3-87ca94260225.png)
