### PR TITLE
OCPBUGS-548: Changes to the application menu with search and favorite options so it is consistent with PatternFly menu and aligns with Project selection menu

### DIFF
--- a/frontend/packages/dev-console/integration-tests/views/git-import-flow.view.ts
+++ b/frontend/packages/dev-console/integration-tests/views/git-import-flow.view.ts
@@ -16,7 +16,7 @@ export const applicationNameField = element(by.id('form-input-application-name-f
 
 export const applicationSelector = element(by.id('form-dropdown-application-name-field'));
 export const applicationDropdown = element(
-  by.className('dropdown-menu__autocomplete-filter pf-c-dropdown__menu dropdown-menu--text-wrap'),
+  by.className('dropdown-menu__autocomplete-filter dropdown-menu--text-wrap'),
 );
 
 export const createApplication = element(by.id('#CREATE_APPLICATION_KEY#-link'));

--- a/frontend/packages/integration-tests-cypress/views/rolebindings.ts
+++ b/frontend/packages/integration-tests-cypress/views/rolebindings.ts
@@ -7,7 +7,7 @@ export const roleBindings = {
       .click()
       .byLegacyTestID('dropdown-text-filter')
       .type(namespace)
-      .get('.pf-c-dropdown__menu-item .co-resource-item__resource-name')
+      .get('.pf-c-menu__item .co-resource-item__resource-name')
       .click(),
   selectRole: (role: string) =>
     cy

--- a/frontend/packages/topology/src/components/dropdowns/NamespaceBarApplicationSelector.tsx
+++ b/frontend/packages/topology/src/components/dropdowns/NamespaceBarApplicationSelector.tsx
@@ -58,7 +58,6 @@ const NamespaceBarApplicationSelector: React.FC<Props> = ({
   return (
     <ApplicationDropdown
       className="co-namespace-selector"
-      menuClassName="co-namespace-selector__menu"
       buttonClassName="pf-m-plain"
       namespace={namespace}
       title={title && <span className="btn-link__title">{title}</span>}

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -1,7 +1,3 @@
-$color-bookmarker--hover: $pf-color-black-500;
-$color-bookmarker: $pf-color-black-400;
-$dropdown-background--hover: $pf-color-black-200; // pf-c-dropdown__menu-item--hover--BackgroundColor
-
 .dropdown--full-width {
   &,
   .pf-c-dropdown__toggle {
@@ -39,10 +35,6 @@ $dropdown-background--hover: $pf-color-black-200; // pf-c-dropdown__menu-item--h
   font-size: ($font-size-base - 1);
   padding: 3px 10px;
   text-transform: uppercase;
-}
-
-.dropdown-menu__filter {
-  padding: 5px var(--pf-c-dropdown__menu-item--PaddingRight) 10px;
 }
 
 .dropdown-menu--text-wrap {
@@ -115,103 +107,6 @@ $dropdown-background--hover: $pf-color-black-200; // pf-c-dropdown__menu-item--h
       margin-right: 6px;
     }
   }
-}
-
-// Custom dropdown menu rules for namespace-selector & resource-item that don't use the default pf4 styles
-.co-namespace-selector .dropdown-menu__autocomplete-filter {
-  li {
-    display: flex;
-    padding: 0;
-    &:focus {
-      outline: none;
-    }
-    &.active a {
-      background-color: var(--pf-global--BackgroundColor--200);
-    }
-    a {
-      cursor: pointer;
-      flex-grow: 1;
-      width: 100%;
-      &.disabled {
-        color: var(--pf-global--Color--dark-200);
-        cursor: not-allowed;
-        &:active,
-        &:focus,
-        &:hover {
-          background-color: inherit;
-          border-color: transparent;
-          color: var(--pf-global--Color--dark-200) !important;
-        }
-      }
-      &.next-to-bookmark {
-        padding-left: 5px;
-      }
-    }
-  }
-
-  ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-}
-
-.co-namespace-selector__menu.pf-c-dropdown__menu {
-  margin: -5px 0 0;
-  max-width: 100%;
-  min-width: 210px;
-
-  @media (min-width: $pf-global--breakpoint--md) {
-    min-width: 325px;
-  }
-
-  a {
-    white-space: nowrap;
-    width: auto;
-  }
-
-  .dropdown__selected {
-    background-color: inherit;
-    color: inherit;
-  }
-  // Mimic PatternFly4 dropdown-menu visual states.
-  // Since namespace selector has multiple <a> tags within each list item,
-  // target the <li> except the one containing the list divider.
-  li {
-    &:not(.co-namespace-selector__divider):hover {
-      background-color: var(--pf-global--BackgroundColor--200);
-      color: var(--pf-global--Color--100);
-      position: relative;
-    }
-    > a {
-      padding: 6px;
-      text-decoration: none;
-      &.bookmarker {
-        display: inline-block;
-        padding-right: 5px;
-        padding-left: var(--pf-c-dropdown__menu-item--PaddingLeft);
-        color: $color-bookmarker;
-        flex: 0;
-        &:hover {
-          background-color: var(--pf-global--BackgroundColor--200);
-          color: $color-bookmarker--hover;
-        }
-        &:focus {
-          background-color: var(--pf-global--BackgroundColor--200);
-        }
-      }
-      &.next-to-bookmark {
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-    }
-  }
-}
-
-.dropdown-menu__autocomplete-filter {
-  max-height: 60vh;
-  overflow-x: hidden;
-  overflow-y: auto;
 }
 
 .pf-c-dropdown .co-m-resource-icon {

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -4,7 +4,8 @@ import * as classNames from 'classnames';
 import * as PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { useTranslation, withTranslation } from 'react-i18next';
-import { CaretDownIcon, MinusCircleIcon, PlusCircleIcon, StarIcon } from '@patternfly/react-icons';
+import { CaretDownIcon, CheckIcon, StarIcon } from '@patternfly/react-icons';
+import { Divider } from '@patternfly/react-core';
 import { impersonateStateToProps, useSafetyFirst } from '@console/dynamic-plugin-sdk';
 import { useUserSettingsCompatibility } from '@console/shared';
 
@@ -146,7 +147,11 @@ class DropDownRowWithTranslation extends React.PureComponent {
       prefix = (
         <a
           href="#"
-          className={classNames('bookmarker', { hover, focus: selected })}
+          className={classNames(
+            'pf-c-menu__item-action pf-m-favorite',
+            { hover, focus: selected },
+            { 'pf-m-favorited': isBookmarked },
+          )}
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
@@ -158,7 +163,9 @@ class DropDownRowWithTranslation extends React.PureComponent {
               : t('public~Add bookmark {{content}}', { content: contentString })
           }
         >
-          {isBookmarked ? <MinusCircleIcon /> : <PlusCircleIcon />}
+          <span className="pf-c-menu__item-action-icon">
+            <StarIcon />
+          </span>
         </a>
       );
     }
@@ -187,22 +194,25 @@ class DropDownRowWithTranslation extends React.PureComponent {
     }
 
     return (
-      <li role="option" className={classNames(className)} key={itemKey}>
-        {prefix}
+      <li role="option" className={classNames('pf-c-menu__list-item', className)} key={itemKey}>
         <a
           href="#"
           ref={this.link}
           id={`${itemKey}-link`}
           data-test="dropdown-menu-item-link"
-          className={classNames('pf-c-dropdown__menu-item', {
-            'next-to-bookmark': !!prefix,
-            hover,
-            focus: selected,
+          className={classNames('pf-c-menu__item', {
+            'pf-m-selected': selected,
           })}
           onClick={(e) => onclick(itemKey, e)}
         >
-          {content}
+          <span className="pf-c-menu__item-main">
+            <span className="pf-c-menu__item-text">{content}</span>
+            <span className="pf-c-menu__item-select-icon">
+              <CheckIcon />
+            </span>
+          </span>
         </a>
+        {prefix}
         {suffix}
       </li>
     );
@@ -347,9 +357,7 @@ class Dropdown_ extends DropdownMixin {
               hover={ai.actionKey === keyboardHoverKey}
             />
           ))}
-          <li className="co-namespace-selector__divider">
-            <div className="dropdown-menu__divider" />
-          </li>
+          <Divider component="li" />
         </>
       );
     }
@@ -467,41 +475,44 @@ class Dropdown_ extends DropdownMixin {
               </div>
             </button>
             {active && (
-              <ul
-                role="listbox"
-                ref={this.dropdownList}
-                className={classNames(
-                  'dropdown-menu__autocomplete-filter',
-                  'pf-c-dropdown__menu',
-                  menuClassName,
-                )}
-              >
-                {autocompleteFilter && (
-                  <div className="dropdown-menu__filter">
-                    <input
-                      autoFocus
-                      type="text"
-                      ref={(input) => (this.input = input)}
-                      onChange={this.changeTextFilter}
-                      placeholder={autocompletePlaceholder}
-                      value={autocompleteText || ''}
-                      autoCapitalize="none"
-                      onKeyDown={this.onKeyDown}
-                      className="pf-c-form-control"
-                      onClick={(e) => e.stopPropagation()}
-                      data-test-id="dropdown-text-filter"
-                    />
-                  </div>
-                )}
-                {this.renderActionItem()}
-                {bookMarkRows}
-                {_.size(bookMarkRows) ? (
-                  <li className="co-namespace-selector__divider">
-                    <div className="dropdown-menu__divider" />
-                  </li>
-                ) : null}
-                {rows}
-              </ul>
+              // Style the Application menu to match the Project selection menu
+              <div className="pf-c-menu pf-m-scrollable co-namespace-dropdown__menu">
+                <div className="pf-c-menu__content" style={{ maxHeight: '60vh' }}>
+                  {autocompleteFilter && (
+                    <>
+                      <div className="pf-c-menu__search">
+                        <input
+                          autoFocus
+                          type="text"
+                          ref={(input) => (this.input = input)}
+                          onChange={this.changeTextFilter}
+                          placeholder={autocompletePlaceholder}
+                          value={autocompleteText || ''}
+                          autoCapitalize="none"
+                          onKeyDown={this.onKeyDown}
+                          className="pf-c-form-control pf-m-search"
+                          onClick={(e) => e.stopPropagation()}
+                          data-test-id="dropdown-text-filter"
+                        />
+                      </div>
+                      <Divider />
+                    </>
+                  )}
+                  <ul
+                    role="listbox"
+                    ref={this.dropdownList}
+                    className="pf-c-menu__list dropdown-menu__autocomplete-filter"
+                  >
+                    {this.renderActionItem()}
+                    {_.size(bookMarkRows) ? (
+                      <li className="pf-c-menu__group-title pf-u-pb-sm">Favorites</li>
+                    ) : null}
+                    {bookMarkRows}
+                    {_.size(bookMarkRows) && _.size(rows) ? <Divider component="li" /> : null}
+                    {rows}
+                  </ul>
+                </div>
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
The application dropdown menu uses a custom component with a configuration to favorite applications, like the Project selection menu favorites projects, but its UX is inconsistent in the way it looks and behaves. The Project selection UI element uses the PatternFly Menu component. This PR modifies the relevant parts of our custom dropdown component to mimic the look and feel of the PF Menu component.

**_Specific changes for consistency_**
1. Add magnify glass icon in search input
2. Add `<Divider />` below search input
3. Add Favorites section heading when there are favorited apps
4. Use `<StarIcon />` to signify favorited
5. Use `<CheckIcon />` to signify current selection
6. Apply correct menu item spacing and positioning of icons
7. Apply correct `hover` `focus` background color

### Visual comparison
**Before**
<img width="1047" alt="Menus-bug" src="https://user-images.githubusercontent.com/1874151/186465765-f00a5551-6cae-4f5c-8580-3afae1c55c94.png">

**After**
<img width="1047" alt="Menus-bug-good" src="https://user-images.githubusercontent.com/1874151/186469810-a5817e0c-3207-409a-860d-1a0e989148ec.png">


### Behavior comparison
**Before**

![app-select-dark-before](https://user-images.githubusercontent.com/1874151/186456195-8eaad898-f12d-4792-99c5-ece66457c6f7.gif)


**After**
![app-select-dark-after](https://user-images.githubusercontent.com/1874151/186456158-67f89771-19a8-46ca-aa5d-90a64a38f95f.gif)

