### PR TITLE
OCPBUGS-4377: Service name search ability while creating the Route from console

### DIFF
--- a/frontend/public/components/routes/create-route.tsx
+++ b/frontend/public/components/routes/create-route.tsx
@@ -1,5 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import * as fuzzy from 'fuzzysearch';
 import { Alert, Button } from '@patternfly/react-core';
 import { PlusCircleIcon, MinusCircleIcon } from '@patternfly/react-icons';
 import { connect, FormikContextType, FormikValues } from 'formik';
@@ -221,6 +222,9 @@ class CreateRouteWithTranslation extends React.Component<
     });
   };
 
+  autocompleteFilter = (strText: string, item: React.ReactElement): boolean =>
+    fuzzy(strText, item?.props?.name);
+
   render() {
     const { t, services, existingRoute } = this.props;
     const {
@@ -362,6 +366,7 @@ class CreateRouteWithTranslation extends React.Component<
           )}
           {!_.isEmpty(serviceOptions) && (
             <Dropdown
+              autocompleteFilter={this.autocompleteFilter}
               items={availableServiceOptions}
               title={service ? serviceOptions[service.metadata.name] : t('public~Select a service')}
               dropDownClassName="dropdown--full-width"


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-4377

**Analysis / Root cause:**
Filter was not added

**Solution Description:**
Added filter to the dropdown

**Screen shots / Gifs for design review:**

-------------- Before -------

NA

-------After-----------------

https://user-images.githubusercontent.com/102503482/208394323-9833aacb-098f-4b9d-be86-91e198097fc3.mov




****Unit test coverage report:****
NA

**Test setup:**
1. Try to select a service while creating the Route

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
