### PR TITLE
OCPBUGS-1040: Add checks for pods in hpaPodRingLabel

### DIFF
--- a/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
@@ -196,7 +196,7 @@ export const hpaPodRingLabel = (
   const desiredPods = hpa.status?.desiredReplicas || desiredPodCount;
   const currentPods = hpa.status?.currentReplicas;
   const scaling =
-    (!currentPods && !!desiredPods) || !pods.every((p) => p.status?.phase === 'Running');
+    (!currentPods && !!desiredPods) || !pods?.every((p) => p.status?.phase === 'Running');
   return {
     title: scaling ? t('console-shared~Autoscaling') : t('console-shared~Autoscaled'),
     subTitle: t('console-shared~to {{count}} Pod', { count: desiredPods }),


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-1040

Analysis / Root cause:
- Pods might be undefined in the topology data. Because of that Topology page is crashing when the user opens the Topology Side panel for the deployment with HPA assigned.

Solution: 
- Use optional chaining on pods before iterating over them.