### PR TITLE
OCPBUGS-1678: Use local test data to mock a devfile registry

### DIFF
--- a/pkg/devfile/sample.go
+++ b/pkg/devfile/sample.go
@@ -11,11 +11,13 @@ const DEVFILE_REGISTRY_URL = "https://registry.devfile.io"
 const DEVFILE_STAGING_REGISTRY_URL = "https://registry.stage.devfile.io"
 const ODC_TELEMETRY_CLIENT_NAME = "openshift-console"
 
+var testRegistryServer = ""
+
 // GetRegistrySamples returns the list of samples, more specifically
 // it gets the content of the index (index.json) of the specified registry.
 // This is based on https://github.com/devfile/registry-support/blob/master/registry-library/library/library.go#L61
 func GetRegistrySamples(registry string) ([]byte, error) {
-	if registry == DEVFILE_REGISTRY_URL || registry == DEVFILE_STAGING_REGISTRY_URL {
+	if registry == DEVFILE_REGISTRY_URL || registry == DEVFILE_STAGING_REGISTRY_URL || registry == testRegistryServer && testRegistryServer != "" {
 		// set registryOption with `user=openshift-console` and `client=openshift-console` for registry telemetry tracking
 		registryOption := registryLibrary.RegistryOptions{Telemetry: registryLibrary.TelemetryData{User: ODC_TELEMETRY_CLIENT_NAME, Client: ODC_TELEMETRY_CLIENT_NAME}}
 

--- a/pkg/devfile/testdata/registrystagedevfileio/sample.json
+++ b/pkg/devfile/testdata/registrystagedevfileio/sample.json
@@ -1,0 +1,113 @@
+[
+  {
+    "name": "nodejs-basic",
+    "displayName": "Basic Node.js",
+    "description": "A simple Hello World Node.js application",
+    "type": "sample",
+    "tags": [
+      "NodeJS",
+      "Express"
+    ],
+    "icon": "https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg",
+    "projectType": "nodejs",
+    "language": "nodejs",
+    "git": {
+      "remotes": {
+        "origin": "https://github.com/nodeshift-starters/devfile-sample.git"
+      }
+    },
+    "provider": "Red Hat"
+  },
+  {
+    "name": "code-with-quarkus",
+    "displayName": "Basic Quarkus",
+    "description": "A simple Hello World Java application using Quarkus",
+    "type": "sample",
+    "tags": [
+      "Java",
+      "Quarkus"
+    ],
+    "icon": "https://design.jboss.org/quarkus/logo/final/SVG/quarkus_icon_rgb_default.svg",
+    "projectType": "quarkus",
+    "language": "java",
+    "git": {
+      "remotes": {
+        "origin": "https://github.com/devfile-samples/devfile-sample-code-with-quarkus.git"
+      }
+    },
+    "provider": "Red Hat"
+  },
+  {
+    "name": "java-springboot-basic",
+    "displayName": "Basic Spring Boot",
+    "description": "A simple Hello World Java Spring Boot application using Maven",
+    "type": "sample",
+    "tags": [
+      "Java",
+      "Spring"
+    ],
+    "icon": "https://spring.io/images/projects/spring-edf462fec682b9d48cf628eaf9e19521.svg",
+    "projectType": "springboot",
+    "language": "java",
+    "git": {
+      "remotes": {
+        "origin": "https://github.com/devfile-samples/devfile-sample-java-springboot-basic.git"
+      }
+    },
+    "provider": "Red Hat"
+  },
+  {
+    "name": "python-basic",
+    "displayName": "Basic Python",
+    "description": "A simple Hello World application using Python",
+    "type": "sample",
+    "tags": [
+      "Python"
+    ],
+    "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/python.svg",
+    "projectType": "python",
+    "language": "python",
+    "git": {
+      "remotes": {
+        "origin": "https://github.com/devfile-samples/devfile-sample-python-basic.git"
+      }
+    },
+    "provider": "Red Hat"
+  },
+  {
+    "name": "go-basic",
+    "displayName": "Basic Go",
+    "description": "A simple Hello World application using Go",
+    "type": "sample",
+    "tags": [
+      "Go"
+    ],
+    "icon": "https://go.dev/blog/go-brand/Go-Logo/SVG/Go-Logo_Blue.svg",
+    "projectType": "go",
+    "language": "go",
+    "git": {
+      "remotes": {
+        "origin": "https://github.com/devfile-samples/devfile-sample-go-basic.git"
+      }
+    },
+    "provider": "Red Hat"
+  },
+  {
+    "name": "dotnet60-basic",
+    "displayName": "Basic .NET 6.0",
+    "description": "A simple application using .NET 6.0",
+    "type": "sample",
+    "tags": [
+      "dotnet"
+    ],
+    "icon": "https://github.com/dotnet/brand/raw/main/logo/dotnet-logo.png",
+    "projectType": "dotnet",
+    "language": "dotnet",
+    "git": {
+      "remotes": {
+        "origin": "https://github.com/devfile-samples/devfile-sample-dotnet60-basic.git"
+      }
+    },
+    "provider": "Red Hat"
+  }
+]


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-1678

**Analysis / Root cause**: 
pkg/devfile/sample_test.go fails after devfile registry was updated (https://github.com/devfile/registry/pull/126)

**Solution Description**: 
Follow up on #12085 that just updated the assertion.

This PR adds a test server that mock a devfile registry and return json data from a testdata folder.
