### PR TITLE
Bug 2117367: Include referenced .scss files when building core plugin SDK package

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/tsconfig-base.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/tsconfig-base.json
@@ -11,7 +11,7 @@
     "experimentalDecorators": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
-    "lib": ["es2016", "es2017.object", "es2020.promise", "dom"],
+    "lib": ["es2016", "es2017.object", "es2020.promise", "es2020.string", "dom"],
     "typeRoots": ["node_modules/@types", "@types"],
     "types": ["node", "sdk"]
   }


### PR DESCRIPTION
This PR uses the existing support for copying additional files when building Console plugin SDK packages.

Instead of using AST processors like [Acorn](https://github.com/acornjs/acorn) we simply match all import statements within the generated `.js` files, resolve the relative asset path and ensure the asset gets copied to the relevant path under `dist` directory.

![](https://user-images.githubusercontent.com/648971/183998198-d3c1dc44-f9a1-4636-b5f0-8cdd0ec387ff.png)
![](https://user-images.githubusercontent.com/648971/183998130-27ffd5f8-4582-4aff-a8ca-e7dae402e0da.png)
