### PR TITLE
OCPBUGS-2904: If all the actions are disabled in add page, Details on/off toggle switch to be disabled

### DIFF
--- a/frontend/packages/dev-console/src/components/add/AddPageLayout.tsx
+++ b/frontend/packages/dev-console/src/components/add/AddPageLayout.tsx
@@ -73,30 +73,31 @@ const AddPageLayout: React.FC<AddPageLayoutProps> = ({ title, hintBlock: additio
               })}
               data-test="details-switch"
             >
-              {extensionsLoaded ? (
-                <Tooltip
-                  content={t('devconsole~Show or hide details about each item')}
-                  position="top"
-                >
-                  <Switch
-                    aria-label={
-                      showDetails
-                        ? t('devconsole~Show add card details')
-                        : t('devconsole~Hide add card details')
-                    }
-                    isChecked={showDetails}
-                    onChange={(checked) => {
-                      setShowDetails(checked);
-                    }}
-                    data-test="switch"
-                    label={t('devconsole~Details on')}
-                    labelOff={t('devconsole~Details off')}
-                    className="odc-add-page-layout__hint-block__details-switch__text"
-                  />
-                </Tooltip>
-              ) : (
-                <Skeleton shape="circle" width="24px" />
-              )}
+              {!allAddActionsDisabled &&
+                (extensionsLoaded ? (
+                  <Tooltip
+                    content={t('devconsole~Show or hide details about each item')}
+                    position="top"
+                  >
+                    <Switch
+                      aria-label={
+                        showDetails
+                          ? t('devconsole~Show add card details')
+                          : t('devconsole~Hide add card details')
+                      }
+                      isChecked={showDetails}
+                      onChange={(checked) => {
+                        setShowDetails(checked);
+                      }}
+                      data-test="switch"
+                      label={t('devconsole~Details on')}
+                      labelOff={t('devconsole~Details off')}
+                      className="odc-add-page-layout__hint-block__details-switch__text"
+                    />
+                  </Tooltip>
+                ) : (
+                  <Skeleton shape="circle" width="24px" />
+                ))}
             </div>
           </div>
           <TopologyQuickSearch


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-2904

**Analysis / Root cause:**
Check to see If all the add actions are disabled was not added.

**Solution Description:**
Added condition to enable show details switch only if all the actions are not disabled

**Screen shots / Gifs for design review:**

-------------- Before -------
<img width="1435" alt="Screenshot 2022-10-27 at 11 29 32 AM" src="https://user-images.githubusercontent.com/102503482/199938475-de0a8413-2cb6-4312-8480-8592e5ebfccb.png">



-------After-----------------

<img width="1437" alt="Screenshot 2022-11-04 at 2 48 44 PM" src="https://user-images.githubusercontent.com/102503482/199938526-16b2ca03-1e47-42c0-968b-d1974fb4db85.png">


**Unit test coverage report:**
NA

**Test setup:**
Add below yaml in config.yaml in local and pass config.yaml to bridge with -config option.

<img width="415" alt="Screenshot 2022-11-04 at 2 55 41 PM" src="https://user-images.githubusercontent.com/102503482/199938691-373c5267-fa41-4992-ad61-5da695fcfdfa.png">


Example:

./bin/bridge -config ../../config.yaml


**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
