### PR TITLE
OCPBUGS-7446: Show type of sample on the samples view

### DIFF
--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -534,7 +534,7 @@
     "type": "console.catalog/item-provider",
     "properties": {
       "catalogId": "samples-catalog",
-      "type": "Sample",
+      "type": "BuilderImage",
       "title": "%devconsole~Builder Images%",
       "provider": { "$codeRef": "catalog.builderImageSamplesProvider" }
     },
@@ -546,7 +546,7 @@
     "type": "console.catalog/item-provider",
     "properties": {
       "catalogId": "samples-catalog",
-      "type": "Sample",
+      "type": "Devfile",
       "title": "%devconsole~Devfiles%",
       "provider": { "$codeRef": "catalog.devfileSamplesProvider" }
     },

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -218,8 +218,8 @@ export const catalogPO = {
 export const samplesPO = {
   search: 'input[placeholder="Filter by keyword..."]',
   cards: {
-    httpdTemplate: 'a[data-test="Sample-Httpd"] .catalog-tile-pf-title',
-    basicgoTemplate: 'a[data-test="Sample-Basic Go"] .catalog-tile-pf-title',
+    httpdTemplate: 'a[data-test="BuilderImage-Httpd"] .catalog-tile-pf-title',
+    basicgoTemplate: 'a[data-test="Devfile-Basic Go"] .catalog-tile-pf-title',
   },
 };
 

--- a/frontend/packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.data.ts
+++ b/frontend/packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.data.ts
@@ -63,8 +63,9 @@ export const devfileSamples: DevfileSample[] = [
 export const expectedCatalogItems: CatalogItem[] = [
   {
     uid: 'nodejs-basic',
-    type: 'Sample',
+    type: 'Devfile',
     name: 'Basic Node.js',
+    provider: undefined,
     description: 'A simple Hello World Node.js application',
     tags: ['NodeJS', 'Express'],
     cta: {
@@ -76,8 +77,9 @@ export const expectedCatalogItems: CatalogItem[] = [
   },
   {
     uid: 'code-with-quarkus',
-    type: 'Sample',
+    type: 'Devfile',
     name: 'Basic Quarkus',
+    provider: undefined,
     description: 'A simple Hello World Java application using Quarkus',
     tags: ['Java', 'Quarkus'],
     cta: {
@@ -89,8 +91,9 @@ export const expectedCatalogItems: CatalogItem[] = [
   },
   {
     uid: 'java-springboot-basic',
-    type: 'Sample',
+    type: 'Devfile',
     name: 'Basic Spring Boot',
+    provider: undefined,
     description: 'A simple Hello World Java Spring Boot application using Maven',
     tags: ['Java', 'Spring'],
     cta: {
@@ -102,8 +105,9 @@ export const expectedCatalogItems: CatalogItem[] = [
   },
   {
     uid: 'python-basic',
-    type: 'Sample',
+    type: 'Devfile',
     name: 'Basic Python',
+    provider: undefined,
     description: 'A simple Hello World application using Python',
     tags: ['Python'],
     cta: {

--- a/frontend/packages/dev-console/src/components/catalog/providers/useBuilderImageSamples.ts
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useBuilderImageSamples.ts
@@ -31,7 +31,7 @@ const normalizeBuilderImages = (
     const creationTimestamp = imageStream.metadata?.creationTimestamp;
     const href = `/samples/ns/${activeNamespace}/${name}/${imageStreamNS}`;
     const createLabel = t('devconsole~Create');
-    const type = 'Sample';
+    const type = 'BuilderImage';
 
     const item: CatalogItem = {
       uid: `${type}-${uid}`,

--- a/frontend/packages/dev-console/src/components/catalog/providers/useDevfileSamples.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useDevfileSamples.tsx
@@ -20,7 +20,7 @@ const normalizeDevfileSamples = (
 
     const item: CatalogItem = {
       uid,
-      type: 'Sample',
+      type: 'Devfile',
       name: displayName,
       description,
       tags,

--- a/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
@@ -169,7 +169,9 @@ When('user clicks Start building your application', () => {
 
 When('user enters {string} builder image in Quick Search bar', (searchItem: string) => {
   cy.get(topologyPO.quickSearch).type(searchItem);
-  cy.byTestID('item-name-.NET-Builder Images').click();
+  cy.byTestID('item-name-.NET-Builder Images')
+    .first()
+    .click();
 });
 
 When('user clicks Create application on Quick Search Dialog', () => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-7198


**Solution Description**: 
Added a condition in the CatalogTileBadge component which will check the href of the item to decide whether its a Builder Image/Devfile and show it in the Badge. 
The condition also checks that the DeveloperCatalog Page, which also uses the same component, does not get affected by this change.

**Screen shots / Gifs for design review**: 

**Before:**
![sssss](https://user-images.githubusercontent.com/47265560/217583636-3ad22359-00ce-4e0e-a892-c3d563bcca3e.png)


**After:**
![asdasdddd](https://user-images.githubusercontent.com/47265560/217582761-9346af6b-c3c5-43dd-b410-c9034bbecd1b.png)

**Unit test coverage report**: 
No changes.

**Test setup:**
1. Go to the Samples Page from the Add Page.
2. Check the Badges displayed on the right of each tile. 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge