### PR TITLE
OCPBUGS-7117: Expose endpoint to obtain copy login command URL for each cluster

### DIFF
--- a/frontend/packages/console-shared/src/hoc/index.ts
+++ b/frontend/packages/console-shared/src/hoc/index.ts
@@ -4,3 +4,4 @@ export * from './withUserSettings';
 export * from './withActivePerspective';
 export * from './withTelemetry';
 export * from './withQuickStartContext';
+export * from './withRequestTokenURL';

--- a/frontend/packages/console-shared/src/hoc/withRequestTokenURL.tsx
+++ b/frontend/packages/console-shared/src/hoc/withRequestTokenURL.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useRequestTokenURL } from '../hooks/useRequestTokenURL';
+
+type WithRequestTokenURLProps = {
+  requestTokenURL: string;
+};
+
+export const withRequestTokenURL = <Props extends WithRequestTokenURLProps>(
+  WrappedComponent: React.ComponentType<Props>,
+): React.FC<Omit<Props, keyof WithRequestTokenURLProps>> => {
+  const Component = (props: Props) => {
+    const requestTokenURL = useRequestTokenURL();
+    return <WrappedComponent {...props} clusterTokenURL={requestTokenURL} />;
+  };
+  Component.displayName = `withRequestTokenURL(${WrappedComponent.displayName ||
+    WrappedComponent.name})`;
+  return Component;
+};

--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -36,3 +36,4 @@ export * from './useTelemetry';
 export * from './useForceRender';
 export * from './useUtilizationDuration';
 export * from './usePrometheusGate';
+export * from './useRequestTokenURL';

--- a/frontend/packages/console-shared/src/hooks/useRequestTokenURL.ts
+++ b/frontend/packages/console-shared/src/hooks/useRequestTokenURL.ts
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { consoleFetchJSON as coFetchJSON } from '@console/dynamic-plugin-sdk/src/utils/fetch';
+import { useActiveCluster } from '@console/shared/src/hooks/useActiveCluster';
+
+export const useRequestTokenURL = (): [string] => {
+  const [clusterName] = useActiveCluster();
+  const [requestTokenURL, setClusterTokenURL] = React.useState<string>();
+  React.useEffect(() => {
+    const url = '/api/request-token';
+    coFetchJSON(url, 'GET', {}, 5000, clusterName)
+      .then((resp) => {
+        setClusterTokenURL(resp?.requestTokenURL);
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.warn(`Could not get request token URL for ${clusterName}: ${err}`);
+        setClusterTokenURL('');
+      });
+  }, [clusterName]);
+
+  return [requestTokenURL];
+};

--- a/frontend/public/components/command-line-tools.tsx
+++ b/frontend/public/components/command-line-tools.tsx
@@ -10,12 +10,15 @@ import { connectToFlags } from '../reducers/connectToFlags';
 import { ConsoleCLIDownloadModel } from '../models';
 import { referenceForModel } from '../module/k8s';
 import { SyncMarkdownView } from './markdown-view';
+import { useRequestTokenURL } from '@console/shared/src/hooks/useRequestTokenURL';
 
 export const CommandLineTools: React.FC<CommandLineToolsProps> = ({ obj }) => {
   const { t } = useTranslation();
+  const [requestTokenURL] = useRequestTokenURL();
   const title = 'Command Line Tools';
   const data = _.sortBy(_.get(obj, 'data'), 'spec.displayName');
   const cliData = _.remove(data, (item) => item.metadata.name === 'oc-cli-downloads');
+
   const additionalCommandLineTools = _.map(cliData.concat(data), (tool) => {
     const displayName = tool.spec.displayName;
     const defaultLinkText = `Download ${displayName}`;
@@ -56,13 +59,10 @@ export const CommandLineTools: React.FC<CommandLineToolsProps> = ({ obj }) => {
         <h1 className="co-m-pane__heading">
           <div className="co-m-pane__name">{title}</div>
         </h1>
-        {window.SERVER_FLAGS.requestTokenURL && (
+        {requestTokenURL && (
           <>
             <Divider className="co-divider" />
-            <ExternalLink
-              href={window.SERVER_FLAGS.requestTokenURL}
-              text={t('public~Copy login command')}
-            />
+            <ExternalLink href={requestTokenURL} text={t('public~Copy login command')} />
           </>
         )}
         {additionalCommandLineTools}

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -44,7 +44,7 @@ import { clusterVersionReference, getReportBugLink } from '../module/k8s/cluster
 import * as redhatLogoImg from '../imgs/logos/redhat.svg';
 import { GuidedTourMastheadTrigger } from '@console/app/src/components/tour';
 import { ConsoleLinkModel } from '../models';
-import { withTelemetry, withQuickStartContext } from '@console/shared/src/hoc';
+import { withTelemetry, withQuickStartContext, withRequestTokenURL } from '@console/shared/src/hoc';
 import ClusterMenu from '@console/app/src/components/nav/ClusterMenu';
 import { ACM_PERSPECTIVE_ID } from '@console/app/src/consts';
 
@@ -513,7 +513,7 @@ class MastheadToolbarContents_ extends React.Component {
   }
 
   _renderMenu(mobile) {
-    const { flags, consoleLinks, t } = this.props;
+    const { clusterTokenURL, flags, consoleLinks, t } = this.props;
     const { isUserDropdownOpen, isKebabDropdownOpen, username } = this.state;
     const additionalUserActions = this._getAdditionalActions(
       this._getAdditionalLinks(consoleLinks?.data, 'UserMenu'),
@@ -550,10 +550,10 @@ class MastheadToolbarContents_ extends React.Component {
         }
       };
 
-      if (window.SERVER_FLAGS.requestTokenURL) {
+      if (clusterTokenURL) {
         userActions.unshift({
           label: t('public~Copy login command'),
-          href: window.SERVER_FLAGS.requestTokenURL,
+          href: clusterTokenURL,
           externalLink: true,
         });
       }
@@ -762,7 +762,7 @@ const mastheadToolbarStateToProps = (state) => ({
 });
 
 const MastheadToolbarContentsWithTranslation = withQuickStartContext(
-  withTranslation()(withTelemetry(MastheadToolbarContents_)),
+  withTranslation()(withTelemetry(withRequestTokenURL(MastheadToolbarContents_))),
 );
 const MastheadToolbarContents = connect(mastheadToolbarStateToProps, {
   drawerToggle: UIActions.notificationDrawerToggleExpanded,


### PR DESCRIPTION
Exposing a new endpoint in the console server which should return the URL for retrieving the token, which is used for the `Copy login command` redirect.

/assign @TheRealJon 