### PR TITLE
OCPBUGS-1829: use service port name instead targetPort in the Pipeline Event listener route

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/submit-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/submit-utils.ts
@@ -43,7 +43,7 @@ export const exposeRoute = async (elName: string, ns: string, iteration = 0) => 
 
     // Get the service, find out what port we are exposed on
     const serviceResource = await k8sGet(ServiceModel, serviceGeneratedName, ns);
-    const servicePort = serviceResource.spec?.ports?.[0]?.targetPort;
+    const servicePort = serviceResource.spec?.ports?.[0]?.name;
 
     // Build the exposed route on the correct port
     const route: RouteKind = createEventListenerRoute(


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-1829

**Analysis / Root cause:** On upgrading to 1.6.2  from 1.5.2 curl command is throwing error  `The application is currently not serving requests at this endpoint. It may not have been started or is still starting`. It is happening because in UI we are using service port TargetPort to create the Pipeline Event listener route instead of the service port name.

**Solution Description:** use service port name instead targetPort in the Pipeline Event listener route