### PR TITLE
ODC-7276: Add cancelled status color in Pipeline metrics page

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineSuccessRatioDonut.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineSuccessRatioDonut.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
-import { ChartVoronoiContainer } from '@patternfly/react-charts';
+import { ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
 import { Grid, GridItem } from '@patternfly/react-core';
+import { global_Color_200 as grayColor } from '@patternfly/react-tokens/dist/js/global_Color_200';
+import { global_danger_color_100 as dangerColor } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import Measure from 'react-measure';
@@ -17,6 +19,12 @@ import {
 } from './pipeline-metrics-utils';
 
 import './pipeline-chart.scss';
+
+const statusColor = {
+  cancelled: grayColor.value,
+  failed: dangerColor.value,
+  success: ChartThemeColor.green,
+};
 
 const PipelineSuccessRatioDonut: React.FC<PipelineMetricsGraphProps> = ({
   pipeline,
@@ -76,6 +84,7 @@ const PipelineSuccessRatioDonut: React.FC<PipelineMetricsGraphProps> = ({
       sortOrder,
       y: parseFloat(percentage),
       name: `${obj.x}: ${percentage}%`,
+      fill: statusColor[obj.x as string],
     };
   });
   let successTimeSeriesObj = finalArray.reduce((acc, obj) => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/charts/successRatioDonut.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/charts/successRatioDonut.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { ChartDonut, ChartDonutProps, ChartLabel, ChartThemeColor } from '@patternfly/react-charts';
-import { global_danger_color_100 as dangerColor } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
+import { ChartDonut, ChartDonutProps, ChartLabel } from '@patternfly/react-charts';
 import * as _ from 'lodash';
 
 interface SuccessRatioDonutProps {
@@ -22,9 +21,8 @@ const SuccessRatioDonut: React.FC<SuccessRatioDonutProps & ChartDonutProps> = ({
       ariaTitle={ariaTitle}
       constrainToVisibleArea
       data={data}
-      sortKey={successValue ? ['success', 'failed'] : ['failed']}
+      sortKey={successValue ? ['success', 'failed', 'cancelled'] : ['failed', 'cancelled']}
       labels={({ datum }) => `${_.capitalize(datum.x)}: ${datum.y}%`}
-      colorScale={successValue ? [ChartThemeColor.green, dangerColor.value] : [dangerColor.value]}
       padding={{
         bottom: 20,
         left: 20,
@@ -38,6 +36,11 @@ const SuccessRatioDonut: React.FC<SuccessRatioDonutProps & ChartDonutProps> = ({
       title={title}
       titleComponent={<ChartLabel style={{ fill: 'var(--pf-global--Color--100)', fontSize: 24 }} />}
       width={width}
+      style={{
+        data: {
+          fill: ({ datum }) => datum.fill,
+        },
+      }}
     />
   );
 };


### PR DESCRIPTION
story: https://issues.redhat.com/browse/ODC-7276

Descriptions: Previously user was not able to visualize the Cancelled Pipeline in the Pipeline metrics page as the Cancelled status color is the same as failed Pipeline color. So, with this change now the user can visualize the Cancelled Pipeline as well.

GIF/screenshots:
![image](https://user-images.githubusercontent.com/2561818/226581848-0d02fbd8-8aaa-45eb-a873-64b201fdc01e.png)

![image](https://user-images.githubusercontent.com/2561818/226564272-279f8fa3-2684-4218-b6e7-6701c8a7147d.png)

![Peek 2023-03-21 16-08](https://user-images.githubusercontent.com/2561818/226582363-701768b3-30f9-4911-a8c7-ef91aae3eda3.gif)
