### PR TITLE
Console-3249: Trim whitespace from when creating image pull Secret

### DIFF
--- a/frontend/packages/console-app/src/actions/providers/pod-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/pod-provider.ts
@@ -2,11 +2,9 @@ import * as React from 'react';
 import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { getCommonResourceActions } from '../creators/common-factory';
-// import { usePDBActions } from '../creators/pdb-factory';
 
 export const usePodActionsProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
-  // const [pdbActions] = usePDBActions(kindObj, resource);
 
   const actions = React.useMemo(() => [...getCommonResourceActions(kindObj, resource)], [
     kindObj,

--- a/frontend/packages/console-app/src/actions/providers/pod-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/pod-provider.ts
@@ -2,14 +2,16 @@ import * as React from 'react';
 import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { getCommonResourceActions } from '../creators/common-factory';
+import { usePDBActions } from '../creators/pdb-factory';
 
 export const usePodActionsProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
+  const [pdbActions] = usePDBActions(kindObj, resource);
 
-  const actions = React.useMemo(() => [...getCommonResourceActions(kindObj, resource)], [
-    kindObj,
-    resource,
-  ]);
+  const actions = React.useMemo(
+    () => [...pdbActions, ...getCommonResourceActions(kindObj, resource)],
+    [kindObj, pdbActions, resource],
+  );
 
   return [actions, !inFlight, undefined];
 };

--- a/frontend/packages/console-app/src/actions/providers/pod-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/pod-provider.ts
@@ -2,16 +2,16 @@ import * as React from 'react';
 import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { getCommonResourceActions } from '../creators/common-factory';
-import { usePDBActions } from '../creators/pdb-factory';
+// import { usePDBActions } from '../creators/pdb-factory';
 
 export const usePodActionsProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
-  const [pdbActions] = usePDBActions(kindObj, resource);
+  // const [pdbActions] = usePDBActions(kindObj, resource);
 
-  const actions = React.useMemo(
-    () => [...pdbActions, ...getCommonResourceActions(kindObj, resource)],
-    [kindObj, pdbActions, resource],
-  );
+  const actions = React.useMemo(() => [...getCommonResourceActions(kindObj, resource)], [
+    kindObj,
+    resource,
+  ]);
 
   return [actions, !inFlight, undefined];
 };

--- a/frontend/packages/integration-tests-cypress/tests/crud/image-pull-secret.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/image-pull-secret.spec.ts
@@ -1,0 +1,89 @@
+import { checkErrors, testName } from '../../support';
+import { listPage } from '../../views/list-page';
+import { nav } from '../../views/nav';
+
+const clickCreateImagePullSecretDropdownButton = () => {
+  cy.byTestID('item-create')
+    .click()
+    .get('body')
+    .then(($body) => {
+      if ($body.find(`[data-test-dropdown-menu="image"]`).length) {
+        cy.get(`[data-test-dropdown-menu="image"]`).click();
+      }
+    });
+};
+
+const typeValue = (testId: string, inputValue: string, blur: boolean) => {
+  !blur
+    ? cy.byTestID(testId).type(inputValue)
+    : cy
+        .byTestID(testId)
+        .type(inputValue)
+        .blur();
+};
+
+const populateImageSecretForm = (
+  name: string,
+  address: string,
+  username: string,
+  password: string,
+  email: string,
+) => {
+  cy.get('.co-m-pane__heading').contains('Create image pull secret');
+  cy.byTestID('secret-name').should('exist');
+  typeValue('secret-name', name, false);
+  typeValue('image-secret-address', address, false);
+  typeValue('image-secret-username', username, false);
+  typeValue('image-secret-password', password, false);
+  typeValue('image-secret-email', email, true);
+};
+
+const isWhitespaceRemoved = (testId: string, expectedValue: string) => {
+  cy.byTestID(testId)
+    .invoke('val')
+    .should('have.length', expectedValue.length);
+};
+
+describe('Create image pull secret', () => {
+  const secretName = `${testName}-image-pull-secret-test`;
+  const rsAddress = 'docker.io';
+  const username = 'testUser51';
+  const password = 'test1234';
+  const email = 'testEmail@email.com';
+  const padRsAddress = ' '.repeat(4) + rsAddress + ' '.repeat(4);
+  const padUsername = ' '.repeat(3) + username + ' '.repeat(3);
+  const padPassword = ' '.repeat(2) + password + ' '.repeat(2);
+  const padEmail = ' '.repeat(1) + email + ' '.repeat(1);
+
+  before(() => {
+    cy.login();
+    cy.visit('/');
+    nav.sidenav.switcher.changePerspectiveTo('Administrator');
+    nav.sidenav.switcher.shouldHaveText('Administrator');
+    cy.createProject(testName);
+  });
+
+  beforeEach(() => {
+    nav.sidenav.clickNavLink(['Workloads', 'Secrets']);
+    listPage.titleShouldHaveText('Secrets');
+    clickCreateImagePullSecretDropdownButton();
+  });
+
+  afterEach(() => {
+    checkErrors();
+  });
+
+  after(() => {
+    cy.deleteProject(testName);
+    cy.logout();
+  });
+
+  it(`Validate a image pull secret whose input values contained whitespace`, () => {
+    populateImageSecretForm(secretName, padRsAddress, padUsername, padPassword, padEmail);
+    isWhitespaceRemoved('image-secret-address', rsAddress);
+    isWhitespaceRemoved('image-secret-username', username);
+    isWhitespaceRemoved('image-secret-password', password);
+    isWhitespaceRemoved('image-secret-email', email);
+    cy.byTestID('save-changes').click();
+  });
+});

--- a/frontend/packages/integration-tests-cypress/tests/crud/image-pull-secret.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/image-pull-secret.spec.ts
@@ -13,13 +13,8 @@ const clickCreateImagePullSecretDropdownButton = () => {
     });
 };
 
-const typeValue = (testId: string, inputValue: string, blur: boolean) => {
-  !blur
-    ? cy.byTestID(testId).type(inputValue)
-    : cy
-        .byTestID(testId)
-        .type(inputValue)
-        .blur();
+const typeValue = (testId: string, inputValue: string) => {
+  cy.byTestID(testId).type(inputValue);
 };
 
 const populateImageSecretForm = (
@@ -31,11 +26,13 @@ const populateImageSecretForm = (
 ) => {
   cy.get('.co-m-pane__heading').contains('Create image pull secret');
   cy.byTestID('secret-name').should('exist');
-  typeValue('secret-name', name, false);
-  typeValue('image-secret-address', address, false);
-  typeValue('image-secret-username', username, false);
-  typeValue('image-secret-password', password, false);
-  typeValue('image-secret-email', email, true);
+  typeValue('secret-name', name);
+  typeValue('image-secret-address', address);
+  typeValue('image-secret-username', username);
+  typeValue('image-secret-password', password);
+  cy.byTestID('image-secret-email')
+    .type(email)
+    .blur();
 };
 
 const isWhitespaceRemoved = (testId: string, expectedValue: string) => {

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -502,6 +502,7 @@ class ConfigEntryFormWithTranslation extends React.Component<
               onChange={this.onAddressChanged}
               value={this.state.address}
               onBlur={this.onBlurHandler}
+              data-test="image-secret-address"
               required
             />
           </div>
@@ -522,6 +523,7 @@ class ConfigEntryFormWithTranslation extends React.Component<
               onChange={this.onUsernameChanged}
               value={this.state.username}
               onBlur={this.onBlurHandler}
+              data-test="image-secret-username"
               required
             />
           </div>
@@ -539,6 +541,7 @@ class ConfigEntryFormWithTranslation extends React.Component<
               onChange={this.onPasswordChanged}
               value={this.state.password}
               onBlur={this.onBlurHandler}
+              data-test="image-secret-password"
               required
             />
           </div>
@@ -556,6 +559,7 @@ class ConfigEntryFormWithTranslation extends React.Component<
               onChange={this.onEmailChanged}
               value={this.state.email}
               onBlur={this.onBlurHandler}
+              data-test="image-secret-email"
             />
           </div>
         </div>

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -188,6 +188,7 @@ export const SecretFormWrapper = withTranslation()(
         disableForm: disable,
       });
     }
+
     save(e) {
       e.preventDefault();
       const { metadata } = this.state.secret;
@@ -269,6 +270,7 @@ export const SecretFormWrapper = withTranslation()(
     render() {
       const { secretTypeAbstraction } = this.state;
       const { t, isCreate, modal, onCancel = history.goBack } = this.props;
+
       const title = secretDisplayType(isCreate, secretTypeAbstraction, t);
       return modal ? (
         <form className="co-create-secret-form modal-content" onSubmit={this.save}>
@@ -478,14 +480,18 @@ class ConfigEntryFormWithTranslation extends React.Component<
 
   onBlurHandler: React.ReactEventHandler<HTMLInputElement> = (event) => {
     const { name, value } = event.currentTarget;
-    this.setState((prevState) => ({
-      ...prevState,
-      [name]: value.trim(),
-    }));
+    this.setState(
+      (prevState) => ({
+        ...prevState,
+        [name]: value.trim(),
+      }),
+      this.propagateChange,
+    );
   };
 
   render() {
     const { t } = this.props;
+
     return (
       <div className="co-m-pane__body-group" data-test-id="create-image-secret-form">
         <div className="form-group">
@@ -1483,3 +1489,11 @@ type WebHookSecretFormProps = {
     WebHookSecretKey: string;
   };
 };
+
+// testMouseOver: React.ReactEventHandler<HTMLDivElement> = (event) => {
+//   console.log('active el', document.activeElement);
+//   console.log('hi', event);
+//   if (document.activeElement instanceof HTMLElement) {
+//     document.activeElement.blur();
+//   }
+// };

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -476,6 +476,14 @@ class ConfigEntryFormWithTranslation extends React.Component<
     this.setState({ email: event.currentTarget.value }, this.propagateChange);
   };
 
+  onBlurHandler: React.ReactEventHandler<HTMLInputElement> = (event) => {
+    const { name, value } = event.currentTarget;
+    this.setState((prevState) => ({
+      ...prevState,
+      [name]: value.trim(),
+    }));
+  };
+
   render() {
     const { t } = this.props;
     return (
@@ -493,6 +501,7 @@ class ConfigEntryFormWithTranslation extends React.Component<
               name="address"
               onChange={this.onAddressChanged}
               value={this.state.address}
+              onBlur={this.onBlurHandler}
               required
             />
           </div>
@@ -512,6 +521,7 @@ class ConfigEntryFormWithTranslation extends React.Component<
               name="username"
               onChange={this.onUsernameChanged}
               value={this.state.username}
+              onBlur={this.onBlurHandler}
               required
             />
           </div>
@@ -528,6 +538,7 @@ class ConfigEntryFormWithTranslation extends React.Component<
               name="password"
               onChange={this.onPasswordChanged}
               value={this.state.password}
+              onBlur={this.onBlurHandler}
               required
             />
           </div>
@@ -544,6 +555,7 @@ class ConfigEntryFormWithTranslation extends React.Component<
               name="email"
               onChange={this.onEmailChanged}
               value={this.state.email}
+              onBlur={this.onBlurHandler}
             />
           </div>
         </div>
@@ -917,6 +929,7 @@ class BasicAuthSubformWithTranslation extends React.Component<
       () => this.props.onChange(this.state),
     );
   }
+
   render() {
     const { t } = this.props;
     return (

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -1489,11 +1489,3 @@ type WebHookSecretFormProps = {
     WebHookSecretKey: string;
   };
 };
-
-// testMouseOver: React.ReactEventHandler<HTMLDivElement> = (event) => {
-//   console.log('active el', document.activeElement);
-//   console.log('hi', event);
-//   if (document.activeElement instanceof HTMLElement) {
-//     document.activeElement.blur();
-//   }
-// };


### PR DESCRIPTION
https://issues.redhat.com/browse/CONSOLE-3249

**Changes to _public/components/secrets/create-secret.tsx_:** 
Added an onBlur event handler to trim whitespace to the form inputs - _Registry Server Address, Username, Password_ and _Email_ when creating/editing an image pull secret.

**File addition - _packages/integration-tests-cypress/tests/crud/image-pull-secret.spec.ts_:** 
This integration test creates an image pull secret and adds additional whitespace to the values on the inputs _Registry Server Address, Username, Password_ and _Email_. 
After adding these values and before saving the secret, the test checks that the input fields automatically removed the whitespace. 

