### PR TITLE
OCPBUGS-9956: update the default pipelineRun template name

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pac/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pac/const.ts
@@ -6,4 +6,4 @@ export const EVENT_LISTNER_NAME = 'pipelines-as-code-interceptor';
 export const PAC_SECRET_NAME = 'pipelines-as-code-secret';
 export const PAC_GH_APP_NAME = 'pipelines-ci-clustername';
 export const PAC_INFO = 'pipelines-as-code-info';
-export const PAC_TEMPLATE_DEFAULT = 'pipelines-as-code-template-default';
+export const PAC_TEMPLATE_DEFAULT = 'pipelines-as-code-pipelinerun-generic';


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-9956

**Analysis / Root cause**: 
PipelineRun default template name has been updated in the backend in Pipeline operator 1.10, So we need to update the name in the UI code as well.

**Solution Description**: 
Changed template name in code

**Screen shots / Gifs for design review**: 

--Before Fix--

https://user-images.githubusercontent.com/122968482/226429660-70a43be9-6784-43a0-a818-f5912323a3f3.mp4

\
--After Fix--

https://user-images.githubusercontent.com/122968482/226429644-cec03081-f512-4d3f-b680-ae0e6255222e.mp4

\
**Unit test coverage report**: 
NA

**Test setup:**
Install Pipelines Operator 1.10 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge