### PR TITLE
ODC-6772: Show resource quota alert in deployment side-panel

### DIFF
--- a/frontend/packages/topology/console-extensions.json
+++ b/frontend/packages/topology/console-extensions.json
@@ -175,6 +175,15 @@
     }
   },
   {
+    "type": "console.topology/details/resource-alert",
+    "properties": {
+      "id": "resource-quota-alert",
+      "contentProvider": {
+        "$codeRef": "workload.useResourceQuotaAlert"
+      }
+    }
+  },
+  {
     "type": "console.context-provider",
     "properties": {
       "provider": { "$codeRef": "exportAppContext.ExportAppContextProvider" },

--- a/frontend/packages/topology/integration-tests/features/topology/resource-quota-warning.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/resource-quota-warning.feature
@@ -23,5 +23,16 @@ Feature: Update user in topology page if Quotas has been reached in a namespace
              When user navigates to Topology page
               And user clicks on link to view resource quota details
              Then user is redirected to resource quota list page
-   
+        
 
+        @regression
+        Scenario: deployment node has yellow border around it and side-panel shows alert when resource quota is reached: T-19-TC03
+            Given user is at Add page
+              And user has created workload "ex-node-js1" with resource type "deployment"
+              And user is at Topology page
+             When user clicks on workload 'ex-node-js1'
+              And user can see sidebar opens with Resources tab selected by default
+             Then user is able to see resource quota alert
+              And user is able to see yellow border around 'ex-node-js1' workload   
+
+              

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -89,6 +89,7 @@ export const topologyPO = {
     editAnnotations: '[data-test="edit-annotations"]',
     tabName: '[role="dialog"] li button',
     healthCheckAlert: 'div.odc-topology-sidebar-alert',
+    resourceQuotaAlert: 'div.odc-topology-sidebar-alert [aria-label="Warning Alert"]',
     podScale: 'button.pf-c-button.pf-m-plain.pf-m-block',
     podText: 'text.pf-chart-donut-title.pod-ring__center-text',
     applicationGroupingsTitle: '.overview__sidebar-pane-head.resource-overview__heading',

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -436,6 +436,11 @@ export const topologyPage = {
       .should('be.visible')
       .click({ force: true });
   },
+  verifyNodeAlert: (nodeName: string) => {
+    cy.get('[data-type="workload"]')
+      .find('.pf-topology__node.pf-m-warning')
+      .contains(nodeName);
+  },
 };
 
 export const addGitWorkload = (

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-side-pane-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-side-pane-page.ts
@@ -81,6 +81,8 @@ export const topologySidePane = {
     cy.get(topologyPO.sidePane.podText, { timeout: 120000 }).should('contain.text', scaleNumber);
   },
   verifyHealthCheckAlert: () => cy.get(topologyPO.sidePane.healthCheckAlert).should('be.visible'),
+  verifyResourceQuotaAlert: () =>
+    cy.get(topologyPO.sidePane.resourceQuotaAlert).should('be.visible'),
   verifyWorkloadInAppSideBar: (workloadName: string) =>
     cy
       .get(topologyPO.sidePane.dialog)

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/resource-quota-warning.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/resource-quota-warning.ts
@@ -1,4 +1,4 @@
-import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { Given, When, Then, And } from 'cypress-cucumber-preprocessor/steps';
 import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
 import { listPage } from '@console/cypress-integration-tests/views/list-page';
 import { modal } from '@console/cypress-integration-tests/views/modal';
@@ -10,6 +10,7 @@ import {
   topologyHelper,
   topologyPage,
   app,
+  topologySidePane,
 } from '@console/dev-console/integration-tests/support/pages';
 
 const deteleResourceQuota = () => {
@@ -68,3 +69,11 @@ When(
     cy.get('h2').should('contain.text', 'ResourceQuota details');
   },
 );
+
+Then('user is able to see resource quota alert', () => {
+  topologySidePane.verifyResourceQuotaAlert();
+});
+
+And('user is able to see yellow border around {string} workload', (workloadName: string) => {
+  topologyPage.verifyNodeAlert(workloadName);
+});

--- a/frontend/packages/topology/locales/en/topology.json
+++ b/frontend/packages/topology/locales/en/topology.json
@@ -133,6 +133,7 @@
   "Container {{containersName}} does not have health checks to ensure your application is running correctly.": "Container {{containersName}} does not have health checks to ensure your application is running correctly.",
   "Health checks": "Health checks",
   "Add health checks": "Add health checks",
+  "Resource Quotas": "Resource Quotas",
   "Visual connector": "Visual connector",
   "Expand groups": "Expand groups",
   "Pod count": "Pod count",

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/BaseNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/BaseNode.tsx
@@ -14,6 +14,7 @@ import {
   WithDndDropProps,
   WithDragNodeProps,
   WithSelectionProps,
+  StatusModifier,
 } from '@patternfly/react-topology';
 import classNames from 'classnames';
 import { useAccessReview } from '@console/internal/components/utils';
@@ -53,6 +54,8 @@ type BaseNodeProps = {
   createConnectorAccessVerb?: K8sVerb;
   nodeStatus?: NodeStatus;
   showStatusBackground?: boolean;
+  showAlertStatus?: boolean;
+  alertVariant?: string;
 } & Partial<WithSelectionProps> &
   Partial<WithDragNodeProps> &
   Partial<WithDndDropProps> &
@@ -72,6 +75,8 @@ const BaseNode: React.FC<BaseNodeProps> = ({
   contextMenuOpen,
   createConnectorAccessVerb = 'patch',
   createConnectorDrag,
+  showAlertStatus,
+  alertVariant,
   ...rest
 }) => {
   const [hoverChange, setHoverChange] = React.useState<boolean>(false);
@@ -115,6 +120,7 @@ const BaseNode: React.FC<BaseNodeProps> = ({
         <DefaultNode
           className={classNames('odc-base-node', className, {
             'is-filtered': filtered,
+            [StatusModifier[alertVariant]]: showAlertStatus,
           })}
           truncateLength={RESOURCE_NAME_TRUNCATE_LENGTH}
           element={element}

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/BaseNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/BaseNode.tsx
@@ -54,8 +54,7 @@ type BaseNodeProps = {
   createConnectorAccessVerb?: K8sVerb;
   nodeStatus?: NodeStatus;
   showStatusBackground?: boolean;
-  showAlertStatus?: boolean;
-  alertVariant?: string;
+  alertVariant?: NodeStatus;
 } & Partial<WithSelectionProps> &
   Partial<WithDragNodeProps> &
   Partial<WithDndDropProps> &
@@ -75,7 +74,6 @@ const BaseNode: React.FC<BaseNodeProps> = ({
   contextMenuOpen,
   createConnectorAccessVerb = 'patch',
   createConnectorDrag,
-  showAlertStatus,
   alertVariant,
   ...rest
 }) => {
@@ -118,10 +116,14 @@ const BaseNode: React.FC<BaseNodeProps> = ({
     <Layer id={hover || contextMenuOpen ? TOP_LAYER : DEFAULT_LAYER}>
       <g ref={nodeHoverRefs} data-test-id={element.getLabel()}>
         <DefaultNode
-          className={classNames('odc-base-node', className, {
-            'is-filtered': filtered,
-            [StatusModifier[alertVariant]]: showAlertStatus,
-          })}
+          className={classNames(
+            'odc-base-node',
+            className,
+            alertVariant && StatusModifier[alertVariant],
+            {
+              'is-filtered': filtered,
+            },
+          )}
           truncateLength={RESOURCE_NAME_TRUNCATE_LENGTH}
           element={element}
           showLabel={showLabel}

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
@@ -194,7 +194,7 @@ const WorkloadPodsNode: React.FC<WorkloadPodsNodeProps> = observer(function Work
   const buildStatus = buildConfigs?.[0]?.builds?.[0]?.status?.phase;
   const pipelineStatus = element.getData()?.resources?.pipelineRunStatus ?? 'Unknown';
   const workloadRqAlert = useResourceQuotaAlert(element);
-  const workloadRqAlertVariant = workloadRqAlert?.variant || 'default';
+  const workloadRqAlertVariant = (workloadRqAlert?.variant as NodeStatus) || NodeStatus.default;
 
   return (
     <g className="odc-workload-node">
@@ -219,7 +219,6 @@ const WorkloadPodsNode: React.FC<WorkloadPodsNodeProps> = observer(function Work
           }
           attachments={nodeDecorators}
           contextMenuOpen={contextMenuOpen}
-          showAlertStatus={!!workloadRqAlert}
           alertVariant={workloadRqAlertVariant}
           {...rest}
         >

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
@@ -28,6 +28,7 @@ import {
 import { WithCreateConnectorProps } from '../../../../behavior/withCreateConnector';
 import { getFilterById, SHOW_POD_COUNT_FILTER_ID, useDisplayFilters } from '../../../../filters';
 import { getResource, getTopologyResourceObject } from '../../../../utils/topology-utils';
+import { useResourceQuotaAlert } from '../../../workload';
 import BaseNode from './BaseNode';
 import { getNodeDecorators } from './decorators/getNodeDecorators';
 import PodSet, { podSetInnerRadius } from './PodSet';
@@ -192,6 +193,8 @@ const WorkloadPodsNode: React.FC<WorkloadPodsNodeProps> = observer(function Work
   const { buildConfigs } = useBuildConfigsWatcher(resource);
   const buildStatus = buildConfigs?.[0]?.builds?.[0]?.status?.phase;
   const pipelineStatus = element.getData()?.resources?.pipelineRunStatus ?? 'Unknown';
+  const workloadRqAlert = useResourceQuotaAlert(element);
+  const workloadRqAlertVariant = workloadRqAlert?.variant || 'default';
 
   return (
     <g className="odc-workload-node">
@@ -216,6 +219,8 @@ const WorkloadPodsNode: React.FC<WorkloadPodsNodeProps> = observer(function Work
           }
           attachments={nodeDecorators}
           contextMenuOpen={contextMenuOpen}
+          showAlertStatus={!!workloadRqAlert}
+          alertVariant={workloadRqAlertVariant}
           {...rest}
         >
           {donutStatus && showDetails ? (

--- a/frontend/packages/topology/src/components/side-bar/components/SideBarAlerts.tsx
+++ b/frontend/packages/topology/src/components/side-bar/components/SideBarAlerts.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
-import { GraphElement } from '@patternfly/react-topology';
+import { GraphElement, observer } from '@patternfly/react-topology';
 import {
   DetailsResourceAlert,
   DetailsResourceAlertContent,
@@ -15,7 +15,7 @@ const ResolveResourceAlerts: React.FC<{
   id?: string;
   useResourceAlertsContent?: (element: GraphElement) => DetailsResourceAlertContent;
   element: GraphElement;
-}> = ({ id, useResourceAlertsContent, element }) => {
+}> = observer(function ResolveResourceAlerts({ id, useResourceAlertsContent, element }) {
   const [showAlert, setShowAlert, loaded] = useUserSettings(
     `${USERSETTINGS_PREFIX}.${SIDEBAR_ALERTS}.${id}.${element.getId()}`,
     true,
@@ -42,7 +42,7 @@ const ResolveResourceAlerts: React.FC<{
       {content}
     </Alert>
   ) : null;
-};
+});
 
 const SideBarAlerts: React.FC<{ element: GraphElement }> = ({ element }) => {
   const [resourceAlertsExtension, resolved] = useResolvedExtensions<DetailsResourceAlert>(


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-6772

This PR adds resource-quota alert in the deployment sidepanel which is shown when there is some resource-quota error.
Also when there is some resource-quota error this PR adds a yellow border around the deployment node.

**Demo:**

https://user-images.githubusercontent.com/20724543/192808815-800b0bd6-f2b7-4511-ae51-3c42171d3125.mov


<img width="316" alt="Screenshot 2022-09-13 at 3 59 19 PM" src="https://user-images.githubusercontent.com/20724543/189879629-3b2d5fd5-bd1a-41f8-b5f9-4ad3b66ae95e.png">
<img width="2560" alt="Screenshot 2022-09-13 at 3 59 58 PM" src="https://user-images.githubusercontent.com/20724543/189879589-d6919918-8166-4a3d-ac00-fcb0b6bcce9b.png">
