### PR TITLE
Monitoring: Fix type of bodyContent prop passed to PopoverField

### DIFF
--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -343,8 +343,11 @@ export const StateCounts: React.FC<{ alerts: PrometheusAlert[] }> = ({ alerts })
   );
 };
 
-const PopoverField: React.FC<{ body: React.ReactNode; label: string }> = ({ body, label }) => (
-  <Popover headerContent={label} bodyContent={body}>
+const PopoverField: React.FC<{ bodyContent: React.ReactNode; label: string }> = ({
+  bodyContent,
+  label,
+}) => (
+  <Popover headerContent={label} bodyContent={bodyContent}>
     <Button variant="plain" className="details-item__popover-button">
       {label}
     </Button>
@@ -778,7 +781,7 @@ const AlertsDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
                   <dt>{t('public~Name')}</dt>
                   <dd>{labels?.alertname}</dd>
                   <dt>
-                    <PopoverField label={t('public~Severity')} body={SeverityHelp} />
+                    <PopoverField bodyContent={<SeverityHelp />} label={t('public~Severity')} />
                   </dt>
                   <dd>
                     <Severity severity={labels?.severity} />
@@ -826,11 +829,11 @@ const AlertsDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
               <div className="col-sm-6">
                 <dl className="co-m-pane__details">
                   <dt>
-                    <PopoverField label={t('public~Source')} body={SourceHelp} />
+                    <PopoverField bodyContent={<SourceHelp />} label={t('public~Source')} />
                   </dt>
                   <dd>{alert && getSourceKey(_.startCase(alertSource(alert)))}</dd>
                   <dt>
-                    <PopoverField label={t('public~State')} body={AlertStateHelp} />
+                    <PopoverField bodyContent={<AlertStateHelp />} label={t('public~State')} />
                   </dt>
                   <dd>
                     <AlertState state={state} />
@@ -1028,7 +1031,7 @@ const AlertRulesDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
                   <dt>{t('public~Name')}</dt>
                   <dd>{rule?.name}</dd>
                   <dt>
-                    <PopoverField label={t('public~Severity')} body={SeverityHelp} />
+                    <PopoverField bodyContent={<SeverityHelp />} label={t('public~Severity')} />
                   </dt>
                   <dd>
                     <Severity severity={rule?.labels?.severity} />
@@ -1068,7 +1071,7 @@ const AlertRulesDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
               <div className="col-sm-6">
                 <dl className="co-m-pane__details">
                   <dt>
-                    <PopoverField label={t('public~Source')} body={SourceHelp} />
+                    <PopoverField bodyContent={<SourceHelp />} label={t('public~Source')} />
                   </dt>
                   <dd>{rule && getSourceKey(_.startCase(alertingRuleSource(rule)))}</dd>
                   {_.isInteger(rule?.duration) && (


### PR DESCRIPTION
This prop is a React.NodeElement, so we should not be passing the component itself. Passing the component itself happened to work because of the way Popover is implemented.

This is related to https://github.com/openshift/console/pull/12166, which fixed a bug, but still didn't pass the prop correctly. This believe this PR is the right way to fix that issue.