### PR TITLE
OCPBUGS-3314: Fix to use and set correct secretReference for build-config triggers

### DIFF
--- a/frontend/packages/dev-console/src/components/buildconfig/form-utils/__tests__/convert-to-buildconfig.spec.ts
+++ b/frontend/packages/dev-console/src/components/buildconfig/form-utils/__tests__/convert-to-buildconfig.spec.ts
@@ -647,7 +647,7 @@ describe('convertFormDataToBuildConfig', () => {
       expect(buildConfig.spec.triggers).toEqual([{ type: 'ImageChange' }]);
     });
 
-    it('convert config a custom trigger to BuildConfig trigger', () => {
+    it('convert config custom trigger to BuildConfig trigger', () => {
       const originBuildConfig = {} as BuildConfig;
       const values = getInitialBuildConfigFormikValues();
       values.formData.triggers.otherTriggers = [
@@ -658,8 +658,24 @@ describe('convertFormDataToBuildConfig', () => {
       const buildConfig = convertFormDataToBuildConfig(originBuildConfig, values);
 
       expect(buildConfig.spec.triggers).toEqual([
+        { type: 'Generic', generic: { secretReference: { name: '19a3' } } },
+        { type: 'GitHub', github: { secretReference: { name: '2cd4' } } },
+      ]);
+    });
+
+    it('convert config custom trigger to BuildConfig trigger with secret/secretReference as per original yaml', () => {
+      const originBuildConfig = {} as BuildConfig;
+      const values = getInitialBuildConfigFormikValues();
+      values.formData.triggers.otherTriggers = [
+        { type: 'Generic', secret: '19a3', data: { secret: '19a3' } },
+        { type: 'GitHub', secret: '2cd4', data: { secretReference: { name: '2cd4' } } },
+      ];
+
+      const buildConfig = convertFormDataToBuildConfig(originBuildConfig, values);
+
+      expect(buildConfig.spec.triggers).toEqual([
         { type: 'Generic', generic: { secret: '19a3' } },
-        { type: 'GitHub', github: { secret: '2cd4' } },
+        { type: 'GitHub', github: { secretReference: { name: '2cd4' } } },
       ]);
     });
 
@@ -678,8 +694,8 @@ describe('convertFormDataToBuildConfig', () => {
       expect(buildConfig.spec.triggers).toEqual([
         { type: 'ConfigChange' },
         { type: 'ImageChange' },
-        { type: 'Generic', generic: { secret: '19a3' } },
-        { type: 'GitHub', github: { secret: '2cd4' } },
+        { type: 'Generic', generic: { secretReference: { name: '19a3' } } },
+        { type: 'GitHub', github: { secretReference: { name: '2cd4' } } },
       ]);
     });
   });

--- a/frontend/packages/dev-console/src/components/buildconfig/form-utils/__tests__/convert-to-form.spec.ts
+++ b/frontend/packages/dev-console/src/components/buildconfig/form-utils/__tests__/convert-to-form.spec.ts
@@ -363,8 +363,8 @@ describe('convertBuildConfigToFormData', () => {
         spec: {
           triggers: [
             { type: 'ConfigChange' },
-            { type: 'Generic', generic: { secret: '19a3' } },
-            { type: 'GitHub', github: { secret: '2cd4' } },
+            { type: 'Generic', generic: { secretReference: { name: '19a3' } } },
+            { type: 'GitHub', github: { secretReference: { name: '2cd4' } } },
           ],
         },
       };
@@ -373,8 +373,8 @@ describe('convertBuildConfigToFormData', () => {
       expectedValues.formData.triggers.configChange = true;
       expectedValues.formData.triggers.imageChange = false;
       expectedValues.formData.triggers.otherTriggers = [
-        { type: 'Generic', secret: '19a3' },
-        { type: 'GitHub', secret: '2cd4' },
+        { type: 'Generic', secret: '19a3', data: { secretReference: { name: '19a3' } } },
+        { type: 'GitHub', secret: '2cd4', data: { secretReference: { name: '2cd4' } } },
       ];
       expect(convertBuildConfigToFormData(buildConfig)).toEqual(expectedValues);
     });
@@ -387,8 +387,8 @@ describe('convertBuildConfigToFormData', () => {
         spec: {
           triggers: [
             { type: 'ImageChange', imageChange: { lastTriggeredImageID: '1234' } },
-            { type: 'Generic', generic: { secret: '19a3' } },
-            { type: 'GitHub', github: { secret: '2cd4' } },
+            { type: 'Generic', generic: { secretReference: { name: '19a3' } } },
+            { type: 'GitHub', github: { secretReference: { name: '2cd4' } } },
           ],
         },
       };
@@ -397,8 +397,8 @@ describe('convertBuildConfigToFormData', () => {
       expectedValues.formData.triggers.configChange = false;
       expectedValues.formData.triggers.imageChange = true;
       expectedValues.formData.triggers.otherTriggers = [
-        { type: 'Generic', secret: '19a3' },
-        { type: 'GitHub', secret: '2cd4' },
+        { type: 'Generic', secret: '19a3', data: { secretReference: { name: '19a3' } } },
+        { type: 'GitHub', secret: '2cd4', data: { secretReference: { name: '2cd4' } } },
       ];
       expect(convertBuildConfigToFormData(buildConfig)).toEqual(expectedValues);
     });

--- a/frontend/packages/dev-console/src/components/buildconfig/form-utils/convert-to-buildconfig.ts
+++ b/frontend/packages/dev-console/src/components/buildconfig/form-utils/convert-to-buildconfig.ts
@@ -223,12 +223,19 @@ const convertFormDataTriggersToBuildConfig = (
   if (values.formData.triggers?.otherTriggers) {
     triggers.push(
       ...values.formData.triggers.otherTriggers
-        .filter((trigger) => trigger.type)
+        .filter((trigger) => trigger.type && trigger.secret)
         .map(
           (trigger) =>
             ({
               type: trigger.type,
-              [trigger.type.toLowerCase()]: { secret: trigger.secret },
+              [trigger.type.toLowerCase()]: {
+                ...(trigger.data
+                  ? trigger.data.secretReference
+                    ? { secretReference: { name: trigger.secret } }
+                    : { secret: trigger.secret }
+                  : { secretReference: { name: trigger.secret } }),
+                ...(trigger.allowEnv ? { allowEnv: trigger.allowEnv } : {}),
+              },
             } as BuildConfigTrigger),
         ),
     );

--- a/frontend/packages/dev-console/src/components/buildconfig/form-utils/convert-to-form.ts
+++ b/frontend/packages/dev-console/src/components/buildconfig/form-utils/convert-to-form.ts
@@ -136,10 +136,21 @@ const convertBuildConfigTriggersToFormData = (
     (trigger) => trigger.type === 'ImageChange',
   );
   values.formData.triggers.otherTriggers = triggers
-    .filter((trigger) => trigger.type && trigger[trigger.type.toLowerCase()]?.secret)
+    .filter(
+      (trigger) =>
+        trigger.type &&
+        (trigger[trigger.type.toLowerCase()]?.secretReference ||
+          trigger[trigger.type.toLowerCase()]?.secret),
+    )
     .map((trigger) => ({
       type: trigger.type,
-      secret: trigger[trigger.type.toLowerCase()].secret,
+      secret:
+        trigger[trigger.type.toLowerCase()].secretReference?.name ||
+        trigger[trigger.type.toLowerCase()].secret,
+      ...(trigger[trigger.type.toLowerCase()].allowEnv
+        ? { allowEnv: trigger[trigger.type.toLowerCase()].allowEnv }
+        : {}),
+      data: trigger[trigger.type.toLowerCase()],
     }));
 };
 

--- a/frontend/packages/dev-console/src/components/buildconfig/sections/TriggersSection.tsx
+++ b/frontend/packages/dev-console/src/components/buildconfig/sections/TriggersSection.tsx
@@ -22,6 +22,8 @@ export type TriggersSectionFormData = {
       otherTriggers: {
         type: string;
         secret: string;
+        allowEnv?: boolean;
+        data?: { [key: string]: any };
       }[];
     };
   };

--- a/frontend/packages/dev-console/src/components/buildconfig/types.ts
+++ b/frontend/packages/dev-console/src/components/buildconfig/types.ts
@@ -124,28 +124,36 @@ export type BuildConfigImageChangeTrigger = {
 export type BuildConfigGenericTrigger = {
   type: 'Generic';
   generic: {
-    secret: string;
+    allowEnv?: boolean;
+    secret?: string;
+    secretReference?: { name: string };
   };
 };
 
 export type BuildConfigGitHubTrigger = {
   type: 'GitHub';
   github: {
-    secret: string;
+    allowEnv?: boolean;
+    secret?: string;
+    secretReference?: { name: string };
   };
 };
 
 export type BuildConfigGitLabTrigger = {
   type: 'GitLab';
   gitlab: {
-    secret: string;
+    allowEnv?: boolean;
+    secret?: string;
+    secretReference?: { name: string };
   };
 };
 
 export type BuildConfigBitbucketTrigger = {
   type: 'Bitbucket';
   bitbucket: {
-    secret: string;
+    allowEnv?: boolean;
+    secret?: string;
+    secretReference?: { name: string };
   };
 };
 


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-3314

Root Cause:
In BuildConfig form only `secret` was being used and set for build-config triggers. So if the user tried to manually set the `secretReference` and tried to edit it using the form, the form was removing it from the yaml.

Solution:
Now using and setting `secretReference`/`secret` as per yaml and by default setting `secretReference` from create build-config form. Also fixed issue wherein `allowEnv` was also getting removed when editing build-config via edit form.


https://user-images.githubusercontent.com/20724543/208079339-36b04bc5-e7bf-4a67-82a1-2ccd2f97268c.mov

Unit test coverage:
<img width="1009" alt="Screenshot 2022-12-19 at 6 55 00 PM" src="https://user-images.githubusercontent.com/20724543/208435997-cf58867b-f467-4673-888f-97ecef99ac24.png">



/kind bug