### PR TITLE
OCPBUGS-3432: Re-enable pipelines e2e tests

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -70,7 +70,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-helm-headless
 # yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
-#  yarn run test-cypress-pipelines-headless
+  yarn run test-cypress-pipelines-headless
   exit;
 fi
 


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-3432

Reverts pipelines part of #12114