### PR TITLE
OCPBUGS-1748: PipelineRun templates must be fetched from OpenShift namespace

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
@@ -67,6 +67,7 @@ export const DEFAULT_SAMPLES = 60;
 export const preferredNameAnnotation = 'pipeline.openshift.io/preferredName';
 
 export const PIPELINE_NAMESPACE = 'openshift-pipelines';
+export const PIPELINERUN_TEMPLATE_NAMESPACE = 'openshift';
 export const PIPELINE_CONFIG_NAME = 'config';
 
 export enum PipelineMetricsLevel {

--- a/frontend/packages/pipelines-plugin/src/components/repository/repository-form-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/repository/repository-form-utils.ts
@@ -17,7 +17,7 @@ import { ConfigMapKind, SecretKind, K8sResourceKind } from '@console/internal/mo
 import { nameRegex } from '@console/shared/src';
 import { RepositoryModel } from '../../models';
 import { PAC_TEMPLATE_DEFAULT } from '../pac/const';
-import { PIPELINE_NAMESPACE } from '../pipelines/const';
+import { PIPELINERUN_TEMPLATE_NAMESPACE } from '../pipelines/const';
 import { RepositoryFormValues } from './types';
 
 export const dryRunOpt = { dryRun: 'All' };
@@ -273,7 +273,7 @@ export const getPipelineRunDefaultTemplate = async (repoName: string): Promise<s
   try {
     const template = await k8sGetResource<ConfigMapKind>({
       model: ConfigMapModel,
-      ns: PIPELINE_NAMESPACE,
+      ns: PIPELINERUN_TEMPLATE_NAMESPACE,
       name: PAC_TEMPLATE_DEFAULT,
     });
     if (template?.data?.template) {
@@ -295,7 +295,7 @@ export const getPipelineRunTemplate = async (
     const [pipelineRunTemplateCfg] = await k8sListResourceItems<ConfigMapKind>({
       model: ConfigMapModel,
       queryParams: {
-        ns: PIPELINE_NAMESPACE,
+        ns: PIPELINERUN_TEMPLATE_NAMESPACE,
         labelSelector: {
           matchLabels: {
             'pipelinesascode.openshift.io/runtime': runtime,


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGS-1748

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
PipelineRun templates are currently fetched from `openshift-pipelines` namespace. It has to be fetched from `openshift` namespace.
Align with operator changes https://issues.redhat.com/browse/SRVKP-2413 in 1.8.1, UI has to update the code to fetch pipelinerun templates from openshift namespace.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Namespace updated in `getPipelineRunDefaultTemplate` & `getPipelineRunTemplate` functions.

**Unit test coverage report**: 
<!-- Attach test coverage report -->
No changes.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge