### PR TITLE
OCPBUGS-5453: Add Pipeline metrics unsupported empty page

### DIFF
--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -275,6 +275,8 @@
   "TaskRun Duration": "TaskRun Duration",
   "Start your pipeline to view pipeline metrics.": "Start your pipeline to view pipeline metrics.",
   "Administrators can try <2>this quick start</2> to configure their metrics level to pipelinerun and taskrun. The pipelinerun and taskrun metrics level collects large volume of metrics over time in unbounded cardinality which may lead to metrics unreliability.": "Administrators can try <2>this quick start</2> to configure their metrics level to pipelinerun and taskrun. The pipelinerun and taskrun metrics level collects large volume of metrics over time in unbounded cardinality which may lead to metrics unreliability.",
+  "Pipeline metrics configuration is unsupported.": "Pipeline metrics configuration is unsupported.",
+  "Pipeline metrics configuration defaults to pipeline and task level.": "Pipeline metrics configuration defaults to pipeline and task level.",
   "Refresh Interval": "Refresh Interval",
   "Time Range": "Time Range",
   "Pipeline run count chart": "Pipeline run count chart",

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetrics.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetrics.tsx
@@ -21,6 +21,7 @@ import PipelineMetricsEmptyState from './PipelineMetricsEmptyState';
 import PipelineMetricsQuickstart from './PipelineMetricsQuickstart';
 import PipelineMetricsRefreshDropdown from './PipelineMetricsRefreshDropdown';
 import PipelineMetricsTimeRangeDropdown from './PipelineMetricsTimeRangeDropdown';
+import PipelineMetricsUnsupported from './PipelineMetricsUnsupported';
 import PipelineRunCount from './PipelineRunCount';
 import PipelineRunDurationGraph from './PipelineRunDurationGraph';
 import PipelineRunTaskRunGraph from './PipelineRunTaskRunGraph';
@@ -41,60 +42,111 @@ const PipelineMetrics: React.FC<PipelineDetailsTabProps> = ({ obj, customData })
   const [loaded, setLoaded] = React.useState(false);
   const totalGraphs = metricsLevel === PipelineMetricsLevel.PIPELINE_TASK_LEVEL ? 2 : 4;
 
-  const graphOnLoad = (graphData: GraphData) => {
-    if (!loadedGraphs.find((g) => g.chartName === graphData.chartName) && graphData.hasData) {
-      setLoadedGraphs([...loadedGraphs, graphData]);
-    }
-  };
+  const graphOnLoad = React.useCallback(
+    (graphData: GraphData) => {
+      if (!loadedGraphs.find((g) => g.chartName === graphData.chartName) && graphData.hasData) {
+        setLoadedGraphs([...loadedGraphs, graphData]);
+      }
+    },
+    [loadedGraphs],
+  );
   React.useEffect(() => {
     if (!loaded && loadedGraphs.length === totalGraphs) {
       setLoaded(true);
     }
   }, [loaded, loadedGraphs, totalGraphs]);
 
+  if (!latestPipelineRun) {
+    return <PipelineMetricsEmptyState />;
+  }
+
+  if (metricsLevel === PipelineMetricsLevel.UNSUPPORTED_LEVEL) {
+    return (
+      <PipelineMetricsUnsupported
+        updatePermission={hasUpdatePermission}
+        metricsLevel={metricsLevel}
+      />
+    );
+  }
+
   return (
-    <>
-      {!latestPipelineRun ? (
-        <PipelineMetricsEmptyState />
-      ) : (
-        <Stack hasGutter key={metricsLevel}>
-          <StackItem className="pipeline-metrics-dashboard__toolbar">
-            {hasUpdatePermission && metricsLevel === PipelineMetricsLevel.PIPELINE_TASK_LEVEL && (
-              <Grid hasGutter style={{ marginBottom: 'var(--pf-global--spacer--lg)' }}>
-                <GridItem xl2={12} xl={12} lg={12}>
-                  <PipelineMetricsQuickstart />
-                </GridItem>
-              </Grid>
-            )}
-            <Flex>
-              <FlexItem>
-                <PipelineMetricsTimeRangeDropdown timespan={timespan} setTimespan={setTimespan} />
-              </FlexItem>
-              <FlexItem>
-                <PipelineMetricsRefreshDropdown interval={interval} setInterval={setInterval} />
-              </FlexItem>
-            </Flex>
-          </StackItem>
-          <StackItem isFilled className="co-m-pane__body pipeline-metrics-dashboard__body">
-            <Grid
-              sm={1}
-              md={1}
-              lg={1}
-              xl={1}
-              xl2={2}
-              hasGutter
-              className="pipeline-metrics-dashboard__body-content"
-            >
+    <Stack hasGutter key={metricsLevel}>
+      <StackItem className="pipeline-metrics-dashboard__toolbar">
+        {hasUpdatePermission && metricsLevel === PipelineMetricsLevel.PIPELINE_TASK_LEVEL && (
+          <Grid hasGutter style={{ marginBottom: 'var(--pf-global--spacer--lg)' }}>
+            <GridItem xl2={12} xl={12} lg={12}>
+              <PipelineMetricsQuickstart />
+            </GridItem>
+          </Grid>
+        )}
+        <Flex>
+          <FlexItem>
+            <PipelineMetricsTimeRangeDropdown timespan={timespan} setTimespan={setTimespan} />
+          </FlexItem>
+          <FlexItem>
+            <PipelineMetricsRefreshDropdown interval={interval} setInterval={setInterval} />
+          </FlexItem>
+        </Flex>
+      </StackItem>
+      <StackItem isFilled className="co-m-pane__body pipeline-metrics-dashboard__body">
+        <Grid
+          sm={1}
+          md={1}
+          lg={1}
+          xl={1}
+          xl2={2}
+          hasGutter
+          className="pipeline-metrics-dashboard__body-content"
+        >
+          <GridItem xl2={7} xl={12} lg={12} md={12} sm={12}>
+            <Card>
+              <CardHeader>
+                <CardTitle>{t('pipelines-plugin~Pipeline Success Ratio')}</CardTitle>
+              </CardHeader>
+              <CardBody>
+                <PipelineSuccessRatioDonut
+                  interval={interval}
+                  timespan={timespan}
+                  pipeline={obj}
+                  loaded={loaded}
+                  onLoad={graphOnLoad}
+                  queryPrefix={queryPrefix}
+                  metricsLevel={metricsLevel}
+                />
+              </CardBody>
+            </Card>
+          </GridItem>
+          <GridItem xl2={5} xl={12} lg={12} md={12} sm={12}>
+            <Card>
+              <CardHeader>
+                <CardTitle>{t('pipelines-plugin~Number of PipelineRuns')}</CardTitle>
+              </CardHeader>
+              <CardBody>
+                <PipelineRunCount
+                  interval={interval}
+                  timespan={timespan}
+                  pipeline={obj}
+                  loaded={loaded}
+                  onLoad={graphOnLoad}
+                  queryPrefix={queryPrefix}
+                  metricsLevel={metricsLevel}
+                />
+              </CardBody>
+            </Card>
+          </GridItem>
+
+          {metricsLevel === PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL && (
+            <>
               <GridItem xl2={7} xl={12} lg={12} md={12} sm={12}>
                 <Card>
                   <CardHeader>
-                    <CardTitle>{t('pipelines-plugin~Pipeline Success Ratio')}</CardTitle>
+                    <CardTitle>{t('pipelines-plugin~PipelineRun Duration')}</CardTitle>
                   </CardHeader>
                   <CardBody>
-                    <PipelineSuccessRatioDonut
+                    <PipelineRunDurationGraph
                       interval={interval}
-                      timespan={timespan}
                       pipeline={obj}
+                      timespan={timespan}
                       loaded={loaded}
                       onLoad={graphOnLoad}
                       queryPrefix={queryPrefix}
@@ -106,10 +158,10 @@ const PipelineMetrics: React.FC<PipelineDetailsTabProps> = ({ obj, customData })
               <GridItem xl2={5} xl={12} lg={12} md={12} sm={12}>
                 <Card>
                   <CardHeader>
-                    <CardTitle>{t('pipelines-plugin~Number of PipelineRuns')}</CardTitle>
+                    <CardTitle>{t('pipelines-plugin~TaskRun Duration')}</CardTitle>
                   </CardHeader>
                   <CardBody>
-                    <PipelineRunCount
+                    <PipelineRunTaskRunGraph
                       interval={interval}
                       timespan={timespan}
                       pipeline={obj}
@@ -121,52 +173,11 @@ const PipelineMetrics: React.FC<PipelineDetailsTabProps> = ({ obj, customData })
                   </CardBody>
                 </Card>
               </GridItem>
-
-              {metricsLevel === PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL && (
-                <>
-                  <GridItem xl2={7} xl={12} lg={12} md={12} sm={12}>
-                    <Card>
-                      <CardHeader>
-                        <CardTitle>{t('pipelines-plugin~PipelineRun Duration')}</CardTitle>
-                      </CardHeader>
-                      <CardBody>
-                        <PipelineRunDurationGraph
-                          interval={interval}
-                          pipeline={obj}
-                          timespan={timespan}
-                          loaded={loaded}
-                          onLoad={graphOnLoad}
-                          queryPrefix={queryPrefix}
-                          metricsLevel={metricsLevel}
-                        />
-                      </CardBody>
-                    </Card>
-                  </GridItem>
-                  <GridItem xl2={5} xl={12} lg={12} md={12} sm={12}>
-                    <Card>
-                      <CardHeader>
-                        <CardTitle>{t('pipelines-plugin~TaskRun Duration')}</CardTitle>
-                      </CardHeader>
-                      <CardBody>
-                        <PipelineRunTaskRunGraph
-                          interval={interval}
-                          timespan={timespan}
-                          pipeline={obj}
-                          loaded={loaded}
-                          onLoad={graphOnLoad}
-                          queryPrefix={queryPrefix}
-                          metricsLevel={metricsLevel}
-                        />
-                      </CardBody>
-                    </Card>
-                  </GridItem>
-                </>
-              )}
-            </Grid>
-          </StackItem>
-        </Stack>
-      )}
-    </>
+            </>
+          )}
+        </Grid>
+      </StackItem>
+    </Stack>
   );
 };
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetricsQuickstart.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetricsQuickstart.tsx
@@ -1,14 +1,19 @@
 import * as React from 'react';
 import { QuickStartContextValues, QuickStartContext } from '@patternfly/quickstarts';
-import { Alert } from '@patternfly/react-core';
-import { Trans } from 'react-i18next';
+import { Alert, AlertVariant } from '@patternfly/react-core';
+import { Trans, useTranslation } from 'react-i18next';
 import { Link, useLocation } from 'react-router-dom';
 import QuickStartsLoader from '@console/app/src/components/quick-starts/loader/QuickStartsLoader';
 import { isModifiedEvent } from '@console/shared/src';
+import { PipelineMetricsLevel } from '../const';
 
 type PipelineMetricsQuickstartInfoProps = {
   onClick: (event: React.MouseEvent<HTMLElement>) => void;
   to: { pathname: string; search: string };
+};
+
+type PipelineMetricsQuickstartProps = {
+  metricsLevel?: string;
 };
 
 export const PipelineMetricsQuickstartInfo: React.FC<PipelineMetricsQuickstartInfoProps> = ({
@@ -26,7 +31,8 @@ export const PipelineMetricsQuickstartInfo: React.FC<PipelineMetricsQuickstartIn
   </Trans>
 );
 
-const PipelineMetricsQuickstart: React.FC = () => {
+const PipelineMetricsQuickstart: React.FC<PipelineMetricsQuickstartProps> = ({ metricsLevel }) => {
+  const { t } = useTranslation();
   const PIPELINE_METRICS_CONFIGURATION_QUICKSTART = 'configure-pipeline-metrics';
   const { pathname, search } = useLocation();
   const { setActiveQuickStart } = React.useContext<QuickStartContextValues>(QuickStartContext);
@@ -59,9 +65,19 @@ const PipelineMetricsQuickstart: React.FC = () => {
           <>
             {isPipelineMetricsQSAvailable && (
               <Alert
-                variant="info"
+                variant={
+                  metricsLevel === PipelineMetricsLevel.UNSUPPORTED_LEVEL
+                    ? AlertVariant.warning
+                    : AlertVariant.info
+                }
                 isInline
-                title="Pipeline metrics configuration defaults to pipeline and task level"
+                title={
+                  metricsLevel === PipelineMetricsLevel.UNSUPPORTED_LEVEL
+                    ? t('pipelines-plugin~Pipeline metrics configuration is unsupported.')
+                    : t(
+                        'pipelines-plugin~Pipeline metrics configuration defaults to pipeline and task level.',
+                      )
+                }
               >
                 <PipelineMetricsQuickstartInfo
                   data-test-id="pipeline-metrics-quickstart-link"

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetricsUnsupported.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetricsUnsupported.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import {
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { ChartLineIcon } from '@patternfly/react-icons';
+import { useTranslation } from 'react-i18next';
+import PipelineMetricsQuickstart from './PipelineMetricsQuickstart';
+
+type PipelineMetricsUnsupportedProps = {
+  updatePermission: boolean;
+  metricsLevel: string;
+};
+
+const PipelineMetricsUnsupported: React.FC<PipelineMetricsUnsupportedProps> = ({
+  updatePermission,
+  metricsLevel,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <>
+      {updatePermission && <PipelineMetricsQuickstart metricsLevel={metricsLevel} />}
+      <Stack className="pipeline-metrics-empty-state">
+        <StackItem isFilled>
+          <Bullseye>
+            <EmptyState variant={EmptyStateVariant.full}>
+              <EmptyStateIcon icon={ChartLineIcon} />
+              <EmptyStateBody>
+                {t('pipelines-plugin~Pipeline metrics configuration is unsupported.')}
+              </EmptyStateBody>
+            </EmptyState>
+          </Bullseye>
+        </StackItem>
+      </Stack>
+    </>
+  );
+};
+
+export default PipelineMetricsUnsupported;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineMetrics.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineMetrics.spec.tsx
@@ -14,6 +14,7 @@ import PipelineMetricsEmptyState from '../PipelineMetricsEmptyState';
 import PipelineMetricsQuickstart from '../PipelineMetricsQuickstart';
 import PipelineMetricsRefreshDropdown from '../PipelineMetricsRefreshDropdown';
 import PipelineMetricsTimeRangeDropdown from '../PipelineMetricsTimeRangeDropdown';
+import PipelineMetricsUnsupported from '../PipelineMetricsUnsupported';
 import PipelineRunCount from '../PipelineRunCount';
 import PipelineRunDurationGraph from '../PipelineRunDurationGraph';
 import PipelineRunTaskRunGraph from '../PipelineRunTaskRunGraph';
@@ -144,5 +145,19 @@ describe('Pipeline Metrics', () => {
       .update();
 
     expect(pipelineMetricsWrapper.find(PipelineMetricsQuickstart).exists()).toBe(false);
+  });
+
+  it('Should render Pipeline Metrics Unsupported empty page', () => {
+    latestPipelineRunSpy.mockReturnValue(pipelineRun);
+    const pipelineMetricsWrapper = shallow(<PipelineMetrics {...PipelineMetricsProps} />);
+    pipelineMetricsWrapper
+      .setProps({
+        customData: {
+          metricsLevel: PipelineMetricsLevel.UNSUPPORTED_LEVEL,
+          hasUpdatePermission: true,
+        },
+      })
+      .update();
+    expect(pipelineMetricsWrapper.find(PipelineMetricsUnsupported).exists()).toBe(true);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineMetricsUnsupported.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineMetricsUnsupported.spec.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { PipelineMetricsLevel } from '../../const';
+import PipelineMetricsQuickstart from '../PipelineMetricsQuickstart';
+import PipelineMetricsUnsupported from '../PipelineMetricsUnsupported';
+
+describe('Pipeline Metrics unsupported', () => {
+  it('Should show PipelineMetricsQuickstart alert', () => {
+    const pipelineMetricsUnsupportedWrapper = shallow(
+      <PipelineMetricsUnsupported
+        updatePermission
+        metricsLevel={PipelineMetricsLevel.UNSUPPORTED_LEVEL}
+      />,
+    );
+    expect(pipelineMetricsUnsupportedWrapper.find(PipelineMetricsQuickstart).exists()).toBe(true);
+  });
+
+  it('Should not show PipelineMetricsQuickstart alert', () => {
+    const pipelineMetricsUnsupportedWrapper = shallow(
+      <PipelineMetricsUnsupported
+        updatePermission={false}
+        metricsLevel={PipelineMetricsLevel.UNSUPPORTED_LEVEL}
+      />,
+    );
+    expect(pipelineMetricsUnsupportedWrapper.find(PipelineMetricsQuickstart).exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-5453

Description: If pipeline metrics configuration is not supported then show Pipeline metrics unsupported empty page.

Screenshots: 
![image](https://user-images.githubusercontent.com/2561818/220637867-64a5d529-b91a-4c64-947e-475c32313159.png)

Tests:
![image](https://user-images.githubusercontent.com/2561818/212835622-ff76a2ac-ac99-477d-815e-c2b26eac1ea6.png)
![image](https://user-images.githubusercontent.com/2561818/212835679-36702556-aeed-43eb-bd3a-326f04453c7c.png)
