### PR TITLE
Add support for param of array type when starting a Pipeline

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
@@ -7,13 +7,13 @@ Feature: Create the pipeline from builder page
 
 
         @smoke
-        Scenario: user navigates to pipelines page from Add page on selecting Pipeline card  : A-02-TC01
+        Scenario: user navigates to pipelines page from Add page on selecting Pipeline card: P-02-TC01
              When user selects "Pipeline" card from add page
              Then user redirects to Pipeline Builder page
 
 
         @regression
-        Scenario: Pipeline Builder page: P-02-TC01
+        Scenario: Pipeline Builder page: P-02-TC02
             Given user is at pipelines page
              When user clicks Create Pipeline button on Pipelines page
              Then user will be redirected to Pipeline Builder page
@@ -24,7 +24,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression
-        Scenario Outline: Create a pipeline with series tasks: P-02-TC02
+        Scenario Outline: Create a pipeline with series tasks: P-02-TC03
             Given user is at Pipeline Builder page
              When user enters pipeline name as "<pipeline_name>"
               And user clicks Add task button under Tasks section
@@ -40,7 +40,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression
-        Scenario Outline: Create a pipeline with parallel tasks: P-02-TC03
+        Scenario Outline: Create a pipeline with parallel tasks: P-02-TC04
             Given user is at Pipeline Builder page
              When user enters pipeline name as "<pipeline_name>"
               And user clicks Add task button under Tasks section
@@ -56,7 +56,7 @@ Feature: Create the pipeline from builder page
 
 
         @smoke
-        Scenario Outline: Create a basic pipeline from pipeline builder page: P-02-TC04
+        Scenario Outline: Create a basic pipeline from pipeline builder page: P-02-TC05
             Given user is at Pipeline Builder page
              When user enters pipeline name as "<pipeline_name>"
               And user clicks Add task button under Tasks section
@@ -70,9 +70,9 @@ Feature: Create the pipeline from builder page
                   | pipe-three    | kn                |
 
 
-    @un-verified
-    #test data required
-        Scenario Outline: Create pipeline with "<resource_type>" as resource type from pipeline builder page: P-02-TC05
+        @un-verified
+        #test data required
+        Scenario Outline: Create pipeline with "<resource_type>" as resource type from pipeline builder page: P-02-TC06
             Given user is at Pipeline Builder page
              When user enters pipeline name as "<pipeline_name>"
               And user clicks on Add task
@@ -92,7 +92,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression
-        Scenario: Add Parameters to the pipeline in pipeline builder page: P-02-TC06
+        Scenario: Add Parameters to the pipeline in pipeline builder page: P-02-TC07
             Given user is at Pipeline Builder page
              When user enters pipeline name as "pipeline-params"
               And user clicks Add task button under Tasks section
@@ -108,7 +108,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression
-        Scenario: Deleting added task with delete icon in pipeline builder page: P-02-TC07
+        Scenario: Deleting added task with delete icon in pipeline builder page: P-02-TC08
             Given user is at Pipeline Builder page
              When user enters pipeline name as "pipeline-delete-task"
               And user clicks Add task button under Tasks section
@@ -121,7 +121,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression
-        Scenario Outline: Create a pipeline with TektonHub task not present in cluster from pipeline builder page: P-02-TC08
+        Scenario Outline: Create a pipeline with TektonHub task not present in cluster from pipeline builder page: P-02-TC09
             Given user is at Pipeline Builder page
              When user enters pipeline name as "<pipeline_name>"
               And user clicks Add task button under Tasks section
@@ -136,7 +136,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression
-        Scenario: Upgrade tasks that are already installed on the cluster in pipeline builder page: P-02-TC09
+        Scenario: Upgrade tasks that are already installed on the cluster in pipeline builder page: P-02-TC10
             Given user is at Pipeline Builder page
              When user enters pipeline name as "pipeline-client"
               And user installs and removes "openshift-client" of "Community" provider
@@ -149,7 +149,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression @manual
-        Scenario: Create the pipeline from yaml editor: P-02-TC10
+        Scenario: Create the pipeline from yaml editor: P-02-TC11
             Given user is at Pipeline Builder page
              When user selects YAML view
               And user clicks Create button on Pipeline Yaml page
@@ -157,7 +157,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression
-        Scenario: Create pipeline with Workspaces: P-02-TC11
+        Scenario: Create pipeline with Workspaces: P-02-TC12
             Given user is at Pipeline Builder page
              When user enters pipeline name as "pipeline-workspace"
               And user clicks Add task button under Tasks section
@@ -176,7 +176,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression
-        Scenario: Create pipeline with optional Workspaces: P-02-TC12
+        Scenario: Create pipeline with optional Workspaces: P-02-TC13
             Given user is at Pipeline Builder page
              When user enters pipeline name as "pipe-opt-workspace"
               And user clicks Add task button under Tasks section
@@ -196,7 +196,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression @manual
-        Scenario: Add finally task node: P-02-TC13
+        Scenario: Add finally task node: P-02-TC14
             Given user is at Pipeline Builder page
              When user clicks on Add finally task
               And user clicks on Add task
@@ -228,7 +228,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression
-        Scenario: When expression in the Pipeline Builder: P-02-TC15
+        Scenario: When expression in the Pipeline Builder: P-02-TC16
             Given user is at Pipeline Builder page
               And user has chain of 3 tasks created in series
         # user uses yaml content "sum-and-multiply-pipeline/sum-and-multiply-pipeline.yaml"
@@ -242,7 +242,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression
-        Scenario: Start pipeline with When expression in the Pipeline Builder: P-02-TC16
+        Scenario: Start pipeline with When expression in the Pipeline Builder: P-02-TC17
             Given user is at Pipeline Builder page
               And user has named pipeline as "pipeline-when-expression"
               And user has tasks "tkn" and "kn" in series
@@ -277,7 +277,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression
-        Scenario: Code assistance for referencing workspaces in the Pipeline Builder: P-02-TC18
+        Scenario: Code assistance for referencing workspaces in the Pipeline Builder: P-02-TC19
             Given user has applied yaml "configMap-test-motd.yaml"
         # user uses yaml content "using-optional-workspaces-in-when-expressions-pipelineRun/configMap-test-motd.yaml" in editor
               And user is at YAML view
@@ -290,7 +290,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression
-        Scenario: Code assistance for referencing Context-based values in the Pipeline Builder: P-02-TC19
+        Scenario: Code assistance for referencing Context-based values in the Pipeline Builder: P-02-TC20
             Given user is at pipelines page
              When user clicks on import YAML button
               And user enters yaml content from yaml file "pipelineRun-using_context_variables.yaml" in the editor
@@ -301,7 +301,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression
-        Scenario: Code assistance for referencing Task Results in the Pipeline Builder: P-02-TC20
+        Scenario: Code assistance for referencing Task Results in the Pipeline Builder: P-02-TC21
             Given user has imported YAML "task-sum.yaml" and "task-multiply.yaml"
         # user uses yaml content "sum-and-multiply-pipeline/task-sum.yaml" and "sum-and-multiply-pipeline/task-multiply.yaml" in editor
               And user is at YAML view of Pipeline Builder page
@@ -317,7 +317,7 @@ Feature: Create the pipeline from builder page
 
 
         @regression @manual @odc-6377
-        Scenario: Disable Tektonhub integration in the pipeline builder : P-02-TC21
+        Scenario: Disable Tektonhub integration in the pipeline builder : P-02-TC22
             Given user is at Search page
               And user searches 'TektonConfig' in Resources dropdown
               And user selects config with apiVersion operator.openshift.io/v1 option from Resources dropdown
@@ -333,10 +333,29 @@ Feature: Create the pipeline from builder page
 
 
         @regression @manual @odc-6236
-        Scenario: Pipeline builder to support local Tekton Hub instances : P-02-TC21
+        Scenario: Pipeline builder to support local Tekton Hub instances : P-02-TC23
             Given user has setup tektonhub instance
         # Refer to document https://docs.google.com/document/d/1HImc2DdtFKMWgk5dTm8Ib-I3wgnVXxdHxzX8Cn0jrZA/edit?usp=sharing for setting up tektonhub insance
               And user is at Pipeline Builder page
              When user clicks on Add task button under Tasks section
               And user searches a tasks that is available in the local tektonhub instance
              Then user will see the intended community task
+
+        @regression @odc-6696
+        Scenario Outline: Start pipeline with parameter of type array: P-02-TC24
+            Given user is at "YAML View" on Pipeline Builder page
+             When user creates pipeline resource using YAML editor from "<pipeline_yaml>"
+              And user will see pipeline "<pipeline_name>" in pipelines page
+              And user selects "Start" from the kebab menu for "<pipeline_name>"
+              And user will see array type parameter "param1" field
+              And user add array type parameter "param1" value "value1"
+              And user click on pipeline start modal Start button
+             Then user will be redirected to Pipeline Run Details page
+              And user navigates to pipelineRun parameters tab
+              And user see the added parameter value
+              And user see the pipeline succeeded
+
+        Examples:
+                  | pipeline_yaml                                | pipeline_name                 |
+                  | testData/pipelineWithParameterTypeArray.yaml | pipeline-with-array-parameter |
+

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
@@ -15,6 +15,7 @@ import {
   pipelineDetailsPage,
   pipelineBuilderSidePane,
   pipelineRunDetailsPage,
+  startPipelineInPipelinesPage,
 } from '../../pages';
 
 When('user clicks Create Pipeline button on Pipelines page', () => {
@@ -605,4 +606,34 @@ When('user changes version to {string}', (menuItem: string) => {
 
 When('user clicks on Update and Add button', () => {
   cy.byTestID('task-cta').click();
+});
+
+When('user will see array type parameter {string} field', (param: string) => {
+  cy.byTestID(`${param}-text-column-field`).should('be.visible');
+});
+
+When('user add array type parameter {string} value {string}', (param: string, value: string) => {
+  cy.byTestID(`${param}-text-column-field`)
+    .get('[data-test="add-action"]')
+    .should('be.visible')
+    .click();
+  cy.get('#form-input-parameters-0-value-2-field').type(value);
+});
+
+When('user click on pipeline start modal Start button', () => {
+  startPipelineInPipelinesPage.clickStart();
+});
+
+Then('user see the added parameter value', () => {
+  cy.get('#form-input-parameters-0-value-field').should('have.value', 'foo,bar,value1');
+});
+
+When('user will see pipeline {string} in pipelines page', (name: string) => {
+  navigateTo(devNavigationMenu.Add);
+  navigateTo(devNavigationMenu.Pipelines);
+  pipelinesPage.search(name);
+});
+
+Then('user see the pipeline succeeded', () => {
+  cy.byTestID('status-text').should('have.text', 'Succeeded');
 });

--- a/frontend/packages/pipelines-plugin/integration-tests/testData/pipelineWithParameterTypeArray.yaml
+++ b/frontend/packages/pipelines-plugin/integration-tests/testData/pipelineWithParameterTypeArray.yaml
@@ -1,0 +1,29 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline-with-array-parameter
+spec:
+  params:
+    - name: param1
+      description: ''
+      default:
+        - foo
+        - bar
+    - name: param2
+      description: ''
+      default: default1
+  resources: []
+  workspaces: []
+  tasks:
+    - name: kn
+      taskRef:
+        kind: ClusterTask
+        name: kn
+      params:
+        - name: kn-image
+          value: >-
+            registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:9bc475db01697e6d6eac2e47a655971cbee7f821684aa48f30729fb49976559d
+        - name: ARGS
+          value:
+            - help
+  finally: []

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineForm.tsx
@@ -4,7 +4,7 @@ import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { k8sUpdate, K8sResourceKind } from '@console/internal/module/k8s';
 import { PipelineModel } from '../../../models';
-import { removeEmptyDefaultFromPipelineParams } from './utils';
+import { sanitizePipelineParams } from './utils';
 
 export interface PipelineFormProps {
   PipelineFormComponent: React.ComponentType<any>;
@@ -32,7 +32,7 @@ const PipelineForm: React.FC<PipelineFormProps> = ({
         ...obj,
         spec: {
           ...obj.spec,
-          params: removeEmptyDefaultFromPipelineParams(values.parameters),
+          params: sanitizePipelineParams(values.parameters),
           resources: values.resources,
         },
       },

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/utils.spec.ts
@@ -1,7 +1,11 @@
 import * as _ from 'lodash';
 import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
 import { TektonParam } from '../../../../types';
-import { getPipelineTaskLinks, removeEmptyDefaultFromPipelineParams } from '../utils';
+import {
+  getPipelineTaskLinks,
+  removeEmptyDefaultFromPipelineParams,
+  sanitizePipelineParams,
+} from '../utils';
 import { pipelineParameters, pipelineParametersWithoutDefaults } from './utils-data';
 
 describe('removeEmptyDefaultFromPipelineParams omits empty default values', () => {
@@ -45,6 +49,37 @@ describe('removeEmptyDefaultFromPipelineParams omits empty default values', () =
   it('should return pipline parameters as is if the default property is not present', () => {
     const result = removeEmptyDefaultFromPipelineParams(pipelineParametersWithoutDefaults);
     expect(result).toEqual(pipelineParametersWithoutDefaults);
+  });
+});
+
+describe('sanitizePipelineParams convert the param default string value to array if param type is array', () => {
+  it('should return empty array if pipeline parameters is null or empty', () => {
+    let result = sanitizePipelineParams(null);
+    expect(result).toEqual([]);
+
+    result = sanitizePipelineParams([]);
+    expect(result).toEqual([]);
+  });
+  it('should convert pipeline parameters default to array if type is array', () => {
+    const pipelineParams = _.cloneDeep(pipelineParameters);
+    pipelineParams[1].default = 'foo, bar';
+    pipelineParams[1].type = 'array';
+    const result = sanitizePipelineParams(pipelineParams);
+    expect(result[1].default).toEqual(['foo', 'bar']);
+  });
+  it('should return pipeline parameters as it is if default is array and type is array', () => {
+    const pipelineParams = _.cloneDeep(pipelineParameters);
+    pipelineParams[1].default = ['foo', 'bar'];
+    pipelineParams[1].type = 'array';
+    const result = sanitizePipelineParams(pipelineParams);
+    expect(result[1].default).toEqual(['foo', 'bar']);
+  });
+  it('should return pipeline parameters as it is if default is string and type is string', () => {
+    const pipelineParams = _.cloneDeep(pipelineParameters);
+    pipelineParams[1].default = 'foo';
+    pipelineParams[1].type = 'string';
+    const result = sanitizePipelineParams(pipelineParams);
+    expect(result[1].default).toEqual('foo');
   });
 });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/utils.ts
@@ -21,6 +21,21 @@ export const removeEmptyDefaultFromPipelineParams = (parameters: TektonParam[]):
       _.omit(parameter, _.isEmpty(parameter.default) ? ['default'] : []) as TektonParam,
   );
 
+export const sanitizePipelineParams = (parameters: TektonParam[]): TektonParam[] => {
+  const pipelineWithNoEmptyDefaultParams = removeEmptyDefaultFromPipelineParams(parameters);
+  return pipelineWithNoEmptyDefaultParams.length > 0
+    ? pipelineWithNoEmptyDefaultParams.map((parameter) => {
+        if (parameter?.type === 'array' && typeof parameter?.default === 'string') {
+          return {
+            ...parameter,
+            default: parameter.default.split(',').map((param) => param.trim()),
+          };
+        }
+        return parameter;
+      })
+    : [];
+};
+
 type PipelineTaskLinks = {
   taskLinks: ResourceModelLink[];
   finallyTaskLinks: ResourceModelLink[];

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineParameterSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineParameterSection.tsx
@@ -3,7 +3,7 @@ import { TextInputTypes } from '@patternfly/react-core';
 import { FieldArray, useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
-import { InputField } from '@console/shared';
+import { InputField, TextColumnField } from '@console/shared';
 import { paramIsRequired } from '../../../../utils/common';
 import AutoCompletePopover from '../../../shared/common/auto-complete/AutoCompletePopover';
 import { CommonPipelineModalFormikValues, ModalParameter } from './types';
@@ -42,8 +42,36 @@ const PipelineParameterSection: React.FC<ParametersSectionProps> = ({ autoComple
                   autoComplete="off"
                 />
               );
-
-              return (
+              return parameter.type === 'array' ? (
+                <TextColumnField
+                  name={name}
+                  label={parameter.name}
+                  helpText={parameter.description}
+                  required={isRequired}
+                  addLabel={`Add ${parameter.name}`}
+                  data-test={`${parameter.name}-text-column-field`}
+                >
+                  {({ name: arrayName, ...additionalProps }) =>
+                    autoCompleteValues ? (
+                      <AutoCompletePopover
+                        autoCompleteValues={autoCompleteValues}
+                        onAutoComplete={(value: string) => setFieldValue(name, value)}
+                      >
+                        {(callbackRef) => (
+                          <InputField
+                            ref={callbackRef}
+                            name={arrayName}
+                            {...additionalProps}
+                            autoComplete="off"
+                          />
+                        )}
+                      </AutoCompletePopover>
+                    ) : (
+                      <InputField name={arrayName} {...additionalProps} autoComplete="off" />
+                    )
+                  }
+                </TextColumnField>
+              ) : (
                 <React.Fragment key={parameter.name}>
                   {autoCompleteValues ? (
                     <AutoCompletePopover

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/switch-to-form-validation-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/switch-to-form-validation-utils.spec.ts
@@ -70,18 +70,10 @@ describe('Pipeline Builder YAML to Form switch validation schema', () => {
     ])
       .then(shouldHaveFailed)
       .catch(
-        hasMultipleErrors([
-          {
-            yupPath: 'spec.params[0].name',
-            errorMessage:
-              'spec.params[0].name must be a `string` type, but the final value was: `{\n  "test": "\\"test\\""\n}`.',
-          },
-          {
-            yupPath: 'spec.params[0].default',
-            errorMessage:
-              'spec.params[0].default must be a `string` type, but the final value was: `[\n  "\\"value\\""\n]`.',
-          },
-        ]),
+        hasError(
+          'spec.params[0].name',
+          'spec.params[0].name must be a `string` type, but the final value was: `{\n  "test": "\\"test\\""\n}`.',
+        ),
       );
   });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/switch-to-form-validation-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/switch-to-form-validation-utils.ts
@@ -89,7 +89,7 @@ export const pipelineBuilderYAMLSchema = (formData: PipelineBuilderFormValues) =
         yup.object({
           name: yup.string(),
           description: yup.string(),
-          default: yup.string(),
+          default: yup.lazy((val) => (Array.isArray(val) ? yup.array() : yup.string())),
         }),
       ),
       resources: yup.array().of(

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/utils.ts
@@ -11,7 +11,7 @@ import {
   TaskKind,
   TektonParam,
 } from '../../../types';
-import { removeEmptyDefaultFromPipelineParams } from '../detail-page-tabs';
+import { sanitizePipelineParams } from '../detail-page-tabs';
 import { getTaskParameters } from '../resource-utils';
 import {
   getTaskErrorString,
@@ -354,7 +354,7 @@ export const convertBuilderFormToPipeline = (
     spec: {
       ...existingPipeline?.spec,
       ...unhandledSpec,
-      params: removeEmptyDefaultFromPipelineParams(params),
+      params: sanitizePipelineParams(params),
       resources,
       workspaces,
       tasks: tasks.map((task) => removeEmptyFormFields(removeListRunAfters(task, listIds))),


### PR DESCRIPTION
**Story:** https://issues.redhat.com/browse/ODC-6773

**Descriptions:**
- Add support param of array type when starting a Pipeline
- user can add array type param in the start modal

**Screenshots:**
<img width="1168" alt="image" src="https://user-images.githubusercontent.com/2561818/184124231-2ff77618-db4c-4937-8dc4-dc4fce42f0bf.png">

![Kapture 2022-08-11 at 17 03 15](https://user-images.githubusercontent.com/2561818/184124588-d11ce814-7983-4164-91df-2217a59d68b4.gif)
