### PR TITLE
OCPBUGS-10619: Enable modal scroll for uninstall operator instances

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
@@ -335,21 +335,23 @@ export const UninstallOperatorModal: React.FC<UninstallOperatorModalProps> = ({
     <OperandsLoadedErrorAlert operandsLoadedErrorMessage={operandsLoadedErrorMessage} />
   ) : (
     showOperandsContent && (
-      <span className="co-operator-uninstall__operands-section">
-        <h2>{t('olm~Operand instances')}</h2>
-        <OperandsTable
-          operands={operands}
-          loaded={operandsLoaded}
-          csvName={csvName}
-          cancel={cancel} // for breadcrumbs & cancel modal when clicking on operand links
-        />
+      <>
+        <span className="co-operator-uninstall__operands-section">
+          <h2>{t('olm~Operand instances')}</h2>
+          <OperandsTable
+            operands={operands}
+            loaded={operandsLoaded}
+            csvName={csvName}
+            cancel={cancel} // for breadcrumbs & cancel modal when clicking on operand links
+          />
+        </span>
         <Checkbox
           onChange={({ currentTarget }) => setDeleteOperands(currentTarget.checked)}
           name="delete-all-operands"
           label={t('olm~Delete all operand instances for this operator')}
           checked={deleteOperands}
         />
-      </span>
+      </>
     )
   );
 
@@ -569,7 +571,7 @@ const OperandsTable: React.FC<OperandsTableProps> = ({ operands, loaded, csvName
       <table className="pf-c-table pf-m-compact pf-m-border-rows">
         <thead>
           <tr key="operand-table-header-row">
-            <th>{t('olm~Name')}</th>
+            <th className="pf-m-width-35">{t('olm~Name')}</th>
             <th>{t('olm~Kind')}</th>
             <th>{t('olm~Namespace')}</th>
           </tr>

--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -298,6 +298,15 @@ $co-affinity-row-margin: 15px;
   padding-bottom: var(--pf-global--spacer--sm);
 }
 
+// Enable inner table to scroll if needed
+@media (min-width: $pf-global--breakpoint--md) and (min-height: 600px) {
+  .co-operator-uninstall__operands-section {
+    display: block;
+    max-height: calc(100vh - 400px);
+    overflow-y: auto;
+  }
+}
+
 .co-operator-uninstall__operands-section loading-skeleton--table::after {
   min-height: 160px;
 }
@@ -318,11 +327,10 @@ $co-affinity-row-margin: 15px;
   margin-right: var(--pf-global--spacer--xl);
 }
 
-.co-operator-details__toggle-value .radio-inline input[type="radio"]
-{
-  position: relative;  //To override bootstrap absolute position
+.co-operator-details__toggle-value .radio-inline input[type='radio'] {
+  position: relative; //To override bootstrap absolute position
 }
 
 .co-operator-details__toggle-value label {
- font-weight: var(--pf-global--FontWeight--normal);
+  font-weight: var(--pf-global--FontWeight--normal);
 }


### PR DESCRIPTION
Request to enable scrolling of tall tables with lots of Operand instances within the Uninstall Operator modal. 
Move checkbox outside of scroll so that it remains visible.
Also, improve readability by setting Name column width to 35% and prevent excessively narrow columns for Kind and Namespace.

fix https://issues.redhat.com/browse/OCPBUGS-10619

**before**
<img width="824" alt="Screenshot 2023-03-27 at 8 27 05 PM" src="https://user-images.githubusercontent.com/1874151/228096226-e5f77b27-0d00-4d3e-bff1-2b82feeb71a0.png">


**after**
![uninstall-scrolling](https://user-images.githubusercontent.com/1874151/228096393-6e8eba47-c671-4a14-b2fe-214fab0cb312.gif)
