### PR TITLE
OCPBUGS-3951: Do not disable dynamic plugin if extension coderef fail…

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-loader.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-loader.ts
@@ -99,7 +99,6 @@ export const getPluginEntryCallback = (
     pluginID,
     () => {
       console.error(`Code reference resolution failed for plugin ${pluginID}`);
-      pluginStore.setDynamicPluginEnabled(pluginID, false);
     },
   );
 


### PR DESCRIPTION
…s to resolve

Register the plugin as failed and rely on ErrorBoundaries and browser logs to troubleshoot failing extensions rather than disabling the plugin altogether.