### PR TITLE
CONSOLE-3334: Update copiedCSVsDisabled to contain managed clusters

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -268,6 +268,10 @@ func main() {
 		hubConsoleURL = bridge.ValidateFlagIsURL("hub-console-url", *fHubConsoleURL)
 	}
 
+	clusterCopiedCSVsDisabled := map[string]bool{
+		serverutils.LocalClusterName: *fCopiedCSVsDisabled,
+	}
+
 	srv := &server.Server{
 		PublicDir:                    *fPublicDir,
 		BaseURL:                      baseURL,
@@ -299,7 +303,6 @@ func main() {
 		Telemetry:                    telemetryFlags,
 		ReleaseVersion:               *fReleaseVersion,
 		NodeArchitectures:            nodeArchitectures,
-		CopiedCSVsDisabled:           *fCopiedCSVsDisabled,
 		HubConsoleURL:                hubConsoleURL,
 	}
 
@@ -688,6 +691,8 @@ func main() {
 				if srv.Authers[managedCluster.Name], err = auth.NewAuthenticator(context.Background(), managedClusterOIDCClientConfig); err != nil {
 					klog.Fatalf("Error initializing managed cluster authenticator: %v", err)
 				}
+
+				clusterCopiedCSVsDisabled[managedCluster.Name] = managedCluster.CopiedCSVsDisabled
 			}
 		}
 	case "disabled":
@@ -715,6 +720,8 @@ func main() {
 	default:
 		bridge.FlagFatalf("k8s-mode", "must be one of: service-account, bearer-token, oidc, openshift")
 	}
+
+	srv.CopiedCSVsDisabled = clusterCopiedCSVsDisabled
 
 	srv.MonitoringDashboardConfigMapLister = server.NewResourceLister(
 		srv.ServiceAccountToken,

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -14,7 +14,7 @@ declare module '*.png' {
 
 declare interface Window {
   SERVER_FLAGS: {
-    copiedCSVsDisabled: boolean;
+    copiedCSVsDisabled: Record<string, boolean>;
     alertManagerBaseURL: string;
     alertmanagerUserWorkloadBaseURL: string;
     authDisabled: boolean;

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
@@ -70,9 +70,14 @@ jest.mock('@console/shared/src/hooks/redux-selectors', () => {
   };
 });
 
+jest.mock('@console/shared/src/hooks/useActiveCluster', () => ({
+  useActiveCluster: () => ['local-cluster', () => {}],
+}));
+
 describe(ClusterServiceVersionTableRow.displayName, () => {
   let wrapper: ShallowWrapper<ClusterServiceVersionTableRowProps>;
   beforeEach(() => {
+    window.SERVER_FLAGS.copiedCSVsDisabled = { 'local-cluster': false };
     wrapper = shallow(
       <ClusterServiceVersionTableRow
         catalogSourceMissing={false}
@@ -553,6 +558,7 @@ describe(ClusterServiceVersionDetailsPage.displayName, () => {
     spyUseAccessReview = jest.spyOn(utils, 'useAccessReview');
     spyUseAccessReview.mockReturnValue([true, false]);
 
+    window.SERVER_FLAGS.copiedCSVsDisabled = { 'local-cluster': false };
     wrapper = mount(
       <ClusterServiceVersionDetailsPage
         match={{ params: { ns, name }, isExact: true, url: '', path: '' }}

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -74,6 +74,7 @@ import { consolePluginModal } from '@console/shared/src/components/modals';
 import { RedExclamationCircleIcon } from '@console/shared/src/components/status/icons';
 import { CONSOLE_OPERATOR_CONFIG_NAME } from '@console/shared/src/constants';
 import { useActiveNamespace } from '@console/shared/src/hooks/redux-selectors';
+import { useActiveCluster } from '@console/shared/src/hooks/useActiveCluster';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { isPluginEnabled } from '@console/shared/src/utils';
 import { GLOBAL_OPERATOR_NAMESPACES, GLOBAL_COPIED_CSV_NAMESPACE } from '../const';
@@ -579,6 +580,7 @@ export const ClusterServiceVersionList: React.FC<ClusterServiceVersionListProps>
 }) => {
   const { t } = useTranslation();
   const activeNamespace = useActiveNamespace();
+  const [cluster] = useActiveCluster();
   const nameHeader: Header = {
     title: t('olm~Name'),
     sortField: 'metadata.name',
@@ -652,7 +654,7 @@ export const ClusterServiceVersionList: React.FC<ClusterServiceVersionListProps>
       }
 
       if (
-        window.SERVER_FLAGS.copiedCSVsDisabled &&
+        window.SERVER_FLAGS.copiedCSVsDisabled[cluster] &&
         operator.metadata.namespace === GLOBAL_COPIED_CSV_NAMESPACE &&
         activeNamespace !== GLOBAL_COPIED_CSV_NAMESPACE
       ) {
@@ -720,6 +722,7 @@ export const ClusterServiceVersionList: React.FC<ClusterServiceVersionListProps>
 
 export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProps> = (props) => {
   const { t } = useTranslation();
+  const [cluster] = useActiveCluster();
   const title = t('olm~Installed Operators');
   const olmURL = getDocumentationURL(documentationURLs.operators);
   const helpText = (
@@ -764,7 +767,7 @@ export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProp
         {...props}
         resources={[
           ...(!GLOBAL_OPERATOR_NAMESPACES.includes(props.namespace) &&
-          window.SERVER_FLAGS.copiedCSVsDisabled
+          window.SERVER_FLAGS.copiedCSVsDisabled[cluster]
             ? [
                 {
                   kind: referenceForModel(ClusterServiceVersionModel),

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -120,6 +120,10 @@ jest.mock('react-redux', () => ({
   useDispatch: () => jest.fn(),
 }));
 
+jest.mock('@console/shared/src/hooks/useActiveCluster', () => ({
+  useActiveCluster: () => ['local-cluster', () => {}],
+}));
+
 const i18nNS = 'public';
 
 describe(OperandTableRow.displayName, () => {
@@ -355,6 +359,7 @@ describe('ResourcesList', () => {
 describe(OperandDetailsPage.displayName, () => {
   const currentURL = `/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp/testapp.coreos.com~v1alpha1~TestResource/my-test-resource`;
   const routePath = `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/:plural/:name`;
+  window.SERVER_FLAGS.copiedCSVsDisabled = { 'local-cluster': false };
 
   it('renders a `DetailsPage` with the correct subpages', () => {
     const wrapper = mountWithRoute(<OperandDetailsPage />, currentURL, routePath);

--- a/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersionPath.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersionPath.tsx
@@ -1,15 +1,17 @@
 import { getReferenceForModel } from '@console/dynamic-plugin-sdk/src/utils/k8s';
 import { resourceObjPath, resourcePath } from '@console/internal/components/utils';
 import { ALL_NAMESPACES_KEY, useActiveNamespace } from '@console/shared';
+import { useActiveCluster } from '@console/shared/src/hooks/useActiveCluster';
 import { ClusterServiceVersionModel } from '../models';
 import { ClusterServiceVersionKind } from '../types';
 
 export const useClusterServiceVersionPath = (csv: ClusterServiceVersionKind): string => {
   const [activeNamespace] = useActiveNamespace();
+  const [cluster] = useActiveCluster();
   const csvReference = getReferenceForModel(ClusterServiceVersionModel);
-  // Don't link to csv in 'openshift' namepsace when copiedCSVsDisabled and in another namespace
+  // Don't link to csv in 'openshift' namespace when copiedCSVsDisabled and in another namespace
   if (
-    window.SERVER_FLAGS.copiedCSVsDisabled &&
+    window.SERVER_FLAGS.copiedCSVsDisabled[cluster] &&
     csv.metadata.namespace === 'openshift' && // Is global csv
     activeNamespace !== ALL_NAMESPACES_KEY
   ) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -116,7 +116,7 @@ type jsGlobals struct {
 	Telemetry                       serverconfig.MultiKeyValue `json:"telemetry"`
 	ReleaseVersion                  string                     `json:"releaseVersion"`
 	NodeArchitectures               []string                   `json:"nodeArchitectures"`
-	CopiedCSVsDisabled              bool                       `json:"copiedCSVsDisabled"`
+	CopiedCSVsDisabled              map[string]bool            `json:"copiedCSVsDisabled"`
 	HubConsoleURL                   string                     `json:"hubConsoleURL"`
 }
 
@@ -181,7 +181,7 @@ type Server struct {
 	ProjectAccessClusterRoles    string
 	Perspectives                 string
 	Telemetry                    serverconfig.MultiKeyValue
-	CopiedCSVsDisabled           bool
+	CopiedCSVsDisabled           map[string]bool
 	HubConsoleURL                *url.URL
 }
 

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -265,7 +265,8 @@ type ManagedClusterOAuthConfig struct {
 
 // ManagedClusterConfig enables proxying to an ACM managed cluster
 type ManagedClusterConfig struct {
-	Name      string                        `json:"name" yaml:"name"`           // ManagedCluster name, provided through ACM
-	APIServer ManagedClusterAPIServerConfig `json:"apiServer" yaml:"apiServer"` // TODO Remove this property once conosle operator has been updated
-	OAuth     ManagedClusterOAuthConfig     `json:"oauth" yaml:"oauth"`
+	Name               string                        `json:"name" yaml:"name"`           // ManagedCluster name, provided through ACM
+	APIServer          ManagedClusterAPIServerConfig `json:"apiServer" yaml:"apiServer"` // TODO Remove this property once conosle operator has been updated
+	OAuth              ManagedClusterOAuthConfig     `json:"oauth" yaml:"oauth"`
+	CopiedCSVsDisabled bool                          `json:"copiedCSVsDisabled" yaml:"copiedCSVsDisabled"`
 }


### PR DESCRIPTION
Includes changes from https://github.com/openshift/console/pull/12372