### PR TITLE
[dyn-plugin-sdk] Cleanup side effects

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/AppInitSDK.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/AppInitSDK.tsx
@@ -48,6 +48,10 @@ const AppInitSDK: React.FC<AppInitSDKProps> = ({ children, configurations }) => 
       // eslint-disable-next-line no-console
       console.warn(e);
     }
+
+    return () => {
+      setUtilsConfig(undefined);
+    };
   }, [configurations, store]);
 
   return !storeContextPresent ? <Provider store={store}>{children}</Provider> : <>{children}</>;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/configSetup.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/configSetup.ts
@@ -17,12 +17,12 @@ let config: UtilsConfig | undefined;
  *
  * This must be done before using any of the Kubernetes utilities.
  */
-export const setUtilsConfig = (c: UtilsConfig) => {
-  if (config !== undefined) {
+export const setUtilsConfig = (c: UtilsConfig | undefined) => {
+  if (config !== undefined && c !== undefined) {
     throw new Error('setUtilsConfig has already been called');
   }
 
-  config = Object.freeze({ ...c });
+  config = config ? Object.freeze({ ...c }) : undefined;
 };
 
 /**

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/configSetup.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/configSetup.ts
@@ -22,7 +22,7 @@ export const setUtilsConfig = (c: UtilsConfig | undefined) => {
     throw new Error('setUtilsConfig has already been called');
   }
 
-  config = config ? Object.freeze({ ...c }) : undefined;
+  config = c ? Object.freeze({ ...c }) : undefined;
 };
 
 /**


### PR DESCRIPTION
As calling `setUtilsConfig` twice is not expected, we must cleanup the effect upon component unmount. Effects are called twice in development mode.

This fix is not needed in prod but is a good thing to have nonetheless.

The function prototype has been modified to additionally accept undefined values but it is only expected to do so when cleaning up the effects. Calling it otherwise with `undefined` is an error.

Fixes: #12492