### PR TITLE
Add additional alerts datasource extension

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/common-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/common-types.ts
@@ -179,11 +179,25 @@ export type PrometheusRule = {
 
 export type Rule = PrometheusRule & {
   id: string;
+  sourceId?: string;
   silencedBy?: Silence[];
 };
 
 export type PrometheusLabels = { [key: string]: string };
 export type PrometheusValue = [number, string];
+
+type Group = {
+  rules: PrometheusRule[];
+  file: string;
+  name: string;
+};
+
+export type PrometheusRulesResponse = {
+  data: {
+    groups: Group[];
+  };
+  status: string;
+};
 
 export type DiscoveryResources = {
   adminResources: string[];

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/alerts.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/alerts.ts
@@ -1,0 +1,38 @@
+import { Rule, PrometheusRulesResponse } from '../api/common-types';
+import { CodeRef, Extension, ExtensionDeclaration } from '../types';
+
+type AlertingRulesFetch = () => Promise<PrometheusRulesResponse>;
+
+/** Alerting rules from additional sources other than Prometheus */
+export type AlertingRulesSourceExtension = ExtensionDeclaration<
+  'console.alerts/rules-source',
+  {
+    /** Id of the alerting rules source */
+    id: string;
+    /** ContextId on which this source of alerting rules should be used */
+    contextId: string;
+    /** Promise that returns Prometheus-compatible alerting rules */
+    getAlertingRules: CodeRef<AlertingRulesFetch>;
+  }
+>;
+
+type AlertingRuleChartProps = { rule?: Rule };
+
+/** Metric charts for alerting rules from additional sources other than Prometheus */
+export type AlertingRuleChartExtension = ExtensionDeclaration<
+  'console.alerts/rules-chart',
+  {
+    /** Source Id belonging to one 'console.alerts/rules-source' used to fetch alerting rule metrics */
+    sourceId: string;
+    /** Chart component to be rendered as alerting rule metrics */
+    chart: CodeRef<React.ComponentType<AlertingRuleChartProps>>;
+  }
+>;
+
+// Type guards
+
+export const isAlertingRulesSource = (e: Extension): e is AlertingRulesSourceExtension =>
+  e.type === 'console.alerts/rules-source';
+
+export const isAlertingRuleChart = (e: Extension): e is AlertingRuleChartExtension =>
+  e.type === 'console.alerts/rules-chart';

--- a/frontend/packages/console-shared/src/utils/__mocks__/alerts-and-rules-data.ts
+++ b/frontend/packages/console-shared/src/utils/__mocks__/alerts-and-rules-data.ts
@@ -1,5 +1,10 @@
-import { Alert, AlertStates, RuleStates } from '@console/dynamic-plugin-sdk';
-import { Alerts, PrometheusRulesResponse } from '@console/internal/components/monitoring/types';
+import {
+  Alert,
+  AlertStates,
+  RuleStates,
+  PrometheusRulesResponse,
+} from '@console/dynamic-plugin-sdk';
+import { Alerts } from '@console/internal/components/monitoring/types';
 
 export const mockAlerts: Alerts = {
   loadError: null,

--- a/frontend/public/components/graphs/prometheus-rules-hook.ts
+++ b/frontend/public/components/graphs/prometheus-rules-hook.ts
@@ -1,6 +1,6 @@
 import { useURLPoll } from '../utils/url-poll-hook';
 import { getPrometheusURL, PrometheusEndpoint } from './helpers';
-import { PrometheusRulesResponse } from '../monitoring/types';
+import { PrometheusRulesResponse } from '@console/dynamic-plugin-sdk';
 
 export const usePrometheusRulesPoll = ({ delay, namespace }: PrometheusPollProps) => {
   const url = getPrometheusURL({

--- a/frontend/public/components/monitoring/fetch-alerts.tsx
+++ b/frontend/public/components/monitoring/fetch-alerts.tsx
@@ -1,0 +1,46 @@
+import { PrometheusRulesResponse } from '@console/dynamic-plugin-sdk';
+import { coFetchJSON } from '@console/internal/co-fetch';
+
+/**
+ * Merges prometheus monitoring alerts with external sources
+ */
+export const fetchAlerts = async (
+  prometheusURL: string,
+  externalAlertsFetch?: Array<{
+    id: string;
+    getAlertingRules: () => Promise<PrometheusRulesResponse>;
+  }>,
+): Promise<PrometheusRulesResponse> => {
+  if (!externalAlertsFetch || externalAlertsFetch.length === 0) {
+    return coFetchJSON(prometheusURL);
+  }
+
+  const resolvedExternalAlertsSources = externalAlertsFetch.map((extensionProperties) => ({
+    id: extensionProperties.id,
+    fetch: extensionProperties.getAlertingRules,
+  }));
+
+  const sourceIds = ['prometheus', ...resolvedExternalAlertsSources.map((source) => source.id)];
+
+  try {
+    const groups = await Promise.allSettled([
+      coFetchJSON(prometheusURL),
+      ...resolvedExternalAlertsSources.map((source) => source.fetch()),
+    ]).then((results) =>
+      results
+        .map((result, i) => ({ sourceId: sourceIds[i], alerts: result }))
+        .flatMap((result) =>
+          result.alerts.status === 'fulfilled' && result.alerts.value?.data?.groups
+            ? result.alerts.value.data.groups.map((group) => ({
+                ...group,
+                rules: [...group.rules.map((rule) => ({ ...rule, sourceId: result.sourceId }))],
+              }))
+            : [],
+        ),
+    );
+
+    return { data: { groups }, status: 'success' };
+  } catch {
+    return coFetchJSON(prometheusURL);
+  }
+};

--- a/frontend/public/components/monitoring/types.ts
+++ b/frontend/public/components/monitoring/types.ts
@@ -1,10 +1,4 @@
-import {
-  Alert,
-  PrometheusLabels,
-  PrometheusRule,
-  Rule,
-  Silence,
-} from '@console/dynamic-plugin-sdk';
+import { Alert, PrometheusLabels, Rule, Silence } from '@console/dynamic-plugin-sdk';
 
 export const enum AlertSource {
   Platform = 'platform',
@@ -36,12 +30,6 @@ export type Rules = {
   loadError?: string | Error;
 };
 
-type Group = {
-  rules: PrometheusRule[];
-  file: string;
-  name: string;
-};
-
 export type PrometheusAPIError = {
   json: {
     error?: string;
@@ -50,13 +38,6 @@ export type PrometheusAPIError = {
   response: {
     status: number;
   };
-};
-
-export type PrometheusRulesResponse = {
-  data: {
-    groups: Group[];
-  };
-  status: string;
 };
 
 export type Target = {

--- a/frontend/public/components/monitoring/utils.ts
+++ b/frontend/public/components/monitoring/utils.ts
@@ -10,9 +10,10 @@ import {
   Rule,
   Silence,
   SilenceStates,
+  PrometheusRulesResponse,
 } from '@console/dynamic-plugin-sdk';
 
-import { AlertSource, MonitoringResource, PrometheusRulesResponse, Target } from './types';
+import { AlertSource, MonitoringResource, Target } from './types';
 
 export const PROMETHEUS_BASE_PATH = window.SERVER_FLAGS.prometheusBaseURL;
 
@@ -87,6 +88,15 @@ export const silenceMatcherEqualitySymbol = (isEqual: boolean, isRegex: boolean)
 
 export const alertDescription = (alert: Alert | Rule): string =>
   alert.annotations?.description || alert.annotations?.message || alert.labels?.alertname;
+
+export const alertAdditionalSource = (alert: Alert): string => {
+  const ruleSourceLabel = alert.rule?.labels?.source;
+  const sourceId = alert.rule.sourceId ?? '';
+  if (ruleSourceLabel) {
+    return `${_.startCase(sourceId)} - ${_.startCase(ruleSourceLabel)}`;
+  }
+  return _.startCase(sourceId);
+};
 
 // Determine if an Alert is silenced by a Silence (if all of the Silence's matchers match one of the
 // Alert's labels)

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -21,7 +21,6 @@ import {
 } from '@console/internal/actions/observe';
 import * as UIActions from '@console/internal/actions/ui';
 import { RootState } from '@console/internal/redux';
-import { PrometheusRulesResponse } from '@console/internal/components/monitoring/types';
 
 import { getClusterID } from '../module/k8s/cluster-settings';
 
@@ -78,7 +77,7 @@ import { LinkifyExternal } from './utils';
 import { PrometheusEndpoint } from './graphs/helpers';
 import { LabelSelector } from '@console/internal/module/k8s/label-selector';
 import { useNotificationAlerts } from '@console/shared/src/hooks/useNotificationAlerts';
-import { useModal } from '@console/dynamic-plugin-sdk/src/lib-core';
+import { useModal, PrometheusRulesResponse } from '@console/dynamic-plugin-sdk/src/lib-core';
 
 const AlertErrorState: React.FC<AlertErrorProps> = ({ errorText }) => {
   const { t } = useTranslation();


### PR DESCRIPTION
This PR will add a new extension that allows plugins to define new alerts datasources, the datasources are expected to be prometheus-compatible such as https://grafana.com/docs/loki/latest/api/#list-rules. This alerts will be fetched and merged with the current alerts from prometheus.

Fixes: 
https://issues.redhat.com/browse/OU-103 
https://issues.redhat.com/browse/OU-104


https://user-images.githubusercontent.com/5461414/214550694-05bfac81-af74-40ad-afa5-fc7649a291fc.mov

