### PR TITLE
CONSOLE-3350: Add a PR template for the console

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/console_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/console_pr.md
@@ -1,0 +1,14 @@
+**CONSOLE Fixes**: 
+<!-- For e.g Fixes: https://issues.redhat.com/browse/CONSOLE-XXXX -->
+
+**Solution Description**: 
+<!-- Describe your code changes in detail and explain the solution / functionality -->
+
+**Screen shots / gifs / design review**: 
+<!-- Add screenshots/gifs for UI changes. If change requires a UX review, tag @openshift/team-ux-review -->
+
+**Add a code reviewer assignee**: 
+<!-- @ someone to review this pr -->
+
+**Test cases:**
+<!-- Outline any test cases here -->


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/CONSOLE-3350

Adding a console template as discussed in sprint 226 retro.

There is already a template for the devconsole. When using multiple templates in github you can provide the syntax described in [step 3 of creating a pr template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository#adding-a-pull-request-template) in the github docs.

IE. append the console PR URL with: "&template=console_pr.md"
