### PR TITLE
Bug 2110565: PDB Remove add/edit/remove actions in Pod resource action menu

### DIFF
--- a/frontend/packages/console-app/src/actions/providers/pod-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/pod-provider.ts
@@ -2,16 +2,14 @@ import * as React from 'react';
 import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { getCommonResourceActions } from '../creators/common-factory';
-import { usePDBActions } from '../creators/pdb-factory';
 
 export const usePodActionsProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
-  const [pdbActions] = usePDBActions(kindObj, resource);
 
-  const actions = React.useMemo(
-    () => [...pdbActions, ...getCommonResourceActions(kindObj, resource)],
-    [kindObj, pdbActions, resource],
-  );
+  const actions = React.useMemo(() => [...getCommonResourceActions(kindObj, resource)], [
+    kindObj,
+    resource,
+  ]);
 
   return [actions, !inFlight, undefined];
 };


### PR DESCRIPTION
[Bug 2110565](https://bugzilla.redhat.com/show_bug.cgi?id=2110565) - PDB: Remove add/edit/remove actions in Pod resource action menu

**Changes:** Pod Disruption Budget actions have been removed from the actions kebab menu in the _Workloads_ > _Pods_ page, as there is no use case to add or edit a PodDisruptionBudget for a singular pod. 
PDB actions are still usable in the _Workloads_ > _Deployments_ page

**Before**

<img width="1435" alt="pod_actionsMenu_original" src="https://user-images.githubusercontent.com/110131308/185705827-3e6931bb-a952-4ab3-a39c-0b024cc7fc1b.png">

**After**

<img width="1369" alt="pod_actionsMenu_changed" src="https://user-images.githubusercontent.com/110131308/185705913-0cc5c3f6-1918-468b-8630-b6c105e51ac6.png">