### PR TITLE
OCPBUGS-5547: Webhook Secret (1 of 2) is not removed when Knative Service is deleted

### DIFF
--- a/frontend/packages/dev-console/src/actions/context-menu.ts
+++ b/frontend/packages/dev-console/src/actions/context-menu.ts
@@ -26,9 +26,7 @@ export const DeleteApplicationAction = (
         resourceType: ApplicationModel.label,
         onSubmit: () => {
           application.resources.forEach((resource) => {
-            reqs.push(
-              cleanUpWorkload(resource.resource, resource.data?.isKnativeResource ?? false),
-            );
+            reqs.push(cleanUpWorkload(resource.resource));
           });
           return Promise.all(reqs);
         },
@@ -38,18 +36,14 @@ export const DeleteApplicationAction = (
   };
 };
 
-export const DeleteResourceAction = (
-  kind: K8sModel,
-  obj: K8sResourceKind,
-  isKnativeResource?: boolean,
-): Action => ({
+export const DeleteResourceAction = (kind: K8sModel, obj: K8sResourceKind): Action => ({
   id: `delete-resource`,
   label: i18next.t('devconsole~Delete {{kind}}', { kind: kind.kind }),
   cta: () =>
     deleteModal({
       kind,
       resource: obj,
-      deleteAllResources: () => cleanUpWorkload(obj, isKnativeResource),
+      deleteAllResources: () => cleanUpWorkload(obj),
     }),
   accessReview: asAccessReview(kind, obj, 'delete'),
 });

--- a/frontend/packages/knative-plugin/src/actions/providers.ts
+++ b/frontend/packages/knative-plugin/src/actions/providers.ts
@@ -97,7 +97,7 @@ export const useKnativeServiceActionsProvider = (resource: K8sResourceKind) => {
       CommonActionFactory.ModifyAnnotations(kindObj, resource),
       CommonActionFactory.Edit(kindObj, resource),
       ...(resource.metadata.annotations?.['openshift.io/generated-by'] === 'OpenShiftWebConsole'
-        ? [DeleteResourceAction(kindObj, resource, true)]
+        ? [DeleteResourceAction(kindObj, resource)]
         : [CommonActionFactory.Delete(kindObj, resource)]),
     ];
   }, [kindObj, resource]);

--- a/frontend/packages/knative-plugin/src/topology/__tests__/data-transformer.spec.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/data-transformer.spec.ts
@@ -166,7 +166,7 @@ describe('knative data transformer ', () => {
     spyAndReturn(checkAccessSpy)(Promise.resolve({ status: { allowed: true } }));
     spyAndReturn(spyK8sList)(Promise.resolve([]));
 
-    cleanUpWorkload(node.resource, true)
+    cleanUpWorkload(node.resource)
       .then(() => {
         const allArgs = spy.calls.allArgs();
         const removedModels = allArgs.map((arg) => arg[0]);

--- a/frontend/packages/topology/src/utils/__tests__/application-utils.spec.ts
+++ b/frontend/packages/topology/src/utils/__tests__/application-utils.spec.ts
@@ -125,7 +125,7 @@ describe('ApplicationUtils ', () => {
     mockBuilds = sampleBuilds.data;
     mockBuildConfigs = sampleBuildConfigs.data;
     mockSecrets = sampleSecrets;
-    cleanUpWorkload(nodeModel.resource, false)
+    cleanUpWorkload(nodeModel.resource)
       .then(() => {
         const allArgs = spy.calls.allArgs();
         const removedModels = allArgs.map((arg) => arg[0]);
@@ -145,7 +145,7 @@ describe('ApplicationUtils ', () => {
   it('Should delete all the specific models related to deployment config if the build config is not present i.e. for resource created through deploy image form', async (done) => {
     const nodeModel = await getTopologyData(MockResources, 'nodejs-ex', 'test-project');
 
-    cleanUpWorkload(nodeModel.resource, false)
+    cleanUpWorkload(nodeModel.resource)
       .then(() => {
         const allArgs = spy.calls.allArgs();
         const removedModels = allArgs.map((arg) => arg[0]);
@@ -162,7 +162,7 @@ describe('ApplicationUtils ', () => {
 
   it('Should delete all the specific models related to daemonsets', async (done) => {
     const nodeModel = await getTopologyData(MockResources, 'daemonset-testing', 'test-project');
-    cleanUpWorkload(nodeModel.resource, false)
+    cleanUpWorkload(nodeModel.resource)
       .then(() => {
         const allArgs = spy.calls.allArgs();
         const removedModels = allArgs.map((arg) => arg[0]);
@@ -176,7 +176,7 @@ describe('ApplicationUtils ', () => {
 
   it('Should delete all the specific models related to statefulsets', async (done) => {
     const nodeModel = await getTopologyData(MockResources, 'alertmanager-main', 'test-project');
-    cleanUpWorkload(nodeModel.resource, false)
+    cleanUpWorkload(nodeModel.resource)
       .then(() => {
         const allArgs = spy.calls.allArgs();
         const removedModels = allArgs.map((arg) => arg[0]);
@@ -196,7 +196,7 @@ describe('ApplicationUtils ', () => {
       'ksservices',
       true,
     );
-    cleanUpWorkload(nodeModel.resource, true)
+    cleanUpWorkload(nodeModel.resource)
       .then(() => {
         const allArgs = spy.calls.allArgs();
         const removedModels = allArgs.map((arg) => arg[0]);
@@ -218,7 +218,7 @@ describe('ApplicationUtils ', () => {
       true,
     );
     spyAndReturn(spyOn(k8s, 'modelFor'))(CamelKameletBindingModel);
-    cleanUpWorkload(nodeModel.resource, true)
+    cleanUpWorkload(nodeModel.resource)
       .then(() => {
         const allArgs = spy.calls.allArgs();
         const removedModels = allArgs.map((arg) => arg[0]);
@@ -239,7 +239,7 @@ describe('ApplicationUtils ', () => {
       true,
     );
     spyAndReturn(spyOn(k8s, 'modelFor'))(KafkaSinkModel);
-    cleanUpWorkload(nodeModel.resource, true)
+    cleanUpWorkload(nodeModel.resource)
       .then(() => {
         const allArgs = spy.calls.allArgs();
         const removedModels = allArgs.map((arg) => arg[0]);
@@ -254,7 +254,7 @@ describe('ApplicationUtils ', () => {
   it('Should not delete any of the models, if delete access is not available', async (done) => {
     const nodeModel = await getTopologyData(MockResources, 'nodejs', 'test-project');
     spyAndReturn(checkAccessSpy)(Promise.resolve({ status: { allowed: false } }));
-    cleanUpWorkload(nodeModel.resource, false)
+    cleanUpWorkload(nodeModel.resource)
       .then(() => {
         const allArgs = spy.calls.allArgs();
         const removedModels = allArgs.map((arg) => arg[0]);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-5547

**Analysis / Root cause**: 
When creating a Knative Service and delete it again with enabled option "Delete other resources created by console" (only available on 4.13+ with the PR above) the secret "$name-github-webhook-secret" is not deleted.

**Solution Description**: 
Removed the condition from the `deleteWebhook` function, which prevented deletion of `git` secrets in case of Knative Workloads.


**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/47265560/216145933-94b56d18-f05a-4d3e-97b7-751ac950baac.mp4

**Unit test coverage report**: 
No Changes.

**Test setup:**

1. Install OpenShift Serverless operator (tested with 1.26.0)
2. Create a new project
3. Navigate to Add > Import from git and create an application
4. In the topology select the Knative Service > "Delete Service" (not Delete App)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge