### PR TITLE
ODC-6780: Provide a code snippet for the console CRD for adding Subcatalogs in Dev Catalog

### DIFF
--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -281,6 +281,8 @@
   "Provides a list of default roles which are shown in the Project Access. The roles must be added below customization projectAccess.": "Provides a list of default roles which are shown in the Project Access. The roles must be added below customization projectAccess.",
   "Add page actions": "Add page actions",
   "Provides a list of all available actions on the Add page in the Developer perspective. The IDs must be added below customization addPage disabledActions to hide these actions.": "Provides a list of all available actions on the Add page in the Developer perspective. The IDs must be added below customization addPage disabledActions to hide these actions.",
+  "Add sub-catalog types": "Add sub-catalog types",
+  "Provides a list of all the available sub-catalog types which are shown in the Developer Catalog. The types must be added below spec customization developerCatalog": "Provides a list of all the available sub-catalog types which are shown in the Developer Catalog. The types must be added below spec customization developerCatalog",
   "Set maxUnavaliable to 0": "Set maxUnavaliable to 0",
   "An eviction is allowed if at most 0 pods selected by \"selector\" are unavailable after the eviction.": "An eviction is allowed if at most 0 pods selected by \"selector\" are unavailable after the eviction.",
   "Set minAvailable to 25%": "Set minAvailable to 25%",

--- a/frontend/packages/console-shared/src/utils/sample-utils.ts
+++ b/frontend/packages/console-shared/src/utils/sample-utils.ts
@@ -3,7 +3,12 @@ import { Map as ImmutableMap } from 'immutable';
 import YAML from 'js-yaml';
 import * as _ from 'lodash';
 import { PodDisruptionBudgetModel } from '@console/app/src/models';
-import { AddAction, isAddAction } from '@console/dynamic-plugin-sdk';
+import {
+  AddAction,
+  CatalogItemType,
+  isAddAction,
+  isCatalogItemType,
+} from '@console/dynamic-plugin-sdk';
 import { FirehoseResult } from '@console/internal/components/utils';
 import * as denyOtherNamespacesImg from '@console/internal/imgs/network-policy-samples/1-deny-other-namespaces.svg';
 import * as limitCertainAppImg from '@console/internal/imgs/network-policy-samples/2-limit-certain-apps.svg';
@@ -343,6 +348,30 @@ const defaultSamples = (t: TFunction) =>
                   unsubscribe();
                 },
                 isAddAction,
+              );
+            });
+          },
+          targetResource: getTargetResource(ConsoleOperatorConfigModel),
+        },
+        {
+          title: t('console-shared~Add sub-catalog types'),
+          description: t(
+            'console-shared~Provides a list of all the available sub-catalog types which are shown in the Developer Catalog. The types must be added below spec customization developerCatalog',
+          ),
+          id: 'devcatalog-types',
+          snippet: true,
+          lazyYaml: () => {
+            return new Promise<string>((resolve) => {
+              const unsubscribe = subscribeToExtensions<CatalogItemType>(
+                (extensions: LoadedExtension<CatalogItemType>[]) => {
+                  const enabledTypes = {
+                    state: 'Enabled',
+                    enabled: extensions.map((extension) => extension.properties.type),
+                  };
+                  resolve(YAML.dump(enabledTypes));
+                  unsubscribe();
+                },
+                isCatalogItemType,
               );
             });
           },


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
- [ODC-6780: Provide a code snippet for the console CRD for Hiding Subcatalogs in Dev Catalog](https://issues.redhat.com/browse/ODC-6780)

**Solution Description**: 
1. Added the code snippet for the console CRD for adding Subcatalogs in Dev Catalog so that a user can paste the snippet into the Console CR YAML. This will help the cluster admins to hide certain sub-catalogs (types) for all users. 
For example for customers who don't want to use Helm charts, or another sub-catalog without disabling Helm support in the whole developer console.

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/47265560/188127023-87b26b0d-3884-4610-b9b7-40e9c3653091.mp4





**Unit test coverage report**: 
No changes.

**Test setup:**
1. CRD URL example: http://localhost:9000/k8s/cluster/customresourcedefinitions/consoles.operator.openshift.io

     a. Search for `developerCatalog`, and add this YAML under the `properties`
```yaml
disabledTypes:
  description: >-
    disabledTypes is a list of developer types that are
    disabled in the web console.
  type: array
  items:
    type: string
```

2. Open the cluster resource of the YAML and open the sidebar.
Cluster config example: http://localhost:9000/k8s/cluster/operator.openshift.io~v1~Console/cluster/yaml

3. Insert the Hide sub-catalogs for all user's snippets and save the resource.


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge