### PR TITLE
OCPBUGS-5940: Wait with CRD/model translation until i18n bundles are loaded

### DIFF
--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -61,7 +61,8 @@ declare interface Window {
   };
   windowError?: string;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;
-  store?: {}; // Redux store
+  i18n?: {}; // i18next instance, only available in development builds for debugging
+  store?: {}; // Redux store, only available in development builds for debugging
   pluginStore?: {}; // Console plugin store
   loadPluginEntry?: Function;
   Cypress?: {};

--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -12,6 +12,12 @@ import { dateTimeFormatter, fromNow } from './components/utils/datetime';
 const params = new URLSearchParams(window.location.search);
 const pseudolocalizationEnabled = params.get('pseudolocalization') === 'true';
 
+let resolvedLoading;
+
+export const loading = new Promise((resolve) => {
+  resolvedLoading = resolve;
+});
+
 export const init = () => {
   i18n
     .use(new Pseudo({ enabled: pseudolocalizationEnabled, wrapped: true }))
@@ -95,7 +101,21 @@ export const init = () => {
         // eslint-disable-next-line no-console
         console.error(window.windowError);
       },
+    })
+    // Update loading promise and pass values and errors to the caller
+    .then((value) => {
+      resolvedLoading(true);
+      return value;
+    })
+    .catch((error) => {
+      resolvedLoading(false);
+      throw error;
     });
 };
+
+if (process.env.NODE_ENV !== 'production') {
+  // Expose i18next for debugging
+  window.i18n = i18n;
+}
 
 export default i18n;

--- a/frontend/public/module/k8s/get-resources.ts
+++ b/frontend/public/module/k8s/get-resources.ts
@@ -14,6 +14,7 @@ import {
 import { API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY } from '@console/shared/src/constants';
 import { fetchURL } from '../../graphql/client';
 import { pluginStore } from '../../plugins';
+import { loading as i18nLoading } from '../../i18n';
 
 const ADMIN_RESOURCES = new Set([
   'roles',
@@ -154,7 +155,13 @@ export const getResources = () =>
       .concat(['/api/v1'])
       .map((p) => fetchURL<APIResourceList>(p).catch((err) => err));
 
+    // Wait also until the known translation bundles are resolved
+    all.push(i18nLoading);
+
     return Promise.all(all).then((data) => {
+      // Drop i18nLoading promise (resolved loaded state)
+      data.pop();
+
       const resourceSet = new Set<string>();
       const namespacedSet = new Set<string>();
       data.forEach(


### PR DESCRIPTION
Breaking this commit out in to a separate PR from https://github.com/openshift/console/pull/12606 since this bug is impacting CI and @jerolimov is on PTO next week.  

### Summary: htpasswd identity provider error -> Missing i18n key -> Do not translate CRD extensions before the i18n files are loaded

**Related issues:**

* [OCPBUGS-5940](https://issues.redhat.com/browse/OCPBUGS-5940) [CI Watcher]: logs in as 'test' user via htpasswd identity provider: Auth test logs in as 'test' user via htpasswd identity provider

    The underlying issue is that the "shipwright-plugin" or "pipelines-plugin" or another translation file wasn't loaded ("i18n key missing").

    [CI Search for `Auth test logs in as`](https://search.ci.openshift.org/?search=Auth+test+logs+in+as&maxAge=336h&context=1&type=junit&name=pull-ci-openshift-console-master-e2e-gcp-console&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job) in the last 14 days (March 1): 433 runs, 77% failed, 7% of failures match = 6% impact

**Analytics / Root cause**: `getResources` calls `getModelExtensionMetadata` which calls `i18n.t` to translate loaded extensions before the translation files were fetched.

https://github.com/openshift/console/blob/04c482a820f3ea8ba43c7db9d79253c28c7662f3/frontend/public/module/k8s/get-resources.ts#L99-L108

This change was introduced a long time ago as part of https://github.com/openshift/console/pull/10330. It's a race condition between loading the extensions and translation files. For an unknown reason the `missingKeyHandler` wasn't called with i18next v19. Starting with v21 I and the PR https://github.com/openshift/console/pull/12124 I could notice these errors. But the errors were logged by i18next as warning also before.

It is possible to enforce the i18n missing key error by adding a 1s sleep into the i18n handler:

![i18n-handler](https://user-images.githubusercontent.com/139310/221719417-d8eccd55-8300-4750-8418-5d7ca8ed7370.png)

4.12 / i18next v19 / without PR https://github.com/openshift/console/pull/12124

![before-1](https://user-images.githubusercontent.com/139310/222197277-072b4615-645f-4533-ae98-1c3719a6ad97.png)

4.13 / i18next v21 / with PR https://github.com/openshift/console/pull/12124

![missing-i18n](https://user-images.githubusercontent.com/139310/221719242-ff6bd7f4-0651-4021-9306-b5c1d8c62c17.png)

**Fix:** To fix the race condition added a loading promise to i18n.js that resolves when the i18n init finishes loading. Added this as an additional condition to the `Promise.all` check (so that it can run in parallel!) to `getResources`.
