### PR TITLE
OCPBUGS-3027: Do not disable metrics when auth is disabled

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -188,7 +188,7 @@ func (s *Server) authDisabled() bool {
 }
 
 func (s *Server) prometheusProxyEnabled() bool {
-	return len(s.Authers) == 1 && s.ThanosTenancyProxyConfig != nil && s.ThanosTenancyProxyForRulesConfig != nil
+	return s.ThanosProxyConfig != nil && s.ThanosTenancyProxyConfig != nil && s.ThanosTenancyProxyForRulesConfig != nil
 }
 
 func (s *Server) alertManagerProxyEnabled() bool {


### PR DESCRIPTION
- Remove erroneous `s.authers` length check in server `prometheusProxyEnabled` func
- Update `cmd/bridge/main.go` to only initialize thanos proxy configurations when no managed clusters are configured.

Explanation:
`s.authers` server property is empty when auth is disabled, meaning `len(s.authers) == 0`.
We assume that `len(s.authers) != 1` indicates multicluster environment.
Console backend automatically disables metrics in a multicluster environment.
Unexpected result: metrics are disabled when auth is disabled.