### PR TITLE
RHSTOR-2124: Add support for documentation links in status card.

### DIFF
--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -43,6 +43,7 @@
   "{{count}} resource reached quota_plural": "{{count}} resources reached quota",
   "none are at quota": "none are at quota",
   "No ResourceQuotas": "No ResourceQuotas",
+  "Go to documentation": "Go to documentation",
   "View details": "View details",
   "Alerts could not be loaded.": "Alerts could not be loaded.",
   "({{operatorStatusLength}} installed)": "({{operatorStatusLength}} installed)",

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
@@ -14,6 +14,8 @@ import {
   getAlertDescription,
   getAlertTime,
   getAlertSummary,
+  getAlertDocumentation,
+  getAlertName,
 } from './alert-utils';
 
 const CriticalIcon = () => <RedExclamationCircleIcon title="Critical" />;
@@ -28,7 +30,15 @@ const getSeverityIcon = (severity: string) => {
   }
 };
 
-export const StatusItem: React.FC<StatusItemProps> = ({ Icon, timestamp, message, children }) => {
+export const StatusItem: React.FC<StatusItemProps> = ({
+  name,
+  documentationLink,
+  Icon,
+  timestamp,
+  message,
+  children,
+}) => {
+  const { t } = useTranslation();
   return (
     <div className="co-status-card__alert-item">
       <div className="co-status-card__alert-item-icon co-dashboard-icon">
@@ -36,6 +46,7 @@ export const StatusItem: React.FC<StatusItemProps> = ({ Icon, timestamp, message
       </div>
       <div className="co-status-card__alert-item-text">
         <div className="co-status-card__alert-item-message">
+          {name && <span className="co-status-card__alert-item-header">{name}</span>}
           <div
             className="co-health-card__alert-item-timestamp co-status-card__health-item-text text-secondary"
             data-test="timestamp"
@@ -43,6 +54,11 @@ export const StatusItem: React.FC<StatusItemProps> = ({ Icon, timestamp, message
             {timestamp && <Timestamp simple timestamp={timestamp} />}
           </div>
           <span className="co-status-card__health-item-text co-break-word">{message}</span>
+          {documentationLink && (
+            <a className="co-status-card__alert-item-doc-link" href={documentationLink}>
+              {t('console-shared~Go to documentation')}
+            </a>
+          )}
         </div>
         {children && <div className="co-status-card__alert-item-more">{children}</div>}
       </div>
@@ -65,6 +81,8 @@ const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {
       Icon={getSeverityIcon(getAlertSeverity(alert))}
       timestamp={getAlertTime(alert)}
       message={getAlertDescription(alert) || getAlertMessage(alert) || getAlertSummary(alert)}
+      documentationLink={getAlertDocumentation(alert)}
+      name={getAlertName(alert)}
     >
       {text && action ? (
         <Button variant={ButtonVariant.link} onClick={() => action(alert)} isInline>
@@ -83,4 +101,6 @@ type StatusItemProps = {
   Icon: React.ComponentType<any>;
   timestamp?: string;
   message: string;
+  name?: string;
+  documentationLink?: string;
 };

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Button, ButtonVariant } from '@patternfly/react-core';
+import { toLower } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { isAlertAction, AlertAction, useResolvedExtensions } from '@console/dynamic-plugin-sdk';
@@ -14,7 +15,6 @@ import {
   getAlertDescription,
   getAlertTime,
   getAlertSummary,
-  getAlertDocumentation,
   getAlertName,
 } from './alert-utils';
 
@@ -74,6 +74,7 @@ const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {
       [alert],
     ),
   );
+  const alertName = getAlertName(alert);
   const actionObj = getAlertActions(actionExtensions).get(alert.rule.name);
   const { text, action } = actionObj || {};
   return (
@@ -81,8 +82,14 @@ const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {
       Icon={getSeverityIcon(getAlertSeverity(alert))}
       timestamp={getAlertTime(alert)}
       message={getAlertDescription(alert) || getAlertMessage(alert) || getAlertSummary(alert)}
-      documentationLink={getAlertDocumentation(alert)}
-      name={getAlertName(alert)}
+      documentationLink={
+        alertName
+          ? `https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html-single/troubleshooting_openshift_data_foundation/index#${toLower(
+              alertName,
+            )}_rhodf`
+          : null
+      }
+      name={alertName}
     >
       {text && action ? (
         <Button variant={ButtonVariant.link} onClick={() => action(alert)} isInline>

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/alert-utils.ts
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/alert-utils.ts
@@ -10,6 +10,3 @@ export const getAlertSummary = (alert: Alert) => alert?.annotations?.summary || 
 export const getAlertTime = (alert: Alert) => (alert ? alert.activeAt : null);
 export const getAlertName = (alert: Alert) =>
   alert && alert.labels ? alert.labels.alertname : null;
-export const getAlertDocumentation = (alert: Alert) =>
-  alert && alert.labels ? alert.labels.documentation : null;
-export const getAlertRuleName = (alert: Alert) => (alert && alert.rule ? alert.rule.name : null);

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/alert-utils.ts
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/alert-utils.ts
@@ -11,5 +11,5 @@ export const getAlertTime = (alert: Alert) => (alert ? alert.activeAt : null);
 export const getAlertName = (alert: Alert) =>
   alert && alert.labels ? alert.labels.alertname : null;
 export const getAlertDocumentation = (alert: Alert) =>
-  alert && alert.annotations ? alert.annotations.documentation : null;
+  alert && alert.labels ? alert.labels.documentation : null;
 export const getAlertRuleName = (alert: Alert) => (alert && alert.rule ? alert.rule.name : null);

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/alert-utils.ts
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/alert-utils.ts
@@ -10,3 +10,6 @@ export const getAlertSummary = (alert: Alert) => alert?.annotations?.summary || 
 export const getAlertTime = (alert: Alert) => (alert ? alert.activeAt : null);
 export const getAlertName = (alert: Alert) =>
   alert && alert.labels ? alert.labels.alertname : null;
+export const getAlertDocumentation = (alert: Alert) =>
+  alert && alert.annotations ? alert.annotations.documentation : null;
+export const getAlertRuleName = (alert: Alert) => (alert && alert.rule ? alert.rule.name : null);

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
@@ -59,10 +59,25 @@
   display: flex;
   justify-content: space-between;
   width: 100%;
+  font-size: small;
+}
+
+.co-status-card__alert-item-header {
+  margin-left: 1rem;
+  font-weight: bold;
+  color: var(--pf-global--Color--black);
+}
+
+.co-status-card__alert-item-doc-link {
+  margin-left: 1rem;
+  margin-top: 0.2rem;
+  width: fit-content;
 }
 
 .co-health-card__alert-item-timestamp {
   white-space: nowrap;
+  font-size: smaller;
+  margin-bottom: 0.5rem;
 }
 
 .co-status-card__alert-item:first-of-type {


### PR DESCRIPTION
Add support for documentation links in status card, in the dashboard, in addition to minor design revamps.

Signed-off-by: Pranshu Srivastava <rexagod@gmail.com>

***

Refer: https://issues.redhat.com/browse/RHSTOR-2124