### PR TITLE
[release-4.10] Bug 2072792: Fetch common templates in a different namespace

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
@@ -14,6 +14,7 @@ import { connectToFlags } from '@console/internal/reducers/connectToFlags';
 import { featureReducerName, FlagsObject } from '@console/internal/reducers/features';
 import { NetworkAttachmentDefinitionModel } from '@console/network-attachment-definition-plugin';
 import { FLAGS } from '@console/shared';
+import { NAMESPACE_OPENSHIFT } from '../../constants';
 import { VMWizardURLParams } from '../../constants/url-params';
 import {
   TEMPLATE_TYPE_BASE,
@@ -465,11 +466,25 @@ export const CreateVMWizardPageComponent: React.FC<CreateVMWizardPageComponentPr
     if (flags[FLAGS.OPENSHIFT]) {
       resources.push(
         getResource(TemplateModel, {
-          namespace: 'openshift',
+          namespace: NAMESPACE_OPENSHIFT,
           prop: VMWizardProps.commonTemplates,
           matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_BASE },
         }),
       );
+
+      if (
+        initialData.commonTemplateNamespace &&
+        initialData.commonTemplateNamespace !== NAMESPACE_OPENSHIFT
+      ) {
+        // common template in a different namespace instead of 'openshift'
+        resources.push(
+          getResource(TemplateModel, {
+            namespace: initialData.commonTemplateNamespace,
+            prop: VMWizardProps.additionalCommonTemplates,
+            matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_BASE },
+          }),
+        );
+      }
 
       if (userMode === VMWizardMode.TEMPLATE) {
         resources.push(

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/prefill-vm-template-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/prefill-vm-template-state-update.ts
@@ -43,6 +43,7 @@ import {
   iGetCommonData,
   iGetLoadedCommonData,
   iGetName,
+  iGetNamespace,
 } from '../../selectors/immutable/selectors';
 import { getStorages } from '../../selectors/selectors';
 import {
@@ -61,17 +62,30 @@ import { InternalActionType, UpdateOptions } from '../types';
 
 export const prefillVmTemplateUpdater = ({ id, dispatch, getState }: UpdateOptions) => {
   const state = getState();
-  const { commonTemplateName } = getInitialData(state, id);
+  const { commonTemplateName, commonTemplateNamespace } = getInitialData(state, id);
 
   const isProviderImport = iGetCommonData(state, id, VMWizardProps.isProviderImport);
 
-  const iTemplate = commonTemplateName
+  let iTemplate = commonTemplateName
     ? iGetLoadedCommonData(
         state,
         id,
         commonTemplateName ? VMWizardProps.commonTemplates : VMWizardProps.userTemplates,
       ).find((template) => iGetName(template) === commonTemplateName)
     : iGetLoadedCommonData(state, id, VMWizardProps.userTemplate);
+
+  // common template in a different namespace instead of 'openshift'
+  const additionalCommonTemplate = iGetLoadedCommonData(
+    state,
+    id,
+    VMWizardProps.additionalCommonTemplates,
+  )?.find(
+    (template) =>
+      iGetName(template) === commonTemplateName &&
+      iGetNamespace(template) === commonTemplateNamespace,
+  );
+
+  iTemplate = iTemplate || additionalCommonTemplate;
 
   let isCloudInitForm = null;
   const vmSettingsUpdate = {

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
@@ -31,6 +31,7 @@ export enum VMWizardProps {
   reduxID = 'reduxID',
   virtualMachines = 'virtualMachines',
   commonTemplates = 'commonTemplates',
+  additionalCommonTemplates = 'additionalCommonTemplates',
   commonTemplateName = 'commonTemplateName',
   openshiftCNVBaseImages = 'openshiftCNVBaseImages',
   storageClassConfigMap = 'storageClassConfigMap',
@@ -239,6 +240,7 @@ export type ChangedCommonDataProp =
   | VMWizardProps.userTemplate
   | VMWizardProps.userTemplates
   | VMWizardProps.commonTemplates
+  | VMWizardProps.additionalCommonTemplates
   | VMWizardProps.cdRom
   | VMWizardProps.openshiftCNVBaseImages
   | VMWizardProps.dataVolumes

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/create-vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/create-vm.tsx
@@ -203,7 +203,7 @@ export const CreateVM: React.FC<RouteComponentProps<{ ns: string }>> = ({ match,
   const storageClassDefaultName = React.useMemo(() => {
     if (storageClasses && storageClassLoaded) {
       const storageClassDefault = storageClasses?.find(
-        (sc) => sc?.metadata?.annotations[DEFAULT_SC_ANNOTATION] === 'true',
+        (sc) => sc?.metadata?.annotations?.[DEFAULT_SC_ANNOTATION] === 'true',
       );
       return storageClassDefault?.metadata?.name;
     }

--- a/frontend/packages/kubevirt-plugin/src/selectors/config-map/sc-defaults.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/config-map/sc-defaults.ts
@@ -61,4 +61,4 @@ export const isConfigMapContainsScModes = (
 export const getDefaultStorageClass = (
   storageClasses: StorageClassResourceKind[],
 ): StorageClassResourceKind =>
-  (storageClasses || []).find((sc) => getAnnotations(sc, {})[DEFAULT_SC_ANNOTATION] === 'true');
+  (storageClasses || []).find((sc) => getAnnotations(sc, {})?.[DEFAULT_SC_ANNOTATION] === 'true');


### PR DESCRIPTION
Common templates are fetched only in the openshift namespace. if `commonTemplateNamespace` is different from 'openshift', add additional templates in the store and get the used template from there