### PR TITLE
[release-4.11] OCPBUGS-1984: fix helm version dropdown entries

### DIFF
--- a/frontend/packages/helm-plugin/src/components/__tests__/helm-release-mock-data.ts
+++ b/frontend/packages/helm-plugin/src/components/__tests__/helm-release-mock-data.ts
@@ -225,6 +225,11 @@ export const mockChartEntries: HelmChartEntries = {
   'hazelcast-enterprise--redhat-helm-repo': mockRedhatHelmChartData,
 };
 
+export const mockChartEntries1: HelmChartEntries = {
+  'ibm-hazelcast-enterprise--ibm-helm-repo': mockIBMHelmChartData,
+  'rh-hazelcast-enterprise--redhat-helm-repo': mockRedhatHelmChartData,
+};
+
 export const mockReleaseResources: FirehoseResourcesResult<{
   Deployment: K8sResourceCommon;
   StatefulSet: K8sResourceCommon;

--- a/frontend/packages/helm-plugin/src/utils/__tests__/helm-utils.spec.ts
+++ b/frontend/packages/helm-plugin/src/utils/__tests__/helm-utils.spec.ts
@@ -7,6 +7,7 @@ import {
   mockChartEntries,
   mockRedhatHelmChartData,
   mockHelmChartRepositories,
+  mockChartEntries1,
 } from '../../components/__tests__/helm-release-mock-data';
 import { HelmRelease, HelmReleaseStatus } from '../../types/helm-types';
 import {
@@ -20,6 +21,7 @@ import {
   getChartReadme,
   getChartEntriesByName,
   loadHelmManifestResources,
+  getChartIndexEntry,
 } from '../helm-utils';
 
 describe('Helm Releases Utils', () => {
@@ -90,6 +92,21 @@ describe('Helm Releases Utils', () => {
       mockHelmChartRepositories,
     );
     expect(chartEntries).toEqual(mockRedhatHelmChartData);
+  });
+
+  it('should return chart index entry', () => {
+    let chartIndexEntry = getChartIndexEntry(
+      mockChartEntries1,
+      'hazelcast-enterprise',
+      'ibm-helm-repo',
+    );
+    expect(chartIndexEntry).toEqual('ibm-hazelcast-enterprise--ibm-helm-repo');
+    chartIndexEntry = getChartIndexEntry(
+      mockChartEntries1,
+      'hazelcast-enterprise',
+      'IBM Helm Repo',
+    );
+    expect(chartIndexEntry).toEqual('ibm-hazelcast-enterprise--ibm-helm-repo');
   });
 
   it('should return chart entries by name from all repos if repo name not provided', () => {

--- a/frontend/packages/helm-plugin/src/utils/helm-utils.ts
+++ b/frontend/packages/helm-plugin/src/utils/helm-utils.ts
@@ -101,6 +101,21 @@ export const getChartRepositoryTitle = (
   return chartRepository?.spec?.name || toTitleCase(chartRepoName);
 };
 
+export const getChartIndexEntry = (
+  chartEntries: HelmChartEntries,
+  chartName: string,
+  chartRepoName: string,
+) => {
+  const repoName = chartRepoName
+    .toLowerCase()
+    .split(' ')
+    .join('-');
+  const indexEntry = Object.keys(chartEntries).find((val) =>
+    val.includes(`${chartName}--${repoName}`),
+  );
+  return indexEntry;
+};
+
 export const getChartEntriesByName = (
   chartEntries: HelmChartEntries,
   chartName: string,
@@ -109,8 +124,10 @@ export const getChartEntriesByName = (
 ): HelmChartMetaData[] => {
   if (chartName && chartRepoName) {
     const chartRepositoryTitle = getChartRepositoryTitle(chartRepositories, chartRepoName);
+    const indexEntry = getChartIndexEntry(chartEntries, chartName, chartRepoName);
+
     return (
-      chartEntries?.[`${chartName}--${chartRepoName}`]?.map((e) => ({
+      chartEntries?.[indexEntry]?.map((e) => ({
         ...e,
         repoName: chartRepositoryTitle,
       })) ?? []


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-1984

**Solution Description:**
using the index entry substring, which is `<chart-name>--<repo-name>` to fetch the chart entries

**Screenshot:**
Before:
<img width="1436" alt="Screenshot 2022-10-04 at 8 46 22 PM" src="https://user-images.githubusercontent.com/22490998/193858659-7d418bae-bff2-423f-8300-f4d57b1e6de5.png">


After:
![Screenshot 2022-10-04 at 8 46 05 PM](https://user-images.githubusercontent.com/22490998/193858681-2da18da3-1c01-4502-81e1-dfa188b29972.png)
