### PR TITLE
Add the possibility login with different IDP and user credentials

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/dev-console/integration-tests/support/commands/hooks.ts
@@ -1,5 +1,8 @@
 before(() => {
-  cy.login();
+  const bridgePasswordIDP: string = Cypress.env('BRIDGE_HTPASSWD_IDP');
+  const bridgePasswordUsername: string = Cypress.env('BRIDGE_HTPASSWD_USERNAME');
+  const bridgePasswordPassword: string = Cypress.env('BRIDGE_KUBEADMIN_PASSWORD');
+  cy.login(bridgePasswordIDP, bridgePasswordUsername, bridgePasswordPassword);
   cy.document()
     .its('readyState')
     .should('eq', 'complete');


### PR DESCRIPTION
This PR allows setting up initial credentials for IDP and user login and user password before the test process (using hooks) for different environments. All parameters are optional. If the env. vars are not set will be applied default behavior (like was before)

**Test Setup:**
Just set up appropriate credentials for a cluster and run tests as well
![screencast-bpconcjcammlapcogcnnelfmaeghhagj-2023 04 06-16_38_52](https://user-images.githubusercontent.com/1640058/230396029-2dcff07e-0a5d-4cd1-92b1-bfdb238b991b.gif)