### PR TITLE
OCPBUGS-10836: fix All projects selection on Pipelines page in dev perspective

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/PipelineTabbedPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/PipelineTabbedPage.tsx
@@ -43,7 +43,7 @@ export const PageContents: React.FC<PipelineTabbedPageProps> = (props) => {
   );
 
   React.useEffect(() => {
-    if (preferredTabLoaded) {
+    if (preferredTabLoaded && namespace) {
       if (isRepositoryEnabled && preferredTab === 'repositories') {
         history.push(`/dev-pipelines/ns/${namespace}/repositories`);
       }


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGS-10836

**Descriptions:** 
Problem: As a user when I select the All projects option from the Projects dropdown in the Dev perspective Pipelines pages then the selected option says as undefined. 

Solution: Check for namespace if it is defined before redirecting to the remembered page.

**GIF:**
**Before:**
![Peek 2023-03-24 17-05](https://user-images.githubusercontent.com/2561818/227511255-bdaee80e-0fb0-4a28-a03d-7ebf4f898bb4.gif)

**After:**
![Peek 2023-03-24 17-19](https://user-images.githubusercontent.com/2561818/227513763-38ba5153-fadd-4102-8e2f-f63a3ddb8766.gif)
