### PR TITLE
ODC-7177: Add SBO label selector support for Topology page

### DIFF
--- a/frontend/packages/console-app/src/actions/creators/common-factory.ts
+++ b/frontend/packages/console-app/src/actions/creators/common-factory.ts
@@ -15,18 +15,25 @@ export type ResourceActionCreator = (
   kind: K8sKind,
   obj: K8sResourceKind,
   relatedResource?: K8sResourceKind,
+  message?: JSX.Element,
 ) => Action;
 
 export type ResourceActionFactory = { [name: string]: ResourceActionCreator };
 
 export const CommonActionFactory: ResourceActionFactory = {
-  Delete: (kind: K8sKind, obj: K8sResourceKind): Action => ({
+  Delete: (
+    kind: K8sKind,
+    obj: K8sResourceKind,
+    relatedResource?: K8sResourceKind,
+    message?: JSX.Element,
+  ): Action => ({
     id: `delete-resource`,
     label: i18next.t('console-app~Delete {{kind}}', { kind: kind.kind }),
     cta: () =>
       deleteModal({
         kind,
         resource: obj,
+        message,
       }),
     accessReview: asAccessReview(kind, obj, 'delete'),
   }),
@@ -106,11 +113,15 @@ export const CommonActionFactory: ResourceActionFactory = {
   }),
 };
 
-export const getCommonResourceActions = (kind: K8sKind, obj: K8sResourceKind): Action[] => {
+export const getCommonResourceActions = (
+  kind: K8sKind,
+  obj: K8sResourceKind,
+  message?: JSX.Element,
+): Action[] => {
   return [
     CommonActionFactory.ModifyLabels(kind, obj),
     CommonActionFactory.ModifyAnnotations(kind, obj),
     CommonActionFactory.Edit(kind, obj),
-    CommonActionFactory.Delete(kind, obj),
+    CommonActionFactory.Delete(kind, obj, undefined, message),
   ];
 };

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -69,6 +69,7 @@
   "From Catalog": "From Catalog",
   "Delete application": "Delete application",
   "Edit {{applicationName}}": "Edit {{applicationName}}",
+  "Deletion of a Service Binding resource that utilizes label selector will result in the removal of all bindings on applications that share the labels defined in the Service Binding resource.": "Deletion of a Service Binding resource that utilizes label selector will result in the removal of all bindings on applications that share the labels defined in the Service Binding resource.",
   "Access permissions needed": "Access permissions needed",
   "Unable to load": "Unable to load",
   "You do not have sufficient permissions to access these add options.": "You do not have sufficient permissions to access these add options.",

--- a/frontend/packages/service-binding-plugin/locales/en/service-binding-plugin.json
+++ b/frontend/packages/service-binding-plugin/locales/en/service-binding-plugin.json
@@ -4,6 +4,7 @@
   "ServiceBinding details": "ServiceBinding details",
   "Conditions": "Conditions",
   "Status": "Status",
+  "Label Selector": "Label Selector",
   "Application": "Application",
   "Services": "Services",
   "Connected": "Connected",

--- a/frontend/packages/service-binding-plugin/src/__tests__/mock-data.ts
+++ b/frontend/packages/service-binding-plugin/src/__tests__/mock-data.ts
@@ -239,3 +239,54 @@ export const allFailedServiceBindings = [
   failedServiceBindingMissingCondition,
   failedServiceBindingWithAllConditions,
 ];
+
+export const connectedServiceBindingWithLabelSelector: ServiceBinding = {
+  apiVersion: 'binding.operators.coreos.com/v1alpha1',
+  kind: 'ServiceBinding',
+  metadata: {
+    namespace: 'a-namespace',
+    name: 'connected-service-binding-with-label-selector',
+  },
+  spec: {
+    application: {
+      group: 'apps',
+      labelSelector: {
+        matchLabels: {
+          test: 'test',
+        },
+      },
+      resource: 'deployments',
+      version: 'v1',
+    },
+    services: [
+      {
+        group: 'postgres-operator.crunchydata.com',
+        kind: 'PostgresCluster',
+        name: 'example',
+        version: 'v1beta1',
+      },
+    ],
+  },
+  status: {
+    conditions: [
+      {
+        type: 'CollectionReady',
+        status: 'True',
+        reason: 'DataCollected',
+        message: '',
+      },
+      {
+        type: 'InjectionReady',
+        status: 'True',
+        reason: 'ApplicationUpdated',
+        message: '',
+      },
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'ApplicationsBound',
+        message: '',
+      },
+    ],
+  },
+};

--- a/frontend/packages/service-binding-plugin/src/components/service-binding-details/ServiceBindingSummary.tsx
+++ b/frontend/packages/service-binding-plugin/src/components/service-binding-details/ServiceBindingSummary.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ResourceLink, DetailsItem } from '@console/internal/components/utils';
+import { ResourceLink, DetailsItem, LabelList } from '@console/internal/components/utils';
+import { useModelFinder } from '@console/internal/module/k8s';
 import { ServiceBinding } from '../../types';
 import ServiceBindingStatus from '../service-binding-status/ServiceBindingStatus';
 
@@ -9,7 +10,13 @@ type ServiceBindingSummaryProps = {
 };
 
 const ServiceBindingSummary: React.FC<ServiceBindingSummaryProps> = ({ serviceBinding }) => {
+  const { findModel } = useModelFinder();
   const { t } = useTranslation();
+
+  const model = findModel(
+    serviceBinding.spec.application.group,
+    serviceBinding.spec.application.resource,
+  );
 
   return (
     <dl>
@@ -18,13 +25,28 @@ const ServiceBindingSummary: React.FC<ServiceBindingSummaryProps> = ({ serviceBi
         <ServiceBindingStatus serviceBinding={serviceBinding} />
       </dd>
 
-      <DetailsItem
-        label={t('service-binding-plugin~Application')}
-        obj={serviceBinding}
-        path="spec.application"
-      >
-        {serviceBinding.spec.application?.name || '-'}
-      </DetailsItem>
+      {serviceBinding.spec?.application?.labelSelector ? (
+        <DetailsItem
+          label={t('service-binding-plugin~Label Selector')}
+          obj={serviceBinding}
+          path="spec.application.labelSelector"
+        >
+          {(
+            <LabelList
+              kind={model.kind}
+              labels={serviceBinding.spec.application.labelSelector.matchLabels}
+            />
+          ) || '-'}
+        </DetailsItem>
+      ) : (
+        <DetailsItem
+          label={t('service-binding-plugin~Application')}
+          obj={serviceBinding}
+          path="spec.application"
+        >
+          {serviceBinding.spec.application?.name || '-'}
+        </DetailsItem>
+      )}
 
       <DetailsItem
         label={t('service-binding-plugin~Services')}

--- a/frontend/packages/service-binding-plugin/src/components/service-binding-details/__tests__/ServiceBindingDetailsPage.spec.tsx
+++ b/frontend/packages/service-binding-plugin/src/components/service-binding-details/__tests__/ServiceBindingDetailsPage.spec.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
-import { render, act } from '@testing-library/react';
+import { render, act, configure } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
 import { Firehose } from '@console/internal/components/utils/firehose';
-import { modelFor } from '@console/internal/module/k8s/k8s-models';
+import { modelFor, useModelFinder } from '@console/internal/module/k8s';
 import store from '@console/internal/redux';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
-import { connectedServiceBinding, failedServiceBinding } from '../../../__tests__/mock-data';
+import {
+  connectedServiceBinding,
+  connectedServiceBindingWithLabelSelector,
+  failedServiceBinding,
+} from '../../../__tests__/mock-data';
 import { ServiceBindingModel } from '../../../models';
 import ServiceBindingDetailsPage from '../ServiceBindingDetailsPage';
 
@@ -29,6 +33,13 @@ jest.mock('@console/shared/src/hooks/useK8sModel', () => ({
 jest.mock('@console/internal/module/k8s/k8s-models', () => ({
   ...require.requireActual('@console/internal/module/k8s/k8s-models'),
   modelFor: jest.fn(),
+}));
+
+jest.mock('@console/internal/module/k8s', () => ({
+  ...require.requireActual('@console/internal/module/k8s'),
+  useModelFinder: jest.fn(() => ({
+    findModel: jest.fn(),
+  })),
 }));
 
 jest.mock('@console/internal/components/utils/rbac', () => ({
@@ -58,6 +69,9 @@ const Wrapper: React.FC = ({ children }) => (
 
 (modelFor as jest.Mock).mockReturnValue(ServiceBindingModel);
 (useK8sModel as jest.Mock).mockReturnValue([ServiceBindingModel]);
+(useModelFinder as jest.Mock).mockImplementation(() => ({ findModel: () => ServiceBindingModel }));
+
+configure({ testIdAttribute: 'data-test' });
 
 describe('ServiceBindingDetailsPage', () => {
   it('should render a connected SB with the right status and attributes', async () => {
@@ -160,5 +174,55 @@ describe('ServiceBindingDetailsPage', () => {
     renderResult.getByText('Ready');
     renderResult.getByText('ErrorReadingBinding');
     renderResult.getAllByText('redisSecret is not found');
+  });
+
+  it('should render a connected SB using label selector with the right status and attributes', async () => {
+    ((Firehose as any) as jest.Mock).mockImplementation((props) => {
+      const childProps = {
+        obj: {
+          loaded: true,
+          data: connectedServiceBindingWithLabelSelector,
+        },
+      };
+      return React.Children.map(props.children, (child) => React.cloneElement(child, childProps));
+    });
+
+    const matchExistingServiceBinding = {
+      params: { ns: 'a-namespace', name: 'connected-service-binding-with-label-selector' },
+      isExact: true,
+      path: '/',
+      url: '',
+    };
+
+    const renderResult = render(
+      <Wrapper>
+        <ServiceBindingDetailsPage match={matchExistingServiceBinding} kind="" />
+      </Wrapper>,
+    );
+    // Consume one rerendering to hide 'test was not wrapped in act' warnings
+    await act(async () => null);
+
+    renderResult.getAllByText('ServiceBinding details');
+
+    // Name
+    renderResult.getByText('Name');
+    renderResult.getByText('connected-service-binding-with-label-selector');
+
+    // Status
+    renderResult.getAllByText('Status');
+    renderResult.getAllByText('Connected');
+    expect(renderResult.queryAllByText('Error')).toEqual([]);
+
+    // Application
+    renderResult.getByText('Label Selector');
+    expect(renderResult.getByTestId('label-list').textContent).toEqual('test=test');
+
+    // Services
+    renderResult.getByText('Services');
+    renderResult.getByText('example');
+
+    // Conditions
+    renderResult.getByText('Conditions');
+    renderResult.getByText('Ready');
   });
 });

--- a/frontend/packages/service-binding-plugin/src/types.ts
+++ b/frontend/packages/service-binding-plugin/src/types.ts
@@ -6,7 +6,12 @@ export type ServiceBinding = K8sResourceCommon & {
       group: string;
       version: string;
       resource: string;
-      name: string;
+      name?: string;
+      labelSelector?: {
+        matchLabels: {
+          [key: string]: string;
+        };
+      };
     };
     services: {
       group: string;

--- a/frontend/packages/topology/integration-tests/features/topology/topology-chart-area-visual.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-chart-area-visual.feature
@@ -470,3 +470,37 @@ Feature: Topology chart area
               And user sees "test-connector4" Title on Service binding details page
               And user navigates to Topology page
              Then user will see service binding connection
+
+
+        @regression @odc-7120
+        Scenario: Label specified in Label Selector section on Service binding details page: T-06-TC38
+            Given user has created namespace "aut-label-details-sb"
+              And user has installed Service Binding operator
+              And user has installed Redis Operator
+              And user is at developer perspective
+              And user is at Topology page chart view
+              And user has created a deployment workload named "node-ej"
+              And user has created a operator backed service of "Redis" operator named "redis-standalone"
+             When user clicks on import YAML button from topology page
+              And user enters yaml content from yaml file "test-data/servicebinding-resource-label-selector.yaml" in the editor
+              And user clicks on Create button in import YAML
+              And user sees "test-connector4" Title on Service binding details page
+             Then user will see "app=node-ej" in Label Selector section on Service binding details page
+
+
+        @regression @odc-7120
+        Scenario: Label specified in Label Selector section on Service binding side panel: T-06-TC39
+            Given user has created namespace "aut-label-panel-sb"
+              And user has installed Service Binding operator
+              And user has installed Redis Operator
+              And user is at developer perspective
+              And user is at Topology page chart view
+              And user has created a deployment workload named "node-ej"
+              And user has created a operator backed service of "Redis" operator named "redis-standalone"
+             When user clicks on import YAML button from topology page
+              And user enters yaml content from yaml file "test-data/servicebinding-resource-label-selector.yaml" in the editor
+              And user clicks on Create button in import YAML
+              And user sees "test-connector4" Title on Service binding details page
+              And user navigates to Topology page
+              And user clicks on service binding connector
+             Then user will see "app=node-ej" in Label Selector section on Service binding connnector topology sidebar

--- a/frontend/packages/topology/integration-tests/features/topology/topology-chart-area-visual.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-chart-area-visual.feature
@@ -174,7 +174,7 @@ Feature: Topology chart area
              Then user is able to see options like Samples, Import from Git, Container Image, From Dockerfile, From Devfile, From Catalog, Database, Operator Backed, Helm Charts, Event Source, Channel
 
 
-        @regression @broken-test
+        @regression 
         Scenario: Add to Project in topology: T-06-TC17
             Given user is at the Topology page
              When user right clicks on the empty chart area
@@ -194,8 +194,8 @@ Feature: Topology chart area
               And user clicks on Create button
     # Crunchy Postgres for Kubernetes operator not installing correctly, won't able to create a postgres.
               And user hovers on Add to Project and clicks on "Operator Backed"
-              And user selects Postgres and clicks on Create
-              And user fills the "Operator Backed" form with yaml at "test-data/postgres-operator-backed.yaml" and clicks Create
+              And user selects Redis and clicks on Create
+              And user fills the "Operator Backed" form with yaml at "test-data/redis-standalone.yaml" and clicks Create
               And user hovers on Add to Project and clicks on "Helm Charts"
               And user selects Nodejs and clicks on Install Helm Charts
               And user fills the "Helm Chart" form and clicks Create
@@ -425,17 +425,16 @@ Feature: Topology chart area
               And user can see "Error" in Status section on service binding connnector topology sidebar
 
 
-        @regression @odc-4944 @broken-test
+        @regression @odc-4944 
         Scenario: Connected status on Service binding details page: T-06-TC35
             Given user has created namespace "aut-connected-sb"
               And user has installed Service Binding operator
-    # Crunchy Postgres for Kubernetes operator not installing correctly
-              And user has installed Crunchy Postgres for Kubernetes operator
+              And user has installed Redis Operator
               And user is at developer perspective
               And user is at Topology page chart view
               And user has created a deployment workload named "node-ej"
-              And user has created a operator backed service "hippo" from yaml "test-data/hippo-postgres-cluster.yaml"
-              And user has created service binding connnector "test-connector2" between "node-ej" and "hippo"
+              And user has created a operator backed service of "Redis" operator named "redis-standalone"
+              And user has created service binding connnector "test-connector2" between "node-ej" and "redis-standalone"
              When user clicks on service binding connector
               And user clicks on the service binding name "test-connector2" at the sidebar
              Then user will see "Connected" Status on Service binding details page
@@ -445,12 +444,29 @@ Feature: Topology chart area
         Scenario: Error status on Service binding details page: T-06-TC36
             Given user has created namespace "aut-error-sb"
               And user has installed Service Binding operator
-              And user has installed Red Hat OpenShift distributed tracing platform
+              And user has installed Redis Operator
               And user is at developer perspective
               And user is at Topology page chart view
               And user has created a deployment workload named "node-ej"
-              And user has created a operator backed service of "Jaeger" operator named "jaeger-test"
-              And user has created service binding connnector "test-connector3" between "node-ej" and "jaeger-test"
+              And user has created a operator backed service "redis-standalone" from yaml "test-data/redis-standalone.yaml"
+              And user has created service binding connnector "test-connector3" between "node-ej" and "redis-standalone"
              When user clicks on service binding connector
               And user clicks on the service binding name "test-connector3" at the sidebar
              Then user will see "Error" Status on Service binding details page
+
+
+        @regression @odc-7120
+        Scenario: Create connection using import YAML with Service Binding using Label Selector: T-06-TC37
+            Given user has created namespace "aut-connected-sb-ls"
+              And user has installed Service Binding operator
+              And user has installed Redis Operator
+              And user is at developer perspective
+              And user is at Topology page chart view
+              And user has created a deployment workload named "node-ej"
+              And user has created a operator backed service of "Redis" operator named "redis-standalone"
+             When user clicks on import YAML button from topology page
+              And user enters yaml content from yaml file "test-data/servicebinding-resource-label-selector.yaml" in the editor
+              And user clicks on Create button in import YAML
+              And user sees "test-connector4" Title on Service binding details page
+              And user navigates to Topology page
+             Then user will see service binding connection

--- a/frontend/packages/topology/integration-tests/support/page-objects/chart-area-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/chart-area-po.ts
@@ -31,6 +31,7 @@ export const chartAreaPO = {
   gitInputURL: '[data-test-id="git-form-input-url"]',
   postgresqlTemplate: '[data-test="Template-PostgreSQL"]',
   operatorBackedPostgres: '[data-test="OperatorBackedService-Postgres Cluster"]',
+  operatorBackedRedis: '[data-test="OperatorBackedService-Redis"]',
   helmNodejs: '[data-test="HelmChart-Nodejs"]',
   helmReleaseName: '#form-input-releaseName-field',
   apiEventSource: '[data-test="EventSource-ApiServerSource"]',

--- a/frontend/packages/topology/integration-tests/support/pages/functions/chart-functions.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/functions/chart-functions.ts
@@ -68,7 +68,7 @@ export const createWorkloadUsingOptions = (optionName: string, optionalData?: st
       const yamlLocation = `support/${optionalData}`;
       yamlEditor.setEditorContent(yamlLocation);
       cy.get(chartAreaPO.saveChanges).click();
-      cy.get('[aria-label="Breadcrumb"]').should('contain', 'PostgresCluster details');
+      cy.get('[aria-label="Breadcrumb"]').should('contain', 'Redis details');
       navigateTo(devNavigationMenu.Topology);
       break;
 

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/chart-view.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/chart-view.ts
@@ -19,6 +19,7 @@ import {
   navigateTo,
   perspective,
   projectNameSpace,
+  yamlEditor,
 } from '@console/dev-console/integration-tests/support/pages/app';
 import { chartAreaPO } from '../../page-objects/chart-area-po';
 import { topologyPO, typeOfWorkload } from '../../page-objects/topology-po';
@@ -351,9 +352,9 @@ When('user selects Postgres Database and clicks on Instantiate Template', () => 
   cy.get(chartAreaPO.overlayCreate).click({ force: true });
 });
 
-When('user selects Postgres and clicks on Create', () => {
-  cy.get(chartAreaPO.filterItem).type('postgresql');
-  cy.get(chartAreaPO.operatorBackedPostgres).click();
+When('user selects Redis and clicks on Create', () => {
+  cy.get(chartAreaPO.filterItem).type('redis');
+  cy.get(chartAreaPO.operatorBackedRedis).click();
   cy.get(chartAreaPO.overlayCreate).click({ force: true });
 });
 
@@ -386,7 +387,7 @@ Then(
       'hello-openshift',
       'python-app',
       'postgres',
-      'postgres-operator-backed',
+      'redis-standalone',
       'helm-nodejs',
       'api-server-source',
       'channel',
@@ -445,4 +446,31 @@ When('user clicks on the service binding name {string} at the sidebar', (binding
 Then('user will see {string} Status on Service binding details page', (status: string) => {
   cy.byTestID('resource-status').should('have.text', status);
   cy.exec(`oc delete namespace ${Cypress.env('NAMESPACE')}`, { failOnNonZeroExit: false });
+});
+
+Then('user will see service binding connection', () => {
+  cy.byLegacyTestID('edge-handler').should('be.visible');
+});
+
+When('user clicks on import YAML button from topology page', () => {
+  app.waitForLoad();
+  topologyPage.verifyTopologyPage();
+  cy.get('[data-test="import-yaml"]').click();
+  cy.get('.yaml-editor').should('be.visible');
+});
+
+When('user enters yaml content from yaml file {string} in the editor', (yamlFile: string) => {
+  const yamlContent = `support/${yamlFile}`;
+  yamlEditor.isLoaded();
+  yamlEditor.clearYAMLEditor();
+  yamlEditor.setEditorContent(yamlContent);
+});
+
+When('user clicks on Create button in import YAML', () => {
+  yamlEditor.clickSave();
+});
+
+When('user sees {string} Title on Service binding details page', (title: string) => {
+  app.waitForLoad();
+  cy.get('[data-test-id="resource-title"]').should('have.text', title);
 });

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/chart-view.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/chart-view.ts
@@ -474,3 +474,18 @@ When('user sees {string} Title on Service binding details page', (title: string)
   app.waitForLoad();
   cy.get('[data-test-id="resource-title"]').should('have.text', title);
 });
+
+Then(
+  'user will see {string} in Label Selector section on Service binding details page',
+  (label: string) => {
+    cy.byTestID('label-list').should('have.text', label);
+  },
+);
+
+Then(
+  'user will see {string} in Label Selector section on Service binding connnector topology sidebar',
+  (label: string) => {
+    topologySidePane.selectTab('Details');
+    cy.byTestID('label-list').should('have.text', label);
+  },
+);

--- a/frontend/packages/topology/integration-tests/support/test-data/redis-standalone.yaml
+++ b/frontend/packages/topology/integration-tests/support/test-data/redis-standalone.yaml
@@ -1,0 +1,23 @@
+kind: Redis
+apiVersion: redis.redis.opstreelabs.in/v1beta1
+metadata:
+  name: redis-standalone
+spec:
+  kubernetesConfig:
+    image: 'quay.io/opstree/redis:v7.0.5'
+    imagePullPolicy: IfNotPresent
+    redisSecret:
+      key: test
+      name: test
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  redisExporter:
+    enabled: true
+    image: 'quay.io/opstree/redis-exporter:v1.44.0'
+    imagePullPolicy: IfNotPresent

--- a/frontend/packages/topology/integration-tests/support/test-data/servicebinding-resource-label-selector.yaml
+++ b/frontend/packages/topology/integration-tests/support/test-data/servicebinding-resource-label-selector.yaml
@@ -1,0 +1,17 @@
+apiVersion: binding.operators.coreos.com/v1alpha1
+kind: ServiceBinding
+metadata:
+  name: test-connector4
+spec:
+  services:
+    - group: redis.redis.opstreelabs.in
+      kind: Redis
+      name: redis-standalone
+      version: v1beta1
+  application:
+    labelSelector:
+      matchLabels:
+        app: node-ej
+    group: apps
+    version: v1
+    resource: deployments

--- a/frontend/packages/topology/src/__tests__/service-binding-test-data.ts
+++ b/frontend/packages/topology/src/__tests__/service-binding-test-data.ts
@@ -1,4 +1,8 @@
-import { apiVersionForModel, DeploymentKind } from '@console/internal/module/k8s';
+import {
+  apiVersionForModel,
+  DeploymentKind,
+  K8sResourceCommon,
+} from '@console/internal/module/k8s';
 import { ServiceBindingModel } from '@console/service-binding-plugin/src/models';
 import { TopologyDataResources } from '../topology-types';
 
@@ -136,6 +140,154 @@ export const sbrBackingServiceSelector: Partial<TopologyDataResources> = {
             resource: 'deployments',
           },
           services: [
+            {
+              group: 'postgresql.baiju.dev',
+              version: 'v1alpha1',
+              kind: 'Jaeger',
+              name: 'jaeger-all-in-one-inmemory',
+            },
+          ],
+          detectBindingResources: true,
+        },
+      },
+    ],
+  },
+};
+
+const deploymentWithLabels: K8sResourceCommon = {
+  apiVersion: 'apps/v1',
+  kind: 'Deployment',
+  metadata: {
+    name: 'app',
+    uid: 'uid-app',
+    labels: { app: 'app' },
+  },
+};
+
+export const sbrLabelSelectorBackingServiceSelector: Partial<TopologyDataResources> = {
+  deployments: {
+    loaded: true,
+    loadError: null,
+    data: [
+      deploymentWithLabels as DeploymentKind,
+      {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: {
+          name: 'db-1',
+          uid: 'uid-db-1',
+          ownerReferences: [
+            {
+              apiVersion: 'db/v1alpha1',
+              kind: 'Database',
+              name: 'db-demo1',
+              uid: 'uid-db-demo1',
+            },
+          ],
+        },
+      } as DeploymentKind,
+    ],
+  },
+  serviceBindingRequests: {
+    loaded: true,
+    loadError: null,
+    data: [
+      {
+        apiVersion: apiVersionForModel(ServiceBindingModel),
+        kind: ServiceBindingModel.kind,
+        metadata: {
+          name: 'sbr-2',
+        },
+        spec: {
+          application: {
+            labelSelector: {
+              matchLabels: {
+                app: 'app',
+              },
+            },
+            group: 'apps',
+            version: 'v1',
+            resource: 'deployments',
+          },
+          services: [
+            {
+              group: 'postgresql.baiju.dev',
+              version: 'v1alpha1',
+              kind: 'Jaeger',
+              name: 'jaeger-all-in-one-inmemory',
+            },
+          ],
+          detectBindingResources: true,
+        },
+      },
+    ],
+  },
+};
+
+export const sbrLabelSelectorBackingServiceSelectors: Partial<TopologyDataResources> = {
+  deployments: {
+    loaded: true,
+    loadError: null,
+    data: [
+      deploymentWithLabels as DeploymentKind,
+      {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: {
+          name: 'db-1',
+          uid: 'uid-db-1',
+          ownerReferences: [
+            {
+              apiVersion: 'db/v1alpha1',
+              kind: 'Database',
+              name: 'db-demo1',
+              uid: 'uid-db-demo1',
+            },
+          ],
+        },
+      } as DeploymentKind,
+      {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: {
+          name: 'db-2',
+          uid: 'uid-db-2',
+          ownerReferences: [
+            {
+              apiVersion: 'postgresql.baiju.dev/v1alpha1',
+              kind: 'Database',
+              name: 'db-demo2',
+              uid: 'uid-db-demo2',
+            },
+          ],
+        },
+      } as DeploymentKind,
+    ],
+  },
+  serviceBindingRequests: {
+    loaded: true,
+    loadError: null,
+    data: [
+      {
+        apiVersion: apiVersionForModel(ServiceBindingModel),
+        kind: ServiceBindingModel.kind,
+        metadata: {
+          name: 'sbr-1',
+        },
+        spec: {
+          application: {
+            name: 'app',
+            group: 'apps',
+            version: 'v1',
+            resource: 'deployments',
+          },
+          services: [
+            {
+              group: 'postgresql.baiju.dev',
+              version: 'v1alpha1',
+              kind: 'Jaeger',
+              name: 'jaeger-all-in-one-inmemory',
+            },
             {
               group: 'postgresql.baiju.dev',
               version: 'v1alpha1',

--- a/frontend/packages/topology/src/operators/__tests__/operator-data-transformer.spec.ts
+++ b/frontend/packages/topology/src/operators/__tests__/operator-data-transformer.spec.ts
@@ -5,6 +5,8 @@ import { MockResources } from '@console/shared/src/utils/__tests__/test-resource
 import {
   sbrBackingServiceSelector,
   sbrBackingServiceSelectors,
+  sbrLabelSelectorBackingServiceSelector,
+  sbrLabelSelectorBackingServiceSelectors,
 } from '../../__tests__/service-binding-test-data';
 import { TEST_KINDS_MAP } from '../../__tests__/topology-test-data';
 import { TYPE_SERVICE_BINDING, TYPE_WORKLOAD } from '../../const';
@@ -149,6 +151,50 @@ describe('operator data transformer ', () => {
     const deployments = sbrBackingServiceSelectors.deployments.data;
     const obsGroups = getOperatorGroupResources(mockResources);
     const sbrs = sbrBackingServiceSelectors.serviceBindingRequests.data;
+    const installedOperators = mockResources?.clusterServiceVersions?.data;
+
+    expect(getServiceBindingEdges(deployments[0], obsGroups, sbrs, installedOperators)).toEqual([
+      {
+        id: `uid-app_3006a8f3-6e2b-4a19-b37e-fbddd9a41f51`,
+        type: TYPE_SERVICE_BINDING,
+        source: 'uid-app',
+        target: '3006a8f3-6e2b-4a19-b37e-fbddd9a41f51',
+        data: { sbr: sbrs[0] },
+        resource: sbrs[0],
+      },
+      {
+        id: `uid-app_3006a8f3-6e2b-4a19-b37e-fbddd9a41f51`,
+        type: TYPE_SERVICE_BINDING,
+        source: 'uid-app',
+        target: '3006a8f3-6e2b-4a19-b37e-fbddd9a41f51',
+        data: { sbr: sbrs[0] },
+        resource: sbrs[0],
+      },
+    ]);
+  });
+
+  it('should support single binding service selector with workload using label selector', async () => {
+    const deployments = sbrLabelSelectorBackingServiceSelector.deployments.data;
+    const obsGroups = getOperatorGroupResources(mockResources);
+    const sbrs = sbrLabelSelectorBackingServiceSelector.serviceBindingRequests.data;
+    const installedOperators = mockResources?.clusterServiceVersions?.data;
+
+    expect(getServiceBindingEdges(deployments[0], obsGroups, sbrs, installedOperators)).toEqual([
+      {
+        id: `uid-app_3006a8f3-6e2b-4a19-b37e-fbddd9a41f51`,
+        type: TYPE_SERVICE_BINDING,
+        source: 'uid-app',
+        target: '3006a8f3-6e2b-4a19-b37e-fbddd9a41f51',
+        data: { sbr: sbrs[0] },
+        resource: sbrs[0],
+      },
+    ]);
+  });
+
+  it('should support multiple binding service selectors with workload using label selector', async () => {
+    const deployments = sbrLabelSelectorBackingServiceSelectors.deployments.data;
+    const obsGroups = getOperatorGroupResources(mockResources);
+    const sbrs = sbrLabelSelectorBackingServiceSelectors.serviceBindingRequests.data;
     const installedOperators = mockResources?.clusterServiceVersions?.data;
 
     expect(getServiceBindingEdges(deployments[0], obsGroups, sbrs, installedOperators)).toEqual([

--- a/frontend/packages/topology/src/operators/operators-data-transformer.ts
+++ b/frontend/packages/topology/src/operators/operators-data-transformer.ts
@@ -32,9 +32,9 @@ export const edgesFromServiceBinding = (
       if (sbr?.spec?.application?.name === source.metadata.name) {
         edgeExists = true;
       } else {
-        const matchLabels = sbr?.spec?.application?.matchLabels;
+        const matchLabels = sbr?.spec?.application?.labelSelector?.matchLabels;
         if (matchLabels) {
-          const sbrSelector = new LabelSelector(sbr.spec.application);
+          const sbrSelector = new LabelSelector(sbr.spec.application.labelSelector);
           if (sbrSelector.matches(source)) {
             edgeExists = true;
           }


### PR DESCRIPTION
Fixes: [ODC-7177](https://issues.redhat.com/browse/ODC-7177)

**Description:**
This PR adds support for service binding resources that defines a label to bind to in the labelSelector field. This is the first implementation that focuses on drawing the connection between the workload that contains the label specified in the service binding resource to a service. This PR also includes an updated deletion message specifically for service binding resources using label selector to explicitly notify the user that deletion of the resource will remove all connections to other resources. 

This PR also updates some of the e2e tests that were failing. [RedisSecrets](https://github.com/redhat-developer/service-binding-operator/issues/1088) are optional with Redis and a recent update with SBO made it so that the binding will not throw an error. I also went in and updated some of the tests that use the Crunchy Postgres for Kubernetes operator. [Crunchy Postgress for Kubernetes 5.2.0](https://github.com/CrunchyData/postgres-operator/issues/3365) isn't currently compatible with Kubernetes 1.25, so the tests will fail when running on an Openshift 4.12 cluster.

**Screenshots / Video:**

https://user-images.githubusercontent.com/82788581/203034924-0aedff8c-0ec9-4c27-b251-1bbd849ab3f3.mp4

![7177-delete](https://user-images.githubusercontent.com/82788581/203035103-22deb892-6aac-4a31-8958-7cd7c79713df.png)

**Unit Test Coverage:**
![7177-test](https://user-images.githubusercontent.com/82788581/203035222-6f6de956-b3a3-4102-8ce7-6a3f681eea82.png)

**Test Setup:**
Install Service Binding operator
Install an operator that supports SBO (above video uses the Redis operator as an example)
Import from git (ensure there is a label defined in the resource, the above video uses "app=nodejs-ex-git)
Navigate to Add > Operator Backed, select "Bindable" 
Create Redis using default name "redis-standalone"
Navigate to Import YAML
Create CR
```
apiVersion: binding.operators.coreos.com/v1alpha1
kind: ServiceBinding
metadata:
  name: test-connector
spec:
  services:
    - group: redis.redis.opstreelabs.in
      version: v1beta1
      kind: Redis
      name: redis-standalone
  application:
    labelSelector:
      matchLabels:
        app: nodejs-ex-git
    group: apps
    version: v1
    resource: deployments
```
Update: 

Fixes: [ODC-7178](https://issues.redhat.com/browse/ODC-7178)

**Description:**
This PR has also been updated to include the support for showing the label specified in the topology side panel and the service binding details page.

**Screenshots / Video:**

![7178-details](https://user-images.githubusercontent.com/82788581/207435582-b8089c58-e65e-44be-96fb-3b5a3fee9949.png)

![7178-side-panel](https://user-images.githubusercontent.com/82788581/207435583-ca9e2496-de51-4064-9580-21428537f873.png)

**Test Setup:**
![7178-test1](https://user-images.githubusercontent.com/82788581/207435713-585dc153-caec-45d9-8656-805df2424d01.png)
![7178-tests2](https://user-images.githubusercontent.com/82788581/207435745-0dd330fd-b083-475e-b9e4-9c40497ccaaa.png)

