### PR TITLE
OCPBUGS-7089, OCPBUGS-7113: move cluster menu to masthead to fix usability issues

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellMastheadButton.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellMastheadButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, PageHeaderToolsItem } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 import { TerminalIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -36,18 +36,16 @@ const ClouldShellMastheadButton: React.FC<Props> = ({ onClick, open }) => {
   };
 
   return (
-    <PageHeaderToolsItem>
-      <Button
-        variant="plain"
-        aria-label={t('console-app~Command line terminal')}
-        onClick={openCloudshell}
-        className={open ? 'pf-m-selected' : undefined}
-        data-tour-id="tour-cloud-shell-button"
-        data-quickstart-id="qs-masthead-cloudshell"
-      >
-        <TerminalIcon className="co-masthead-icon" />
-      </Button>
-    </PageHeaderToolsItem>
+    <Button
+      variant="plain"
+      aria-label={t('console-app~Command line terminal')}
+      onClick={openCloudshell}
+      className={open ? 'pf-m-selected' : undefined}
+      data-tour-id="tour-cloud-shell-button"
+      data-quickstart-id="qs-masthead-cloudshell"
+    >
+      <TerminalIcon className="co-masthead-icon" />
+    </Button>
   );
 };
 

--- a/frontend/packages/console-app/src/components/nav/ClusterMenu.tsx
+++ b/frontend/packages/console-app/src/components/nav/ClusterMenu.tsx
@@ -26,8 +26,6 @@ import {
 import { ACM_PERSPECTIVE_ID } from '../../consts';
 import ClusterMenuToggle from './ClusterMenuToggle';
 
-const ClusterCIcon: React.FC = () => <span className="co-m-resource-icon">C</span>;
-
 const NoResults: React.FC<{
   onClear: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }> = ({ onClear }) => {
@@ -89,7 +87,6 @@ const ClusterGroup: React.FC<{
               cluster.onClick();
             }}
           >
-            {cluster.showIcon && <ClusterCIcon />}
             {cluster.title}
           </MenuItem>
         ))}
@@ -145,7 +142,6 @@ const ClusterMenu = () => {
         .map((cluster) => ({
           key: cluster,
           title: cluster,
-          showIcon: true,
           onClick: () => onClusterClick(cluster),
         })),
     ],
@@ -198,13 +194,9 @@ const ClusterMenu = () => {
       isOpen={dropdownOpen}
       onToggle={setDropdownOpen}
       title={
-        `${activePerspective}` === ACM_PERSPECTIVE_ID ? (
-          t('console-app~All Clusters')
-        ) : (
-          <>
-            <ClusterCIcon /> {activeCluster}
-          </>
-        )
+        `${activePerspective}` === ACM_PERSPECTIVE_ID
+          ? t('console-app~All Clusters')
+          : activeCluster
       }
     />
   );
@@ -213,7 +205,6 @@ const ClusterMenu = () => {
 type ClusterMenuItem = {
   key: string;
   title: string;
-  showIcon?: boolean;
   onClick: () => void;
 };
 

--- a/frontend/packages/console-app/src/components/nav/ClusterMenu.tsx
+++ b/frontend/packages/console-app/src/components/nav/ClusterMenu.tsx
@@ -71,6 +71,7 @@ const ClusterGroup: React.FC<{
   clusters: ClusterMenuItem[];
 }> = ({ clusters }) => {
   const [activeCluster] = useActiveCluster();
+  const [activePerspective] = useActivePerspective();
 
   return clusters.length === 0 ? null : (
     <MenuGroup translate="no" label="Clusters">
@@ -81,7 +82,11 @@ const ClusterGroup: React.FC<{
             data-test-id="cluster-dropdown-item"
             key={cluster.key}
             itemId={cluster.key}
-            isSelected={activeCluster === cluster.key}
+            isSelected={
+              activePerspective === ACM_PERSPECTIVE_ID
+                ? cluster.key === ACM_PERSPECTIVE_ID
+                : cluster.key === activeCluster
+            }
             onClick={(e) => {
               e.preventDefault();
               cluster.onClick();

--- a/frontend/packages/console-app/src/components/nav/ClusterMenuToggle.tsx
+++ b/frontend/packages/console-app/src/components/nav/ClusterMenuToggle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { MenuToggle, Popper } from '@patternfly/react-core';
+import { MenuToggle, Popper, ToolbarItem } from '@patternfly/react-core';
 
 const ClusterMenuToggle = (props: {
   disabled: boolean;
@@ -12,7 +12,6 @@ const ClusterMenuToggle = (props: {
   const { disabled, menu, isOpen, menuRef, onToggle, title } = props;
 
   const toggleRef = React.useRef(null);
-  const containerRef = React.useRef(null);
 
   const handleMenuKeys = (event) => {
     if (menuRef.current) {
@@ -52,7 +51,7 @@ const ClusterMenuToggle = (props: {
       onClick={() => onToggle(!isOpen)}
       isExpanded={isOpen}
       variant="plainText"
-      isFullWidth
+      isFullHeight
       disabled={disabled}
       className="co-cluster-selector"
       data-test-id="cluster-dropdown-toggle"
@@ -62,7 +61,7 @@ const ClusterMenuToggle = (props: {
   );
 
   return (
-    <div ref={containerRef}>
+    <ToolbarItem>
       <Popper
         trigger={menuToggle}
         popper={menu}
@@ -73,7 +72,7 @@ const ClusterMenuToggle = (props: {
         popperMatchesTriggerWidth={false}
         enableFlip={false}
       />
-    </div>
+    </ToolbarItem>
   );
 };
 

--- a/frontend/packages/console-app/src/components/nav/NavHeader.scss
+++ b/frontend/packages/console-app/src/components/nav/NavHeader.scss
@@ -1,15 +1,6 @@
 @import '~@patternfly/patternfly/sass-utilities/all';
 @import '~@console/internal/style/vars';
 
-$sidebar-toggle-button-background-color: var(--pf-global--BackgroundColor--dark-200);
-$sidebar-toggle-button-background-color--dark: var(--pf-global--BackgroundColor--dark-300);
-
-.co-cluster-menu.pf-c-menu {
-  // Default to match perspective switcher menu
-  // --pf-c-page__sidebar--Width - left and right padding.
-  min-width: 258px;
-}
-
 .oc-nav-header {
   border-bottom: 1px solid var(--pf-global--BackgroundColor--dark-200);
   padding: 0.6rem var(--pf-global--spacer--sm);
@@ -31,15 +22,6 @@ $sidebar-toggle-button-background-color--dark: var(--pf-global--BackgroundColor-
   &__dropdown-toggle--is-empty {
     cursor: default !important;
   }
-
-  // Style menu toggle component to match sidebar navigation list
-  .co-cluster-selector.pf-m-expanded {
-    background-color: $sidebar-toggle-button-background-color;
-    :where(.pf-theme-dark) & {
-      background-color: $sidebar-toggle-button-background-color--dark;
-    }
-  }
-
   .pf-c-dropdown {
     --pf-c-dropdown__menu-item--PaddingLeft: 7px;
     width: 100%;
@@ -47,9 +29,9 @@ $sidebar-toggle-button-background-color--dark: var(--pf-global--BackgroundColor-
 
     &.pf-m-expanded {
       .pf-c-dropdown__toggle {
-        background-color: $sidebar-toggle-button-background-color;
+        background-color: var(--pf-global--BackgroundColor--dark-200);
         :where(.pf-theme-dark) & {
-          background-color: $sidebar-toggle-button-background-color--dark;
+          background-color: var(--pf-global--BackgroundColor--dark-300);
         }
       }
     }
@@ -92,16 +74,6 @@ $sidebar-toggle-button-background-color--dark: var(--pf-global--BackgroundColor-
     // Needed until https://github.com/patternfly/patternfly-design/issues/1068 is resolved
     &:before {
       border: none;
-    }
-  }
-
-  .pf-c-menu-toggle {
-    color: var(--pf-global--Color--light-100);
-    font-size: $co-side-nav-section-font-size;
-
-    .pf-c-menu-toggle__toggle-icon {
-      color: var(--pf-global--Color--light-100);
-      font-size: $co-side-nav-section-font-size;
     }
   }
 }

--- a/frontend/packages/console-app/src/components/nav/NavHeader.tsx
+++ b/frontend/packages/console-app/src/components/nav/NavHeader.tsx
@@ -3,9 +3,6 @@ import { Dropdown, DropdownItem, DropdownToggle, Title } from '@patternfly/react
 import { CaretDownIcon } from '@patternfly/react-icons';
 import * as cx from 'classnames';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-import isMultiClusterEnabled from '@console/app/src/utils/isMultiClusterEnabled';
 import { Perspective, useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource';
 import * as acmIcon from '@console/internal/imgs/ACM-icon.svg';
@@ -13,7 +10,6 @@ import { ConsoleLinkModel } from '@console/internal/models';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { ACM_LINK_ID, usePerspectiveExtension, usePerspectives } from '@console/shared';
 import { ACM_PERSPECTIVE_ID } from '../../consts';
-import ClusterMenu from './ClusterMenu';
 import './NavHeader.scss';
 
 export type NavHeaderProps = {
@@ -80,7 +76,6 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
       ),
     [consoleLinks],
   );
-  const showMultiClusterDropdown = acmPerspectiveExtension || isMultiClusterEnabled();
 
   const onPerspectiveSelect = React.useCallback(
     (perspective: string): void => {
@@ -139,11 +134,6 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
 
   return (
     <>
-      {showMultiClusterDropdown && (
-        <div className="oc-nav-header">
-          <ClusterMenu />
-        </div>
-      )}
       {activePerspective !== ACM_PERSPECTIVE_ID && (
         <div
           className="oc-nav-header"

--- a/frontend/public/components/_masthead.scss
+++ b/frontend/public/components/_masthead.scss
@@ -31,6 +31,6 @@
   }
 }
 
-.pf-c-page__header-tools-item .pf-c-notification-badge {
+.pf-c-masthead__content .pf-c-notification-badge {
   --pf-c-notification-badge--m-unread--hover--after--BackgroundColor: transparent;
 }

--- a/frontend/public/components/_masthead.scss
+++ b/frontend/public/components/_masthead.scss
@@ -1,3 +1,60 @@
+.co-app-launcher {
+  ul {
+    list-style: none;
+    margin-bottom: 0;
+    padding-left: 0;
+  }
+
+  .pf-c-app-launcher__menu-item-external-icon {
+    --pf-c-app-launcher__menu-item-external-icon--Color: var(--pf-global--icon--Color--light);
+
+    opacity: 1;
+  }
+}
+
+.co-cluster-menu {
+  max-width: 80vw;
+
+  @media (min-width: $pf-global--breakpoint--md) {
+    max-width: 90vw;
+  }
+}
+
+.co-cluster-selector {
+  display: inline-grid !important;
+  grid-template-columns: 1fr auto;
+  max-width: 140px !important;
+
+  @media (min-width: 360px) {
+    max-width: 180px !important;
+  }
+
+  @media (min-width: $screen-xs) {
+    max-width: 300px !important;
+  }
+
+  @media (min-width: $screen-lg) {
+    max-width: 400px !important;
+  }
+
+  // PatternFly does not fully support <MenuToggle isFullHeight> styling in <Masthead>
+  &::before {
+    border: 1px solid var(--pf-global--palette--black-800) !important;
+    border-bottom: 0 !important;
+    border-top: 0 !important;
+    bottom: 0;
+    content: "";
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+
+    .pf-theme-dark & {
+      border-color: var(--pf-global--palette--black-700) !important;
+    }
+  }
+}
+
 .co-masthead-icon {
   font-size: $pf-header-icon-fontsize;
 }
@@ -14,20 +71,6 @@
   }
   @media (min-width: $screen-lg-min) {
     max-width: 300px !important;
-  }
-}
-
-.co-app-launcher {
-  ul {
-    list-style: none;
-    margin-bottom: 0;
-    padding-left: 0;
-  }
-
-  .pf-c-app-launcher__menu-item-external-icon {
-    --pf-c-app-launcher__menu-item-external-icon--Color: var(--pf-global--icon--Color--light);
-
-    opacity: 1;
   }
 }
 

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -58,7 +58,8 @@ import '@patternfly/quickstarts/dist/quickstarts.min.css';
 // load dark theme here as MiniCssExtractPlugin ignores load order of sass and dark theme must load after all other css
 import '@patternfly/patternfly/patternfly-charts-theme-dark.css';
 
-const breakpointMD = 1200;
+const PF_BREAKPOINT_MD = 768;
+const PF_BREAKPOINT_XL = 1200;
 const NOTIFICATION_DRAWER_BREAKPOINT = 1800;
 // Edge lacks URLSearchParams
 import 'url-search-params-polyfill';
@@ -84,11 +85,14 @@ class App_ extends React.PureComponent {
     this._onNavSelect = this._onNavSelect.bind(this);
     this._onNotificationDrawerToggle = this._onNotificationDrawerToggle.bind(this);
     this._isDesktop = this._isDesktop.bind(this);
+    this._isMobile = this._isMobile.bind(this);
     this._onResize = this._onResize.bind(this);
     this.previousDesktopState = this._isDesktop();
+    this.previousMobileState = this._isMobile();
     this.previousDrawerInlineState = this._isLargeLayout();
 
     this.state = {
+      isMastheadStacked: this._isMobile(),
       isNavOpen: this._isDesktop(),
       isDrawerInline: this._isLargeLayout(),
     };
@@ -120,7 +124,11 @@ class App_ extends React.PureComponent {
   }
 
   _isDesktop() {
-    return window.innerWidth >= breakpointMD;
+    return window.innerWidth >= PF_BREAKPOINT_XL;
+  }
+
+  _isMobile() {
+    return window.innerWidth < PF_BREAKPOINT_MD;
   }
 
   _onNavToggle() {
@@ -155,10 +163,15 @@ class App_ extends React.PureComponent {
 
   _onResize() {
     const isDesktop = this._isDesktop();
+    const isMobile = this._isMobile();
     const isDrawerInline = this._isLargeLayout();
     if (this.previousDesktopState !== isDesktop) {
       this.setState({ isNavOpen: isDesktop });
       this.previousDesktopState = isDesktop;
+    }
+    if (this.previousMobileState !== isMobile) {
+      this.setState({ isMastheadStacked: isMobile });
+      this.previousMobileState = isMobile;
     }
     if (this.previousDrawerInlineState !== isDrawerInline) {
       this.setState({ isDrawerInline });
@@ -167,7 +180,7 @@ class App_ extends React.PureComponent {
   }
 
   render() {
-    const { isNavOpen, isDrawerInline } = this.state;
+    const { isNavOpen, isDrawerInline, isMastheadStacked } = this.state;
     const { contextProviderExtensions } = this.props;
     const { productName } = getBrandingDetails();
 
@@ -180,7 +193,13 @@ class App_ extends React.PureComponent {
             <Page
               // Need to pass mainTabIndex=null to enable keyboard scrolling as default tabIndex is set to -1 by patternfly
               mainTabIndex={null}
-              header={<Masthead isNavOpen={isNavOpen} onNavToggle={this._onNavToggle} />}
+              header={
+                <Masthead
+                  isNavOpen={isNavOpen}
+                  onNavToggle={this._onNavToggle}
+                  isMastheadStacked={isMastheadStacked}
+                />
+              }
               sidebar={
                 <Navigation
                   isNavOpen={isNavOpen}

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -15,9 +15,10 @@ import {
   ApplicationLauncherItem,
   ApplicationLauncherSeparator,
   NotificationBadge,
-  PageHeaderTools,
-  PageHeaderToolsGroup,
-  PageHeaderToolsItem,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { FLAGS, YellowExclamationTriangleIcon, ACM_LINK_ID } from '@console/shared';
@@ -55,20 +56,18 @@ const defaultHelpLinks = [
   },
 ];
 
-const SystemStatusButton = ({ statuspageData, className }) => {
+const SystemStatusButton = ({ statuspageData }) => {
   const { t } = useTranslation();
   return !_.isEmpty(_.get(statuspageData, 'incidents')) ? (
-    <PageHeaderToolsItem className={className}>
-      <a
-        className="pf-c-button pf-m-plain"
-        aria-label={t('public~System status')}
-        href={statuspageData.page.url}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <YellowExclamationTriangleIcon className="co-masthead-icon" />
-      </a>
-    </PageHeaderToolsItem>
+    <a
+      className="pf-c-button pf-m-plain"
+      aria-label={t('public~System status')}
+      href={statuspageData.page.url}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <YellowExclamationTriangleIcon className="co-masthead-icon" />
+    </a>
   ) : null;
 };
 
@@ -628,85 +627,95 @@ class MastheadToolbarContents_ extends React.Component {
       showAboutModal,
       statuspageData,
     } = this.state;
-    const { consoleLinks, drawerToggle, canAccessNS, alertCount, t } = this.props;
+    const {
+      alertCount,
+      canAccessNS,
+      consoleLinks,
+      drawerToggle,
+      isMastheadStacked,
+      t,
+    } = this.props;
     const launchActions = this._launchActions();
     const alertAccess = canAccessNS && !!window.SERVER_FLAGS.prometheusBaseURL;
     return (
       <>
-        <PageHeaderTools>
-          <PageHeaderToolsGroup className="hidden-xs">
-            {/* desktop -- (system status button) */}
-            <SystemStatusButton statuspageData={statuspageData} />
-            {/* desktop -- (application launcher dropdown), import yaml, help dropdown [documentation, about] */}
-            {!_.isEmpty(launchActions) && (
-              <PageHeaderToolsItem>
+        <Toolbar isFullHeight isStatic>
+          <ToolbarContent>
+            {/* <ToolbarGroup spacer={{ default: 'spacerNone' }}>
+              cluster picker goes here
+            </ToolbarGroup> */}
+            <ToolbarGroup
+              alignment={{ default: 'alignRight' }}
+              spacer={{ default: 'spacerNone' }}
+              visibility={{ default: isMastheadStacked ? 'hidden' : 'visible' }}
+            >
+              <ToolbarItem spacer={{ default: 'spacerNone', lg: 'spacerLg' }}>
+                <SystemStatusButton statuspageData={statuspageData} />
+                {!_.isEmpty(launchActions) && (
+                  <ApplicationLauncher
+                    aria-label={t('public~Application launcher')}
+                    className="co-app-launcher"
+                    data-test-id="application-launcher"
+                    onSelect={this._onApplicationLauncherDropdownSelect}
+                    onToggle={this._onApplicationLauncherDropdownToggle}
+                    isOpen={isApplicationLauncherDropdownOpen}
+                    items={this._renderApplicationItems(this._launchActions())}
+                    data-quickstart-id="qs-masthead-applications"
+                    position="right"
+                    isGrouped
+                  />
+                )}
+                {alertAccess && (
+                  <NotificationBadge
+                    aria-label={t('public~Notification drawer')}
+                    onClick={drawerToggle}
+                    variant="read"
+                    count={alertCount || 0}
+                    data-quickstart-id="qs-masthead-notifications"
+                  >
+                    <BellIcon alt="" />
+                  </NotificationBadge>
+                )}
+                <Link
+                  to={this._getImportYAMLPath()}
+                  className="pf-c-button pf-m-plain"
+                  aria-label={t('public~Import YAML')}
+                  data-quickstart-id="qs-masthead-import"
+                  data-test="import-yaml"
+                >
+                  <PlusCircleIcon className="co-masthead-icon" alt="" />
+                </Link>
+                <CloudShellMastheadButton />
                 <ApplicationLauncher
-                  aria-label={t('public~Application launcher')}
+                  aria-label={t('public~Help menu')}
                   className="co-app-launcher"
-                  data-test-id="application-launcher"
-                  onSelect={this._onApplicationLauncherDropdownSelect}
-                  onToggle={this._onApplicationLauncherDropdownToggle}
-                  isOpen={isApplicationLauncherDropdownOpen}
-                  items={this._renderApplicationItems(this._launchActions())}
-                  data-quickstart-id="qs-masthead-applications"
+                  data-test="help-dropdown-toggle"
+                  data-tour-id="tour-help-button"
+                  data-quickstart-id="qs-masthead-help"
+                  onSelect={this._onHelpDropdownSelect}
+                  onToggle={this._onHelpDropdownToggle}
+                  isOpen={isHelpDropdownOpen}
+                  items={this._renderApplicationItems(
+                    this._helpActions(
+                      this._getAdditionalActions(
+                        this._getAdditionalLinks(consoleLinks?.data, 'HelpMenu'),
+                      ),
+                    ),
+                  )}
                   position="right"
+                  toggleIcon={<QuestionCircleIcon className="co-masthead-icon" alt="" />}
                   isGrouped
                 />
-              </PageHeaderToolsItem>
-            )}
-            {/* desktop -- (notification drawer button) */
-            alertAccess && (
-              <PageHeaderToolsItem>
-                <NotificationBadge
-                  aria-label={t('public~Notification drawer')}
-                  onClick={drawerToggle}
-                  variant="read"
-                  count={alertCount || 0}
-                  data-quickstart-id="qs-masthead-notifications"
-                >
-                  <BellIcon alt="" />
-                </NotificationBadge>
-              </PageHeaderToolsItem>
-            )}
-            <PageHeaderToolsItem>
-              <Link
-                to={this._getImportYAMLPath()}
-                className="pf-c-button pf-m-plain"
-                aria-label={t('public~Import YAML')}
-                data-quickstart-id="qs-masthead-import"
-                data-test="import-yaml"
-              >
-                <PlusCircleIcon className="co-masthead-icon" alt="" />
-              </Link>
-            </PageHeaderToolsItem>
-            <CloudShellMastheadButton />
-            <PageHeaderToolsItem>
-              <ApplicationLauncher
-                aria-label={t('public~Help menu')}
-                className="co-app-launcher"
-                data-test="help-dropdown-toggle"
-                data-tour-id="tour-help-button"
-                data-quickstart-id="qs-masthead-help"
-                onSelect={this._onHelpDropdownSelect}
-                onToggle={this._onHelpDropdownToggle}
-                isOpen={isHelpDropdownOpen}
-                items={this._renderApplicationItems(
-                  this._helpActions(
-                    this._getAdditionalActions(
-                      this._getAdditionalLinks(consoleLinks?.data, 'HelpMenu'),
-                    ),
-                  ),
-                )}
-                position="right"
-                toggleIcon={<QuestionCircleIcon alt="" />}
-                isGrouped
-              />
-            </PageHeaderToolsItem>
-          </PageHeaderToolsGroup>
-          <PageHeaderToolsGroup>
-            {/* mobile -- (notification drawer button) */
-            alertAccess && alertCount > 0 && (
-              <PageHeaderToolsItem className="visible-xs-block">
+              </ToolbarItem>
+              <ToolbarItem>{this._renderMenu(false)}</ToolbarItem>
+            </ToolbarGroup>
+            <ToolbarGroup
+              alignment={{ default: 'alignRight' }}
+              spacer={{ default: 'spacerNone' }}
+              visibility={{ default: isMastheadStacked ? 'visible' : 'hidden' }}
+            >
+              <SystemStatusButton statuspageData={statuspageData} />
+              {alertAccess && alertCount > 0 && (
                 <NotificationBadge
                   aria-label={t('public~Notification drawer')}
                   onClick={drawerToggle}
@@ -716,20 +725,11 @@ class MastheadToolbarContents_ extends React.Component {
                 >
                   <BellIcon />
                 </NotificationBadge>
-              </PageHeaderToolsItem>
-            )}
-            {/* mobile -- (system status button) */}
-            <SystemStatusButton statuspageData={statuspageData} className="visible-xs-block" />
-            {/* mobile -- kebab dropdown [(application launcher |) import yaml | documentation, about (| logout)] */}
-            <PageHeaderToolsItem className="visible-xs-block">
-              {this._renderMenu(true)}
-            </PageHeaderToolsItem>
-            {/* desktop -- (user dropdown [logout]) */}
-            <PageHeaderToolsItem className="hidden-xs">
-              {this._renderMenu(false)}
-            </PageHeaderToolsItem>
-          </PageHeaderToolsGroup>
-        </PageHeaderTools>
+              )}
+              <ToolbarItem>{this._renderMenu(true)}</ToolbarItem>
+            </ToolbarGroup>
+          </ToolbarContent>
+        </Toolbar>
         <AboutModal isOpen={showAboutModal} closeAboutModal={this._closeAboutModal} />
       </>
     );
@@ -760,7 +760,7 @@ const MastheadToolbarContents = connect(mastheadToolbarStateToProps, {
 export const MastheadToolbar = connectToFlags(
   FLAGS.CLUSTER_VERSION,
   FLAGS.CONSOLE_LINK,
-)(({ flags }) => {
+)(({ flags, isMastheadStacked }) => {
   const resources = [];
   if (flags[FLAGS.CLUSTER_VERSION]) {
     resources.push({
@@ -780,7 +780,7 @@ export const MastheadToolbar = connectToFlags(
 
   return (
     <Firehose resources={resources}>
-      <MastheadToolbarContents />
+      <MastheadToolbarContents isMastheadStacked={isMastheadStacked} />
     </Firehose>
   );
 });

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -21,7 +21,12 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
-import { FLAGS, YellowExclamationTriangleIcon, ACM_LINK_ID } from '@console/shared';
+import {
+  ACM_LINK_ID,
+  FLAGS,
+  usePerspectiveExtension,
+  YellowExclamationTriangleIcon,
+} from '@console/shared';
 import { formatNamespacedRouteForResource } from '@console/shared/src/utils';
 import CloudShellMastheadButton from '@console/app/src/components/cloud-shell/CloudShellMastheadButton';
 import CloudShellMastheadAction from '@console/app/src/components/cloud-shell/CloudShellMastheadAction';
@@ -40,6 +45,8 @@ import * as redhatLogoImg from '../imgs/logos/redhat.svg';
 import { GuidedTourMastheadTrigger } from '@console/app/src/components/tour';
 import { ConsoleLinkModel } from '../models';
 import { withTelemetry, withQuickStartContext } from '@console/shared/src/hoc';
+import ClusterMenu from '@console/app/src/components/nav/ClusterMenu';
+import { ACM_PERSPECTIVE_ID } from '@console/app/src/consts';
 
 const defaultHelpLinks = [
   {
@@ -55,6 +62,18 @@ const defaultHelpLinks = [
     href: 'https://blog.openshift.com',
   },
 ];
+
+const MultiClusterToolbarGroup = () => {
+  const showMultiClusterToolbarGroup =
+    usePerspectiveExtension(ACM_PERSPECTIVE_ID) || isMultiClusterEnabled();
+  return (
+    showMultiClusterToolbarGroup && (
+      <ToolbarGroup spacer={{ default: 'spacerNone' }}>
+        <ClusterMenu />
+      </ToolbarGroup>
+    )
+  );
+};
 
 const SystemStatusButton = ({ statuspageData }) => {
   const { t } = useTranslation();
@@ -641,9 +660,7 @@ class MastheadToolbarContents_ extends React.Component {
       <>
         <Toolbar isFullHeight isStatic>
           <ToolbarContent>
-            {/* <ToolbarGroup spacer={{ default: 'spacerNone' }}>
-              cluster picker goes here
-            </ToolbarGroup> */}
+            <MultiClusterToolbarGroup />
             <ToolbarGroup
               alignment={{ default: 'alignRight' }}
               spacer={{ default: 'spacerNone' }}

--- a/frontend/public/components/masthead.jsx
+++ b/frontend/public/components/masthead.jsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { Brand, PageHeader } from '@patternfly/react-core';
+import {
+  Brand,
+  Masthead as PfMasthead,
+  MastheadBrand,
+  MastheadContent,
+  MastheadMain,
+  MastheadToggle,
+  PageToggleButton,
+} from '@patternfly/react-core';
+import { BarsIcon } from '@patternfly/react-icons/dist/esm/icons/bars-icon';
 
 import { MastheadToolbar } from './masthead-toolbar';
 import { history } from './utils';
@@ -46,7 +55,7 @@ export const getBrandingDetails = () => {
   return { logoImg, productName };
 };
 
-export const Masthead = React.memo(({ onNavToggle, isNavOpen }) => {
+export const Masthead = React.memo(({ isMastheadStacked, isNavOpen, onNavToggle }) => {
   const details = getBrandingDetails();
   const defaultRoute = '/';
   const logoProps = {
@@ -59,19 +68,26 @@ export const Masthead = React.memo(({ onNavToggle, isNavOpen }) => {
   };
 
   return (
-    <PageHeader
-      id="page-main-header"
-      logo={<Brand src={details.logoImg} alt={details.productName} />}
-      logoProps={logoProps}
-      headerTools={<MastheadToolbar />}
-      showNavToggle
-      onNavToggle={onNavToggle}
-      isNavOpen={isNavOpen}
-    />
+    <PfMasthead id="page-main-header" display={{ default: isMastheadStacked ? 'stack' : 'inline' }}>
+      <MastheadToggle>
+        <PageToggleButton onNavToggle={onNavToggle} isNavOpen={isNavOpen}>
+          <BarsIcon />
+        </PageToggleButton>
+      </MastheadToggle>
+      <MastheadMain>
+        <MastheadBrand {...logoProps}>
+          <Brand src={details.logoImg} alt={details.productName} />
+        </MastheadBrand>
+      </MastheadMain>
+      <MastheadContent>
+        <MastheadToolbar isMastheadStacked={isMastheadStacked} />
+      </MastheadContent>
+    </PfMasthead>
   );
 });
 
 Masthead.propTypes = {
-  onNavToggle: PropTypes.func,
+  isMastheadStacked: PropTypes.bool,
   isNavOpen: PropTypes.bool,
+  onNavToggle: PropTypes.func,
 };

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -200,6 +200,7 @@ form.pf-c-form {
 .pf-c-masthead__content {
   .pf-c-app-launcher__toggle,
   .pf-c-dropdown__toggle,
+  .pf-c-menu-toggle,
   .pf-c-notification-badge {
     font-size: $pf-header-icon-fontsize !important;
   }

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -159,20 +159,6 @@ form.pf-c-form {
 
 // Page
 .pf-c-page {
-  &__header-brand-link {
-    flex: 0 1 auto !important; // so link doesn't grow larger than logo
-  }
-
-  &__header-tools {
-    .pf-c-dropdown__toggle,
-    .pf-c-app-launcher__toggle {
-      font-size: $pf-header-icon-fontsize !important;
-    }
-    .pf-c-notification-badge {
-      font-size: $pf-header-icon-fontsize;
-    }
-  }
-
   // Positions fullscreen terminal on top of mast header
   &__main.default-overflow {
     z-index: calc(var(--pf-c-page__header--ZIndex) + 50);
@@ -183,10 +169,6 @@ form.pf-c-form {
     display: flex;
     flex-direction: column;
     height: 100%;
-  }
-
-  .pf-c-page__header {
-    background-color: var(--pf-global--palette--black-1000);
   }
 }
 
@@ -212,6 +194,23 @@ form.pf-c-form {
     --pf-global--FontSize--md: #{$font-size-base};
   }
 }
+
+// reset toggles to original size
+// overriding .pf-c-button rule above
+.pf-c-masthead__content {
+  .pf-c-app-launcher__toggle,
+  .pf-c-dropdown__toggle,
+  .pf-c-notification-badge {
+    font-size: $pf-header-icon-fontsize !important;
+  }
+}
+
+// reset toggle to original size
+// overriding .pf-c-button rule above
+.pf-c-masthead__toggle .pf-c-button {
+  font-size: var(--pf-c-masthead__toggle--c-button--FontSize);
+}
+
 
 :where(:root:not(.pf-theme-dark)) .pf-c-page {
   --pf-c-page__sidebar--BoxShadow: none;


### PR DESCRIPTION
Note I removed the icon from the menu items as Joy's latest design omits them and it improves the readability of the menu toggle, especially at mobile.

Known differences in the masthead:
* the masthead background color override (black) is removed, so the masthead matches PatternFly (near black)
* the masthead is 70px tall instead of 76px due to the difference in PatternFly's `<Masthead>` vs.`<PageHeader>` 

Without cluster menu and nearly all masthead toolbar icons:

https://user-images.githubusercontent.com/895728/215136439-915145e0-139f-4255-ac3d-0ddc7033dfd8.mov

With cluster menu and relevant masthead toolbar icons:

https://user-images.githubusercontent.com/895728/216684107-a2cc062d-dfc9-4e10-ac1e-7dd4dc8365e8.mov

