### PR TITLE
OCPBUGS-3822: improve subscription exists alert message

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -290,6 +290,7 @@
   "The {{namespace}} Namespace is reserved for global Operators that watch all Namespaces. To install an Operator in a single Namespace, select a different Namespace where the operand should run.": "The {{namespace}} Namespace is reserved for global Operators that watch all Namespaces. To install an Operator in a single Namespace, select a different Namespace where the operand should run.",
   "The OperatorGroup in the {{namespace}} Namespace does not support the {{mode}} installation mode. Select a different installation Namespace that supports this mode.": "The OperatorGroup in the {{namespace}} Namespace does not support the {{mode}} installation mode. Select a different installation Namespace that supports this mode.",
   "A Subscription for this Operator already exists in Namespace \"{{namespace}}\"": "A Subscription for this Operator already exists in Namespace \"{{namespace}}\"",
+  "Remove the <2>existing Subscription</2> in order to install this Operator in Namespace \"{{selectedTargetNamespace}}\"": "Remove the <2>existing Subscription</2> in order to install this Operator in Namespace \"{{selectedTargetNamespace}}\"",
   "Operator conflicts exist": "Operator conflicts exist",
   "Installing this Operator in the selected Namespace would cause conflicts with another Operator providing these APIs:": "Installing this Operator in the selected Namespace would cause conflicts with another Operator providing these APIs:",
   "Operator not available for selected Namespaces": "Operator not available for selected Namespaces",

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.spec.tsx
@@ -32,6 +32,10 @@ jest.mock('react-i18next', () => {
   };
 });
 
+jest.mock('@console/dynamic-plugin-sdk/src/utils/k8s', () => ({
+  k8sGetResource: jest.fn(),
+}));
+
 describe(UninstallOperatorModal.name, () => {
   let wrapper: ReactWrapper<UninstallOperatorModalProps>;
   let k8sKill: Spy;

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
@@ -69,6 +69,9 @@ export const UninstallOperatorModal: React.FC<UninstallOperatorModalProps> = ({
   const [operandDeletionVerificationError, setOperandDeletionVerificationError] = React.useState(
     false,
   );
+  const [clusterServiceVersionExistsError, setClusterServiceVersionExistsError] = React.useState(
+    '',
+  );
 
   const canPatchConsoleOperatorConfig = useAccessReview({
     group: ConsoleOperatorConfigModel.apiGroup,
@@ -140,8 +143,9 @@ export const UninstallOperatorModal: React.FC<UninstallOperatorModalProps> = ({
         });
         return true;
       } catch (err) {
-        // eslint-disable-next-line no-console
-        console.log(err.message);
+        if (err.json.code !== 404) {
+          setClusterServiceVersionExistsError(err.message);
+        }
         return false;
       }
     };
@@ -357,6 +361,7 @@ export const UninstallOperatorModal: React.FC<UninstallOperatorModalProps> = ({
     <>
       <UninstallAlert
         errorMessage={
+          clusterServiceVersionExistsError ||
           operatorUninstallErrorMessage ||
           (operandDeletionErrors.length
             ? t('olm~Operator could not be uninstalled due to error deleting its Operands')

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Alert, Progress, ProgressSize } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
+import { k8sGetResource } from '@console/dynamic-plugin-sdk/src/utils/k8s';
 import { settleAllPromises } from '@console/dynamic-plugin-sdk/src/utils/promise';
 import { getActiveNamespace } from '@console/internal/actions/ui';
 import { coFetchJSON } from '@console/internal/co-fetch';
@@ -125,14 +126,29 @@ export const UninstallOperatorModal: React.FC<UninstallOperatorModalProps> = ({
     propagationPolicy: 'Foreground',
   };
 
-  const uninstallOperator = React.useCallback(() => {
+  const uninstallOperator = React.useCallback(async () => {
     const patch = removePlugins
       ? getPatchForRemovingPlugins(consoleOperatorConfig, enabledPlugins)
       : null;
 
+    const clusterServiceVersionExists = async () => {
+      try {
+        await k8sGetResource({
+          model: ClusterServiceVersionModel,
+          name: subscription.status.installedCSV,
+          ns: subscription.metadata.namespace,
+        });
+        return true;
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.log(err.message);
+        return false;
+      }
+    };
+
     const operatorUninstallPromises = [
       k8sKill(SubscriptionModel, subscription, {}, deleteOptions),
-      ...(subscription?.status?.installedCSV
+      ...(subscription?.status?.installedCSV && (await clusterServiceVersionExists())
         ? [
             k8sKill(
               ClusterServiceVersionModel,

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 import { Helmet } from 'react-helmet';
 import { Trans, useTranslation } from 'react-i18next';
 import { match } from 'react-router';
+import { Link } from 'react-router-dom';
 import { RadioGroup, RadioInput } from '@console/internal/components/radio';
 import {
   documentationURLs,
@@ -18,6 +19,7 @@ import {
   PageHeading,
   ResourceIcon,
   ResourceName,
+  resourcePathFromModel,
   StatusBox,
 } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
@@ -494,7 +496,21 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
               namespace: selectedTargetNamespace,
             },
           )}
-        />
+        >
+          <p>
+            <Trans t={t} ns="olm">
+              Remove the{' '}
+              <Link
+                to={resourcePathFromModel(SubscriptionModel, packageName, selectedTargetNamespace)}
+              >
+                existing Subscription
+              </Link>{' '}
+              in order to install this Operator in Namespace {'"'}
+              {{ selectedTargetNamespace }}
+              {'"'}
+            </Trans>
+          </p>
+        </Alert>
       )) ||
       (!_.isEmpty(conflictingProvidedAPIs(selectedTargetNamespace)) && (
         <Alert


### PR DESCRIPTION
Updated alert:
<img width="1274" alt="Screenshot 2023-01-20 at 4 08 08 PM" src="https://user-images.githubusercontent.com/895728/213805611-26f77548-5a4c-4759-9e90-32c882ba8a16.png">

In order to avoid the following error when deleting the existing Subscription, we need to first [check if the CSV exists](https://github.com/openshift/console/pull/12454/files#diff-5e377323073b833a3b2cb0aa8937636dc4aaf36ab1d136bff79ffd92ea2c83bcR151) before trying to delete it in the event it was already deleted:
<img width="709" alt="Screenshot 2023-01-20 at 3 54 06 PM" src="https://user-images.githubusercontent.com/895728/213804083-43237bff-8d93-47cb-8294-24cd95d2e1b3.png">
