### PR TITLE
OU-117: No response for duplicate query with default disabled status when click 'Hide all queries'

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -247,7 +247,13 @@ const QueryKebab: React.FC<{ index: number }> = ({ index }) => {
     <DropdownItem key="toggle-query" component="button" onClick={toggleIsEnabled}>
       {isEnabled ? t('public~Disable query') : t('public~Enable query')}
     </DropdownItem>,
-    <DropdownItem key="toggle-all-series" component="button" onClick={toggleAllSeries}>
+    <DropdownItem
+      tooltip={!isEnabled ? t('Query must be enabled') : undefined}
+      isDisabled={!isEnabled}
+      key="toggle-all-series"
+      component="button"
+      onClick={toggleAllSeries}
+    >
       {isDisabledSeriesEmpty ? t('public~Hide all series') : t('public~Show all series')}
     </DropdownItem>,
     <DropdownItem key="delete" component="button" onClick={doDelete}>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1033,6 +1033,7 @@
   "Hide series": "Hide series",
   "Disable query": "Disable query",
   "Enable query": "Enable query",
+  "Query must be enabled": "Query must be enabled",
   "Hide all series": "Hide all series",
   "Show all series": "Show all series",
   "Delete query": "Delete query",


### PR DESCRIPTION
**Related:** 
[OU-117](https://issues.redhat.com/browse/OU-117)

**Summary** 
The Observe > Metrics > Query Kebab contains a toggling DropDownItem named 'Hide all queries/Show all queries'. Users must enable the query to use this feature. To make this clearer to the user, this PR disables the 'Hide all queries/Show all queries' DropDownItem if the query is disabled and renders a tooltip. 

**Before:** 
The duplicate query is disabled and clicking 'Hide all queries' results in nothing happening. 
<img width="1137" alt="OU117-Before" src="https://user-images.githubusercontent.com/59589720/222562158-9f522807-7730-4849-99da-bbba18f010bb.png">

**After:** 
The duplicate query shows a tooltip, 'Query must be enabled', when the user hovers over the option 'Hide all queries'.
<img width="1123" alt="OU117-After" src="https://user-images.githubusercontent.com/59589720/222562187-6fc4dbed-46b5-4e12-8d1b-5433b29739b1.png">

**Demo:** 
https://user-images.githubusercontent.com/59589720/222566408-0b73ce69-02c8-439a-893d-65f0ad0db93b.mov

**Testing:** 
1. Navigate to page Observe->Metrics
2. Click 'Insert example query'
3. Click the icon 'Vertical three dots' -> click 'Duplicate query'. The duplicate query will be disabled by default. 
4. Go to the duplicate query. Click the icon 'Vertical three dots' -> hover over 'Hide all queries'.  The dropDropItem 'Hide all queries' should be disabled and render a tooltip 'Query must be enabled'.

