### PR TITLE
OU-110: Observe > Dashboards page: Use datasource defined in dashboard definition

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -3,6 +3,7 @@ import { ButtonProps } from '@patternfly/react-core';
 import { ICell, OnSelect, SortByDirection, TableGridBreakpoint } from '@patternfly/react-table';
 import MonacoEditor from 'react-monaco-editor/lib/editor';
 import { RouteComponentProps } from 'react-router';
+import { CustomDataSource } from '@console/dynamic-plugin-sdk/src/extensions/dashboard-data-source';
 import {
   ExtensionK8sGroupKindModel,
   K8sModel,
@@ -163,6 +164,8 @@ export type PrometheusPollProps = {
   samples?: number;
   /** A vector-query search parameter */
   timespan?: number;
+  /** An object used to facilitate fetching from different data sources. */
+  customDataSource?: CustomDataSource;
 };
 
 export type UsePrometheusPoll = (

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/dashboard-data-source.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/dashboard-data-source.ts
@@ -1,0 +1,19 @@
+import { Extension, ExtensionDeclaration, CodeRef } from '../types';
+
+export type DataSource = ExtensionDeclaration<
+  'console.dashboards/datasource',
+  {
+    contextId: string;
+    /** Returns a extension function that provides a custom data source object */
+    getDataSource: CodeRef<(dataSourceID: string) => Promise<CustomDataSource>>;
+  }
+>;
+
+export const isDataSource = (e: Extension): e is DataSource => {
+  return e.type === 'console.dashboards/datasource';
+};
+
+export type CustomDataSource = {
+  basePath: string;
+  dataSourceType: string;
+};

--- a/frontend/public/components/graphs/bar.tsx
+++ b/frontend/public/components/graphs/bar.tsx
@@ -17,6 +17,8 @@ import { DataPoint } from '.';
 import { getInstantVectorStats } from './utils';
 import { GraphEmpty } from './graph-empty';
 
+import { CustomDataSource } from '@console/dynamic-plugin-sdk/src/extensions/dashboard-data-source';
+
 const DEFAULT_BAR_WIDTH = 10;
 const PADDING_RATIO = 1 / 3;
 
@@ -94,12 +96,14 @@ export const Bar: React.FC<BarProps> = ({
   query,
   theme,
   title,
+  customDataSource,
 }) => {
   const [response, , loading] = usePrometheusPoll({
     delay,
     endpoint: PrometheusEndpoint.QUERY,
     namespace,
     query,
+    customDataSource,
   });
   const data = getInstantVectorStats(response, metric, humanize);
 
@@ -149,4 +153,5 @@ type BarProps = {
   theme?: any; // TODO figure out the best way to import VictoryThemeDefinition
   title?: string;
   titleClassName: string;
+  customDataSource?: CustomDataSource;
 };

--- a/frontend/public/components/graphs/prometheus-poll-hook.ts
+++ b/frontend/public/components/graphs/prometheus-poll-hook.ts
@@ -14,8 +14,14 @@ export const usePrometheusPoll: UsePrometheusPoll = ({
   samples = DEFAULT_PROMETHEUS_SAMPLES,
   timeout,
   timespan = DEFAULT_PROMETHEUS_TIMESPAN,
+  customDataSource,
 }) => {
-  const url = getPrometheusURL({ endpoint, endTime, namespace, query, samples, timeout, timespan });
+  const prometheusURLProps = { endpoint, endTime, namespace, query, samples, timeout, timespan };
 
-  return useURLPoll<PrometheusResponse>(url, delay, query, timespan);
+  return useURLPoll<PrometheusResponse>(
+    getPrometheusURL(prometheusURLProps, customDataSource?.basePath),
+    delay,
+    query,
+    timespan,
+  );
 };

--- a/frontend/public/components/monitoring/dashboards/bar-chart.tsx
+++ b/frontend/public/components/monitoring/dashboards/bar-chart.tsx
@@ -3,9 +3,11 @@ import * as React from 'react';
 
 import { Bar } from '../../graphs';
 
+import { CustomDataSource } from '@console/dynamic-plugin-sdk/src/extensions/dashboard-data-source';
+
 const Label = ({ metric }) => <>{_.values(metric).join()}</>;
 
-const BarChart: React.FC<BarChartProps> = ({ pollInterval, query }) => (
+const BarChart: React.FC<BarChartProps> = ({ pollInterval, query, customDataSource }) => (
   <Bar
     barSpacing={5}
     barWidth={8}
@@ -13,6 +15,7 @@ const BarChart: React.FC<BarChartProps> = ({ pollInterval, query }) => (
     LabelComponent={Label}
     noLink={true}
     query={query}
+    customDataSource={customDataSource}
   />
 );
 
@@ -20,5 +23,6 @@ type BarChartProps = {
   pollInterval: number;
   query: string;
   namespace?: string;
+  customDataSource?: CustomDataSource;
 };
 export default BarChart;

--- a/frontend/public/components/monitoring/dashboards/graph.tsx
+++ b/frontend/public/components/monitoring/dashboards/graph.tsx
@@ -8,6 +8,8 @@ import { RootState } from '../../../redux';
 import { FormatSeriesTitle, QueryBrowser } from '../query-browser';
 import { DEFAULT_GRAPH_SAMPLES, getActivePerspective } from './monitoring-dashboard-utils';
 
+import { CustomDataSource } from '@console/dynamic-plugin-sdk/src/extensions/dashboard-data-source';
+
 type Props = {
   formatSeriesTitle?: FormatSeriesTitle;
   isStack: boolean;
@@ -17,6 +19,7 @@ type Props = {
   units: string;
   onZoomHandle?: (timeRange: number, endTime: number) => void;
   namespace?: string;
+  customDataSource?: CustomDataSource;
 };
 
 const Graph: React.FC<Props> = ({
@@ -28,6 +31,7 @@ const Graph: React.FC<Props> = ({
   units,
   onZoomHandle,
   namespace,
+  customDataSource,
 }) => {
   const dispatch = useDispatch();
   const activePerspective = getActivePerspective(namespace);
@@ -61,6 +65,7 @@ const Graph: React.FC<Props> = ({
       timespan={timespan}
       units={units}
       namespace={namespace}
+      customDataSource={customDataSource}
     />
   );
 };

--- a/frontend/public/components/monitoring/dashboards/monitoring-dashboard-utils.ts
+++ b/frontend/public/components/monitoring/dashboards/monitoring-dashboard-utils.ts
@@ -27,6 +27,7 @@ export const getAllVariables = (boards: Board[], newBoardName: string, namespace
       }
 
       allVariables[v.name] = ImmutableMap({
+        datasource: v.datasource,
         includeAll: !!v.includeAll,
         isHidden: namespace && v.name === 'namespace' ? true : v.hide !== 0,
         isLoading: namespace ? v.type === 'query' && !namespace : v.type === 'query',

--- a/frontend/public/components/monitoring/dashboards/types.ts
+++ b/frontend/public/components/monitoring/dashboards/types.ts
@@ -22,6 +22,7 @@ type YAxis = {
 
 export type Panel = {
   breakpoint?: string;
+  datasource?: DataSource;
   decimals?: number;
   format?: string;
   gridPos?: {
@@ -65,6 +66,7 @@ export type Panel = {
 };
 
 export type TemplateVariable = {
+  datasource: DataSource;
   hide: number;
   includeAll: boolean;
   name: string;
@@ -95,4 +97,9 @@ export type Board = {
 
 export type TimeDropdownsProps = {
   namespace?: string;
+};
+
+export type DataSource = {
+  name: string;
+  type: string;
 };

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -67,6 +67,8 @@ import { useBoolean } from './hooks/useBoolean';
 import { queryBrowserTheme } from './query-browser-theme';
 import { PrometheusAPIError } from './types';
 
+import { CustomDataSource } from '@console/dynamic-plugin-sdk/src/extensions/dashboard-data-source';
+
 const spans = ['5m', '15m', '30m', '1h', '2h', '6h', '12h', '1d', '2d', '1w', '2w'];
 export const colors = queryBrowserTheme.line.colorScale;
 
@@ -656,6 +658,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   namespace,
   onZoom,
   pollInterval,
+  customDataSource,
   queries,
   showLegend,
   showStackedControl = false,
@@ -737,15 +740,18 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
       _.isEmpty(query)
         ? Promise.resolve()
         : safeFetch(
-            getPrometheusURL({
-              endpoint: PrometheusEndpoint.QUERY_RANGE,
-              endTime: endTime || now,
-              namespace,
-              query,
-              samples,
-              timeout: '60s',
-              timespan: span,
-            }),
+            getPrometheusURL(
+              {
+                endpoint: PrometheusEndpoint.QUERY_RANGE,
+                endTime: endTime || now,
+                namespace,
+                query,
+                samples,
+                timeout: '60s',
+                timespan: span,
+              },
+              customDataSource?.basePath,
+            ),
           ),
     );
 
@@ -1036,6 +1042,7 @@ export type QueryBrowserProps = {
   namespace?: string;
   onZoom?: GraphOnZoom;
   pollInterval?: number;
+  customDataSource?: CustomDataSource;
   queries: string[];
   showLegend?: boolean;
   showStackedControl?: boolean;

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1004,6 +1004,7 @@
   "Refresh interval": "Refresh interval",
   "Dashboards": "Dashboards",
   "Inspect": "Inspect",
+  "Error loading card": "Error loading card",
   "Metrics dashboards": "Metrics dashboards",
   "panel.styles attribute not found": "panel.styles attribute not found",
   "No data found": "No data found",


### PR DESCRIPTION
### Related: 
https://issues.redhat.com/browse/OU-110

### Overview:
Previously, metrics could only be fetched from a default in-cluster Prometheus. This feature allows custom Prometheus data source definitions for each panel within Admin > Observe > Dashboard Page. 

The [Dashboard Console Plugin](https://github.com/jgbernalp/dashboards-console-plugin) creates proxy configurations to the custom Prometheus data sources. In this PR, the Console UI has been updated to use the plugin's extension functions to fetch metrics from these custom data source. 

**Before** 
metrics queries fetch from default Prometheus using `/api/prometheus/api/v1`
<img width="2556" alt="OU11-Before" src="https://user-images.githubusercontent.com/59589720/218875640-83cd99f9-a28d-4047-ab2f-970c3a556b43.png">

**After** 
metrics queries fetch from custom-defined Prometheus via proxy configured by plugin `/api/proxy/plugin/dashboards-console-plugin/backend/proxy/<custom-datasource-name>`
<img width="2544" alt="OU110-After" src="https://user-images.githubusercontent.com/59589720/218875670-7bd2c134-7079-42f7-a015-5e2fb1aabe89.png">



### Video Demo: 
https://drive.google.com/file/d/1JMcD3fFhlrQOGY9zFqvwtnaLq36kp9qk/view?usp=sharing

### Testing Instructions 
- Obtain an OpenShift Cluster and launch this pull request (We have been using the ClusterBot and entering :  `launch openshift/console#12422`) 
- Clone the [dashboard-console-plugin](https://github.com/jgbernalp/dashboards-console-plugin) and check out the `plugin-backend` branch
`$ git clone https://github.com/jgbernalp/dashboards-console-plugin.git`
`$ cd dashboards-console-plugin`
`$ git checkout plugin-backend`
- Install the helm chart, this will add a custom data source named `cluster-prometheus-proxy`
` $ helm upgrade -i  dashboards-console-plugin charts/dashboards-console-plugin -n console-dashboards --create-namespace `
- Clone this [configMap](https://github.com/zhuje/OU110-dashboard-configMap-for-testing)  and apply it to your cluster. This creates a test dashboard name `JZ-TEST: VariableDropDown + Panels` that will pull metrics from the custom Prometheus. The metrics are fetched using the proxy provided by plugin. For more information on creating your own configMap see the [documentation](https://github.com/jgbernalp/dashboards-console-plugin/blob/plugin-backend/docs/add-datasource.md). 
`$ git clone https://github.com/zhuje/OU110-dashboard-configMap-for-testing.git` 
`$ oc apply -f JZ-cluster-prometheus-proxy.yaml `



