### PR TITLE
OCPBUGS-5851: Using OLM descriptor components deletes operand 

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.spec.ts
@@ -109,8 +109,12 @@ describe('Using OLM descriptor components', () => {
       `/k8s/ns/${testName}/operators.coreos.com~v1alpha1~ClusterServiceVersion/${testCSV.metadata.name}/${testCRD.spec.group}~${testCRD.spec.versions[0].name}~${testCRD.spec.names.kind}`,
     );
     cy.byTestOperandLink('olm-descriptors-test').should('exist');
-    cy.byLegacyTestID('kebab-button').click({ force: true });
-    cy.byTestActionID(`Delete ${testCRD.spec.names.kind}`).click();
+    cy.byLegacyTestID('kebab-button')
+      .should('exist')
+      .click({ force: true });
+    cy.byTestActionID(`Delete ${testCRD.spec.names.kind}`)
+      .should('exist')
+      .click();
     modal.shouldBeOpened();
     modal.submit();
     modal.shouldBeClosed();


### PR DESCRIPTION
Search: https://search.ci.openshift.org/?search=Using+OLM+descriptor+components+deletes+operand&maxAge=48h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

Prow: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console/12422/pull-ci-openshift-console-master-e2e-gcp-console/1614020742284840960

Artifacts: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_console/12422/pull-ci-openshift-console-master-e2e-gcp-console/1614020742284840960/artifacts/e2e-gcp-console/test/artifacts/gui_test_screenshots/cypress/screenshots/descriptors.spec.ts/1_Using%20OLM%20descriptor%20components%20--%20deletes%20operand%20(failed).png

Bug: [OCPBUGS-5851](https://issues.redhat.com/browse/OCPBUGS-5851)

Before:
<img width="1279" alt="image" src="https://user-images.githubusercontent.com/65410551/212618227-386afddd-44fd-4417-ae69-228a249bf33f.png">

After:
<img width="1400" alt="image" src="https://user-images.githubusercontent.com/65410551/212618103-e87a426c-4758-40e4-882b-4c5e3a2f5b12.png">
