### PR TITLE
Bug 2092289: Don't proxy CORS response headers

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -35,7 +35,17 @@ type Proxy struct {
 // These headers aren't things that proxies should pass along. Some are forbidden by http2.
 // This fixes the bug where Chrome users saw a ERR_SPDY_PROTOCOL_ERROR for all proxied requests.
 func FilterHeaders(r *http.Response) error {
-	badHeaders := []string{"Connection", "Keep-Alive", "Proxy-Connection", "Transfer-Encoding", "Upgrade"}
+	badHeaders := []string{
+		"Connection",
+		"Keep-Alive",
+		"Proxy-Connection",
+		"Transfer-Encoding",
+		"Upgrade",
+		"Access-Control-Allow-Headers",
+		"Access-Control-Allow-Methods",
+		"Access-Control-Allow-Origin",
+		"Access-Control-Expose-Headers",
+	}
 	for _, h := range badHeaders {
 		r.Header.Del(h)
 	}


### PR DESCRIPTION
Harden our proxy by filtering out any CORS response headers.

/assign @jhadvig 