### PR TITLE
OCPBUGS-193: Corrected kebab action overlapping issue in Helm page

### DIFF
--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenuToggle.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenuToggle.tsx
@@ -45,22 +45,27 @@ const ActionMenuToggle: React.FC<ActionMenuToggleProps> = ({
   };
 
   const handleClickOutside = (event) => {
-    if (isOpen && !menuRef.current?.contains(event.target)) {
+    if (
+      toggleRef.current !== event.target &&
+      !toggleRef.current?.contains(event.target) &&
+      !menuRef.current?.contains(event.target)
+    ) {
       onToggleClick(false);
     }
   };
 
   React.useEffect(() => {
-    window.addEventListener('keydown', handleMenuKeys);
-    window.addEventListener('click', handleClickOutside);
+    if (isOpen) {
+      window.addEventListener('keydown', handleMenuKeys);
+      window.addEventListener('click', handleClickOutside);
+    }
     return () => {
       window.removeEventListener('keydown', handleMenuKeys);
       window.removeEventListener('click', handleClickOutside);
     }; // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]); // This needs to be run only on component mount/unmount
 
-  const handleToggleClick = (ev) => {
-    ev.stopPropagation(); // Stop handleClickOutside from handling
+  const handleToggleClick = () => {
     setTimeout(() => {
       const firstElement = menuRef?.current?.querySelector<HTMLElement>(
         'li > button:not(:disabled)',


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-193

**Analysis / Root cause**: 
On click outside event was not triggered on click of kebab menu button in other row. 

**Solution Description**: 
Added mousedown event instead of click event. mousedown event is used in ResourceKebab component as well

**Screen shots / Gifs for design review**: 
----BEFORE----
https://issues.redhat.com/secure/attachment/12751774/Screencast%20from%2008-06-2022%20061155PM.webm


----AFTER----
![helm-chart-repo-kebab](https://user-images.githubusercontent.com/102503482/186344100-457e127d-e1cc-4cf2-9e40-501e37dd96ca.gif)

**Unit test coverage report**: 
NA

**Test setup:**
Steps to Reproduce:
1. Create some helm chart repository
2. Go to the Helm page and switch to the repositories tab
3. Open kebab menu for different repos

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge