### PR TITLE
OCPBUGS-5997: Add Git Repository (PAC) showed empty permission content and non-working help link until a git url is entered

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/repository/consts.ts
+++ b/frontend/packages/pipelines-plugin/src/components/repository/consts.ts
@@ -65,6 +65,4 @@ export const WebhookDocLinks = {
   [GitProvider.GITLAB]:
     'https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#configure-a-webhook-in-gitlab',
   [GitProvider.BITBUCKET]: 'https://support.atlassian.com/bitbucket-cloud/docs/manage-webhooks/',
-  [GitProvider.UNSURE]:
-    'https://docs.github.com/en/developers/webhooks-and-events/webhooks/creating-webhooks',
 };

--- a/frontend/packages/pipelines-plugin/src/components/repository/sections/WebhookSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/sections/WebhookSection.tsx
@@ -229,18 +229,25 @@ const WebhookSection: React.FC<WebhoookSectionProps> = ({ pac, formContextField 
         </InputGroup>
       </FormGroup>
 
-      <ExpandableSection toggleText={getPermssionSectionHeading(gitProvider)}>
-        <FormGroup label={t('pipelines-plugin~Repository Permissions:')} fieldId="repo-permissions">
-          <Text component={TextVariants.small}>
-            <PermissionsSection formContextField={formContextField} />
-          </Text>
-        </FormGroup>
-      </ExpandableSection>
+      {gitProvider && gitProvider !== GitProvider.UNSURE ? (
+        <>
+          <ExpandableSection toggleText={getPermssionSectionHeading(gitProvider)}>
+            <FormGroup
+              label={t('pipelines-plugin~Repository Permissions:')}
+              fieldId="repo-permissions"
+            >
+              <Text component={TextVariants.small}>
+                <PermissionsSection formContextField={formContextField} />
+              </Text>
+            </FormGroup>
+          </ExpandableSection>
 
-      <ExternalLink
-        text={t('pipelines-plugin~Read more about setting up webhook')}
-        href={WebhookDocLinks[gitProvider]}
-      />
+          <ExternalLink
+            text={t('pipelines-plugin~Read more about setting up webhook')}
+            href={WebhookDocLinks[gitProvider]}
+          />
+        </>
+      ) : null}
     </FormSection>
   );
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-5997

**Analysis / Root cause**: 
The PAC form to add a Git Repository shows additional information based on the detected Git provider.

When the form was opened the provider isn't known and the permission content shows nothing and the read more link was broken as well.

**Solution Description**: 
Hide the section until the git provider is known.

**Screen shots / Gifs for design review**: 
Before:

https://user-images.githubusercontent.com/139310/213235016-2c787bf0-9598-48ac-a497-67fc5ab30581.mp4

After:

https://user-images.githubusercontent.com/139310/213235044-008c3a99-0d20-4f33-bc35-483672473649.mp4

**Unit test coverage report**: 
Unchanged

**Test setup:**
Steps to Reproduce:

1. Install Pipelines operator
2. Navigate to the Developer perspective > Pipelines
3. Press "Create" and select "Repository"
4. Click on "Show configuration options"
5. Click on "See Git permissions"
6. Click on "Read more about setting up webhook"

Actual results:
1. The Git permission section shows no git permissions.
2. The Read more link doesn't open any new page.

Expected results:
1. The Git permission section should show some info or must not be disabled.
2. The Read more link should open a page or must not be displayed as well.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
