### PR TITLE
OCPBUGS-10509: Sync Debug in Terminal feature availability with 3.x pods in web console

### DIFF
--- a/frontend/public/components/utils/resource-log.tsx
+++ b/frontend/public/components/utils/resource-log.tsx
@@ -133,7 +133,7 @@ const showDebugAction = (pod: PodKind, containerName: string) => {
     return false;
   }
   const containerStatus = pod?.status?.containerStatuses?.find((c) => c.name === containerName);
-  if (pod?.status?.phase === 'Succeeded' || pod?.status?.phase === 'Pending') {
+  if (pod?.status?.phase === 'Succeeded') {
     return false;
   }
   if (pod?.metadata?.annotations?.['openshift.io/build.name']) {


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-10509

Sync with 3.x debug in terminal feature: https://github.com/openshift/origin-web-console/blob/c37982397087036321312172282e139da378eff2/app/scripts/directives/resources.js#L33-L53