### PR TITLE
ODC-7281: Provide Column management option for the TaskRuns list page

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipeline-task-runs-display.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipeline-task-runs-display.feature
@@ -6,7 +6,7 @@ Feature: Display task runs page
             Given user has created or selected namespace "aut-pipelines"
               And user is at pipelines page
 
- 
+
         @smoke
         Scenario: Task runs tab: P-05-TC01
             Given pipeline run is displayed for "pipe-one" with resource
@@ -79,3 +79,22 @@ Feature: Display task runs page
              Then user is redirected to Task Run Details tab
              When user scrolls to the Task Run results section
              Then user can see Name and Value column under Task Run results
+
+        @regression
+        Scenario: Check for Duration column when enabled: P-05-TC07
+            Given user is at PipelineRuns tab with pipeline runs for pipeline "pipe-one"
+             When user clicks on Pipeline Run for "pipe-one"
+              And user clicks on TaskRuns tab
+              And user clicks manage columns button
+              And user enables Duration column
+             Then user sees Duration column
+
+        @regression
+        Scenario: Check for absence of Duration column when disabled: P-05-TC08
+            Given user is at PipelineRuns tab with pipeline runs for pipeline "pipe-one"
+             When user clicks on Pipeline Run for "pipe-one"
+              And user clicks on TaskRuns tab
+              And user verifies that duration column is visible
+              And user clicks manage columns button
+              And user disables Duration column
+             Then user does not see Duration column

--- a/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
@@ -222,6 +222,11 @@ export const pipelineRunDetailsPO = {
       duration: '[data-label="Duration"]',
       branch: '[data-label="Branch/Tag"]',
     },
+    enableManageColumns: '[data-test="manage-columns"]',
+    manageColumns: {
+      durationCheckbox: 'input[id="duration"]',
+      submitButton: '[data-test="confirm-action"]',
+    },
   },
   taskRunsDetails: {
     columnNames: {

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-task-runs-display.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-task-runs-display.ts
@@ -206,3 +206,32 @@ Then('user can see Name and Value column under Task Run results', () => {
     .contains('Value')
     .should('be.visible');
 });
+
+When('user clicks manage columns button', () => {
+  cy.get(pipelineRunDetailsPO.taskRuns.enableManageColumns).click();
+});
+
+When('user enables Duration column', () => {
+  cy.get(pipelineRunDetailsPO.taskRuns.manageColumns.durationCheckbox).check();
+  cy.get(pipelineRunDetailsPO.taskRuns.manageColumns.submitButton).click();
+});
+
+When('user disables Duration column', () => {
+  cy.get(pipelineRunDetailsPO.taskRuns.manageColumns.durationCheckbox).uncheck();
+  cy.get(pipelineRunDetailsPO.taskRuns.manageColumns.submitButton).click();
+});
+
+Then('user sees Duration column', () => {
+  cy.get(pipelineRunDetailsPO.taskRuns.columnNames.duration).should('be.visible');
+});
+
+Then('user does not see Duration column', () => {
+  cy.get(pipelineRunDetailsPO.taskRuns.columnNames.duration).should('not.exist');
+});
+
+When('user verifies that duration column is visible', () => {
+  cy.get(pipelineRunDetailsPO.taskRuns.enableManageColumns).click();
+  cy.get(pipelineRunDetailsPO.taskRuns.manageColumns.durationCheckbox).check();
+  cy.get(pipelineRunDetailsPO.taskRuns.manageColumns.submitButton).click();
+  cy.get(pipelineRunDetailsPO.taskRuns.columnNames.duration).should('be.visible');
+});

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsHeader.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsHeader.tsx
@@ -60,9 +60,11 @@ const TaskRunsHeader = (showPipelineColumn: boolean = true) => () => {
       transforms: [sortable],
       props: { className: tableColumnClasses[7] },
       id: 'duration',
+      additional: true,
     },
     {
       title: '',
+      id: '',
       props: { className: tableColumnClasses[8] },
     },
   ].filter((item) => !(item.id === 'pipeline' && !showPipelineColumn));

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsList.tsx
@@ -1,27 +1,46 @@
 import * as React from 'react';
 import { SortByDirection } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
+import { ColumnLayout } from '@console/dynamic-plugin-sdk';
 import { Table } from '@console/internal/components/factory';
+import { useActiveColumns } from '@console/internal/components/factory/Table/active-columns-hook';
 import { TaskRunModel } from '../../../models';
 import TaskRunsHeader from './TaskRunsHeader';
 import TaskRunsRow from './TaskRunsRow';
 
 interface TaskRunsListProps {
   customData?: { [key: string]: any };
+  columnLayout: ColumnLayout;
 }
 
 const TaskRunsList: React.FC<TaskRunsListProps> = (props) => {
   const { t } = useTranslation();
+  const {
+    columnLayout: { columns, id },
+    customData,
+  } = props;
+  const [activeColumns, userSettingsLoaded] = useActiveColumns({
+    columns,
+    columnManagementID: id,
+  });
+  const selectedColumns = React.useMemo(() => new Set(activeColumns.map((col) => col.id)), [
+    activeColumns,
+  ]);
+  const newCustomData = { ...customData, selectedColumns };
   return (
-    <Table
-      {...props}
-      aria-label={t(TaskRunModel.labelPluralKey)}
-      defaultSortField="status.startTime"
-      defaultSortOrder={SortByDirection.desc}
-      Header={TaskRunsHeader(props.customData?.showPipelineColumn)}
-      Row={TaskRunsRow}
-      virtualize
-    />
+    userSettingsLoaded && (
+      <Table
+        {...props}
+        aria-label={t(TaskRunModel.labelPluralKey)}
+        defaultSortField="status.startTime"
+        defaultSortOrder={SortByDirection.desc}
+        Header={TaskRunsHeader(props.customData?.showPipelineColumn)}
+        Row={TaskRunsRow}
+        virtualize
+        activeColumns={selectedColumns}
+        customData={newCustomData}
+      />
+    )
   );
 };
 

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsListPage.tsx
@@ -1,12 +1,20 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { ListPage } from '@console/internal/components/factory';
 import { getURLSearchParams } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
+import {
+  COLUMN_MANAGEMENT_CONFIGMAP_KEY,
+  COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY,
+  TableColumnsType,
+  useUserSettingsCompatibility,
+} from '@console/shared';
 import { TaskRunModel } from '../../../models';
 import { usePipelineTechPreviewBadge } from '../../../utils/hooks';
 import { runFilters as taskRunFilters } from '../../pipelines/detail-page-tabs/PipelineRuns';
+import TaskRunsHeader from './TaskRunsHeader';
 import TaskRunsList from './TaskRunsList';
 
 interface TaskRunsListPageProps {
@@ -29,21 +37,41 @@ const TaskRunsListPage: React.FC<Omit<
     }),
     [showPipelineColumn],
   );
+  const columnManagementID = referenceForModel(TaskRunModel);
+  const [tableColumns, , userSettingsLoaded] = useUserSettingsCompatibility<TableColumnsType>(
+    COLUMN_MANAGEMENT_CONFIGMAP_KEY,
+    COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY,
+    undefined,
+    true,
+  );
   return (
     <>
       <Helmet>
         <title>{t('pipelines-plugin~TaskRuns')}</title>
       </Helmet>
-      <ListPage
-        {...props}
-        customData={customData}
-        canCreate={kind?.includes(referenceForModel(TaskRunModel)) ?? false}
-        kind={referenceForModel(TaskRunModel)}
-        ListComponent={TaskRunsList}
-        rowFilters={taskRunFilters(t)}
-        badge={hideBadge ? null : badge}
-        namespace={namespace}
-      />
+      {userSettingsLoaded && (
+        <ListPage
+          {...props}
+          customData={customData}
+          canCreate={kind?.includes(referenceForModel(TaskRunModel)) ?? false}
+          kind={referenceForModel(TaskRunModel)}
+          ListComponent={TaskRunsList}
+          rowFilters={taskRunFilters(t)}
+          badge={hideBadge ? null : badge}
+          namespace={namespace}
+          columnLayout={{
+            columns: TaskRunsHeader()().map((column) =>
+              _.pick(column, ['title', 'additional', 'id']),
+            ),
+            id: columnManagementID,
+            selectedColumns:
+              tableColumns?.[columnManagementID]?.length > 0
+                ? new Set(tableColumns[columnManagementID])
+                : null,
+            type: t('pipelines-plugin~TaskRun'),
+          }}
+        />
+      )}
     </>
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
@@ -15,62 +15,77 @@ import { tableColumnClasses } from './taskruns-table';
 const taskRunsReference = referenceForModel(TaskRunModel);
 const pipelineReference = referenceForModel(PipelineModel);
 
-const TaskRunsRow: React.FC<RowFunctionArgs<TaskRunKind>> = ({ obj, customData }) => (
-  <>
-    <TableData className={tableColumnClasses[0]}>
-      <ResourceLink
-        kind={taskRunsReference}
-        name={obj.metadata.name}
-        namespace={obj.metadata.namespace}
-        data-test-id={obj.metadata.name}
-      />
-    </TableData>
-    <TableData className={tableColumnClasses[1]} columnID="namespace">
-      <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
-    </TableData>
-    {customData?.showPipelineColumn && (
-      <TableData className={tableColumnClasses[2]}>
-        {obj.metadata.labels[TektonResourceLabel.pipeline] ? (
-          <ResourceLink
-            kind={pipelineReference}
-            name={obj.metadata.labels[TektonResourceLabel.pipeline]}
-            namespace={obj.metadata.namespace}
-          />
-        ) : (
-          '-'
-        )}
-      </TableData>
-    )}
-    <TableData className={tableColumnClasses[3]}>
-      {obj.spec.taskRef?.name ? (
+const TaskRunsRow: React.FC<RowFunctionArgs<TaskRunKind>> = ({ obj, customData }) => {
+  const { selectedColumns } = customData;
+  return (
+    <>
+      <TableData className={tableColumnClasses[0]}>
         <ResourceLink
-          kind={getModelReferenceFromTaskKind(obj.spec.taskRef?.kind)}
-          displayName={obj.metadata.labels[TektonResourceLabel.pipelineTask]}
-          name={obj.spec.taskRef.name}
+          kind={taskRunsReference}
+          name={obj.metadata.name}
           namespace={obj.metadata.namespace}
+          data-test-id={obj.metadata.name}
         />
-      ) : (
-        '-'
+      </TableData>
+      {selectedColumns?.has('namespace') && (
+        <TableData className={tableColumnClasses[1]} columnID="namespace">
+          <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
+        </TableData>
       )}
-    </TableData>
-    <TableData className={tableColumnClasses[4]}>
-      {obj.status?.podName ? (
-        <ResourceLink kind="Pod" name={obj.status.podName} namespace={obj.metadata.namespace} />
-      ) : (
-        '-'
+      {customData?.showPipelineColumn && selectedColumns?.has('pipeline') && (
+        <TableData className={tableColumnClasses[2]}>
+          {obj.metadata.labels[TektonResourceLabel.pipeline] ? (
+            <ResourceLink
+              kind={pipelineReference}
+              name={obj.metadata.labels[TektonResourceLabel.pipeline]}
+              namespace={obj.metadata.namespace}
+            />
+          ) : (
+            '-'
+          )}
+        </TableData>
       )}
-    </TableData>
-    <TableData className={tableColumnClasses[5]}>
-      <TaskRunStatus status={taskRunFilterReducer(obj)} taskRun={obj} />
-    </TableData>
-    <TableData className={tableColumnClasses[6]}>
-      <Timestamp timestamp={obj?.status?.startTime} />
-    </TableData>
-    <TableData className={tableColumnClasses[7]}>{pipelineRunDuration(obj)}</TableData>
-    <TableData className={tableColumnClasses[8]}>
-      <ResourceKebab actions={getTaskRunKebabActions()} kind={taskRunsReference} resource={obj} />
-    </TableData>
-  </>
-);
+      {selectedColumns?.has('task') && (
+        <TableData className={tableColumnClasses[3]}>
+          {obj.spec.taskRef?.name ? (
+            <ResourceLink
+              kind={getModelReferenceFromTaskKind(obj.spec.taskRef?.kind)}
+              displayName={obj.metadata.labels[TektonResourceLabel.pipelineTask]}
+              name={obj.spec.taskRef.name}
+              namespace={obj.metadata.namespace}
+            />
+          ) : (
+            '-'
+          )}
+        </TableData>
+      )}
+      {selectedColumns?.has('pod') && (
+        <TableData className={tableColumnClasses[4]}>
+          {obj.status?.podName ? (
+            <ResourceLink kind="Pod" name={obj.status.podName} namespace={obj.metadata.namespace} />
+          ) : (
+            '-'
+          )}
+        </TableData>
+      )}
+      {selectedColumns?.has('status') && (
+        <TableData className={tableColumnClasses[5]}>
+          <TaskRunStatus status={taskRunFilterReducer(obj)} taskRun={obj} />
+        </TableData>
+      )}
+      {selectedColumns?.has('started') && (
+        <TableData className={tableColumnClasses[6]}>
+          <Timestamp timestamp={obj?.status?.startTime} />
+        </TableData>
+      )}
+      {selectedColumns?.has('duration') && (
+        <TableData className={tableColumnClasses[7]}>{pipelineRunDuration(obj)}</TableData>
+      )}
+      <TableData className={tableColumnClasses[8]}>
+        <ResourceKebab actions={getTaskRunKebabActions()} kind={taskRunsReference} resource={obj} />
+      </TableData>
+    </>
+  );
+};
 
 export default TaskRunsRow;

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/__tests__/TaskRunsRow.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/__tests__/TaskRunsRow.spec.tsx
@@ -32,6 +32,16 @@ describe('TaskRunsRow', () => {
       },
       customData: {
         showPipelineColumn: true,
+        selectedColumns: new Set([
+          'name',
+          'namespace',
+          'task',
+          'pod',
+          'status',
+          'started',
+          'pipeline',
+          'duration',
+        ]),
       },
       columns: null,
     };


### PR DESCRIPTION
**Story**: 
https://issues.redhat.com/browse/ODC-7281

**Description**: 
Added Button with associated Modal for handling Column Management

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/122968482/228800792-9fb5a256-40b5-4ba4-81f6-355654a08cf9.mp4

\
**Unit test coverage report**: 
WIP

**Test setup:** 
- Install Pipelines Operator
- Create a TaskRun

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge