### PR TITLE
OCPBUGS-2894: UI crash when storage class had missing annotation

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/create-vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/create-vm.tsx
@@ -203,7 +203,7 @@ export const CreateVM: React.FC<RouteComponentProps<{ ns: string }>> = ({ match,
   const storageClassDefaultName = React.useMemo(() => {
     if (storageClasses && storageClassLoaded) {
       const storageClassDefault = storageClasses?.find(
-        (sc) => sc?.metadata?.annotations[DEFAULT_SC_ANNOTATION] === 'true',
+        (sc) => sc?.metadata?.annotations?.[DEFAULT_SC_ANNOTATION] === 'true',
       );
       return storageClassDefault?.metadata?.name;
     }

--- a/frontend/packages/kubevirt-plugin/src/selectors/config-map/sc-defaults.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/config-map/sc-defaults.ts
@@ -61,4 +61,4 @@ export const isConfigMapContainsScModes = (
 export const getDefaultStorageClass = (
   storageClasses: StorageClassResourceKind[],
 ): StorageClassResourceKind =>
-  (storageClasses || []).find((sc) => getAnnotations(sc, {})[DEFAULT_SC_ANNOTATION] === 'true');
+  (storageClasses || []).find((sc) => getAnnotations(sc, {})?.[DEFAULT_SC_ANNOTATION] === 'true');


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

Before:
<img width="1374" alt="image" src="https://user-images.githubusercontent.com/14824964/198256834-4fc2bf5c-9ddb-446f-afcb-32bb3c00a549.png">


After:
<img width="1178" alt="image" src="https://user-images.githubusercontent.com/14824964/198254040-f6156233-7f46-4899-9516-d21978922043.png">
