### PR TITLE
Bug 2115522: Strange padding in new Helm Chart Repository table row

### DIFF
--- a/frontend/packages/helm-plugin/src/components/list-page/HelmChartRepositoryRow.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmChartRepositoryRow.tsx
@@ -42,7 +42,7 @@ const HelmChartRepositoryRow: React.FC<RowFunctionArgs> = ({ obj }) => {
           <ExternalLink
             href={obj.spec.connectionConfig.url}
             text={obj.spec.connectionConfig.url}
-            additionalClassName="co-break-all"
+            additionalClassName="co-external-link--block"
           />
         ) : (
           '-'

--- a/frontend/packages/helm-plugin/src/components/list-page/ProjectHelmChartRepositoryRow.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/ProjectHelmChartRepositoryRow.tsx
@@ -49,7 +49,7 @@ const ProjectHelmChartRepositoryRow: React.FC<RowFunctionArgs> = ({ obj }) => {
           <ExternalLink
             href={obj.spec.connectionConfig.url}
             text={obj.spec.connectionConfig.url}
-            additionalClassName="co-break-all"
+            additionalClassName="co-external-link--block"
           />
         ) : (
           '-'

--- a/frontend/packages/helm-plugin/src/components/list-page/RepositoriesRow.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/RepositoriesRow.tsx
@@ -55,7 +55,7 @@ const RepositoriesRow: React.FC<RowFunctionArgs> = ({ obj }) => {
           <ExternalLink
             href={obj.spec.connectionConfig.url}
             text={obj.spec.connectionConfig.url}
-            additionalClassName="co-break-all"
+            additionalClassName="co-external-link--block"
           />
         ) : (
           '-'


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGSM-47497

**Analysis / Root cause:**
Class name used was different

**Solution Description:**
Added correct class to remove the extra padding

**Screen shots / Gifs for design review:**

----BEFORE----
https://bugzilla.redhat.com/attachment.cgi?id=1903756

---After----
<img width="964" alt="Screenshot 2022-09-27 at 11 46 09 AM" src="https://user-images.githubusercontent.com/102503482/192467043-63510480-6852-4825-82b5-e7e6f657783b.png">

**Unit test coverage report:**
NA

**Test setup:**
1. Search for resource type HelmChartRepository
2. Take a look at the row 

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

