### PR TITLE
ODC-7225: Update Helm Releases list page and the details page

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/Status.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/Status.tsx
@@ -54,6 +54,8 @@ const Status: React.FC<StatusProps> = ({
 
     case 'ContainerCreating':
     case 'UpgradePending':
+    case 'PendingUpgrade':
+    case 'PendingRollback':
       return <ProgressStatus {...statusProps} />;
 
     case 'In Progress':
@@ -63,6 +65,7 @@ const Status: React.FC<StatusProps> = ({
     case 'Running':
     case 'Updating':
     case 'Upgrading':
+    case 'PendingInstall':
       return <StatusIconAndText {...statusProps} icon={<SyncAltIcon />} />;
 
     case 'Cancelled':
@@ -71,6 +74,8 @@ const Status: React.FC<StatusProps> = ({
     case 'Not Ready':
     case 'Cancelling':
     case 'Terminating':
+    case 'Superseded':
+    case 'Uninstalling':
       return <StatusIconAndText {...statusProps} icon={<BanIcon />} />;
 
     case 'Warning':
@@ -105,6 +110,7 @@ const Status: React.FC<StatusProps> = ({
     case 'Provisioned as node':
     case 'Preferred':
     case 'Connected':
+    case 'Deployed':
       return <SuccessStatus {...statusProps} />;
 
     case 'Info':

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
@@ -8,6 +8,12 @@ export const helmPO = {
   revisionHistoryTab: '[data-test-id="horizontal-link-Revision history"]',
   releaseNotesTab: '[data-test-id="horizontal-link-Release notes"]',
   filterDropdown: '[data-test-id="filter-dropdown-toggle"] button',
+  filterDropdownItem: '.co-filter-dropdown-item__name',
+  filter: {
+    pendingInstall: '[data-test-row-filter="pending-install"]',
+    pendingUpgrade: '[data-test-row-filter="pending-upgrade"]',
+    pendingRollback: '[data-test-row-filter="pending-rollback"]',
+  },
   filterDropdownDialog: '.pf-c-dropdown__group.co-filter-dropdown-group',
   filterToolBar: '#filter-toolbar',
   clearAllFilter: '.pf-c-button.pf-m-link.pf-m-inline',

--- a/frontend/packages/helm-plugin/integration-tests/features/helm-release.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm-release.feature
@@ -68,14 +68,13 @@ Feature: Helm Release
               And user will see the Release Notes tab
               And user will see the Actions drop down menu with options Upgrade, Rollback, and Delete Helm Release
 
-
         Scenario: Actions menu on Helm page after helm chart upgrade: HR-08-TC01
             Given user is on the Helm page with helm release "nodejs-release"
              When user clicks on the Kebab menu
              Then user is able to see kebab menu with actions Upgrade, Rollback and Delete Helm Release
 
 
-        Scenario: Perform Upgrade action on Helm Release through Context Menu: HR-01-TC04
+        Scenario: Perform Upgrade action on Helm Release through Context Menu: HR-08-TC04
             Given user is at the Topology page
              When user right clicks on the helm release "nodejs-release" to open the context menu
               And user clicks on the "Upgrade" action
@@ -110,3 +109,14 @@ Feature: Helm Release
               And user enters the release name "nodejs-release"
               And user clicks on the Delete button
              Then user will be redirected to Topology page
+
+        Scenario: Helm release status verification: HR-01-TC04
+          Given user has installed helm chart "Nodejs" with helm release name "nodejs-release"
+            And user is able to see "nodejs-release" in helm page
+            And user is able to see the status and status icon of "nodejs-release" under helm releases tab
+            And user is able to see the "PendingInstall", "PendingUpgrade" and "PendingRollback" options under filter bar
+           When user clicks on the helm release name "nodejs-release"
+           Then user is able to see the status and status icon in title after "nodejs-release"
+            And user is able to see the status and status icon under helm release details
+            And user switch to Revision history tab
+            And user is able to see the status and status icon of Revision history page

--- a/frontend/packages/helm-plugin/integration-tests/features/helm/actions-on-helm-release-after-upgrade.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/actions-on-helm-release-after-upgrade.feature
@@ -7,7 +7,7 @@ Feature: Verify the Actions on Helm Release after upgrade
 
 
         @pre-condition
-        Scenario: Perform Upgrade action on Helm Release through Context Menu: HR-01-TC04
+        Scenario: Perform Upgrade action on Helm Release through Context Menu: HR-08-TC04
             Given user has installed helm chart "Nodejs" with helm release name "nodejs-release-1"
               And user is at the Topology page
              When user right clicks on the helm release "nodejs-release-1" to open the context menu

--- a/frontend/packages/helm-plugin/integration-tests/features/helm/actions-on-helm-release.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/actions-on-helm-release.feature
@@ -37,3 +37,14 @@ Feature: Perform Actions on Helm Releases
               And user enters the release name "nodejs-release-2"
               And user clicks on the Delete button
              Then user will be redirected to Topology page
+
+        Scenario: Helm release status verification: HR-01-TC04
+          Given user has installed helm chart "Nodejs" with helm release name "nodejs-release"
+            And user is able to see "nodejs-release" in helm page
+            And user is able to see the status and status icon of "nodejs-release" under helm releases tab
+            And user is able to see the "PendingInstall", "PendingUpgrade" and "PendingRollback" options under filter bar
+           When user clicks on the helm release name "nodejs-release"
+           Then user is able to see the status and status icon in title after "nodejs-release"
+            And user is able to see the status and status icon under helm release details
+            And user switch to Revision history tab
+            And user is able to see the status and status icon of Revision history page

--- a/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-details-page.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-details-page.ts
@@ -6,6 +6,7 @@ const actions = [helmActions.upgrade, helmActions.rollback, helmActions.deleteHe
 
 export const helmDetailsPage = {
   verifyTitle: () => cy.byTestSectionHeading('Helm Release details').should('be.visible'),
+  verifyHelmReleaseStatus: () => cy.get('[data-test="status-text"]').should('be.visible'),
   verifyResourcesTab: () => cy.get(helmPO.resourcesTab).should('be.visible'),
   verifyReleaseNotesTab: () => cy.get(helmPO.revisionHistoryTab).should('be.visible'),
   verifyActionsDropdown: () => cy.byLegacyTestID('actions-menu-button').should('be.visible'),
@@ -79,4 +80,5 @@ export const helmDetailsPage = {
       .contains('Repository')
       .click();
   },
+  clickRevisionHistoryTab: () => cy.get(helmPO.revisionHistoryTab).click(),
 };

--- a/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-page.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-page.ts
@@ -70,6 +70,10 @@ export const helmPage = {
       .its('length')
       .should('be.greaterThan', 0);
   },
+  verifyHelmChartStatus: () => {
+    cy.byTestID('success-icon').should('be.visible');
+    cy.byTestID('status-text').should('exist');
+  },
   verifySearchMessage: (message: string) =>
     cy.get(helmPO.noHelmSearchMessage).should('contain.text', message),
   selectHelmFilterDropDown: () => {
@@ -187,4 +191,16 @@ export const helmPage = {
       .get('a')
       .contains(installLink)
       .should('be.visible'),
+  verifyDropdownItem: (item1: string, item2: string, item3: string) => {
+    cy.get(helmPO.filterDropdown).click();
+    cy.get(helmPO.filter.pendingInstall).within(() => {
+      cy.get(helmPO.filterDropdownItem).should('contain.text', item1);
+    });
+    cy.get(helmPO.filter.pendingUpgrade).within(() => {
+      cy.get(helmPO.filterDropdownItem).should('contain.text', item2);
+    });
+    cy.get(helmPO.filter.pendingRollback).within(() => {
+      cy.get(helmPO.filterDropdownItem).should('contain.text', item3);
+    });
+  },
 };

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-navigation.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-navigation.ts
@@ -321,3 +321,46 @@ When('user can see {string} {string} details page', (type: string, name: string)
   cy.get(`[title=${type}`).should('be.visible');
   cy.byLegacyTestID('resource-title').contains(name);
 });
+
+Given(
+  'user has installed helm chart {string} with helm release name {string}',
+  (chartName: string, releaseName: string) => {
+    catalogPage.createHelmChart(releaseName, chartName);
+  },
+);
+
+Given('user is able to see {string} in helm page', (helmRelease: string) => {
+  navigateTo(devNavigationMenu.Helm);
+  helmPage.search(helmRelease);
+});
+
+Given('user is able to see the status and status icon of {string} under helm releases tab', () => {
+  helmPage.verifyHelmChartStatus();
+});
+
+Given(
+  'user is able to see the {string}, {string} and {string} options under filter bar',
+  (item1: string, item2: string, item3: string) => {
+    helmPage.verifyDropdownItem(item1, item2, item3);
+  },
+);
+
+Then('user is able to see the status and status icon in title after {string}', () => {
+  cy.byLegacyTestID('resource-title').within(() => {
+    helmPage.verifyHelmChartStatus();
+  });
+});
+
+Then('user is able to see the status and status icon under helm release details', () => {
+  cy.byTestID('helm-release-status-details').within(() => {
+    helmPage.verifyHelmChartStatus();
+  });
+});
+
+Then('user is able to see the status and status icon of Revision history page', () => {
+  helmPage.verifyHelmChartStatus();
+});
+
+Then('user switch to Revision history tab', () => {
+  helmDetailsPage.clickRevisionHistoryTab();
+});

--- a/frontend/packages/helm-plugin/src/actions/providers.ts
+++ b/frontend/packages/helm-plugin/src/actions/providers.ts
@@ -14,6 +14,7 @@ import {
   HELM_CHART_CATALOG_TYPE_ID,
 } from '../const';
 import { TYPE_HELM_RELEASE } from '../topology/components/const';
+import { HelmReleaseStatus } from '../types/helm-types';
 import { AddHelmChartAction } from './add-resources';
 import {
   getHelmDeleteAction,
@@ -27,15 +28,22 @@ export const useHelmActionProvider = (scope: HelmActionsScope) => {
   const { t } = useTranslation();
   const result = React.useMemo(() => {
     if (!scope) return [[], true, undefined];
-    return [
-      [
-        getHelmUpgradeAction(scope, t),
-        ...(scope.release.version > 1 ? [getHelmRollbackAction(scope, t)] : []),
-        getHelmDeleteAction(scope, t),
-      ],
-      true,
-      undefined,
-    ];
+    switch (scope?.release?.info?.status) {
+      case HelmReleaseStatus.PendingInstall:
+      case HelmReleaseStatus.PendingRollback:
+      case HelmReleaseStatus.PendingUpgrade:
+        return [[getHelmDeleteAction(scope, t)], true, undefined];
+      default:
+        return [
+          [
+            getHelmUpgradeAction(scope, t),
+            ...(scope.release.version > 1 ? [getHelmRollbackAction(scope, t)] : []),
+            getHelmDeleteAction(scope, t),
+          ],
+          true,
+          undefined,
+        ];
+    }
   }, [scope, t]);
   return result;
 };

--- a/frontend/packages/helm-plugin/src/actions/types.ts
+++ b/frontend/packages/helm-plugin/src/actions/types.ts
@@ -1,6 +1,11 @@
 import { HelmRelease } from '../types/helm-types';
 
-type HelmActionObj = { name: string; namespace: string; version: number | string };
+type HelmActionObj = {
+  name: string;
+  namespace: string;
+  version: number | string;
+  info?: { status: string };
+};
 
 export type HelmActionsScope = {
   release: HelmRelease | HelmActionObj;

--- a/frontend/packages/helm-plugin/src/components/__tests__/helm-release-mock-data.ts
+++ b/frontend/packages/helm-plugin/src/components/__tests__/helm-release-mock-data.ts
@@ -125,6 +125,36 @@ export const mockHelmReleases: HelmRelease[] = [
     version: 1,
     namespace: 'test-helm',
   },
+  {
+    name: 'node-test-chart',
+    info: {
+      first_deployed: '2020-01-20T15:12:04.19900271+05:30',
+      last_deployed: '2020-01-20T15:12:04.19900271+05:30',
+      deleted: '',
+      description: 'superseded',
+      status: 'superseded',
+      notes: '',
+    },
+    chart: {
+      metadata: {
+        name: 'nodejs-ex-k',
+        version: '0.1.0',
+        description: 'A Helm chart for Kubernetes',
+        apiVersion: 'v2',
+        appVersion: '1.16.0',
+        type: 'application',
+        urls: ['https://kubernetes-charts/repo/community/nodejs-0.1.0.tgz'],
+      },
+      lock: null,
+      templates: [],
+      values: {},
+      schema: null,
+      files: [],
+    },
+    manifest: '',
+    version: 1,
+    namespace: 'test-helm',
+  },
 ];
 
 export const mockIBMHelmChartData: HelmChartMetaData[] = [

--- a/frontend/packages/helm-plugin/src/components/details-page/HelmReleaseDetailsPage.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/HelmReleaseDetailsPage.tsx
@@ -3,8 +3,7 @@ import { match as RMatch } from 'react-router';
 import NamespacedPage, {
   NamespacedPageVariants,
 } from '@console/dev-console/src/components/NamespacedPage';
-import { Firehose, history } from '@console/internal/components/utils';
-import { SecretModel } from '@console/internal/models';
+import { history } from '@console/internal/components/utils';
 import { ALL_NAMESPACES_KEY } from '@console/shared';
 import HelmReleaseDetails from './HelmReleaseDetails';
 
@@ -24,27 +23,13 @@ const handleNamespaceChange = (newNamespace: string): void => {
 };
 
 const HelmReleaseDetailsPage: React.FC<HelmReleaseDetailsPageProps> = ({ match }) => {
-  const namespace = match.params.ns;
-  const helmReleaseName = match.params.name;
   return (
     <NamespacedPage
       variant={NamespacedPageVariants.light}
       hideApplications
       onNamespaceChange={handleNamespaceChange}
     >
-      <Firehose
-        resources={[
-          {
-            namespace,
-            kind: SecretModel.kind,
-            prop: SecretModel.id,
-            isList: true,
-            selector: { name: `${helmReleaseName}` },
-          },
-        ]}
-      >
-        <HelmReleaseDetails match={match} />
-      </Firehose>
+      <HelmReleaseDetails match={match} />
     </NamespacedPage>
   );
 };

--- a/frontend/packages/helm-plugin/src/components/details-page/history/HelmReleaseHistoryRow.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/history/HelmReleaseHistoryRow.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { TFunction } from 'i18next';
-import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
@@ -8,6 +7,7 @@ import { confirmModal } from '@console/internal/components/modals';
 import { Timestamp } from '@console/internal/components/utils';
 import { ActionMenu, Status } from '@console/shared';
 import { HelmRelease } from '../../../types/helm-types';
+import { HelmReleaseStatusLabels, releaseStatus } from '../../../utils/helm-utils';
 import { tableColumnClasses } from './HelmReleaseHistoryHeader';
 
 type HelmReleaseHistoryKebabProps = {
@@ -62,7 +62,10 @@ const HelmReleaseHistoryRow: React.FC<RowFunctionArgs> = ({ obj, customData }) =
       <Timestamp timestamp={obj.info.last_deployed} />
     </TableData>
     <TableData className={tableColumnClasses.status}>
-      <Status status={_.capitalize(obj.info.status)} />
+      <Status
+        status={releaseStatus(obj.info.status)}
+        title={HelmReleaseStatusLabels[obj.info.status]}
+      />
     </TableData>
     <TableData className={tableColumnClasses.chartName}>{obj.chart.metadata.name}</TableData>
     <TableData className={tableColumnClasses.chartVersion}>{obj.chart.metadata.version}</TableData>

--- a/frontend/packages/helm-plugin/src/components/details-page/overview/HelmChartSummary.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/overview/HelmChartSummary.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Timestamp } from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
+import { Status } from '@console/shared';
 import { HelmRelease } from '../../../types/helm-types';
+import { HelmReleaseStatusLabels, releaseStatus } from '../../../utils/helm-utils';
 
 interface HelmChartSummaryProps {
   obj: K8sResourceKind;
@@ -28,6 +30,13 @@ const HelmChartSummary: React.FC<HelmChartSummaryProps> = ({ obj, helmRelease })
 
   return (
     <dl className="co-m-pane__details">
+      <dt>{t('helm-plugin~Status')}</dt>
+      <dd data-test="helm-release-status-details">
+        <Status
+          status={releaseStatus(helmRelease?.info?.status)}
+          title={HelmReleaseStatusLabels[helmRelease?.info?.status]}
+        />
+      </dd>
       <dt>{t('helm-plugin~Chart name')}</dt>
       <dd>{chartName}</dd>
       <dt>{t('helm-plugin~Chart version')}</dt>

--- a/frontend/packages/helm-plugin/src/components/forms/rollback/RevisionListRow.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/rollback/RevisionListRow.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
 import { Timestamp } from '@console/internal/components/utils';
 import { Status, RadioButtonField } from '@console/shared';
+import { HelmReleaseStatusLabels, releaseStatus } from '../../../utils/helm-utils';
 import { tableColumnClasses } from './RevisionListHeader';
 
 const RevisionListRow: React.FC<RowFunctionArgs> = ({ obj }) => {
@@ -16,7 +16,10 @@ const RevisionListRow: React.FC<RowFunctionArgs> = ({ obj }) => {
         <Timestamp timestamp={obj.info.last_deployed} />
       </TableData>
       <TableData className={tableColumnClasses.status}>
-        <Status status={_.capitalize(obj.info.status)} />
+        <Status
+          status={releaseStatus(obj.info.status)}
+          title={HelmReleaseStatusLabels[obj.info.status]}
+        />
       </TableData>
       <TableData className={tableColumnClasses.chartName}>{obj.chart.metadata.name}</TableData>
       <TableData className={tableColumnClasses.chartVersion}>

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseListRow.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseListRow.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import { Link } from 'react-router-dom';
 import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
 import { Timestamp, ResourceIcon } from '@console/internal/components/utils';
 import { LazyActionMenu, Status } from '@console/shared';
 import { HelmRelease, HelmActionOrigins } from '../../types/helm-types';
+import { HelmReleaseStatusLabels, releaseStatus } from '../../utils/helm-utils';
 import { tableColumnClasses } from './HelmReleaseListHeader';
 
 const HelmReleaseListRow: React.FC<RowFunctionArgs<HelmRelease>> = ({ obj }) => {
@@ -29,7 +29,10 @@ const HelmReleaseListRow: React.FC<RowFunctionArgs<HelmRelease>> = ({ obj }) => 
         <Timestamp timestamp={obj.info.last_deployed} />
       </TableData>
       <TableData className={tableColumnClasses.status}>
-        <Status status={_.capitalize(obj.info.status)} />
+        <Status
+          status={releaseStatus(obj.info.status)}
+          title={HelmReleaseStatusLabels[obj.info.status]}
+        />
       </TableData>
       <TableData className={tableColumnClasses.chartName}>{obj.chart.metadata.name}</TableData>
       <TableData className={tableColumnClasses.chartVersion}>

--- a/frontend/packages/helm-plugin/src/types/helm-types.ts
+++ b/frontend/packages/helm-plugin/src/types/helm-types.ts
@@ -68,6 +68,9 @@ export interface HelmReleaseResourcesMap {
 export enum HelmReleaseStatus {
   Deployed = 'deployed',
   Failed = 'failed',
+  PendingInstall = 'pending-install',
+  PendingUpgrade = 'pending-upgrade',
+  PendingRollback = 'pending-rollback',
   Other = 'other',
 }
 

--- a/frontend/packages/helm-plugin/src/utils/__tests__/helm-utils.spec.ts
+++ b/frontend/packages/helm-plugin/src/utils/__tests__/helm-utils.spec.ts
@@ -30,8 +30,13 @@ describe('Helm Releases Utils', () => {
     expect(releaseStatusReducer(release)).toEqual(HelmReleaseStatus.Deployed);
   });
 
-  it('should return other for all other statuses for a helm release', () => {
+  it('should return pending-install status for a helm release', () => {
     const release = mockHelmReleases[2];
+    expect(releaseStatusReducer(release)).toEqual(HelmReleaseStatus.PendingInstall);
+  });
+
+  it('should return other for all other statuses for a helm release', () => {
+    const release = mockHelmReleases[3];
     expect(releaseStatusReducer(release)).toEqual(HelmReleaseStatus.Other);
   });
 

--- a/frontend/packages/helm-plugin/src/utils/helm-utils.ts
+++ b/frontend/packages/helm-plugin/src/utils/helm-utils.ts
@@ -21,24 +21,28 @@ import {
 export const HelmReleaseStatusLabels = {
   [HelmReleaseStatus.Deployed]: 'Deployed',
   [HelmReleaseStatus.Failed]: 'Failed',
+  [HelmReleaseStatus.PendingInstall]: 'PendingInstall',
+  [HelmReleaseStatus.PendingUpgrade]: 'PendingUpgrade',
+  [HelmReleaseStatus.PendingRollback]: 'PendingRollback',
   [HelmReleaseStatus.Other]: 'Other',
 };
 
 export const SelectedReleaseStatuses = [
   HelmReleaseStatus.Deployed,
   HelmReleaseStatus.Failed,
+  HelmReleaseStatus.PendingInstall,
+  HelmReleaseStatus.PendingUpgrade,
+  HelmReleaseStatus.PendingRollback,
   HelmReleaseStatus.Other,
 ];
 
-export const OtherReleaseStatuses = [
-  'unknown',
-  'uninstalled',
-  'superseded',
-  'uninstalling',
-  'pending-install',
-  'pending-upgrade',
-  'pending-rollback',
-];
+export const OtherReleaseStatuses = ['unknown', 'uninstalled', 'superseded', 'uninstalling'];
+
+export const releaseStatus = (status: string) =>
+  status
+    .split('-')
+    .map((s) => toTitleCase(s))
+    .join('');
 
 export const releaseStatusReducer = (release: HelmRelease) => {
   if (OtherReleaseStatuses.includes(release.info.status)) {


### PR DESCRIPTION
**JIRA story:**
https://issues.redhat.com/browse/ODC-7225

**Description**:
Users should able to see the correct status on the list page and on the details page when a helm release is installed.
1) Showing the status of the helm release in the correct format on the helm releases list page and on the details page next to the release name and on the revision history page
2) Added status information under the details tab
3) Showing an empty state for the Resources tab when the installation is pending
4) Disabled the "Upgrade" and "Rollback" options in the kebab menu in the list page and Actions dropdown on the details page when the installation/upgrade/rollback is in pending

**Demo:**

https://user-images.githubusercontent.com/102503482/212607235-f25f884e-5c37-438f-b070-3710d0dc5dc7.mov

**Tests:**
<img width="570" alt="Screenshot 2023-01-16 at 11 25 19 AM" src="https://user-images.githubusercontent.com/102503482/212608771-f2e51b93-cb07-4c1d-8e5e-5d57774a0fc8.png">


**How to test:**
Install gitlab helm chart to test pending-install, pending-upgrade and pending-rollback status. 