### PR TITLE
Add document and support url

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/providers/useBuilderImages.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useBuilderImages.tsx
@@ -37,6 +37,8 @@ const normalizeBuilderImages = (
     const builderImageTag = _.head(imageStream.spec?.tags);
     const sampleRepo = builderImageTag?.['annotations']?.['sampleRepo'];
     const creationTimestamp = imageStream.metadata?.creationTimestamp;
+    const documentationUrl = annotations[ANNOTATIONS.documentationURL];
+    const supportUrl = annotations[ANNOTATIONS.supportURL];
 
     const detailsProperties = [
       {
@@ -100,6 +102,8 @@ const normalizeBuilderImages = (
       name: displayName,
       provider,
       description,
+      documentationUrl,
+      supportUrl,
       tags,
       creationTimestamp,
       cta: {


### PR DESCRIPTION
This PR makes it possible to display documentation and support links of the builder images in the web console. Currently the builder images display the documentation and support URL fields, but can not show contents. 