### PR TITLE
ODC-6778: add list of disabled dev catalog types to server flags

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -133,6 +133,7 @@ func main() {
 	fLoadTestFactor := fs.Int("load-test-factor", 0, "DEV ONLY. The factor used to multiply k8s API list responses for load testing purposes.")
 
 	fDevCatalogCategories := fs.String("developer-catalog-categories", "", "Allow catalog categories customization. (JSON as string)")
+	fDevCatalogTypes := fs.String("developer-catalog-types", "", "Allow enabling/disabling of sub-catalog types from the developer catalog. (JSON as string)")
 	fUserSettingsLocation := fs.String("user-settings-location", "configmap", "DEV ONLY. Define where the user settings should be stored. (configmap | localstorage).")
 	fQuickStarts := fs.String("quick-starts", "", "Allow customization of available ConsoleQuickStart resources in console. (JSON as string)")
 	fAddPage := fs.String("add-page", "", "DEV ONLY. Allow add page customization. (JSON as string)")
@@ -262,6 +263,7 @@ func main() {
 		LoadTestFactor:               *fLoadTestFactor,
 		InactivityTimeout:            *fInactivityTimeout,
 		DevCatalogCategories:         *fDevCatalogCategories,
+		DevCatalogTypes:              *fDevCatalogTypes,
 		UserSettingsLocation:         *fUserSettingsLocation,
 		EnabledConsolePlugins:        consolePluginsFlags,
 		I18nNamespaces:               i18nNamespaces,

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -45,6 +45,7 @@ declare interface Window {
     graphqlBaseURL: string;
     developerCatalogCategories: string;
     perspectives: string;
+    developerCatalogTypes: string;
     userSettingsLocation: string;
     addPage: string; // JSON encoded configuration
     consolePlugins: string[]; // Console dynamic plugins enabled on the cluster

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -103,6 +103,7 @@ type jsGlobals struct {
 	GOOS                            string                     `json:"GOOS"`
 	GraphQLBaseURL                  string                     `json:"graphqlBaseURL"`
 	DevCatalogCategories            string                     `json:"developerCatalogCategories"`
+	DevCatalogTypes                 string                     `json:"developerCatalogTypes"`
 	UserSettingsLocation            string                     `json:"userSettingsLocation"`
 	AddPage                         string                     `json:"addPage"`
 	ConsolePlugins                  []string                   `json:"consolePlugins"`
@@ -168,6 +169,7 @@ type Server struct {
 	AlertManagerUserWorkloadHost string
 	AlertManagerTenancyHost      string
 	DevCatalogCategories         string
+	DevCatalogTypes              string
 	UserSettingsLocation         string
 	QuickStarts                  string
 	AddPage                      string
@@ -722,6 +724,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		LoadTestFactor:             s.LoadTestFactor,
 		GraphQLBaseURL:             proxy.SingleJoiningSlash(s.BaseURL.Path, graphQLEndpoint),
 		DevCatalogCategories:       s.DevCatalogCategories,
+		DevCatalogTypes:            s.DevCatalogTypes,
 		UserSettingsLocation:       s.UserSettingsLocation,
 		ConsolePlugins:             plugins,
 		I18nNamespaces:             s.I18nNamespaces,

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -299,6 +299,15 @@ func addCustomization(fs *flag.FlagSet, customization *Customization) {
 		}
 	}
 
+	if (customization.DeveloperCatalog.Types != DeveloperConsoleCatalogTypesState{}) {
+		types, err := json.Marshal(customization.DeveloperCatalog.Types)
+		if err == nil {
+			fs.Set("developer-catalog-types", string(types))
+		} else {
+			klog.Fatalf("Could not marshal ConsoleConfig customization.developerCatalog.types field: %v", err)
+		}
+	}
+
 	if customization.QuickStarts.Disabled != nil {
 		quickStarts, err := json.Marshal(customization.QuickStarts)
 		if err == nil {

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -90,7 +90,7 @@ type Customization struct {
 	DocumentationBaseURL string `yaml:"documentationBaseURL,omitempty"`
 	CustomProductName    string `yaml:"customProductName,omitempty"`
 	CustomLogoFile       string `yaml:"customLogoFile,omitempty"`
-	// developerCatalog allows to configure the shown developer catalog categories.
+	// developerCatalog allows to configure the shown developer catalog categories and it's types.
 	DeveloperCatalog DeveloperConsoleCatalogCustomization `yaml:"developerCatalog,omitempty"`
 	QuickStarts      QuickStarts                          `yaml:"quickStarts,omitempty"`
 	// addPage allows customizing actions on the Add page in developer perspective.
@@ -109,10 +109,40 @@ type ProjectAccess struct {
 	AvailableClusterRoles []string `json:"availableClusterRoles,omitempty" yaml:"availableClusterRoles,omitempty"`
 }
 
+// CatalogTypesState defines the state of the catalog types based on which the types will be enabled or disabled.
+type CatalogTypesState string
+
+const (
+	CatalogTypeEnabled  CatalogTypesState = "Enabled"
+	CatalogTypeDisabled CatalogTypesState = "Disabled"
+)
+
+// DeveloperConsoleCatalogTypesState defines the state of the sub-catalog types.
+type DeveloperConsoleCatalogTypesState struct {
+	// state defines if a list of catalog types should be enabled or disabled.
+	State CatalogTypesState `json:"state,omitempty" yaml:"state,omitempty"`
+	// enabled is a list of developer catalog types (sub-catalogs IDs) that will be shown to users.
+	// Types (sub-catalogs) are added via console plugins, the available types (sub-catalog IDs) are available
+	// in the console on the cluster configuration page, or when editing the YAML in the console.
+	// Example: "Devfile", "HelmChart", "BuilderImage"
+	// If the list is non-empty, a new type will not be shown to the user until it is added to list.
+	// If the list is empty the complete developer catalog will be shown.
+	Enabled *[]string `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	// disabled is a list of developer catalog types (sub-catalogs IDs) that are not shown to users.
+	// Types (sub-catalogs) are added via console plugins, the available types (sub-catalog IDs) are available
+	// in the console on the cluster configuration page, or when editing the YAML in the console.
+	// Example: "Devfile", "HelmChart", "BuilderImage"
+	// If the list is empty or all the available sub-catalog types are added, then the complete developer catalog should be hidden.
+	Disabled *[]string `json:"disabled,omitempty" yaml:"disabled,omitempty"`
+}
+
 // DeveloperConsoleCatalogCustomization allow cluster admin to configure developer catalog.
 type DeveloperConsoleCatalogCustomization struct {
 	// categories which are shown the in developer catalog.
 	Categories []DeveloperConsoleCatalogCategory `json:"categories,omitempty" yaml:"categories,omitempty"`
+	// types allows enabling or disabling of sub-catalog types that user can see in the Developer catalog.
+	// When omitted, all the sub-catalog types will be shown.
+	Types DeveloperConsoleCatalogTypesState `json:"types,omitempty" yaml:"types,omitempty"`
 }
 
 // DeveloperConsoleCatalogCategoryMeta are the key identifiers of a developer catalog category.

--- a/pkg/serverconfig/validate.go
+++ b/pkg/serverconfig/validate.go
@@ -15,6 +15,10 @@ func Validate(fs *flag.FlagSet) error {
 		return err
 	}
 
+	if _, err := validateDeveloperCatalogTypes(fs.Lookup("developer-catalog-types").Value.String()); err != nil {
+		return err
+	}
+
 	bridge.ValidateFlagIs("user-settings-location", fs.Lookup("user-settings-location").Value.String(), "configmap", "localstorage")
 
 	if _, err := validateQuickStarts(fs.Lookup("quick-starts").Value.String()); err != nil {
@@ -64,6 +68,21 @@ func validateDeveloperCatalogCategories(value string) ([]DeveloperConsoleCatalog
 	}
 
 	return categories, nil
+}
+
+func validateDeveloperCatalogTypes(value string) (DeveloperConsoleCatalogTypesState, error) {
+	if value == "" {
+		return DeveloperConsoleCatalogTypesState{}, nil
+	}
+	var developerCatalogTypesState DeveloperConsoleCatalogTypesState
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(&developerCatalogTypesState); err != nil {
+		return DeveloperConsoleCatalogTypesState{}, err
+	}
+
+	return developerCatalogTypesState, nil
 }
 
 func validateQuickStarts(value string) (QuickStarts, error) {

--- a/pkg/serverconfig/validate_test.go
+++ b/pkg/serverconfig/validate_test.go
@@ -87,6 +87,32 @@ func TestUnknownPropertyInDeveloperCatalogCategory(t *testing.T) {
 	}
 }
 
+func TestValidEmptyDeveloperCatalogTypes(t *testing.T) {
+	_, err := validateDeveloperCatalogTypes("")
+	if err != nil {
+		t.Error("Unexpected error when parsing an empty string.", err)
+	}
+}
+
+func TestValidEntriesForDeveloperCatalogTypes(t *testing.T) {
+	types, err := validateDeveloperCatalogTypes("{ \"state\": \"Disabled\", \"disabled\": [ \"Type1\", \"Type2\", \"Type3\" ]}")
+	if err != nil {
+		t.Error("Unexpected error when parsing data.", err)
+	}
+	if len(*types.Disabled) != 3 {
+		t.Errorf("Unexpected value: actual %v, expected %v", len(*types.Disabled), 3)
+	}
+}
+
+func TestInvalidEntriesForDeveloperCatalogTypes(t *testing.T) {
+	_, err := validateDeveloperCatalogTypes("{\"state\": \"Disabled\", \"disable\": [ \"Type1\", \"Type2\", \"Type3\" ]}")
+	actualMsg := err.Error()
+	expectedMsg := "json: unknown field \"disable\""
+	if actualMsg != expectedMsg {
+		t.Errorf("Unexpected error: actual\n%s\n, expected\n%s", actualMsg, expectedMsg)
+	}
+}
+
 func TestValidEmptyQuickStarts(t *testing.T) {
 	_, err := validateQuickStarts("")
 	if err != nil {


### PR DESCRIPTION
Story:
https://issues.redhat.com/browse/ODC-6778

Add dev catalog types customization API based on https://github.com/openshift/enhancements/pull/1206

Description:
Based on the enhancement proposal https://github.com/openshift/enhancements/pull/1206, get the developer catalog types from console-config or through arguments supplied to bridge. And make it available in window.SERVER_FLAGS.

Fetching of options from Console CRD into the console-config ConfigMap is handled in https://github.com/openshift/console-operator/pull/676

Test setup:
Pass options as a string to bridge with -developer-catalog-disabled-types or pass a ConsoleConfig yaml with -config option.

Example:

- Specify developer catalog types to bridge with `./bin/bridge -developer-catalog-types '{ "state": "Disabled" ,"disabled": ["Type1", "Type2"] }'`.

- Open localhost:9000 and check SERVER_FLAGS in console:
```
> window.SERVER_FLAGS.developerCatalogTypes
'{"state": "Disabled" ,"disabled": ["Type1", "Type2"] }'
```