### PR TITLE
CONSOLE-3077: Promote ConsolePlugins API version to v1 in console repository

### DIFF
--- a/dynamic-demo-plugin/README.md
+++ b/dynamic-demo-plugin/README.md
@@ -94,8 +94,7 @@ spec:
 
 In case the plugin needs to communicate with some in-cluster service, it can
 declare a service proxy in its `ConsolePlugin` resource using the
-`spec.proxy` array field. Each entry needs to specify type and alias of the proxy, under the `type` and `alias` field. For the `Service` proxy type, a `service` field with `name`, `namespace` and `port`
-needs to be specified.
+`spec.proxy` array field. Each entry needs to specify ednpoint and alias of the proxy, under the `endpoint` and `alias` field. For the `Service` proxy type, endpoint's `type` field will need to be set to `Service` and `service` field with `name`, `namespace` and `port` needs to be specified.
 
 Console backend exposes following endpoint in order to proxy the communication
 between plugin and the service:
@@ -107,8 +106,8 @@ An example proxy request path from `helm` plugin with a `helm-charts` service to
 Proxied request will use [service CA bundle](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/security_and_compliance/certificate-types-and-descriptions#cert-types-service-ca-certificates) by default. The service must use HTTPS.
 If the service uses a custom service CA, the `caCertificate` field
 must contain the certificate bundle. In case the service proxy request
-needs to contain logged-in user's OpenShift access token, the `authorize`
-field needs to be set to `true`. The user's OpenShift access token will be
+needs to contain logged-in user's OpenShift access token, the `authorization`
+field needs to be set to `UserToken`. The user's OpenShift access token will be
 then passed in the HTTP `Authorization` request header, for example:
 
 `Authorization: Bearer sha256~kV46hPnEYhCWFnB85r5NrprAxggzgb6GOeLbgcKNsH0`
@@ -117,16 +116,20 @@ then passed in the HTTP `Authorization` request header, for example:
 # ...
 spec:
   proxy:
-  - type: Service
-    alias: helm-charts
-    authorize: true
-    caCertificate: '-----BEGIN CERTIFICATE-----\nMIID....'
-    service:
-      name: helm-charts
-      namespace: helm
-      port: 8443
+  - alias: helm-charts
+    authorization: UserToken
+    caCertificate: '-----BEGIN CERTIFICATE-----\nMIID....'en
+    endpoint:
+      service:
+        name: helm-charts
+        namespace: helm
+        port: 8443
+      type: Service
 # ...
 ```
+
+In case the service proxy request shouldn't contain logged-in user's
+OpenShift access token, the `authorization` field needs to be set to `None`.
 
 ### Local development
 
@@ -183,12 +186,34 @@ conster Header: React.FC = () => {
 };
 ```
 
-The demo plugin contains `console.openshift.io/use-i18n` annotation, which
-indicates whether the `ConsolePlugin` contains localization resources.
-If the annotation is set to `"true"`, the localization resources from
-the i18n namespace named after the dynamic plugin, in this case `plugin__console-demo-plugin`,
-are loaded. If the annotation is set to any other value or is missing on the `ConsolePlugin`
-resource, localization resources are not loaded.
+To indicate whether the `ConsolePlugin` contains localization resources,
+set `spec.i18n.loadType` field based on needed behavior. `Preload` will
+load all plugin's localization resources from the i18n namespace named
+after the dynamic plugin during loading. In this case, `plugin__console-demo-plugin`.
+If set to `Lazy`, the plugin's localization resources wont be preload,
+instead will leave their loading to runtime's lazy-loading.
+
+```yaml
+spec:
+  backend:
+    service:
+      basePath: /
+      name: console-demo-plugin
+      namespace: console-demo-plugin
+      port: 9001
+    type: Service
+  displayName: OpenShift Console Demo Plugin
+  i18n:
+    loadType: Preload
+  proxy:
+```
+
+The `v1alpha1` apiVersion of `ConsolePlugin` supports `console.openshift.io/use-i18n`
+annotation, which indicates whether the `ConsolePlugin` contains localization
+resources. If the annotation is set to `"true"`, the localization resources from
+the i18n namespace named after the dynamic plugin are preloaded. If the annotation
+is set to any other value or is missing on the `ConsolePlugin` resource, localization
+resources are not preloaded.
 
 For labels in `console-extensions.json`, you can use the format
 `%plugin__console-demo-plugin~My Label%`. Console will replace the value with

--- a/dynamic-demo-plugin/oc-manifest.yaml
+++ b/dynamic-demo-plugin/oc-manifest.yaml
@@ -75,24 +75,27 @@ spec:
   type: ClusterIP
   sessionAffinity: None
 ---
-apiVersion: console.openshift.io/v1alpha1
+apiVersion: console.openshift.io/v1
 kind: ConsolePlugin
 metadata:
   name: console-demo-plugin
-  annotations:
-    console.openshift.io/use-i18n: "true" 
 spec:
-  displayName: 'OpenShift Console Demo Plugin'
-  service:
-    name: console-demo-plugin
-    namespace: console-demo-plugin
-    port: 9001
-    basePath: '/'
+  backend:
+    service:
+      basePath: /
+      name: console-demo-plugin
+      namespace: console-demo-plugin
+      port: 9001
+    type: Service
+  displayName: OpenShift Console Demo Plugin
+  i18n:
+    loadType: Preload
   proxy:
-    - type: Service
-      alias: thanos-querier
-      authorize: true
-      service:
-        name: thanos-querier
-        namespace: openshift-monitoring
-        port: 9091
+    - alias: thanos-querier
+      authorization: UserToken
+      endpoint:
+        service:
+          name: thanos-querier
+          namespace: openshift-monitoring
+          port: 9091
+        type: Service

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -1248,7 +1248,7 @@ export const ConsolePluginModel: K8sKind = {
   label: 'ConsolePlugin',
   // t('public~ConsolePlugin')
   labelKey: 'public~ConsolePlugin',
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1',
   apiGroup: 'console.openshift.io',
   plural: 'consoleplugins',
   abbr: 'CP',

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -1113,12 +1113,33 @@ export type NetworkPolicyPort = {
 export type ConsolePluginKind = K8sResourceCommon & {
   spec: {
     displayName: string;
+    backend: {
+      service: {
+        basePath: string;
+        name: string;
+        namespace: string;
+        port: number;
+      };
+      type: 'Service';
+    };
+    i18n: {
+      loadType: 'Preload' | 'Lazy' | '';
+    };
+    proxy: ConsolePluginProxy[];
+  };
+};
+
+export type ConsolePluginProxy = {
+  alias: string;
+  authorization: 'UserToken' | 'None';
+  caCertificate: string;
+  endpoint: {
     service: {
-      basePath: string;
       name: string;
       namespace: string;
-      port: number;
+      port: string;
     };
+    type: 'Service';
   };
 };
 


### PR DESCRIPTION
Story: https://issues.redhat.com/browse/CONSOLE-3077

Updating ConsolePlugin manifest, model and type in console and also Readme docs.
Link to the v1 api for ConsolePlugin CRD - https://github.com/openshift/api/blob/master/console/v1/types_console_plugin.go


/assign @TheRealJon 