### PR TITLE
CONSOLE-3190: update OperatorHub filter to use nodeArchitectures instead of GOARCH

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -141,6 +141,7 @@ func main() {
 	fManagedClusterConfigs := fs.String("managed-clusters", "", "List of managed cluster configurations. (JSON as string)")
 	fControlPlaneTopology := fs.String("control-plane-topology-mode", "", "Defines the topology mode of the control/infra nodes (External | HighlyAvailable | SingleReplica)")
 	fReleaseVersion := fs.String("release-version", "", "Defines the release version of the cluster")
+	fNodeArchitectures := fs.String("node-architectures", "", "List of node architectures. Example --node-architecture=amd64,arm64")
 
 	if err := serverconfig.Parse(fs, os.Args[1:], "BRIDGE"); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -234,12 +235,25 @@ func main() {
 		}
 	}
 
-	i18nNamespaces := strings.Split(*fI18NamespacesFlags, ",")
+	i18nNamespaces := []string{}
 	if *fI18NamespacesFlags != "" {
-		for _, str := range i18nNamespaces {
+		for _, str := range strings.Split(*fI18NamespacesFlags, ",") {
+			str = strings.TrimSpace(str)
 			if str == "" {
 				bridge.FlagFatalf("i18n-namespaces", "list must contain name of i18n namespaces separated by comma")
 			}
+			i18nNamespaces = append(i18nNamespaces, str)
+		}
+	}
+
+	nodeArchitectures := []string{}
+	if *fNodeArchitectures != "" {
+		for _, str := range strings.Split(*fNodeArchitectures, ",") {
+			str = strings.TrimSpace(str)
+			if str == "" {
+				bridge.FlagFatalf("node-architectures", "list must contain name of node architectures separated by comma")
+			}
+			nodeArchitectures = append(nodeArchitectures, str)
 		}
 	}
 
@@ -274,6 +288,7 @@ func main() {
 		K8sClients:                   make(map[string]*http.Client),
 		Telemetry:                    telemetryFlags,
 		ReleaseVersion:               *fReleaseVersion,
+		NodeArchitectures:            nodeArchitectures,
 	}
 
 	managedClusterConfigs := []serverconfig.ManagedClusterConfig{}

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -54,6 +54,7 @@ declare interface Window {
     clusters: string[];
     controlPlaneTopology: string;
     telemetry: Record<string, string>;
+    nodeArchitectures: string[];
   };
   windowError?: string;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -40,14 +40,15 @@ import {
 const osBaseLabel = 'operatorframework.io/os.';
 const targetGOOSLabel = window.SERVER_FLAGS.GOOS ? `${osBaseLabel}${window.SERVER_FLAGS.GOOS}` : '';
 const archBaseLabel = 'operatorframework.io/arch.';
-const targetGOARCHLabel = window.SERVER_FLAGS.GOARCH
-  ? `${archBaseLabel}${window.SERVER_FLAGS.GOARCH}`
-  : '';
+const targetNodeArchitectures = window.SERVER_FLAGS.nodeArchitectures ?? [];
+const targetNodeArchitecturesLabels = targetNodeArchitectures.map(
+  (arch) => `${archBaseLabel}${arch}`,
+);
 // if no label present, these are the assumed defaults
 const archDefaultAMD64Label = 'operatorframework.io/arch.amd64';
 const osDefaultLinuxLabel = 'operatorframework.io/os.linux';
 const filterByArchAndOS = (items: OperatorHubItem[]): OperatorHubItem[] => {
-  if (!window.SERVER_FLAGS.GOARCH || !window.SERVER_FLAGS.GOOS) {
+  if (_.isEmpty(targetNodeArchitectures) || !window.SERVER_FLAGS.GOOS) {
     return items;
   }
   return items.filter((item: OperatorHubItem) => {
@@ -80,7 +81,7 @@ const filterByArchAndOS = (items: OperatorHubItem[]): OperatorHubItem[] => {
 
     return (
       _.includes(relevantLabels.os, targetGOOSLabel) &&
-      _.includes(relevantLabels.arch, targetGOARCHLabel)
+      _.some(relevantLabels.arch, (arch) => _.includes(targetNodeArchitecturesLabels, arch))
     );
   });
 };

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -114,6 +114,7 @@ type jsGlobals struct {
 	ControlPlaneTopology            string                     `json:"controlPlaneTopology"`
 	Telemetry                       serverconfig.MultiKeyValue `json:"telemetry"`
 	ReleaseVersion                  string                     `json:"releaseVersion"`
+	NodeArchitectures               []string                   `json:"nodeArchitectures"`
 }
 
 type Server struct {
@@ -137,6 +138,7 @@ type Server struct {
 	LoadTestFactor       int
 	InactivityTimeout    int
 	ReleaseVersion       string
+	NodeArchitectures    []string
 	// Map that contains list of enabled plugins and their endpoints.
 	EnabledConsolePlugins serverconfig.MultiKeyValue
 	I18nNamespaces        []string
@@ -732,6 +734,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		Clusters:                   clusters,
 		Telemetry:                  s.Telemetry,
 		ReleaseVersion:             s.ReleaseVersion,
+		NodeArchitectures:          s.NodeArchitectures,
 	}
 
 	localAuther := s.getLocalAuther()

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -213,6 +213,10 @@ func addClusterInfo(fs *flag.FlagSet, clusterInfo *ClusterInfo) {
 	if clusterInfo.ReleaseVersion != "" {
 		fs.Set("release-version", string(clusterInfo.ReleaseVersion))
 	}
+
+	if len(clusterInfo.NodeArchitectures) > 0 {
+		fs.Set("node-architectures", strings.Join(clusterInfo.NodeArchitectures, ","))
+	}
 }
 
 func addAuth(fs *flag.FlagSet, auth *Auth) {

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -73,6 +73,7 @@ type ClusterInfo struct {
 	MasterPublicURL      string                `yaml:"masterPublicURL,omitempty"`
 	ControlPlaneTopology configv1.TopologyMode `yaml:"controlPlaneTopology,omitempty"`
 	ReleaseVersion       string                `yaml:"releaseVersion,omitempty"`
+	NodeArchitectures    []string              `yaml:"nodeArchitectures,omitempty"`
 }
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".


### PR DESCRIPTION
Thanks to @jhadvig for the server changes.

Note testing should be done using a Cluster Bot cluster with the changes in this PR as the filter does not apply when running console in development mode.

<img width="1709" alt="Screen Shot 2022-09-21 at 11 11 12 AM" src="https://user-images.githubusercontent.com/895728/191542208-b2740491-3308-4de0-96c8-bf23f7ce5935.png">
The total count of available operators is `390 items` and `window.SERVER_FLAGS.nodeArchitectures` is `['amd64']`.
