### PR TITLE
Bug 2094502: Fix bug where the create required custom resource button points to the wrong namespace.

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -914,11 +914,6 @@ const InitializationResourceAlert: React.FC<InitializationResourceAlertProps> = 
         <CreateInitializationResourceButton
           obj={props.csv}
           initializationResource={initializationResource}
-          targetNamespace={
-            model?.namespaced
-              ? initializationResource?.metadata.namespace || csv.metadata?.namespace
-              : null
-          }
         />
       </Alert>
     );

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
@@ -23,7 +23,6 @@ import {
 } from '@console/internal/components/utils';
 import {
   k8sPatch,
-  modelFor,
   referenceForModel,
   referenceFor,
   K8sResourceKind,
@@ -156,14 +155,9 @@ export const CreateInitializationResourceButton: React.FC<InitializationResource
   disabled,
   initializationResource,
   obj,
-  targetNamespace,
 }) => {
   const { t } = useTranslation();
   const reference = referenceFor(initializationResource);
-  const model = modelFor(reference);
-  const initializationResourceNamespace = model?.namespaced
-    ? initializationResource?.metadata?.namespace || targetNamespace
-    : null;
   const kind = initializationResource?.kind;
   const button = (
     <Button aria-disabled={disabled} isDisabled={disabled} variant="primary">
@@ -178,7 +172,7 @@ export const CreateInitializationResourceButton: React.FC<InitializationResource
       to={`${resourcePathFromModel(
         ClusterServiceVersionModel,
         obj.metadata.name,
-        initializationResourceNamespace,
+        obj.metadata.namespace,
       )}/${reference}/~new?useInitializationResource`}
     >
       {button}
@@ -243,7 +237,6 @@ const InstallSucceededMessage: React.FC<InstallSuccededMessageProps> = ({
           <CreateInitializationResourceButton
             initializationResource={initializationResource}
             obj={obj}
-            targetNamespace={namespace}
           />
         ) : (
           <Link to={resourcePathFromModel(ClusterServiceVersionModel, csvName, namespace)}>
@@ -291,7 +284,6 @@ const InstallingMessage: React.FC<InstallingMessageProps> = ({ namespace, obj })
             disabled
             initializationResource={initializationResource}
             obj={obj}
-            targetNamespace={namespace}
           />
         )}
         <ViewInstalledOperatorsButton namespace={namespace} />
@@ -520,7 +512,6 @@ type InitializationResourceButtonProps = {
   disabled?: boolean;
   initializationResource: K8sResourceKind;
   obj: ClusterServiceVersionKind | InstallPlanKind | SubscriptionKind;
-  targetNamespace: string;
 };
 type ViewOperatorButtonProps = {
   namespace: string;


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2094502

cc @spadgett @zherman0 

**Advanced Cluster Management for Kubernetes bug**
<img width="1346" alt="MCH-bug" src="https://user-images.githubusercontent.com/1874151/183939013-ac1c6529-d22b-4ba0-836f-11d38984e0d5.png">

----

**multicluster engine for Kubernetes bug**
<img width="1341" alt="MCE-bug" src="https://user-images.githubusercontent.com/1874151/183939206-de224a90-8719-4b40-9878-3bb4ec274b90.png">

