### PR TITLE
OU-75 New Query Added to the Beginning  of List 

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -696,9 +696,10 @@ const QueriesList: React.FC<{}> = () => {
 
   return (
     <>
-      {_.range(count).map((i) => (
-        <Query index={i} key={i} />
-      ))}
+      {_.range(count).map((index) => {
+        const reversedIndex = count - index - 1;
+        return <Query index={reversedIndex} key={reversedIndex} />;
+      })}
     </>
   );
 };


### PR DESCRIPTION
**Description**:  Under the Observe > Metrics Page, clicking the 'Add query' button renders it at the top of the queries list rather than the bottom. 

**Related to** : [OU-75](https://issues.redhat.com/browse/OU-75)

https://user-images.githubusercontent.com/59589720/204889817-707a6573-3859-45fb-bb55-e6cda7f49616.mov

