### PR TITLE
ODC-7279: Correcting CI failures of ODC Packages

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/e2e/add-flow-ci.feature
+++ b/frontend/packages/dev-console/integration-tests/features/e2e/add-flow-ci.feature
@@ -123,16 +123,16 @@ Feature: Create the different workloads from Add page
               And Application Name, Name fields displayed in General section
               And Advanced options sections are displayed
               And Create button is in disabled state
-
+              
         Scenario Outline: Create Sample Application from Add page: GS-03-TC05
             Given user is at Add page
              When user clicks on the Samples card
               And user selects "<card_name>" sample from Samples
               And user is able to see the form header name as "<form_header>"
-              And user clicks on Create button
+              And user clicks on Create button for creating sample
              Then user will be redirected to Topology page
               And user is able to see workload "<workload_name>" in topology page list view
-              
+
         Examples:
                   | card_name | form_header               | workload_name |
                   | Httpd     | Create Sample application | httpd-sample  |

--- a/frontend/packages/dev-console/integration-tests/support/commands/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/commands/app.ts
@@ -22,6 +22,7 @@ declare global {
       dropdownSwitchTo(dropdownMenuOption: string): Chainable<Element>;
       isDropdownVisible(): Chainable<Element>;
       checkErrors(): Chainable<Element>;
+      waitUntilEnabled(selector: string): Chainable<Element>;
     }
   }
 }
@@ -147,5 +148,25 @@ Cypress.Commands.add('checkErrors', () => {
     } else if ($body.find('button[aria-label="Close"]').length !== 0) {
       cy.get('button[aria-label="Close"]').click({ force: true });
     }
+  });
+});
+
+Cypress.Commands.add('waitUntilEnabled', (selector, timeout = 20000) => {
+  const start = new Date().getTime();
+
+  return cy.get(selector).then(($el) => {
+    return new Promise((resolve, reject) => {
+      const checkEnabled = () => {
+        if ($el.is(':enabled')) {
+          resolve($el);
+        } else if (new Date().getTime() - start > timeout) {
+          reject(new Error(`Timed out waiting for ${selector} to become enabled`));
+        } else {
+          setTimeout(checkEnabled, 100);
+        }
+      };
+
+      checkEnabled();
+    });
   });
 });

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-git.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-git.ts
@@ -272,3 +272,7 @@ When('user enters Devfile Path as {string}', (devfilePath: string) => {
 Then('user see message {string}', (message: string) => {
   gitPage.checkDevFileHelpText(message);
 });
+
+Then('user clicks on Create button for creating sample', () => {
+  cy.waitUntilEnabled('[data-test-id="submit-button"]').click();
+});

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/actions-on-knative-service.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/actions-on-knative-service.ts
@@ -200,6 +200,7 @@ Given('service should have at least 2 revisions', () => {
 When(
   'user selects {string} context menu option of knative service {string}',
   (option: string, knativeServiceName: string) => {
+    cy.get(topologyPO.graph.fitToScreen).click();
     topologyPage.rightClickOnGroup(knativeServiceName);
     topologyPage.selectContextMenuAction(option);
   },
@@ -329,6 +330,7 @@ Then(
 );
 
 Then('{string} service should not be displayed in project', (serviceName: string) => {
+  cy.reload();
   cy.get(topologyPO.graph.knativeServiceNode)
     .should('not.exist')
     .then(() => {

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineBuilder-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineBuilder-page.ts
@@ -62,6 +62,11 @@ export const pipelineBuilderPage = {
     cy.get(pipelineBuilderPO.formView.quickSearch).type(taskName);
     cy.byTestID('task-cta').click();
   },
+  addRedHatTask: (taskName: string) => {
+    cy.get(pipelineBuilderPO.formView.quickSearch).type(taskName);
+    cy.byTestID(`item-name-${taskName}-Red Hat`).click();
+    cy.byTestID('task-cta').click();
+  },
   clickAddTask: () => {
     cy.get(pipelineBuilderPO.formView.taskDropdown).click();
   },
@@ -79,7 +84,7 @@ export const pipelineBuilderPage = {
       .eq(2)
       .click({ force: true });
     cy.get(pipelineBuilderPO.formView.parallelTask).click();
-    pipelineBuilderPage.AddTask(taskName);
+    pipelineBuilderPage.addRedHatTask(taskName);
   },
   selectSeriesTask: (taskName: string) => {
     cy.mouseHover(pipelineBuilderPO.formView.task);

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-secrets.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-secrets.ts
@@ -35,6 +35,7 @@ Then(
 
 Given('user is at Start Pipeline modal for pipeline {string}', (pipelineName: string) => {
   navigateTo(devNavigationMenu.Pipelines);
+  cy.get(pipelinesPO.pipelinesTab).click();
   pipelinesPage.search(pipelineName);
   pipelinesPage.selectActionForPipeline(pipelineName, pipelineActions.Start);
   modal.modalTitleShouldContain('Start Pipeline');

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -320,6 +320,7 @@ export const topologyPage = {
     topologyPage.getDeploymentNode(nodeName).click();
   },
   clickOnApplicationGroupings: (appName: string) => {
+    cy.reload();
     const id = `[data-id="group:${appName}"] .odc-resource-icon-application`;
     cy.get(id)
       .next('text')


### PR DESCRIPTION
Epic: [ODC-7279](https://issues.redhat.com/browse/ODC-7279)

Knative: 

- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console/12704/pull-ci-openshift-console-master-e2e-gcp-console/1643253453482364928
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console/12683/pull-ci-openshift-console-master-e2e-gcp-console/1640729080988962816
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console/12697/pull-ci-openshift-console-master-e2e-gcp-console/1642023676993867776

Pipelines:

- Entire pipeline flow from Builder page Add secret to pipeline with authentication type as Basic Authentication
- Entire pipeline flow from Builder page Delete the Pipeline Run

Dev-Console:

- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console/12678/pull-ci-openshift-console-master-e2e-gcp-console/1643263038301671424