### PR TITLE
[DON'T MERGE] disable single ns operator  test

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -19,7 +19,7 @@ const testOperand: TestOperandProps = {
   exampleName: `backend1-sample`,
 };
 
-describe(`Installing "${testOperator.name}" operator in test namespace`, () => {
+xdescribe(`[https://issues.redhat.com/browse/OCPBUGS-2182] Installing "${testOperator.name}" operator in test namespace`, () => {
   before(() => {
     cy.login();
     cy.visit('/');


### PR DESCRIPTION
Tracks: https://issues.redhat.com/browse/OCPBUGS-2181

disabled `operator-install-single-namespace.spec.ts` as the tests are failing