### PR TITLE
OCPBUGS-4047: delete each created secret in case first test attempt r…

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crud/secrets.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/secrets.spec.ts
@@ -40,6 +40,7 @@ describe('Create key/value secrets', () => {
   });
 
   afterEach(() => {
+    secrets.deleteSecret();
     checkErrors();
   });
 

--- a/frontend/packages/integration-tests-cypress/views/secret.ts
+++ b/frontend/packages/integration-tests-cypress/views/secret.ts
@@ -1,3 +1,7 @@
+import { detailsPage } from './details-page';
+import { listPage } from './list-page';
+import { modal } from './modal';
+
 export const secrets = {
   clickCreateKeyValSecretDropdownButton: () => {
     cy.byTestID('item-create')
@@ -8,5 +12,12 @@ export const secrets = {
           cy.get(`[data-test-dropdown-menu="generic"]`).click();
         }
       });
+  },
+  deleteSecret: () => {
+    detailsPage.clickPageActionFromDropdown('Delete Secret');
+    modal.shouldBeOpened();
+    modal.submit();
+    modal.shouldBeClosed();
+    listPage.titleShouldHaveText('Secrets');
   },
 };


### PR DESCRIPTION
…esults in secret with empty value

It looks like this bug is occurring because the value doesn’t properly get set when creating a key/value secret (value is empty).  See [https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cons[…]20value%20is%20an%20ascii%20file%20(failed).png](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_console/12227/pull-ci-openshift-console-master-e2e-gcp-console/1595684800046305280/artifacts/e2e-gcp-console/test/artifacts/gui_test_screenshots/cypress/screenshots/crud/secrets.spec.ts/1_Create%20keyvalue%20secrets%20--%20Validate%20a%20keyvalue%20secret%20whose%20value%20is%20an%20ascii%20file%20(failed).png) and [https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cons[…]0value%20is%20a%20unicode%20file%20(failed).png](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_console/12303/pull-ci-openshift-console-master-e2e-gcp-console/1596995952625848320/artifacts/e2e-gcp-console/test/artifacts/gui_test_screenshots/cypress/screenshots/crud/secrets.spec.ts/1_Create%20keyvalue%20secrets%20--%20Validate%20a%20keyvalue%20secret%20whose%20value%20is%20a%20unicode%20file%20(failed).png).  So Cypress retries, but fails again because it can’t recreate the same secret as it already exists.  See [https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cons[…]20unicode%20file%20(failed)%20(attempt%202).png](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_console/12303/pull-ci-openshift-console-master-e2e-gcp-console/1596995952625848320/artifacts/e2e-gcp-console/test/artifacts/gui_test_screenshots/cypress/screenshots/crud/secrets.spec.ts/2_Create%20keyvalue%20secrets%20--%20Validate%20a%20keyvalue%20secret%20whose%20value%20is%20a%20unicode%20file%20(failed)%20(attempt%202).png)  It seems like we need to figure out why the value doesn’t get properly set, but perhaps deleting each secret in afterEach would workaround?