### PR TITLE
Bug 2005232: Pods list page should only show Create Pod button to user has sufficient permission

### DIFF
--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -1021,13 +1021,17 @@ export const PodsPage: React.FC<PodPageProps> = ({
   const [data, filteredData, onFilterChange] = useListPageFilter(pods, filters, {
     name: { selected: [nameFilter] },
   });
-
+  const resourceKind = referenceForModel(PodModel);
+  const accessReview = {
+    groupVersionKind: resourceKind,
+    namespace: namespace || 'default',
+  };
   return (
     userSettingsLoaded && (
       <>
         <ListPageHeader title={showTitle ? t('public~Pods') : undefined}>
           {canCreate && (
-            <ListPageCreate groupVersionKind={referenceForModel(PodModel)}>
+            <ListPageCreate groupVersionKind={resourceKind} createAccessReview={accessReview}>
               {t('public~Create Pod')}
             </ListPageCreate>
           )}


### PR DESCRIPTION

### Before
 ![Screen Shot 2022-08-29 at 3 08 21 PM](https://user-images.githubusercontent.com/15249132/187282649-9ff69864-2b86-4113-a11f-e197132c2768.png)

### After
![Screen Shot 2022-08-29 at 3 08 38 PM](https://user-images.githubusercontent.com/15249132/187282756-a991173c-7e59-4e6b-a618-bd8c67c6953f.png)
