### PR TITLE
Update PL/PLR visualization to use new PF pipeline package

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.scss
@@ -1,3 +1,7 @@
 .odc-pipeline-visualization {
   margin-bottom: var(--pf-global--spacer--md);
+
+  .pf-topology-visualization-surface {
+    font-size: 1rem;
+  }
 }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.tsx
@@ -22,7 +22,7 @@ const PipelineVisualization: React.FC<PipelineTopologyVisualizationProps> = ({
 
   const model = getGraphDataModel(pipeline, pipelineRun);
 
-  if (model?.nodes.length === 0 && model?.edges.length === 0) {
+  if (!model || (model.nodes.length === 0 && model.edges.length === 0)) {
     // Nothing to render
     // TODO: Confirm wording with UX; ODC-1860
     content = (

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { Alert } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { PipelineKind, PipelineRunKind } from '../../../../types';
-import { PipelineLayout } from '../../pipeline-topology/const';
+import { dagreViewerComponentFactory } from '../../pipeline-topology/factories';
 import PipelineTopologyGraph from '../../pipeline-topology/PipelineTopologyGraph';
-import { getTopologyNodesEdges, hasWhenExpression } from '../../pipeline-topology/utils';
+import { getGraphDataModel } from '../../pipeline-topology/utils';
 
 import './PipelineVisualization.scss';
 
@@ -20,9 +20,9 @@ const PipelineVisualization: React.FC<PipelineTopologyVisualizationProps> = ({
   const { t } = useTranslation();
   let content: React.ReactElement;
 
-  const { nodes, edges } = getTopologyNodesEdges(pipeline, pipelineRun);
+  const model = getGraphDataModel(pipeline, pipelineRun);
 
-  if (nodes.length === 0 && edges.length === 0) {
+  if (model?.nodes.length === 0 && model?.edges.length === 0) {
     // Nothing to render
     // TODO: Confirm wording with UX; ODC-1860
     content = (
@@ -35,15 +35,10 @@ const PipelineVisualization: React.FC<PipelineTopologyVisualizationProps> = ({
   } else {
     content = (
       <PipelineTopologyGraph
-        id={`${pipelineRun?.metadata?.name || pipeline.metadata.name}-graph`}
         data-test="pipeline-visualization"
-        nodes={nodes}
-        edges={edges}
-        layout={
-          hasWhenExpression(pipeline)
-            ? PipelineLayout.DAGRE_VIEWER_SPACED
-            : PipelineLayout.DAGRE_VIEWER
-        }
+        componentFactory={dagreViewerComponentFactory}
+        model={model}
+        showControlBar
       />
     );
   }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.tsx
@@ -24,7 +24,6 @@ const PipelineVisualization: React.FC<PipelineTopologyVisualizationProps> = ({
 
   if (!model || (model.nodes.length === 0 && model.edges.length === 0)) {
     // Nothing to render
-    // TODO: Confirm wording with UX; ODC-1860
     content = (
       <Alert
         variant="info"

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationStepList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationStepList.tsx
@@ -13,6 +13,7 @@ export interface PipelineVisualizationStepListProps {
   taskName: string;
   steps: StepStatus[];
   isFinallyTask?: boolean;
+  hideHeader?: boolean;
 }
 
 const TooltipColoredStatusIcon = ({ status }) => {
@@ -50,11 +51,14 @@ export const PipelineVisualizationStepList: React.FC<PipelineVisualizationStepLi
   taskName,
   steps,
   isFinallyTask,
+  hideHeader,
 }) => {
   const { t } = useTranslation();
   return (
     <div className="odc-pipeline-visualization-step-list">
-      <div className="odc-pipeline-visualization-step-list__task-name">{taskName}</div>
+      {!hideHeader && (
+        <div className="odc-pipeline-visualization-step-list__task-name">{taskName}</div>
+      )}
       {isFinallyTask && (
         <div className="odc-pipeline-visualization-step-list__task-type">
           {t('pipelines-plugin~Finally task')}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/StatusIcon.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/StatusIcon.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   AngleDoubleRightIcon,
-  BanIcon,
   CheckCircleIcon,
   CircleIcon,
   ExclamationCircleIcon,
@@ -9,6 +8,7 @@ import {
   SyncAltIcon,
 } from '@patternfly/react-icons';
 import * as cx from 'classnames';
+import { YellowExclamationTriangleIcon } from '@console/dynamic-plugin-sdk';
 import { ComputedStatus } from '../../../../types';
 import { getRunStatusColor } from '../../../../utils/pipeline-augment';
 
@@ -36,7 +36,7 @@ export const StatusIcon: React.FC<StatusIconProps> = ({ status, disableSpin, ...
       return <HourglassHalfIcon {...props} />;
 
     case ComputedStatus.Cancelled:
-      return <BanIcon {...props} />;
+      return <YellowExclamationTriangleIcon {...props} />;
 
     case ComputedStatus.Skipped:
       return <AngleDoubleRightIcon {...props} />;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/__tests__/PipelineVisualization.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/__tests__/PipelineVisualization.spec.tsx
@@ -17,6 +17,13 @@ describe('Pipeline Visualization', () => {
     expect(PipelineTopologyGraphComponent).toHaveLength(1);
   });
 
+  it('Should render a Alert message if the pipeline is null', () => {
+    wrapper.setProps({ pipeline: null });
+    const alert = wrapper.find(Alert);
+    expect(alert).toHaveLength(1);
+    expect(alert.props().title).toBe('This Pipeline has no tasks to visualize.');
+  });
+
   it('Should render a Alert message if the pipeline does not have tasks', () => {
     wrapper.setProps({ pipeline: { ...mockPipelinesJSON[2], spec: { tasks: [] } } });
     const alert = wrapper.find(Alert);

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderVisualization.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderVisualization.tsx
@@ -81,7 +81,7 @@ const PipelineBuilderVisualization: React.FC<PipelineBuilderVisualizationProps> 
       // TODO: fix this; the graph layout isn't properly laying out nodes
       key={`${nodes.map((n) => n.id).join('-')}${hasWhenExpression ? '-spaced' : ''}`}
       data-test="pipeline-builder"
-      fluid
+      builder
       model={model}
       componentFactory={builderComponentsFactory}
     />

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderVisualization.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderVisualization.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import { Alert } from '@patternfly/react-core';
+import { ModelKind } from '@patternfly/react-topology';
 import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { LoadingBox } from '@console/internal/components/utils';
 import { PipelineLayout } from '../pipeline-topology/const';
+import { builderComponentsFactory } from '../pipeline-topology/factories';
 import PipelineTopologyGraph from '../pipeline-topology/PipelineTopologyGraph';
-import { getEdgesFromNodes, nodesHasWhenExpression } from '../pipeline-topology/utils';
+import { getBuilderEdgesFromNodes, nodesHasWhenExpression } from '../pipeline-topology/utils';
 import { useNodes } from './hooks';
 import {
   PipelineBuilderFormikValues,
@@ -62,18 +64,26 @@ const PipelineBuilderVisualization: React.FC<PipelineBuilderVisualizationProps> 
     );
   }
 
+  const model = {
+    graph: {
+      id: 'pipeline-builder',
+      type: ModelKind.graph,
+      layout: hasWhenExpression
+        ? PipelineLayout.DAGRE_BUILDER_SPACED
+        : PipelineLayout.DAGRE_BUILDER,
+    },
+    nodes,
+    edges: getBuilderEdgesFromNodes(nodes),
+  };
+
   return (
     <PipelineTopologyGraph
       // TODO: fix this; the graph layout isn't properly laying out nodes
       key={`${nodes.map((n) => n.id).join('-')}${hasWhenExpression ? '-spaced' : ''}`}
-      id="pipeline-builder"
       data-test="pipeline-builder"
       fluid
-      nodes={nodes}
-      edges={getEdgesFromNodes(nodes)}
-      layout={
-        hasWhenExpression ? PipelineLayout.DAGRE_BUILDER_SPACED : PipelineLayout.DAGRE_BUILDER
-      }
+      model={model}
+      componentFactory={builderComponentsFactory}
     />
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.tsx
@@ -94,6 +94,7 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
     data?.status !== ComputedStatus.Idle &&
     data?.status !== ComputedStatus.Pending &&
     data?.status !== ComputedStatus.Cancelled &&
+    data?.status !== ComputedStatus.Skipped &&
     !!path;
 
   const taskNode = (
@@ -104,7 +105,7 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
           : DEFAULT_LAYER
       }
     >
-      <g ref={hoverRef}>
+      <g ref={hoverRef} style={{ cursor: enableLogLink ? 'pointer' : 'default' }}>
         <TaskNode
           element={element}
           onContextMenu={data.showContextMenu ? onContextMenu : undefined}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import { PopoverProps } from '@patternfly/react-core';
+import {
+  DEFAULT_LAYER,
+  DEFAULT_WHEN_OFFSET,
+  Layer,
+  Node,
+  ScaleDetailsLevel,
+  TaskNode,
+  TOP_LAYER,
+  useDetailsLevel,
+  useHover,
+  WhenDecorator,
+  WithContextMenuProps,
+  WithSelectionProps,
+} from '@patternfly/react-topology';
+import { observer } from 'mobx-react';
+import { ComputedStatus } from '../../../types';
+import {
+  createStepStatus,
+  StepStatus,
+} from '../detail-page-tabs/pipeline-details/pipeline-step-utils';
+import { PipelineVisualizationStepList } from '../detail-page-tabs/pipeline-details/PipelineVisualizationStepList';
+
+type PipelineTaskNodeProps = {
+  element: Node;
+} & WithContextMenuProps &
+  WithSelectionProps;
+
+const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
+  element,
+  onContextMenu,
+  contextMenuOpen,
+  ...rest
+}) => {
+  const data = element.getData();
+  const [hover, hoverRef] = useHover();
+  const detailsLevel = useDetailsLevel();
+  const stepList = data?.task?.status?.steps || [];
+  const stepStatusList: StepStatus[] = stepList.map((step) =>
+    createStepStatus(step, data?.task?.status),
+  );
+  const succeededStepsCount =
+    stepStatusList.filter(({ status }) => status === ComputedStatus.Succeeded)?.length || 0;
+
+  const badge =
+    stepStatusList.length > 0 ? `${succeededStepsCount}/${stepStatusList.length}` : null;
+  const badgePopoverParams: PopoverProps = {
+    headerContent: <div>{element.getLabel()}</div>,
+    bodyContent: (
+      <PipelineVisualizationStepList
+        isSpecOverview={false}
+        taskName={element.getLabel()}
+        steps={stepStatusList}
+        isFinallyTask={false}
+        hideHeader
+      />
+    ),
+  };
+
+  const passedData = React.useMemo(() => {
+    const newData = { ...data };
+    Object.keys(newData).forEach((key) => {
+      if (newData[key] === undefined) {
+        delete newData[key];
+      }
+    });
+    return newData;
+  }, [data]);
+
+  const hasTaskIcon = !!(data.taskIconClass || data.taskIcon);
+  const whenDecorator = data.whenStatus ? (
+    <WhenDecorator
+      element={element}
+      status={data.whenStatus}
+      leftOffset={
+        hasTaskIcon
+          ? DEFAULT_WHEN_OFFSET + (element.getBounds().height - 4) * 0.75
+          : DEFAULT_WHEN_OFFSET
+      }
+    />
+  ) : null;
+
+  return (
+    <Layer id={detailsLevel !== ScaleDetailsLevel.high && hover ? TOP_LAYER : DEFAULT_LAYER}>
+      <g ref={hoverRef}>
+        <TaskNode
+          element={element}
+          onContextMenu={data.showContextMenu ? onContextMenu : undefined}
+          contextMenuOpen={contextMenuOpen}
+          scaleNode={(hover || contextMenuOpen) && detailsLevel !== ScaleDetailsLevel.high}
+          hideDetailsAtMedium
+          {...passedData}
+          {...rest}
+          badgePopoverParams={badgePopoverParams}
+          badge={badge}
+          truncateLength={element.getData()?.label?.length}
+        >
+          {whenDecorator}
+        </TaskNode>
+      </g>
+    </Layer>
+  );
+};
+
+export default observer(PipelineTaskNode);

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.tsx
@@ -45,36 +45,36 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
   const detailsLevel = useDetailsLevel();
   const isFinallyTask = element.getType() === NodeType.FINALLY_NODE;
   let resources;
-  if (data?.task?.taskRef?.kind === ClusterTaskModel.kind) {
+  if (data.task?.taskRef?.kind === ClusterTaskModel.kind) {
     resources = {
       kind: referenceForModel(ClusterTaskModel),
-      name: data?.task.taskRef.name,
+      name: data.task.taskRef.name,
       prop: 'task',
     };
-  } else if (data?.task?.taskRef) {
+  } else if (data.task?.taskRef) {
     resources = {
       kind: referenceForModel(TaskModel),
-      name: data?.task.taskRef.name,
-      namespace: data?.pipeline.metadata?.namespace,
+      name: data.task.taskRef.name,
+      namespace: data.pipeline.metadata.namespace,
       prop: 'task',
     };
   }
   const [task] = useK8sWatchResource<TaskKind>(resources);
 
-  const computedTask = task && Object.keys(task).length ? task : data?.task;
+  const computedTask = task && Object.keys(task).length ? task : data.task;
   const stepList =
     computedTask?.status?.steps || computedTask?.spec?.steps || computedTask?.taskSpec?.steps || [];
 
-  const pipelineRunStatus = data?.pipelineRun && pipelineRunFilterReducer(data?.pipelineRun);
+  const pipelineRunStatus = data.pipelineRun && pipelineRunFilterReducer(data.pipelineRun);
   const isSkipped = !!(
     computedTask &&
-    data?.pipelineRun?.status?.skippedTasks?.some(
-      (t) => t.name === data?.task.name,
+    data.pipelineRun?.status?.skippedTasks?.some(
+      (t) => t.name === data.task.name,
       (t) => t.name === computedTask.name,
     )
   );
 
-  const taskStatus = data?.task?.status || {
+  const taskStatus = data.task?.status || {
     duration: '',
     reason: ComputedStatus.Idle,
   };
@@ -83,8 +83,8 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
     pipelineRunStatus === ComputedStatus.Cancelled
   ) {
     if (
-      data?.task?.status?.reason === ComputedStatus.Idle ||
-      data?.task?.status?.reason === ComputedStatus.Pending
+      data.task?.status?.reason === ComputedStatus.Idle ||
+      data.task?.status?.reason === ComputedStatus.Pending
     ) {
       taskStatus.reason = ComputedStatus.Cancelled;
     }
@@ -100,7 +100,7 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
   ).length;
 
   const badge =
-    stepStatusList.length > 0 && data?.status
+    stepStatusList.length > 0 && data.status
       ? `${succeededStepsCount}/${stepStatusList.length}`
       : null;
 
@@ -114,11 +114,11 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
     return newData;
   }, [data]);
 
-  const hasTaskIcon = !!(data?.taskIconClass || data?.taskIcon);
-  const whenDecorator = data?.whenStatus ? (
+  const hasTaskIcon = !!(data.taskIconClass || data.taskIcon);
+  const whenDecorator = data.whenStatus ? (
     <WhenDecorator
       element={element}
-      status={data?.whenStatus}
+      status={data.whenStatus}
       leftOffset={
         hasTaskIcon
           ? DEFAULT_WHEN_OFFSET + (element.getBounds().height - 4) * 0.75
@@ -133,10 +133,10 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
     : undefined;
 
   const enableLogLink =
-    data?.status !== ComputedStatus.Idle &&
-    data?.status !== ComputedStatus.Pending &&
-    data?.status !== ComputedStatus.Cancelled &&
-    data?.status !== ComputedStatus.Skipped &&
+    data.status !== ComputedStatus.Idle &&
+    data.status !== ComputedStatus.Pending &&
+    data.status !== ComputedStatus.Cancelled &&
+    data.status !== ComputedStatus.Skipped &&
     !!path;
 
   const taskNode = (
@@ -153,7 +153,7 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
           enableFlip={false}
           content={
             <PipelineVisualizationStepList
-              isSpecOverview={!data?.status}
+              isSpecOverview={!data.status}
               taskName={element.getLabel()}
               steps={stepStatusList}
               isFinallyTask={isFinallyTask}
@@ -162,7 +162,7 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
         >
           <TaskNode
             element={element}
-            onContextMenu={data?.showContextMenu ? onContextMenu : undefined}
+            onContextMenu={data.showContextMenu ? onContextMenu : undefined}
             contextMenuOpen={contextMenuOpen}
             scaleNode={(hover || contextMenuOpen) && detailsLevel !== ScaleDetailsLevel.high}
             hideDetailsAtMedium

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.tsx
@@ -44,8 +44,9 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
     createStepStatus(step, data?.task?.status),
   );
   const { pipelineRun } = data;
-  const succeededStepsCount =
-    stepStatusList.filter(({ status }) => status === ComputedStatus.Succeeded)?.length || 0;
+  const succeededStepsCount = stepStatusList.filter(
+    ({ status }) => status === ComputedStatus.Succeeded,
+  ).length;
 
   const badge =
     stepStatusList.length > 0 ? `${succeededStepsCount}/${stepStatusList.length}` : null;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.scss
@@ -2,14 +2,11 @@
   display: inline-block;
   background: var(--pf-global--BackgroundColor--200);
   border-radius: 20px;
+  font-size: var(--pf-global--FontSize--xs);
   max-width: 100%;
   overflow: hidden;
 
   .pf-topology-content {
     border-radius: 20px;
-  }
-
-  .pf-topology-visualization-surface {
-    font-size: 1rem;
   }
 }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.scss
@@ -2,11 +2,14 @@
   display: inline-block;
   background: var(--pf-global--BackgroundColor--200);
   border-radius: 20px;
-  font-size: var(--pf-global--FontSize--xs);
   max-width: 100%;
-  overflow: auto;
-}
+  overflow: hidden;
 
-.odc-pipeline-topology-graph .pf-topology-content {
-  border-radius: 20px;
+  .pf-topology-content {
+    border-radius: 20px;
+  }
+
+  .pf-topology-visualization-surface {
+    font-size: 1rem;
+  }
 }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.scss
@@ -1,10 +1,13 @@
 .odc-pipeline-topology-graph {
-  display: inline-block;
-  background: var(--pf-global--BackgroundColor--200);
   border-radius: 20px;
   font-size: var(--pf-global--FontSize--xs);
   max-width: 100%;
   overflow: hidden;
+
+  &.builder {
+    display: block;
+    background: var(--pf-global--BackgroundColor--200);
+  }
 
   .pf-topology-content {
     border-radius: 20px;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.scss
@@ -6,3 +6,7 @@
   max-width: 100%;
   overflow: auto;
 }
+
+.odc-pipeline-topology-graph .pf-topology-content {
+  border-radius: 20px;
+}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.tsx
@@ -26,7 +26,7 @@ const PipelineTopologyGraph: React.FC<PipelineTopologyGraphProps> = ({
       <PipelineVisualizationSurface
         model={model}
         componentFactory={componentFactory}
-        fixedWidth={builder}
+        noScrollbar={builder}
         {...props}
       />
     </div>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.tsx
@@ -1,29 +1,34 @@
 import * as React from 'react';
 import { ComponentFactory, Model } from '@patternfly/react-topology';
+import * as cx from 'classnames';
 import PipelineVisualizationSurface from './PipelineVisualizationSurface';
 
 import './PipelineTopologyGraph.scss';
 
 type PipelineTopologyGraphProps = {
-  fluid?: boolean;
+  builder?: boolean;
   model: Model;
   componentFactory: ComponentFactory;
   showControlBar?: boolean;
 };
 
 const PipelineTopologyGraph: React.FC<PipelineTopologyGraphProps> = ({
-  fluid,
+  builder,
   model,
   componentFactory,
   ...props
 }) => {
   return (
     <div
-      className="odc-pipeline-topology-graph"
+      className={cx('odc-pipeline-topology-graph', { builder })}
       data-test={props['data-test'] || 'pipeline-topology-graph'}
-      style={{ display: fluid ? 'block' : undefined }}
     >
-      <PipelineVisualizationSurface model={model} componentFactory={componentFactory} {...props} />
+      <PipelineVisualizationSurface
+        model={model}
+        componentFactory={componentFactory}
+        fixedWidth={builder}
+        {...props}
+      />
     </div>
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.tsx
@@ -1,25 +1,20 @@
 import * as React from 'react';
-import { ModelKind } from '@patternfly/react-topology';
-import { PipelineLayout } from './const';
+import { ComponentFactory, Model } from '@patternfly/react-topology';
 import PipelineVisualizationSurface from './PipelineVisualizationSurface';
-import { PipelineEdgeModel, PipelineMixedNodeModel } from './types';
 
 import './PipelineTopologyGraph.scss';
 
 type PipelineTopologyGraphProps = {
-  id: string;
   fluid?: boolean;
-  nodes: PipelineMixedNodeModel[];
-  edges: PipelineEdgeModel[];
-  layout: PipelineLayout;
+  model: Model;
+  componentFactory: ComponentFactory;
+  showControlBar?: boolean;
 };
 
 const PipelineTopologyGraph: React.FC<PipelineTopologyGraphProps> = ({
-  id,
   fluid,
-  nodes,
-  edges,
-  layout,
+  model,
+  componentFactory,
   ...props
 }) => {
   return (
@@ -28,19 +23,9 @@ const PipelineTopologyGraph: React.FC<PipelineTopologyGraphProps> = ({
       data-test={props['data-test'] || 'pipeline-topology-graph'}
       style={{ display: fluid ? 'block' : undefined }}
     >
-      <PipelineVisualizationSurface
-        model={{
-          graph: {
-            id,
-            type: ModelKind.graph,
-            layout,
-          },
-          nodes,
-          edges,
-        }}
-      />
+      <PipelineVisualizationSurface model={model} componentFactory={componentFactory} {...props} />
     </div>
   );
 };
 
-export default PipelineTopologyGraph;
+export default React.memo(PipelineTopologyGraph);

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineVisualizationSurface.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineVisualizationSurface.tsx
@@ -22,7 +22,7 @@ import {
   TOOLBAR_HEIGHT,
   GRAPH_MIN_WIDTH,
   PipelineLayout,
-  GRAPH_MAX_HEIGHT,
+  GRAPH_MAX_HEIGHT_PERCENT,
 } from './const';
 import { layoutFactory } from './factories';
 import { getLayoutData } from './utils';
@@ -154,7 +154,9 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
         <div ref={measureRef}>
           <div
             style={{
-              height: noScrollbar ? maxSize?.height : Math.min(GRAPH_MAX_HEIGHT, maxSize?.height),
+              height: noScrollbar
+                ? maxSize?.height
+                : Math.min((GRAPH_MAX_HEIGHT_PERCENT / 100) * window.innerHeight, maxSize?.height),
               width: noScrollbar ? maxSize?.width : Math.min(maxSize?.width, width),
             }}
           >

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineVisualizationSurface.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineVisualizationSurface.tsx
@@ -6,18 +6,33 @@ import {
   Visualization,
   VisualizationSurface,
   VisualizationProvider,
+  action,
+  createTopologyControlButtons,
+  defaultControlButtonsOptions,
+  TopologyControlBar,
+  TopologyView,
+  Controller,
+  GRAPH_POSITION_CHANGE_EVENT,
+  ComponentFactory,
 } from '@patternfly/react-topology';
-import { DROP_SHADOW_SPACING, NODE_HEIGHT, PipelineLayout } from './const';
-import { componentFactory, layoutFactory } from './factories';
+import { DROP_SHADOW_SPACING, NODE_HEIGHT, TOOLBAR_HEIGHT, PipelineLayout } from './const';
+import { layoutFactory } from './factories';
 import { getLayoutData } from './utils';
 
 type PipelineVisualizationSurfaceProps = {
   model: Model;
+  componentFactory: ComponentFactory;
+  showControlBar?: boolean;
 };
 
-const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> = ({ model }) => {
-  const [vis, setVis] = React.useState(null);
+const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> = ({
+  model,
+  componentFactory,
+  showControlBar = false,
+}) => {
+  const [vis, setVis] = React.useState<Controller>(null);
   const [maxSize, setMaxSize] = React.useState(null);
+  const storedGraphModel = React.useRef(null);
 
   const layout: PipelineLayout = model.graph.layout as PipelineLayout;
 
@@ -49,7 +64,7 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
       const regularTaskHeight = maxY + NODE_HEIGHT + DROP_SHADOW_SPACING + verticalMargin * 2;
 
       setMaxSize({
-        height: Math.max(finallyTaskHeight, regularTaskHeight),
+        height: Math.max(finallyTaskHeight, regularTaskHeight) + TOOLBAR_HEIGHT,
         width: maxX + maxWidth + DROP_SHADOW_SPACING + horizontalMargin * 2,
       });
     },
@@ -62,22 +77,68 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
       visualization.registerLayoutFactory(layoutFactory);
       visualization.registerComponentFactory(componentFactory);
       visualization.fromModel(model);
+      visualization.addEventListener(GRAPH_POSITION_CHANGE_EVENT, () => {
+        storedGraphModel.current = visualization.getGraph().toModel();
+      });
       visualization.addEventListener(GRAPH_LAYOUT_END_EVENT, () => {
         onLayoutUpdate(visualization.getGraph().getNodes());
       });
       setVis(visualization);
     } else {
+      const graph = storedGraphModel.current;
+      if (graph) {
+        model.graph = graph;
+      }
       vis.fromModel(model);
       vis.getGraph().layout();
     }
-  }, [vis, model, onLayoutUpdate]);
+  }, [vis, model, onLayoutUpdate, componentFactory]);
+
+  React.useEffect(() => {
+    if (model && vis) {
+      const graph = storedGraphModel.current;
+      if (graph) {
+        model.graph = graph;
+      }
+      vis.fromModel(model);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [model, vis]);
 
   if (!vis) return null;
+
+  const controlBar = (controller) => (
+    <TopologyControlBar
+      controlButtons={createTopologyControlButtons({
+        ...defaultControlButtonsOptions,
+        zoomInCallback: action(() => {
+          controller.getGraph().scaleBy(4 / 3);
+        }),
+        zoomOutCallback: action(() => {
+          controller.getGraph().scaleBy(0.75);
+        }),
+        fitToScreenCallback: action(() => {
+          controller.getGraph().fit(70);
+        }),
+        resetViewCallback: action(() => {
+          controller.getGraph().reset();
+          controller.getGraph().layout();
+        }),
+        legend: false,
+      })}
+    />
+  );
 
   return (
     <div style={{ height: maxSize?.height, width: maxSize?.width }}>
       <VisualizationProvider controller={vis}>
-        <VisualizationSurface />
+        {showControlBar ? (
+          <TopologyView controlBar={controlBar ? controlBar(vis) : undefined}>
+            <VisualizationSurface />
+          </TopologyView>
+        ) : (
+          <VisualizationSurface />
+        )}
       </VisualizationProvider>
     </div>
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineVisualizationSurface.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineVisualizationSurface.tsx
@@ -15,7 +15,13 @@ import {
   GRAPH_POSITION_CHANGE_EVENT,
   ComponentFactory,
 } from '@patternfly/react-topology';
-import { DROP_SHADOW_SPACING, NODE_HEIGHT, TOOLBAR_HEIGHT, PipelineLayout } from './const';
+import {
+  DROP_SHADOW_SPACING,
+  NODE_HEIGHT,
+  TOOLBAR_HEIGHT,
+  GRAPH_MIN_WIDTH,
+  PipelineLayout,
+} from './const';
 import { layoutFactory } from './factories';
 import { getLayoutData } from './utils';
 
@@ -65,7 +71,10 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
 
       setMaxSize({
         height: Math.max(finallyTaskHeight, regularTaskHeight) + TOOLBAR_HEIGHT,
-        width: maxX + maxWidth + DROP_SHADOW_SPACING + horizontalMargin * 2,
+        width: Math.max(
+          maxX + maxWidth + DROP_SHADOW_SPACING + horizontalMargin * 2,
+          GRAPH_MIN_WIDTH,
+        ),
       });
     },
     [setMaxSize, layout],

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineVisualizationSurface.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineVisualizationSurface.tsx
@@ -133,7 +133,7 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
     <div style={{ height: maxSize?.height, width: maxSize?.width }}>
       <VisualizationProvider controller={vis}>
         {showControlBar ? (
-          <TopologyView controlBar={controlBar ? controlBar(vis) : undefined}>
+          <TopologyView controlBar={controlBar(vis)}>
             <VisualizationSurface />
           </TopologyView>
         ) : (

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineVisualizationSurface.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineVisualizationSurface.tsx
@@ -15,12 +15,14 @@ import {
   GRAPH_POSITION_CHANGE_EVENT,
   ComponentFactory,
 } from '@patternfly/react-topology';
+import Measure from 'react-measure';
 import {
   DROP_SHADOW_SPACING,
   NODE_HEIGHT,
   TOOLBAR_HEIGHT,
   GRAPH_MIN_WIDTH,
   PipelineLayout,
+  GRAPH_MAX_HEIGHT,
 } from './const';
 import { layoutFactory } from './factories';
 import { getLayoutData } from './utils';
@@ -29,19 +31,19 @@ type PipelineVisualizationSurfaceProps = {
   model: Model;
   componentFactory: ComponentFactory;
   showControlBar?: boolean;
-  fixedWidth?: boolean;
+  noScrollbar?: boolean;
 };
 
 const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> = ({
   model,
   componentFactory,
   showControlBar = false,
-  fixedWidth = false,
+  noScrollbar = false,
 }) => {
   const [vis, setVis] = React.useState<Controller>(null);
   const [maxSize, setMaxSize] = React.useState(null);
+  const [width, setWidth] = React.useState(null);
   const storedGraphModel = React.useRef(null);
-  const containerRef = React.useRef(null);
 
   const layout: PipelineLayout = model.graph.layout as PipelineLayout;
 
@@ -142,25 +144,33 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
   );
 
   return (
-    <div
-      ref={containerRef}
-      style={{
-        height: maxSize?.height,
-        width: fixedWidth
-          ? maxSize?.width
-          : Math.min(maxSize?.width, containerRef.current?.clientWidth || 0),
+    <Measure
+      bounds
+      onResize={(contentRect) => {
+        setWidth(contentRect.bounds?.width);
       }}
     >
-      <VisualizationProvider controller={vis}>
-        {showControlBar ? (
-          <TopologyView controlBar={controlBar(vis)}>
-            <VisualizationSurface />
-          </TopologyView>
-        ) : (
-          <VisualizationSurface />
-        )}
-      </VisualizationProvider>
-    </div>
+      {({ measureRef }) => (
+        <div ref={measureRef}>
+          <div
+            style={{
+              height: noScrollbar ? maxSize?.height : Math.min(GRAPH_MAX_HEIGHT, maxSize?.height),
+              width: noScrollbar ? maxSize?.width : Math.min(maxSize?.width, width),
+            }}
+          >
+            <VisualizationProvider controller={vis}>
+              {showControlBar ? (
+                <TopologyView controlBar={controlBar(vis)}>
+                  <VisualizationSurface />
+                </TopologyView>
+              ) : (
+                <VisualizationSurface />
+              )}
+            </VisualizationProvider>
+          </div>
+        </div>
+      )}
+    </Measure>
   );
 };
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineVisualizationSurface.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineVisualizationSurface.tsx
@@ -29,16 +29,19 @@ type PipelineVisualizationSurfaceProps = {
   model: Model;
   componentFactory: ComponentFactory;
   showControlBar?: boolean;
+  fixedWidth?: boolean;
 };
 
 const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> = ({
   model,
   componentFactory,
   showControlBar = false,
+  fixedWidth = false,
 }) => {
   const [vis, setVis] = React.useState<Controller>(null);
   const [maxSize, setMaxSize] = React.useState(null);
   const storedGraphModel = React.useRef(null);
+  const containerRef = React.useRef(null);
 
   const layout: PipelineLayout = model.graph.layout as PipelineLayout;
 
@@ -127,7 +130,7 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
           controller.getGraph().scaleBy(0.75);
         }),
         fitToScreenCallback: action(() => {
-          controller.getGraph().fit(70);
+          controller.getGraph().fit(80);
         }),
         resetViewCallback: action(() => {
           controller.getGraph().reset();
@@ -139,7 +142,15 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
   );
 
   return (
-    <div style={{ height: maxSize?.height, width: maxSize?.width }}>
+    <div
+      ref={containerRef}
+      style={{
+        height: maxSize?.height,
+        width: fixedWidth
+          ? maxSize?.width
+          : Math.min(maxSize?.width, containerRef.current?.clientWidth || 0),
+      }}
+    >
       <VisualizationProvider controller={vis}>
         {showControlBar ? (
           <TopologyView controlBar={controlBar(vis)}>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/dag.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/dag.spec.ts
@@ -1,0 +1,102 @@
+import { DAG } from '../dag';
+
+describe('dag', () => {
+  describe('addVertex:', () => {
+    it('should add the vertex to the graph', () => {
+      const dag = new DAG();
+
+      dag.addVertex('task1');
+      dag.addVertex('task2');
+
+      expect(dag.names).toHaveLength(2);
+    });
+
+    it('should skip the duplicate vertex added to the graph', () => {
+      const dag = new DAG();
+
+      dag.addVertex('task1');
+      dag.addVertex('task1');
+
+      expect(dag.names).toHaveLength(1);
+    });
+  });
+
+  describe('AddEdge:', () => {
+    it('should add the vertex if it not available in the graph', () => {
+      const dag = new DAG();
+
+      dag.addEdge('task1', 'task2');
+      expect(dag.names).toHaveLength(2);
+    });
+
+    it('should add the edges to the graph', () => {
+      const dag = new DAG();
+
+      dag.addVertex('task1');
+      dag.addVertex('task2');
+
+      dag.addEdge('task1', 'task2');
+      expect(dag.vertices.get('task2').dependancyNames).toContain('task1');
+    });
+
+    it('should skip the duplicate edges added to the graph', () => {
+      const dag = new DAG();
+
+      dag.addVertex('task1');
+      dag.addVertex('task2');
+
+      dag.addEdge('task1', 'task2');
+      dag.addEdge('task1', 'task2');
+      expect(dag.vertices.get('task2').dependancyNames).toContain('task1');
+    });
+  });
+
+  describe('AddEdges', () => {
+    it('should form the dependancies when addEdges is called with multiple before and after tasks', () => {
+      const dag = new DAG();
+
+      dag.addVertex('task1');
+      dag.addVertex('task2');
+      dag.addVertex('task3');
+      dag.addVertex('task4');
+      dag.addVertex('task5');
+
+      const runAfter = ['task1', 'task2'];
+      const runBefore = ['task4', 'task5'];
+
+      dag.addEdges('task3', { id: 'task3' }, runBefore, runAfter);
+
+      expect(dag.printGraph()).toEqual('task1 --> task2 --> task3 --> task4 --> task5');
+    });
+
+    it('should throw an error if there is any cycle detected', () => {
+      const dag = new DAG();
+
+      dag.addVertex('task1');
+      dag.addVertex('task2');
+      dag.addVertex('task3');
+
+      const runAfter = ['task1', 'task2'];
+      const runBefore = ['task1'];
+
+      expect(() => dag.addEdges('task3', { id: 'task3' }, runBefore, runAfter)).toThrow(
+        'cycle detected: task3 --> task1 --> task3',
+      );
+    });
+  });
+
+  it('should print the tasks in topological sort order ', () => {
+    const dag = new DAG();
+
+    dag.addVertex('task1');
+    dag.addVertex('task2');
+    dag.addVertex('task3');
+    dag.addVertex('task4');
+
+    dag.addEdge('task1', 'task2');
+    dag.addEdge('task2', 'task3');
+    dag.addEdge('task3', 'task4');
+
+    expect(dag.printGraph()).toEqual('task1 --> task2 --> task3 --> task4');
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
@@ -4,6 +4,7 @@ import { chart_color_green_400 as successColor } from '@patternfly/react-tokens/
 import { RunStatus, WhenStatus } from '@patternfly/react-topology';
 import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
 import { ComputedStatus, PipelineTaskWithStatus } from '../../../../types';
+import { NodeType } from '../const';
 import {
   getLastRegularTasks,
   getGraphDataModel,
@@ -238,5 +239,38 @@ describe('taskWhenStatus:', () => {
     };
     expect(taskWhenStatus(succeededTask)).toBe(WhenStatus.Met);
     expect(taskWhenStatus(skippedTask)).toBe(WhenStatus.Unmet);
+  });
+});
+
+describe('getGraphDataModel', () => {
+  it('should return null for invalid values', () => {
+    expect(getGraphDataModel(null)).toBeNull();
+    expect(getGraphDataModel(undefined, undefined)).toBeNull();
+  });
+
+  it('should return graph, nodes and edges for valid pipeline', () => {
+    const model = getGraphDataModel(pipeline);
+    expect(model.graph).toBeDefined();
+    expect(model.nodes).toHaveLength(13);
+    expect(model.edges).toHaveLength(19);
+  });
+
+  it('should return graph, nodes and edges for valid pipeline', () => {
+    const model = getGraphDataModel(pipeline);
+    expect(model.graph).toBeDefined();
+    expect(model.nodes).toHaveLength(13);
+    expect(model.edges).toHaveLength(19);
+  });
+
+  it('should include the finally group and nodes for the pipeline with finally task', () => {
+    const pData = pipelineTestData[PipelineExampleNames.PIPELINE_WITH_FINALLY];
+    const { pipeline: pipelineWithFinallyTasks } = pData;
+
+    const { nodes } = getGraphDataModel(pipelineWithFinallyTasks);
+    const finallyGroup = nodes.filter((n) => n.type === NodeType.FINALLY_GROUP);
+    const finallyNodes = nodes.filter((n) => n.type === NodeType.FINALLY_NODE);
+
+    expect(finallyGroup).toHaveLength(1);
+    expect(finallyNodes).toHaveLength(1);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
@@ -15,7 +15,7 @@ import {
   nodesHasWhenExpression,
   getWhenExpressionDiamondState,
   extractDepsFromContextVariables,
-  taskWhenStatus,
+  getTaskWhenStatus,
 } from '../utils';
 
 const pipelineData = pipelineTestData[PipelineExampleNames.COMPLEX_PIPELINE];
@@ -202,7 +202,7 @@ describe('extractDepsFromContextVariables: ', () => {
   });
 });
 
-describe('taskWhenStatus:', () => {
+describe('getTaskWhenStatus:', () => {
   const [task1] = pipeline.spec.tasks;
 
   const taskWithStatus = (
@@ -227,7 +227,7 @@ describe('taskWhenStatus:', () => {
   };
 
   it('should return undefined if the task does not have when expression', () => {
-    expect(taskWhenStatus(taskWithStatus())).toBeUndefined();
+    expect(getTaskWhenStatus(taskWithStatus())).toBeUndefined();
   });
 
   it('should return a matching when status', () => {
@@ -237,8 +237,8 @@ describe('taskWhenStatus:', () => {
     const skippedTask: PipelineTaskWithStatus = {
       ...taskWithStatus(RunStatus.Skipped, true),
     };
-    expect(taskWhenStatus(succeededTask)).toBe(WhenStatus.Met);
-    expect(taskWhenStatus(skippedTask)).toBe(WhenStatus.Unmet);
+    expect(getTaskWhenStatus(succeededTask)).toBe(WhenStatus.Met);
+    expect(getTaskWhenStatus(skippedTask)).toBe(WhenStatus.Unmet);
   });
 });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
@@ -1,44 +1,24 @@
 import { chart_color_black_400 as skippedColor } from '@patternfly/react-tokens/dist/js/chart_color_black_400';
 import { chart_color_blue_300 as runningColor } from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
 import { chart_color_green_400 as successColor } from '@patternfly/react-tokens/dist/js/chart_color_green_400';
+import { RunStatus, WhenStatus } from '@patternfly/react-topology';
 import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
-import { ComputedStatus } from '../../../../types';
+import { ComputedStatus, PipelineTaskWithStatus } from '../../../../types';
 import {
   getLastRegularTasks,
-  getTopologyNodesEdges,
+  getGraphDataModel,
   getFinallyTaskHeight,
   hasWhenExpression,
   getFinallyTaskWidth,
   taskHasWhenExpression,
   nodesHasWhenExpression,
   getWhenExpressionDiamondState,
+  extractDepsFromContextVariables,
+  taskWhenStatus,
 } from '../utils';
 
 const pipelineData = pipelineTestData[PipelineExampleNames.COMPLEX_PIPELINE];
 const { pipeline } = pipelineData;
-const pipelineWithFinally = {
-  ...pipeline,
-  spec: {
-    ...pipeline.spec,
-    finally: [{ ...pipeline.spec.tasks[0], name: 'finally-task' }],
-  },
-};
-
-describe('getTopologyNodesEdges', () => {
-  it('expect to return nodes and edges for a pipeline without finally tasks', () => {
-    const { nodes, edges } = getTopologyNodesEdges(pipeline);
-    expect(nodes).toHaveLength(pipeline.spec.tasks.length);
-    expect(edges).toHaveLength(19);
-  });
-
-  it('expect to return nodes and edges for a pipeline with finally tasks', () => {
-    const { nodes, edges } = getTopologyNodesEdges(pipelineWithFinally);
-    expect(nodes).toHaveLength(
-      pipelineWithFinally.spec.tasks.length + pipelineWithFinally.spec.finally.length,
-    );
-    expect(edges).toHaveLength(20);
-  });
-});
 
 describe('getLastRegularTasks', () => {
   it('expect to handle the empty array input', () => {
@@ -46,7 +26,7 @@ describe('getLastRegularTasks', () => {
   });
 
   it('expect to return the last regular task name in the pipeline', () => {
-    const { nodes } = getTopologyNodesEdges(pipeline);
+    const { nodes } = getGraphDataModel(pipeline);
     expect(getLastRegularTasks(nodes)).toHaveLength(1);
     expect(getLastRegularTasks(nodes)).toEqual(['verify']);
   });
@@ -60,7 +40,7 @@ describe('getLastRegularTasks', () => {
         tasks: [task1, task2, task3, task4],
       },
     };
-    const { nodes } = getTopologyNodesEdges(pipelineWithMultipleLastTasks);
+    const { nodes } = getGraphDataModel(pipelineWithMultipleLastTasks);
     expect(getLastRegularTasks(nodes)).toHaveLength(3);
     expect(getLastRegularTasks(nodes)).toEqual(['analyse-code', 'style-checks', 'find-bugs']);
   });
@@ -106,7 +86,7 @@ describe('nodesHasWhenExpression', () => {
   const { pipeline: pipelineWithWhenExpression } = conditionalPipeline;
 
   it('expect to return false if the nodes does not contain when expressions', () => {
-    const { nodes } = getTopologyNodesEdges({
+    const { nodes } = getGraphDataModel({
       ...pipelineWithWhenExpression,
       spec: {
         ...pipelineWithWhenExpression.spec,
@@ -117,7 +97,7 @@ describe('nodesHasWhenExpression', () => {
   });
 
   it('expect to return true if the node contains when expressions', () => {
-    const { nodes } = getTopologyNodesEdges(pipelineWithWhenExpression);
+    const { nodes } = getGraphDataModel(pipelineWithWhenExpression);
     expect(nodesHasWhenExpression(nodes)).toBe(true);
   });
 });
@@ -194,5 +174,69 @@ describe('When expression decorator color', () => {
     );
     expect(diamondColor).toBe(skippedColor.value);
     expect(tooltipContent).toBe('When expression was not met');
+  });
+});
+
+describe('extractDepsFromContextVariables: ', () => {
+  it('should return emtpy array for invalid values', () => {
+    expect(extractDepsFromContextVariables('')).toEqual([]);
+    expect(extractDepsFromContextVariables(null)).toEqual([]);
+    expect(extractDepsFromContextVariables(undefined)).toEqual([]);
+  });
+
+  it('should return empty array if the context variable string does not contain results', () => {
+    expect(extractDepsFromContextVariables('$(context.pipeline.name)')).toEqual([]);
+    expect(extractDepsFromContextVariables('$(context.pipelinerun.name)')).toEqual([]);
+  });
+
+  it('should return a task name if the context variable string contains results', () => {
+    const contextVariable = '$(tasks.task1.results.sum)';
+    expect(extractDepsFromContextVariables(contextVariable)).toEqual(['task1']);
+  });
+
+  it('should return a list of task names if the context variable string contains multiple results', () => {
+    const contextVariable = '$(tasks.task1.results.sum)  $(tasks.task2.results.sum)';
+
+    expect(extractDepsFromContextVariables(contextVariable)).toEqual(['task1', 'task2']);
+  });
+});
+
+describe('taskWhenStatus:', () => {
+  const [task1] = pipeline.spec.tasks;
+
+  const taskWithStatus = (
+    reason: RunStatus = RunStatus.Succeeded,
+    when?: boolean,
+  ): PipelineTaskWithStatus => {
+    return {
+      ...task1,
+      ...(when && {
+        when: [
+          {
+            input: 'params.test',
+            operator: 'IN',
+            values: ['pass'],
+          },
+        ],
+      }),
+      status: {
+        reason,
+      },
+    };
+  };
+
+  it('should return undefined if the task does not have when expression', () => {
+    expect(taskWhenStatus(taskWithStatus())).toBeUndefined();
+  });
+
+  it('should return a matching when status', () => {
+    const succeededTask: PipelineTaskWithStatus = {
+      ...taskWithStatus(RunStatus.Succeeded, true),
+    };
+    const skippedTask: PipelineTaskWithStatus = {
+      ...taskWithStatus(RunStatus.Skipped, true),
+    };
+    expect(taskWhenStatus(succeededTask)).toBe(WhenStatus.Met);
+    expect(taskWhenStatus(skippedTask)).toBe(WhenStatus.Unmet);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/const.ts
@@ -23,6 +23,7 @@ export const DEFAULT_NODE_ICON_WIDTH = 30;
 export const DEFAULT_BADGE_WIDTH = 40;
 export const DEFAULT_FINALLLY_GROUP_PADDING = 35;
 export const TOOLBAR_HEIGHT = 40;
+export const GRAPH_MIN_WIDTH = 300;
 
 export enum NodeType {
   TASK_NODE = 'task',

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/const.ts
@@ -24,6 +24,7 @@ export const DEFAULT_BADGE_WIDTH = 40;
 export const DEFAULT_FINALLLY_GROUP_PADDING = 35;
 export const TOOLBAR_HEIGHT = 40;
 export const GRAPH_MIN_WIDTH = 300;
+export const GRAPH_MAX_HEIGHT = 300;
 
 export enum NodeType {
   TASK_NODE = 'task',

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/const.ts
@@ -24,7 +24,7 @@ export const DEFAULT_BADGE_WIDTH = 40;
 export const DEFAULT_FINALLLY_GROUP_PADDING = 35;
 export const TOOLBAR_HEIGHT = 40;
 export const GRAPH_MIN_WIDTH = 300;
-export const GRAPH_MAX_HEIGHT = 300;
+export const GRAPH_MAX_HEIGHT_PERCENT = 45;
 
 export enum NodeType {
   TASK_NODE = 'task',

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/const.ts
@@ -17,6 +17,13 @@ export const FINALLY_ADD_LINK_SIZE = 15;
 export const WHEN_EXPRESSSION_DIAMOND_SIZE = 10;
 export const WHEN_EXPRESSION_SPACING = 25;
 
+export const DEFAULT_NODE_HEIGHT = 32;
+export const NODE_PADDING = 12;
+export const DEFAULT_NODE_ICON_WIDTH = 30;
+export const DEFAULT_BADGE_WIDTH = 40;
+export const DEFAULT_FINALLLY_GROUP_PADDING = 35;
+export const TOOLBAR_HEIGHT = 40;
+
 export enum NodeType {
   TASK_NODE = 'task',
   SPACER_NODE = 'spacer',
@@ -26,6 +33,8 @@ export enum NodeType {
   INVALID_TASK_LIST_NODE = 'invalid-task-list',
   FINALLY_NODE = 'finally-node',
   BUILDER_FINALLY_NODE = 'builder-finally-node',
+  FINALLY_GROUP = 'finally-group',
+  EDGE = 'edge',
 }
 export enum DrawDesign {
   INTEGRAL_SHAPE = 'integral-shape',

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/dag.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/dag.ts
@@ -1,0 +1,146 @@
+export interface Vertex {
+  name: string;
+  level: number;
+  dependancy: {};
+  dependancyNames: string[];
+  hasOutgoing: boolean;
+  data: any;
+}
+
+type Vertices = Map<string, Vertex>;
+
+export class DAG {
+  names: string[];
+
+  vertices: Vertices;
+
+  constructor() {
+    this.names = [];
+    this.vertices = new Map();
+  }
+
+  private visit(
+    vertex: Vertex,
+    fn: (v: Vertex, path: string[]) => void,
+    visited?: any,
+    path?: string[],
+  ) {
+    const { name } = vertex;
+    const vertices = vertex.dependancy;
+    const names = vertex.dependancyNames;
+    const len = names.length;
+
+    if (!visited) {
+      // eslint-disable-next-line no-param-reassign
+      visited = new Map();
+    }
+    if (!path) {
+      // eslint-disable-next-line no-param-reassign
+      path = [];
+    }
+    if (visited.has(name)) {
+      return;
+    }
+    path.push(name);
+    visited.set(name, true);
+    for (let i = 0; i < len; i++) {
+      this.visit(vertices[names[i]], fn, visited, path);
+    }
+    fn(vertex, path);
+    path.pop();
+  }
+
+  private map(name: string, data: any) {
+    const vertex = this.addVertex(name);
+    vertex.data = data;
+  }
+
+  addVertex(name: string) {
+    if (!name) {
+      return null;
+    }
+    if (this.vertices.has(name)) {
+      return this.vertices.get(name);
+    }
+
+    const vertex: Vertex = {
+      name,
+      level: 0,
+      dependancy: {},
+      dependancyNames: [],
+      hasOutgoing: false,
+      data: {},
+    };
+    this.vertices.set(name, vertex);
+    this.names.push(name);
+    return vertex;
+  }
+
+  addEdge(source: string, target: string): void {
+    if (!source || !target || source === target) {
+      return;
+    }
+    const fromNode = this.addVertex(source);
+    const toNode = this.addVertex(target);
+
+    if (toNode.dependancy[source]) {
+      return;
+    }
+
+    const checkCycle = (vertex: Vertex, path: string[]) => {
+      if (vertex.name === target) {
+        throw new Error(`cycle detected: ${path.reverse().join(' --> ')} --> ${target}`);
+      } else {
+        vertex.level = path.length;
+      }
+    };
+    this.visit(fromNode, checkCycle);
+    fromNode.hasOutgoing = true;
+    toNode.dependancy[source] = fromNode;
+    toNode.dependancyNames.push(source);
+  }
+
+  addEdges(name: string, data: any, before: string | string[], after: string | string[]): void {
+    this.map(name, data);
+
+    if (before) {
+      if (typeof before === 'string') {
+        this.addEdge(name, before);
+      } else {
+        before.forEach((b) => this.addEdge(name, b));
+      }
+    }
+    if (after) {
+      if (typeof after === 'string') {
+        this.addEdge(after, name);
+      } else {
+        after.forEach((a) => this.addEdge(a, name));
+      }
+    }
+  }
+
+  topologicalSort(fn: any): void {
+    const visited = new Map();
+    const { vertices } = this;
+    const { names } = this;
+    const len = names.length;
+
+    for (let i = 0; i < len; i++) {
+      const vertex: Vertex = vertices.get(names[i]);
+      if (!vertex.hasOutgoing) {
+        this.visit(vertex, fn, visited);
+      }
+    }
+  }
+
+  printGraph() {
+    const orderedNodes = [];
+    this.topologicalSort((v, t) => {
+      v.data.stage = this.names.length - t.length;
+      orderedNodes.push(v.name);
+    });
+    // eslint-disable-next-line no-console
+    console.log(orderedNodes.join(' --> '));
+    return orderedNodes.join(' --> ');
+  }
+}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/factories.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/factories.ts
@@ -18,6 +18,7 @@ import FinallyNode from './FinallyNode';
 import InvalidTaskListNode from './InvalidTaskListNode';
 import LoadingNode from './LoadingNode';
 import PipelineTaskNode from './PipelineTaskNode';
+import BuilderTaskEdge from './TaskEdge';
 import TaskListNode from './TaskListNode';
 import TaskNode from './TaskNode';
 import { getLayoutData } from './utils';
@@ -27,7 +28,7 @@ export const builderComponentsFactory: ComponentFactory = (kind: ModelKind, type
     case ModelKind.graph:
       return GraphComponent;
     case ModelKind.edge:
-      return TaskEdge;
+      return BuilderTaskEdge;
     case ModelKind.node:
       switch (type) {
         case NodeType.TASK_NODE:

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/factories.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/factories.ts
@@ -5,6 +5,11 @@ import {
   LayoutFactory,
   ModelKind,
   Graph,
+  TaskEdge,
+  PipelineDagreLayout,
+  withPanZoom,
+  SpacerNode,
+  DefaultTaskGroup,
 } from '@patternfly/react-topology';
 import BuilderFinallyNode from './BuilderFinallyNode';
 import BuilderNode from './BuilderNode';
@@ -12,13 +17,12 @@ import { NodeType, PipelineLayout } from './const';
 import FinallyNode from './FinallyNode';
 import InvalidTaskListNode from './InvalidTaskListNode';
 import LoadingNode from './LoadingNode';
-import SpacerNode from './SpacerNode';
-import TaskEdge from './TaskEdge';
+import PipelineTaskNode from './PipelineTaskNode';
 import TaskListNode from './TaskListNode';
 import TaskNode from './TaskNode';
 import { getLayoutData } from './utils';
 
-export const componentFactory: ComponentFactory = (kind: ModelKind, type: string) => {
+export const builderComponentsFactory: ComponentFactory = (kind: ModelKind, type: string) => {
   switch (kind) {
     case ModelKind.graph:
       return GraphComponent;
@@ -50,11 +54,32 @@ export const componentFactory: ComponentFactory = (kind: ModelKind, type: string
   }
 };
 
+export const dagreViewerComponentFactory: ComponentFactory = (kind: ModelKind, type: string) => {
+  switch (kind) {
+    case ModelKind.graph:
+      return withPanZoom()(GraphComponent);
+    case ModelKind.edge:
+      return TaskEdge;
+    case ModelKind.node:
+      switch (type) {
+        case NodeType.TASK_NODE:
+        case NodeType.FINALLY_NODE:
+          return PipelineTaskNode;
+        case NodeType.FINALLY_GROUP:
+          return DefaultTaskGroup;
+        case NodeType.SPACER_NODE:
+          return SpacerNode;
+        default:
+          return undefined;
+      }
+    default:
+      return undefined;
+  }
+};
+
 export const layoutFactory: LayoutFactory = (type: string, graph: Graph) => {
   switch (type) {
     case PipelineLayout.DAGRE_BUILDER:
-    case PipelineLayout.DAGRE_VIEWER:
-    case PipelineLayout.DAGRE_VIEWER_SPACED:
     case PipelineLayout.DAGRE_BUILDER_SPACED:
       return new DagreLayout(graph, {
         // Hack to get around undesirable defaults
@@ -69,6 +94,8 @@ export const layoutFactory: LayoutFactory = (type: string, graph: Graph) => {
         layoutOnDrag: false,
         ...getLayoutData(type),
       });
+    case PipelineLayout.DAGRE_VIEWER:
+      return new PipelineDagreLayout(graph, { nodesep: 25 });
     default:
       return undefined;
   }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/types.ts
@@ -1,4 +1,4 @@
-import { EdgeModel, NodeModel, RunStatus } from '@patternfly/react-topology';
+import { EdgeModel, NodeModel, RunStatus, WhenStatus } from '@patternfly/react-topology';
 import { PipelineKind, TaskKind, PipelineRunKind, PipelineTask } from '../../../types';
 import { PipelineBuilderLoadingTask, TaskSearchCallback } from '../pipeline-builder/types';
 import { AddNodeDirection, NodeType } from './const';
@@ -16,7 +16,7 @@ export type PipelineRunAfterNodeModelData = {
   height?: number;
   selected?: boolean;
   status?: RunStatus;
-  whenStatus?: string;
+  whenStatus?: WhenStatus;
   pipeline?: PipelineKind;
   pipelineRun?: PipelineRunKind;
   label?: string;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/types.ts
@@ -16,6 +16,9 @@ export type PipelineRunAfterNodeModelData = {
   height?: number;
   selected?: boolean;
   status?: RunStatus;
+  whenStatus?: string;
+  pipeline?: PipelineKind;
+  pipelineRun?: PipelineRunKind;
   label?: string;
   runAfterTasks?: string[];
   task: {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/types.ts
@@ -1,4 +1,4 @@
-import { EdgeModel, NodeModel } from '@patternfly/react-topology';
+import { EdgeModel, NodeModel, RunStatus } from '@patternfly/react-topology';
 import { PipelineKind, TaskKind, PipelineRunKind, PipelineTask } from '../../../types';
 import { PipelineBuilderLoadingTask, TaskSearchCallback } from '../pipeline-builder/types';
 import { AddNodeDirection, NodeType } from './const';
@@ -11,7 +11,11 @@ export type NodeSelectionCallback = (nodeData: BuilderNodeModelData) => void;
 
 // Node Data Models
 export type PipelineRunAfterNodeModelData = {
+  id?: string;
+  width?: number;
+  height?: number;
   selected?: boolean;
+  status?: RunStatus;
   label?: string;
   runAfterTasks?: string[];
   task: {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/types.ts
@@ -12,6 +12,8 @@ export type NodeSelectionCallback = (nodeData: BuilderNodeModelData) => void;
 // Node Data Models
 export type PipelineRunAfterNodeModelData = {
   selected?: boolean;
+  label?: string;
+  runAfterTasks?: string[];
   task: {
     name: string;
     runAfter?: string[];

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
@@ -106,10 +106,8 @@ export const createBuilderFinallyNode = (
 ): NodeCreator<BuilderFinallyNodeModel> =>
   createGenericNode(NodeType.BUILDER_FINALLY_NODE, width, height);
 
-const createPipelineRunNode = (
-  type: NodeType,
-  data: any, // PipelineRunNodeData,
-) => createGenericNode(type, data.width, data.height)(data.id, data);
+const createPipelineTaskNode = (type: NodeType, data: PipelineRunAfterNodeModelData) =>
+  createGenericNode(type, data.width, data.height)(data.id, data);
 
 export const getNodeCreator = (type: NodeType): NodeCreator<PipelineRunAfterNodeModelData> => {
   switch (type) {
@@ -504,7 +502,7 @@ export const getGraphDataModel = (
     }
     const badgePadding = Object.keys(pipelineRun.spec)?.length > 0 ? DEFAULT_BADGE_WIDTH : 0;
     nodes.push(
-      createPipelineRunNode(NodeType.TASK_NODE, {
+      createPipelineTaskNode(NodeType.TASK_NODE, {
         id: vertex.name,
         label: vertex.name,
         width:
@@ -513,10 +511,11 @@ export const getGraphDataModel = (
           DEFAULT_NODE_ICON_WIDTH +
           badgePadding,
         runAfterTasks,
-        noLocation: true,
         status: vertex.data.status?.reason,
         whenStatus: taskWhenStatus(vertex.data),
         task: vertex.data,
+        pipeline,
+        pipelineRun,
       }),
     );
   });
@@ -526,7 +525,7 @@ export const getGraphDataModel = (
   const maxFinallyNodeName =
     finallyTaskList.sort((a, b) => b.name.length - a.name.length)[0]?.name || '';
   const finallyNodes = finallyTaskList.map((fTask) =>
-    createPipelineRunNode(NodeType.FINALLY_NODE, {
+    createPipelineTaskNode(NodeType.FINALLY_NODE, {
       id: fTask.name,
       label: fTask.name,
       width:
@@ -536,6 +535,8 @@ export const getGraphDataModel = (
       status: fTask.status?.reason,
       whenStatus: taskWhenStatus(fTask),
       task: fTask,
+      pipeline,
+      pipelineRun,
     }),
   );
   const finallyGroup = finallyNodes.length

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
@@ -438,6 +438,10 @@ export const getGraphDataModel = (
   nodes: PipelineMixedNodeModel[];
   edges: EdgeModel[];
 } => {
+  if (!pipeline) {
+    return null;
+  }
+
   const taskList = _.flatten(getPipelineTasks(pipeline, pipelineRun));
 
   const dag = new DAG();

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
@@ -402,7 +402,7 @@ export const getSpacerNode = (node: PipelineMixedNodeModel): PipelineMixedNodeMo
   width: 1,
 });
 
-export const getWhenStatus = (status: RunStatus): string => {
+export const getWhenStatus = (status: RunStatus): WhenStatus => {
   switch (status) {
     case RunStatus.Succeeded:
     case RunStatus.Failed:
@@ -412,11 +412,11 @@ export const getWhenStatus = (status: RunStatus): string => {
     case RunStatus.Idle:
       return WhenStatus.Unmet;
     default:
-      return '';
+      return undefined;
   }
 };
 
-export const taskWhenStatus = (task: PipelineTaskWithStatus) => {
+export const getTaskWhenStatus = (task: PipelineTaskWithStatus): WhenStatus => {
   if (!task.when) {
     return undefined;
   }
@@ -514,7 +514,7 @@ export const getGraphDataModel = (
           badgePadding,
         runAfterTasks,
         status: isTaskSkipped ? RunStatus.Skipped : vertex.data.status?.reason,
-        whenStatus: taskWhenStatus(vertex.data),
+        whenStatus: getTaskWhenStatus(vertex.data),
         task: vertex.data,
         pipeline,
         pipelineRun,
@@ -537,7 +537,7 @@ export const getGraphDataModel = (
       height: DEFAULT_NODE_HEIGHT,
       runAfterTasks: [],
       status: isTaskSkipped ? RunStatus.Skipped : fTask.status?.reason,
-      whenStatus: taskWhenStatus(fTask),
+      whenStatus: getTaskWhenStatus(fTask),
       task: fTask,
       pipeline,
       pipelineRun,
@@ -575,10 +575,7 @@ export const getGraphDataModel = (
       id: `${pipelineRun?.metadata?.name || pipeline.metadata.name}-graph`,
       type: ModelKind.graph,
       layout: PipelineLayout.DAGRE_VIEWER,
-      scale: 0.5,
       scaleExtent: [0.5, 1],
-      x: 25,
-      y: 10,
     },
     nodes: [...nodes, ...spacerNodes, ...finallyNodes, ...finallyGroup],
     edges,

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
@@ -1,10 +1,29 @@
 import { chart_color_green_400 as successColor } from '@patternfly/react-tokens/dist/js/chart_color_green_400';
+import {
+  getSpacerNodes,
+  getEdgesFromNodes,
+  WhenStatus,
+  RunStatus,
+  ModelKind,
+  GraphModel,
+  EdgeModel,
+} from '@patternfly/react-topology';
 import * as dagre from 'dagre';
 import * as _ from 'lodash';
 import i18n from '@console/internal/i18n';
-import { ComputedStatus, PipelineKind, PipelineRunKind, PipelineTask } from '../../../types';
+import {
+  ComputedStatus,
+  PipelineKind,
+  PipelineRunKind,
+  PipelineTask,
+  PipelineTaskWithStatus,
+} from '../../../types';
 import { getRunStatusColor } from '../../../utils/pipeline-augment';
-import { getPipelineTasks, getFinallyTasksWithStatus } from '../../../utils/pipeline-utils';
+import {
+  getPipelineTasks,
+  getFinallyTasksWithStatus,
+  appendPipelineRunStatus,
+} from '../../../utils/pipeline-utils';
 import { CheckTaskErrorMessage } from '../pipeline-builder/types';
 import {
   NODE_HEIGHT,
@@ -19,7 +38,13 @@ import {
   WHEN_EXPRESSION_SPACING,
   DAGRE_VIEWER_SPACED_PROPS,
   DAGRE_BUILDER_SPACED_PROPS,
+  NODE_PADDING,
+  DEFAULT_NODE_ICON_WIDTH,
+  DEFAULT_FINALLLY_GROUP_PADDING,
+  DEFAULT_NODE_HEIGHT,
+  DEFAULT_BADGE_WIDTH,
 } from './const';
+import { DAG, Vertex } from './dag';
 import {
   PipelineEdgeModel,
   NodeCreator,
@@ -40,7 +65,9 @@ import {
 
 const createGenericNode: NodeCreatorSetup = (type, width?, height?) => (name, data) => ({
   id: name,
-  data,
+  label: data?.label || name,
+  runAfterTasks: data?.runAfterTasks || [],
+  ...(data && { data }),
   height: height ?? NODE_HEIGHT,
   width: width ?? NODE_WIDTH,
   type,
@@ -78,6 +105,11 @@ export const createBuilderFinallyNode = (
   width: number,
 ): NodeCreator<BuilderFinallyNodeModel> =>
   createGenericNode(NodeType.BUILDER_FINALLY_NODE, width, height);
+
+const createPipelineRunNode = (
+  type: NodeType,
+  data: any, // PipelineRunNodeData,
+) => createGenericNode(type, data.width, data.height)(data.id, data);
 
 export const getNodeCreator = (type: NodeType): NodeCreator<PipelineRunAfterNodeModelData> => {
   switch (type) {
@@ -238,7 +270,7 @@ export const tasksToBuilderNodes = (
   });
 };
 
-export const getEdgesFromNodes = (nodes: PipelineMixedNodeModel[]): PipelineEdgeModel[] =>
+export const getBuilderEdgesFromNodes = (nodes: PipelineMixedNodeModel[]): PipelineEdgeModel[] =>
   _.flatten(
     nodes.map((node) => {
       const {
@@ -331,6 +363,216 @@ export const getTopologyNodesEdges = (
   const edges: PipelineEdgeModel[] = getEdgesFromNodes(nodes);
 
   return { nodes, edges };
+};
+
+export const getTextWidth = (text: string, font: string = '0.8rem RedHatText'): number => {
+  if (!text || text.length === 0) {
+    return 0;
+  }
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d');
+  if (!context) {
+    return text.length;
+  }
+  context.font = font;
+  const { width } = context.measureText(text);
+  return width;
+};
+
+export const extractDepsFromContextVariables = (contextVariable: string) => {
+  const regex = /(?:(?:\$\(tasks.))([a-z0-9_-]+)(?:.results+)(?:[.^\w]+\))/g;
+  let matches;
+  const deps = [];
+  // eslint-disable-next-line no-cond-assign
+  while ((matches = regex.exec(contextVariable)) !== null) {
+    // This is necessary to avoid infinite loops with zero-width matches
+    if (matches.index === regex.lastIndex) {
+      regex.lastIndex++;
+    }
+    if (matches) {
+      if (!deps.includes(matches[1])) {
+        deps.push(matches[1]);
+      }
+    }
+  }
+  return deps;
+};
+
+export const getSpacerNode = (node: PipelineMixedNodeModel): PipelineMixedNodeModel => ({
+  ...node,
+  height: 1,
+  width: 1,
+});
+
+export const getWhenStatus = (status: RunStatus): string => {
+  switch (status) {
+    case RunStatus.Succeeded:
+    case RunStatus.Failed:
+      return WhenStatus.Met;
+    case RunStatus.Skipped:
+    case RunStatus['In Progress']:
+    case RunStatus.Idle:
+      return WhenStatus.Unmet;
+    default:
+      return '';
+  }
+};
+
+export const taskWhenStatus = (task: PipelineTaskWithStatus) => {
+  if (!task.when) {
+    return undefined;
+  }
+  return getWhenStatus(task.status?.reason);
+};
+
+export const getGraphDataModel = (
+  pipeline: PipelineKind,
+  pipelineRun: PipelineRunKind = {
+    apiVersion: '',
+    metadata: {},
+    kind: 'PipelineRun',
+    spec: {},
+  },
+): {
+  graph: GraphModel;
+  nodes: PipelineMixedNodeModel[];
+  edges: EdgeModel[];
+} => {
+  const taskList = _.flatten(getPipelineTasks(pipeline, pipelineRun));
+
+  const dag = new DAG();
+  taskList?.forEach((task: PipelineTask) => {
+    dag.addEdges(task.name, task, '', task.runAfter || []);
+  });
+
+  const nodes = [];
+  const maxWidthForLevel = {};
+  dag.topologicalSort((v: Vertex) => {
+    if (!maxWidthForLevel[v.level]) {
+      maxWidthForLevel[v.level] = getTextWidth(v.name);
+    } else {
+      maxWidthForLevel[v.level] = Math.max(maxWidthForLevel[v.level], getTextWidth(v.name));
+    }
+  });
+  dag.topologicalSort((vertex: Vertex) => {
+    const runAfterTasks = [];
+    const task = vertex.data;
+    const depsFromContextVariables = [];
+    if (task.params) {
+      task.params.forEach((p) => {
+        if (Array.isArray(p.value)) {
+          p.value.forEach((paramValue) => {
+            depsFromContextVariables.push(...extractDepsFromContextVariables(paramValue));
+          });
+        } else {
+          depsFromContextVariables.push(...extractDepsFromContextVariables(p.value));
+        }
+      });
+    }
+    if (task?.when) {
+      task.when.forEach(({ input, values }) => {
+        depsFromContextVariables.push(...extractDepsFromContextVariables(input));
+        values.forEach((whenValue) => {
+          depsFromContextVariables.push(...extractDepsFromContextVariables(whenValue));
+        });
+      });
+    }
+    const dependancies = _.uniq([...vertex.dependancyNames]);
+    if (dependancies) {
+      dependancies.forEach((dep) => {
+        const depObj = dag.vertices.get(dep);
+        if (depObj.level - vertex.level <= 1 || vertex.data.runAfter?.includes(depObj.name)) {
+          runAfterTasks.push(dep);
+        }
+      });
+    }
+    if (depsFromContextVariables.length > 0) {
+      const v = depsFromContextVariables.map((d) => {
+        return dag.vertices.get(d);
+      });
+      const minLevelDep = _.minBy(v, (d) => d.level);
+      const nearestDeps = v.filter((v1) => v1.level === minLevelDep.level);
+      nearestDeps.forEach((nd) => {
+        if (nd.level - vertex.level <= 1 || vertex.dependancyNames.length === 0) {
+          runAfterTasks.push(nd.name);
+        }
+      });
+    }
+    const badgePadding = Object.keys(pipelineRun.spec)?.length > 0 ? DEFAULT_BADGE_WIDTH : 0;
+    nodes.push(
+      createPipelineRunNode(NodeType.TASK_NODE, {
+        id: vertex.name,
+        label: vertex.name,
+        width:
+          maxWidthForLevel[vertex.level] +
+          NODE_PADDING * 2 +
+          DEFAULT_NODE_ICON_WIDTH +
+          badgePadding,
+        runAfterTasks,
+        noLocation: true,
+        status: vertex.data.status?.reason,
+        whenStatus: taskWhenStatus(vertex.data),
+        task: vertex.data,
+      }),
+    );
+  });
+
+  const finallyTaskList = appendPipelineRunStatus(pipeline, pipelineRun, true);
+
+  const maxFinallyNodeName =
+    finallyTaskList.sort((a, b) => b.name.length - a.name.length)[0]?.name || '';
+  const finallyNodes = finallyTaskList.map((fTask) =>
+    createPipelineRunNode(NodeType.FINALLY_NODE, {
+      id: fTask.name,
+      label: fTask.name,
+      width:
+        getTextWidth(maxFinallyNodeName) + NODE_PADDING * 2 + DEFAULT_FINALLLY_GROUP_PADDING * 2,
+      height: DEFAULT_NODE_HEIGHT,
+      runAfterTasks: [],
+      status: fTask.status?.reason,
+      whenStatus: taskWhenStatus(fTask),
+      task: fTask,
+    }),
+  );
+  const finallyGroup = finallyNodes.length
+    ? [
+        {
+          id: 'finally-group-id',
+          type: NodeType.FINALLY_GROUP,
+          children: finallyNodes.map((n) => n.id),
+          group: true,
+          style: { padding: DEFAULT_FINALLLY_GROUP_PADDING },
+        },
+      ]
+    : [];
+  const spacerNodes: PipelineMixedNodeModel[] = getSpacerNodes(
+    [...nodes, ...finallyNodes],
+    NodeType.SPACER_NODE,
+    [NodeType.FINALLY_NODE],
+  ).map(getSpacerNode);
+
+  const edges: PipelineEdgeModel[] = getEdgesFromNodes(
+    [...nodes, ...spacerNodes, ...finallyNodes],
+    NodeType.SPACER_NODE,
+    NodeType.EDGE,
+    NodeType.EDGE,
+    [NodeType.FINALLY_NODE],
+    NodeType.EDGE,
+  );
+
+  return {
+    graph: {
+      id: `${pipelineRun?.metadata?.name || pipeline.metadata.name}-graph`,
+      type: ModelKind.graph,
+      layout: PipelineLayout.DAGRE_VIEWER,
+      scale: 0.5,
+      scaleExtent: [0.5, 1],
+      x: 25,
+      y: 10,
+    },
+    nodes: [...nodes, ...spacerNodes, ...finallyNodes, ...finallyGroup],
+    edges,
+  };
 };
 
 export const taskHasWhenExpression = (task: PipelineTask): boolean => task?.when?.length > 0;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
@@ -501,6 +501,8 @@ export const getGraphDataModel = (
       });
     }
     const badgePadding = Object.keys(pipelineRun.spec)?.length > 0 ? DEFAULT_BADGE_WIDTH : 0;
+    const isTaskSkipped = pipelineRun?.status?.skippedTasks?.some((t) => t.name === task.name);
+
     nodes.push(
       createPipelineTaskNode(NodeType.TASK_NODE, {
         id: vertex.name,
@@ -511,7 +513,7 @@ export const getGraphDataModel = (
           DEFAULT_NODE_ICON_WIDTH +
           badgePadding,
         runAfterTasks,
-        status: vertex.data.status?.reason,
+        status: isTaskSkipped ? RunStatus.Skipped : vertex.data.status?.reason,
         whenStatus: taskWhenStatus(vertex.data),
         task: vertex.data,
         pipeline,
@@ -524,21 +526,24 @@ export const getGraphDataModel = (
 
   const maxFinallyNodeName =
     finallyTaskList.sort((a, b) => b.name.length - a.name.length)[0]?.name || '';
-  const finallyNodes = finallyTaskList.map((fTask) =>
-    createPipelineTaskNode(NodeType.FINALLY_NODE, {
+  const finallyNodes = finallyTaskList.map((fTask) => {
+    const isTaskSkipped = pipelineRun?.status?.skippedTasks?.some((t) => t.name === fTask.name);
+
+    return createPipelineTaskNode(NodeType.FINALLY_NODE, {
       id: fTask.name,
       label: fTask.name,
       width:
         getTextWidth(maxFinallyNodeName) + NODE_PADDING * 2 + DEFAULT_FINALLLY_GROUP_PADDING * 2,
       height: DEFAULT_NODE_HEIGHT,
       runAfterTasks: [],
-      status: fTask.status?.reason,
+      status: isTaskSkipped ? RunStatus.Skipped : fTask.status?.reason,
       whenStatus: taskWhenStatus(fTask),
       task: fTask,
       pipeline,
       pipelineRun,
-    }),
-  );
+    });
+  });
+
   const finallyGroup = finallyNodes.length
     ? [
         {

--- a/frontend/packages/pipelines-plugin/src/types/pipeline.ts
+++ b/frontend/packages/pipelines-plugin/src/types/pipeline.ts
@@ -1,3 +1,4 @@
+import { RunStatus } from '@patternfly/react-topology';
 import { K8sResourceCommon } from '@console/internal/module/k8s';
 import {
   TektonParam,
@@ -50,6 +51,12 @@ export type PipelineTask = {
   taskSpec?: TektonTaskSpec;
   when?: WhenExpression[];
   workspaces?: PipelineTaskWorkspace[];
+};
+
+export type PipelineTaskWithStatus = PipelineTask & {
+  status: {
+    reason: RunStatus;
+  };
 };
 
 export type PipelineSpec = {

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
@@ -249,7 +249,7 @@ describe('pipeline-utils ', () => {
     expect(serviceAccount.imagePullSecrets).toHaveLength(2);
   });
 
-  it('should append Idle status if a taskrun status reason is missing', () => {
+  it('should append Pending status if a taskrun status reason is missing', () => {
     const { pipeline, pipelineRuns } = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
     const pipelineRunWithoutStatus = _.cloneDeep(pipelineRuns[DataState.IN_PROGRESS]);
     _.forIn(pipelineRunWithoutStatus.status.taskRuns, (taskRun, name) => {
@@ -260,7 +260,7 @@ describe('pipeline-utils ', () => {
       ]);
     });
     const taskList = appendPipelineRunStatus(pipeline, pipelineRunWithoutStatus);
-    expect(taskList.filter((t) => t.status.reason === ComputedStatus.Idle)).toHaveLength(2);
+    expect(taskList.filter((t) => t.status.reason === ComputedStatus.Pending)).toHaveLength(2);
   });
 
   it('should append pipelineRun running status for all the tasks', () => {

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
@@ -145,11 +145,11 @@ export const appendPipelineRunStatus = (pipeline, pipelineRun, isFinallyTasks = 
     }
     // append task status
     if (!mTask.status) {
-      mTask.status = { reason: ComputedStatus.Idle };
+      mTask.status = { reason: ComputedStatus.Pending };
     } else if (mTask.status && mTask.status.conditions) {
-      mTask.status.reason = pipelineRunStatus(mTask) || ComputedStatus.Idle;
+      mTask.status.reason = pipelineRunStatus(mTask) || ComputedStatus.Pending;
     } else if (mTask.status && !mTask.status.reason) {
-      mTask.status.reason = ComputedStatus.Idle;
+      mTask.status.reason = ComputedStatus.Pending;
     }
     return mTask;
   });

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2015,19 +2015,6 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-core@^4.236.7":
-  version "4.236.14"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.236.14.tgz#a672ec06f625149f5a61d0f18898901efa870831"
-  integrity sha512-htxD/Mkkw2axbHD4RuMgQSS4GUTGqy+qtvP3Kgq0dILydStMLlwA3o3ckbevS0AtuKfBm+1lU8w91EMHYm8UQQ==
-  dependencies:
-    "@patternfly/react-icons" "^4.87.14"
-    "@patternfly/react-styles" "^4.86.14"
-    "@patternfly/react-tokens" "^4.88.14"
-    focus-trap "6.9.2"
-    react-dropzone "9.0.0"
-    tippy.js "5.1.2"
-    tslib "^2.0.0"
-
 "@patternfly/react-icons@^4.11.4":
   version "4.11.4"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.11.4.tgz#8fae0bf215e39e382661a089a1d43f3ccb7fdeef"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2015,6 +2015,19 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
+"@patternfly/react-core@^4.236.7":
+  version "4.236.14"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.236.14.tgz#a672ec06f625149f5a61d0f18898901efa870831"
+  integrity sha512-htxD/Mkkw2axbHD4RuMgQSS4GUTGqy+qtvP3Kgq0dILydStMLlwA3o3ckbevS0AtuKfBm+1lU8w91EMHYm8UQQ==
+  dependencies:
+    "@patternfly/react-icons" "^4.87.14"
+    "@patternfly/react-styles" "^4.86.14"
+    "@patternfly/react-tokens" "^4.88.14"
+    focus-trap "6.9.2"
+    react-dropzone "9.0.0"
+    tippy.js "5.1.2"
+    tslib "^2.0.0"
+
 "@patternfly/react-icons@^4.11.4":
   version "4.11.4"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.11.4.tgz#8fae0bf215e39e382661a089a1d43f3ccb7fdeef"


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/ODC-6690
https://issues.redhat.com/browse/OCPBUGSM-44997


**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

Update ODC pipeline to new PF pipeline package.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

This PR brings in the latest PF pipeline topology, which includes
1. Zoom in/out to changes the node shapes/details
2. Standard topology icons to zoom in/out, fit and reset button controls.


**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
Pipeline default view:
---

<img width="644" alt="image" src="https://user-images.githubusercontent.com/9964343/191729059-729c804c-9205-47e5-ba70-4f04e62ac2ef.png">


PipelineRun default view:
---

<img width="763" alt="image" src="https://user-images.githubusercontent.com/9964343/191729318-73e502af-4d27-459a-86a7-1b34c1b49b6d.png">



Zoomed out view:
---
<img width="1468" alt="image" src="https://user-images.githubusercontent.com/9964343/191729824-13fbdfa0-6a15-4b2f-b664-2dddc7a32ed9.png">



Hovering on a node and opening tooltip:
---
<img width="998" alt="image" src="https://user-images.githubusercontent.com/9964343/190086354-bb109c89-00ae-4718-b8a1-397ac60f2668.png">

Gif:
---
![pipelinerun](https://user-images.githubusercontent.com/9964343/191734879-9c5a2ca3-2d91-452a-8710-e5271a314c62.gif)

![complex-pipeline](https://user-images.githubusercontent.com/9964343/191734914-cc60dd9e-1f77-43c1-8559-12ee9724790d.gif)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

```
utils.spec.ts:
extractDepsFromContextVariables: 
    ✓ should return emtpy array for invalid values (1ms)
    ✓ should return empty array if the context variable string does not contain results
    ✓ should return a task name if the context variable string contains results
    ✓ should return a list of task names if the context variable string contains multiple results
  taskWhenStatus:
    ✓ should return undefined if the task does not have when expression
    ✓ should return a matching when status (1ms)
  getGraphDataModel
    ✓ should return null for invalid values (2ms)
    ✓ should return graph, nodes and edges for valid pipeline (5ms)
    ✓ should return graph, nodes and edges for valid pipeline (1ms)
    ✓ should include the finally group and nodes for the pipeline with finally task (1ms)
```    

```
 dag
    ✓ should print the tasks in topological sort order 
    addVertex:
      ✓ should add the vertex to the graph (2ms)
      ✓ should skip the duplicate vertex added to the graph (1ms)
    AddEdge:
      ✓ should add the vertex if it not available in the graph
      ✓ should add the edges to the graph
      ✓ should skip the duplicate edges added to the graph
    AddEdges
      ✓ should form the dependancies when addEdges is called with multiple before and after tasks (5ms)
      ✓ should throw an error if there is any cycle detected (1ms)
```
      
**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

1. Add a resource with pipeline from Git import flow.
2. Visit Pipeline and pipelineRun Details view.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


cc: @serenamarie125 @siamaksade @jeff-phillips-18 