### PR TITLE
CONSOLE-3282: update display of Dynamic plugins in About modal

### DIFF
--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -6,13 +6,6 @@ import {
   TextList,
   TextListItem,
 } from '@patternfly/react-core';
-import {
-  Table,
-  TableBody,
-  TableGridBreakpoint,
-  TableHeader,
-  TableVariant,
-} from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
 import { Trans, useTranslation } from 'react-i18next';
 import { useClusterVersion, BlueArrowCircleUpIcon, useCanClusterUpgrade } from '@console/shared';
@@ -38,39 +31,27 @@ import {
 const DynamicPlugins: React.FC = () => {
   const { t } = useTranslation();
   const [pluginInfoEntries] = useDynamicPluginInfo();
-  const [rows, setRows] = React.useState([]);
+  const [items, setItems] = React.useState([]);
 
   React.useEffect(() => {
     const loadedPlugins = pluginInfoEntries.filter(isLoadedDynamicPluginInfo);
-    setRows(
-      loadedPlugins?.map((plugin) => {
-        return {
-          cells: [plugin.metadata.name, plugin.metadata.version],
-        };
+    const sortedLoadedPlugins = loadedPlugins.sort((a, b) =>
+      a.metadata.name.localeCompare(b.metadata.name),
+    );
+
+    setItems(
+      sortedLoadedPlugins?.map((plugin) => {
+        return (
+          <TextListItem
+            key={plugin.pluginID}
+          >{`${plugin.metadata.name} (${plugin.metadata.version})`}</TextListItem>
+        );
       }),
     );
   }, [pluginInfoEntries]);
 
-  const headers = [
-    {
-      title: t('public~Name'),
-    },
-    {
-      title: t('public~Version'),
-    },
-  ];
-
-  return rows.length > 0 ? (
-    <Table
-      aria-label={t('public~Dynamic Plugins table')}
-      cells={headers}
-      gridBreakPoint={TableGridBreakpoint.none}
-      rows={rows}
-      variant={TableVariant.compact}
-    >
-      <TableHeader />
-      <TableBody />
-    </Table>
+  return items.length > 0 ? (
+    <TextList className="co-text-list-plain">{items}</TextList>
   ) : (
     t('public~None')
   );

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1,7 +1,4 @@
 {
-  "Name": "Name",
-  "Version": "Version",
-  "Dynamic Plugins table": "Dynamic Plugins table",
   "None": "None",
   "unknown": "unknown",
   "Cluster update available. <2>Update cluster</2>": "Cluster update available. <2>Update cluster</2>",
@@ -14,8 +11,10 @@
   "OpenShift is Red Hat's container application platform that allows developers to quickly develop, host, and scale applications in a cloud environment.": "OpenShift is Red Hat's container application platform that allows developers to quickly develop, host, and scale applications in a cloud environment.",
   "Alertmanager details": "Alertmanager details",
   "Alertmanager node selector": "Alertmanager node selector",
+  "Name": "Name",
   "Namespace": "Namespace",
   "Labels": "Labels",
+  "Version": "Version",
   "Node selector": "Node selector",
   "Alertmanagers": "Alertmanagers",
   "API resources": "API resources",

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -339,6 +339,14 @@ dl.co-inline {
   padding: 0 5px;
 }
 
+// PatternFly's TextList lacks a plain variant
+// see https://github.com/patternfly/patternfly-react/issues/8434
+.co-text-list-plain {
+  list-style: none !important;
+  margin-left: 0 !important;
+  padding-left: 0 !important;
+}
+
 .co-toolbar {
   align-items: stretch;
   display: flex;


### PR DESCRIPTION
Per https://issues.redhat.com/browse/PD-1442, this PR changes the display of the items from a table to a plain list, which also addresses the issue with the table remaining white in dark mode.

Light mode:
<img width="1268" alt="Screenshot 2022-12-09 at 9 32 37 AM" src="https://user-images.githubusercontent.com/895728/206725450-d0111d41-76d5-4fd7-865e-f70103676884.png">

Dark mode:
<img width="1274" alt="Screenshot 2022-12-09 at 9 32 52 AM" src="https://user-images.githubusercontent.com/895728/206725491-4d1d7060-7323-417e-8d1e-f67ffe43eddb.png">

Scrolling and resizing demo:

https://user-images.githubusercontent.com/895728/206725532-c89c2242-d3bd-4af0-b24c-a06636d7218c.mov

Note the mocks in https://issues.redhat.com/browse/PD-1442 incorrectly label `Dynamic plugins` as `Operators installed`, and I did not add a truncation/expandable region to the list as that can result in the need to both scroll and click to see all.  
