### PR TITLE
[release-4.12] OCPBUGS-7506: Fix different CI issues

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/mocks/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/mocks/index.tsx
@@ -291,3 +291,23 @@ export const testCSV = {
     },
   },
 };
+
+export const testCatalogSource = {
+  apiVersion: 'operators.coreos.com/v1alpha1',
+  kind: 'CatalogSource',
+  metadata: {
+    name: testName,
+    namespace: testName,
+    labels: { [testLabel]: testName },
+  },
+  spec: {
+    displayName: 'Test catalog',
+    image: '',
+    sourceType: 'grpc',
+    updateStrategy: {
+      registryPoll: {
+        interval: '10m',
+      },
+    },
+  },
+};

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/catalog-source-details.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/catalog-source-details.spec.ts
@@ -1,9 +1,13 @@
-import { checkErrors, testName } from '../../../integration-tests-cypress/support';
+import { checkErrors, create, testName } from '../../../integration-tests-cypress/support';
 import { detailsPage } from '../../../integration-tests-cypress/views/details-page';
 import { modal } from '../../../integration-tests-cypress/views/modal';
 import { nav } from '../../../integration-tests-cypress/views/nav';
+import { testCatalogSource } from '../mocks';
 
-const catalogSource = 'redhat-operators';
+const managedCatalogSource = {
+  name: 'redhat-operators',
+  displayName: 'Red Hat Operators',
+};
 
 describe(`Interacting with CatalogSource page`, () => {
   before(() => {
@@ -12,27 +16,23 @@ describe(`Interacting with CatalogSource page`, () => {
     nav.sidenav.switcher.changePerspectiveTo('Administrator');
     nav.sidenav.switcher.shouldHaveText('Administrator');
     cy.createProject(testName);
+    create(testCatalogSource);
   });
 
   beforeEach(() => {
     cy.log('navigate to Catalog Source page');
-    cy.visit(`/settings/cluster`);
+    nav.sidenav.clickNavLink(['Administration', 'Cluster Settings']);
     cy.byLegacyTestID('horizontal-link-Configuration').click();
-    cy.byLegacyTestID('OperatorHub').click();
+    cy.byTestID('loading-indicator').should('not.exist');
+    cy.byLegacyTestID('OperatorHub')
+      .scrollIntoView()
+      .click();
 
     // verfiy operatorHub details page is open
     detailsPage.sectionHeaderShouldExist('OperatorHub details');
+
+    // navigate to Catalog Sources list
     cy.byLegacyTestID('horizontal-link-Sources').click();
-    cy.byLegacyTestID(catalogSource).click();
-
-    // verfiy catalogSource details page is open
-    detailsPage.sectionHeaderShouldExist('CatalogSource details');
-
-    // verify catalogSource/'redhat-operators' is READY
-    cy.byTestSelector('details-item-value__Status', { timeout: 300000 }).should(
-      'have.text',
-      'READY',
-    ); // 5 mins
   });
 
   afterEach(() => {
@@ -44,17 +44,31 @@ describe(`Interacting with CatalogSource page`, () => {
     cy.logout();
   });
 
-  it(`renders details about the ${catalogSource} catalog source`, () => {
+  it(`renders details about the ${managedCatalogSource.name} catalog source`, () => {
+    cy.byLegacyTestID(managedCatalogSource.name).click();
+
+    // verfiy catalogSource details page is open
+    detailsPage.sectionHeaderShouldExist('CatalogSource details');
+
+    // verify catalogSource/redhat-operators' is READY
+    cy.byTestSelector('details-item-value__Status', { timeout: 300000 }).should(
+      'have.text',
+      'READY',
+    ); // 5 mins
+
     // validate Name field
     cy.byTestSelector('details-item-label__Name').should('be.visible');
-    cy.byTestSelector('details-item-value__Name').should('have.text', catalogSource);
+    cy.byTestSelector('details-item-value__Name').should('have.text', managedCatalogSource.name);
 
     // validate Status field
     cy.byTestSelector('details-item-label__Status').should('be.visible');
 
     // validate DisplayName field
     cy.byTestSelector('details-item-label__Display name').should('be.visible');
-    cy.byTestSelector('details-item-value__Display name').should('have.text', 'Red Hat Operators');
+    cy.byTestSelector('details-item-value__Display name').should(
+      'have.text',
+      managedCatalogSource.displayName,
+    );
 
     // validate RegistryPollInterval field
     cy.byTestID('Registry poll interval')
@@ -73,19 +87,26 @@ describe(`Interacting with CatalogSource page`, () => {
       .should('be.visible');
   });
 
-  it('allows modifying registry poll interval', () => {
+  it(`lists all the package manifests for ${managedCatalogSource.name} under Operators tab`, () => {
+    cy.byLegacyTestID(managedCatalogSource.name).click();
+
+    // verfiy catalogSource details page is open
+    detailsPage.sectionHeaderShouldExist('CatalogSource details');
+
+    cy.byLegacyTestID('horizontal-link-olm~Operators').click();
+    cy.get('[data-label=Name]').should('exist');
+  });
+
+  it(`allows modifying registry poll interval on test catalog source`, () => {
+    cy.byLegacyTestID(testCatalogSource.metadata.name).click();
+
     cy.byTestID('Registry poll interval-details-item__edit-button').click();
     modal.modalTitleShouldContain('Edit registry poll interval');
     cy.byLegacyTestID('dropdown-button').click();
-    cy.byTestDropDownMenu('30m0s').click();
+    cy.byTestDropDownMenu('30m').click();
     modal.submit();
 
     // verify that registryPollInterval is updated
-    cy.byTestSelector('details-item-value__Registry poll interval').should('have.text', '30m0s');
-  });
-
-  it(`lists all the package manifests for ${catalogSource} under Operators tab`, () => {
-    cy.byLegacyTestID('horizontal-link-olm~Operators').click();
-    cy.get('[data-label=Name]').should('exist');
+    cy.byTestSelector('details-item-value__Registry poll interval').should('have.text', '30m');
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/catalog-source-details.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/catalog-source-details.spec.ts
@@ -103,7 +103,9 @@ describe(`Interacting with CatalogSource page`, () => {
     cy.byTestID('Registry poll interval-details-item__edit-button').click();
     modal.modalTitleShouldContain('Edit registry poll interval');
     cy.byLegacyTestID('dropdown-button').click();
-    cy.byTestDropDownMenu('30m').click();
+    cy.byTestDropDownMenu('30m')
+      .should('be.visible')
+      .click();
     modal.submit();
 
     // verify that registryPollInterval is updated

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -110,7 +110,11 @@ const DefaultPage_: React.FC<DefaultPageProps> = ({ flags }) => {
   );
 };
 
-const DefaultPage = connectToFlags(FLAGS.OPENSHIFT, FLAGS.CAN_LIST_NS)(DefaultPage_);
+const DefaultPage = connectToFlags(
+  FLAGS.OPENSHIFT,
+  FLAGS.CAN_LIST_NS,
+  FLAGS.MONITORING,
+)(DefaultPage_);
 
 const LazyRoute = (props) => (
   <Route


### PR DESCRIPTION
This is a manual backport of #12554

it includes two UI fixes

1. [OCPBUGS-3033](https://issues.redhat.com/browse/OCPBUGS-3033) Clicking the logo in the masthead goes to `/dashboards`, even if metrics are disabled
2. An issue with catalog sources and the edit registry poll interval modal. It works fine when the intervals format is `10m0s` but not when its just `10m`

Let's see if this helps...
