### PR TITLE
Action on Knative-Revision | Knative Serverless

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/modal.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/modal.ts
@@ -11,10 +11,7 @@ export const editLabels = {
     return cy.get('tags-input span.tag-item-content');
   },
   removeLabel: (labelName: string) => {
-    cy.get('tags-input span.tag-item')
-      .contains(labelName)
-      .next('a.remove-button')
-      .click();
+    cy.get(`[aria-label="Close ${labelName}"]`).click();
   },
 };
 

--- a/frontend/packages/knative-plugin/integration-tests/cypress.json
+++ b/frontend/packages/knative-plugin/integration-tests/cypress.json
@@ -19,7 +19,7 @@
   "screenshotsFolder": "../../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../../gui_test_screenshots/cypress/videos",
   "env": {
-    "TAGS": "(@knative or @knative-admin or @knative-camelk or @knative-eventing or @knative-kafka) and (@pre-condition or @smoke or @regression) and not (@manual or @to-do or @un-verified or @broken-test)",
+    "TAGS": "(@knative or @knative-admin or @knative-camelk or @knative-eventing or @knative-kafka or @knative-serverless) and (@pre-condition or @smoke or @regression) and not (@manual or @to-do or @un-verified or @broken-test)",
     "NAMESPACE": "aut-knative"
   },
   "retries": {

--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/actions-on-knative-revision.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/actions-on-knative-revision.feature
@@ -1,4 +1,4 @@
-@knative
+@knative-serverless
 Feature: Perform actions on knative revision
               As a user, I want to perform edit or delete operations on knative revision in topology page
 
@@ -21,83 +21,81 @@ Feature: Perform actions on knative revision
 
         Examples:
                   | git_url                                 | workload_name   |
-                  | https://github.com/sclorg/nodejs-ex.git | nodejs-ex-git-2 |
+                  | https://github.com/sclorg/nodejs-ex.git | nodejs-ex-git-1 |
 
 
         @smoke
         Scenario: Context menu for knative Revision: KN-01-TC01
-             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
+             When user right clicks on the revision of knative service "nodejs-ex-git-1" to open the context menu
              Then user is able to see Edit Labels, Edit Annotations, Edit Revision, Delete Revision options in context menu
 
 
         @regression
         Scenario: Add new label to knative Revision: KN-01-TC02
-             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
+             When user right clicks on the revision of knative service "nodejs-ex-git-1" to open the context menu
               And user selects "Edit labels" option from knative revision context menu
               And user adds the label "app=label" to existing labels list in Edit Labels modal
               And user clicks on Save button
-             Then user can see the label "app=label" in the Details tab of the Sidebar of "nodejs-ex-git-2"
+             Then user can see the label "app=label" in the Details tab of the Sidebar of "nodejs-ex-git-1"
 
 
         @regression
         Scenario: Remove label from knative Revision: KN-01-TC03
-             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
+             When user right clicks on the revision of knative service "nodejs-ex-git-1" to open the context menu
               And user selects "Edit labels" option from knative revision context menu
               And user removes the label "app=label" from existing labels list in "Edit labels" modal
               And user clicks on Save button
-             Then user will not see the label "app=label" in the Details tab of the Sidebar of "nodejs-ex-git-2"
+             Then user will not see the label "app=label" in the Details tab of the Sidebar of "nodejs-ex-git-1"
 
 
         @regression
         Scenario: Add labels to existing labels list and cancel the activity: KN-01-TC04
-             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
+             When user right clicks on the revision of knative service "nodejs-ex-git-1" to open the context menu
               And user selects "Edit labels" option from knative revision context menu
               And user adds the label "app=label" to existing labels list in Edit Labels modal
               And user clicks cancel button on the "Edit labels" modal
-             Then user will not see the label "app=label" in the Details tab of the Sidebar of "nodejs-ex-git-2"
+             Then user will not see the label "app=label" in the Details tab of the Sidebar of "nodejs-ex-git-1"
 
 
-        @regression @to-do
+        @regression
         Scenario: Add annotation to the existing annonations list: KN-01-TC05
-            Given Revision of Knative service "nodejs-ex-git-2" consists of annotations in topology side bar
-             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
-              And user selects "Edit annotaions" option from knative revision context menu
+            Given Revision of Knative service "nodejs-ex-git-1" consists of annotations in topology side bar
+             When user right clicks on the revision of knative service "nodejs-ex-git-1" to open the context menu
+              And user selects "Edit annotations" option from knative revision context menu
               And user clicks Add button on the Edit Annotations modal
-              And user enters annotation key as "serving.knative.dev/creator"
-              And user enters annotation value as "kube:admin"
-              And user clicks the save button on the "Edit annotaions" modal
-             Then number of annotations increases for revision of knative service "nodejs-ex-git-2" in topology side bar
+              And user enters annotation key as "new-annotation"
+              And user enters annotation value as "new-pw"
+              And user clicks the save button on the "Edit annotations" modal
+             Then verify the number of annotations equal to "7" in side bar details knative revision
 
 
-        @regression @to-do
+        @regression
         Scenario: perform cancel action on Edit Annotations: KN-01-TC06
-            Given number of annotations are "5" present in revision side bar details of service "nodejs-ex-git-2"
-             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
-              And number of annotations are "6" present in side bar - details tab- annotation section
-             When user selects "Edit annotations" option from knative revision context menu
-              And user clicks on "remove" icon for the annotation with key "serving.knative.dev/creator" present in "Edit annotaions" modal
-              And user clicks cancel button on the "Edit annotaions" modal
-             Then verify the number of annotations equal to "6" in side bar details
+            Given number of annotations are "7" present in revision side bar details of service "nodejs-ex-git-1"
+             When user right clicks on the revision of knative service "nodejs-ex-git-1" to open the context menu
+              And user selects "Edit annotations" option from knative revision context menu
+              And user clicks on "remove" icon for the annotation with key "new-annotation"
+              And user clicks cancel button on the "Edit annotations" modal
+             Then verify the number of annotations equal to "7" in side bar details knative revision
 
 
-        @regression @to-do
+        @regression
         Scenario Outline: Remove annotation from existing annonations list: KN-01-TC07
-            Given number of annotations are "5" present in revision side bar details of service "nodejs-ex-git-2"
-             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
-              And number of annotations are "6" present in side bar - details tab
-             When user selects "Edit annotaions" option from knative revision context menu
-              And user clicks on "remove" icon for the annotation with key "<key_name>" present in "Edit annotaions" modal
-              And user clicks the save button on the "Edit annotaions" modal
-             Then verify the number of annotations decreased to "5" in side bar details
+            Given number of annotations are "7" present in revision side bar details of service "nodejs-ex-git-1"
+             When user right clicks on the revision of knative service "nodejs-ex-git-1" to open the context menu
+              And user selects "Edit annotations" option from knative revision context menu
+              And user clicks on "remove" icon for the annotation with key "<key_name>"
+              And user clicks the save button on the "Edit annotations" modal
+             Then verify the number of annotations equal to "6" in side bar details knative revision
 
         Examples:
-                  | key_name                    |
-                  | serving.knative.dev/creator |
+                  | key_name       |
+                  | new-annotation |
 
 
         @regression @manual
         Scenario: Edit revision details page: KN-01-TC08
-             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
+             When user right clicks on the revision of knative service "nodejs-ex-git-1" to open the context menu
               And user selects "Edit Revision" option from knative revision context menu
               And user clicks on Details tab
              Then details tab displayed with Revision Details and Conditions sections
@@ -106,7 +104,7 @@ Feature: Perform actions on knative revision
 
         @smoke @manual
         Scenario: Update the revision detials: KN-01-TC09
-             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
+             When user right clicks on the revision of knative service "nodejs-ex-git-1" to open the context menu
               And user selects "Edit Revision" option from knative revision context menu
               And user modifies the Yaml file of the Revision details page
               And user clicks save button on Revision Yaml page
@@ -114,22 +112,16 @@ Feature: Perform actions on knative revision
               And another message display as "This object has been updated."
 
 
-        @regression @broken-test
-        Scenario: Delete revision modal details for service with multiple revisions: KN-01-TC10
-            Given Knative service with multiple revisions
-             When user selects "Delete Revision" option from knative revision context menu
-             Then modal with "Update the traffic distribution among the remaining Revisions" appears
-
-
-        @regression @broken-test
-        Scenario: Delete revision for the service which contains multiple revisions: KN-01-TC11
-            Given Knative service with multiple revisions
-             When user selects "Delete Revision" option from knative revision context menu
-             Then modal with "Update the traffic distribution among the remaining Revisions" appears
-
-
         @smoke
-        Scenario: Delete Revision not possible for the service which contains one revision: KN-01-TC12
-             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
+        Scenario: Delete Revision not possible for the service which contains one revision: KN-01-TC10
+             When user right clicks on the revision of knative service "nodejs-ex-git-1" to open the context menu
               And user selects "Delete Revision" option from knative revision context menu
              Then user is able to see message "You cannot delete the last Revision for the Service." in modal with header "Unable to delete Revision"
+
+
+        @regression
+        Scenario: Delete revision modal details for service with multiple revisions: KN-01-TC11
+            Given knative service "nodejs-ex-git-1" with multiple revisions
+             When user selects "Delete Revision" option from knative revision context menu of knative service "nodejs-ex-git-1"
+             Then modal with "Delete Revision?" appears
+

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -235,7 +235,7 @@ export const topologyPage = {
       .contains(eventSource);
   },
   getRevisionNode: (serviceName: string) => {
-    cy.get('[data-type="knative-service"] g.pf-topology__group__label > text')
+    cy.get('[data-type="knative-service"] g.pf-topology__group__label > text', { timeout: 80000 })
       .contains(serviceName)
       .should('be.visible');
     return cy.get('[data-type="knative-revision"] ellipse.pf-topology__node__background');

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-side-pane-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-side-pane-page.ts
@@ -103,7 +103,10 @@ export const topologySidePane = {
       .should('be.visible');
   },
   verifyNumberOfAnnotations: (num: string) => {
-    cy.get(topologyPO.sidePane.detailsTab.annotations).should('be.visible');
+    cy.wait(3000);
+    cy.get(topologyPO.sidePane.detailsTab.annotations)
+      .scrollIntoView()
+      .should('be.visible');
     // eslint-disable-next-line promise/catch-or-return
     cy.get(topologyPO.sidePane.editAnnotations).then(($el) => {
       const res = $el.text().split(' ');


### PR DESCRIPTION
**Description:**

<!-- PR description-->
- Automation of actions-on-knative-revision.feature | Knative Serverless

**Jira Id:**
- Story: 
      - [ODC-7109](https://issues.redhat.com/browse/ODC-7109)
    
<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.12-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p knative
```

**Screen shots**:
<!--   -->
<img width="1671" alt="image" src="https://user-images.githubusercontent.com/65410551/190116287-3714ed76-b312-4487-a9e0-6f5fe0015165.png">


**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge