### PR TITLE
OCPBUGS-10411: Edit deployment don't enable save button if image stream is added

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/deployment/deployment-dev-perspective.feature
+++ b/frontend/packages/dev-console/integration-tests/features/deployment/deployment-dev-perspective.feature
@@ -21,3 +21,17 @@ Feature: Deployment form view
                   | deployment_name | strategy_type  | image                                                                   |
                   | test-depoyment1 | Rolling Update | image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest |
                   | test-depoyment2 | Recreate       | image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest |
+
+       @smoke
+        Scenario Outline: Create deployment using ImageStream in form view: D-01-TC02
+            Given user is at Deployments page
+             When user clicks on Create Deployment
+              And user selects Strategy type as "<strategy_type>"
+              And user selects ImageStream with id "<imagestream_id>"
+              And user clicks on Create button
+             Then user sees "<deployment_name>" deployment created
+
+        Examples:
+                  | deployment_name | strategy_type  | imagestream_id |
+                  | cli             | Rolling Update | #cli-link      |
+                  | dotnet          | Recreate       | #dotnet-link   |

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -383,3 +383,14 @@ export const helmChartRepositoriesPO = {
   description: '#form-input-formData-repoDescription-field',
   url: '#form-input-formData-repoUrl-field',
 };
+
+export const deploymentStrategyFormP0 = {
+  images: {
+    deployFromImageStreamCheckbox: '#form-checkbox-formData-fromImageStreamTag-field',
+    projectDropdown: '#form-ns-dropdown-formData-imageStream-namespace-field',
+    selectProjectOpenshift: '#openshift-link',
+    imageStreamDropdown: '#form-ns-dropdown-formData-imageStream-image-field',
+    tagDropdown: '#form-dropdown-formData-imageStream-tag-field',
+    selectTagLatest: '#latest-link',
+  },
+};

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/deployment/deployment-dev-perspective.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/deployment/deployment-dev-perspective.ts
@@ -1,7 +1,7 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
 import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
 import { devNavigationMenu } from '../../constants';
-import { eventSourcePO, pagePO } from '../../pageObjects';
+import { deploymentStrategyFormP0, eventSourcePO, pagePO } from '../../pageObjects';
 import { createForm, navigateTo } from '../../pages';
 
 Given('user is at Deployments page', () => {
@@ -49,4 +49,15 @@ Then('user sees {string} deployment created', (name: string) => {
     .contains('Deployments')
     .should('be.visible');
   detailsPage.titleShouldContain(name);
+});
+
+When('user selects ImageStream with id {string}', (imageStreamId: string) => {
+  cy.get(deploymentStrategyFormP0.images.deployFromImageStreamCheckbox).check();
+  cy.get(deploymentStrategyFormP0.images.projectDropdown).click();
+  cy.get(deploymentStrategyFormP0.images.selectProjectOpenshift).click();
+  cy.get(deploymentStrategyFormP0.images.imageStreamDropdown).click();
+  cy.get(imageStreamId).click();
+  cy.get(deploymentStrategyFormP0.images.tagDropdown).click();
+  cy.get(deploymentStrategyFormP0.images.selectTagLatest).click();
+  cy.get(eventSourcePO.createPingSource.name).scrollIntoView();
 });

--- a/frontend/packages/dev-console/src/components/deployments/utils/deployment-utils.ts
+++ b/frontend/packages/dev-console/src/components/deployments/utils/deployment-utils.ts
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import { getAPIVersionForModel } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { DeploymentConfigModel, DeploymentModel } from '@console/internal/models';
 import { ContainerSpec, EnvVar, K8sResourceKind } from '@console/internal/module/k8s';
+import { TRIGGERS_ANNOTATION } from '@console/shared';
 import { getTriggerAnnotation } from '../../../utils/resource-label-utils';
 import {
   checkIfTriggerExists,
@@ -636,6 +637,8 @@ export const convertEditFormToDeployment = (
       },
     };
   } else {
+    newDeployment?.metadata?.annotations?.[TRIGGERS_ANNOTATION] &&
+      delete newDeployment.metadata.annotations[TRIGGERS_ANNOTATION];
     newDeployment = {
       ...newDeployment,
       metadata: {

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamDropdown.tsx
@@ -17,7 +17,7 @@ const ImageStreamDropdown: React.FC<{
   const imgCollection = {};
 
   const { values, setFieldValue, initialValues } = useFormikContext<FormikValues>();
-  const { imageStream } = _.get(values, formContextField) || values;
+  const { imageStream, formType } = _.get(values, formContextField) || values;
   const { isi: initialIsi } = _.get(initialValues, formContextField) || initialValues;
   const { state, dispatch, hasImageStreams, setHasImageStreams } = React.useContext(
     ImageStreamContext,
@@ -46,18 +46,19 @@ const ImageStreamDropdown: React.FC<{
         `${fieldPrefix}imageStream.tag`,
         img === imageStream.image ? imageStream.tag : '',
       );
-      setFieldValue(`${fieldPrefix}isi`, initialIsi);
+      formType !== 'edit' && setFieldValue(`${fieldPrefix}isi`, initialIsi);
       const image = _.get(imgCollection, [imageStream.namespace, img], {});
       dispatch({ type: ImageStreamActions.setSelectedImageStream, value: image });
     },
     [
       setFieldValue,
       fieldPrefix,
-      imageStream.tag,
       imageStream.image,
+      imageStream.tag,
+      imageStream.namespace,
+      formType,
       initialIsi,
       imgCollection,
-      imageStream.namespace,
       dispatch,
     ],
   );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-10411

**Analysis / Root cause**: 
Save button wasn't enabling because there was an error in initializing isi values, additionally there was also an error in saving checkbox values because of reusing previous value for updating when the formData gets converted to yamlData

**Solution Description**: 
For fixing initialIsi value, I made sure that isi value doesn't get initialized everytime
For fixing checkbox and imageStream updation, there was an issue where annotation was getting saved everytime so it didnt get updated, so made sure that particular annotation doesn't get reused or persisted

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
--Before Fix--

https://user-images.githubusercontent.com/122968482/227312231-bea43d6b-abf6-424b-b89c-ac74127b19f6.mp4

https://user-images.githubusercontent.com/122968482/227310598-8a499a16-6cb9-40cc-b035-cd62f8dc1b35.mp4

\
--After Fix--

https://user-images.githubusercontent.com/122968482/227319483-01db613a-3a98-4963-b682-904fa46ce305.mp4

\
**Unit test coverage report**: 
<!-- Attach test coverage report -->
NA

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Search Deployment under resources
2. Create deployment with Image stream
3. Edit deployment 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge