### PR TITLE
[release-4.9] OCPBUGS-2173: do not show NodesUpdateGroup if there are 0 nodes

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -563,7 +563,7 @@ export const NodesUpdatesGroup: React.FC<NodesUpdatesGroupProps> = ({
     MCPUpdatingTime > updateStartedTime ? machineConfigPool?.status?.updatedMachineCount : 0;
   const percentMCPNodes = calculatePercentage(updatedMCPNodes, totalMCPNodes);
   const { t } = useTranslation();
-  return hideIfComplete && percentMCPNodes === 100 ? null : (
+  return totalMCPNodes === 0 || (hideIfComplete && percentMCPNodes === 100) ? null : (
     <UpdatesGroup divided={divided}>
       <UpdatesType>
         <Link to={`/k8s/cluster/nodes?rowFilter-node-role=${machineConfigPool.metadata.name}`}>


### PR DESCRIPTION
Manual back port of https://github.com/openshift/console/pull/12061