### PR TITLE
OCPBUGS-3372: Fix create silence error message adding response from the backend

### DIFF
--- a/frontend/public/components/monitoring/silence-form.tsx
+++ b/frontend/public/components/monitoring/silence-form.tsx
@@ -214,7 +214,11 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => 
         history.push(`${SilenceResource.plural}/${encodeURIComponent(silenceID)}`);
       })
       .catch((err) => {
-        setError(_.get(err, 'json.error') || err.message || 'Error saving Silence');
+        const errorMessage =
+          typeof _.get(err, 'json') === 'string'
+            ? _.get(err, 'json')
+            : err.message || 'Error saving Silence';
+        setError(errorMessage);
         setInProgress(false);
       });
   };


### PR DESCRIPTION
Fixes: 
https://issues.redhat.com/browse/OCPBUGS-3372

Cause:
The single string response from the backend was not considered as an error source

Solution:
display first the string response from the backend if available