### PR TITLE
OCPBUGS-2480: Task delete icon is not align properly on the Pipeline builder page

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/RemoveNodeDecorator.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/RemoveNodeDecorator.tsx
@@ -30,7 +30,7 @@ const RemoveNodeDecorator: React.FC<RemoveNodeDecoratorProps> = ({
       data-id="delete-task"
     >
       <circle cx={0} cy={0} r={BUILDER_NODE_DECORATOR_RADIUS} fill={greyColor.value} />
-      <g transform="translate(-5, -7)">
+      <g transform="translate(-5, -9)">
         <foreignObject
           width={BUILDER_NODE_DECORATOR_RADIUS * 2}
           height={BUILDER_NODE_DECORATOR_RADIUS * 2}


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGS-2480

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Delete task icon is not align properly on the Pipeline builder page


**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Added the `noVerticalAlign` parameter to the `TrashIcon` Component. 

**Screenshots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
Before:
![Screenshot from 2022-11-14 17-03-29](https://user-images.githubusercontent.com/47265560/201650647-dd7be66a-a43c-416b-aa2a-00725fddd4d6.png)



After:
![Screenshot from 2022-11-14 17-06-28](https://user-images.githubusercontent.com/47265560/201650672-0f2b7dbf-9f14-4541-944f-c19f3f5d75e0.png)



**Unit test coverage report**: 
<!-- Attach test coverage report -->
Not Changed

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Navigate to the Pipeline builder page.
2. click on Add task button and add a task
3. hover over the task and click on plus(+)
4. Hover over the Add task button and see the delete button in the corner


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge