### PR TITLE
OCPBUGS-9909: Could not import multiple resources via JSON (while YAML supports this)

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -493,8 +493,21 @@ export const EditYAML_ = connect(stateToProps)(
               return;
             }
             if (objs.length === 1) {
-              this.save();
-              return;
+              if (
+                objs[0]?.apiVersion === 'v1' &&
+                objs[0]?.kind?.includes('List') &&
+                objs[0]?.items
+              ) {
+                if (objs[0]?.items?.length > 0) {
+                  objs = objs[0].items;
+                } else {
+                  this.handleError(t('public~"items" list is empty'));
+                  return;
+                }
+              } else {
+                this.save();
+                return;
+              }
             } else if (objs.length === 0) {
               return;
             }

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -471,6 +471,7 @@
   "Cannot change resource namespace (original: \"{{namespace}}\", updated: \"{{newNamespace}}\").": "Cannot change resource namespace (original: \"{{namespace}}\", updated: \"{{newNamespace}}\").",
   "Cannot change resource kind (original: \"{{original}}\", updated: \"{{updated}}\").": "Cannot change resource kind (original: \"{{original}}\", updated: \"{{updated}}\").",
   "Cannot change API group (original: \"{{apiGroup}}\", updated: \"{{newAPIGroup}}\").": "Cannot change API group (original: \"{{apiGroup}}\", updated: \"{{newAPIGroup}}\").",
+  "\"items\" list is empty": "\"items\" list is empty",
   "Resources in the same namespace and API group must have unique names": "Resources in the same namespace and API group must have unique names",
   "Failed to parse YAML sample": "Failed to parse YAML sample",
   "An error occurred.": "An error occurred.",


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-9909

**Analysis / Root cause:**
List of resources in JSON format was not considered

**Solution Description:**
Considered list of resources in import YAML flow

**Screen shots / Gifs for design review:**

-------Before-----
<img width="786" alt="Screenshot 2023-04-13 at 1 17 03 PM" src="https://user-images.githubusercontent.com/102503482/231695341-aad63690-8d1c-4be6-ba75-108ee1ebf21b.png">


-------After----

https://user-images.githubusercontent.com/102503482/231695144-b9d6f292-eb0b-4220-b8ca-d32a71d8118d.mov




****Unit test coverage report:****
NA

**Test setup:**

Import below JSON to create multiple resources

```
{
  "apiVersion": "v1",
  "kind": "List",
  "items": [
    {
      "apiVersion": "v1",
      "kind": "ConfigMap",
      "metadata": {
        "generateName": "a-configmap-"
      }
    },
    {
      "apiVersion": "v1",
      "kind": "ConfigMap",
      "metadata": {
        "generateName": "a-configmap-"
      }
    }
  ]
}
```

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
