### PR TITLE
OCPBUGS-186: PipelineRun task status overlaps status text

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunHeader.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunHeader.tsx
@@ -7,7 +7,7 @@ export const tableColumnClasses = [
   'pf-u-w-16-on-lg pf-u-w-25-on-md',
   'pf-m-u-w-16-on-md pf-m-u-w-8-on-lg',
   'pf-u-w-16-on-md',
-  'pf-m-hidden pf-m-visible-on-md pf-u-w-8-on-xl',
+  'pf-m-hidden pf-m-visible-on-md',
   'pf-m-hidden pf-m-visible-on-lg pf-u-w-25-on-lg',
   'pf-m-hidden pf-m-visible-on-lg',
   'pf-m-hidden pf-m-visible-on-xl',


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-186

**Analysis / Root cause**: 
When resizing the browser window, the PipelineRun task status bar would overlap the status text that says "Succeeded".

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Adjusted patternfly classes for resolving the issue.

**Screen shots / Gifs for design review**: 

**Before:**

<img width="935" alt="pipelinerun-status" src="https://user-images.githubusercontent.com/47265560/215585049-3dbf2b54-e1c5-4ce4-9b23-e9d911654e93.png">

**After:**

https://user-images.githubusercontent.com/47265560/215585411-92dfec63-d8f0-4b59-b9eb-3259ad3c9a0c.mp4



**Unit test coverage report**: 
No Changes.

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Create a Pipeline Repository and start a PLR.
2. Adjust the width of the screen.


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge