### PR TITLE
OCPBUGS-1256: Improve OLM descriptors e2e tests

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.spec.ts
@@ -109,7 +109,7 @@ describe('Using OLM descriptor components', () => {
       `/k8s/ns/${testName}/operators.coreos.com~v1alpha1~ClusterServiceVersion/${testCSV.metadata.name}/${testCRD.spec.group}~${testCRD.spec.versions[0].name}~${testCRD.spec.names.kind}`,
     );
     cy.byTestOperandLink('olm-descriptors-test').should('exist');
-    cy.byLegacyTestID('kebab-button').click();
+    cy.byLegacyTestID('kebab-button').click({ force: true });
     cy.byTestActionID(`Delete ${testCRD.spec.names.kind}`).click();
     modal.shouldBeOpened();
     modal.submit();
@@ -181,9 +181,12 @@ describe('Using OLM descriptor components', () => {
   });
 
   it('successfully creates operand using form', () => {
+    cy.get('#root_metadata_name')
+      .clear()
+      .type('olm-descriptors-form-test');
     cy.byTestID('create-dynamic-form').click();
     // TODO figure out why this element is detaching
-    cy.byTestOperandLink('olm-descriptors-test').click({ force: true });
+    cy.byTestOperandLink('olm-descriptors-form-test').click({ force: true });
     cy.get('.co-operand-details__section--info').should('exist');
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com//browse/OCPBUGS-1256

**Analysis / Root cause**: 
In build https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console-operator/680/pull-ci-openshift-console-operator-master-e2e-aws-console/1569323396364242944

I found these 3 errors in packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.spec.ts:

### 1. Kebab button doesn't open on click

![image](https://user-images.githubusercontent.com/139310/190023591-8633f70b-6a49-4072-ae14-44d994465523.png)

### 2. Delete App is not found because menu is not opened (related to issue 1)

![image](https://user-images.githubusercontent.com/139310/190023605-eb050468-58f0-44d6-b350-84c8c1660229.png)

https://search.ci.openshift.org/?search=data-test-action%3D%22Delete+App%22&maxAge=336h&context=1&type=bug%2Bjunit&name=pull-ci-openshift-console-master-e2e-gcp-console&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

> pull-ci-openshift-console-master-e2e-gcp-console
> 251 runs, 64% failed, 1% of failures match = 1% impact

https://search.ci.openshift.org/?search=data-test-action%3D%22Delete+App%22&maxAge=336h&context=1&type=bug%2Bjunit&name=pull-ci-openshift-console-operator-master-e2e-aws-console&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

> pull-ci-openshift-console-operator-master-e2e-aws-console
> 68 runs, 69% failed, 21% of failures match = 15% impact :warning: 

### 3. Error when creating another App because the old app could not be removed in another test (issue 2)

![image](https://user-images.githubusercontent.com/139310/190023616-1a1bf09b-0871-4a94-a673-7d58a3ebe241.png)

https://search.ci.openshift.org/?search=data-test-operand-link%3D%22olm-descriptors-test%22&maxAge=336h&context=1&type=bug%2Bjunit&name=pull-ci-openshift-console-master-e2e-gcp-console&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

> pull-ci-openshift-console-master-e2e-gcp-console
> 251 runs, 64% failed, 2% of failures match = 1% impact

https://search.ci.openshift.org/?search=data-test-operand-link%3D%22olm-descriptors-test%22&maxAge=336h&context=1&type=bug%2Bjunit&name=pull-ci-openshift-console-operator-master-e2e-aws-console&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

> pull-ci-openshift-console-operator-master-e2e-aws-console
> 68 runs, 69% failed, 23% of failures match = 16% impact :warning: (similar to above because it's a follow up)

**Solution Description**: 
### 1. Kebab button doesn't open on click
### 2. Delete App is not found because menu is not opened (related to issue 1)

Try to fix them by forcing the kebab action click.

Will continue to analyse why the kebab button looks ready but nothing happens when it was clicked. Maybe it's a timing/race condition error.

### 3. Error when creating another App because the old app could not be removed in another test (issue 2)

This step should also run successful if the delete fails. To fix this I changed the resource name in the form before it is created.
