### PR TITLE
OCPBUGS-4203: remove padding from debug pod alert

### DIFF
--- a/frontend/public/components/_terminal.scss
+++ b/frontend/public/components/_terminal.scss
@@ -33,10 +33,6 @@ $console-collapse-link-z-index: $console-z-index + 20;
   z-index: $console-collapse-link-z-index; // in fullscreen mode, to get above console's z-index
 }
 
-.co-terminal-info-message {
-  padding: 10px;
-}
-
 .default-overflow {
   overflow: visible !important;
 }

--- a/frontend/public/components/debug-terminal.tsx
+++ b/frontend/public/components/debug-terminal.tsx
@@ -56,15 +56,13 @@ const DebugTerminalError: React.FC<DebugTerminalErrorProps> = ({ error, descript
 const DebugTerminalInner: React.FC<DebugTerminalInnerProps> = ({ debugPod, initialContainer }) => {
   const { t } = useTranslation();
   const infoMessage = (
-    <div className="co-terminal-info-message">
-      <Alert
-        variant="info"
-        isInline
-        title={t(
-          'public~This temporary pod has a modified entrypoint command to debug a failing container. The pod will be deleted when the terminal window is closed.',
-        )}
-      />
-    </div>
+    <Alert
+      variant="info"
+      isInline
+      title={t(
+        'public~This temporary pod has a modified entrypoint command to debug a failing container. The pod will be deleted when the terminal window is closed.',
+      )}
+    />
   );
   switch (debugPod?.status?.phase) {
     case 'Failed':


### PR DESCRIPTION
Before:
<img width="1603" alt="Screenshot 2022-11-28 at 3 37 13 PM" src="https://user-images.githubusercontent.com/895728/204377925-a61ff5b1-e6d1-4a65-88dd-2e49173381c1.png">

After:
<img width="1605" alt="Screenshot 2022-11-28 at 3 37 31 PM" src="https://user-images.githubusercontent.com/895728/204377941-faf92741-7869-4605-b0bc-2b8d58dd1554.png">
