### PR TITLE
[release-4.12] OCPBUGS-6764: Add Git Repository (PAC) showed empty permission content and non-working help link until a git url is entered

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/repository/consts.ts
+++ b/frontend/packages/pipelines-plugin/src/components/repository/consts.ts
@@ -64,6 +64,4 @@ export const WebhookDocLinks = {
   [GitProvider.GITLAB]:
     'https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#configure-a-webhook-in-gitlab',
   [GitProvider.BITBUCKET]: 'https://support.atlassian.com/bitbucket-cloud/docs/manage-webhooks/',
-  [GitProvider.UNSURE]:
-    'https://docs.github.com/en/developers/webhooks-and-events/webhooks/creating-webhooks',
 };

--- a/frontend/packages/pipelines-plugin/src/components/repository/sections/WebhookSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/sections/WebhookSection.tsx
@@ -225,18 +225,25 @@ const WebhookSection: React.FC<WebhoookSectionProps> = ({ pac }) => {
         </InputGroup>
       </FormGroup>
 
-      <ExpandableSection toggleText={getPermssionSectionHeading(values.gitProvider)}>
-        <FormGroup label={t('pipelines-plugin~Repository Permissions:')} fieldId="repo-permissions">
-          <Text component={TextVariants.small}>
-            <PermissionsSection />
-          </Text>
-        </FormGroup>
-      </ExpandableSection>
+      {values.gitProvider && values.gitProvider !== GitProvider.UNSURE ? (
+        <>
+          <ExpandableSection toggleText={getPermssionSectionHeading(values.gitProvider)}>
+            <FormGroup
+              label={t('pipelines-plugin~Repository Permissions:')}
+              fieldId="repo-permissions"
+            >
+              <Text component={TextVariants.small}>
+                <PermissionsSection />
+              </Text>
+            </FormGroup>
+          </ExpandableSection>
 
-      <ExternalLink
-        text={t('pipelines-plugin~Read more about setting up webhook')}
-        href={WebhookDocLinks[values.gitProvider]}
-      />
+          <ExternalLink
+            text={t('pipelines-plugin~Read more about setting up webhook')}
+            href={WebhookDocLinks[values.gitProvider]}
+          />
+        </>
+      ) : null}
     </FormSection>
   );
 };


### PR DESCRIPTION
This is a manual backport of #12445

**Screen recording:**

https://user-images.githubusercontent.com/139310/215353909-43fae4dc-8030-40c4-9795-667d4677e943.mp4
