### PR TITLE
OCPBUGS-3316: Remove `refs-heads` from the branch name for Repository pipelineRun row

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryLinkList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryLinkList.tsx
@@ -17,6 +17,7 @@ import {
   RepositoryAnnotations,
   RepoAnnotationFields,
 } from './consts';
+import { sanitizeBranchName } from './repository-utils';
 
 export type RepositoryLinkListProps = {
   pipelineRun: PipelineRunKind;
@@ -55,7 +56,7 @@ const RepositoryLinkList: React.FC<RepositoryLinkListProps> = ({ pipelineRun }) 
         <>
           <dt>{t('pipelines-plugin~Branch')}</dt>
           <dd data-test="pl-repository-branch">
-            {plrLabels[RepositoryLabels[RepositoryFields.BRANCH]]}
+            {sanitizeBranchName(plrLabels[RepositoryLabels[RepositoryFields.BRANCH]])}
           </dd>
         </>
       )}

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunRow.tsx
@@ -25,6 +25,7 @@ import {
   RepoAnnotationFields,
   RepositoryAnnotations,
 } from './consts';
+import { sanitizeBranchName } from './repository-utils';
 import { tableColumnClasses } from './RepositoryPipelineRunHeader';
 
 const pipelinerunReference = referenceForModel(PipelineRunModel);
@@ -92,7 +93,7 @@ const RepositoryPipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ 
       </TableData>
       <TableData className={tableColumnClasses[6]}>{pipelineRunDuration(obj)}</TableData>
       <TableData className={tableColumnClasses[7]}>
-        {plrLabels?.[RepositoryLabels[RepositoryFields.BRANCH]]}
+        {sanitizeBranchName(plrLabels?.[RepositoryLabels[RepositoryFields.BRANCH]])}
       </TableData>
       <TableData className={tableColumnClasses[8]}>
         <ResourceKebabWithUserLabel

--- a/frontend/packages/pipelines-plugin/src/components/repository/__tests__/repository-utils.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/__tests__/repository-utils.spec.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { GithubIcon, GitAltIcon, GitlabIcon, BitbucketIcon } from '@patternfly/react-icons';
-import { getGitProviderIcon, getLatestRepositoryPLRName } from '../repository-utils';
+import {
+  getGitProviderIcon,
+  getLatestRepositoryPLRName,
+  sanitizeBranchName,
+} from '../repository-utils';
 import { mockRepository } from './repository-mock';
 
 describe('repository-util', () => {
@@ -55,5 +59,16 @@ describe('repository-util', () => {
         title="https://githube.com/sclorg/ruby-ex.git"
       />,
     );
+  });
+
+  it('sanitizeBranchName should return branch name', () => {
+    const branch1 = sanitizeBranchName('refs-heads-main');
+    expect(branch1).toBe('main');
+    const branch2 = sanitizeBranchName('refs-heads-cicd-demo');
+    expect(branch2).toBe('cicd-demo');
+    const branch3 = sanitizeBranchName('refs/heads/foo');
+    expect(branch3).toBe('foo');
+    const branch4 = sanitizeBranchName('refs/tags/1.0');
+    expect(branch4).toBe('refs/tags/1.0');
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/repository/repository-utils.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/repository-utils.tsx
@@ -36,3 +36,14 @@ export const getGitProviderIcon = (url: string) => {
     }
   }
 };
+
+export const sanitizeBranchName = (branchName: string): string => {
+  if (branchName.startsWith('refs/heads/')) {
+    return branchName.replace('refs/heads/', '');
+  }
+
+  if (branchName.startsWith('refs-heads-')) {
+    return branchName.replace('refs-heads-', '');
+  }
+  return branchName;
+};


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-3316

Descriptions: Remove `refs-heads` from the Repository PipelineRun row branch name.

Screenshots:
**Before:**
![image](https://user-images.githubusercontent.com/2561818/200303448-994d59ae-2936-49ed-87cc-2551063bca7b.png)
![image](https://user-images.githubusercontent.com/2561818/200315697-c0963ec1-bf0a-44a0-8745-8d22d1d55caa.png)


**After:**
![image](https://user-images.githubusercontent.com/2561818/200303041-0c054d82-de09-4d7e-af19-81ab03ec739a.png)
![image](https://user-images.githubusercontent.com/2561818/200316802-7cc7f9ef-5575-4f09-a8e1-f1d0418f8780.png)

