### PR TITLE
OCPBUGS-2100: Fix warning icon color

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/Status.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/Status.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   BanIcon,
   ClipboardListIcon,
-  ExclamationTriangleIcon,
   HourglassHalfIcon,
   HourglassStartIcon,
   NotStartedIcon,
@@ -75,8 +74,6 @@ const Status: React.FC<StatusProps> = ({
       return <StatusIconAndText {...statusProps} icon={<BanIcon />} />;
 
     case 'Warning':
-      return <StatusIconAndText {...statusProps} icon={<ExclamationTriangleIcon />} />;
-
     case 'RequiresApproval':
       return <StatusIconAndText {...statusProps} icon={<YellowExclamationTriangleIcon />} />;
 


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-2100

Descriptions: 
- Change to alert icon color for the warning to `--pf-global--warning-color--100`.

Screenshots:
![image](https://user-images.githubusercontent.com/2561818/196205602-f69ef51f-20db-454d-bdb3-c6bcd6a64afb.png)
![image](https://user-images.githubusercontent.com/2561818/196205698-262d74de-0b88-406e-a84f-8b5d44b666b5.png)
