### PR TITLE
Bug 2072790: Regression "Create VM"

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/create-vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/create-vm.tsx
@@ -265,7 +265,11 @@ export const CreateVM: React.FC<RouteComponentProps<{ ns: string }>> = ({ match,
   React.useEffect(() => {
     if ((initData.commonTemplateName || initData.userTemplateName) && !selectedTemplate && loaded) {
       const name = initData.commonTemplateName ?? initData.userTemplateName;
-      const ns = initData?.userTemplateNs || searchParams?.get('namespace') || 'openshift';
+      const ns =
+        initData?.userTemplateNs ||
+        initData?.commonTemplateNamespace ||
+        searchParams?.get('template-ns') ||
+        'openshift';
       let templateVariant: TemplateKind;
       const templateItem = templates?.find((tItem) => {
         templateVariant = tItem.variants.find(

--- a/frontend/packages/kubevirt-plugin/src/types/url.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/url.ts
@@ -3,6 +3,7 @@ export type VMWizardInitialData = {
   startVM?: boolean;
   source?: VMWizardBootSourceParams;
   commonTemplateName?: string;
+  commonTemplateNamespace?: string;
   userTemplateName?: string;
   userTemplateNs?: string;
   storageClass?: string;

--- a/frontend/packages/kubevirt-plugin/src/utils/url.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/url.ts
@@ -119,6 +119,7 @@ export const getVMWizardCreateLink = ({
     if (template) {
       if (isCommonTemplate(template)) {
         initialData.commonTemplateName = template.metadata.name;
+        initialData.commonTemplateNamespace = template.metadata.namespace;
       } else {
         initialData.userTemplateName = template.metadata.name;
         initialData.userTemplateNs = template.metadata.namespace;
@@ -138,6 +139,7 @@ export const getVMWizardCreateLink = ({
   if (template) {
     if (isCommonTemplate(template)) {
       initialData.commonTemplateName = template.metadata.name;
+      initialData.commonTemplateNamespace = template.metadata.namespace;
     } else {
       initialData.userTemplateName = template.metadata.name;
       initialData.userTemplateNs = template.metadata.namespace;


### PR DESCRIPTION
we needs not only the `commonTemplateName` but also `commonTemplateNamespace` to really identify a template 
`searchParams?.get('namespace')` is the wrong namespace.