### PR TITLE
OCPBUGS-6098: Show Git icon and repo link as per the Git provider

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryLinkList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryLinkList.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { GithubIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import {
   ResourceLink,
@@ -11,13 +10,12 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { RepositoryModel } from '../../models';
 import { PipelineRunKind } from '../../types';
 import {
-  baseURL,
   RepositoryLabels,
   RepositoryFields,
   RepositoryAnnotations,
   RepoAnnotationFields,
 } from './consts';
-import { getLabelValue, sanitizeBranchName } from './repository-utils';
+import { getGitProviderIcon, getLabelValue, sanitizeBranchName } from './repository-utils';
 
 export type RepositoryLinkListProps = {
   pipelineRun: PipelineRunKind;
@@ -29,9 +27,7 @@ const RepositoryLinkList: React.FC<RepositoryLinkListProps> = ({ pipelineRun }) 
   const plrAnnotations = pipelineRun.metadata.annotations;
   const repoLabel = RepositoryLabels[RepositoryFields.REPOSITORY];
   const repoName = plrLabels?.[repoLabel];
-  const urlOrg = plrLabels?.[RepositoryLabels[RepositoryFields.URL_ORG]];
-  const urlRepo = plrLabels?.[RepositoryLabels[RepositoryFields.URL_REPO]];
-  const repoURL = urlOrg && urlRepo && `${baseURL}/${urlOrg}/${urlRepo}`;
+  const repoURL = plrAnnotations?.[RepositoryAnnotations[RepoAnnotationFields.REPO_URL]];
   const shaURL = plrAnnotations?.[RepositoryAnnotations[RepoAnnotationFields.SHA_URL]];
 
   if (!repoName) return null;
@@ -48,7 +44,7 @@ const RepositoryLinkList: React.FC<RepositoryLinkListProps> = ({ pipelineRun }) 
         />
         {repoURL && (
           <ExternalLink href={repoURL}>
-            <GithubIcon title={repoURL} /> {repoURL}
+            {getGitProviderIcon(repoURL)} {repoURL}
           </ExternalLink>
         )}
       </dd>

--- a/frontend/packages/pipelines-plugin/src/components/repository/consts.ts
+++ b/frontend/packages/pipelines-plugin/src/components/repository/consts.ts
@@ -13,6 +13,7 @@ export enum RepositoryFields {
 export enum RepoAnnotationFields {
   SHA_MESSAGE = 'sha_message',
   SHA_URL = 'sha_url',
+  REPO_URL = 'repo_url',
 }
 
 export const RepositoryLabels: Record<RepositoryFields, string> = {
@@ -27,6 +28,7 @@ export const RepositoryLabels: Record<RepositoryFields, string> = {
 export const RepositoryAnnotations: Record<RepoAnnotationFields, string> = {
   [RepoAnnotationFields.SHA_MESSAGE]: 'pipelinesascode.tekton.dev/sha-title',
   [RepoAnnotationFields.SHA_URL]: 'pipelinesascode.tekton.dev/sha-url',
+  [RepoAnnotationFields.REPO_URL]: 'pipelinesascode.tekton.dev/repo-url',
 };
 
 export const baseURL = 'https://github.com';


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-6098

Descriptions: Show the Git icon and repository URL as per the Git provider

GIF:
![Peek 2023-01-23 13-22](https://user-images.githubusercontent.com/2561818/213989818-43336d4c-8f66-4e09-8648-4a09ddf8738f.gif)
