### PR TITLE
OCPBUGS-10916: fix translation string for Image pull secret created alert

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -454,7 +454,7 @@
   "No Secret": "No Secret",
   "docker.io/openshift/hello-openshift or quay.io/<username>/<image-name>": "docker.io/openshift/hello-openshift or quay.io/<username>/<image-name>",
   "To deploy an Image from a private registry, you must <2>create an Image pull secret</2> with your Image registry credentials.": "To deploy an Image from a private registry, you must <2>create an Image pull secret</2> with your Image registry credentials.",
-  "Secret {{newImageSecret}} was created.": "Secret {{newImageSecret}} was created.",
+  "Secret \"{{newImageSecret}}\" was created.": "Secret \"{{newImageSecret}}\" was created.",
   "Allow Images from insecure registries": "Allow Images from insecure registries",
   "Image": "Image",
   "Deploy an existing Image from an Image Stream or Image registry.": "Deploy an existing Image from an Image Stream or Image registry.",

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
@@ -216,7 +216,7 @@ const ImageSearch: React.FC = () => {
           isInline
           className="co-alert"
           variant="success"
-          title={t('devconsole~Secret {{newImageSecret}} was created.', newImageSecret)}
+          title={t('devconsole~Secret "{{newImageSecret}}" was created.', { newImageSecret })}
           actionClose={<AlertActionCloseButton onClose={() => shouldHideAlert(false)} />}
         />
       )}


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGS-10916

**Screenshots:**
**Before:**
![image (7)](https://user-images.githubusercontent.com/2561818/228141227-9561b738-f884-46ae-8805-d9b399699904.png)

**After:**
![image](https://user-images.githubusercontent.com/2561818/228142001-0306f5ef-6b5f-434c-8c1f-7fd29d47f328.png)
