### PR TITLE
OCPBUGS-2075: Hide silent switch for alerting rule if no associated alerts are present in devconsole

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/alerts/monitoring-alerts-utils.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/monitoring-alerts-utils.tsx
@@ -74,7 +74,7 @@ export const monitoringAlertRows = (
           title: _.isEmpty(rls.alerts) ? '-' : <StateCounts alerts={rls.alerts} />,
         },
         {
-          title: <SilenceAlert rule={rls} namespace={namespace} />,
+          title: _.isEmpty(rls.alerts) ? '-' : <SilenceAlert rule={rls} namespace={namespace} />,
         },
         {
           title: (


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-2075

Descriptions: We got feedback from the support team that it is confusing to see a switch in the Notifications column for the Alerting rule which has no alerts associated with it, as the user can not silence the Alerting rule. So, hide the silent switch if alerts are not present for the associated alerting rule.

Screenshots:
![image](https://user-images.githubusercontent.com/2561818/194933767-d739c30f-91be-415d-8113-ff554b2f2757.png)
