### PR TITLE
Monitoring: Clean up use of ISO datetime helpers

### DIFF
--- a/frontend/public/components/monitoring/dashboards/custom-time-range-modal.tsx
+++ b/frontend/public/components/monitoring/dashboards/custom-time-range-modal.tsx
@@ -15,10 +15,23 @@ import {
   ModalSubmitFooter,
   ModalTitle,
 } from '../../factory/modal';
-import { toISODateString, twentyFourHourTime } from '../../utils/datetime';
 import { setQueryArguments } from '../../utils';
 
 type CustomTimeRangeModalProps = ModalComponentProps & { activePerspective: string };
+
+const zeroPad = (number: number) => (number < 10 ? `0${number}` : number);
+
+// Get YYYY-MM-DD date string for a date object
+const toISODateString = (date: Date): string =>
+  `${date.getFullYear()}-${zeroPad(date.getMonth() + 1)}-${zeroPad(date.getDate())}`;
+
+// Get HH:MM time string for a date object
+const toISOTimeString = (date: Date): string =>
+  new Intl.DateTimeFormat(
+    'en',
+    // TODO: TypeScript 3 doesn't allow the `hourCycle` attribute so use "as any" until we upgrade
+    { hour: 'numeric', minute: 'numeric', hourCycle: 'h23' } as any,
+  ).format(date);
 
 const CustomTimeRangeModal = ({ cancel, close, activePerspective }: CustomTimeRangeModalProps) => {
   const { t } = useTranslation();
@@ -36,11 +49,11 @@ const CustomTimeRangeModal = ({ cancel, close, activePerspective }: CustomTimeRa
   const defaultFrom = endTime && timespan ? new Date(endTime - timespan) : undefined;
   const [fromDate, setFromDate] = React.useState(toISODateString(defaultFrom ?? now));
   const [fromTime, setFromTime] = React.useState(
-    defaultFrom ? twentyFourHourTime(defaultFrom) : '00:00',
+    defaultFrom ? toISOTimeString(defaultFrom) : '00:00',
   );
   const [toDate, setToDate] = React.useState(toISODateString(endTime ? new Date(endTime) : now));
   const [toTime, setToTime] = React.useState(
-    endTime ? twentyFourHourTime(new Date(endTime)) : '23:59',
+    endTime ? toISOTimeString(new Date(endTime)) : '23:59',
   );
 
   const submit: React.FormEventHandler<HTMLFormElement> = (e) => {

--- a/frontend/public/components/utils/datetime.ts
+++ b/frontend/public/components/utils/datetime.ts
@@ -178,10 +178,6 @@ export const parsePrometheusDuration = (duration: string): number => {
 
 const zeroPad = (number: number) => (number < 10 ? `0${number}` : number);
 
-// Get YYYY-MM-DD date string for a date object
-export const toISODateString = (date: Date): string =>
-  `${date.getFullYear()}-${zeroPad(date.getMonth() + 1)}-${zeroPad(date.getDate())}`;
-
 export const twentyFourHourTime = (date: Date, showSeconds?: boolean): string => {
   const hours = zeroPad(date.getHours() ?? 0);
   const minutes = `:${zeroPad(date.getMinutes() ?? 0)}`;


### PR DESCRIPTION
Removes one dependency to bring us one small step closer to having the monitoring pages run as a plugin.

This change was extracted from https://github.com/openshift/console/pull/12037 following @spadgett's comment https://github.com/openshift/console/pull/12037#discussion_r969985932.