### PR TITLE
Bug 2071517: Fix swap usage queries for Top Consumers card in virtualization Overview page

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/top-consumers-card/queries.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/top-consumers-card/queries.ts
@@ -14,7 +14,7 @@ const topConsumerQueries = {
       `sort_desc(sum(topk(<%= numItemsToShow %>, container_fs_usage_bytes{pod=~".*virt-launcher.*"})) by (namespace)) > 0`,
     ),
     [Metric.MEMORY_SWAP.getValue()]: _.template(
-      `sort_desc(topk(<%= numItemsToShow %>, sum(kubevirt_vmi_memory_swap_in_traffic_bytes_total-kubevirt_vmi_memory_swap_out_traffic_bytes_total) by (namespace))) > 0`,
+      `sort_desc(topk(5, sum(avg_over_time(kubevirt_vmi_memory_swap_in_traffic_bytes_total[5m]) + avg_over_time(kubevirt_vmi_memory_swap_out_traffic_bytes_total[5m])) by(namespace))) > 0`,
     ),
     [Metric.VCPU_WAIT.getValue()]: _.template(
       `sort_desc(topk(<%= numItemsToShow %>, sum(rate(kubevirt_vmi_vcpu_wait_seconds[4h])) by (namespace))) > 0`,
@@ -37,7 +37,7 @@ const topConsumerQueries = {
       `sort_desc(sum(topk(<%= numItemsToShow %>, avg_over_time(container_fs_usage_bytes{pod=~".*virt-launcher.*"}[4h]))) by (pod, namespace, label_vm_kubevirt_io_name)) + on (pod, namespace) group_left(label_vm_kubevirt_io_name) ( 0 * topk by (pod,namespace) (1, kube_pod_labels{pod=~".*virt-launcher.*"} )) > 0`,
     ),
     [Metric.MEMORY_SWAP.getValue()]: _.template(
-      `sort_desc(topk (<%= numItemsToShow %>, sum(kubevirt_vmi_memory_swap_in_traffic_bytes_total-kubevirt_vmi_memory_swap_out_traffic_bytes_total) by(name, namespace))) > 0`,
+      `sort_desc(topk(5, sum(avg_over_time(kubevirt_vmi_memory_swap_in_traffic_bytes_total[5m]) + avg_over_time(kubevirt_vmi_memory_swap_out_traffic_bytes_total[5m])) by (name, namespace))) > 0`,
     ),
     [Metric.VCPU_WAIT.getValue()]: _.template(
       `sort_desc(topk(<%= numItemsToShow %>, sum(rate(kubevirt_vmi_vcpu_wait_seconds[4h])) by (namespace, name))) > 0`,
@@ -60,7 +60,7 @@ const topConsumerQueries = {
       `sort_desc(sum(topk(<%= numItemsToShow %>, container_fs_usage_bytes{pod=~".*virt-launcher.*"})) by (node)) > 0`,
     ),
     [Metric.MEMORY_SWAP.getValue()]: _.template(
-      `sort_desc(topk(<%= numItemsToShow %>, sum(kubevirt_vmi_memory_swap_in_traffic_bytes_total-kubevirt_vmi_memory_swap_out_traffic_bytes_total) by (node))) > 0`,
+      `sort_desc(topk(5, sum(avg_over_time(kubevirt_vmi_memory_swap_in_traffic_bytes_total[5m]) + avg_over_time(kubevirt_vmi_memory_swap_out_traffic_bytes_total[5m])) by (node))) > 0`,
     ),
     [Metric.VCPU_WAIT.getValue()]: _.template(
       `sort_desc(topk(<%= numItemsToShow %>, sum(rate(kubevirt_vmi_vcpu_wait_seconds[4h])) by (node))) > 0`,

--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/top-consumers-card/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/top-consumers-card/utils.ts
@@ -22,7 +22,7 @@ export const humanizeTopConsumerMetric = (value: number, metric: TopConsumerMetr
       humanizedValue = humanizeBinaryBytes(value, 'B');
       break;
     case TopConsumerMetric.MEMORY_SWAP:
-      humanizedValue = humanizeDecimalBytes(value, 'MB');
+      humanizedValue = humanizeDecimalBytes(value);
       break;
     case TopConsumerMetric.VCPU_WAIT:
       humanizedValue = humanizeSeconds(value, 's', 'ms');


### PR DESCRIPTION
This PR fixes the swap memory query for the Top Consumers card in the virtualization Overview page. It also removes an incorrectly used parameter in the humanize method used to calculate the display value and unit.

## Screenshots:
Before:
![Selection_174](https://user-images.githubusercontent.com/8544299/197919218-a60d8d88-0225-4d9e-99b8-a58c439719a5.png)

After:
![Selection_173](https://user-images.githubusercontent.com/8544299/197919234-9b0ad5dd-5ec5-4cf4-9272-8d4fa6ec1e0d.png)
