### PR TITLE
Monitoring: Convert Targets list page to use plugin SDK list filters

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -438,6 +438,9 @@ export type ListPageFilterProps<D = any> = {
   data: D;
   loaded: boolean;
   rowFilters?: RowFilter[];
+  labelFilter?: string;
+  labelPath?: string;
+  nameFilterTitle?: string;
   nameFilterPlaceholder?: string;
   labelFilterPlaceholder?: string;
   hideNameLabelFilters?: boolean;

--- a/frontend/public/components/factory/ListPage/ListPageFilter.tsx
+++ b/frontend/public/components/factory/ListPage/ListPageFilter.tsx
@@ -8,6 +8,9 @@ const ListPageFilter: React.FC<ListPageFilterProps> = ({
   data,
   loaded,
   rowFilters,
+  labelFilter,
+  labelPath,
+  nameFilterTitle,
   nameFilterPlaceholder,
   labelFilterPlaceholder,
   hideNameLabelFilters,
@@ -20,6 +23,9 @@ const ListPageFilter: React.FC<ListPageFilterProps> = ({
   !_.isEmpty(data) && (
     <FilterToolbar
       rowFilters={rowFilters}
+      labelFilter={labelFilter}
+      labelPath={labelPath}
+      nameFilterTitle={nameFilterTitle}
       data={data}
       nameFilterPlaceholder={nameFilterPlaceholder}
       labelFilterPlaceholder={labelFilterPlaceholder}

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -63,10 +63,6 @@ export const tableFilters: FilterMap = {
   'observe-target-labels': (values, target: Target) =>
     !values.all || values.all.every((v) => getLabelsAsString(target, 'labels').includes(v)),
 
-  'observe-target-text': (filter, target: Target) =>
-    fuzzyCaseInsensitive(filter.selected?.[0], target.scrapeUrl) ||
-    fuzzyCaseInsensitive(filter.selected?.[0], target.labels?.namespace),
-
   'silence-name': (filter, silence: Silence) =>
     fuzzyCaseInsensitive(filter.selected?.[0], silence.name),
 

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -44,7 +44,6 @@ import { defaultChannelFor } from '@console/operator-lifecycle-manager/src/compo
 import { RowFilter as RowFilterExt } from '@console/dynamic-plugin-sdk';
 import { RowFilter } from '../filter-toolbar';
 import * as UIActions from '../../actions/ui';
-import { Target } from '../monitoring/types';
 import {
   alertingRuleSource,
   alertingRuleStateOrder,
@@ -107,7 +106,6 @@ const sorts = {
   pvcStorage: (pvc) => _.toInteger(convertToBaseValue(pvc?.status?.capacity?.storage)),
   silenceFiringAlertsOrder,
   silenceStateOrder,
-  targetScrapeDuration: (target: Target): number => target?.lastScrapeDuration,
   string: (val) => JSON.stringify(val),
   number: (val) => _.toNumber(val),
   getClusterOperatorStatus: (operator: ClusterOperator) => getClusterOperatorStatus(operator),


### PR DESCRIPTION
This is a refactoring change to use the plugin SDK instead of components from `factory/table.tsx`.

The only functionality difference is changing the error message that previously appeared as a `title` attribute of the whole table row, to a `Tooltip` on just the "Health" table cell.

Error message tooltip now looks like:
<img width="510" alt="Screen Shot 2022-12-06 at 12 39 45" src="https://user-images.githubusercontent.com/460802/205898268-30a6b5c4-4d64-4f22-a4ad-9f7e4313eb66.png">
