### PR TITLE
CONSOLE-3659: Move favicon branding tags outside of 'if .CustomBrandName'

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -33,20 +33,19 @@
       <title>Azure Red Hat OpenShift</title>
       <meta name="application-name" content="Azure Red Hat OpenShift">
       [[ end ]]
-
-      [[ if eq .Branding "okd" ]]
-      <link rel="shortcut icon" href="<%= require('./imgs/okd-favicon.png') %>">
-      <link rel="apple-touch-icon-precomposed" sizes="144x144" href="<%= require('./imgs/okd-apple-touch-icon-precomposed.png') %>">
-      <link rel="mask-icon" href="<%= require('./imgs/okd-mask-icon.svg') %>" color="#DB242F">
-      <meta name="msapplication-TileColor" content="#000000">
-      <meta name="msapplication-TileImage" content="<%= require('./imgs/okd-mstile-144x144.png') %>">
-      [[ else ]]
-      <link rel="shortcut icon" href="<%= require('./imgs/openshift-favicon.png') %>">
-      <link rel="apple-touch-icon-precomposed" sizes="144x144" href="<%= require('./imgs/openshift-apple-touch-icon-precomposed.png') %>">
-      <link rel="mask-icon" href="<%= require('./imgs/openshift-mask-icon.svg') %>" color="#DB242F">
-      <meta name="msapplication-TileColor" content="#000000">
-      <meta name="msapplication-TileImage" content="<%= require('./imgs/openshift-mstile-144x144.png') %>">
-      [[ end ]]
+    [[ end ]]
+    [[ if eq .Branding "okd" ]]
+    <link rel="shortcut icon" href="<%= require('./imgs/okd-favicon.png') %>">
+    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="<%= require('./imgs/okd-apple-touch-icon-precomposed.png') %>">
+    <link rel="mask-icon" href="<%= require('./imgs/okd-mask-icon.svg') %>" color="#DB242F">
+    <meta name="msapplication-TileColor" content="#000000">
+    <meta name="msapplication-TileImage" content="<%= require('./imgs/okd-mstile-144x144.png') %>">
+    [[ else ]]
+    <link rel="shortcut icon" href="<%= require('./imgs/openshift-favicon.png') %>">
+    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="<%= require('./imgs/openshift-apple-touch-icon-precomposed.png') %>">
+    <link rel="mask-icon" href="<%= require('./imgs/openshift-mask-icon.svg') %>" color="#DB242F">
+    <meta name="msapplication-TileColor" content="#000000">
+    <meta name="msapplication-TileImage" content="<%= require('./imgs/openshift-mstile-144x144.png') %>">
     [[ end ]]
 
     <meta name="description" content="">


### PR DESCRIPTION
Issue is that when a custom product name is set, console favicon disapears with no way to set it back. This change fix that.
![image](https://user-images.githubusercontent.com/58644999/220878210-81a2a244-4759-45ed-bea2-95e7bf9b0663.png)
