### PR TITLE
[WIP] Bug 2079944: prevent creating service binding with pods and jobs

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -151,6 +151,34 @@
         "version": "v1",
         "kind": "StatefulSet"
       },
+      "provider": { "$codeRef": "actions.useCreateServiceBindingProvider" }
+    },
+    "flags": {
+      "required": ["ALLOW_SERVICE_BINDING"]
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "apps",
+        "version": "v1",
+        "kind": "DaemonSet"
+      },
+      "provider": { "$codeRef": "actions.useCreateServiceBindingProvider" }
+    },
+    "flags": {
+      "required": ["ALLOW_SERVICE_BINDING"]
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "apps",
+        "version": "v1",
+        "kind": "StatefulSet"
+      },
       "provider": { "$codeRef": "actions.useStatefulSetActionsProvider" }
     }
   },

--- a/frontend/packages/topology/src/operators/components/OperatorBackedServiceGroup.tsx
+++ b/frontend/packages/topology/src/operators/components/OperatorBackedServiceGroup.tsx
@@ -85,7 +85,7 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
       <NodeShadows />
       <Layer id={dragging || labelDragging ? undefined : 'groups2'}>
         <Tooltip
-          content={t('topology~Create Service Binding')}
+          content={canDrop && t('topology~Create Service Binding')}
           trigger="manual"
           isVisible={dropTarget && canDrop}
           animationDuration={0}

--- a/frontend/packages/topology/src/operators/components/OperatorBackedServiceNode.tsx
+++ b/frontend/packages/topology/src/operators/components/OperatorBackedServiceNode.tsx
@@ -33,7 +33,7 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
   const { t } = useTranslation();
   return (
     <Tooltip
-      content={t('topology~Create Service Binding')}
+      content={canDrop && t('topology~Create Service Binding')}
       trigger="manual"
       isVisible={dropTarget && canDrop}
       animationDuration={0}


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGSM-43763

**Root Cause:**
Pods, Jobs and CronJobs are not directly supported. The only way to get to pods is through deployments or through another CR that supports PodSpec, the reason is that pods and jobs are immutable. Cannot mount a volume after the pod is already running.

**Solution Description:**
Preventing the creation of service binding using the drag and drop action between a Pod/Job/CronJob and Operator-backed service.

**GIF:**
https://user-images.githubusercontent.com/22490998/204502076-e2c168bd-e4dd-4972-93ea-d15383043fe1.mov

/kind bug