### PR TITLE
OCPBUGS-5435, OCPBUGS-7111: Don't block console pod startup when managed cluster authenticator can't be initialized

### DIFF
--- a/cmd/bridge/utils.go
+++ b/cmd/bridge/utils.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+
+	"github.com/openshift/library-go/pkg/crypto"
+	"k8s.io/klog"
+)
+
+// Read bytes from a file. Panic if any error is encountered.
+func ReadFileOrDie(fileName string) []byte {
+	data, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		klog.Fatalf("Failed to read file %s: %v", fileName, err)
+	}
+	return data
+}
+
+// Read certs from a file and build a TLS client config contianing the parsed certs. Panic if any
+// error is encountered.
+func ReadCAFileToTLSConfigOrDie(fileName string) *tls.Config {
+	pem := ReadFileOrDie(fileName)
+	rootCAs := x509.NewCertPool()
+	if !rootCAs.AppendCertsFromPEM(pem) {
+		klog.Fatalf("Unable to parse PEM certs from file %s", fileName)
+	}
+	return crypto.SecureTLSConfig(&tls.Config{
+		RootCAs: rootCAs,
+	})
+}

--- a/contrib/multicluster-environment.sh
+++ b/contrib/multicluster-environment.sh
@@ -23,6 +23,7 @@ CA_FILE_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'bridge-ca-files')
 
 oc get -n openshift-config-managed cm kube-root-ca.crt -o json | jq -r '.data["ca.crt"]' >"$CA_FILE_DIR/api-ca.crt"
 oc get -n openshift-config-managed cm default-ingress-cert -o json | jq -r '.data["ca-bundle.crt"]' >"$CA_FILE_DIR/oauth-ca.crt"
+oc get -n multicluster-engine secret proxy-server-ca -o json | jq -r '.data["ca.crt"]' >"$CA_FILE_DIR/cluster-proxy-ca.crt"
 
 for CONTEXT in $(oc config get-contexts -o name); do
     # Set up the OAuthClient for this cluster
@@ -78,6 +79,9 @@ export BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT
 
 BRIDGE_K8S_MODE_OFF_CLUSTER_MANAGED_CLUSTER_PROXY="https://$(oc get route cluster-proxy-addon-user -n multicluster-engine -o json | jq -r '.spec.host')"
 export BRIDGE_K8S_MODE_OFF_CLUSTER_MANAGED_CLUSTER_PROXY
+
+BRIDGE_K8S_MODE_OFF_CLUSTER_MANAGED_CLUSTER_PROXY_CA_FILE="$CA_FILE_DIR/cluster-proxy-ca.crt"
+export BRIDGE_K8S_MODE_OFF_CLUSTER_MANAGED_CLUSTER_PROXY_CA_FILE
 
 BRIDGE_CA_FILE="$CA_FILE_DIR/api-ca.crt"
 export BRIDGE_CA_FILE


### PR DESCRIPTION
Use cluster proxy to initialize managed cluster authenticators, and do it concurrently with goroutines.