### PR TITLE
[release-4.10]  Bug 2072790: Select template using also queryParams

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/create-vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/create-vm.tsx
@@ -230,7 +230,7 @@ export const CreateVM: React.FC<RouteComponentProps<{ ns: string }>> = ({ match,
   React.useEffect(() => {
     if ((initData.commonTemplateName || initData.userTemplateName) && !selectedTemplate && loaded) {
       const name = initData.commonTemplateName ?? initData.userTemplateName;
-      const ns = initData.commonTemplateName ? 'openshift' : initData.userTemplateNs;
+      const ns = initData?.userTemplateNs || searchParams?.get('namespace') || 'openshift';
       let templateVariant: TemplateKind;
       const templateItem = templates?.find((tItem) => {
         templateVariant = tItem.variants.find(
@@ -246,7 +246,7 @@ export const CreateVM: React.FC<RouteComponentProps<{ ns: string }>> = ({ match,
         setTemplatePreselectError('kubevirt-plugin~Requested template could not be found');
       }
     }
-  }, [loaded, initData, templates, userTemplates, selectedTemplate, t]);
+  }, [loaded, initData, templates, userTemplates, selectedTemplate, t, searchParams]);
 
   React.useEffect(() => {
     const vm = new VMWrapper(selectVM(selectedTemplate?.variants?.[0]));


### PR DESCRIPTION
Template selected!

**Cause**
Template deployed on a custom namespace had the label `template.kubevirt.io/type: base`. This means that the template is not custom. The frontend was searching on `openshift` namespace by default because the template was not custom.

**Fix**
take the template namespace and fetch in that namespace 

Note: Cloning the template with also this label, create a template that cannot be edited
  
![Screenshot from 2022-09-26 12-12-07](https://user-images.githubusercontent.com/29160323/192251317-f9ed949d-7952-4585-af26-7d5dfb12630d.png)
