### PR TITLE
Bug 2030406: Remove nav override for fixed demo plugin nav component dom structure

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -308,7 +308,6 @@ ul {
 }
 // And here we explicitly remove it from PF components so it doesn't show.
 ul.pf-c-alert-group,
-.pf-c-nav__item,
 ul.pf-c-nav__list,
 ul.pf-c-options-menu__menu,
 ul.pf-c-select__menu,


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2030406

The issue in the bug referenced has been fixed, but the override still existed in the _overrides.scss file. Removed the unnecessary nav override.