### PR TITLE
Monitoring: Don't import EmptyBox

### DIFF
--- a/frontend/public/components/monitoring/dashboards/table.tsx
+++ b/frontend/public/components/monitoring/dashboards/table.tsx
@@ -1,7 +1,12 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { PrometheusEndpoint, PrometheusResponse } from '@console/dynamic-plugin-sdk';
-import { PerPageOptions } from '@patternfly/react-core';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  PerPageOptions,
+} from '@patternfly/react-core';
 import {
   ISortBy,
   sortable,
@@ -17,7 +22,7 @@ import ErrorAlert from '@console/shared/src/components/alerts/error';
 import { formatNumber } from '../format';
 import { ColumnStyle, Panel } from './types';
 import { getPrometheusURL } from '../../graphs/helpers';
-import { EmptyBox, usePoll, useSafeFetch } from '../../utils';
+import { usePoll, useSafeFetch } from '../../utils';
 import TablePagination from '../table-pagination';
 
 import { useTranslation } from 'react-i18next';
@@ -122,7 +127,11 @@ const Table: React.FC<Props> = ({ panel, pollInterval, queries, namespace }) => 
     return <ErrorAlert message={t('public~panel.styles attribute not found')} />;
   }
   if (_.isEmpty(data)) {
-    return <EmptyBox label={t('public~Data')} />;
+    return (
+      <EmptyState variant={EmptyStateVariant.xs}>
+        <EmptyStateBody>{t('public~No data found')}</EmptyStateBody>
+      </EmptyState>
+    );
   }
 
   const columns: AugmentedColumnStyle[] = getColumns(panel.styles);

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1007,6 +1007,7 @@
   "Inspect": "Inspect",
   "Metrics dashboards": "Metrics dashboards",
   "panel.styles attribute not found": "panel.styles attribute not found",
+  "No data found": "No data found",
   "query results table": "query results table",
   "Last {{count}} minute": "Last {{count}} minute",
   "Last {{count}} minute_plural": "Last {{count}} minutes",


### PR DESCRIPTION
This component is very simple, so probably better to not use it to remove one dependency on the web console codebase. It was used for the tables on the Observe > Dashboards page.

Before | After
-|-
![before](https://user-images.githubusercontent.com/460802/199188738-54b6954b-549a-4b88-a8ef-9704ac32079c.png) | ![after](https://user-images.githubusercontent.com/460802/199188755-d10da0a7-bf42-4898-9026-0133632c4760.png)