### PR TITLE
[release-4.10] Bug 2072792: Use additional common templates in fields

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/flavor.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/flavor.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { SelectOption } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
+import { TemplateKind } from '@console/internal/module/k8s';
 import { CUSTOM_FLAVOR } from '../../../../constants';
 import { Flavor } from '../../../../constants/vm/flavor';
 import { asValidationObject, ValidationErrorType, getLabelValue } from '../../../../selectors';
@@ -32,6 +33,7 @@ export const FlavorSelect: React.FC<FlavorProps> = React.memo(
     iUserTemplate,
     cnvBaseImages,
     commonTemplates,
+    additionalCommonTemplates,
     os,
     flavorField,
     workloadProfile,
@@ -52,7 +54,10 @@ export const FlavorSelect: React.FC<FlavorProps> = React.memo(
       ? isUserTemplateValid
         ? [toShallowJS(iGetLoadedData(iUserTemplate))]
         : []
-      : immutableListToShallowJS(iGetLoadedData(commonTemplates));
+      : [
+          ...immutableListToShallowJS(iGetLoadedData(commonTemplates)),
+          ...immutableListToShallowJS(iGetLoadedData(additionalCommonTemplates)),
+        ];
 
     const defaultTemplate = getOsDefaultTemplate(templates, os);
 
@@ -152,6 +157,7 @@ export const FlavorSelect: React.FC<FlavorProps> = React.memo(
 type FlavorProps = {
   iUserTemplate: any;
   commonTemplates: any;
+  additionalCommonTemplates: TemplateKind[];
   flavorField: any;
   os: string;
   workloadProfile: string;

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { ResourceLink, useAccessReview } from '@console/internal/components/utils';
 import { PersistentVolumeClaimModel } from '@console/internal/models';
+import { TemplateKind } from '@console/internal/module/k8s';
 import { getPVCUploadURL } from '../../../../constants';
 import { operatingSystemsNative } from '../../../../constants/vm-templates/os';
 import { asValidationObject, ValidationErrorType } from '../../../../selectors';
@@ -41,6 +42,7 @@ export const OS: React.FC<OSProps> = React.memo(
   ({
     iUserTemplate,
     commonTemplates,
+    additionalCommonTemplates,
     operatinSystemField,
     cloneBaseDiskImageField,
     isCreateTemplate,
@@ -74,7 +76,10 @@ export const OS: React.FC<OSProps> = React.memo(
       ? isUserTemplateValid
         ? [toShallowJS(iGetLoadedData(iUserTemplate))]
         : []
-      : immutableListToShallowJS(iGetLoadedData(commonTemplates));
+      : [
+          ...immutableListToShallowJS(iGetLoadedData(commonTemplates)),
+          ...immutableListToShallowJS(iGetLoadedData(additionalCommonTemplates)),
+        ];
 
     let operatingSystems;
 
@@ -325,6 +330,7 @@ export const OS: React.FC<OSProps> = React.memo(
 type OSProps = {
   iUserTemplate: any;
   commonTemplates: any;
+  additionalCommonTemplates: TemplateKind[];
   flavor: string;
   commonTemplateName: string;
   operatinSystemField: any;

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { useAccessReview2 } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { StorageClassModel } from '@console/internal/models';
-import { StorageClassResourceKind } from '@console/internal/module/k8s';
+import { StorageClassResourceKind, TemplateKind } from '@console/internal/module/k8s';
 import { TemplateSupport } from '../../../../constants/vm-templates/support';
 import useV2VConfigMap from '../../../../hooks/use-v2v-config-map';
 import { getDefaultStorageClass } from '../../../../selectors/config-map/sc-defaults';
@@ -47,6 +47,7 @@ import './vm-settings-tab.scss';
 export const VMSettingsTabComponent: React.FC<VMSettingsTabComponentProps> = ({
   iUserTemplate,
   commonTemplates,
+  additionalCommonTemplates,
   commonTemplateName,
   cnvBaseImages,
   dataSources,
@@ -173,6 +174,7 @@ export const VMSettingsTabComponent: React.FC<VMSettingsTabComponentProps> = ({
       <OS
         iUserTemplate={iUserTemplate}
         commonTemplates={commonTemplates}
+        additionalCommonTemplates={additionalCommonTemplates}
         commonTemplateName={commonTemplateName}
         operatinSystemField={getField(VMSettingsField.OPERATING_SYSTEM)}
         isCreateTemplate={isCreateTemplate}
@@ -220,6 +222,7 @@ export const VMSettingsTabComponent: React.FC<VMSettingsTabComponentProps> = ({
       <FlavorSelect
         iUserTemplate={iUserTemplate}
         commonTemplates={commonTemplates}
+        additionalCommonTemplates={additionalCommonTemplates}
         os={getFieldValue(VMSettingsField.OPERATING_SYSTEM)}
         flavorField={getField(VMSettingsField.FLAVOR)}
         workloadProfile={getFieldValue(VMSettingsField.WORKLOAD_PROFILE)}
@@ -235,6 +238,7 @@ export const VMSettingsTabComponent: React.FC<VMSettingsTabComponentProps> = ({
       <WorkloadSelect
         iUserTemplate={iUserTemplate}
         commonTemplates={commonTemplates}
+        additionalCommonTemplates={additionalCommonTemplates}
         os={getFieldValue(VMSettingsField.OPERATING_SYSTEM)}
         workloadProfileField={getField(VMSettingsField.WORKLOAD_PROFILE)}
         operatingSystem={getFieldValue(VMSettingsField.OPERATING_SYSTEM)}
@@ -250,6 +254,11 @@ const stateToProps = (state, { wizardReduxID }) => ({
   vmSettings: iGetVmSettings(state, wizardReduxID),
   vmAdvancedSettings: iGetVmAdvancedSettings(state, wizardReduxID),
   commonTemplates: iGetCommonData(state, wizardReduxID, VMWizardProps.commonTemplates),
+  additionalCommonTemplates: iGetCommonData(
+    state,
+    wizardReduxID,
+    VMWizardProps.additionalCommonTemplates,
+  ),
   iUserTemplate: iGetCommonData(state, wizardReduxID, VMWizardProps.userTemplate),
   commonTemplateName: getInitialData(state, wizardReduxID).commonTemplateName,
   cnvBaseImages: iGetCommonData(state, wizardReduxID, VMWizardProps.openshiftCNVBaseImages),
@@ -271,6 +280,7 @@ type VMSettingsTabComponentProps = {
   vmAdvancedSettings: any;
   provisionSourceStorage: VMWizardStorage;
   commonTemplates: any;
+  additionalCommonTemplates: TemplateKind[];
   iUserTemplate: any;
   commonTemplateName: string;
   cnvBaseImages: any;

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/workload-profile.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/workload-profile.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { SelectOption } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
+import { TemplateKind } from '@console/internal/module/k8s';
 import { WorkloadProfile } from '../../../../constants/vm/workload-profile';
 import { getLabelValue } from '../../../../selectors/selectors';
 import {
@@ -28,6 +29,7 @@ export const WorkloadSelect: React.FC<WorkloadProps> = React.memo(
     iUserTemplate,
     cnvBaseImages,
     commonTemplates,
+    additionalCommonTemplates,
     os,
     workloadProfileField,
     operatingSystem,
@@ -41,7 +43,10 @@ export const WorkloadSelect: React.FC<WorkloadProps> = React.memo(
       ? isUserTemplateValid
         ? [toShallowJS(iGetLoadedData(iUserTemplate))]
         : []
-      : immutableListToShallowJS(iGetLoadedData(commonTemplates));
+      : [
+          ...immutableListToShallowJS(iGetLoadedData(commonTemplates)),
+          ...immutableListToShallowJS(iGetLoadedData(additionalCommonTemplates)),
+        ];
 
     const defaultTemplate = getOsDefaultTemplate(templates, os);
 
@@ -110,6 +115,7 @@ export const WorkloadSelect: React.FC<WorkloadProps> = React.memo(
 type WorkloadProps = {
   iUserTemplate: any;
   commonTemplates: any;
+  additionalCommonTemplates: TemplateKind[];
   os: string;
   workloadProfileField: any;
   flavor: string;


### PR DESCRIPTION
- Removed `openshiftCNVBaseImages` as the data for that key are not used. 
- Search relevant template also into additional common templates
- use additional common templates also in fields