### PR TITLE
Bug 2077138: update version of quick-start library to latest

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -142,7 +142,7 @@
     "@lezer/highlight": "^1.0.0",
     "@lezer/lr": "^1.0.0",
     "@patternfly/patternfly": "4.210.2",
-    "@patternfly/quickstarts": "2.0.1",
+    "@patternfly/quickstarts": "2.3.1",
     "@patternfly/react-catalog-view-extension": "4.86.7",
     "@patternfly/react-charts": "6.88.7",
     "@patternfly/react-core": "4.235.7",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1905,10 +1905,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.210.2.tgz#3c0ba9a40897e209cf59b465baa985b7b2d739e4"
   integrity sha512-aZiW24Bxi6uVmk5RyNTp+6q6ThtlJZotNRJfWVeGuwu1UlbBuV4DFa1bpjA6jfTZpfEpX2YL5+R+4ZVSCFAVdw==
 
-"@patternfly/quickstarts@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-2.0.1.tgz#8e8270782eae0e2476ccf4cdbbaa22c7c095097e"
-  integrity sha512-tbF1sqlkVb9rEriiHPnKAN5SercMxP27ty+PB87uZ/aF9YkvDD5BUuCbU3JR0e2qe189WksvLrgrAEaamh3gig==
+"@patternfly/quickstarts@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-2.3.1.tgz#4ac7f5500d2f8a1e8a53948d1b69e7978da5231c"
+  integrity sha512-BG1BLU+9Nvs86asfuGwS7EM3H7HIjMxY4/yGCGMCCDp5NNc3OkptJ2TbqtjCL/TbPDnE2j8mqJ7ZjSBPz5xgCw==
   dependencies:
     "@patternfly/react-catalog-view-extension" "4.12.15"
     dompurify "^2.2.6"


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGSM-43474

**Reference**:

Refer https://github.com/openshift/console/pull/11572 for initial changes
https://bugzilla.redhat.com/show_bug.cgi?id=2077138

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Bumps the version of pattern `@patternfly/quickstarts` from `2.0.1` to `2.3.1`.

**Screen shots / Gifs for design review**: 

<img width="1792" alt="Screenshot 2022-09-14 at 3 10 56 PM" src="https://user-images.githubusercontent.com/47265560/190132371-62128186-8307-4564-bbd9-f3774f388809.png">


**Unit test coverage report**: 
<!-- Attach test coverage report -->
Not changed

**Test setup:**
<!-- If any setup is required to test this PR, mention the details -->
1. Create ConsoleQuickStart from the attached [YAML](https://bugzilla-attachments.redhat.com/attachment.cgi?id=1912064)
   a. Search ConsoleQuickStarts resource. 
   b. Create the resource with the [YAML](https://bugzilla-attachments.redhat.com/attachment.cgi?id=1912064)
   c. Install Web Terminal Operator
   d. Come back to the Add page and click View all Quickstarts
   e. Select the Deploy image Quickstart and click the Start button

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge



/cc @abhinandan13jan @invincibleJai 