### PR TITLE
Bug 2116415: e2e: Disable Shipwright e2e tests

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -40,7 +40,6 @@ if [ $# -eq 0 ]; then
     echo "  test-cypress.sh -p gitops                             // opens Cypress Test Runner for gitops tests"
     echo "  test-cypress.sh -p knative                            // opens Cypress Test Runner for knative tests"
     echo "  test-cypress.sh -p pipelines                          // opens Cypress Test Runner for pipelines tests"
-    echo "  test-cypress.sh -p shipwright                         // opens Cypress Test Runner for shipwright tests"
     echo "  test-cypress.sh -h true                               // runs all packages in headless mode"
     echo "  test-cypress.sh -p olm -h true                        // runs OLM tests in headless mode"
     echo "  test-cypress.sh -p console -s 'tests/crud/*' -h true  // runs console CRUD tests in headless mode"
@@ -58,7 +57,6 @@ if [ -n "${nightly-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-dev-console-nightly
   yarn run test-cypress-helm-nightly
   yarn run test-cypress-pipelines-nightly
-  yarn run test-cypress-shipwright-nightly
   yarn run test-cypress-topology-nightly
   yarn run test-cypress-knative-nightly
 
@@ -73,7 +71,6 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
   yarn run test-cypress-pipelines-headless
-  yarn run test-cypress-shipwright-headless
   exit;
 fi
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2116415

Descriptions:
- Disabling the Shipwright e2e tests as getting timeout error in CI.