### PR TITLE
OCPBUGS-5948: Better fix for runtime error in schema tab of api explorer when no schema exists

### DIFF
--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -44,18 +44,13 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
     ? currentSelection.path
     : [kindObj ? getDefinitionKey(kindObj, allDefinitions) : 'custom-schema'];
   const currentDefinition: SwaggerDefinition = _.get(allDefinitions, currentPath);
-  // If there's no match for group/version/kind in our definition list, return null
-  if (!currentDefinition) {
-    return null;
-  }
-  const currentProperties =
-    _.get(currentDefinition, 'properties') || _.get(currentDefinition, 'items.properties');
+  const currentProperties = currentDefinition?.properties || currentDefinition?.items?.properties;
 
   // Prefer the description saved in `currentSelection`. It won't always be defined in the definition itself.
   const description = currentSelection
-    ? currentSelection.description
-    : currentDefinition.description;
-  const required = new Set(currentDefinition.required || []);
+    ? currentSelection?.description
+    : currentDefinition?.description;
+  const required = new Set(currentDefinition?.required || []);
   const kindLabel = kindObj?.labelKey ? t(kindObj.labelKey) : kindObj?.kind;
   const breadcrumbs = drilldownHistory.length
     ? [kindObj ? kindLabel : t('public~Schema'), ..._.map(drilldownHistory, 'name')]


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-5948

Use existing empty schema component when none exists in swagger instead of returning early.

![Screenshot 2023-01-30 at 6 02 04 PM](https://user-images.githubusercontent.com/35978579/215616157-48368671-262b-4746-aedd-6396335b3c97.png)
