### PR TITLE
OCPBUGS-3761: close the guided tour modal before any action

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/events/events.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/events/events.spec.ts
@@ -1,4 +1,5 @@
 import { testName, checkErrors } from '../../support';
+import { guidedTour } from '../../views/guided-tour';
 import { nav } from '../../views/nav';
 
 const name = `${testName}-event-test-pod`;
@@ -34,6 +35,7 @@ const testpod = {
 describe('Events', () => {
   before(() => {
     cy.login();
+    guidedTour.close();
     cy.visit('/');
     nav.sidenav.switcher.changePerspectiveTo('Administrator');
     nav.sidenav.switcher.shouldHaveText('Administrator');


### PR DESCRIPTION
We should close the guided tour before any actions
<img width="1350" alt="Screen Shot 2022-12-12 at 1 45 11 PM" src="https://user-images.githubusercontent.com/12692381/206969445-f1f67081-3fb0-4e60-9348-e5a2e4914f1f.png">
