### PR TITLE
OCPBUGS-3161: 'CatalogSource not found' in the virtualization

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/hooks/use-kubevirt-csv-details.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-kubevirt-csv-details.ts
@@ -90,7 +90,7 @@ export const useKubevirtCsvDetails = (): UseKubevirtCsvDetails => {
 
       const catalogSrcMissing =
         !_.isEmpty(updatedResources.catalogSources.data) &&
-        !catalogSourceForSubscription(updatedResources.catalogSources.data, kubevirtSub) &&
+        !catalogSourceForSubscription(updatedResources.catalogSources.data, kubevirtSubscription) &&
         !isPackageServer(kubevirtCSV);
 
       setName(kubevirtCSV?.spec?.displayName);


### PR DESCRIPTION
### Before:
![missing-CatalogSource-b4](https://user-images.githubusercontent.com/67270715/197457871-9d99f1ef-8eb9-4414-b711-b0159cc9b13e.png)

### After:
![missing-CatalogSource](https://user-images.githubusercontent.com/67270715/197457899-19ab6306-fd4c-49ce-960c-7cfc0634dde6.png)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>