### PR TITLE
Use core extensions in Console dynamic plugin SDK

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md
@@ -28,53 +28,56 @@
 26.  [`console.dashboards/project/overview/item`](#consoledashboardsprojectoverviewitem)
 27.  [`console.dashboards/tab`](#consoledashboardstab)
 28.  [`console.file-upload`](#consolefile-upload)
-29.  [`console.flag`](#consoleflag)
-30.  [`console.flag/hookProvider`](#consoleflaghookProvider)
-31.  [`console.flag/model`](#consoleflagmodel)
-32.  [`console.global-config`](#consoleglobal-config)
-33.  [`console.model-metadata`](#consolemodel-metadata)
-34.  [`console.navigation/href`](#consolenavigationhref)
-35.  [`console.navigation/resource-cluster`](#consolenavigationresource-cluster)
-36.  [`console.navigation/resource-ns`](#consolenavigationresource-ns)
-37.  [`console.navigation/section`](#consolenavigationsection)
-38.  [`console.navigation/separator`](#consolenavigationseparator)
-39.  [`console.page/resource/details`](#consolepageresourcedetails)
-40.  [`console.page/resource/list`](#consolepageresourcelist)
-41.  [`console.page/route`](#consolepageroute)
-42.  [`console.page/route/standalone`](#consolepageroutestandalone)
-43.  [`console.perspective`](#consoleperspective)
-44.  [`console.project-overview/inventory-item`](#consoleproject-overviewinventory-item)
-45.  [`console.project-overview/utilization-item`](#consoleproject-overviewutilization-item)
-46.  [`console.pvc/alert`](#consolepvcalert)
-47.  [`console.pvc/create-prop`](#consolepvccreate-prop)
-48.  [`console.pvc/delete`](#consolepvcdelete)
-49.  [`console.pvc/status`](#consolepvcstatus)
-50.  [`console.redux-reducer`](#consoleredux-reducer)
-51.  [`console.resource/create`](#consoleresourcecreate)
-52.  [`console.storage-class/provisioner`](#consolestorage-classprovisioner)
-53.  [`console.storage-provider`](#consolestorage-provider)
-54.  [`console.tab/horizontalNav`](#consoletabhorizontalNav)
-55.  [`console.telemetry/listener`](#consoletelemetrylistener)
-56.  [`console.topology/adapter/build`](#consoletopologyadapterbuild)
-57.  [`console.topology/adapter/network`](#consoletopologyadapternetwork)
-58.  [`console.topology/adapter/pod`](#consoletopologyadapterpod)
-59.  [`console.topology/component/factory`](#consoletopologycomponentfactory)
-60.  [`console.topology/create/connector`](#consoletopologycreateconnector)
-61.  [`console.topology/data/factory`](#consoletopologydatafactory)
-62.  [`console.topology/decorator/provider`](#consoletopologydecoratorprovider)
-63.  [`console.topology/details/resource-alert`](#consoletopologydetailsresource-alert)
-64.  [`console.topology/details/resource-link`](#consoletopologydetailsresource-link)
-65.  [`console.topology/details/tab`](#consoletopologydetailstab)
-66.  [`console.topology/details/tab-section`](#consoletopologydetailstab-section)
-67.  [`console.topology/display/filters`](#consoletopologydisplayfilters)
-68.  [`console.topology/relationship/provider`](#consoletopologyrelationshipprovider)
-69.  [`console.user-preference/group`](#consoleuser-preferencegroup)
-70.  [`console.user-preference/item`](#consoleuser-preferenceitem)
-71.  [`console.yaml-template`](#consoleyaml-template)
+29.  [`console.flag/hookProvider`](#consoleflaghookProvider)
+30.  [`console.global-config`](#consoleglobal-config)
+31.  [`console.model-metadata`](#consolemodel-metadata)
+32.  [`console.navigation/href`](#consolenavigationhref)
+33.  [`console.navigation/resource-cluster`](#consolenavigationresource-cluster)
+34.  [`console.navigation/resource-ns`](#consolenavigationresource-ns)
+35.  [`console.navigation/section`](#consolenavigationsection)
+36.  [`console.navigation/separator`](#consolenavigationseparator)
+37.  [`console.page/resource/details`](#consolepageresourcedetails)
+38.  [`console.page/resource/list`](#consolepageresourcelist)
+39.  [`console.page/route`](#consolepageroute)
+40.  [`console.page/route/standalone`](#consolepageroutestandalone)
+41.  [`console.perspective`](#consoleperspective)
+42.  [`console.project-overview/inventory-item`](#consoleproject-overviewinventory-item)
+43.  [`console.project-overview/utilization-item`](#consoleproject-overviewutilization-item)
+44.  [`console.pvc/alert`](#consolepvcalert)
+45.  [`console.pvc/create-prop`](#consolepvccreate-prop)
+46.  [`console.pvc/delete`](#consolepvcdelete)
+47.  [`console.pvc/status`](#consolepvcstatus)
+48.  [`console.resource/create`](#consoleresourcecreate)
+49.  [`console.storage-class/provisioner`](#consolestorage-classprovisioner)
+50.  [`console.storage-provider`](#consolestorage-provider)
+51.  [`console.tab/horizontalNav`](#consoletabhorizontalNav)
+52.  [`console.telemetry/listener`](#consoletelemetrylistener)
+53.  [`console.topology/adapter/build`](#consoletopologyadapterbuild)
+54.  [`console.topology/adapter/network`](#consoletopologyadapternetwork)
+55.  [`console.topology/adapter/pod`](#consoletopologyadapterpod)
+56.  [`console.topology/component/factory`](#consoletopologycomponentfactory)
+57.  [`console.topology/create/connector`](#consoletopologycreateconnector)
+58.  [`console.topology/data/factory`](#consoletopologydatafactory)
+59.  [`console.topology/decorator/provider`](#consoletopologydecoratorprovider)
+60.  [`console.topology/details/resource-alert`](#consoletopologydetailsresource-alert)
+61.  [`console.topology/details/resource-link`](#consoletopologydetailsresource-link)
+62.  [`console.topology/details/tab`](#consoletopologydetailstab)
+63.  [`console.topology/details/tab-section`](#consoletopologydetailstab-section)
+64.  [`console.topology/display/filters`](#consoletopologydisplayfilters)
+65.  [`console.topology/relationship/provider`](#consoletopologyrelationshipprovider)
+66.  [`console.user-preference/group`](#consoleuser-preferencegroup)
+67.  [`console.user-preference/item`](#consoleuser-preferenceitem)
+68.  [`console.yaml-template`](#consoleyaml-template)
+69.  [`core.flag`](#coreflag)
+70.  [`core.flag/model`](#coreflagmodel)
+71.  [`core.redux-reducer`](#coreredux-reducer)
 72.  [`dev-console.add/action`](#dev-consoleaddaction)
 73.  [`dev-console.add/action-group`](#dev-consoleaddaction-group)
 74.  [`dev-console.import/environment`](#dev-consoleimportenvironment)
-75. [DEPRECATED] [`console.page/resource/tab`](#consolepageresourcetab)
+75. [DEPRECATED] [`console.flag`](#consoleflag)
+76. [DEPRECATED] [`console.flag/model`](#consoleflagmodel)
+77. [DEPRECATED] [`console.page/resource/tab`](#consolepageresourcetab)
+78. [DEPRECATED] [`console.redux-reducer`](#consoleredux-reducer)
 
 ---
 
@@ -543,20 +546,6 @@ Adds a new dashboard tab, placed after the Overview tab.
 
 ---
 
-## `console.flag`
-
-### Summary 
-
-Gives full control over Console feature flags.
-
-### Properties
-
-| Name | Value Type | Optional | Description |
-| ---- | ---------- | -------- | ----------- |
-| `handler` | `CodeRef<FeatureFlagHandler>` | no | Used to set/unset arbitrary feature flags. |
-
----
-
 ## `console.flag/hookProvider`
 
 ### Summary 
@@ -568,21 +557,6 @@ Gives full control over Console feature flags with hook handlers.
 | Name | Value Type | Optional | Description |
 | ---- | ---------- | -------- | ----------- |
 | `handler` | `CodeRef<FeatureFlagHandler>` | no | Used to set/unset arbitrary feature flags. |
-
----
-
-## `console.flag/model`
-
-### Summary 
-
-Adds new Console feature flag driven by the presence of a CRD on the cluster.
-
-### Properties
-
-| Name | Value Type | Optional | Description |
-| ---- | ---------- | -------- | ----------- |
-| `flag` | `string` | no | The name of the flag to set once the CRD is detected. |
-| `model` | `ExtensionK8sModel` | no | The model which refers to a `CustomResourceDefinition`. |
 
 ---
 
@@ -904,21 +878,6 @@ Adds a new project overview utilization item.
 | `priority` | `number` | no | Priority for the status component. Bigger value means higher priority. |
 | `status` | `CodeRef<React.ComponentType<{ pvc: K8sResourceCommon; }>>` | no | The status component. |
 | `predicate` | `CodeRef<(pvc: K8sResourceCommon) => boolean>` | no | Predicate that tells whether to render the status component or not. |
-
----
-
-## `console.redux-reducer`
-
-### Summary 
-
-Adds new reducer to Console Redux store which operates on `plugins.<scope>` substate.
-
-### Properties
-
-| Name | Value Type | Optional | Description |
-| ---- | ---------- | -------- | ----------- |
-| `scope` | `string` | no | The key to represent the reducer-managed substate within the Redux state object. |
-| `reducer` | `CodeRef<Reducer<any, AnyAction>>` | no | The reducer function, operating on the reducer-managed substate. |
 
 ---
 
@@ -1255,6 +1214,50 @@ YAML templates for editing resources via the yaml editor.
 
 ---
 
+## `core.flag`
+
+### Summary 
+
+Core equivalent of `console.flag` extension.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `handler` | `CodeRef<(callback: SetFeatureFlag) => void>` | no | Used to set/unset arbitrary feature flags. |
+
+---
+
+## `core.flag/model`
+
+### Summary 
+
+Core equivalent of `console.flag/model` extension.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `flag` | `string` | no | The name of the flag to set once the CRD is detected. |
+| `model` | `ExtensionK8sResourceIdentifier & { group: string; version: string; kind: string; }` | no | The model which refers to a `CustomResourceDefinition`. |
+
+---
+
+## `core.redux-reducer`
+
+### Summary 
+
+Core equivalent of `console.redux-reducer` extension.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `scope` | `string` | no | The key to represent the reducer-managed substate within the Redux state object. |
+| `reducer` | `CodeRef<Reducer<any, AnyAction>>` | no | The reducer function, operating on the reducer-managed substate. |
+
+---
+
 ## `dev-console.add/action`
 
 ### Summary 
@@ -1309,6 +1312,35 @@ YAML templates for editing resources via the yaml editor.
 
 ---
 
+## `console.flag`
+
+### Summary [DEPRECATED]
+
+@deprecated use `core.flag` extension instead<br/>Gives full control over Console feature flags.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `handler` | `CodeRef<FeatureFlagHandler>` | no | Used to set/unset arbitrary feature flags. |
+
+---
+
+## `console.flag/model`
+
+### Summary [DEPRECATED]
+
+@deprecated use `core.flag/model` extension instead<br/>Adds new Console feature flag driven by the presence of a CRD on the cluster.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `flag` | `string` | no | The name of the flag to set once the CRD is detected. |
+| `model` | `ExtensionK8sModel` | no | The model which refers to a `CustomResourceDefinition`. |
+
+---
+
 ## `console.page/resource/tab`
 
 ### Summary [DEPRECATED]
@@ -1324,4 +1356,19 @@ YAML templates for editing resources via the yaml editor.
 | `name` | `string` | no | The name of the tab. |
 | `href` | `string` | yes | The optional href for the tab link. If not provided, the first `path` is used. |
 | `exact` | `boolean` | yes | When true, will only match if the path matches the `location.pathname` exactly. |
+
+---
+
+## `console.redux-reducer`
+
+### Summary [DEPRECATED]
+
+@deprecated use `core.redux-reducer` extension instead<br/>Adds new reducer to Console Redux store which operates on `plugins.<scope>` substate.
+
+### Properties
+
+| Name | Value Type | Optional | Description |
+| ---- | ---------- | -------- | ----------- |
+| `scope` | `string` | no | The key to represent the reducer-managed substate within the Redux state object. |
+| `reducer` | `CodeRef<Reducer<any, AnyAction>>` | no | The reducer function, operating on the reducer-managed substate. |
 

--- a/frontend/packages/console-dynamic-plugin-sdk/package.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "main": "src/index.ts",
   "scripts": {
-    "clean": "rm -rf dist generated schema",
+    "clean": "rm -rf dist generated",
     "build": "yarn clean && yarn validate && yarn compile && yarn generate",
     "compile": "for ext in '' '-internal' '-webpack' ; do ./node_modules/.bin/tsc -p tsconfig${ext}.json || exit $? ; done",
     "generate": "yarn generate-schema && yarn generate-doc && yarn generate-pkg-assets",
@@ -16,6 +16,7 @@
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'"
   },
   "devDependencies": {
+    "@openshift/dynamic-plugin-sdk": "1.0.0-alpha15",
     "@microsoft/tsdoc": "0.13.2",
     "@types/ejs": "3.x",
     "@types/fs-extra": "9.x",

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/parsers/CodeRefTypeReferenceParser.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/parsers/CodeRefTypeReferenceParser.ts
@@ -1,7 +1,5 @@
-import * as _ from 'lodash';
 import * as tsj from 'ts-json-schema-generator';
 import * as ts from 'typescript';
-import { ConsoleTypeDeclarations } from '../utils/type-resolver';
 
 /**
  * Parse references to `CodeRef<T>` functions as references to `EncodedCodeRef` object literals.
@@ -9,21 +7,14 @@ import { ConsoleTypeDeclarations } from '../utils/type-resolver';
 export class CodeRefTypeReferenceParser implements tsj.SubNodeParser {
   constructor(
     private readonly typeChecker: ts.TypeChecker,
-    private readonly consoleTypeDeclarations: ConsoleTypeDeclarations,
+    private readonly consoleTypeDeclarations: Record<string, ts.Declaration>,
     private readonly getMainParser: () => tsj.NodeParser,
   ) {}
 
   supportsNode(node: ts.Node) {
-    if (ts.isTypeReferenceNode(node)) {
-      const nodeType = this.typeChecker.getTypeAtLocation(node);
-
-      return (
-        nodeType.aliasSymbol?.name === 'CodeRef' &&
-        _.head(nodeType.aliasSymbol?.declarations) === this.consoleTypeDeclarations.CodeRef
-      );
-    }
-
-    return false;
+    return ts.isTypeReferenceNode(node)
+      ? this.typeChecker.getTypeAtLocation(node).aliasSymbol?.name === 'CodeRef'
+      : false;
   }
 
   createType() {

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/utils/type-resolver.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/utils/type-resolver.ts
@@ -10,8 +10,6 @@ import {
   hasDeprecationJSDoc,
 } from './typescript';
 
-export type ConsoleTypeDeclarations = Record<'CodeRef' | 'EncodedCodeRef', ts.Declaration>;
-
 type ContainsJSDoc = {
   /** JSDoc comments attached to the corresponding AST node. */
   docComments: string[];
@@ -38,7 +36,7 @@ export type ExtensionTypeInfo = {
 } & ContainsJSDoc;
 
 type ConsoleTypeResolver = {
-  getDeclarations: () => ConsoleTypeDeclarations;
+  getDeclarations: () => Record<string, ts.Declaration>;
 
   getConsoleExtensions: (
     exitOnErrors?: boolean,
@@ -141,7 +139,6 @@ export const getConsoleTypeResolver = (program: ts.Program): ConsoleTypeResolver
 
   return {
     getDeclarations: () => ({
-      CodeRef: getTypeAliasDeclaration(srcFile('src/types.ts'), 'CodeRef'),
       EncodedCodeRef: getTypeAliasDeclaration(srcFile('src/types.ts'), 'EncodedCodeRef'),
     }),
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/feature-flags.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/feature-flags.ts
@@ -1,7 +1,14 @@
+import {
+  FeatureFlag as FeatureFlagCoreType,
+  ModelFeatureFlag as ModelFeatureFlagCoreType,
+} from '@openshift/dynamic-plugin-sdk';
 import { ExtensionK8sModel } from '../api/common-types';
 import { Extension, ExtensionDeclaration, CodeRef } from '../types';
 
-/** Gives full control over Console feature flags. */
+/**
+ * @deprecated use `core.flag` extension instead
+ * Gives full control over Console feature flags.
+ */
 export type FeatureFlag = ExtensionDeclaration<
   'console.flag',
   {
@@ -10,7 +17,13 @@ export type FeatureFlag = ExtensionDeclaration<
   }
 >;
 
-/** Adds new Console feature flag driven by the presence of a CRD on the cluster. */
+/** Core equivalent of `console.flag` extension. */
+export type CoreFeatureFlag = ExtensionDeclaration<'core.flag', FeatureFlagCoreType['properties']>;
+
+/**
+ * @deprecated use `core.flag/model` extension instead
+ * Adds new Console feature flag driven by the presence of a CRD on the cluster.
+ */
 export type ModelFeatureFlag = ExtensionDeclaration<
   'console.flag/model',
   {
@@ -19,6 +32,12 @@ export type ModelFeatureFlag = ExtensionDeclaration<
     /** The model which refers to a `CustomResourceDefinition`. */
     model: ExtensionK8sModel;
   }
+>;
+
+/** Core equivalent of `console.flag/model` extension. */
+export type CoreModelFeatureFlag = ExtensionDeclaration<
+  'core.flag/model',
+  ModelFeatureFlagCoreType['properties']
 >;
 
 /** Gives full control over Console feature flags with hook handlers. */
@@ -34,8 +53,13 @@ export type FeatureFlagHookProvider = ExtensionDeclaration<
 
 export const isFeatureFlag = (e: Extension): e is FeatureFlag => e.type === 'console.flag';
 
+export const isCoreFeatureFlag = (e: Extension): e is CoreFeatureFlag => e.type === 'core.flag';
+
 export const isModelFeatureFlag = (e: Extension): e is ModelFeatureFlag =>
   e.type === 'console.flag/model';
+
+export const isCoreModelFeatureFlag = (e: Extension): e is CoreModelFeatureFlag =>
+  e.type === 'core.flag/model';
 
 export const isFeatureFlagHookProvider = (e: Extension): e is FeatureFlagHookProvider =>
   e.type === 'console.flag/hookProvider';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/redux.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/redux.ts
@@ -1,7 +1,11 @@
+import { ReduxReducer as ReduxReducerCoreType } from '@openshift/dynamic-plugin-sdk';
 import { Reducer } from 'redux';
 import { Extension, ExtensionDeclaration, CodeRef } from '../types';
 
-/** Adds new reducer to Console Redux store which operates on `plugins.<scope>` substate. */
+/**
+ * @deprecated use `core.redux-reducer` extension instead
+ * Adds new reducer to Console Redux store which operates on `plugins.<scope>` substate.
+ */
 export type ReduxReducer = ExtensionDeclaration<
   'console.redux-reducer',
   {
@@ -12,7 +16,16 @@ export type ReduxReducer = ExtensionDeclaration<
   }
 >;
 
+/** Core equivalent of `console.redux-reducer` extension. */
+export type CoreReduxReducer = ExtensionDeclaration<
+  'core.redux-reducer',
+  ReduxReducerCoreType['properties']
+>;
+
 // Type guards
 
 export const isReduxReducer = (e: Extension): e is ReduxReducer =>
   e.type === 'console.redux-reducer';
+
+export const isCoreReduxReducer = (e: Extension): e is CoreReduxReducer =>
+  e.type === 'core.redux-reducer';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/schema/console-extensions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/schema/console-extensions.ts
@@ -27,7 +27,9 @@ import {
 } from '../extensions/dashboards';
 import {
   FeatureFlag,
+  CoreFeatureFlag,
   ModelFeatureFlag,
+  CoreModelFeatureFlag,
   FeatureFlagHookProvider,
 } from '../extensions/feature-flags';
 import { FileUpload } from '../extensions/file-upload';
@@ -54,7 +56,7 @@ import {
   ProjectOverviewUtilizationItem,
 } from '../extensions/project-overview';
 import { PVCCreateProp, PVCStatus, PVCAlert, PVCDelete } from '../extensions/pvc';
-import { ReduxReducer } from '../extensions/redux';
+import { ReduxReducer, CoreReduxReducer } from '../extensions/redux';
 import { ModelMetadata } from '../extensions/resource-metadata';
 import { StorageClassProvisioner } from '../extensions/storage-class-provisioner';
 import { StorageProvider } from '../extensions/storage-provider';
@@ -73,9 +75,12 @@ import { YAMLTemplate } from '../extensions/yaml-templates';
 
 export type SupportedExtension =
   | FeatureFlag
+  | CoreFeatureFlag
   | ModelFeatureFlag
+  | CoreModelFeatureFlag
   | FeatureFlagHookProvider
   | ReduxReducer
+  | CoreReduxReducer
   | ContextProvider
   | StandaloneRoutePage
   | PVCCreateProp

--- a/frontend/public/actions/features.ts
+++ b/frontend/public/actions/features.ts
@@ -10,7 +10,9 @@ import {
 } from '@console/plugin-sdk/src/api/pluginSubscriptionService';
 import {
   FeatureFlag as DynamicFeatureFlag,
+  CoreFeatureFlag as DynamicCoreFeatureFlag,
   isFeatureFlag as isDynamicFeatureFlag,
+  isCoreFeatureFlag as isDynamicCoreFeatureFlag,
   SetFeatureFlag,
   setUser,
 } from '@console/dynamic-plugin-sdk';
@@ -258,7 +260,7 @@ export const featureFlagController: SetFeatureFlag = (flag, enabled) => {
   store.dispatch(setFlag(flag, enabled));
 };
 
-subscribeToExtensions<DynamicFeatureFlag>(
+subscribeToExtensions<DynamicFeatureFlag | DynamicCoreFeatureFlag>(
   extensionDiffListener((added) => {
     added.forEach((e) => {
       resolveExtension(e)
@@ -272,4 +274,5 @@ subscribeToExtensions<DynamicFeatureFlag>(
     });
   }),
   isDynamicFeatureFlag,
+  isDynamicCoreFeatureFlag,
 );

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -35,6 +35,7 @@ import {
   useResolvedExtensions,
   isContextProvider,
   isReduxReducer,
+  isCoreReduxReducer,
   isStandaloneRoutePage,
   AppInitSDK,
   getUser,
@@ -235,7 +236,11 @@ class App_ extends React.PureComponent {
 }
 
 const AppWithExtensions = withTranslation()(function AppWithExtensions(props) {
-  const [reduxReducerExtensions, reducersResolved] = useResolvedExtensions(isReduxReducer);
+  const [reduxReducerExtensions, reducersResolved] = useResolvedExtensions(
+    isReduxReducer,
+    isCoreReduxReducer,
+  );
+
   const [contextProviderExtensions, providersResolved] = useResolvedExtensions(isContextProvider);
 
   if (reducersResolved && providersResolved) {

--- a/frontend/public/redux.ts
+++ b/frontend/public/redux.ts
@@ -4,6 +4,7 @@ import thunk from 'redux-thunk';
 import {
   ResolvedExtension,
   ReduxReducer,
+  CoreReduxReducer,
   SDKReducers,
   SDKStoreState,
 } from '@console/dynamic-plugin-sdk';
@@ -40,7 +41,9 @@ const store = createStore(
   composeEnhancers(applyMiddleware(thunk)),
 );
 
-export const applyReduxExtensions = (reducerExtensions: ResolvedExtension<ReduxReducer>[]) => {
+export const applyReduxExtensions = (
+  reducerExtensions: ResolvedExtension<ReduxReducer | CoreReduxReducer>[],
+) => {
   const pluginReducers: ReducersMapObject = {};
 
   reducerExtensions.forEach(({ properties: { scope, reducer } }) => {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1145,6 +1145,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.15.4":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.3.1":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
@@ -1889,6 +1896,14 @@
     octokit-pagination-methods "^1.1.0"
     once "^1.4.0"
     universal-user-agent "^4.0.0"
+
+"@openshift/dynamic-plugin-sdk@1.0.0-alpha15":
+  version "1.0.0-alpha15"
+  resolved "https://registry.yarnpkg.com/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-1.0.0-alpha15.tgz#34183954d524b86c910035938efe7cf0df0bc854"
+  integrity sha512-d3+Toj20VxnWbdlE/tLES+Jiyzt4IL//81+f4iUJmXLHsYZtV4vVheGuobyL3qu6ilKjNF1A1juxUW4E6/bSNA==
+  dependencies:
+    lodash-es "^4.17.21"
+    yup "^0.32.11"
 
 "@patternfly/patternfly@4.122.2":
   version "4.122.2"
@@ -2832,6 +2847,11 @@
 "@types/lodash@*":
   version "4.14.106"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.106.tgz#6093e9a02aa567ddecfe9afadca89e53e5dce4dd"
+
+"@types/lodash@^4.14.175":
+  version "4.14.185"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.185.tgz#c9843f5a40703a8f5edfd53358a58ae729816908"
+  integrity sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==
 
 "@types/long@^4.0.1":
   version "4.0.1"
@@ -13373,6 +13393,11 @@ nan@^2.3.0, nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
+nanoclone@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
+  integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
+
 nanoid@^2.1.0:
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
@@ -14873,6 +14898,11 @@ property-expr@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.5.1.tgz#22e8706894a0c8e28d58735804f6ba3a3673314f"
   integrity sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==
+
+property-expr@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
+  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
 
 protobufjs@^6.8.8:
   version "6.10.2"
@@ -19933,6 +19963,19 @@ yup@^0.27.0:
     lodash "^4.17.11"
     property-expr "^1.5.0"
     synchronous-promise "^2.0.6"
+    toposort "^2.0.2"
+
+yup@^0.32.11:
+  version "0.32.11"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.11.tgz#d67fb83eefa4698607982e63f7ca4c5ed3cf18c5"
+  integrity sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/lodash" "^4.14.175"
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+    nanoclone "^0.2.1"
+    property-expr "^2.0.4"
     toposort "^2.0.2"
 
 zen-observable-ts@^0.8.21:


### PR DESCRIPTION
This PR can be used as a baseline for using the available [core extensions](https://github.com/openshift/dynamic-plugin-sdk/tree/main/packages/lib-core/src/extensions) in [OpenShift dynamic plugin SDK](https://github.com/openshift/dynamic-plugin-sdk).