### PR TITLE
OCPBUGS-7632: fix issue where project deletion fails

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-uninstall.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-uninstall.spec.ts
@@ -65,6 +65,9 @@ describe(`Testing uninstall of ${testOperator.name} Operator`, () => {
   });
 
   after(() => {
+    cy.visit('/');
+    nav.sidenav.switcher.changePerspectiveTo('Administrator');
+    nav.sidenav.switcher.shouldHaveText('Administrator');
     cy.deleteProject(testName);
     cy.logout();
   });


### PR DESCRIPTION
The only thing I can get to reproduce locally is project deletion, so adding a workaround fix for that.