### PR TITLE
OCPBUGS-238: enable knative e2e in ci

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -68,7 +68,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-dev-console-headless
   yarn run test-cypress-olm-headless
   yarn run test-cypress-helm-headless
-  # yarn run test-cypress-knative-headless
+  yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
   yarn run test-cypress-pipelines-headless
   exit;


### PR DESCRIPTION
Tracks: https://issues.redhat.com/browse/OCPBUGS-238


Knative tests where disabled with https://github.com/openshift/console/pull/12006 as it was blocking the queue in the console operator repo for test `pull-ci-openshift-console-operator-master-e2e-aws-console` ([here](https://prow.ci.openshift.org/job-history/origin-ci-test/pr-logs/directory/pull-ci-openshift-console-operator-master-e2e-aws-console)) and not in e2e gcp and the reason was the timeout (can be seen [here](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_console-operator/675/pull-ci-openshift-console-operator-master-e2e-aws-console/1564917310869737472/artifacts/e2e-aws-console/test/build-log.txt)

with this change https://github.com/openshift/release/pull/31999 i think we can enable the tests.

