### PR TITLE
OCPBUGS-4352: bump HorizontalPodAutoscaler to v2 and add redirect for…

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -793,7 +793,7 @@
       "name": "%console-app~HorizontalPodAutoscalers%",
       "model": {
         "group": "autoscaling",
-        "version": "v2beta2",
+        "version": "v2",
         "kind": "HorizontalPodAutoscaler"
       }
     }

--- a/frontend/packages/console-shared/src/utils/__tests__/hpa-utils-data.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/hpa-utils-data.ts
@@ -20,7 +20,7 @@ export const deploymentConfigHasCpuAndMemoryLimits = {
 
 export const cpuScaled: HorizontalPodAutoscalerKind = {
   kind: 'HorizontalPodAutoscaler',
-  apiVersion: 'autoscaling/v2beta2',
+  apiVersion: 'autoscaling/v2',
   metadata: {
     name: 'example',
     namespace: 'test-ns',

--- a/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils-data.ts
+++ b/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils-data.ts
@@ -601,7 +601,7 @@ export const deploymentConfigExamples: { [key: string]: K8sResourceKind } = {
 export const hpaExamples: { [key: string]: HorizontalPodAutoscalerKind } = {
   noMetrics: {
     kind: 'HorizontalPodAutoscaler',
-    apiVersion: 'autoscaling/v2beta2',
+    apiVersion: 'autoscaling/v2',
     metadata: {
       name: 'example',
       namespace: 'test-ns',
@@ -618,7 +618,7 @@ export const hpaExamples: { [key: string]: HorizontalPodAutoscalerKind } = {
   },
   cpuScaled: {
     kind: 'HorizontalPodAutoscaler',
-    apiVersion: 'autoscaling/v2beta2',
+    apiVersion: 'autoscaling/v2',
     metadata: {
       name: 'example',
       namespace: 'test-ns',

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
@@ -200,7 +200,7 @@ export const deploymentData: K8sResourceKind = {
 
 export const hpaData: K8sResourceKind = {
   kind: 'HorizontalPodAutoscaler',
-  apiVersion: 'autoscaling/v2beta2',
+  apiVersion: 'autoscaling/v2',
   metadata: {
     name: 'example',
     namespace: 'testproject3',

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -19,7 +19,12 @@ import { SearchPage } from './search';
 import { ResourceDetailsPage, ResourceListPage } from './resource-list';
 import { AsyncComponent, LoadingBox } from './utils';
 import { namespacedPrefixes } from './utils/link';
-import { AlertmanagerModel, CronJobModel, VolumeSnapshotModel } from '../models';
+import {
+  AlertmanagerModel,
+  CronJobModel,
+  HorizontalPodAutoscalerModel,
+  VolumeSnapshotModel,
+} from '../models';
 import { referenceForModel } from '../module/k8s';
 import { NamespaceRedirect } from './utils/namespace-redirect';
 
@@ -296,6 +301,12 @@ const AppContents: React.FC<{}> = () => {
         exact
         from="/k8s/ns/:ns/batch~v1beta1~CronJob/:name"
         to={`/k8s/ns/:ns/${CronJobModel.plural}/:name`}
+      />
+
+      <Redirect
+        exact
+        from="/k8s/ns/:ns/autoscaling~v2beta2~HorizontalPodAutoscaler/:name"
+        to={`/k8s/ns/:ns/${HorizontalPodAutoscalerModel.plural}/:name`}
       />
 
       <LazyRoute

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -150,7 +150,7 @@ export const HorizontalPodAutoscalerModel: K8sKind = {
   // t('public~HorizontalPodAutoscaler')
   labelKey: 'public~HorizontalPodAutoscaler',
   plural: 'horizontalpodautoscalers',
-  apiVersion: 'v2beta2',
+  apiVersion: 'v2',
   apiGroup: 'autoscaling',
   abbr: 'HPA',
   namespaced: true,

--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -349,7 +349,7 @@ spec:
   .setIn(
     [referenceForModel(k8sModels.HorizontalPodAutoscalerModel), 'default'],
     `
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -407,6 +407,18 @@ export type HPAMetric = {
   };
 };
 
+type HPAScalingPolicy = {
+  hpaScalingPolicyType: 'Pods' | 'Percent';
+  value: number;
+  periodSeconds: number;
+};
+
+type HPAScalingRules = {
+  stabilizationWindowSeconds?: number;
+  selectPolicy?: 'Max' | 'Min' | 'Disabled';
+  policies?: HPAScalingPolicy[];
+};
+
 type HPACurrentMetrics = {
   type: 'Object' | 'Pods' | 'Resource' | 'External';
   external?: {
@@ -438,6 +450,10 @@ export type HorizontalPodAutoscalerKind = K8sResourceCommon & {
     minReplicas?: number;
     maxReplicas: number;
     metrics?: HPAMetric[];
+    behavior?: {
+      scaleUp?: HPAScalingRules;
+      scaleDown?: HPAScalingRules;
+    };
   };
   status?: {
     currentReplicas: number;


### PR DESCRIPTION
… v2beta2

No changes between `v2beta1` and `v2` per https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125. 

And
```
Warning: autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
```

After:

https://user-images.githubusercontent.com/895728/205699991-d669152b-7a89-4753-80c0-96267ef16ed9.mov

