### PR TITLE
ODC-6771: Add telemetry support

### DIFF
--- a/frontend/packages/dev-console/src/components/resource-quota/ResourceQuotaAlert.tsx
+++ b/frontend/packages/dev-console/src/components/resource-quota/ResourceQuotaAlert.tsx
@@ -9,6 +9,7 @@ import {
 import { resourcePathFromModel } from '@console/internal/components/utils/resource-link';
 import { AppliedClusterResourceQuotaModel, ResourceQuotaModel } from '@console/internal/models';
 import { AppliedClusterResourceQuotaKind, ResourceQuotaKind } from '@console/internal/module/k8s';
+import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 import { checkQuotaLimit } from '@console/topology/src/components/utils/checkResourceQuota';
 
 export interface ResourceQuotaAlertProps {
@@ -17,6 +18,7 @@ export interface ResourceQuotaAlertProps {
 
 export const ResourceQuotaAlert: React.FC<ResourceQuotaAlertProps> = ({ namespace }) => {
   const { t } = useTranslation();
+  const fireTelemetryEvent = useTelemetry();
   const [warningMessageFlag, setWarningMessageFlag] = React.useState<boolean>();
   const [resourceQuotaName, setResourceQuotaName] = React.useState(null);
   const [resourceQuotaKind, setResourceQuotaKind] = React.useState(null);
@@ -95,11 +97,20 @@ export const ResourceQuotaAlert: React.FC<ResourceQuotaAlertProps> = ({ namespac
     }
     return resourcePathFromModel(ResourceQuotaModel, null, namespace);
   };
+
+  const onResourceQuotaLinkClick = () => {
+    fireTelemetryEvent('Resource Quota Warning Label Clicked');
+  };
+
   return (
     <>
       {warningMessageFlag && resourcequotas.loaded && appliedclusterresourcequotas.loaded ? (
         <Label color="orange" icon={<YellowExclamationTriangleIcon />}>
-          <Link to={getRedirectLink()} data-test="resource-quota-warning">
+          <Link
+            to={getRedirectLink()}
+            data-test="resource-quota-warning"
+            onClick={onResourceQuotaLinkClick}
+          >
             {t('devconsole~{{count}} resource reached quota', {
               count: totalResourcesAtQuota.reduce((a, b) => a + b, 0),
             })}

--- a/frontend/packages/topology/src/components/workload/resource-alert.tsx
+++ b/frontend/packages/topology/src/components/workload/resource-alert.tsx
@@ -19,6 +19,7 @@ import {
   referenceForModel,
 } from '@console/internal/module/k8s';
 import { ServiceModel as KnativeServiceModel } from '@console/knative-plugin';
+import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 import { getResource } from '../../utils';
 
 const addHealthChecksRefs = [
@@ -87,6 +88,7 @@ export const useHealthChecksAlert = (element: GraphElement): DetailsResourceAler
 
 export const useResourceQuotaAlert = (element: GraphElement): DetailsResourceAlertContent => {
   const { t } = useTranslation();
+  const fireTelemetryEvent = useTelemetry();
   const resource = getResource(element);
   const name = resource?.metadata?.name;
   const namespace = resource?.metadata?.namespace;
@@ -117,10 +119,13 @@ export const useResourceQuotaAlert = (element: GraphElement): DetailsResourceAle
 
   const alertActionCta = alertAction?.cta as () => void;
 
+  const onAlertActionClick = () => {
+    fireTelemetryEvent('Resource Quota Warning Alert Action Link Clicked');
+    alertActionCta();
+  };
+
   const alertActionLink = showAlertActionLink ? (
-    <AlertActionLink onClick={() => alertActionCta()}>
-      {alertAction.label as string}
-    </AlertActionLink>
+    <AlertActionLink onClick={onAlertActionClick}>{alertAction.label as string}</AlertActionLink>
   ) : (
     undefined
   );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-7116

**Solution Description**: 
- Added telemetry support for when RQ/ACRQ warning label is clicked.
- Added telemetry support for when the node side panel RQ warning alert action link is clicked. 

**Screenshots / Gifs for design review**: 

_Added telemetry support for when RQ/ACRQ warning label is clicked_

https://user-images.githubusercontent.com/47265560/194245085-c46b3b7d-4e3a-467c-87d2-18c9288b4224.mp4

_Added telemetry support for when the node side panel RQ warning alert action link is clicked_

https://user-images.githubusercontent.com/47265560/194245888-f8608483-0dcd-4120-81a3-e067e29f94c5.mp4


**Unit test coverage report**: 
Not changed

**Test setup:**
to verify it locally run the bridge as:
`./bin/bridge -listen "http://0.0.0.0:9000/" -user-settings-location configmap --telemetry=DEBUG=true`
on chrome make sure log level verbose is selected if testing in debug mode



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge