### PR TITLE
OCPBUGS-3776: Update the tooltip to trigger only on mouseenter to remove focus trigger

### DIFF
--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -407,7 +407,7 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
         {columnLayout?.id && !hideColumnManagement && (
           <ToolbarGroup>
             <ToolbarItem>
-              <Tooltip content={t('public~Manage columns')}>
+              <Tooltip content={t('public~Manage columns')} trigger="mouseenter">
                 <Button
                   variant="plain"
                   onClick={() =>


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/OCPBUGS-3776

