### PR TITLE
OCPBUGS-2824: The dropdown list component will be covered by deployment details page on Topology page

### DIFF
--- a/frontend/packages/topology/src/components/side-bar/TopologySideBar.tsx
+++ b/frontend/packages/topology/src/components/side-bar/TopologySideBar.tsx
@@ -4,6 +4,7 @@ import { TopologySideBar as PFTopologySideBar } from '@patternfly/react-topology
 import { useUserSettings } from '@console/shared';
 import CloseButton from '@console/shared/src/components/close-button';
 import { TOPOLOGY_SIDE_BAR_WIDTH_STORAGE_KEY } from '../../const';
+import './TopologySideBarTabSection.scss';
 
 type TopologySideBarProps = {
   onClose: () => void;
@@ -28,6 +29,7 @@ const TopologySideBar: React.FC<TopologySideBarProps> = ({ children, onClose }) 
       minSize="400px"
       defaultSize={`${sideBarSizeLoaded ? sideBarSize : DEFAULT_SIDE_BAR_SIZE}px`}
       onResize={handleResizeCallback}
+      className="ocs-sidebar-index"
     >
       <PFTopologySideBar resizable className="pf-topology-side-bar-resizable">
         <div className="pf-topology-side-bar__body">

--- a/frontend/packages/topology/src/components/side-bar/TopologySideBarTabSection.scss
+++ b/frontend/packages/topology/src/components/side-bar/TopologySideBarTabSection.scss
@@ -1,3 +1,7 @@
 .ocs-sidebar-tabsection {
   padding: 0 20px;
 }
+
+.ocs-sidebar-index {
+  z-index: 0;
+}


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/OCPBUGS-2824

Analysis / Root cause:
z-index was not set for topology side bar

Solution Description:
Added z-index to topology side bar

Screen shots / Gifs for design review:

-------------- Before -------

https://issues.redhat.com/secure/attachment/12776679/image_720.png

-------After-----------------

<img width="769" alt="Screenshot 2022-12-15 at 3 20 04 PM" src="https://user-images.githubusercontent.com/102503482/207828965-a6940761-d945-4bd6-a3f1-84d77638a2f7.png">



**Unit test coverage report:**
NA

**Test setup:**
1. Login OCP, go to developer perspective -> Topology page
2. Click and open one resource (eg: deployment), make sure the resource sidebar has been opened
3. Adjust the browser windows to small size
4. Check if the dropdown list component has been covered 

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
