### PR TITLE
CONSOLE-3287, CONSOLE-3288: OLM Pages work when copied CSVs are disabled

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -147,6 +147,7 @@ func main() {
 	fControlPlaneTopology := fs.String("control-plane-topology-mode", "", "Defines the topology mode of the control/infra nodes (External | HighlyAvailable | SingleReplica)")
 	fReleaseVersion := fs.String("release-version", "", "Defines the release version of the cluster")
 	fNodeArchitectures := fs.String("node-architectures", "", "List of node architectures. Example --node-architecture=amd64,arm64")
+	fCopiedCSVsDisabled := fs.Bool("copied-csvs-disabled", false, "Flag to indicate if OLM copied CSVs are disabled.")
 
 	if err := serverconfig.Parse(fs, os.Args[1:], "BRIDGE"); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -293,6 +294,7 @@ func main() {
 		Telemetry:                    telemetryFlags,
 		ReleaseVersion:               *fReleaseVersion,
 		NodeArchitectures:            nodeArchitectures,
+		CopiedCSVsDisabled:           *fCopiedCSVsDisabled,
 	}
 
 	managedClusterConfigs := []serverconfig.ManagedClusterConfig{}

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -14,6 +14,7 @@ declare module '*.png' {
 
 declare interface Window {
   SERVER_FLAGS: {
+    copiedCSVsDisabled: boolean;
     alertManagerBaseURL: string;
     alertmanagerUserWorkloadBaseURL: string;
     authDisabled: boolean;

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
@@ -12,7 +12,8 @@ const testOperand: TestOperandProps = {
   group: 'binding.operators.coreos.com',
   version: 'v1alpha1',
   kind: 'ServiceBinding',
-  createActionID: 'list-page-create-dropdown-item-servicebindings.binding.operators.coreos.com',
+  createActionID:
+    'list-page-create-dropdown-item-binding.operators.coreos.com~v1alpha1~ServiceBinding',
   exampleName: 'example-servicebinding',
 };
 

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -15,7 +15,7 @@ const testOperand: TestOperandProps = {
   group: 'capabilities.3scale.net',
   version: 'v1beta1',
   kind: 'Backend',
-  createActionID: 'list-page-create-dropdown-item-backends.capabilities.3scale.net',
+  createActionID: 'list-page-create-dropdown-item-capabilities.3scale.net~v1beta1~Backend',
   exampleName: `backend1-sample`,
 };
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { CardTitle, CardBody, CardFooter } from '@patternfly/react-core';
 import { shallow, ShallowWrapper, mount, ReactWrapper } from 'enzyme';
 import * as _ from 'lodash';
-import { Link } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { Link, Router } from 'react-router-dom';
 import {
   DetailsPage,
   Table,
@@ -16,9 +17,11 @@ import {
   SectionHeading,
   resourceObjPath,
   StatusBox,
+  history,
 } from '@console/internal/components/utils';
 import * as operatorLogo from '@console/internal/imgs/operator.svg';
 import { referenceForModel } from '@console/internal/module/k8s';
+import store from '@console/internal/redux';
 import { ErrorBoundary } from '@console/shared/src/components/error';
 import { useActiveNamespace } from '@console/shared/src/hooks/redux-selectors';
 import {
@@ -33,7 +36,7 @@ import {
 import { ClusterServiceVersionModel } from '../models';
 import { ClusterServiceVersionKind, ClusterServiceVersionPhase } from '../types';
 import {
-  ClusterServiceVersionsDetailsPage,
+  ClusterServiceVersionDetailsPage,
   ClusterServiceVersionsDetailsPageProps,
   ClusterServiceVersionDetails,
   ClusterServiceVersionDetailsProps,
@@ -538,16 +541,23 @@ describe(CSVSubscription.displayName, () => {
   });
 });
 
-describe(ClusterServiceVersionsDetailsPage.displayName, () => {
-  let wrapper: ShallowWrapper<ClusterServiceVersionsDetailsPageProps>;
+describe(ClusterServiceVersionDetailsPage.displayName, () => {
+  let wrapper: ReactWrapper<ClusterServiceVersionsDetailsPageProps>;
   const name = 'example';
   const ns = 'default';
 
   beforeEach(() => {
-    wrapper = shallow(
-      <ClusterServiceVersionsDetailsPage
+    wrapper = mount(
+      <ClusterServiceVersionDetailsPage
         match={{ params: { ns, name }, isExact: true, url: '', path: '' }}
       />,
+      {
+        wrappingComponent: (props) => (
+          <Router history={history}>
+            <Provider store={store} {...props} />
+          </Router>
+        ),
+      },
     );
   });
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -1263,7 +1263,6 @@ export const ClusterServiceVersionDetailsPage: React.FC<ClusterServiceVersionsDe
           pageData: {
             csv: obj,
             kind: referenceForProvidedAPI(api),
-            namespace: obj.metadata.namespace,
           },
         })),
       ];

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -14,7 +14,7 @@ import * as classNames from 'classnames';
 import * as _ from 'lodash';
 import { Helmet } from 'react-helmet';
 import { Trans, useTranslation } from 'react-i18next';
-import { Link, match as RouterMatch } from 'react-router-dom';
+import { Link, match as RouterMatch, useParams } from 'react-router-dom';
 import {
   WatchK8sResource,
   ResourceStatus,
@@ -76,7 +76,7 @@ import { CONSOLE_OPERATOR_CONFIG_NAME } from '@console/shared/src/constants';
 import { useActiveNamespace } from '@console/shared/src/hooks/redux-selectors';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { isPluginEnabled } from '@console/shared/src/utils';
-import { OPERATOR_TYPE_ANNOTATION, NON_STANDALONE_ANNOTATION_VALUE } from '../const';
+import { GLOBAL_OPERATOR_NAMESPACES, GLOBAL_COPIED_CSV_NAMESPACE } from '../const';
 import {
   ClusterServiceVersionModel,
   SubscriptionModel,
@@ -102,6 +102,9 @@ import {
   isCatalogSourceTrusted,
   upgradeRequiresApproval,
 } from '../utils';
+import { isCopiedCSV, isStandaloneCSV } from '../utils/clusterserviceversions';
+import { useClusterServiceVersion } from '../utils/useClusterServiceVersion';
+import { useClusterServiceVersionPath } from '../utils/useClusterServiceVersionPath';
 import { createUninstallOperatorModal } from './modals/uninstall-operator-modal';
 import { ProvidedAPIsPage, ProvidedAPIPage, ProvidedAPIPageProps } from './operand';
 import { operatorGroupFor, operatorNamespaceFor } from './operator-group';
@@ -358,7 +361,7 @@ export const ClusterServiceVersionTableRow = withFallback<ClusterServiceVersionT
     const { t } = useTranslation();
     const olmOperatorNamespace = obj.metadata?.annotations?.['olm.operatorNamespace'] ?? '';
     const [icon] = obj.spec.icon ?? [];
-    const route = resourceObjPath(obj, referenceFor(obj));
+    const route = useClusterServiceVersionPath(obj);
     const providedAPIs = providedAPIsForCSV(obj);
     const csvPlugins = getClusterServiceVersionPlugins(obj?.metadata?.annotations);
 
@@ -636,35 +639,26 @@ export const ClusterServiceVersionList: React.FC<ClusterServiceVersionListProps>
     kebabHeader,
   ];
 
-  const isCopiedCSV = (source: ClusterServiceVersionKind, kind: string) => {
-    return (
-      referenceForModel(ClusterServiceVersionModel) === kind &&
-      (source.status?.reason === 'Copied' || source.metadata?.labels?.['olm.copiedFrom'])
-    );
-  };
-
-  const isStandaloneCSV = (operator: ClusterServiceVersionKind) => {
-    return (
-      operator.metadata.annotations?.[OPERATOR_TYPE_ANNOTATION] !==
-        NON_STANDALONE_ANNOTATION_VALUE ||
-      operator.status?.phase === ClusterServiceVersionPhase.CSVPhaseFailed
-    );
-  };
-
   const filterOperators = (
     operators: (ClusterServiceVersionKind | SubscriptionKind)[],
     allNamespaceActive: boolean,
   ): (ClusterServiceVersionKind | SubscriptionKind)[] => {
-    return operators.filter((source) => {
-      const kind = referenceFor(source);
-      if (isSubscription(source)) {
+    return operators.filter((operator) => {
+      if (isSubscription(operator)) {
         return true;
       }
-      const csv = source as ClusterServiceVersionKind;
       if (allNamespaceActive) {
-        return !isCopiedCSV(csv, kind) && isStandaloneCSV(csv);
+        return !isCopiedCSV(operator) && isStandaloneCSV(operator);
       }
-      return isStandaloneCSV(csv);
+
+      if (
+        window.SERVER_FLAGS.copiedCSVsDisabled &&
+        operator.metadata.namespace === GLOBAL_COPIED_CSV_NAMESPACE &&
+        activeNamespace !== GLOBAL_COPIED_CSV_NAMESPACE
+      ) {
+        return isCopiedCSV(operator) && isStandaloneCSV(operator);
+      }
+      return isStandaloneCSV(operator);
     });
   };
 
@@ -696,7 +690,7 @@ export const ClusterServiceVersionList: React.FC<ClusterServiceVersionListProps>
 
   const customData = React.useMemo(
     () => ({
-      catalogSources: catalogSources?.data ?? [],
+      catalogoperators: catalogSources?.data ?? [],
       subscriptions: subscriptions?.data ?? [],
       activeNamespace,
     }),
@@ -739,10 +733,12 @@ export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProp
   );
 
   const flatten: Flatten<{
+    globalClusterServiceVersions: ClusterServiceVersionKind[];
     clusterServiceVersions: ClusterServiceVersionKind[];
     subscriptions: SubscriptionKind[];
-  }> = ({ clusterServiceVersions, subscriptions }) =>
+  }> = ({ globalClusterServiceVersions, clusterServiceVersions, subscriptions }) =>
     [
+      ...(globalClusterServiceVersions?.data ?? []),
       ...(clusterServiceVersions?.data ?? []),
       ...(subscriptions?.data ?? []).filter(
         (sub) =>
@@ -767,6 +763,16 @@ export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProp
       <MultiListPage
         {...props}
         resources={[
+          ...(!GLOBAL_OPERATOR_NAMESPACES.includes(props.namespace) &&
+          window.SERVER_FLAGS.copiedCSVsDisabled
+            ? [
+                {
+                  kind: referenceForModel(ClusterServiceVersionModel),
+                  namespace: GLOBAL_COPIED_CSV_NAMESPACE,
+                  prop: 'globalClusterServiceVersions',
+                },
+              ]
+            : []),
           {
             kind: referenceForModel(ClusterServiceVersionModel),
             namespace: props.namespace,
@@ -1195,10 +1201,13 @@ export const CSVSubscription: React.FC<CSVSubscriptionProps> = ({
   );
 };
 
-export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsDetailsPageProps> = (
+export const ClusterServiceVersionDetailsPage: React.FC<ClusterServiceVersionsDetailsPageProps> = (
   props,
 ) => {
   const { t } = useTranslation();
+  const { name, ns } = useParams();
+  const [data, loaded, loadError] = useClusterServiceVersion(name, ns);
+
   const menuActions = (
     model,
     obj: ClusterServiceVersionKind,
@@ -1265,6 +1274,7 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
   return (
     <DetailsPage
       {...props}
+      obj={{ data, loaded, loadError }}
       breadcrumbsFor={() => [
         {
           name: t('olm~Installed Operators'),
@@ -1280,10 +1290,10 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
       ]}
       icon={({ obj }) => (
         <ClusterServiceVersionLogo
-          displayName={_.get(obj.spec, 'displayName')}
-          icon={_.get(obj.spec, 'icon[0]')}
-          provider={_.get(obj.spec, 'provider')}
-          version={_.get(obj.spec, 'version')}
+          displayName={obj?.spec?.displayName}
+          icon={obj?.spec?.icon?.[0]}
+          provider={obj?.spec?.provider}
+          version={obj?.spec?.version}
         />
       )}
       namespace={props.match.params.ns}
@@ -1405,6 +1415,6 @@ ClusterServiceVersionList.displayName = 'ClusterServiceVersionList';
 ClusterServiceVersionsPage.displayName = 'ClusterServiceVersionsPage';
 ClusterServiceVersionTableRow.displayName = 'ClusterServiceVersionTableRow';
 CRDCard.displayName = 'CRDCard';
-ClusterServiceVersionsDetailsPage.displayName = 'ClusterServiceVersionsDetailsPage';
+ClusterServiceVersionDetailsPage.displayName = 'ClusterServiceVersionsDetailsPage';
 ClusterServiceVersionDetails.displayName = 'ClusterServiceVersionDetails';
 CSVSubscription.displayName = 'CSVSubscription';

--- a/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { match } from 'react-router';
+import { useParams } from 'react-router-dom';
 import {
   MultiListPage,
   Table,
@@ -27,7 +27,6 @@ import {
 } from '@console/internal/models';
 import {
   K8sResourceKind,
-  GroupVersionKind,
   kindForReference,
   modelFor,
   referenceForGroupVersionKind,
@@ -152,7 +151,8 @@ export const linkForCsvResource = (
 
 export const Resources: React.FC<ResourcesProps> = (props) => {
   const { t } = useTranslation();
-  const providedAPI = providedAPIForReference(props.csv, props.match.params.plural);
+  const { plural } = useParams();
+  const providedAPI = providedAPIForReference(props.csv, plural);
 
   const firehoseResources = (providedAPI?.resources ?? DEFAULT_RESOURCES).map(
     ({ name, kind, version }): FirehoseResource => {
@@ -201,7 +201,6 @@ export const Resources: React.FC<ResourcesProps> = (props) => {
 export type ResourcesProps = {
   obj: K8sResourceKind;
   csv: ClusterServiceVersionKind;
-  match: match<{ plural: GroupVersionKind; ns: string; appName: string; name: string }>;
 };
 
 export type ResourceListProps = {};

--- a/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
@@ -152,10 +152,7 @@ export const linkForCsvResource = (
 
 export const Resources: React.FC<ResourcesProps> = (props) => {
   const { t } = useTranslation();
-  const providedAPI = providedAPIForReference(
-    props.clusterServiceVersion,
-    props.match.params.plural,
-  );
+  const providedAPI = providedAPIForReference(props.csv, props.match.params.plural);
 
   const firehoseResources = (providedAPI?.resources ?? DEFAULT_RESOURCES).map(
     ({ name, kind, version }): FirehoseResource => {
@@ -203,7 +200,7 @@ export const Resources: React.FC<ResourcesProps> = (props) => {
 
 export type ResourcesProps = {
   obj: K8sResourceKind;
-  clusterServiceVersion: ClusterServiceVersionKind;
+  csv: ClusterServiceVersionKind;
   match: match<{ plural: GroupVersionKind; ns: string; appName: string; name: string }>;
 };
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
@@ -34,7 +34,10 @@ import { CONSOLE_OPERATOR_CONFIG_NAME } from '@console/shared/src/constants';
 import { usePromiseHandler } from '@console/shared/src/hooks/promise-handler';
 import { useOperands } from '@console/shared/src/hooks/useOperands';
 import { getPatchForRemovingPlugins, isPluginEnabled } from '@console/shared/src/utils';
-import { GLOBAL_OPERATOR_NAMESPACE, OPERATOR_UNINSTALL_MESSAGE_ANNOTATION } from '../../const';
+import {
+  DEFAULT_GLOBAL_OPERATOR_INSTALLATION_NAMESPACE,
+  OPERATOR_UNINSTALL_MESSAGE_ANNOTATION,
+} from '../../const';
 import { ClusterServiceVersionModel, SubscriptionModel } from '../../models';
 import { ClusterServiceVersionKind, SubscriptionKind } from '../../types';
 import { getClusterServiceVersionPlugins } from '../../utils';
@@ -192,7 +195,7 @@ export const UninstallOperatorModal: React.FC<UninstallOperatorModalProps> = ({
   const name = csv?.spec?.displayName || subscription?.spec?.name;
   const csvName = csv?.metadata?.name;
   const namespace =
-    subscription.metadata.namespace === GLOBAL_OPERATOR_NAMESPACE
+    subscription.metadata.namespace === DEFAULT_GLOBAL_OPERATOR_INSTALLATION_NAMESPACE
       ? 'all-namespaces'
       : subscription.metadata.namespace;
   const uninstallMessage = csv?.metadata?.annotations?.[OPERATOR_UNINSTALL_MESSAGE_ANNOTATION];

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { match as RouterMatch } from 'react-router';
+import { useParams } from 'react-router-dom';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import {
   PageHeading,
@@ -17,7 +18,6 @@ import {
   K8sResourceKind,
   K8sResourceKindReference,
   kindForReference,
-  referenceForModel,
   nameForModel,
   CustomResourceDefinitionKind,
   definitionFor,
@@ -36,6 +36,7 @@ import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { exampleForModel, providedAPIForModel } from '..';
 import { ClusterServiceVersionModel } from '../../models';
 import { ClusterServiceVersionKind, ProvidedAPI } from '../../types';
+import { useClusterServiceVersion } from '../../utils/useClusterServiceVersion';
 import ModelStatusBox from '../model-status-box';
 import { DEFAULT_K8S_SCHEMA } from './const';
 // eslint-disable-next-line @typescript-eslint/camelcase
@@ -153,12 +154,8 @@ export const CreateOperand: React.FC<CreateOperandProps> = ({
 const CreateOperandPage: React.FC<CreateOperandPageProps> = ({ match }) => {
   const { t } = useTranslation();
   const createResourceExtension = useCreateResourceExtension(match.params.plural);
-  const [csv, loaded, loadError] = useK8sWatchResource<ClusterServiceVersionKind>({
-    kind: referenceForModel(ClusterServiceVersionModel),
-    name: match.params.csvName,
-    namespace: match.params.ns,
-    isList: false,
-  });
+  const { csvName, ns } = useParams();
+  const [csv, loaded, loadError] = useClusterServiceVersion(csvName, ns);
 
   return (
     <>

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { shallow, ShallowWrapper, mount, ReactWrapper } from 'enzyme';
 import * as _ from 'lodash';
 import { Provider } from 'react-redux';
-import { Router } from 'react-router';
-import { match as RouterMatch } from 'react-router-dom';
+import { MemoryRouter, Router, Route } from 'react-router-dom';
 import { ListPageBody } from '@console/dynamic-plugin-sdk';
 import { Table, DetailsPage, MultiListPage } from '@console/internal/components/factory';
 import {
@@ -42,7 +41,6 @@ import {
   OperandTableRowProps,
   OperandTableRow,
   OperandDetails,
-  OperandDetailsPageProps,
   OperandDetailsProps,
   OperandDetailsPage,
   ProvidedAPIPage,
@@ -50,6 +48,17 @@ import {
   OperandStatus,
   OperandStatusProps,
 } from '.';
+
+const mountWithRoute = <T,>(component, currentURL, routePath): ReactWrapper<T> =>
+  mount<T>(component, {
+    wrappingComponent: ({ children }) => (
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[currentURL]}>
+          <Route path={routePath}>{children}</Route>
+        </MemoryRouter>
+      </Provider>
+    ),
+  });
 
 jest.mock('@console/shared/src/hooks/useK8sModels', () => ({
   useK8sModels: () => [
@@ -314,28 +323,18 @@ describe(OperandDetails.displayName, () => {
 });
 
 describe('ResourcesList', () => {
-  let match: RouterMatch<any>;
-
-  beforeEach(() => {
-    match = {
-      params: {
-        appName: 'etcd',
-        plural: k8sModels.referenceFor(testResourceInstance),
-        name: 'my-etcd',
-        ns: 'default',
-      },
-      isExact: false,
-      url: `/k8s/ns/default/${ClusterServiceVersionModel.plural}/etcd/etcdclusters/my-etcd`,
-      path: `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/:plural/:name`,
-    };
-  });
-
+  const currentURL = `/k8s/ns/default/${
+    ClusterServiceVersionModel.plural
+  }/etcd/${k8sModels.referenceFor(testResourceInstance)}/my-etcd`;
+  const routePath = `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/:plural/:name`;
   it('uses the resources defined in the CSV', () => {
-    const resourceComponent = shallow(
-      <Resources match={match} csv={testClusterServiceVersion} obj={testResourceInstance} />,
+    const wrapper = mountWithRoute(
+      <Resources csv={testClusterServiceVersion} obj={testResourceInstance} />,
+      currentURL,
+      routePath,
     );
-
-    expect(resourceComponent.props().resources).toEqual(
+    const multiListPage = wrapper.find(MultiListPage);
+    expect(multiListPage.props().resources).toEqual(
       testClusterServiceVersion.spec.customresourcedefinitions.owned[0].resources.map(
         (resource) => ({ kind: resource.kind, namespaced: true, prop: 'Pod' }),
       ),
@@ -343,38 +342,23 @@ describe('ResourcesList', () => {
   });
 
   it('uses the default resources if the kind is not found in the CSV', () => {
-    const resourceComponent = shallow(
-      <Resources match={match} csv={null} obj={testResourceInstance} />,
+    const wrapper = mountWithRoute(
+      <Resources csv={null} obj={testResourceInstance} />,
+      currentURL,
+      routePath,
     );
-    expect(resourceComponent.props().resources.length > 5).toEqual(true);
+    const multiListPage = wrapper.find(MultiListPage);
+    expect(multiListPage.props().resources.length > 5).toEqual(true);
   });
 });
 
 describe(OperandDetailsPage.displayName, () => {
-  let wrapper: ReactWrapper<OperandDetailsPageProps>;
-  let match: RouterMatch<any>;
-
-  beforeEach(() => {
-    match = {
-      params: {
-        appName: 'testapp',
-        plural: 'testapp.coreos.com~v1alpha1~TestResource',
-        name: 'my-test-resource',
-        ns: 'default',
-      },
-      isExact: false,
-      url: `/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp/testapp.coreos.com~v1alpha1~TestResource/my-test-resource`,
-      path: `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/:plural/:name`,
-    };
-
-    wrapper = mount(<OperandDetailsPage match={match} />, {
-      wrappingComponent: ({ children }) => <Provider store={store}>{children}</Provider>,
-    });
-  });
+  const currentURL = `/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp/testapp.coreos.com~v1alpha1~TestResource/my-test-resource`;
+  const routePath = `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/:plural/:name`;
 
   it('renders a `DetailsPage` with the correct subpages', () => {
+    const wrapper = mountWithRoute(<OperandDetailsPage />, currentURL, routePath);
     const detailsPage = wrapper.find(DetailsPage);
-
     expect(detailsPage.props().pages[0].nameKey).toEqual(`${i18nNS}~Details`);
     expect(detailsPage.props().pages[0].href).toEqual('');
     expect(detailsPage.props().pages[1].nameKey).toEqual(`${i18nNS}~YAML`);
@@ -384,6 +368,7 @@ describe(OperandDetailsPage.displayName, () => {
   });
 
   it('renders a `DetailsPage` which also watches the parent CSV', () => {
+    const wrapper = mountWithRoute(<OperandDetailsPage />, currentURL, routePath);
     expect(wrapper.find(DetailsPage).prop('resources')[0]).toEqual({
       kind: 'CustomResourceDefinition',
       name: 'testresources.testapp.coreos.com',
@@ -393,10 +378,12 @@ describe(OperandDetailsPage.displayName, () => {
   });
 
   it('menu actions to `DetailsPage`', () => {
+    const wrapper = mountWithRoute(<OperandDetailsPage />, currentURL, routePath);
     expect(wrapper.find(DetailsPage).prop('customActionMenu')).toBeTruthy();
   });
 
   it('passes function to create breadcrumbs for resource to `DetailsPage`', () => {
+    const wrapper = mountWithRoute(<OperandDetailsPage />, currentURL, routePath);
     expect(
       wrapper
         .find(DetailsPage)
@@ -419,12 +406,11 @@ describe(OperandDetailsPage.displayName, () => {
   });
 
   it('creates correct breadcrumbs even if `namespace`, `plural`, `appName`, and `name` URL parameters are the same', () => {
-    match.params = Object.keys(match.params).reduce(
-      (params, name) => Object.assign(params, { [name]: 'example' }),
-      {},
+    const wrapper = mountWithRoute(
+      <OperandDetailsPage />,
+      `/k8s/ns/example/${ClusterServiceVersionModel.plural}/example/example/example`,
+      routePath,
     );
-    match.url = `/k8s/ns/${ClusterServiceVersionModel.plural}/example/example/example`;
-    wrapper.setProps({ match });
 
     expect(
       wrapper
@@ -436,19 +422,24 @@ describe(OperandDetailsPage.displayName, () => {
         name: 'Installed Operators',
         path: `/k8s/ns/example/${ClusterServiceVersionModel.plural}`,
       },
-      { name: 'example', path: `/k8s/ns/${ClusterServiceVersionModel.plural}/example/example` },
+      {
+        name: 'example',
+        path: `/k8s/ns/example/${ClusterServiceVersionModel.plural}/example/example`,
+      },
       {
         name: `example details`,
-        path: `/k8s/ns/${ClusterServiceVersionModel.plural}/example/example/example`,
+        path: `/k8s/ns/example/${ClusterServiceVersionModel.plural}/example/example/example`,
       },
     ]);
   });
 
   it('passes `flatten` function to Resources component which returns only objects with `ownerReferences` to each other or parent object', () => {
-    const resourceComponent = shallow(
-      <Resources csv={testClusterServiceVersion} obj={testResourceInstance} match={match} />,
+    const wrapper = mountWithRoute(
+      <Resources csv={testClusterServiceVersion} obj={testResourceInstance} />,
+      currentURL,
+      routePath,
     );
-    const { flatten } = resourceComponent.find(MultiListPage).props();
+    const { flatten } = wrapper.find(MultiListPage).props();
     const pod = {
       kind: 'Pod',
       metadata: {
@@ -503,25 +494,10 @@ describe(ProvidedAPIsPage.displayName, () => {
   });
 
   beforeEach(() => {
-    wrapper = mount(
-      <ProvidedAPIsPage
-        match={{
-          isExact: true,
-          params: {
-            ns: 'default',
-          },
-          path: `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/instances`,
-          url: `/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp/instances`,
-        }}
-        obj={testClusterServiceVersion}
-      />,
-      {
-        wrappingComponent: (props) => (
-          <Router history={history}>
-            <Provider store={store} {...props} />
-          </Router>
-        ),
-      },
+    wrapper = mountWithRoute<ProvidedAPIsPageProps>(
+      <ProvidedAPIsPage obj={testClusterServiceVersion} />,
+      `/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp/instances`,
+      `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/instances`,
     );
   });
   it('render listpage components', () => {
@@ -568,28 +544,10 @@ describe(ProvidedAPIPage.displayName, () => {
   let wrapper: ReactWrapper<ProvidedAPIPageProps>;
 
   beforeEach(() => {
-    wrapper = mount(
-      <ProvidedAPIPage
-        match={{
-          isExact: true,
-          params: {
-            plural: 'TestResourceRO',
-            ns: 'default',
-          },
-          path: `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/`,
-          url: `/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp`,
-        }}
-        kind="TestResourceRO"
-        csv={testClusterServiceVersion}
-        namespace="foo"
-      />,
-      {
-        wrappingComponent: (props) => (
-          <Router history={history}>
-            <Provider store={store} {...props} />
-          </Router>
-        ),
-      },
+    wrapper = mountWithRoute(
+      <ProvidedAPIPage kind="TestResourceRO" csv={testClusterServiceVersion} namespace="foo" />,
+      `/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp/TestResourceRO`,
+      `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/:plural`,
     );
   });
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -545,7 +545,7 @@ describe(ProvidedAPIPage.displayName, () => {
 
   beforeEach(() => {
     wrapper = mountWithRoute(
-      <ProvidedAPIPage kind="TestResourceRO" csv={testClusterServiceVersion} namespace="foo" />,
+      <ProvidedAPIPage kind="TestResourceRO" csv={testClusterServiceVersion} />,
       `/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp/TestResourceRO`,
       `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/:plural`,
     );

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -66,6 +66,7 @@ import {
   LazyActionMenu,
   ActionMenuVariant,
   getNamespace,
+  useActiveNamespace,
 } from '@console/shared';
 import ErrorAlert from '@console/shared/src/components/alerts/error';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
@@ -340,6 +341,7 @@ const getK8sWatchResources = (
 export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
   const { t } = useTranslation();
   const match = useRouteMatch();
+  const [namespace] = useActiveNamespace();
   const [showOperandsInAllNamespaces] = useShowOperandsInAllNamespaces();
   const {
     obj,
@@ -382,7 +384,7 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
   const watchedResources = getK8sWatchResources(
     models,
     providedAPIs,
-    listAllNamespaces ? null : obj.metadata.namespace,
+    listAllNamespaces ? null : namespace,
   );
 
   const resources = useK8sWatchResources<{ [key: string]: K8sResourceKind[] }>(watchedResources);
@@ -532,7 +534,7 @@ const DefaultProvidedAPIPage: React.FC<DefaultProvidedAPIPageProps> = (props) =>
 
 export const ProvidedAPIPage = (props: ProvidedAPIPageProps) => {
   const resourceListPage = useResourceListPage(props.kind);
-  const { ns } = useParams();
+  const [namespace] = useActiveNamespace();
   const [k8sModel, inFlight] = useK8sModel(props.kind);
   const [apiRefreshed, setAPIRefreshed] = React.useState(false);
   const dispatch = useDispatch();
@@ -561,11 +563,11 @@ export const ProvidedAPIPage = (props: ProvidedAPIPageProps) => {
       {...props}
       model={{ group, version, kind }}
       kind={props.kind}
-      namespace={ns}
+      namespace={namespace}
       loader={resourceListPage}
     />
   ) : (
-    <DefaultProvidedAPIPage {...props} k8sModel={k8sModel} />
+    <DefaultProvidedAPIPage {...props} namespace={namespace} k8sModel={k8sModel} />
   );
 };
 
@@ -845,14 +847,13 @@ export type ProvidedAPIsPageProps = {
 export type ProvidedAPIPageProps = {
   csv: ClusterServiceVersionKind;
   kind: GroupVersionKind;
-  namespace: string;
   showTitle?: boolean;
   hideLabelFilter?: boolean;
   hideNameLabelFilters?: boolean;
   hideColumnManagement?: boolean;
 };
 
-type DefaultProvidedAPIPageProps = ProvidedAPIPageProps & { k8sModel: K8sModel };
+type DefaultProvidedAPIPageProps = ProvidedAPIPageProps & { k8sModel: K8sModel; namespace: string };
 
 type PodStatusesProps = {
   kindObj: K8sKind;

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
-import { useHistory, match as routerMatch, useParams } from 'react-router-dom';
+import { useHistory, useParams, useRouteMatch } from 'react-router-dom';
 import { ListPageBody, K8sModel } from '@console/dynamic-plugin-sdk';
 import { getResources } from '@console/internal/actions/k8s';
 import { Conditions } from '@console/internal/components/conditions';
@@ -339,6 +339,7 @@ const getK8sWatchResources = (
 
 export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
   const { t } = useTranslation();
+  const match = useRouteMatch();
   const [showOperandsInAllNamespaces] = useShowOperandsInAllNamespaces();
   const {
     obj,
@@ -404,7 +405,7 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
         )
       : {};
 
-  const createNavigate = (kind) => history.push(`${props.match.url}/${kind}/~new`);
+  const createNavigate = (kind) => history.push(`${match.url.replace('instances', kind)}/~new`);
 
   const data = React.useMemo(() => flatten(resources), [resources, flatten]);
 
@@ -472,18 +473,18 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
 
 const DefaultProvidedAPIPage: React.FC<DefaultProvidedAPIPageProps> = (props) => {
   const { t } = useTranslation();
+  const match = useRouteMatch();
   const [showOperandsInAllNamespaces] = useShowOperandsInAllNamespaces();
 
   const {
     namespace,
-    kind: apiGroupVersionKind,
     csv,
     showTitle = true,
     hideLabelFilter = false,
     hideNameLabelFilters = false,
     hideColumnManagement = false,
   } = props;
-  const createPath = `${props.match.url}/${apiGroupVersionKind}/~new`;
+  const createPath = `${match.url}/~new`;
 
   const { apiGroup: group, apiVersion: version, kind, namespaced, label } = props.k8sModel;
   const managesAllNamespaces = namespaced && hasAllNamespaces(csv);
@@ -531,6 +532,7 @@ const DefaultProvidedAPIPage: React.FC<DefaultProvidedAPIPageProps> = (props) =>
 
 export const ProvidedAPIPage = (props: ProvidedAPIPageProps) => {
   const resourceListPage = useResourceListPage(props.kind);
+  const { ns } = useParams();
   const [k8sModel, inFlight] = useK8sModel(props.kind);
   const [apiRefreshed, setAPIRefreshed] = React.useState(false);
   const dispatch = useDispatch();
@@ -559,7 +561,7 @@ export const ProvidedAPIPage = (props: ProvidedAPIPageProps) => {
       {...props}
       model={{ group, version, kind }}
       kind={props.kind}
-      namespace={props.match.params.ns}
+      namespace={ns}
       loader={resourceListPage}
     />
   ) : (
@@ -716,9 +718,10 @@ export const OperandDetails = connectToModel(({ crd, csv, kindObj, obj }: Operan
   );
 });
 
-const DefaultOperandDetailsPage = ({ match, k8sModel }: DefaultOperandDetailsPageProps) => {
+const DefaultOperandDetailsPage = ({ k8sModel }: DefaultOperandDetailsPageProps) => {
   const { t } = useTranslation();
-  const { appName, ns } = useParams();
+  const match = useRouteMatch();
+  const { appName, ns, name, plural } = useParams();
   const [csv] = useClusterServiceVersion(appName, ns);
   const actionItems = React.useCallback((resourceModel: K8sKind, resource: K8sResourceKind) => {
     const context = {
@@ -731,9 +734,9 @@ const DefaultOperandDetailsPage = ({ match, k8sModel }: DefaultOperandDetailsPag
   return (
     <DetailsPage
       match={match}
-      name={match.params.name}
-      kind={match.params.plural}
-      namespace={match.params.ns}
+      name={name}
+      kind={plural}
+      namespace={ns}
       resources={[
         {
           kind: CustomResourceDefinitionModel.kind,
@@ -772,9 +775,10 @@ const DefaultOperandDetailsPage = ({ match, k8sModel }: DefaultOperandDetailsPag
   );
 };
 
-export const OperandDetailsPage = (props: OperandDetailsPageProps) => {
-  const resourceDetailsPage = useResourceDetailsPage(props.match.params.plural);
-  const [k8sModel, inFlight] = useK8sModel(props.match.params.plural);
+export const OperandDetailsPage = (props) => {
+  const { plural, ns, name } = useParams();
+  const resourceDetailsPage = useResourceDetailsPage(plural);
+  const [k8sModel, inFlight] = useK8sModel(plural);
   if (inFlight && !k8sModel) {
     return null;
   }
@@ -788,9 +792,9 @@ export const OperandDetailsPage = (props: OperandDetailsPageProps) => {
     <AsyncComponent
       {...props}
       model={{ group, version, kind }}
-      namespace={props.match.params.ns}
-      kind={props.match.params.plural} // TODO remove when static plugins are no longer supported
-      name={props.match.params.name} // TODO remove when static plugins are no longer supported
+      namespace={ns}
+      kind={plural} // TODO remove when static plugins are no longer supported
+      name={name} // TODO remove when static plugins are no longer supported
       loader={resourceDetailsPage}
     />
   ) : (
@@ -836,9 +840,6 @@ export type ProvidedAPIsPageProps = {
   hideLabelFilter?: boolean;
   hideNameLabelFilters?: boolean;
   hideColumnManagement?: boolean;
-  match: routerMatch<{
-    ns: string;
-  }>;
 };
 
 export type ProvidedAPIPageProps = {
@@ -849,10 +850,6 @@ export type ProvidedAPIPageProps = {
   hideLabelFilter?: boolean;
   hideNameLabelFilters?: boolean;
   hideColumnManagement?: boolean;
-  match?: routerMatch<{
-    ns: string;
-    plural: string;
-  }>;
 };
 
 type DefaultProvidedAPIPageProps = ProvidedAPIPageProps & { k8sModel: K8sModel };
@@ -872,23 +869,13 @@ export type OperandDetailsProps = {
   crd: CustomResourceDefinitionKind;
 };
 
-export type OperandDetailsPageProps = {
-  match: routerMatch<{
-    name: string;
-    ns: string;
-    appName: string;
-    plural: string;
-  }>;
-};
-
-type DefaultOperandDetailsPageProps = OperandDetailsPageProps & { k8sModel: K8sModel };
+type DefaultOperandDetailsPageProps = { k8sModel: K8sModel };
 
 export type OperandResourceDetailsProps = {
   csv?: { data: ClusterServiceVersionKind };
   gvk: GroupVersionKind;
   name: string;
   namespace: string;
-  match: routerMatch<{ appName: string }>;
 };
 
 type Header = {

--- a/frontend/packages/operator-lifecycle-manager/src/const.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/const.ts
@@ -1,3 +1,5 @@
+import { ALL_NAMESPACES_KEY } from '@console/shared/src';
+
 export enum Flags {
   OPERATOR_LIFECYCLE_MANAGER = 'OPERATOR_LIFECYCLE_MANAGER',
 }
@@ -17,10 +19,16 @@ export enum DefaultCatalogSourceDisplayName {
   Custom = 'Custom',
 }
 
-export const GLOBAL_OPERATOR_NAMESPACE = 'openshift-operators';
 export const OPERATOR_UNINSTALL_MESSAGE_ANNOTATION = 'operator.openshift.io/uninstall-message';
 export const OPERATOR_TYPE_ANNOTATION = 'operators.operatorframework.io/operator-type';
 export const NON_STANDALONE_ANNOTATION_VALUE = 'non-standalone';
 export const INTERNAL_OBJECTS_ANNOTATION = 'operators.operatorframework.io/internal-objects';
 export const DEFAULT_SOURCE_NAMESPACE = 'openshift-marketplace';
 export const OPERATOR_PLUGINS_ANNOTATION = 'console.openshift.io/plugins';
+export const DEFAULT_GLOBAL_OPERATOR_INSTALLATION_NAMESPACE = 'openshift-operators';
+export const GLOBAL_COPIED_CSV_NAMESPACE = 'openshift';
+export const GLOBAL_OPERATOR_NAMESPACES = [
+  DEFAULT_GLOBAL_OPERATOR_INSTALLATION_NAMESPACE,
+  GLOBAL_COPIED_CSV_NAMESPACE,
+  ALL_NAMESPACES_KEY,
+];

--- a/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
@@ -133,7 +133,7 @@ const plugin: Plugin<ConsumedExtensions> = [
           await import(
             './components/clusterserviceversion' /* webpackChunkName: "clusterserviceversion" */
           )
-        ).ClusterServiceVersionsDetailsPage,
+        ).ClusterServiceVersionDetailsPage,
     },
   },
   {

--- a/frontend/packages/operator-lifecycle-manager/src/utils/clusterserviceversions.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/utils/clusterserviceversions.ts
@@ -1,0 +1,16 @@
+import { K8sResourceKind, referenceFor, referenceForModel } from '@console/internal/module/k8s';
+import { NON_STANDALONE_ANNOTATION_VALUE, OPERATOR_TYPE_ANNOTATION } from '../const';
+import { ClusterServiceVersionModel } from '../models';
+import { ClusterServiceVersionPhase } from '../types';
+
+export const isCSV = (obj: K8sResourceKind): boolean =>
+  Boolean(obj) && referenceFor(obj) === referenceForModel(ClusterServiceVersionModel);
+
+export const isCopiedCSV = (obj: K8sResourceKind): boolean =>
+  isCSV(obj) &&
+  (obj.status?.reason === 'Copied' || Boolean(obj.metadata?.labels?.['olm.copiedFrom']));
+
+export const isStandaloneCSV = (obj: K8sResourceKind): boolean =>
+  isCSV(obj) &&
+  (obj.metadata.annotations?.[OPERATOR_TYPE_ANNOTATION] !== NON_STANDALONE_ANNOTATION_VALUE ||
+    obj.status?.phase === ClusterServiceVersionPhase.CSVPhaseFailed);

--- a/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersion.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/lib-core';
+import { GLOBAL_COPIED_CSV_NAMESPACE } from '../const';
+import { ClusterServiceVersionModel } from '../models';
+import { ClusterServiceVersionKind } from '../types';
+import { isCopiedCSV } from './clusterserviceversions';
+
+const groupVersionKind = {
+  group: ClusterServiceVersionModel.apiGroup,
+  version: ClusterServiceVersionModel.apiVersion,
+  kind: ClusterServiceVersionModel.kind,
+};
+
+export const useClusterServiceVersion = (
+  name: string,
+  namespace: string,
+): [ClusterServiceVersionKind, boolean, any] => {
+  const [namespacedCSV, namespacedCSVLoaded, namespacedCSVLoadError] = useK8sWatchResource<
+    ClusterServiceVersionKind
+  >({
+    groupVersionKind,
+    name,
+    namespace,
+    optional: window.SERVER_FLAGS.copiedCSVsDisabled,
+  });
+  const [globalCSV, globalCSVLoaded, globalCSVLoadError] = useK8sWatchResource<
+    ClusterServiceVersionKind
+  >({
+    groupVersionKind,
+    name,
+    namespace: GLOBAL_COPIED_CSV_NAMESPACE,
+    optional: window.SERVER_FLAGS.copiedCSVsDisabled,
+  });
+
+  return React.useMemo(() => {
+    if (window.SERVER_FLAGS.copiedCSVsDisabled && Boolean(namespacedCSVLoadError)) {
+      return [isCopiedCSV(globalCSV) ? globalCSV : null, globalCSVLoaded, globalCSVLoadError];
+    }
+    return [namespacedCSV, namespacedCSVLoaded, namespacedCSVLoadError];
+  }, [
+    globalCSV,
+    globalCSVLoadError,
+    globalCSVLoaded,
+    namespacedCSV,
+    namespacedCSVLoadError,
+    namespacedCSVLoaded,
+  ]);
+};

--- a/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersionPath.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersionPath.tsx
@@ -1,0 +1,19 @@
+import { getReferenceForModel } from '@console/dynamic-plugin-sdk/src/utils/k8s';
+import { resourceObjPath, resourcePath } from '@console/internal/components/utils';
+import { ALL_NAMESPACES_KEY, useActiveNamespace } from '@console/shared';
+import { ClusterServiceVersionModel } from '../models';
+import { ClusterServiceVersionKind } from '../types';
+
+export const useClusterServiceVersionPath = (csv: ClusterServiceVersionKind): string => {
+  const [activeNamespace] = useActiveNamespace();
+  const csvReference = getReferenceForModel(ClusterServiceVersionModel);
+  // Don't link to csv in 'openshift' namepsace when copiedCSVsDisabled and in another namespace
+  if (
+    window.SERVER_FLAGS.copiedCSVsDisabled &&
+    csv.metadata.namespace === 'openshift' && // Is global csv
+    activeNamespace !== ALL_NAMESPACES_KEY
+  ) {
+    return resourcePath(csvReference, csv.metadata.name, activeNamespace);
+  }
+  return resourceObjPath(csv, csvReference);
+};

--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -19,6 +19,7 @@ import {
   K8sModel,
   isDetailPageBreadCrumbs as isDynamicDetailPageBreadCrumbs,
   DetailPageBreadCrumbs as DynamicDetailPageBreadCrumbs,
+  FirehoseResult,
 } from '@console/dynamic-plugin-sdk';
 import {
   Firehose,
@@ -129,6 +130,13 @@ export const DetailsPage = withFallback<DetailsPageProps>(({ pages = [], ...prop
   let allPages = [...pages, ...pluginPages];
   allPages = allPages.length ? allPages : null;
 
+  const objResource: FirehoseResource = {
+    kind: props.kind,
+    name: props.name,
+    namespace: props.namespace,
+    isList: false,
+    prop: 'obj',
+  };
   return (
     <>
       {resolvedBreadcrumbExtension && (
@@ -140,18 +148,10 @@ export const DetailsPage = withFallback<DetailsPageProps>(({ pages = [], ...prop
         />
       )}
       <Firehose
-        resources={[
-          {
-            kind: props.kind,
-            kindObj,
-            name: props.name,
-            namespace: props.namespace,
-            isList: false,
-            prop: 'obj',
-          } as FirehoseResource,
-        ].concat(props.resources || [])}
+        resources={[...(_.isNil(props.obj) ? [objResource] : []), ...(props.resources ?? [])]}
       >
         <PageHeading
+          obj={props.obj}
           detail={true}
           title={props.title || props.name}
           titleFunc={props.titleFunc}
@@ -173,6 +173,7 @@ export const DetailsPage = withFallback<DetailsPageProps>(({ pages = [], ...prop
           {props.children}
         </PageHeading>
         <HorizontalNav
+          obj={props.obj}
           pages={allPages}
           pagesFor={props.pagesFor}
           className={`co-m-${_.get(props.kind, 'kind', props.kind)}`}
@@ -188,6 +189,7 @@ export const DetailsPage = withFallback<DetailsPageProps>(({ pages = [], ...prop
 }, ErrorBoundaryFallbackPage);
 
 export type DetailsPageProps = {
+  obj?: FirehoseResult<K8sResourceKind>;
   match: match<any>;
   title?: string | JSX.Element;
   titleFunc?: (obj: K8sResourceKind) => string | JSX.Element;

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -116,6 +116,7 @@ type jsGlobals struct {
 	Telemetry                       serverconfig.MultiKeyValue `json:"telemetry"`
 	ReleaseVersion                  string                     `json:"releaseVersion"`
 	NodeArchitectures               []string                   `json:"nodeArchitectures"`
+	CopiedCSVsDisabled              bool                       `json:"copiedCSVsDisabled"`
 }
 
 type Server struct {
@@ -179,6 +180,7 @@ type Server struct {
 	ProjectAccessClusterRoles    string
 	Perspectives                 string
 	Telemetry                    serverconfig.MultiKeyValue
+	CopiedCSVsDisabled           bool
 }
 
 func (s *Server) authDisabled() bool {
@@ -749,6 +751,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		Telemetry:                  s.Telemetry,
 		ReleaseVersion:             s.ReleaseVersion,
 		NodeArchitectures:          s.NodeArchitectures,
+		CopiedCSVsDisabled:         s.CopiedCSVsDisabled,
 	}
 
 	localAuther := s.getLocalAuther()

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -217,6 +217,10 @@ func addClusterInfo(fs *flag.FlagSet, clusterInfo *ClusterInfo) {
 	if len(clusterInfo.NodeArchitectures) > 0 {
 		fs.Set("node-architectures", strings.Join(clusterInfo.NodeArchitectures, ","))
 	}
+
+	if clusterInfo.CopiedCSVsDisabled {
+		fs.Set("copied-csvs-disabled", "true")
+	}
 }
 
 func addAuth(fs *flag.FlagSet, auth *Auth) {

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -74,6 +74,7 @@ type ClusterInfo struct {
 	ControlPlaneTopology configv1.TopologyMode `yaml:"controlPlaneTopology,omitempty"`
 	ReleaseVersion       string                `yaml:"releaseVersion,omitempty"`
 	NodeArchitectures    []string              `yaml:"nodeArchitectures,omitempty"`
+	CopiedCSVsDisabled   bool                  `yaml:"copiedCSVsDisabled,omitempty"`
 }
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".


### PR DESCRIPTION
- Add copied csvs disabled flag to bridge command and server server config
- Forward copied csvs disabled flag to frontend through js globals
- On the installed operators page, list copied CSVs from 'openshift' namespace when copied csvs are disabled
- On the CSV details page, create operand, and operand details pages:
  -  use copied CSV from 'openshift' namespace when copied csvs are disabled, and no CSV is found in the current active namespace