### PR TITLE
OCPBUGS-5948: Fix runtime error in schema editor when theres no match for g/v/k in swagger definitions

### DIFF
--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -44,6 +44,10 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
     ? currentSelection.path
     : [kindObj ? getDefinitionKey(kindObj, allDefinitions) : 'custom-schema'];
   const currentDefinition: SwaggerDefinition = _.get(allDefinitions, currentPath);
+  // If there's no match for group/version/kind in our definition list, return null
+  if (!currentDefinition) {
+    return null;
+  }
   const currentProperties =
     _.get(currentDefinition, 'properties') || _.get(currentDefinition, 'items.properties');
 


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-5948

@TheRealJon @rhamilto
This fixes the runtime error but does not explain why the admissionreview schema isn't present in the list of swagger definitions:

Kind
AdmissionReview
API group
admission.hive.openshift.io
API version
v1
Namespaced
false
Verbs
create