### PR TITLE
OCPBUGS-869: correct Azure product name for support link

### DIFF
--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -254,8 +254,7 @@ export const getReportBugLink = (cv: ClusterVersionKind): { label: string; href:
       productName = 'OpenShift Dedicated';
       break;
     case 'azure':
-      // TODO:  change to 'Azure Red Hat OpenShift' once https://issues.redhat.com/browse/CPCCM-9926 is complete
-      productName = 'OpenShift Managed (Azure)';
+      productName = 'Azure Red Hat OpenShift';
       break;
     default:
       productName = 'OKD';


### PR DESCRIPTION
After:

https://user-images.githubusercontent.com/895728/188207601-7b85553e-85ec-405a-892a-1dc67e4b0cf9.mov

Note testing is a bit tricky since prerelease versions show a link to Jira to open a bug instead of a support case.  To test locally, change https://github.com/openshift/console/blob/3c60c636c7b2908344f436df13b15c73840196cc/frontend/public/module/k8s/cluster-settings.ts#L270 to `  return !_.isEmpty(prerelease)` while running `./bin/bridge -branding=azure`.