### PR TITLE
OCPBUGS-9329: update dynamic plugin info for development mode

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -302,6 +302,7 @@ func main() {
 		NodeArchitectures:            nodeArchitectures,
 		HubConsoleURL:                hubConsoleURL,
 		AuthMetrics:                  auth.NewMetrics(),
+		K8sMode:                      *fK8sMode,
 	}
 
 	managedClusterConfigs := []serverconfig.ManagedClusterConfig{}

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -57,6 +57,7 @@ declare interface Window {
     telemetry: Record<string, string>;
     nodeArchitectures: string[];
     hubConsoleURL: string;
+    k8sMode: string,
   };
   windowError?: string;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;

--- a/frontend/packages/console-app/src/components/console-operator/ConsoleOperatorConfig.tsx
+++ b/frontend/packages/console-app/src/components/console-operator/ConsoleOperatorConfig.tsx
@@ -97,7 +97,40 @@ const ConsolePluginsList: React.FC<ConsolePluginsListType> = ({ obj }) => {
   const [rows, setRows] = React.useState([]);
   const [sortBy, setSortBy] = React.useState<ISortBy>({});
   const pluginColumns = ['name', 'version', 'description', 'status'];
+  const developmentMode = window.SERVER_FLAGS.k8sMode === 'off-cluster';
   React.useEffect(() => {
+    const placeholder = '-';
+    if (developmentMode) {
+      const data = pluginInfoEntries.filter(isLoadedDynamicPluginInfo).map((plugin) => {
+        return {
+          name: plugin.metadata.name,
+          version: plugin.metadata.version,
+          description: plugin.metadata?.description || placeholder,
+          enabled: plugin.enabled,
+          status: plugin.status,
+        };
+      });
+      setRows(
+        data?.map((item) => {
+          return {
+            cells: [
+              {
+                title: item.name,
+              },
+              item.version,
+              item.description,
+              {
+                title: <Status status={item.status} title={item.status} />,
+              },
+              {
+                title: t('console-app~Enabled'),
+              },
+            ],
+          };
+        }),
+      );
+      return;
+    }
     const data = consolePlugins.map((plugin) => {
       const pluginName = plugin?.metadata?.name;
       const loadedPluginInfo = pluginInfoEntries
@@ -132,7 +165,6 @@ const ConsolePluginsList: React.FC<ConsolePluginsListType> = ({ obj }) => {
             : undefined,
       };
     });
-    const placeholder = '-';
     const sortedData = !_.isEmpty(sortBy)
       ? data.sort((a, b) => {
           const sortCol = pluginColumns[sortBy.index];
@@ -184,19 +216,19 @@ const ConsolePluginsList: React.FC<ConsolePluginsListType> = ({ obj }) => {
   const headers = [
     {
       title: t('console-app~Name'),
-      transforms: [sortable],
+      transforms: developmentMode ? [] : [sortable],
     },
     {
       title: t('console-app~Version'),
-      transforms: [sortable],
+      transforms: developmentMode ? [] : [sortable],
     },
     {
       title: t('console-app~Description'),
-      transforms: [sortable],
+      transforms: developmentMode ? [] : [sortable],
     },
     {
       title: t('console-app~Status'),
-      transforms: [sortable],
+      transforms: developmentMode ? [] : [sortable],
     },
     { title: '' },
   ];

--- a/frontend/packages/console-app/src/components/dashboards-page/dynamic-plugins-health-resource/DynamicPluginsPopover.tsx
+++ b/frontend/packages/console-app/src/components/dashboards-page/dynamic-plugins-health-resource/DynamicPluginsPopover.tsx
@@ -18,6 +18,7 @@ const DynamicPluginsPopover: React.FC<DynamicPluginsPopoverProps> = ({ consolePl
   const pendingPlugins = notLoadedDynamicPluginInfo.filter((plugin) => plugin.status === 'Pending');
   const loadedPlugins = pluginInfoEntries.filter(isLoadedDynamicPluginInfo);
   const enabledPlugins = loadedPlugins.filter((plugin) => plugin.enabled === true);
+  const developmentMode = window.SERVER_FLAGS.k8sMode === 'off-cluster';
 
   return (
     <Stack hasGutter>
@@ -41,8 +42,8 @@ const DynamicPluginsPopover: React.FC<DynamicPluginsPopoverProps> = ({ consolePl
           secondColumn={
             <>
               {t('console-app~{{enabledCount}}/{{totalCount}} enabled', {
-                enabledCount: enabledPlugins.length,
-                totalCount: consolePlugins.data.length,
+                enabledCount: developmentMode ? loadedPlugins.length : enabledPlugins.length,
+                totalCount: developmentMode ? loadedPlugins.length : consolePlugins.data.length,
               })}
             </>
           }

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -192,8 +192,6 @@ to your local plugin asset server (web server hosting the plugin's generated ass
 Your plugin should start loading automatically upon Console application startup. Inspect the value of
 `window.SERVER_FLAGS.consolePlugins` to see the list of plugins which Console loads upon its startup.
 
-Note running plugins in this way will likely result in incorrect data in the Cluster Dashboard Dynamic Plugins popover.
-
 ## Plugin detection and management
 
 [Console operator](https://github.com/openshift/console-operator) detects available plugins through

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -130,6 +130,7 @@ type jsGlobals struct {
 	Telemetry                       serverconfig.MultiKeyValue `json:"telemetry"`
 	ThanosPublicURL                 string                     `json:"thanosPublicURL"`
 	UserSettingsLocation            string                     `json:"userSettingsLocation"`
+	K8sMode                         string                     `json:"k8sMode"`
 }
 
 type Server struct {
@@ -161,6 +162,7 @@ type Server struct {
 	I18nNamespaces                      []string
 	InactivityTimeout                   int
 	K8sClient                           *http.Client
+	K8sMode                             string
 	K8sProxyConfig                      *proxy.Config
 	KnativeChannelCRDLister             ResourceLister
 	KnativeEventSourceCRDLister         ResourceLister
@@ -754,6 +756,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		NodeArchitectures:          s.NodeArchitectures,
 		CopiedCSVsDisabled:         s.CopiedCSVsDisabled,
 		HubConsoleURL:              s.HubConsoleURL.String(),
+		K8sMode:                    s.K8sMode,
 	}
 
 	localAuther := s.getLocalAuther()


### PR DESCRIPTION
Only show information regarding plugins running locally, and disable the `Enable` button since its not relevant.
 
https://user-images.githubusercontent.com/895728/230417051-dda2a105-3faf-413d-a4b2-6a1259075d08.mov

