### PR TITLE
OCPBUGS-7090: Fix that Add to navigation does nothing when pinnedResource is {}

### DIFF
--- a/frontend/packages/console-shared/src/hooks/usePinnedResources.ts
+++ b/frontend/packages/console-shared/src/hooks/usePinnedResources.ts
@@ -74,7 +74,7 @@ export const usePinnedResources = (): [string[], (pinnedResources: string[]) => 
       setPinnedResources((prevPR) => {
         _.difference(
           newPins,
-          prevPR?.[activePerspective].length > 0 ? prevPR[activePerspective] : pins,
+          prevPR?.[activePerspective]?.length > 0 ? prevPR[activePerspective] : pins,
         ).forEach((resource) =>
           fireTelemetryEvent('Navigation Added', {
             resource,
@@ -83,7 +83,7 @@ export const usePinnedResources = (): [string[], (pinnedResources: string[]) => 
         );
 
         _.difference(
-          prevPR?.[activePerspective].length > 0 ? prevPR[activePerspective] : pins,
+          prevPR?.[activePerspective]?.length > 0 ? prevPR[activePerspective] : pins,
           newPins,
         ).forEach((resource) =>
           fireTelemetryEvent('Navigation Removed', {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-7090

**Analysis / Root cause**: 
When searching for a resource, I tried to add some to the pinned resource with the "Add to navigation" button. But nothing happened. The browser log shows this error:

```
main-881e214a8ddf8f8a8eb8.js:53201 unhandled error: Uncaught TypeError: Cannot read properties of undefined (reading 'length') TypeError: Cannot read properties of undefined (reading 'length')
    at http://localhost:9000/static/main-881e214a8ddf8f8a8eb8.js:37694:147
    at http://localhost:9000/static/main-881e214a8ddf8f8a8eb8.js:38349:57
    at http://localhost:9000/static/main-881e214a8ddf8f8a8eb8.js:37693:9
    at pinToggle (http://localhost:9000/static/main-881e214a8ddf8f8a8eb8.js:67199:9)
    at onClick (http://localhost:9000/static/main-881e214a8ddf8f8a8eb8.js:67281:341)
    at HTMLUnknownElement.callCallback (http://localhost:9000/static/vendors~main-99688ccb22de160eb977.js:446274:14)
    at Object.invokeGuardedCallbackDev (http://localhost:9000/static/vendors~main-99688ccb22de160eb977.js:446323:16)

main-881e214a8ddf8f8a8eb8.js:37694 Uncaught TypeError: Cannot read properties of undefined (reading 'length')
    at main-881e214a8ddf8f8a8eb8.js:37694:147
    at main-881e214a8ddf8f8a8eb8.js:38349:57
    at main-881e214a8ddf8f8a8eb8.js:37693:9
    at pinToggle (main-881e214a8ddf8f8a8eb8.js:67199:9)
    at onClick (main-881e214a8ddf8f8a8eb8.js:67281:341)
    at HTMLUnknownElement.callCallback (vendors~main-99688ccb22de160eb977.js:446274:14)
    at Object.invokeGuardedCallbackDev (vendors~main-99688ccb22de160eb977.js:446323:16)
    at invokeGuardedCallback (vendors~main-99688ccb22de160eb977.js:446385:31)
    at invokeGuardedCallbackAndCatchFirstError (vendors~main-99688ccb22de160eb977.js:446399:25)
    at executeDispatch (vendors~main-99688ccb22de160eb977.js:450572:3)
...
window.onerror @ main-881e214a8ddf8f8a8eb8.js:53201
vendors~main-99688ccb22de160eb977.js:446420 Uncaught TypeError: Cannot read properties of undefined (reading 'length')
    at main-881e214a8ddf8f8a8eb8.js:37694:147
    at main-881e214a8ddf8f8a8eb8.js:38349:57
    at main-881e214a8ddf8f8a8eb8.js:37693:9
    at pinToggle (main-881e214a8ddf8f8a8eb8.js:67199:9)
    at onClick (main-881e214a8ddf8f8a8eb8.js:67281:341)
    at HTMLUnknownElement.callCallback (vendors~main-99688ccb22de160eb977.js:446274:14)
    at Object.invokeGuardedCallbackDev (vendors~main-99688ccb22de160eb977.js:446323:16)
    at invokeGuardedCallback (vendors~main-99688ccb22de160eb977.js:446385:31)
    at invokeGuardedCallbackAndCatchFirstError (vendors~main-99688ccb22de160eb977.js:446399:25)
    at executeDispatch (vendors~main-99688ccb22de160eb977.js:450572:3)
```

**Solution Description**: 
This happened when the pinnedResources was `{}` in the user settings ConfigMap.

I don't know how I can reproduce with just UI interactions. Maybe when switching between 4.12 and 413. :man_shrugging: 

**Screen shots / Gifs for design review**: 
Before:

https://user-images.githubusercontent.com/139310/217026705-38faa93d-e027-4cfa-92cd-c26bc38e185b.mp4

After:

https://user-images.githubusercontent.com/139310/217026691-6a88115c-55d8-443d-8930-854ed4021fd1.mp4

**Unit test coverage report**: 
Unchanged

**Test setup:**
Open the user-settings ConfigMap and set `"console.pinedResources"` to `"{}"` (with quotes as all ConfigMap values need to be strings)

```
  console.pinnedResources: '{}'
```

Or run this patch command:

```bash
oc patch -n openshift-console-user-settings configmaps user-settings-kubeadmin --type=merge --patch '{"data":{"console.pinnedResources":"null"}}'
```

After that:

1. Open dev perspective
2. Navigate to Search
3. Select a resource type
4. Click on "Add to navigation"

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
