### PR TITLE
Monitoring: Import enums from dynamic plugin SDK

### DIFF
--- a/frontend/packages/console-shared/src/components/alerts/AlertSeverityIcon.tsx
+++ b/frontend/packages/console-shared/src/components/alerts/AlertSeverityIcon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ExclamationTriangleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
-import { AlertSeverity } from '@console/internal/components/monitoring/types';
+import { AlertSeverity } from '@console/dynamic-plugin-sdk';
 
 interface AlertSeverityIconProps {
   severityAlertType: AlertSeverity;

--- a/frontend/packages/console-shared/src/utils/__mocks__/alerts-and-rules-data.ts
+++ b/frontend/packages/console-shared/src/utils/__mocks__/alerts-and-rules-data.ts
@@ -1,8 +1,7 @@
-import { RuleStates } from '@console/dynamic-plugin-sdk';
+import { AlertStates, RuleStates } from '@console/dynamic-plugin-sdk';
 import {
   Alert,
   Alerts,
-  AlertStates,
   PrometheusRulesResponse,
 } from '@console/internal/components/monitoring/types';
 

--- a/frontend/packages/console-shared/src/utils/__mocks__/alerts-and-rules-data.ts
+++ b/frontend/packages/console-shared/src/utils/__mocks__/alerts-and-rules-data.ts
@@ -1,9 +1,9 @@
+import { RuleStates } from '@console/dynamic-plugin-sdk';
 import {
   Alert,
   Alerts,
   AlertStates,
   PrometheusRulesResponse,
-  RuleStates,
 } from '@console/internal/components/monitoring/types';
 
 export const mockAlerts: Alerts = {

--- a/frontend/packages/console-shared/src/utils/__tests__/alert-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/alert-utils.spec.ts
@@ -1,4 +1,4 @@
-import { AlertSeverity } from '@console/internal/components/monitoring/types';
+import { AlertSeverity } from '@console/dynamic-plugin-sdk';
 import { mockAlerts, mockAlerts2, expectedFiringAlerts } from '../__mocks__/alerts-and-rules-data';
 import {
   getSeverityAlertType,

--- a/frontend/packages/console-shared/src/utils/alert-utils.ts
+++ b/frontend/packages/console-shared/src/utils/alert-utils.ts
@@ -1,5 +1,6 @@
 import * as _ from 'lodash';
-import { Alert, AlertSeverity, AlertStates } from '@console/internal/components/monitoring/types';
+import { AlertStates } from '@console/dynamic-plugin-sdk';
+import { Alert, AlertSeverity } from '@console/internal/components/monitoring/types';
 import { alertSeverityOrder } from '@console/internal/components/monitoring/utils';
 
 export const sortMonitoringAlerts = (alerts: Alert[]): Alert[] =>

--- a/frontend/packages/console-shared/src/utils/alert-utils.ts
+++ b/frontend/packages/console-shared/src/utils/alert-utils.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
-import { AlertStates } from '@console/dynamic-plugin-sdk';
-import { Alert, AlertSeverity } from '@console/internal/components/monitoring/types';
+import { AlertSeverity, AlertStates } from '@console/dynamic-plugin-sdk';
+import { Alert } from '@console/internal/components/monitoring/types';
 import { alertSeverityOrder } from '@console/internal/components/monitoring/utils';
 
 export const sortMonitoringAlerts = (alerts: Alert[]): Alert[] =>

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceAlert.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceAlert.tsx
@@ -5,6 +5,7 @@ import * as _ from 'lodash';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import { useDispatch } from 'react-redux';
+import { RuleStates } from '@console/dynamic-plugin-sdk';
 import { alertingSetRules } from '@console/internal/actions/observe';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import {
@@ -12,7 +13,7 @@ import {
   PROMETHEUS_TENANCY_BASE_PATH,
 } from '@console/internal/components/graphs';
 import { StateTimestamp } from '@console/internal/components/monitoring/alerting';
-import { Rule, RuleStates } from '@console/internal/components/monitoring/types';
+import { Rule } from '@console/internal/components/monitoring/types';
 import {
   alertingRuleStateOrder,
   getAlertsAndRules,

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.tsx
@@ -5,11 +5,11 @@ import { useTranslation } from 'react-i18next';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import { useSelector, useDispatch } from 'react-redux';
-import { getUser, RuleStates, SilenceStates } from '@console/dynamic-plugin-sdk';
+import { AlertStates, getUser, RuleStates, SilenceStates } from '@console/dynamic-plugin-sdk';
 import { alertingSetRules } from '@console/internal/actions/observe';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { ALERTMANAGER_TENANCY_BASE_PATH } from '@console/internal/components/graphs';
-import { AlertStates, Rule, Silence } from '@console/internal/components/monitoring/types';
+import { Rule, Silence } from '@console/internal/components/monitoring/types';
 import { isSilenced } from '@console/internal/components/monitoring/utils';
 import { Dropdown, LoadingInline } from '@console/internal/components/utils';
 import { parsePrometheusDuration } from '@console/internal/components/utils/datetime';

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.tsx
@@ -5,16 +5,11 @@ import { useTranslation } from 'react-i18next';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import { useSelector, useDispatch } from 'react-redux';
-import { getUser, SilenceStates } from '@console/dynamic-plugin-sdk';
+import { getUser, RuleStates, SilenceStates } from '@console/dynamic-plugin-sdk';
 import { alertingSetRules } from '@console/internal/actions/observe';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { ALERTMANAGER_TENANCY_BASE_PATH } from '@console/internal/components/graphs';
-import {
-  AlertStates,
-  Rule,
-  RuleStates,
-  Silence,
-} from '@console/internal/components/monitoring/types';
+import { AlertStates, Rule, Silence } from '@console/internal/components/monitoring/types';
 import { isSilenced } from '@console/internal/components/monitoring/utils';
 import { Dropdown, LoadingInline } from '@console/internal/components/utils';
 import { parsePrometheusDuration } from '@console/internal/components/utils/datetime';

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import { useSelector, useDispatch } from 'react-redux';
-import { getUser } from '@console/dynamic-plugin-sdk';
+import { getUser, SilenceStates } from '@console/dynamic-plugin-sdk';
 import { alertingSetRules } from '@console/internal/actions/observe';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { ALERTMANAGER_TENANCY_BASE_PATH } from '@console/internal/components/graphs';
@@ -14,7 +14,6 @@ import {
   Rule,
   RuleStates,
   Silence,
-  SilenceStates,
 } from '@console/internal/components/monitoring/types';
 import { isSilenced } from '@console/internal/components/monitoring/utils';
 import { Dropdown, LoadingInline } from '@console/internal/components/utils';

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/__tests__/monitoring-alerts-utils.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/__tests__/monitoring-alerts-utils.spec.tsx
@@ -1,4 +1,4 @@
-import { AlertStates } from '@console/internal/components/monitoring/types';
+import { AlertStates } from '@console/dynamic-plugin-sdk';
 import { getAlertsAndRules } from '@console/internal/components/monitoring/utils';
 import { rules } from '@console/shared/src/utils/__mocks__/alerts-and-rules-data';
 import { monitoringAlertRows } from '../monitoring-alerts-utils';

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/monitoring-alerts-utils.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/monitoring-alerts-utils.tsx
@@ -7,6 +7,7 @@ import * as _ from 'lodash';
 // @ts-ignore
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { AlertStates } from '@console/dynamic-plugin-sdk';
 import {
   alertingErrored,
   alertingLoaded,
@@ -21,7 +22,7 @@ import {
   severityRowFilter,
   alertStateFilter,
 } from '@console/internal/components/monitoring/alerting';
-import { Alert, Rule, AlertStates, Silence } from '@console/internal/components/monitoring/types';
+import { Alert, Rule, Silence } from '@console/internal/components/monitoring/types';
 import {
   alertDescription,
   alertState,

--- a/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringOverview.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringOverview.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Badge } from '@patternfly/react-core';
 import { shallow, ShallowWrapper } from 'enzyme';
-import { AlertStates } from '@console/internal/components/monitoring/types';
+import { AlertStates } from '@console/dynamic-plugin-sdk';
 import { mockAlerts } from '@console/shared/src/utils/__mocks__/alerts-and-rules-data';
 import MonitoringOverview from '../MonitoringOverview';
 import { mockPodEvents, mockResourceEvents, mockPods } from './mockData';

--- a/frontend/packages/dev-console/src/components/monitoring/overview/monitoring-overview-alerts-utils.ts
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/monitoring-overview-alerts-utils.ts
@@ -1,4 +1,4 @@
-import { AlertSeverity } from '@console/internal/components/monitoring/types';
+import { AlertSeverity } from '@console/dynamic-plugin-sdk';
 
 export const getAlertType = (severity: string): 'danger' | 'warning' | 'info' => {
   switch (severity) {

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/HighPriorityAlerts.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/HighPriorityAlerts.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Alert } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { AlertSeverity } from '@console/internal/components/monitoring/types';
+import { AlertSeverity } from '@console/dynamic-plugin-sdk';
 import { ExternalLink } from '@console/internal/components/utils';
 import useFilteredAlerts from '../../hooks/useFilteredAlerts';
 

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
@@ -13,8 +13,8 @@ import {
   WithSelectionProps,
 } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
+import { AlertSeverity } from '@console/dynamic-plugin-sdk';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
-import { AlertSeverity } from '@console/internal/components/monitoring/types';
 import {
   AllPodStatus,
   calculateRadius,

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as fuzzy from 'fuzzysearch';
 import { nodeStatus, volumeSnapshotStatus } from '@console/app/src/status';
 import { getNodeRoles, getLabelsAsString } from '@console/shared';
-import { FilterValue, RowFilter } from '@console/dynamic-plugin-sdk';
+import { AlertStates, FilterValue, RowFilter } from '@console/dynamic-plugin-sdk';
 import { routeStatus } from '../routes';
 import { secretTypeFilterReducer } from '../secret';
 import { roleType } from '../RBAC';
@@ -24,7 +24,7 @@ import {
   targetSource,
 } from '../monitoring/utils';
 
-import { Alert, AlertStates, Rule, Silence, Target } from '../monitoring/types';
+import { Alert, Rule, Silence, Target } from '../monitoring/types';
 import { requesterFilter } from '@console/shared/src/components/namespace';
 
 export const fuzzyCaseInsensitive = (a: string, b: string): boolean =>

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -10,6 +10,7 @@ import {
   PrometheusLabels,
   RedExclamationCircleIcon,
   ResourceStatus,
+  SilenceStates,
   useActivePerspective,
   YellowExclamationTriangleIcon,
 } from '@console/dynamic-plugin-sdk';
@@ -77,7 +78,6 @@ import {
   Rule,
   Silence,
   Silences,
-  SilenceStates,
 } from './types';
 import {
   alertDescription,

--- a/frontend/public/components/monitoring/silence-form.tsx
+++ b/frontend/public/components/monitoring/silence-form.tsx
@@ -7,7 +7,7 @@ import { Trans, useTranslation } from 'react-i18next';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import { useSelector } from 'react-redux';
-import { getUser } from '@console/dynamic-plugin-sdk';
+import { getUser, SilenceStates } from '@console/dynamic-plugin-sdk';
 
 import { withFallback } from '@console/shared/src/components/error';
 import { coFetchJSON } from '../../co-fetch';
@@ -20,7 +20,7 @@ import { PageHeading, SectionHeading } from '../utils/headings';
 import { ExternalLink, getURLSearchParams } from '../utils/link';
 import { history } from '../utils/router';
 import { StatusBox } from '../utils/status-box';
-import { Silence, Silences, SilenceStates } from './types';
+import { Silence, Silences } from './types';
 import { SilenceResource, silenceState } from './utils';
 
 const pad = (i: number): string => (i < 10 ? `0${i}` : String(i));

--- a/frontend/public/components/monitoring/types.ts
+++ b/frontend/public/components/monitoring/types.ts
@@ -1,6 +1,5 @@
 import {
   Alert,
-  AlertSeverity,
   PrometheusLabels,
   PrometheusRule,
   Rule,
@@ -9,10 +8,6 @@ import {
 
 import { RowFunctionArgs } from '../factory';
 import { RowFilter } from '../filter-toolbar';
-
-export {
-  AlertSeverity,
-};
 
 // prettier 1.x doesn't support TS 3.8 syntax
 // eslint-disable-next-line prettier/prettier

--- a/frontend/public/components/monitoring/types.ts
+++ b/frontend/public/components/monitoring/types.ts
@@ -5,7 +5,6 @@ import {
   PrometheusLabels,
   PrometheusRule,
   Rule,
-  RuleStates,
   Silence,
 } from '@console/dynamic-plugin-sdk';
 
@@ -14,7 +13,6 @@ import { RowFilter } from '../filter-toolbar';
 
 export {
   AlertSeverity,
-  RuleStates,
   AlertStates,
 };
 

--- a/frontend/public/components/monitoring/types.ts
+++ b/frontend/public/components/monitoring/types.ts
@@ -7,14 +7,12 @@ import {
   Rule,
   RuleStates,
   Silence,
-  SilenceStates,
 } from '@console/dynamic-plugin-sdk';
 
 import { RowFunctionArgs } from '../factory';
 import { RowFilter } from '../filter-toolbar';
 
 export {
-  SilenceStates,
   AlertSeverity,
   RuleStates,
   AlertStates,

--- a/frontend/public/components/monitoring/types.ts
+++ b/frontend/public/components/monitoring/types.ts
@@ -1,7 +1,6 @@
 import {
   Alert,
   AlertSeverity,
-  AlertStates,
   PrometheusLabels,
   PrometheusRule,
   Rule,
@@ -13,7 +12,6 @@ import { RowFilter } from '../filter-toolbar';
 
 export {
   AlertSeverity,
-  AlertStates,
 };
 
 // prettier 1.x doesn't support TS 3.8 syntax

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -1,13 +1,13 @@
 import * as _ from 'lodash-es';
 import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
-import { RuleStates, SilenceStates } from '@console/dynamic-plugin-sdk';
+import { AlertStates, RuleStates, SilenceStates } from '@console/dynamic-plugin-sdk';
 
 import { ActionType, ObserveAction } from '../actions/observe';
 import {
   MONITORING_DASHBOARDS_DEFAULT_TIMESPAN,
   MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY,
 } from '../components/monitoring/dashboards/types';
-import { Alert, AlertStates } from '../components/monitoring/types';
+import { Alert } from '../components/monitoring/types';
 import { isSilenced } from '../components/monitoring/utils';
 
 export type ObserveState = ImmutableMap<string, any>;

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -1,13 +1,13 @@
 import * as _ from 'lodash-es';
 import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
-import { SilenceStates } from '@console/dynamic-plugin-sdk';
+import { RuleStates, SilenceStates } from '@console/dynamic-plugin-sdk';
 
 import { ActionType, ObserveAction } from '../actions/observe';
 import {
   MONITORING_DASHBOARDS_DEFAULT_TIMESPAN,
   MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY,
 } from '../components/monitoring/dashboards/types';
-import { Alert, AlertStates, RuleStates } from '../components/monitoring/types';
+import { Alert, AlertStates } from '../components/monitoring/types';
 import { isSilenced } from '../components/monitoring/utils';
 
 export type ObserveState = ImmutableMap<string, any>;

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -1,12 +1,13 @@
 import * as _ from 'lodash-es';
 import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
+import { SilenceStates } from '@console/dynamic-plugin-sdk';
 
 import { ActionType, ObserveAction } from '../actions/observe';
 import {
   MONITORING_DASHBOARDS_DEFAULT_TIMESPAN,
   MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY,
 } from '../components/monitoring/dashboards/types';
-import { Alert, AlertStates, RuleStates, SilenceStates } from '../components/monitoring/types';
+import { Alert, AlertStates, RuleStates } from '../components/monitoring/types';
 import { isSilenced } from '../components/monitoring/utils';
 
 export type ObserveState = ImmutableMap<string, any>;


### PR DESCRIPTION
`AlertSeverity`, `AlertStates`, `RuleStates` and `SilenceStates` were sometimes imported from the dynamic plugin SDK and sometimes from `components/monitoring/types.ts`.

This PR changes that to always import them from the SDK and removes them from `components/monitoring/types.ts`.