### PR TITLE
OCPBUGS-3896: Make aria-expanded state label reflect correct expanded state in the masthead navigation button

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -179,7 +179,7 @@ class App_ extends React.PureComponent {
             <Page
               // Need to pass mainTabIndex=null to enable keyboard scrolling as default tabIndex is set to -1 by patternfly
               mainTabIndex={null}
-              header={<Masthead onNavToggle={this._onNavToggle} />}
+              header={<Masthead isNavOpen={isNavOpen} onNavToggle={this._onNavToggle} />}
               sidebar={
                 <Navigation
                   isNavOpen={isNavOpen}

--- a/frontend/public/components/masthead.jsx
+++ b/frontend/public/components/masthead.jsx
@@ -46,7 +46,7 @@ export const getBrandingDetails = () => {
   return { logoImg, productName };
 };
 
-export const Masthead = React.memo(({ onNavToggle }) => {
+export const Masthead = React.memo(({ onNavToggle, isNavOpen }) => {
   const details = getBrandingDetails();
   const defaultRoute = '/';
   const logoProps = {
@@ -66,10 +66,12 @@ export const Masthead = React.memo(({ onNavToggle }) => {
       headerTools={<MastheadToolbar />}
       showNavToggle
       onNavToggle={onNavToggle}
+      isNavOpen={isNavOpen}
     />
   );
 });
 
 Masthead.propTypes = {
   onNavToggle: PropTypes.func,
+  isNavOpen: PropTypes.bool,
 };


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-3896

![expanded](https://user-images.githubusercontent.com/1874151/204567482-c26df5c6-c50d-468c-9202-f4b5e814c15d.gif)
