### PR TITLE
OCPBUGS-10655: Do not show builder ImageStreams without `sampleRepo` as samples

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/providers/useBuilderImages.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useBuilderImages.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
-import { ExtensionHook, CatalogItem } from '@console/dynamic-plugin-sdk';
+import {
+  ExtensionHook,
+  CatalogItem,
+  CatalogItemDetailsDescription,
+  CatalogItemDetailsProperty,
+} from '@console/dynamic-plugin-sdk';
 import {
   getImageForIconClass,
   getImageStreamIcon,
@@ -38,14 +43,15 @@ const normalizeBuilderImages = (
     const sampleRepo = builderImageTag?.['annotations']?.['sampleRepo'];
     const creationTimestamp = imageStream.metadata?.creationTimestamp;
 
-    const detailsProperties = [
-      {
+    const detailsProperties: CatalogItemDetailsProperty[] = [];
+    if (sampleRepo) {
+      detailsProperties.push({
         label: t('devconsole~Sample repository'),
         value: (
           <ExternalLink href={sampleRepo} additionalClassName="co-break-all" text={sampleRepo} />
         ),
-      },
-    ];
+      });
+    }
 
     const imageStreamText = (
       <>
@@ -85,7 +91,7 @@ const normalizeBuilderImages = (
       </>
     );
 
-    const detailsDescriptions = [
+    const detailsDescriptions: CatalogItemDetailsDescription[] = [
       {
         value: <p>{description}</p>,
       },

--- a/frontend/packages/dev-console/src/components/catalog/providers/useDevfile.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useDevfile.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
-import { CatalogItem, ExtensionHook } from '@console/dynamic-plugin-sdk';
+import {
+  CatalogItem,
+  CatalogItemDetailsDescription,
+  CatalogItemDetailsProperty,
+  ExtensionHook,
+} from '@console/dynamic-plugin-sdk';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { ExternalLink } from '@console/internal/components/utils';
 import { APIError } from '@console/shared';
@@ -15,16 +20,17 @@ const normalizeDevfile = (devfileSamples: DevfileSample[], t: TFunction): Catalo
     const createLabel = t('devconsole~Create');
     const type = 'Devfile';
 
-    const detailsProperties = [
-      {
+    const detailsProperties: CatalogItemDetailsProperty[] = [];
+    if (gitRepoUrl) {
+      detailsProperties.push({
         label: t('devconsole~Sample repository'),
         value: (
           <ExternalLink href={gitRepoUrl} additionalClassName="co-break-all" text={gitRepoUrl} />
         ),
-      },
-    ];
+      });
+    }
 
-    const detailsDescriptions = [
+    const detailsDescriptions: CatalogItemDetailsDescription[] = [
       {
         value: <p>{description}</p>,
       },

--- a/frontend/packages/helm-plugin/src/catalog/utils/catalog-utils.tsx
+++ b/frontend/packages/helm-plugin/src/catalog/utils/catalog-utils.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import { TFunction } from 'i18next';
 import * as _ from 'lodash';
-import { CatalogItem } from '@console/dynamic-plugin-sdk';
+import {
+  CatalogItem,
+  CatalogItemDetailsDescription,
+  CatalogItemDetailsProperty,
+} from '@console/dynamic-plugin-sdk';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import { ExternalLink } from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
@@ -83,7 +87,7 @@ export const normalizeHelmCharts = (
           <ExternalLink href={chart.home} additionalClassName="co-break-all" text={chart.home} />
         );
 
-        const detailsProperties = [
+        const detailsProperties: CatalogItemDetailsProperty[] = [
           {
             label: t('helm-plugin~Latest Chart version'),
             value: version,
@@ -114,7 +118,7 @@ export const normalizeHelmCharts = (
           },
         ];
 
-        const detailsDescriptions = [
+        const detailsDescriptions: CatalogItemDetailsDescription[] = [
           {
             label: t('helm-plugin~Description'),
             value: <p>{description}</p>,
@@ -130,7 +134,7 @@ export const normalizeHelmCharts = (
           },
         ];
 
-        const helmChart = {
+        const helmChart: CatalogItem = {
           uid: `${chartRepoName}--${chartURL}`,
           type: 'HelmChart',
           name: displayName,

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/dev-console/use-catalog-vm-templates.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/dev-console/use-catalog-vm-templates.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { Form, Stack, StackItem } from '@patternfly/react-core';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
-import { CatalogItem, ExtensionHook } from '@console/dynamic-plugin-sdk';
+import {
+  CatalogItem,
+  CatalogItemDetailsDescription,
+  CatalogItemDetailsProperty,
+  ExtensionHook,
+} from '@console/dynamic-plugin-sdk';
 import { humanizeBinaryBytes, SectionHeading } from '@console/internal/components/utils';
 import { PersistentVolumeClaimKind, PodKind } from '@console/internal/module/k8s';
 import { BOOT_SOURCE_AVAILABLE } from '../../../constants';
@@ -48,7 +53,7 @@ const normalizeVmTemplates = (
   activeNamespace: string = '',
   t: TFunction,
 ): CatalogItem[] =>
-  templates.map((temp) => {
+  templates.map<CatalogItem>((temp) => {
     const [tmp] = temp?.variants;
     const sourceStatus = getTemplateSourceStatus({
       pods,
@@ -93,7 +98,7 @@ const normalizeVmTemplates = (
       </Stack>
     );
 
-    const detailsDescription = [
+    const detailsDescription: CatalogItemDetailsDescription[] = [
       {
         value: (
           <Stack hasGutter>
@@ -167,7 +172,7 @@ const normalizeVmTemplates = (
       },
     ];
 
-    const detailsProperties = [
+    const detailsProperties: CatalogItemDetailsProperty[] = [
       {
         label: t('kubevirt-plugin~Support'),
         value: <VMTemplateSupportDescription template={tmp} />,

--- a/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersions.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersions.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { ExtensionHook, CatalogItem } from '@console/dynamic-plugin-sdk';
+import {
+  ExtensionHook,
+  CatalogItem,
+  CatalogItemDetailsDescription,
+  CatalogItemDetailsProperty,
+} from '@console/dynamic-plugin-sdk';
 import { SyncMarkdownView } from '@console/internal/components/markdown-view';
 import { ExpandCollapse } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
@@ -53,7 +58,7 @@ const normalizeClusterServiceVersions = (
           : all.concat([cur]),
       [],
     )
-    .map((desc) => {
+    .map<CatalogItem>((desc) => {
       const { creationTimestamp } = desc.csv.metadata;
       const uid = `${desc.csv.metadata.uid}-${desc.displayName}`;
       const { description } = desc;
@@ -74,7 +79,7 @@ const normalizeClusterServiceVersions = (
         .toLowerCase()
         .replace(/\s/g, '');
 
-      const detailsProperties = [
+      const detailsProperties: CatalogItemDetailsProperty[] = [
         {
           label: t('olm~Capability level'),
           value: capabilityLevel,
@@ -87,7 +92,7 @@ const normalizeClusterServiceVersions = (
         </ExpandCollapseDescription>
       );
 
-      const detailsDescriptions = [
+      const detailsDescriptions: CatalogItemDetailsDescription[] = [
         {
           value: <p>{description}</p>,
         },


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-10655

**Analysis / Root cause**: 
Builder ImageStreams that have no `repoSample` annotation were shown in the sample list, but could not be created then. The next page requires that git repository.

**Solution Description**: 
Added a filter to skip all "builder image streams" without git repository (`repoSample`).

I also noticed that the same git repository (`repoSample`) was displayed in the developer catalog. Skipped the rendering of the "Sample repository" there as well.

**Screenshots**: 

Before:

Sample catalog:

![before-jboss-samples](https://user-images.githubusercontent.com/139310/226750845-a6b44a31-0c30-4cc6-8fac-0e9dee7133fc.png)

After clicking on the sample:

![before-jboss-sample](https://user-images.githubusercontent.com/139310/226750849-cafd684e-08ae-493e-9dc5-ab2087293ffd.png)

When open the same builder image in the developer catalog:

![before-catalog-jboss](https://user-images.githubusercontent.com/139310/226750853-7b52228a-ce4f-44c7-bd78-66f473561c62.png)

After:

Sample catalog doesn't show builder images without `sampleRepo` anymore:

![after-samples](https://user-images.githubusercontent.com/139310/226750872-b4a7e47d-42f2-4e38-9d82-32c8d44afb29.png)

The developer catalog doesn't show the empty "Sample repository" link anymore:

![after-catalog-jboss](https://user-images.githubusercontent.com/139310/226750867-6c0b3e00-32a4-4acc-896e-76bd678e6660.png)

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Switch to the Developer perspective
2. Navigate to Add > All Samples
3. Search for Jboss
4. Click on "JBoss EAP XP 4.0 with OpenJDK 11" (for example)

Before:
The git repository is not filled and the create button is disabled.

Now:
Samples without git repositories are not part of the list anymore.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
