### PR TITLE
OCPBUGS-2479: Right border radius is 0 for the pipeline visualization wrapper in dark mode

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.scss
@@ -3,5 +3,6 @@
 
   .pf-topology-visualization-surface {
     font-size: 1rem;
+    border-radius: 1rem;
   }
 }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTopologyGraph.scss
@@ -1,11 +1,11 @@
 .odc-pipeline-topology-graph {
-  border-radius: 20px;
   font-size: var(--pf-global--FontSize--xs);
   max-width: 100%;
   overflow: hidden;
 
   &.builder {
     display: block;
+    border-radius: 20px;
     background: var(--pf-global--BackgroundColor--200);
   }
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-2479

**Analysis / Root cause**: 
Right border radius is 0 for the pipeline visualization wrapper in dark mode but looks fine in light mode

**Solution Description**: 
Adjusted Styles to set border-radius

**Screen shots / Gifs for design review**: 

**Before:**
![image-2022-10-17-23-47-44-307](https://user-images.githubusercontent.com/47265560/215753624-9d0aec81-59bd-484b-a7c2-b13854d8661b.png)

**After:**
![rwer](https://user-images.githubusercontent.com/47265560/215754507-057516d7-405f-422e-97e2-31eafc2d0d4b.png)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
1. Switch the theme to dark mode
2. Create a pipeline and navigate to the Pipeline details page



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge