### PR TITLE
OCPBUGS-194: Switch api explorer filters to use PF toolbar component for structure and adjustments.

### DIFF
--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -6,7 +6,14 @@ import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';
 import { Map as ImmutableMap } from 'immutable';
 import * as fuzzy from 'fuzzysearch';
-import { Tooltip } from '@patternfly/react-core';
+import {
+  Tooltip,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+  ToolbarToggleGroup,
+} from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons';
 import { sortable } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';
@@ -301,39 +308,47 @@ const APIResourcesList = compose(
 
   return (
     <>
-      <div className="co-m-pane__filter-bar">
-        <div className="co-m-pane__filter-bar-group">
-          <Dropdown
-            autocompleteFilter={autocompleteGroups}
-            items={groupOptions}
-            onChange={onGroupSelected}
-            selectedKey={groupFilter}
-            spacerBefore={groupSpacer}
-            title={groupOptions[groupFilter]}
-            className="co-m-pane__filter-bar-dropdown"
-          />
-          <Dropdown
-            items={versionOptions}
-            onChange={onVersionSelected}
-            selectedKey={versionFilter}
-            spacerBefore={versionSpacer}
-            title={versionOptions[versionFilter]}
-            className="co-m-pane__filter-bar-dropdown"
-          />
-          <Dropdown
-            items={scopeOptions}
-            onChange={onScopeSelected}
-            selectedKey={scopeFilter}
-            spacerBefore={scopeSpacer}
-            title={scopeOptions[scopeFilter]}
-            className="co-m-pane__filter-bar-dropdown"
-          />
-        </div>
-        <div className="co-m-pane__filter-bar-group co-m-pane__filter-bar-group--filter">
-          <TextFilter value={textFilter} label={t('public~by kind')} onChange={setTextFilter} />
-        </div>
-      </div>
-      <div className="co-m-pane__body">
+      <div className="co-m-pane__body co-m-pane__body--no-top-margin">
+        <Toolbar className="co-toolbar-no-padding pf-m-toggle-group-container">
+          <ToolbarContent>
+            <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="md">
+              <ToolbarItem>
+                <Dropdown
+                  autocompleteFilter={autocompleteGroups}
+                  items={groupOptions}
+                  onChange={onGroupSelected}
+                  selectedKey={groupFilter}
+                  spacerBefore={groupSpacer}
+                  title={groupOptions[groupFilter]}
+                  dropDownClassName="dropdown--full-width"
+                />
+              </ToolbarItem>
+              <ToolbarItem>
+                <Dropdown
+                  items={versionOptions}
+                  onChange={onVersionSelected}
+                  selectedKey={versionFilter}
+                  spacerBefore={versionSpacer}
+                  title={versionOptions[versionFilter]}
+                  dropDownClassName="dropdown--full-width"
+                />
+              </ToolbarItem>
+              <ToolbarItem>
+                <Dropdown
+                  items={scopeOptions}
+                  onChange={onScopeSelected}
+                  selectedKey={scopeFilter}
+                  spacerBefore={scopeSpacer}
+                  title={scopeOptions[scopeFilter]}
+                  dropDownClassName="dropdown--full-width"
+                />
+              </ToolbarItem>
+            </ToolbarToggleGroup>
+            <ToolbarItem>
+              <TextFilter value={textFilter} label={t('public~by kind')} onChange={setTextFilter} />
+            </ToolbarItem>
+          </ToolbarContent>
+        </Toolbar>
         <Table
           EmptyMsg={EmptyAPIResourcesMsg}
           Header={APIResourceHeader}

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -64,14 +64,9 @@ dl.co-inline {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  .co-m-pane__filter-bar-dropdown,
   .co-m-primary-action,
   .pf-c-form-control {
     margin-bottom: 10px;
-  }
-  .co-m-pane__filter-bar-dropdown {
-    margin-right: 10px;
-    min-width: 0; // enables truncation of selected item, if needed
   }
 }
 


### PR DESCRIPTION
- (Bug) Correct bottom spacing
- (Consistency) Align filter input with other inputs to match resource list page toolbar
- (Behavior) Enable responsive filter

Fix bug https://issues.redhat.com/browse/OCPBUGS-194

**Before** 
<img width="1626" alt="oldAPI" src="https://user-images.githubusercontent.com/1874151/192894436-98d25a9e-fd1f-4d6b-8b0a-0f5f09f6dfdd.png">


**After**
<img width="1545" alt="API" src="https://user-images.githubusercontent.com/1874151/192894478-d7dde16d-fb21-40f2-8f05-3f3bd8e0710e.png">
<img width="393" alt="APIm" src="https://user-images.githubusercontent.com/1874151/192894489-bfda072a-0566-496f-82e4-e124aec7ef70.png">
<img width="390" alt="APImx" src="https://user-images.githubusercontent.com/1874151/192894497-cef722bf-05fc-4708-804f-0240016b6ab6.png">
