### PR TITLE
add apiVersion v1beta1 for KnativeServingModel

### DIFF
--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -16,6 +16,17 @@
       "model": {
         "group": "operator.knative.dev",
         "version": "v1alpha1",
+        "kind": "KnativeServing"
+      },
+      "flag": "KNATIVE_SERVING_V1ALPHA1"
+    }
+  },
+  {
+    "type": "console.flag/model",
+    "properties": {
+      "model": {
+        "group": "operator.knative.dev",
+        "version": "v1alpha1",
         "kind": "KnativeEventing"
       },
       "flag": "KNATIVE_EVENTING"
@@ -254,6 +265,20 @@
       "model": {
         "group": "operator.knative.dev",
         "version": "v1alpha1",
+        "kind": "KnativeServing"
+      },
+      "component": { "$codeRef": "overviewComponent.KnativeServingDetailsPage" }
+    },
+    "flags": {
+      "required": ["KNATIVE_SERVING"]
+    }
+  },
+  {
+    "type": "console.page/resource/details",
+    "properties": {
+      "model": {
+        "group": "operator.knative.dev",
+        "version": "v1beta1",
         "kind": "KnativeServing"
       },
       "component": { "$codeRef": "overviewComponent.KnativeServingDetailsPage" }
@@ -642,11 +667,27 @@
   {
     "type": "console.global-config",
     "properties": {
-      "id": "knative-serving",
+      "id": "knative-serving-v1alpha1",
       "name": "knative-serving",
       "model": {
         "group": "operator.knative.dev",
         "version": "v1alpha1",
+        "kind": "KnativeServing"
+      },
+      "namespace": "knative-serving"
+    },
+    "flags": {
+      "required": ["KNATIVE_SERVING_V1ALPHA1"]
+    }
+  },
+  {
+    "type": "console.global-config",
+    "properties": {
+      "id": "knative-serving",
+      "name": "knative-serving",
+      "model": {
+        "group": "operator.knative.dev",
+        "version": "v1beta1",
         "kind": "KnativeServing"
       },
       "namespace": "knative-serving"

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeServingDetailsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeServingDetailsPage.tsx
@@ -4,11 +4,17 @@ import { DetailsForKind } from '@console/internal/components/default-resource';
 import { DetailsPage } from '@console/internal/components/factory';
 import { navFactory } from '@console/internal/components/utils';
 import { K8sResourceKindReference, referenceForModel } from '@console/internal/module/k8s';
-import { KnativeServingModel } from '../../models';
-
-const knativeServingReference: K8sResourceKindReference = referenceForModel(KnativeServingModel);
+import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
+import { KnativeServingModelV1Alpha1, KnativeServingModel } from '../../models';
 
 const KnativeServingDetailsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (props) => {
+  const [model] = useK8sModel(props.kind);
+
+  // Added the check for apiVersion as apiversion `v1alpha1` is deprecated with Serverless operator 1.26 and get removed in 1.27 and `v1beta1` is supported
+  const knativeServingReference: K8sResourceKindReference =
+    model.apiVersion === 'v1alpha1'
+      ? referenceForModel(KnativeServingModelV1Alpha1)
+      : referenceForModel(KnativeServingModel);
   const pages = [navFactory.details(DetailsForKind(props.kind)), navFactory.editYaml()];
 
   return (

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -29,9 +29,30 @@ export const ConfigurationModel: K8sKind = {
   color: knativeServingColor.value,
 };
 
-export const KnativeServingModel: K8sKind = {
+/**
+ * @deprecated apiVersion `v1alpha1` is depricated with Serverless operator 1.26 and get removed in 1.27 and `v1beta1` is supported
+ */
+export const KnativeServingModelV1Alpha1: K8sKind = {
   apiGroup: 'operator.knative.dev',
   apiVersion: 'v1alpha1',
+  kind: 'KnativeServing',
+  label: 'KnativeServing',
+  // t('knative-plugin~KnativeServing')
+  labelKey: 'knative-plugin~KnativeServing',
+  labelPlural: 'KnativeServings',
+  // t('knative-plugin~KnativeServings')
+  labelPluralKey: 'knative-plugin~KnativeServings',
+  plural: 'knativeservings',
+  id: 'knativeserving',
+  abbr: 'KS',
+  namespaced: true,
+  crd: true,
+  color: knativeServingColor.value,
+};
+
+export const KnativeServingModel: K8sKind = {
+  apiGroup: 'operator.knative.dev',
+  apiVersion: 'v1beta1',
   kind: 'KnativeServing',
   label: 'KnativeServing',
   // t('knative-plugin~KnativeServing')


### PR DESCRIPTION
**Description:** In RedHat Serverless operator 1.26 apiVersion `v1alpha1` for `KnativeServing` is deprecated and in upcoming RedHat Serverless operator 1.27 only apiVersion `v1beta1` will be supported. 

**Test setup:**
- Install RedHat Serverless Operator and create Knative Serving CR
- Navigate to `CustomResourceDefinitions` page and open the KnativeServing CRD YAML
- under `spec.versions` change served to false for `v1alpha1`
- Test all the serverless features
- Navigate to `Cluster setting -> Configuration` page
- Search for `KnativeServing` 
- You will see multiple `KnativeServing` for apiVersion `v1alpha1` and `v1beta1` 
- For the apiVersion `v1alpha1` of the `KnativeServing`  details page you will get 404  error page as it is disabled
- For the apiVersion `v1beta1` of the `KnativeServing` details page open as expected.