### PR TITLE
CONSOLE-3425: Expose 'nameFilter' prop to 'ListPageFilter' component

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -858,12 +858,16 @@ Component that generates filter for list page
 | `loaded` | indicates that data has loaded |
 | `onFilterChange` | callback function for when filter is updated |
 | `rowFilters` | (optional) An array of RowFilter elements that define the available filter options |
+| `labelFilter` | (optional) a unique name key for label filter. This may be useful if there are multiple `ListPageFilter` components rendered at once. |
+| `labelPath` | (optional) the path to labels to filter from |
+| `nameFilterTitle` | (optional) title for name filter |
 | `nameFilterPlaceholder` | (optional) placeholder for name filter |
 | `labelFilterPlaceholder` | (optional) placeholder for label filter |
 | `hideLabelFilter` | (optional) only shows the name filter instead of both name and label filter |
 | `hideNameLabelFilter` | (optional) hides both name and label filter |
 | `columnLayout` | (optional) column layout object |
 | `hideColumnManagement` | (optional) flag to hide the column management |
+| `nameFilter` | (optional) a unique name key for name filter. This may be useful if there are multiple `ListPageFilter` components rendered at once. |
 
 
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -264,12 +264,16 @@ export const ListPageCreateDropdown: React.FC<ListPageCreateDropdownProps> = req
  * @param {boolean} loaded - indicates that data has loaded
  * @param {function} onFilterChange - callback function for when filter is updated
  * @param {RowFilter[]} [rowFilters] - (optional) An array of RowFilter elements that define the available filter options
+ * @param {string} [labelFilter] - (optional) a unique name key for label filter. This may be useful if there are multiple `ListPageFilter` components rendered at once.
+ * @param {string} [labelPath] - (optional) the path to labels to filter from
+ * @param {string} [nameFilterTitle] - (optional) title for name filter
  * @param {string} [nameFilterPlaceholder] -  (optional) placeholder for name filter
  * @param {string} [labelFilterPlaceholder] -  (optional) placeholder for label filter
  * @param {boolean} [hideLabelFilter] -  (optional) only shows the name filter instead of both name and label filter
  * @param {boolean} [hideNameLabelFilter] -  (optional) hides both name and label filter
  * @param {ColumnLayout} [columnLayout] -  (optional) column layout object
  * @param {boolean} [hideColumnManagement] -  (optional) flag to hide the column management
+ * @param {string} [nameFilter] - (optional) a unique name key for name filter. This may be useful if there are multiple `ListPageFilter` components rendered at once.
  * @example
  * ```tsx
  *   // See implementation for more details on RowFilter and FilterValue types

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -448,6 +448,7 @@ export type ListPageFilterProps<D = any> = {
   columnLayout?: ColumnLayout;
   onFilterChange: OnFilterChange;
   hideColumnManagement?: boolean;
+  nameFilter?: string;
 };
 
 export type UseListPageFilter = <D, R>(

--- a/frontend/public/components/factory/ListPage/ListPageFilter.tsx
+++ b/frontend/public/components/factory/ListPage/ListPageFilter.tsx
@@ -18,6 +18,7 @@ const ListPageFilter: React.FC<ListPageFilterProps> = ({
   columnLayout,
   onFilterChange,
   hideColumnManagement,
+  nameFilter,
 }) =>
   loaded &&
   !_.isEmpty(data) && (
@@ -34,6 +35,7 @@ const ListPageFilter: React.FC<ListPageFilterProps> = ({
       hideLabelFilter={hideLabelFilter}
       columnLayout={columnLayout}
       hideColumnManagement={hideColumnManagement}
+      textFilter={nameFilter}
     />
   );
 


### PR DESCRIPTION
Exposing the nameFilter prop will allow multiple tables and multiple filter components and avoiding name filter collision

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>