### PR TITLE
OCPBUGS-10884: add multipath device type to LocalVolumeSet

### DIFF
--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/body.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/body.tsx
@@ -181,7 +181,7 @@ export const LocalVolumeSetBody: React.FC<LocalVolumeSetBodyProps> = ({
         >
           <MultiSelectDropdown
             id="create-lso-device-type-dropdown"
-            options={[deviceTypeOptions.DISK, deviceTypeOptions.PART]}
+            options={[deviceTypeOptions.DISK, deviceTypeOptions.PART, deviceTypeOptions.MPATH]}
             placeholder="Select disk types"
             onChange={(selectedValues: string[]) => {
               dispatch({ type: 'setDeviceType', value: selectedValues });

--- a/frontend/packages/local-storage-operator-plugin/src/constants/index.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/constants/index.ts
@@ -26,6 +26,7 @@ export const DISK_TYPES: {
 export const deviceTypeDropdownItems = Object.freeze({
   DISK: 'Disk',
   PART: 'Part',
+  MPATH: 'Mpath',
 });
 
 export const fsTypeDropdownItems = Object.freeze({


### PR DESCRIPTION
Local Storage Operator supports multipath aside from disk and partition device types for `LocalVolumeSet`. If multipath option is missing, users can not specify it in the console when creating `LocalVolumeSet` and have to edit the object manually later if they want to use multipath.

cc @openshift/storage