### PR TITLE
Domain-Mapping feature | Knative Serverless

### DIFF
--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/domain-mapping.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/domain-mapping.feature
@@ -5,12 +5,12 @@ Feature: Custom Domain Mapping Support
 
         Background:
             Given user has installed OpenShift Serverless Operator
-              And user has created Knative Eventing CR
-              And user has created Knative Serving CR
               And user has created or selected namespace "aut-eventing-domain"
+              And user is at developer perspective
+              And user is at Add page
 
 
-        @smoke @to-do
+        @smoke
         Scenario Outline: Create knative workload from From Git card and add domain mapping to knative service: KN-07-TC01
             Given user is at Import from git page
              When user enters Git Repo url as "<git_url>"
@@ -18,10 +18,11 @@ Feature: Custom Domain Mapping Support
               And user selects resource type as "Serverless Deployment"
               And user clicks on Show advanced Routing options
               And user enters Domain mapping as "<custom_domain>"
-              And user clicks on "Create <custom_domain>"
-              And user clicks Create button
+              And user clicks on "Create <custom_domain>" in dropdown
+              And user clicks create button
              Then user will be redirected to Topology page
               And user is able to see workload "<workload_name>" in topology page
+              And user clicks on knative workload "<workload_name>"
               And user will see "<custom_domain>" under Domain Mappings of Resources tab on sidebar
 
         Examples:
@@ -29,37 +30,40 @@ Feature: Custom Domain Mapping Support
                   | https://github.com/sclorg/golang-ex.git | knative-git   | domain.kn     |
 
 
-        @regression @to-do
+        @regression
         Scenario: Add domain mapping to knative service using edit option: KN-07-TC02
-            Given user has created knative service "kn-service"
-             When user selects "Edit kn-service" context menu option of knative service "kn-service"
+            Given user has created knative service "knative-git"
+             When user selects "Edit knative-git" context menu option of knative service "knative-git"
               And user clicks on Show advanced Routing options
-              And user creates new custom domain mapping "knative.org"
-              And user clicks on "Create knative.org"
+              And user enters Domain mapping as "knative.org"
+              And user clicks on "Create knative.org" in dropdown
               And user clicks Save button
              Then user will be redirected to Topology page
+              And user clicks on knative workload "knative-git"
               And user will see "knative.org" under Domain Mappings of Resources tab on sidebar
 
 
-        @regression @to-do
+        @regression
         Scenario: Edit domain mapping already added to knative service: KN-07-TC03
-            Given user has created knative service "kn-service" with domain mapping "domain.org"
-             When user selects "Edit kn-service" from actions drop down menu of knative service "kn-service"
+            Given user can see knative service "knative-git" exist in topology page
+             When user selects "Edit knative-git" from actions drop down menu of knative service "knative-git"
               And user clicks on Show advanced Routing options
-              And user removes already added custom domain mapping "domain.org"
-              And user creates new custom domain mapping "knative.org"
-              And user clicks on "Create knative.org"
+              And user removes already added custom domain mapping "knative.org" and "domain.kn"
+              And user enters Domain mapping as "url.org"
+              And user clicks on "Create url.org" in dropdown
               And user clicks Save button
              Then user will be redirected to Topology page
-              And user will see "knative.org" under Domain Mappings of Resources tab on sidebar
+              And user will see "url.org" under Domain Mappings of Resources tab on sidebar
 
 
-        @regression @to-do
+
+        @regression
         Scenario: Remove already added domain mapping to knative service: KN-07-TC04
-            Given user has created knative service "kn-service" with domain mapping "domain.org"
-             When user selects "Edit kn-service" context menu option of knative service "kn-service"
+            Given user can see knative service "knative-git" exist in topology page
+             When user selects "Edit knative-git" context menu option of knative service "knative-git"
               And user clicks on Show advanced Routing options
-              And user removes already added custom domain mapping "domain.org"
+              And user removes already added custom domain mapping "url.org"
               And user clicks Save button
              Then user will be redirected to Topology page
-              And user will not see "knative.org" under Domain Mappings of Resources tab on sidebar
+              And user clicks on knative workload "knative-git"
+              And user will not see "url.org" under Domain Mappings of Resources tab on sidebar

--- a/frontend/packages/knative-plugin/integration-tests/support/pageObjects/global-po.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/pageObjects/global-po.ts
@@ -262,3 +262,11 @@ export const hpaPO = {
   cpu: '[id="cpu"]',
   memory: '[id="memory"]',
 };
+
+export const domainPO = {
+  domainMapping: '[aria-label="Domain mapping"]',
+  chipGroup: '[aria-label="Chip group category"]',
+  contentScroll: '[id="content-scrollable"]',
+  removeLabel: '[aria-label="Remove"]',
+  chipText: '[class="pf-c-chip__text"]',
+};

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/domain-mapping.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/domain-mapping.ts
@@ -1,0 +1,139 @@
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import {
+  devNavigationMenu,
+  resourceTypes,
+} from '@console/dev-console/integration-tests/support/constants';
+import {
+  createGitWorkloadIfNotExistsOnTopologyPage,
+  gitPage,
+  navigateTo,
+} from '@console/dev-console/integration-tests/support/pages';
+import { eventingPO } from '@console/knative-plugin/integration-tests/support/pageObjects/global-po';
+import {
+  topologyPage,
+  topologySidePane,
+} from '@console/topology/integration-tests/support/pages/topology';
+import { formPO } from '../../../../../dev-console/integration-tests/support/pageObjects/global-po';
+import { domainPO } from '../../pageObjects/global-po';
+
+When('user enters Domain mapping as {string}', (domain: string) => {
+  cy.get(domainPO.domainMapping)
+    .clear()
+    .type(domain)
+    .should('have.value', domain);
+});
+
+When('user clicks on {string} in dropdown', () => {
+  cy.get(eventingPO.kafka.dropdownOptions)
+    .contains('Create')
+    .click();
+  cy.get(domainPO.chipGroup).should('be.visible');
+});
+
+When('user clicks on knative workload {string}', (workloadName: string) => {
+  topologyPage.waitForLoad();
+  topologyPage.knativeNode(workloadName).click({ force: true });
+});
+
+Then(
+  'user will see {string} under Domain Mappings of Resources tab on sidebar',
+  (domain: string) => {
+    topologySidePane.verifySelectedTab('Resources');
+    cy.get(`[href="https://${domain}"]`)
+      .scrollIntoView()
+      .should('be.visible');
+  },
+);
+
+When('user clicks Save button', () => {
+  cy.get(formPO.create).click();
+});
+
+When('user clicks on Show advanced Routing options', () => {
+  cy.get(domainPO.contentScroll)
+    .contains('Show advanced Routing options')
+    .click();
+});
+
+When('user clicks create button', () => {
+  gitPage.clickCreate();
+});
+
+Then('user will be redirected to Topology page', () => {
+  topologyPage.verifyTopologyPage();
+});
+
+Then('user is able to see workload {string} in topology page', (workloadName: string) => {
+  topologyPage.verifyWorkloadInTopologyPage(workloadName);
+});
+
+Given(
+  'user has created knative service {string} with domain mapping {string}',
+  (workloadName: string, domain: string) => {
+    createGitWorkloadIfNotExistsOnTopologyPage(
+      'https://github.com/sclorg/nodejs-ex.git',
+      workloadName,
+      resourceTypes.knativeService,
+    );
+    topologyPage.rightClickOnGroup(workloadName);
+    topologyPage.selectContextMenuAction(`Edit ${workloadName}`);
+    cy.get(domainPO.contentScroll)
+      .contains('Show advanced Routing options')
+      .click();
+    cy.get(domainPO.domainMapping)
+      .clear()
+      .type(domain)
+      .should('have.value', domain);
+    cy.get(eventingPO.kafka.dropdownOptions).click();
+    cy.get(domainPO.chipGroup).should('be.visible');
+    cy.get(formPO.create).click();
+    topologyPage.verifyTopologyPage();
+    topologyPage.verifyWorkloadInTopologyPage(workloadName);
+  },
+);
+
+When(
+  'user selects {string} from actions drop down menu of knative service {string}',
+  (option: string, workloadName: string) => {
+    topologyPage.waitForLoad();
+    topologyPage.knativeNode(workloadName).click({ force: true });
+    cy.get(eventingPO.broker.actionMenu).click();
+    cy.byTestActionID(option).click();
+  },
+);
+
+When('user removes already added custom domain mapping {string} and {string}', (d1, d2) => {
+  cy.get(domainPO.chipText)
+    .contains(d1)
+    .parent()
+    .find(domainPO.removeLabel)
+    .click();
+  cy.get(domainPO.chipText)
+    .contains(d2)
+    .parent()
+    .find(domainPO.removeLabel)
+    .click();
+  cy.get(domainPO.removeLabel).should('not.exist');
+});
+
+Then(
+  'user will not see {string} under Domain Mappings of Resources tab on sidebar',
+  (domain: string) => {
+    topologySidePane.verifySelectedTab('Resources');
+    cy.get(`[href="https://${domain}"]`).should('not.exist');
+  },
+);
+
+Given('user can see knative service {string} exist in topology page', (workloadName: string) => {
+  navigateTo(devNavigationMenu.Topology);
+  topologyPage.verifyWorkloadInTopologyPage(workloadName);
+});
+
+When('user removes already added custom domain mapping {string}', (d1) => {
+  cy.get(domainPO.chipText)
+    .contains(d1)
+    .parent()
+    .find(domainPO.removeLabel)
+    .click();
+  cy.get(domainPO.removeLabel).should('not.exist');
+});


### PR DESCRIPTION
**Description:**

<!-- PR description-->
- Automation of Domain-mapping feature | Knative Serverless

**Jira Id:**
- Story: 
      - [ODC-7206](https://issues.redhat.com/browse/ODC-7206)
    
<!-- For e.g User story Jira Id : https://issues.redhat.com/browse/ODC-XXX -->
<!-- For Epic related gherkin scripts, e.g Epic Jira Id : https://issues.redhat.com/browse/ODC-XXX -->

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.12-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p knative
```

**Screen shots**:
<!--   -->
<img width="468" alt="image" src="https://user-images.githubusercontent.com/65410551/206398355-d1fb1471-5786-49a2-99cb-9e1072d258bb.png">




**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge