### PR TITLE
OCPBUGS-4012: disabled Serverless add actions is not displayed in topology menu

### DIFF
--- a/frontend/packages/knative-plugin/src/const.ts
+++ b/frontend/packages/knative-plugin/src/const.ts
@@ -46,3 +46,7 @@ export const EVENT_SOURCE_CATALOG_TYPE_ID = 'EventSource';
 export const EVENT_SINK_CATALOG_TYPE_ID = 'EventSink';
 export const FLAG_EVENT_SOURCE_PING = 'FLAG_EVENT_SOURCE_PING';
 export const FLAG_KNATIVE_EVENTING_ENABLED = 'FLAG_KNATIVE_EVENTING_ENABLED';
+export const EVENT_SOURCE_ACTION_ID = 'knative-event-source';
+export const EVENT_SINK_ACTION_ID = 'knative-event-sink';
+export const EVENTING_CHANNEL_ACTION_ID = 'knative-eventing-channel';
+export const EVENTING_BROKER_ACTION_ID = 'knative-eventing-broker';


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-4012

**Description:** Eventing resources were not disabled in topology actions if actions are disabled in customization

**Test Setup**: 

Add below yaml in `config.yaml` in local and pass `config.yaml` to bridge with -config option as below

`./bin/bridge -config ../config.yaml`

```
apiVersion: console.openshift.io/v1
kind: ConsoleConfig
customization:
  addPage:
    disabledActions:
      - dev-catalog
      - dev-catalog-databases
      - helm
      - import-from-git
      - import-from-samples
      - import-yaml
      - operator-backed
      - project-access
      - project-helm-chart-repositories
      - upload-jar
      - knative-event-source
      - knative-event-sink
      - knative-eventing-channel
      - knative-eventing-broker
```

/kind bug
