### PR TITLE
OCPBUGS-7199: Fix CatalogSource poll interval modal dropdown and e2e tests

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-sample.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-sample.ts
@@ -1,9 +1,10 @@
 import { When } from 'cypress-cucumber-preprocessor/steps';
 import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
 import { addOptions } from '../../constants';
-import { addPage, app, samplesPage } from '../../pages';
+import { addPage, app, samplesPage, verifyAddPage } from '../../pages';
 
 When('user clicks on the Samples card', () => {
+  verifyAddPage.verifyAddPageCard('Samples');
   addPage.selectCardFromOptions(addOptions.Samples);
 });
 

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/mocks/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/mocks/index.tsx
@@ -291,3 +291,23 @@ export const testCSV = {
     },
   },
 };
+
+export const testCatalogSource = {
+  apiVersion: 'operators.coreos.com/v1alpha1',
+  kind: 'CatalogSource',
+  metadata: {
+    name: testName,
+    namespace: testName,
+    labels: { [testLabel]: testName },
+  },
+  spec: {
+    displayName: 'Test catalog',
+    image: '',
+    sourceType: 'grpc',
+    updateStrategy: {
+      registryPoll: {
+        interval: '10m',
+      },
+    },
+  },
+};

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/catalog-source-details.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/catalog-source-details.spec.ts
@@ -1,9 +1,13 @@
-import { checkErrors, testName } from '../../../integration-tests-cypress/support';
+import { checkErrors, create, testName } from '../../../integration-tests-cypress/support';
 import { detailsPage } from '../../../integration-tests-cypress/views/details-page';
 import { modal } from '../../../integration-tests-cypress/views/modal';
 import { nav } from '../../../integration-tests-cypress/views/nav';
+import { testCatalogSource } from '../mocks';
 
-const catalogSource = 'redhat-operators';
+const managedCatalogSource = {
+  name: 'redhat-operators',
+  displayName: 'Red Hat Operators',
+};
 
 describe(`Interacting with CatalogSource page`, () => {
   before(() => {
@@ -12,27 +16,23 @@ describe(`Interacting with CatalogSource page`, () => {
     nav.sidenav.switcher.changePerspectiveTo('Administrator');
     nav.sidenav.switcher.shouldHaveText('Administrator');
     cy.createProject(testName);
+    create(testCatalogSource);
   });
 
   beforeEach(() => {
     cy.log('navigate to Catalog Source page');
-    cy.visit(`/settings/cluster`);
+    nav.sidenav.clickNavLink(['Administration', 'Cluster Settings']);
     cy.byLegacyTestID('horizontal-link-Configuration').click();
-    cy.byLegacyTestID('OperatorHub').click();
+    cy.byTestID('loading-indicator').should('not.exist');
+    cy.byLegacyTestID('OperatorHub')
+      .scrollIntoView()
+      .click();
 
     // verfiy operatorHub details page is open
     detailsPage.sectionHeaderShouldExist('OperatorHub details');
+
+    // navigate to Catalog Sources list
     cy.byLegacyTestID('horizontal-link-Sources').click();
-    cy.byLegacyTestID(catalogSource).click();
-
-    // verfiy catalogSource details page is open
-    detailsPage.sectionHeaderShouldExist('CatalogSource details');
-
-    // verify catalogSource/'redhat-operators' is READY
-    cy.byTestSelector('details-item-value__Status', { timeout: 300000 }).should(
-      'have.text',
-      'READY',
-    ); // 5 mins
   });
 
   afterEach(() => {
@@ -44,17 +44,31 @@ describe(`Interacting with CatalogSource page`, () => {
     cy.logout();
   });
 
-  it(`renders details about the ${catalogSource} catalog source`, () => {
+  it(`renders details about the ${managedCatalogSource.name} catalog source`, () => {
+    cy.byLegacyTestID(managedCatalogSource.name).click();
+
+    // verfiy catalogSource details page is open
+    detailsPage.sectionHeaderShouldExist('CatalogSource details');
+
+    // verify catalogSource/redhat-operators' is READY
+    cy.byTestSelector('details-item-value__Status', { timeout: 300000 }).should(
+      'have.text',
+      'READY',
+    ); // 5 mins
+
     // validate Name field
     cy.byTestSelector('details-item-label__Name').should('be.visible');
-    cy.byTestSelector('details-item-value__Name').should('have.text', catalogSource);
+    cy.byTestSelector('details-item-value__Name').should('have.text', managedCatalogSource.name);
 
     // validate Status field
     cy.byTestSelector('details-item-label__Status').should('be.visible');
 
     // validate DisplayName field
     cy.byTestSelector('details-item-label__Display name').should('be.visible');
-    cy.byTestSelector('details-item-value__Display name').should('have.text', 'Red Hat Operators');
+    cy.byTestSelector('details-item-value__Display name').should(
+      'have.text',
+      managedCatalogSource.displayName,
+    );
 
     // validate RegistryPollInterval field
     cy.byTestID('Registry poll interval')
@@ -73,19 +87,26 @@ describe(`Interacting with CatalogSource page`, () => {
       .should('be.visible');
   });
 
-  it('allows modifying registry poll interval', () => {
+  it(`lists all the package manifests for ${managedCatalogSource.name} under Operators tab`, () => {
+    cy.byLegacyTestID(managedCatalogSource.name).click();
+
+    // verfiy catalogSource details page is open
+    detailsPage.sectionHeaderShouldExist('CatalogSource details');
+
+    cy.byLegacyTestID('horizontal-link-olm~Operators').click();
+    cy.get('[data-label=Name]').should('exist');
+  });
+
+  it(`allows modifying registry poll interval on test catalog source`, () => {
+    cy.byLegacyTestID(testCatalogSource.metadata.name).click();
+
     cy.byTestID('Registry poll interval-details-item__edit-button').click();
     modal.modalTitleShouldContain('Edit registry poll interval');
     cy.byLegacyTestID('dropdown-button').click();
-    cy.byTestDropDownMenu('30m0s').click();
+    cy.byTestDropDownMenu('30m').click();
     modal.submit();
 
     // verify that registryPollInterval is updated
-    cy.byTestSelector('details-item-value__Registry poll interval').should('have.text', '30m0s');
-  });
-
-  it(`lists all the package manifests for ${catalogSource} under Operators tab`, () => {
-    cy.byLegacyTestID('horizontal-link-olm~Operators').click();
-    cy.get('[data-label=Name]').should('exist');
+    cy.byTestSelector('details-item-value__Registry poll interval').should('have.text', '30m');
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/catalog-source-details.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/catalog-source-details.spec.ts
@@ -103,7 +103,9 @@ describe(`Interacting with CatalogSource page`, () => {
     cy.byTestID('Registry poll interval-details-item__edit-button').click();
     modal.modalTitleShouldContain('Edit registry poll interval');
     cy.byLegacyTestID('dropdown-button').click();
-    cy.byTestDropDownMenu('30m').click();
+    cy.byTestDropDownMenu('30m')
+      .should('be.visible')
+      .click();
     modal.submit();
 
     // verify that registryPollInterval is updated


### PR DESCRIPTION
## [OCPBUGS-7199](https://issues.redhat.com/browse/OCPBUGS-7199) CatalogSource issue

1. The edit registry modal works only with poll intervals in the format `10m0s` but not with `10m` which is now used. Fixed that in `edit-registry-poll-interval-modal.tsx` and use a memorized items prop for the Dropdown. Changed the UI so that it shows also just 10m, 15m, etc.
2. Also after this UI fix the tests still fail because the `CatalogSource` is now managed (?) and is overridden instantly and a change couldn't be validated. Added an unmanaged `CatalogSource` in the test to test the UI component.

## [OCPBUGS-7195](https://issues.redhat.com/browse/OCPBUGS-7195)

## TODO