### PR TITLE
OCPBUGS-7806: Add NFS-export details for PersistentVolume details

### DIFF
--- a/frontend/public/components/persistent-volume.jsx
+++ b/frontend/public/components/persistent-volume.jsx
@@ -90,6 +90,7 @@ const Details = ({ obj: pv }) => {
   const accessModes = _.get(pv, 'spec.accessModes');
   const volumeMode = _.get(pv, 'spec.volumeMode');
   const reclaimPolicy = _.get(pv, 'spec.persistentVolumeReclaimPolicy');
+  const nfsExport = _.get(pv, 'spec.csi.volumeAttributes.share');
   return (
     <div className="co-m-pane__body">
       <SectionHeading text={t('public~PersistentVolume details')} />
@@ -134,6 +135,12 @@ const Details = ({ obj: pv }) => {
                 <dd>
                   <ResourceLink kind="PersistentVolumeClaim" name={pvcName} namespace={namespace} />
                 </dd>
+              </>
+            )}
+            {nfsExport && (
+              <>
+                <dt>{t('public~NFS-export')}</dt>
+                <dd>{nfsExport}</dd>
               </>
             )}
           </dl>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1290,6 +1290,7 @@
   "PersistentVolume details": "PersistentVolume details",
   "Reclaim policy": "Reclaim policy",
   "PersistentVolumeClaim": "PersistentVolumeClaim",
+  "NFS-export": "NFS-export",
   "Claim": "Claim",
   "The terminal connection has closed.": "The terminal connection has closed.",
   "Reconnect": "Reconnect",


### PR DESCRIPTION
Shows the NFS-export details if exists. 
The details fetched from spec.csi.volumeAttributes.share of a pv