### PR TITLE
ODC-7226: update helm install and upgrade flow

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/Status.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/Status.tsx
@@ -54,6 +54,8 @@ const Status: React.FC<StatusProps> = ({
 
     case 'ContainerCreating':
     case 'UpgradePending':
+    case 'PendingUpgrade':
+    case 'PendingRollback':
       return <ProgressStatus {...statusProps} />;
 
     case 'In Progress':
@@ -63,6 +65,7 @@ const Status: React.FC<StatusProps> = ({
     case 'Running':
     case 'Updating':
     case 'Upgrading':
+    case 'PendingInstall':
       return <StatusIconAndText {...statusProps} icon={<SyncAltIcon />} />;
 
     case 'Cancelled':
@@ -71,6 +74,7 @@ const Status: React.FC<StatusProps> = ({
     case 'Not Ready':
     case 'Cancelling':
     case 'Terminating':
+    case 'Uninstalling':
       return <StatusIconAndText {...statusProps} icon={<BanIcon />} />;
 
     case 'Warning':
@@ -105,6 +109,7 @@ const Status: React.FC<StatusProps> = ({
     case 'Provisioned as node':
     case 'Preferred':
     case 'Connected':
+    case 'Deployed':
       return <SuccessStatus {...statusProps} />;
 
     case 'Info':

--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -601,10 +601,10 @@ const getPodTemplate = (resource: K8sResourceKind): PodTemplate => {
             },
           },
         },
-        resource.spec.template,
+        resource.spec?.template,
       );
     default:
-      return resource.spec.template;
+      return resource.spec?.template;
   }
 };
 

--- a/frontend/packages/helm-plugin/console-extensions.json
+++ b/frontend/packages/helm-plugin/console-extensions.json
@@ -379,5 +379,14 @@
     "flags": {
       "required": ["OPENSHIFT_HELM"]
     }
+  },
+  {
+    "type": "console.topology/decorator/provider",
+    "properties": {
+      "id": "helm-release-status-decorator",
+      "priority": 100,
+      "quadrant": "lowerLeft",
+      "decorator": { "$codeRef": "helmTopology.getHelmReleaseStatusDecorator" }
+    }
   }
 ]

--- a/frontend/packages/helm-plugin/locales/en/helm-plugin.json
+++ b/frontend/packages/helm-plugin/locales/en/helm-plugin.json
@@ -123,6 +123,7 @@
   "Repositories": "Repositories",
   "Select a Project to view its details or <2>create a Project</2>.": "Select a Project to view its details or <2>create a Project</2>.",
   "No repositories found": "No repositories found",
+  "Helm release is {{status}}": "Helm release is {{status}}",
   "Unable to find resource for {{helmLabel}}": "Unable to find resource for {{helmLabel}}",
   " / App Version {{appVersion}}": " / App Version {{appVersion}}",
   " (Provided by {{chartRepoName}})": " (Provided by {{chartRepoName}})",

--- a/frontend/packages/helm-plugin/src/actions/types.ts
+++ b/frontend/packages/helm-plugin/src/actions/types.ts
@@ -1,6 +1,11 @@
 import { HelmRelease } from '../types/helm-types';
 
-type HelmActionObj = { name: string; namespace: string; version: number | string };
+type HelmActionObj = {
+  name: string;
+  namespace: string;
+  version: number | string;
+  info?: { status: string };
+};
 
 export type HelmActionsScope = {
   release: HelmRelease | HelmActionObj;

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
@@ -12,8 +12,6 @@ import NamespacedPage, {
 } from '@console/dev-console/src/components/NamespacedPage';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { history, LoadingBox } from '@console/internal/components/utils';
-import { SecretModel } from '@console/internal/models';
-import { k8sGet } from '@console/internal/module/k8s';
 import { prune } from '@console/shared/src/components/dynamic-form/utils';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
 import {
@@ -23,7 +21,14 @@ import {
   HelmActionConfigType,
   HelmActionOrigins,
 } from '../../../types/helm-types';
-import { getHelmActionConfig, getChartValuesYAML, getChartReadme } from '../../../utils/helm-utils';
+import {
+  getHelmActionConfig,
+  getChartValuesYAML,
+  getChartReadme,
+  fetchHelmRelease,
+  loadHelmManifestResources,
+  isGoingToTopology,
+} from '../../../utils/helm-utils';
 import { getHelmActionValidationSchema } from '../../../utils/helm-validation-utils';
 import HelmChartMetaDescription from './HelmChartMetaDescription';
 import HelmInstallUpgradeForm from './HelmInstallUpgradeForm';
@@ -95,7 +100,7 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
   React.useEffect(() => {
     let ignore = false;
 
-    const fetchHelmRelease = async () => {
+    const fetchHelmChart = async () => {
       let res;
       let error: Error = null;
       try {
@@ -122,7 +127,7 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
       setChartError(error);
     };
 
-    fetchHelmRelease();
+    fetchHelmChart();
 
     return () => {
       ignore = true;
@@ -188,30 +193,26 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
       ...(valuesObj ? { values: valuesObj } : {}),
     };
 
-    const isGoingToTopology =
-      helmAction === HelmActionType.Create || helmActionOrigin === HelmActionOrigins.topology;
-
     return config
-      .fetch('/api/helm/release', payload, null, -1)
-      .then(async (res: HelmRelease) => {
+      .fetch('/api/helm/release/async', payload, null, -1)
+      .then(async (res: { secret_name: string }) => {
         let redirect = config.redirectURL;
-
-        if (isGoingToTopology && res?.info?.notes) {
-          const options = {
-            queryParams: { labelSelector: `name=${res.name},version=${res.version},owner=helm` },
-          };
-          let secret;
-          try {
-            secret = await k8sGet(SecretModel, null, res.namespace, options);
-          } catch (err) {
-            console.error('Could not fetch all helm chart releases', err); // eslint-disable-line no-console
-          }
-          const secretId = secret?.items?.[0]?.metadata?.uid;
-          if (secretId) {
-            redirect = `${config.redirectURL}?selectId=${secretId}&selectTab=${t(
-              'helm-plugin~Release notes',
-            )}`;
-          }
+        let helmRelease: HelmRelease;
+        try {
+          helmRelease = await fetchHelmRelease(namespace, releaseName);
+        } catch (err) {
+          console.error('Could not fetch the helm release', err); // eslint-disable-line no-console
+        }
+        const resources = loadHelmManifestResources(helmRelease);
+        if (isGoingToTopology(resources)) {
+          const secretId = res.secret_name;
+          redirect = helmRelease?.info?.notes
+            ? `${config.redirectURL}?selectId=${secretId}&selectTab=${t(
+                'helm-plugin~Release notes',
+              )}`
+            : config.redirectURL;
+        } else {
+          redirect = `/helm-releases/ns/${namespace}/release/${releaseName}`;
         }
 
         history.push(redirect);

--- a/frontend/packages/helm-plugin/src/topology/components/HelmReleaseGroup.tsx
+++ b/frontend/packages/helm-plugin/src/topology/components/HelmReleaseGroup.tsx
@@ -21,6 +21,7 @@ import {
   NODE_SHADOW_FILTER_ID,
   noRegroupDragSourceSpec,
 } from '@console/topology/src/components/graph-view';
+import { getNodeDecorators } from '@console/topology/src/components/graph-view/components/nodes/decorators/getNodeDecorators';
 import { useSearchFilter } from '@console/topology/src/filters';
 import { useShowLabel } from '@console/topology/src/filters/useShowLabel';
 import { getResource } from '@console/topology/src/utils';
@@ -37,6 +38,7 @@ type HelmReleaseGroupProps = {
   WithDragNodeProps &
   WithDndDropProps;
 
+const DECORATOR_RADIUS = 13;
 const HelmReleaseGroup: React.FC<HelmReleaseGroupProps> = ({
   element,
   badge,
@@ -60,6 +62,17 @@ const HelmReleaseGroup: React.FC<HelmReleaseGroupProps> = ({
   const hasChildren = element.getChildren()?.length > 0;
   const { x, y, width, height } = element.getBounds();
   const typeIconClass = element.getData().data.chartIcon || 'icon-helm';
+
+  const decorators = getNodeDecorators(
+    element,
+    element.getGraph().getData().decorators,
+    x + width / 2,
+    y + height / 2,
+    -1,
+    DECORATOR_RADIUS,
+    width,
+    height,
+  );
 
   return (
     <g
@@ -108,6 +121,7 @@ const HelmReleaseGroup: React.FC<HelmReleaseGroupProps> = ({
           )}
         </g>
       </Layer>
+      {decorators}
       {showLabel && element.getLabel() && (
         <NodeLabel
           className="pf-topology__group__label odc-base-node__label"

--- a/frontend/packages/helm-plugin/src/topology/components/HelmReleaseStatusDecorator.tsx
+++ b/frontend/packages/helm-plugin/src/topology/components/HelmReleaseStatusDecorator.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Node } from '@patternfly/react-topology';
+import { useTranslation } from 'react-i18next';
+import { Status } from '@console/shared';
+import { BuildDecoratorBubble } from '@console/topology/src/components/graph-view';
+import { releaseStatus } from '../../utils/helm-utils';
+
+type HelmReleaseStatusDecoratorProps = {
+  element: Node;
+  radius: number;
+  x: number;
+  y: number;
+};
+
+const HelmReleaseStatusDecorator: React.FC<HelmReleaseStatusDecoratorProps> = ({
+  element,
+  radius,
+  x,
+  y,
+}) => {
+  const { t } = useTranslation();
+  const { data } = element.getData();
+
+  if (!data) {
+    return null;
+  }
+  const status = releaseStatus(data.status);
+  const label = t('helm-plugin~Helm release is {{status}}', { status });
+
+  return (
+    <Tooltip content={label} position={TooltipPosition.left}>
+      <BuildDecoratorBubble x={x} y={y} radius={radius} ariaLabel={label}>
+        <Status status={status} iconOnly noTooltip />
+      </BuildDecoratorBubble>
+    </Tooltip>
+  );
+};
+
+export default HelmReleaseStatusDecorator;

--- a/frontend/packages/helm-plugin/src/topology/components/getHelmReleaseStatusDecorator.tsx
+++ b/frontend/packages/helm-plugin/src/topology/components/getHelmReleaseStatusDecorator.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { Node } from '@patternfly/react-topology/src/types';
+import { TYPE_HELM_RELEASE } from './const';
+import HelmReleaseStatusDecorator from './HelmReleaseStatusDecorator';
+
+export const getHelmReleaseStatusDecorator = (
+  element: Node,
+  radius: number,
+  x: number,
+  y: number,
+) => {
+  if (element.getType() !== TYPE_HELM_RELEASE || element.isCollapsed()) {
+    return null;
+  }
+
+  return <HelmReleaseStatusDecorator element={element} radius={radius} x={x} y={y} />;
+};

--- a/frontend/packages/helm-plugin/src/topology/helm-data-transformer.ts
+++ b/frontend/packages/helm-plugin/src/topology/helm-data-transformer.ts
@@ -91,6 +91,7 @@ export const getTopologyHelmReleaseGroupItem = (
       },
       data: {
         chartIcon: helmResources?.chartIcon,
+        status: helmResources?.status,
         manifestResources: helmResources?.manifestResources || [],
         releaseNotes,
       },
@@ -170,6 +171,7 @@ const getHelmReleaseMap = (namespace: string) => {
                 chartIcon: release.chart.metadata.icon,
                 manifestResources,
                 releaseNotes: release.info.notes,
+                status: release.info.status,
               };
             }
           });

--- a/frontend/packages/helm-plugin/src/topology/index.ts
+++ b/frontend/packages/helm-plugin/src/topology/index.ts
@@ -3,5 +3,6 @@ import { getHelmTopologyDataModel as getTopologyDataModel } from './helm-data-tr
 export { getHelmComponentFactory } from './components/helmComponentFactory';
 export { isHelmResourceInModel } from './isHelmResource';
 export { getTopologyFilters, applyHelmDisplayOptions } from './helmFilters';
+export { getHelmReleaseStatusDecorator } from './components/getHelmReleaseStatusDecorator';
 
 export const getHelmTopologyDataModel = getTopologyDataModel();

--- a/frontend/packages/helm-plugin/src/types/helm-types.ts
+++ b/frontend/packages/helm-plugin/src/types/helm-types.ts
@@ -59,6 +59,7 @@ export interface HelmReleaseResourcesData {
   chartIcon: string;
   manifestResources: K8sResourceKind[];
   releaseNotes: string;
+  status: string;
 }
 
 export interface HelmReleaseResourcesMap {
@@ -68,6 +69,9 @@ export interface HelmReleaseResourcesMap {
 export enum HelmReleaseStatus {
   Deployed = 'deployed',
   Failed = 'failed',
+  PendingInstall = 'pending-install',
+  PendingUpgrade = 'pending-upgrade',
+  PendingRollback = 'pending-rollback',
   Other = 'other',
 }
 

--- a/frontend/packages/helm-plugin/src/utils/__tests__/helm-utils.spec.ts
+++ b/frontend/packages/helm-plugin/src/utils/__tests__/helm-utils.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '../../components/__tests__/helm-release-mock-data';
 import { HelmRelease, HelmReleaseStatus } from '../../types/helm-types';
 import {
-  OtherReleaseStatuses,
+  SelectedReleaseStatuses,
   releaseStatusReducer,
   filterHelmReleasesByName,
   filterHelmReleasesByStatus,
@@ -22,6 +22,7 @@ import {
   getChartEntriesByName,
   loadHelmManifestResources,
   getChartIndexEntry,
+  isGoingToTopology,
 } from '../helm-utils';
 
 describe('Helm Releases Utils', () => {
@@ -30,9 +31,9 @@ describe('Helm Releases Utils', () => {
     expect(releaseStatusReducer(release)).toEqual(HelmReleaseStatus.Deployed);
   });
 
-  it('should return other for all other statuses for a helm release', () => {
+  it('should return pending-install for a helm release', () => {
     const release = mockHelmReleases[2];
-    expect(releaseStatusReducer(release)).toEqual(HelmReleaseStatus.Other);
+    expect(releaseStatusReducer(release)).toEqual(HelmReleaseStatus.PendingInstall);
   });
 
   it('should return filtered release items with deployed and failed status for row filters', () => {
@@ -42,11 +43,13 @@ describe('Helm Releases Utils', () => {
     expect(filteredReleases[0].info.status).toBe(HelmReleaseStatus.Deployed);
   });
 
-  it('should return filtered release items with other status for row filters', () => {
-    const filter = ['other'];
+  it('should return filtered release items with pending-install status for row filters', () => {
+    const filter = ['pending-install'];
     const filteredReleases = filterHelmReleasesByStatus(mockHelmReleases, filter);
     expect(filteredReleases.length).toEqual(1);
-    expect(OtherReleaseStatuses.includes(filteredReleases[0].info.status)).toBeTruthy();
+    expect(
+      SelectedReleaseStatuses.includes(filteredReleases[0].info.status as HelmReleaseStatus),
+    ).toBeTruthy();
   });
 
   it('should return filtered release items for text filter', () => {
@@ -144,6 +147,75 @@ describe('Helm Releases Utils', () => {
 
   it('should return the readme for the chart provided', () => {
     expect(getChartReadme(mockHelmReleases[0].chart)).toEqual('example readme content');
+  });
+
+  it('should navigate to topology', () => {
+    let resources = [
+      {
+        apiVersion: 'v1',
+        kind: 'ServiceAccount',
+        metadata: {
+          name: 'example-account',
+        },
+      },
+      {
+        apiVersion: 'v1',
+        kind: 'StatefulSet',
+        metadata: {
+          name: 'example-d',
+        },
+      },
+    ];
+    expect(isGoingToTopology(resources)).toBe(true);
+
+    resources = [
+      {
+        apiVersion: 'v1',
+        kind: 'DaemonSet',
+        metadata: {
+          name: 'example-account',
+        },
+      },
+      {
+        apiVersion: 'v1',
+        kind: 'DeploymentConfig',
+        metadata: {
+          name: 'example-d',
+        },
+      },
+    ];
+    expect(isGoingToTopology(resources)).toBe(true);
+  });
+
+  it('should navigate to helm release details page', () => {
+    let resources = [
+      {
+        apiVersion: 'v1',
+        kind: 'ServiceAccount',
+        metadata: {
+          name: 'example-account',
+        },
+      },
+      {
+        apiVersion: 'v1',
+        kind: 'Secret',
+        metadata: {
+          name: 'example-d',
+        },
+      },
+    ];
+    expect(isGoingToTopology(resources)).toBe(false);
+
+    resources = [
+      {
+        apiVersion: 'v1',
+        kind: 'ConfigMap',
+        metadata: {
+          name: 'example-d',
+        },
+      },
+    ];
+    expect(isGoingToTopology(resources)).toBe(false);
   });
 
   describe('loadHelmManifestResources', () => {

--- a/frontend/packages/topology/src/__tests__/topology-test-data.ts
+++ b/frontend/packages/topology/src/__tests__/topology-test-data.ts
@@ -199,6 +199,7 @@ export const sampleHelmResourcesMap = {
     chartIcon: '',
     manifestResources: [sampleHelmChartDeploymentConfig],
     releaseNotes: 'test release notes',
+    status: 'deployed',
   },
 };
 


### PR DESCRIPTION
**JIRA story:**
https://issues.redhat.com/browse/ODC-7226

**Solution description:**
- Using the api `/api/helm/release/async` for installing and upgrading helm charts
- When creating a Helm Release, if there are no workloads to be generated by a release's chart then navigate the user to the Helm Release details page otherwise navigating the user to the topology page with the release notes(if exists) tab opened in the side panel
- Added helm release grouping with installation status
- Disable "Upgrade" and "Rollback" options from the context menu and action dropdown on the side panel when the install/upgrade/rollback is in progress
- Added tests

**Test coverage:**
<img width="509" alt="Screenshot 2023-01-23 at 1 58 44 PM" src="https://user-images.githubusercontent.com/22490998/213995011-bac4c2e2-b43b-41fa-8541-a69dadf154df.png">


**GIF:**
**Helm Charts with workloads**
https://user-images.githubusercontent.com/22490998/213994774-f223fce9-3622-4529-a413-7d57d0227230.mov

**Helm Charts without workloads**
https://user-images.githubusercontent.com/22490998/213994830-ed1c29f8-66f9-47b7-a70f-389158fc8097.mov

/kind feature