### PR TITLE
OCPBUGS-3235: Fix for initial showing of topology contents

### DIFF
--- a/frontend/packages/topology/src/data-transforms/TopologyDataRetriever.tsx
+++ b/frontend/packages/topology/src/data-transforms/TopologyDataRetriever.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { observer } from '@patternfly/react-topology';
 import * as _ from 'lodash';
 import { WatchK8sResources, WatchK8sResults } from '@console/dynamic-plugin-sdk';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
@@ -14,12 +15,12 @@ type TopologyDataRetrieverProps = {
 
 const TopologyDataRetriever: React.FC<TopologyDataRetrieverProps> = ({ trafficData }) => {
   const dataModelContext = React.useContext<ExtensibleModel>(ModelContext);
-  const { namespace } = dataModelContext;
+  const { namespace, extensionsLoaded, watchedResources } = dataModelContext;
   const [resources, setResources] = React.useState<WatchK8sResults<TopologyResourcesObject>>();
   const monitoringAlerts = useMonitoringAlerts(namespace);
   const resourcesList = React.useMemo<WatchK8sResources<any>>(
-    () => (namespace && dataModelContext.extensionsLoaded ? dataModelContext.watchedResources : {}),
-    [dataModelContext.extensionsLoaded, dataModelContext.watchedResources, namespace],
+    () => (namespace && extensionsLoaded ? watchedResources : {}),
+    [extensionsLoaded, watchedResources, namespace],
   );
 
   const debouncedUpdateResources = useDebounceCallback(setResources, 250);
@@ -53,4 +54,4 @@ const TopologyDataRetriever: React.FC<TopologyDataRetrieverProps> = ({ trafficDa
   return null;
 };
 
-export default TopologyDataRetriever;
+export default observer(TopologyDataRetriever);


### PR DESCRIPTION
**Fixes**: 
Fixes [OCPBUGS-3235](https://issues.redhat.com/browse/OCPBUGS-3235)

**Analysis / Root cause**: 
Topology data retriever was not observing changes to the data context so it did not auto load once the extensions are loaded.

**Solution Description**: 
Make the TopologyDataRetriever an observer so that it updates when the data context changes.

