### PR TITLE
OCPBUGS-1950: Devfile samples (in Developer Catalog) link doesn't include the current selected namespace

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.data.ts
+++ b/frontend/packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.data.ts
@@ -70,7 +70,7 @@ export const expectedCatalogItems: CatalogItem[] = [
     cta: {
       label: 'Create Devfile Sample',
       href:
-        '/import?importType=devfile&formType=sample&devfileName=nodejs-basic&gitRepo=https://github.com/nodeshift-starters/devfile-sample.git',
+        '/import/ns/test?importType=devfile&formType=sample&devfileName=nodejs-basic&gitRepo=https://github.com/nodeshift-starters/devfile-sample.git',
     },
     icon: { url: 'trimmed' },
   },
@@ -83,7 +83,7 @@ export const expectedCatalogItems: CatalogItem[] = [
     cta: {
       label: 'Create Devfile Sample',
       href:
-        '/import?importType=devfile&formType=sample&devfileName=code-with-quarkus&gitRepo=https://github.com/devfile-samples/devfile-sample-code-with-quarkus.git',
+        '/import/ns/test?importType=devfile&formType=sample&devfileName=code-with-quarkus&gitRepo=https://github.com/devfile-samples/devfile-sample-code-with-quarkus.git',
     },
     icon: { url: 'trimmed' },
   },
@@ -96,7 +96,7 @@ export const expectedCatalogItems: CatalogItem[] = [
     cta: {
       label: 'Create Devfile Sample',
       href:
-        '/import?importType=devfile&formType=sample&devfileName=java-springboot-basic&gitRepo=https://github.com/devfile-samples/devfile-sample-java-springboot-basic.git',
+        '/import/ns/test?importType=devfile&formType=sample&devfileName=java-springboot-basic&gitRepo=https://github.com/devfile-samples/devfile-sample-java-springboot-basic.git',
     },
     icon: { url: 'trimmed' },
   },
@@ -109,7 +109,7 @@ export const expectedCatalogItems: CatalogItem[] = [
     cta: {
       label: 'Create Devfile Sample',
       href:
-        '/import?importType=devfile&formType=sample&devfileName=python-basic&gitRepo=https://github.com/devfile-samples/devfile-sample-python-basic.git',
+        '/import/ns/test?importType=devfile&formType=sample&devfileName=python-basic&gitRepo=https://github.com/devfile-samples/devfile-sample-python-basic.git',
     },
     icon: { url: 'trimmed' },
   },

--- a/frontend/packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.spec.ts
+++ b/frontend/packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.spec.ts
@@ -1,18 +1,27 @@
 import { act } from 'react-dom/test-utils';
 import { coFetchJSON } from '@console/internal/co-fetch';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { testHook } from '../../../../../../../__tests__/utils/hooks-utils';
 import { DevfileSample } from '../../../import/devfile/devfile-types';
 import useDevfileSamples from '../useDevfileSamples';
 import { devfileSamples, expectedCatalogItems } from './useDevfileSamples.data';
 
+const ns: string = 'test';
+
 jest.mock('@console/internal/co-fetch', () => ({
   coFetchJSON: jest.fn(),
 }));
 
+jest.mock('@console/shared/src/hooks/useActiveNamespace', () => ({
+  useActiveNamespace: jest.fn(),
+}));
+
 const getMock = (coFetchJSON as unknown) as jest.Mock;
+const useActiveNamespaceMock = useActiveNamespace as jest.Mock;
 
 beforeEach(() => {
   jest.resetAllMocks();
+  useActiveNamespaceMock.mockReturnValue([ns]);
 });
 
 describe('useDevfileSamples:', () => {

--- a/frontend/packages/dev-console/src/components/catalog/providers/useDevfileSamples.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useDevfileSamples.tsx
@@ -3,15 +3,19 @@ import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { CatalogItem, ExtensionHook } from '@console/dynamic-plugin-sdk';
 import { coFetchJSON } from '@console/internal/co-fetch';
-import { APIError } from '@console/shared';
+import { APIError, useActiveNamespace } from '@console/shared';
 import { DevfileSample } from '../../import/devfile/devfile-types';
 
-const normalizeDevfileSamples = (devfileSamples: DevfileSample[], t: TFunction): CatalogItem[] => {
+const normalizeDevfileSamples = (
+  devfileSamples: DevfileSample[],
+  activeNamespace: string,
+  t: TFunction,
+): CatalogItem[] => {
   const normalizedDevfileSamples = devfileSamples.map((sample) => {
     const { name: uid, displayName, description, tags, git, icon, provider } = sample;
     const gitRepoUrl = Object.values(git.remotes)[0];
     const label = t('devconsole~Create Devfile Sample');
-    const href = `/import?importType=devfile&formType=sample&devfileName=${uid}&gitRepo=${gitRepoUrl}`;
+    const href = `/import/ns/${activeNamespace}?importType=devfile&formType=sample&devfileName=${uid}&gitRepo=${gitRepoUrl}`;
     const iconUrl = icon || '';
 
     const item: CatalogItem = {
@@ -36,6 +40,7 @@ const normalizeDevfileSamples = (devfileSamples: DevfileSample[], t: TFunction):
 
 const useDevfileSamples: ExtensionHook<CatalogItem[]> = (): [CatalogItem[], boolean, any] => {
   const { t } = useTranslation();
+  const [activeNamespace] = useActiveNamespace();
   const [devfileSamples, setDevfileSamples] = React.useState<DevfileSample[]>();
   const [loadedError, setLoadedError] = React.useState<APIError>();
 
@@ -53,8 +58,8 @@ const useDevfileSamples: ExtensionHook<CatalogItem[]> = (): [CatalogItem[], bool
   }, []);
 
   const normalizedDevfileSamples = React.useMemo(
-    () => normalizeDevfileSamples(devfileSamples || [], t),
-    [devfileSamples, t],
+    () => normalizeDevfileSamples(devfileSamples || [], activeNamespace, t),
+    [activeNamespace, devfileSamples, t],
   );
 
   const loaded = !!devfileSamples;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-1950

**Analysis / Root cause**: 
When opening the Devfile sample developer catalog, switching the project in another browser tab, and then opening devfile samples link in a new tab, the current project context is getting lost.

**Solution Description**: 
The activeNamespace is appended to the URL of the Devfiles. Thus, the cards in the Samples Page have the redirection link containing the active namespace, which in turn sets the project name accordingly.

**Screenshots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/47265560/196746130-a8a14062-a07e-4fdb-8740-d08d009d642f.mp4

**Unit test coverage report**: 
<!-- Attach test coverage report -->
Changes made to `useDevFileSamples.data.ts` for passing the preexisting tests.
![Screenshot from 2022-10-20 12-39-50](https://user-images.githubusercontent.com/47265560/196880604-afd564a7-6176-4ba8-aea7-5bd31e79f4d0.png)



**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Switch to the developer perspective, navigate to Add > Samples
2. Open a new browser tab and create a new project
3. Ctrl+click a sample in the first tab.


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge