### PR TITLE
OCPBUGS-3403: Fix resource table sorting crash

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
@@ -150,12 +150,10 @@ export const linkForCsvResource = (
     <ResourceLink kind={obj.kind} name={obj.metadata.name} namespace={obj.metadata.namespace} />
   );
 
-type ResourcesPageRouteParams = RouteParams<'plural'>;
-
 export const Resources: React.FC<ResourcesProps> = (props) => {
   const { t } = useTranslation();
-  const { plural } = useParams<ResourcesPageRouteParams>();
-  const providedAPI = providedAPIForReference(props.csv, plural);
+  const { plural } = useParams();
+  const providedAPI = providedAPIForReference(props.customData, plural);
 
   const firehoseResources = (providedAPI?.resources ?? DEFAULT_RESOURCES).map(
     ({ name, kind, version }): FirehoseResource => {
@@ -203,7 +201,7 @@ export const Resources: React.FC<ResourcesProps> = (props) => {
 
 export type ResourcesProps = {
   obj: K8sResourceKind;
-  csv: ClusterServiceVersionKind;
+  customData: any;
 };
 
 export type ResourceListProps = {};

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -319,7 +319,7 @@ describe('ResourcesList', () => {
   const routePath = `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/:plural/:name`;
   it('uses the resources defined in the CSV', () => {
     const wrapper = mountWithRoute(
-      <Resources csv={testClusterServiceVersion} obj={testResourceInstance} />,
+      <Resources customData={testClusterServiceVersion} obj={testResourceInstance} />,
       currentURL,
       routePath,
     );
@@ -333,7 +333,7 @@ describe('ResourcesList', () => {
 
   it('uses the default resources if the kind is not found in the CSV', () => {
     const wrapper = mountWithRoute(
-      <Resources csv={null} obj={testResourceInstance} />,
+      <Resources customData={null} obj={testResourceInstance} />,
       currentURL,
       routePath,
     );
@@ -416,7 +416,7 @@ describe(OperandDetailsPage.displayName, () => {
 
   it('passes `flatten` function to Resources component which returns only objects with `ownerReferences` to each other or parent object', () => {
     const wrapper = mountWithRoute(
-      <Resources csv={testClusterServiceVersion} obj={testResourceInstance} />,
+      <Resources customData={testClusterServiceVersion} obj={testResourceInstance} />,
       currentURL,
       routePath,
     );

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -756,6 +756,7 @@ const DefaultOperandDetailsPage = ({ k8sModel }: DefaultOperandDetailsPageProps)
       name={name}
       kind={plural}
       namespace={ns}
+      customData={csv}
       resources={[
         {
           kind: CustomResourceDefinitionModel.kind,
@@ -787,7 +788,7 @@ const DefaultOperandDetailsPage = ({ k8sModel }: DefaultOperandDetailsPageProps)
           // t('olm~Resources')
           nameKey: 'olm~Resources',
           href: 'resources',
-          component: (props) => <Resources {...props} csv={csv} />,
+          component: Resources,
         },
         navFactory.events(ResourceEventStream),
       ]}
@@ -888,7 +889,7 @@ export type OperandDetailsProps = {
   crd: CustomResourceDefinitionKind;
 };
 
-type DefaultOperandDetailsPageProps = { k8sModel: K8sModel };
+type DefaultOperandDetailsPageProps = { customData: any; k8sModel: K8sModel };
 
 export type OperandResourceDetailsProps = {
   csv?: { data: ClusterServiceVersionKind };


### PR DESCRIPTION
Fixes an issue with sorting Operator resources. The root cause was [passing an inline React component instead of passing the csv prop directly through `customData` prop](https://github.com/openshift/console/commit/48569e73bf62f28fcc5c4da57df7e0dd25d5615d#r104263249).

https://issues.redhat.com/browse/OCPBUGS-3403

