### PR TITLE
OCPBUGS-7484: When there are 2 pipelines displayed in the dropdown menu, selecting one, unchecks the Add Pipeline checkbox

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/PipelineTemplate.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/PipelineTemplate.tsx
@@ -56,6 +56,7 @@ const PipelineTemplate: React.FC<PipelineTemplateProps> = ({ builderImages, exis
   const { t } = useTranslation();
   const [noTemplateForRuntime, setNoTemplateForRuntime] = React.useState(false);
   const [isPacRepo, setIsPacRepo] = React.useState(false);
+  const [isPipelineTypeChanged, setIsPipelineTypeChanged] = React.useState(false);
   const [isExpanded, setIsExpanded] = React.useState(false);
   const [pipelineTemplates, setPipelineTemplates] = React.useState([]);
   const pipelineStorageRef = React.useRef<{ [image: string]: PipelineKind[] }>({});
@@ -95,6 +96,7 @@ const PipelineTemplate: React.FC<PipelineTemplateProps> = ({ builderImages, exis
       setFieldValue('pipeline.enabled', false);
       setFieldValue('pipeline.type', PipelineType.PIPELINE);
     }
+    setIsPipelineTypeChanged(true);
   }, [url, type, ref, dir, secretResource, isRepositoryEnabled, setFieldValue]);
 
   React.useEffect(() => {
@@ -165,7 +167,7 @@ const PipelineTemplate: React.FC<PipelineTemplateProps> = ({ builderImages, exis
     };
 
     fetchPipelineTemplate();
-    if (!isPipelineAttached) {
+    if (!isPipelineAttached && !isPipelineTypeChanged) {
       handlePipelineTypeChange();
     }
     return () => {
@@ -183,6 +185,7 @@ const PipelineTemplate: React.FC<PipelineTemplateProps> = ({ builderImages, exis
     existingPipeline,
     handlePipelineTypeChange,
     isServerlessFunctionStrategy,
+    isPipelineTypeChanged,
   ]);
 
   const pipelineTemplateItems = React.useMemo(() => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-7484

**Analysis / Root cause**: 
function handlePipelineTypeChange was being used multiple times causing a reset in state of pipeline checkbox

**Solution Description**: 
restricted calling of the function so as to prevent resetting of checkbox

**Screen shots / Gifs for design review**: 

--Before fix--

https://user-images.githubusercontent.com/122968482/225061801-c185c033-9384-40c6-9dad-defde580bce6.mp4

\
--After fix--

https://user-images.githubusercontent.com/122968482/225062334-dd81d606-4cd8-4870-b0dc-cd02365c9a20.mp4

\
**Unit test coverage report**: 
NA

**Test setup:**
1. Go to the Git Import Page. Create the application with Add Pipelines checked and a pipeline selected.
2. Go to the Serverless Function Page. Select Add Pipelines checkbox and try to select a pipeline from the drop-down. 

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge