### PR TITLE
OCPBUGS-4700: only show upgrade details if cluster not externally man…

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -117,6 +117,7 @@ import {
   BlueArrowCircleUpIcon,
   BlueInfoCircleIcon,
   GreenCheckCircleIcon,
+  isClusterExternallyManaged,
   RedExclamationCircleIcon,
   useCanClusterUpgrade,
   YellowExclamationTriangleIcon,
@@ -762,6 +763,10 @@ export const UpdatesGraph: React.FC<UpdatesGraphProps> = ({ cv }) => {
   const similarChannels = getSimilarClusterVersionChannels(cv, currentPrefix);
   const newerChannel = getNewerClusterVersionChannel(similarChannels, currentChannel);
   const clusterUpgradeableFalse = !!getConditionUpgradeableFalse(cv);
+  const newestVersionIsBlocked =
+    clusterUpgradeableFalse &&
+    isMinorVersionNewer(lastVersion, newestVersion) &&
+    !isClusterExternallyManaged();
   const { t } = useTranslation();
 
   return (
@@ -792,18 +797,12 @@ export const UpdatesGraph: React.FC<UpdatesGraphProps> = ({ cv }) => {
           <ChannelLine>
             {newestVersion && (
               <>
-                <ChannelVersion
-                  updateBlocked={
-                    clusterUpgradeableFalse && isMinorVersionNewer(lastVersion, newestVersion)
-                  }
-                >
+                <ChannelVersion updateBlocked={newestVersionIsBlocked}>
                   {newestVersion}
                 </ChannelVersion>
                 <ChannelVersionDot
                   channel={currentChannel}
-                  updateBlocked={
-                    clusterUpgradeableFalse && isMinorVersionNewer(lastVersion, newestVersion)
-                  }
+                  updateBlocked={newestVersionIsBlocked}
                   version={newestVersion}
                 />
               </>

--- a/frontend/public/components/modals/cluster-more-updates-modal.tsx
+++ b/frontend/public/components/modals/cluster-more-updates-modal.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ActionGroup, Button } from '@patternfly/react-core';
 
+import { isClusterExternallyManaged } from '@console/shared';
 import {
   ClusterVersionKind,
   getConditionUpgradeableFalse,
@@ -28,14 +29,17 @@ export const ClusterMoreUpdatesModal: React.FC<ClusterMoreUpdatesModalProps> = (
   const availableUpdates = getSortedAvailableUpdates(cv);
   const moreAvailableUpdates = availableUpdates.slice(1).reverse();
   const releaseNotes = showReleaseNotes();
-  const clusterUpgradeableFalse = !!getConditionUpgradeableFalse(cv);
+  const clusterUpgradeableFalseAndNotExternallyManaged =
+    !!getConditionUpgradeableFalse(cv) && !isClusterExternallyManaged();
   const { t } = useTranslation();
 
   return (
     <div className="modal-content">
       <ModalTitle>{t('public~Other available paths')}</ModalTitle>
       <ModalBody>
-        {clusterUpgradeableFalse && <ClusterNotUpgradeableAlert cv={cv} onCancel={cancel} />}
+        {clusterUpgradeableFalseAndNotExternallyManaged && (
+          <ClusterNotUpgradeableAlert cv={cv} onCancel={cancel} />
+        )}
         <table className="table">
           <thead>
             <tr>
@@ -49,7 +53,7 @@ export const ClusterMoreUpdatesModal: React.FC<ClusterMoreUpdatesModalProps> = (
                 <tr key={update.version}>
                   <td>
                     {update.version}
-                    {clusterUpgradeableFalse &&
+                    {clusterUpgradeableFalseAndNotExternallyManaged &&
                       isMinorVersionNewer(getLastCompletedUpdate(cv), update.version) && (
                         <UpdateBlockedLabel />
                       )}


### PR DESCRIPTION
…aged

It seems the simplest fix for this bug is to hide any update blocked information (see below) if the cluster is externally managed.

In other words, do not display the following in the cluster is externally managed:

`Update blocked` badge in graph popover and more version modal (not pictured)
<img width="379" alt="Screenshot 2022-12-14 at 10 58 32 AM" src="https://user-images.githubusercontent.com/895728/207645518-0dd48cd8-a741-4b14-841c-f69c24266a5c.png">

`See the alert above the visualization for instructions on how to unblock this version.` popover text
<img width="354" alt="Screenshot 2022-12-14 at 11 00 01 AM" src="https://user-images.githubusercontent.com/895728/207645795-1295aff6-95d6-4343-9058-382af2df1dc3.png">
 
warning icon beside blocked version in graph
<img width="289" alt="Screenshot 2022-12-14 at 11 14 43 AM" src="https://user-images.githubusercontent.com/895728/207649477-ed3a124f-5bd2-49be-84fa-4d5bf42cd3d4.png">

update blocked graph indicator (yellow circle)
<img width="320" alt="Screenshot 2022-12-14 at 11 02 58 AM" src="https://user-images.githubusercontent.com/895728/207646170-055337cf-a94d-4ee1-bb98-56b520ef211f.png">

cluster not upgradeable alert in more versions modal
![image](https://user-images.githubusercontent.com/895728/207645857-e04cf9f7-e884-4b5d-a6ea-88aa6773337b.png)
