### PR TITLE
OCPBUGS-6581: Serverless - Eventing - Channels: Conditions column i18n misses

### DIFF
--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -193,6 +193,7 @@
   "Ready": "Ready",
   "Conditions": "Conditions",
   "Created": "Created",
+  "{{OKcount}} OK / {{conditionsSize}}": "{{OKcount}} OK / {{conditionsSize}}",
   "Subscriber": "Subscriber",
   "Filters": "Filters",
   "There is an existing placeholder Service with name {{name}} in namespace {{namespace}}. Please provide another name": "There is an existing placeholder Service with name {{name}} in namespace {{namespace}}. Please provide another name",

--- a/frontend/packages/knative-plugin/locales/zh/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/zh/knative-plugin.json
@@ -276,5 +276,6 @@
   "Knative Services": "Knative 服务",
   "All Revisions are autoscaled to 0.": "所有修订版本都将自动缩放到 0。",
   "No Source found for this resource.": "没有找到此资源的源。",
-  "Domain mappings": "域映射"
+  "Domain mappings": "域映射",
+  "{{OKcount}} OK / {{conditionsSize}}": "{{OKcount}}个 OK(共{{conditionsSize}}个)"
 }

--- a/frontend/packages/knative-plugin/locales/zh/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/zh/knative-plugin.json
@@ -276,6 +276,5 @@
   "Knative Services": "Knative 服务",
   "All Revisions are autoscaled to 0.": "所有修订版本都将自动缩放到 0。",
   "No Source found for this resource.": "没有找到此资源的源。",
-  "Domain mappings": "域映射",
-  "{{OKcount}} OK / {{conditionsSize}}": "{{OKcount}}个 OK(共{{conditionsSize}}个)"
+  "Domain mappings": "域映射"
 }

--- a/frontend/packages/knative-plugin/src/components/eventing/channels-list/ChannelRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/eventing/channels-list/ChannelRow.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
 import { Kebab, ResourceKebab, ResourceLink, Timestamp } from '@console/internal/components/utils';
 import { NamespaceModel } from '@console/internal/models';
 import { referenceFor } from '@console/internal/module/k8s';
 import { EventChannelKind, ChannelConditionTypes } from '../../../types';
-import { getCondition, getConditionString } from '../../../utils/condition-utils';
+import { getCondition, getConditionStats } from '../../../utils/condition-utils';
 import { getDynamicChannelModel } from '../../../utils/fetch-dynamic-eventsources-utils';
 
 const ChannelRow: React.FC<RowFunctionArgs<EventChannelKind>> = ({ obj }) => {
   const {
     metadata: { name, namespace, creationTimestamp, uid },
   } = obj;
+  const { t } = useTranslation();
   const objReference = referenceFor(obj);
   const kind = getDynamicChannelModel(objReference);
   const menuActions = [...Kebab.getExtensionsActionsForKind(kind), ...Kebab.factory.common];
@@ -27,7 +29,12 @@ const ChannelRow: React.FC<RowFunctionArgs<EventChannelKind>> = ({ obj }) => {
       </TableData>
       <TableData columnID="ready">{(readyCondition && readyCondition.status) || '-'}</TableData>
       <TableData columnID="condition">
-        {obj.status ? getConditionString(obj.status.conditions) : '-'}
+        {obj.status
+          ? t(
+              'knative-plugin~{{OKcount}} OK / {{conditionsSize}}',
+              getConditionStats(obj.status.conditions),
+            )
+          : '-'}
       </TableData>
       <TableData>{kind.label}</TableData>
       <TableData>

--- a/frontend/packages/knative-plugin/src/components/eventing/channels-list/ChannelRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/eventing/channels-list/ChannelRow.tsx
@@ -1,18 +1,16 @@
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
 import { Kebab, ResourceKebab, ResourceLink, Timestamp } from '@console/internal/components/utils';
 import { NamespaceModel } from '@console/internal/models';
 import { referenceFor } from '@console/internal/module/k8s';
 import { EventChannelKind, ChannelConditionTypes } from '../../../types';
-import { getCondition, getConditionStats } from '../../../utils/condition-utils';
+import { getCondition, getConditionString } from '../../../utils/condition-utils';
 import { getDynamicChannelModel } from '../../../utils/fetch-dynamic-eventsources-utils';
 
 const ChannelRow: React.FC<RowFunctionArgs<EventChannelKind>> = ({ obj }) => {
   const {
     metadata: { name, namespace, creationTimestamp, uid },
   } = obj;
-  const { t } = useTranslation();
   const objReference = referenceFor(obj);
   const kind = getDynamicChannelModel(objReference);
   const menuActions = [...Kebab.getExtensionsActionsForKind(kind), ...Kebab.factory.common];
@@ -29,12 +27,7 @@ const ChannelRow: React.FC<RowFunctionArgs<EventChannelKind>> = ({ obj }) => {
       </TableData>
       <TableData columnID="ready">{(readyCondition && readyCondition.status) || '-'}</TableData>
       <TableData columnID="condition">
-        {obj.status
-          ? t(
-              'knative-plugin~{{OKcount}} OK / {{conditionsSize}}',
-              getConditionStats(obj.status.conditions),
-            )
-          : '-'}
+        {obj.status ? getConditionString(obj.status.conditions) : '-'}
       </TableData>
       <TableData>{kind.label}</TableData>
       <TableData>

--- a/frontend/packages/knative-plugin/src/utils/condition-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/condition-utils.ts
@@ -7,6 +7,15 @@ export const getConditionOKCount = (conditions: K8sResourceCondition[]): number 
 export const getConditionString = (conditions: K8sResourceCondition[]): string =>
   `${getConditionOKCount(conditions)} OK / ${_.size(conditions)}`;
 
+export const getConditionStats = (
+  conditions: K8sResourceCondition[],
+): { OKcount: number; conditionsSize: number } => {
+  return {
+    OKcount: getConditionOKCount(conditions),
+    conditionsSize: _.size(conditions),
+  };
+};
+
 export const getCondition = (
   conditions: K8sResourceCondition[],
   type: K8sResourceCondition['type'],

--- a/frontend/packages/knative-plugin/src/utils/condition-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/condition-utils.ts
@@ -7,15 +7,6 @@ export const getConditionOKCount = (conditions: K8sResourceCondition[]): number 
 export const getConditionString = (conditions: K8sResourceCondition[]): string =>
   `${getConditionOKCount(conditions)} OK / ${_.size(conditions)}`;
 
-export const getConditionStats = (
-  conditions: K8sResourceCondition[],
-): { OKcount: number; conditionsSize: number } => {
-  return {
-    OKcount: getConditionOKCount(conditions),
-    conditionsSize: _.size(conditions),
-  };
-};
-
 export const getCondition = (
   conditions: K8sResourceCondition[],
   type: K8sResourceCondition['type'],

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1968,11 +1968,6 @@
   "HTTP GET": "HTTP GET",
   "TCP socket (port)": "TCP socket (port)",
   "Default pull Secret_plural": "Default pull Secret_plural",
-  "Loading {{title}} status": "Loading {{title}} status",
-  "Disable": "Disable",
-  "default": "default",
-  "Disabled": "Disabled",
-  "Enabled": "Enabled",
   "Are you sure you want to remove <1>{{label}}</1> from navigation?": "Are you sure you want to remove <1>{{label}}</1> from navigation?",
   "Refer to your cluster administrator to know which network provider is used.": "Refer to your cluster administrator to know which network provider is used.",
   "Input error: selectors must start and end by a letter or number, and can only contain -, _, / or . Offending value: {{offendingSelector}}": "Input error: selectors must start and end by a letter or number, and can only contain -, _, / or . Offending value: {{offendingSelector}}",
@@ -1992,5 +1987,10 @@
   "No log files exist": "No log files exist",
   "Select a log file above": "Select a log file above",
   "Filter by unit": "Filter by unit",
-  "Unit": "Unit"
+  "Unit": "Unit",
+  "Loading {{title}} status": "Loading {{title}} status",
+  "Disable": "Disable",
+  "default": "default",
+  "Disabled": "Disabled",
+  "Enabled": "Enabled"
 }

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1968,6 +1968,11 @@
   "HTTP GET": "HTTP GET",
   "TCP socket (port)": "TCP socket (port)",
   "Default pull Secret_plural": "Default pull Secret_plural",
+  "Loading {{title}} status": "Loading {{title}} status",
+  "Disable": "Disable",
+  "default": "default",
+  "Disabled": "Disabled",
+  "Enabled": "Enabled",
   "Are you sure you want to remove <1>{{label}}</1> from navigation?": "Are you sure you want to remove <1>{{label}}</1> from navigation?",
   "Refer to your cluster administrator to know which network provider is used.": "Refer to your cluster administrator to know which network provider is used.",
   "Input error: selectors must start and end by a letter or number, and can only contain -, _, / or . Offending value: {{offendingSelector}}": "Input error: selectors must start and end by a letter or number, and can only contain -, _, / or . Offending value: {{offendingSelector}}",
@@ -1987,10 +1992,5 @@
   "No log files exist": "No log files exist",
   "Select a log file above": "Select a log file above",
   "Filter by unit": "Filter by unit",
-  "Unit": "Unit",
-  "Loading {{title}} status": "Loading {{title}} status",
-  "Disable": "Disable",
-  "default": "default",
-  "Disabled": "Disabled",
-  "Enabled": "Enabled"
+  "Unit": "Unit"
 }


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-6581

Restructured  `getConditionString` utils method to `getConditionStats` so that it returns only the numbers making up the string, as they can change dynamically. The string is then constructed inside the react component as it needs to be translated with `useTranslation` hook.

result
<img width="1437" alt="Screenshot 2023-03-13 at 14 49 34" src="https://user-images.githubusercontent.com/49416557/224721559-a1daa8b7-4c9d-4ffe-a4f6-ac927d6ff04e.png">
