### PR TITLE
OCPBUGS-1268: Remove required flags from helm actions to show the HCR actions also if no helm repo is enabled

### DIFF
--- a/frontend/packages/helm-plugin/console-extensions.json
+++ b/frontend/packages/helm-plugin/console-extensions.json
@@ -34,9 +34,6 @@
         "kind": "HelmChartRepository"
       },
       "provider": { "$codeRef": "helmActions.useHelmChartRepositoryActions" }
-    },
-    "flags": {
-      "required": ["OPENSHIFT_HELM"]
     }
   },
   {
@@ -48,9 +45,6 @@
         "kind": "ProjectHelmChartRepository"
       },
       "provider": { "$codeRef": "helmActions.useHelmChartRepositoryActions" }
-    },
-    "flags": {
-      "required": ["OPENSHIFT_HELM"]
     }
   },
   {
@@ -147,9 +141,6 @@
   },
   {
     "type": "dev-console.add/action",
-    "flags": {
-      "required": ["OPENSHIFT_HELM"]
-    },
     "properties": {
       "id": "helm",
       "groupId": "developer-catalog",
@@ -157,6 +148,9 @@
       "label": "%helm-plugin~Helm Chart%",
       "description": "%helm-plugin~Browse the catalog to discover and install Helm Charts%",
       "icon": { "$codeRef": "helmUtils.helmCatalogIconSVG" }
+    },
+    "flags": {
+      "required": ["OPENSHIFT_HELM"]
     }
   },
   {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-1268

**Analysis / Root cause**: 
Helm chart repo actions are now added via an `console.action/resource-provider` extension.

And it was flagged with `OPENSHIFT_HELM`, but this flag is true if at least one HCR or PHCR is enabled.

**Solution Description**: 
Remove the required flag so that the actions are always available for HCR and PHCR.

**Screen shots / Gifs for design review**: 

Before:

https://user-images.githubusercontent.com/139310/190011903-41915e3e-afd4-42dd-b317-4496253346ea.mp4

After:

https://user-images.githubusercontent.com/139310/190012202-1a514fbc-7327-4c98-8474-695c08473600.mp4

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Switch to developer perspective
2. Navigate to Helm > Repos > Edit the default repo and disable it
3. Helm Navigation should disappear and the content area maybe switch to 404, that's fine.
4. Navigate to Search and select HelmChartRepository as resource
5. Click on the action menu (kebab icon) to edit the HCR

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge