### PR TITLE
Cards-display-on-serverless-operator-installation | Knative-serverless

### DIFF
--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/cards-display-on-serverless-operator-installation.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/cards-display-on-serverless-operator-installation.feature
@@ -11,7 +11,7 @@ Feature: Event sources cards display
         Scenario: Different event source display in event sources add page: KN-03-TC01
             Given user is at Add page
               And user has installed one or more operators that contribute event sources
-             When user clicks on "Event Source" card
+             When user clicks on "Event Source" Card
              Then user will be redirected to "Event Sources" page
               And user will see the list of Providers
               And user will see the Event Sources cards
@@ -20,7 +20,7 @@ Feature: Event sources cards display
               And user is able to see event sources like ApiServerSource, ContainerSource, PingSource, SinkBinding
 
 
-        @smoke @broken-test
+        @smoke
         Scenario: Event Source card display on serverless operator installation: KN-03-TC02
             Given user is at Add page
              Then user is able to see "Event Source" card on Add page
@@ -29,46 +29,39 @@ Feature: Event sources cards display
               And user is able to see "Broker" card on Add page
 
 
-        @regression @broken-test
+        @regression
         Scenario: knative eventing in operator backed: KN-03-TC03
             Given user is at Add page
-             When user clicks on "Operator Backed" card
-             Then user will be redirected to "Developer Catalog" page
-              And user is able to see knative Eventing card
+             When user clicks on "Operator Backed" Card
+             Then user will be redirected to "Operator Backed" page
+              And user can see knative Eventing card
 
 
-        @smoke @to-do
+  @smoke @broken-test
+  #   Kamelet Source option does not exist on Even Sources page
         Scenario: Kamelets in event source: KN-03-TC04
             Given user is at developer perspective
               And user is at Add page
-             When user clicks on "Event Source" card
-             Then user will be redirected  to "Event Sources" page
+             When user clicks on "Event Source" Card
+             Then user will be redirected to "Event Sources" page
               And user is able to see "Kamelet Source" type
 
-
-        @regression @broken-test
-        Scenario: Operator Backed card display on serverless operator installation: KN-03-TC06
-              And user is at namespace "aut-namespace"
-             When user selects Add option from left side navigation menu
-             Then user will be redirected to Add page
-              And user is able to see "Operator Backed" card on Add page
-
-
-        @regression @broken-test
-        Scenario: Notifier message display in Event sources page when knative service is not available in namespace: KN-03-TC07
+        @regression
+        Scenario: Notifier message display in Event sources page when knative service is not available in namespace: KN-03-TC05
             Given user is at Add page
-             When user clicks on "Event Source" card
+             When user clicks on "Event Source" Card
               And user selects event source type "Api Server Source"
-              And user selects Resource option in Sink section
+              And user selects Create Event Source
+              And user selects Resource option in Target section
              Then user is able to see notifier header "No resources available"
-              And user can see message in sink section as "Event Sources can only sink to knative Services. No knative Services exist in this project."
+              And user can see message in sink section as "Select the URI option, or exit this form and create a Knative Service, Broker, or Channel first."
 
 
         @smoke @manual
-        Scenario: Different event source display in event sources add page: KN-03-TC08
+        Scenario: Different event source display in event sources add page: KN-03-TC06
             Given user is at Add page
               And user has installed one or more operators that contribute event sources
-             When user clicks on "Event Source" card
+             When user clicks on "Event Source" Card
              Then user will be redirected to "Event Sources" page
               And user will see the list of Providers
               And user will see the Event Sources cards

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/cards-display-on-serverless-operator-installation.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/cards-display-on-serverless-operator-installation.ts
@@ -1,0 +1,66 @@
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
+import {
+  devNavigationMenu,
+  pageTitle,
+} from '@console/dev-console/integration-tests/support/constants';
+import { eventSourcePO } from '@console/dev-console/integration-tests/support/pageObjects';
+import {
+  addPage,
+  eventSourcesPage,
+  navigateTo,
+  projectNameSpace,
+} from '@console/dev-console/integration-tests/support/pages';
+
+Then('user is able to see {string} card on Add page', (cardName: string) => {
+  addPage.verifyCard(cardName);
+});
+
+When('user clicks on {string} Card', (cardName: string) => {
+  addPage.selectCardFromOptions(cardName);
+});
+
+Then('user will be redirected to {string} page', (title: string) => {
+  detailsPage.titleShouldContain(title);
+});
+
+Then('user can see knative Eventing card', () => {
+  cy.byTestID('OperatorBackedService-Knative Eventing').should('be.visible');
+});
+
+When('user selects Add option from left side navigation menu', () => {
+  navigateTo(devNavigationMenu.Add);
+});
+
+Then('user will be redirected to Add page', () => {
+  cy.get('.ocs-page-layout__title').should('contain.text', pageTitle.Add);
+});
+
+When('user selects event source type {string}', (eventSourceType: string) => {
+  const eventSourceT = eventSourceType.replace(/ /g, '');
+  cy.log(eventSourceT);
+  eventSourcesPage.clickEventSourceType(eventSourceT);
+});
+
+When('user selects Resource option in Target section', () => {
+  cy.byTestID('uri-view-input', { timeout: 7000 }).should('be.checked');
+  cy.get(eventSourcePO.sinkBinding.sink.resourceRadioButton).check();
+});
+
+Then('user is able to see notifier header {string}', (message: string) => {
+  cy.get(eventSourcePO.sinkBinding.notifierHeader).should('contain.text', message);
+});
+
+Then('user can see message in sink section as {string}', (message: string) => {
+  cy.get(eventSourcePO.sinkBinding.notifierMessage);
+  cy.log(message);
+});
+
+Given('user is at namespace {string}', (projectName: string) => {
+  Cypress.env('NAMESPACE', projectName);
+  projectNameSpace.selectOrCreateProject(projectName);
+});
+
+When('user selects Create Event Source', () => {
+  eventSourcesPage.clickCreateEventSourceOnSidePane();
+});


### PR DESCRIPTION
**Description:**

<!-- PR description-->
- Automation of cards-display-on-serverless-operator-installation feature | Knative Serverless

**Jira Id:**
- Story: 
      - [ODC-7115](https://issues.redhat.com/browse/ODC-7115)
    
<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.12-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p knative
```

**Screen shots**:
<!--   -->
<img width="1727" alt="image" src="https://user-images.githubusercontent.com/65410551/192231707-77c2ca45-731d-4daf-9012-9628bfa1f0a9.png">



**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge