### PR TITLE
OCPBUGS-1606: Do not filter spoke cluster operators by arch/os

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -22,6 +22,8 @@ import {
   GreenCheckCircleIcon,
   Modal,
   useUserSettingsCompatibility,
+  useActiveCluster,
+  HUB_CLUSTER_NAME,
 } from '@console/shared';
 import { getURLWithParams } from '@console/shared/src/components/catalog/utils';
 import { isModifiedEvent } from '@console/shared/src/utils';
@@ -394,13 +396,14 @@ const OperatorHubTile: React.FC<OperatorHubTileProps> = ({ item, onClick }) => {
 
 export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) => {
   const { t } = useTranslation();
+  const [activeCluster] = useActiveCluster();
   const [detailsItem, setDetailsItem] = React.useState(null);
   const [showDetails, setShowDetails] = React.useState(false);
   const [ignoreOperatorWarning, setIgnoreOperatorWarning, loaded] = useUserSettingsCompatibility<
     boolean
   >(userSettingsKey, storeKey, false);
-
-  const filteredItems = filterByArchAndOS(props.items);
+  const filteredItems =
+    activeCluster === HUB_CLUSTER_NAME ? filterByArchAndOS(props.items) : props.items;
 
   React.useEffect(() => {
     const detailsItemID = new URLSearchParams(window.location.search).get('details-item');


### PR DESCRIPTION
When on a multicluster console viewing a spoke cluster, do not filter OperatorHub items by arch/os since we cannot assume all spokes share the same arch/os as the hub.