### PR TITLE
OU-85: Monitoring: Add runbook URLs to alert and rule details pages

### DIFF
--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -833,6 +833,8 @@ const AlertsDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
                 </dl>
               </div>
             </div>
+          </div>
+          <div className="co-m-pane__body-group">
             <div className="row">
               <div className="col-xs-12">
                 <dl className="co-m-pane__details" data-test="label-list">
@@ -843,6 +845,8 @@ const AlertsDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
                 </dl>
               </div>
             </div>
+          </div>
+          <div className="co-m-pane__body-group">
             <div className="row">
               <div className="col-xs-12">
                 <dl className="co-m-pane__details">
@@ -1080,6 +1084,8 @@ const AlertRulesDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
                 </dl>
               </div>
             </div>
+          </div>
+          <div className="co-m-pane__body-group">
             <div className="row">
               <div className="col-xs-12">
                 <dl className="co-m-pane__details">

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -80,7 +80,7 @@ import { ActionsMenu } from '../utils/dropdown';
 import { Firehose } from '../utils/firehose';
 import { ActionButtons, BreadCrumbs, SectionHeading } from '../utils/headings';
 import { Kebab } from '../utils/kebab';
-import { getURLSearchParams, LinkifyExternal } from '../utils/link';
+import { ExternalLink, getURLSearchParams, LinkifyExternal } from '../utils/link';
 import { ResourceLink } from '../utils/resource-link';
 import { history } from '../utils/router';
 import { LoadingInline, StatusBox } from '../utils/status-box';
@@ -688,6 +688,9 @@ const AlertsDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const labels: PrometheusLabels = React.useMemo(() => alert?.labels, [labelsMemoKey]);
 
+  // eslint-disable-next-line camelcase
+  const runbookURL = alert?.annotations?.runbook_url;
+
   const actionsContext: ActionContext = { 'alert-detail-toolbar-actions': { alert } };
 
   return (
@@ -801,6 +804,14 @@ const AlertsDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
                           labels={labels}
                           template={rule?.annotations?.message}
                         />
+                      </dd>
+                    </>
+                  )}
+                  {runbookURL && (
+                    <>
+                      <dt>{t('public~Runbook')}</dt>
+                      <dd>
+                        <ExternalLink href={runbookURL} text={runbookURL} />
                       </dd>
                     </>
                   )}
@@ -965,6 +976,9 @@ const AlertRulesDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
     return `${nameLabel}{${_.map(otherLabels, (v, k) => `${k}="${v}"`).join(',')}}`;
   };
 
+  // eslint-disable-next-line camelcase
+  const runbookURL = rule?.annotations?.runbook_url;
+
   return (
     <>
       <Helmet>
@@ -1028,6 +1042,14 @@ const AlertRulesDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
                       <dt>{t('public~Message')}</dt>
                       <dd>
                         <PrometheusTemplate text={rule.annotations.message} />
+                      </dd>
+                    </>
+                  )}
+                  {runbookURL && (
+                    <>
+                      <dt>{t('public~Runbook')}</dt>
+                      <dd>
+                        <ExternalLink href={runbookURL} text={runbookURL} />
                       </dd>
                     </>
                   )}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -968,6 +968,7 @@
   "Alerts": "Alerts",
   "Alert details": "Alert details",
   "Severity": "Severity",
+  "Runbook": "Runbook",
   "Alerting rule": "Alerting rule",
   "Silenced by": "Silenced by",
   "Active since": "Active since",


### PR DESCRIPTION
The field is only displayed if the `runbook_url` annotation exists.

Originally implemented by https://github.com/openshift/console/pull/9376, which was then reverted due to concerns about the documentation. We now have agreement regarding concerns and are moving ahead with adding these links.

Also adds back some vertical space around the Labels field that seems to have been accidentally removed.

![screenshot](https://user-images.githubusercontent.com/460802/189045693-da0da37f-c1e7-49f7-9fdc-46c579d2ea5d.png)

FYI @jan--f, @vmartini01 