### PR TITLE
OCPBUGS-2654: Update OperatorHub tests

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.spec.ts
@@ -61,7 +61,7 @@ describe('Interacting with OperatorHub', () => {
   });
 
   it('filters Operators by name', () => {
-    const operatorName = 'Couchbase Operator';
+    const operatorName = 'Datadog Operator';
     cy.byTestID('search-operatorhub').type(operatorName);
     cy.get('.catalog-tile-pf')
       .its('length')


### PR DESCRIPTION
Problem: The couchbase operator is no longer present in the 4.12 certified catalogsource, causing one of the operatorhub tests to fail.

Solution: Update the operator referenced by the test.