### PR TITLE
OCPBUGS-4646: delete application should delete all part-of resources

### DIFF
--- a/frontend/packages/console-shared/src/utils/__tests__/pod-resource-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/pod-resource-utils.spec.ts
@@ -136,12 +136,12 @@ describe('getPodsFor...', () => {
 
   it('should return pods and replication controllers for a set of DeploymentConfigs', () => {
     let podRCDataArray = getPodsForDeploymentConfigs(sampleDeploymentConfigs.data, mockResources);
-    expect(podRCDataArray).toHaveLength(2);
+    expect(podRCDataArray).toHaveLength(3);
     expect(podRCDataArray[0].pods).toHaveLength(1);
     expect(podRCDataArray[0].current).not.toBeNull();
     expect(podRCDataArray[0].previous).toBeFalsy();
     expect(podRCDataArray[0].isRollingOut).toBeFalsy();
-    expect(podRCDataArray[1].pods).toHaveLength(0);
+    expect(podRCDataArray[1].pods).toHaveLength(1);
 
     podRCDataArray = getPodsForDeploymentConfigs([], mockResources);
     expect(podRCDataArray).toHaveLength(0);
@@ -151,13 +151,13 @@ describe('getPodsFor...', () => {
 
     mockResources.replicationControllers = { loaded: false, loadError: 'error', data: [] };
     podRCDataArray = getPodsForDeploymentConfigs(sampleDeploymentConfigs.data, mockResources);
-    expect(podRCDataArray).toHaveLength(2);
+    expect(podRCDataArray).toHaveLength(3);
     expect(podRCDataArray[0].pods).toHaveLength(0);
     expect(podRCDataArray[1].pods).toHaveLength(0);
 
     delete mockResources.replicationControllers;
     podRCDataArray = getPodsForDeploymentConfigs(sampleDeploymentConfigs.data, mockResources);
-    expect(podRCDataArray).toHaveLength(2);
+    expect(podRCDataArray).toHaveLength(3);
     expect(podRCDataArray[0].pods).toHaveLength(0);
     expect(podRCDataArray[1].pods).toHaveLength(0);
   });

--- a/frontend/packages/console-shared/src/utils/__tests__/test-resource-data.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/test-resource-data.ts
@@ -75,6 +75,68 @@ export const sampleDeploymentConfigs: FirehoseResult = {
       kind: 'DeploymentConfig',
       apiVersion: 'apps/v1',
       metadata: {
+        name: 'nodejs-with-bc',
+        namespace: 'testproject',
+        uid: '02f680df-680f-11e9-b69e-5254003f9382',
+        resourceVersion: '732186',
+        generation: 2,
+        creationTimestamp: '2019-04-22T11:58:33Z',
+        labels: {
+          app: 'nodejs-with-bc',
+          'app.kubernetes.io/instance': 'nodejs-with-bc',
+          'app.openshift.io/runtime': 'nodejs',
+          'app.openshift.io/part-of': 'nodejs-with-bc',
+        },
+        annotations: {
+          'app.openshift.io/vcs-uri': 'https://github.com/redhat-developer/topology-example',
+          'app.openshift.io/vcs-ref': 'master',
+        },
+      },
+      spec: {
+        strategy: {
+          type: 'Rolling',
+        },
+        template: {
+          metadata: {
+            creationTimestamp: null,
+            labels: {
+              app: 'nodejs-with-bc',
+              deploymentconfig: 'nodejs-with-bc',
+            },
+          },
+          spec: {},
+        },
+        triggers: [
+          {
+            type: 'ImageChange',
+            imageChangeParams: {
+              automatic: true,
+              containerNames: ['nodejs-with-bc'],
+              from: {
+                kind: 'ImageStreamTag',
+                namespace: 'testproject',
+                name: 'nodejs:latest',
+              },
+            },
+          },
+          {
+            type: 'ConfigChange',
+          },
+        ],
+      },
+      status: {
+        availableReplicas: 1,
+        unavailableReplicas: 0,
+        latestVersion: 1,
+        updatedReplicas: 1,
+        replicas: 1,
+        readyReplicas: 1,
+      },
+    },
+    {
+      kind: 'DeploymentConfig',
+      apiVersion: 'apps/v1',
+      metadata: {
         name: 'nodejs-ex',
         namespace: 'testproject1',
         uid: '02f680df-b69e-5254003f9382',
@@ -1398,6 +1460,29 @@ export const sampleServices: FirehoseResult = {
     {
       kind: 'Service',
       metadata: {
+        name: 'nodejs-with-bc',
+        namespace: 'testproject',
+        uid: '02f53542-680f-11e9-8c69-5254003f9382',
+        resourceVersion: '1160881',
+        creationTimestamp: '2019-04-26T10:35:29Z',
+        labels: {
+          app: 'nodejs-with-bc',
+          'app.openshift.io/part-of': 'nodejs-with-bc',
+        },
+      },
+      spec: {
+        selector: {
+          app: 'nodejs-with-bc',
+          deploymentconfig: 'nodejs-with-bc',
+        },
+      },
+      status: {
+        loadBalancer: {},
+      },
+    },
+    {
+      kind: 'Service',
+      metadata: {
         name: 'wit-service',
         namespace: 'testproject3',
         uid: '60e010cc-680d-11e9-8c69-5254003f9382',
@@ -1484,6 +1569,32 @@ export const sampleRoutes: FirehoseResult = {
         to: {
           kind: 'Service',
           name: 'nodejs',
+          weight: 100,
+        },
+      },
+      status: {},
+    },
+    {
+      kind: 'Route',
+      metadata: {
+        name: 'nodejs-with-bc',
+        namespace: 'testproject',
+        uid: '02f63696-680f-11e9-b69e-5254003f9382',
+        resourceVersion: '1160889',
+        creationTimestamp: '2019-04-26T10:35:29Z',
+        labels: {
+          app: 'nodejs-with-bc',
+          'app.openshift.io/part-of': 'nodejs-with-bc',
+        },
+        annotations: {
+          'openshift.io/host.generated': 'true',
+        },
+      },
+      spec: {
+        host: 'nodejs-testproject3.192.168.42.60.nip.io',
+        to: {
+          kind: 'Service',
+          name: 'nodejs-with-bc',
           weight: 100,
         },
       },
@@ -1616,6 +1727,64 @@ export const sampleBuildConfigs: FirehoseResult = {
           to: {
             kind: 'ImageStreamTag',
             name: 'nodejs:latest',
+          },
+        },
+        triggers: [
+          { type: 'Generic', generic: {} },
+          { type: 'Github', github: {} },
+        ],
+      },
+      status: {
+        lastVersion: 1,
+      },
+    },
+    {
+      kind: 'BuildConfig',
+      metadata: {
+        name: 'nodejs-with-bc',
+        namespace: 'testproject',
+        uid: '02fc958f-680f-11e9-b69e-5254003f9382',
+        resourceVersion: '1160891',
+        creationTimestamp: '2019-04-26T10:35:29Z',
+        labels: {
+          app: 'nodejs-with-bc',
+          'app.openshift.io/part-of': 'nodejs-with-bc',
+        },
+      },
+      spec: {
+        output: {
+          to: {
+            kind: 'ImageStreamTag',
+            name: 'nodejs-with-bc:latest',
+          },
+        },
+        triggers: [
+          { type: 'Generic', generic: {} },
+          { type: 'Github', github: {} },
+        ],
+      },
+      status: {
+        lastVersion: 1,
+      },
+    },
+    {
+      kind: 'BuildConfig',
+      metadata: {
+        name: 'nodejs-with-bc-binary',
+        namespace: 'testproject',
+        uid: '02fc958f-680f-11e9-b69e-5254003f9382',
+        resourceVersion: '1160891',
+        creationTimestamp: '2019-04-26T10:35:29Z',
+        labels: {
+          app: 'nodejs-with-bc',
+          'app.openshift.io/part-of': 'nodejs-with-bc',
+        },
+      },
+      spec: {
+        output: {
+          to: {
+            kind: 'ImageStreamTag',
+            name: 'nodejs-with-bc:latest',
           },
         },
         triggers: [

--- a/frontend/packages/topology/src/data-transforms/__tests__/__snapshots__/data-transformer.spec.ts.snap
+++ b/frontend/packages/topology/src/data-transforms/__tests__/__snapshots__/data-transformer.spec.ts.snap
@@ -1155,6 +1155,235 @@ Object {
           "vcsRef": "master",
           "vcsURI": "https://github.com/redhat-developer/topology-example",
         },
+        "id": "02f680df-680f-11e9-b69e-5254003f9382",
+        "name": "nodejs-with-bc",
+        "resource": Object {
+          "apiVersion": "apps/v1",
+          "kind": "DeploymentConfig",
+          "metadata": Object {
+            "annotations": Object {
+              "app.openshift.io/vcs-ref": "master",
+              "app.openshift.io/vcs-uri": "https://github.com/redhat-developer/topology-example",
+            },
+            "creationTimestamp": "2019-04-22T11:58:33Z",
+            "generation": 2,
+            "labels": Object {
+              "app": "nodejs-with-bc",
+              "app.kubernetes.io/instance": "nodejs-with-bc",
+              "app.openshift.io/part-of": "nodejs-with-bc",
+              "app.openshift.io/runtime": "nodejs",
+            },
+            "name": "nodejs-with-bc",
+            "namespace": "testproject",
+            "resourceVersion": "732186",
+            "uid": "02f680df-680f-11e9-b69e-5254003f9382",
+          },
+          "spec": Object {
+            "strategy": Object {
+              "type": "Rolling",
+            },
+            "template": Object {
+              "metadata": Object {
+                "creationTimestamp": null,
+                "labels": Object {
+                  "app": "nodejs-with-bc",
+                  "deploymentconfig": "nodejs-with-bc",
+                },
+              },
+              "spec": Object {},
+            },
+            "triggers": Array [
+              Object {
+                "imageChangeParams": Object {
+                  "automatic": true,
+                  "containerNames": Array [
+                    "nodejs-with-bc",
+                  ],
+                  "from": Object {
+                    "kind": "ImageStreamTag",
+                    "name": "nodejs:latest",
+                    "namespace": "testproject",
+                  },
+                },
+                "type": "ImageChange",
+              },
+              Object {
+                "type": "ConfigChange",
+              },
+            ],
+          },
+          "status": Object {
+            "availableReplicas": 1,
+            "latestVersion": 1,
+            "readyReplicas": 1,
+            "replicas": 1,
+            "unavailableReplicas": 0,
+            "updatedReplicas": 1,
+          },
+        },
+        "resources": Object {
+          "hpas": undefined,
+          "isMonitorable": true,
+          "isOperatorBackedService": false,
+          "monitoringAlerts": Array [],
+          "obj": Object {
+            "apiVersion": "apps/v1",
+            "kind": "DeploymentConfig",
+            "metadata": Object {
+              "annotations": Object {
+                "app.openshift.io/vcs-ref": "master",
+                "app.openshift.io/vcs-uri": "https://github.com/redhat-developer/topology-example",
+              },
+              "creationTimestamp": "2019-04-22T11:58:33Z",
+              "generation": 2,
+              "labels": Object {
+                "app": "nodejs-with-bc",
+                "app.kubernetes.io/instance": "nodejs-with-bc",
+                "app.openshift.io/part-of": "nodejs-with-bc",
+                "app.openshift.io/runtime": "nodejs",
+              },
+              "name": "nodejs-with-bc",
+              "namespace": "testproject",
+              "resourceVersion": "732186",
+              "uid": "02f680df-680f-11e9-b69e-5254003f9382",
+            },
+            "spec": Object {
+              "strategy": Object {
+                "type": "Rolling",
+              },
+              "template": Object {
+                "metadata": Object {
+                  "creationTimestamp": null,
+                  "labels": Object {
+                    "app": "nodejs-with-bc",
+                    "deploymentconfig": "nodejs-with-bc",
+                  },
+                },
+                "spec": Object {},
+              },
+              "triggers": Array [
+                Object {
+                  "imageChangeParams": Object {
+                    "automatic": true,
+                    "containerNames": Array [
+                      "nodejs-with-bc",
+                    ],
+                    "from": Object {
+                      "kind": "ImageStreamTag",
+                      "name": "nodejs:latest",
+                      "namespace": "testproject",
+                    },
+                  },
+                  "type": "ImageChange",
+                },
+                Object {
+                  "type": "ConfigChange",
+                },
+              ],
+            },
+            "status": Object {
+              "availableReplicas": 1,
+              "latestVersion": 1,
+              "readyReplicas": 1,
+              "replicas": 1,
+              "unavailableReplicas": 0,
+              "updatedReplicas": 1,
+            },
+          },
+        },
+        "type": "workload",
+      },
+      "group": false,
+      "height": 104,
+      "id": "02f680df-680f-11e9-b69e-5254003f9382",
+      "label": "nodejs-with-bc",
+      "resource": Object {
+        "apiVersion": "apps/v1",
+        "kind": "DeploymentConfig",
+        "metadata": Object {
+          "annotations": Object {
+            "app.openshift.io/vcs-ref": "master",
+            "app.openshift.io/vcs-uri": "https://github.com/redhat-developer/topology-example",
+          },
+          "creationTimestamp": "2019-04-22T11:58:33Z",
+          "generation": 2,
+          "labels": Object {
+            "app": "nodejs-with-bc",
+            "app.kubernetes.io/instance": "nodejs-with-bc",
+            "app.openshift.io/part-of": "nodejs-with-bc",
+            "app.openshift.io/runtime": "nodejs",
+          },
+          "name": "nodejs-with-bc",
+          "namespace": "testproject",
+          "resourceVersion": "732186",
+          "uid": "02f680df-680f-11e9-b69e-5254003f9382",
+        },
+        "spec": Object {
+          "strategy": Object {
+            "type": "Rolling",
+          },
+          "template": Object {
+            "metadata": Object {
+              "creationTimestamp": null,
+              "labels": Object {
+                "app": "nodejs-with-bc",
+                "deploymentconfig": "nodejs-with-bc",
+              },
+            },
+            "spec": Object {},
+          },
+          "triggers": Array [
+            Object {
+              "imageChangeParams": Object {
+                "automatic": true,
+                "containerNames": Array [
+                  "nodejs-with-bc",
+                ],
+                "from": Object {
+                  "kind": "ImageStreamTag",
+                  "name": "nodejs:latest",
+                  "namespace": "testproject",
+                },
+              },
+              "type": "ImageChange",
+            },
+            Object {
+              "type": "ConfigChange",
+            },
+          ],
+        },
+        "status": Object {
+          "availableReplicas": 1,
+          "latestVersion": 1,
+          "readyReplicas": 1,
+          "replicas": 1,
+          "unavailableReplicas": 0,
+          "updatedReplicas": 1,
+        },
+      },
+      "resourceKind": "apps~v1~DeploymentConfig",
+      "shape": undefined,
+      "style": Object {
+        "padding": Array [
+          0,
+          20,
+        ],
+      },
+      "type": "workload",
+      "visible": true,
+      "width": 104,
+    },
+    Object {
+      "data": Object {
+        "data": Object {
+          "builderImage": "test-file-stub",
+          "editURL": undefined,
+          "isKnativeResource": false,
+          "kind": "apps~v1~DeploymentConfig",
+          "monitoringAlerts": Array [],
+          "vcsRef": "master",
+          "vcsURI": "https://github.com/redhat-developer/topology-example",
+        },
         "id": "02f680df-b69e-5254003f9382",
         "name": "nodejs-ex",
         "resource": Object {

--- a/frontend/packages/topology/src/data-transforms/__tests__/updateModelFromFilters.spec.ts
+++ b/frontend/packages/topology/src/data-transforms/__tests__/updateModelFromFilters.spec.ts
@@ -42,7 +42,7 @@ describe('topology model ', () => {
 
   it('should have the correct nodes, groups, and edges when no filters', () => {
     const topologyTransformedData = getTransformedTopologyData();
-    expect(topologyTransformedData.nodes.filter((n) => !n.group)).toHaveLength(10);
+    expect(topologyTransformedData.nodes.filter((n) => !n.group)).toHaveLength(11);
     expect(topologyTransformedData.nodes.filter((n) => n.group)).toHaveLength(2);
     expect(topologyTransformedData.edges).toHaveLength(1);
   });
@@ -55,7 +55,7 @@ describe('topology model ', () => {
       'application-1',
       filterers,
     );
-    expect(newModel.nodes.filter((n) => !n.group).length).toBe(10);
+    expect(newModel.nodes.filter((n) => !n.group).length).toBe(11);
     expect(newModel.nodes.filter((n) => !n.group && n.visible).length).toBe(2);
     expect(newModel.nodes.filter((n) => n.group).length).toBe(2);
     expect(newModel.nodes.filter((n) => n.group && n.visible).length).toBe(1);

--- a/frontend/packages/topology/src/operators/__tests__/operator-data-transformer.spec.ts
+++ b/frontend/packages/topology/src/operators/__tests__/operator-data-transformer.spec.ts
@@ -72,7 +72,7 @@ describe('operator data transformer ', () => {
     expect(getNodeById(operatorBackedServices[0].id, graphData).type).toBe(
       TYPE_OPERATOR_BACKED_SERVICE,
     );
-    expect(graphData.nodes.filter((n) => !n.group)).toHaveLength(10);
+    expect(graphData.nodes.filter((n) => !n.group)).toHaveLength(11);
     expect(graphData.nodes.filter((n) => n.group)).toHaveLength(3);
     expect(graphData.edges).toHaveLength(1);
   });

--- a/frontend/packages/topology/src/utils/__tests__/application-utils.spec.ts
+++ b/frontend/packages/topology/src/utils/__tests__/application-utils.spec.ts
@@ -160,6 +160,24 @@ describe('ApplicationUtils ', () => {
       .catch((err) => fail(err));
   });
 
+  it('Should delete all the specific models related to deployment config if the build config is present', async (done) => {
+    const nodeModel = await getTopologyData(MockResources, 'nodejs-with-bc', 'testproject');
+
+    cleanUpWorkload(nodeModel.resource)
+      .then(() => {
+        const allArgs = spy.calls.allArgs();
+        const removedModels = allArgs.map((arg) => arg[0]);
+        expect(spy.calls.count()).toEqual(5);
+        expect(removedModels).toContain(BuildConfigModel);
+        expect(removedModels).toContain(DeploymentConfigModel);
+        expect(removedModels).toContain(ImageStreamModel);
+        expect(removedModels).toContain(ServiceModel);
+        expect(removedModels).toContain(RouteModel);
+        done();
+      })
+      .catch((err) => fail(err));
+  });
+
   it('Should delete all the specific models related to daemonsets', async (done) => {
     const nodeModel = await getTopologyData(MockResources, 'daemonset-testing', 'test-project');
     cleanUpWorkload(nodeModel.resource)

--- a/frontend/packages/topology/src/utils/application-utils.ts
+++ b/frontend/packages/topology/src/utils/application-utils.ts
@@ -199,15 +199,16 @@ export const cleanUpWorkload = async (resource: K8sResourceKind): Promise<K8sRes
 
   const deleteModels = [ServiceModel, RouteModel, ImageStreamModel];
   const knativeDeleteModels = [KnativeServiceModel, ImageStreamModel];
-  if (isBuildConfigPresent) {
-    deleteModels.push(BuildConfigModel);
-    knativeDeleteModels.push(BuildConfigModel);
-  }
   const resourceData = _.cloneDeep(resource);
   const deleteRequest = (model: K8sKind, resourceObj: K8sResourceKind) => {
     const req = safeKill(model, resourceObj);
     req && reqs.push(req);
   };
+  if (isBuildConfigPresent) {
+    resourceBuildConfigs.forEach((bc) => {
+      deleteRequest(BuildConfigModel, bc);
+    });
+  }
   const batchDeleteRequests = (models: K8sKind[], resourceObj: K8sResourceKind): void => {
     models.forEach((model) => deleteRequest(model, resourceObj));
   };


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-4646

**Root analysis:**
The BuildConfig which is created has the same `app.kubernetes.io/part-of` but its name is set to `test-webapp-binary`.

**Solution description:**
- Deleting the buildconfig resources separately if it is present
- Added test

**Test coverage:**
<img width="642" alt="Screenshot 2023-02-14 at 7 01 38 PM" src="https://user-images.githubusercontent.com/22490998/218753631-0836bc10-84eb-42ee-861e-b6639e524326.png">

**Test setup:**
Apply the resources.json file attached to the bug

**GIF:**
https://user-images.githubusercontent.com/22490998/218834801-afdd3b2d-1555-4007-836e-576b3565c100.mov


/kind bug