### PR TITLE
OCPBUGS-9948: docs: fix typo in component description

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -947,7 +947,7 @@ Component that creates a link to a specific resource type with an icon badge
 | Parameter Name | Description |
 | -------------- | ----------- |
 | `kind` | (optional) the kind of resource i.e. Pod, Deployment, Namespace |
-| `groupVersionKind` | (optional) object with groupd, version, and kind |
+| `groupVersionKind` | (optional) object with group, version, and kind |
 | `className` | (optional) class style for component |
 | `displayName` | (optional) display name for component, overwrites the resource name if set |
 | `inline` | (optional) flag to create icon badge and name inline with children |

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -324,7 +324,7 @@ export const useListPageFilter: UseListPageFilter = require('@console/internal/c
 /**
  * Component that creates a link to a specific resource type with an icon badge
  * @param {K8sResourceKindReference} [kind] - (optional) the kind of resource i.e. Pod, Deployment, Namespace
- * @param {K8sGroupVersionKind} [groupVersionKind] - (optional) object with groupd, version, and kind
+ * @param {K8sGroupVersionKind} [groupVersionKind] - (optional) object with group, version, and kind
  * @param {string} [className] -  (optional) class style for component
  * @param {string} [displayName] -  (optional) display name for component, overwrites the resource name if set
  * @param {boolean} [inline=false] -  (optional) flag to create icon badge and name inline with children


### PR DESCRIPTION
This typo is also in the docs:
https://github.com/openshift/console/blob/d216f9985b72cf54f9c5d17257637c138db57610/frontend/packages/console-dynamic-plugin-sdk/docs/api.md?plain=1#L950

but I guess this is autogenerated?