### PR TITLE
CONSOLE-3323: Switch to admin perspective when user navigates directly to a cluster-scoped route and is in the "All Clusters" perspective 

### DIFF
--- a/frontend/packages/console-app/src/components/detect-perspective/DetectPerspective.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/DetectPerspective.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useRouteMatch } from 'react-router-dom';
 import { PerspectiveContext } from '@console/dynamic-plugin-sdk';
-import { CLUSTER_SCOPED_PREFIXES } from '@console/internal/components/utils';
+import { CLUSTER_SCOPED_ROUTES } from '@console/internal/components/utils';
 import { usePerspectives, useQueryParams } from '@console/shared/src';
 import PerspectiveDetector from './PerspectiveDetector';
 import { useValuesForPerspectiveContext } from './useValuesForPerspectiveContext';
@@ -12,13 +12,14 @@ type DetectPerspectiveProps = {
 
 const useOverridePerspective = (activePerspective) => {
   const perspectiveExtensions = usePerspectives();
-  const perspectiveParam = useQueryParams().get('perspective');
+  const queryParams = useQueryParams();
+  const perspectiveParam = queryParams.get('perspective');
 
   // Force admin perspective if current perspective is ACM and matching route is cluster-scoped
   // FIXME: This is a temporary work-around to prevent linking to cluster-scoped resources without
   // showing the current cluster context. Ideally we will be able to detect multi-cluster or
   // single-cluster scope more dynamically using the plugin API in the future.
-  const clusterRouteMatch = useRouteMatch({ path: CLUSTER_SCOPED_PREFIXES });
+  const clusterRouteMatch = useRouteMatch({ path: CLUSTER_SCOPED_ROUTES });
   const isMulticlusterPerspective = activePerspective === 'acm';
   const overrideClusterScope = !perspectiveParam && clusterRouteMatch && isMulticlusterPerspective;
   const overridePerspective = overrideClusterScope ? 'admin' : perspectiveParam;

--- a/frontend/packages/console-app/src/components/detect-perspective/DetectPerspective.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/DetectPerspective.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
-import { Perspective, PerspectiveContext } from '@console/dynamic-plugin-sdk';
-import { usePerspectives } from '@console/shared/src';
+import { useRouteMatch } from 'react-router-dom';
+import { PerspectiveContext } from '@console/dynamic-plugin-sdk';
+import { CLUSTER_SCOPED_PREFIXES } from '@console/internal/components/utils';
+import { usePerspectives, useQueryParams } from '@console/shared/src';
 import PerspectiveDetector from './PerspectiveDetector';
 import { useValuesForPerspectiveContext } from './useValuesForPerspectiveContext';
 
@@ -8,25 +10,37 @@ type DetectPerspectiveProps = {
   children: React.ReactNode;
 };
 
-const getPerspectiveURLParam = (perspectives: Perspective[]) => {
-  const perspectiveIDs = perspectives.map(
-    (nextPerspective: Perspective) => nextPerspective.properties.id,
-  );
+const useOverridePerspective = (activePerspective) => {
+  const perspectiveExtensions = usePerspectives();
+  const perspectiveParam = useQueryParams().get('perspective');
 
-  const urlParams = new URLSearchParams(window.location.search);
-  const perspectiveParam = urlParams.get('perspective');
-  return perspectiveIDs.includes(perspectiveParam) ? perspectiveParam : null;
+  // Force admin perspective if current perspective is ACM and matching route is cluster-scoped
+  // FIXME: This is a temporary work-around to prevent linking to cluster-scoped resources without
+  // showing the current cluster context. Ideally we will be able to detect multi-cluster or
+  // single-cluster scope more dynamically using the plugin API in the future.
+  const clusterRouteMatch = useRouteMatch({ path: CLUSTER_SCOPED_PREFIXES });
+  const isMulticlusterPerspective = activePerspective === 'acm';
+  const overrideClusterScope = !perspectiveParam && clusterRouteMatch && isMulticlusterPerspective;
+  const overridePerspective = overrideClusterScope ? 'admin' : perspectiveParam;
+
+  // Only override if the perspective exists.
+  return React.useMemo(
+    () =>
+      perspectiveExtensions.some((e) => e.properties.id === overridePerspective)
+        ? overridePerspective
+        : null,
+    [overridePerspective, perspectiveExtensions],
+  );
 };
 
 const DetectPerspective: React.FC<DetectPerspectiveProps> = ({ children }) => {
   const [activePerspective, setActivePerspective, loaded] = useValuesForPerspectiveContext();
-  const perspectiveExtensions = usePerspectives();
-  const perspectiveParam = getPerspectiveURLParam(perspectiveExtensions);
+  const overridePerspective = useOverridePerspective(activePerspective);
   React.useEffect(() => {
-    if (perspectiveParam && perspectiveParam !== activePerspective) {
-      setActivePerspective(perspectiveParam);
+    if (overridePerspective && overridePerspective !== activePerspective) {
+      setActivePerspective(overridePerspective);
     }
-  }, [perspectiveParam, activePerspective, setActivePerspective]);
+  }, [activePerspective, overridePerspective, setActivePerspective]);
   return loaded ? (
     activePerspective ? (
       <PerspectiveContext.Provider value={{ activePerspective, setActivePerspective }}>

--- a/frontend/packages/console-app/src/components/detect-perspective/__tests__/DetectPerspective.spec.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/__tests__/DetectPerspective.spec.tsx
@@ -7,12 +7,18 @@ import { useValuesForPerspectiveContext } from '../useValuesForPerspectiveContex
 
 const MockApp = () => <h1>App</h1>;
 
+jest.mock('react-router-dom', () => ({
+  ...require.requireActual('react-router-dom'),
+  useRouteMatch: jest.fn(() => true),
+}));
+
 jest.mock('../useValuesForPerspectiveContext', () => ({
   useValuesForPerspectiveContext: jest.fn(),
 }));
 
 jest.mock('@console/shared/src', () => ({
   usePerspectives: jest.fn(),
+  useQueryParams: jest.fn(() => ({ get: () => undefined })),
 }));
 const useValuesForPerspectiveContextMock = useValuesForPerspectiveContext as jest.Mock;
 const usePerspectivesMock = usePerspectives as jest.Mock;

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -33,14 +33,15 @@ export const namespacedPrefixes = [
   '/status',
 ];
 
-export const CLUSTER_SCOPED_PREFIXES = [
-  ...namespacedPrefixes,
+export const CLUSTER_SCOPED_ROUTES = [
+  '/*/ns/:ns',
+  '/*/all-namespaces',
   '/overview',
   '/dashboards',
   '/settings',
   '/api-explorer',
   '/catalog',
-  '/c/',
+  '/monitoring',
 ];
 
 export const stripBasePath = (path: string): string => path.replace(basePathPattern, '/');

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -33,6 +33,16 @@ export const namespacedPrefixes = [
   '/status',
 ];
 
+export const CLUSTER_SCOPED_PREFIXES = [
+  ...namespacedPrefixes,
+  '/overview',
+  '/dashboards',
+  '/settings',
+  '/api-explorer',
+  '/catalog',
+  '/c/',
+];
+
 export const stripBasePath = (path: string): string => path.replace(basePathPattern, '/');
 
 export const getNamespace = (path: string): string => {


### PR DESCRIPTION
When manually navigating to a known cluster-scoped route, the console will automatically switch to the admin perspective so that the active cluster context is clear.