### PR TITLE
OCPBUGS-2195: fixes npe on topology

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/service/CatalogServiceProvider.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/service/CatalogServiceProvider.tsx
@@ -72,7 +72,7 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
       catalogProviderExtensions.map((e) =>
         catalogFilterExtensions
           .filter((fe) => fe.properties.type === e.properties.type)
-          .reduce((acc, ext) => acc.filter(ext.properties.filter), extItemsMap[e.uid]),
+          .reduce((acc, ext) => acc.filter(ext.properties.filter), extItemsMap[e.uid] ?? []),
       ),
     ).reduce((acc, item) => {
       if (!item) return acc;


### PR DESCRIPTION
Tracks: https://issues.redhat.com/browse/OCPBUGS-2195

**Before:**
![npeTopologyBefore](https://user-images.githubusercontent.com/5129024/195062900-27ea1c9a-dd21-4b68-bf77-d298e8eae3a8.gif)


**After:**
![npeTopologyAfter](https://user-images.githubusercontent.com/5129024/195062987-756e71c2-220a-41a6-8b3c-8f8658c20f2b.gif)


**Test Setup:**

1. Login as regular user
2. Create a ns and delete the ns
3. visit the deleted ns in the topology or use {cluster_domain}/topology/ns/jai-test-59?view=graph