### PR TITLE
ODC-6784: Provide a code snippet for the console CRD for Adding Perspectives in Dev Console

### DIFF
--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -281,6 +281,8 @@
   "Provides a list of default roles which are shown in the Project Access. The roles must be added below customization projectAccess.": "Provides a list of default roles which are shown in the Project Access. The roles must be added below customization projectAccess.",
   "Add page actions": "Add page actions",
   "Provides a list of all available actions on the Add page in the Developer perspective. The IDs must be added below customization addPage disabledActions to hide these actions.": "Provides a list of all available actions on the Add page in the Developer perspective. The IDs must be added below customization addPage disabledActions to hide these actions.",
+  "Add user perspectives": "Add user perspectives",
+  "Provides a list of all the available user perspectives which are shown in the perspective dropdown. The perspectives must be added below spec customization.": "Provides a list of all the available user perspectives which are shown in the perspective dropdown. The perspectives must be added below spec customization.",
   "Set maxUnavaliable to 0": "Set maxUnavaliable to 0",
   "An eviction is allowed if at most 0 pods selected by \"selector\" are unavailable after the eviction.": "An eviction is allowed if at most 0 pods selected by \"selector\" are unavailable after the eviction.",
   "Set minAvailable to 25%": "Set minAvailable to 25%",

--- a/frontend/packages/console-shared/src/utils/sample-utils.ts
+++ b/frontend/packages/console-shared/src/utils/sample-utils.ts
@@ -3,7 +3,7 @@ import { Map as ImmutableMap } from 'immutable';
 import YAML from 'js-yaml';
 import * as _ from 'lodash';
 import { PodDisruptionBudgetModel } from '@console/app/src/models';
-import { AddAction, isAddAction } from '@console/dynamic-plugin-sdk';
+import { AddAction, isAddAction, isPerspective, Perspective } from '@console/dynamic-plugin-sdk';
 import { FirehoseResult } from '@console/internal/components/utils';
 import * as denyOtherNamespacesImg from '@console/internal/imgs/network-policy-samples/1-deny-other-namespaces.svg';
 import * as limitCertainAppImg from '@console/internal/imgs/network-policy-samples/2-limit-certain-apps.svg';
@@ -343,6 +343,35 @@ const defaultSamples = (t: TFunction) =>
                   unsubscribe();
                 },
                 isAddAction,
+              );
+            });
+          },
+          targetResource: getTargetResource(ConsoleOperatorConfigModel),
+        },
+        {
+          title: t('console-shared~Add user perspectives'),
+          description: t(
+            'console-shared~Provides a list of all the available user perspectives which are shown in the perspective dropdown. The perspectives must be added below spec customization.',
+          ),
+          id: 'user-perspectives',
+          snippet: true,
+          lazyYaml: () => {
+            return new Promise<string>((resolve) => {
+              const unsubscribe = subscribeToExtensions<Perspective>(
+                (extensions: LoadedExtension<Perspective>[]) => {
+                  const yaml = extensions.map((extension) => {
+                    const { id } = extension.properties;
+                    return {
+                      id,
+                      visibility: {
+                        state: 'Enabled',
+                      },
+                    };
+                  });
+                  resolve(YAML.dump(yaml));
+                  unsubscribe();
+                },
+                isPerspective,
               );
             });
           },


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
- [ODC-6784: Provide a code snippet for the console CRD for Hiding Perspectives in Dev Console](https://issues.redhat.com/browse/ODC-6784)

**Solution Description**: 
Added the code snippet for the console CRD for Perspectives in Dev Console so that a user can paste the snippet into the Console CR YAML. This will help the cluster admins to hide the user perspectives based on resource permissions (RBAC).


**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/47265560/188127023-87b26b0d-3884-4610-b9b7-40e9c3653091.mp4





**Unit test coverage report**: 
No changes.

**Test setup:**
1. CRD URL example: http://localhost:9000/k8s/cluster/customresourcedefinitions/consoles.operator.openshift.io

Search for `customization`, and add this YAML under the `properties`
```yaml
perspectives:
  description: perspectives allows enabling/disabling of perspective(s) that the user can see in the Perspective switcher dropdown.
  type: object
  required:
    - id
  properties:
    id:
      description: id defines the id of perspective to disable. Incorrect or unknown ids will be ignored.
      type: string
    requiresAccessReview:
      description: requiresAccessReview defines a list of permission checks. The perspective will only be shown when all checks are successful.
      type: array
      items:
        description: ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface
        type: object
        properties:
          group:
            description: Group is the API Group of the Resource.  "*" means all.
            type: string
          name:
            description: Name is the name of the resource being requested for a "get" or deleted for a "delete". "" (empty) means all.
            type: string
          namespace:
            description: Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces "" (empty) is defaulted for LocalSubjectAccessReviews "" (empty) is empty for cluster-scoped resources "" (empty) means "all" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview
            type: string
          resource:
            description: Resource is one of the existing resource types.  "*" means all.
            type: string
          subresource:
            description: Subresource is one of the existing resource types.  "" means none.
            type: string
          verb:
            description: 'Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  "*" means all.'
            type: string
          version:
            description: Version is the API Version of the Resource.  "*" means all.
            type: string
    state:
      description: state defines the perspective is enabled or disabled.
      type: string
      enum:
        - Enabled
        - Disabled
```

2. Open the cluster resource of the YAML and open the sidebar.
Cluster config example: http://localhost:9000/k8s/cluster/operator.openshift.io~v1~Console/cluster/yaml

3. Insert the Hide sub-catalogs for all users & Hide user perspectives snippet and save the resource.


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge