### PR TITLE
OCPBUGS-7416: get Kamelets from the camel-k-operator namespace as well

### DIFF
--- a/frontend/packages/knative-plugin/src/const.ts
+++ b/frontend/packages/knative-plugin/src/const.ts
@@ -30,6 +30,7 @@ export const KNATIVE_AUTOSCALEWINDOW_ANNOTATION = `${KNATIVE_AUTOSCALING_APIGROU
 export const SERVERLESS_FUNCTION_LABEL_DEPRECATED = 'boson.dev/function'; // TODO: remove deprecated label for serverless function
 export const SERVERLESS_FUNCTION_LABEL = 'function.knative.dev';
 export const GLOBAL_OPERATOR_NS = 'openshift-operators';
+export const CAMEL_K_OPERATOR_NS = 'camel-k-operator';
 export const EVENTING_KAFKA_CHANNEL_KIND = 'KafkaChannel';
 export const EVENTING_CHANNEL_KIND = 'Channel';
 export const EVENTING_IMC_KIND = 'InMemoryChannel';

--- a/frontend/packages/knative-plugin/src/hooks/useEventSinkStatus.ts
+++ b/frontend/packages/knative-plugin/src/hooks/useEventSinkStatus.ts
@@ -4,7 +4,7 @@ import { useAccessReview } from '@console/dynamic-plugin-sdk';
 import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { KnEventCatalogMetaData } from '../components/add/import-types';
-import { GLOBAL_OPERATOR_NS } from '../const';
+import { CAMEL_K_OPERATOR_NS, GLOBAL_OPERATOR_NS } from '../const';
 import { CamelKameletBindingModel, CamelKameletModel, KafkaSinkModel } from '../models';
 import { getEventSinkMetadata } from '../utils/create-eventsink-utils';
 import { getKameletMetadata } from '../utils/create-eventsources-utils';
@@ -32,9 +32,15 @@ export const useEventSinkStatus = (
     kameletName,
     GLOBAL_OPERATOR_NS,
   );
+  const [kameletGlobalNs2, kameletGlobalNs2Loaded] = useK8sGet<K8sResourceKind>(
+    CamelKameletModel,
+    kameletName,
+    CAMEL_K_OPERATOR_NS,
+  );
 
-  const kameletLoaded = kameletNsLoaded && kameletGlobalNsLoaded;
-  const kamelet = kameletName && kameletLoaded && (kameletNs || kameletGlobalNs);
+  const kameletLoaded = kameletNsLoaded && kameletGlobalNsLoaded && kameletGlobalNs2Loaded;
+  const kamelet =
+    kameletName && kameletLoaded && (kameletNs || kameletGlobalNs || kameletGlobalNs2);
 
   const isKameletSink = kameletName && sinkKindProp === CamelKameletBindingModel.kind;
   const isSinkKindPresent = sinkKindProp || isKameletSink;

--- a/frontend/packages/knative-plugin/src/hooks/useEventSourceStatus.ts
+++ b/frontend/packages/knative-plugin/src/hooks/useEventSourceStatus.ts
@@ -4,7 +4,7 @@ import { useAccessReview2 } from '@console/internal/components/utils';
 import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
 import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { KnEventCatalogMetaData } from '../components/add/import-types';
-import { GLOBAL_OPERATOR_NS } from '../const';
+import { CAMEL_K_OPERATOR_NS, GLOBAL_OPERATOR_NS } from '../const';
 import { CamelKameletBindingModel, CamelKameletModel } from '../models';
 import { getEventSourceMetadata, getKameletMetadata } from '../utils/create-eventsources-utils';
 import { useEventSourceModels } from '../utils/fetch-dynamic-eventsources-utils';
@@ -33,9 +33,14 @@ export const useEventSourceStatus = (
     kameletName,
     GLOBAL_OPERATOR_NS,
   );
+  const [kameletGlobalNs2, kameletGlobalNs2Loaded] = useK8sGet<K8sResourceKind>(
+    CamelKameletModel,
+    kameletName,
+    CAMEL_K_OPERATOR_NS,
+  );
 
-  const kameletLoaded = kameletNsLoaded && kameletGlobalNsLoaded;
-  const kamelet = kameletLoaded && (kameletNs || kameletGlobalNs);
+  const kameletLoaded = kameletNsLoaded && kameletGlobalNsLoaded && kameletGlobalNs2Loaded;
+  const kamelet = kameletLoaded && (kameletNs || kameletGlobalNs || kameletGlobalNs2);
 
   const isKameletSource = kameletName && sourceKindProp === CamelKameletBindingModel.kind;
   const isSourceKindPresent = sourceKindProp || isKameletSource;


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-7416

Descriptions:  Load Kamelets as event sources/sinks from custom Camel K operator namespace