### PR TITLE
OCPBUGS-3476: Show Tag label and tag name if tag is detected in repository PipelineRun list and details page

### DIFF
--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -344,6 +344,7 @@
   "Branch": "Branch",
   "Close": "Close",
   "Commit id": "Commit id",
+  "Branch/Tag": "Branch/Tag",
   "Hide configuration options": "Hide configuration options",
   "Show configuration options": "Show configuration options",
   "A GitHub App is already set up for this cluster. To use it, install the GitHub app on your personal account or GitHub organization.": "A GitHub App is already set up for this cluster. To use it, install the GitHub app on your personal account or GitHub organization.",

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryLinkList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryLinkList.tsx
@@ -17,7 +17,7 @@ import {
   RepositoryAnnotations,
   RepoAnnotationFields,
 } from './consts';
-import { sanitizeBranchName } from './repository-utils';
+import { getLabelValue, sanitizeBranchName } from './repository-utils';
 
 export type RepositoryLinkListProps = {
   pipelineRun: PipelineRunKind;
@@ -54,7 +54,7 @@ const RepositoryLinkList: React.FC<RepositoryLinkListProps> = ({ pipelineRun }) 
       </dd>
       {plrLabels?.[RepositoryLabels[RepositoryFields.BRANCH]] && (
         <>
-          <dt>{t('pipelines-plugin~Branch')}</dt>
+          <dt>{t(getLabelValue(plrLabels[RepositoryLabels[RepositoryFields.BRANCH]]))}</dt>
           <dd data-test="pl-repository-branch">
             {sanitizeBranchName(plrLabels[RepositoryLabels[RepositoryFields.BRANCH]])}
           </dd>

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunHeader.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunHeader.tsx
@@ -61,7 +61,7 @@ const RepositoryPipelineRunHeader = () => {
       props: { className: tableColumnClasses[6] },
     },
     {
-      title: i18n.t('pipelines-plugin~Branch'),
+      title: i18n.t('pipelines-plugin~Branch/Tag'),
       sortField: `metadata.labels.${RepositoryLabels[RepositoryFields.BRANCH]}`,
       transforms: [sortable],
       props: { className: tableColumnClasses[7] },

--- a/frontend/packages/pipelines-plugin/src/components/repository/__tests__/RepositoryLinkList.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/__tests__/RepositoryLinkList.spec.tsx
@@ -1,7 +1,22 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { PipeLineRunWithRepoMetadata } from '../../../test-data/pipeline-data';
+import { getLabelValue, sanitizeBranchName } from '../repository-utils';
 import RepositoryLinkList from '../RepositoryLinkList';
+
+jest.mock('../repository-utils', () => ({
+  getLabelValue: jest.fn(),
+  sanitizeBranchName: jest.fn(),
+}));
+
+const getLabelValueMock = getLabelValue as jest.Mock;
+const sanitizeBranchNameMock = sanitizeBranchName as jest.Mock;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  getLabelValueMock.mockReturnValue('pipelines-plugin~Branch');
+  sanitizeBranchNameMock.mockReturnValue('main');
+});
 
 describe('RepositoryLinkList', () => {
   it('should not render when repo label is missing', () => {

--- a/frontend/packages/pipelines-plugin/src/components/repository/__tests__/repository-utils.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/__tests__/repository-utils.spec.tsx
@@ -4,6 +4,7 @@ import {
   getGitProviderIcon,
   getLatestRepositoryPLRName,
   sanitizeBranchName,
+  getLabelValue,
 } from '../repository-utils';
 import { mockRepository } from './repository-mock';
 
@@ -69,6 +70,17 @@ describe('repository-util', () => {
     const branch3 = sanitizeBranchName('refs/heads/foo');
     expect(branch3).toBe('foo');
     const branch4 = sanitizeBranchName('refs/tags/1.0');
-    expect(branch4).toBe('refs/tags/1.0');
+    expect(branch4).toBe('1.0');
+  });
+
+  it('getLabelValue should return correct label based on ref', () => {
+    const label1 = getLabelValue('refs-heads-main');
+    expect(label1).toBe('pipelines-plugin~Branch');
+    const label2 = getLabelValue('refs-tags-cicd-demo');
+    expect(label2).toBe('pipelines-plugin~Tag');
+    const label3 = getLabelValue('refs/heads/main');
+    expect(label3).toBe('pipelines-plugin~Branch');
+    const label4 = getLabelValue('refs/tags/cicd/demo');
+    expect(label4).toBe('pipelines-plugin~Tag');
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/repository/repository-utils.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/repository-utils.tsx
@@ -37,6 +37,17 @@ export const getGitProviderIcon = (url: string) => {
   }
 };
 
+export const getLabelValue = (branchName: string): string => {
+  if (branchName.startsWith('refs/heads/') || branchName.startsWith('refs-heads-')) {
+    return 'pipelines-plugin~Branch';
+  }
+
+  if (branchName.startsWith('refs/tags/') || branchName.startsWith('refs-tags-')) {
+    return 'pipelines-plugin~Tag';
+  }
+  return 'pipelines-plugin~Branch';
+};
+
 export const sanitizeBranchName = (branchName: string): string => {
   if (branchName.startsWith('refs/heads/')) {
     return branchName.replace('refs/heads/', '');
@@ -44,6 +55,14 @@ export const sanitizeBranchName = (branchName: string): string => {
 
   if (branchName.startsWith('refs-heads-')) {
     return branchName.replace('refs-heads-', '');
+  }
+
+  if (branchName.startsWith('refs/tags/')) {
+    return branchName.replace('refs/tags/', '');
+  }
+
+  if (branchName.startsWith('refs-tags-')) {
+    return branchName.replace('refs-tags-', '');
   }
   return branchName;
 };


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGS-3476

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
When we detect a refs/heads/branchname we should show the label as what we have now:
- Branch: branchname
And when we detect a refs/tags/tagname we should instead show the label as:
- Tag: tagname

**Solution** 
**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/47265560/202281110-44e89b61-1976-4b8e-95c2-33e2062a8d50.mp4



**Unit test coverage report**: 
<!-- Attach test coverage report -->
Changed.
![fsdfsdf](https://user-images.githubusercontent.com/47265560/202281354-b42a61b1-4c81-42f0-83ef-8180452bcd7f.png)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Create a repository
2. Trigger the pipelineruns by push or pull request event on the github  


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge