### PR TITLE
[release-4.10] Bug 2094074: Remove error on user template with DS

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/statuses/template/template-source-status.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/template/template-source-status.ts
@@ -180,18 +180,22 @@ export const getTemplateSourceStatus: GetTemplateSourceStatus = ({
     );
     if (dataVolumeTemplate) {
       const dataVolumeWrapper = new DataVolumeWrapper(dataVolumeTemplate);
-      return supportedDVSources.includes(dataVolumeWrapper.getType())
-        ? {
-            source: SOURCE_TYPE.DATA_VOLUME_TEMPLATE,
-            provider: customTemplateProvider,
-            isReady: true,
-            dvTemplate: dataVolumeWrapper.asResource(),
-            isCDRom: isCDRom(dataVolumeWrapper.asResource(), null),
-            addedOn: getCreationTimestamp(template),
-          }
-        : {
-            error: 'Source not supported.',
-          };
+
+      if (
+        supportedDVSources.includes(dataVolumeWrapper.getType()) ||
+        dataVolumeTemplate?.spec?.sourceRef
+      )
+        return {
+          source: SOURCE_TYPE.DATA_VOLUME_TEMPLATE,
+          provider: customTemplateProvider,
+          isReady: true,
+          dvTemplate: dataVolumeWrapper.asResource(),
+          isCDRom: isCDRom(dataVolumeWrapper.asResource(), null),
+          addedOn: getCreationTimestamp(template),
+        };
+      return {
+        error: 'Source not supported.',
+      };
     }
     const dataVolume = dataVolumes.find(
       ({ metadata }) =>


### PR DESCRIPTION
Regarding user template, dataVolume `sourceRef` is not supported in this function. The function `dataVolumeWrapper.getType()` return `undefined` for this type of DV.  A little dangerous change the getType function and the class

![Screenshot from 2022-09-26 14-19-44](https://user-images.githubusercontent.com/29160323/192274445-f5256eb0-9f76-4731-8526-bdc8982a9c52.png)
