### PR TITLE
OCPBUGS-4701:  display 'Control plane is hosted' alert only when isCl…

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -117,6 +117,7 @@ import {
   BlueArrowCircleUpIcon,
   BlueInfoCircleIcon,
   GreenCheckCircleIcon,
+  isClusterExternallyManaged,
   RedExclamationCircleIcon,
   useCanClusterUpgrade,
   YellowExclamationTriangleIcon,
@@ -1040,12 +1041,12 @@ export const MachineConfigPoolsArePausedAlert: React.FC<MachineConfigPoolsArePau
 };
 
 export const ClusterSettingsAlerts: React.FC<ClusterSettingsAlertsProps> = ({
-  canUpgrade,
   cv,
   machineConfigPools,
 }) => {
   const { t } = useTranslation();
-  if (!canUpgrade) {
+
+  if (isClusterExternallyManaged()) {
     return (
       <Alert
         variant="info"
@@ -1099,12 +1100,7 @@ export const ClusterVersionDetailsTable: React.FC<ClusterVersionDetailsTableProp
     <>
       <div className="co-m-pane__body">
         <div className="co-m-pane__body-group">
-          <ClusterSettingsAlerts
-            canUpgrade={canUpgrade}
-            cv={cv}
-            machineConfigPools={machineConfigPools}
-            status={status}
-          />
+          <ClusterSettingsAlerts cv={cv} machineConfigPools={machineConfigPools} />
           <div className="co-cluster-settings">
             <div className="co-cluster-settings__row">
               <div className="co-cluster-settings__section co-cluster-settings__section--current">
@@ -1503,10 +1499,8 @@ type MachineConfigPoolsArePausedAlertProps = {
 };
 
 type ClusterSettingsAlertsProps = {
-  canUpgrade: boolean;
   cv: ClusterVersionKind;
   machineConfigPools: MachineConfigPoolKind[];
-  status: ClusterUpdateStatus;
 };
 
 type ClusterVersionDetailsTableProps = {


### PR DESCRIPTION
…usterExternallyManaged

The alert was displaying any time the cluster could not be upgraded, of which `isClusterExternallyManaged` is one of the conditions.