### PR TITLE
OCPBUGS-4894: Disabled Serverless add actions should not be displayed for Knative Service

### DIFF
--- a/frontend/packages/knative-plugin/src/actions/providers.ts
+++ b/frontend/packages/knative-plugin/src/actions/providers.ts
@@ -222,7 +222,7 @@ export const useTopologyActionsProvider = ({
     }
     switch (sourceKind) {
       case referenceForModel(ServiceModel):
-        return isEventSourceTypeEnabled
+        return isEventSourceTypeEnabled && isEventSourceAddEnabled && isEventingEnabled
           ? [
               AddEventSourceAction(
                 namespace,


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/OCPBUGS-4894

Analysis / Root cause:
Customization of add actions was not considered for event source

Solution Description:
Added the check 

Screen shots / Gifs for design review:

-------------- Before -------

https://user-images.githubusercontent.com/102503482/208036860-c65757fd-bafc-4110-a807-f2731189c5ce.mov

-------After-----------------

https://user-images.githubusercontent.com/102503482/208036869-d9675ade-dce5-4982-9077-5be734549acb.mov

**Unit test coverage report:**
NA

**Test setup:**
1. Install Serverless operator and create Eventing and Serving resources
2. Import an application (Developer perspective > add > container image) and create a Knative Service
3. Open customization (path /cluster-configuration/) and disable all add actions
4. Wait some seconds and check that the Developer perspective > Add page shows no items
5. Navigate to topology perspective and drag and drop the arrow from a Knative Service to an empty area.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
