### PR TITLE
OCPBUGS-6767: Regression: OpenShift Console no-longer filters SecretList when displaying ServiceAccount

### DIFF
--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -1,7 +1,7 @@
-import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
+import { useTranslation } from 'react-i18next';
 import { DetailsPage, ListPage, Table, TableData } from './factory';
 import {
   Kebab,
@@ -13,8 +13,6 @@ import {
   Timestamp,
 } from './utils';
 import { ServiceAccountModel } from '../models';
-import { SecretsPage } from './secret';
-import { useTranslation } from 'react-i18next';
 
 const { common } = Kebab.factory;
 const menuActions = [...Kebab.getExtensionsActionsForKind(ServiceAccountModel), ...common];
@@ -57,35 +55,17 @@ const ServiceAccountTableRow = ({ obj: serviceaccount }) => {
 };
 
 const Details = ({ obj: serviceaccount }) => {
-  const {
-    metadata: { namespace },
-    secrets,
-  } = serviceaccount;
-  const filters = { selector: { field: 'metadata.name', values: new Set(_.map(secrets, 'name')) } };
   const { t } = useTranslation();
 
   return (
-    <>
-      <div className="co-m-pane__body">
-        <SectionHeading text={t('public~ServiceAccount details')} />
-        <div className="row">
-          <div className="col-md-6">
-            <ResourceSummary resource={serviceaccount} />
-          </div>
+    <div className="co-m-pane__body">
+      <SectionHeading text={t('public~ServiceAccount details')} />
+      <div className="row">
+        <div className="col-md-6">
+          <ResourceSummary resource={serviceaccount} />
         </div>
       </div>
-      <div className="co-m-pane__body co-m-pane__body--section-heading">
-        <SectionHeading text={t('public~Secrets')} />
-      </div>
-      <SecretsPage
-        kind="Secret"
-        canCreate={false}
-        namespace={namespace}
-        filters={filters}
-        autoFocus={false}
-        showTitle={false}
-      />
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION

### Before:
![Screenshot 2023-03-27 at 10 45 16 AM](https://user-images.githubusercontent.com/15249132/227976141-925c3a1a-5a31-419b-9829-2ad72a87c72d.png)

Removing the Service Accounts(SA) Secrets section on SA details page in the version after 4.12 since  the change to remove autogenerated secrets was introduced in 4.12
### After:
![Screenshot 2023-04-20 at 8 40 12 AM](https://user-images.githubusercontent.com/15249132/233372394-6adb768c-c281-4dde-8def-9fb3f1ca2570.png)

