### PR TITLE
OCPBUGS-1677: Fix devfile registry assertion

### DIFF
--- a/pkg/devfile/sample_test.go
+++ b/pkg/devfile/sample_test.go
@@ -72,7 +72,7 @@ func TestGetRegistrySamples(t *testing.T) {
 					DisplayName: "Basic Python",
 					Description: "A simple Hello World application using Python",
 					Tags:        []string{"Python"},
-					Icon:        "https://www.python.org/static/community_logos/python-logo-generic.svg",
+					Icon:        "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/python.svg",
 					Type:        schema.SampleDevfileType,
 					ProjectType: "python",
 					Language:    "python",


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-1677

**Analysis / Root cause**: 
pkg/devfile/sample_test.go fails after devfile registry was updated (https://github.com/devfile/registry/pull/126)

**Solution Description**: 
Just updated the assertion.

https://issues.redhat.com/browse/OCPBUGS-1678 is about updating the code so that the test should use a mock response instead of the latest registry content OR check some specific attributes instead of comparing the full JSON response.
