### PR TITLE
OCPBUGS-10232: Fixes argocd link for non-KAM added application envs

### DIFF
--- a/frontend/packages/gitops-plugin/src/components/details/ArgoCdLink.tsx
+++ b/frontend/packages/gitops-plugin/src/components/details/ArgoCdLink.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { SplitItem } from '@patternfly/react-core';
+import { ExternalLink } from '@console/internal/components/utils';
+import * as argoIcon from '../../images/argo.png';
+
+type ArgoCdLinkProps = {
+  envName: string;
+  appName: string;
+  argocdLink: any;
+};
+
+const ArgoCdLink: React.FC<ArgoCdLinkProps> = ({ envName, appName, argocdLink }) => {
+  // Use environment name as is or the original KAM-based design
+  const appNameLink = envName.includes(appName) ? envName : `${envName}-${appName}`;
+  return (
+    <SplitItem className="gitops-plugin__environment-details__env-section__deployment-history__argocd-link">
+      <ExternalLink href={`${argocdLink.spec.href}/applications/${appNameLink}`}>
+        <span className="gitops-plugin__environment-details__env-section__argo-external-link">
+          <img loading="lazy" src={argoIcon} alt="Argo CD" width="19px" height="24px" />
+        </span>
+      </ExternalLink>
+    </SplitItem>
+  );
+};
+
+export default ArgoCdLink;

--- a/frontend/packages/gitops-plugin/src/components/details/GitOpsDetails.tsx
+++ b/frontend/packages/gitops-plugin/src/components/details/GitOpsDetails.tsx
@@ -19,8 +19,8 @@ import { ExternalLink, Timestamp } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ConsoleLinkModel } from '@console/internal/models';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
-import * as argoIcon from '../../images/argo.png';
 import { GitOpsEnvironment } from '../utils/gitops-types';
+import ArgoCdLink from './ArgoCdLink';
 import GitOpsRenderStatusLabel from './GitOpsRenderStatusLabel';
 import GitOpsResourcesSection from './GitOpsResourcesSection';
 import './GitOpsDetails.scss';
@@ -160,21 +160,11 @@ const GitOpsDetails: React.FC<GitOpsDetailsProps> = ({ envs, appName, manifestUR
                           </SplitItem>
                           {argocdLink && (
                             <Tooltip content="Argo CD">
-                              <SplitItem className="gop-gitops-details__env-section__deployment-history__argocd-link">
-                                <ExternalLink
-                                  href={`${argocdLink.spec.href}/applications/${env.environment}-${appName}`}
-                                >
-                                  <span className="gop-gitops-details__env-section__argo-external-link">
-                                    <img
-                                      loading="lazy"
-                                      src={argoIcon}
-                                      alt="Argo CD"
-                                      width="19px"
-                                      height="24px"
-                                    />
-                                  </span>
-                                </ExternalLink>
-                              </SplitItem>
+                              <ArgoCdLink
+                                appName={appName}
+                                envName={env.environment}
+                                argocdLink={argocdLink}
+                              />
                             </Tooltip>
                           )}
                         </Split>


### PR DESCRIPTION
Fixes [gitops-2475: [UI] Argo CD link in details panel is KAM-specific](https://issues.redhat.com/browse/GITOPS-2475).

signed by: [yicai@redhat.com](mailto:yicai@redhat.com)