### PR TITLE
OCPBUGS-939: Fix flaky CI and usability issue: Disable create button until Devfile is parsed

### DIFF
--- a/frontend/packages/dev-console/src/components/import/devfile/devfileHooks.ts
+++ b/frontend/packages/dev-console/src/components/import/devfile/devfileHooks.ts
@@ -56,6 +56,7 @@ export const useDevfileServer = (
     }
 
     setParsingDevfile(true);
+    setFieldValue('devfile.devfileSuggestedResources', null);
     coFetchJSON
       .post('/api/devfile/', devfileData)
       .then((value: DevfileSuggestedResources) => {

--- a/frontend/packages/dev-console/src/components/import/validation-schema.ts
+++ b/frontend/packages/dev-console/src/components/import/validation-schema.ts
@@ -322,8 +322,13 @@ export const devfileValidationSchema = (t: TFunction) =>
   yup.object().when('build', {
     is: (build) => build.strategy === 'Devfile',
     then: yup.object().shape({
-      devfileHasError: yup.boolean().oneOf([false]),
       devfilePath: yup.string().required(t('devconsole~Required')),
+      devfileContent: yup
+        .string()
+        .min(1, t('devconsole~Required'))
+        .required(t('devconsole~Required')),
+      devfileHasError: yup.boolean().oneOf([false]),
+      devfileSuggestedResources: yup.object().required(t('devconsole~Required')),
     }),
   });
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-939

**Analysis / Root cause**: 
When importing a Devfile, the Devfile content (yaml) got parsed in the bridge (our backend). But the UI shows already an enabled "Create" button. But when clicking this button the creation flow fails with an internal error until the parsing was successfully (or failed).

Error:
```
Cannot convert undefined or null to object
```

The CI fails currently less than earlier because we cached the `/api/devfile/` response with Cypress `cy.inception`, so the response is really fast.

**Solution Description**: 
1. Add some form validation rules to `validation-schema.ts` so that the Create button is disabled until the Devfile itself was fetched (`devfileContent`).
2. And until the devfile was parsed (`devfileSuggestedResource`).
3. Finally clear the parsed devfile (`devfileSuggestedResource`) when the devfile content was used to parse it again (calling `/api/devfile/`)

**Screen shots / Gifs for design review**: 

Before:

https://user-images.githubusercontent.com/139310/188665362-af1b642f-ddd5-4986-9d7b-70c6b6c3b672.mp4

After:

https://user-images.githubusercontent.com/139310/188665346-cafc7463-037c-41fe-a3a2-9040accc0209.mp4

**Unit test coverage report**: 


**Test setup:**
1. Switch to developer perspective, navigate to add > Import from git
2. Enter a git URL that contains a Devffile like `https://github.com/nodeshift-starters/devfile-sample`
3. While the validation happen, click fast on the Create button to get an error

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
