### PR TITLE
OCPBUGS-800: Name of workload get changed, when project and image stream gets changed on reloading the form on the edit deployment page of the workload

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-deployment/EditDeployment.tsx
+++ b/frontend/packages/dev-console/src/components/edit-deployment/EditDeployment.tsx
@@ -39,10 +39,7 @@ const EditDeployment: React.FC<EditDeploymentProps> = ({ heading, resource, name
     yamlData: safeJSToYAML(resource, 'yamlData', {
       skipInvalid: true,
     }),
-    formData: {
-      ...convertDeploymentToEditForm(resource),
-      formType: isNew ? 'create' : 'edit',
-    },
+    formData: convertDeploymentToEditForm(resource),
     formReloadCount: 0,
   });
 

--- a/frontend/packages/dev-console/src/components/edit-deployment/EditDeploymentForm.tsx
+++ b/frontend/packages/dev-console/src/components/edit-deployment/EditDeploymentForm.tsx
@@ -80,7 +80,7 @@ const EditDeploymentForm: React.FC<FormikProps<FormikValues> & {
     setFieldValue('formData.resourceVersion', resource.metadata.resourceVersion);
     setFieldValue('yamlData', safeJSToYAML(resource, 'yamlData', { skipInvalid: true }));
     setFieldValue('formReloadCount', formReloadCount + 1);
-  }, [editorType, resource, setErrors, setFieldValue, setStatus, formReloadCount]);
+  }, [setStatus, setErrors, editorType, setFieldValue, resource, formReloadCount]);
 
   return (
     <FlexForm onSubmit={handleSubmit}>

--- a/frontend/packages/dev-console/src/components/edit-deployment/utils/edit-deployment-types.ts
+++ b/frontend/packages/dev-console/src/components/edit-deployment/utils/edit-deployment-types.ts
@@ -88,6 +88,7 @@ export interface EditDeploymentFormData extends TriggersAndImageStreamFormData {
   imagePullSecret?: string;
   paused?: boolean;
   replicas?: number;
+  formType?: string;
 }
 
 export interface EditDeploymentData {

--- a/frontend/packages/dev-console/src/components/edit-deployment/utils/edit-deployment-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-deployment/utils/edit-deployment-utils.ts
@@ -280,6 +280,7 @@ export const convertDeploymentToEditForm = (
 ): EditDeploymentFormData => {
   const resourceType = getResourcesType(deployment);
   return {
+    formType: deployment.metadata.name ? 'edit' : 'create',
     name: deployment.metadata.name ?? '',
     resourceVersion: deployment.metadata.resourceVersion ?? '',
     deploymentStrategy: getStrategy(deployment, resourceType),


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-800

**Analysis / Root cause**: 
Name of workload get changed, when project and image stream gets changed on reloading the form on the edit deployment page of the workload

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Reset the formType when the Reload button is pressed.

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/47265560/188634133-b83b2eca-cd78-4fd4-b7f3-fa033fd7e479.mp4

**Unit test coverage report**: 
<!-- Attach test coverage report -->
Not changed.

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Create a deployment workload
2. Select Edit Deployment option on workload
3. Verify initially name was same as workload name and field was not changeable.
4. Change the project to "openshift", image stream to "golang" or anything and tag to "latest"
5. Reload the form
6. Now check that the name also got changed to golang. 


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge