### PR TITLE
OCPBUGS-4781: use /api/helm/release endpoint on helm release details page

### DIFF
--- a/frontend/packages/helm-plugin/src/components/details-page/HelmReleaseDetails.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/HelmReleaseDetails.tsx
@@ -15,7 +15,7 @@ import { SecretModel } from '@console/internal/models';
 import { K8sResourceKindReference } from '@console/internal/module/k8s';
 import { ActionMenu, ActionMenuVariant, Status, ActionServiceProvider } from '@console/shared';
 import { HelmRelease, HelmActionOrigins } from '../../types/helm-types';
-import { fetchHelmReleases } from '../../utils/helm-utils';
+import { fetchHelmRelease } from '../../utils/helm-utils';
 import HelmReleaseHistory from './history/HelmReleaseHistory';
 import HelmReleaseNotes from './notes/HelmReleaseNotes';
 import HelmReleaseOverview from './overview/HelmReleaseOverview';
@@ -137,18 +137,17 @@ const HelmReleaseDetails: React.FC<HelmReleaseDetailsProps> = ({ secret, match }
   React.useEffect(() => {
     let ignore = false;
 
-    const getHelmReleases = async () => {
+    const getHelmRelease = async () => {
       try {
-        const helmReleases = await fetchHelmReleases(namespace);
+        const helmRelease = await fetchHelmRelease(namespace, helmReleaseName);
         if (!ignore) {
-          const releaseData = helmReleases.find((release) => release.name === helmReleaseName);
-          setHelmReleaseData(releaseData);
+          setHelmReleaseData(helmRelease);
         }
         // eslint-disable-next-line no-empty
       } catch {}
     };
 
-    getHelmReleases();
+    getHelmRelease();
 
     return () => {
       ignore = true;

--- a/frontend/packages/helm-plugin/src/utils/helm-utils.ts
+++ b/frontend/packages/helm-plugin/src/utils/helm-utils.ts
@@ -73,13 +73,16 @@ export const filterHelmReleasesByName = (releases: HelmRelease[], filter: string
   return releases.filter((release: HelmRelease) => fuzzy(filter, release.name));
 };
 
-export const fetchHelmReleases = (
+export const fetchHelmReleases = (namespace: string): Promise<HelmRelease[]> => {
+  const fetchString = `/api/helm/releases?ns=${namespace}`;
+  return coFetchJSON(fetchString);
+};
+
+export const fetchHelmRelease = (
   namespace: string,
-  helmReleaseName?: string,
-): Promise<HelmRelease[]> => {
-  const fetchString = `/api/helm/releases?ns=${namespace}${
-    helmReleaseName ? `&name=${helmReleaseName}` : ''
-  }`;
+  helmReleaseName: string,
+): Promise<HelmRelease> => {
+  const fetchString = `/api/helm/release?ns=${namespace}&name=${helmReleaseName}`;
   return coFetchJSON(fetchString);
 };
 


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-4781

**Root analysis:**
The helm release details page calls the `/api/helm/releases` endpoint with the namespace param which returns all the helm releases in the namespace

**Solution Description:**
Using `/api/helm/release` endpoint with name and namespace params to fetch the details of the helm release

**Screenshot:**
![Screenshot 2022-12-27 at 1 07 28 PM](https://user-images.githubusercontent.com/22490998/209630126-80e0c66b-9436-4b34-ab27-13371da3e6b1.png)

/kind bug
