### PR TITLE
ODC7127: Change node background color to yellow on zoom out

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
@@ -148,6 +148,7 @@ export const gitPage = {
   verifyNodeName: (componentName: string) =>
     cy.get(gitPO.nodeName).should('have.value', componentName),
   selectResource: (resource: string = 'deployment') => {
+    gitPage.selectAdvancedOptions(gitAdvancedOptions.Resources);
     cy.get(gitPO.advancedOptions.resourcesDropdown)
       .scrollIntoView()
       .click();

--- a/frontend/packages/topology/integration-tests/features/topology/resource-quota-warning.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/resource-quota-warning.feature
@@ -35,4 +35,10 @@ Feature: Update user in topology page if Quotas has been reached in a namespace
              Then user is able to see resource quota alert
               And user is able to see yellow border around 'ex-node-js1' workload   
 
+        @regression
+        Scenario: checking background color of deployment node for resource quota alert: T-19-TC04
+            Given user is at Topology page
+             When user continously clicks on zoom-out button until it gets maximum zoomed out
+             Then user is able to see yellow background on workload for resource quota alert
+
               

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -67,6 +67,7 @@ export const topologyPO = {
     },
     addLink: '[data-test="add-page"]',
     quickSearch: '[data-test="quick-search-bar"]',
+    warningBackground: '[class="pf-topology__node__background pf-m-warning"]',
   },
   list: {
     appName: '#HelmRelease ul li div',

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -441,6 +441,13 @@ export const topologyPage = {
       .find('.pf-topology__node.pf-m-warning')
       .contains(nodeName);
   },
+  clickMaxZoomOut: () => {
+    cy.get(topologyPO.graph.emptyGraph).click();
+    cy.get(topologyPO.graph.reset).click();
+    for (let i = 0; i < 5; i++) {
+      cy.get(topologyPO.graph.zoomOut).click();
+    }
+  },
 };
 
 export const addGitWorkload = (

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/resource-quota-warning.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/resource-quota-warning.ts
@@ -12,6 +12,7 @@ import {
   app,
   topologySidePane,
 } from '@console/dev-console/integration-tests/support/pages';
+import { topologyPO } from '../../page-objects/topology-po';
 
 const deteleResourceQuota = () => {
   detailsPage.isLoaded();
@@ -76,4 +77,14 @@ Then('user is able to see resource quota alert', () => {
 
 And('user is able to see yellow border around {string} workload', (workloadName: string) => {
   topologyPage.verifyNodeAlert(workloadName);
+});
+
+And('user continously clicks on zoom-out button until it gets maximum zoomed out', () => {
+  topologyPage.clickMaxZoomOut();
+});
+
+Then('user is able to see yellow background on workload for resource quota alert', () => {
+  cy.byLegacyTestID('ex-node-js1')
+    .get(topologyPO.graph.warningBackground)
+    .should('be.visible');
 });

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
@@ -112,6 +112,7 @@ export const getAggregateStatus = (
   alertSeverity: AlertSeverity,
   buildStatus: string,
   pipelineStatus: string,
+  workloadRqAlertVariant: NodeStatus,
 ): NodeStatus => {
   const worstPodStatus =
     donutStatus?.pods?.reduce((acc, pod) => {
@@ -130,7 +131,8 @@ export const getAggregateStatus = (
     worstPodStatus === POD_STATUS_WARNING ||
     alertSeverity === AlertSeverity.Warning ||
     StatusSeverities.warning.includes(buildStatus) ||
-    StatusSeverities.warning.includes(pipelineStatus)
+    StatusSeverities.warning.includes(pipelineStatus) ||
+    workloadRqAlertVariant === NodeStatus.warning
   ) {
     return NodeStatus.warning;
   }
@@ -215,7 +217,13 @@ const WorkloadPodsNode: React.FC<WorkloadPodsNodeProps> = observer(function Work
           canDrop={canDrop}
           nodeStatus={
             !showDetails &&
-            getAggregateStatus(donutStatus, severityAlertType, buildStatus, pipelineStatus)
+            getAggregateStatus(
+              donutStatus,
+              severityAlertType,
+              buildStatus,
+              pipelineStatus,
+              workloadRqAlertVariant,
+            )
           }
           attachments={nodeDecorators}
           contextMenuOpen={contextMenuOpen}


### PR DESCRIPTION
JIRA story:
https://issues.redhat.com/browse/ODC-7127

Description:
Added warning (yellow) background for deployment node for the resource quota alert

Demo:

https://user-images.githubusercontent.com/102503482/194274966-be02830e-c95d-4ce5-8d4f-c19d40a9099f.mov

Test Cases:
<img width="571" alt="Screenshot 2022-10-06 at 2 49 14 PM" src="https://user-images.githubusercontent.com/102503482/194275886-c8908006-25cb-47b5-afcb-5b6bd36154b0.png">


**NOTE:**
Depends on PR - https://github.com/openshift/console/pull/12029 . This feature is worked on top of #12029 PR, once that is merged with master I will rebase this PR. 