### PR TITLE
OCPBUGS-3033: Update admin landing page if monitoring is disabled

### DIFF
--- a/frontend/packages/console-app/src/utils/perspective.tsx
+++ b/frontend/packages/console-app/src/utils/perspective.tsx
@@ -10,7 +10,9 @@ export const getLandingPageURL: ResolvedExtension<Perspective>['properties']['la
   if (!flags[FLAGS.OPENSHIFT]) {
     return '/search';
   }
-  return flags[FLAGS.CAN_LIST_NS] ? '/dashboards' : '/k8s/cluster/projects';
+  return flags[FLAGS.CAN_LIST_NS] && flags[FLAGS.MONITORING]
+    ? '/dashboards'
+    : '/k8s/cluster/projects';
 };
 
 export const getImportRedirectURL: ResolvedExtension<


### PR DESCRIPTION
Redirect to Projects page rather than Overview when monitoring is disabled.