### PR TITLE
"OCPBUGS-4512: Fix navsection bug"

### DIFF
--- a/frontend/packages/console-app/src/components/nav/NavSection.tsx
+++ b/frontend/packages/console-app/src/components/nav/NavSection.tsx
@@ -30,7 +30,7 @@ export const NavSection: React.FC<NavSectionProps> = ({ id, name, dataAttributes
     (e: LoadedExtension<ResourceNavItem>): K8sModel => {
       const { model } = e.properties;
       const gvk = referenceForExtensionModel(model);
-      return k8sModels?.[gvk] ?? k8sModels[e.properties.model.kind ?? ''];
+      return k8sModels?.[gvk] ?? k8sModels[e?.properties?.model?.kind ?? ''];
     },
     [k8sModels],
   );


### PR DESCRIPTION
When CNV 4.11 is installed on OCP 4.12 only an empty page is displayed after logging into the cluster.

Cause: The error occurs when code within the NavSection component attempts to access properties of a LoadedExtension that don't exist.

Fix: Replace the normal chaining operators with optional chaining operators. 