### PR TITLE
CONSOLE 3250: Configure default behavior for "Wrap lines" in log viewers

### DIFF
--- a/frontend/public/components/utils/resource-log.tsx
+++ b/frontend/public/components/utils/resource-log.tsx
@@ -401,6 +401,19 @@ export const ResourceLog: React.FC<ResourceLogProps> = ({
     false,
     true,
   );
+  const hasWrapAnnotation =
+    resource?.metadata?.annotations?.['console.openshift.io/wrap-log-lines'] === 'true';
+
+  const [wrapLinesCheckbox, setWrapLinesCheckbox] = React.useState(wrapLines || hasWrapAnnotation);
+  const firstRender = React.useRef(true);
+
+  React.useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    setWrapLines(wrapLinesCheckbox);
+  }, [wrapLinesCheckbox, setWrapLines]);
 
   const timeoutIdRef = React.useRef(null);
   const countRef = React.useRef(0);
@@ -589,8 +602,8 @@ export const ResourceLog: React.FC<ResourceLogProps> = ({
       containerName={containerName}
       podLogLinks={podLogLinks}
       namespaceUID={namespaceUID}
-      toggleWrapLines={setWrapLines}
-      isWrapLines={wrapLines}
+      toggleWrapLines={setWrapLinesCheckbox}
+      isWrapLines={wrapLinesCheckbox}
       hasPreviousLog={hasPreviousLogs}
       changeLogType={setLogType}
       logType={logType}
@@ -662,7 +675,7 @@ export const ResourceLog: React.FC<ResourceLogProps> = ({
             data={content}
             ref={logViewerRef}
             height="100%"
-            isTextWrapped={wrapLines}
+            isTextWrapped={wrapLinesCheckbox}
             toolbar={logControls}
             footer={
               <FooterButton
@@ -692,7 +705,7 @@ type LogControlsProps = {
   namespaceUID?: string;
   toggleStreaming?: () => void;
   toggleFullscreen: () => void;
-  toggleWrapLines: (wrapLines: boolean) => void;
+  toggleWrapLines: (wrapLinesCheckbox: boolean) => void;
   isWrapLines: boolean;
   changeLogType: (type: LogTypeStatus) => void;
   hasPreviousLog?: boolean;


### PR DESCRIPTION
Add the ability to include a pod annotation `console.openshift.io/wrap-log-lines` which will default the log viewer to wrap log lines.
https://issues.redhat.com/browse/CONSOLE-3250


@jhadvig @TheRealJon there is a consequence of this change. Since `wrapLines` is stored in local storage, if a user has selected to turn off wrap lines checkbox in the past and then views the log of a pod with the configured default wrap annotation, then this "wrapped" preference will persist to subsequent pod logs. Is this behavior acceptable?

cc @rhamilto 

Example: The left side pod has `console.openshift.io/wrap-log-lines` annotation. On the right side, the pod wrap lines setting is unchecked. Once user has viewed left side pod logs with default wrap config, then subsequent pod log settings are switched to wrapped. 
![setWrapLines-true-persists-to-other-pod-logs](https://user-images.githubusercontent.com/1874151/188182692-8ca8d4ed-3342-4526-a880-cab447612219.gif)
