### PR TITLE
Bug 2090457: openshift-debug-node- namespaces do not get deleted for …

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeTerminal.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeTerminal.tsx
@@ -140,7 +140,7 @@ const NodeTerminal: React.FC<NodeTerminalProps> = ({ obj: node }) => {
     };
     const closeTab = (event) => {
       event.preventDefault();
-      deleteNamespace(namespace.metadata.name);
+      k8sKillByName(NamespaceModel, namespace.metadata.name);
     };
     const createDebugPod = async () => {
       try {

--- a/frontend/public/components/debug-terminal.tsx
+++ b/frontend/public/components/debug-terminal.tsx
@@ -121,7 +121,7 @@ export const DebugTerminal: React.FC<DebugTerminalProps> = ({ podData, container
     let newDebugPod;
     const closeTab = (event) => {
       event.preventDefault();
-      deleteDebugPod(newDebugPod.metadata.name);
+      k8sKillByName(PodModel, newDebugPod.metadata.name, podNamespace);
     };
     const createDebugPod = async () => {
       try {


### PR DESCRIPTION
…debug terminals launched via console

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2090457