### PR TITLE
[release-4.12] OCPBUGS-6831: Fix crash when pinnedResources is null

### DIFF
--- a/frontend/packages/console-shared/src/hooks/usePinnedResources.ts
+++ b/frontend/packages/console-shared/src/hooks/usePinnedResources.ts
@@ -35,10 +35,10 @@ export const usePinnedResources = (): [string[], (pinnedResources: string[]) => 
   >(PINNED_RESOURCES_CONFIG_MAP_KEY, PINNED_RESOURCES_LOCAL_STORAGE_KEY, defaultPins, true);
 
   const pins = useMemo(() => {
-    if (!loaded) {
+    if (!loaded || !pinnedResources) {
       return [];
     }
-    return pinnedResources[activePerspective] ?? [];
+    return pinnedResources[activePerspective] || [];
   }, [loaded, pinnedResources, activePerspective]);
 
   const setPins = useCallback(


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-6831

**Analysis / Root cause**: 
We noticed a crash on 4.13.0-ec.1 when `console.pinnedResource` is `"null"` in user settings. The issue is already fixed in #12354 for 4.13+ but when switching or downgrading servers this could also crash on 4.13.

**Solution Description**: 
Added a null check.

**Test setup:**
Open the user-settings ConfigMap and set "console.pinedResources" to "null" (with quotes as all ConfigMap values needs to be strings)

Or run this patch command:

```bash
oc patch -n openshift-console-user-settings configmaps user-settings-kubeadmin --type=merge --patch '{"data":{"console.pinnedResources":"null"}}'
```

Reload or open console...

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/cc @vikram-raj @invincibleJai 
/king bug