### PR TITLE
CONSOLE-3224: Expose errorMessage and errorCause for failed plugins

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-dependencies.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-dependencies.spec.ts
@@ -46,6 +46,7 @@ describe('resolvePluginDependencies', () => {
   ): NotLoadedDynamicPluginInfo => ({
     status: 'Failed',
     pluginName: manifest.name,
+    errorMessage: `Test error message for plugin ${manifest.name}`,
   });
 
   it('throws an error if Console plugin API dependency is not met', async () => {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-loader.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-loader.spec.ts
@@ -376,8 +376,8 @@ describe('loadAndEnablePlugin', () => {
     await loadAndEnablePlugin('Test', pluginStore, onError);
 
     expect(onError).toHaveBeenCalledTimes(1);
-    expect(consoleMock).toHaveBeenLastCalledWith(
-      `Error while loading plugin Test from /test/api/plugins/Test/`,
+    expect(onError).toHaveBeenLastCalledWith(
+      'Failed to get a valid plugin manifest from /test/api/plugins/Test/',
       new Error('boom1'),
     );
 
@@ -387,8 +387,8 @@ describe('loadAndEnablePlugin', () => {
     await loadAndEnablePlugin('Test', pluginStore, onError);
 
     expect(onError).toHaveBeenCalledTimes(2);
-    expect(consoleMock).toHaveBeenLastCalledWith(
-      `Error while loading plugin Test from /test/api/plugins/Test/`,
+    expect(onError).toHaveBeenLastCalledWith(
+      'Failed to resolve dependencies of plugin Test',
       new Error('boom2'),
     );
 
@@ -399,8 +399,8 @@ describe('loadAndEnablePlugin', () => {
     await loadAndEnablePlugin('Test', pluginStore, onError);
 
     expect(onError).toHaveBeenCalledTimes(3);
-    expect(consoleMock).toHaveBeenLastCalledWith(
-      `Error while loading plugin Test from /test/api/plugins/Test/`,
+    expect(onError).toHaveBeenLastCalledWith(
+      'Failed to load entry script of plugin Test',
       new Error('boom3'),
     );
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-init.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-init.ts
@@ -8,15 +8,19 @@ import { registerPluginEntryCallback, loadAndEnablePlugin } from './plugin-loade
 
 export const initConsolePlugins = _.once(
   (pluginStore: PluginStore, reduxStore: Store<RootState>) => {
+    // Initialize dynamic plugin infrastructure
     initSubscriptionService(pluginStore, reduxStore);
     registerPluginEntryCallback(pluginStore);
+    setPluginStore(pluginStore);
 
+    // Load dynamic plugins
     pluginStore.getAllowedDynamicPluginNames().forEach((pluginName) => {
-      loadAndEnablePlugin(pluginName, pluginStore, () => {
+      loadAndEnablePlugin(pluginName, pluginStore, (errorMessage, errorCause) => {
+        // eslint-disable-next-line no-console
+        console.error(..._.compact([errorMessage, errorCause]));
+        pluginStore.registerFailedDynamicPlugin(pluginName, errorMessage, errorCause);
         // TODO(vojtech): add new entry into the notification drawer
-        pluginStore.registerFailedDynamicPlugin(pluginName);
       });
     });
-    setPluginStore(pluginStore);
   },
 );

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/error/custom-error.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/error/custom-error.ts
@@ -40,3 +40,9 @@ export class CustomError extends Error {
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }
+
+export class ErrorWithCause extends CustomError {
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+  }
+}


### PR DESCRIPTION
Fixes [CONSOLE-3224](https://issues.redhat.com/browse/CONSOLE-3224)

When a Console dynamic plugin fails to load properly, the corresponding plugin info object now contains `errorMessage` and `errorCause` properties.

This is basically a backport of the following code improvement

> When `PluginLoader` fails to load a plugin, we pass `errorMessage` and `errorCause` properties as part of the load result. These properties are exposed to consumers via `PluginStore.getPluginInfo` method.

from openshift/dynamic-plugin-sdk#134.

`errorMessage` is intended to provide a brief explanation of what went wrong. `errorCause` can be used for better debugging.
