### PR TITLE
OCPBUGS-6689: Fix NPE when displaying CSV with incomplete information

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -590,7 +590,7 @@ export const ProvidedAPIPage: React.FC<ProvidedAPIPageProps> = (props) => {
           namespaced,
           ...(!listAllNamespaces && namespaced && namespace ? { namespace } : {}),
         }
-      : {},
+      : null,
   );
 
   const [staticData, filteredData, onFilterChange] = useListPageFilter(resources);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-6689
A follow-up on https://bugzilla.redhat.com/show_bug.cgi?id=2084287 and #11544

**Analysis / Root cause**: 
This is a follow-up on #11544 as I noticed while validating the Bug that there is still a crash on the operator details page.

The crash happens on 4.8-4.11. It was fixed as part of #11883 from 4.12 onwards.

`packages/operator-lifecycle-manager/src/components/operand/index.tsx`  used `useK8sWatchResource` to watch a resource list (`isList: true`) when the modal is defined. But it requests `{}` if not. But this default (without `isList: true`)  returns an empty object as `resources`. This crashes later in `public/components/factory/ListPage/filter-hook.ts`  because data is defined, but not an array:

```ts
const filterData = <D>(
  data: D[],
  filter: { [key: string]: FilterValue } = {},
  rowFilters?: FilterMap,
) => {
  const filterTypes = Object.keys(filter);
  return data?.filter((d) =>            // crashes here because is not null/undefined, but also not an array
    filterTypes.every((type) =>
      rowFilters[type] && !_.isEmpty(filter?.[type]) ? rowFilters[type](filter[type], d) : true,
    ),
  );
};
```

**Solution Description**: 
use `null` instead of `{}` for fetching the resources. This returns `undefined` instead of `{}`.

**Screen shots / Gifs for design review**: 
Before:

![before](https://user-images.githubusercontent.com/139310/214893828-b8e2dcf3-2191-4915-85cb-b4f4eb4466a7.png)

After:

![after](https://user-images.githubusercontent.com/139310/214893876-1920b278-fc7f-45f9-852a-3bec3617fc68.png)

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Apply this minimal ClusterServiceVersion: 

```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: ClusterServiceVersion
metadata:
  name: minimal-csv
  namespace: christoph
spec:
  apiservicedefinitions:
    owned:
      - group: A
        kind: A
        name: A
        version: v1
  customresourcedefinitions:
    owned:
      - kind: B
        name: B
        version: v1
  displayName: My minimal CSV
  install:
    strategy: ''
```

2. Open the Admin perspective > Installed Operator > Operator detail page

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
