### PR TITLE
Bug: 2041389 - Fix reading properties of undefined in yaml sidebar

### DIFF
--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -4,8 +4,8 @@ import { Breadcrumb, BreadcrumbItem, Button, TextContent } from '@patternfly/rea
 import { useTranslation } from 'react-i18next';
 import { CamelCaseWrap } from '@console/dynamic-plugin-sdk';
 import {
+  fetchSwagger,
   getDefinitionKey,
-  getSwaggerDefinitions,
   getSwaggerPath,
   K8sKind,
   SwaggerDefinition,
@@ -25,19 +25,30 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
   // entry contains the name, description, and path to the definition in the
   // OpenAPI document.
   const [drilldownHistory, setDrilldownHistory] = React.useState([]);
+  const [allDefinitions, setAllDefinitions] = React.useState<SwaggerDefinitions>(null);
   const { kindObj, schema } = props;
   const { t } = useTranslation();
+
+  React.useEffect(() => {
+    if (kindObj) {
+      fetchSwagger().then((swagger) => {
+        setAllDefinitions(swagger);
+      });
+    } else if (schema) {
+      setAllDefinitions({ 'custom-schema': schema });
+    } else {
+      return null;
+    }
+  }, [kindObj, schema]);
 
   if (!kindObj && !schema) {
     return null;
   }
 
-  const allDefinitions: SwaggerDefinitions = kindObj
-    ? getSwaggerDefinitions()
-    : schema && { 'custom-schema': schema };
   if (!allDefinitions) {
     return null;
   }
+
   const currentSelection = _.last(drilldownHistory);
   // Show the current selected property or the top-level definition for the kind.
   const currentPath = currentSelection


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGSM-39437

Root Cause: `module/k8s/swagger.ts` saves result of `fetchSwagger()` in `swaggerDefinitions`. I believe there was a data race, because this var is updated periodically and is not always up-to-date when user opens yaml sidebar resulting in reading undefined. The definitions in `swaggerDefinitions` had two different forms which when changed in the process of browsing in the sidebar, caused the error. One has `$ref` field with references to other kinds/resources/ while the other has these `$ref`s resolved.

Solution Description:
When opening a yaml sidebar, the data now gets directly loaded into a state variable using function `fetchSwagger()` bypassing the `swaggerDefinitions` in `swagger.ts`.

Further action required:
Since the data now gets loaded into a state variable `allDefinitions` when opening the sidebar for the first time, this is causing a significant delay till the data is shown to the user. Some loading feedback is needed(possibly not even showing the `View sidebar` button until the data is ready).

Further information:
The bug was present since 4.10
