### PR TITLE
OCPBUGS-7971: Monitoring: Fix "Label" filter on "Alerting rules" list page

### DIFF
--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -57,6 +57,14 @@ export const tableFilters: FilterMap = {
     return !!values.all.every((v) => labels.includes(v));
   },
 
+  'observe-rules': (values, rule: Rule) => {
+    if (!values.all) {
+      return true;
+    }
+    const labels = getLabelsAsString(rule, 'labels');
+    return !!values.all.every((v) => labels.includes(v));
+  },
+
   'observe-target-labels': (values, target: Target) =>
     !values.all || values.all.every((v) => getLabelsAsString(target, 'labels').includes(v)),
 

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -1901,7 +1901,8 @@ const RulesPage_: React.FC<{}> = () => {
       <div className="co-m-pane__body">
         <ListPageFilter
           data={staticData}
-          labelFilter="alerts"
+          labelFilter="observe-rules"
+          labelPath="labels"
           loaded={loaded}
           onFilterChange={onFilterChange}
           rowFilters={rowFilters}


### PR DESCRIPTION
The bug is fixed by adding the missing attribute `labelPath="labels"`.

Also added a separate `observe-rules` list filter to distinguish between the alerts filter and the alerting rules filter (although they happen to have the same logic).