### PR TITLE
CONSOLE-3622: k8sResourcePrefix x-descriptor labelSelector filtering support

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/widgets.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/widgets.tsx
@@ -4,6 +4,7 @@ import { WidgetProps } from '@rjsf/core';
 import { getSchemaType } from '@rjsf/core/dist/cjs/utils';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { Selector } from '@console/dynamic-plugin-sdk/src/api/common-types';
 import { RadioGroup } from '@console/internal/components/radio';
 import { NumberSpinner, ListDropdown, Dropdown } from '@console/internal/components/utils';
 import { K8sKind, GroupVersionKind, ImagePullPolicy } from '@console/internal/module/k8s';
@@ -119,7 +120,7 @@ export const K8sResourceWidget: React.FC<K8sResourceWidgetProps> = ({
   onChange,
 }) => {
   const { t } = useTranslation();
-  const { model, groupVersionKind } = options;
+  const { model, groupVersionKind, selector } = options;
   const { namespace } = formContext;
   const selectedKey = value ? `${value}-${model.kind}` : null;
 
@@ -129,7 +130,9 @@ export const K8sResourceWidget: React.FC<K8sResourceWidgetProps> = ({
         <ListDropdown
           key={id}
           id={id}
-          resources={[{ kind: groupVersionKind, namespace: model.namespaced ? namespace : null }]}
+          resources={[
+            { kind: groupVersionKind, selector, namespace: model.namespaced ? namespace : null },
+          ]}
           desc={label}
           placeholder={t('console-shared~Select {{label}}', { label: model.label })}
           onChange={(next) => onChange(next)}
@@ -196,6 +199,7 @@ type K8sResourceWidgetProps = WidgetProps & {
   options: {
     model: K8sKind;
     groupVersionKind: GroupVersionKind;
+    selector: Selector;
   };
 };
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/const.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/const.ts
@@ -6,7 +6,7 @@ export const REGEXP_FIELD_DEPENDENCY_CAPABILITY = _.escapeRegExp(SpecCapability.
 export const REGEXP_SELECT_CAPABILITY = _.escapeRegExp(SpecCapability.select);
 
 export const REGEXP_K8S_RESOURCE_SUFFIX = new RegExp(
-  `^${REGEXP_K8S_RESOURCE_CAPABILITY}(?:core[:~]v1[:~])?(.*)$`,
+  `^${REGEXP_K8S_RESOURCE_CAPABILITY}(?:core[:~]v1[:~])?([^?]*)[?]?(.*)$`,
 );
 export const REGEXP_SELECT_OPTION = new RegExp(`${REGEXP_SELECT_CAPABILITY}(.*)$`);
 export const REGEXP_FIELD_DEPENDENCY_PATH_VALUE = new RegExp(

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md
@@ -141,6 +141,15 @@ x-descriptors:
 …
 ```
 
+With optional label selector being specified:
+
+```yaml
+…
+x-descriptors:
+- urn:alm:descriptor:io.kubernetes:Deployment?tier!=frontend,environment in (production, qa)'
+…
+```
+
 **UI**
 <table style="width:100%">
   <tr valign="top">

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.spec.ts
@@ -1,4 +1,5 @@
 import { ServiceAccountModel } from '@console/internal/models';
+import { selectorFromString } from '@console/internal/module/k8s/selector';
 import { getJSONSchemaOrder } from '@console/shared/src/components/dynamic-form/utils';
 import { SpecCapability } from '../descriptors/types';
 import { capabilitiesToUISchema } from './utils';
@@ -98,6 +99,28 @@ describe('capabilitiesToUISchema', () => {
     expect(uiSchema['ui:widget']).toEqual('K8sResourceWidget');
     expect(uiSchema['ui:options'].model).toEqual(ServiceAccountModel);
     expect(uiSchema['ui:options'].groupVersionKind).toEqual('ServiceAccount');
+  });
+  it('Handles SpecCapability.k8sResourcePrefix with equality-based label queries', () => {
+    const uiSchema = capabilitiesToUISchema([
+      `${SpecCapability.k8sResourcePrefix}ServiceAccount?label!=test,level=production` as SpecCapability,
+    ]);
+    expect(uiSchema['ui:widget']).toEqual('K8sResourceWidget');
+    expect(uiSchema['ui:options'].model).toEqual(ServiceAccountModel);
+    expect(uiSchema['ui:options'].groupVersionKind).toEqual('ServiceAccount');
+    expect(uiSchema['ui:options'].selector).toEqual(
+      selectorFromString('label!=test,level=production'),
+    );
+  });
+  it('Handles SpecCapability.k8sResourcePrefix with set-based label queries', () => {
+    const uiSchema = capabilitiesToUISchema([
+      `${SpecCapability.k8sResourcePrefix}ServiceAccount?level in (production,qa)` as SpecCapability,
+    ]);
+    expect(uiSchema['ui:widget']).toEqual('K8sResourceWidget');
+    expect(uiSchema['ui:options'].model).toEqual(ServiceAccountModel);
+    expect(uiSchema['ui:options'].groupVersionKind).toEqual('ServiceAccount');
+    expect(uiSchema['ui:options'].selector).toEqual(
+      selectorFromString('level in (production, qa)'),
+    );
   });
   it('Handles SpecCapablitiy.select', () => {
     const uiSchema = capabilitiesToUISchema([

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.ts
@@ -4,6 +4,7 @@ import { JSONSchema7 } from 'json-schema';
 import * as _ from 'lodash';
 import i18n from '@console/internal/i18n';
 import { modelFor } from '@console/internal/module/k8s';
+import { selectorFromString } from '@console/internal/module/k8s/selector';
 import { getSchemaAtPath } from '@console/shared';
 import {
   getJSONSchemaOrder,
@@ -33,13 +34,16 @@ export const hideAllExistingProperties = (schema: JSONSchema7) => {
 };
 
 const k8sResourceCapabilityToUISchema = (capability: SpecCapability): UiSchema => {
-  const [, suffix] = capability.match(REGEXP_K8S_RESOURCE_SUFFIX) ?? [];
-  const groupVersionKind = suffix?.replace(/:/g, '~');
+  const [, groupVersionKindToken, selectorToken] =
+    capability.match(REGEXP_K8S_RESOURCE_SUFFIX) ?? [];
+  const groupVersionKind = groupVersionKindToken?.replace(/:/g, '~');
+  const selector = selectorFromString(selectorToken);
+
   const model = groupVersionKind && modelFor(groupVersionKind);
   if (model) {
     return {
       'ui:widget': 'K8sResourceWidget',
-      'ui:options': { model, groupVersionKind },
+      'ui:options': { model, groupVersionKind, selector },
     };
   }
   return {};

--- a/frontend/public/components/utils/list-dropdown.jsx
+++ b/frontend/public/components/utils/list-dropdown.jsx
@@ -196,6 +196,7 @@ ListDropdown.propTypes = {
     PropTypes.shape({
       kind: PropTypes.string.isRequired,
       namespace: PropTypes.string,
+      selector: PropTypes.object,
     }),
   ).isRequired,
   placeholder: PropTypes.string,


### PR DESCRIPTION
Adds an optional label selector to the k8sResourcePrefix x-descriptor,
The syntax follows the URI standards so the character '?' is used to begin the query and '+' to encode spaces, the label query is a standard Kubernetes label selector and can be equity based or set based. https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

So when combined with spec descriptors, 
the syntax `urn:alm:descriptor:io.kubernetes:ServiceAccount?label!=test,level=production` should render a dropdown listing only the ServiceAccounts that match the equity based label selector, 
while the syntax  `urn:alm:descriptor:io.kubernetes:ServiceAccount?environment+in+(production,qa)` should list the ServiceAccounts that match the set-based label selector.



