### PR TITLE
Bug 2079249: Find latest pipeline run without firehose selector

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesResourceList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesResourceList.tsx
@@ -53,7 +53,10 @@ const PipelinesResourceList: React.FC<PipelinesResourceListProps> = (props) => {
       badge={badge}
     >
       <Firehose resources={resources}>
-        <PipelineAugmentRunsWrapper hideNameLabelFilters={props.hideNameLabelFilters} />
+        <PipelineAugmentRunsWrapper
+          namespace={namespace}
+          hideNameLabelFilters={props.hideNameLabelFilters}
+        />
       </Firehose>
     </FireMan>
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/hooks.ts
@@ -82,7 +82,7 @@ export const useLatestPipelineRun = (pipelineName: string, namespace: string): P
   const [pipelineRun, pipelineRunLoaded, pipelineRunError] = useK8sWatchResource<PipelineRunKind[]>(
     pipelineRunResource,
   );
-  const latestRun = getLatestRun({ data: pipelineRun }, 'creationTimestamp');
+  const latestRun = getLatestRun(pipelineRun, 'creationTimestamp');
   return pipelineRunLoaded && !pipelineRunError ? latestRun : null;
 };
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRuns.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRuns.tsx
@@ -3,17 +3,15 @@ import { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import { RowFilter } from '@console/internal/components/filter-toolbar';
 import { inject } from '@console/internal/components/utils';
-import { K8sKind } from '@console/internal/module/k8s';
-import { augmentRunsToData, PropPipelineData, KeyedRuns } from '../../../utils/pipeline-augment';
+import { FirehoseResult } from '@console/internal/module/k8s';
+import { PipelineRunKind } from '../../../types';
+import { augmentRunsToData, PropPipelineData } from '../../../utils/pipeline-augment';
 import {
   pipelineFilterReducer,
   pipelineStatusFilter,
 } from '../../../utils/pipeline-filter-reducer';
 import { ListFilterId, ListFilterLabels } from '../../../utils/pipeline-utils';
 
-interface ListPipelineData extends K8sKind {
-  data: PropPipelineData[];
-}
 export const filters = (t: TFunction): RowFilter[] => {
   return [
     {
@@ -34,24 +32,21 @@ export const filters = (t: TFunction): RowFilter[] => {
 
 export type PipelineAugmentRunsProps = {
   data?: PropPipelineData[];
-  propsReferenceForRuns?: string[];
-  pipeline?: ListPipelineData;
+  pipeline?: FirehoseResult<PropPipelineData[]>;
+  pipelinerun?: FirehoseResult<PipelineRunKind[]>;
   reduxIDs?: string[];
   applyFilter?: () => void;
   filters?: Record<string, any>[];
 };
 // Firehose injects a lot of props and some of those are considered the KeyedRuns
-const PipelineAugmentRuns: React.FC<PipelineAugmentRunsProps> = ({
-  propsReferenceForRuns,
-  ...props
-}) => {
+const PipelineAugmentRuns: React.FC<PipelineAugmentRunsProps> = ({ ...props }) => {
   const allFilters = {
     ...props.filters,
     ...(_.get(props.pipeline, 'filters.name') && { name: _.get(props.pipeline, 'filters.name') }),
   };
   const resourceData =
-    props.pipeline && props.pipeline.data && propsReferenceForRuns
-      ? augmentRunsToData(props.pipeline.data, propsReferenceForRuns, props as KeyedRuns)
+    props.pipeline?.data && props.pipelinerun?.data
+      ? augmentRunsToData(props.pipeline.data, props.pipelinerun.data)
       : null;
 
   const children = inject(props.children, {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRunsWrapper.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRunsWrapper.tsx
@@ -3,11 +3,13 @@ import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { ListPageWrapper } from '@console/internal/components/factory';
 import { EmptyBox, Firehose, LoadingBox } from '@console/internal/components/utils';
-import { Resource, getResources } from '../../../utils/pipeline-augment';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { PipelineRunModel } from '../../../models';
 import PipelineAugmentRuns, { filters } from './PipelineAugmentRuns';
 import PipelineList from './PipelineList';
 
 interface PipelineAugmentRunsWrapperProps {
+  namespace: string;
   pipeline?: any;
   reduxIDs?: string[];
   hideNameLabelFilters?: boolean;
@@ -24,13 +26,18 @@ const PipelineAugmentRunsWrapper: React.FC<PipelineAugmentRunsWrapperProps> = (p
   if (pipelineData.length === 0) {
     return <EmptyBox label={t('pipelines-plugin~Pipelines')} />;
   }
-  const firehoseResources: Resource = getResources(props.pipeline.data);
   return (
-    <Firehose resources={firehoseResources.resources}>
-      <PipelineAugmentRuns
-        {...props}
-        propsReferenceForRuns={firehoseResources.propsReferenceForRuns}
-      >
+    <Firehose
+      resources={[
+        {
+          kind: referenceForModel(PipelineRunModel),
+          namespace: props.namespace,
+          prop: 'pipelinerun',
+          isList: true,
+        },
+      ]}
+    >
+      <PipelineAugmentRuns {...props}>
         <ListPageWrapper
           {...props}
           flatten={(_resources) => _.get(_resources, ['pipeline', 'data'], {})}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelinesList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelinesList.tsx
@@ -29,7 +29,7 @@ const PipelinesList: React.FC<PipelinesListProps> = ({
   return (
     <div className="co-m-pane__body">
       <Firehose resources={resources}>
-        <PipelineAugmentRunsWrapper />
+        <PipelineAugmentRunsWrapper namespace={namespace} />
       </Firehose>
     </div>
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/__tests__/PipelineAugmentRunsWrapper.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/__tests__/PipelineAugmentRunsWrapper.spec.tsx
@@ -19,6 +19,7 @@ describe('Pipeline Augment Run Wrapper', () => {
         data: [pipeline],
         loaded: false,
       },
+      namespace: 'test',
     };
     wrapper = shallow(<PipelineAugmentRunsWrapper {...pipelineAugmentRunsWrapperProps} />);
   });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/TriggerLastRunButton.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/TriggerLastRunButton.tsx
@@ -24,9 +24,7 @@ const TriggerLastRunButton: React.FC<TriggerLastRunButtonProps> = ({
   impersonate,
 }) => {
   const { t } = useTranslation();
-  const latestRun = usePipelineRunWithUserAnnotation(
-    getLatestRun({ data: pipelineRuns }, 'startTimestamp'),
-  );
+  const latestRun = usePipelineRunWithUserAnnotation(getLatestRun(pipelineRuns, 'startTimestamp'));
   const { labelKey, callback, accessReview: utilityAccessReview } = rerunPipelineAndStay(
     PipelineRunModel,
     latestRun,

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment-test-data.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment-test-data.ts
@@ -1,16 +1,16 @@
-import { PropPipelineData, KeyedRuns } from '../pipeline-augment';
+import { PipelineRunKind } from '../../types';
+import { PropPipelineData } from '../pipeline-augment';
 
 interface PipelineAugmentData {
-  data?: PropPipelineData[];
-  propsReferenceForRuns?: string[];
-  keyedRuns?: KeyedRuns;
+  pipelines?: PropPipelineData[];
+  pipelineruns?: PipelineRunKind[];
 }
 
 export const testData: PipelineAugmentData[] = [
   {},
-  { data: [] },
+  { pipelines: [] },
   {
-    data: [
+    pipelines: [
       {
         metadata: {
           name: 'apple1',
@@ -18,26 +18,25 @@ export const testData: PipelineAugmentData[] = [
         },
       },
     ],
-    propsReferenceForRuns: ['apple1Runs'],
-    keyedRuns: {
-      apple1Runs: {
-        data: [
-          {
-            apiVersion: 'abhiapi/v1',
-            kind: 'PipelineRun',
-            metadata: { name: 'apple-1-run1', creationTimestamp: '21-05-2019' },
-            spec: {},
-            status: {
-              pipelineSpec: { tasks: [] },
-              conditions: [{ type: 'Succeeded', status: 'True' }],
-            },
-          },
-        ],
+    pipelineruns: [
+      {
+        apiVersion: 'abhiapi/v1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'apple-1-run1',
+          creationTimestamp: '21-05-2019',
+          labels: { 'tekton.dev/pipeline': 'apple1' },
+        },
+        spec: {},
+        status: {
+          pipelineSpec: { tasks: [] },
+          conditions: [{ type: 'Succeeded', status: 'True' }],
+        },
       },
-    },
+    ],
   },
   {
-    data: [
+    pipelines: [
       {
         metadata: {
           name: 'apple1',
@@ -51,52 +50,49 @@ export const testData: PipelineAugmentData[] = [
         },
       },
     ],
-    propsReferenceForRuns: ['apple1Runs', 'apple2Runs'],
-    keyedRuns: {
-      apple1Runs: {
-        data: [
-          {
-            apiVersion: 'tekton.dev/v1alpha1',
-            kind: 'Pipeline',
-            metadata: {
-              creationTimestamp: '2019-05-30T10:33:14Z',
-              generation: 1,
-              name: 'simple-pipeline-run-1',
-              namespace: 'tekton-pipelines',
-              resourceVersion: '345586',
-              uid: '7f06aeb0-838f-11e9-8282-525400bab8f1',
-            },
-            spec: {},
-          },
-          {
-            apiVersion: 'tekton.dev/v1alpha1',
-            kind: 'Pipeline',
-            metadata: {
-              creationTimestamp: '2019-05-31T10:33:14Z',
-              generation: 1,
-              name: 'voting-deploy-pipeline',
-              namespace: 'tekton-pipelines',
-              resourceVersion: '345587',
-              uid: '7f07d2c1-838f-11e9-8282-525400bab8f1',
-            },
-            spec: {},
-          },
-        ],
+    pipelineruns: [
+      {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          creationTimestamp: '2019-05-30T10:33:14Z',
+          generation: 1,
+          name: 'simple-pipeline-run-1',
+          namespace: 'tekton-pipelines',
+          resourceVersion: '345586',
+          uid: '7f06aeb0-838f-11e9-8282-525400bab8f1',
+          labels: { 'tekton.dev/pipeline': 'apple2' },
+        },
+        spec: {},
       },
-      apple2Runs: {
-        data: [
-          {
-            apiVersion: 'abhiapi/v1',
-            kind: 'PipelineRun',
-            metadata: { name: 'apple-2-run1', creationTimestamp: '31-04-2019' },
-            spec: {},
-            status: {
-              pipelineSpec: { tasks: [] },
-              conditions: [{ type: 'Succeeded', status: 'True' }],
-            },
-          },
-        ],
+      {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          creationTimestamp: '2019-05-31T10:33:14Z',
+          generation: 1,
+          name: 'voting-deploy-pipeline',
+          namespace: 'tekton-pipelines',
+          resourceVersion: '345587',
+          uid: '7f07d2c1-838f-11e9-8282-525400bab8f1',
+          labels: { 'tekton.dev/pipeline': 'apple1' },
+        },
+        spec: {},
       },
-    },
+      {
+        apiVersion: 'abhiapi/v1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'apple-2-run1',
+          creationTimestamp: '31-04-2019',
+          labels: { 'tekton.dev/pipeline': 'apple2' },
+        },
+        spec: {},
+        status: {
+          pipelineSpec: { tasks: [] },
+          conditions: [{ type: 'Succeeded', status: 'True' }],
+        },
+      },
+    ],
   },
 ];

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
@@ -1,8 +1,7 @@
 import * as _ from 'lodash';
-import { referenceForModel, apiVersionForModel } from '@console/internal/module/k8s';
+import { apiVersionForModel } from '@console/internal/module/k8s';
 import {
   ClusterTaskModel,
-  PipelineRunModel,
   TaskModel,
   PipelineModel,
   ClusterTriggerBindingModel,
@@ -11,7 +10,6 @@ import {
 import { pipelineTestData, DataState, PipelineExampleNames } from '../../test-data/pipeline-data';
 import { ComputedStatus, PipelineKind } from '../../types';
 import {
-  getResources,
   augmentRunsToData,
   getTaskStatus,
   TaskStatus,
@@ -27,64 +25,18 @@ import {
 } from '../pipeline-augment';
 import { testData } from './pipeline-augment-test-data';
 
-describe('PipelineAugment test getResources create correct resources for firehose', () => {
-  it('expect resources to be null for no data', () => {
-    const resources = getResources(testData[0].data);
-    expect(resources.resources).toBe(null);
-    expect(resources.propsReferenceForRuns).toBe(null);
-  });
-
-  it('expect resources to be null for empty data array', () => {
-    const resources = getResources(testData[1].data);
-    expect(resources.resources).toBe(null);
-    expect(resources.propsReferenceForRuns).toBe(null);
-  });
-
-  it('expect resources to be of length 1 and have the following properties & childprops', () => {
-    const resources = getResources(testData[2].data);
-    expect(resources.resources.length).toBe(1);
-    expect(resources.resources[0].kind).toBe(referenceForModel(PipelineRunModel));
-    expect(resources.resources[0].namespace).toBe(testData[2].data[0].metadata.namespace);
-    expect(resources.propsReferenceForRuns.length).toBe(1);
-  });
-
-  it('expect resources to be of length 2 and have the following properties & childprops', () => {
-    const resources = getResources(testData[3].data);
-    expect(resources.resources.length).toBe(2);
-    expect(resources.resources[0].kind).toBe(referenceForModel(PipelineRunModel));
-    expect(resources.resources[1].kind).toBe(referenceForModel(PipelineRunModel));
-    expect(resources.resources[0].namespace).toBe(testData[3].data[0].metadata.namespace);
-    expect(resources.resources[0].namespace).toBe(testData[3].data[1].metadata.namespace);
-    expect(resources.propsReferenceForRuns.length).toBe(2);
-  });
-});
-
 describe('PipelineAugment test correct data is augmented', () => {
   it('expect additional resources to be correctly added using augmentRunsToData', () => {
-    const newData = augmentRunsToData(
-      testData[2].data,
-      testData[2].propsReferenceForRuns,
-      testData[2].keyedRuns,
-    );
+    const newData = augmentRunsToData(testData[2].pipelines, testData[2].pipelineruns);
     expect(newData.length).toBe(1);
-    expect(newData[0].latestRun.metadata.name).toBe(
-      testData[2].keyedRuns.apple1Runs.data[0].metadata.name,
-    );
+    expect(newData[0].latestRun.metadata.name).toBe(testData[2].pipelineruns[0].metadata.name);
   });
 
   it('expect additional resources to be added using latest run', () => {
-    const newData = augmentRunsToData(
-      testData[3].data,
-      testData[3].propsReferenceForRuns,
-      testData[3].keyedRuns,
-    );
+    const newData = augmentRunsToData(testData[3].pipelines, testData[3].pipelineruns);
     expect(newData.length).toBe(2);
-    expect(newData[0].latestRun.metadata.name).toBe(
-      testData[3].keyedRuns.apple1Runs.data[1].metadata.name,
-    );
-    expect(newData[1].latestRun.metadata.name).toBe(
-      testData[3].keyedRuns.apple2Runs.data[0].metadata.name,
-    );
+    expect(newData[0].latestRun.metadata.name).toBe(testData[3].pipelineruns[1].metadata.name);
+    expect(newData[1].latestRun.metadata.name).toBe(testData[3].pipelineruns[0].metadata.name);
   });
 });
 

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
@@ -15,7 +15,6 @@ import { TektonResourceLabel } from '../components/pipelines/const';
 import {
   ClusterTaskModel,
   ClusterTriggerBindingModel,
-  PipelineRunModel,
   TaskModel,
   TriggerBindingModel,
   PipelineModel,
@@ -48,74 +47,33 @@ export interface TaskStatus {
   Skipped: number;
 }
 
-export interface Resource {
-  propsReferenceForRuns: string[];
-  resources: FirehoseResource[];
-}
-
-export interface Runs {
-  data?: PipelineRunKind[];
-}
-
-export type KeyedRuns = { [key: string]: Runs };
-
-interface FirehoseResource {
-  kind: string;
-  namespace?: string;
-  isList?: boolean;
-  selector?: object;
-}
-
-export const getResources = (data: PropPipelineData[]): Resource => {
-  const resources = [];
-  const propsReferenceForRuns = [];
-  if (data && data.length > 0) {
-    data.forEach((pipeline, i) => {
-      if (pipeline.metadata && pipeline.metadata.namespace && pipeline.metadata.name) {
-        propsReferenceForRuns.push(`PipelineRun_${i}`);
-        resources.push({
-          kind: referenceForModel(PipelineRunModel),
-          namespace: pipeline.metadata.namespace,
-          isList: true,
-          prop: `PipelineRun_${i}`,
-          selector: {
-            'tekton.dev/pipeline': pipeline.metadata.name,
-          },
-        });
-      }
-    });
-    return { propsReferenceForRuns, resources };
-  }
-  return { propsReferenceForRuns: null, resources: null };
-};
-
-export const getLatestRun = (runs: Runs, field: string): PipelineRunKind => {
-  if (!runs || !runs.data || !(runs.data.length > 0) || !field) {
+export const getLatestRun = (runs: PipelineRunKind[], field: string): PipelineRunKind => {
+  if (!runs || !(runs.length > 0) || !field) {
     return null;
   }
-  let latestRun = runs.data[0];
+  let latestRun = runs[0];
   if (field === 'creationTimestamp') {
-    for (let i = 1; i < runs.data.length; i++) {
+    for (let i = 1; i < runs.length; i++) {
       latestRun =
-        runs.data[i] &&
-        runs.data[i].metadata &&
-        runs.data[i].metadata[field] &&
-        new Date(runs.data[i].metadata[field]) > new Date(latestRun.metadata[field])
-          ? runs.data[i]
+        runs[i] &&
+        runs[i].metadata &&
+        runs[i].metadata[field] &&
+        new Date(runs[i].metadata[field]) > new Date(latestRun.metadata[field])
+          ? runs[i]
           : latestRun;
     }
   } else if (field === 'startTime' || field === 'completionTime') {
-    for (let i = 1; i < runs.data.length; i++) {
+    for (let i = 1; i < runs.length; i++) {
       latestRun =
-        runs.data[i] &&
-        runs.data[i].status &&
-        runs.data[i].status[field] &&
-        new Date(runs.data[i].status[field]) > new Date(latestRun.status[field])
-          ? runs.data[i]
+        runs[i] &&
+        runs[i].status &&
+        runs[i].status[field] &&
+        new Date(runs[i].status[field]) > new Date(latestRun.status[field])
+          ? runs[i]
           : latestRun;
     }
   } else {
-    latestRun = runs.data[runs.data.length - 1];
+    latestRun = runs[runs.length - 1];
   }
   if (!latestRun.status) {
     latestRun = { ...latestRun, status: { pipelineSpec: { tasks: [] } } };
@@ -128,24 +86,16 @@ export const getLatestRun = (runs: Runs, field: string): PipelineRunKind => {
 };
 
 export const augmentRunsToData = (
-  data: PropPipelineData[],
-  propsReferenceForRuns: string[],
-  runs: { [key: string]: Runs },
+  pipelines: PropPipelineData[],
+  pipelineruns: PipelineRunKind[],
 ): PropPipelineData[] => {
-  if (propsReferenceForRuns) {
-    const newData: PropPipelineData[] = [];
-    propsReferenceForRuns.forEach((reference, i) => {
-      const latestRun = getLatestRun(runs[reference], 'creationTimestamp');
-      if (latestRun !== data[i].latestRun) {
-        // ensure we create a new data object if the latestRun has changed so that shallow compare fails
-        newData.push({ ...data[i], latestRun });
-      } else {
-        newData.push(data[i]);
-      }
-    });
-    return newData;
-  }
-  return data;
+  return pipelines.map((pipeline) => {
+    const prsForPipeline = pipelineruns.filter(
+      (pr) => pr.metadata.labels?.['tekton.dev/pipeline'] === pipeline.metadata.name,
+    );
+    pipeline.latestRun = getLatestRun(prsForPipeline, 'creationTimestamp');
+    return pipeline;
+  });
 };
 
 export const getRunStatusColor = (status: string): StatusMessage => {

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
@@ -276,7 +276,7 @@ export const getLatestPipelineRunStatus = (
     return { latestPipelineRun: null, status: ComputedStatus.PipelineNotStarted };
   }
 
-  const latestPipelineRun = getLatestRun({ data: pipelineRuns }, 'creationTimestamp');
+  const latestPipelineRun = getLatestRun(pipelineRuns, 'creationTimestamp');
 
   if (!latestPipelineRun) {
     // Without the latestRun we will not have progress to show


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-43696
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Firehose selectors were used to find all pipeline runs for every pipeline, this resulted in many websocket calls when there were a lot of pipelines.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Fetch all pipeline runs in a single websocket call and find latest run on the clientside.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
(No UI changes)
Before:
![before](https://user-images.githubusercontent.com/20013884/191308724-fd05169a-afa3-4029-ae17-800548a09b63.png)

https://user-images.githubusercontent.com/20013884/191742292-e827eb17-2584-4293-ad13-3a2c6a8e72da.mp4

After:
![after](https://user-images.githubusercontent.com/20013884/191308747-71dcd61f-8ec0-4917-ba8e-37e33a89ff2c.png)

https://user-images.githubusercontent.com/20013884/191742331-17b45806-20de-4c71-aac7-a49d12ad78fa.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
