### PR TITLE
OCPBUGS-5542: Project dropdown order is not as smart as project list page order

### DIFF
--- a/frontend/packages/console-app/src/components/user-preferences/namespace/NamespaceDropdown.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/namespace/NamespaceDropdown.tsx
@@ -67,7 +67,12 @@ const NamespaceDropdown: React.FC = () => {
       const { name } = item.metadata;
       return { title: name, key: name };
     });
-    items.sort((a, b) => a.title.localeCompare(b.title));
+    items.sort((a, b) => {
+      return a.title.localeCompare(b.title, undefined, {
+        numeric: true,
+        sensitivity: 'base',
+      });
+    });
     return items;
   }, [options, optionsLoaded]);
 

--- a/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.tsx
+++ b/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.tsx
@@ -250,7 +250,12 @@ const NamespaceMenu: React.FC<{
     if (!items.some((option) => option.title === selected) && selected !== ALL_NAMESPACES_KEY) {
       items.push({ title: selected, key: selected }); // Add current namespace if it isn't included
     }
-    items.sort((a, b) => a.title.localeCompare(b.title));
+    items.sort((a, b) => {
+      return a.title.localeCompare(b.title, undefined, {
+        numeric: true,
+        sensitivity: 'base',
+      });
+    });
 
     if (canList) {
       items.unshift({ title: allNamespacesTitle, key: ALL_NAMESPACES_KEY });


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-5542

**Analysis / Root cause:**
alphanumeric sorting was not added 

**Solution Description:**
Added alphanumeric sorting

**Screen shots / Gifs for design review:**

-------------- Before -------

<img width="698" alt="Screenshot 2023-01-12 at 4 46 49 PM" src="https://user-images.githubusercontent.com/102503482/212055717-f54b339e-d0dc-4b94-820a-00b1055b0657.png">

<img width="469" alt="Screenshot 2023-01-12 at 4 45 07 PM" src="https://user-images.githubusercontent.com/102503482/212055967-412f61e6-f94b-4bc4-97da-e714151eecf4.png">


-------After-----------------

<img width="726" alt="Screenshot 2023-01-12 at 4 46 09 PM" src="https://user-images.githubusercontent.com/102503482/212055772-122bf3f3-4fe6-46d9-b152-e2ae4458cf15.png">

<img width="470" alt="Screenshot 2023-01-12 at 4 45 27 PM" src="https://user-images.githubusercontent.com/102503482/212055794-9433fac6-789b-4a95-adf9-fef10ac3a780.png">



****Unit test coverage report:****
NA

**Test setup:**
1. Create some new projects called test-1, test-11, [test-2](https://issues.redhat.com//browse/test-2)
2. Check the project dropdown (in dev perspective)
3. Check project dropdown in user preference page

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
