### PR TITLE
OCPBUGS-10269: Fix grammatical error in feedback modal

### DIFF
--- a/frontend/public/components/feedback-local.jsx
+++ b/frontend/public/components/feedback-local.jsx
@@ -24,7 +24,7 @@ export function useFeedbackLocal(reportBug) {
     enterFeedback: t('public~Enter your feedback'),
     feedback: t('public~Feedback'),
     feedbackSent: t('public~Feedback Sent'),
-    helpUsImproveHCC: t('public~Help us improve the Red Hat OpenShift.'),
+    helpUsImproveHCC: t('public~Help us improve Red Hat OpenShift.'),
     howIsConsoleExperience: t('public~What has your experience been like so far?'),
     joinMailingList: t('public~Join mailing list'),
     informDirectionDescription: t(

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -553,7 +553,7 @@
   "Enter your feedback": "Enter your feedback",
   "Feedback": "Feedback",
   "Feedback Sent": "Feedback Sent",
-  "Help us improve the Red Hat OpenShift.": "Help us improve the Red Hat OpenShift.",
+  "Help us improve Red Hat OpenShift.": "Help us improve Red Hat OpenShift.",
   "What has your experience been like so far?": "What has your experience been like so far?",
   "Join mailing list": "Join mailing list",
   "By participating in feedback sessions, usability tests, and interviews with our": "By participating in feedback sessions, usability tests, and interviews with our",


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-10269
Removes a "the" that isn't needed.