### PR TITLE
OCPBUGS-7195: e2e issue with tests: Create Samples Page Timeout Error

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-sample.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-sample.ts
@@ -1,9 +1,10 @@
 import { When } from 'cypress-cucumber-preprocessor/steps';
 import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
 import { addOptions } from '../../constants';
-import { addPage, app, samplesPage } from '../../pages';
+import { addPage, app, samplesPage, verifyAddPage } from '../../pages';
 
 When('user clicks on the Samples card', () => {
+  verifyAddPage.verifyAddPageCard('Samples');
   addPage.selectCardFromOptions(addOptions.Samples);
 });
 

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/catalog-source-details.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/catalog-source-details.spec.ts
@@ -77,7 +77,9 @@ describe(`Interacting with CatalogSource page`, () => {
     cy.byTestID('Registry poll interval-details-item__edit-button').click();
     modal.modalTitleShouldContain('Edit registry poll interval');
     cy.byLegacyTestID('dropdown-button').click();
-    cy.byTestDropDownMenu('30m0s').click();
+    cy.byTestDropDownMenu('30m0s')
+      .should('be.visible')
+      .click();
     modal.submit();
 
     // verify that registryPollInterval is updated


### PR DESCRIPTION
https://search.ci.openshift.org/?search=allows+modifying+registry+poll+interval&maxAge=168h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job
[OCPBUGS-7195](https://issues.redhat.com/browse/OCPBUGS-7195)