### PR TITLE
OCPBUGS-5016: Editing Pipeline in the ocp console should show correct information

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/utils.ts
@@ -354,11 +354,17 @@ export const convertBuilderFormToPipeline = (
     spec: {
       ...existingPipeline?.spec,
       ...unhandledSpec,
-      params: sanitizePipelineParams(params),
-      resources,
-      workspaces,
-      tasks: tasks.map((task) => removeEmptyFormFields(removeListRunAfters(task, listIds))),
-      finally: finallyTasks,
+      params: sanitizePipelineParams(
+        params.length > 0 ? params : existingPipeline?.spec?.params ?? [],
+      ),
+      resources: resources.length > 0 ? resources : existingPipeline?.spec?.resources ?? [],
+      workspaces: workspaces.length > 0 ? workspaces : existingPipeline?.spec?.workspaces ?? [],
+      tasks:
+        tasks.length > 0
+          ? tasks
+          : existingPipeline?.spec?.tasks ??
+            [].map((task) => task && removeEmptyFormFields(removeListRunAfters(task, listIds))),
+      finally: finallyTasks.length > 0 ? finallyTasks : existingPipeline?.spec?.finally ?? [],
     },
   };
 };


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-5016

**Solution description:**
 Checking if the formValues are empty,if empty the reading that values from the existing pipeline obj

**GIF:**

Before:
https://user-images.githubusercontent.com/22490998/213396438-051d5aac-d154-467d-8555-6d96473fb1f5.mov

After:
https://user-images.githubusercontent.com/22490998/213396475-953fb3b8-b5c0-4ef9-b871-aeaf8e5076c2.mov

/kind bug