### PR TITLE
OCPBUGS-3450: Missing containerd and wicd service logs in Windows nodes

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
@@ -152,7 +152,7 @@ const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
   const isWindows = status?.nodeInfo?.operatingSystem === 'windows';
   const pathItems = ['journal'];
   isWindows
-    ? pathItems.push('containers', 'hybrid-overlay', 'kube-proxy', 'kubelet')
+    ? pathItems.push('containers', 'hybrid-overlay', 'kube-proxy', 'kubelet', 'containerd', 'wicd')
     : labels['node-role.kubernetes.io/master'] === '' &&
       pathItems.push('openshift-apiserver', 'kube-apiserver', 'oauth-apiserver');
   const pathQueryArgument = 'path';


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/OCPBUGS-3450

Analysis / Root cause:
The dropdown in the Logs tab for Windows nodes does not show the `containerd` and `wicd` services

Solution Description:
Added strings to the array pathItems, so that the corresponding paths for these services are available from the dropdown.