### PR TITLE
[release-4.11] OCPBUGS-4496: Fix Sample/Snippet tab when creating a new resource

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-deployment/EditDeploymentForm.tsx
+++ b/frontend/packages/dev-console/src/components/edit-deployment/EditDeploymentForm.tsx
@@ -57,7 +57,7 @@ const EditDeploymentForm: React.FC<FormikProps<FormikValues> & {
     <YAMLEditorField
       name="yamlData"
       model={resourceType === Resources.OpenShift ? DeploymentConfigModel : DeploymentModel}
-      showSamples={!resource}
+      showSamples={isNew}
       onSave={handleSubmit}
     />
   );


### PR DESCRIPTION
When creating/editing a resource a Sample/Snippet tab may appear, if a correct `ConsoleYAMLSample` was previously applied to a cluster.

The original logic was incorrect, since the Samples tab should show up if a NEW resource is being created.

The logic on showing Samples/Snippets tabs should be as follows(`sample` is a ConsoleYAMLSample resource without the `snippet: true`; snippet is a ConsoleYAMLSample resource with the `snippet: true`):

no sample  && no snippet -> no tabs
no sample && snippet       -> snippet tab when editing
		  			        snippet tab when creating				
sample && no snippet       -> sample tab when creating
					        no sample tab when editing				
sample && snippet            -> sample and snippet tab when creating
				                only snippet tab when editing