### PR TITLE
Create-Knative-Workload | Knative Serverless

### DIFF
--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/create-knative-workload.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/create-knative-workload.feature
@@ -14,20 +14,20 @@ Feature: Create a workload of 'knative Service' type resource
               And Knative Service option is displayed under Resources section
 
 
-        @regression @to-do
+        @regression
         Scenario: knative resource type in docker file add flow: KN-05-TC02
             Given user is at Add page
-             When user clicks on Import from Git
+             When user clicks Import From Git card on the Add page
               And user enters git url "https://github.com/rohitkrai03/flask-dockerfile-example"
              Then Knative Service option is displayed under Resources section
 
 
-        @regression @broken-test
+        @regression
         Scenario: knative resource type in catalog add flow: KN-05-TC03
             Given user is at Add page
              When user clicks on From Catalog card
               And create the application with s2i builder image
-             Then user will be redirected to page with header name "Create Source-to-Image Application"
+             Then user will be redirected to page with header name "Create Source-to-Image application"
               And Knative Service option is displayed under Resources section
 
 
@@ -61,11 +61,11 @@ Feature: Create a workload of 'knative Service' type resource
                   | openshift/hello-openshift | knative-ex-registry |
 
 
-        @regression @to-do
+        @regression
         Scenario Outline: Create a workload from Docker file card on Add page: KN-05-TC06
             Given user is on Import from Git form
              When user enters Docker URL as "<docker_git_url>"
-              And user clicks on "Edit import strategy"
+              And user clicks on Edit import strategy
               And user selects Import Strategy as Dockerfile
               And user enters Dockerfile path as "<dockerfile_path>"
               And user enters workload name as "<workload_name>"
@@ -79,11 +79,9 @@ Feature: Create a workload of 'knative Service' type resource
                   | https://github.com/rohitkrai03/flask-dockerfile-example | Dockerfile      | knative-docker |
 
 
-        @regression @broken-test
+        @regression
         Scenario: Create a workload from DevCatalog BuilderImages card on Add page: KN-05-TC07
             Given user is at Developer Catalog page
-              And builder images are displayed
-             When user searches and selects the "node" card
               And user creates the application with the selected builder image
               And user enters S2I Git Repo url as "https://github.com/sclorg/nodejs-ex.git"
               And user enters workload name as "knative-dev-catalog"
@@ -93,13 +91,14 @@ Feature: Create a workload of 'knative Service' type resource
               And user is able to see workload "nodejs-ex-git" in topology page
 
 
-        @regression @to-do
+        @regression @broken-test
         Scenario: Create a knative workload with advanced option "Scaling" from From Git card: KN-05-TC08
             Given user is at Import from Git form
              When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
               And user enters Name as "dancer-ex-git" in General section
               And user selects resource type as "Serverless Deployment"
               And user clicks "Scaling" link in Advanced Options section
+        #Bug: Can't change the values by typing in max and min pod fields - https://issues.redhat.com/browse/OCPBUGS-2306
               And user enters number of Min Pods as "1"
               And user enters number of Max Pods as "5"
               And user enters number of Concurrency target as "3"

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/create-knative-workload.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/create-knative-workload.ts
@@ -7,13 +7,14 @@ import {
   devNavigationMenu,
   gitAdvancedOptions,
 } from '@console/dev-console/integration-tests/support/constants';
-import { gitPO } from '@console/dev-console/integration-tests/support/pageObjects';
+import { gitPO, topologyPO } from '@console/dev-console/integration-tests/support/pageObjects';
 import {
   addPage,
   gitPage,
   containerImagePage,
   catalogPage,
   navigateTo,
+  topologyPage,
 } from '@console/dev-console/integration-tests/support/pages';
 
 Given('user is on {string} form', (formName: string) => {
@@ -76,6 +77,8 @@ Then('user will be redirected to page with header name {string}', (headerName: s
 });
 
 Then('Knative Service option is displayed under Resources section', () => {
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(4000);
   gitPage.selectAdvancedOptions(gitAdvancedOptions.Resources);
   cy.get(gitPO.advancedOptions.resourcesDropdown)
     .scrollIntoView()
@@ -95,4 +98,55 @@ When('user enters Image name from external registry as {string}', (imageName: st
 
 Given('user is at Deploy Image page', () => {
   addPage.selectCardFromOptions(addOptions.ContainerImage);
+});
+
+When('user enters git url {string}', (url: string) => {
+  gitPage.enterGitUrl(url);
+});
+
+When('user enters Docker URL as {string}', (url: string) => {
+  gitPage.enterGitUrl(url);
+});
+
+When('user clicks on Import From Git option', () => {
+  cy.get(topologyPO.grouping.importFromGitOption).click();
+});
+
+When('user clicks on Edit import strategy', () => {
+  cy.get('.odc-import-strategy-section__edit-strategy-button').click();
+});
+
+When('user enters Git Repo URL as {string}', (gitUrl: string) => {
+  gitPage.enterGitUrl(gitUrl);
+  gitPage.verifyValidatedMessage(gitUrl);
+});
+
+When('user clicks Import From Git card on the Add page', () => {
+  addPage.selectCardFromOptions(addOptions.ImportFromGit);
+});
+
+When('user selects Import Strategy as Dockerfile', () => {
+  cy.byTestID('import-strategy Dockerfile').click();
+});
+
+When('user enters Dockerfile path as {string}', (dockerfilePath: string) => {
+  cy.get('#form-input-docker-dockerfilePath-field')
+    .clear()
+    .type(dockerfilePath);
+});
+
+When('user enters workload name as {string}', (name: string) => {
+  gitPage.enterWorkloadName(name);
+});
+
+When('user selects resource type as {string}', (resourceType: string) => {
+  gitPage.selectResource(resourceType);
+});
+
+When('user clicks Create button on Add page', () => {
+  gitPage.clickCreate();
+});
+
+Then('user is able to see workload {string} in topology page', (workloadName: string) => {
+  topologyPage.verifyWorkloadInTopologyPage(workloadName);
 });


### PR DESCRIPTION
**Description:**

<!-- PR description-->
- Automation of Create-Knative-Workload feature | Knative Serverless

**Jira Id:**
- Story: 
      - [ODC-7133](https://issues.redhat.com/browse/ODC-7133)
    
<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.12-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p knative
```

**Screen shots**:
<!--   -->
<img width="1671" alt="image" src="https://user-images.githubusercontent.com/65410551/195551424-87c37dab-8f0d-49b7-bbd0-e0ec1defe996.png">




**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge