### PR TITLE
[release-4.10] OCPBUGS-5296: Pan nodes into view if all nodes are not visible on load

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/Topology.tsx
+++ b/frontend/packages/topology/src/components/graph-view/Topology.tsx
@@ -17,6 +17,8 @@ import {
   SELECTION_EVENT,
   NODE_POSITIONED_EVENT,
   GRAPH_POSITION_CHANGE_EVENT,
+  Node,
+  Rect,
 } from '@patternfly/react-topology';
 import * as _ from 'lodash';
 import { action } from 'mobx';
@@ -61,6 +63,28 @@ const setTopologyLayout = (namespace: string, nodes: NodeModel[], layout: string
     layout,
   };
   return currentStore;
+};
+
+// Backport of https://github.com/patternfly/patternfly-react/blob/%40patternfly/react-topology%404.68.3/packages/react-topology/src/elements/BaseGraph.ts#L300-L310
+const isNodeInView = (element: Node) => {
+  const graph = element.getGraph();
+  const { x: viewX, y: viewY, width: viewWidth, height: viewHeight } = graph.getBounds();
+  const { x, y, width, height } = element
+    .getBounds()
+    .clone()
+    .scale(graph.getScale())
+    .translate(viewX, viewY);
+  return x + width > 0 && x < viewWidth && y + height > 0 && y < viewHeight;
+};
+
+const nodeDistanceToBounds = (node: Node, bounds: Rect): number => {
+  const nodeBounds = node.getBounds();
+  const nodeX = nodeBounds.x + nodeBounds.width / 2;
+  const nodeY = nodeBounds.y + nodeBounds.height / 2;
+
+  const dx = Math.max(bounds.x - nodeX, 0, nodeX - (bounds.x + bounds.width));
+  const dy = Math.max(bounds.y - nodeY, 0, nodeY - (bounds.y + bounds.height));
+  return Math.sqrt(dx * dx + dy * dy);
 };
 
 interface TopologyGraphViewProps {
@@ -223,9 +247,35 @@ const Topology: React.FC<TopologyProps &
             }
           });
         }
-        storedLayoutApplied.current = true;
       }
       visualization.fromModel(model);
+
+      // Make sure something is visible in the case where stored locations are off the screen
+      if (!storedLayoutApplied.current) {
+        storedLayoutApplied.current = true;
+        if (topologyLayoutDataJson?.[namespace]) {
+          const graph = visualization.getGraph();
+          const nodes = visualization.getElements().filter(isNode);
+          if (nodes.length) {
+            const nodesVisible = nodes.find(isNodeInView);
+            if (!nodesVisible) {
+              const graphBounds = graph.getBounds();
+              const [viewNode] = nodes.reduce(
+                ([closestNode, closestDistance], nextNode) => {
+                  const distance = nodeDistanceToBounds(nextNode, graphBounds);
+                  if (!closestNode || distance < closestDistance) {
+                    return [nextNode, distance];
+                  }
+                  return [closestNode, closestDistance];
+                },
+                [null, 0],
+              );
+              graph.panIntoView(viewNode);
+            }
+          }
+        }
+      }
+
       const selectedItem = selectedId ? visualization.getElementById(selectedId) : null;
       if (!selectedItem || !selectedItem.isVisible()) {
         onSelect();


### PR DESCRIPTION
This is a manual cherry-pick of #12398, it replaces the automatic cherry-pick #12408

The merge works fine, but the build fails because the old PatternFly Topology package doesn't contain `graph.isNodeInView` in 4.10. Added a local copy of this function.

release-4.10 before:

https://user-images.githubusercontent.com/139310/215223403-f581bdbd-858a-4bf6-94b7-8c7b9074c55c.mp4

With this PR:

https://user-images.githubusercontent.com/139310/215222782-a3b5062d-4c96-4012-bb07-14e0d0524a91.mp4

/kind bug
/cc @jeff-phillips-18 @invincibleJai
/cherry-pick release-4.9