### PR TITLE
HELM-479: Uninstall the Helm Charts Asynchronously

### DIFF
--- a/docs/helm/endpoints_api.md
+++ b/docs/helm/endpoints_api.md
@@ -431,7 +431,7 @@ _Verifies if a Helm chart is compliant with a certain set of independent checks 
 * **Success Response:**
 
   * **Code:** 201 <br />
-  * JSON encoded [Release structure](https://github.com/openshift/console/blob/master/pkg/helm/actions/utility.go#L21)
+  * JSON encoded [Secret structure](https://github.com/openshift/console/blob/master/vendor/k8s.io/api/core/v1/types.go#L6110)
 
 * **Error Response:**
 
@@ -479,7 +479,7 @@ _Verifies if a Helm chart is compliant with a certain set of independent checks 
 * **Success Response:**
 
   * **Code:** 201 <br />
-  * JSON encoded [Release structure](https://github.com/openshift/console/blob/master/pkg/helm/actions/utility.go#L21)
+  * JSON encoded [Secret structure](https://github.com/openshift/console/blob/master/vendor/k8s.io/api/core/v1/types.go#L6110)
 
 * **Error Response:**
 
@@ -487,5 +487,35 @@ _Verifies if a Helm chart is compliant with a certain set of independent checks 
     **Content:** `{ error : "error message" }`
 
 
+**Uninstall Helm Release Asynchronously**
+----
+  _Uninstall Helm release asynchronously_
 
+* **URL**
+
+    `/api/helm/release/async`
+
+* **Method:**
+
+  `DELETE`
+
+*  **URL Params**
+
+   `ns=[string]` - Namespace
+
+   `name=[string]` - Helm Release Name
+
+   `version=[string]` - Helm Release Version
+
+* **Success Response:**
+
+  * **Code:** 204 <br />
+
+  * **Code:** 404 NOT FOUND <br />
+    **Content:** `{ error : "error message" }`
+
+* **Error Response:**
+
+  * **Code:** 502 BAD GATEWAY <br />
+    **Content:** `{ error : "error message" }`
 

--- a/pkg/helm/actions/install_chart.go
+++ b/pkg/helm/actions/install_chart.go
@@ -10,6 +10,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/release"
+	kv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -110,7 +111,7 @@ func InstallChart(ns, name, url string, vals map[string]interface{}, conf *actio
 	return release, nil
 }
 
-func InstallChartAsync(ns, name, url string, vals map[string]interface{}, conf *action.Configuration, client dynamic.Interface, coreClient corev1client.CoreV1Interface, fileCleanUp bool, indexEntry string) (*Secret, error) {
+func InstallChartAsync(ns, name, url string, vals map[string]interface{}, conf *action.Configuration, client dynamic.Interface, coreClient corev1client.CoreV1Interface, fileCleanUp bool, indexEntry string) (*kv1.Secret, error) {
 	var err error
 	var chartInfo *ChartInfo
 	var cp, chartLocation string

--- a/pkg/helm/actions/install_chart_test.go
+++ b/pkg/helm/actions/install_chart_test.go
@@ -365,14 +365,13 @@ func TestInstallChartAsync(t *testing.T) {
 			client := K8sDynamicClientFromCRs(tt.helmCRS...)
 			clientInterface := k8sfake.NewSimpleClientset(objs...)
 			coreClient := clientInterface.CoreV1()
-			var rel *Secret
+			var rel *v1.Secret
 			var err error
 			go func() {
 				rel, err = InstallChartAsync(tt.namespace, tt.releaseName, tt.chartPath, nil, actionConfig, client, coreClient, false, tt.indexEntry)
-				fmt.Println(rel, err)
 				if tt.releaseName == "myrelease" {
 					require.NoError(t, err)
-					require.Equal(t, fmt.Sprintf("sh.helm.release.v1.%v.v1", tt.releaseName), rel.SecretName)
+					require.Equal(t, fmt.Sprintf("sh.helm.release.v1.%v.v1", tt.releaseName), rel.ObjectMeta.Name)
 				} else if tt.releaseName == "invalid chart path" {
 					require.Error(t, err)
 				}

--- a/pkg/helm/actions/uninstall_release.go
+++ b/pkg/helm/actions/uninstall_release.go
@@ -1,11 +1,15 @@
 package actions
 
 import (
+	"context"
+	"fmt"
 	"strings"
 
 	"github.com/openshift/console/pkg/helm/metrics"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/release"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 func UninstallRelease(name string, conf *action.Configuration) (*release.UninstallReleaseResponse, error) {
@@ -24,4 +28,25 @@ func UninstallRelease(name string, conf *action.Configuration) (*release.Uninsta
 	}
 
 	return resp, nil
+}
+
+func UninstallReleaseAsync(name string, ns string, version string, conf *action.Configuration, coreClient corev1client.CoreV1Interface) error {
+	client := action.NewUninstall(conf)
+	go func() {
+		resp, err := client.Run(name)
+		if err != nil || resp == nil {
+			return
+		}
+
+		ch := resp.Release.Chart
+		if ch != nil && ch.Metadata != nil && ch.Metadata.Name != "" && ch.Metadata.Version != "" {
+			metrics.HandleconsoleHelmUninstallsTotal(ch.Metadata.Name, ch.Metadata.Version)
+		}
+	}()
+	secretName := fmt.Sprintf("sh.helm.release.v1.%v.v%v", name, version)
+	_, err := coreClient.Secrets(ns).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		return ErrReleaseNotFound
+	}
+	return err
 }

--- a/pkg/helm/actions/uninstall_release_test.go
+++ b/pkg/helm/actions/uninstall_release_test.go
@@ -2,15 +2,19 @@ package actions
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestUninstallRelease(t *testing.T) {
@@ -82,6 +86,99 @@ func TestUninstallInvalidRelease(t *testing.T) {
 			if resp != nil && resp.Release.Info.Status != release.StatusUninstalled {
 				t.Error(errors.New("Release status is not uninstalled"))
 			}
+		})
+	}
+}
+
+func TestUninstallReleaseAsync(t *testing.T) {
+	tests := []struct {
+		name         string
+		createSecret bool
+		version      string
+		namespace    string
+		requireError bool
+		releaseName  string
+		release      *release.Release
+	}{
+		{
+			name:         "successful release uninstall should remove release installed",
+			requireError: false,
+			createSecret: true,
+			releaseName:  "test-release",
+			namespace:    "default",
+			version:      "1",
+			release: &release.Release{
+				Name: "test-release",
+				Info: &release.Info{
+					Status: release.StatusDeployed,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		store := storage.Init(driver.NewMemory())
+		t.Run(tt.name, func(t *testing.T) {
+			actionConfig := &action.Configuration{
+				Releases:     store,
+				KubeClient:   &kubefake.PrintingKubeClient{Out: ioutil.Discard},
+				Capabilities: chartutil.DefaultCapabilities,
+				Log:          func(format string, v ...interface{}) {},
+			}
+			// create fake release
+			err := store.Create(tt.release)
+			if err != nil {
+				t.Error(err)
+			}
+			clientInterface := k8sfake.NewSimpleClientset()
+			coreClient := clientInterface.CoreV1()
+			if tt.requireError == false {
+				secretsDriver := driver.NewSecrets(coreClient.Secrets(tt.namespace))
+				time.Sleep(10 * time.Second)
+				err = secretsDriver.Create(fmt.Sprintf("sh.helm.release.v1.%v.v1", tt.releaseName), tt.release)
+				require.NoError(t, err)
+			}
+
+			err = UninstallReleaseAsync(tt.release.Name, tt.namespace, tt.version, actionConfig, coreClient)
+			require.Nil(t, err)
+		})
+	}
+}
+
+func TestUninstallInvalidReleaseAsync(t *testing.T) {
+	tests := []struct {
+		name        string
+		release     *release.Release
+		version     string
+		namespace   string
+		releaseName string
+		err         error
+	}{
+		{
+			name: "non exist release uninstall should error out with no release found",
+			release: &release.Release{
+				Name: "invalid-release",
+			},
+			namespace:   "default",
+			version:     "1",
+			releaseName: "invalid-release",
+			err:         ErrReleaseNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		store := storage.Init(driver.NewMemory())
+		t.Run(tt.name, func(t *testing.T) {
+			actionConfig := &action.Configuration{
+				Releases:     store,
+				KubeClient:   &kubefake.PrintingKubeClient{Out: ioutil.Discard},
+				Capabilities: chartutil.DefaultCapabilities,
+				Log:          func(format string, v ...interface{}) {},
+			}
+			clientInterface := k8sfake.NewSimpleClientset()
+			coreClient := clientInterface.CoreV1()
+			err := UninstallReleaseAsync(tt.releaseName, tt.namespace, tt.version, actionConfig, coreClient)
+			require.Error(t, err)
 		})
 	}
 }

--- a/pkg/helm/actions/upgrade_release.go
+++ b/pkg/helm/actions/upgrade_release.go
@@ -11,6 +11,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/release"
+	kv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
@@ -140,7 +141,7 @@ func UpgradeReleaseAsync(
 	coreClient corev1client.CoreV1Interface,
 	fileCleanUp bool,
 	indexEntry string,
-) (*Secret, error) {
+) (*kv1.Secret, error) {
 	client := action.NewUpgrade(conf)
 	client.Namespace = releaseNamespace
 	var ch *chart.Chart

--- a/pkg/helm/actions/upgrade_release_test.go
+++ b/pkg/helm/actions/upgrade_release_test.go
@@ -502,7 +502,7 @@ func TestUpgradeReleaseWithoutDependenciesAsync(t *testing.T) {
 			clientInterface := k8sfake.NewSimpleClientset(objs...)
 			coreClient := clientInterface.CoreV1()
 			secretsDriver := driver.NewSecrets(coreClient.Secrets(tt.namespace))
-			var rel *Secret
+			var rel *v1.Secret
 			var err error
 			go func() {
 				rel, err = UpgradeReleaseAsync(tt.namespace, tt.releaseName, tt.chartPath, nil, actionConfig, client, coreClient, false, tt.indexEntry)
@@ -511,7 +511,7 @@ func TestUpgradeReleaseWithoutDependenciesAsync(t *testing.T) {
 					require.Error(t, err)
 				} else {
 					require.NoError(t, err)
-					require.Equal(t, fmt.Sprintf("sh.helm.release.v1.%v.v2", tt.releaseName), rel.SecretName)
+					require.Equal(t, fmt.Sprintf("sh.helm.release.v1.%v.v2", tt.releaseName), rel.ObjectMeta.Name)
 				}
 			}()
 			time.Sleep(10 * time.Second)
@@ -579,7 +579,7 @@ func TestUpgradeReleaseWithDependenciesAsync(t *testing.T) {
 			clientInterface := k8sfake.NewSimpleClientset()
 			coreClient := clientInterface.CoreV1()
 			secretsDriver := driver.NewSecrets(coreClient.Secrets(tt.releaseNamespace))
-			var rel *Secret
+			var rel *v1.Secret
 			var err error
 			r := release.Release{
 				Name:      tt.releaseName,
@@ -603,7 +603,7 @@ func TestUpgradeReleaseWithDependenciesAsync(t *testing.T) {
 			go func() {
 				rel, err = UpgradeReleaseAsync(tt.releaseNamespace, tt.releaseName, tt.chartPath, tt.values, actionConfig, client, coreClient, true, tt.indexEntry)
 				require.NoError(t, err)
-				require.Equal(t, fmt.Sprintf("sh.helm.release.v1.%v.v2", tt.releaseName), rel.SecretName)
+				require.Equal(t, fmt.Sprintf("sh.helm.release.v1.%v.v2", tt.releaseName), rel.ObjectMeta.Name)
 			}()
 			time.Sleep(10 * time.Second)
 			r.Version = 2
@@ -690,12 +690,12 @@ func TestUpgradeReleaseWithCustomValuesAsync(t *testing.T) {
 			clientInterface := k8sfake.NewSimpleClientset()
 			coreClient := clientInterface.CoreV1()
 			secretsDriver := driver.NewSecrets(coreClient.Secrets(tt.releaseNamespace))
-			var rel *Secret
+			var rel *v1.Secret
 			var err error
 			go func() {
 				rel, err = UpgradeReleaseAsync(tt.releaseNamespace, tt.releaseName, tt.chartPath, tt.values, actionConfig, client, coreClient, true, tt.indexEntry)
 				require.NoError(t, err)
-				require.Equal(t, fmt.Sprintf("sh.helm.release.v1.%v.v2", tt.releaseName), rel.SecretName)
+				require.Equal(t, fmt.Sprintf("sh.helm.release.v1.%v.v2", tt.releaseName), rel.ObjectMeta.Name)
 			}()
 			time.Sleep(10 * time.Second)
 			r.Version = 2

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -675,9 +675,11 @@ func (s *Server) HTTPHandler() http.Handler {
 			helmHandlers.HandleHelmInstallAsync(user, w, r)
 		case http.MethodPut:
 			helmHandlers.HandleUpgradeReleaseAsync(user, w, r)
+		case http.MethodDelete:
+			helmHandlers.HandleUninstallReleaseAsync(user, w, r)
 		default:
-			w.Header().Set("Allow", " POST, PUT")
-			serverutils.SendResponse(w, http.StatusMethodNotAllowed, serverutils.ApiError{Err: "Unsupported method, supported methods are GET, POST, PATCH, PUT, DELETE"})
+			w.Header().Set("Allow", "POST, PUT , DELETE")
+			serverutils.SendResponse(w, http.StatusMethodNotAllowed, serverutils.ApiError{Err: "Unsupported method, supported methods are POST, PUT , DELETE"})
 		}
 	}))
 


### PR DESCRIPTION
This PR adds an endpoint  to uninstall Helm Releases asynchronously.
Signed-off-by: Kartikey Mamgain <mamgainkartikey@gmail.com>