### PR TITLE
OCPBUGS-938:  do not show NodesUpdateGroup if there are 0 nodes

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -637,7 +637,7 @@ export const NodesUpdatesGroup: React.FC<NodesUpdatesGroupProps> = ({
   const percentMCPNodes = calculatePercentage(updatedMCPNodes, totalMCPNodes);
   const isUpdated = percentMCPNodes === 100;
   const { t } = useTranslation();
-  return hideIfComplete && isUpdated
+  return totalMCPNodes === 0 || (hideIfComplete && isUpdated)
     ? null
     : machineConfigOperatorLoaded && renderedConfigLoaded && (
         <UpdatesGroup divided={divided}>


### PR DESCRIPTION
Note [this bug was previously reported and fixed in 4.11](https://github.com/openshift/console/pull/11694), but it was not back ported since the severity of that bug is `low`.  I will plan to back port this fix to 4.8 to avoid future duplicates.