### PR TITLE
Action on Knative-Service | Knative Serverless

### DIFF
--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/actions-on-knative-service.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/actions-on-knative-service.feature
@@ -1,4 +1,4 @@
-@knative
+@knative-serverless
 Feature: Perform actions on knative service
               As a user I want to perform edit or delete operations and Set Traffic Distribution on knative Service in topology page
 
@@ -8,7 +8,7 @@ Feature: Perform actions on knative service
 
 
         @pre-condition
-        Scenario Outline: Create knative workload using Container image with extrenal registry on Add page: KN-05-TC05
+        Scenario Outline: Create knative workload using Container image with extrenal registry on Add page: KN-05-TC01
             Given user is at Add page
               And user is at Deploy Image page
              When user enters Image name from external registry as "<image_name>"
@@ -24,28 +24,28 @@ Feature: Perform actions on knative service
 
 
         @smoke
-        Scenario: knative service menu options: KN-02-TC01
+        Scenario: knative service menu options: KN-02-TC02
              When user right clicks on the knative service "kn-service"
              Then user is able to see the options like Edit Application Grouping, Set Traffic Distribution, Edit Health Checks, Edit Labels, Edit Annotations, Edit Service, Delete Service, Edit "kn-service"
 
 
         @regression
-        Scenario: Edit labels modal details: KN-02-TC02
+        Scenario: Edit labels modal details: KN-02-TC03
              When user right clicks on the knative service "kn-service"
               And user selects "Edit labels" from context menu
              Then modal with "Edit labels" appears
               And save, cancel buttons are displayed
 
-
-        Scenario: Add label to the existing labels list: KN-02-TC03
+        @regression
+        Scenario: Add label to the existing labels list: KN-02-TC04
              When user right clicks on the knative service "kn-service"
               And user selects "Edit labels" from context menu
               And user adds the label "app=label" to existing labels list in Edit Labels modal
               And user clicks on Save button
              Then user will see the label "app=label" in "kn-service" service side bar details
 
-
-        Scenario: Remove label from existing labels list: KN-02-TC04
+        @regression
+        Scenario: Remove label from existing labels list: KN-02-TC05
              When user selects "Edit labels" context menu option of knative service "kn-service"
               And user removes the label "app=label" from existing labels list in "Edit labels" modal
               And user clicks save button on the "Edit labels" modal
@@ -53,42 +53,44 @@ Feature: Perform actions on knative service
 
 
         @regression
-        Scenario: Edit Annotation modal details: KN-02-TC17
+        Scenario: Edit Annotation modal details: KN-02-TC06
              When user selects "Edit annotations" context menu option of knative service "kn-service"
              Then modal with "Edit annotations" appears
               And key, value columns are displayed with respective text fields
               And Add more link is enabled
               And save, cancel buttons are displayed
 
-
-        Scenario: Add annotation to the existing annotations list: KN-02-TC05
+        @regression
+        Scenario: Add annotation to the existing annotations list: KN-02-TC07
             Given number of annotations present in topology side bar for "kn-service" service
              When user selects "Edit annotations" context menu option of knative service "kn-service"
               And user clicks Add button on the Edit Annotations modal
               And user enters annotation key as "serving.knative.qe/creator"
               And user enters annotation value as "kube:admin"
               And user clicks save button on the "Edit annotations" modal
-             Then number of Annotations increased for "kn-service" service in topology side bar details
+              And user clicks on service "kn-service" to open sidebar
+             Then verify the number of annotations equal to "6" in side bar details knative revision
 
-
-        Scenario: Remove annotation from existing annotations list: KN-02-TC06
+        @regression
+        Scenario: Remove annotation from existing annotations list: KN-02-TC08
              When user selects "Edit annotations" context menu option of knative service "kn-service"
               And user clicks on remove icon for the annotation with key "serving.knative.qe/creator" present in Edit Annotations modal
               And user clicks save button on the "Edit annotations" modal
-             Then number of Annotations decreased for "kn-service" service in topology side bar details
+              And user clicks on service "kn-service" to open sidebar
+             Then verify the number of annotations equal to "5" in side bar details knative revision
 
 
-        @regression @to-do
-        Scenario: Edit the service from yaml editor: KN-02-TC07
+        @regression @manual
+        Scenario: Edit the service from yaml editor: KN-02-TC09
              When user selects "Edit Service" context menu option of knative service "kn-service"
-              And user modifies the Yaml file of the Service details page
+              And user modifies the Yaml by changing spec.template.spec.timeoutSeconds to 301
               And user clicks save button on yaml page
-             Then message should display as "{service name} has been updated to version {nnnnnn}"
+             Then message should display as "kn-service has been updated to version"
               And another message should display as "This object has been updated."
 
 
         @smoke
-        Scenario: Update the service to new application group: KN-02-TC08
+        Scenario: Update the service to new application group: KN-02-TC10
              When user selects "Edit application grouping" context menu option of knative service "kn-service"
               And user selects the Create Application option from application drop down present in Edit Application grouping modal
               And user enters "openshift-app" into the Application Name text box
@@ -99,7 +101,7 @@ Feature: Perform actions on knative service
 
 
         @regression
-        Scenario: Update the service to different application group existing in same project: KN-02-TC09
+        Scenario: Update the service to different application group existing in same project: KN-02-TC11
              When user selects "Edit application grouping" context menu option of knative service "kn-service"
               And user selects the "hello-openshift-app" option from application drop down present in Edit Application grouping modal
               And user clicks save button on the "Edit application grouping" modal
@@ -107,9 +109,9 @@ Feature: Perform actions on knative service
               And user clicks on application node "hello-openshift-app" on topology page
              Then updated service "kn-service" is present in side bar of application "hello-openshift-app"
 
-        @to-do
-        Scenario: Set traffic distribution greater than 100% for the Revisions of the knative Service: KN-02-TC10
-            Given user created another revision for knative Service "kn-service"
+        @regression
+        Scenario: Set traffic distribution greater than 100% for the Revisions of the knative Service: KN-02-TC12
+            Given knative service "kn-service" with multiple revisions
               And user is at the Topology page
              When user selects "Set traffic distribution" context menu option of knative service "kn-service"
               And user clicks on Add Revision button present in Set Traffic Distribution modal
@@ -118,9 +120,9 @@ Feature: Perform actions on knative service
               And user clicks save button on the "Set traffic distribution" modal
              Then error message displays as "validation failed: Traffic targets sum to 150, want 100: spec.traffic"
 
-        @to-do
-        Scenario: Set traffic distribution less than 100% for the Revisions of the knative Service: KN-02-TC11
-            Given user created another revision for knative Service "kn-service"
+        @regression
+        Scenario: Set traffic distribution less than 100% for the Revisions of the knative Service: KN-02-TC13
+            Given knative service "kn-service" with multiple revisions
               And user is at the Topology page
              When user selects "Set traffic distribution" context menu option of knative service "kn-service"
               And user enters "25" into the Split text box of new revision
@@ -131,9 +133,9 @@ Feature: Perform actions on knative service
              Then error message displays as "validation failed: Traffic targets sum to 75, want 100: spec.traffic"
 
 
-        @regression @broken-test
-        Scenario: Set traffic distribution equal to 100% for the Revisions of the knative Service: KN-02-TC12
-            Given user created another revision for knative Service "kn-service"
+        @regression
+        Scenario: Set traffic distribution equal to 100% for the Revisions of the knative Service: KN-02-TC14
+            Given knative service "kn-service" with multiple revisions
               And user is at the Topology page
              When user selects "Set traffic distribution" context menu option of knative service "kn-service"
               And user enters "51" into the Split text box of new revision
@@ -146,22 +148,22 @@ Feature: Perform actions on knative service
 
 
         @regression
-        Scenario: Edit Health Checks for a service: KN-02-TC13
+        Scenario: Edit Health Checks for a service: KN-02-TC15
             Given user is at the Topology page
              When user selects "Edit Health Checks" context menu option of knative service "kn-service"
               And user adds the Liveness probe details
               And user clicks Save on Edit health checks page
              Then user redirects to topology page
 
-
-        Scenario: Perform cancel opeartion on Edit NameOfWorkload for a service: KN-02-TC14
+        @regression
+        Scenario: Perform cancel opeartion on Edit NameOfWorkload for a service: KN-02-TC16
              When user selects "Edit kn-service" context menu option of knative service "kn-service"
-              And user clicks cancel button on "Edit Service" page
+              And user clicks cancel button on "Deploy Image" page
              Then user will be redirected to Topology page
 
 
-        @regression @broken-test
-        Scenario: Edit NameOfWorkload for a service: KN-02-TC15
+        @regression
+        Scenario: Edit NameOfWorkload for a service: KN-02-TC17
              When user selects "Edit kn-service" context menu option of knative service "kn-service"
               And user selects the "No Application group" option from Application drop down
               And user clicks save button on the Deploy Image Page
@@ -169,8 +171,8 @@ Feature: Perform actions on knative service
               And user is not able to see application group in Topology page
 
 
-        @smoke @broken-test
-        Scenario: Delete service: KN-02-TC16
-             When user selects "Delete Service" context menu option of knative service "kn-service-1"
+        @smoke
+        Scenario: Delete service: KN-02-TC18
+             When user selects "Delete Service" context menu option of knative service "kn-service"
               And user clicks Delete button on Delete Service modal
-             Then "kn-service-1" service should not be displayed in project
+             Then "kn-service" service should not be displayed in project

--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/cards-display-on-serverless-operator-installation.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/cards-display-on-serverless-operator-installation.feature
@@ -1,4 +1,4 @@
-@knative
+@knative-serverless
 Feature: Event sources cards display
               As a user, I want to create event sources
 

--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/create-knative-service-from-deployment-or-deployment-config.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/create-knative-service-from-deployment-or-deployment-config.feature
@@ -1,4 +1,4 @@
-@knative
+@knative-serverless
 Feature: Create Knative service from existing Deployment/Deployment Config workloads
               As a user, I should be able to create a serverless app(knative service) from existing deployment/deployment-config and specify any advanced options which I'm able to specify upon creating a knative service
 

--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/create-knative-workload.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/create-knative-workload.feature
@@ -1,4 +1,4 @@
-@knative
+@knative-serverless
 Feature: Create a workload of 'knative Service' type resource
               As a user, I want to create workload from Add Flow page
 

--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/domain-mapping.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/domain-mapping.feature
@@ -1,4 +1,4 @@
-@knative
+@knative-serverless
 Feature: Custom Domain Mapping Support
               As a user, I would like to have the ability to provide a custom domain for the routes configured for serverless applications.
 

--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/serverless-function.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/serverless-function.feature
@@ -1,4 +1,4 @@
-@knative
+@knative-serverless
 Feature: Visualisation of serverless fuctions
               As a user, I should be able to differentiate between a plain Knative Service and a Serverless Function when looking at the Details page of the KSVC and the details tab of the side panel in Topology
 

--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/side-bar-of-knative-revision-and-service.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/side-bar-of-knative-revision-and-service.feature
@@ -1,4 +1,4 @@
-@knative
+@knative-serverless
 Feature: side bar details
               As a user, I want to see the details of the revision and service in side bar
 
@@ -34,12 +34,12 @@ Feature: side bar details
              Then side bar is displayed with heading name as "nodejs-ex-git"
               And Name, Namespace, Labels, Annotations, Created at, Owner fields displayed in topology details
               And Pods, Revisions, Routes and Builds displayed in Resources section
-            # And Name display as "nodejs-ex-git-1" in topology details
-            # And Namespace display as "aut-knative-side-pane-details" in topology details
-            # And Labels section contain n number of Labels in topology details
-            # And Annotations section contain "{number of annotations} Annotations" in topology details
-            # And "Created on" field display the date in format "{month date, hour:minutes am/pm}" in topology details
-            # And owner field displayed in topology details
+    # And Name display as "nodejs-ex-git-1" in topology details
+    # And Namespace display as "aut-knative-side-pane-details" in topology details
+    # And Labels section contain n number of Labels in topology details
+    # And Annotations section contain "{number of annotations} Annotations" in topology details
+    # And "Created on" field display the date in format "{month date, hour:minutes am/pm}" in topology details
+    # And owner field displayed in topology details
 
 
         @smoke @broken-test

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/actions-on-knative-revision.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/actions-on-knative-revision.ts
@@ -91,7 +91,6 @@ Given('knative service {string} with multiple revisions', (serviceName: string) 
   topologyPage.verifyUserIsInGraphView();
   topologyPage.waitForLoad();
   topologyPage.rightClickOnKnativeService(serviceName);
-
   topologyPage.selectContextMenuAction(`Edit ${serviceName}`);
 
   app.waitForLoad();
@@ -100,12 +99,17 @@ Given('knative service {string} with multiple revisions', (serviceName: string) 
     .scrollIntoView()
     .click();
   gitPage.enterLabels('app=frontend');
-
   cy.get(formPO.create).click();
   topologyPage.verifyTopologyPage();
-
   topologyPage.verifyUserIsInGraphView();
-  topologyPage.clickOnKnativeService(serviceName);
+  app.waitForLoad();
+
+  // Open sidebar if not already opened
+  cy.get('body').then(($body) => {
+    if ($body.find('[data-test-id="actions-menu-button"]').length === 0) {
+      topologyPage.clickOnKnativeService(serviceName);
+    }
+  });
 
   cy.log(`user is able to see revisions in knative service : ${serviceName} of topology side pane`);
   topologySidePane.selectTab('Resources');

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/actions-on-knative-service.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/actions-on-knative-service.ts
@@ -456,3 +456,7 @@ Given('workload build is completed', () => {
 Given('workload {string} is present in topology page', (workloadName: string) => {
   topologyPage.verifyWorkloadInTopologyPage(workloadName);
 });
+
+When('user clicks on service {string} to open sidebar', () => {
+  cy.get('.odc-knative-service__label').click();
+});


### PR DESCRIPTION
**Description:**

<!-- PR description-->
- Automation of actions-on-knative-service.feature | Knative Serverless

**Jira Id:**
- Story: 
      - [ODC-7113](https://issues.redhat.com/browse/ODC-7113)
    
<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.12-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p knative
```

**Screen shots**:
<!--   -->
<img width="1726" alt="image" src="https://user-images.githubusercontent.com/65410551/191926458-9ba31a6d-13c4-4eda-91ad-a5451cde20d1.png">



**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge