### PR TITLE
Monitoring: Add popover help text for silence form's negative matchers

### DIFF
--- a/frontend/public/components/monitoring/silence-form.tsx
+++ b/frontend/public/components/monitoring/silence-form.tsx
@@ -72,6 +72,23 @@ const DatetimeTextInput = (props) => {
   );
 };
 
+const NegativeMatcherHelp = () => {
+  const { t } = useTranslation();
+
+  return (
+    <dl>
+      <dd>
+        {t('Select the negative matcher option to update the label value to a not equals matcher.')}
+      </dd>
+      <dd>
+        {t(
+          'If both the RegEx and negative matcher options are selected, the label value must not match the regular expression.',
+        )}
+      </dd>
+    </dl>
+  );
+};
+
 const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => {
   const { t } = useTranslation();
 
@@ -330,14 +347,16 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => 
                       />
                       &nbsp; {t('public~RegEx')}
                     </label>
-                    <label>
-                      <input
-                        checked={matcher.isEqual === false}
-                        onChange={(e) => setMatcherField(i, 'isEqual', !e.currentTarget.checked)}
-                        type="checkbox"
-                      />
-                      &nbsp; {t('public~Negative matcher')}
-                    </label>
+                    <Tooltip content={<NegativeMatcherHelp />}>
+                      <label>
+                        <input
+                          checked={matcher.isEqual === false}
+                          onChange={(e) => setMatcherField(i, 'isEqual', !e.currentTarget.checked)}
+                          type="checkbox"
+                        />
+                        &nbsp; {t('public~Negative matcher')}
+                      </label>
+                    </Tooltip>
                     <Tooltip content={t('public~Remove')}>
                       <Button
                         type="button"

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1138,6 +1138,8 @@
   "The endpoint to send HTTP POST requests to.": "The endpoint to send HTTP POST requests to.",
   "Invalid date / time": "Invalid date / time",
   "Datetime": "Datetime",
+  "Select the negative matcher option to update the label value to a not equals matcher.": "Select the negative matcher option to update the label value to a not equals matcher.",
+  "If both the RegEx and negative matcher options are selected, the label value must not match the regular expression.": "If both the RegEx and negative matcher options are selected, the label value must not match the regular expression.",
   "30m": "30m",
   "1h": "1h",
   "2h": "2h",


### PR DESCRIPTION
The negative matcher support was recently added by https://github.com/openshift/console/pull/12139

![screenshot](https://user-images.githubusercontent.com/460802/201236624-e4feac84-a463-4ba7-b2c2-25ad0affbbce.png)
