### PR TITLE
OCPBUGS-1569: add admin flag to disabled extensions

### DIFF
--- a/frontend/packages/ceph-storage-plugin/console-extensions.json
+++ b/frontend/packages/ceph-storage-plugin/console-extensions.json
@@ -71,7 +71,7 @@
       }
     },
     "flags": {
-      "required": ["MCG"],
+      "required": ["MCG", "ODF_ADMIN"],
       "disallowed": ["MCG_RESOURCE"]
     }
   },
@@ -90,7 +90,7 @@
       }
     },
     "flags": {
-      "required": ["RGW"],
+      "required": ["RGW", "ODF_ADMIN"],
       "disallowed": ["MCG", "MCG_RESOURCE"]
     }
   },
@@ -108,7 +108,7 @@
       }
     },
     "flags": {
-      "required": ["MCG"],
+      "required": ["MCG", "ODF_ADMIN"],
       "disallowed": ["MCG_RESOURCE"]
     }
   },
@@ -127,7 +127,7 @@
       }
     },
     "flags": {
-      "required": ["RGW"],
+      "required": ["RGW", "ODF_ADMIN"],
       "disallowed": ["MCG", "MCG_RESOURCE"]
     }
   },

--- a/frontend/packages/ceph-storage-plugin/src/features.ts
+++ b/frontend/packages/ceph-storage-plugin/src/features.ts
@@ -41,6 +41,8 @@ export const OCS_FLAG = 'OCS';
 
 export const MCG_STANDALONE = 'MCG_STANDALONE';
 
+export const ODF_ADMIN = 'ODF_ADMIN'; // Set to "true" if user is an "openshift-storage" admin (access to StorageSystems)
+
 export enum FEATURES {
   // Flag names to be prefixed with "OCS_" so as to seperate from console flags
   OCS_MULTUS = 'OCS_MULTUS',

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -32,6 +32,7 @@ import {
   detectComponents,
   FEATURES,
   RGW_FLAG,
+  ODF_ADMIN,
 } from './features';
 import { ODF_MODEL_FLAG } from './constants';
 import { getObcStatusGroups } from './components/dashboards/object-service/buckets-card/utils';
@@ -284,7 +285,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         ).then((m) => m.ObjectBucketsPage),
     },
     flags: {
-      required: [OCS_MODEL_FLAG],
+      required: [OCS_MODEL_FLAG, ODF_ADMIN],
       disallowed: [FEATURES.MCG_RESOURCE],
     },
   },
@@ -298,7 +299,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         ).then((m) => m.ObjectBucketDetailsPage),
     },
     flags: {
-      required: [OCS_MODEL_FLAG],
+      required: [OCS_MODEL_FLAG, ODF_ADMIN],
       disallowed: [FEATURES.MCG_RESOURCE],
     },
   },
@@ -312,7 +313,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         ).then((m) => m.ObjectBucketClaimsPage),
     },
     flags: {
-      required: [OCS_MODEL_FLAG],
+      required: [OCS_MODEL_FLAG, ODF_ADMIN],
       disallowed: [FEATURES.MCG_RESOURCE],
     },
   },
@@ -326,7 +327,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         ).then((m) => m.ObjectBucketClaimsDetailsPage),
     },
     flags: {
-      required: [OCS_MODEL_FLAG],
+      required: [OCS_MODEL_FLAG, ODF_ADMIN],
       disallowed: [FEATURES.MCG_RESOURCE],
     },
   },
@@ -340,7 +341,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         ).then((m) => m.CreateOBCPage),
     },
     flags: {
-      required: [MCG_FLAG],
+      required: [MCG_FLAG, ODF_ADMIN],
       disallowed: [FEATURES.MCG_RESOURCE],
     },
   },
@@ -355,7 +356,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         ).then((m) => m.CreateOBCPage),
     },
     flags: {
-      required: [RGW_FLAG],
+      required: [RGW_FLAG, ODF_ADMIN],
       disallowed: [MCG_FLAG, FEATURES.MCG_RESOURCE],
     },
   },


### PR DESCRIPTION
From 4.11 onwards we have migrated our code from older OCP repo to a new ODF repo. We disable/hide older code and enable a new one based on certain flags which UI reads from the ODF operator's CSV.
For non-privileged user (created from htpasswd method), he doesn't has an access to read the CSV, hence flags are never getting set and both older and new UI can be seen (two OB/OBC options, one from old repo another from new).
Jira: https://issues.redhat.com/browse/OCPBUGS-1569

"ODF_ADMIN" will be `false` for the non-admin user, so adding it to "required" field of extensions for truly blocking them, cause flags read from CSV (added to "disallowed" field) will be `undefined` in this case.

Ticket: https://issues.redhat.com/browse/OCPBUGS-1569

Follow up PR: https://github.com/red-hat-storage/odf-console/pull/408