### PR TITLE
[release-4.12] OCPBUGS-4960: Fix that topology sidebar actions shows outdated data (Edit Pod Count, Edit labels, Edit annotations, etc.)

### DIFF
--- a/frontend/packages/helm-plugin/src/actions/providers.ts
+++ b/frontend/packages/helm-plugin/src/actions/providers.ts
@@ -36,11 +36,11 @@ export const useHelmActionProvider = (scope: HelmActionsScope) => {
 };
 
 export const useHelmActionProviderForTopology = (element: GraphElement) => {
+  const resource = getResource(element);
   const scope = React.useMemo(() => {
     const nodeType = element.getType();
     if (nodeType !== TYPE_HELM_RELEASE) return undefined;
     const releaseName = element.getLabel();
-    const resource = getResource(element);
     if (!resource?.metadata) return null;
     const {
       namespace,
@@ -54,7 +54,7 @@ export const useHelmActionProviderForTopology = (element: GraphElement) => {
       },
       actionOrigin: 'topology',
     };
-  }, [element]);
+  }, [element, resource]);
   const result = useHelmActionProvider(scope);
   return result;
 };

--- a/frontend/packages/topology/src/actions/TopologyActions.tsx
+++ b/frontend/packages/topology/src/actions/TopologyActions.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { GraphElement } from '@patternfly/react-topology';
+import { observer, GraphElement } from '@patternfly/react-topology';
 import { referenceFor } from '@console/internal/module/k8s';
 import { ActionMenu, ActionMenuVariant, ActionServiceProvider } from '@console/shared';
 import { getResource } from '../utils';
@@ -9,8 +9,8 @@ type TopologyActionsProps = {
 };
 
 const TopologyActions: React.FC<TopologyActionsProps> = ({ element }) => {
+  const resource = getResource(element);
   const context = React.useMemo(() => {
-    const resource = getResource(element);
     const { csvName } = element.getData()?.data ?? {};
     return {
       'topology-actions': element,
@@ -18,7 +18,7 @@ const TopologyActions: React.FC<TopologyActionsProps> = ({ element }) => {
       ...(resource ? { [referenceFor(resource)]: resource } : {}),
       ...(csvName ? { 'csv-actions': { csvName, resource } } : {}),
     };
-  }, [element]);
+  }, [element, resource]);
   return (
     <ActionServiceProvider key={element.getId()} context={context}>
       {({ actions, options, loaded }) => {
@@ -32,4 +32,4 @@ const TopologyActions: React.FC<TopologyActionsProps> = ({ element }) => {
   );
 };
 
-export default TopologyActions;
+export default observer(TopologyActions);

--- a/frontend/packages/topology/src/actions/provider.ts
+++ b/frontend/packages/topology/src/actions/provider.ts
@@ -8,15 +8,15 @@ import { DeleteConnectorAction, MoveConnectorAction } from './edgeActions';
 import { getModifyApplicationAction } from './modify-application';
 
 export const useTopologyWorkloadActionProvider = (element: GraphElement) => {
+  const resource = getResource(element);
   const actions = useMemo(() => {
     if (element.getType() !== TYPE_WORKLOAD) return undefined;
-    const resource = getResource(element);
     if (!resource) {
       return [];
     }
     const k8sKind = modelFor(referenceFor(resource));
     return [getModifyApplicationAction(k8sKind, resource)];
-  }, [element]);
+  }, [element, resource]);
 
   return useMemo(() => {
     if (!actions) return [[], true, undefined];


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-4960

This is a manual backport of #12365 and incl. #12332

**Analysis / Root cause**: 
Action menu wasn't updated when the underlying mobx data changed.

**Solution Description**: 
Add `resource` as a dependency on the `useMemo` and also add a mobx `observe()`  wrapper around the `TopologyActions` component so that it was directly rerendered when the element/resource changes.

**Screen shots / Gifs for design review**: 
Before in 4.9:
https://user-images.githubusercontent.com/139310/207294033-00d853b2-0b84-49c9-a816-409d935bf269.mp4

With this PR:
https://user-images.githubusercontent.com/139310/207295437-2460c8ab-35c3-43a7-93b8-6e8a992d131c.mp4

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Import a deployment
2. Select the deployment to open the topology sidebar
3. Click on actions and one of the 4 options to update the deployment with a modal
    1. Edit labels
    2. Edit annotatations
    3. Edit update strategy
    4. Edit resource limits
4. Click on the action again and check if the data in the modal reflects the changes from step 3

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
/cc @lokanandaprabhu
