### PR TITLE
OCPBUGS-4252: fix issue where node debug terminal doesn't load

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeTerminal.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeTerminal.tsx
@@ -44,6 +44,7 @@ const getDebugPod = async (name: string, namespace: string, nodeName: string): P
       annotations: {
         'debug.openshift.io/source-container': 'container-00',
         'debug.openshift.io/source-resource': `/v1, Resource=nodes/${nodeName}`,
+        'openshift.io/scc': 'privileged',
       },
     },
     spec: {
@@ -89,7 +90,7 @@ const getDebugPod = async (name: string, namespace: string, nodeName: string): P
 const NodeTerminalError: React.FC<NodeTerminalErrorProps> = ({ error }) => {
   return (
     <div className="co-m-pane__body">
-      <Alert variant="danger" isInline title={error} />
+      <Alert variant="danger" isInline title={error} data-test="node-terminal-error" />
     </div>
   );
 };
@@ -146,9 +147,13 @@ const NodeTerminal: React.FC<NodeTerminalProps> = ({ obj: node }) => {
       try {
         namespace = await k8sCreate(NamespaceModel, {
           metadata: {
-            generateName: 'openshift-debug-node-',
+            generateName: 'openshift-debug-',
             labels: {
               'openshift.io/run-level': '0',
+              'pod-security.kubernetes.io/audit': 'privileged',
+              'pod-security.kubernetes.io/enforce': 'privileged',
+              'pod-security.kubernetes.io/warn': 'privileged',
+              'security.openshift.io/scc.podSecurityLabelSync': 'false',
             },
             annotations: {
               'openshift.io/node-selector': '',

--- a/frontend/packages/integration-tests-cypress/tests/app/node-terminal.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/node-terminal.spec.ts
@@ -1,0 +1,33 @@
+import { checkErrors } from '../../support';
+import { detailsPage } from '../../views/details-page';
+import { listPage } from '../../views/list-page';
+
+describe('Node terminal', () => {
+  before(() => {
+    cy.login();
+    cy.visit('/');
+  });
+
+  afterEach(() => {
+    checkErrors();
+  });
+
+  after(() => {
+    cy.logout();
+  });
+
+  it('Opens a debug terminal', () => {
+    cy.visit(`/k8s/cluster/nodes`);
+    listPage.titleShouldHaveText('Nodes');
+    listPage.rows.shouldBeLoaded();
+    listPage.rows.clickFirstLinkInFirstRow();
+    detailsPage.isLoaded();
+    detailsPage.selectTab('Terminal');
+    cy.byTestID('node-terminal-error').should('not.exist');
+    cy.get('[class="xterm-viewport"]').should('exist');
+    // navigate back to Overview tab so the temporary namespace is deleted
+    cy.get('a[data-test-id="horizontal-link-Overview"]')
+      .should('exist')
+      .click();
+  });
+});


### PR DESCRIPTION
The bug occurred because of pod security measures introduced in 4.12 that require the addition of the included annotations, so this fix needs to be backported to 4.12.