### PR TITLE
OCPBUGS-1470: i18n Incorrect plural for maxUnavailable pod count

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -428,6 +428,8 @@
   "Mark as schedulable": "Mark as schedulable",
   "Min available {{minAvailable}} of {{count}} pod": "Min available {{minAvailable}} of {{count}} pod",
   "Min available {{minAvailable}} of {{count}} pod_plural": "Min available {{minAvailable}} of {{count}} pods",
+  "Max unavailable {{maxUnavailable}} of {{count}} pod": "Max unavailable {{maxUnavailable}} of {{count}} pod",
+  "Max unavailable {{maxUnavailable}} of {{count}} pod_plural": "Max unavailable {{maxUnavailable}} of {{count}} pods",
   "Availability requirement": "Availability requirement",
   "maxUnavailable": "maxUnavailable",
   "An eviction is allowed if at most \"maxUnavailable\" pods selected by \"selector\" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with \"minAvailable\".": "An eviction is allowed if at most \"maxUnavailable\" pods selected by \"selector\" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with \"minAvailable\".",

--- a/frontend/packages/console-app/src/components/pdb/AvailabilityRequirement.tsx
+++ b/frontend/packages/console-app/src/components/pdb/AvailabilityRequirement.tsx
@@ -12,7 +12,7 @@ const AvailabilityRequirement: React.FC<AvailabilityRequirementProps> = ({ pdb, 
             minAvailable: pdb.spec.minAvailable,
             count: replicas,
           })
-        : t('public~Max unavailable {{maxUnavailable}} of {{count}} pod', {
+        : t('console-app~Max unavailable {{maxUnavailable}} of {{count}} pod', {
             maxUnavailable: pdb?.spec?.maxUnavailable,
             count: replicas,
           })}


### PR DESCRIPTION
### Before
 ![Screen Shot 2022-09-19 at 2 29 41 PM](https://user-images.githubusercontent.com/15249132/191093993-4687a82c-c327-4e54-a072-7fe8cf545247.png)

### After
![Screen Shot 2022-09-19 at 2 51 27 PM](https://user-images.githubusercontent.com/15249132/191094102-0740d379-8ff0-456a-9984-3d5eb02d675b.png)
