### PR TITLE
OCPBUGS-8268: OpenShift pipeline TaskRun(s) column Duration is not present as column in UI

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsHeader.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsHeader.tsx
@@ -55,8 +55,15 @@ const TaskRunsHeader = (showPipelineColumn: boolean = true) => () => {
       id: 'started',
     },
     {
-      title: '',
+      title: i18next.t('pipelines-plugin~Duration'),
+      sortField: 'status.completionTime',
+      transforms: [sortable],
       props: { className: tableColumnClasses[7] },
+      id: 'duration',
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[8] },
     },
   ].filter((item) => !(item.id === 'pipeline' && !showPipelineColumn));
 };

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
@@ -7,6 +7,7 @@ import { TaskRunKind } from '../../../types';
 import { getTaskRunKebabActions } from '../../../utils/pipeline-actions';
 import { getModelReferenceFromTaskKind } from '../../../utils/pipeline-augment';
 import { taskRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
+import { pipelineRunDuration } from '../../../utils/pipeline-utils';
 import { TektonResourceLabel } from '../../pipelines/const';
 import TaskRunStatus from '../status/TaskRunStatus';
 import { tableColumnClasses } from './taskruns-table';
@@ -65,7 +66,8 @@ const TaskRunsRow: React.FC<RowFunctionArgs<TaskRunKind>> = ({ obj, customData }
     <TableData className={tableColumnClasses[6]}>
       <Timestamp timestamp={obj?.status?.startTime} />
     </TableData>
-    <TableData className={tableColumnClasses[7]}>
+    <TableData className={tableColumnClasses[7]}>{pipelineRunDuration(obj)}</TableData>
+    <TableData className={tableColumnClasses[8]}>
       <ResourceKebab actions={getTaskRunKebabActions()} kind={taskRunsReference} resource={obj} />
     </TableData>
   </>

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/__tests__/TaskRunsRow.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/__tests__/TaskRunsRow.spec.tsx
@@ -39,7 +39,7 @@ describe('TaskRunsRow', () => {
 
   it('should show the pipeline column', () => {
     const wrapper = shallow(<TaskRunsRow {...taskRunsData} />);
-    expect(wrapper.find(TableData)).toHaveLength(8);
+    expect(wrapper.find(TableData)).toHaveLength(9);
   });
 
   it('should render proper data', () => {
@@ -61,6 +61,6 @@ describe('TaskRunsRow', () => {
   it('should not show the pipeline column', () => {
     taskRunsData.customData.showPipelineColumn = false;
     const wrapper = shallow(<TaskRunsRow {...taskRunsData} />);
-    expect(wrapper.find(TableData)).toHaveLength(7);
+    expect(wrapper.find(TableData)).toHaveLength(8);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/taskruns-table.ts
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/taskruns-table.ts
@@ -8,5 +8,6 @@ export const tableColumnClasses = [
   'pf-m-hidden pf-m-visible-on-sm', // pod
   'pf-m-hidden pf-m-visible-on-sm', // status
   'pf-m-hidden pf-m-visible-on-sm', // started
+  'pf-m-hidden pf-m-visible-on-sm', // duration
   Kebab.columnClass,
 ];


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-8268

**Analysis / Root cause**: 
PipelineRun has a Duration column and inside it, TaskRun - doesn't

**Solution Description**: 
Added Duration Column to TaskRun

**Screenshots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/47265560/224120293-75cd1a71-dddb-4800-a717-214ef36f20b7.png)


**Unit test coverage report**: 
Fixed.

**Test setup:**
1. Once PipelineRun is invoked - navigate to invoked TaskRuns
2. You will see there columns like Status, and Started, but no Duration



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge