### PR TITLE
Bug 2115265: Search page: LazyActionMenus are shown below Add/Remove from navigation button

### DIFF
--- a/frontend/packages/console-shared/src/components/actions/LazyActionMenu.tsx
+++ b/frontend/packages/console-shared/src/components/actions/LazyActionMenu.tsx
@@ -12,7 +12,6 @@ import { ActionMenuVariant } from './types';
 type LazyMenuRendererProps = {
   isOpen: boolean;
   actions: Action[];
-  containerRef: React.RefObject<HTMLDivElement>;
   menuRef: React.RefObject<HTMLDivElement>;
   toggleRef: React.RefObject<HTMLButtonElement>;
 } & React.ComponentProps<typeof ActionMenuContent>;
@@ -20,7 +19,6 @@ type LazyMenuRendererProps = {
 const LazyMenuRenderer: React.FC<LazyMenuRendererProps> = ({
   isOpen,
   actions,
-  containerRef,
   menuRef,
   toggleRef,
   ...restProps
@@ -54,7 +52,6 @@ const LazyMenuRenderer: React.FC<LazyMenuRendererProps> = ({
       popper={menu}
       placement="bottom-end"
       isVisible={isOpen}
-      appendTo={containerRef.current}
       popperMatchesTriggerWidth={false}
     />
   );
@@ -71,7 +68,6 @@ const LazyActionMenu: React.FC<LazyActionMenuProps> = ({
   const [initActionLoader, setInitActionLoader] = React.useState<boolean>(false);
   const menuRef = React.useRef<HTMLDivElement>(null);
   const toggleRef = React.useRef<HTMLButtonElement>(null);
-  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const hideMenu = () => {
     setIsOpen(false);
@@ -82,7 +78,7 @@ const LazyActionMenu: React.FC<LazyActionMenuProps> = ({
   }, []);
 
   return (
-    <div ref={containerRef}>
+    <>
       <ActionMenuToggle
         isOpen={isOpen}
         isDisabled={isDisabled}
@@ -104,7 +100,6 @@ const LazyActionMenu: React.FC<LazyActionMenuProps> = ({
                   isOpen={isOpen}
                   actions={extra ? menuActions : actions}
                   options={extra ? menuOptions : options}
-                  containerRef={containerRef}
                   menuRef={menuRef}
                   toggleRef={toggleRef}
                   onClick={hideMenu}
@@ -115,7 +110,7 @@ const LazyActionMenu: React.FC<LazyActionMenuProps> = ({
           }}
         </ActionServiceProvider>
       )}
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/OCPBUGSM-47470

Analysis / Root cause:
In LazyActionMenu component, Popper is appended to parent, so the z-index was in-effective. 

Solution Description:
Detached popper component from parent like in ResourceKebab component 

Screen shots / Gifs for design review:

-------------- Before -------

<img width="1399" alt="Screenshot 2022-10-19 at 12 35 15 PM" src="https://user-images.githubusercontent.com/102503482/196621982-88e0e0f0-8e80-4b9f-a27d-a81da240258b.png">

<img width="415" alt="Screenshot 2022-10-19 at 12 35 37 PM" src="https://user-images.githubusercontent.com/102503482/196622001-f9e2bd84-501e-46b3-981b-cb36fbd1189c.png">

-------After-----------------

<img width="1387" alt="Screenshot 2022-10-19 at 12 33 51 PM" src="https://user-images.githubusercontent.com/102503482/196621974-05079e97-a36a-4e27-9369-adcb55e4fc85.png">

<img width="347" alt="Screenshot 2022-10-19 at 12 35 54 PM" src="https://user-images.githubusercontent.com/102503482/196622029-2a572cc5-75fa-40e9-99b6-2b6fbf93eb55.png">

**Unit test coverage report:**
NA

**Test setup:**
1. Navigate to the search
2. Open the resource selector and search for HelmChartRepo, select HelmChartRepositories and ProjectHelmChartRepositories
3. HCR should have at least one repo. Click on the action menu of the first table.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
