### PR TITLE
OCPBUGS-4684: In DeploymentConfig both the Form view and Yaml view are not in sync

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-deployment/utils/edit-deployment-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-deployment/utils/edit-deployment-utils.ts
@@ -490,7 +490,7 @@ export const convertEditFormToDeployment = (
           ...deployment.spec.template.metadata,
           labels: {
             ...deployment.spec.template.metadata.labels,
-            ...(name ? { app: name } : {}),
+            ...(deployment.metadata.name ? {} : name ? { app: name } : {}),
           },
         },
         spec: {
@@ -512,7 +512,11 @@ export const convertEditFormToDeployment = (
         ...newDeployment.spec,
         selector: {
           ...newDeployment.spec.selector,
-          ...(newDeployment.metadata.name ? { app: newDeployment.metadata.name } : {}),
+          ...(deployment.metadata.name
+            ? {}
+            : newDeployment.metadata.name
+            ? { app: newDeployment.metadata.name }
+            : {}),
         },
         triggers: [
           ...(fromImageStreamTag
@@ -553,7 +557,11 @@ export const convertEditFormToDeployment = (
           ...newDeployment.spec.selector,
           matchLabels: {
             ...newDeployment.spec.selector.matchLabels,
-            ...(newDeployment.metadata.name ? { app: newDeployment.metadata.name } : {}),
+            ...(deployment.metadata.name
+              ? {}
+              : newDeployment.metadata.name
+              ? { app: newDeployment.metadata.name }
+              : {}),
           },
         },
       },


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-4684

**Analysis / Root cause:**
For edit, saved values are not used. On switching between form and YAML, resource name is fetched from form and that was populated in YAML data.

**Solution Description:**
If edit, don't add resource name which is fetched from form in YAML.

**Screen shots / Gifs for design review:**

-------------- Before -------


https://user-images.githubusercontent.com/102503482/210975251-8d7cf13e-472f-4467-b31e-b27456a9b612.mov



-------After-----------------

https://user-images.githubusercontent.com/102503482/210975264-ed844895-b538-431a-8645-e5d222688950.mov





****Unit test coverage report:****
NA

**Test setup:**

```
1. Create a DC with selector and labels as given below
spec:
  replicas: 1
  selector:
    app: apigateway
    deploymentconfig: qa-apigateway
    environment: qa
  strategy:
    activeDeadlineSeconds: 21600
    resources: {}
    rollingParams:
      intervalSeconds: 1
      maxSurge: 25%
      maxUnavailable: 25%
      timeoutSeconds: 600
      updatePeriodSeconds: 1
    type: Rolling
  template:
    metadata:
      labels:
        app: apigateway
        deploymentconfig: qa-apigateway
        environment: qa

2. Now go to GUI--> Workloads--> DeploymentConfig --> Actions--> Edit DeploymentConfig, first go to Form view and now switch to Yaml view, the selector and labels shows as app: ubi8 while it should display app: apigateway

  selector:
    app: ubi8
    deploymentconfig: qa-apigateway
    environment: qa
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: ubi8
        deploymentconfig: qa-apigateway
        environment: qa

3. Now in yaml view just click reload and the value is displayed as it is when it was created (app: apigateway).
```

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
