### PR TITLE
[WIP] OU-75 Add New Queries to the Top of the Queries List.

### DIFF
--- a/frontend/public/actions/observe.ts
+++ b/frontend/public/actions/observe.ts
@@ -17,6 +17,7 @@ export enum ActionType {
   QueryBrowserDuplicateQuery = 'queryBrowserDuplicateQuery',
   QueryBrowserDuplicateQuery2 = 'queryBrowserDuplicateQuery2',
   QueryBrowserDeleteAllQueries = 'queryBrowserDeleteAllQueries',
+  QueryBrowserDeleteAllQueries2 = 'queryBrowserDeleteAllQueries2',
   QueryBrowserDeleteAllSeries = 'queryBrowserDeleteAllSeries',
   QueryBrowserDeleteAllSeries2 = 'queryBrowserDeleteAllSeries2',
   QueryBrowserDeleteQuery = 'queryBrowserDeleteQuery',
@@ -109,6 +110,8 @@ export const queryBrowserDuplicateQuery2 = (id: string) =>
 
 export const queryBrowserDeleteAllQueries = () => action(ActionType.QueryBrowserDeleteAllQueries);
 
+export const queryBrowserDeleteAllQueries2 = () => action(ActionType.QueryBrowserDeleteAllQueries2);
+
 export const queryBrowserDeleteAllSeries = () => action(ActionType.QueryBrowserDeleteAllSeries);
 
 export const queryBrowserDeleteAllSeries2 = () => action(ActionType.QueryBrowserDeleteAllSeries2);
@@ -132,6 +135,7 @@ export const queryBrowserRunQueries = () => action(ActionType.QueryBrowserRunQue
 
 export const queryBrowserRunQueries2 = () => action(ActionType.QueryBrowserRunQueries2);
 
+// JZ NOTE: only referenced in metric.tsx 
 export const queryBrowserSetAllExpanded = (isExpanded: boolean) =>
   action(ActionType.QueryBrowserSetAllExpanded, { isExpanded });
 
@@ -175,6 +179,7 @@ const actions = {
   queryBrowserDuplicateQuery,
   queryBrowserDuplicateQuery2,
   queryBrowserDeleteAllQueries,
+  queryBrowserDeleteAllQueries2,
   queryBrowserDeleteAllSeries,
   queryBrowserDeleteAllSeries2,
   queryBrowserDeleteQuery,

--- a/frontend/public/actions/observe.ts
+++ b/frontend/public/actions/observe.ts
@@ -32,6 +32,8 @@ export enum ActionType {
   QueryBrowserToggleIsEnabled = 'queryBrowserToggleIsEnabled',
   QueryBrowserToggleIsEnabled2 = 'queryBrowserToggleIsEnabled2',
   QueryBrowserToggleSeries = 'queryBrowserToggleSeries',
+  QueryBrowserToggleSeries2 = 'queryBrowserToggleSeries2',
+
   SetAlertCount = 'SetAlertCount',
   ToggleGraphs = 'toggleGraphs',
 }
@@ -148,7 +150,10 @@ export const queryBrowserToggleIsEnabled2 = (id: string) =>
 export const queryBrowserToggleSeries = (index: number, labels: { [key: string]: unknown }) =>
   action(ActionType.QueryBrowserToggleSeries, { index, labels });
 
-export const setAlertCount = (alertCount) => action(ActionType.SetAlertCount, { alertCount });
+  export const queryBrowserToggleSeries2 = (id: string, labels: { [key: string]: unknown }) =>
+  action(ActionType.QueryBrowserToggleSeries2, { id, labels });
+
+  export const setAlertCount = (alertCount) => action(ActionType.SetAlertCount, { alertCount });
 
 const actions = {
   alertingErrored,
@@ -182,6 +187,7 @@ const actions = {
   queryBrowserToggleIsEnabled,
   queryBrowserToggleIsEnabled2,
   queryBrowserToggleSeries,
+  queryBrowserToggleSeries2,
   setAlertCount,
   toggleGraphs,
 };

--- a/frontend/public/actions/observe.ts
+++ b/frontend/public/actions/observe.ts
@@ -13,6 +13,7 @@ export enum ActionType {
   DashboardsSetTimespan = 'dashboardsSetTimespan',
   DashboardsVariableOptionsLoaded = 'dashboardsVariableOptionsLoaded',
   QueryBrowserAddQuery = 'queryBrowserAddQuery',
+  QueryBrowserAddQuery2 = 'queryBrowserAddQuery2',
   QueryBrowserDuplicateQuery = 'queryBrowserDuplicateQuery',
   QueryBrowserDeleteAllQueries = 'queryBrowserDeleteAllQueries',
   QueryBrowserDeleteAllSeries = 'queryBrowserDeleteAllSeries',
@@ -90,6 +91,8 @@ export const toggleGraphs = () => action(ActionType.ToggleGraphs);
 
 export const queryBrowserAddQuery = () => action(ActionType.QueryBrowserAddQuery);
 
+export const queryBrowserAddQuery2 = () => action(ActionType.QueryBrowserAddQuery2);
+
 export const queryBrowserDuplicateQuery = (index: number) =>
   action(ActionType.QueryBrowserDuplicateQuery, { index });
 
@@ -141,6 +144,7 @@ const actions = {
   dashboardsSetTimespan,
   dashboardsVariableOptionsLoaded,
   queryBrowserAddQuery,
+  queryBrowserAddQuery2,
   queryBrowserDuplicateQuery,
   queryBrowserDeleteAllQueries,
   queryBrowserDeleteAllSeries,

--- a/frontend/public/actions/observe.ts
+++ b/frontend/public/actions/observe.ts
@@ -20,12 +20,14 @@ export enum ActionType {
   QueryBrowserDeleteQuery = 'queryBrowserDeleteQuery',
   QueryBrowserDismissNamespaceAlert = 'queryBrowserDismissNamespaceAlert',
   QueryBrowserPatchQuery = 'queryBrowserPatchQuery',
+  QueryBrowserPatchQuery2 = 'queryBrowserPatchQuery2',
   QueryBrowserRunQueries = 'queryBrowserRunQueries',
   QueryBrowserSetAllExpanded = 'queryBrowserSetAllExpanded',
   QueryBrowserSetMetrics = 'queryBrowserSetMetrics',
   QueryBrowserSetPollInterval = 'queryBrowserSetPollInterval',
   QueryBrowserSetTimespan = 'queryBrowserSetTimespan',
   QueryBrowserToggleIsEnabled = 'queryBrowserToggleIsEnabled',
+  QueryBrowserToggleIsEnabled2 = 'queryBrowserToggleIsEnabled2',
   QueryBrowserToggleSeries = 'queryBrowserToggleSeries',
   SetAlertCount = 'SetAlertCount',
   ToggleGraphs = 'toggleGraphs',
@@ -109,6 +111,9 @@ export const queryBrowserDeleteQuery = (index: number) =>
 export const queryBrowserPatchQuery = (index: number, patch: { [key: string]: unknown }) =>
   action(ActionType.QueryBrowserPatchQuery, { index, patch });
 
+export const queryBrowserPatchQuery2 = (id: string, patch: { [key: string]: unknown }) =>
+  action(ActionType.QueryBrowserPatchQuery2, { id, patch });
+
 export const queryBrowserRunQueries = () => action(ActionType.QueryBrowserRunQueries);
 
 export const queryBrowserSetAllExpanded = (isExpanded: boolean) =>
@@ -125,6 +130,9 @@ export const queryBrowserSetTimespan = (timespan: number) =>
 
 export const queryBrowserToggleIsEnabled = (index: number) =>
   action(ActionType.QueryBrowserToggleIsEnabled, { index });
+
+export const queryBrowserToggleIsEnabled2 = (id: string) =>
+  action(ActionType.QueryBrowserToggleIsEnabled2, { id });
 
 export const queryBrowserToggleSeries = (index: number, labels: { [key: string]: unknown }) =>
   action(ActionType.QueryBrowserToggleSeries, { index, labels });
@@ -151,12 +159,14 @@ const actions = {
   queryBrowserDeleteQuery,
   queryBrowserDismissNamespaceAlert,
   queryBrowserPatchQuery,
+  queryBrowserPatchQuery2,
   queryBrowserRunQueries,
   queryBrowserSetAllExpanded,
   queryBrowserSetMetrics,
   queryBrowserSetPollInterval,
   queryBrowserSetTimespan,
   queryBrowserToggleIsEnabled,
+  queryBrowserToggleIsEnabled2,
   queryBrowserToggleSeries,
   setAlertCount,
   toggleGraphs,

--- a/frontend/public/actions/observe.ts
+++ b/frontend/public/actions/observe.ts
@@ -18,6 +18,7 @@ export enum ActionType {
   QueryBrowserDuplicateQuery2 = 'queryBrowserDuplicateQuery2',
   QueryBrowserDeleteAllQueries = 'queryBrowserDeleteAllQueries',
   QueryBrowserDeleteAllSeries = 'queryBrowserDeleteAllSeries',
+  QueryBrowserDeleteAllSeries2 = 'queryBrowserDeleteAllSeries2',
   QueryBrowserDeleteQuery = 'queryBrowserDeleteQuery',
   QueryBrowserDeleteQuery2 = 'queryBrowserDeleteQuery2',
   QueryBrowserDismissNamespaceAlert = 'queryBrowserDismissNamespaceAlert',
@@ -110,6 +111,8 @@ export const queryBrowserDeleteAllQueries = () => action(ActionType.QueryBrowser
 
 export const queryBrowserDeleteAllSeries = () => action(ActionType.QueryBrowserDeleteAllSeries);
 
+export const queryBrowserDeleteAllSeries2 = () => action(ActionType.QueryBrowserDeleteAllSeries2);
+
 export const queryBrowserDismissNamespaceAlert = () =>
   action(ActionType.QueryBrowserDismissNamespaceAlert);
 
@@ -173,6 +176,7 @@ const actions = {
   queryBrowserDuplicateQuery2,
   queryBrowserDeleteAllQueries,
   queryBrowserDeleteAllSeries,
+  queryBrowserDeleteAllSeries2,
   queryBrowserDeleteQuery,
   queryBrowserDeleteQuery2,
   queryBrowserDismissNamespaceAlert,

--- a/frontend/public/actions/observe.ts
+++ b/frontend/public/actions/observe.ts
@@ -15,13 +15,16 @@ export enum ActionType {
   QueryBrowserAddQuery = 'queryBrowserAddQuery',
   QueryBrowserAddQuery2 = 'queryBrowserAddQuery2',
   QueryBrowserDuplicateQuery = 'queryBrowserDuplicateQuery',
+  QueryBrowserDuplicateQuery2 = 'queryBrowserDuplicateQuery2',
   QueryBrowserDeleteAllQueries = 'queryBrowserDeleteAllQueries',
   QueryBrowserDeleteAllSeries = 'queryBrowserDeleteAllSeries',
   QueryBrowserDeleteQuery = 'queryBrowserDeleteQuery',
+  QueryBrowserDeleteQuery2 = 'queryBrowserDeleteQuery2',
   QueryBrowserDismissNamespaceAlert = 'queryBrowserDismissNamespaceAlert',
   QueryBrowserPatchQuery = 'queryBrowserPatchQuery',
   QueryBrowserPatchQuery2 = 'queryBrowserPatchQuery2',
   QueryBrowserRunQueries = 'queryBrowserRunQueries',
+  QueryBrowserRunQueries2 = 'queryBrowserRunQueries2',
   QueryBrowserSetAllExpanded = 'queryBrowserSetAllExpanded',
   QueryBrowserSetMetrics = 'queryBrowserSetMetrics',
   QueryBrowserSetPollInterval = 'queryBrowserSetPollInterval',
@@ -98,6 +101,9 @@ export const queryBrowserAddQuery2 = () => action(ActionType.QueryBrowserAddQuer
 export const queryBrowserDuplicateQuery = (index: number) =>
   action(ActionType.QueryBrowserDuplicateQuery, { index });
 
+export const queryBrowserDuplicateQuery2 = (id: string) =>
+  action(ActionType.QueryBrowserDuplicateQuery2, { id });
+
 export const queryBrowserDeleteAllQueries = () => action(ActionType.QueryBrowserDeleteAllQueries);
 
 export const queryBrowserDeleteAllSeries = () => action(ActionType.QueryBrowserDeleteAllSeries);
@@ -108,6 +114,9 @@ export const queryBrowserDismissNamespaceAlert = () =>
 export const queryBrowserDeleteQuery = (index: number) =>
   action(ActionType.QueryBrowserDeleteQuery, { index });
 
+export const queryBrowserDeleteQuery2 = (id: string) =>
+  action(ActionType.QueryBrowserDeleteQuery2, { id });
+
 export const queryBrowserPatchQuery = (index: number, patch: { [key: string]: unknown }) =>
   action(ActionType.QueryBrowserPatchQuery, { index, patch });
 
@@ -115,6 +124,8 @@ export const queryBrowserPatchQuery2 = (id: string, patch: { [key: string]: unkn
   action(ActionType.QueryBrowserPatchQuery2, { id, patch });
 
 export const queryBrowserRunQueries = () => action(ActionType.QueryBrowserRunQueries);
+
+export const queryBrowserRunQueries2 = () => action(ActionType.QueryBrowserRunQueries2);
 
 export const queryBrowserSetAllExpanded = (isExpanded: boolean) =>
   action(ActionType.QueryBrowserSetAllExpanded, { isExpanded });
@@ -154,13 +165,16 @@ const actions = {
   queryBrowserAddQuery,
   queryBrowserAddQuery2,
   queryBrowserDuplicateQuery,
+  queryBrowserDuplicateQuery2,
   queryBrowserDeleteAllQueries,
   queryBrowserDeleteAllSeries,
   queryBrowserDeleteQuery,
+  queryBrowserDeleteQuery2,
   queryBrowserDismissNamespaceAlert,
   queryBrowserPatchQuery,
   queryBrowserPatchQuery2,
   queryBrowserRunQueries,
+  queryBrowserRunQueries2,
   queryBrowserSetAllExpanded,
   queryBrowserSetMetrics,
   queryBrowserSetPollInterval,

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -58,6 +58,7 @@ import {
   queryBrowserToggleIsEnabled,
   queryBrowserToggleSeries,
   toggleGraphs,
+  queryBrowserAddQuery2,
 } from '../../actions/observe';
 import { RootState } from '../../redux';
 import { getPrometheusURL } from '../graphs/helpers';
@@ -526,6 +527,7 @@ const Query: React.FC<{ index: number }> = ({ index }) => {
   const switchKey = `${id}-${isEnabled}`;
   const switchLabel = isEnabled ? t('public~Disable query') : t('public~Enable query');
 
+
   return (
     <div
       className={classNames('query-browser__table', {
@@ -651,11 +653,12 @@ const AddQueryButton: React.FC<{}> = () => {
 
   const dispatch = useDispatch();
   const addQuery = React.useCallback(() => dispatch(queryBrowserAddQuery()), [dispatch]);
+  const addQuery2 = React.useCallback(() => dispatch(queryBrowserAddQuery2()), [dispatch]);
 
   return (
     <Button
       className="query-browser__inline-control"
-      onClick={addQuery}
+      onClick={addQuery && addQuery2}
       type="button"
       variant="secondary"
     >
@@ -677,19 +680,37 @@ const RunQueriesButton: React.FC<{}> = () => {
   );
 };
 
+
 const QueriesList: React.FC<{}> = () => {
-  const count = useSelector(
-    ({ observe }: RootState) => observe.getIn(['queryBrowser', 'queries']).size,
+
+  const queries =  useSelector(
+    ({ observe }: RootState) => observe.getIn(['queryBrowser', 'queries']),
   );
 
+  const queries2 = useSelector(
+    ({ observe }: RootState) => observe.getIn(['queryBrowser2', 'queries2']),
+  );
+
+  console.log("JZ Queries2: " + queries2)
+
+  console.log("JZ Queries : " + queries)
+
+  
+  // State > Queries > Object structure is List[Map<string:string>]
+  // TODO: QueriesList need to sort the map by ID then render 
   return (
     <>
-      {_.range(count).map((i) => (
-        <Query index={i} key={i} />
+      {_.range(queries.size).map((i) => (
+        <div>
+          The Index is : {i}   key : {queries.get(i).get("id")} 
+          <Query index={i} key={queries.get(i).get("id")} />
+        </div>
       ))}
     </>
   );
+
 };
+
 
 const PollIntervalDropdown = () => {
   const interval = useSelector(({ observe }: RootState) =>

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -171,34 +171,36 @@ const ExpandButton = ({ isExpanded, onClick }) => {
 const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
   const { t } = useTranslation();
 
-  console.log("JZ SeriesBtn2 > labels : "  + labels)
 
   const [colorIndex, isDisabled, isSeriesEmpty] = useSelector(({ observe }: RootState) => {
     const disabledSeries = observe.getIn(['queryBrowser2', 'queries2', id, 'disabledSeries']);
     if (_.some(disabledSeries, (s) => _.isEqual(s, labels))) {
-      console.log("JZ SeriesBtn2 > disabledSeries  " )
       return [null, true, false];
     }
 
     const series = observe.getIn(['queryBrowser2', 'queries2', id, 'series']);
     if (_.isEmpty(series)) {
-      console.log("JZ SeriesBtn2 > isSeriesEmpty " )
       return [null, false, true];
     }
 
-    // JZ NOTE: this fx() gets the numnber of series that are enabled for a given query 
     const colorOffset = observe
       .getIn(['queryBrowser2', 'queries2'])
       .take(id)
       .filter((q) => q.get('isEnabled'))
       .reduce((sum, q) => sum + _.size(q.get('series')), 0);
 
-    // JZ NOTE: Find the index of the series that correspond with the query's labels
     const seriesIndex = _.findIndex(series, (s) => _.isEqual(s, labels));
 
+    console.log("JZ SeriesBtn2 > labels : "  + JSON.stringify(labels))
     console.log (" JZ seriesBtn2 > series + ", series )
 
-    // TODO checkout why seriesIndex is coming back -1 
+    series.forEach((s) => {
+      console.log("JZ SeriesBtn2 > s : ", s)
+      console.log("JZ SeriesBtn2 > _.isEqual(s, labels) : ", _.isEqual(s, labels))
+    })
+
+    console.log("JZ SeriesBtn2 > ====================== END ==================== ")
+
 
 
     // console.log("JZ SeriesBtn2 >  colorIndex is [(colorOffset + seriesIndex)] % colors.length : " + (colorOffset + seriesIndex) % colors.length)
@@ -491,7 +493,7 @@ export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
 
 
 
-  // JZ save callback and poll the request at set time intervals 
+  // JZ NOTES: saves callback and poll the request at set time intervals 
   usePoll(tick, pollInterval, namespace, query, span, lastRequestTime);
 
   // JZ clear previous data? 
@@ -539,8 +541,6 @@ export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
     );
   }
 
-  console.log("JZ QueryTable2 > data.result %s", JSON.stringify(data.result))
-
   const transforms = [sortable, wrappable];
 
   // JZ LEFT OFF HERE Oct 19 5:30pm -- Query{...series:undefined} -- Prometheus data is not getting properly set 
@@ -587,7 +587,6 @@ export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
         },
       ];
     } else {
-      // JZ NOTE: key:value pair 
       rowMapper = ({ metric, value }) => [
         buttonCell(metric),
         ..._.map(allLabelKeys, (k) => metric[k]),

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -477,6 +477,41 @@ const PromQLExpressionInput = (props) => (
   />
 );
 
+const Query2 : React.FC<{ id: string }> = ({ id }) => {
+  const { t } = useTranslation();
+
+  // QueriesList {id:Map{}, id:Map{}, id:Map{}}
+  const isEnabled = useSelector(({ observe }: RootState) =>
+    observe.getIn(['queryBrowser2', 'queries2', id, 'isEnabled']),
+  );
+  const isExpanded = useSelector(({ observe }: RootState) =>
+    observe.getIn(['queryBrowser2', 'queries2', id, 'isExpanded']),
+  );
+  const text = useSelector(({ observe }: RootState) =>
+    observe.getIn(['queryBrowser2', 'queries2', id, 'text'], ''),
+  );
+
+  const queries = useSelector(({ observe }: RootState) =>
+    observe.getIn(['queryBrowser2', 'queries2', id]),
+  );
+
+  console.log("QueryComponent : " + id + " " + queries.toString())
+
+  return (
+    <div
+      className={classNames('query-browser__table', {
+        'query-browser__table--expanded': true,
+      })}
+    >
+      <div className="query-browser__query-controls">
+       
+      </div>
+    </div>
+  );
+  
+
+};
+
 const Query: React.FC<{ index: number }> = ({ index }) => {
   const { t } = useTranslation();
 
@@ -695,17 +730,56 @@ const QueriesList: React.FC<{}> = () => {
 
   console.log("JZ Queries : " + queries)
 
+
+  queries2.forEach((value, key) => {
+    console.log("JZ Key:Value " + key +  " : " + value.toString());
+  })
+
+  // TODO: Need to Sort this in reverse but the .sort() function handles
+  // sorting by ASCII so we need to write a lambda to handle sorting by 
+  // values and not ASCII ... would this work if the keys were numbers 
+  // instead of strings?
+  // console.log("JZ KeySeq() : " + queries2.keySeq().sort().reverse())
+
+  // JZ NOTE: number ID APPROACH
+  // const queryKeys = queries2.keySeq().sort().reverse()
+
+  queries2.keySeq().sort((key:string) => console.log("Slice Key: " + +key.slice(22) + " type: " + typeof +key.slice(22) ));
+  
+  // JZ NOTE: string ID APPROACH 
+  // comparator to sort IDs in reverse (newest queries precede older queries)
+  // .slice() to seperate the ID number from the string "query-browser-query-id-123"
+  const queryKeys = queries2.keySeq().sort((k1,k2) => {
+    k1 = +k1.slice(23)
+    k2 = +k2.slice(23)
+    if (k1 < k2) {
+      return 1;
+    }
+    if (k1 > k2) {
+        return -1;
+    }
+    return 0;
+   }
+  )
   
   // State > Queries > Object structure is List[Map<string:string>]
   // TODO: QueriesList need to sort the map by ID then render 
   return (
     <>
-      {_.range(queries.size).map((i) => (
+      {/* {_.range(queries.size).map((i) => (
         <div>
           The Index is : {i}   key : {queries.get(i).get("id")} 
           <Query index={i} key={queries.get(i).get("id")} />
         </div>
-      ))}
+      ))} */}
+      {
+        queryKeys.map(key => 
+          <div>
+            {key.toString()}
+            <Query2 id={key} key={key} />
+          </div>
+          )
+      }
     </>
   );
 

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -173,22 +173,25 @@ const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
   const [colorIndex, isDisabled, isSeriesEmpty] = useSelector(({ observe }: RootState) => {
     const disabledSeries = observe.getIn(['queryBrowser2', 'queries2', id, 'disabledSeries']);
     if (_.some(disabledSeries, (s) => _.isEqual(s, labels))) {
+      console.log("JZ isSeriesEmpty : " + false )
       return [null, true, false];
     }
 
     const series = observe.getIn(['queryBrowser2', 'queries2', id, 'series']);
     if (_.isEmpty(series)) {
+      console.log("JZ isSeriesEmpty : " + true )
       return [null, false, true];
     }
 
-    // JZ LEFT OFF HERE Oct 18 7pm
-    // .take() might be the issue here 
     const colorOffset = observe
       .getIn(['queryBrowser2', 'queries2'])
       .take(id)
       .filter((q) => q.get('isEnabled'))
       .reduce((sum, q) => sum + _.size(q.get('series')), 0);
     const seriesIndex = _.findIndex(series, (s) => _.isEqual(s, labels));
+
+    console.log("JZ colorIndex is (colorOffset + seriesIndex) % colors.length : " + (colorOffset + seriesIndex) % colors.length)
+
     return [(colorOffset + seriesIndex) % colors.length, false, false];
   });
 
@@ -206,6 +209,7 @@ const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
 
   return (
     <div className="query-browser__series-btn-wrap">
+      <h1> hellow </h1>
       <Button
         aria-label={title}
         className={classNames('query-browser__series-btn', {

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -167,6 +167,7 @@ const ExpandButton = ({ isExpanded, onClick }) => {
   );
 };
 
+// TODO: Resolve series:undefined -- in query-browser.tsx there is a dispatch(queryBrowswerPatch(i, series:<Prometheus_data>) that needs to be udpated)
 const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
   const { t } = useTranslation();
 
@@ -209,7 +210,6 @@ const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
 
   return (
     <div className="query-browser__series-btn-wrap">
-      <h1> hellow </h1>
       <Button
         aria-label={title}
         className={classNames('query-browser__series-btn', {
@@ -463,6 +463,8 @@ export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
     }
   };
 
+  console.log("JZ Prometheus data: " +  JSON.stringify(data))
+
   usePoll(tick, pollInterval, namespace, query, span, lastRequestTime);
 
   React.useEffect(() => {
@@ -510,7 +512,11 @@ export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
 
   const transforms = [sortable, wrappable];
 
-  // JZ LEFT OFF HERE Oct 18 7pm
+  // JZ LEFT OFF HERE Oct 19 5:30pm -- Query{...series:undefined} -- Prometheus data is not getting properly set 
+
+  const dispatch = useDispatch();
+  dispatch(queryBrowserPatchQuery2(id, {series: data.result}))
+
   const buttonCell = (labels) => ({ title: <SeriesButton2 id={id} labels={labels} /> });
 
   let columns, rows;
@@ -888,13 +894,14 @@ const Query2 : React.FC<{ id: string }> = ({ id }) => {
         <div className="dropdown-kebab-pf">
           <QueryKebab2 id={id} />
         </div>
+        </div>
+
         <QueryTable2 id={id} />
       </div>
-    </div>
   );
   
 
-};
+}
 
 const Query: React.FC<{ index: number }> = ({ index }) => {
   const { t } = useTranslation();
@@ -1006,6 +1013,9 @@ const QueryBrowserWrapper: React.FC<{}> = () => {
       );
     }
   }, [dispatch]);
+
+  // TODO: DON'T Change the query-browser NOTE -- 10-20-11:08
+  // Loop through the QueryMAP and match the query-string to get the Object ID 
 
   /* eslint-disable react-hooks/exhaustive-deps */
   // Use React.useMemo() to prevent these two arrays being recreated on every render, which would

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -221,75 +221,6 @@ const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
   );
 };
 
-const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
-  const { t } = useTranslation();
-
-  const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
-
-  const isDisabledSeriesEmpty = useSelector(({ observe }: RootState) =>
-    _.isEmpty(observe.getIn(['queryBrowser', 'queries', index, 'disabledSeries'])),
-  );
-  const isEnabled = useSelector(({ observe }: RootState) =>
-    observe.getIn(['queryBrowser', 'queries', index, 'isEnabled']),
-  );
-  const series = useSelector(({ observe }: RootState) =>
-    observe.getIn(['queryBrowser', 'queries', index, 'series']),
-  );
-
-  const dispatch = useDispatch();
-
-  const toggleIsEnabled = React.useCallback(() => dispatch(queryBrowserToggleIsEnabled(index)), [
-    dispatch,
-    index,
-  ]);
-
-  const toggleAllSeries = React.useCallback(
-    () =>
-      dispatch(
-        queryBrowserPatchQuery(index, {
-          disabledSeries: isDisabledSeriesEmpty ? series : [],
-        }),
-      ),
-    [dispatch, index, isDisabledSeriesEmpty, series],
-  );
-
-  const doDelete = React.useCallback(() => {
-    dispatch(queryBrowserDeleteQuery(index));
-    focusedQuery = undefined;
-  }, [dispatch, index]);
-
-  const doClone = React.useCallback(() => {
-    dispatch(queryBrowserDuplicateQuery(index));
-  }, [dispatch, index]);
-
-  const dropdownItems = [
-    <DropdownItem key="toggle-query" component="button" onClick={toggleIsEnabled}>
-      {isEnabled ? t('public~Disable query') : t('public~Enable query')}
-    </DropdownItem>,
-    <DropdownItem key="toggle-all-series" component="button" onClick={toggleAllSeries}>
-      {isDisabledSeriesEmpty ? t('public~Hide all series') : t('public~Show all series')}
-    </DropdownItem>,
-    <DropdownItem key="delete" component="button" onClick={doDelete}>
-      {t('public~Delete query')}
-    </DropdownItem>,
-    <DropdownItem key="duplicate" component="button" onClick={doClone}>
-      {t('public~Duplicate query')}
-    </DropdownItem>,
-  ];
-
-  return (
-    <PFDropdown
-      data-test-id="kebab-button"
-      dropdownItems={dropdownItems}
-      isOpen={isOpen}
-      isPlain
-      onSelect={setClosed}
-      position={DropdownPosition.right}
-      toggle={<KebabToggle id="toggle-kebab" onToggle={setIsOpen} />}
-    />
-  );
-};
-
 const QueryKebab2: React.FC<{ id: string }> = ({ id }) => {
   const { t } = useTranslation();
 
@@ -571,6 +502,8 @@ export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
   );
 };
 
+// JZ NOTE: This Component is referenced in MetricsChart.tsx
+// need to refactor 
 export const QueryTable: React.FC<QueryTableProps> = ({ index, namespace }) => {
   const { t } = useTranslation();
 
@@ -770,11 +703,6 @@ const PromQLExpressionInput = (props) => (
 const Query2 : React.FC<{ id: string }> = ({ id }) => {
   const { t } = useTranslation();
 
-  // const q = useSelector(({ observe }: RootState) =>
-  //   observe.getIn(['queryBrowser2', 'queries2']),
-  // );
-
-  // QueriesList {id:Map{}, id:Map{}, id:Map{}}
   const isEnabled = useSelector(({ observe }: RootState) =>
     observe.getIn(['queryBrowser2', 'queries2', id, 'isEnabled']),
   );
@@ -783,10 +711,6 @@ const Query2 : React.FC<{ id: string }> = ({ id }) => {
   );
   const text = useSelector(({ observe }: RootState) =>
     observe.getIn(['queryBrowser2', 'queries2', id, 'text'], ''),
-  );
-
-  const queries = useSelector(({ observe }: RootState) =>
-    observe.getIn(['queryBrowser2', 'queries2', id]),
   );
 
   const dispatch = useDispatch();
@@ -812,9 +736,6 @@ const Query2 : React.FC<{ id: string }> = ({ id }) => {
     dispatch(queryBrowserRunQueries2());
   }, [dispatch]);
 
-  // TODO: NOT sure if this actually is working ... 
-  // when you click on a selection from the dropdown, the query runs with out 
-  // clicking 'run query'
   const handleSelectionChange = (
     target: { focus: () => void; setSelectionRange: (start: number, end: number) => void },
     start: number,
@@ -853,96 +774,11 @@ const Query2 : React.FC<{ id: string }> = ({ id }) => {
           <QueryKebab2 id={id} />
         </div>
         </div>
-
         <QueryTable2 id={id} />
       </div>
   );
-  
-
 }
 
-const Query: React.FC<{ index: number }> = ({ index }) => {
-  const { t } = useTranslation();
-
-  const id = useSelector(({ observe }: RootState) =>
-    observe.getIn(['queryBrowser', 'queries', index, 'id']),
-  );
-  const isEnabled = useSelector(({ observe }: RootState) =>
-    observe.getIn(['queryBrowser', 'queries', index, 'isEnabled']),
-  );
-  const isExpanded = useSelector(({ observe }: RootState) =>
-    observe.getIn(['queryBrowser', 'queries', index, 'isExpanded']),
-  );
-  const text = useSelector(({ observe }: RootState) =>
-    observe.getIn(['queryBrowser', 'queries', index, 'text'], ''),
-  );
-
-  const dispatch = useDispatch();
-
-  const toggleIsEnabled = React.useCallback(() => dispatch(queryBrowserToggleIsEnabled(index)), [
-    dispatch,
-    index,
-  ]);
-
-  const toggleIsExpanded = React.useCallback(
-    () => dispatch(queryBrowserPatchQuery(index, { isExpanded: !isExpanded })),
-    [dispatch, index, isExpanded],
-  );
-
-  const handleTextChange = React.useCallback(
-    (value: string) => {
-      dispatch(queryBrowserPatchQuery(index, { text: value }));
-    },
-    [dispatch, index],
-  );
-
-  const handleExecuteQueries = React.useCallback(() => {
-    dispatch(queryBrowserRunQueries());
-  }, [dispatch]);
-
-  const handleSelectionChange = (
-    target: { focus: () => void; setSelectionRange: (start: number, end: number) => void },
-    start: number,
-    end: number,
-  ) => {
-    focusedQuery = { index, selection: { start, end }, target };
-  };
-
-  const switchKey = `${id}-${isEnabled}`;
-  const switchLabel = isEnabled ? t('public~Disable query') : t('public~Enable query');
-
-
-  return (
-    <div
-      className={classNames('query-browser__table', {
-        'query-browser__table--expanded': isExpanded,
-      })}
-    >
-      <div className="query-browser__query-controls">
-        <ExpandButton isExpanded={isExpanded} onClick={toggleIsExpanded} />
-        <PromQLExpressionInput
-          value={text}
-          onValueChange={handleTextChange}
-          onExecuteQuery={handleExecuteQueries}
-          onSelectionChange={handleSelectionChange}
-        />
-        <div title={switchLabel}>
-          <Switch
-            aria-label={switchLabel}
-            id={switchKey}
-            isChecked={isEnabled}
-            key={switchKey}
-            onChange={toggleIsEnabled}
-          />
-        </div>
-        <div className="dropdown-kebab-pf">
-          <QueryKebab index={index} />
-        </div>
-      </div>
-      <QueryTable index={index} />
-    </div>
-  );
-};
 
 const QueryBrowserWrapper: React.FC<{}> = () => {
   const { t } = useTranslation();
@@ -972,17 +808,16 @@ const QueryBrowserWrapper: React.FC<{}> = () => {
     }
   }, [dispatch]);
 
-  // TODO: DON'T Change the query-browser NOTE -- 10-20-11:08
-  // Loop through the QueryMAP and match the query-string to get the Object ID 
-
   /* eslint-disable react-hooks/exhaustive-deps */
   // Use React.useMemo() to prevent these two arrays being recreated on every render, which would
   // trigger unnecessary re-renders of QueryBrowser, which can be quite slow
   const queriesMemoKey = JSON.stringify(_.map(queries, 'query'));
   const queryStrings = React.useMemo(() => _.map(queries, 'query'), [queriesMemoKey]);
   
-  // JZ NOTES: LEFT OFF HERE NOV3 --- Need to pass queryIDs to <QueryBrowsers/> 
-  // ln 785 query-broser.tsx > update dispatch(queryBrowserPatchQuery2('queryIDs[i]', {series ....}))
+  // TODO: DON'T Change the query-browser NOTE -- 10-20-11:08
+  // Loop through the QueryMAP and match the query-string to get the Object ID 
+  // JZ NOTE:  passes queryIDs to <QueryBrowsers/> 
+  // ~ln 785 query-broser.tsx > update dispatch(queryBrowserPatchQuery2('queryIDs[i]', {series ....}))
   const queriesMemoIDs = JSON.stringify(_.map(queries, 'query'));
   const queryIDs = React.useMemo(() => _.keys(queries), [queriesMemoIDs]);
 
@@ -1056,7 +891,7 @@ const AddQueryButton: React.FC<{}> = () => {
     // TODO: Update onClick so that its only one function that is called 
     <Button
       className="query-browser__inline-control"
-      onClick={addQuery && addQuery2}
+      onClick={addQuery2}
       type="button"
       variant="secondary"
     >

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -191,10 +191,26 @@ const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
       .reduce((sum, q) => sum + _.size(q.get('series')), 0);
     const seriesIndex = _.findIndex(series, (s) => _.isEqual(s, labels));
 
+    const cherries = observe
+    .getIn(['queryBrowser2', 'queries2',id])
+    .get('series')
+    .reduce((sum, q) => sum + _.size(q), 0)
+
+    console.log("JZ id %s", id)
+    console.log("JZ cherries %s", JSON.stringify(cherries))
+
     console.log("JZ colorIndex is (colorOffset + seriesIndex) % colors.length : " + (colorOffset + seriesIndex) % colors.length)
+    console.log("JZ colorOffSet %s, seriesIndex %s, colors %s , colors.length %s", colorOffset , seriesIndex, colors, colors.length)
+    console.log("JZ Labels %s", JSON.stringify(labels))
+    console.log("JZ series %s", JSON.stringify(series))
 
     return [(colorOffset + seriesIndex) % colors.length, false, false];
   });
+
+  console.log("JZ colories %s", colors)
+  console.log("JZ colorIndex %s", colorIndex)
+
+
 
   const dispatch = useDispatch();
   const toggleSeries = React.useCallback(() => dispatch(queryBrowserToggleSeries2(id, labels)), [
@@ -225,57 +241,57 @@ const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
   );
 };
 
-const SeriesButton: React.FC<SeriesButtonProps> = ({ index, labels }) => {
-  const { t } = useTranslation();
+// const SeriesButton: React.FC<SeriesButtonProps> = ({ index, labels }) => {
+//   const { t } = useTranslation();
 
-  const [colorIndex, isDisabled, isSeriesEmpty] = useSelector(({ observe }: RootState) => {
-    const disabledSeries = observe.getIn(['queryBrowser', 'queries', index, 'disabledSeries']);
-    if (_.some(disabledSeries, (s) => _.isEqual(s, labels))) {
-      return [null, true, false];
-    }
+//   const [colorIndex, isDisabled, isSeriesEmpty] = useSelector(({ observe }: RootState) => {
+//     const disabledSeries = observe.getIn(['queryBrowser', 'queries', index, 'disabledSeries']);
+//     if (_.some(disabledSeries, (s) => _.isEqual(s, labels))) {
+//       return [null, true, false];
+//     }
 
-    const series = observe.getIn(['queryBrowser', 'queries', index, 'series']);
-    if (_.isEmpty(series)) {
-      return [null, false, true];
-    }
+//     const series = observe.getIn(['queryBrowser', 'queries', index, 'series']);
+//     if (_.isEmpty(series)) {
+//       return [null, false, true];
+//     }
 
-    const colorOffset = observe
-      .getIn(['queryBrowser', 'queries'])
-      .take(index)
-      .filter((q) => q.get('isEnabled'))
-      .reduce((sum, q) => sum + _.size(q.get('series')), 0);
-    const seriesIndex = _.findIndex(series, (s) => _.isEqual(s, labels));
-    return [(colorOffset + seriesIndex) % colors.length, false, false];
-  });
+//     const colorOffset = observe
+//       .getIn(['queryBrowser', 'queries'])
+//       .take(index)
+//       .filter((q) => q.get('isEnabled'))
+//       .reduce((sum, q) => sum + _.size(q.get('series')), 0);
+//     const seriesIndex = _.findIndex(series, (s) => _.isEqual(s, labels));
+//     return [(colorOffset + seriesIndex) % colors.length, false, false];
+//   });
 
-  const dispatch = useDispatch();
-  const toggleSeries = React.useCallback(() => dispatch(queryBrowserToggleSeries(index, labels)), [
-    dispatch,
-    index,
-    labels,
-  ]);
+//   const dispatch = useDispatch();
+//   const toggleSeries = React.useCallback(() => dispatch(queryBrowserToggleSeries(index, labels)), [
+//     dispatch,
+//     index,
+//     labels,
+//   ]);
 
-  if (isSeriesEmpty) {
-    return <div className="query-browser__series-btn-wrap"></div>;
-  }
-  const title = isDisabled ? t('public~Show series') : t('public~Hide series');
+//   if (isSeriesEmpty) {
+//     return <div className="query-browser__series-btn-wrap"></div>;
+//   }
+//   const title = isDisabled ? t('public~Show series') : t('public~Hide series');
 
-  return (
-    <div className="query-browser__series-btn-wrap">
-      <Button
-        aria-label={title}
-        className={classNames('query-browser__series-btn', {
-          'query-browser__series-btn--disabled': isDisabled,
-        })}
-        onClick={toggleSeries}
-        style={colorIndex === null ? undefined : { backgroundColor: colors[colorIndex] }}
-        title={title}
-        type="button"
-        variant="plain"
-      />
-    </div>
-  );
-};
+//   return (
+//     <div className="query-browser__series-btn-wrap">
+//       <Button
+//         aria-label={title}
+//         className={classNames('query-browser__series-btn', {
+//           'query-browser__series-btn--disabled': isDisabled,
+//         })}
+//         onClick={toggleSeries}
+//         style={colorIndex === null ? undefined : { backgroundColor: colors[colorIndex] }}
+//         title={title}
+//         type="button"
+//         variant="plain"
+//       />
+//     </div>
+//   );
+// };
 
 const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
   const { t } = useTranslation();
@@ -418,6 +434,7 @@ const QueryKebab2: React.FC<{ id: string }> = ({ id }) => {
 export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
   const { t } = useTranslation();
 
+  // Set all the Variables 
   const [data, setData] = React.useState<PrometheusData>();
   const [error, setError] = React.useState<PrometheusAPIError>();
   const [page, setPage] = React.useState(1);
@@ -430,9 +447,11 @@ export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
   const isExpanded = useSelector(({ observe }: RootState) =>
     observe.getIn(['queryBrowser2', 'queries2', id, 'isExpanded']),
   );
-  const pollInterval = useSelector(({ observe }: RootState) =>
-    observe.getIn(['queryBrowser2', 'pollInterval'], 15 * 1000),
-  );
+  // const pollInterval = useSelector(({ observe }: RootState) =>
+  //   observe.getIn(['queryBrowser2', 'pollInterval'], 15 * 1000),
+  // );
+  const pollInterval = 15 * 1000
+
   const query = useSelector(({ observe }: RootState) =>
     observe.getIn(['queryBrowser2', 'queries2', id, 'query']),
   );
@@ -447,6 +466,7 @@ export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
 
   const safeFetch = React.useCallback(useSafeFetch(), []);
 
+  // JZ if there's a query and the table row is send a request to Prometheus 
   const tick = () => {
     if (isEnabled && isExpanded && query) {
       safeFetch(getPrometheusURL({ endpoint: PrometheusEndpoint.QUERY, namespace, query }))
@@ -464,9 +484,14 @@ export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
   };
 
   console.log("JZ Prometheus data: " +  JSON.stringify(data))
+  console.log("JZ PollInterval data: " +  JSON.stringify(pollInterval))
 
+
+
+  // JZ save callback and poll the request at set time intervals 
   usePoll(tick, pollInterval, namespace, query, span, lastRequestTime);
 
+  // JZ clear previous data? 
   React.useEffect(() => {
     setData(undefined);
     setError(undefined);
@@ -510,14 +535,19 @@ export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
     );
   }
 
+  console.log("JZ result %s", JSON.stringify(result))
+
   const transforms = [sortable, wrappable];
 
   // JZ LEFT OFF HERE Oct 19 5:30pm -- Query{...series:undefined} -- Prometheus data is not getting properly set 
+  // Hacked this -- by queryBrowserPatchQuery
 
   const dispatch = useDispatch();
   dispatch(queryBrowserPatchQuery2(id, {series: data.result}))
 
   const buttonCell = (labels) => ({ title: <SeriesButton2 id={id} labels={labels} /> });
+
+  console.log("JZ buttonCell %s", buttonCell)
 
   let columns, rows;
   if (data.resultType === 'scalar') {
@@ -562,6 +592,11 @@ export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
         _.get(value, '[1]', { title: <span className="text-muted">{t('public~None')}</span> }),
       ];
     }
+
+    console.log("JZ Rows %s", rows)
+    console.log("JZ columns %s", columns)
+    console.log("JZ rowMapper %s", rowMapper)
+    
 
     rows = _.map(result, rowMapper);
     if (sortBy) {

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -59,6 +59,7 @@ import {
   queryBrowserToggleSeries,
   toggleGraphs,
   queryBrowserAddQuery2,
+  queryBrowserDeleteAllQueries2,
   queryBrowserDeleteQuery2,
   queryBrowserDuplicateQuery2,
   queryBrowserToggleIsEnabled2,
@@ -79,6 +80,9 @@ import { PrometheusAPIError } from './types';
 // Stores information about the currently focused query input
 let focusedQuery;
 
+// JZ NOTE: 
+// Refactor : DONE 
+// FunctionComponent Reuse: NONE  
 const MetricsActionsMenu: React.FC<{}> = () => {
   const { t } = useTranslation();
 
@@ -89,10 +93,10 @@ const MetricsActionsMenu: React.FC<{}> = () => {
   );
 
   const dispatch = useDispatch();
-  const addQuery = React.useCallback(() => dispatch(queryBrowserAddQuery()), [dispatch]);
+  const addQuery = React.useCallback(() => dispatch(queryBrowserAddQuery2()), [dispatch]);
 
   const doDelete = () => {
-    dispatch(queryBrowserDeleteAllQueries());
+    dispatch(queryBrowserDeleteAllQueries2());
     focusedQuery = undefined;
   };
 
@@ -124,6 +128,9 @@ const MetricsActionsMenu: React.FC<{}> = () => {
   );
 };
 
+// JZ NOTE: 
+// Refactor : NONE  
+// FunctionComponent Reuse: alerts  
 export const ToggleGraph: React.FC<{}> = () => {
   const { t } = useTranslation();
 
@@ -146,10 +153,12 @@ export const ToggleGraph: React.FC<{}> = () => {
   );
 };
 
+// JZ NOTE: 
+// Refactor : NONE  
+// FunctionComponent Reuse: alerts  
 const ExpandButton = ({ isExpanded, onClick }) => {
   const { t } = useTranslation();
   const title = isExpanded ? t('public~Hide table') : t('public~Show table');
-  console.log("JZ Expanded Button : " + isExpanded + " " + onClick)
   return (
     <Button
       aria-label={title}
@@ -167,7 +176,9 @@ const ExpandButton = ({ isExpanded, onClick }) => {
   );
 };
 
-// TODO: Resolve series:undefined -- in query-browser.tsx there is a dispatch(queryBrowswerPatch(i, series:<Prometheus_data>) that needs to be udpated)
+// JZ NOTE: 
+// Refactor : IN-Progress, There's still an issue with the buttonSeries rendering colors that don't match the graph   
+// FunctionComponent Reuse: none   
 const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
   const { t } = useTranslation();
 
@@ -189,6 +200,7 @@ const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
       .reduce((sum, q) => sum + _.size(q.get('series')), 0);
     const seriesIndex = _.findIndex(series, (s) => _.isEqual(s, labels));
 
+    // TODO: colors.length might be the reason why the colors QueryTable don't make the Graph 
     return [(colorOffset + seriesIndex) % colors.length, false, false];
   });
 
@@ -221,19 +233,23 @@ const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
   );
 };
 
+
+// JZ NOTE: 
+// Refactor : DONE
+// FunctionComponent Reuse: none 
 const QueryKebab2: React.FC<{ id: string }> = ({ id }) => {
   const { t } = useTranslation();
 
   const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
 
   const isDisabledSeriesEmpty = useSelector(({ observe }: RootState) =>
-    _.isEmpty(observe.getIn(['queryBrowser', 'queries', id, 'disabledSeries'])),
+    _.isEmpty(observe.getIn(['queryBrowser2', 'queries2', id, 'disabledSeries'])),
   );
   const isEnabled = useSelector(({ observe }: RootState) =>
-    observe.getIn(['queryBrowser', 'queries', id, 'isEnabled']),
+    observe.getIn(['queryBrowser2', 'queries2', id, 'isEnabled']),
   );
   const series = useSelector(({ observe }: RootState) =>
-    observe.getIn(['queryBrowser', 'queries', id, 'series']),
+    observe.getIn(['queryBrowser2', 'queries2', id, 'series']),
   );
 
   const dispatch = useDispatch();
@@ -289,6 +305,8 @@ const QueryKebab2: React.FC<{ id: string }> = ({ id }) => {
     />
   );
 };
+
+// JZ NOTE: Left off Here NOV 4 5:30pm
 
 export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
   const { t } = useTranslation();
@@ -792,6 +810,8 @@ const QueryBrowserWrapper: React.FC<{}> = () => {
 
   const queries = queriesList.toJS();
 
+  // TODO: update useEffect so that it used queryBrowserPatchQuery2(id ... )
+
   // Initialize queries from URL parameters
   React.useEffect(() => {
     const searchParams = getURLSearchParams();
@@ -884,11 +904,9 @@ const AddQueryButton: React.FC<{}> = () => {
   const { t } = useTranslation();
 
   const dispatch = useDispatch();
-  const addQuery = React.useCallback(() => dispatch(queryBrowserAddQuery()), [dispatch]);
   const addQuery2 = React.useCallback(() => dispatch(queryBrowserAddQuery2()), [dispatch]);
 
   return (
-    // TODO: Update onClick so that its only one function that is called 
     <Button
       className="query-browser__inline-control"
       onClick={addQuery2}

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -171,7 +171,6 @@ const ExpandButton = ({ isExpanded, onClick }) => {
 const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
   const { t } = useTranslation();
 
-
   const [colorIndex, isDisabled, isSeriesEmpty] = useSelector(({ observe }: RootState) => {
     const disabledSeries = observe.getIn(['queryBrowser2', 'queries2', id, 'disabledSeries']);
     if (_.some(disabledSeries, (s) => _.isEqual(s, labels))) {
@@ -188,35 +187,10 @@ const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
       .take(id)
       .filter((q) => q.get('isEnabled'))
       .reduce((sum, q) => sum + _.size(q.get('series')), 0);
-
     const seriesIndex = _.findIndex(series, (s) => _.isEqual(s, labels));
-
-    console.log("JZ SeriesBtn2 > labels : "  + JSON.stringify(labels))
-    console.log ("JZ seriesBtn2 > series : ", series )
-
-    // series.forEach((s) => {
-    //   console.log("JZ SeriesBtn2 > series.forEach( (s) => : ", s)
-    //   console.log("JZ SeriesBtn2 > _.isEqual(s, labels) : ", _.isEqual(s, labels))
-    // })
-    console.log("JZ seriesIndex : ", seriesIndex )
-    console.log("JZ colorOffSet : ", colorOffset )
-    console.log("JZ SeriesBtn2 > ====================== END ==================== ")
-
-
-
-    // console.log("JZ SeriesBtn2 >  colorIndex is [(colorOffset + seriesIndex)] % colors.length : " + (colorOffset + seriesIndex) % colors.length)
-    // console.log("JZ SeriesBtn2 >  colorOffSet %s, seriesIndex %s, colors %s , colors.length %s", colorOffset , seriesIndex, colors, colors.length)
-
-    // TODO: Delete -- this is a test  
-    if ( ((colorOffset + seriesIndex) % colors.length) == -1 ) {
-      return [0, false, false]
-    }
 
     return [(colorOffset + seriesIndex) % colors.length, false, false];
   });
-
-    // console.log("JZ SeriesBtn2 > [colorIndex %s, isDisabled %s, isSeriesEmpty %s]", colorIndex, isDisabled, isSeriesEmpty)
-    // console.log("JZ SeriesBtn2 > backgroundColor: colors:%s [colorsIndex:%s] = ", colors, colorIndex, colors[colorIndex] )
 
   const dispatch = useDispatch();
   const toggleSeries = React.useCallback(() => dispatch(queryBrowserToggleSeries2(id, labels)), [
@@ -246,58 +220,6 @@ const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
     </div>
   );
 };
-
-// const SeriesButton: React.FC<SeriesButtonProps> = ({ index, labels }) => {
-//   const { t } = useTranslation();
-
-//   const [colorIndex, isDisabled, isSeriesEmpty] = useSelector(({ observe }: RootState) => {
-//     const disabledSeries = observe.getIn(['queryBrowser', 'queries', index, 'disabledSeries']);
-//     if (_.some(disabledSeries, (s) => _.isEqual(s, labels))) {
-//       return [null, true, false];
-//     }
-
-//     const series = observe.getIn(['queryBrowser', 'queries', index, 'series']);
-//     if (_.isEmpty(series)) {
-//       return [null, false, true];
-//     }
-
-//     const colorOffset = observe
-//       .getIn(['queryBrowser', 'queries'])
-//       .take(index)
-//       .filter((q) => q.get('isEnabled'))
-//       .reduce((sum, q) => sum + _.size(q.get('series')), 0);
-//     const seriesIndex = _.findIndex(series, (s) => _.isEqual(s, labels));
-//     return [(colorOffset + seriesIndex) % colors.length, false, false];
-//   });
-
-//   const dispatch = useDispatch();
-//   const toggleSeries = React.useCallback(() => dispatch(queryBrowserToggleSeries(index, labels)), [
-//     dispatch,
-//     index,
-//     labels,
-//   ]);
-
-//   if (isSeriesEmpty) {
-//     return <div className="query-browser__series-btn-wrap"></div>;
-//   }
-//   const title = isDisabled ? t('public~Show series') : t('public~Hide series');
-
-//   return (
-//     <div className="query-browser__series-btn-wrap">
-//       <Button
-//         aria-label={title}
-//         className={classNames('query-browser__series-btn', {
-//           'query-browser__series-btn--disabled': isDisabled,
-//         })}
-//         onClick={toggleSeries}
-//         style={colorIndex === null ? undefined : { backgroundColor: colors[colorIndex] }}
-//         title={title}
-//         type="button"
-//         variant="plain"
-//       />
-//     </div>
-//   );
-// };
 
 const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
   const { t } = useTranslation();
@@ -1118,6 +1040,7 @@ const QueryBrowserWrapper: React.FC<{}> = () => {
       disabledSeries={disabledSeries}
       queries={queryStrings}
       showStackedControl
+      queryIDs={queryIDs}
     />
   );
 };

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -811,12 +811,15 @@ const QueryBrowserWrapper: React.FC<{}> = () => {
   const queries = queriesList.toJS();
 
   // TODO: update useEffect so that it used queryBrowserPatchQuery2(id ... )
+  const searchParams = getURLSearchParams();
+  console.log("JZ BrowserWrapper > searchParams : " + searchParams )
+
 
   // Initialize queries from URL parameters
   React.useEffect(() => {
-    const searchParams = getURLSearchParams();
-    for (let i = 0; _.has(searchParams, `query${i}`); ++i) {
-      const query = searchParams[`query${i}`];
+    const searchParams = getURLSearchParams(); // get URL
+    for (let i = 0; _.has(searchParams, `query${i}`); ++i) { // iterate, search all the queries of the URL 
+      const query = searchParams[`query${i}`]; // patch 
       dispatch(
         queryBrowserPatchQuery(i, {
           isEnabled: true,
@@ -840,9 +843,6 @@ const QueryBrowserWrapper: React.FC<{}> = () => {
   // ~ln 785 query-broser.tsx > update dispatch(queryBrowserPatchQuery2('queryIDs[i]', {series ....}))
   const queriesMemoIDs = JSON.stringify(_.map(queries, 'query'));
   const queryIDs = React.useMemo(() => _.keys(queries), [queriesMemoIDs]);
-
-  console.log("JZ query-browser component > QueryBrowserWrapper queryStrings: ", queryStrings)
-  console.log("JZ query-browser component > QueryBrowserWrapper queryIDs: ", queryIDs)
 
   const disabledSeriesMemoKey = JSON.stringify(
     _.reject(_.map(queries, 'disabledSeries'), _.isEmpty),
@@ -942,6 +942,8 @@ const QueriesList: React.FC<{}> = () => {
     ({ observe }: RootState) => observe.getIn(['queryBrowser2', 'queries2']),
   );
 
+  // Sort queries by the attribute `sortOrder` so that 
+  // newer queries preceed older queries. 
   const sortedQueries = queries2.sort((k1,k2) => {
     if (k1.get("sortOrder") < k2.get("sortOrder")) {
       return 1;

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -85,7 +85,7 @@ const MetricsActionsMenu: React.FC<{}> = () => {
   const [isOpen, setIsOpen, , setClosed] = useBoolean(false);
 
   const isAllExpanded = useSelector(({ observe }: RootState) =>
-    observe.getIn(['queryBrowser', 'queries']).every((q) => q.get('isExpanded')),
+    observe.getIn(['queryBrowser2', 'queries2']).every((q) => q.get('isExpanded')),
   );
 
   const dispatch = useDispatch();
@@ -192,13 +192,14 @@ const SeriesButton2: React.FC<SeriesButtonProps2> = ({ id, labels }) => {
     const seriesIndex = _.findIndex(series, (s) => _.isEqual(s, labels));
 
     console.log("JZ SeriesBtn2 > labels : "  + JSON.stringify(labels))
-    console.log (" JZ seriesBtn2 > series + ", series )
+    console.log ("JZ seriesBtn2 > series : ", series )
 
-    series.forEach((s) => {
-      console.log("JZ SeriesBtn2 > s : ", s)
-      console.log("JZ SeriesBtn2 > _.isEqual(s, labels) : ", _.isEqual(s, labels))
-    })
-
+    // series.forEach((s) => {
+    //   console.log("JZ SeriesBtn2 > series.forEach( (s) => : ", s)
+    //   console.log("JZ SeriesBtn2 > _.isEqual(s, labels) : ", _.isEqual(s, labels))
+    // })
+    console.log("JZ seriesIndex : ", seriesIndex )
+    console.log("JZ colorOffSet : ", colorOffset )
     console.log("JZ SeriesBtn2 > ====================== END ==================== ")
 
 
@@ -532,6 +533,8 @@ export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
     ? [...data.result, ...expiredSeries.map((metric) => ({ metric }))]
     : data.result;
 
+  console.log("JZ SeriesBtn2 > QueryTable2 > expiredSeries : ", JSON.stringify(expiredSeries))
+  console.log("JZ SeriesBtn2 > QueryTable2 > result : ", JSON.stringify(result))
 
   if (!result || result.length === 0) {
     return (
@@ -545,8 +548,8 @@ export const QueryTable2: React.FC<QueryTableProps2> = ({ id, namespace }) => {
 
   // JZ LEFT OFF HERE Oct 19 5:30pm -- Query{...series:undefined} -- Prometheus data is not getting properly set 
   // Hacked this -- by queryBrowserPatchQuery
-  const dispatch = useDispatch();
-  dispatch(queryBrowserPatchQuery2(id, {series: data.result}))
+  // const dispatch = useDispatch();
+  // dispatch(queryBrowserPatchQuery2(id, {series: data.result}))
 
   const buttonCell = (labels) => ({ title: <SeriesButton2 id={id} labels={labels} /> });
 
@@ -1055,6 +1058,15 @@ const QueryBrowserWrapper: React.FC<{}> = () => {
   // trigger unnecessary re-renders of QueryBrowser, which can be quite slow
   const queriesMemoKey = JSON.stringify(_.map(queries, 'query'));
   const queryStrings = React.useMemo(() => _.map(queries, 'query'), [queriesMemoKey]);
+  
+  // JZ NOTES: LEFT OFF HERE NOV3 --- Need to pass queryIDs to <QueryBrowsers/> 
+  // ln 785 query-broser.tsx > update dispatch(queryBrowserPatchQuery2('queryIDs[i]', {series ....}))
+  const queriesMemoIDs = JSON.stringify(_.map(queries, 'query'));
+  const queryIDs = React.useMemo(() => _.keys(queries), [queriesMemoIDs]);
+
+  console.log("JZ query-browser component > QueryBrowserWrapper queryStrings: ", queryStrings)
+  console.log("JZ query-browser component > QueryBrowserWrapper queryIDs: ", queryIDs)
+
   const disabledSeriesMemoKey = JSON.stringify(
     _.reject(_.map(queries, 'disabledSeries'), _.isEmpty),
   );

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -779,15 +779,15 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
           });
           setGraphData(newGraphData);
 
-          console.log("JZ query-browser component newResults: ", newResults)
-
-          _.each(newResults, (r, i) => {
-            dispatch(queryBrowserPatchQuery(i, { series: r ? _.map(r, 'metric') : 'undefined' })),
-            dispatch(queryBrowserPatchQuery2(queryIDs[i], { series: r ? _.map(r, 'metric') : 'undefined' })),
-
-            console.log("JZ query-browser component > r : %s, i : %s ", JSON.stringify(r), i )
-            }
-          );
+          if (_.isEmpty(queryIDs)) {
+            _.each(newResults, (r, i) => 
+              dispatch(queryBrowserPatchQuery(i, { series: r ? _.map(r, 'metric') : 'undefined' })) 
+            );
+          } else {
+            _.each(newResults, (r, i) => 
+              dispatch(queryBrowserPatchQuery2(queryIDs[i], { series: r ? _.map(r, 'metric') : 'undefined' }))
+            )
+          }
           setUpdating(false);
         }
         setError(undefined);

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -645,6 +645,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   onZoom,
   pollInterval,
   queries,
+  queryIDs,
   showLegend,
   showStackedControl = false,
   timespan,
@@ -782,7 +783,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
 
           _.each(newResults, (r, i) => {
             dispatch(queryBrowserPatchQuery(i, { series: r ? _.map(r, 'metric') : 'undefined' })),
-            dispatch(queryBrowserPatchQuery2("query-browser-query5", { series: r ? _.map(r, 'metric') : 'undefined' })),
+            dispatch(queryBrowserPatchQuery2(queryIDs[i], { series: r ? _.map(r, 'metric') : 'undefined' })),
 
             console.log("JZ query-browser component > r : %s, i : %s ", JSON.stringify(r), i )
             }
@@ -1032,12 +1033,12 @@ export type QueryBrowserProps = {
   onZoom?: GraphOnZoom;
   pollInterval?: number;
   queries: string[];
+  queryIDs?: string[];
   showLegend?: boolean;
   showStackedControl?: boolean;
   timespan?: number;
   units?: string;
   wrapperClassName?: string;
-  queryIDs?: string[];
 };
 
 type SpanControlsProps = {

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -41,6 +41,7 @@ import withFallback from '@console/shared/src/components/error/fallbacks/withFal
 import {
   queryBrowserDeleteAllSeries,
   queryBrowserPatchQuery,
+  queryBrowserPatchQuery2,
   queryBrowserSetTimespan,
 } from '../../actions/observe';
 import { RootState } from '../../redux';
@@ -777,8 +778,14 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
           });
           setGraphData(newGraphData);
 
-          _.each(newResults, (r, i) =>
-            dispatch(queryBrowserPatchQuery(i, { series: r ? _.map(r, 'metric') : undefined })),
+          console.log("JZ query-browser component newResults: ", newResults)
+
+          _.each(newResults, (r, i) => {
+            dispatch(queryBrowserPatchQuery(i, { series: r ? _.map(r, 'metric') : 'undefined' })),
+            dispatch(queryBrowserPatchQuery2("query-browser-query5", { series: r ? _.map(r, 'metric') : 'undefined' })),
+
+            console.log("JZ query-browser component > r : %s, i : %s ", JSON.stringify(r), i )
+            }
           );
           setUpdating(false);
         }
@@ -1030,6 +1037,7 @@ export type QueryBrowserProps = {
   timespan?: number;
   units?: string;
   wrapperClassName?: string;
+  queryIDs?: string[];
 };
 
 type SpanControlsProps = {

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -317,10 +317,10 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
     }
 
     case ActionType.QueryBrowserSetAllExpanded: {
-      const queries = state.getIn(['queryBrowser', 'queries']).map((q) => {
+      const queries = state.getIn(['queryBrowser2', 'queries2']).map((q) => {
         return q.set('isExpanded', action.payload.isExpanded);
       });
-      return state.setIn(['queryBrowser', 'queries'], queries);
+      return state.setIn(['queryBrowser2', 'queries2'], queries);
     }
 
     case ActionType.QueryBrowserSetMetrics:

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -309,6 +309,10 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
         const isEnabled = q.get('isEnabled');
         const query = q.get('query');
         const text = _.trim(q.get('text'));
+        console.log("JZ Hello from REducer RunQueries2 isEnabled %s, query %s, text %s", isEnabled, query, text)
+        console.log("JZ Hello from REducer RunQueries2 isEnabled %s, query %s, text %s", isEnabled, query, text)
+
+
         return isEnabled && query !== text ? q.merge({ query: text, series: undefined }) : q;
       });
 

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -224,13 +224,13 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
       // Update global counter to account for shift  
       nextSortOrderID++
 
+      // Create the duplicate and add it to the queriesList
       var duplicate = newQueryBrowserQuery2()
       duplicate[0][1] = duplicate[0][1].mergeDeep({
         text: originQueryText,
         isEnabled: false,
         sortOrder: originSortOrder + 1
       });
-
       const updatedQueriesList = sortOrderUpdateQueries.merge(duplicate)
 
       return state.setIn(['queryBrowser2', 'queries2'], updatedQueriesList)
@@ -278,6 +278,7 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
     case ActionType.QueryBrowserDismissNamespaceAlert:
       return state.setIn(['queryBrowser', 'dismissNamespaceAlert'], true);
 
+    // TODO: Need to update other components that reference this?
     case ActionType.QueryBrowserPatchQuery: {
       const { index, patch } = action.payload;
       const query = state.hasIn(['queryBrowser', 'queries', index])
@@ -288,9 +289,12 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
 
     case ActionType.QueryBrowserPatchQuery2: {
       const { id, patch } = action.payload;
-      const query = state.hasIn(['queryBrowser2', 'queries2', id])
-        ? ImmutableMap(patch)
-        : newQueryBrowserQuery2()[0][1].merge(patch);
+      if (!state.hasIn(['queryBrowser2', 'queries2', id])) {
+        var newQuery = newQueryBrowserQuery2();
+        newQuery[0][1] = newQuery[0][1].merge(patch);
+        return state.mergeIn(['queryBrowser2', 'queries2'], newQuery);
+      }
+      const query = ImmutableMap(patch)
       return state.mergeIn(['queryBrowser2', 'queries2', id], query);
     }
 

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -26,9 +26,9 @@ let nextID: number = 0;
 const newQueryBrowserQueryID = () : number => nextID++ 
 
 // returns a Key/Value Pair Map {id: 'query-browser-quer-123', Value:Map{isEnabled:true, isExpanded:true} }
-const newQueryBrowserQuery2 = () : [[number, ImmutableMap<string, any>]] =>  {
+const newQueryBrowserQuery2 = () : [[string, ImmutableMap<string, any>]] =>  {
   return [[
-    nextID++, 
+    "query-browser-query-id-" + nextID++, 
     ImmutableMap({
       isEnabled: true,
       isExpanded: true,
@@ -74,7 +74,6 @@ export const silenceFiringAlerts = (firingAlerts, silences) => {
 };
 
 export default (state: ObserveState, action: ObserveAction): ObserveState => {
-
   if (!state) {
     return ImmutableMap({
       dashboards: ImmutableMap({

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -11,34 +11,19 @@ import { isSilenced } from '../components/monitoring/utils';
 
 export type ObserveState = ImmutableMap<string, any>;
 
-let nextID: number = 0; 
-
-// const newQueryBrowserQueryID = () : number => nextID++ 
-
-// // returns a Key/Value Pair Map {id: 'query-browser-quer-123', Value:Map{isEnabled:true, isExpanded:true} }
-// const newQueryBrowserQuery2 = () : ImmutableMap<string, any> =>  
-//     ImmutableMap({
-//         isEnabled: true,
-//         isExpanded: true,
-//       }) 
-
-
-// const newQueryBrowserQueryID = () : number => nextID++ 
-
-
-
+let nextSortOrderID: number = 0; 
 
 // JZ2 returns a Key/Value Pair Map {id: 'query-browser-quer-123', Value:Map{isEnabled:true, isExpanded:true} }
 const newQueryBrowserQuery2 = () : [[string, ImmutableMap<string, any>]] =>  {
   return [[
     // replace with lodash _.uniqueID 
-    "query-browser-query-id-" + nextID++, 
+    _.uniqueId('query-browser-query'), 
     ImmutableMap({
       isEnabled: true,
       isExpanded: true,
       query: "", 
       text: "",
-      // sortOrder: 1 2 3 4 
+      sortOrder: nextSortOrderID++
     }) 
   ]]
 }
@@ -253,29 +238,8 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
     // JZ NOTE: Left off Here OCt 17 2022 5pm
     // Problem is that const duplicate returns on the Map{} without the key 
     // May need to use the same method as QueryPATCH
-    case ActionType.QueryBrowserDuplicateQuery2: {
-      const id = action.payload.id;
-      const originQueryText = state.getIn(['queryBrowser2', 'queries2', id, 'text'])
-      console.log("JZ QueryBrowserDuplicateQuery2 " + "id " + id + " originQueryText " + originQueryText)
-      
-
-      // const duplicate = newQueryBrowserQuery2()[0][1].update({
-      //   text: originQueryText,
-      //   isEnabled: false,
-      // });
-      console.log("JZ QueryBrowserDuplicateQuery2 " + "state.getIn " +  state.getIn(['queryBrowser2', 'queries2']).merge(duplicate))
-
+    case ActionType.QueryBrowserDuplicateQuery2: {     
       return state;
-      // const duplicate = newQueryBrowserQuery2()[0][1].merge({
-      //   text: originQueryText,
-      //   isEnabled: false,
-      // });
-      // console.log("JZ QueryBrowserDuplicateQuery2 " + "duplicate Query " + duplicate)
-      
-      // return state.setIn(
-      //   ['queryBrowser2', 'queries2'],
-      //   state.getIn(['queryBrowser2', 'queries2']).set(duplicate),
-      // );
     }
 
     case ActionType.QueryBrowserDeleteAllQueries:
@@ -297,11 +261,10 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
       return state.setIn(['queryBrowser', 'queries'], queries);
     }
 
-    // TODO: Update the line queries.push() --- doesn't work for MAP 
     case ActionType.QueryBrowserDeleteQuery2: {
       let queries = state.getIn(['queryBrowser2', 'queries2']).delete(action.payload.id);
       if (queries.size === 0) {
-        queries = queries.push(newQueryBrowserQuery2());
+        queries = queries.merge(newQueryBrowserQuery2());
       }
       return state.setIn(['queryBrowser2', 'queries2'], queries);
     }
@@ -401,6 +364,14 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
         ['queryBrowser', 'queries', action.payload.index, 'disabledSeries'],
         (v) => _.xorWith(v, [action.payload.labels], _.isEqual),
       );
+
+
+    case ActionType.QueryBrowserToggleSeries2:
+      return state.updateIn(
+        ['queryBrowser2', 'queries2', action.payload.id, 'disabledSeries'],
+        (v) => _.xorWith(v, [action.payload.labels], _.isEqual),
+      );
+
 
     case ActionType.SetAlertCount:
       return state.set('alertCount', action.payload.alertCount);

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -252,6 +252,13 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
       );
     }
 
+    case ActionType.QueryBrowserDeleteAllSeries2: {
+      return state.setIn(
+        ['queryBrowser2', 'queries2'],
+        state.getIn(['queryBrowser2', 'queries2']).map((q) => q.set('series', undefined)),
+      );
+    }
+
     // TODO: delete 
     case ActionType.QueryBrowserDeleteQuery: {
       let queries = state.getIn(['queryBrowser', 'queries']).delete(action.payload.index);

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -32,6 +32,8 @@ const newQueryBrowserQuery2 = () : [[string, ImmutableMap<string, any>]] =>  {
     ImmutableMap({
       isEnabled: true,
       isExpanded: true,
+      query: "", 
+      text: ""
     }) 
   ]]
 }
@@ -272,6 +274,16 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
       return state.mergeIn(['queryBrowser', 'queries', index], query);
     }
 
+    case ActionType.QueryBrowserPatchQuery2: {
+      const { id, patch } = action.payload;
+      const patch2 = [[id,patch]]
+      const query = state.hasIn(['queryBrowser', 'queries', id])
+        ? ImmutableMap(patch)
+        : newQueryBrowserQuery2()[0][1].merge(patch2);
+        console.log("JZ QueryBrowserPathQuery2 : " + query)
+      return state.mergeIn(['queryBrowser', 'queries', id], query);
+    }
+
     case ActionType.QueryBrowserRunQueries: {
       const queries = state.getIn(['queryBrowser', 'queries']).map((q) => {
         const isEnabled = q.get('isEnabled');
@@ -306,6 +318,19 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
       const isEnabled = !query.get('isEnabled');
       return state.setIn(
         ['queryBrowser', 'queries', action.payload.index],
+        query.merge({
+          isEnabled,
+          isExpanded: isEnabled,
+          query: isEnabled ? query.get('text') : '',
+        }),
+      );
+    }
+
+    case ActionType.QueryBrowserToggleIsEnabled2: {
+      const query = state.getIn(['queryBrowser', 'queries', action.payload.id]);
+      const isEnabled = !query.get('isEnabled');
+      return state.setIn(
+        ['queryBrowser', 'queries', action.payload.id],
         query.merge({
           isEnabled,
           isExpanded: isEnabled,

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -236,9 +236,14 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
       return state.setIn(['queryBrowser2', 'queries2'], updatedQueriesList)
     }
 
+    // TODO: Delete 
     case ActionType.QueryBrowserDeleteAllQueries:
       return state.setIn(['queryBrowser', 'queries'], ImmutableList([newQueryBrowserQuery()]));
-
+    
+    case ActionType.QueryBrowserDeleteAllQueries2:
+        return state.setIn(['queryBrowser2', 'queries2'], ImmutableMap(newQueryBrowserQuery2()));
+      
+    // TODO: Delete 
     case ActionType.QueryBrowserDeleteAllSeries: {
       return state.setIn(
         ['queryBrowser', 'queries'],
@@ -316,6 +321,7 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
         .setIn(['queryBrowser2', 'lastRequestTime'], Date.now());
     }
 
+    
     case ActionType.QueryBrowserSetAllExpanded: {
       const queries = state.getIn(['queryBrowser2', 'queries2']).map((q) => {
         return q.set('isExpanded', action.payload.isExpanded);

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -185,30 +185,6 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
     case ActionType.ToggleGraphs:
       return state.set('hideGraphs', !state.get('hideGraphs'));
 
-    // case ActionType.QueryBrowserAddQuery: { 
-
-    //   // gets current state of state.queryBrowser.queries[] 
-    //   const prev = state.getIn(['queryBrowser', 'queries'])
-    //   console.log("JZ reducer > addQuery | PREVIOUS State of QueryList:" + prev )
-
-    //   // creates a new Query to be added to tate.queryBrowser.queries[] 
-    //   const newQuery = newQueryBrowserQuery();
-    //   console.log("JZ reducer > addQuery | newQuery: " + newQuery)
-
-    //   // copies current state.queryBrowser.queries[] and appends a newQuery 
-    //   const updateValue = state.getIn(['queryBrowser', 'queries']).push(newQuery)
-    //   console.log("JZ reducer > addQuery | state.getIn....push(newQueryBrowserQuery()) :" +  updateValue)
-
-    //   const update = state.setIn(
-    //     ['queryBrowser', 'queries'],
-    //     updateValue,
-    //   );
-
-    //   console.log('JZ reducer > addQuery |  UPDATED State of QueryList: ' + update)
-
-    //   return update;
-    // }
-
     case ActionType.QueryBrowserAddQuery2:
       return state.setIn(
         ['queryBrowser2', 'queries2'],
@@ -238,8 +214,39 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
     // JZ NOTE: Left off Here OCt 17 2022 5pm
     // Problem is that const duplicate returns on the Map{} without the key 
     // May need to use the same method as QueryPATCH
-    case ActionType.QueryBrowserDuplicateQuery2: {     
-      return state;
+    case ActionType.QueryBrowserDuplicateQuery2: {    
+      const id = action.payload.id;
+      const queries = state.getIn(['queryBrowser2', 'queries2'])
+      const originQueryText = state.getIn(['queryBrowser2', 'queries2', id, 'text']);
+      const originSortOrder = state.getIn(['queryBrowser2', 'queries2', id, 'sortOrder']);
+
+      console.log("JZ originQueryText " + originQueryText)
+
+      // duplicate query appears on top of origin query
+      var duplicate = newQueryBrowserQuery2()
+      duplicate[0][1] = duplicate[0][1].mergeDeep({
+        text: originQueryText,
+        isEnabled: false,
+        sortOrder: originSortOrder + 1
+      });
+
+      // Update sort order so the duplicate query appears on top of 
+      // origin query in the queriesList. 
+      // Update all existing queries, then update the counter.
+      const queryIDs = queries.keySeq() 
+      
+      // JZ NOTE: LEFT OFF NOV1 5:30pm 
+
+
+      nextSortOrderID++
+
+      
+
+
+      return state.setIn(
+        ['queryBrowser2', 'queries2'],
+        state.getIn(['queryBrowser2', 'queries2']).merge(duplicate),
+      ); 
     }
 
     case ActionType.QueryBrowserDeleteAllQueries:
@@ -310,16 +317,10 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
 
 
     case ActionType.QueryBrowserRunQueries2: {
-      console.log("JZ Hello from REducer RunQueries2")
       const queries = state.getIn(['queryBrowser2', 'queries2']).map((q) => {
-        console.log("JZ QueryBrowserRunQueries2 .map(q) " + q)
         const isEnabled = q.get('isEnabled');
         const query = q.get('query');
         const text = _.trim(q.get('text'));
-        console.log("JZ Hello from REducer RunQueries2 isEnabled %s, query %s, text %s", isEnabled, query, text)
-        console.log("JZ Hello from REducer RunQueries2 isEnabled %s, query %s, text %s", isEnabled, query, text)
-
-
         return isEnabled && query !== text ? q.merge({ query: text, series: undefined }) : q;
       });
 

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -11,12 +11,40 @@ import { isSilenced } from '../components/monitoring/utils';
 
 export type ObserveState = ImmutableMap<string, any>;
 
+let nextID: number = 0; 
+
+// const newQueryBrowserQueryID = () : number => nextID++ 
+
+// // returns a Key/Value Pair Map {id: 'query-browser-quer-123', Value:Map{isEnabled:true, isExpanded:true} }
+// const newQueryBrowserQuery2 = () : ImmutableMap<string, any> =>  
+//     ImmutableMap({
+//         isEnabled: true,
+//         isExpanded: true,
+//       }) 
+
+
+const newQueryBrowserQueryID = () : number => nextID++ 
+
+// returns a Key/Value Pair Map {id: 'query-browser-quer-123', Value:Map{isEnabled:true, isExpanded:true} }
+const newQueryBrowserQuery2 = () : [[number, ImmutableMap<string, any>]] =>  {
+  return [[
+    nextID++, 
+    ImmutableMap({
+      isEnabled: true,
+      isExpanded: true,
+    }) 
+  ]]
+}
+
 const newQueryBrowserQuery = (): ImmutableMap<string, any> =>
   ImmutableMap({
     id: _.uniqueId('query-browser-query'),
     isEnabled: true,
     isExpanded: true,
   });
+    
+
+
 
 export const silenceFiringAlerts = (firingAlerts, silences) => {
   // For each firing alert, store a list of the Silences that are silencing it
@@ -46,6 +74,7 @@ export const silenceFiringAlerts = (firingAlerts, silences) => {
 };
 
 export default (state: ObserveState, action: ObserveAction): ObserveState => {
+
   if (!state) {
     return ImmutableMap({
       dashboards: ImmutableMap({
@@ -62,6 +91,16 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
           variables: ImmutableMap(),
         }),
       }),
+
+      // Create a ImmutableMap Similar in structure to the dashboards 
+      queryBrowser2: ImmutableMap({
+        metrics: [],
+        pollInterval: null,
+        queries2: ImmutableMap(newQueryBrowserQuery2()), // initialize queries Map with a Key:Value Pair 
+        timespan: MONITORING_DASHBOARDS_DEFAULT_TIMESPAN,
+      }),
+
+      // intiial state creates an ImmutableList with one Query 
       queryBrowser: ImmutableMap({
         metrics: [],
         pollInterval: null,
@@ -155,6 +194,36 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
 
     case ActionType.ToggleGraphs:
       return state.set('hideGraphs', !state.get('hideGraphs'));
+
+    // case ActionType.QueryBrowserAddQuery: { 
+
+    //   // gets current state of state.queryBrowser.queries[] 
+    //   const prev = state.getIn(['queryBrowser', 'queries'])
+    //   console.log("JZ reducer > addQuery | PREVIOUS State of QueryList:" + prev )
+
+    //   // creates a new Query to be added to tate.queryBrowser.queries[] 
+    //   const newQuery = newQueryBrowserQuery();
+    //   console.log("JZ reducer > addQuery | newQuery: " + newQuery)
+
+    //   // copies current state.queryBrowser.queries[] and appends a newQuery 
+    //   const updateValue = state.getIn(['queryBrowser', 'queries']).push(newQuery)
+    //   console.log("JZ reducer > addQuery | state.getIn....push(newQueryBrowserQuery()) :" +  updateValue)
+
+    //   const update = state.setIn(
+    //     ['queryBrowser', 'queries'],
+    //     updateValue,
+    //   );
+
+    //   console.log('JZ reducer > addQuery |  UPDATED State of QueryList: ' + update)
+
+    //   return update;
+    // }
+
+    case ActionType.QueryBrowserAddQuery2:
+      return state.setIn(
+        ['queryBrowser2', 'queries2'],
+        state.getIn(['queryBrowser2', 'queries2']).merge(newQueryBrowserQuery2()),
+      );
 
     case ActionType.QueryBrowserAddQuery:
       return state.setIn(

--- a/frontend/public/reducers/observe.ts
+++ b/frontend/public/reducers/observe.ts
@@ -220,29 +220,8 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
 
     case ActionType.QueryBrowserDuplicateQuery2: {    
       const id = action.payload.id;
-      const queries = state.getIn(['queryBrowser2', 'queries2'])
       const originQueryText = state.getIn(['queryBrowser2', 'queries2', id, 'text']);
       const originSortOrder = state.getIn(['queryBrowser2', 'queries2', id, 'sortOrder']);
-
-      // 1. Sort queryKeys by sortOrder -- DONE 
-      const sortedQueries = queries.sort((k1,k2) => {
-        if (k1.get("sortOrder") < k2.get("sortOrder")) {
-          return 1;
-        }
-        if (k1.get("sortOrder") > k2.get("sortOrder")) {
-            return -1;
-        }
-        return 0;
-       }
-      )
-
-      // 2. Find key of Origin Query -- DONE
-      const queryKeys = sortedQueries.keySeq().toArray() 
-      console.log("JZ Duplicate > originQueryID: %s, index %s queryKeys: %s", id, _.indexOf(queryKeys, id), queryKeys) 
-      const indexOfOrignQuery = _.indexOf(queryKeys, id)
-
-      console.log("JZ Duplicate > sortedQueries : ", sortedQueries)
-
 
       // 3. Update the queries preceding duplicate 
       const updatedQueries = state.getIn(['queryBrowser2', 'queries2']).map((q) => {
@@ -253,6 +232,7 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
 
       // JZ NOTE: Left Off Here 11/2/22 9pm 
       // updated 'sortOrder > originSortOrder' need to be tested -- 
+      // the output of these console logs should be the same 
       console.log("JZ Duplicate > updatedQueries : ", JSON.stringify(updatedQueries) )
       console.log("JZ Duplicate > setIn(updatedQueries) : ", JSON.stringify(state.setIn(['queryBrowser2', 'queries2'], updatedQueries)))
 
@@ -270,15 +250,13 @@ export default (state: ObserveState, action: ObserveAction): ObserveState => {
         sortOrder: originSortOrder + 1
       });
 
+      const updateAndDuplicateQueries = updatedQueries.merge(duplicate)
 
-      // return state.setIn(
-      //   ['queryBrowser2', 'queries2'],
-      //   state.getIn(['queryBrowser2', 'queries2']).merge(duplicate),
-      // ); 
+      console.log("JZ Duplicate > updateAndDuplicateQueries " + updateAndDuplicateQueries)
 
       return state
-        .setIn(['queryBrowser2', 'queries2'], updatedQueries)
-        .setIn(['queryBrowser2', 'queries2'], state.getIn(['queryBrowser2', 'queries2']).merge(duplicate)); 
+        .setIn(['queryBrowser2', 'queries2'], updateAndDuplicateQueries)
+        // .setIn(['queryBrowser2', 'queries2'], state.getIn(['queryBrowser2', 'queries2']).merge(duplicate)); 
 
     }
 


### PR DESCRIPTION
**Description**:  .unshift() adds new queries to the beginning of the list instead of the back. 

**Related**: https://issues.redhat.com/browse/OU-75

**Demo**: Clicking on 'Add query' will add a new query to the top of the list instead of the bottom. Duplicating a query by clicking on 'Duplicate query' will also add the duplicated query to the top of the list instead of the bottom. 

https://user-images.githubusercontent.com/59589720/192003513-c0e3e45c-d1c7-4c6c-98d8-890f8a7514d7.mov

