### PR TITLE
OCPBUGS-6757: Get the Event type value from the latest PLR of the Repository

### DIFF
--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -341,7 +341,6 @@
   "Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.": "Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.",
   "Invalid Git URL.": "Invalid Git URL.",
   "Repository details": "Repository details",
-  "Branch": "Branch",
   "Close": "Close",
   "Commit id": "Commit id",
   "Branch/Tag": "Branch/Tag",

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryDetails.tsx
@@ -28,18 +28,6 @@ const RepositoryDetails: React.FC<RepositoryDetailsProps> = ({ obj: repository }
                   {getGitProviderIcon(spec?.url)} {spec?.url}
                 </ExternalLink>
               </dd>
-              {spec?.branch && (
-                <>
-                  <dt>{t('pipelines-plugin~Branch')}</dt>
-                  <dd data-test="pl-repository-branch">{spec.branch}</dd>
-                </>
-              )}
-              {spec?.event_type && (
-                <>
-                  <dt>{t('pipelines-plugin~Event type')}</dt>
-                  <dd data-test="pl-repository-eventtype">{spec.event_type}</dd>
-                </>
-              )}
             </dl>
           </div>
         )}

--- a/frontend/packages/pipelines-plugin/src/components/repository/__tests__/RepositoryDetails.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/__tests__/RepositoryDetails.spec.tsx
@@ -4,20 +4,6 @@ import { mockRepositories } from '../../../test-data/pipeline-data';
 import RepositoryDetails from '../RepositoryDetails';
 
 describe('RepositoryDetails', () => {
-  it('should render branch and eventtype when corresponding specs are available', () => {
-    const repositoryWrapper = shallow(<RepositoryDetails obj={mockRepositories[0]} />);
-    expect(repositoryWrapper.find('[data-test="pl-repository-customdetails"]').exists()).toBe(true);
-    expect(repositoryWrapper.find('[data-test="pl-repository-branch"]').exists()).toBe(true);
-    expect(repositoryWrapper.find('[data-test="pl-repository-eventtype"]').exists()).toBe(true);
-  });
-
-  it('should not render branch and eventtype when corresponding specs are not available', () => {
-    const repositoryWrapper = shallow(<RepositoryDetails obj={mockRepositories[1]} />);
-    expect(repositoryWrapper.find('[data-test="pl-repository-customdetails"]').exists()).toBe(true);
-    expect(repositoryWrapper.find('[data-test="pl-repository-branch"]').exists()).toBe(false);
-    expect(repositoryWrapper.find('[data-test="pl-repository-eventtype"]').exists()).toBe(false);
-  });
-
   it('should not render custom details section when spec url are not available', () => {
     const repositoryWrapper = shallow(<RepositoryDetails obj={mockRepositories[2]} />);
     expect(repositoryWrapper.find('[data-test="pl-repository-customdetails"]').exists()).toBe(

--- a/frontend/packages/pipelines-plugin/src/components/repository/__tests__/repository-mock.ts
+++ b/frontend/packages/pipelines-plugin/src/components/repository/__tests__/repository-mock.ts
@@ -30,6 +30,8 @@ export const mockRepository: RepositoryKind = {
       sha: '72954b86ee80eb9cf561b109b2fce63e57d10561',
       startTime: '2021-07-13T09:18:09Z',
       title: 'Delete test-1.txt',
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      event_type: 'pull_request',
     },
     {
       completionTime: '2021-07-13T10:30:08Z',
@@ -48,6 +50,8 @@ export const mockRepository: RepositoryKind = {
       sha: 'fa854c0a4821eac3dcc7f862e08396835fec2804',
       startTime: '2021-07-13T10:28:45Z',
       title: 'test push two test push',
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      event_type: 'push',
     },
     {
       completionTime: '2021-07-13T10:33:51Z',
@@ -66,6 +70,8 @@ export const mockRepository: RepositoryKind = {
       sha: 'dc204e919fc6fd984d24ac6f146b183c1695113d',
       startTime: '2021-07-13T10:33:08Z',
       title: 'Delete test-1.txt',
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      event_type: 'pull_request',
     },
     {
       completionTime: '2021-07-13T10:45:19Z',
@@ -84,12 +90,12 @@ export const mockRepository: RepositoryKind = {
       sha: '9ef2e6554d1846a7b0782c2dcdd8844070ecf242',
       startTime: '2021-07-13T10:44:45Z',
       title: 'Delete test-2.txt',
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      event_type: 'pull_request',
     },
   ],
   spec: {
     branch: 'main',
-    // eslint-disable-next-line @typescript-eslint/camelcase
-    event_type: 'pull_request',
     namespace: 'karthik',
     url: 'https://github.com/karthikjeeyar/demo-app',
   },

--- a/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoryRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoryRow.tsx
@@ -40,6 +40,8 @@ const RepositoryRow: React.FC<RowFunctionArgs<RepositoryKind>> = ({ obj }) => {
 
   const latestRun = loaded && getLatestRun(pipelineRun, 'creationTimestamp');
 
+  const latestPLREventType =
+    latestRun && latestRun?.metadata?.labels[RepositoryLabels[RepositoryFields.EVENT_TYPE]];
   return (
     <>
       <TableData className={repositoriesTableColumnClasses[0]}>
@@ -55,7 +57,9 @@ const RepositoryRow: React.FC<RowFunctionArgs<RepositoryKind>> = ({ obj }) => {
       <TableData className={repositoriesTableColumnClasses[1]} columnID="namespace">
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
-      <TableData className={repositoriesTableColumnClasses[2]}>{obj.spec?.event_type}</TableData>
+      <TableData className={repositoriesTableColumnClasses[2]}>
+        {latestPLREventType || '-'}
+      </TableData>
       <TableData className={repositoriesTableColumnClasses[3]}>
         {loaded ? (
           latestRun ? (

--- a/frontend/packages/pipelines-plugin/src/components/repository/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/repository/types.ts
@@ -10,13 +10,14 @@ export type RepositoryStatus = {
   sha?: string;
   startTime?: string;
   title?: string;
+  event_type?: string;
+  target_branch?: string;
 };
 
 export type RepositoryKind = K8sResourceKind & {
   spec?: {
     url: string;
     branch?: string;
-    event_type?: string;
     namespace?: string;
   };
   pipelinerun_status?: RepositoryStatus[];


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-6757

Descriptions: We used to read the `event_type` from the Repository `spec` but it got removed from the Repository spec. Now it is present in the PipelineRuns of the Repository.

Screenshots:
![image](https://user-images.githubusercontent.com/2561818/215493789-0cec6f15-1d01-4a25-a030-71d46d122b23.png)

![image](https://user-images.githubusercontent.com/2561818/215494125-1404b258-782a-4838-bed3-951f488418da.png)
