### PR TITLE
OCPBUGS-3767: fixed node maintenance plugin route configuration for BareMetalNodesPage

### DIFF
--- a/frontend/packages/metal3-plugin/src/plugin.tsx
+++ b/frontend/packages/metal3-plugin/src/plugin.tsx
@@ -230,7 +230,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       exact: true,
-      path: ['/k8s/cluster/nodes/'],
+      path: [`/k8s/cluster/${referenceForModel(NodeModel)}`],
       loader: () =>
         import(
           './components/baremetal-nodes/BareMetalNodesPage' /* webpackChunkName: "node" */


### PR DESCRIPTION
Route for BareMetalNodesPage stopped working following [CONSOLE-3166, Bug 2116973: Refactor nav components and console app nav extensions](https://github.com/openshift/console/pull/11793):
