### PR TITLE
OCPBUGS-4540: Fix NavSection bug

### DIFF
--- a/frontend/packages/console-app/src/components/nav/NavSection.tsx
+++ b/frontend/packages/console-app/src/components/nav/NavSection.tsx
@@ -30,7 +30,7 @@ export const NavSection: React.FC<NavSectionProps> = ({ id, name, dataAttributes
     (e: LoadedExtension<ResourceNavItem>): K8sModel => {
       const { model } = e.properties;
       const gvk = referenceForExtensionModel(model);
-      return k8sModels?.[gvk] ?? k8sModels[e.properties.model.kind ?? ''];
+      return k8sModels?.[gvk] ?? k8sModels[e?.properties?.model?.kind ?? ''];
     },
     [k8sModels],
   );


### PR DESCRIPTION
This PR fixes a bug that causes the UI to crash and only display a white screen if values missing expected properties are passed.