### PR TITLE
ODC-7232, ODC-7233: Add new auth, serverconfig and usage metrics

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/console/pkg/serverutils"
 	oscrypto "github.com/openshift/library-go/pkg/crypto"
 
+	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 )
 
@@ -304,6 +305,7 @@ func main() {
 		ReleaseVersion:               *fReleaseVersion,
 		NodeArchitectures:            nodeArchitectures,
 		HubConsoleURL:                hubConsoleURL,
+		AuthMetrics:                  auth.NewMetrics(),
 	}
 
 	managedClusterConfigs := []serverconfig.ManagedClusterConfig{}
@@ -642,6 +644,12 @@ func main() {
 			RefererPath:   refererPath,
 			SecureCookies: secureCookies,
 			ClusterName:   serverutils.LocalClusterName,
+
+			K8sConfig: &rest.Config{
+				Host:      apiServerEndpoint,
+				Transport: srv.LocalK8sClient.Transport,
+			},
+			Metrics: srv.AuthMetrics,
 		}
 
 		// NOTE: This won't work when using the OpenShift auth mode.
@@ -686,6 +694,12 @@ func main() {
 					RefererPath:   refererPath,
 					SecureCookies: secureCookies,
 					ClusterName:   managedCluster.Name,
+
+					K8sConfig: &rest.Config{
+						Host:      apiServerEndpoint,
+						Transport: srv.LocalK8sClient.Transport,
+					},
+					Metrics: srv.AuthMetrics,
 				}
 
 				if srv.Authers[managedCluster.Name], err = auth.NewAuthenticator(context.Background(), managedClusterOIDCClientConfig); err != nil {

--- a/frontend/packages/console-telemetry-plugin/console-extensions.json
+++ b/frontend/packages/console-telemetry-plugin/console-extensions.json
@@ -5,7 +5,15 @@
       "handler": { "$codeRef": "telemetryFlags.detectTelemetry" }
     }
   },
-
+  {
+    "type": "console.telemetry/listener",
+    "properties": {
+      "listener": {
+        "$codeRef": "telemetryListeners.usage"
+      }
+    },
+    "flags": { "required": ["TELEMETRY"] }
+  },
   {
     "type": "console.telemetry/listener",
     "properties": {

--- a/frontend/packages/console-telemetry-plugin/src/listeners/index.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/index.ts
@@ -1,1 +1,2 @@
+export { eventListener as usage } from './usage';
 export { eventListener as segment } from './segment';

--- a/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { TelemetryEventListener } from '@console/dynamic-plugin-sdk/src';
 import { SEGMENT_API_KEY, TELEMETRY_DISABLED, TELEMETRY_DEBUG } from './const';
 
@@ -9,58 +8,59 @@ const initSegment = () => {
     return;
   }
   if (analytics.invoked) {
+    // eslint-disable-next-line no-console
     console.error('console-telemetry-plugin: segment snippet included twice');
-  } else {
-    analytics.invoked = true;
-    analytics.methods = [
-      'trackSubmit',
-      'trackClick',
-      'trackLink',
-      'trackForm',
-      'pageview',
-      'identify',
-      'reset',
-      'group',
-      'track',
-      'ready',
-      'alias',
-      'debug',
-      'page',
-      'once',
-      'off',
-      'on',
-      'addSourceMiddleware',
-      'addIntegrationMiddleware',
-      'setAnonymousId',
-      'addDestinationMiddleware',
-    ];
-    analytics.factory = function(e: string) {
-      return function() {
-        // eslint-disable-next-line prefer-rest-params
-        const t = Array.prototype.slice.call(arguments);
-        t.unshift(e);
-        analytics.push(t);
-        return analytics;
-      };
-    };
-    for (const key of analytics.methods) {
-      analytics[key] = analytics.factory(key);
-    }
-    analytics.load = function(key: string, e: Event) {
-      const t = document.createElement('script');
-      t.type = 'text/javascript';
-      t.async = true;
-      t.src = `https://cdn.segment.com/analytics.js/v1/${encodeURIComponent(key)}/analytics.min.js`;
-      const n = document.getElementsByTagName('script')[0];
-      if (n.parentNode) {
-        n.parentNode.insertBefore(t, n);
-      }
-      // eslint-disable-next-line no-underscore-dangle
-      analytics._loadOptions = e;
-    };
-    analytics.SNIPPET_VERSION = '4.13.1';
-    analytics.load(SEGMENT_API_KEY);
+    return;
   }
+  analytics.invoked = true;
+  analytics.methods = [
+    'trackSubmit',
+    'trackClick',
+    'trackLink',
+    'trackForm',
+    'pageview',
+    'identify',
+    'reset',
+    'group',
+    'track',
+    'ready',
+    'alias',
+    'debug',
+    'page',
+    'once',
+    'off',
+    'on',
+    'addSourceMiddleware',
+    'addIntegrationMiddleware',
+    'setAnonymousId',
+    'addDestinationMiddleware',
+  ];
+  analytics.factory = function(e: string) {
+    return function() {
+      // eslint-disable-next-line prefer-rest-params
+      const t = Array.prototype.slice.call(arguments);
+      t.unshift(e);
+      analytics.push(t);
+      return analytics;
+    };
+  };
+  for (const key of analytics.methods) {
+    analytics[key] = analytics.factory(key);
+  }
+  analytics.load = function(key: string, e: Event) {
+    const t = document.createElement('script');
+    t.type = 'text/javascript';
+    t.async = true;
+    t.src = `https://cdn.segment.com/analytics.js/v1/${encodeURIComponent(key)}/analytics.min.js`;
+    const n = document.getElementsByTagName('script')[0];
+    if (n.parentNode) {
+      n.parentNode.insertBefore(t, n);
+    }
+    // eslint-disable-next-line no-underscore-dangle
+    analytics._loadOptions = e;
+  };
+  analytics.SNIPPET_VERSION = '4.13.1';
+  analytics.load(SEGMENT_API_KEY);
 };
 
 SEGMENT_API_KEY && !TELEMETRY_DISABLED && initSegment();
@@ -76,36 +76,39 @@ export const eventListener: TelemetryEventListener = async (
   properties?: any,
 ) => {
   if (TELEMETRY_DEBUG) {
+    // eslint-disable-next-line no-console
     console.debug('console-telemetry-plugin: received telemetry event:', eventType, properties);
-  } else if (SEGMENT_API_KEY) {
-    switch (eventType) {
-      case 'identify':
-        {
-          const { user, ...otherProperties } = properties;
-          const id = user?.metadata?.name;
-          if (id) {
-            // Use SHA1 hash algorithm to anonymize the user
-            const anonymousIdBuffer = await crypto.subtle.digest(
-              'SHA-1',
-              new TextEncoder().encode(id),
-            );
-            const anonymousIdArray = Array.from(new Uint8Array(anonymousIdBuffer));
-            const anonymousId = anonymousIdArray
-              .map((b) => b.toString(16).padStart(2, '0'))
-              .join('');
-            (window as any).analytics.identify(anonymousId, otherProperties, anonymousIP);
-          } else {
-            console.error(
-              'console-telemetry-plugin: unable to identify as no user name was provided',
-            );
-          }
+    return;
+  }
+  if (!SEGMENT_API_KEY || TELEMETRY_DISABLED) {
+    return;
+  }
+  switch (eventType) {
+    case 'identify':
+      {
+        const { user, ...otherProperties } = properties;
+        const id = user?.metadata?.name;
+        if (id) {
+          // Use SHA1 hash algorithm to anonymize the user
+          const anonymousIdBuffer = await crypto.subtle.digest(
+            'SHA-1',
+            new TextEncoder().encode(id),
+          );
+          const anonymousIdArray = Array.from(new Uint8Array(anonymousIdBuffer));
+          const anonymousId = anonymousIdArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+          (window as any).analytics.identify(anonymousId, otherProperties, anonymousIP);
+        } else {
+          // eslint-disable-next-line no-console
+          console.error(
+            'console-telemetry-plugin: unable to identify as no user name was provided',
+          );
         }
-        break;
-      case 'page':
-        (window as any).analytics.page(undefined, properties, anonymousIP);
-        break;
-      default:
-        (window as any).analytics.track(eventType, properties, anonymousIP);
-    }
+      }
+      break;
+    case 'page':
+      (window as any).analytics.page(undefined, properties, anonymousIP);
+      break;
+    default:
+      (window as any).analytics.track(eventType, properties, anonymousIP);
   }
 };

--- a/frontend/packages/console-telemetry-plugin/src/listeners/usage.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/usage.ts
@@ -1,0 +1,49 @@
+import { TelemetryEventListener } from '@console/dynamic-plugin-sdk/src';
+
+/**
+ * Fire and forget implementation to send usage data to the backend.
+ * See pkg/usage/ for more information.
+ */
+const trackUsage = (data: { event: string; perspective: string }) => {
+  return fetch('/metrics/usage', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+    .then((response) => {
+      if (!response.ok) {
+        // eslint-disable-next-line no-console
+        console.error('console-telemetry-plugin: unable to track usage:', response.statusText);
+      }
+    })
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error('console-telemetry-plugin: unable to track usage:', error);
+    });
+};
+
+export const eventListener: TelemetryEventListener = async (
+  eventType: string,
+  properties?: any,
+) => {
+  switch (eventType) {
+    case 'identify': {
+      // identify is triggered once per "browser load" ~= page_view
+      const perspective = properties?.perspective || 'unknown';
+      trackUsage({ event: 'page_view', perspective });
+      break;
+    }
+    case 'page': {
+      // page URL changed, incl. history.push / react-router.push/replace ~= page_impression
+      const perspective = properties?.perspective || 'unknown';
+      trackUsage({ event: 'page_impression', perspective });
+      break;
+    }
+    case 'Perspective Changed': {
+      const perspective = properties?.perspective || 'unknown';
+      trackUsage({ event: 'perspective_changed', perspective });
+      break;
+    }
+    default:
+    // ignore all other events
+  }
+};

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -21,6 +21,7 @@ import (
 
 	oscrypto "github.com/openshift/library-go/pkg/crypto"
 
+	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 )
 
@@ -62,6 +63,9 @@ type Authenticator struct {
 	cookiePath    string
 	refererURL    *url.URL
 	secureCookies bool
+
+	k8sConfig *rest.Config
+	metrics   *Metrics
 }
 
 type SpecialAuthURLs struct {
@@ -114,6 +118,9 @@ type Config struct {
 	CookiePath    string
 	SecureCookies bool
 	ClusterName   string
+
+	K8sConfig *rest.Config
+	Metrics   *Metrics
 }
 
 func newHTTPClient(issuerCA string, includeSystemRoots bool) (*http.Client, error) {
@@ -301,6 +308,8 @@ func newUnstartedAuthenticator(c *Config) (*Authenticator, error) {
 		cookiePath:    c.CookiePath,
 		refererURL:    refUrl,
 		secureCookies: c.SecureCookies,
+		k8sConfig:     c.K8sConfig,
+		metrics:       c.Metrics,
 	}, nil
 }
 
@@ -317,6 +326,10 @@ func (a *Authenticator) Authenticate(r *http.Request) (*User, error) {
 
 // LoginFunc redirects to the OIDC provider for user login.
 func (a *Authenticator) LoginFunc(w http.ResponseWriter, r *http.Request) {
+	if a.metrics != nil {
+		a.metrics.LoginRequested()
+	}
+
 	var randData [4]byte
 	if _, err := io.ReadFull(rand.Reader, randData[:]); err != nil {
 		panic(err)
@@ -337,6 +350,10 @@ func (a *Authenticator) LoginFunc(w http.ResponseWriter, r *http.Request) {
 
 // LogoutFunc cleans up session cookies.
 func (a *Authenticator) LogoutFunc(w http.ResponseWriter, r *http.Request) {
+	if a.metrics != nil {
+		a.metrics.LogoutRequested(UnknownLogoutReason)
+	}
+
 	a.getLoginMethod().logout(w, r)
 }
 
@@ -394,6 +411,10 @@ func (a *Authenticator) CallbackFunc(fn func(loginInfo LoginJSON, successURL str
 			return
 		}
 
+		if a.metrics != nil {
+			a.metrics.LoginSuccessful(a.k8sConfig, ls)
+		}
+
 		klog.Infof("oauth success, redirecting to: %q", a.successURL)
 		fn(ls.toLoginJSON(), a.successURL, w)
 	}
@@ -410,6 +431,10 @@ func (a *Authenticator) getLoginMethod() loginMethod {
 }
 
 func (a *Authenticator) redirectAuthError(w http.ResponseWriter, authErr string) {
+	if a.metrics != nil {
+		a.metrics.LoginFailed(UnknownLoginFailureReason)
+	}
+
 	var u url.URL
 	up, err := url.Parse(a.errorURL)
 	if err != nil {

--- a/pkg/auth/metrics.go
+++ b/pkg/auth/metrics.go
@@ -1,0 +1,201 @@
+package auth
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	authv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+)
+
+var userResource = schema.GroupVersionResource{
+	Group:    "user.openshift.io",
+	Version:  "v1",
+	Resource: "users",
+}
+
+type LoginRole string
+
+const (
+	KubeadminLoginRole    LoginRole = "kubeadmin"
+	ClusterAdminLoginRole LoginRole = "cluster-admin"
+	DeveloperLoginRole    LoginRole = "developer"
+	UnknownLoginRole      LoginRole = "unknown"
+)
+
+type LoginFailureReason string
+
+const (
+	UnknownLoginFailureReason LoginFailureReason = "unknown"
+)
+
+type LogoutReason string
+
+const (
+	UnknownLogoutReason LogoutReason = "unknown"
+)
+
+type Metrics struct {
+	loginRequests   prometheus.Counter
+	loginSuccessful *prometheus.CounterVec
+	loginFailures   *prometheus.CounterVec
+	logoutRequests  *prometheus.CounterVec
+}
+
+func (m *Metrics) GetCollectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		m.loginRequests,
+		m.loginSuccessful,
+		m.loginFailures,
+		m.logoutRequests,
+	}
+}
+
+func (m *Metrics) LoginRequested() {
+	klog.V(4).Info("auth.Metrics LoginRequested\n")
+	m.loginRequests.Inc()
+}
+
+func (m *Metrics) LoginSuccessful(k8sConfig *rest.Config, ls *loginState) {
+	if k8sConfig == nil || ls == nil || len(ls.rawToken) == 0 {
+		return
+	}
+	go func() {
+		m.loginSuccessfulSync(k8sConfig, ls)
+	}()
+}
+
+func (m *Metrics) loginSuccessfulSync(k8sConfig *rest.Config, ls *loginState) {
+	if k8sConfig == nil || ls == nil || len(ls.rawToken) == 0 {
+		return
+	}
+
+	ctx := context.TODO()
+	configWithBearerToken := &rest.Config{
+		Host:        k8sConfig.Host,
+		Transport:   k8sConfig.Transport,
+		BearerToken: ls.rawToken,
+		Timeout:     30 * time.Second,
+	}
+
+	role := UnknownLoginRole
+
+	if isKubeAdmin, err := m.isKubeAdmin(ctx, configWithBearerToken); isKubeAdmin && err == nil {
+		role = KubeadminLoginRole
+	} else if canGetNamespaces, err := m.canGetNamespaces(ctx, configWithBearerToken); err == nil {
+		if canGetNamespaces {
+			role = ClusterAdminLoginRole
+		} else {
+			role = DeveloperLoginRole
+		}
+	}
+
+	klog.V(4).Infof("auth.Metrics loginSuccessfulSync - increase metric for role %q\n", role)
+	counter, err := m.loginSuccessful.GetMetricWithLabelValues(string(role))
+	if counter != nil && err == nil {
+		counter.Inc()
+	}
+}
+
+func (m *Metrics) LoginFailed(reason LoginFailureReason) {
+	klog.V(4).Infof("auth.Metrics LoginFailed with reason %q\n", reason)
+	counter, err := m.loginFailures.GetMetricWithLabelValues(string(reason))
+	if counter != nil && err == nil {
+		counter.Inc()
+	}
+}
+
+func (m *Metrics) LogoutRequested(reason LogoutReason) {
+	klog.V(4).Infof("auth.Metrics LogoutRequested with reason %q\n", reason)
+	counter, err := m.logoutRequests.GetMetricWithLabelValues(string(reason))
+	if counter != nil && err == nil {
+		counter.Inc()
+	}
+}
+
+func (m *Metrics) canGetNamespaces(ctx context.Context, config *rest.Config) (bool, error) {
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		klog.Errorf("Error in auth.metrics canGetNamespaces: %v\n", err)
+		return false, err
+	}
+	canGetNamespaceAccessReview := &authv1.SelfSubjectAccessReview{
+		Spec: authv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authv1.ResourceAttributes{
+				Verb:     "get",
+				Resource: "namespaces",
+			},
+		},
+	}
+	res, err := client.AuthorizationV1().SelfSubjectAccessReviews().Create(
+		ctx,
+		canGetNamespaceAccessReview,
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		klog.Errorf("Error in auth.metrics canGetNamespaces: %v\n", err)
+		return false, err
+	}
+	return res.Status.Allowed, nil
+}
+
+func (m *Metrics) isKubeAdmin(ctx context.Context, config *rest.Config) (bool, error) {
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		klog.Errorf("Error in auth.metrics isKubeAdmin: %v\n", err)
+		return false, err
+	}
+	userInfo, err := client.Resource(userResource).Get(ctx, "~", metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("Error in auth.metrics isKubeAdmin: %v\n", err)
+		return false, err
+	}
+
+	isKubeAdmin := userInfo.GetUID() == "" && userInfo.GetName() == "kube:admin"
+	return isKubeAdmin, nil
+}
+
+func NewMetrics() *Metrics {
+	m := new(Metrics)
+
+	m.loginRequests = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "console",
+		Subsystem: "auth",
+		Name:      "login_requests_total",
+		Help:      "Total number of login requests from the frontend.",
+	})
+
+	m.loginSuccessful = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "console",
+		Subsystem: "auth",
+		Name:      "login_successes_total",
+		Help:      "Total number of successful logins. Role label is based on RBAC can list namespaces check.",
+	}, []string{"role"})
+	for _, role := range []LoginRole{KubeadminLoginRole, ClusterAdminLoginRole, DeveloperLoginRole} {
+		m.loginSuccessful.GetMetricWithLabelValues(string(role))
+	}
+
+	m.loginFailures = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "console",
+		Subsystem: "auth",
+		Name:      "login_failures_total",
+		Help:      "Total number of login failures.",
+	}, []string{"reason"})
+	m.loginFailures.GetMetricWithLabelValues(string(UnknownLoginFailureReason))
+
+	m.logoutRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "console",
+		Subsystem: "auth",
+		Name:      "logout_requests_total",
+		Help:      "Total number of logout requests from the frontend.",
+	}, []string{"reason"})
+	m.logoutRequests.GetMetricWithLabelValues(string(UnknownLogoutReason))
+
+	return m
+}

--- a/pkg/auth/metrics_test.go
+++ b/pkg/auth/metrics_test.go
@@ -1,0 +1,175 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openshift/console/pkg/metrics"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/rest"
+)
+
+func TestDefaultMetrics(t *testing.T) {
+	m := NewMetrics()
+
+	assert.Equal(t,
+		metrics.RemoveComments(`
+		console_auth_login_failures_total{reason="unknown"} 0
+		console_auth_login_requests_total 0
+		console_auth_login_successes_total{role="cluster-admin"} 0
+		console_auth_login_successes_total{role="developer"} 0
+		console_auth_login_successes_total{role="kubeadmin"} 0
+		console_auth_logout_requests_total{reason="unknown"} 0
+		`),
+		metrics.RemoveComments(metrics.FormatMetrics(m.GetCollectors()...)),
+	)
+}
+
+func TestLoginRequested(t *testing.T) {
+	m := NewMetrics()
+	m.LoginRequested()
+
+	assert.Equal(t,
+		metrics.RemoveComments(`
+		console_auth_login_requests_total 1
+		`),
+		metrics.RemoveComments(metrics.FormatMetrics(m.loginRequests)),
+	)
+}
+
+func TestLoginSuccessful(t *testing.T) {
+	testcases := []struct {
+		name            string
+		handler         http.Handler
+		expectedMetrics string
+	}{
+		{
+			name: "api-failures",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// fmt.Printf("Mock testserver handles: %s\n", r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectedMetrics: `
+			console_auth_login_successes_total{role="cluster-admin"} 0
+			console_auth_login_successes_total{role="developer"} 0
+			console_auth_login_successes_total{role="kubeadmin"} 0
+			console_auth_login_successes_total{role="unknown"} 1
+			`,
+		},
+		{
+			name: "developer",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Printf("Mock testserver handles: %s\n", r.URL.Path)
+				if r.URL.Path == "/apis/user.openshift.io/v1/users/~" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{ "kind": "User", "metadata": { "name": "developer1", "uid": "1234" } }`))
+				} else if r.URL.Path == "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{ "status": { "allowed": false } }`))
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}),
+			expectedMetrics: `
+			console_auth_login_successes_total{role="cluster-admin"} 0
+			console_auth_login_successes_total{role="developer"} 1
+			console_auth_login_successes_total{role="kubeadmin"} 0
+			`,
+		},
+		{
+			name: "clusteradmin",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Printf("Mock testserver handles: %s\n", r.URL.Path)
+				if r.URL.Path == "/apis/user.openshift.io/v1/users/~" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{ "kind": "User", "metadata": { "name": "clusteradmin1", "uid": "1234" } }`))
+				} else if r.URL.Path == "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{ "status": { "allowed": true } }`))
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}),
+			expectedMetrics: `
+			console_auth_login_successes_total{role="cluster-admin"} 1
+			console_auth_login_successes_total{role="developer"} 0
+			console_auth_login_successes_total{role="kubeadmin"} 0
+			`,
+		},
+		{
+			name: "kubeadmin",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Printf("Mock testserver handles: %s\n", r.URL.Path)
+				if r.URL.Path == "/apis/user.openshift.io/v1/users/~" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{ "kind": "User", "metadata": { "name": "kube:admin", "uid": "" } }`))
+				} else if r.URL.Path == "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{ "status": { "allowed": true } }`))
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}),
+			expectedMetrics: `
+			console_auth_login_successes_total{role="cluster-admin"} 0
+			console_auth_login_successes_total{role="developer"} 0
+			console_auth_login_successes_total{role="kubeadmin"} 1
+			`,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			testserver := httptest.NewServer(testcase.handler)
+			defer testserver.Close()
+
+			k8sConfig := &rest.Config{
+				Host: strings.TrimPrefix(testserver.URL, "http://"),
+			}
+			ls := &loginState{
+				rawToken: testcase.name,
+			}
+
+			m := NewMetrics()
+			m.loginSuccessfulSync(k8sConfig, ls)
+
+			assert.Equal(t,
+				metrics.RemoveComments(testcase.expectedMetrics),
+				metrics.RemoveComments(metrics.FormatMetrics(m.loginSuccessful)),
+			)
+		})
+	}
+}
+
+func TestLoginFailed(t *testing.T) {
+	m := NewMetrics()
+	m.LoginFailed(UnknownLoginFailureReason)
+
+	assert.Equal(t,
+		metrics.RemoveComments(`
+		console_auth_login_failures_total{reason="unknown"} 1
+		`),
+		metrics.RemoveComments(metrics.FormatMetrics(m.loginFailures)),
+	)
+}
+
+func TestLogoutRequests(t *testing.T) {
+	m := NewMetrics()
+	m.LogoutRequested(UnknownLogoutReason)
+
+	assert.Equal(t,
+		metrics.RemoveComments(`
+		console_auth_logout_requests_total{reason="unknown"} 1
+		`),
+		metrics.RemoveComments(metrics.FormatMetrics(m.logoutRequests)),
+	)
+}

--- a/pkg/devfile/handler.go
+++ b/pkg/devfile/handler.go
@@ -1,4 +1,4 @@
-package server
+package devfile
 
 import (
 	"encoding/json"
@@ -7,7 +7,6 @@ import (
 	"path"
 	"strings"
 
-	devfilePkg "github.com/openshift/console/pkg/devfile"
 	"github.com/openshift/console/pkg/serverutils"
 	"k8s.io/klog"
 
@@ -15,8 +14,7 @@ import (
 	"github.com/devfile/library/pkg/devfile/parser"
 )
 
-func (s *Server) devfileSamplesHandler(w http.ResponseWriter, r *http.Request) {
-
+func DevfileSamplesHandler(w http.ResponseWriter, r *http.Request) {
 	registry := r.URL.Query().Get("registry")
 	if registry == "" {
 		errMsg := "The registry parameter is missing"
@@ -25,7 +23,7 @@ func (s *Server) devfileSamplesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sampleIndex, err := devfilePkg.GetRegistrySamples(registry)
+	sampleIndex, err := GetRegistrySamples(registry)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to read from registry %s: %v", registry, err)
 		klog.Error(errMsg)
@@ -36,9 +34,9 @@ func (s *Server) devfileSamplesHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(sampleIndex)
 }
 
-func (s *Server) devfileHandler(w http.ResponseWriter, r *http.Request) {
+func DevfileHandler(w http.ResponseWriter, r *http.Request) {
 	var (
-		data       devfilePkg.DevfileForm
+		data       DevfileForm
 		devfileObj parser.DevfileObj
 	)
 
@@ -68,7 +66,7 @@ func (s *Server) devfileHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deployAssociatedComponents, err := devfilePkg.GetDeployComponents(devfileObj)
+	deployAssociatedComponents, err := GetDeployComponents(devfileObj)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to get the deploy command associated components from devfile: %v", err)
 		klog.Error(errMsg)
@@ -76,7 +74,7 @@ func (s *Server) devfileHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	imageBuildComponent, err := devfilePkg.GetImageBuildComponent(devfileObj, deployAssociatedComponents)
+	imageBuildComponent, err := GetImageBuildComponent(devfileObj, deployAssociatedComponents)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to get an image component from the devfile: %v", err)
 		klog.Error(errMsg)
@@ -100,7 +98,7 @@ func (s *Server) devfileHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deploymentResource, serviceResource, routeResource, err := devfilePkg.GetResourceFromDevfile(devfileObj, deployAssociatedComponents, data.Name)
+	deploymentResource, serviceResource, routeResource, err := GetResourceFromDevfile(devfileObj, deployAssociatedComponents, data.Name)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to get Kubernetes resource for the devfile: %v", err)
 		klog.Error(errMsg)
@@ -110,9 +108,9 @@ func (s *Server) devfileHandler(w http.ResponseWriter, r *http.Request) {
 
 	dockerContextDir := path.Join(data.Git.Dir, dockerRelativeSrcContext)
 
-	devfileResources := devfilePkg.DevfileResources{
-		ImageStream:    devfilePkg.GetImageStream(),
-		BuildResource:  devfilePkg.GetBuildResource(data, dockerfileRelativePath, dockerContextDir),
+	devfileResources := DevfileResources{
+		ImageStream:    GetImageStream(),
+		BuildResource:  GetBuildResource(data, dockerfileRelativePath, dockerContextDir),
 		DeployResource: *deploymentResource,
 		Service:        serviceResource,
 		Route:          routeResource,

--- a/pkg/helm/.gitignore
+++ b/pkg/helm/.gitignore
@@ -1,0 +1,10 @@
+# Artifacts fetched my chartmuseum.sh when running test-backend.sh
+/actions/*.tar.gz
+/actions/*/chartmuseum
+/actions/*/LICENSE
+/actions/*/README.md
+
+/chartproxy/*.tar.gz
+/chartproxy/*/chartmuseum
+/chartproxy/*/LICENSE
+/chartproxy/*/README.md

--- a/pkg/metrics/handler.go
+++ b/pkg/metrics/handler.go
@@ -1,0 +1,16 @@
+package metrics
+
+import "net/http"
+
+func AddHeaderAsCookieMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Requests from prometheus-k8s have the access token in headers instead of cookies.
+		// This allows metric requests with proper tokens in either headers or cookies.
+		if r.URL.Path == "/metrics" {
+			openshiftSessionCookieName := "openshift-session-token"
+			openshiftSessionCookieValue := r.Header.Get("Authorization")
+			r.AddCookie(&http.Cookie{Name: openshiftSessionCookieName, Value: openshiftSessionCookieValue})
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/metrics/helpers.go
+++ b/pkg/metrics/helpers.go
@@ -1,0 +1,45 @@
+package metrics
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
+)
+
+// (Only) Used in different metrics_tests.
+//
+// Format multiple metrics into the common prometheus text format with a comment
+// for the metric title and description.
+//
+//	# TEXT metric title
+//	# HELP metric description
+//	a_metric_total 1
+func FormatMetrics(cs ...prometheus.Collector) string {
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(cs...)
+	mfs, _ := registry.Gather()
+	writer := &bytes.Buffer{}
+	enc := expfmt.NewEncoder(writer, expfmt.FmtText)
+	for _, mf := range mfs {
+		enc.Encode(mf)
+	}
+	return writer.String()
+}
+
+// (Only) Used in different metrics_tests.
+//
+// Removes all lines starting with an # (comments) from the input string,
+// so that the metric title and description could be ignored in unit tests.
+func RemoveComments(s string) string {
+	lines := strings.Split(s, "\n")
+	filteredLines := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if len(trimmedLine) > 0 && !strings.HasPrefix(trimmedLine, "#") {
+			filteredLines = append(filteredLines, trimmedLine)
+		}
+	}
+	return strings.Join(filteredLines, "\n")
+}

--- a/pkg/serverconfig/metrics.go
+++ b/pkg/serverconfig/metrics.go
@@ -1,0 +1,76 @@
+package serverconfig
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Metrics struct {
+	pluginsInfo      *prometheus.GaugeVec
+	perspectivesInfo *prometheus.GaugeVec
+}
+
+type PerspectiveMetricState string
+
+const (
+	PerspectiveMetricStateEnabled              PerspectiveMetricState = "enabled"
+	PerspectiveMetricStateDisabled             PerspectiveMetricState = "disabled"
+	PerspectiveMetricStateOnlyForClusterAdmins PerspectiveMetricState = "only-for-cluster-admins"
+	PerspectiveMetricStateOnlyForDevelopers    PerspectiveMetricState = "only-for-developers"
+	PerspectiveMetricStateCustomPermissions    PerspectiveMetricState = "custom-permissions"
+)
+
+func (m *Metrics) GetCollectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		m.pluginsInfo,
+		m.perspectivesInfo,
+	}
+}
+
+func NewMetrics(config *Config) *Metrics {
+	m := new(Metrics)
+
+	m.pluginsInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "console",
+		Subsystem: "plugins",
+		Name:      "info",
+		Help:      "List all plugins with their name and state as label. State is currently always enabled. Reports 1 for each plugin (per console pod instance).",
+	}, []string{"name", "state"})
+	if config != nil && config.Plugins != nil {
+		for name, _ := range config.Plugins {
+			m.pluginsInfo.WithLabelValues(name, "enabled").Inc()
+		}
+	}
+
+	m.perspectivesInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "console",
+		Subsystem: "customization_perspectives",
+		Name:      "info",
+		Help:      "List of customized perspectives, for example perspective=dev with state=disabled and 1 as metric.",
+	}, []string{"name", "state"})
+	if config != nil && config.Customization.Perspectives != nil {
+		for _, perspective := range config.Customization.Perspectives {
+			switch perspective.Visibility.State {
+			default:
+				if perspective.ID != "admin" && perspective.ID != "dev" {
+					m.perspectivesInfo.WithLabelValues(perspective.ID, string(PerspectiveMetricStateEnabled)).Inc()
+				}
+			case PerspectiveDisabled:
+				m.perspectivesInfo.WithLabelValues(perspective.ID, string(PerspectiveMetricStateDisabled)).Inc()
+			case PerspectiveAccessReview:
+				if perspective.Visibility.AccessReview != nil {
+					required := perspective.Visibility.AccessReview.Required
+					missing := perspective.Visibility.AccessReview.Missing
+					if len(required) == 1 && len(missing) == 0 && required[0].Resource == "namespaces" && required[0].Verb == "get" {
+						m.perspectivesInfo.WithLabelValues(perspective.ID, string(PerspectiveMetricStateOnlyForClusterAdmins)).Inc()
+					} else if len(required) == 0 && len(missing) == 1 && missing[0].Resource == "namespaces" && missing[0].Verb == "get" {
+						m.perspectivesInfo.WithLabelValues(perspective.ID, string(PerspectiveMetricStateOnlyForDevelopers)).Inc()
+					} else {
+						m.perspectivesInfo.WithLabelValues(perspective.ID, string(PerspectiveMetricStateCustomPermissions)).Inc()
+					}
+				}
+			}
+		}
+	}
+
+	return m
+}

--- a/pkg/serverconfig/metrics_test.go
+++ b/pkg/serverconfig/metrics_test.go
@@ -1,0 +1,189 @@
+package serverconfig
+
+import (
+	"testing"
+
+	"github.com/openshift/console/pkg/metrics"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/authorization/v1"
+)
+
+func TestNoPluginMetrics(t *testing.T) {
+	m := NewMetrics(&Config{
+		Plugins: MultiKeyValue{},
+	})
+	assert.Equal(t,
+		"",
+		metrics.RemoveComments(metrics.FormatMetrics(m.pluginsInfo)),
+	)
+}
+
+func TestPluginMetrics(t *testing.T) {
+	m := NewMetrics(&Config{
+		Plugins: MultiKeyValue{
+			"plugin-a": "reference to installed plugin a",
+			"plugin-b": "reference to installed plugin b",
+		},
+	})
+	assert.Equal(t,
+		metrics.RemoveComments(`
+		console_plugins_info{name="plugin-a",state="enabled"} 1
+		console_plugins_info{name="plugin-b",state="enabled"} 1
+		`),
+		metrics.RemoveComments(metrics.FormatMetrics(m.pluginsInfo)),
+	)
+}
+
+func TestPerspectiveMetrics(t *testing.T) {
+	testcases := []struct {
+		name            string
+		perspectives    []Perspective
+		expectedMetrics string
+	}{
+		{
+			name:            "no-perspective",
+			perspectives:    []Perspective{},
+			expectedMetrics: "",
+		},
+
+		{
+			name: "ignore-enabled-default-perspective",
+			perspectives: []Perspective{
+				{
+					ID: "admin",
+				},
+				{
+					ID: "dev",
+					Visibility: PerspectiveVisibility{
+						State: PerspectiveEnabled,
+					},
+				},
+			},
+			expectedMetrics: "",
+		},
+
+		{
+			name: "perspective-enabled",
+			perspectives: []Perspective{
+				{
+					ID: "enabled-perspective",
+					Visibility: PerspectiveVisibility{
+						State: PerspectiveEnabled,
+					},
+				},
+				{
+					ID: "enabled-perspective-without-visibility",
+				},
+				{
+					ID:         "enabled-perspective-without-state",
+					Visibility: PerspectiveVisibility{},
+				},
+			},
+			expectedMetrics: `
+			console_customization_perspectives_info{name="enabled-perspective",state="enabled"} 1
+			console_customization_perspectives_info{name="enabled-perspective-without-state",state="enabled"} 1
+			console_customization_perspectives_info{name="enabled-perspective-without-visibility",state="enabled"} 1
+			`,
+		},
+
+		{
+			name: "perspective-disabled",
+			perspectives: []Perspective{
+				{
+					ID: "disabled-perspective",
+					Visibility: PerspectiveVisibility{
+						State: PerspectiveDisabled,
+					},
+				},
+			},
+			expectedMetrics: `
+			console_customization_perspectives_info{name="disabled-perspective",state="disabled"} 1
+			`,
+		},
+
+		{
+			name: "perspective-only-visible-for-cluster-admins",
+			perspectives: []Perspective{
+				{
+					ID: "cluster-admin-perspective",
+					Visibility: PerspectiveVisibility{
+						State: PerspectiveAccessReview,
+						AccessReview: &ResourceAttributesAccessReview{
+							Required: []v1.ResourceAttributes{
+								{
+									Resource: "namespaces",
+									Verb:     "get",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedMetrics: `
+			console_customization_perspectives_info{name="cluster-admin-perspective",state="only-for-cluster-admins"} 1
+			`,
+		},
+
+		{
+			name: "perspective-only-visible-for-developers",
+			perspectives: []Perspective{
+				{
+					ID: "developer-perspective",
+					Visibility: PerspectiveVisibility{
+						State: PerspectiveAccessReview,
+						AccessReview: &ResourceAttributesAccessReview{
+							Missing: []v1.ResourceAttributes{
+								{
+									Resource: "namespaces",
+									Verb:     "get",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedMetrics: `
+			console_customization_perspectives_info{name="developer-perspective",state="only-for-developers"} 1
+			`,
+		},
+
+		{
+			name: "perspective-with-custom-permissions",
+			perspectives: []Perspective{
+				{
+					ID: "custom-permission-perspective",
+					Visibility: PerspectiveVisibility{
+						State: PerspectiveAccessReview,
+						AccessReview: &ResourceAttributesAccessReview{
+							Required: []v1.ResourceAttributes{
+								{
+									Resource: "configmaps",
+									Verb:     "get",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedMetrics: `
+			console_customization_perspectives_info{name="custom-permission-perspective",state="custom-permissions"} 1
+			`,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			config := &Config{
+				Customization: Customization{
+					Perspectives: testcase.perspectives,
+				},
+			}
+
+			m := NewMetrics(config)
+			assert.Equal(t,
+				metrics.RemoveComments(testcase.expectedMetrics),
+				metrics.RemoveComments(metrics.FormatMetrics(m.perspectivesInfo)),
+			)
+		})
+	}
+}

--- a/pkg/usage/handler.go
+++ b/pkg/usage/handler.go
@@ -1,0 +1,41 @@
+package usage
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/openshift/console/pkg/serverutils"
+)
+
+type Request struct {
+	Event       string `json:"event"`
+	Perspective string `json:"perspective"`
+}
+
+func Handle(metrics *Metrics, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		serverutils.SendResponse(w, http.StatusMethodNotAllowed, serverutils.ApiError{Err: "Unsupported method, supported methods are POST"})
+	}
+
+	var req Request
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		serverutils.SendResponse(w, http.StatusBadRequest, serverutils.ApiError{Err: fmt.Sprintf("Failed to parse request: %v", err)})
+		return
+	}
+
+	if req.Event == "" {
+		serverutils.SendResponse(w, http.StatusBadRequest, serverutils.ApiError{Err: "Event type is required"})
+		return
+	}
+	if req.Perspective == "" {
+		serverutils.SendResponse(w, http.StatusBadRequest, serverutils.ApiError{Err: "Perspective is required"})
+		return
+	}
+	if err := metrics.HandleUsage(req.Event, req.Perspective); err != nil {
+		serverutils.SendResponse(w, http.StatusBadRequest, serverutils.ApiError{Err: fmt.Sprintf("Failed to handle page view: %v", err)})
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/pkg/usage/metrics.go
+++ b/pkg/usage/metrics.go
@@ -1,0 +1,221 @@
+package usage
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	authv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+)
+
+// We don't expect that the users metrics (console users count) changes often.
+// And because we check the permission for each console user we update this
+// only when the bridge starts and then every 6 hours.
+const updateConsoleUsersInterval = 6 * time.Hour
+
+// Reduce load peaks when checking permissions for hunders of console users.
+// This distributes the requests to 10-20 per second.
+// In other words the update takes round about 10 seconds per 100 users.
+// Setting this to zero in unit tests.
+var delayBetweenConsoleUserPermissionChecks = 100 * time.Millisecond
+
+type Metrics struct {
+	usageTotal *prometheus.CounterVec
+	users      *prometheus.GaugeVec
+}
+
+type UserRole string
+
+const (
+	KubeadminUserRole    UserRole = "kubeadmin"
+	ClusterAdminUserRole UserRole = "cluster-admin"
+	DeveloperUserRole    UserRole = "developer"
+	UnknownUserRole      UserRole = "unknown"
+)
+
+func (m *Metrics) GetCollectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		m.usageTotal,
+		m.users,
+	}
+}
+
+func (m *Metrics) HandleUsage(event string, perspective string) error {
+	counter, err := m.usageTotal.GetMetricWithLabelValues(event, perspective)
+	if counter != nil && err == nil {
+		counter.Inc()
+	}
+	return err
+}
+
+func (m *Metrics) MonitorUsers(
+	userSettingsClient *http.Client,
+	userSettingsEndpoint string,
+	serviceAccountToken string,
+) {
+	go func() {
+		time.Sleep(3 * time.Second)
+		go m.updateUsersMetric(userSettingsClient, userSettingsEndpoint, serviceAccountToken)
+	}()
+
+	ticker := time.NewTicker(updateConsoleUsersInterval)
+	quit := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				m.updateUsersMetric(userSettingsClient, userSettingsEndpoint, serviceAccountToken)
+			case <-quit:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+func (m *Metrics) updateUsersMetric(
+	userSettingsClient *http.Client,
+	userSettingsEndpoint string,
+	serviceAccountToken string,
+) error {
+	klog.Info("usage.Metrics: Count console users...\n")
+	startTime := time.Now()
+
+	ctx := context.TODO()
+	config := &rest.Config{
+		Host:        userSettingsEndpoint,
+		BearerToken: serviceAccountToken,
+		Transport:   userSettingsClient.Transport,
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		klog.Errorf("usage.Metrics: Failed to create service account client: %v\n", err)
+		return err
+	}
+
+	roleBindingList, err := client.RbacV1().RoleBindings("openshift-console-user-settings").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		klog.Errorf("usage.Metrics: Failed to get user-settings RoleBindings: %v\n", err)
+		return err
+	}
+
+	var kubeAdmin, clusterAdmins, developers, unknowns int
+
+	for _, roleBinding := range roleBindingList.Items {
+		// Reduce load for clusters with hunders of console users (role bindings)
+		time.Sleep(delayBetweenConsoleUserPermissionChecks)
+
+		if !strings.HasPrefix(roleBinding.Name, "user-settings-") || !strings.HasSuffix(roleBinding.Name, "-rolebinding") {
+			if klog.V(4) {
+				klog.Infof("usage.Metrics: Ignore role binding: %q (name doesn't match user-settings-*-rolebinding)\n", roleBinding.Name)
+			}
+			continue
+		}
+		if len(roleBinding.Subjects) != 1 {
+			klog.Infof("usage.Metrics: Ignore role binding: %q (unexpected subject length %d != 1)\n", roleBinding.Name, len(roleBinding.Subjects))
+			unknowns++
+			continue
+		}
+		user := roleBinding.Subjects[0]
+		if user.Kind != "User" {
+			klog.Infof("usage.Metrics: Ignore role binding: %q (unexpected subject kind %q != 'User')\n", roleBinding.Name, user.Kind)
+			unknowns++
+			continue
+		}
+
+		if user.Name == "kube:admin" {
+			if klog.V(4) {
+				klog.Infof("usage.Metrics: Count %q as %q...\n", user.Name, KubeadminUserRole)
+			}
+			kubeAdmin++
+			continue
+		}
+
+		canGetNamespacesAccessReview := &authv1.SubjectAccessReview{
+			Spec: authv1.SubjectAccessReviewSpec{
+				User: user.Name,
+				ResourceAttributes: &authv1.ResourceAttributes{
+					Verb:     "get",
+					Resource: "namespaces",
+				},
+			},
+		}
+		res, err := client.AuthorizationV1().SubjectAccessReviews().Create(
+			ctx,
+			canGetNamespacesAccessReview,
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			klog.Errorf("usage.Metrics: Error when checking permissions for %q: %v\n", user.Name, err)
+			unknowns++
+			continue
+		}
+
+		if res.Status.Allowed {
+			if klog.V(4) && clusterAdmins < 10 {
+				klog.Infof("usage.Metrics: Count %q as %q...\n", user.Name, ClusterAdminUserRole)
+			}
+			clusterAdmins++
+		} else {
+			if klog.V(4) && developers < 10 {
+				klog.Infof("usage.Metrics: Count %q as %q...\n", user.Name, DeveloperUserRole)
+			}
+			developers++
+		}
+	}
+
+	klog.Infof("usage.Metrics: Update console users metrics: %d %s, %d %ss, %d %ss, %d %s/errors (took %v)\n",
+		kubeAdmin, KubeadminUserRole,
+		clusterAdmins, ClusterAdminUserRole,
+		developers, DeveloperUserRole,
+		unknowns, UnknownUserRole,
+		time.Since(startTime),
+	)
+	if gauge, err := m.users.GetMetricWithLabelValues(string(KubeadminUserRole)); gauge != nil && err == nil {
+		gauge.Set(float64(kubeAdmin))
+	}
+	if gauge, err := m.users.GetMetricWithLabelValues(string(ClusterAdminUserRole)); gauge != nil && err == nil {
+		gauge.Set(float64(clusterAdmins))
+	}
+	if gauge, err := m.users.GetMetricWithLabelValues(string(DeveloperUserRole)); gauge != nil && err == nil {
+		gauge.Set(float64(developers))
+	}
+	if gauge, err := m.users.GetMetricWithLabelValues(string(UnknownUserRole)); gauge != nil && err == nil {
+		gauge.Set(float64(unknowns))
+	}
+	return nil
+}
+
+func NewMetrics() *Metrics {
+	m := new(Metrics)
+
+	m.usageTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "console",
+		Subsystem: "usage",
+		Name:      "total",
+		Help:      "Total number of events like \"page_views\" (loading index.html without history.push) and \"page_impressions\".",
+	}, []string{"event", "perspective"})
+
+	events := []string{"page_view", "page_impression"}
+	perspectives := []string{"admin", "dev"} // the developer perspective uses "dev" has perspective ID!
+	for _, event := range events {
+		for _, perspective := range perspectives {
+			m.usageTotal.GetMetricWithLabelValues(event, perspective)
+		}
+	}
+
+	m.users = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "console",
+		Subsystem: "usage",
+		Name:      "users",
+		Help:      "The number of console users splitten into roles (cluster-admin, developer, and unknown if a RBAC check fails)",
+	}, []string{"role"})
+
+	return m
+}

--- a/pkg/usage/metrics_test.go
+++ b/pkg/usage/metrics_test.go
@@ -1,0 +1,293 @@
+package usage
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	authv1 "k8s.io/api/authorization/v1"
+	rbac "k8s.io/api/rbac/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/console/pkg/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	delayBetweenConsoleUserPermissionChecks = 0
+}
+
+func TestDefaultUsageMetrics(t *testing.T) {
+	m := NewMetrics()
+	assert.Equal(t,
+		metrics.RemoveComments(`
+		console_usage_total{event="page_impression",perspective="admin"} 0
+		console_usage_total{event="page_impression",perspective="dev"} 0
+		console_usage_total{event="page_view",perspective="admin"} 0
+		console_usage_total{event="page_view",perspective="dev"} 0
+		`),
+		metrics.RemoveComments(metrics.FormatMetrics(m.GetCollectors()...)),
+	)
+}
+
+func TestPageImpressionsAndViewsMetrics(t *testing.T) {
+	m := NewMetrics()
+	for i := 0; i < 1; i++ {
+		assert.NoError(t, m.HandleUsage("page_impression", "admin"))
+	}
+	for i := 0; i < 2; i++ {
+		assert.NoError(t, m.HandleUsage("page_impression", "dev"))
+	}
+	for i := 0; i < 3; i++ {
+		assert.NoError(t, m.HandleUsage("page_view", "admin"))
+	}
+	for i := 0; i < 4; i++ {
+		assert.NoError(t, m.HandleUsage("page_view", "dev"))
+	}
+	assert.Equal(t,
+		metrics.RemoveComments(`
+		console_usage_total{event="page_impression",perspective="admin"} 1
+		console_usage_total{event="page_impression",perspective="dev"} 2
+		console_usage_total{event="page_view",perspective="admin"} 3
+		console_usage_total{event="page_view",perspective="dev"} 4
+		`),
+		metrics.RemoveComments(metrics.FormatMetrics(m.usageTotal)),
+	)
+}
+
+func TestUsersMetrics(t *testing.T) {
+	testcases := []struct {
+		name            string
+		handler         http.Handler
+		expectedError   string
+		expectedMetrics string
+	}{
+		{
+			name: "get-rolebindings-fails",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Printf("Mock testserver handles: %s\n", r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectedError:   "the server could not find the requested resource (get rolebindings.rbac.authorization.k8s.io)",
+			expectedMetrics: "",
+		},
+		{
+			name: "can-get-namespaces-fails",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Printf("Mock testserver handles: %s\n", r.URL.Path)
+				if r.URL.Path == "/apis/rbac.authorization.k8s.io/v1/namespaces/openshift-console-user-settings/rolebindings" {
+					w.Header().Set("Content-Type", "application/json")
+
+					roleBindingList := rbac.RoleBindingList{
+						Items: []rbac.RoleBinding{
+							{
+								ObjectMeta: v1.ObjectMeta{
+									Name: "user-settings-unknown-user-role-rolebinding",
+								},
+								Subjects: []rbac.Subject{
+									{
+										Kind: "User",
+										Name: "unknown-user-role",
+									},
+								},
+							},
+						},
+					}
+
+					if res, err := json.Marshal(roleBindingList); err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write([]byte(err.Error()))
+					} else {
+						w.WriteHeader(http.StatusOK)
+						w.Write(res)
+					}
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}),
+			expectedMetrics: `
+			console_usage_users{role="cluster-admin"} 0
+			console_usage_users{role="developer"} 0
+			console_usage_users{role="kubeadmin"} 0
+			console_usage_users{role="unknown"} 1
+			`,
+		},
+		{
+			name: "kubeadmin-and-two-cluster-admins-and-three-developers",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Printf("Mock testserver handles: %s\n", r.URL.Path)
+				if r.URL.Path == "/apis/rbac.authorization.k8s.io/v1/namespaces/openshift-console-user-settings/rolebindings" {
+					roleBindingList := rbac.RoleBindingList{
+						Items: []rbac.RoleBinding{
+							{
+								ObjectMeta: v1.ObjectMeta{
+									Name: "user-settings-kubeadmin-rolebinding",
+								},
+								Subjects: []rbac.Subject{
+									{
+										Kind: "User",
+										Name: "kube:admin",
+									},
+								},
+							},
+							{
+								ObjectMeta: v1.ObjectMeta{
+									Name: "user-settings-kubeadmin-rolebinding",
+								},
+								Subjects: []rbac.Subject{
+									{
+										Kind: "User",
+										Name: "clusteradmin1",
+									},
+								},
+							},
+							{
+								ObjectMeta: v1.ObjectMeta{
+									Name: "user-settings-kubeadmin-rolebinding",
+								},
+								Subjects: []rbac.Subject{
+									{
+										Kind: "User",
+										Name: "clusteradmin2",
+									},
+								},
+							},
+							{
+								ObjectMeta: v1.ObjectMeta{
+									Name: "user-settings-developer1-rolebinding",
+								},
+								Subjects: []rbac.Subject{
+									{
+										Kind: "User",
+										Name: "developer1",
+									},
+								},
+							},
+							{
+								ObjectMeta: v1.ObjectMeta{
+									Name: "user-settings-developer2-rolebinding",
+								},
+								Subjects: []rbac.Subject{
+									{
+										Kind: "User",
+										Name: "developer2",
+									},
+								},
+							},
+							{
+								ObjectMeta: v1.ObjectMeta{
+									Name: "user-settings-developer2-rolebinding",
+								},
+								Subjects: []rbac.Subject{
+									{
+										Kind: "User",
+										Name: "developer3",
+									},
+								},
+							},
+							// This rolebinding with two subjects will be count as unknown
+							{
+								ObjectMeta: v1.ObjectMeta{
+									Name: "user-settings-both-developers-rolebinding",
+								},
+								Subjects: []rbac.Subject{
+									{
+										Kind: "User",
+										Name: "developer1",
+									},
+									{
+										Kind: "User",
+										Name: "developer2",
+									},
+								},
+							},
+							// This rolebinding with an unexpected resource name will be ignored
+							{
+								ObjectMeta: v1.ObjectMeta{
+									Name: "another-rolebinding",
+								},
+								Subjects: []rbac.Subject{
+									{
+										Kind: "User",
+										Name: "developer1",
+									},
+								},
+							},
+						},
+					}
+
+					if res, err := json.Marshal(roleBindingList); err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write([]byte(err.Error()))
+					} else {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						w.Write(res)
+					}
+				} else if r.Method == http.MethodPost && r.URL.Path == "/apis/authorization.k8s.io/v1/subjectaccessreviews" {
+					var accessReviewReq authv1.SubjectAccessReview
+					err := json.NewDecoder(r.Body).Decode(&accessReviewReq)
+					if err != nil {
+						w.WriteHeader(http.StatusBadRequest)
+						w.Write([]byte(fmt.Sprintf("Unexpected request: %s", err)))
+						return
+					}
+
+					// Fail for unexpected users, even kubeadmin
+					username := accessReviewReq.Spec.User
+					if !strings.HasPrefix(username, "clusteradmin") && !strings.HasPrefix(username, "developer") {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write([]byte(fmt.Sprintf("Unexpected username: %s", username)))
+						return
+					}
+
+					accessReviewRes := authv1.SubjectAccessReview{
+						Spec: accessReviewReq.Spec,
+						Status: authv1.SubjectAccessReviewStatus{
+							Allowed: strings.HasPrefix(username, "clusteradmin"),
+						},
+					}
+					if res, err := json.Marshal(accessReviewRes); err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write([]byte(err.Error()))
+					} else {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						w.Write(res)
+					}
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}),
+			expectedMetrics: `
+			console_usage_users{role="cluster-admin"} 2
+			console_usage_users{role="developer"} 3
+			console_usage_users{role="kubeadmin"} 1
+			console_usage_users{role="unknown"} 1
+			`,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			testserver := httptest.NewServer(testcase.handler)
+			defer testserver.Close()
+
+			m := NewMetrics()
+			err := m.updateUsersMetric(&http.Client{}, testserver.URL, "ignored-service-account-token")
+			if testcase.expectedError != "" {
+				assert.Equal(t, testcase.expectedError, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t,
+				metrics.RemoveComments(testcase.expectedMetrics),
+				metrics.RemoveComments(metrics.FormatMetrics(m.users)),
+			)
+		})
+	}
+}

--- a/pkg/usersettings/handlers.go
+++ b/pkg/usersettings/handlers.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/klog"
 
 	"github.com/openshift/console/pkg/auth"
-	"github.com/openshift/console/pkg/proxy"
 	"github.com/openshift/console/pkg/serverutils"
 )
 
@@ -28,7 +27,6 @@ var USER_RESOURCE = schema.GroupVersionResource{
 }
 
 type UserSettingsHandler struct {
-	K8sProxyConfig      *proxy.Config
 	Client              *http.Client
 	Endpoint            string
 	ServiceAccountToken string
@@ -165,13 +163,13 @@ func (h *UserSettingsHandler) createUserProxyClient(user *auth.User) (dynamic.In
 	return dynamic.NewForConfig(config)
 }
 
-func (h *UserSettingsHandler) getUserSettingMeta(context context.Context, user *auth.User) (*UserSettingMeta, error) {
+func (h *UserSettingsHandler) getUserSettingMeta(ctx context.Context, user *auth.User) (*UserSettingMeta, error) {
 	client, err := h.createUserProxyClient(user)
 	if err != nil {
 		return nil, err
 	}
 
-	userInfo, err := client.Resource(USER_RESOURCE).Get(context, "~", meta.GetOptions{})
+	userInfo, err := client.Resource(USER_RESOURCE).Get(ctx, "~", meta.GetOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Implements
**Epic [ODC-7171](https://issues.redhat.com/browse/ODC-7171) Improved telemetry (provide new metrics via insight**
* [ODC-7232](https://issues.redhat.com/browse/ODC-7232) Add new metrics and new API to count events to console backend
* [ODC-7233](https://issues.redhat.com/browse/ODC-7233) Track frontend usage and report it to the new metrics API

Aligned documentation:

* [OpenShift UI Telemetry - Prometheus Metrics overview](https://docs.google.com/document/d/1PqbKv_-q2PW8mK3lwGEjpLwO5jdf9TojOchnjUY9YMU/edit) (gdocs)

# Available metrics

## Capability ➔ Is the console installed?

To detect if the console is installed or not you can use this existing (4.12?) metric:

0. `cluster_version_capability` with label `name=Console`

**Query examples:**

```
sum by (name) (cluster_version_capability)

cluster_version_capability{name="Console"}
```

![image](https://user-images.githubusercontent.com/139310/222422541-3e157c9a-9fad-4296-9c2f-24ced3a39b28.png)

## Auth (login/logout) ➔ how many users use the console / what user roles

The login process uses OAuth and counts outgoing redirects from the console and when the user comes "back".

1. `console_auth_login_requests_total` without any label
2. `console_auth_login_successes_total` with label `role` that diff. `kubeadmin`, `cluster-admin` and `developer`
3. `console_auth_login_failures_total` with label `reason`. The reason is currently always `unknown`.
4. `console_auth_logout_requests_total` with label `reason` as well. The reason is currently always `unknown`, too. We could add reasons like `session_timeout` or `user_request` in the future

**Note:** With the default oauth-controller provider we can not "cancel" or fail the login. Other oauth providers might have a "back" button that triggers this.

**Query examples:**

```
sum (rate(console_auth_login_requests_total[1h])) * 3600

sum by (role) (rate(console_auth_login_successes_total[1h])) * 3600

sum by (reason) (rate(console_auth_login_failures_total[1h])) * 3600

sum by (reason) (rate(console_auth_logout_requests_total[1h])) * 3600
```

![image](https://user-images.githubusercontent.com/139310/222438359-db6678b5-a648-4519-90e7-39c434dc95b1.png)

## Usage (page views and impressions) ➔ how many users use the console / what perspective

5. `console_usage_total` metric with labels `event` and `perspective`. Current events are
   * `page_view` is triggered once per "browser load" ~= page_view
   * `page_impression` is used every time the page URL changes, incl. history.push / react-router.push/replace
   * `perspective_changed` when the perspective is changed ;)

**Query examples:**

```
sum by (event, perspective) (console_usage_total)

sum by (event, perspective) (rate(console_usage_total[1h])) * 3600
```

![image](https://user-images.githubusercontent.com/139310/222439386-a4b0fd06-ac83-416b-9a50-f64f0f9fabb3.png)

## Users (console users) ➔ many users use the console / what user roles

6. `console_usage_users` with label `role` that differentiates this roles:
   * `kubeadmin`
   * `cluster-admin`
   * `developer`
   * `unknown` (is only used if any of the permission checks fail)


**Query examples:**

```
max by (role) (console_usage_users)
```

![image](https://user-images.githubusercontent.com/139310/222543449-5d198b87-0476-4aea-be6b-131098e5c6f3.png)

## Plugins ➔ Which plugins are our customers use?

7. `console_plugins_info`  with label (plugin) `name` and `state`. The state is currently always `enabled`. And the counter is always 1.

**Query examples:**

```
avg by (name, state) (console_plugins_info)
```

![image](https://user-images.githubusercontent.com/139310/222452873-72ce5de3-1b26-4008-92ee-76f7fa9466ef.png)

## Customizations (perspectives) ➔ Are customers using this feature?

8. `console_customization_perspectives_info` with label `name` and `state`
   * name is admin, dev, acm, etc.
   * state is one of this: `enabled`, `disabled`, `only-for-cluster-admins`, `only-for-developers`, `custom-permissions`

**Query examples:**

```
avg by (name, state) (console_customization_perspectives_info)
```

![image](https://user-images.githubusercontent.com/139310/222445379-b514343a-5421-4c6a-ae62-d4d4599e54b5.png)

# Tests

## Unit tests

Added a bunch of backend tests:

```bash
go test -count 1 ./pkg/auth ./pkg/serverconfig ./pkg/usage
ok      github.com/openshift/console/pkg/auth   0.007s
ok      github.com/openshift/console/pkg/serverconfig   0.007s
ok      github.com/openshift/console/pkg/usage  0.005s
```

## Manual tests

Trigger logins, and page requests and open the observe > metrics page in the admin perspective. These are cluster metrics that are not shown in the dev perspective.

Small script to trigger usage events "manually":

```bash
server_url=localhost:9000
# or
server_url=$(oc whoami --show-console)

curl "$server_url/metrics/usage" -d '{ "event": "page_view", "perspective": "dev" }'
for i in {1..20}; do
  curl "$server_url/metrics/usage" -d '{ "event": "page_impression", "perspective": "dev" }'
  sleep 3
done
```

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/cc @debsmita1 @Lucifergene 