### PR TITLE
OCPBUGS-1061: Monitoring: Fix permission check for Prometheus & Alertmanager pollers

### DIFF
--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -74,7 +74,6 @@ import {
   splitClusterVersionChannel,
 } from '../module/k8s';
 import { pluginStore } from '../plugins';
-import { useAccessReview2 } from './utils/rbac';
 import { LinkifyExternal } from './utils';
 import { PrometheusEndpoint } from './graphs/helpers';
 import { LabelSelector } from '@console/internal/module/k8s/label-selector';
@@ -231,78 +230,80 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
 }) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const [rulesAccess] = useAccessReview2({
-    group: 'monitoring.coreos.com',
-    resource: 'prometheusrules',
-    verb: 'list',
-  });
   const clusterID = getClusterID(useClusterVersion());
   const showServiceLevelNotification = useShowServiceLevelNotifications(clusterID);
 
   React.useEffect(() => {
-    if (rulesAccess) {
-      const poll: NotificationPoll = (url, key: 'notificationAlerts' | 'silences', dataHandler) => {
-        dispatch(alertingLoading(key));
-        const notificationPoller = (): void => {
-          coFetchJSON(url)
-            .then((response) => dataHandler(response))
-            .then((data) => dispatch(alertingLoaded(key, data)))
-            .catch((e) => dispatch(alertingErrored(key, e)))
-            .then(() => (pollerTimeouts[key] = setTimeout(notificationPoller, 15 * 1000)));
-        };
-        pollers[key] = notificationPoller;
-        notificationPoller();
-      };
-      const { alertManagerBaseURL, prometheusBaseURL } = window.SERVER_FLAGS;
+    const poll: NotificationPoll = (url, key: 'notificationAlerts' | 'silences', dataHandler) => {
+      dispatch(alertingLoading(key));
+      const notificationPoller = (): void => {
+        coFetchJSON(url)
+          .then((response) => dataHandler(response))
+          .then((data) => {
+            dispatch(alertingLoaded(key, data));
+            pollerTimeouts[key] = setTimeout(notificationPoller, 15 * 1000);
+          })
+          .catch((e) => {
+            dispatch(alertingErrored(key, e));
 
-      if (prometheusBaseURL) {
-        poll(
-          `${prometheusBaseURL}/${PrometheusEndpoint.RULES}`,
-          'notificationAlerts',
-          (alertsResults: PrometheusRulesResponse): Alert[] =>
-            alertsResults
-              ? getAlertsAndRules(alertsResults.data)
-                  .alerts.filter(
-                    (a) =>
-                      a.state === 'firing' &&
-                      getAlertName(a) !== 'Watchdog' &&
-                      getAlertName(a) !== 'UpdateAvailable',
-                  )
-                  .sort((a, b) => +new Date(getAlertTime(b)) - +new Date(getAlertTime(a)))
-              : [],
-        );
-      } else {
-        dispatch(
-          alertingErrored('notificationAlerts', new Error(t('public~prometheusBaseURL not set'))),
-        );
-      }
-
-      if (alertManagerBaseURL) {
-        poll(`${alertManagerBaseURL}/api/v2/silences`, 'silences', (silences) => {
-          // Set a name field on the Silence to make things easier
-          _.each(silences, (s) => {
-            s.name = _.get(_.find(s.matchers, { name: 'alertname' }), 'value');
-            if (!s.name) {
-              // No alertname, so fall back to displaying the other matchers
-              s.name = s.matchers
-                .map(
-                  (m) => `${m.name}${silenceMatcherEqualitySymbol(m.isEqual, m.isRegex)}${m.value}`,
-                )
-                .join(', ');
-            }
+            // If the API returned an error, poll less frequently to avoid excessive calls. For
+            // example, if the user doesn't have permission to access the API, polling will probably
+            // continue to fail, but it is possible that permissions will be granted so we don't
+            // stop completely.
+            pollerTimeouts[key] = setTimeout(notificationPoller, 60 * 1000);
           });
-          return silences;
-        });
-      } else {
-        dispatch(alertingErrored('silences', new Error(t('public~alertManagerBaseURL not set'))));
-      }
+      };
+      pollers[key] = notificationPoller;
+      notificationPoller();
+    };
 
-      return () => _.each(pollerTimeouts, clearTimeout);
+    const { alertManagerBaseURL, prometheusBaseURL } = window.SERVER_FLAGS;
+
+    if (prometheusBaseURL) {
+      poll(
+        `${prometheusBaseURL}/${PrometheusEndpoint.RULES}`,
+        'notificationAlerts',
+        (alertsResults: PrometheusRulesResponse): Alert[] =>
+          alertsResults
+            ? getAlertsAndRules(alertsResults.data)
+                .alerts.filter(
+                  (a) =>
+                    a.state === 'firing' &&
+                    getAlertName(a) !== 'Watchdog' &&
+                    getAlertName(a) !== 'UpdateAvailable',
+                )
+                .sort((a, b) => +new Date(getAlertTime(b)) - +new Date(getAlertTime(a)))
+            : [],
+      );
+    } else {
+      dispatch(
+        alertingErrored('notificationAlerts', new Error(t('public~prometheusBaseURL not set'))),
+      );
     }
-    dispatch(
-      alertingErrored('notificationAlerts', new Error(t('public~monitoring access not granted'))),
-    );
-  }, [dispatch, t, rulesAccess]);
+
+    if (alertManagerBaseURL) {
+      poll(`${alertManagerBaseURL}/api/v2/silences`, 'silences', (silences) => {
+        // Set a name field on the Silence to make things easier
+        _.each(silences, (s) => {
+          s.name = _.get(_.find(s.matchers, { name: 'alertname' }), 'value');
+          if (!s.name) {
+            // No alertname, so fall back to displaying the other matchers
+            s.name = s.matchers
+              .map(
+                (m) => `${m.name}${silenceMatcherEqualitySymbol(m.isEqual, m.isRegex)}${m.value}`,
+              )
+              .join(', ');
+          }
+        });
+        return silences;
+      });
+    } else {
+      dispatch(alertingErrored('silences', new Error(t('public~alertManagerBaseURL not set'))));
+    }
+
+    return () => _.each(pollerTimeouts, clearTimeout);
+  }, [dispatch, t]);
+
   const clusterVersion: ClusterVersionKind = useClusterVersion();
   const [alerts, , loadError] = useNotificationAlerts();
   const launchModal = useModal();

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1241,7 +1241,6 @@
   "Dynamic plugin error": "Dynamic plugin error",
   "prometheusBaseURL not set": "prometheusBaseURL not set",
   "alertManagerBaseURL not set": "alertManagerBaseURL not set",
-  "monitoring access not granted": "monitoring access not granted",
   "Critical Alerts": "Critical Alerts",
   "Other Alerts": "Other Alerts",
   "Recommendations": "Recommendations",


### PR DESCRIPTION
Checking whether the user can list `prometheusrules` was not the right test of whether the user can access the Prometheus and Alertmanager APIs. Instead just try to hit the APIs and if an error is returned, reduce the polling rate so we don't make excessive calls to the APIs that will probably continue to fail. However, continuing at a reduced polling rate means that things will still automatically start working again if the APIs start to respond. (For example, if the user is granted additional permissions.)

Normally polls every 15 seconds (same as now).

If there is an error (any error, not just `403`), it waits 60 seconds before trying again. So this will reduce the load it puts on Thanos and Alertmanager by a factor of 4 in all error situations at the expense of having it notice more slowly if the error gets resolved.

It could be nice to implement some form of exponential backoff, but I'm keeping this fix simple because we are close to code freeze.

This also removes the `monitoring access not granted` error logging since we will log any 403 response anyway.

This effectively reverts https://github.com/openshift/console/pull/10725, which appears to have introduced the issue.

![screenshot](https://user-images.githubusercontent.com/460802/198430797-82f3549a-18c8-4b68-808a-11a750a80f08.png)

![screenshot-1](https://user-images.githubusercontent.com/460802/198430835-a434e48e-c6d0-4e9c-a2fb-e59cb440266f.png)
