### PR TITLE
OCPBUGS-6647: Added translation to Last used in resource type dropdown

### DIFF
--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -896,7 +896,7 @@
         "options": [
           {
             "value": "latest",
-            "label": "Last used",
+            "label": "%devconsole~Last used%",
             "description": "%devconsole~The last resource type used when adding a resource.%"
           },
           {
@@ -932,7 +932,7 @@
         "options": [
           {
             "value": "latest",
-            "label": "Last used",
+            "label": "%devconsole~Last used%",
             "description": "%devconsole~The last resource type used when adding a resource.%"
           },
           {

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -58,6 +58,7 @@
   "Resource type": "Resource type",
   "If resource type is not selected, the console default to the latest.": "If resource type is not selected, the console default to the latest.",
   "The defaults below will only apply to the Import from Git and Deploy Image forms when creating Deployments or Deployment Configs.": "The defaults below will only apply to the Import from Git and Deploy Image forms when creating Deployments or Deployment Configs.",
+  "Last used": "Last used",
   "The last resource type used when adding a resource.": "The last resource type used when adding a resource.",
   "Deployment": "Deployment",
   "A Deployment enables declarative updates for Pods and ReplicaSets.": "A Deployment enables declarative updates for Pods and ReplicaSets.",


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-6647

**Analysis / Root cause:**
Translation was missed to "Last used" menu in resource type dropdown

**Solution Description:**
Added translation

**Screen shots / Gifs for design review:**

-------------- Before -------
<img width="985" alt="Screenshot 2023-01-31 at 6 29 29 PM" src="https://user-images.githubusercontent.com/102503482/215766498-443cdd8f-3673-4cc7-8ef1-e30a91c2ff2a.png">



-------After-----------------
<img width="1010" alt="Screenshot 2023-01-31 at 6 28 53 PM" src="https://user-images.githubusercontent.com/102503482/215766529-bd3d0fe7-95c7-4762-9ad0-8f9dbc0fab0a.png">




****Unit test coverage report:****
NA

**Test setup:**
1. Navigate to kube:admin -> User Preferences -> Applications
2. Click on Resource type dorp-down

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
