### PR TITLE
OCPBUGS-6610: Developer - Topology : 'Filter by resource' drop-down i18n misses

### DIFF
--- a/frontend/packages/topology/locales/en/topology.json
+++ b/frontend/packages/topology/locales/en/topology.json
@@ -61,6 +61,7 @@
   "{{ready, number}} of {{count, number}} Pod_other": "{{ready, number}} of {{count, number}} Pods",
   "{{length}} Pods": "{{length}} Pods",
   "Rollout in progress...": "Rollout in progress...",
+  "Helm Release": "Helm Release",
   "{{groupLabel}} {{resourceLabel}}": "{{groupLabel}} {{resourceLabel}}",
   "{{resourceLabel}} sub-resources": "{{resourceLabel}} sub-resources",
   "{{kindLabel}} {{label}}": "{{kindLabel}} {{label}}",

--- a/frontend/packages/topology/src/components/list-view/list-view-utils.tsx
+++ b/frontend/packages/topology/src/components/list-view/list-view-utils.tsx
@@ -3,6 +3,11 @@ import * as _ from 'lodash';
 import { K8sKind, modelFor } from '@console/internal/module/k8s';
 import { getResourceKind } from '../../utils/topology-utils';
 
+export const translationForResourceKind = {
+  // t('topology~Helm Release')
+  HelmRelease: `topology~Helm Release`,
+};
+
 export const labelForNodeKind = (kindString: string) => {
   const model: K8sKind | undefined = modelFor(kindString);
   if (model) {
@@ -18,6 +23,9 @@ export const labelKeyForNodeKind = (kindString: string) => {
       return model.labelKey;
     }
     return model.label;
+  }
+  if (translationForResourceKind[kindString]) {
+    return translationForResourceKind[kindString];
   }
   return _.startCase(kindString);
 };

--- a/frontend/packages/topology/src/filters/KindFilterDropdown.tsx
+++ b/frontend/packages/topology/src/filters/KindFilterDropdown.tsx
@@ -2,9 +2,8 @@ import * as React from 'react';
 import { Button, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { ResourceIcon } from '@console/internal/components/utils';
-import { modelFor } from '@console/internal/module/k8s';
+import { labelForNodeKind, labelKeyForNodeKind } from '../components/list-view/list-view-utils';
 import { TopologyDisplayFilterType, DisplayFilters } from '../topology-types';
-
 import './KindFilterDropdown.scss';
 
 type KindFilterDropdownProps = {
@@ -31,11 +30,11 @@ const KindFilterDropdown: React.FC<KindFilterDropdownProps> = ({
   const selectedFilterCount = kindFilters.filter((f) => f.value).length;
   kindFilters = Object.keys(supportedKinds).reduce((acc, kind) => {
     if (!filters.find((f) => f.id === kind)) {
-      const model = modelFor(kind);
       acc.push({
         type: TopologyDisplayFilterType.kind,
         id: kind,
-        label: model ? model.label : kind,
+        label: labelForNodeKind(kind),
+        labelKey: labelKeyForNodeKind(kind),
         value: false,
         priority: 1,
       });
@@ -81,7 +80,7 @@ const KindFilterDropdown: React.FC<KindFilterDropdownProps> = ({
           data-test={filter.label}
         >
           <ResourceIcon kind={filter.id} />
-          {filter.label} ({supportedKinds[filter.id]})
+          {t(filter.labelKey)} ({supportedKinds[filter.id]})
         </SelectOption>
       ))}
     </div>

--- a/frontend/packages/topology/src/filters/__tests__/KindFilterDropdown.spec.tsx
+++ b/frontend/packages/topology/src/filters/__tests__/KindFilterDropdown.spec.tsx
@@ -63,6 +63,7 @@ describe(KindFilterDropdown.displayName, () => {
       type: TopologyDisplayFilterType.kind,
       id: 'Kind-A',
       label: 'Kind-A',
+      labelKey: 'Kind-A',
       priority: 1,
       value: true,
     });
@@ -70,6 +71,7 @@ describe(KindFilterDropdown.displayName, () => {
       type: TopologyDisplayFilterType.kind,
       id: 'Kind-C',
       label: 'Kind-C',
+      labelKey: 'Kind-C',
       priority: 1,
       value: true,
     });
@@ -90,7 +92,8 @@ describe(KindFilterDropdown.displayName, () => {
     dropdownFilter.push({
       type: TopologyDisplayFilterType.kind,
       id: 'Kind-A',
-      label: 'Kind-A',
+      label: 'Kind A',
+      labelKey: 'Kind A',
       priority: 1,
       value: true,
     });


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-6610

**Analysis / Root cause:**
Translation was not added for resource filter dropdown

**Solution Description:**
Added translation
1) If k8s model is available for the resource kind and  If `labelKey` is present in that model, then `labelKey` is used for translation or else `label` is used (`label` is not translated value)
2) If k8s model is not available for the resource kind, defined new type `translationForResourceKind`, if translation is available for that resource kind then it is used or else `kind` value will be displayed

In the below screenshot(In After section), for ContainerSource, Broker and Channel k8s models are present but `labelKey` attribute is not present. So `label` value is used in dropdown.

**Screen shots / Gifs for design review:**

-------------- Before -------
<img width="711" alt="Screenshot 2023-02-02 at 5 49 06 PM" src="https://user-images.githubusercontent.com/102503482/216323730-b742e481-6f76-4795-97fc-c6e070be2241.png">



-------After-----------------
<img width="930" alt="Screenshot 2023-02-02 at 5 45 51 PM" src="https://user-images.githubusercontent.com/102503482/216323719-c356a6b7-6154-4fae-86d4-925ece04f0ef.png">




****Unit test coverage report:****
NA

**Test setup:**
1.Navigate to Developer -> Topology -> Filter by resource

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
