### PR TITLE
OCPBUGS-4022: Fix react warning when open console, add missing keys in navigation

### DIFF
--- a/frontend/packages/console-app/src/components/nav/NavSection.tsx
+++ b/frontend/packages/console-app/src/components/nav/NavSection.tsx
@@ -66,6 +66,7 @@ export const NavSection: React.FC<NavSectionProps> = ({ id, name, dataAttributes
     if (isHrefNavItem(extension)) {
       return (
         <NavItemHref
+          key={extension.uid}
           href={extension.properties.href}
           namespaced={extension.properties.namespaced}
           prefixNamespaced={extension.properties.prefixNamespaced}
@@ -79,6 +80,7 @@ export const NavSection: React.FC<NavSectionProps> = ({ id, name, dataAttributes
     if (isResourceNavItem(extension)) {
       return (
         <NavItemResource
+          key={extension.uid}
           namespaced={isResourceNSNavItem(extension)}
           model={extension.properties.model}
           startsWith={extension.properties.startsWith}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-4022

**Analysis / Root cause**: 
Unnecessary react warning:

```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `NavSection`. See https://reactjs.org/link/warning-keys for more information.
NavItemHref@http://localhost:9012/static/main-785e94355aeacc12c321.js:5141:88
NavSection@http://localhost:9012/static/main-785e94355aeacc12c321.js:5294:20
PluginNavItem@http://localhost:9012/static/main-785e94355aeacc12c321.js:5582:23
div
PerspectiveNav@http://localhost:9012/static/main-785e94355aeacc12c321.js:5398:134
```

**Solution Description**: 
Add missing react keys when map navigation item

**Screen shots / Gifs for design review**: 
Before when open the console:

![warning](https://user-images.githubusercontent.com/139310/203505647-28820305-9fb8-4ce8-b9bd-e1e2c8771171.png)

With this PR:

![image](https://user-images.githubusercontent.com/139310/203505740-69694a91-b71d-4409-bf77-4af4477294a2.png)

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Open browser log
2. Open web console

**Browser conformance**: 
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug