### PR TITLE
add list of enabled/disabled perspectives to server flags

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -137,6 +137,7 @@ func main() {
 	fQuickStarts := fs.String("quick-starts", "", "Allow customization of available ConsoleQuickStart resources in console. (JSON as string)")
 	fAddPage := fs.String("add-page", "", "DEV ONLY. Allow add page customization. (JSON as string)")
 	fProjectAccessClusterRoles := fs.String("project-access-cluster-roles", "", "The list of Cluster Roles assignable for the project access page. (JSON as string)")
+	fPerspectives := fs.String("perspectives", "", "Allow enabling/disabling of perspectives in the console. (JSON as string)")
 	fManagedClusterConfigs := fs.String("managed-clusters", "", "List of managed cluster configurations. (JSON as string)")
 	fControlPlaneTopology := fs.String("control-plane-topology-mode", "", "Defines the topology mode of the control/infra nodes (External | HighlyAvailable | SingleReplica)")
 	fReleaseVersion := fs.String("release-version", "", "Defines the release version of the cluster")
@@ -268,6 +269,7 @@ func main() {
 		QuickStarts:                  *fQuickStarts,
 		AddPage:                      *fAddPage,
 		ProjectAccessClusterRoles:    *fProjectAccessClusterRoles,
+		Perspectives:                 *fPerspectives,
 		K8sProxyConfigs:              make(map[string]*proxy.Config),
 		K8sClients:                   make(map[string]*http.Client),
 		Telemetry:                    telemetryFlags,

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -44,6 +44,7 @@ declare interface Window {
     GOOS: string;
     graphqlBaseURL: string;
     developerCatalogCategories: string;
+    perspectives: string;
     userSettingsLocation: string;
     addPage: string; // JSON encoded configuration
     consolePlugins: string[]; // Console dynamic plugins enabled on the cluster

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -109,6 +109,7 @@ type jsGlobals struct {
 	I18nNamespaces                  []string                   `json:"i18nNamespaces"`
 	QuickStarts                     string                     `json:"quickStarts"`
 	ProjectAccessClusterRoles       string                     `json:"projectAccessClusterRoles"`
+	Perspectives                    string                     `json:"perspectives"`
 	Clusters                        []string                   `json:"clusters"`
 	ControlPlaneTopology            string                     `json:"controlPlaneTopology"`
 	Telemetry                       serverconfig.MultiKeyValue `json:"telemetry"`
@@ -171,6 +172,7 @@ type Server struct {
 	QuickStarts                  string
 	AddPage                      string
 	ProjectAccessClusterRoles    string
+	Perspectives                 string
 	Telemetry                    serverconfig.MultiKeyValue
 }
 
@@ -726,6 +728,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		QuickStarts:                s.QuickStarts,
 		AddPage:                    s.AddPage,
 		ProjectAccessClusterRoles:  s.ProjectAccessClusterRoles,
+		Perspectives:               s.Perspectives,
 		Clusters:                   clusters,
 		Telemetry:                  s.Telemetry,
 		ReleaseVersion:             s.ReleaseVersion,

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -323,6 +323,15 @@ func addCustomization(fs *flag.FlagSet, customization *Customization) {
 			fs.Set("project-access-cluster-roles", string(projectAccessClusterRoles))
 		}
 	}
+
+	if customization.Perspectives != nil {
+		perspectives, err := json.Marshal(customization.Perspectives)
+		if err != nil {
+			klog.Fatalf("Could not marshal ConsoleConfig customization.perspectives field: %v", err)
+		} else {
+			fs.Set("perspectives", string(perspectives))
+		}
+	}
 }
 
 func isAlreadySet(fs *flag.FlagSet, name string) bool {

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -2,6 +2,7 @@ package serverconfig
 
 import (
 	configv1 "github.com/openshift/api/config/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 )
 
 // This file is a copy of the struct within the console operator:
@@ -95,6 +96,7 @@ type Customization struct {
 	// addPage allows customizing actions on the Add page in developer perspective.
 	AddPage       AddPage       `yaml:"addPage,omitempty"`
 	ProjectAccess ProjectAccess `yaml:"projectAccess,omitempty"`
+	Perspectives  []Perspective `yaml:"perspectives,omitempty"`
 }
 
 // QuickStarts contains options for ConsoleQuickStarts resource
@@ -138,6 +140,45 @@ type AddPage struct {
 	// disabledActions is a list of actions that are not shown to users.
 	// Each action in the list is represented by its ID.
 	DisabledActions []string `json:"disabledActions,omitempty" yaml:"disabledActions,omitempty"`
+}
+
+// PerspectiveState defines the visibility state of the perspective. "Enabled" means the perspective is shown.
+// "Disabled" means the Perspective is hidden.
+// "AccessReview" means access review check is required to show or hide a Perspective.
+type PerspectiveState string
+
+const (
+	PerspectiveEnabled      PerspectiveState = "Enabled"
+	PerspectiveDisabled     PerspectiveState = "Disabled"
+	PerspectiveAccessReview PerspectiveState = "AccessReview"
+)
+
+// ResourceAttributesAccessReview defines the visibility of the perspective depending on the access review checks.
+// `required` and  `missing` can work together esp. in the case where the cluster admin
+// wants to show another perspective to users without specific permissions. Out of `required` and `missing` atleast one property should be non-empty.
+type ResourceAttributesAccessReview struct {
+	// required defines a list of permission checks. The perspective will only be shown when all checks are successful. When omitted, the access review is skipped and the perspective will not be shown unless it is required to do so based on the configuration of the missing access review list.
+	Required []authorizationv1.ResourceAttributes `json:"required" yaml:"required"`
+	// missing defines a list of permission checks. The perspective will only be shown when at least one check fails. When omitted, the access review is skipped and the perspective will not be shown unless it is required to do so based on the configuration of the required access review list.
+	Missing []authorizationv1.ResourceAttributes `json:"missing" yaml:"missing"`
+}
+
+// PerspectiveVisibility defines the criteria to show/hide a perspective.
+type PerspectiveVisibility struct {
+	// state defines the perspective is enabled or disabled or access review check is required.
+	State PerspectiveState `json:"state" yaml:"state"`
+	// accessReview defines required and missing access review checks.
+	AccessReview *ResourceAttributesAccessReview `json:"accessReview,omitempty" yaml:"accessReview,omitempty"`
+}
+
+type Perspective struct {
+	// id defines the id of the perspective.
+	// Example: "dev", "admin".
+	// The available perspective ids can be found in the code snippet section next to the yaml editor.
+	// Incorrect or unknown ids will be ignored.
+	ID string `json:"id" yaml:"id"`
+	// visibility defines the state of perspective along with access review checks if needed for that perspective.
+	Visibility PerspectiveVisibility `json:"visibility" yaml:"visibility"`
 }
 
 type Providers struct {

--- a/pkg/serverconfig/validate_test.go
+++ b/pkg/serverconfig/validate_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+
+	v1 "k8s.io/api/authorization/v1"
 )
 
 func TestValidEmptyDeveloperCatalogCategories(t *testing.T) {
@@ -169,5 +171,95 @@ func TestValidObjectForProjectAccessClusterRoles(t *testing.T) {
 	}
 	if len(projectAccess) != 3 {
 		t.Errorf("Unexpected value: actual %v, expected %v", len(projectAccess), 3)
+	}
+}
+
+func TestValidEmptyPerspectives(t *testing.T) {
+	_, err := validatePerspectives("")
+	if err != nil {
+		t.Error("Unexpected error when parsing an empty string.", err)
+	}
+}
+
+func TestValidEntriesForPerspectives(t *testing.T) {
+	actualPerspectives, err := validatePerspectives("[{ \"id\": \"perspective1\", \"visibility\": { \"state\" : \"AccessReview\", \"accessReview\": { \"required\": [{ \"resource\": \"namespaces\", \"verb\": \"list\" }] , \"missing\": [{ \"resource\": \"clusterroles\", \"verb\": \"list\" }]}}} , { \"id\": \"perspective2\", \"visibility\": { \"state\" : \"Disabled\"}}]")
+	exectedPerspectives := []Perspective{
+		{
+			ID: "perspective1",
+			Visibility: PerspectiveVisibility{
+				State: PerspectiveAccessReview,
+				AccessReview: &ResourceAttributesAccessReview{
+					Required: []v1.ResourceAttributes{
+						{
+							Resource: "namespaces",
+							Verb:     "list",
+						},
+					},
+					Missing: []v1.ResourceAttributes{
+						{
+							Resource: "clusterroles",
+							Verb:     "list",
+						},
+					},
+				},
+			},
+		},
+		{
+			ID: "perspective2",
+			Visibility: PerspectiveVisibility{
+				State: PerspectiveDisabled,
+			},
+		},
+	}
+	if err != nil {
+		t.Error("Unexpected error when parsing data.", err)
+	}
+	if !reflect.DeepEqual(actualPerspectives, exectedPerspectives) {
+		t.Errorf("Unexpected value: actual %v, expected %v", actualPerspectives, exectedPerspectives)
+	}
+}
+
+func TestInvalidPropertyForPerspectives(t *testing.T) {
+	_, err := validatePerspectives("[{ \"id\": \"perspective1\", \"accessReview\": [{ \"resource\": \"namespaces\", \"verb\": \"list\" }]} , { \"id\": \"perspective2\", \"visibility\": { \"state\" : \"Disabled\"}}]")
+	actualMsg := err.Error()
+	expectedMsg := "json: unknown field \"accessReview\""
+	if actualMsg != expectedMsg {
+		t.Errorf("Unexpected error: actual\n%s\n, expected\n%s", actualMsg, expectedMsg)
+	}
+}
+
+func TestMissingPropertyForPerspectives(t *testing.T) {
+	_, err := validatePerspectives("[{ \"id\": \"perspective1\"}]")
+	actualMsg := err.Error()
+	expectedMsg := "Perspective id perspective1 must have visibility property."
+	if actualMsg != expectedMsg {
+		t.Errorf("Unexpected error: actual\n%s\n, expected\n%s", actualMsg, expectedMsg)
+	}
+}
+
+func TestInvalidPropertyValueForPerspectivesState(t *testing.T) {
+	_, err := validatePerspectives("[{ \"id\": \"perspective1\", \"visibility\": { \"state\" : \"AccessReview\", \"AccessReview\": { \"required\": [{ \"resource\": \"namespaces\", \"verb\": \"list\" }] , \"missing\": [{ \"resource\": \"clusterroles\", \"verb\": \"list\" }]}}} , { \"id\": \"perspective2\", \"visibility\": { \"state\" : \"Disable\"}}]")
+	actualMsg := err.Error()
+	expectedMsg := "Perspective state for id perspective2 must have value \"Enabled\" or \"Disabled\" or \"AccessReview\"."
+	if actualMsg != expectedMsg {
+		t.Errorf("Unexpected error: actual\n%s\n, expected\n%s", actualMsg, expectedMsg)
+	}
+}
+
+func TestEmptyAccessReviewPropertyForPerspectiveVisibility(t *testing.T) {
+	_, err := validatePerspectives("[{ \"id\": \"perspective1\", \"visibility\": { \"state\" : \"AccessReview\", \"AccessReview\": { \"required\": [] , \"missing\": []}}} , { \"id\": \"perspective2\", \"visibility\": { \"state\" : \"Disable\"}}]")
+	actualMsg := err.Error()
+	expectedMsg := "Perspective accessReview for id perspective1 must have atleast required or missing property as non-empty."
+	if actualMsg != expectedMsg {
+		t.Errorf("Unexpected error: actual\n%s\n, expected\n%s", actualMsg, expectedMsg)
+	}
+}
+
+func TestMissingConfigurationForAccessReviewProperty(t *testing.T) {
+	_, err := validatePerspectives("[{ \"id\": \"perspective1\", \"visibility\": { \"state\" : \"AccessReview\"}} , { \"id\": \"perspective2\", \"visibility\": { \"state\" : \"Disable\"}}]")
+	actualMsg := err.Error()
+	expectedMsg := "Perspective accessReview for id perspective1 must be configured for state AccessReview."
+	if actualMsg != expectedMsg {
+		t.Errorf("Unexpected error: actual\n%s\n, expected\n%s", actualMsg, expectedMsg)
 	}
 }


### PR DESCRIPTION
**Story:**
https://issues.redhat.com/browse/ODC-6783

Add dev catalog types customization API based on https://github.com/openshift/enhancements/pull/1205

Description:
Based on the enhancement proposal https://github.com/openshift/enhancements/pull/1205, get the perspectives from console-config or through arguments supplied to bridge. And make it available in window.SERVER_FLAGS.

Fetching of options from Console CRD into the console-config ConfigMap is handled in https://github.com/openshift/console-operator/pull/678

Test setup:
Pass options as an array of objects to bridge with -perspectives or pass a ConsoleConfig yaml with -config option.

Example:

- Specify perspectives to bridge with 
```
./bin/bridge -perspectives '[{ "id" : "dev", "visibility": {"state": "AccessReview" , "accessReview": { "missing" : [{ "resource" : "namespaces", "verb" : "list" }]}}}, { "id" : "dev-test", "visibility": {"state" : "Disabled" }}, { "id" : "admin", "visibility": {"state" : "Disabled" }}]'
 ```

- Open localhost:9000 and check SERVER_FLAGS in console:

```
window.SERVER_FLAGS.perspectives

>'[{ "id" : "dev", "visibility": {"state": "AccessReview" , "accessReview": { "missing" : [{ "resource" : "namespaces", "verb" : "list" }]}}}, { "id" : "dev-test", "visibility": {"state" : "Disabled" }}, { "id" : "admin", "visibility": {"state" : "Disabled" }}]'
```