### PR TITLE
OCPBUGS-1017: Persist last cluster dropdown selection in session storage only

### DIFF
--- a/frontend/packages/console-app/src/components/detect-cluster/cluster.ts
+++ b/frontend/packages/console-app/src/components/detect-cluster/cluster.ts
@@ -18,7 +18,7 @@ export const useValuesForClusterContext = () => {
     LAST_CLUSTER_USER_SETTINGS_KEY,
     LAST_CLUSTER_USER_SETTINGS_KEY,
     HUB_CLUSTER_NAME,
-    true,
+    false,
     true,
   );
 


### PR DESCRIPTION
Update last cluster setting to only be tracked per session, instead of local storage. This prevents user from being trapped at login screen for the last cluster they selected from the dropdown.