### PR TITLE
CONSOLE-3371: Add missing children prop to ResourceLink

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -468,6 +468,7 @@ export type ResourceLinkProps = {
   dataTest?: string;
   onClick?: () => void;
   truncate?: boolean;
+  children?: React.ReactNode;
 };
 
 export type ResourceIconProps = {


### PR DESCRIPTION
Issue:
`ResourceLink` is defined with `children` props [1] and this prop is used by some components [2]
But it's props type does not include this prop [3]

Proposed:
Add `children` to the component prop.


[1] https://github.com/openshift/console/blob/master/frontend/public/components/utils/resource-link.tsx#L82
[2] https://github.com/openshift/console/blob/master/frontend/public/components/storage-class.tsx#L77
[3] https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts#L456