### PR TITLE
OCPBUGS-3228: fix broken pipeline secret

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/SecretForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/SecretForm.tsx
@@ -138,7 +138,7 @@ const SecretForm: React.FC<FormikProps<SecretFormValues>> = ({
   };
 
   const onDataChanged = (value: string) => {
-    setStringData(_.merge(stringData, { [values.type]: value }));
+    setStringData({ ...stringData, [values.type]: value });
     setValues(values.type);
   };
 


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-3228

**Solution description:**
replaced lodash merge with spread operator

**Screenshot:**

Before
<img width="1456" alt="Screenshot 2023-01-24 at 10 49 13 PM" src="https://user-images.githubusercontent.com/22490998/214362807-dc5de8c1-30cc-4e86-b9e4-e213bc82eff6.png">

After
<img width="1456" alt="Screenshot 2023-01-24 at 10 49 57 PM" src="https://user-images.githubusercontent.com/22490998/214362985-228dcdd4-c960-4d4e-adf0-c25e23516884.png">

/kind bug