### PR TITLE
Bug 2083087: Fix to provide an option to delete all app resources on delete-resource modal for D/DC/KSVC

### DIFF
--- a/frontend/packages/console-app/src/actions/providers/deployment-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/deployment-provider.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { DeleteResourceAction } from '@console/dev-console/src/actions/context-menu';
 import { DeploymentKind, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { CommonActionFactory } from '../creators/common-factory';
@@ -26,7 +27,9 @@ export const useDeploymentActionsProvider = (resource: DeploymentKind) => {
       CommonActionFactory.ModifyLabels(kindObj, resource),
       CommonActionFactory.ModifyAnnotations(kindObj, resource),
       DeploymentActionFactory.EditDeployment(kindObj, resource),
-      CommonActionFactory.Delete(kindObj, resource),
+      ...(resource.metadata.annotations?.['openshift.io/generated-by'] === 'OpenShiftWebConsole'
+        ? [DeleteResourceAction(kindObj, resource)]
+        : [CommonActionFactory.Delete(kindObj, resource)]),
     ],
     [hpaActions, pdbActions, kindObj, relatedHPAs, resource],
   );
@@ -52,7 +55,9 @@ export const useDeploymentConfigActionsProvider = (resource: DeploymentKind) => 
       CommonActionFactory.ModifyLabels(kindObj, resource),
       CommonActionFactory.ModifyAnnotations(kindObj, resource),
       DeploymentActionFactory.EditDeployment(kindObj, resource),
-      CommonActionFactory.Delete(kindObj, resource),
+      ...(resource.metadata.annotations?.['openshift.io/generated-by'] === 'OpenShiftWebConsole'
+        ? [DeleteResourceAction(kindObj, resource)]
+        : [CommonActionFactory.Delete(kindObj, resource)]),
     ],
     [hpaActions, pdbActions, kindObj, relatedHPAs, resource],
   );

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -68,6 +68,7 @@
   "Container Image": "Container Image",
   "From Catalog": "From Catalog",
   "Delete application": "Delete application",
+  "Delete {{kind}}": "Delete {{kind}}",
   "Edit {{applicationName}}": "Edit {{applicationName}}",
   "Deletion of a Service Binding resource that utilizes label selector will result in the removal of all bindings on applications that share the labels defined in the Service Binding resource.": "Deletion of a Service Binding resource that utilizes label selector will result in the removal of all bindings on applications that share the labels defined in the Service Binding resource.",
   "Access permissions needed": "Access permissions needed",

--- a/frontend/packages/dev-console/src/actions/context-menu.ts
+++ b/frontend/packages/dev-console/src/actions/context-menu.ts
@@ -1,7 +1,9 @@
 import i18next from 'i18next';
 import { Action, K8sModel } from '@console/dynamic-plugin-sdk';
 import { TopologyApplicationObject } from '@console/dynamic-plugin-sdk/src/extensions/topology-types';
+import { deleteModal } from '@console/internal/components/modals';
 import { asAccessReview } from '@console/internal/components/utils';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import { deleteResourceModal } from '@console/shared';
 import { ApplicationModel } from '@console/topology/src/models';
 import { cleanUpWorkload } from '@console/topology/src/utils';
@@ -35,3 +37,19 @@ export const DeleteApplicationAction = (
     accessReview: asAccessReview(resourceModel, primaryResource, 'delete'),
   };
 };
+
+export const DeleteResourceAction = (
+  kind: K8sModel,
+  obj: K8sResourceKind,
+  isKnativeResource?: boolean,
+): Action => ({
+  id: `delete-resource`,
+  label: i18next.t('devconsole~Delete {{kind}}', { kind: kind.kind }),
+  cta: () =>
+    deleteModal({
+      kind,
+      resource: obj,
+      deleteAllResources: () => cleanUpWorkload(obj, isKnativeResource),
+    }),
+  accessReview: asAccessReview(kind, obj, 'delete'),
+});

--- a/frontend/packages/knative-plugin/src/actions/providers.ts
+++ b/frontend/packages/knative-plugin/src/actions/providers.ts
@@ -1,9 +1,13 @@
 import * as React from 'react';
 import { GraphElement, Graph, Node, Edge, isEdge, isGraph } from '@patternfly/react-topology';
-import { getCommonResourceActions } from '@console/app/src/actions/creators/common-factory';
+import {
+  CommonActionFactory,
+  getCommonResourceActions,
+} from '@console/app/src/actions/creators/common-factory';
 import { DeploymentActionFactory } from '@console/app/src/actions/creators/deployment-factory';
 import { getHealthChecksAction } from '@console/app/src/actions/creators/health-checks-factory';
 import { disabledActionsFilter } from '@console/dev-console/src/actions/add-resources';
+import { DeleteResourceAction } from '@console/dev-console/src/actions/context-menu';
 import { getDisabledAddActions } from '@console/dev-console/src/utils/useAddActionExtensions';
 import { Action } from '@console/dynamic-plugin-sdk';
 import {
@@ -89,7 +93,12 @@ export const useKnativeServiceActionsProvider = (resource: K8sResourceKind) => {
       getHealthChecksAction(kindObj, resource),
       editKnativeService(kindObj, resource),
       DeploymentActionFactory.EditResourceLimits(kindObj, resource),
-      ...getCommonResourceActions(kindObj, resource),
+      CommonActionFactory.ModifyLabels(kindObj, resource),
+      CommonActionFactory.ModifyAnnotations(kindObj, resource),
+      CommonActionFactory.Edit(kindObj, resource),
+      ...(resource.metadata.annotations?.['openshift.io/generated-by'] === 'OpenShiftWebConsole'
+        ? [DeleteResourceAction(kindObj, resource, true)]
+        : [CommonActionFactory.Delete(kindObj, resource)]),
     ];
   }, [kindObj, resource]);
 

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -852,6 +852,7 @@
   "Are you sure you want to delete <2>{{resourceName}}</2> in namespace <5>{{namespace}}</5>?": "Are you sure you want to delete <2>{{resourceName}}</2> in namespace <5>{{namespace}}</5>?",
   "Are you sure you want to delete <2>{{resourceName}}</2>?": "Are you sure you want to delete <2>{{resourceName}}</2>?",
   "Delete dependent objects of this resource": "Delete dependent objects of this resource",
+  "Delete other resources created by console": "Delete other resources created by console",
   "Managed resource": "Managed resource",
   "This resource is managed by <2></2> and any modifications may be overwritten. Edit the managing resource to preserve changes.": "This resource is managed by <2></2> and any modifications may be overwritten. Edit the managing resource to preserve changes.",
   "Delete": "Delete",


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGSM-44070

This PR adds a `Delete other resources created by console` checkbox to D/DC/KSVC resources delete-modal which were created via console add flows alongside other app resources to provide an option to the user to delete all app resources.

D/DC/KSVC created by console add flows:

https://user-images.githubusercontent.com/20724543/208964188-c82a9254-e278-4251-8c15-99026028faad.mov

D/DC/KSVC not created via console add flows:

https://user-images.githubusercontent.com/20724543/208964461-ba14a149-c357-4010-b13f-4d80d3d321da.mov



