### PR TITLE
OCPBUGS-7232: Fixes resource status alignment issue

### DIFF
--- a/frontend/packages/gitops-plugin/src/components/details/GitOpsResourceRow.tsx
+++ b/frontend/packages/gitops-plugin/src/components/details/GitOpsResourceRow.tsx
@@ -32,8 +32,8 @@ const GitOpsResourceRow: React.FC<GitOpsResourceRowProps> = ({
         >
           <SplitItem>
             <>
-              {degradedResources.length}{' '}
-              <HeartBrokenIcon color={RedColor.value} className="co-icon-space-r" />
+              {degradedResources.length}
+              <HeartBrokenIcon color={RedColor.value} className="co-icon-space-l" />
             </>
           </SplitItem>
         </Tooltip>
@@ -47,8 +47,8 @@ const GitOpsResourceRow: React.FC<GitOpsResourceRowProps> = ({
         >
           <SplitItem>
             <>
-              {nonSyncedResources.length}{' '}
-              <ExclamationTriangleIcon color={YellowColor.value} className="co-icon-space-r" />
+              {nonSyncedResources.length}
+              <ExclamationTriangleIcon color={YellowColor.value} className="co-icon-space-l" />
             </>
           </SplitItem>
         </Tooltip>

--- a/frontend/packages/gitops-plugin/src/components/details/GitOpsResourcesSection.scss
+++ b/frontend/packages/gitops-plugin/src/components/details/GitOpsResourcesSection.scss
@@ -9,4 +9,12 @@
   &__list {
     display: flex;
   }
+
+  .pf-l-split.pf-m-gutter {
+    justify-content: space-between;
+
+    &>*:not(:last-child) {
+      margin-right: var(--pf-global--spacer--sm);
+    }
+  }
 }


### PR DESCRIPTION
Fixes [gitops-2450: [UI] Issue with alignment of health status, occurrence, and resource text](https://issues.redhat.com/browse/GITOPS-2450).

signed by: yicai@redhat.com

Screenshot after fix:
![Screenshot 2023-01-11 at 3 21 04 PM](https://user-images.githubusercontent.com/26255262/211909946-4d682d20-baef-4cf3-8992-2f8165669e3c.png)
![Screenshot 2023-01-11 at 3 21 27 PM](https://user-images.githubusercontent.com/26255262/211909947-c25cade8-b719-45db-ae8d-d52d573af44c.png)