### PR TITLE
CONSOLE-3336: Make dynamic plugin dependencies optional

### DIFF
--- a/dynamic-demo-plugin/package.json
+++ b/dynamic-demo-plugin/package.json
@@ -70,9 +70,6 @@
       "projectOverview": "./utils/project-overview",
       "modalPage": "./components/Modals/ModalPage"
     },
-    "dependencies": {
-      "@console/pluginAPI": "*"
-    },
     "disableStaticPlugins": [
       "@console/demo-plugin"
     ]

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -75,7 +75,7 @@ Plugin metadata is declared via the `consolePlugin` object.
       "barUtils": "./utils/bar"
     },
     "dependencies": {
-      "@console/pluginAPI": "*"
+      "@console/pluginAPI": "~4.11.0"
     }
   }
 }
@@ -93,9 +93,12 @@ at runtime. A separate [webpack chunk](https://webpack.js.org/guides/code-splitt
 each entry in `consolePlugin.exposedModules` object. Exposed modules are resolved relative to plugin's
 webpack `context` option.
 
-The `@console/pluginAPI` dependency is mandatory and refers to Console versions this dynamic plugin is
+The `@console/pluginAPI` dependency is optional and refers to Console versions this dynamic plugin is
 compatible with. The `consolePlugin.dependencies` object may also refer to other dynamic plugins that
-are required for this dynamic plugin to work correctly.
+are required for this dynamic plugin to work correctly. For dependencies whose versions may include
+a [semver pre-release](https://semver.org/#spec-item-9) identifier, adapt your semver range constraint
+to include the relevant pre-release prefix, e.g. use `~4.11.0-0.ci` when targeting pre-release versions
+like `4.11.0-0.ci-1234`.
 
 See `ConsolePluginMetadata` type for details on the `consolePlugin` object and its schema.
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-dependencies.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-dependencies.spec.ts
@@ -78,7 +78,6 @@ describe('resolvePluginDependencies', () => {
 
   it('completes if there are no required plugins', async () => {
     const manifest = getPluginManifest('Test', '1.2.3');
-    manifest.dependencies = { '@console/pluginAPI': '*' };
 
     await resolvePluginDependencies(manifest, '4.11.1-test.2', ['Test', 'Foo', 'Bar']);
 
@@ -88,7 +87,7 @@ describe('resolvePluginDependencies', () => {
 
   it('throws an error if some of the required plugins are not available', async () => {
     const manifest = getPluginManifest('Test', '1.2.3');
-    manifest.dependencies = { '@console/pluginAPI': '*', Foo: '*', Bar: '*' };
+    manifest.dependencies = { Foo: '*', Bar: '*' };
 
     try {
       await resolvePluginDependencies(manifest, '4.11.1-test.2', ['Test']);
@@ -103,7 +102,7 @@ describe('resolvePluginDependencies', () => {
 
   it('subscribes to changes in dynamic plugin information', async () => {
     const manifest = getPluginManifest('Test', '1.2.3');
-    manifest.dependencies = { '@console/pluginAPI': '*', Foo: '*', Bar: '*' };
+    manifest.dependencies = { Foo: '*', Bar: '*' };
 
     subscribeToDynamicPlugins.mockImplementation((listener: DynamicPluginListener) => {
       listener([
@@ -137,7 +136,7 @@ describe('resolvePluginDependencies', () => {
 
   it('completes when all required plugins are loaded successfully', async () => {
     const manifest = getPluginManifest('Test', '1.2.3');
-    manifest.dependencies = { '@console/pluginAPI': '*', Foo: '*', Bar: '*' };
+    manifest.dependencies = { Foo: '*', Bar: '*' };
 
     subscribeToDynamicPlugins.mockImplementation((listener: DynamicPluginListener) => {
       listener([
@@ -154,7 +153,7 @@ describe('resolvePluginDependencies', () => {
 
   it('throws an error if some of the required plugins fail to load successfully', async () => {
     const manifest = getPluginManifest('Test', '1.2.3');
-    manifest.dependencies = { '@console/pluginAPI': '*', Foo: '*', Bar: '*', Baz: '*' };
+    manifest.dependencies = { Foo: '*', Bar: '*', Baz: '*' };
 
     subscribeToDynamicPlugins.mockImplementation((listener: DynamicPluginListener) => {
       listener([
@@ -178,7 +177,6 @@ describe('resolvePluginDependencies', () => {
   it('throws an error if some of the required plugin dependencies are not met', async () => {
     const manifest = getPluginManifest('Test', '1.2.3');
     manifest.dependencies = {
-      '@console/pluginAPI': '*',
       Foo: '^1.0.0',
       Bar: '~1.1.1',
       Baz: '=1.1.1',

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-dependencies.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-dependencies.ts
@@ -37,8 +37,8 @@ export const resolvePluginDependencies = (
   consolePluginAPIVersion: string,
   allowedPluginNames: string[],
 ) => {
-  const { dependencies } = manifest;
   const pluginID = getPluginID(manifest);
+  const dependencies = manifest.dependencies || {};
 
   if (unsubListenerMap.has(pluginID)) {
     throw new Error(`Dependency resolution for plugin ${pluginID} is already in progress`);
@@ -56,6 +56,7 @@ export const resolvePluginDependencies = (
 
   if (
     consolePluginAPIVersion &&
+    dependencies[pluginAPIDepName] &&
     !semver.satisfies(consolePluginAPIVersion, dependencies[pluginAPIDepName], semverOptions)
   ) {
     throw new UnmetPluginDependenciesError('Unmet dependency on Console plugin API', [

--- a/frontend/packages/console-dynamic-plugin-sdk/src/schema/plugin-package.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/schema/plugin-package.ts
@@ -18,13 +18,16 @@ export type ConsolePluginMetadata = {
   /** Specific modules exposed through the plugin's remote entry. */
   exposedModules?: { [moduleName: string]: string };
   /**
-   * Plugin API and other plugins required for this plugin to work.
+   * Additional dependencies required for this plugin to work.
    * Values must be valid semver ranges or `*` representing any version.
+   *
+   * Console plugins may depend on other Console plugins or on Console
+   * application itself, represented as `@console/pluginAPI` dependency.
+   *
+   * If present, `@console/pluginAPI` version range is matched against
+   * the Console release version, as provided by the Console operator.
    */
-  dependencies: {
-    '@console/pluginAPI': string;
-    [pluginName: string]: string;
-  };
+  dependencies?: { [pluginName: string]: string };
   /** Disable the given static plugins when this plugin gets loaded. */
   disableStaticPlugins?: string[];
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/test-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/test-utils.ts
@@ -12,7 +12,6 @@ export const getPluginManifest = (
   name,
   version,
   extensions: extensions as ConsoleExtensionsJSON,
-  dependencies: { '@console/pluginAPI': '*' },
   disableStaticPlugins,
 });
 


### PR DESCRIPTION
Fixes [CONSOLE-3336](https://issues.redhat.com/browse/CONSOLE-3336)

- Plugin metadata field `dependencies` is now optional.
- Plugin dependency `@console/pluginAPI` is now optional. If missing, the Console version check is skipped.
- Existing plugins with `@console/pluginAPI` dependency (regardless of version range used) are not affected.
- Removed `@console/pluginAPI` dependency from dynamic demo plugin.
- Updated README to account for semver pre-release specifics when declaring plugin dependencies.