### PR TITLE
OCPBUGS-3172:  check that user can patch console operator config in s…

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -394,7 +394,10 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
         ...previousPlugins.filter((plugin: string) => !csvPlugins.includes(plugin)),
         ...enabledPlugins,
       ];
-      if (!_.isEqual(previousPlugins.sort(), updatedPlugins.sort())) {
+      if (
+        !_.isEqual(previousPlugins.sort(), updatedPlugins.sort()) &&
+        canPatchConsoleOperatorConfig
+      ) {
         await k8sPatch(ConsoleOperatorConfigModel, consoleOperatorConfig, [
           {
             path: '/spec/plugins',


### PR DESCRIPTION
…ubmit

We shouldn't try to patch the console operator config without confirming the user has the necessary access to do so.