### PR TITLE
OCPBUGS-1141: fetch shared resource imagestreams based on labels instance and name

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/EditApplicationPage.tsx
+++ b/frontend/packages/dev-console/src/components/edit-application/EditApplicationPage.tsx
@@ -12,6 +12,7 @@ import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s
 import { ServiceModel } from '@console/knative-plugin';
 import { PipelineModel } from '@console/pipelines-plugin/src/models';
 import { PipelineKind } from '@console/pipelines-plugin/src/types';
+import { INSTANCE_LABEL, NAME_LABEL } from '../../const';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import EditApplicationComponent from './EditApplicationComponent';
 
@@ -50,11 +51,12 @@ const EditApplicationPage: React.FunctionComponent<EditApplicationPageProps> = (
   >(watchedEditResource);
 
   const watchedResources = React.useMemo(() => {
-    const NAME_LABEL = 'app.kubernetes.io/name';
     const nameLabel =
       isEditResDataLoaded &&
       !editResDataLoadError &&
-      (editResData?.metadata?.labels?.[NAME_LABEL] || appName);
+      (editResData?.metadata?.labels?.[NAME_LABEL] ||
+        editResData?.metadata?.labels?.[INSTANCE_LABEL] ||
+        appName);
     return {
       service: {
         kind: 'Service',
@@ -73,27 +75,20 @@ const EditApplicationPage: React.FunctionComponent<EditApplicationPageProps> = (
         kind: 'BuildConfig',
         isList: true,
         namespace,
-        selector: {
-          matchLabels: { [NAME_LABEL]: nameLabel },
-        },
+        name: nameLabel,
         optional: true,
       },
       [PipelineModel.id]: {
         kind: referenceForModel(PipelineModel),
         isList: true,
         namespace,
-        selector: {
-          matchLabels: { [NAME_LABEL]: nameLabel },
-        },
+        name: nameLabel,
         optional: true,
       },
       imageStream: {
         kind: 'ImageStream',
         isList: true,
         namespace,
-        selector: {
-          matchLabels: { [NAME_LABEL]: nameLabel },
-        },
         optional: true,
       },
       imageStreams: {

--- a/frontend/packages/dev-console/src/const.ts
+++ b/frontend/packages/dev-console/src/const.ts
@@ -23,3 +23,6 @@ export const SAMPLE_APPLICATION_GROUP = 'sample-app';
 
 export const PREFERRED_RESOURCE_TYPE_USER_SETTING_KEY = 'devconsole.preferredResourceType';
 export const LAST_RESOURCE_TYPE_STORAGE_KEY = `devconsole.last.resource-type`;
+
+export const NAME_LABEL = 'app.kubernetes.io/name';
+export const INSTANCE_LABEL = 'app.kubernetes.io/instance';


### PR DESCRIPTION
**Tracks:** https://issues.redhat.com/browse/OCPBUGS-1141

**Problem Description:**

with https://github.com/openshift/console/pull/8607 in 4.8, the shared resources like imageStreams were fetched based on the label selector for `app.kubernetes.io/name` over `app.kubernetes.io/instance` as imagestrems can be shared across different workloads

**Solution:**

With this change, imageStreams are looked up for both the labels(`app.kubernetes.io/name` or `app.kubernetes.io/instance` ) thus adding a fallback.

