### PR TITLE
Bug 2102341: Include min-width on operator icon img so that Firefox displays them correctly

### DIFF
--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -82,6 +82,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
     align-items: center;
     display: flex;
     min-height: 40px;
+    min-width: 40px; // prevent Firefox from collapsing the img since it assigns base64 encoded svg without height and width values to 0 https://bugzilla.mozilla.org/show_bug.cgi?id=1328124 and https://jsbin.com/kuzovihumo/edit?js,console
   }
 
   &__icon {


### PR DESCRIPTION
Firefox rendering an encoded image `<img src="data:image/svg+xml;base64...` without height and width values... it defaults the image size to 0x0. 
So a `min-width` is needed for operator icons to display correctly in the Installed Operators list.
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2102341


https://bugzilla.mozilla.org/show_bug.cgi?id=1328124

https://jsbin.com/kuzovihumo/edit?js,console Test case showing height and width output

**Before**
<img width="780" alt="Screen Shot 2022-08-04 at 4 18 46 PM (2)" src="https://user-images.githubusercontent.com/1874151/182951267-578abfae-eb24-4348-8049-342c78398f04.png">


**After**
<img width="712" alt="Screen Shot 2022-08-04 at 4 59 03 PM" src="https://user-images.githubusercontent.com/1874151/182951610-d28c9889-a70e-4b04-bb27-5be1080438fc.png">

