### PR TITLE
OCPBUGS-10964: Add namespace to the useAccessReview for Subscription tab

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -1229,6 +1229,7 @@ export const ClusterServiceVersionDetailsPage: React.FC<ClusterServiceVersionsDe
     group: SubscriptionModel.apiGroup,
     resource: SubscriptionModel.plural,
     verb: 'list',
+    namespace: ns,
   });
 
   const pagesFor = React.useCallback(


### PR DESCRIPTION
We need to add namespace when evaluating the permissions to list subscriptions in the operator's detail page.
/assign @rhamilto 