### PR TITLE
OCPBUGS-2369: adds check for metadata as metadata is not required in template spec

### DIFF
--- a/frontend/public/module/k8s/label-selector.js
+++ b/frontend/public/module/k8s/label-selector.js
@@ -157,7 +157,7 @@ export class LabelSelector {
     if (!resource) {
       return false;
     }
-    const labels = resource.metadata.labels || {};
+    const labels = resource.metadata?.labels || {};
     return this.matchesLabels(labels);
   }
   hasConjunct(conjunct) {


### PR DESCRIPTION
Tracks: https://issues.redhat.com/browse/OCPBUGS-2369

**Screenshots:**

**Before:**

<img width="1578" alt="image" src="https://user-images.githubusercontent.com/5129024/195853919-577eb9ab-09e5-4a07-9055-ac904c4ad669.png">


**After:**

<img width="1787" alt="image" src="https://user-images.githubusercontent.com/5129024/195854036-265dfee6-b7c1-4793-82df-686a7acef232.png">


**Test Setup:**

1. Install serverless operator
2. Create CR for knativeServign
3. Create a namespace or go to any existing namespace
4. Create a ksvc as below and create a k8s Svc as below

KSVC

```
apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  name: sample
spec:
  template:
    spec:
      containers:
        - image: openshift/hello-openshift
```

k8s svc

```
apiVersion: v1
kind: Service
metadata:
  name: example
  namespace: jai-test-4
spec:
  selector:
    app: MyApp
  ports:
    - protocol: TCP
      port: 80
      targetPort: 9376
```

