### PR TITLE
Bug 2100843: Fix selection on add connector context menu option opens the side panel of the node

### DIFF
--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenuItem.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenuItem.tsx
@@ -44,6 +44,7 @@ const ActionItem: React.FC<ActionMenuItemProps & { isAllowed: boolean }> = ({
         }
       }
       onClick && onClick();
+      event.stopPropagation();
     },
     [cta, onClick],
   );


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGSM-45936

Descriptions:
- Stop the propagation of the event from the context menu to the node.

GIF:
![Peek 2022-09-20 18-01](https://user-images.githubusercontent.com/2561818/191258218-2c619c4c-be28-46d8-878d-d3e42d5d88ee.gif)
