### PR TITLE
Bug 2001211: Resource usage measurement data display the concatenatio…

### DIFF
--- a/frontend/public/components/utils/datetime.ts
+++ b/frontend/public/components/utils/datetime.ts
@@ -9,6 +9,7 @@ export const maxClockSkewMS = -60000;
 export const timeFormatter = new Intl.DateTimeFormat(getLastLanguage() || undefined, {
   hour: 'numeric',
   minute: 'numeric',
+  hour12: true,
 });
 
 export const timeFormatterWithSeconds = new Intl.DateTimeFormat(getLastLanguage() || undefined, {


### PR DESCRIPTION
…n of English and translation sentence fragments on utilization section when moving the mouse over each resource usage chart in Developer->Project

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2001211