### PR TITLE
OCPBUGS-7970: always close filter dropdown

### DIFF
--- a/frontend/packages/integration-tests-cypress/views/list-page.ts
+++ b/frontend/packages/integration-tests-cypress/views/list-page.ts
@@ -57,6 +57,7 @@ export const listPage = {
       cy.get('.pf-c-toolbar__content-section').within(() => {
         cy.byLegacyTestID('filter-dropdown-toggle')
           .find('button')
+          .as('filterDropdownToggleButton')
           .click();
         /* PF Filter dropdown menu items are:
            <li id="cluster">
@@ -67,6 +68,7 @@ export const listPage = {
          */
         cy.get(`#${rowFilter}`).click(); // clicking on the <li /> works!
         cy.url().should('include', '?rowFilter');
+        cy.get('@filterDropdownToggleButton').click();
       });
     },
   },


### PR DESCRIPTION
In [QE Downstream automation](https://github.com/openshift/openshift-tests-private/pull/7801/files#diff-8dbeb3d3922e46b32811945361d25b2e2feb8d912c0eedaecf374c14d1af5efc), `listPage.filter.by` is also re-used and we'd better close the toggle dropdown every time it is opened so that it would be possible to filter twice or more in sequence 
```
listPage.filter.by('namespace');
listPage.filter.by('system');
```