### PR TITLE
OCPBUGS-3373: Observe > Metrics > Monitors,  Error Message to indicate limited view due to user privileges  

### DIFF
--- a/frontend/public/components/monitoring/targets.tsx
+++ b/frontend/public/components/monitoring/targets.tsx
@@ -5,7 +5,7 @@ import {
   RedExclamationCircleIcon,
   RowFilter,
 } from '@console/dynamic-plugin-sdk';
-import { Alert, Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
+import { Alert, AlertActionCloseButton, Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
@@ -33,6 +33,7 @@ import { RootState } from '../../redux';
 import { RowFunctionArgs, Table, TableData } from '../factory';
 import { FilterToolbar } from '../filter-toolbar';
 import { PageHeading, SectionHeading } from '../utils/headings';
+import { useBoolean } from './hooks/useBoolean';
 import { usePoll } from '../utils/poll-hook';
 import { useSafeFetch } from '../utils/safe-fetch-hook';
 import { LoadingInline, StatusBox } from '../utils/status-box';
@@ -52,8 +53,20 @@ const PodMonitorsWatchContext = React.createContext([]);
 const PodsWatchContext = React.createContext([]);
 
 const PodMonitor: React.FC<{ target: Target }> = ({ target }) => {
-  const [podMonitors, podMonitorsLoaded] = React.useContext(PodMonitorsWatchContext);
+  const { t } = useTranslation();
+
+  const [podMonitors, podMonitorsLoaded, podMonitorsLoadError] = React.useContext(
+    PodMonitorsWatchContext,
+  );
   const [pods, podsLoaded] = React.useContext(PodsWatchContext);
+
+  if (podMonitorsLoadError) {
+    return (
+      <>
+        <RedExclamationCircleIcon /> {t('public~Error')}
+      </>
+    );
+  }
 
   if (!podsLoaded || !podMonitorsLoaded) {
     return <LoadingInline />;
@@ -92,8 +105,20 @@ const PodMonitor: React.FC<{ target: Target }> = ({ target }) => {
 };
 
 const ServiceMonitor: React.FC<{ target: Target }> = ({ target }) => {
-  const [monitors, monitorsLoaded] = React.useContext(ServiceMonitorsWatchContext);
+  const { t } = useTranslation();
+
+  const [monitors, monitorsLoaded, monitorsLoadError] = React.useContext(
+    ServiceMonitorsWatchContext,
+  );
   const [services, servicesLoaded] = React.useContext(ServicesWatchContext);
+
+  if (monitorsLoadError) {
+    return (
+      <>
+        <RedExclamationCircleIcon /> {t('public~Error')}
+      </>
+    );
+  }
 
   if (!servicesLoaded || !monitorsLoaded) {
     return <LoadingInline />;
@@ -145,6 +170,30 @@ const Health: React.FC<{ health: string }> = React.memo(({ health }) => {
   );
 });
 
+type WatchErrorAlertProps = {
+  loadError: { code: number; message: string };
+  title: string;
+};
+
+const WatchErrorAlert: React.FC<WatchErrorAlertProps> = ({ loadError, title }) => {
+  const [showError, , , hideError] = useBoolean(true);
+
+  if (!showError) {
+    return null;
+  }
+
+  return (
+    <Alert
+      className="co-alert"
+      title={title}
+      variant="danger"
+      actionClose={<AlertActionCloseButton onClose={hideError} />}
+    >
+      {loadError.message}
+    </Alert>
+  );
+};
+
 type DetailsProps = RouteComponentProps<{ scrapeUrl?: string }> & {
   loaded: boolean;
   loadError: string;
@@ -157,8 +206,15 @@ const Details = withRouter<DetailsProps>(({ loaded, loadError, match, targets })
   const scrapeUrl = atob(match?.params?.scrapeUrl ?? '');
   const target: Target = scrapeUrl ? _.find(targets, { scrapeUrl }) : undefined;
 
-  const isServiceMonitor: boolean = target.scrapePool.includes(MonitorType.ServiceMonitor);
-  const isPodMonitor: boolean = target.scrapePool.includes(MonitorType.PodMonitor);
+  const isServiceMonitor: boolean = target
+    ? target.scrapePool.includes(MonitorType.ServiceMonitor)
+    : undefined;
+  const isPodMonitor: boolean = target
+    ? target.scrapePool.includes(MonitorType.PodMonitor)
+    : undefined;
+
+  const [, , serviceMonitorsLoadError] = React.useContext(ServiceMonitorsWatchContext);
+  const [, , podMonitorsLoadError] = React.useContext(PodMonitorsWatchContext);
 
   return (
     <>
@@ -183,6 +239,18 @@ const Details = withRouter<DetailsProps>(({ loaded, loadError, match, targets })
       <StatusBox data={target} label="target" loaded={loaded} loadError={loadError}>
         <div className="co-m-pane__body">
           <SectionHeading text={t('public~Target details')} />
+          {isServiceMonitor && serviceMonitorsLoadError && (
+            <WatchErrorAlert
+              loadError={serviceMonitorsLoadError}
+              title={t('public~Error loading service monitor data')}
+            />
+          )}
+          {isPodMonitor && podMonitorsLoadError && (
+            <WatchErrorAlert
+              loadError={podMonitorsLoadError}
+              title={t('public~Error loading pod monitor data')}
+            />
+          )}
           <div className="co-m-pane__body-group">
             <div className="row">
               <div className="col-sm-6">
@@ -296,6 +364,9 @@ const getRowProps = (target: Target) => ({ id: target.scrapeUrl, title: target.l
 const List: React.FC<ListProps> = ({ loaded, loadError, targets }) => {
   const { t } = useTranslation();
 
+  const [, , serviceMonitorsLoadError] = React.useContext(ServiceMonitorsWatchContext);
+  const [, , podMonitorsLoadError] = React.useContext(PodMonitorsWatchContext);
+
   const filters = useSelector(({ k8s }: RootState) => k8s.getIn([REDUX_ID, 'filters']));
 
   const Header = () => [
@@ -377,6 +448,18 @@ const List: React.FC<ListProps> = ({ loaded, loadError, targets }) => {
           >
             {loadError}
           </Alert>
+        )}
+        {serviceMonitorsLoadError && (
+          <WatchErrorAlert
+            loadError={serviceMonitorsLoadError}
+            title={t('public~Error loading service monitor data')}
+          />
+        )}
+        {podMonitorsLoadError && (
+          <WatchErrorAlert
+            loadError={podMonitorsLoadError}
+            title={t('public~Error loading pod monitor data')}
+          />
         )}
         <FilterToolbar
           data={targets}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1176,6 +1176,8 @@
   "Down": "Down",
   "Target details": "Target details",
   "Targets": "Targets",
+  "Error loading service monitor data": "Error loading service monitor data",
+  "Error loading pod monitor data": "Error loading pod monitor data",
   "Endpoint": "Endpoint",
   "Last scrape": "Last scrape",
   "Scrape failed": "Scrape failed",


### PR DESCRIPTION
**Description**: Observe > Metrics Target page. Previously, if a 403 status code were received (e.g., a user is not authorized to access this information), the 'Monitor' column would continuously loop a loading icon. Now, the page renders an Alert if the 'Monitor' column encounters an error. 

**Related to** : [OCPBUGS-3373](https://issues.redhat.com/browse/OCPBUGS-3373)

**Before**

https://user-images.githubusercontent.com/59589720/205392814-466aa6e1-8836-4a35-afc3-8e82d78b76b0.mov


**After** 

https://user-images.githubusercontent.com/59589720/206232659-4335bcbd-9897-4ca7-8629-a40719fff81f.mov


