### PR TITLE
OCPBUGS-943: Use the Deployment as resource kind and label also when importing a Devfile

### DIFF
--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -105,7 +105,7 @@ export const createOrUpdateImageStream = async (
   ).catch(() => createdImageStream);
 };
 
-const getMetadata = (formData: DeployImageFormData) => {
+const getMetadata = (resource: Resources, formData: DeployImageFormData) => {
   const {
     application: { name: applicationName },
     name,
@@ -113,7 +113,6 @@ const getMetadata = (formData: DeployImageFormData) => {
     labels: userLabels,
     imageStream: { image: imageStreamName, tag: selectedTag, namespace },
     runtimeIcon,
-    resources,
   } = formData;
   const defaultLabels = getAppLabels({
     name,
@@ -124,7 +123,7 @@ const getMetadata = (formData: DeployImageFormData) => {
     namespace,
   });
   const labels = { ...defaultLabels, ...userLabels };
-  const podLabels = getPodLabels(resources, name);
+  const podLabels = getPodLabels(resource, name);
 
   const volumes = [];
   const volumeMounts = [];
@@ -181,7 +180,7 @@ export const createOrUpdateDeployment = (
   };
   const templateAnnotations = getCommonAnnotations();
 
-  const { labels, podLabels, volumes, volumeMounts } = getMetadata(formData);
+  const { labels, podLabels, volumes, volumeMounts } = getMetadata(Resources.Kubernetes, formData);
 
   const imageRef =
     registry === RegistryType.External
@@ -251,7 +250,7 @@ export const createOrUpdateDeploymentConfig = (
     healthChecks,
   } = formData;
 
-  const { labels, podLabels, volumes, volumeMounts } = getMetadata(formData);
+  const { labels, podLabels, volumes, volumeMounts } = getMetadata(Resources.OpenShift, formData);
 
   const defaultAnnotations = {
     ...getCommonAnnotations(),

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -326,7 +326,6 @@ export const createOrUpdateDeployment = (
     limits: { cpu, memory },
     git: { url: repository, ref },
     healthChecks,
-    resources,
   } = formData;
 
   const imageStreamName = imageStream && imageStream.metadata.name;
@@ -339,7 +338,7 @@ export const createOrUpdateDeployment = (
     'alpha.image.policy.openshift.io/resolve-names': '*',
     ...getTriggerAnnotation(name, imageName, namespace, imageChange),
   };
-  const podLabels = getPodLabels(resources, name);
+  const podLabels = getPodLabels(Resources.Kubernetes, name);
   const templateLabels = getTemplateLabels(originalDeployment);
 
   const newDeployment = {
@@ -401,7 +400,6 @@ export const createOrUpdateDeploymentConfig = (
     limits: { cpu, memory },
     git: { url: repository, ref },
     healthChecks,
-    resources,
   } = formData;
 
   const imageStreamName = imageStream && imageStream.metadata.name;
@@ -411,7 +409,7 @@ export const createOrUpdateDeploymentConfig = (
     ...getGitAnnotations(repository, ref),
     ...getRouteAnnotations(),
   };
-  const podLabels = getPodLabels(resources, name);
+  const podLabels = getPodLabels(Resources.OpenShift, name);
   const templateLabels = getTemplateLabels(originalDeploymentConfig);
 
   const newDeploymentConfig = {

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -291,16 +291,17 @@ export enum Resources {
   KnativeService = 'knative',
 }
 
-export const ReadableResourcesNames = {
+export const ReadableResourcesNames: Record<Resources, string> = {
   [Resources.OpenShift]: DeploymentConfigModel.labelKey,
   [Resources.Kubernetes]: DeploymentModel.labelKey,
   // t('devconsole~Serverless Deployment')
   [Resources.KnativeService]: `devconsole~Serverless Deployment`,
 };
 
-export const ResourcesKinds = {
+export const ResourcesKinds: Record<Resources, string> = {
   [Resources.OpenShift]: DeploymentConfigModel.kind,
   [Resources.Kubernetes]: DeploymentModel.kind,
+  [Resources.KnativeService]: 'Service',
 };
 
 export interface ImportData {

--- a/frontend/packages/dev-console/src/components/import/upload-jar-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/upload-jar-submit-utils.ts
@@ -55,7 +55,6 @@ export const createOrUpdateDeployment = (
     limits: { cpu, memory },
     healthChecks,
     runtimeIcon,
-    resources,
   } = formData;
 
   const imageStreamName = imageStream && imageStream.metadata.name;
@@ -74,7 +73,7 @@ export const createOrUpdateDeployment = (
     ...getTriggerAnnotation(name, imageName, namespace, imageChange),
     jarFileName: fileName,
   };
-  const podLabels = getPodLabels(resources, name);
+  const podLabels = getPodLabels(Resources.Kubernetes, name);
   const templateLabels = getTemplateLabels(originalDeployment);
 
   const jArgsIndex = env?.findIndex((e) => e.name === 'JAVA_ARGS');
@@ -147,12 +146,11 @@ const createOrUpdateDeploymentConfig = (
     labels: userLabels,
     limits: { cpu, memory },
     healthChecks,
-    resources,
   } = formData;
 
   const imageStreamName = imageStream && imageStream.metadata.name;
   const defaultLabels = getAppLabels({ name, applicationName, imageStreamName, selectedTag });
-  const podLabels = getPodLabels(resources, name);
+  const podLabels = getPodLabels(Resources.OpenShift, name);
   const templateLabels = getTemplateLabels(originalDeploymentConfig);
 
   const jArgsIndex = env?.findIndex((e) => e.name === 'JAVA_ARGS');

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -94,10 +94,15 @@ export const getUserAnnotations = (allAnnotations: { [key: string]: string }) =>
 };
 
 export const getPodLabels = (resource: Resources, name: string) => {
-  const resourceKind = _.toLower(ResourcesKinds[resource]);
+  const resourceKind = ResourcesKinds[resource];
+  if (resourceKind) {
+    return {
+      app: name,
+      [resourceKind.toLowerCase()]: name,
+    };
+  }
   return {
     app: name,
-    [resourceKind]: name,
   };
 };
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-943

**Analysis / Root cause**: 
The selected resource type can not be changed for Devfiles.

But `getPodLabels` used this to create the right labels. If the resource was unknown it creates a invalid label for the Deployment (not the selected resource!)

```ts
"": app
```

**Solution Description**: 
Use a "hard coded" (based on the calling function name) `Resources.Kubernetes` or `Resources.Openshift` instead of the selected resource type when creating the Pod labels.

**Screen shots / Gifs for design review**: 
Before 4.11:

https://user-images.githubusercontent.com/139310/188630347-efcab895-1429-4def-a84c-9145a14abb87.mp4

Before 4.12:

https://user-images.githubusercontent.com/139310/188630364-ff294028-29b6-4a12-8af4-a3543cddd54e.mp4

With this PR:

https://user-images.githubusercontent.com/139310/188630385-c8eed582-ae95-4555-a6bf-91ac36d55e8d.mp4

Labels for a Devfile, Deployment and DeploymentConfig:

In the recording the label key is `Deployment`, but the PR is updated again to use lowercase `deployment` as before!

https://user-images.githubusercontent.com/139310/188630397-2eabce34-a50b-41ec-90f1-28d20ddd0c93.mp4

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Install and setup Serverless operator
1. Switch to dev perspective, navigate to add > import from git
3. Enter a non-Devfile git URL like https://github.com/jerolimov/nodeinfo
4. On 4.11 select resource type Serverless (on 4.12 this should be selected automatically)
5. Update the git URL to a repo with a Devfile like https://github.com/nodeshift-starters/devfile-sample
6. Press create

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
