### PR TITLE
OCPBUGS-5773: Uninstall helm chart not deleting all resources when the status is pending-install

### DIFF
--- a/pkg/helm/actions/upgrade_release.go
+++ b/pkg/helm/actions/upgrade_release.go
@@ -230,10 +230,6 @@ func UpgradeReleaseAsync(
 	}
 
 	go func() {
-		// Create context and prepare the handle of SIGTERM
-		// ctx := context.Background()
-		// ctx, cancel := context.WithCancel(ctx)
-		// remove all the tls related files created by this process
 		ctx, cancel := context.WithCancel(context.Background())
 		cancelChan := make(chan bool, 1)
 		go func() {
@@ -272,12 +268,15 @@ func UpgradeReleaseAsync(
 		if err != nil {
 			createSecret(releaseNamespace, releaseName, rel.Version+1, coreClient, err)
 		} else {
-			val := <-cancelChan
-				if val == true {
-					cancel()
-				}
 			if ch.Metadata.Name != "" && ch.Metadata.Version != "" {
 				metrics.HandleconsoleHelmUpgradesTotal(ch.Metadata.Name, ch.Metadata.Version)
+			}
+			val := <-cancelChan
+			if val {
+				fmt.Println("Reachig here for cancellation")
+				cancel()
+				fmt.Println("--------------------")
+				fmt.Println(ctx.Err())
 			}
 		}
 		defer func() {

--- a/vendor/helm.sh/helm/v3/pkg/action/install.go
+++ b/vendor/helm.sh/helm/v3/pkg/action/install.go
@@ -421,9 +421,11 @@ func (i *Install) performInstall(c chan<- resultMessage, rel *release.Release, t
 func (i *Install) handleContext(ctx context.Context, c chan<- resultMessage, done chan struct{}, rel *release.Release) {
 	select {
 	case <-ctx.Done():
+		fmt.Println("YES-----------------")
 		err := ctx.Err()
 		i.reportToRun(c, rel, err)
 	case <-done:
+		fmt.Println("NO-----------------")
 		return
 	}
 }
@@ -438,12 +440,14 @@ func (i *Install) reportToRun(c chan<- resultMessage, rel *release.Release, err 
 func (i *Install) failRelease(rel *release.Release, err error) (*release.Release, error) {
 	rel.SetStatus(release.StatusFailed, fmt.Sprintf("Release %q failed: %s", i.ReleaseName, err.Error()))
 	if i.Atomic {
+		fmt.Println("Reaching Here Yippeee")
 		i.cfg.Log("Install failed and atomic is set, uninstalling release")
 		uninstall := NewUninstall(i.cfg)
 		uninstall.DisableHooks = i.DisableHooks
 		uninstall.KeepHistory = false
 		uninstall.Timeout = i.Timeout
 		if _, uninstallErr := uninstall.Run(i.ReleaseName); uninstallErr != nil {
+			fmt.Println("Let's see it does not reach here")
 			return rel, errors.Wrapf(uninstallErr, "an error occurred while uninstalling the release. original install error: %s", err)
 		}
 		return rel, errors.Wrapf(err, "release %s failed, and has been uninstalled due to atomic being set", i.ReleaseName)


### PR DESCRIPTION

This PR aims at stopping the install and upgarde helm releases when a pending-install, upgrade release is uninstalled.
Signed-off-by: Kartikey Mamgain <mamgainkartikey@gmail.com>