### PR TITLE
OCPBUGS-896: Allows launching of modals from alert actions

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md
@@ -153,7 +153,7 @@ ResourceActionProvider contributes a hook that returns list of actions for speci
 | ---- | ---------- | -------- | ----------- |
 | `alert` | `string` | no |  |
 | `text` | `string` | no |  |
-| `action` | `CodeRef<(alert: any) => void>` | no |  |
+| `action` | `CodeRef<(alert: Alert, launchModal: LaunchModal) => void>` | no |  |
 
 ---
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/notification-alert.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/notification-alert.ts
@@ -1,3 +1,5 @@
+import { Alert } from '../api/common-types';
+import { LaunchModal } from '../app/modal-support/ModalProvider';
 import { Extension, ExtensionDeclaration, CodeRef } from '../types';
 
 export type AlertAction = ExtensionDeclaration<
@@ -8,7 +10,7 @@ export type AlertAction = ExtensionDeclaration<
     /* Action text */
     text: string;
     /* Function to perform side effect */
-    action: CodeRef<(alert) => void>;
+    action: CodeRef<(alert: Alert, launchModal: LaunchModal) => void>;
   }
 >;
 

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { isAlertAction, AlertAction, useResolvedExtensions } from '@console/dynamic-plugin-sdk';
 import { AlertItemProps } from '@console/dynamic-plugin-sdk/src/api/internal-types';
+import { useModal } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { alertURL } from '@console/internal/components/monitoring/utils';
 import { getAlertActions } from '@console/internal/components/notification-drawer';
 import { Timestamp } from '@console/internal/components/utils/timestamp';
@@ -52,6 +53,7 @@ export const StatusItem: React.FC<StatusItemProps> = ({ Icon, timestamp, message
 
 const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {
   const { t } = useTranslation();
+  const launchModal = useModal();
   const [actionExtensions] = useResolvedExtensions<AlertAction>(
     React.useCallback(
       (e): e is AlertAction => isAlertAction(e) && e.properties.alert === alert.rule.name,
@@ -67,7 +69,7 @@ const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {
       message={getAlertDescription(alert) || getAlertMessage(alert) || getAlertSummary(alert)}
     >
       {text && action ? (
-        <Button variant={ButtonVariant.link} onClick={() => action(alert)} isInline>
+        <Button variant={ButtonVariant.link} onClick={() => action(alert, launchModal)} isInline>
           {text}
         </Button>
       ) : (

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -74,6 +74,7 @@ import { LinkifyExternal } from './utils';
 import { PrometheusEndpoint } from './graphs/helpers';
 import { LabelSelector } from '@console/internal/module/k8s/label-selector';
 import { useNotificationAlerts } from '@console/shared/src/hooks/useNotificationAlerts';
+import { useModal } from '@console/dynamic-plugin-sdk/src/lib-core';
 
 const AlertErrorState: React.FC<AlertErrorProps> = ({ errorText }) => {
   const { t } = useTranslation();
@@ -297,6 +298,7 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
   }, [dispatch, t, rulesAccess]);
   const clusterVersion: ClusterVersionKind = useClusterVersion();
   const [alerts, , loadError] = useNotificationAlerts();
+  const launchModal = useModal();
   const alertIds = React.useMemo(() => alerts?.map((alert) => alert.rule.name) || [], [alerts]);
   const [alertActionExtensions] = useResolvedExtensions<AlertAction>(
     React.useCallback(
@@ -391,7 +393,7 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
                 toggleNotificationDrawer={toggleNotificationDrawer}
                 targetPath={alertURL(alert, alert.rule.id)}
                 actionText={action?.text}
-                alertAction={() => action?.action?.(alert)}
+                alertAction={() => action?.action?.(alert, launchModal)}
               />
             );
           })
@@ -423,7 +425,7 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
               toggleNotificationDrawer={toggleNotificationDrawer}
               targetPath={alertURL(alert, alert.rule.id)}
               actionText={action?.text}
-              alertAction={() => action?.action?.(alert)}
+              alertAction={() => action?.action?.(alert, launchModal)}
             />
           );
         })}


### PR DESCRIPTION
ODF has a use case where launching of modal needs to be supported from Alert Actions.
Passing `launchModal` allows consumers to launch Modals from a function. 
`useModal` cannot be directly used inside the function passed by the user as it breaks the rules of hooks.

Recording:


https://user-images.githubusercontent.com/54092533/188437021-61bc7f0b-e705-45ad-9320-1697b2a98196.mp4


Signed-off-by: Bipul Adhikari <badhikar@redhat.com>