### PR TITLE
OCPBUGS-704: Disable knative test suite

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -68,7 +68,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-dev-console-headless
   yarn run test-cypress-olm-headless
   yarn run test-cypress-helm-headless
-  yarn run test-cypress-knative-headless
+  # yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
   yarn run test-cypress-pipelines-headless
   exit;


### PR DESCRIPTION
After https://github.com/openshift/console/pull/11963/files got merged `e2e-aws-console` tests in the `console-operator` repo started to fail on the all the PRs.
Disabling the unblock the merge queue in the `console-operator` repo.

/assign @spadgett 