### PR TITLE
OCPBUGS-2651: Show focus border on pipeline run nodes

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.scss
@@ -1,0 +1,10 @@
+.odc-pipeline-topology__task-node {
+  &.is-link {
+    > a:hover {
+      text-decoration: none;
+    }
+  }
+  &:focus {
+    outline: -webkit-focus-ring-color auto 5px;
+  }
+}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.tsx
@@ -14,6 +14,7 @@ import {
   WithContextMenuProps,
   WithSelectionProps,
 } from '@patternfly/react-topology';
+import classNames from 'classnames';
 import { observer } from 'mobx-react';
 import { Link } from 'react-router-dom';
 import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/lib-core';
@@ -28,6 +29,8 @@ import {
 } from '../detail-page-tabs/pipeline-details/pipeline-step-utils';
 import { PipelineVisualizationStepList } from '../detail-page-tabs/pipeline-details/PipelineVisualizationStepList';
 import { NodeType } from './const';
+
+import './PipelineTaskNode.scss';
 
 type PipelineTaskNodeProps = {
   element: Node;
@@ -140,6 +143,24 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
     !!path;
 
   const taskNode = (
+    <TaskNode
+      className="odc-pipeline-topology__task-node"
+      element={element}
+      onContextMenu={data.showContextMenu ? onContextMenu : undefined}
+      contextMenuOpen={contextMenuOpen}
+      scaleNode={(hover || contextMenuOpen) && detailsLevel !== ScaleDetailsLevel.high}
+      hideDetailsAtMedium
+      {...passedData}
+      {...rest}
+      badge={badge}
+      truncateLength={element.getData()?.label?.length}
+    >
+      {whenDecorator}
+    </TaskNode>
+  );
+
+  const classes = classNames('odc-pipeline-topology__task-node', { 'is-link': enableLogLink });
+  return (
     <Layer
       id={
         detailsLevel !== ScaleDetailsLevel.high && (hover || contextMenuOpen)
@@ -147,7 +168,7 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
           : DEFAULT_LAYER
       }
     >
-      <g ref={hoverRef} style={{ cursor: enableLogLink ? 'pointer' : 'default' }}>
+      <g data-test={`task ${element.getLabel()}`} className={classes} ref={hoverRef}>
         <Tooltip
           position="bottom"
           enableFlip={false}
@@ -160,30 +181,10 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
             />
           }
         >
-          <TaskNode
-            element={element}
-            onContextMenu={data.showContextMenu ? onContextMenu : undefined}
-            contextMenuOpen={contextMenuOpen}
-            scaleNode={(hover || contextMenuOpen) && detailsLevel !== ScaleDetailsLevel.high}
-            hideDetailsAtMedium
-            {...passedData}
-            {...rest}
-            badge={badge}
-            truncateLength={element.getData()?.label?.length}
-          >
-            {whenDecorator}
-          </TaskNode>
+          {enableLogLink ? <Link to={path}>{taskNode}</Link> : taskNode}
         </Tooltip>
       </g>
     </Layer>
-  );
-
-  return enableLogLink ? (
-    <Link to={path}>
-      <g data-test={`task ${element.getLabel()}`}>{taskNode}</g>
-    </Link>
-  ) : (
-    taskNode
   );
 };
 


### PR DESCRIPTION
**Fixes**: 
Fixes [ODC-7130](https://issues.redhat.com/browse/ODC-7130)

**Analysis / Root cause**: 
PF sets the focus border to be hidden on all <g> elements. Updating the layer on hover/focus causes elements to lose focus shortly after gaining it.

**Solution Description**: 
Add styling to show the focus border on the task nodes. Restructure the pieces of the node so they remain under the `Layer`.

