### PR TITLE
OCPBUGS-4571: Operator recommended namespace during installation incorrect.

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -636,15 +636,15 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
       <RadioInput
         onChange={() => {
           setUseSuggestedNSForSingleInstallMode(true);
-          setTargetNamespace(suggestedNamespace);
+          setTargetNamespace(operatorSuggestedNamespace);
         }}
-        value={suggestedNamespace}
+        value={operatorSuggestedNamespace}
         checked={useSuggestedNSForSingleInstallMode}
         title={t('olm~Operator recommended Namespace:')}
       >
         {' '}
         <ResourceIcon kind="Project" />
-        <b>{suggestedNamespace}</b>
+        <b>{operatorSuggestedNamespace}</b>
       </RadioInput>
       {useSuggestedNSForSingleInstallMode && suggestedNamespaceDetails}
       <RadioInput
@@ -652,7 +652,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
           setUseSuggestedNSForSingleInstallMode(false);
           setTargetNamespace(null);
         }}
-        value={suggestedNamespace}
+        value={operatorSuggestedNamespace}
         checked={!useSuggestedNSForSingleInstallMode}
         title={t('olm~Select a Namespace')}
       />
@@ -756,7 +756,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
                     onChange={(e) => {
                       setInstallMode(e.target.value);
                       setTargetNamespace(
-                        useSuggestedNSForSingleInstallMode ? suggestedNamespace : null,
+                        useSuggestedNSForSingleInstallMode ? operatorSuggestedNamespace : null,
                       );
                       setCannotResolve(false);
                     }}


### PR DESCRIPTION
An Operator that has both `suggested-namespace` and `suggested-namespace-template` annotations and the Installation mode selection is "A specific namespace on the cluster", was incorrectly installing the operator to the suggested-namespace instead of the preferred suggested-namespace-template. Which should take precedence.

Bug contains catalog source code for testing.


