### PR TITLE
OU-122: Monitoring: Convert modals to use PatternFly directly

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
@@ -3,7 +3,6 @@ import { projectDropdown } from '../../views/common';
 import { detailsPage } from '../../views/details-page';
 import { submitButton, errorMessage } from '../../views/form';
 import { listPage } from '../../views/list-page';
-import { modal } from '../../views/modal';
 import { nav } from '../../views/nav';
 
 const shouldBeWatchdogAlertDetailsPage = () => {
@@ -154,12 +153,10 @@ describe('Monitoring: Alerts', () => {
     cy.byTestID('silence-actions')
       .contains('Expire silence')
       .click();
-    modal.shouldBeOpened();
     cy.testA11y('Expire silence modal');
-    modal.submit();
-    modal.shouldBeClosed();
+    cy.get('button.pf-m-primary').click();
     cy.get(errorMessage).should('not.exist');
-    // Wait for expiredSilenceIcon to exist
+    // Wait for expired silence icon to exist
     cy.byLegacyTestID('ban-icon').should('exist');
   });
 });

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -25,6 +25,17 @@
   margin-top: -15px;
 }
 
+.pf-c-modal-box {
+  .custom-time-range-modal {
+    overflow: visible;
+    padding: var(--pf-c-modal-box__body--PaddingTop) var(--pf-c-modal-box__body--PaddingLeft);
+  }
+
+  .custom-time-range-modal-footer {
+    padding-top: var(--pf-c-modal-box__body--PaddingTop);
+  }
+}
+
 .graph-empty-state {
   min-height: 310px;
   &__loaded {

--- a/frontend/public/components/monitoring/dashboards/timespan-dropdown.tsx
+++ b/frontend/public/components/monitoring/dashboards/timespan-dropdown.tsx
@@ -14,7 +14,7 @@ import { dashboardsSetEndTime, dashboardsSetTimespan } from '../../../actions/ob
 import { RootState } from '../../../redux';
 import { getQueryArgument, removeQueryArgument, setQueryArgument } from '../../utils';
 import { useBoolean } from '../hooks/useBoolean';
-import customTimeRangeModal from './custom-time-range-modal';
+import CustomTimeRangeModal from './custom-time-range-modal';
 import { TimeDropdownsProps } from './types';
 import { getActivePerspective } from './monitoring-dashboard-utils';
 
@@ -23,7 +23,9 @@ const CUSTOM_TIME_RANGE_KEY = 'CUSTOM_TIME_RANGE_KEY';
 const TimespanDropdown: React.FC<TimeDropdownsProps> = ({ namespace }) => {
   const { t } = useTranslation();
   const activePerspective = getActivePerspective(namespace);
+
   const [isOpen, toggleIsOpen, , setClosed] = useBoolean(false);
+  const [isModalOpen, , setModalOpen, setModalClosed] = useBoolean(false);
 
   const timespan = useSelector(({ observe }: RootState) =>
     observe.getIn(['dashboards', activePerspective, 'timespan']),
@@ -39,7 +41,7 @@ const TimespanDropdown: React.FC<TimeDropdownsProps> = ({ namespace }) => {
   const onChange = React.useCallback(
     (v: string) => {
       if (v === CUSTOM_TIME_RANGE_KEY) {
-        customTimeRangeModal({ activePerspective });
+        setModalOpen();
       } else {
         setQueryArgument('timeRange', parsePrometheusDuration(v).toString());
         removeQueryArgument('endTime');
@@ -66,39 +68,46 @@ const TimespanDropdown: React.FC<TimeDropdownsProps> = ({ namespace }) => {
   };
 
   return (
-    <div className="form-group monitoring-dashboards__dropdown-wrap">
-      <label
-        className="monitoring-dashboards__dropdown-title"
-        htmlFor="monitoring-time-range-dropdown"
-      >
-        {t('public~Time range')}
-      </label>
-      <Dropdown
-        className="monitoring-dashboards__variable-dropdown"
-        dropdownItems={_.map(items, (name, key) => (
-          <DropdownItem component="button" key={key} onClick={() => onChange(key)}>
-            {name}
-          </DropdownItem>
-        ))}
-        isOpen={isOpen}
-        onSelect={setClosed}
-        toggle={
-          <DropdownToggle
-            className="monitoring-dashboards__dropdown-button"
-            id="monitoring-time-range-dropdown"
-            onToggle={toggleIsOpen}
-          >
-            {
-              items[
-                endTime || endTimeFromParams
-                  ? CUSTOM_TIME_RANGE_KEY
-                  : formatPrometheusDuration(_.toNumber(timeSpanFromParams) || timespan)
-              ]
-            }
-          </DropdownToggle>
-        }
+    <>
+      <CustomTimeRangeModal
+        activePerspective={activePerspective}
+        isOpen={isModalOpen}
+        setClosed={setModalClosed}
       />
-    </div>
+      <div className="form-group monitoring-dashboards__dropdown-wrap">
+        <label
+          className="monitoring-dashboards__dropdown-title"
+          htmlFor="monitoring-time-range-dropdown"
+        >
+          {t('public~Time range')}
+        </label>
+        <Dropdown
+          className="monitoring-dashboards__variable-dropdown"
+          dropdownItems={_.map(items, (name, key) => (
+            <DropdownItem component="button" key={key} onClick={() => onChange(key)}>
+              {name}
+            </DropdownItem>
+          ))}
+          isOpen={isOpen}
+          onSelect={setClosed}
+          toggle={
+            <DropdownToggle
+              className="monitoring-dashboards__dropdown-button"
+              id="monitoring-time-range-dropdown"
+              onToggle={toggleIsOpen}
+            >
+              {
+                items[
+                  endTime || endTimeFromParams
+                    ? CUSTOM_TIME_RANGE_KEY
+                    : formatPrometheusDuration(_.toNumber(timeSpanFromParams) || timespan)
+                ]
+              }
+            </DropdownToggle>
+          }
+        />
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
Use PatternFly components directly for the monitoring UI modals to reduce our dependencies on the console codebase in preparation for switching over to the dynamic plugin SDK.

The refactored modals are the "Expire silence" modal on the silences list page and the "Custom time range" modal on the Dashboards page.