### PR TITLE
Bug 2100334: separate fetching of serving and eventing as they can be enabled independently

### DIFF
--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -780,11 +780,22 @@
     "type": "console.topology/component/factory",
     "properties": {
       "getFactory": {
-        "$codeRef": "topology.getKnativeComponentFactory"
+        "$codeRef": "topology.getKnativeServingComponentFactory"
       }
     },
     "flags": {
-      "required": ["KNATIVE_SERVING", "KNATIVE_SERVING_SERVICE", "KNATIVE_EVENTING"]
+      "required": ["KNATIVE_SERVING", "KNATIVE_SERVING_SERVICE"]
+    }
+  },
+  {
+    "type": "console.topology/component/factory",
+    "properties": {
+      "getFactory": {
+        "$codeRef": "topology.getKnativeEventingComponentFactory"
+      }
+    },
+    "flags": {
+      "required": ["KNATIVE_EVENTING"]
     }
   },
   {

--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
@@ -68,7 +68,7 @@ const dragOperationKafka: EditableDragOperationType = {
   edit: true,
 };
 
-export const getKnativeComponentFactory = (
+export const getKnativeServingComponentFactory = (
   kind,
   type,
 ): React.ComponentType<{ element: GraphElement }> | undefined => {
@@ -91,6 +91,24 @@ export const getKnativeComponentFactory = (
           ),
         ),
       );
+    case TYPE_KNATIVE_REVISION:
+      return withDragNode(nodeDragSourceSpec(type, false))(
+        withSelection({ controlled: true })(
+          withContextMenu(contextMenuActions)(withNoDrop()(RevisionNode)),
+        ),
+      );
+    case TYPE_REVISION_TRAFFIC:
+      return TrafficLink;
+    default:
+      return undefined;
+  }
+};
+
+export const getKnativeEventingComponentFactory = (
+  kind,
+  type,
+): React.ComponentType<{ element: GraphElement }> | undefined => {
+  switch (type) {
     case TYPE_EVENT_SOURCE:
       return withEditReviewAccess('patch')(
         withDragNode(nodeDragSourceSpec(type))(
@@ -131,14 +149,6 @@ export const getKnativeComponentFactory = (
           ),
         ),
       );
-    case TYPE_KNATIVE_REVISION:
-      return withDragNode(nodeDragSourceSpec(type, false))(
-        withSelection({ controlled: true })(
-          withContextMenu(contextMenuActions)(withNoDrop()(RevisionNode)),
-        ),
-      );
-    case TYPE_REVISION_TRAFFIC:
-      return TrafficLink;
     case TYPE_EVENT_SOURCE_LINK:
       return withTargetDrag(eventSourceLinkDragSourceSpec())(EventSourceLink);
     case TYPE_EVENT_SINK_LINK:

--- a/frontend/packages/knative-plugin/src/topology/data-transformer.ts
+++ b/frontend/packages/knative-plugin/src/topology/data-transformer.ts
@@ -65,36 +65,17 @@ export const getKafkaSinkKnativeTopologyData = (
   return Promise.resolve(knativeTopologyGraphModel);
 };
 
-export const getKnativeTopologyDataModel = (
+export const getKnativeServingTopologyDataModel = (
   namespace: string,
   resources: TopologyDataResources,
 ): Promise<Model> => {
-  const eventSourceProps = getDynamicEventSourcesModelRefs();
-  const channelResourceProps = getDynamicChannelModelRefs();
-  const knativeTopologyGraphModel: Model = { nodes: [], edges: [] };
+  const knativeServingTopologyGraphModel: Model = { nodes: [], edges: [] };
   const knSvcResources: K8sResourceKind[] = resources?.ksservices?.data ?? [];
-  const allKnEventSources: K8sResourceKind[] = getKnativeDynamicResources(
-    resources,
-    eventSourceProps,
-  );
-  const knEventSourcesKafka: K8sResourceKind[] = allKnEventSources.filter(
-    (knEventSource) => knEventSource.kind === EVENT_SOURCE_KAFKA_KIND,
-  );
-  const knEventSources: K8sResourceKind[] = allKnEventSources.filter(
-    (knEventSource) => knEventSource.kind !== EVENT_SOURCE_KAFKA_KIND,
-  );
   const knRevResources: K8sResourceKind[] = resources?.revisions?.data ?? [];
-  const knChannelResources: K8sResourceKind[] = getKnativeDynamicResources(
-    resources,
-    channelResourceProps,
-  );
-  const knBrokerResources: K8sResourceKind[] = resources?.brokers?.data ?? [];
-  const { camelSinkKameletBindings, camelSourceKameletBindings } = getKameletSinkAndSourceBindings(
-    resources,
-  );
+  const { camelSinkKameletBindings } = getKameletSinkAndSourceBindings(resources);
   const addTopologyData = (KnResources: K8sResourceKind[], type?: string) => {
     addKnativeTopologyData(
-      knativeTopologyGraphModel,
+      knativeServingTopologyGraphModel,
       KnResources,
       type,
       resources,
@@ -103,26 +84,21 @@ export const getKnativeTopologyDataModel = (
   };
 
   addTopologyData(knSvcResources, NodeType.KnService);
-  addTopologyData(knEventSources, NodeType.EventSource);
-  addTopologyData(knEventSourcesKafka, NodeType.EventSourceKafka);
-  addTopologyData(knChannelResources, NodeType.PubSub);
-  addTopologyData(knBrokerResources, NodeType.PubSub);
-  addTopologyData(camelSourceKameletBindings, NodeType.EventSource);
-  addTopologyData(camelSinkKameletBindings, NodeType.EventSink);
 
   const revisionData = getRevisionsData(knRevResources, resources, getKnativeTopologyDataUtils());
 
-  knativeTopologyGraphModel.nodes.forEach((n) => {
+  knativeServingTopologyGraphModel.nodes.forEach((n) => {
     if (n.type === NodeType.KnService) {
       n.data.groupResources =
-        n.children?.map((id) => knativeTopologyGraphModel.nodes.find((c) => id === c.id)) ?? [];
+        n.children?.map((id) => knativeServingTopologyGraphModel.nodes.find((c) => id === c.id)) ??
+        [];
     }
     if (n.type === NodeType.Revision) {
       n.data = revisionData[n.id];
     }
   });
   // filter out knative services/revision that belong to a integration type created by kamelet sinks
-  const knativeGraphNodes = knativeTopologyGraphModel.nodes.filter((n: OdcNodeModel) => {
+  const knativeGraphNodes = knativeServingTopologyGraphModel.nodes.filter((n: OdcNodeModel) => {
     if (n.type === NodeType.KnService) {
       if (
         camelSinkKameletBindings.findIndex((binding) =>
@@ -150,7 +126,64 @@ export const getKnativeTopologyDataModel = (
     return true;
   });
 
-  knativeTopologyGraphModel.nodes = knativeGraphNodes;
+  knativeServingTopologyGraphModel.nodes = knativeGraphNodes;
 
-  return Promise.resolve(knativeTopologyGraphModel);
+  return Promise.resolve(knativeServingTopologyGraphModel);
+};
+
+export const getKnativeEventingTopologyDataModel = (
+  namespace: string,
+  resources: TopologyDataResources,
+): Promise<Model> => {
+  const eventSourceProps = getDynamicEventSourcesModelRefs();
+  const channelResourceProps = getDynamicChannelModelRefs();
+  const knativeEventingTopologyGraphModel: Model = { nodes: [], edges: [] };
+  const allKnEventSources: K8sResourceKind[] = getKnativeDynamicResources(
+    resources,
+    eventSourceProps,
+  );
+  const knEventSourcesKafka: K8sResourceKind[] = allKnEventSources.filter(
+    (knEventSource) => knEventSource.kind === EVENT_SOURCE_KAFKA_KIND,
+  );
+  const knEventSources: K8sResourceKind[] = allKnEventSources.filter(
+    (knEventSource) => knEventSource.kind !== EVENT_SOURCE_KAFKA_KIND,
+  );
+  const knChannelResources: K8sResourceKind[] = getKnativeDynamicResources(
+    resources,
+    channelResourceProps,
+  );
+  const knBrokerResources: K8sResourceKind[] = resources?.brokers?.data ?? [];
+  const addTopologyData = (KnResources: K8sResourceKind[], type?: string) => {
+    addKnativeTopologyData(
+      knativeEventingTopologyGraphModel,
+      KnResources,
+      type,
+      resources,
+      getKnativeTopologyDataUtils(),
+    );
+  };
+
+  addTopologyData(knEventSources, NodeType.EventSource);
+  addTopologyData(knEventSourcesKafka, NodeType.EventSourceKafka);
+  addTopologyData(knChannelResources, NodeType.PubSub);
+  addTopologyData(knBrokerResources, NodeType.PubSub);
+  return Promise.resolve(knativeEventingTopologyGraphModel);
+};
+
+export const getKnativeKameletsTopologyDataModel = (
+  namespace: string,
+  resources: TopologyDataResources,
+): Promise<Model> => {
+  const knativeKameletsTopologyGraphModel: Model = { nodes: [], edges: [] };
+  const { camelSinkKameletBindings, camelSourceKameletBindings } = getKameletSinkAndSourceBindings(
+    resources,
+  );
+  const addTopologyData = (KnResources: K8sResourceKind[], type?: string) => {
+    addKnativeTopologyData(knativeKameletsTopologyGraphModel, KnResources, type, resources);
+  };
+
+  addTopologyData(camelSourceKameletBindings, NodeType.EventSource);
+  addTopologyData(camelSinkKameletBindings, NodeType.EventSink);
+
+  return Promise.resolve(knativeKameletsTopologyGraphModel);
 };

--- a/frontend/packages/knative-plugin/src/topology/index.ts
+++ b/frontend/packages/knative-plugin/src/topology/index.ts
@@ -1,4 +1,3 @@
-export { getKnativeComponentFactory } from './components/knativeComponentFactory';
 export { getTopologyFilters, applyKnativeDisplayOptions } from './knativeFilters';
 export { getCreateConnector } from './create-connector-utils';
 export { getServiceRouteDecorator } from './components/decorators/getServiceRouteDecorator';
@@ -10,3 +9,5 @@ export {
 
 export { getKafkaSinkKnativeTopologyData } from './data-transformer';
 export { getKafkaSinkComponentFactory } from './components/knativeComponentFactory';
+export { getKnativeServingComponentFactory } from './components/knativeComponentFactory';
+export { getKnativeEventingComponentFactory } from './components/knativeComponentFactory';

--- a/frontend/packages/knative-plugin/src/topology/topology-plugin.ts
+++ b/frontend/packages/knative-plugin/src/topology/topology-plugin.ts
@@ -22,9 +22,19 @@ import {
   getKnativeServingResources,
 } from '../utils/get-knative-resources';
 
-const getKnativeTopologyDataModel = () =>
-  import('./data-transformer' /* webpackChunkName: "knative-components" */).then(
-    (m) => m.getKnativeTopologyDataModel,
+const getKnativeServingTopologyDataModel = () =>
+  import('./data-transformer' /* webpackChunkName: "serving-components" */).then(
+    (m) => m.getKnativeServingTopologyDataModel,
+  );
+
+const getKnativeEventingTopologyDataModel = () =>
+  import('./data-transformer' /* webpackChunkName: "eventing-components" */).then(
+    (m) => m.getKnativeEventingTopologyDataModel,
+  );
+
+const getKnativeKameletsTopologyDataModel = () =>
+  import('./data-transformer' /* webpackChunkName: "kamelets-components" */).then(
+    (m) => m.getKnativeKameletsTopologyDataModel,
   );
 
 const getIsKnativeResource = () =>
@@ -47,7 +57,7 @@ export const topologyPlugin: Plugin<TopologyConsumedExtensions> = [
       priority: 100,
       resources: getKnativeServingResources,
       workloadKeys: ['ksservices'],
-      getDataModel: applyCodeRefSymbol(getKnativeTopologyDataModel),
+      getDataModel: applyCodeRefSymbol(getKnativeServingTopologyDataModel),
       isResourceDepicted: applyCodeRefSymbol(getIsKnativeResource),
     },
     flags: {
@@ -67,7 +77,7 @@ export const topologyPlugin: Plugin<TopologyConsumedExtensions> = [
       priority: 100,
       resources: getKnativeEventingResources,
       workloadKeys: ['eventingsubscription'],
-      getDataModel: applyCodeRefSymbol(getKnativeTopologyDataModel),
+      getDataModel: applyCodeRefSymbol(getKnativeEventingTopologyDataModel),
       isResourceDepicted: applyCodeRefSymbol(getIsKnativeResource),
     },
     flags: {
@@ -81,7 +91,7 @@ export const topologyPlugin: Plugin<TopologyConsumedExtensions> = [
       priority: 100,
       resources: getKnativeEventingKameletsResources,
       workloadKeys: ['kameletbindings'],
-      getDataModel: applyCodeRefSymbol(getKnativeTopologyDataModel),
+      getDataModel: applyCodeRefSymbol(getKnativeKameletsTopologyDataModel),
       isResourceDepicted: applyCodeRefSymbol(getIsKnativeResource),
     },
     flags: {

--- a/frontend/packages/knative-plugin/src/topology/topology-plugin.ts
+++ b/frontend/packages/knative-plugin/src/topology/topology-plugin.ts
@@ -8,6 +8,7 @@ import {
   TopologyDecoratorProvider,
 } from '@console/topology/src/extensions';
 import {
+  FLAG_CAMEL_KAMELETS,
   FLAG_KNATIVE_EVENTING,
   FLAG_KNATIVE_SERVING,
   FLAG_KNATIVE_SERVING_CONFIGURATION,
@@ -15,7 +16,11 @@ import {
   FLAG_KNATIVE_SERVING_ROUTE,
   FLAG_KNATIVE_SERVING_SERVICE,
 } from '../const';
-import { getKnativeResources } from '../utils/get-knative-resources';
+import {
+  getKnativeEventingKameletsResources,
+  getKnativeEventingResources,
+  getKnativeServingResources,
+} from '../utils/get-knative-resources';
 
 const getKnativeTopologyDataModel = () =>
   import('./data-transformer' /* webpackChunkName: "knative-components" */).then(
@@ -38,9 +43,9 @@ export const topologyPlugin: Plugin<TopologyConsumedExtensions> = [
   {
     type: 'Topology/DataModelFactory',
     properties: {
-      id: 'knative-topology-model-factory',
+      id: 'knative-serving-topology-model-factory',
       priority: 100,
-      resources: getKnativeResources,
+      resources: getKnativeServingResources,
       workloadKeys: ['ksservices'],
       getDataModel: applyCodeRefSymbol(getKnativeTopologyDataModel),
       isResourceDepicted: applyCodeRefSymbol(getIsKnativeResource),
@@ -52,8 +57,35 @@ export const topologyPlugin: Plugin<TopologyConsumedExtensions> = [
         FLAG_KNATIVE_SERVING_REVISION,
         FLAG_KNATIVE_SERVING_ROUTE,
         FLAG_KNATIVE_SERVING_SERVICE,
-        FLAG_KNATIVE_EVENTING,
       ],
+    },
+  },
+  {
+    type: 'Topology/DataModelFactory',
+    properties: {
+      id: 'knative-eventing-topology-model-factory',
+      priority: 100,
+      resources: getKnativeEventingResources,
+      workloadKeys: ['eventingsubscription'],
+      getDataModel: applyCodeRefSymbol(getKnativeTopologyDataModel),
+      isResourceDepicted: applyCodeRefSymbol(getIsKnativeResource),
+    },
+    flags: {
+      required: [FLAG_KNATIVE_EVENTING],
+    },
+  },
+  {
+    type: 'Topology/DataModelFactory',
+    properties: {
+      id: 'knative-kamelets-topology-model-factory',
+      priority: 100,
+      resources: getKnativeEventingKameletsResources,
+      workloadKeys: ['kameletbindings'],
+      getDataModel: applyCodeRefSymbol(getKnativeTopologyDataModel),
+      isResourceDepicted: applyCodeRefSymbol(getIsKnativeResource),
+    },
+    flags: {
+      required: [FLAG_KNATIVE_EVENTING, FLAG_CAMEL_KAMELETS],
     },
   },
 ];

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -438,17 +438,28 @@ export const getSinkableResources = (namespace: string): FirehoseResource[] => {
     : [];
 };
 
-export const getKnativeResources = (namespace: string) => {
+export const getKnativeServingResources = (namespace: string) => {
   return {
     ...knativeServingResourcesRevisionWatchers(namespace),
     ...knativeServingResourcesConfigurationsWatchers(namespace),
     ...knativeServingResourcesRoutesWatchers(namespace),
     ...knativeServingResourcesServicesWatchers(namespace),
+    ...knativeCamelDomainMappingResourceWatchers(namespace),
+  };
+};
+
+export const getKnativeEventingResources = (namespace: string) => {
+  return {
     ...knativeEventingResourcesSubscriptionWatchers(namespace),
     ...getDynamicEventSourcesWatchers(namespace),
     ...getDynamicEventingChannelWatchers(namespace),
     ...knativeEventingBrokerResourceWatchers(namespace),
     ...knativeEventingTriggerResourceWatchers(namespace),
+  };
+};
+
+export const getKnativeEventingKameletsResources = (namespace: string) => {
+  return {
     ...knativeCamelIntegrationsResourceWatchers(namespace),
     ...knativeCamelKameletBindingResourceWatchers(namespace),
     ...knativeCamelDomainMappingResourceWatchers(namespace),

--- a/frontend/packages/topology/src/utils/__tests__/application-utils.spec.ts
+++ b/frontend/packages/topology/src/utils/__tests__/application-utils.spec.ts
@@ -18,7 +18,9 @@ import {
 import { MockKnativeResources } from '@console/knative-plugin/src/topology/__tests__/topology-knative-test-data';
 import {
   getKafkaSinkKnativeTopologyData,
-  getKnativeTopologyDataModel,
+  getKnativeEventingTopologyDataModel,
+  getKnativeKameletsTopologyDataModel,
+  getKnativeServingTopologyDataModel,
 } from '@console/knative-plugin/src/topology/data-transformer';
 import {
   MockResources,
@@ -55,7 +57,16 @@ const getTopologyData = async (
     workloadType,
   ]);
   if (isKnativeResource) {
-    model = await getKnativeTopologyDataModel(name, mockData);
+    const [servingModel, eventingModel, kameletModel] = await Promise.all([
+      getKnativeServingTopologyDataModel(name, mockData),
+      getKnativeEventingTopologyDataModel(name, mockData),
+      getKnativeKameletsTopologyDataModel(name, mockData),
+    ]);
+
+    model = {
+      nodes: [...servingModel.nodes, ...eventingModel.nodes, ...kameletModel.nodes],
+      edges: [...servingModel.edges, ...eventingModel.edges, ...kameletModel.edges],
+    };
   }
   const result = baseDataModelGetter(model, namespace, mockData, workloadResources, []);
   return result.nodes.find((n) => n.data.resources?.obj.metadata.name === name);


### PR DESCRIPTION
**Tracks:** https://issues.redhat.com/browse/OCPBUGSM-45852


**Description:** Event sources do not show up until `KnativeServing` is installed and even if `knativeEventing` is installed.

**Solution:** separate fetching of serving and eventing as they can be enabled independently

**Tests:**

<img width="1211" alt="image" src="https://user-images.githubusercontent.com/5129024/191985532-66c33704-aa96-46c9-8e57-e453781639fb.png">
