### PR TITLE
OCPBUGS-7031: Pipelines repository list and creation form doesn't show Tech Preview status

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoriesList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoriesList.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { useUserSettings } from '@console/shared/src';
+import { getBadgeFromType, useUserSettings } from '@console/shared/src';
 import { PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY } from '../../../const';
 import { RepositoryModel } from '../../../models';
 import RepositoryList from './ReppositoryList';
@@ -30,6 +30,7 @@ const RepositoriesList: React.FC<React.ComponentProps<typeof ListPage>> = (props
       canCreate={props.canCreate ?? true}
       kind={referenceForModel(RepositoryModel)}
       ListComponent={RepositoryList}
+      badge={getBadgeFromType(RepositoryModel.badge)}
     />
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/repository/sections/RepositoryFormSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/sections/RepositoryFormSection.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { TextInputTypes } from '@patternfly/react-core';
+import { Flex, FlexItem, TextInputTypes, Title } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 import { getGitService, ImportStrategy } from '@console/git-service/src';
 import { detectImportStrategies } from '@console/git-service/src/utils/import-strategy-detector';
-import { FormHeader, InputField, useDebounceCallback } from '@console/shared';
+import { FormHeader, getBadgeFromType, InputField, useDebounceCallback } from '@console/shared';
+import { RepositoryModel } from '../../../models';
 import { useBuilderImages } from '../hooks/useBuilderImages';
 import {
   recommendRepositoryName,
@@ -56,9 +57,18 @@ const RepositoryFormSection = () => {
   };
   const debouncedHandleGitUrlChange = useDebounceCallback(handleGitUrlChange);
 
+  const title = (
+    <Flex className="odc-pipeline-builder-header__content">
+      <FlexItem grow={{ default: 'grow' }}>
+        <Title headingLevel="h1">{t('pipelines-plugin~Add Git Repository')}</Title>
+      </FlexItem>
+      <FlexItem>{getBadgeFromType(RepositoryModel.badge)}</FlexItem>
+    </Flex>
+  );
+
   return (
     <>
-      <FormHeader title={t('pipelines-plugin~Add Git Repository')} />
+      <FormHeader title={title} />
       <FormSection>
         <InputField
           label={t('pipelines-plugin~Git Repo URL')}


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-7031

**Analysis / Root cause:**
Tech preview label was not added

**Solution Description:**
Added Tech preview label for pipeline repository list and create page

**Screen shots / Gifs for design review:**

-------------- Before -------
<img width="1438" alt="Screenshot 2023-02-07 at 5 50 58 PM" src="https://user-images.githubusercontent.com/102503482/217244151-6d9156bb-ab5d-4c45-a471-c0cc7ff898f2.png">
<img width="1432" alt="Screenshot 2023-02-07 at 5 51 10 PM" src="https://user-images.githubusercontent.com/102503482/217244159-3429a0f7-e605-49c5-bd4a-e74619370b63.png">



-------After-----------------
<img width="1433" alt="Screenshot 2023-02-07 at 5 48 42 PM" src="https://user-images.githubusercontent.com/102503482/217244170-93c263a5-2187-4f94-bab1-4e27215783ed.png">

<img width="1438" alt="Screenshot 2023-02-07 at 5 48 52 PM" src="https://user-images.githubusercontent.com/102503482/217244182-0a463252-7bd5-4491-99e1-c33aefe7c5d3.png">



****Unit test coverage report:****
NA

**Test setup:**

1. Install OpenShift Pipelines operator
2. Navigate to Pipelines > Repository tab
3. Select Create > Repository

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
