### PR TITLE
[release-4.10] OCPBUGS-403: fix broken update server link

### DIFF
--- a/frontend/public/components/modals/configure-cluster-upstream-modal.tsx
+++ b/frontend/public/components/modals/configure-cluster-upstream-modal.tsx
@@ -45,8 +45,8 @@ export const ConfigureClusterUpstreamModal = withHandlePromise(
     const { t } = useTranslation();
 
     const updateLink = isUpstream()
-      ? `${openshiftHelpBase}updating/installing-update-service.html`
-      : `${openshiftHelpBase}html/updating_clusters/installing-update-service`;
+      ? `${openshiftHelpBase}updating/understanding-openshift-updates.html`
+      : `${openshiftHelpBase}html/updating_clusters/updating-restricted-network-cluster#update-service-overview_updating-restricted-network-cluster`;
 
     return (
       <form onSubmit={submit} name="form" className="modal-content modal-content--no-inner-scroll">


### PR DESCRIPTION
Manual back port of https://github.com/openshift/console/pull/11830 as #11830 has more extensive changes that are not being back ported to 4.10.