### PR TITLE
[release-4.8] OCPBUGS-604: Backport CI test fix to previous releases

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
@@ -31,6 +31,12 @@ describe('Create namespace from install operators', () => {
     cy.byTestID(operatorSelector).click();
     cy.byLegacyTestID('operator-install-btn').click({ force: true });
 
+    // 3scale 2.11 supports only installation mode 'A specific namespace',
+    // so it was automatically selected.
+    // But starting with 2.12 it also supports 'All namespaces'.
+    // So it is required   to select this radio option to specify the namespace.
+    cy.byTestID('A specific namespace on the cluster-radio-input').click();
+
     // configure operator install
     cy.byTestID('dropdown-selectbox')
       .click()


### PR DESCRIPTION
Backport CI test fix to previous releases.  Original bug https://bugzilla.redhat.com/show_bug.cgi?id=2117642 for 4.10.  4.8 will need a new bug.