### PR TITLE
CONSOLE-3577: Remove deprecated metering endpoint from backend

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -51,9 +51,6 @@ const (
 	// Default location of the tenant aware Alert Manager service for OpenShift. This is only accessible in-cluster.
 	openshiftAlertManagerTenancyHost = "alertmanager-main.openshift-monitoring.svc:9092"
 
-	// Well-known location of metering service for OpenShift. This is only accessible in-cluster.
-	openshiftMeteringHost = "reporting-operator.openshift-metering.svc:8080"
-
 	// Well-known location of the GitOps service. This is only accessible in-cluster
 	openshiftGitOpsHost = "cluster.openshift-gitops.svc:8080"
 
@@ -94,7 +91,6 @@ func main() {
 	fK8sModeOffClusterSkipVerifyTLS := fs.Bool("k8s-mode-off-cluster-skip-verify-tls", false, "DEV ONLY. When true, skip verification of certs presented by k8s API server.")
 	fK8sModeOffClusterThanos := fs.String("k8s-mode-off-cluster-thanos", "", "DEV ONLY. URL of the cluster's Thanos server.")
 	fK8sModeOffClusterAlertmanager := fs.String("k8s-mode-off-cluster-alertmanager", "", "DEV ONLY. URL of the cluster's AlertManager server.")
-	fK8sModeOffClusterMetering := fs.String("k8s-mode-off-cluster-metering", "", "DEV ONLY. URL of the cluster's metering server.")
 	fK8sModeOffClusterManagedClusterProxy := fs.String("k8s-mode-off-cluster-managed-cluster-proxy", "", "DEV ONLY. Public URL of the ACM/MCE cluster proxy.")
 
 	fK8sAuth := fs.String("k8s-auth", "service-account", "service-account | bearer-token | oidc | openshift")
@@ -444,11 +440,6 @@ func main() {
 				HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
 				Endpoint:        &url.URL{Scheme: "https", Host: *fAlertmanagerTenancyHost, Path: "/api"},
 			}
-			srv.MeteringProxyConfig = &proxy.Config{
-				TLSClientConfig: serviceProxyTLSConfig,
-				HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
-				Endpoint:        &url.URL{Scheme: "https", Host: openshiftMeteringHost, Path: "/api"},
-			}
 			srv.TerminalProxyTLSConfig = serviceProxyTLSConfig
 			srv.PluginsProxyTLSConfig = serviceProxyTLSConfig
 
@@ -519,16 +510,6 @@ func main() {
 				TLSClientConfig: serviceProxyTLSConfig,
 				HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
 				Endpoint:        offClusterAlertManagerURL,
-			}
-		}
-
-		if *fK8sModeOffClusterMetering != "" {
-			offClusterMeteringURL := bridge.ValidateFlagIsURL("k8s-mode-off-cluster-metering", *fK8sModeOffClusterMetering)
-			offClusterMeteringURL.Path += "/api"
-			srv.MeteringProxyConfig = &proxy.Config{
-				TLSClientConfig: serviceProxyTLSConfig,
-				HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
-				Endpoint:        offClusterMeteringURL,
 			}
 		}
 

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -33,7 +33,6 @@ declare interface Window {
     loginURL: string;
     logoutRedirect: string;
     logoutURL: string;
-    meteringBaseURL: string;
     prometheusBaseURL: string;
     prometheusTenancyBaseURL: string;
     quickStarts: string;

--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -1247,7 +1247,7 @@
       "perspective": "admin",
       "section": "administration",
       "id": "customresourcedefinitions",
-      "insertAfter": "metering",
+      "insertAfter": "limitranges",
       "name": "%console-app~CustomResourceDefinitions%",
       "model": {
         "group": "apiextensions.k8s.io",


### PR DESCRIPTION
Also, remove a couple of orphaned metering references in the frontend code.