### PR TITLE
OCPBUGS-1305: Re-enable Shipwright e2e tests

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -40,6 +40,7 @@ if [ $# -eq 0 ]; then
     echo "  test-cypress.sh -p gitops                             // opens Cypress Test Runner for gitops tests"
     echo "  test-cypress.sh -p knative                            // opens Cypress Test Runner for knative tests"
     echo "  test-cypress.sh -p pipelines                          // opens Cypress Test Runner for pipelines tests"
+    echo "  test-cypress.sh -p shipwright                         // opens Cypress Test Runner for shipwright tests"
     echo "  test-cypress.sh -h true                               // runs all packages in headless mode"
     echo "  test-cypress.sh -p olm -h true                        // runs OLM tests in headless mode"
     echo "  test-cypress.sh -p console -s 'tests/crud/*' -h true  // runs console CRUD tests in headless mode"
@@ -57,6 +58,7 @@ if [ -n "${nightly-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-dev-console-nightly
   yarn run test-cypress-helm-nightly
   yarn run test-cypress-pipelines-nightly
+  yarn run test-cypress-shipwright-nightly
   yarn run test-cypress-topology-nightly
   yarn run test-cypress-knative-nightly
 
@@ -71,6 +73,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
   yarn run test-cypress-pipelines-headless
+  yarn run test-cypress-shipwright-headless
   exit;
 fi
 


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-1305

Reverts #11947

This PR contains two commits, the first one is of #12242 because Shipwright Builds depends on Tekton / OpenShift Pipelines.

We should run this multiple times to check if the job timeouts or work fine after increasing the job time from 2h30m to 3h here https://github.com/openshift/release/pull/31168 and here https://github.com/openshift/release/pull/31999
