### PR TITLE
add preferred tab per user for dev perspective Pipelines page and make PipelineRuns tab default for Repository details page

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/pageTitle.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/pageTitle.ts
@@ -15,7 +15,7 @@ export const pageTitle = {
   GitOPs: 'GitOps',
   Observe: 'Observe',
   Builds: 'Builds',
-  BuildConfigs: 'Build Configs',
+  BuildConfigs: 'BuildConfigs',
   Search: 'Search',
   HelmReleases: 'Helm Releases',
   Project: 'Project Details',
@@ -61,4 +61,5 @@ export const pageTitle = {
   Helm: 'Helm',
   Samples: 'Samples',
   CreateServerlessFunction: 'Create Serverless function',
+  AddGitRepository: 'Add Git Repository',
 };

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -120,7 +120,7 @@ export const navigateTo = (opt: devNavigationMenu) => {
     }
     case devNavigationMenu.Builds: {
       cy.get(devNavigationMenuPO.builds).click();
-      detailsPage.titleShouldContain(pageTitle.Builds);
+      detailsPage.titleShouldContain(pageTitle.BuildConfigs);
       cy.testA11y('Builds Page in dev perspective');
       break;
     }

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipeline-navigation.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipeline-navigation.feature
@@ -1,0 +1,32 @@
+@pipelines
+Feature: Perform the actions on Pipelines page
+              As a user, I want to navigate through the Pipeline pages in dev perspective
+
+        Background:
+            Given user has created or selected namespace "aut-pipelines-nav"
+             And user is at pipelines page
+
+        @regression @odc-7131
+        Scenario: Remember last visited tab for the Pipeline page: P-12-TC01
+             When user navigates to Repositories page
+              And user navigates to Builds page
+              And user navigates to Pipelines page
+             Then user will be redirected to the repositories page
+
+        @regression @odc-7131
+        Scenario: user will be redirect to Repository details page Details tab if user coming from the create repository flow: P-12-TC02
+             When user click on create repository button
+              And user will redirects to Add Git Repository page
+              And user enter the GitRepo URL "https://github.com/vikram-raj/hello-func"
+              And user enters the name "git-hello-func"
+              And user clicks on add button
+             Then user will be redirected to Git Repository added page
+              And user clicks on close button
+              And user will be redirected to Repository details page with header name "git-hello-func"
+
+        @regression @odc-7131
+        Scenario: Default tab for respository details page is PipelineRuns if user is not coming from the create repository flow: P-12-TC03
+            Given repository "git-hello-func" is present on the Repositories page
+             When user searches repository "git-hello-func" in repositories page
+              And user clicks repository "git-hello-func" from searched results on Repositories page
+             Then user will be redirected to PipelineRuns tab

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/repositories-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/repositories-page.ts
@@ -1,6 +1,11 @@
+import { pageTitle } from '@console/dev-console/integration-tests/support/constants';
 import { pipelinesPO } from '../../page-objects';
 
 export const repositoriesPage = {
+  verifyTitle: () => {
+    cy.byTestID('form-title').should('have.text', pageTitle.AddGitRepository);
+    cy.testA11y(pageTitle.AddGitRepository);
+  },
   verifyRepositoryTableColumns: () => {
     cy.get('[role="grid"] tr th').each(($el) => {
       expect([

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/repositoryDetails-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/repositoryDetails-page.ts
@@ -35,6 +35,7 @@ export const repositoryDetailsPage = {
   },
 
   verifyFieldsInDetailsTab: () => {
+    cy.get(repositoryDetailsPO.detailsTab).click();
     cy.get(repositoryDetailsPO.details.fieldNames.name).should('be.visible');
     cy.get(repositoryDetailsPO.details.fieldNames.namespace).should('be.visible');
     cy.get(repositoryDetailsPO.details.fieldNames.labels).should('be.visible');

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-as-code.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-as-code.ts
@@ -212,6 +212,7 @@ When('user adds key {string} and value {string}', (key: string, value: string) =
 });
 
 Then('annotation section contains the value {string}', (numOfAnnotations: string) => {
+  repositoryDetailsPage.selectTab(repositoryDetailsTabs.Details);
   repositoryDetailsPage.verifyAnnotations(numOfAnnotations);
 });
 

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-navigation.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-navigation.ts
@@ -1,0 +1,58 @@
+import { When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { devNavigationMenu } from '@console/dev-console/integration-tests/support/constants';
+import { navigateTo } from '@console/dev-console/integration-tests/support/pages';
+import { pipelineTabs } from '../../constants';
+import { pipelinesPage } from '../../pages/pipelines/pipelines-page';
+import { repositoriesPage } from '../../pages/pipelines/repositories-page';
+
+When('user navigates to Repositories page', () => {
+  pipelinesPage.selectTab(pipelineTabs.Repositories);
+});
+
+When('user navigates to Builds page', () => {
+  navigateTo(devNavigationMenu.Builds);
+});
+
+Then('user will be redirected to the repositories page', () => {
+  cy.get('.co-m-horizontal-nav__menu-item.co-m-horizontal-nav-item--active > a').should(
+    'have.text',
+    'Repositories',
+  );
+});
+
+When('user click on create repository button', () => {
+  pipelinesPage.clickCreateRepository();
+});
+
+When('user will redirects to Add Git Repository page', () => {
+  repositoriesPage.verifyTitle();
+});
+
+When('user enter the GitRepo URL {string}', (GitRepoURL: string) => {
+  cy.get('#form-input-gitUrl-field')
+    .clear()
+    .type(GitRepoURL);
+});
+
+When('user enters the name {string}', (name: string) => {
+  cy.get('#form-input-name-field').should('have.value', name);
+});
+
+When('user clicks on add button', () => {
+  cy.byLegacyTestID('submit-button').click();
+});
+
+Then('user will be redirected to Git Repository added page', () => {
+  cy.byTestID('repository-overview-title').should('have.text', 'Git repository added.');
+});
+
+Then('user clicks on close button', () => {
+  cy.byLegacyTestID('submit-button').click();
+});
+
+Then('user will be redirected to PipelineRuns tab', () => {
+  cy.get('.co-m-horizontal-nav__menu-item.co-m-horizontal-nav-item--active > a').should(
+    'have.text',
+    'PipelineRuns',
+  );
+});

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/PipelineTabbedPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/PipelineTabbedPage.tsx
@@ -7,9 +7,18 @@ import NamespacedPage, {
 } from '@console/dev-console/src/components/NamespacedPage';
 import CreateProjectListPage from '@console/dev-console/src/components/projects/CreateProjectListPage';
 import { withStartGuide } from '@console/internal/components/start-guide';
-import { Page } from '@console/internal/components/utils';
-import { MenuAction, MenuActions, MultiTabListPage, useFlag } from '@console/shared';
-import { FLAG_OPENSHIFT_PIPELINE_AS_CODE } from '../../const';
+import { Page, history } from '@console/internal/components/utils';
+import {
+  MenuAction,
+  MenuActions,
+  MultiTabListPage,
+  useFlag,
+  useUserSettings,
+} from '@console/shared';
+import {
+  FLAG_OPENSHIFT_PIPELINE_AS_CODE,
+  PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY,
+} from '../../const';
 import { PipelineModel, RepositoryModel } from '../../models';
 import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 import RepositoriesList from '../repository/list-page/RepositoriesList';
@@ -27,6 +36,19 @@ export const PageContents: React.FC<PipelineTabbedPageProps> = (props) => {
   } = props;
   const badge = usePipelineTechPreviewBadge(namespace);
   const isRepositoryEnabled = useFlag(FLAG_OPENSHIFT_PIPELINE_AS_CODE);
+  const [preferredTab, , preferredTabLoaded] = useUserSettings<string>(
+    PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY,
+    'pipelines',
+  );
+
+  React.useEffect(() => {
+    if (preferredTabLoaded) {
+      if (isRepositoryEnabled && preferredTab === 'repositories') {
+        history.push(`/dev-pipelines/ns/${namespace}/repositories`);
+      }
+    }
+  }, [isRepositoryEnabled, namespace, preferredTab, preferredTabLoaded]);
+
   const [showTitle, hideBadge, canCreate] = [false, true, false];
   const menuActions: MenuActions = {
     pipeline: {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/__tests__/PipelineTabbedPage.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/__tests__/PipelineTabbedPage.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import NamespacedPage from '@console/dev-console/src/components/NamespacedPage';
 import CreateProjectListPage from '@console/dev-console/src/components/projects/CreateProjectListPage';
-import { MultiTabListPage, useFlag } from '@console/shared';
+import { MultiTabListPage, useFlag, useUserSettings } from '@console/shared';
 import { PipelinesPage } from '../PipelinesPage';
 import PipelineTabbedPage, { PageContents } from '../PipelineTabbedPage';
 
@@ -14,7 +14,13 @@ jest.mock('@console/shared', () => {
   };
 });
 
+jest.mock('@console/shared/src/hooks/useUserSettings', () => ({
+  useUserSettings: jest.fn(),
+}));
+
 const useFlagMock = useFlag as jest.Mock;
+
+const mockUserSettings = useUserSettings as jest.Mock;
 
 describe('PipelineTabbedPage', () => {
   let PipelineTabbedPageProps: React.ComponentProps<typeof PipelineTabbedPage> = {
@@ -29,6 +35,10 @@ describe('PipelineTabbedPage', () => {
       },
     },
   };
+
+  beforeAll(() => {
+    mockUserSettings.mockReturnValue(['pipelines', jest.fn(), true]);
+  });
 
   it('should render NamespacedPage', () => {
     useFlagMock.mockReturnValue(true);

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRunsWrapper.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRunsWrapper.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { ListPageWrapper } from '@console/internal/components/factory';
 import { EmptyBox, Firehose, LoadingBox } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
+import { useUserSettings } from '@console/shared/src';
+import { PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY } from '../../../const';
 import { PipelineRunModel } from '../../../models';
 import PipelineAugmentRuns, { filters } from './PipelineAugmentRuns';
 import PipelineList from './PipelineList';
@@ -17,6 +20,17 @@ interface PipelineAugmentRunsWrapperProps {
 
 const PipelineAugmentRunsWrapper: React.FC<PipelineAugmentRunsWrapperProps> = (props) => {
   const { t } = useTranslation();
+  const activePerspective = useActivePerspective()[0];
+  const [, setPreferredTab, preferredTabLoaded] = useUserSettings<string>(
+    PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY,
+    'pipelines',
+  );
+
+  React.useEffect(() => {
+    if (preferredTabLoaded && activePerspective === 'dev') {
+      setPreferredTab('pipelines');
+    }
+  }, [activePerspective, preferredTabLoaded, setPreferredTab]);
   const pipelineData = _.get(props.pipeline, 'data', []);
 
   if (!props.pipeline.loaded) {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/__tests__/PipelineAugmentRunsWrapper.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/__tests__/PipelineAugmentRunsWrapper.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { ListPageWrapper } from '@console/internal/components/factory';
 import { EmptyBox, LoadingBox } from '@console/internal/components/utils';
+import { useUserSettings } from '@console/shared';
 import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
 import PipelineAugmentRunsWrapper from '../PipelineAugmentRunsWrapper';
 
@@ -10,10 +11,17 @@ const { pipeline } = mockData;
 
 type PipelineAugmentRunsWrapperProps = React.ComponentProps<typeof PipelineAugmentRunsWrapper>;
 
+jest.mock('@console/shared/src/hooks/useUserSettings', () => ({
+  useUserSettings: jest.fn(),
+}));
+
+const mockUserSettings = useUserSettings as jest.Mock;
+
 describe('Pipeline Augment Run Wrapper', () => {
   let pipelineAugmentRunsWrapperProps: PipelineAugmentRunsWrapperProps;
   let wrapper: ShallowWrapper;
   beforeEach(() => {
+    mockUserSettings.mockReturnValue(['pipelines', jest.fn(), true]);
     pipelineAugmentRunsWrapperProps = {
       pipeline: {
         data: [pipeline],

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryLinkList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryLinkList.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import { GithubIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import {
-  ResourceLink,
   ExternalLink,
   CopyToClipboard,
   truncateMiddle,
+  ResourceIcon,
+  resourcePath,
 } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { RepositoryModel } from '../../models';
@@ -40,12 +42,20 @@ const RepositoryLinkList: React.FC<RepositoryLinkListProps> = ({ pipelineRun }) 
     <dl>
       <dt>{t('pipelines-plugin~Repository')}</dt>
       <dd>
-        <ResourceLink
-          data-test="pl-repository-link"
-          kind={referenceForModel(RepositoryModel)}
-          name={repoName}
-          namespace={pipelineRun.metadata.namespace}
-        />
+        <div>
+          <ResourceIcon kind={referenceForModel(RepositoryModel)} />
+          <Link
+            data-test="pl-repository-link"
+            to={`${resourcePath(
+              referenceForModel(RepositoryModel),
+              repoName,
+              pipelineRun.metadata.namespace,
+            )}/Runs`}
+            className="co-resource-item__resource-name"
+          >
+            {repoName}
+          </Link>
+        </div>
         {repoURL && (
           <ExternalLink href={repoURL}>
             <GithubIcon title={repoURL} /> {repoURL}

--- a/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoriesList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoriesList.tsx
@@ -1,19 +1,37 @@
 import * as React from 'react';
+import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
+import { useUserSettings } from '@console/shared/src';
+import { PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY } from '../../../const';
 import { RepositoryModel } from '../../../models';
 import RepositoryList from './ReppositoryList';
 
-const RepositoriesList: React.FC<React.ComponentProps<typeof ListPage>> = (props) => (
-  <ListPage
-    {...props}
-    createProps={{
-      to: `/k8s/ns/${props.namespace || 'default'}/${referenceForModel(RepositoryModel)}/~new/form`,
-    }}
-    canCreate={props.canCreate ?? true}
-    kind={referenceForModel(RepositoryModel)}
-    ListComponent={RepositoryList}
-  />
-);
+const RepositoriesList: React.FC<React.ComponentProps<typeof ListPage>> = (props) => {
+  const activePerspective = useActivePerspective()[0];
+  const [, setPreferredTab, preferredTabLoaded] = useUserSettings<string>(
+    PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY,
+    'pipelines',
+  );
+
+  React.useEffect(() => {
+    if (preferredTabLoaded && activePerspective === 'dev') {
+      setPreferredTab('repositories');
+    }
+  }, [activePerspective, preferredTabLoaded, setPreferredTab]);
+  return (
+    <ListPage
+      {...props}
+      createProps={{
+        to: `/k8s/ns/${props.namespace || 'default'}/${referenceForModel(
+          RepositoryModel,
+        )}/~new/form`,
+      }}
+      canCreate={props.canCreate ?? true}
+      kind={referenceForModel(RepositoryModel)}
+      ListComponent={RepositoryList}
+    />
+  );
+};
 
 export default RepositoriesList;

--- a/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoryRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoryRow.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
 import {
   Kebab,
   LoadingInline,
+  ResourceIcon,
   ResourceKebab,
   ResourceLink,
+  resourcePath,
   Timestamp,
 } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
@@ -43,7 +46,14 @@ const RepositoryRow: React.FC<RowFunctionArgs<RepositoryKind>> = ({ obj }) => {
   return (
     <>
       <TableData className={repositoriesTableColumnClasses[0]}>
-        <ResourceLink kind={referenceForModel(RepositoryModel)} name={name} namespace={namespace} />
+        <ResourceIcon kind={referenceForModel(RepositoryModel)} />
+        <Link
+          to={`${resourcePath(referenceForModel(RepositoryModel), name, namespace)}/Runs`}
+          className="co-resource-item__resource-name"
+          data-test-id={name}
+        >
+          {name}
+        </Link>
       </TableData>
       <TableData className={repositoriesTableColumnClasses[1]} columnID="namespace">
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />

--- a/frontend/packages/pipelines-plugin/src/components/repository/sections/RepositoryOverview.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/sections/RepositoryOverview.tsx
@@ -15,7 +15,7 @@ const RepositoryOverview = () => {
   return (
     <FormSection>
       <FormGroup fieldId="title">
-        <Title headingLevel="h4" size={TitleSizes.xl}>
+        <Title headingLevel="h4" size={TitleSizes.xl} data-test="repository-overview-title">
           {t('pipelines-plugin~Git repository added.')}
         </Title>
         <Text>

--- a/frontend/packages/pipelines-plugin/src/const.ts
+++ b/frontend/packages/pipelines-plugin/src/const.ts
@@ -5,3 +5,4 @@ export const CLUSTER_PIPELINE_NS = 'openshift';
 export const PIPELINE_RUNTIME_LABEL = 'pipeline.openshift.io/runtime';
 export const PIPELINE_RUNTIME_VERSION_LABEL = 'pipeline.openshift.io/runtime-version';
 export const PIPELINE_STRATEGY_LABEL = 'pipeline.openshift.io/strategy';
+export const PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY = 'pipeline.preferredPipelinePageTab';


### PR DESCRIPTION
**Story:** https://issues.redhat.com/browse/ODC-7229

**GIF:**

![Peek 2023-01-11 10-17](https://user-images.githubusercontent.com/2561818/211720067-2f76ead7-7625-4bc9-b9d8-d51f3a769a7a.gif)

Tests:
![image](https://user-images.githubusercontent.com/2561818/213263727-66743289-b7ac-444e-94d5-ce8bbe710ac0.png)
