### PR TITLE
Bug 1904106: Fix Y-axis labels for minimal / no data

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -372,7 +372,7 @@ const Graph: React.FC<GraphProps> = React.memo(
         _.every(series, ([, values]) => _.every(values, { y: 0 })),
       );
       if (isAllZero) {
-        domain.y = [-1, 1];
+        domain.y = [0, 1];
       }
     } else {
       // Set a reasonable Y-axis range based on the min and max values in the data
@@ -381,7 +381,7 @@ const Graph: React.FC<GraphProps> = React.memo(
       let minY: number = findMin(data.map(findMin))?.y ?? 0;
       let maxY: number = findMax(data.map(findMax))?.y ?? 0;
       if (minY === 0 && maxY === 0) {
-        minY = -1;
+        minY = 0;
         maxY = 1;
       } else if (minY > 0 && maxY > 0) {
         minY = 0;


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/OCPBUGSM-21236


**Analysis / Root cause**: Default values are set for the Y-axis on graphs to [-1,1] when there is minimal / no data.


**Solution Description**: Update the default values for the Y-axis from [-1,1] to [0,1].


**Screen shots**: 
Before
![cpu-usage-before-1](https://user-images.githubusercontent.com/82788581/192049179-420641b4-490a-4c2d-bc0c-991c4ab8cdfc.png)
![dropped-packets-before-1](https://user-images.githubusercontent.com/82788581/192049189-ecc65ef3-7473-427b-b3ed-dd73367ce4bc.png)


After
![cpu-usage-after-1](https://user-images.githubusercontent.com/82788581/192049199-262d7d0d-5f9f-4915-ba1e-e217d5fe9158.png)
![dropped-packets-after-1](https://user-images.githubusercontent.com/82788581/192049211-bf0203d4-1671-4bea-858e-81bffe931395.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge