### PR TITLE
Update ODC owner files

### DIFF
--- a/dynamic-demo-plugin/OWNERS
+++ b/dynamic-demo-plugin/OWNERS
@@ -1,12 +1,10 @@
 reviewers:
-  - andrewballantyne
   - christianvogt
   - glekner
   - rawagner
   - spadgett
   - vojtechszocs
 approvers:
-  - andrewballantyne
   - christianvogt
   - invincibleJai
   - jerolimov

--- a/frontend/packages/console-telemetry-plugin/OWNERS
+++ b/frontend/packages/console-telemetry-plugin/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-  - andrewballantyne
   - abhinandan13jan
   - debsmita1
   - divyanshiGupta
@@ -7,11 +6,14 @@ reviewers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - rottencandy
   - sahil143
   - vikram-raj
 approvers:
+  - debsmita1
   - divyanshiGupta
   - invincibleJai
   - jerolimov

--- a/frontend/packages/dev-console/OWNERS
+++ b/frontend/packages/dev-console/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-  - andrewballantyne
   - abhinandan13jan
   - debsmita1
   - divyanshiGupta
@@ -7,11 +6,14 @@ reviewers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - rottencandy
   - sahil143
   - vikram-raj
 approvers:
+  - debsmita1
   - divyanshiGupta
   - invincibleJai
   - jerolimov

--- a/frontend/packages/git-service/OWNERS
+++ b/frontend/packages/git-service/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-  - andrewballantyne
   - abhinandan13jan
   - debsmita1
   - divyanshiGupta
@@ -7,11 +6,14 @@ reviewers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - rottencandy
   - sahil143
   - vikram-raj
 approvers:
+  - debsmita1
   - divyanshiGupta
   - invincibleJai
   - jerolimov

--- a/frontend/packages/gitops-plugin/OWNERS
+++ b/frontend/packages/gitops-plugin/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-  - andrewballantyne
   - abhinandan13jan
   - debsmita1
   - divyanshiGupta
@@ -7,11 +6,14 @@ reviewers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - rottencandy
   - sahil143
   - vikram-raj
 approvers:
+  - debsmita1
   - divyanshiGupta
   - invincibleJai
   - jerolimov

--- a/frontend/packages/helm-plugin/OWNERS
+++ b/frontend/packages/helm-plugin/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-  - andrewballantyne
   - abhinandan13jan
   - debsmita1
   - divyanshiGupta
@@ -7,11 +6,14 @@ reviewers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - rottencandy
   - sahil143
   - vikram-raj
 approvers:
+  - debsmita1
   - divyanshiGupta
   - invincibleJai
   - jerolimov

--- a/frontend/packages/knative-plugin/OWNERS
+++ b/frontend/packages/knative-plugin/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-  - andrewballantyne
   - abhinandan13jan
   - debsmita1
   - divyanshiGupta
@@ -7,11 +6,14 @@ reviewers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - rottencandy
   - sahil143
   - vikram-raj
 approvers:
+  - debsmita1
   - divyanshiGupta
   - invincibleJai
   - jerolimov

--- a/frontend/packages/pipelines-plugin/OWNERS
+++ b/frontend/packages/pipelines-plugin/OWNERS
@@ -7,11 +7,14 @@ reviewers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - rottencandy
   - sahil143
   - vikram-raj
 approvers:
+  - debsmita1
   - divyanshiGupta
   - invincibleJai
   - jerolimov

--- a/frontend/packages/service-binding-plugin/OWNERS
+++ b/frontend/packages/service-binding-plugin/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-  - andrewballantyne
   - abhinandan13jan
   - debsmita1
   - divyanshiGupta
@@ -7,11 +6,14 @@ reviewers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - rottencandy
   - sahil143
   - vikram-raj
 approvers:
+  - debsmita1
   - divyanshiGupta
   - invincibleJai
   - jerolimov

--- a/frontend/packages/shipwright-plugin/OWNERS
+++ b/frontend/packages/shipwright-plugin/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-  - andrewballantyne
   - abhinandan13jan
   - debsmita1
   - divyanshiGupta
@@ -7,11 +6,14 @@ reviewers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - rottencandy
   - sahil143
   - vikram-raj
 approvers:
+  - debsmita1
   - divyanshiGupta
   - invincibleJai
   - jerolimov

--- a/frontend/packages/topology/OWNERS
+++ b/frontend/packages/topology/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-  - andrewballantyne
   - abhinandan13jan
   - debsmita1
   - divyanshiGupta
@@ -8,11 +7,14 @@ reviewers:
   - jeff-phillips-18
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - rottencandy
   - sahil143
   - vikram-raj
 approvers:
+  - debsmita1
   - divyanshiGupta
   - invincibleJai
   - jeff-phillips-18


### PR DESCRIPTION
1. Added @debsmita1 as approver for all ODC packages :tada: 
2. Added @lokanandaprabhu and @lucifergene as reviewers for all ODC packages
    also if you could add lgtm already before
3. Removed Andrew :(
    keep you/him in the pipelines package as a reviewer and you still have frontend approval permissions, but I want keep our ODC-related OWNER files reflecting our team
