### PR TITLE
OCPBUGS-2579: Helm Charts and Samples are not disabled in topology actions if actions are disabled in customization

### DIFF
--- a/frontend/packages/dev-console/src/actions/add-resources.tsx
+++ b/frontend/packages/dev-console/src/actions/add-resources.tsx
@@ -111,7 +111,7 @@ export const AddActions: { [name: string]: ActionFactory } = {
     disabled: accessReviewDisabled,
   }),
   Samples: (namespace, application, contextSource, path, accessReviewDisabled) => ({
-    id: 'import-form-samples',
+    id: 'import-from-samples',
     label: i18next.t('devconsole~Samples'),
     icon: <LaptopCodeIcon />,
     cta: {

--- a/frontend/packages/helm-plugin/src/actions/providers.ts
+++ b/frontend/packages/helm-plugin/src/actions/providers.ts
@@ -2,12 +2,17 @@ import * as React from 'react';
 import { GraphElement, isGraph, Node } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
 import { getCommonResourceActions } from '@console/app/src/actions/creators/common-factory';
+import { getDisabledAddActions } from '@console/dev-console/src/utils/useAddActionExtensions';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { SetFeatureFlag, useK8sModel } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 import { isCatalogTypeEnabled, useActiveNamespace } from '@console/shared';
 import { getResource } from '@console/topology/src/utils';
-import { FLAG_HELM_CHARTS_CATALOG_TYPE, HELM_CHART_CATALOG_TYPE_ID } from '../const';
+import {
+  FLAG_HELM_CHARTS_CATALOG_TYPE,
+  HELM_CHART_ACTION_ID,
+  HELM_CHART_CATALOG_TYPE_ID,
+} from '../const';
 import { TYPE_HELM_RELEASE } from '../topology/components/const';
 import { AddHelmChartAction } from './add-resources';
 import {
@@ -67,13 +72,14 @@ export const useTopologyActionProvider = ({
   connectorSource?: Node;
 }) => {
   const [namespace] = useActiveNamespace();
-
+  const disabledAddActions = getDisabledAddActions();
+  const isHelmDisabled = disabledAddActions?.includes(HELM_CHART_ACTION_ID);
   return React.useMemo(() => {
-    if (isGraph(element) && !connectorSource) {
+    if (isGraph(element) && !connectorSource && !isHelmDisabled) {
       return [[AddHelmChartAction(namespace, 'add-to-project', true)], true, undefined];
     }
     return [[], true, undefined];
-  }, [connectorSource, element, namespace]);
+  }, [connectorSource, element, namespace, isHelmDisabled]);
 };
 
 export const useHelmChartRepositoryActions = (resource: K8sResourceKind) => {

--- a/frontend/packages/helm-plugin/src/const.ts
+++ b/frontend/packages/helm-plugin/src/const.ts
@@ -1,3 +1,4 @@
 export const FLAG_OPENSHIFT_HELM = 'OPENSHIFT_HELM';
 export const FLAG_HELM_CHARTS_CATALOG_TYPE = 'HELM_CHARTS_CATALOG_TYPE';
 export const HELM_CHART_CATALOG_TYPE_ID = 'HelmChart';
+export const HELM_CHART_ACTION_ID = 'helm';


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-2579

**Analysis / Root cause:**
Access check was not added for topology add actions for Helm Charts and Samples

**Solution Description:**
Added access check for topology add actions for Helm Charts and Samples

**Screen shots / Gifs for design review:**

-------------- Before -------

<img width="888" alt="Screenshot 2022-10-20 at 2 09 12 PM" src="https://user-images.githubusercontent.com/102503482/196900037-10b03fc0-cfea-4efb-9186-4768eee62c99.png">


-------After-----------------

<img width="820" alt="Screenshot 2022-10-20 at 2 06 46 PM" src="https://user-images.githubusercontent.com/102503482/196900014-2bfef9f8-3cdc-460d-bd21-e1a00252bf01.png">

**Unit test coverage report:**
NA

**Test setup:**
Add below yaml in config.yaml in local and pass config.yaml to bridge with -config option.

<img width="296" alt="image" src="https://user-images.githubusercontent.com/102503482/196900524-c9957a2c-f624-4e35-bcaa-d6220ef2952a.png">

Example:

./bin/bridge -config ../../config.yaml


**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
