### PR TITLE
OCPBUGS-7308: remove 'Download kubeconfig file' from ServiceAccounts

### DIFF
--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1543,8 +1543,6 @@
   "Remove key/value": "Remove key/value",
   "Add key/value": "Add key/value",
   "Drag and drop file with your value here or browse to upload it.": "Drag and drop file with your value here or browse to upload it.",
-  "Download kubeconfig file": "Download kubeconfig file",
-  "Unable to get ServiceAccount token.": "Unable to get ServiceAccount token.",
   "ServiceAccount details": "ServiceAccount details",
   "ServiceAccounts": "ServiceAccounts",
   "Node port": "Node port",


### PR DESCRIPTION
This feature relied an an autogenerated secret that was removed in 4.11 (see https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html#ocp-4-11-legacy-service-account), so removing the feature fixes the bug.  I opened https://issues.redhat.com/browse/CONSOLE-3524 to add token creation to replace it based on a conversation I had with @spadgett regarding the complexity of the feature [1] and the need for design.

[1] tokens have an optional expiration duration and can be bound to a secret, so we'd likely want to account for this in our implementation