### PR TITLE
OCPBUGS-4415: Disable shipwright tests again

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -73,7 +73,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
   yarn run test-cypress-pipelines-headless
-  yarn run test-cypress-shipwright-headless
+#  yarn run test-cypress-shipwright-headless
   exit;
 fi
 


### PR DESCRIPTION
Disable shipwright tests because the overall build (build and tests) timeouted currently close to always.

First time we disabled them: https://github.com/openshift/console/pull/11947 / https://bugzilla.redhat.com/show_bug.cgi?id=2116415
And then just re-enabled them: https://github.com/openshift/console/pull/12049 / https://issues.redhat.com/browse/OCPBUGS-1305

Here is a ticket that tracks that we re-enable them again: https://issues.redhat.com/browse/OCPBUGS-4418