### PR TITLE
[release-4.10] Bug 2052469: Filter template list for boot source available

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/select-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/select-template.tsx
@@ -233,7 +233,7 @@ export const SelectTemplate: React.FC<SelectTemplateProps> = ({
         bootSourceFilter = filters.bootSource.includes(BOOT_SOURCE_REQUIRED);
       } else if (!isTemplateSourceError(item.sourceStatus)) {
         bootSourceFilter =
-          filters.bootSource.includes(item.sourceStatus?.provider) && item.sourceStatus?.isReady;
+          filters.bootSource.includes(BOOT_SOURCE_AVAILABLE) && item.sourceStatus?.isReady;
       }
     }
     return textFilter && providerFilter && bootSourceFilter;


### PR DESCRIPTION
`filters.bootSource` does not contain providers but `BOOT_SOURCE_AVAILABLE` or `BOOT_SOURCE_REQUIRED`.

If there is no source status, check for BOOT_SOURCE_REQUIRED
if there is status, is ready, and is not in error, check for BOOT_SOURCE_AVAILABLE

If both are in the array, the item will be filtered only if the source has some error

**Before**
https://bugzilla.redhat.com/attachment.cgi?id=1860056

**After**

[Screencast from 12-10-2022 16:48:47.webm](https://user-images.githubusercontent.com/29160323/195375365-36e3f0b5-8022-4cb1-9a5b-54993194ee91.webm)
