### PR TITLE
[release-4.11] OCPBUGS-1523: Show already loaded catalog items after a timeout (3sec)

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-catalog.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-catalog.feature
@@ -23,10 +23,10 @@ Feature: Create Application from Catalog file
 
 
         @smoke
-        Scenario Outline: Deploy Application using Catalog Template "<template_type>": A-01-TC02
+        Scenario Outline: Deploy Application using Catalog Template "<template_category>": A-01-TC02
             Given user is at Developer Catalog page
               And user is at Templates page
-             When user selects "<template_type>" from Templates type
+             When user selects Template category "<template_category>"
               And user searches and selects Template card "<card_name>" from catalog page
               And user clicks Instantiate Template button on side bar
               And user clicks create button on Instantiate Template page
@@ -34,9 +34,9 @@ Feature: Create Application from Catalog file
               And user is able to see workload "<workload_name>" in topology page
 
         Examples:
-                  | template_type | card_name                             | workload_name             |
-                  | CI/CD         | Jenkins                               | jenkins                   |
-                  | Databases     | MariaDB                               | mariadb                   |
-                  | Languages     | Node.js + PostgreSQL (Ephemeral)      | nodejs-postgresql-example |
-                  | Middleware    | Apache HTTP Server                    | httpd-example             |
-                  | Other         | Nginx HTTP server and a reverse proxy | nginx-example             |
+                  | template_category | card_name                             | workload_name             |
+                  | CI/CD             | Jenkins                               | jenkins                   |
+                  | Databases         | MariaDB                               | mariadb                   |
+                  | Languages         | Node.js + PostgreSQL (Ephemeral)      | nodejs-postgresql-example |
+                  | Middleware        | Apache HTTP Server                    | httpd-example             |
+                  | Other             | Nginx HTTP server and a reverse proxy | nginx-example             |

--- a/frontend/packages/dev-console/integration-tests/features/e2e/add-flow-ci.feature
+++ b/frontend/packages/dev-console/integration-tests/features/e2e/add-flow-ci.feature
@@ -16,10 +16,10 @@ Feature: Create the different workloads from Add page
               And user will see "Samples" option
               And user will see Import YAML, Upload JAR file under From Local Machine section
 
-        Scenario Outline: Deploy Application using Catalog Template "<template_type>": A-01-TC02
+        Scenario Outline: Deploy Application using Catalog Template "<template_category>": A-01-TC02
             Given user is at Developer Catalog page
               And user is at Templates page
-             When user selects "<template_type>" from Templates type
+             When user selects Template category "<template_category>"
               And user searches and selects Template card "<card_name>" from catalog page
               And user clicks Instantiate Template button on side bar
               And user clicks create button on Instantiate Template page
@@ -27,12 +27,12 @@ Feature: Create the different workloads from Add page
               And user is able to see workload "<workload_name>" in topology page
 
         Examples:
-                  | template_type | card_name                             | workload_name             |
-                  | CI/CD         | Jenkins                               | jenkins                   |
-                  | Databases     | MariaDB                               | mariadb                   |
-                  | Languages     | Node.js + PostgreSQL (Ephemeral)      | nodejs-postgresql-example |
-                  | Middleware    | Apache HTTP Server                    | httpd-example             |
-                  | Other         | Nginx HTTP server and a reverse proxy | nginx-example             |
+                  | template_category | card_name                             | workload_name             |
+                  | CI/CD             | Jenkins                               | jenkins                   |
+                  | Databases         | MariaDB                               | mariadb                   |
+                  | Languages         | Node.js + PostgreSQL (Ephemeral)      | nodejs-postgresql-example |
+                  | Middleware        | Apache HTTP Server                    | httpd-example             |
+                  | Other             | Nginx HTTP server and a reverse proxy | nginx-example             |
 
         Scenario Outline: Deploy <image> image with Runtime icon from external registry: A-02-TC02
             Given user is at Deploy Image page

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -133,6 +133,13 @@ export const catalogPO = {
     eventSources: '[data-test="tab EventSource"]',
     eventSinks: '[data-test="tab EventSink"]',
   },
+  catalogCategoriesByTitle: {
+    'CI/CD': '[data-test="tab cicd"]',
+    Databases: '[data-test="tab databases"]',
+    Languages: '[data-test="tab languages"]',
+    Middleware: '[data-test="tab middleware"]',
+    Other: '[data-test="tab other"]',
+  },
   cards: {
     mariaDBTemplate: 'a[data-test="Template-MariaDB"] .catalog-tile-pf-title',
     phpCakeTemplate: '[data-test="Template-CakePHP + MySQL"] .catalog-tile-pf-title',

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
@@ -48,7 +48,7 @@ export const catalogPage = {
     cy.get(catalogPO.sidePane.instantiateTemplate).click({ force: true });
   },
   clickOnCancelButton: () => cy.byButtonText('Cancel').click(),
-  selectCatalogType: (type: string | catalogTypes) => {
+  selectCatalogType: (type: catalogTypes) => {
     switch (type) {
       case catalogTypes.OperatorBacked:
       case 'Operator Backed': {
@@ -60,13 +60,11 @@ export const catalogPage = {
         cy.get(catalogPO.catalogTypes.helmCharts).click();
         break;
       }
-      case catalogTypes.BuilderImage:
-      case 'Builder Images': {
+      case catalogTypes.BuilderImage: {
         cy.get(catalogPO.catalogTypes.builderImage).click();
         break;
       }
-      case catalogTypes.Template:
-      case 'Templates': {
+      case catalogTypes.Template: {
         cy.get(catalogPO.catalogTypes.template).click();
         break;
       }
@@ -95,12 +93,17 @@ export const catalogPage = {
       }
     }
   },
-  selectTemplateTypes: (type: string | catalogTypes) => {
-    cy.get(catalogPO.catalogTypeLink)
-      .contains(type)
-      .scrollIntoView()
-      .click();
-    cy.log(`Select ${type} from Types section`);
+  selectTemplateCategory: (templateCategoryTitle: string) => {
+    const selector =
+      catalogPO.catalogCategoriesByTitle[
+        templateCategoryTitle as keyof typeof catalogPO.catalogCategoriesByTitle
+      ];
+    if (!selector) {
+      throw new Error(`Selector not found for Template category "${templateCategoryTitle}"`);
+    }
+    cy.get(selector).scrollIntoView();
+    cy.get(selector).click();
+    cy.log(`Select Template category ${templateCategoryTitle}`);
   },
   selectKnativeServingCard: () =>
     cy

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-catalog.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-catalog.ts
@@ -1,6 +1,6 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
 import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
-import { addOptions, pageTitle } from '../../constants';
+import { addOptions, catalogTypes, pageTitle } from '../../constants';
 import { catalogPO } from '../../pageObjects';
 import { addPage, catalogPage, gitPage } from '../../pages';
 
@@ -13,7 +13,7 @@ When('user searches {string} card from catalog page', (cardName: string) => {
 });
 
 When('user selects {string} option from Type section', (catalogType: string) => {
-  catalogPage.selectCatalogType(catalogType);
+  catalogPage.selectCatalogType(catalogType as catalogTypes);
 });
 
 When('user searches and selects {string} card from catalog page', (cardName: string) => {
@@ -108,9 +108,9 @@ When('user searches and selects {string} helm chart from catalog page', (helmCha
 });
 
 Given('user is at Templates page', () => {
-  catalogPage.selectCatalogType('Templates');
+  catalogPage.selectCatalogType(catalogTypes.Template);
 });
 
-When('user selects {string} from Templates type', (templateType: string) => {
-  catalogPage.selectTemplateTypes(templateType);
+When('user selects Template category {string}', (templateCategoryTitle: string) => {
+  catalogPage.selectTemplateCategory(templateCategoryTitle);
 });

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/common/common.ts
@@ -5,6 +5,7 @@ import {
   switchPerspective,
   addOptions,
   catalogCards,
+  catalogTypes,
 } from '@console/dev-console/integration-tests/support/constants';
 import {
   navigateTo,
@@ -38,7 +39,7 @@ When('user enters Git Repo url as {string}', (gitUrl: string) => {
 });
 
 When('user creates the application with the selected builder image', () => {
-  catalogPage.selectCatalogType('Builder Image');
+  catalogPage.selectCatalogType(catalogTypes.BuilderImage);
   catalogPage.selectCardInCatalog(catalogCards.nodeJs);
   catalogPage.clickButtonOnCatalogPageSidePane();
 });

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-navigation.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-navigation.ts
@@ -4,6 +4,7 @@ import {
   devNavigationMenu,
   addOptions,
   pageTitle,
+  catalogTypes,
 } from '@console/dev-console/integration-tests/support/constants';
 import { catalogPO } from '@console/dev-console/integration-tests/support/pageObjects/add-flow-po';
 import {
@@ -148,7 +149,7 @@ Then('user will see the helm charts listed', () => {
 });
 
 When('user selects {string} option from Type section', (catalogType: string) => {
-  catalogPage.selectCatalogType(catalogType);
+  catalogPage.selectCatalogType(catalogType as catalogTypes);
 });
 
 Then('user can see {string} card on the Add page', (cardName: string) => {

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/create-knative-workload.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/create-knative-workload.ts
@@ -37,7 +37,7 @@ When('user clicks on From Catalog card', () => {
 });
 
 When('create the application with s2i builder image', () => {
-  catalogPage.selectCatalogType('Builder Image');
+  catalogPage.selectCatalogType(catalogTypes.BuilderImage);
   catalogPage.selectCardInCatalog(catalogCards.nodeJs);
   catalogPage.clickButtonOnCatalogPageSidePane();
 });
@@ -61,7 +61,7 @@ When('user searches and selects the {string} card', (cardName: string) => {
 });
 
 When('user creates the application with the selected builder image', () => {
-  catalogPage.selectCatalogType('Builder Image');
+  catalogPage.selectCatalogType(catalogTypes.BuilderImage);
   catalogPage.selectCardInCatalog(catalogCards.nodeJs);
   catalogPage.clickButtonOnCatalogPageSidePane();
 });

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/common.ts
@@ -6,6 +6,7 @@ import {
   devNavigationMenu,
   switchPerspective,
   catalogCards,
+  catalogTypes,
 } from '@console/dev-console/integration-tests/support/constants';
 import {
   topologyPage,
@@ -51,7 +52,7 @@ When('user enters Git Repo URL as {string}', (gitUrl: string) => {
 });
 
 When('user creates the application with the selected builder image', () => {
-  catalogPage.selectCatalogType('Builder Image');
+  catalogPage.selectCatalogType(catalogTypes.BuilderImage);
   catalogPage.selectCardInCatalog(catalogCards.nodeJs);
   catalogPage.clickButtonOnCatalogPageSidePane();
 });


### PR DESCRIPTION
Manual backport of #12019

Just a merge conflict in `frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-navigation.ts` import

4.12 ticket: https://issues.redhat.com/browse/OCPBUGS-270
4.11 ticket: https://issues.redhat.com/browse/OCPBUGS-1523

/kind bug
/cc @rohitkrai03 