### PR TITLE
HELM-471:Modify list releases response

### DIFF
--- a/docs/helm/endpoints_api.md
+++ b/docs/helm/endpoints_api.md
@@ -13,6 +13,7 @@
 *  **URL Params**
 
    `ns=[string]` - Namespace
+   `limitInfo=[boolean]` - limitInfo
 
 * **Success Response:**
 

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
@@ -76,7 +76,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = (props) => {
         setReleases([]);
       } else if (newCount !== secretsCountRef.current) {
         setReleasesLoaded(false);
-        fetchHelmReleases(namespace)
+        fetchHelmReleases(namespace, true)
           .then((helmReleases) => {
             if (!destroyed) {
               setReleases(helmReleases);

--- a/frontend/packages/helm-plugin/src/utils/helm-utils.ts
+++ b/frontend/packages/helm-plugin/src/utils/helm-utils.ts
@@ -73,8 +73,11 @@ export const filterHelmReleasesByName = (releases: HelmRelease[], filter: string
   return releases.filter((release: HelmRelease) => fuzzy(filter, release.name));
 };
 
-export const fetchHelmReleases = (namespace: string): Promise<HelmRelease[]> => {
-  const fetchString = `/api/helm/releases?ns=${namespace}`;
+export const fetchHelmReleases = (
+  namespace: string,
+  limitInfo?: boolean,
+): Promise<HelmRelease[]> => {
+  const fetchString = `/api/helm/releases?ns=${namespace}&limitInfo=${limitInfo || false}`;
   return coFetchJSON(fetchString);
 };
 

--- a/pkg/helm/actions/list_releases.go
+++ b/pkg/helm/actions/list_releases.go
@@ -2,10 +2,11 @@ package actions
 
 import (
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
 )
 
-func ListReleases(conf *action.Configuration) ([]*release.Release, error) {
+func ListReleases(conf *action.Configuration, limitInfo bool) ([]*release.Release, error) {
 	cmd := action.NewList(conf)
 	cmd.StateMask = action.ListAll
 	releases, err := cmd.Run()
@@ -15,6 +16,22 @@ func ListReleases(conf *action.Configuration) ([]*release.Release, error) {
 	if releases == nil {
 		rs := make([]*release.Release, 0)
 		return rs, nil
+	}
+	limitedReleaseInformation := make([]*release.Release, 0)
+	if limitInfo != false {
+		for _, rel := range releases {
+			releaseInformation := release.Release{
+				Name:      rel.Name,
+				Version:   rel.Version,
+				Namespace: rel.Namespace,
+				Info:      rel.Info,
+				Chart: &chart.Chart{
+					Metadata: rel.Chart.Metadata,
+				},
+			}
+			limitedReleaseInformation = append(limitedReleaseInformation, &releaseInformation)
+		}
+		return limitedReleaseInformation, nil
 	}
 	return releases, nil
 }

--- a/pkg/helm/actions/list_releases_test.go
+++ b/pkg/helm/actions/list_releases_test.go
@@ -48,7 +48,7 @@ func TestListReleases(t *testing.T) {
 				Capabilities: chartutil.DefaultCapabilities,
 				Log:          func(format string, v ...interface{}) {},
 			}
-			rels, err := ListReleases(actionConfig)
+			rels, err := ListReleases(actionConfig, true)
 			if err != nil {
 				t.Error("Error occurred while installing chartPath")
 			}

--- a/pkg/helm/handlers/handler_test.go
+++ b/pkg/helm/handlers/handler_test.go
@@ -73,8 +73,8 @@ func fakeInstallChartAsync(mockedSecret *actions.Secret, err error) func(ns stri
 	}
 }
 
-func fakeListReleases(mockedReleases []*release.Release, err error) func(conf *action.Configuration) ([]*release.Release, error) {
-	return func(conf *action.Configuration) (releases []*release.Release, er error) {
+func fakeListReleases(mockedReleases []*release.Release, err error) func(conf *action.Configuration, isTopology bool) ([]*release.Release, error) {
+	return func(conf *action.Configuration, isTopology bool) (releases []*release.Release, er error) {
 		return mockedReleases, err
 	}
 }


### PR DESCRIPTION
This PR modifies the response to be returned for list releases endpoint. The PR is aimed at improving the performance of list releases api . If the call is made from list releases page we can return limited information else the entire manifests and notes will be returned too
Signed-off-by: Kartikey Mamgain <mamgainkartikey@gmail.com>