### PR TITLE
Bug 2110570: Topology sidebar: Edit pod count shows not the latest replicas value when edit the count again

### DIFF
--- a/frontend/packages/topology/src/actions/TopologyActions.tsx
+++ b/frontend/packages/topology/src/actions/TopologyActions.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import { referenceFor } from '@console/internal/module/k8s';
-import { ActionMenu, ActionMenuVariant, ActionServiceProvider } from '@console/shared';
+import {
+  ActionMenu,
+  ActionMenuVariant,
+  ActionServiceProvider,
+  useDeepCompareMemoize,
+} from '@console/shared';
 import { getResource } from '../utils';
 
 type TopologyActionsProps = {
@@ -9,16 +14,17 @@ type TopologyActionsProps = {
 };
 
 const TopologyActions: React.FC<TopologyActionsProps> = ({ element }) => {
+  const resource = getResource(element);
+  const memoizedRes = useDeepCompareMemoize(resource);
   const context = React.useMemo(() => {
-    const resource = getResource(element);
     const { csvName } = element.getData()?.data ?? {};
     return {
       'topology-actions': element,
       'topology-context-actions': { element },
-      ...(resource ? { [referenceFor(resource)]: resource } : {}),
-      ...(csvName ? { 'csv-actions': { csvName, resource } } : {}),
+      ...(memoizedRes ? { [referenceFor(memoizedRes)]: memoizedRes } : {}),
+      ...(csvName ? { 'csv-actions': { csvName, memoizedRes } } : {}),
     };
-  }, [element]);
+  }, [element, memoizedRes]);
   return (
     <ActionServiceProvider key={element.getId()} context={context}>
       {({ actions, options, loaded }) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-47202

**Analysis / Root cause**: 
Resource was not updated for edit actions.

**Solution Description**: 
Updated the resource with the new values.

**Screen shots / Gifs for design review**: 
-----BEFORE----

https://bugzilla.redhat.com/attachment.cgi?id=1899201

---AFTER-----


https://user-images.githubusercontent.com/102503482/204982141-5d70810a-e624-46e0-b247-4366be5e8955.mov



**Unit test coverage report**: 
NA

**Test setup:**
1. Switch to developer perspective
2. Import a Deployment from a container image or from git
3. Select the Deployment in the topology to open the sidebar
4. Select the Action "Edit pod count" and change the pod (replicas) count
5. Select the Action again

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge