### PR TITLE
OCPBUGS-4496: Fix Samples/Snippets tab

### DIFF
--- a/frontend/packages/dev-console/src/components/deployments/DeploymentForm.tsx
+++ b/frontend/packages/dev-console/src/components/deployments/DeploymentForm.tsx
@@ -52,7 +52,7 @@ const EditDeploymentForm: React.FC<FormikProps<FormikValues> & {
     <YAMLEditorField
       name="yamlData"
       model={resourceType === Resources.OpenShift ? DeploymentConfigModel : DeploymentModel}
-      showSamples={!resource}
+      showSamples={isNew}
       onSave={handleSubmit}
     />
   );


### PR DESCRIPTION
When creating/editing a resource a Sample/Snippet tab may appear, if a correct `ConsoleYAMLSample` was previously applied to a cluster.

The logic on showing Samples/Snippets tabs should be as follows(sample is a ConsoleYAMLSample resource without the snippet: true; snippet is a ConsoleYAMLSample resource with the snippet: true):

no sample && no snippet -> no tabs
no sample && snippet -> snippet tab when editing and tab when creating
sample && no snippet -> sample tab when creating and sample tab when editing
sample && snippet -> sample and snippet tab when creating and snippet tab when editing