### PR TITLE
[release-4.9] OCPBUGS-2576, OCPBUGS-2719: Fix backend test (devfile registry change), fix console e2e test (3scale operator name change)

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -5,7 +5,7 @@ import { nav } from '../../../integration-tests-cypress/views/nav';
 import { GlobalInstalledNamespace, operator, TestOperandProps } from '../views/operator.view';
 
 const testOperator = {
-  name: 'Red Hat Integration - 3scale',
+  name: 'Red Hat Integration - 3scale - Managed Application Services',
   operatorHubCardTestID: '3scale-operator-redhat-operators-openshift-marketplace',
   installedNamespace: testName,
 };

--- a/pkg/devfile/sample.go
+++ b/pkg/devfile/sample.go
@@ -13,11 +13,13 @@ const ODC_TELEMETRY_CLIENT_NAME = "openshift-console"
 
 const DEVFILE_REGISTRY_PLACEHOLDER_URL = "sample-placeholder"
 
+var testRegistryServer = ""
+
 // GetRegistrySamples returns the list of samples, more specifically
 // it gets the content of the index (index.json) of the specified registry.
 // This is based on https://github.com/devfile/registry-support/blob/master/registry-library/library/library.go#L61
 func GetRegistrySamples(registry string) ([]byte, error) {
-	if registry == DEVFILE_REGISTRY_URL || registry == DEVFILE_STAGING_REGISTRY_URL {
+	if registry == DEVFILE_REGISTRY_URL || registry == DEVFILE_STAGING_REGISTRY_URL || registry == testRegistryServer && testRegistryServer != "" {
 		// set registryOption with `user=openshift-console` for registry telemetry tracking
 		registryOption := registryLibrary.RegistryOptions{User: ODC_TELEMETRY_CLIENT_NAME}
 

--- a/pkg/devfile/testdata/registrystagedevfileio/sample.json
+++ b/pkg/devfile/testdata/registrystagedevfileio/sample.json
@@ -1,0 +1,113 @@
+[
+  {
+    "name": "nodejs-basic",
+    "displayName": "Basic Node.js",
+    "description": "A simple Hello World Node.js application",
+    "type": "sample",
+    "tags": [
+      "NodeJS",
+      "Express"
+    ],
+    "icon": "https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg",
+    "projectType": "nodejs",
+    "language": "nodejs",
+    "git": {
+      "remotes": {
+        "origin": "https://github.com/nodeshift-starters/devfile-sample.git"
+      }
+    },
+    "provider": "Red Hat"
+  },
+  {
+    "name": "code-with-quarkus",
+    "displayName": "Basic Quarkus",
+    "description": "A simple Hello World Java application using Quarkus",
+    "type": "sample",
+    "tags": [
+      "Java",
+      "Quarkus"
+    ],
+    "icon": "https://design.jboss.org/quarkus/logo/final/SVG/quarkus_icon_rgb_default.svg",
+    "projectType": "quarkus",
+    "language": "java",
+    "git": {
+      "remotes": {
+        "origin": "https://github.com/devfile-samples/devfile-sample-code-with-quarkus.git"
+      }
+    },
+    "provider": "Red Hat"
+  },
+  {
+    "name": "java-springboot-basic",
+    "displayName": "Basic Spring Boot",
+    "description": "A simple Hello World Java Spring Boot application using Maven",
+    "type": "sample",
+    "tags": [
+      "Java",
+      "Spring"
+    ],
+    "icon": "https://spring.io/images/projects/spring-edf462fec682b9d48cf628eaf9e19521.svg",
+    "projectType": "springboot",
+    "language": "java",
+    "git": {
+      "remotes": {
+        "origin": "https://github.com/devfile-samples/devfile-sample-java-springboot-basic.git"
+      }
+    },
+    "provider": "Red Hat"
+  },
+  {
+    "name": "python-basic",
+    "displayName": "Basic Python",
+    "description": "A simple Hello World application using Python",
+    "type": "sample",
+    "tags": [
+      "Python"
+    ],
+    "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/python.svg",
+    "projectType": "python",
+    "language": "python",
+    "git": {
+      "remotes": {
+        "origin": "https://github.com/devfile-samples/devfile-sample-python-basic.git"
+      }
+    },
+    "provider": "Red Hat"
+  },
+  {
+    "name": "go-basic",
+    "displayName": "Basic Go",
+    "description": "A simple Hello World application using Go",
+    "type": "sample",
+    "tags": [
+      "Go"
+    ],
+    "icon": "https://go.dev/blog/go-brand/Go-Logo/SVG/Go-Logo_Blue.svg",
+    "projectType": "go",
+    "language": "go",
+    "git": {
+      "remotes": {
+        "origin": "https://github.com/devfile-samples/devfile-sample-go-basic.git"
+      }
+    },
+    "provider": "Red Hat"
+  },
+  {
+    "name": "dotnet60-basic",
+    "displayName": "Basic .NET 6.0",
+    "description": "A simple application using .NET 6.0",
+    "type": "sample",
+    "tags": [
+      "dotnet"
+    ],
+    "icon": "https://github.com/dotnet/brand/raw/main/logo/dotnet-logo.png",
+    "projectType": "dotnet",
+    "language": "dotnet",
+    "git": {
+      "remotes": {
+        "origin": "https://github.com/devfile-samples/devfile-sample-dotnet60-basic.git"
+      }
+    },
+    "provider": "Red Hat"
+  }
+]


### PR DESCRIPTION
Manual backport of #12194 and rebased on top of #12188 because both PR are in a deadlock. This fixes a backend test issue, the other one a console e2e issue.

Just a small merge conflict in sample.go, the test merges automatically.

4.12: https://issues.redhat.com/browse/OCPBUGS-1678 / #12088
4.11: https://issues.redhat.com/browse/OCPBUGS-2014 / #12137
4.10: https://issues.redhat.com/browse/OCPBUGS-2622 / #12194
4.9: https://issues.redhat.com/browse/OCPBUGS-2719 / this PR

/kind bug
/cc @jhadvig @sanketpathak 