### PR TITLE
OCPBUGS-7620: Edit Deployment (and DC) form doesn't enable Save button when changing strategy type

### DIFF
--- a/frontend/packages/dev-console/src/components/deployments/deployment-strategy/DeploymentStrategySection.tsx
+++ b/frontend/packages/dev-console/src/components/deployments/deployment-strategy/DeploymentStrategySection.tsx
@@ -34,7 +34,6 @@ const DeploymentStrategySection: React.FC<DeploymentStrategySectionProps> = ({
         deploymentStrategy,
       },
     },
-    initialValues,
     setFieldValue,
   } = useFormikContext<FormikValues>();
 
@@ -59,17 +58,9 @@ const DeploymentStrategySection: React.FC<DeploymentStrategySectionProps> = ({
         ..._.merge(strategyDefaultValues, deploymentStrategy),
         type: value,
       };
-      initialValues.formData.deploymentStrategy = strategyData;
       setFieldValue('formData.deploymentStrategy', strategyData);
     },
-    [
-      initialValues.formData.deploymentStrategy,
-      resName,
-      resNamespace,
-      resourceType,
-      setFieldValue,
-      deploymentStrategy,
-    ],
+    [resName, resNamespace, resourceType, setFieldValue, deploymentStrategy],
   );
 
   return (

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
@@ -26,13 +26,9 @@ const ImageStreamTagDropdown: React.FC<{
   const unmounted = React.useRef(false);
   let imageStreamTagList = {};
   const { values, setFieldValue, initialValues, touched } = useFormikContext<FormikValues>();
-  const {
-    name: resourceName,
-    imageStream,
-    application,
-    formType,
-    isi: { ports: isiPorts },
-  } = _.get(values, formContextField) || values;
+  const { name: resourceName, imageStream, application, formType, isi: isiValues } =
+    _.get(values, formContextField) || values;
+  const isiPorts = isiValues?.ports;
   const { imageStream: initialImageStream, route: initialRoute } =
     _.get(initialValues, formContextField) || initialValues;
   const fieldPrefix = formContextField ? `${formContextField}.` : '';
@@ -43,6 +39,7 @@ const ImageStreamTagDropdown: React.FC<{
   const isStreamsAvailable = isNamespaceSelected && hasImageStreams && !loading;
   const isTagsAvailable = isStreamsAvailable && !_.isEmpty(imageStreamTagList);
   const isImageStreamSelected = imageStream.image !== '';
+  const initialImageStreamImage = initialImageStream?.image;
 
   const searchImageTag = React.useCallback(
     (selectedTag: string) => {
@@ -129,7 +126,7 @@ const ImageStreamTagDropdown: React.FC<{
       initialRoute &&
       getIn(_.get(touched, `${fieldPrefix}imageStream`), 'image') &&
       !getIn(_.get(touched, `${fieldPrefix}route`), 'targetPort') &&
-      !_.isEqual(initialImageStream.image, imageStream.image)
+      !_.isEqual(initialImageStreamImage, imageStream.image)
     ) {
       const targetPort: ContainerPort = _.head(isiPorts);
       targetPort && setFieldValue(`${fieldPrefix}route.targetPort`, makePortName(targetPort));
@@ -141,7 +138,7 @@ const ImageStreamTagDropdown: React.FC<{
     setFieldValue,
     isiPorts,
     initialRoute,
-    initialImageStream.image,
+    initialImageStreamImage,
     fieldPrefix,
     touched,
   ]);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-7620

**Analysis / Root cause**: 
Initial Formik value is set to final formik value on change of dropdown items so the save button doesn't get enabled since there is no difference between initial & final formik value

**Solution Description**: 
Removed setting of initial formik value on change of dropdown item

**Screen shots / Gifs for design review**: 

--Before fix--

https://user-images.githubusercontent.com/122968482/221510829-d91dfd63-5302-4a74-a6b9-d0e4592c9327.mp4

\
--After fix--
  
https://user-images.githubusercontent.com/122968482/221510842-24baacca-282f-4a77-9c7d-6ad5b267f0fe.mp4

\
**Unit test coverage report**: 
NA

**Test setup:**
1. go to developer's perspective
2. create deployment or deployment config
3. click on edit deployment or deployment config
4. change deployment strategy type

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge