### PR TITLE
OCPBUGS-2281: Re-enable serverless e2e tests

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/knativeSubscriptions.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/knativeSubscriptions.ts
@@ -30,15 +30,10 @@ export const createKnativeServing = () => {
       detailsPage.titleShouldContain(pageTitle.CreateKnativeServing);
       cy.byTestID('create-dynamic-form').click();
       cy.byLegacyTestID('details-actions').should('be.visible');
-      // Currently disabling the check for ready and DeploymentsAvailable status due to https://issues.redhat.com/browse/SRVKS-953
-      // Enable it once the issue is fixed in Serverless operator
-      // cy.contains(
-      //   'DependenciesInstalled, DeploymentsAvailable, InstallSucceeded, Ready, VersionMigrationEligible',
-      //   { timeout: 150000 },
-      // ).should('be.visible');
-      cy.contains('DependenciesInstalled, InstallSucceeded, VersionMigrationEligible', {
-        timeout: 150000,
-      }).should('be.visible');
+      cy.contains(
+        'DependenciesInstalled, DeploymentsAvailable, InstallSucceeded, Ready, VersionMigrationEligible',
+        { timeout: 150000 },
+      ).should('be.visible');
     }
   });
 };

--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -68,7 +68,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-dev-console-headless
   yarn run test-cypress-olm-headless
   yarn run test-cypress-helm-headless
-# yarn run test-cypress-knative-headless
+  yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
 #  yarn run test-cypress-pipelines-headless
   exit;


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-2281

Reverts serverless part of #12114