### PR TITLE
OCPBUGS-3709: URI encode subjectName in CreateRoleBinding

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -289,7 +289,7 @@ export const RoleBindingsPage = ({
   name,
   kind,
   createPath = `/k8s/cluster/rolebindings/~new${
-    name && kind ? `?subjectName=${name}&subjectKind=${kind}` : ''
+    name && kind ? `?subjectName=${encodeURIComponent(name)}&subjectKind=${kind}` : ''
   }`,
   hideLabelFilter = false,
   hideNameLabelFilters = false,


### PR DESCRIPTION
subjectName can contain special characters like `#` which is a reserved character in a URI. This change URI encodes this parameter to avoid creating a broken link.

Before this change it was possible to create a group with a `#` in the name and click "Create binding" from the "RoleBindings" tab to create a broken view where the data is not correctly pre-filled.

Before:
![image](https://user-images.githubusercontent.com/14909670/198665196-767a606a-b6eb-44da-8ae1-6ec9a831b13a.png)
![image](https://user-images.githubusercontent.com/14909670/198665307-c1ac0995-50e0-46f0-832a-d6788399fc31.png)
![image](https://user-images.githubusercontent.com/14909670/198665400-8a8ffb68-ac17-4ac3-af05-f55275d10aaa.png)

After:
![image](https://user-images.githubusercontent.com/14909670/198665640-67f1b056-c3a0-428a-8a41-bf0c04d305c2.png)
![image](https://user-images.githubusercontent.com/14909670/198665879-d45e31e2-ab38-4841-b578-251299a98799.png)

This is my first change in openshift and I'm not really familiar with frontend. If you think this change should have a test somewhere please point me where to put it.