### PR TITLE
OCPBUGS-5540: fixes typo for milliseconds

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -237,7 +237,7 @@
   "Seconds": "Seconds",
   "Minutes": "Minutes",
   "Hours": "Hours",
-  "Miliseconds": "Miliseconds",
+  "Milliseconds": "Milliseconds",
   "Set timeout for the terminal.": "Set timeout for the terminal.",
   "Connecting to your OpenShift command line terminal ...": "Connecting to your OpenShift command line terminal ...",
   "Cluster configuration": "Cluster configuration",

--- a/frontend/packages/console-app/src/components/cloud-shell/setup/TimeoutSection.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/setup/TimeoutSection.tsx
@@ -10,7 +10,7 @@ const TimeoutSection: React.FC = () => {
     s: t('console-app~Seconds'),
     m: t('console-app~Minutes'),
     h: t('console-app~Hours'),
-    ms: t('console-app~Miliseconds'),
+    ms: t('console-app~Milliseconds'),
   };
 
   return (

--- a/frontend/packages/console-app/src/components/cloud-shell/setup/cloud-shell-types.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/setup/cloud-shell-types.ts
@@ -1,6 +1,0 @@
-export enum TimeoutUnits {
-  h = 'hours',
-  m = 'minutes',
-  s = 'seconds',
-  ms = 'miliseconds',
-}


### PR DESCRIPTION
Fixes : https://issues.redhat.com/browse/OCPBUGS-5540

Screenshots:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/5129024/211530916-0ae9e929-6a65-4aa1-b279-61278b77b4fd.png">
