### PR TITLE
CONSOLE-3367: Back end code for passing up hubConsoleURL to the GUI

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -148,6 +148,7 @@ func main() {
 	fReleaseVersion := fs.String("release-version", "", "Defines the release version of the cluster")
 	fNodeArchitectures := fs.String("node-architectures", "", "List of node architectures. Example --node-architecture=amd64,arm64")
 	fCopiedCSVsDisabled := fs.Bool("copied-csvs-disabled", false, "Flag to indicate if OLM copied CSVs are disabled.")
+	fHubConsoleURL := fs.String("hub-console-url", "", "URL of the hub cluster in a multi cluster environment.")
 
 	if err := serverconfig.Parse(fs, os.Args[1:], "BRIDGE"); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -263,6 +264,11 @@ func main() {
 		}
 	}
 
+    hubConsoleURL := &url.URL{}
+    if *fHubConsoleURL != "" {
+        hubConsoleURL = bridge.ValidateFlagIsURL("hub-console-url", *fHubConsoleURL)
+    }
+
 	srv := &server.Server{
 		PublicDir:                    *fPublicDir,
 		BaseURL:                      baseURL,
@@ -295,6 +301,7 @@ func main() {
 		ReleaseVersion:               *fReleaseVersion,
 		NodeArchitectures:            nodeArchitectures,
 		CopiedCSVsDisabled:           *fCopiedCSVsDisabled,
+		HubConsoleURL:                hubConsoleURL,
 	}
 
 	managedClusterConfigs := []serverconfig.ManagedClusterConfig{}

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -148,8 +148,7 @@ func main() {
 	fReleaseVersion := fs.String("release-version", "", "Defines the release version of the cluster")
 	fNodeArchitectures := fs.String("node-architectures", "", "List of node architectures. Example --node-architecture=amd64,arm64")
 	fCopiedCSVsDisabled := fs.Bool("copied-csvs-disabled", false, "Flag to indicate if OLM copied CSVs are disabled.")
-	fHubConsoleURL := fs.String("hub-console-url", "", "URL of the hub cluster in a multi cluster environment.")
-
+    fHubConsoleURL := fs.String("hub-console-url", "", "URL of the hub cluster's console in a multi cluster environment.")
 	if err := serverconfig.Parse(fs, os.Args[1:], "BRIDGE"); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -264,10 +264,10 @@ func main() {
 		}
 	}
 
-    hubConsoleURL := &url.URL{}
-    if *fHubConsoleURL != "" {
-        hubConsoleURL = bridge.ValidateFlagIsURL("hub-console-url", *fHubConsoleURL)
-    }
+	hubConsoleURL := &url.URL{}
+	if *fHubConsoleURL != "" {
+		hubConsoleURL = bridge.ValidateFlagIsURL("hub-console-url", *fHubConsoleURL)
+	}
 
 	srv := &server.Server{
 		PublicDir:                    *fPublicDir,

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -148,7 +148,7 @@ func main() {
 	fReleaseVersion := fs.String("release-version", "", "Defines the release version of the cluster")
 	fNodeArchitectures := fs.String("node-architectures", "", "List of node architectures. Example --node-architecture=amd64,arm64")
 	fCopiedCSVsDisabled := fs.Bool("copied-csvs-disabled", false, "Flag to indicate if OLM copied CSVs are disabled.")
-    fHubConsoleURL := fs.String("hub-console-url", "", "URL of the hub cluster's console in a multi cluster environment.")
+	fHubConsoleURL := fs.String("hub-console-url", "", "URL of the hub cluster's console in a multi cluster environment.")
 	if err := serverconfig.Parse(fs, os.Args[1:], "BRIDGE"); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -57,6 +57,7 @@ declare interface Window {
     controlPlaneTopology: string;
     telemetry: Record<string, string>;
     nodeArchitectures: string[];
+    hubConsoleURL: string;
   };
   windowError?: string;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -117,6 +117,7 @@ type jsGlobals struct {
 	ReleaseVersion                  string                     `json:"releaseVersion"`
 	NodeArchitectures               []string                   `json:"nodeArchitectures"`
 	CopiedCSVsDisabled              bool                       `json:"copiedCSVsDisabled"`
+	HubConsoleURL                   string                     `json:"hubConsoleURL"`
 }
 
 type Server struct {
@@ -181,6 +182,7 @@ type Server struct {
 	Perspectives                 string
 	Telemetry                    serverconfig.MultiKeyValue
 	CopiedCSVsDisabled           bool
+	HubConsoleURL                *url.URL
 }
 
 func (s *Server) authDisabled() bool {
@@ -752,6 +754,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		ReleaseVersion:             s.ReleaseVersion,
 		NodeArchitectures:          s.NodeArchitectures,
 		CopiedCSVsDisabled:         s.CopiedCSVsDisabled,
+		HubConsoleURL:              s.HubConsoleURL.String(),
 	}
 
 	localAuther := s.getLocalAuther()


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/CONSOLE-3367

Proof of work:

In a multi cluster env, I ran bridge as follows: /bin/bridge -hub-console-url="http://www.google.com". To make sure this was passed correctly, I rendered the hubConsoleURL windows.SERVER_FLAG in the cluster switcher as shown in the screenshot:
![Screenshot 2022-11-23 at 2 09 39 PM](https://user-images.githubusercontent.com/35978579/203630452-f97bef5f-4469-4f10-beb1-6f89bfc36b5b.png)
