### PR TITLE
CONSOLE-3623: Add X-CSRF token to console request headers

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch-utils.ts
@@ -5,6 +5,21 @@ type ConsoleRequestHeaders = {
   'Impersonate-Group'?: string;
   'Impersonate-User'?: string;
   'X-Cluster'?: string;
+  'X-CSRFToken'?: string;
+};
+
+export const getCSRFToken = () => {
+  const cookiePrefix = 'csrf-token=';
+  return (
+    document &&
+    document.cookie &&
+    document.cookie
+      .split(';')
+      .map((c) => c.trim())
+      .filter((c) => c.startsWith(cookiePrefix))
+      .map((c) => c.slice(cookiePrefix.length))
+      .pop()
+  );
 };
 
 /**
@@ -21,6 +36,7 @@ export const getConsoleRequestHeaders = (targetCluster?: string): ConsoleRequest
   const cluster = getActiveCluster(state);
   const headers: ConsoleRequestHeaders = {
     'X-Cluster': targetCluster ?? cluster,
+    'X-CSRFToken': getCSRFToken(),
   };
 
   // Set impersonation headers

--- a/frontend/public/co-fetch.ts
+++ b/frontend/public/co-fetch.ts
@@ -3,36 +3,18 @@ import { HttpError, RetryError } from '@console/dynamic-plugin-sdk/src/utils/err
 import { authSvc } from './module/auth';
 import { getActiveCluster } from '@console/dynamic-plugin-sdk/src';
 import storeHandler from '@console/dynamic-plugin-sdk/src/app/storeHandler';
-
-// set required headers for console
-const getCSRFToken = () => {
-  const cookiePrefix = 'csrf-token=';
-  return (
-    document &&
-    document.cookie &&
-    document.cookie
-      .split(';')
-      .map((c) => _.trim(c))
-      .filter((c) => c.startsWith(cookiePrefix))
-      .map((c) => c.slice(cookiePrefix.length))
-      .pop()
-  );
-};
+import { getCSRFToken } from '@console/dynamic-plugin-sdk/src/utils/fetch/console-fetch-utils';
 
 export const applyConsoleHeaders = (url, options) => {
-  if (options.method !== 'GET') {
-    const token = getCSRFToken();
-    if (options.headers) {
-      options.headers['X-CSRFToken'] = token;
-    } else {
-      options.headers = { 'X-CSRFToken': token };
-    }
+  const token = getCSRFToken();
+  if (options.headers) {
+    options.headers['X-CSRFToken'] = token;
+  } else {
+    options.headers = { 'X-CSRFToken': token };
   }
 
-  // If the URL being requested is absolute (and therefore, not a local request),
-  // remove the authorization header to prevent credentials from leaking.
-  if (url.indexOf('://') >= 0 && options.headers) {
-    delete options.headers.Authorization;
+  // X-CSRFToken is used only for non-GET requests targeting bridge
+  if (options.method === 'GET' || url.indexOf('://') >= 0) {
     delete options.headers['X-CSRFToken'];
   }
   return options;


### PR DESCRIPTION
This will enable plugins to use custom fetch/axios for the network requests. The `consoleFetch` is not suitable for non-k8s APIs due to its custom error handling.