### PR TITLE
OU-66 Add a 'Select/Unselect All' button to Observe > Metrics Page > …

### DIFF
--- a/frontend/public/actions/observe.ts
+++ b/frontend/public/actions/observe.ts
@@ -26,6 +26,7 @@ export enum ActionType {
   QueryBrowserSetTimespan = 'queryBrowserSetTimespan',
   QueryBrowserToggleIsEnabled = 'queryBrowserToggleIsEnabled',
   QueryBrowserToggleSeries = 'queryBrowserToggleSeries',
+  QueryBrowserToggleAllSeries = 'queryBrowserToggleAllSeries',
   SetAlertCount = 'SetAlertCount',
   ToggleGraphs = 'toggleGraphs',
 }
@@ -120,6 +121,9 @@ export const queryBrowserSetPollInterval = (pollInterval: number) =>
 export const queryBrowserSetTimespan = (timespan: number) =>
   action(ActionType.QueryBrowserSetTimespan, { timespan });
 
+export const queryBrowserToggleAllSeries = (index: number) =>
+  action(ActionType.QueryBrowserToggleAllSeries, { index });
+
 export const queryBrowserToggleIsEnabled = (index: number) =>
   action(ActionType.QueryBrowserToggleIsEnabled, { index });
 
@@ -152,6 +156,7 @@ const actions = {
   queryBrowserSetMetrics,
   queryBrowserSetPollInterval,
   queryBrowserSetTimespan,
+  queryBrowserToggleAllSeries,
   queryBrowserToggleIsEnabled,
   queryBrowserToggleSeries,
   setAlertCount,

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -495,6 +495,10 @@ $monitoring-line-height: 18px;
   }
 }
 
+.query-browser__table-wrapper .query-browser__series-select-all-btn {
+  margin-top: var(--pf-global--spacer--md);
+}
+
 .query-browser__table-message {
   border-bottom: solid 1px var(--pf-global--BorderColor--100);
   padding: 10px 20px;
@@ -590,6 +594,7 @@ $monitoring-line-height: 18px;
   &:focus {
     outline: none;
   }
+  height: 200px;
 }
 
 .query-browser__zoom-overlay {

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -55,6 +55,7 @@ import {
   queryBrowserRunQueries,
   queryBrowserSetAllExpanded,
   queryBrowserSetPollInterval,
+  queryBrowserToggleAllSeries,
   queryBrowserToggleIsEnabled,
   queryBrowserToggleSeries,
   toggleGraphs,
@@ -222,9 +223,6 @@ const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
   const isEnabled = useSelector(({ observe }: RootState) =>
     observe.getIn(['queryBrowser', 'queries', index, 'isEnabled']),
   );
-  const series = useSelector(({ observe }: RootState) =>
-    observe.getIn(['queryBrowser', 'queries', index, 'series']),
-  );
 
   const dispatch = useDispatch();
 
@@ -233,15 +231,10 @@ const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
     index,
   ]);
 
-  const toggleAllSeries = React.useCallback(
-    () =>
-      dispatch(
-        queryBrowserPatchQuery(index, {
-          disabledSeries: isDisabledSeriesEmpty ? series : [],
-        }),
-      ),
-    [dispatch, index, isDisabledSeriesEmpty, series],
-  );
+  const toggleAllSeries = React.useCallback(() => dispatch(queryBrowserToggleAllSeries(index)), [
+    dispatch,
+    index,
+  ]);
 
   const doDelete = React.useCallback(() => {
     dispatch(queryBrowserDeleteQuery(index));
@@ -308,6 +301,17 @@ export const QueryTable: React.FC<QueryTableProps> = ({ index, namespace }) => {
 
   const lastRequestTime = useSelector(({ observe }: RootState) =>
     observe.getIn(['queryBrowser', 'lastRequestTime']),
+  );
+
+  const dispatch = useDispatch();
+
+  const toggleAllSeries = React.useCallback(() => dispatch(queryBrowserToggleAllSeries(index)), [
+    dispatch,
+    index,
+  ]);
+
+  const isDisabledSeriesEmpty = useSelector(({ observe }: RootState) =>
+    _.isEmpty(observe.getIn(['queryBrowser', 'queries', index, 'disabledSeries'])),
   );
 
   const safeFetch = React.useCallback(useSafeFetch(), []);
@@ -444,6 +448,14 @@ export const QueryTable: React.FC<QueryTableProps> = ({ index, namespace }) => {
     <>
       <div className="query-browser__table-wrapper">
         <div className="horizontal-scroll">
+          <Button
+            variant="link"
+            isInline
+            onClick={toggleAllSeries}
+            className="query-browser__series-select-all-btn"
+          >
+            {isDisabledSeriesEmpty ? t('public~Unselect all') : t('public~Select all')}
+          </Button>
           <Table
             aria-label={t('public~query results table')}
             cells={columns}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1034,6 +1034,8 @@
   "Delete query": "Delete query",
   "Duplicate query": "Duplicate query",
   "Error loading values": "Error loading values",
+  "Unselect all": "Unselect all",
+  "Select all": "Select all",
   "No query entered": "No query entered",
   "Enter a query in the box below to explore metrics for this cluster.": "Enter a query in the box below to explore metrics for this cluster.",
   "Insert example query": "Insert example query",

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -72,6 +72,13 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
     });
   }
 
+  const queryBrowserPatchQueryHelper = (index: number, patch: { [key: string]: unknown }) => {
+    const query = state.hasIn(['queryBrowser', 'queries', index])
+      ? ImmutableMap(patch)
+      : newQueryBrowserQuery().merge(patch);
+    return state.mergeIn(['queryBrowser', 'queries', index], query);
+  };
+
   switch (action.type) {
     case ActionType.DashboardsPatchVariable:
       return state.mergeIn(
@@ -199,10 +206,7 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
 
     case ActionType.QueryBrowserPatchQuery: {
       const { index, patch } = action.payload;
-      const query = state.hasIn(['queryBrowser', 'queries', index])
-        ? ImmutableMap(patch)
-        : newQueryBrowserQuery().merge(patch);
-      return state.mergeIn(['queryBrowser', 'queries', index], query);
+      return queryBrowserPatchQueryHelper(index, patch);
     }
 
     case ActionType.QueryBrowserRunQueries: {
@@ -233,6 +237,16 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
 
     case ActionType.QueryBrowserSetTimespan:
       return state.setIn(['queryBrowser', 'timespan'], action.payload.timespan);
+
+    case ActionType.QueryBrowserToggleAllSeries: {
+      const index = action.payload.index;
+      const isDisabledSeriesEmpty = _.isEmpty(
+        state.getIn(['queryBrowser', 'queries', index, 'disabledSeries']),
+      );
+      const series = state.getIn(['queryBrowser', 'queries', index, 'series']);
+      const patch = { disabledSeries: isDisabledSeriesEmpty ? series : [] };
+      return queryBrowserPatchQueryHelper(index, patch);
+    }
 
     case ActionType.QueryBrowserToggleIsEnabled: {
       const query = state.getIn(['queryBrowser', 'queries', action.payload.index]);


### PR DESCRIPTION
…Query > Series Table

**Description**: The 'Select/Unselect All' button toggles series data from a metrics query. Clicking 'Select All' displays all series on the graph. Clicking 'Unselect All' eliminates all series from the graph. 

**Related to** : [OU-66](https://issues.redhat.com/browse/OU-66)


Signed-off-by: Jenny Zhu <jenny.a.zhu@gmail.com>

https://user-images.githubusercontent.com/59589720/191616005-8db22fd3-fe1e-4c09-b88a-e4b462f737ea.mov

