### PR TITLE
OCPBUGS-2455: Pods and PDBs list page just reports 'Not found' when no Pod/PDB

### DIFF
--- a/frontend/packages/console-app/src/components/pdb/PDBList.tsx
+++ b/frontend/packages/console-app/src/components/pdb/PDBList.tsx
@@ -14,6 +14,7 @@ const PodDisruptionBudgetList: React.FC<PodDisruptionBudgetsListProps> = (props)
     <VirtualizedTable<PodDisruptionBudgetKind>
       {...props}
       aria-label={t('console-app~PodDisruptionBudgets')}
+      label={t('console-app~PodDisruptionBudgets')}
       columns={columns}
       Row={PodDisruptionBudgetTableRow}
     />

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -929,6 +929,7 @@ export const PodList: React.FC<PodListProps> = ({ showNamespaceOverride, showNod
       <VirtualizedTable<PodKind, PodRowData>
         {...props}
         aria-label={t('public~Pods')}
+        label={t('public~Pods')}
         columns={activeColumns}
         Row={PodTableRow}
         rowData={rowData}


### PR DESCRIPTION
### Before
![Screen Shot 2022-10-17 at 12 49 51 PM](https://user-images.githubusercontent.com/15249132/196238514-fcc5e1d8-c1e5-47ee-bef8-cdf62d22a6b3.png)
![Screen Shot 2022-10-17 at 12 50 01 PM](https://user-images.githubusercontent.com/15249132/196238517-92eff658-326a-4cf2-a28d-d34924b926a9.png)

### After
![Screen Shot 2022-10-17 at 12 50 17 PM](https://user-images.githubusercontent.com/15249132/196238587-5a687645-5804-4769-80b4-33693ec824d6.png)
![Screen Shot 2022-10-17 at 12 50 34 PM](https://user-images.githubusercontent.com/15249132/196238590-fcb90375-4239-4033-9915-48eba566ae16.png)
