### PR TITLE
OCPBUGS-4883: Default Git type to other info alert should get remove after changing the git type

### DIFF
--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -536,7 +536,7 @@ const GitSection: React.FC<GitSectionProps> = ({
             fullWidth
             required
           />
-          {values.git.detectedType === GitProvider.UNSURE && (
+          {values.git.type === GitProvider.UNSURE && (
             <Alert isInline variant="info" title={t('devconsole~Defaulting Git type to other')}>
               {t('devconsole~We failed to detect the Git type.')}
             </Alert>


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-4883

**Analysis / Root cause:**
Detected git type was used to check the condition

**Solution Description:**
Used present git type instead of detected type in the condition

**Screen shots / Gifs for design review:**

-------------- Before -------

https://issues.redhat.com/secure/attachment/12795754/aa-207015735-92bf35a6-4906-4a82-b608-76b8e76d9d58.gif

-------After-----------------


https://user-images.githubusercontent.com/102503482/208414822-b390d92f-0aae-418e-a96e-4ff3c48b2008.mov


****Unit test coverage report:****
NA

**Test setup:**
1. In import from the git flow enter the git URL https://stash.danskenet.net/scm/~bc0508/github.com_sclorg_django-ex.git
2. Notice the info alert below the Git type field
3. change the git type

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
