### PR TITLE
CONSOLE-3600: Filter operators based on nodes OS type

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -144,6 +144,7 @@ func main() {
 	fControlPlaneTopology := fs.String("control-plane-topology-mode", "", "Defines the topology mode of the control/infra nodes (External | HighlyAvailable | SingleReplica)")
 	fReleaseVersion := fs.String("release-version", "", "Defines the release version of the cluster")
 	fNodeArchitectures := fs.String("node-architectures", "", "List of node architectures. Example --node-architecture=amd64,arm64")
+	fNodeOperatingSystems := fs.String("node-operating-systems", "", "List of node operating systems. Example --node-operating-system=linux,windows")
 	fCopiedCSVsDisabled := fs.Bool("copied-csvs-disabled", false, "Flag to indicate if OLM copied CSVs are disabled.")
 	fHubConsoleURL := fs.String("hub-console-url", "", "URL of the hub cluster's console in a multi cluster environment.")
 	if err := serverconfig.Parse(fs, os.Args[1:], "BRIDGE"); err != nil {
@@ -260,6 +261,17 @@ func main() {
 		}
 	}
 
+	nodeOperatingSystems := []string{}
+	if *fNodeOperatingSystems != "" {
+		for _, str := range strings.Split(*fNodeOperatingSystems, ",") {
+			str = strings.TrimSpace(str)
+			if str == "" {
+				bridge.FlagFatalf("node-operating-systems", "list must contain name of node architectures separated by comma")
+			}
+			nodeOperatingSystems = append(nodeOperatingSystems, str)
+		}
+	}
+
 	hubConsoleURL := &url.URL{}
 	if *fHubConsoleURL != "" {
 		hubConsoleURL = bridge.ValidateFlagIsURL("hub-console-url", *fHubConsoleURL)
@@ -300,6 +312,7 @@ func main() {
 		Telemetry:                    telemetryFlags,
 		ReleaseVersion:               *fReleaseVersion,
 		NodeArchitectures:            nodeArchitectures,
+		NodeOperatingSystems:         nodeOperatingSystems,
 		HubConsoleURL:                hubConsoleURL,
 		AuthMetrics:                  auth.NewMetrics(),
 	}
@@ -321,6 +334,7 @@ func main() {
 	}
 
 	// if !in-cluster (dev) we should not pass these values to the frontend
+	// is used by catalog-utils.ts
 	if *fK8sMode == "in-cluster" {
 		srv.GOARCH = runtime.GOARCH
 		srv.GOOS = runtime.GOOS

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -56,6 +56,7 @@ declare interface Window {
     controlPlaneTopology: string;
     telemetry: Record<string, string>;
     nodeArchitectures: string[];
+    nodeOperatingSystems: string[];
     hubConsoleURL: string;
   };
   windowError?: string;

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -40,8 +40,11 @@ import {
 } from './index';
 
 const osBaseLabel = 'operatorframework.io/os.';
-const targetGOOSLabel = window.SERVER_FLAGS.GOOS ? `${osBaseLabel}${window.SERVER_FLAGS.GOOS}` : '';
 const archBaseLabel = 'operatorframework.io/arch.';
+const targetNodeOperatingSystems = window.SERVER_FLAGS.nodeOperatingSystems ?? [];
+const targetNodeOperatingSystemsLabels = targetNodeOperatingSystems.map(
+  (os) => `${osBaseLabel}${os}`,
+);
 const targetNodeArchitectures = window.SERVER_FLAGS.nodeArchitectures ?? [];
 const targetNodeArchitecturesLabels = targetNodeArchitectures.map(
   (arch) => `${archBaseLabel}${arch}`,
@@ -50,7 +53,7 @@ const targetNodeArchitecturesLabels = targetNodeArchitectures.map(
 const archDefaultAMD64Label = 'operatorframework.io/arch.amd64';
 const osDefaultLinuxLabel = 'operatorframework.io/os.linux';
 const filterByArchAndOS = (items: OperatorHubItem[]): OperatorHubItem[] => {
-  if (_.isEmpty(targetNodeArchitectures) || !window.SERVER_FLAGS.GOOS) {
+  if (_.isEmpty(targetNodeArchitectures) && _.isEmpty(targetNodeOperatingSystems)) {
     return items;
   }
   return items.filter((item: OperatorHubItem) => {
@@ -82,7 +85,7 @@ const filterByArchAndOS = (items: OperatorHubItem[]): OperatorHubItem[] => {
     }
 
     return (
-      _.includes(relevantLabels.os, targetGOOSLabel) &&
+      _.some(relevantLabels.os, (os) => _.includes(targetNodeOperatingSystemsLabels, os)) &&
       _.some(relevantLabels.arch, (arch) => _.includes(targetNodeArchitecturesLabels, arch))
     );
   });

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -118,6 +118,7 @@ type jsGlobals struct {
 	LogoutURL                       string                     `json:"logoutURL"`
 	MulticlusterLogoutRedirect      string                     `json:"multiclusterLogoutRedirect"`
 	NodeArchitectures               []string                   `json:"nodeArchitectures"`
+	NodeOperatingSystems            []string                   `json:"nodeOperatingSystems"`
 	Perspectives                    string                     `json:"perspectives"`
 	ProjectAccessClusterRoles       string                     `json:"projectAccessClusterRoles"`
 	PrometheusBaseURL               string                     `json:"prometheusBaseURL"`
@@ -172,6 +173,7 @@ type Server struct {
 	ManagedClusterProxyConfig           *proxy.Config
 	MonitoringDashboardConfigMapLister  ResourceLister
 	NodeArchitectures                   []string
+	NodeOperatingSystems                []string
 	Perspectives                        string
 	PluginProxy                         string
 	PluginsProxyTLSConfig               *tls.Config
@@ -752,6 +754,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		Telemetry:                  s.Telemetry,
 		ReleaseVersion:             s.ReleaseVersion,
 		NodeArchitectures:          s.NodeArchitectures,
+		NodeOperatingSystems:       s.NodeOperatingSystems,
 		CopiedCSVsDisabled:         s.CopiedCSVsDisabled,
 		HubConsoleURL:              s.HubConsoleURL.String(),
 	}

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -218,6 +218,10 @@ func addClusterInfo(fs *flag.FlagSet, clusterInfo *ClusterInfo) {
 		fs.Set("node-architectures", strings.Join(clusterInfo.NodeArchitectures, ","))
 	}
 
+	if len(clusterInfo.NodeOperatingSystems) > 0 {
+		fs.Set("node-operating-systems", strings.Join(clusterInfo.NodeOperatingSystems, ","))
+	}
+
 	if clusterInfo.CopiedCSVsDisabled {
 		fs.Set("copied-csvs-disabled", "true")
 	}

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -74,6 +74,7 @@ type ClusterInfo struct {
 	ControlPlaneTopology configv1.TopologyMode `yaml:"controlPlaneTopology,omitempty"`
 	ReleaseVersion       string                `yaml:"releaseVersion,omitempty"`
 	NodeArchitectures    []string              `yaml:"nodeArchitectures,omitempty"`
+	NodeOperatingSystems []string              `yaml:"nodeOperatingSystems,omitempty"`
 	CopiedCSVsDisabled   bool                  `yaml:"copiedCSVsDisabled,omitempty"`
 }
 


### PR DESCRIPTION
Console-operator changes [CONSOLE-3279](https://issues.redhat.com/browse/CONSOLE-3279) which need to get in first.

Adding screen to confirm that the `console-config.yaml` contains the new field:
<img width="1066" alt="Screenshot 2023-04-11 at 12 38 52" src="https://user-images.githubusercontent.com/1668218/231136075-19f7ef48-3e39-472e-8dc5-4c418d59ca68.png">


/assign @rhamilto @TheRealJon 

