### PR TITLE
OCPBUGS-7801: taskrun ui fails when using object type results

### DIFF
--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/render-utils.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/render-utils.spec.tsx
@@ -6,11 +6,11 @@ import { handleURLs, GROUP_MATCH_REGEXP } from '../render-utils';
 describe('handleURLs', () => {
   it('should return the same value if it is not a string', () => {
     // We will only likely get strings, but it shouldn't break/NPE if they are not
-    expect(handleURLs(null)).toBe(null);
+    expect(handleURLs(null)).toBe('null');
     expect(handleURLs(undefined)).toBe(undefined);
-    expect(handleURLs(true as any)).toBe(true);
+    expect(handleURLs(true as any)).toBe('true');
     const v = {};
-    expect(handleURLs(v as any)).toBe(v);
+    expect(handleURLs(v as any)).toBe('{}');
   });
 
   it('should not do anything if there are no URLs in the string', () => {

--- a/frontend/packages/pipelines-plugin/src/utils/render-utils.tsx
+++ b/frontend/packages/pipelines-plugin/src/utils/render-utils.tsx
@@ -7,7 +7,7 @@ const URL_REGEXP = /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-
 export const GROUP_MATCH_REGEXP = new RegExp(`^(.*\\s)?(${URL_REGEXP.source})(\\s.*)?$`, 'i');
 
 export const handleURLs = (value: string): React.ReactNode => {
-  if (typeof value !== 'string') return value;
+  if (typeof value !== 'string') return JSON.stringify(value, null, 2);
 
   const matches = value.match(GROUP_MATCH_REGEXP);
   const [, prefix, link, suffix] = matches || [];


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-7801

**Analysis / Root cause:**
Formatting of value is not added

**Solution Description:**
Added JSON.strinfy for value if type of value is not string

**Screen shots / Gifs for design review:**

----Array -- Before----

<img width="924" alt="Screenshot 2023-03-07 at 4 46 30 PM" src="https://user-images.githubusercontent.com/102503482/223407757-ea5219d5-5fb3-4eb1-8600-e59e14b514d6.png">


----Array -- After----

<img width="953" alt="Screenshot 2023-03-07 at 4 45 45 PM" src="https://user-images.githubusercontent.com/102503482/223407805-ad41f220-9fa3-4164-ad16-af2f7509465c.png">

----object -- Before----
<img width="925" alt="Screenshot 2023-03-07 at 4 46 41 PM" src="https://user-images.githubusercontent.com/102503482/223407988-79edceea-e1a6-4fc5-a2de-7c0ddb6de661.png">


----object -- After----



<img width="816" alt="Screenshot 2023-03-07 at 4 46 01 PM" src="https://user-images.githubusercontent.com/102503482/223407790-bcdc3ef8-4eaf-47c0-9c7f-601b4f65bc12.png">




****Unit test coverage report:****
NA

**Test setup:**
TaskRun for object type:

```
apiVersion: tekton.dev/v1beta1
kind: TaskRun
metadata:
  generateName: example-task
spec:
  taskSpec:
    results:
      - description: The object results
        name: object-results
        properties:
          name:
            type: string
        type: object
    steps:
      - image: 'bash:latest'
        name: write-object
        resources: {}
        script: >
          #!/usr/bin/env bash

          echo -n "{\"name\":\"hello joe\"}" | tee
          $(results.object-results.path)    
```    

TaskRun for array type:

```
apiVersion: tekton.dev/v1beta1
kind: TaskRun
metadata:
  generateName: array-example
spec:
  taskSpec:
    results:
      - description: The array results
        name: array-results
        type: array
    steps:
      - image: 'bash:latest'
        name: write-array
        resources: {}
        script: >
          #!/usr/bin/env bash

          echo -n "[\"hello\", \"joe\"]" | tee
          $(results.array-results.path) 
```

1. create TaskRuns using above YAML's
2. Go to TaskRun List page
3. Click on TaskRun to see details

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
