### PR TITLE
OU-68 Add PodMonitors to Metrics targets Page

### DIFF
--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1794,6 +1794,8 @@
   "Prometheuses": "Prometheuses",
   "ServiceMonitor": "ServiceMonitor",
   "ServiceMonitors": "ServiceMonitors",
+  "PodMonitor": "PodMonitor",
+  "PodMonitors": "PodMonitors",
   "DaemonSet": "DaemonSet",
   "ReplicationController": "ReplicationController",
   "HorizontalPodAutoscaler": "HorizontalPodAutoscaler",

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -34,6 +34,23 @@ export const ServiceMonitorModel: K8sKind = {
   propagationPolicy: 'Foreground',
 };
 
+export const PodMonitorModel: K8sKind = {
+  kind: 'PodMonitor',
+  label: 'PodMonitor',
+  // t('public~PodMonitor')
+  labelKey: 'public~PodMonitor',
+  labelPlural: 'PodMonitors',
+  // t('public~PodMonitors')
+  labelPluralKey: 'public~PodMonitors',
+  apiGroup: 'monitoring.coreos.com',
+  apiVersion: 'v1',
+  abbr: 'PM',
+  namespaced: true,
+  crd: true,
+  plural: 'podmonitors',
+  propagationPolicy: 'Foreground',
+};
+
 export const AlertmanagerModel: K8sKind = {
   kind: 'Alertmanager',
   label: 'Alertmanager',


### PR DESCRIPTION
**Description** : Display PodMonitors on Observe > Metrics target Page. 

**Related** : [OU-68](https://issues.redhat.com/browse/OU-68)

**Screenshot**: PodMonitors are noted as 'PM'. 3 example PodMonitors were deployed in the namespace ns2. 

<img width="1851" alt="Screen Shot 2022-08-31 at 7 27 28 PM" src="https://user-images.githubusercontent.com/59589720/188519427-222b9f18-7e7d-4af5-86e9-3c466175596e.png">

