### PR TITLE
OCPBUGS-4026: Fix rerender loop/crash when bindable-kinds is found but has no status

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/providers/useBindableItemMetadataProvider.ts
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useBindableItemMetadataProvider.ts
@@ -8,19 +8,17 @@ import {
 import { getGroupVersionKindForModel } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { BindableServicesModel } from '../../topology/bindable-services/models';
-import { BindableServiceGVK, BindableServicesKind } from '../../topology/bindable-services/types';
+import { BindableServicesKind } from '../../topology/bindable-services/types';
 
 const useBindableItemMetadataProvider: ExtensionHook<CatalogItemMetadataProviderFunction> = () => {
-  const [bindableKindsRes, loaded, error] = useK8sWatchResource<BindableServicesKind>({
+  const [bindableKinds, loaded, error] = useK8sWatchResource<BindableServicesKind>({
     groupVersionKind: getGroupVersionKindForModel(BindableServicesModel),
     name: 'bindable-kinds',
   });
 
-  const bindableServices: BindableServiceGVK[] = bindableKindsRes?.status ?? [];
-
   const [t] = useTranslation();
 
-  const bindableMtadata = React.useRef<ReturnType<CatalogItemMetadataProviderFunction>>({
+  const bindableMetadata = React.useRef<ReturnType<CatalogItemMetadataProviderFunction>>({
     tags: ['bindable'],
     badges: [{ text: t('devconsole~Bindable') }],
     attributes: {
@@ -30,9 +28,11 @@ const useBindableItemMetadataProvider: ExtensionHook<CatalogItemMetadataProvider
 
   const provider = React.useCallback<CatalogItemMetadataProviderFunction>(
     (item: CatalogItem) => {
+      if (!loaded || !Array.isArray(bindableKinds?.status)) {
+        return null;
+      }
       if (
-        loaded &&
-        bindableServices.some(
+        bindableKinds.status.some(
           (value) =>
             value.kind === item.data.kind &&
             value.version === item.data.version &&
@@ -43,11 +43,11 @@ const useBindableItemMetadataProvider: ExtensionHook<CatalogItemMetadataProvider
                 .join('.'),
         )
       ) {
-        return bindableMtadata.current;
+        return bindableMetadata.current;
       }
       return null;
     },
-    [bindableServices, loaded],
+    [bindableKinds, loaded],
   );
   return [provider, loaded, error];
 };

--- a/frontend/packages/dev-console/src/components/topology/bindable-services/types.ts
+++ b/frontend/packages/dev-console/src/components/topology/bindable-services/types.ts
@@ -1,4 +1,4 @@
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceCommon } from '@console/internal/module/k8s';
 
 export type BindableServiceGVK = {
   group: string;
@@ -6,9 +6,6 @@ export type BindableServiceGVK = {
   kind: string;
 };
 
-export type BindableServicesKind = {
-  metadata: {
-    name: string;
-  };
+export type BindableServicesKind = K8sResourceCommon & {
   status: BindableServiceGVK[];
-} & K8sResourceKind;
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-4026

**Analysis / Root cause**: 
This statement creates always a new `bindableServices` array when the `bindable-kinds` resource is found, but has no status.

```tsx
  const bindableServices: BindableServiceGVK[] = bindableKindsRes?.status ?? [];
```

Since this is used for the `useCallback` dependencies this catalog providers updates the catalog again and again.

**Solution Description**: 
Changed the `useCallback` dependencies to the `bindableKinds` and `loaded` so that the callback is only updated if one of these both changed. Checked that the status array is defined (with isArray) in the callback function.

**Screen shots / Gifs for design review**: 
Before:

https://user-images.githubusercontent.com/139310/203537132-6ea75fc6-1465-49b4-9a69-679b44745e10.mp4

After:

https://user-images.githubusercontent.com/139310/203537126-0455cc3c-8e0a-4b06-bcf5-99858f872d02.mp4


**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Install Service Binding Operator
2. Create or update the BindableKinds resource "bindable-kinds"

```yaml
apiVersion: binding.operators.coreos.com/v1alpha1
kind: BindableKinds
metadata:
  name: bindable-kinds
```

3. Open the browser console log
4. Open the console UI and navigate to the add page

**Browser conformance**: 
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
