### PR TITLE
OCPBUGS-9214: Create button is disabled in Git Import form when git repo url has hyphens in owner part of the url

### DIFF
--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -297,7 +297,7 @@
   "Set minAvailable to 25%": "Set minAvailable to 25%",
   "An eviction is allowed if at least 25% of pods selected by \"selector\" will still be available after the eviction.": "An eviction is allowed if at least 25% of pods selected by \"selector\" will still be available after the eviction.",
   "Helm Release": "Helm Release",
-  "Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.": "Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.",
+  "Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.": "Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.",
   "Cannot be longer than {{characterCount}} characters.": "Cannot be longer than {{characterCount}} characters.",
   "Required": "Required"
 }

--- a/frontend/packages/console-shared/src/utils/__tests__/yup-validations.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/yup-validations.spec.ts
@@ -2,18 +2,31 @@ import { nameRegex } from '../yup-validations';
 
 describe('nameRegex', () => {
   it('should match valid resource names', () => {
-    const validNames = ['appname', 'app-name', 'app-name123', 'app-name123-app'];
+    const validNames = [
+      'appname',
+      'app-name',
+      'app-name123',
+      'app-name123-app',
+      'app--name',
+      'app-name.1',
+      'app.name.1',
+      'app-name-1',
+      '4appname',
+    ];
     validNames.forEach((name) => expect(name).toMatch(nameRegex));
   });
 
   it('should not match invalid resource names', () => {
     const invalidNames = [
       'AppName',
-      '4appname',
       '-app-name',
       'app$name!',
       'app name',
-      'app--name',
+      'app.-name',
+      'app-.name',
+      'app..name',
+      'app-name-',
+      'app.name.',
       '',
       '-',
     ];

--- a/frontend/packages/console-shared/src/utils/yup-validations.ts
+++ b/frontend/packages/console-shared/src/utils/yup-validations.ts
@@ -1,13 +1,15 @@
 import { TFunction } from 'i18next';
 import * as yup from 'yup';
 
-export const nameRegex = /^[a-z]([a-z0-9]-?)*[a-z0-9]$/;
+// eslint-disable-next-line no-useless-escape
+export const nameRegex = /^[a-z0-9](?!.*\.\.)(?!.*-\.)(?!.*\.-)[a-z0-9\.-]*[a-z0-9]$/;
+export const resourceNameRegex = /^[a-z]([a-z0-9-]?)*[a-z0-9]$/;
 export const nameValidationSchema = (t: TFunction, maxLength = 263) =>
   yup
     .string()
     .matches(nameRegex, {
       message: t(
-        'console-shared~Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.',
+        'console-shared~Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.',
       ),
       excludeEmptyString: true,
     })

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -352,7 +352,7 @@
   "This is not a supported in-context type": "This is not a supported in-context type",
   "{{label}} Utilization": "{{label}} Utilization",
   "{{label}} request and limit must be set before {{label}} utilization can be set.": "{{label}} request and limit must be set before {{label}} utilization can be set.",
-  "Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.": "Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.",
+  "Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.": "Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.",
   "Cannot be longer than 253 characters.": "Cannot be longer than 253 characters.",
   "Minimum Pods must be an integer.": "Minimum Pods must be an integer.",
   "Minimum Pods must greater than or equal to 1.": "Minimum Pods must greater than or equal to 1.",

--- a/frontend/packages/dev-console/src/components/hpa/validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/hpa/validation-utils.ts
@@ -14,7 +14,7 @@ export const hpaValidationSchema = (t: TFunction) =>
             .string()
             .matches(nameRegex, {
               message: t(
-                'devconsole~Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.',
+                'devconsole~Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.',
               ),
               excludeEmptyString: true,
             })

--- a/frontend/packages/dev-console/src/components/import/__tests__/deployImage-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/deployImage-validation-utils.spec.ts
@@ -38,7 +38,7 @@ describe('Deploy Image ValidationUtils', () => {
         .validate(mockData)
         .catch((err) => {
           expect(err.message).toBe(
-            'Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.',
+            'Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.',
           );
         });
     });

--- a/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
@@ -45,7 +45,7 @@ describe('ValidationUtils', () => {
   describe('createComponentName', () => {
     const invalidConvertedtoValidNamePair: { [key: string]: string } = {
       '-2name': 'ocp-2-name',
-      '0name': 'ocp-0-name',
+      '.0name': 'ocp-0-name',
       Name: 'name',
       '-name': 'name',
       'name-': 'name',
@@ -153,7 +153,7 @@ describe('ValidationUtils', () => {
       ).toEqual('wild-west-frontend');
       expect(
         detectGitRepoName('https://github.com/openshift-evangelists/wild-west-frontend.git'),
-      ).toEqual('wild-west-frontend-git');
+      ).toEqual('wild-west-frontend.git');
       expect(
         detectGitRepoName('https://github.com/openshift-evangelists/Wild-West-Frontend123'),
       ).toEqual('wild-west-frontend-123');
@@ -175,7 +175,7 @@ describe('ValidationUtils', () => {
         .validate(mockData)
         .catch((err) => {
           expect(err.message).toBe(
-            'Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.',
+            'Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.',
           );
         });
     });

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -32,6 +32,7 @@ import { createRoute, createService, dryRunOpt } from '../../utils/shared-submit
 import { AppResources } from '../edit-application/edit-application-types';
 import { getProbesData } from '../health-checks/create-health-checks-probe-utils';
 import { DeployImageFormData, Resources } from './import-types';
+import { createResourceName } from './import-validation-utils';
 
 const WAIT_FOR_IMAGESTREAM_UPDATE_TIMEOUT = 5000;
 const WAIT_FOR_IMAGESTREAM_GENERATION = 2;
@@ -212,7 +213,7 @@ export const createOrUpdateDeployment = (
           volumes,
           containers: [
             {
-              name,
+              name: createResourceName(name),
               image: imageRef,
               ports,
               volumeMounts,
@@ -279,7 +280,7 @@ export const createOrUpdateDeploymentConfig = (
           volumes,
           containers: [
             {
-              name,
+              name: createResourceName(name),
               image: _.get(image, ['dockerImageMetadata', 'Config', 'Image']),
               ports,
               volumeMounts,

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -72,6 +72,7 @@ import {
   ServerlessData,
   DeploymentData,
 } from './import-types';
+import { createResourceName } from './import-validation-utils';
 
 export const generateSecret = () => {
   // http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
@@ -366,7 +367,7 @@ export const createOrUpdateDeployment = (
         spec: {
           containers: [
             {
-              name,
+              name: createResourceName(name),
               image: `${name}:latest`,
               ports,
               env,
@@ -433,7 +434,7 @@ export const createOrUpdateDeploymentConfig = (
         spec: {
           containers: [
             {
-              name,
+              name: createResourceName(name),
               image: `${name}:latest`,
               ports,
               env,

--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -2,7 +2,7 @@ import { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import * as yup from 'yup';
 import { GitProvider } from '@console/git-service/src';
-import { nameValidationSchema, nameRegex } from '@console/shared';
+import { nameValidationSchema, nameRegex, resourceNameRegex } from '@console/shared';
 import { healthChecksProbesValidationSchema } from '../health-checks/health-checks-probe-validation-utils';
 import {
   projectNameValidationSchema,
@@ -66,6 +66,17 @@ export const detectGitType = (url: string): GitProvider => {
 
 export const createComponentName = (nameString: string): string => {
   if (nameRegex.test(nameString)) {
+    return nameString;
+  }
+
+  const kebabCaseStr = _.kebabCase(nameString);
+  return nameString.match(/^\d/) || kebabCaseStr.match(/^\d/)
+    ? `ocp-${kebabCaseStr}`
+    : kebabCaseStr;
+};
+
+export const createResourceName = (nameString: string): string => {
+  if (resourceNameRegex.test(nameString)) {
     return nameString;
   }
 

--- a/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
+++ b/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
@@ -6,6 +6,7 @@ import {
   DeployImageFormData,
   UploadJarFormData,
 } from '../components/import/import-types';
+import { createResourceName } from '../components/import/import-validation-utils';
 import { makePortName } from './imagestream-utils';
 import {
   getAppLabels,
@@ -90,7 +91,7 @@ export const createService = (
     kind: 'Service',
     apiVersion: 'v1',
     metadata: {
-      name,
+      name: createResourceName(name),
       namespace,
       labels: { ...defaultLabels, ...userLabels },
       annotations: { ...defaultAnnotations },

--- a/frontend/packages/helm-plugin/locales/en/helm-plugin.json
+++ b/frontend/packages/helm-plugin/locales/en/helm-plugin.json
@@ -88,7 +88,7 @@
   "TLS Client config": "TLS Client config",
   "Select Secret": "Select Secret",
   "Edit Helm Chart Repository": "Edit Helm Chart Repository",
-  "Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.": "Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.",
+  "Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.": "Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.",
   "The repository name cannot exceed than 100 characters.": "The repository name cannot exceed than 100 characters.",
   "Required": "Required",
   "The repository name cannot exceed than 2048 characters.": "The repository name cannot exceed than 2048 characters.",

--- a/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/helmchartrepository-validation-utils.ts
+++ b/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/helmchartrepository-validation-utils.ts
@@ -12,7 +12,7 @@ export const createHelmChartRepositoryValidationSchema = (t: TFunction) =>
       .string()
       .matches(nameRegex, {
         message: t(
-          'helm-plugin~Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.',
+          'helm-plugin~Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.',
         ),
         excludeEmptyString: true,
       })

--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -347,7 +347,7 @@
   "Pipeline Repositories": "Pipeline Repositories",
   "Event type": "Event type",
   "Last run duration": "Last run duration",
-  "Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.": "Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.",
+  "Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.": "Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.",
   "Invalid Git URL.": "Invalid Git URL.",
   "Repository details": "Repository details",
   "Git access token": "Git access token",

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/switch-to-form-validation-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/switch-to-form-validation-utils.spec.ts
@@ -208,7 +208,7 @@ describe('Tasks validation', () => {
       .catch(
         hasError(
           'spec.tasks[0].name',
-          'Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.',
+          'Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.',
         ),
       );
   });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/validation-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/validation-utils.spec.ts
@@ -64,7 +64,7 @@ describe('Pipeline Build validation schema', () => {
         .catch(
           hasError(
             'formData.name',
-            'Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.',
+            'Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.',
           ),
         );
     });

--- a/frontend/packages/pipelines-plugin/src/components/repository/repository-form-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/repository/repository-form-utils.ts
@@ -29,7 +29,7 @@ export const repositoryValidationSchema = (t: TFunction) =>
       .string()
       .matches(nameRegex, {
         message: t(
-          'pipelines-plugin~Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.',
+          'pipelines-plugin~Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.',
         ),
         excludeEmptyString: true,
       })


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-9214

**Analysis / Root cause:**
hyphen in the 2nd character of the name was not allowed due to regular expression check

**Solution Description:**
Allowed to add hyphen in the 2nd character of the name
Name - 
    Should contain only letter(a-z) or number(0-9) as first character
    Should contain only letter(a-z) or number(0-9) as last character
    Should contain only letter(a-z) or number(0-9) or hyphens(-) or dots(.) in between
    Should not contain 2 dots consecutively

**Screen shots / Gifs for design review:**

-------Before-----
<img width="764" alt="Screenshot 2023-03-15 at 3 59 28 PM" src="https://user-images.githubusercontent.com/102503482/225304161-65039a4a-262f-4139-a317-9f77c7d40593.png">


-------After----
<img width="740" alt="Screenshot 2023-03-15 at 3 59 20 PM" src="https://user-images.githubusercontent.com/102503482/225304184-c47a5ff3-1462-45d2-949d-ae070588cc3c.png">


****Unit test coverage report:****
NA

**Test setup:**

1. Go to Developer -> Add -> Import from Git page
2. use the repo url https://github.com/redhat-developer/s2i-dotnetcore-ex.git
3. add `/app` in the context dir under advanced git options.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
