### PR TITLE
OCPBUGS-7692: Fix that helm details page shows an inf. loading indicator when api call fails

### DIFF
--- a/frontend/packages/helm-plugin/src/components/details-page/HelmReleaseDetails.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/HelmReleaseDetails.tsx
@@ -13,7 +13,7 @@ import {
 } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { SecretModel } from '@console/internal/models';
-import { K8sResourceCommon, K8sResourceKindReference } from '@console/internal/module/k8s';
+import { K8sResourceKindReference, SecretKind } from '@console/internal/module/k8s';
 import { ActionMenu, ActionMenuVariant, Status, ActionServiceProvider } from '@console/shared';
 import { HelmRelease, HelmActionOrigins } from '../../types/helm-types';
 import { fetchHelmRelease, HelmReleaseStatusLabels, releaseStatus } from '../../utils/helm-utils';
@@ -29,49 +29,52 @@ interface HelmReleaseDetailsProps {
     ns?: string;
     name?: string;
   }>;
-  secret?: FirehoseResult;
+  secrets?: FirehoseResult<SecretKind[]>;
 }
 
 interface LoadedHelmReleaseDetailsProps extends HelmReleaseDetailsProps {
-  helmReleaseData: HelmRelease;
+  helmRelease: {
+    loaded: boolean;
+    loadError: Error;
+    data: HelmRelease;
+  };
 }
 
 export const LoadedHelmReleaseDetails: React.FC<LoadedHelmReleaseDetailsProps> = ({
   match,
-  secret,
-  helmReleaseData,
+  helmRelease,
+  secrets,
 }) => {
   const { t } = useTranslation();
   const namespace = match.params.ns;
-  if (!helmReleaseData || !secret || (!secret.loaded && _.isEmpty(secret.loadError))) {
+
+  if (helmRelease.loadError) {
+    return <StatusBox loadError={helmRelease.loadError} />;
+  }
+  if (helmRelease.loaded && secrets.loadError) {
+    return <StatusBox loadError={secrets.loadError} />;
+  }
+  if (!helmRelease.loaded || !secrets.loaded) {
     return <LoadingBox />;
   }
-
-  if (secret.loadError) {
-    return <StatusBox loaded={secret.loaded} loadError={secret.loadError} />;
+  if (!helmRelease.data || _.isEmpty(secrets.data)) {
+    return <ErrorPage404 />;
   }
 
-  const secretResources = secret.data;
+  const sortedSecrets = _.orderBy(secrets.data, (o) => Number(o.metadata.labels.version), 'desc');
 
-  if (_.isEmpty(secretResources)) return <ErrorPage404 />;
-
-  const sortedSecretResources = _.orderBy(
-    secretResources,
-    (o) => Number(o.metadata.labels.version),
-    'desc',
-  );
-
-  const latestReleaseSecret = sortedSecretResources[0];
-  const secretName = latestReleaseSecret?.metadata.name;
-  const releaseName = helmReleaseData?.name;
+  const releaseName = helmRelease.data?.name;
+  const latestReleaseSecret = sortedSecrets[0];
+  const latestSecretName = latestReleaseSecret?.metadata.name;
+  const latestSecretStatus = latestReleaseSecret?.metadata?.labels?.status;
 
   const title = (
     <>
       {releaseName}
       <Badge isRead style={{ verticalAlign: 'middle', marginLeft: 'var(--pf-global--spacer--md)' }}>
         <Status
-          status={releaseStatus(latestReleaseSecret?.metadata?.labels?.status)}
-          title={HelmReleaseStatusLabels[latestReleaseSecret?.metadata?.labels?.status]}
+          status={releaseStatus(latestSecretStatus)}
+          title={HelmReleaseStatusLabels[latestSecretStatus]}
         />
       </Badge>
     </>
@@ -81,8 +84,8 @@ export const LoadedHelmReleaseDetails: React.FC<LoadedHelmReleaseDetailsProps> =
     release: {
       name: releaseName,
       namespace,
-      version: helmReleaseData.version,
-      info: { status: latestReleaseSecret?.metadata?.labels?.status },
+      version: helmRelease.data?.version,
+      info: { status: latestSecretStatus },
     },
     actionOrigin: HelmActionOrigins.details,
   };
@@ -102,9 +105,9 @@ export const LoadedHelmReleaseDetails: React.FC<LoadedHelmReleaseDetailsProps> =
       kindObj={SecretModel}
       match={match}
       customActionMenu={customActionMenu}
-      name={secretName}
+      name={latestSecretName}
       namespace={namespace}
-      customData={helmReleaseData}
+      customData={helmRelease.data}
       breadcrumbsFor={() => [
         {
           name: t('helm-plugin~Helm Releases'),
@@ -142,47 +145,75 @@ const HelmReleaseDetails: React.FC<HelmReleaseDetailsProps> = ({ match }) => {
   const helmReleaseName = match.params.name;
 
   const [helmReleaseData, setHelmReleaseData] = React.useState<HelmRelease>();
+  const [helmReleaseError, setHelmReleaseError] = React.useState<Error>();
 
-  const [secrets, secretLoaded, secretLoaderror] = useK8sWatchResource<K8sResourceCommon[]>({
-    namespace,
-    groupVersionKind: {
-      version: 'v1',
-      kind: SecretModel.kind,
-    },
-    selector: { matchLabels: { name: `${helmReleaseData?.name}` } },
-    isList: true,
-  });
+  const [secrets, secretLoaded, secretLoadError] = useK8sWatchResource<SecretKind[]>(
+    helmReleaseData
+      ? {
+          namespace,
+          groupVersionKind: {
+            version: 'v1',
+            kind: SecretModel.kind,
+          },
+          selector: { matchLabels: { name: helmReleaseData.name } },
+          isList: true,
+        }
+      : {
+          isList: true,
+        },
+  );
+
   React.useEffect(() => {
-    let ignore = false;
+    let mounted = true;
 
     const getHelmRelease = async () => {
       try {
         const helmRelease = await fetchHelmRelease(namespace, helmReleaseName);
-        if (!ignore) {
+        if (mounted) {
           setHelmReleaseData(helmRelease);
         }
-        // eslint-disable-next-line no-empty
-      } catch {}
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.log('Error while loading helm release', err);
+        setHelmReleaseError(err);
+      }
     };
 
-    getHelmRelease();
+    // Implementation note: secretLoaded is initially true also when no helmReleaseData
+    // is available and NO SECRETS are yet loaded. See helmReleaseData condition above.
+    // It jumps to false when the data are loading... and back to true as soon as
+    // the initial or updated data are fetched.
+    // This if statement helps a little bit (there are still 2 calls) to reduce unneccessary API calls.
+    if (secretLoaded) {
+      getHelmRelease();
+    }
 
     return () => {
-      ignore = true;
+      mounted = false;
     };
     // On upgrading/rolling back to another version a new helm release is created.
-    // For fetching and showing the details of the new release adding secret.data as depedency here
-    // since secret's data list gets updated when a new release is created.
-  }, [helmReleaseName, namespace, secrets]);
+    // For fetching and showing the details of the new release adding secrets and
+    // secretLoaded as dependency here since they are updated when a new release is created.
+  }, [namespace, helmReleaseName, secrets, secretLoaded]);
 
-  const secret = {
-    data: secrets,
+  const helmRelease = {
+    loaded: !!(helmReleaseData || helmReleaseError),
+    loadError: helmReleaseError,
+    data: helmReleaseData,
+  };
+
+  const secretsFirehoseResult: FirehoseResult<SecretKind[]> = {
     loaded: secretLoaded,
-    loadError: secretLoaderror,
+    loadError: secretLoadError,
+    data: secrets,
   };
 
   return (
-    <LoadedHelmReleaseDetails match={match} secret={secret} helmReleaseData={helmReleaseData} />
+    <LoadedHelmReleaseDetails
+      match={match}
+      helmRelease={helmRelease}
+      secrets={secretsFirehoseResult}
+    />
   );
 };
 

--- a/frontend/packages/helm-plugin/src/components/details-page/__tests__/HelmReleaseDetails.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/__tests__/HelmReleaseDetails.spec.tsx
@@ -12,7 +12,7 @@ let loadedHelmReleaseDetailsProps: React.ComponentProps<typeof LoadedHelmRelease
 describe('HelmReleaseDetails', () => {
   beforeEach(() => {
     helmReleaseDetailsProps = {
-      secret: {
+      secrets: {
         data: [
           {
             metadata: {
@@ -42,21 +42,33 @@ describe('HelmReleaseDetails', () => {
 
     loadedHelmReleaseDetailsProps = {
       ...helmReleaseDetailsProps,
-      helmReleaseData: mockHelmReleases[0],
+      helmRelease: {
+        loaded: true,
+        loadError: null,
+        data: mockHelmReleases[0],
+      },
     };
   });
 
   it('should show the loading box if helm release data is not loaded', () => {
-    loadedHelmReleaseDetailsProps.helmReleaseData = null;
+    loadedHelmReleaseDetailsProps.helmRelease.loaded = false;
     const helmReleaseDetails = shallow(
       <LoadedHelmReleaseDetails {...loadedHelmReleaseDetailsProps} />,
     );
     expect(helmReleaseDetails.find(LoadingBox).exists()).toBe(true);
   });
 
+  it('should show an error if helm release data could not be loaded', () => {
+    loadedHelmReleaseDetailsProps.helmRelease.loadError = new Error('An error!');
+    const helmReleaseDetails = shallow(
+      <LoadedHelmReleaseDetails {...loadedHelmReleaseDetailsProps} />,
+    );
+    expect(helmReleaseDetails.find(StatusBox).exists()).toBe(true);
+  });
+
   it('should show the loading box if secret is not loaded', () => {
-    loadedHelmReleaseDetailsProps.secret.loaded = false;
-    loadedHelmReleaseDetailsProps.secret.loadError = undefined;
+    loadedHelmReleaseDetailsProps.secrets.loaded = false;
+    loadedHelmReleaseDetailsProps.secrets.loadError = undefined;
     const helmReleaseDetails = shallow(
       <LoadedHelmReleaseDetails {...loadedHelmReleaseDetailsProps} />,
     );
@@ -64,7 +76,7 @@ describe('HelmReleaseDetails', () => {
   });
 
   it('should show the status box if there is an error loading the secret', () => {
-    loadedHelmReleaseDetailsProps.secret.loadError = 'error 404';
+    loadedHelmReleaseDetailsProps.secrets.loadError = 'error 404';
     const helmReleaseDetails = shallow(
       <LoadedHelmReleaseDetails {...loadedHelmReleaseDetailsProps} />,
     );
@@ -79,7 +91,7 @@ describe('HelmReleaseDetails', () => {
   });
 
   it('should show the ErrorPage404 for an incorrect release name in the url', () => {
-    loadedHelmReleaseDetailsProps.secret.data = [];
+    loadedHelmReleaseDetailsProps.secrets.data = [];
     const helmReleaseDetails = shallow(
       <LoadedHelmReleaseDetails {...loadedHelmReleaseDetailsProps} />,
     );

--- a/frontend/packages/helm-plugin/src/utils/helm-utils.ts
+++ b/frontend/packages/helm-plugin/src/utils/helm-utils.ts
@@ -38,11 +38,15 @@ export const SelectedReleaseStatuses = [
 
 export const OtherReleaseStatuses = ['unknown', 'uninstalled', 'superseded', 'uninstalling'];
 
-export const releaseStatus = (status: string) =>
-  status
+export const releaseStatus = (status: string) => {
+  if (!status) {
+    return 'Unknown';
+  }
+  return status
     .split('-')
     .map((s) => toTitleCase(s))
     .join('');
+};
 
 export const releaseStatusReducer = (release: HelmRelease) => {
   if (OtherReleaseStatuses.includes(release.info.status)) {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-7692

**Analysis / Root cause**: 
When the helm/release API call fails, for some reason, the helm release data will be never set and the error is ignored. The page shows forever a loading indicator.

**Solution Description**: 
Added a new state for the helm release error.

**Screen shots / Gifs for design review**: 
Before:
![image](https://user-images.githubusercontent.com/139310/219663554-6f0c1648-8f69-418e-bc60-0cf92fe28ade.png)

With this PR:
![image](https://user-images.githubusercontent.com/139310/219663642-bdf423a0-b506-41d5-9c44-bac0d3870d86.png)

**Unit test coverage report**: 
Updated some tests, added one.

```
yarn test --maxWorkers=2  packages/helm-plugin/src/components/details-page/__tests__/*spec*
yarn run v1.22.15
$ LANG=en_US.UTF-8 jest --maxWorkers=2 packages/helm-plugin/src/components/details-page/__tests__/HelmReleaseDetailsPage.spec.tsx packages/helm-plugin/src/components/details-page/__tests__/HelmReleaseDetails.spec.tsx packages/helm-plugin/src/components/details-page/__tests__/HelmReleaseNotes.spec.tsx
 PASS  packages/helm-plugin/src/components/details-page/__tests__/HelmReleaseDetails.spec.tsx (22.075s)
 PASS  packages/helm-plugin/src/components/details-page/__tests__/HelmReleaseDetailsPage.spec.tsx (22.993s)
 PASS  packages/helm-plugin/src/components/details-page/__tests__/HelmReleaseNotes.spec.tsx (6.095s)

Test Suites: 3 passed, 3 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        31.262s
```

**Test setup:**
1. Test the helm chart from https://issues.redhat.com/browse/OCPBUGS-7692
2. Change the URL of the helm details page to a namespace or helm release that doesn't exist.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
