### PR TITLE
OCPBUGS-3761: follow on fix to ensure Administrator perspective is se…

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/events/events.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/events/events.spec.ts
@@ -1,4 +1,5 @@
 import { testName, checkErrors } from '../../support';
+import { nav } from '../../views/nav';
 
 const name = `${testName}-event-test-pod`;
 const testpod = {
@@ -33,6 +34,9 @@ const testpod = {
 describe('Events', () => {
   before(() => {
     cy.login();
+    cy.visit('/');
+    nav.sidenav.switcher.changePerspectiveTo('Administrator');
+    nav.sidenav.switcher.shouldHaveText('Administrator');
     cy.createProject(testName);
     try {
       cy.exec(`echo '${JSON.stringify(testpod)}' | kubectl create -n ${testName} -f -`);


### PR DESCRIPTION
…lected

@yapei noticed we're seeing failures with the migrated test.  See https://issues.redhat.com/browse/OCPBUGS-3761?focusedCommentId=21321580&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-21321580.  This appears to be the result of the Developer perspective modal being present (see screenshot below).  It looks like we account for this elsewhere by checking the Administrator perspective is active before trying to create a project.

<img width="1274" alt="Screenshot 2022-11-28 at 10 25 05 AM" src="https://user-images.githubusercontent.com/895728/204318571-31879700-e7bc-4681-95d7-e773645cb704.png">
