### PR TITLE
OCPBUGS-1522: Allow regular users to access debug pods

### DIFF
--- a/frontend/public/components/debug-terminal.tsx
+++ b/frontend/public/components/debug-terminal.tsx
@@ -19,6 +19,7 @@ const getDebugPod = (debugPodName: string, podToDebug: PodKind, containerName: s
   delete debugPod.metadata.uid;
   delete debugPod.metadata.managedFields;
   delete debugPod.metadata.name;
+  delete debugPod.metadata.ownerReferences;
   delete debugPod.metadata.labels;
   debugPod.metadata.generateName = debugPodName;
   debugPod.metadata.annotations['debug.openshift.io/source-container'] = containerName;


### PR DESCRIPTION
Allow regular users to access debug pods when the original pod has owner references set.
Bugs[OCPBUGS-1522](https://issues.redhat.com/browse/OCPBUGS-1522) and [OCPBUGS-1668](https://issues.redhat.com/browse/OCPBUGS-1668)