### PR TITLE
OCPBUGS-6770: Pipeline doesn't render correctly when displayed but looks fine in edit mode

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
@@ -495,8 +495,10 @@ export const getGraphDataModel = (
       const minLevelDep = _.minBy(v, (d) => d.level);
       const nearestDeps = v.filter((v1) => v1.level === minLevelDep.level);
       nearestDeps.forEach((nd) => {
-        if (nd.level - vertex.level <= 1 || vertex.dependancyNames.length === 0) {
-          runAfterTasks.push(nd.name);
+        if (vertex.dependancyNames.includes(nd.name)) {
+          if (nd.level - vertex.level <= 1 || vertex.dependancyNames.length === 0) {
+            runAfterTasks.push(nd.name);
+          }
         }
       });
     }


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: [https://issues.redhat.com/browse/ODC-XXX](https://issues.redhat.com/browse/ODC-XXX) -->
https://issues.redhat.com/browse/OCPBUGS-6770

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
This issue was caused by an unhandled edge case in the function that generates nodes for the graph, causing it to create unwanted edges for the same

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
fixed the issue by making sure the dependencies present in the current node are the only ones that are being used as nearest dependencies

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
--Before--
![render-bad](https://user-images.githubusercontent.com/122968482/231744806-ca1c3ab6-068a-4e86-bc80-5ecbfaf58168.png)

--After--
![Screenshot from 2023-04-13 16-51-24](https://user-images.githubusercontent.com/122968482/231744923-b19f4590-50b0-4880-a35c-dc404bb4ebeb.png)

**Unit test coverage report**: 
<!-- Attach test coverage report -->
NA


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
For the setup, just make sure pipelines operator is installed
Then create a pipeline using the following YAML file, https://github.com/gnunn-gitops/product-catalog/blob/main/components/tekton/pipelines/server/base/server-pipeline.yaml

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge