### PR TITLE
OCPBUGS-11099: add support for minimal status of tekton

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunCustomDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunCustomDetails.tsx
@@ -16,6 +16,7 @@ import DynamicResourceLinkList from '../../pipelines/resource-overview/DynamicRe
 import RepositoryLinkList from '../../repository/RepositoryLinkList';
 import PipelineResourceRef from '../../shared/common/PipelineResourceRef';
 import WorkspaceResourceLinkList from '../../shared/workspaces/WorkspaceResourceLinkList';
+import { useTaskRuns } from '../../taskruns/useTaskRuns';
 import { getPLRLogSnippet } from '../logs/pipelineRunLogSnippet';
 import RunDetailsErrorLog from '../logs/RunDetailsErrorLog';
 import TriggeredBySection from './TriggeredBySection';
@@ -26,6 +27,10 @@ export type PipelineRunCustomDetailsProps = {
 
 const PipelineRunCustomDetails: React.FC<PipelineRunCustomDetailsProps> = ({ pipelineRun }) => {
   const { t } = useTranslation();
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(
+    pipelineRun?.metadata?.namespace,
+    pipelineRun?.metadata?.name,
+  );
   const pipelineResourceLinks = getPipelineResourceLinks(
     pipelineRun.status?.pipelineSpec?.resources,
     pipelineRun.spec.resources,
@@ -42,10 +47,12 @@ const PipelineRunCustomDetails: React.FC<PipelineRunCustomDetailsProps> = ({ pip
           />
         </dd>
       </dl>
-      <RunDetailsErrorLog
-        logDetails={getPLRLogSnippet(pipelineRun)}
-        namespace={pipelineRun.metadata.namespace}
-      />
+      {taskRunsLoaded && (
+        <RunDetailsErrorLog
+          logDetails={getPLRLogSnippet(pipelineRun, taskRuns)}
+          namespace={pipelineRun.metadata.namespace}
+        />
+      )}
       <dl>
         <dt>{t('pipelines-plugin~Pipeline')}</dt>
         <dd>

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.tsx
@@ -7,9 +7,11 @@ import { RouteComponentProps } from 'react-router';
 import { Link } from 'react-router-dom';
 import { Firehose, resourcePathFromModel } from '@console/internal/components/utils';
 import { PipelineRunModel } from '../../../models';
-import { PipelineRunKind } from '../../../types';
+import { PipelineRunKind, TaskRunKind } from '../../../types';
 import { pipelineRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
+import { TektonResourceLabel } from '../../pipelines/const';
 import { ColoredStatusIcon } from '../../pipelines/detail-page-tabs/pipeline-details/StatusIcon';
+import { useTaskRuns } from '../../taskruns/useTaskRuns';
 import { ErrorDetailsWithStaticLog } from '../logs/log-snippet-types';
 import { getDownloadAllLogsCallback } from '../logs/logs-utils';
 import LogsWrapperComponent from '../logs/LogsWrapperComponent';
@@ -20,6 +22,7 @@ interface PipelineRunLogsProps {
   obj: PipelineRunKind;
   activeTask?: string;
   t: TFunction;
+  taskRuns: TaskRunKind[];
 }
 interface PipelineRunLogsState {
   activeItem: string;
@@ -35,47 +38,40 @@ class PipelineRunLogsWithTranslation extends React.Component<
   }
 
   componentDidMount() {
-    const { obj, activeTask } = this.props;
-    const taskRunFromYaml = _.get(obj, ['status', 'taskRuns'], {});
-    const taskRuns = this.getSortedTaskRun(taskRunFromYaml);
-    const activeItem = this.getActiveTaskRun(obj, taskRuns, activeTask);
+    const { activeTask, taskRuns } = this.props;
+    const sortedTaskRuns = this.getSortedTaskRun(taskRuns);
+    const activeItem = this.getActiveTaskRun(sortedTaskRuns, activeTask);
     this.setState({ activeItem });
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    if (this.props.obj !== nextProps.obj) {
-      const { obj, activeTask } = this.props;
-      const taskRunFromYaml = _.get(obj, ['status', 'taskRuns'], {});
-      const taskRuns = this.getSortedTaskRun(taskRunFromYaml);
-      const activeItem = this.getActiveTaskRun(obj, taskRuns, activeTask);
+    if (this.props.obj !== nextProps.obj || this.props.taskRuns !== nextProps.taskRuns) {
+      const { activeTask, taskRuns } = this.props;
+      const sortedTaskRuns = this.getSortedTaskRun(taskRuns);
+      const activeItem = this.getActiveTaskRun(sortedTaskRuns, activeTask);
       this.state.navUntouched && this.setState({ activeItem });
     }
   }
 
-  getActiveTaskRun = (obj: PipelineRunKind, taskRuns: string[], activeTask: string): string => {
-    const activeTaskRun: string = _.findKey(
-      obj?.status?.taskRuns,
-      (taskRun) => taskRun.pipelineTaskName === activeTask,
-    );
-    return activeTaskRun || taskRuns[taskRuns.length - 1];
-  };
+  getActiveTaskRun = (taskRuns: string[], activeTask: string): string =>
+    activeTask
+      ? taskRuns.find((taskRun) => taskRun.includes(activeTask))
+      : taskRuns[taskRuns.length - 1];
 
-  getSortedTaskRun = (taskRunFromYaml) => {
-    const taskRuns = Object.keys(taskRunFromYaml).sort((a, b) => {
-      if (_.get(taskRunFromYaml, [a, 'status', 'completionTime'], false)) {
-        return taskRunFromYaml[b].status?.completionTime &&
-          new Date(taskRunFromYaml[a].status.completionTime) >
-            new Date(taskRunFromYaml[b].status.completionTime)
+  getSortedTaskRun = (tRuns: TaskRunKind[]): string[] => {
+    const taskRuns = tRuns?.sort((a, b) => {
+      if (_.get(a, ['status', 'completionTime'], false)) {
+        return b.status?.completionTime &&
+          new Date(a.status.completionTime) > new Date(b.status.completionTime)
           ? 1
           : -1;
       }
-      return taskRunFromYaml[b].status?.completionTime ||
-        new Date(taskRunFromYaml[a].status?.startTime) >
-          new Date(taskRunFromYaml[b].status?.startTime)
+      return b.status?.completionTime ||
+        new Date(a.status?.startTime) > new Date(b.status?.startTime)
         ? 1
         : -1;
     });
-    return taskRuns;
+    return taskRuns?.map((tr) => tr?.metadata?.name) || [];
   };
 
   onNavSelect = (item) => {
@@ -86,11 +82,14 @@ class PipelineRunLogsWithTranslation extends React.Component<
   };
 
   render() {
-    const { obj, t } = this.props;
+    const { obj, t, taskRuns: tRuns } = this.props;
     const { activeItem } = this.state;
-    const taskRunFromYaml = _.get(obj, ['status', 'taskRuns'], {});
-    const taskRuns = this.getSortedTaskRun(taskRunFromYaml);
-    const logDetails = getPLRLogSnippet(obj) as ErrorDetailsWithStaticLog;
+    const taskRuns = this.getSortedTaskRun(tRuns);
+    const taskRunFromYaml = tRuns?.reduce((acc, value) => {
+      acc[value?.metadata?.name] = value;
+      return acc;
+    }, {});
+    const logDetails = getPLRLogSnippet(obj, tRuns) as ErrorDetailsWithStaticLog;
 
     const taskCount = taskRuns.length;
     const downloadAllCallback =
@@ -102,7 +101,9 @@ class PipelineRunLogsWithTranslation extends React.Component<
             obj.metadata?.name,
           )
         : undefined;
-    const podName = taskRunFromYaml[activeItem]?.status?.podName;
+    const podName = taskRunFromYaml?.[activeItem]?.status?.podName;
+    const taskName =
+      taskRunFromYaml?.[activeItem]?.metadata?.labels?.[TektonResourceLabel.pipelineTask] || '-';
     const resources = taskCount > 0 &&
       podName && [
         {
@@ -132,14 +133,25 @@ class PipelineRunLogsWithTranslation extends React.Component<
                       isActive={activeItem === task}
                       className="odc-pipeline-run-logs__navitem"
                     >
-                      <Link to={path + _.get(taskRunFromYaml, [task, `pipelineTaskName`], '-')}>
+                      <Link
+                        to={
+                          path +
+                            taskRunFromYaml?.[task]?.metadata?.labels?.[
+                              TektonResourceLabel.pipelineTask
+                            ] || '-'
+                        }
+                      >
                         <ColoredStatusIcon
                           status={pipelineRunFilterReducer(
-                            _.get(obj, ['status', 'taskRuns', task]),
+                            obj?.status?.taskRuns
+                              ? _.get(obj, ['status', 'taskRuns', task])
+                              : tRuns?.find((tr) => tr?.metadata?.name === task),
                           )}
                         />
                         <span className="odc-pipeline-run-logs__namespan">
-                          {_.get(taskRunFromYaml, [task, `pipelineTaskName`], '-')}
+                          {taskRunFromYaml[task]?.metadata?.labels?.[
+                            TektonResourceLabel.pipelineTask
+                          ] || '-'}
                         </span>
                       </Link>
                     </NavItem>
@@ -157,7 +169,7 @@ class PipelineRunLogsWithTranslation extends React.Component<
           {activeItem && resources ? (
             <Firehose key={activeItem} resources={resources}>
               <LogsWrapperComponent
-                taskName={_.get(taskRunFromYaml, [activeItem, 'pipelineTaskName'], '-')}
+                taskName={taskName}
                 downloadAllLabel={t('pipelines-plugin~Download all task logs')}
                 onDownloadAll={downloadAllCallback}
               />
@@ -196,7 +208,10 @@ export const PipelineRunLogsWithActiveTask: React.FC<PipelineRunLogsWithActiveTa
   params,
 }) => {
   const activeTask = _.get(params, 'match.params.name');
-  return <PipelineRunLogs obj={obj} activeTask={activeTask} />;
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(obj?.metadata?.namespace, obj?.metadata?.name);
+  return (
+    taskRunsLoaded && <PipelineRunLogs obj={obj} activeTask={activeTask} taskRuns={taskRuns} />
+  );
 };
 
 export default PipelineRunLogs;

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunVisualization.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunVisualization.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { LoadingInline } from '@console/internal/components/utils';
 import { PipelineKind, PipelineRunKind } from '../../../types';
 import PipelineVisualization from '../../pipelines/detail-page-tabs/pipeline-details/PipelineVisualization';
+import { useTaskRuns } from '../../taskruns/useTaskRuns';
 import { usePipelineFromPipelineRun } from '../hooks/usePipelineFromPipelineRun';
 import './PipelineRunVisualization.scss';
 
@@ -10,6 +11,10 @@ type PipelineRunVisualizationProps = {
 };
 
 const PipelineRunVisualization: React.FC<PipelineRunVisualizationProps> = ({ pipelineRun }) => {
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(
+    pipelineRun?.metadata?.namespace,
+    pipelineRun?.metadata?.name,
+  );
   const pipeline: PipelineKind = usePipelineFromPipelineRun(pipelineRun);
   if (!pipeline) {
     return (
@@ -18,7 +23,11 @@ const PipelineRunVisualization: React.FC<PipelineRunVisualizationProps> = ({ pip
       </div>
     );
   }
-  return <PipelineVisualization pipeline={pipeline} pipelineRun={pipelineRun} />;
+  return (
+    taskRunsLoaded && (
+      <PipelineVisualization pipeline={pipeline} pipelineRun={pipelineRun} taskRuns={taskRuns} />
+    )
+  );
 };
 
 export default PipelineRunVisualization;

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/__tests__/PipelineRunVisualization.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/__tests__/PipelineRunVisualization.spec.tsx
@@ -7,11 +7,14 @@ import {
   pipelineTestData,
 } from '../../../../test-data/pipeline-data';
 import PipelineVisualization from '../../../pipelines/detail-page-tabs/pipeline-details/PipelineVisualization';
+import * as utils from '../../../taskruns/useTaskRuns';
 import * as plrDetailsHooks from '../../hooks/usePipelineFromPipelineRun';
 import PipelineRunVisualization from '../PipelineRunVisualization';
 
 const pipelineData = pipelineTestData[PipelineExampleNames.COMPLEX_PIPELINE];
 const pipelineRun = pipelineData.pipelineRuns[DataState.SUCCESS];
+
+const spyUseTaskRuns = jest.spyOn(utils, 'useTaskRuns');
 
 describe('PipelineRunVisualization', () => {
   type PipelineRunVisualizationProps = React.ComponentProps<typeof PipelineRunVisualization>;
@@ -24,6 +27,7 @@ describe('PipelineRunVisualization', () => {
 
   it('Should render the loading component if pipeline from pipeline run is not defined or null', () => {
     usePipelineFromPipelineRunSpy.mockReturnValueOnce(null);
+    spyUseTaskRuns.mockReturnValue([[], true]);
     wrapper = shallow(<PipelineRunVisualization pipelineRun={pipelineRun} />);
     const LoadingInlineComponent = wrapper.find(LoadingInline);
     expect(LoadingInlineComponent.exists()).toBe(true);
@@ -31,6 +35,7 @@ describe('PipelineRunVisualization', () => {
 
   it('Should render the visualization component if the pipelinerun has the graphable data', () => {
     usePipelineFromPipelineRunSpy.mockReturnValueOnce(pipelineData.pipeline);
+    spyUseTaskRuns.mockReturnValue([[], true]);
     wrapper = shallow(<PipelineRunVisualization pipelineRun={pipelineRun} />);
     const PipelineVisualizationComponent = wrapper.find(PipelineVisualization);
     expect(PipelineVisualizationComponent.exists()).toBe(true);

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTaskStatus.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTaskStatus.ts
@@ -1,8 +1,11 @@
-import { PipelineKind, PipelineRunKind } from '../../../types';
+import { PipelineKind, PipelineRunKind, TaskRunKind } from '../../../types';
 import { getTaskStatus, TaskStatus } from '../../../utils/pipeline-augment';
 import { usePipelineFromPipelineRun } from './usePipelineFromPipelineRun';
 
-export const useTaskStatus = (pipelineRun: PipelineRunKind): TaskStatus => {
+export const useTaskStatus = (
+  pipelineRun: PipelineRunKind,
+  taskRuns: TaskRunKind[],
+): TaskStatus => {
   const pipeline: PipelineKind = usePipelineFromPipelineRun(pipelineRun);
-  return getTaskStatus(pipelineRun, pipeline);
+  return getTaskStatus(pipelineRun, pipeline, taskRuns);
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/pipelineRunLogSnippet.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/pipelineRunLogSnippet.ts
@@ -1,10 +1,19 @@
 import i18next from 'i18next';
-import { Condition, PipelineRunKind, PLRTaskRunData, PLRTaskRunStep } from '../../../types';
+import {
+  Condition,
+  PipelineRunKind,
+  PLRTaskRunData,
+  PLRTaskRunStep,
+  TaskRunKind,
+} from '../../../types';
 import { pipelineRunStatus } from '../../../utils/pipeline-filter-reducer';
 import { CombinedErrorDetails } from './log-snippet-types';
 import { taskRunSnippetMessage } from './log-snippet-utils';
 
-export const getPLRLogSnippet = (pipelineRun: PipelineRunKind): CombinedErrorDetails => {
+export const getPLRLogSnippet = (
+  pipelineRun: PipelineRunKind,
+  taskRuns: TaskRunKind[],
+): CombinedErrorDetails => {
   if (!pipelineRun?.status) {
     // Lack information to pull from the Pipeline Run
     return null;
@@ -23,8 +32,8 @@ export const getPLRLogSnippet = (pipelineRun: PipelineRunKind): CombinedErrorDet
     return null;
   }
 
-  const taskRuns: PLRTaskRunData[] = Object.values(pipelineRun.status.taskRuns || {});
-  const failedTaskRuns = taskRuns.filter((taskRun) =>
+  const tRuns: PLRTaskRunData[] = Object.values(taskRuns || pipelineRun.status.taskRuns || {});
+  const failedTaskRuns = tRuns.filter((taskRun) =>
     taskRun?.status?.conditions?.find(
       (condition) => condition.type === 'Succeeded' && condition.status === 'False',
     ),

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/LinkedPipelineRunTaskStatus.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/LinkedPipelineRunTaskStatus.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { resourcePathFromModel } from '@console/internal/components/utils';
+import { LoadingInline, resourcePathFromModel } from '@console/internal/components/utils';
 import { PipelineRunModel } from '../../../models';
 import { PipelineRunKind } from '../../../types';
+import { useTaskRuns } from '../../taskruns/useTaskRuns';
 import { PipelineBars } from './PipelineBars';
 
 export interface LinkedPipelineRunTaskStatusProps {
@@ -18,9 +19,14 @@ const LinkedPipelineRunTaskStatus: React.FC<LinkedPipelineRunTaskStatusProps> = 
   pipelineRun,
 }) => {
   const { t } = useTranslation();
-
-  const pipelineStatus = (
-    <PipelineBars key={pipelineRun.metadata?.name} pipelinerun={pipelineRun} />
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(
+    pipelineRun.metadata.namespace,
+    pipelineRun.metadata.name,
+  );
+  const pipelineStatus = taskRunsLoaded ? (
+    <PipelineBars key={pipelineRun.metadata?.name} pipelinerun={pipelineRun} taskRuns={taskRuns} />
+  ) : (
+    <LoadingInline />
   );
 
   if (pipelineRun.metadata?.name && pipelineRun.metadata?.namespace) {

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineBars.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineBars.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
-import { ComputedStatus, PipelineRunKind } from '../../../types';
+import { ComputedStatus, PipelineRunKind, TaskRunKind } from '../../../types';
 import { getRunStatusColor } from '../../../utils/pipeline-augment';
 import HorizontalStackedBars from '../../charts/HorizontalStackedBars';
 import { useTaskStatus } from '../hooks/useTaskStatus';
@@ -8,11 +8,11 @@ import TaskStatusToolTip from './TaskStatusTooltip';
 
 export interface PipelineBarProps {
   pipelinerun: PipelineRunKind;
+  taskRuns: TaskRunKind[];
 }
 
-export const PipelineBars: React.FC<PipelineBarProps> = ({ pipelinerun }) => {
-  const taskStatus = useTaskStatus(pipelinerun);
-
+export const PipelineBars: React.FC<PipelineBarProps> = ({ pipelinerun, taskRuns }) => {
+  const taskStatus = useTaskStatus(pipelinerun, taskRuns);
   return (
     <Tooltip content={<TaskStatusToolTip taskStatus={taskStatus} />}>
       <HorizontalStackedBars

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatus.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatus.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { resourcePathFromModel } from '@console/internal/components/utils';
+import { LoadingInline, resourcePathFromModel } from '@console/internal/components/utils';
 import { DASH } from '@console/shared';
 import { PipelineRunModel } from '../../../models';
 import { PipelineRunKind } from '../../../types';
+import { useTaskRuns } from '../../taskruns/useTaskRuns';
 import { getPLRLogSnippet } from '../logs/pipelineRunLogSnippet';
 import PipelineResourceStatus from './PipelineResourceStatus';
 import StatusPopoverContent from './StatusPopoverContent';
@@ -16,24 +17,32 @@ type PipelineRunStatusProps = {
 };
 const PipelineRunStatus: React.FC<PipelineRunStatusProps> = ({ status, pipelineRun, title }) => {
   const { t } = useTranslation();
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(
+    pipelineRun?.metadata?.namespace,
+    pipelineRun?.metadata?.name,
+  );
   return pipelineRun ? (
-    <PipelineResourceStatus status={status} title={title}>
-      <StatusPopoverContent
-        logDetails={getPLRLogSnippet(pipelineRun)}
-        namespace={pipelineRun.metadata.namespace}
-        link={
-          <Link
-            to={`${resourcePathFromModel(
-              PipelineRunModel,
-              pipelineRun.metadata.name,
-              pipelineRun.metadata.namespace,
-            )}/logs`}
-          >
-            {t('pipelines-plugin~View logs')}
-          </Link>
-        }
-      />
-    </PipelineResourceStatus>
+    taskRunsLoaded ? (
+      <PipelineResourceStatus status={status} title={title}>
+        <StatusPopoverContent
+          logDetails={getPLRLogSnippet(pipelineRun, taskRuns)}
+          namespace={pipelineRun.metadata.namespace}
+          link={
+            <Link
+              to={`${resourcePathFromModel(
+                PipelineRunModel,
+                pipelineRun.metadata.name,
+                pipelineRun.metadata.namespace,
+              )}/logs`}
+            >
+              {t('pipelines-plugin~View logs')}
+            </Link>
+          }
+        />
+      </PipelineResourceStatus>
+    ) : (
+      <LoadingInline />
+    )
   ) : (
     <>{DASH}</>
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Alert } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { PipelineKind, PipelineRunKind } from '../../../../types';
+import { PipelineKind, PipelineRunKind, TaskRunKind } from '../../../../types';
 import { dagreViewerComponentFactory } from '../../pipeline-topology/factories';
 import PipelineTopologyGraph from '../../pipeline-topology/PipelineTopologyGraph';
 import { getGraphDataModel } from '../../pipeline-topology/utils';
@@ -11,16 +11,17 @@ import './PipelineVisualization.scss';
 interface PipelineTopologyVisualizationProps {
   pipeline: PipelineKind;
   pipelineRun?: PipelineRunKind;
+  taskRuns?: TaskRunKind[];
 }
 
 const PipelineVisualization: React.FC<PipelineTopologyVisualizationProps> = ({
   pipeline,
   pipelineRun,
+  taskRuns,
 }) => {
   const { t } = useTranslation();
   let content: React.ReactElement;
-
-  const model = getGraphDataModel(pipeline, pipelineRun);
+  const model = getGraphDataModel(pipeline, pipelineRun, taskRuns);
 
   if (!model || (model.nodes.length === 0 && model.edges.length === 0)) {
     // Nothing to render

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineRunItem.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineRunItem.tsx
@@ -12,6 +12,7 @@ import { pipelineRunStatus } from '../../../utils/pipeline-filter-reducer';
 import LogSnippetBlock from '../../pipelineruns/logs/LogSnippetBlock';
 import { getPLRLogSnippet } from '../../pipelineruns/logs/pipelineRunLogSnippet';
 import './PipelineRunItem.scss';
+import { useTaskRuns } from '../../taskruns/useTaskRuns';
 
 type PipelineRunItemProps = {
   pipelineRun: PipelineRunKind;
@@ -23,11 +24,12 @@ const PipelineRunItem: React.FC<PipelineRunItemProps> = ({ pipelineRun }) => {
     metadata: { name, namespace, creationTimestamp },
     status,
   } = pipelineRun;
+  const [taskRuns] = useTaskRuns(pipelineRun?.metadata?.namespace, pipelineRun?.metadata?.name);
   const path = resourcePath(referenceForModel(PipelineRunModel), name, namespace);
   const lastUpdated = status
     ? status.completionTime || status.startTime || creationTimestamp
     : creationTimestamp;
-  const logDetails = getPLRLogSnippet(pipelineRun);
+  const logDetails = getPLRLogSnippet(pipelineRun, taskRuns);
 
   return (
     <li className="odc-pipeline-run-item list-group-item">

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
@@ -21,13 +21,20 @@ import {
 const pipelineData = pipelineTestData[PipelineExampleNames.COMPLEX_PIPELINE];
 const { pipeline } = pipelineData;
 
+const pipelineRun = {
+  apiVersion: '',
+  metadata: {},
+  kind: 'PipelineRun',
+  spec: {},
+};
+
 describe('getLastRegularTasks', () => {
   it('expect to handle the empty array input', () => {
     expect(getLastRegularTasks([])).toHaveLength(0);
   });
 
   it('expect to return the last regular task name in the pipeline', () => {
-    const { nodes } = getGraphDataModel(pipeline);
+    const { nodes } = getGraphDataModel(pipeline, pipelineRun, []);
     expect(getLastRegularTasks(nodes)).toHaveLength(1);
     expect(getLastRegularTasks(nodes)).toEqual(['verify']);
   });
@@ -41,7 +48,7 @@ describe('getLastRegularTasks', () => {
         tasks: [task1, task2, task3, task4],
       },
     };
-    const { nodes } = getGraphDataModel(pipelineWithMultipleLastTasks);
+    const { nodes } = getGraphDataModel(pipelineWithMultipleLastTasks, pipelineRun, []);
     expect(getLastRegularTasks(nodes)).toHaveLength(3);
     expect(getLastRegularTasks(nodes)).toEqual(['analyse-code', 'style-checks', 'find-bugs']);
   });
@@ -87,18 +94,22 @@ describe('nodesHasWhenExpression', () => {
   const { pipeline: pipelineWithWhenExpression } = conditionalPipeline;
 
   it('expect to return false if the nodes does not contain when expressions', () => {
-    const { nodes } = getGraphDataModel({
-      ...pipelineWithWhenExpression,
-      spec: {
-        ...pipelineWithWhenExpression.spec,
-        tasks: [pipelineWithWhenExpression.spec.tasks[0]],
+    const { nodes } = getGraphDataModel(
+      {
+        ...pipelineWithWhenExpression,
+        spec: {
+          ...pipelineWithWhenExpression.spec,
+          tasks: [pipelineWithWhenExpression.spec.tasks[0]],
+        },
       },
-    });
+      pipelineRun,
+      [],
+    );
     expect(nodesHasWhenExpression(nodes)).toBe(false);
   });
 
   it('expect to return true if the node contains when expressions', () => {
-    const { nodes } = getGraphDataModel(pipelineWithWhenExpression);
+    const { nodes } = getGraphDataModel(pipelineWithWhenExpression, pipelineRun, []);
     expect(nodesHasWhenExpression(nodes)).toBe(true);
   });
 });
@@ -244,19 +255,19 @@ describe('getTaskWhenStatus:', () => {
 
 describe('getGraphDataModel', () => {
   it('should return null for invalid values', () => {
-    expect(getGraphDataModel(null)).toBeNull();
-    expect(getGraphDataModel(undefined, undefined)).toBeNull();
+    expect(getGraphDataModel(null, null, [])).toBeNull();
+    expect(getGraphDataModel(undefined, undefined, [])).toBeNull();
   });
 
   it('should return graph, nodes and edges for valid pipeline', () => {
-    const model = getGraphDataModel(pipeline);
+    const model = getGraphDataModel(pipeline, pipelineRun, []);
     expect(model.graph).toBeDefined();
     expect(model.nodes).toHaveLength(13);
     expect(model.edges).toHaveLength(19);
   });
 
   it('should return graph, nodes and edges for valid pipeline', () => {
-    const model = getGraphDataModel(pipeline);
+    const model = getGraphDataModel(pipeline, pipelineRun, []);
     expect(model.graph).toBeDefined();
     expect(model.nodes).toHaveLength(13);
     expect(model.edges).toHaveLength(19);
@@ -266,7 +277,7 @@ describe('getGraphDataModel', () => {
     const pData = pipelineTestData[PipelineExampleNames.PIPELINE_WITH_FINALLY];
     const { pipeline: pipelineWithFinallyTasks } = pData;
 
-    const { nodes } = getGraphDataModel(pipelineWithFinallyTasks);
+    const { nodes } = getGraphDataModel(pipelineWithFinallyTasks, pipelineRun, []);
     const finallyGroup = nodes.filter((n) => n.type === NodeType.FINALLY_GROUP);
     const finallyNodes = nodes.filter((n) => n.type === NodeType.FINALLY_NODE);
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
@@ -17,6 +17,7 @@ import {
   PipelineRunKind,
   PipelineTask,
   PipelineTaskWithStatus,
+  TaskRunKind,
 } from '../../../types';
 import { getRunStatusColor } from '../../../utils/pipeline-augment';
 import {
@@ -318,9 +319,10 @@ export const connectFinallyTasksToNodes = (
   nodes: PipelineMixedNodeModel[],
   pipeline?: PipelineKind,
   pipelineRun?: PipelineRunKind,
+  taskRuns?: TaskRunKind[],
 ): PipelineMixedNodeModel[] => {
   const finallyTasks = pipelineRun
-    ? getFinallyTasksWithStatus(pipeline, pipelineRun)
+    ? getFinallyTasksWithStatus(pipeline, pipelineRun, taskRuns)
     : pipeline.spec?.finally ?? [];
   if (finallyTasks.length === 0) {
     return nodes;
@@ -349,14 +351,16 @@ export const connectFinallyTasksToNodes = (
 export const getTopologyNodesEdges = (
   pipeline: PipelineKind,
   pipelineRun?: PipelineRunKind,
+  taskRuns?: TaskRunKind[],
 ): { nodes: PipelineMixedNodeModel[]; edges: PipelineEdgeModel[] } => {
-  const taskList: PipelineTask[] = _.flatten(getPipelineTasks(pipeline, pipelineRun));
+  const taskList: PipelineTask[] = _.flatten(getPipelineTasks(pipeline, pipelineRun, taskRuns));
   const taskNodes: PipelineMixedNodeModel[] = tasksToNodes(taskList, pipeline, pipelineRun);
 
   const nodes: PipelineMixedNodeModel[] = connectFinallyTasksToNodes(
     taskNodes,
     pipeline,
     pipelineRun,
+    taskRuns,
   );
   const edges: PipelineEdgeModel[] = getEdgesFromNodes(nodes);
 
@@ -431,6 +435,7 @@ export const getGraphDataModel = (
     kind: 'PipelineRun',
     spec: {},
   },
+  taskRuns: TaskRunKind[],
 ): {
   graph: GraphModel;
   nodes: PipelineMixedNodeModel[];
@@ -440,7 +445,7 @@ export const getGraphDataModel = (
     return null;
   }
 
-  const taskList = _.flatten(getPipelineTasks(pipeline, pipelineRun));
+  const taskList = _.flatten(getPipelineTasks(pipeline, pipelineRun, taskRuns));
 
   const dag = new DAG();
   taskList?.forEach((task: PipelineTask) => {
@@ -524,7 +529,7 @@ export const getGraphDataModel = (
     );
   });
 
-  const finallyTaskList = appendPipelineRunStatus(pipeline, pipelineRun, true);
+  const finallyTaskList = appendPipelineRunStatus(pipeline, pipelineRun, taskRuns, true);
 
   const maxFinallyNodeName =
     finallyTaskList.sort((a, b) => b.name.length - a.name.length)[0]?.name || '';

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/useTaskRuns.ts
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/useTaskRuns.ts
@@ -1,0 +1,36 @@
+import { k8sListResource } from '@console/dynamic-plugin-sdk/src/utils/k8s';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { TaskRunModel } from '../../models';
+import { TaskRunKind } from '../../types';
+import { TektonResourceLabel } from '../pipelines/const';
+
+export const useTaskRuns = (
+  namespace: string,
+  pipelineRunName: string,
+): [TaskRunKind[], boolean, unknown] =>
+  useK8sWatchResource<TaskRunKind[]>({
+    kind: referenceForModel(TaskRunModel),
+    namespace,
+    selector: {
+      matchLabels: {
+        [TektonResourceLabel.pipelinerun]: pipelineRunName,
+      },
+    },
+    isList: true,
+  });
+
+export const getTaskRuns = async (namespace: string, pipelineRunName: string) => {
+  const taskRuns = await k8sListResource({
+    model: TaskRunModel,
+    queryParams: {
+      ns: namespace,
+      labelSelector: {
+        matchLabels: {
+          [TektonResourceLabel.pipelinerun]: pipelineRunName,
+        },
+      },
+    },
+  });
+  return taskRuns;
+};

--- a/frontend/packages/pipelines-plugin/src/topology/build-decorators/PipelineBuildDecoratorTooltip.tsx
+++ b/frontend/packages/pipelines-plugin/src/topology/build-decorators/PipelineBuildDecoratorTooltip.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import HorizontalStackedBars from '../../components/charts/HorizontalStackedBars';
 import { useTaskStatus } from '../../components/pipelineruns/hooks/useTaskStatus';
 import TaskStatusToolTip from '../../components/pipelineruns/status/TaskStatusTooltip';
-import { ComputedStatus, PipelineRunKind } from '../../types';
+import { ComputedStatus, PipelineRunKind, TaskRunKind } from '../../types';
 import { getRunStatusColor } from '../../utils/pipeline-augment';
 
 import './PipelineBuildDecoratorTooltip.scss';
@@ -11,14 +11,16 @@ import './PipelineBuildDecoratorTooltip.scss';
 export interface PipelineBuildDecoratorTooltipProps {
   pipelineRun: PipelineRunKind;
   status: string;
+  taskRuns: TaskRunKind[];
 }
 
 const PipelineBuildDecoratorTooltip: React.FC<PipelineBuildDecoratorTooltipProps> = ({
   pipelineRun,
   status,
+  taskRuns,
 }) => {
   const { t } = useTranslation();
-  const taskStatus = useTaskStatus(pipelineRun);
+  const taskStatus = useTaskStatus(pipelineRun, taskRuns);
   if (!pipelineRun || !status) {
     return null;
   }

--- a/frontend/packages/pipelines-plugin/src/topology/build-decorators/PipelineRunDecorator.tsx
+++ b/frontend/packages/pipelines-plugin/src/topology/build-decorators/PipelineRunDecorator.tsx
@@ -11,6 +11,7 @@ import { getLatestPipelineRunStatus } from '@console/pipelines-plugin/src/utils/
 import { Status } from '@console/shared';
 import { BuildDecoratorBubble } from '@console/topology/src/components/graph-view';
 import { startPipelineModal } from '../../components/pipelines/modals';
+import { useTaskRuns } from '../../components/taskruns/useTaskRuns';
 import { PipelineRunModel } from '../../models';
 import { PipelineKind, PipelineRunKind } from '../../types';
 
@@ -40,7 +41,10 @@ export const ConnectedPipelineRunDecorator: React.FC<PipelineRunDecoratorProps &
 }) => {
   const { t } = useTranslation();
   const { latestPipelineRun, status } = getLatestPipelineRunStatus(pipelineRuns);
-
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(
+    latestPipelineRun?.metadata?.namespace,
+    latestPipelineRun?.metadata?.name,
+  );
   const statusIcon = <Status status={status} iconOnly noTooltip />;
 
   const defaultAccessReview: AccessReviewResourceAttributes = {
@@ -56,8 +60,12 @@ export const ConnectedPipelineRunDecorator: React.FC<PipelineRunDecoratorProps &
   let decoratorContent;
   if (latestPipelineRun) {
     ariaLabel = t(`pipelines-plugin~Pipeline status is {{status}}. View logs.`, { status });
-    tooltipContent = (
-      <PipelineBuildDecoratorTooltip pipelineRun={latestPipelineRun} status={status} />
+    tooltipContent = taskRunsLoaded && (
+      <PipelineBuildDecoratorTooltip
+        pipelineRun={latestPipelineRun}
+        status={status}
+        taskRuns={taskRuns}
+      />
     );
     const link = `${resourcePathFromModel(
       PipelineRunModel,

--- a/frontend/packages/pipelines-plugin/src/topology/build-decorators/__tests__/PipelineRunDecorator.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/topology/build-decorators/__tests__/PipelineRunDecorator.spec.tsx
@@ -3,14 +3,18 @@ import { shallow } from 'enzyme';
 import { Link } from 'react-router-dom';
 import * as utils from '@console/internal/components/utils';
 import { BuildDecoratorBubble } from '@console/topology/src/components/graph-view';
+import * as taskRunsUtils from '../../../components/taskruns/useTaskRuns';
 import { ConnectedPipelineRunDecorator } from '../PipelineRunDecorator';
 import { connectedPipelineOne } from './decorator-data';
+
+const spyUseTaskRuns = jest.spyOn(taskRunsUtils, 'useTaskRuns');
 
 describe('PipelineRunDecorator renders', () => {
   let spyUseAccessReview;
   beforeEach(() => {
     spyUseAccessReview = jest.spyOn(utils, 'useAccessReview');
     spyUseAccessReview.mockReturnValue(true);
+    spyUseTaskRuns.mockReturnValue([[], true]);
   });
 
   it('expect a log link when it contains at least one PipelineRun', () => {

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
@@ -72,7 +72,7 @@ describe('PipelineAugment test getRunStatusColor handles all ComputedStatus valu
 describe('PipelineAugment test correct task status state is pulled from pipeline/pipelineruns', () => {
   it('expect no arguments to produce a net-zero result', () => {
     // Null check + showcasing we get at least 1 value out of the function
-    const emptyTaskStatus = getTaskStatus(null, null);
+    const emptyTaskStatus = getTaskStatus(null, null, null);
     expect(emptyTaskStatus).toEqual({
       PipelineNotStarted: 1,
       Pending: 0,
@@ -98,6 +98,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const taskStatus = getTaskStatus(
         simpleTestData.pipelineRuns[DataState.SUCCESS],
         simpleTestData.pipeline,
+        [],
       );
       const taskCount = totalPipelineRunTasks(simpleTestData.pipeline);
 
@@ -113,6 +114,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const taskStatus = getTaskStatus(
         complexTestData.pipelineRuns[DataState.SUCCESS],
         complexTestData.pipeline,
+        [],
       );
       const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
@@ -128,6 +130,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const taskStatus = getTaskStatus(
         finallyTestData.pipelineRuns[DataState.SUCCESS],
         finallyTestData.pipeline,
+        [],
       );
       const taskCount = totalPipelineRunTasks(finallyTestData.pipeline);
 
@@ -151,6 +154,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const taskStatus = getTaskStatus(
         simpleTestData.pipelineRuns[DataState.IN_PROGRESS],
         simpleTestData.pipeline,
+        [],
       );
       const taskCount = totalPipelineRunTasks(simpleTestData.pipeline);
 
@@ -166,6 +170,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const taskStatus = getTaskStatus(
         complexTestData.pipelineRuns[DataState.IN_PROGRESS],
         complexTestData.pipeline,
+        [],
       );
       const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
@@ -224,11 +229,11 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
 
     it('expect a partial pipeline to have task-count equal to Failed and Cancelled states', () => {
       const partialTestData = pipelineTestData[PipelineExampleNames.PARTIAL_PIPELINE];
-
       const expectedTaskCount = getExpectedTaskCount(partialTestData.pipeline);
       const taskStatus = getTaskStatus(
         partialTestData.pipelineRuns[DataState.FAILED_BUT_COMPLETE],
         partialTestData.pipeline,
+        null,
       );
       const taskCount = totalPipelineRunTasks(partialTestData.pipeline);
 
@@ -244,6 +249,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const taskStatus = getTaskStatus(
         complexTestData.pipelineRuns[DataState.CANCELLED1],
         complexTestData.pipeline,
+        [],
       );
       const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
@@ -260,6 +266,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const taskStatus = getTaskStatus(
         complexTestData.pipelineRuns[DataState.FAILED1],
         complexTestData.pipeline,
+        [],
       );
       const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
@@ -276,6 +283,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const taskStatus = getTaskStatus(
         complexTestData.pipelineRuns[DataState.CANCELLED2],
         complexTestData.pipeline,
+        [],
       );
       const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
@@ -292,6 +300,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const taskStatus = getTaskStatus(
         complexTestData.pipelineRuns[DataState.FAILED2],
         complexTestData.pipeline,
+        [],
       );
       const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
@@ -308,6 +317,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const taskStatus = getTaskStatus(
         complexTestData.pipelineRuns[DataState.CANCELLED3],
         complexTestData.pipeline,
+        [],
       );
       const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
@@ -324,6 +334,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const taskStatus = getTaskStatus(
         complexTestData.pipelineRuns[DataState.FAILED3],
         complexTestData.pipeline,
+        [],
       );
       const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
@@ -347,6 +358,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const taskStatus = getTaskStatus(
         complexTestData.pipelineRuns[DataState.SKIPPED],
         complexTestData.pipeline,
+        [],
       );
       const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@console/internal/components/utils';
 import * as k8s from '@console/internal/module/k8s';
 import { ContainerStatus } from '@console/internal/module/k8s';
-import { SecretAnnotationId } from '../../components/pipelines/const';
+import { SecretAnnotationId, TektonResourceLabel } from '../../components/pipelines/const';
 import { PipelineRunModel } from '../../models';
 import { DataState, PipelineExampleNames, pipelineTestData } from '../../test-data/pipeline-data';
 import { ComputedStatus } from '../../types';
@@ -32,18 +32,25 @@ import {
   pvcWithPipelineOwnerRef,
 } from './pipeline-test-data';
 
+const plRun = {
+  apiVersion: '',
+  metadata: {},
+  kind: 'PipelineRun',
+  spec: {},
+};
+
 beforeAll(() => {
   jest.spyOn(k8s, 'k8sUpdate').mockImplementation((model, data) => data);
 });
 
 describe('pipeline-utils ', () => {
   it('For first pipeline there should be 1 stage of length 3', () => {
-    const stages = getPipelineTasks(mockPipelinesJSON[0]);
+    const stages = getPipelineTasks(mockPipelinesJSON[0], plRun, []);
     expect(stages).toHaveLength(1);
     expect(stages[0]).toHaveLength(3);
   });
   it('should transform pipelines', () => {
-    const stages = getPipelineTasks(mockPipelinesJSON[1]);
+    const stages = getPipelineTasks(mockPipelinesJSON[1], plRun, []);
     expect(stages).toHaveLength(4);
     expect(stages[0]).toHaveLength(1);
     expect(stages[1]).toHaveLength(2);
@@ -252,6 +259,20 @@ describe('pipeline-utils ', () => {
   it('should append Pending status if a taskrun status reason is missing', () => {
     const { pipeline, pipelineRuns } = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
     const pipelineRunWithoutStatus = _.cloneDeep(pipelineRuns[DataState.IN_PROGRESS]);
+    const testTaskRuns = Object.keys(pipelineRunWithoutStatus.status.taskRuns).map((trName) => ({
+      apiVersion: 'v1alpha1',
+      kind: 'TaskRun',
+      metadata: {
+        labels: {
+          [TektonResourceLabel.pipelineTask]:
+            pipelineRunWithoutStatus.status.taskRuns[trName].pipelineTaskName,
+        },
+        name: trName,
+      },
+      spec: {},
+      pipelineTaskName: pipelineRunWithoutStatus.status.taskRuns[trName].pipelineTaskName,
+      status: pipelineRunWithoutStatus.status.taskRuns[trName].status,
+    }));
     _.forIn(pipelineRunWithoutStatus.status.taskRuns, (taskRun, name) => {
       pipelineRunWithoutStatus.status.taskRuns[name] = _.omit(taskRun, [
         'status.conditions',
@@ -259,21 +280,34 @@ describe('pipeline-utils ', () => {
         'status.completionTime',
       ]);
     });
-    const taskList = appendPipelineRunStatus(pipeline, pipelineRunWithoutStatus);
+    const taskList = appendPipelineRunStatus(pipeline, pipelineRunWithoutStatus, testTaskRuns);
     expect(taskList.filter((t) => t.status.reason === ComputedStatus.Pending)).toHaveLength(2);
   });
 
   it('should append pipelineRun running status for all the tasks', () => {
     const { pipeline, pipelineRuns } = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
     const pipelineRun = pipelineRuns[DataState.IN_PROGRESS];
-    const taskList = appendPipelineRunStatus(pipeline, pipelineRun);
+    const testTaskRuns = Object.keys(pipelineRun.status.taskRuns).map((trName) => ({
+      apiVersion: 'v1alpha1',
+      kind: 'TaskRun',
+      metadata: {
+        labels: {
+          [TektonResourceLabel.pipelineTask]: pipelineRun.status.taskRuns[trName].pipelineTaskName,
+        },
+        name: trName,
+      },
+      spec: {},
+      pipelineTaskName: pipelineRun.status.taskRuns[trName].pipelineTaskName,
+      status: pipelineRun.status.taskRuns[trName].status,
+    }));
+    const taskList = appendPipelineRunStatus(pipeline, pipelineRun, testTaskRuns);
     expect(taskList.filter((t) => t.status.reason === ComputedStatus.Running)).toHaveLength(2);
   });
 
   it('should append pipelineRun pending status for all the tasks if taskruns are not present and pipelinerun status is PipelineRunPending', () => {
     const { pipeline, pipelineRuns } = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
     const pipelineRun = pipelineRuns[DataState.PIPELINE_RUN_PENDING];
-    const taskList = appendPipelineRunStatus(pipeline, pipelineRun);
+    const taskList = appendPipelineRunStatus(pipeline, pipelineRun, []);
     expect(taskList.filter((t) => t.status.reason === ComputedStatus.Idle)).toHaveLength(
       pipeline.spec.tasks.length,
     );
@@ -282,7 +316,7 @@ describe('pipeline-utils ', () => {
   it('should append pipelineRun cancelled status for all the tasks if taskruns are not present and pipelinerun status is PipelineRunCancelled', () => {
     const { pipeline, pipelineRuns } = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
     const pipelineRun = pipelineRuns[DataState.PIPELINE_RUN_CANCELLED];
-    const taskList = appendPipelineRunStatus(pipeline, pipelineRun);
+    const taskList = appendPipelineRunStatus(pipeline, pipelineRun, []);
     expect(taskList.filter((t) => t.status.reason === ComputedStatus.Cancelled)).toHaveLength(
       pipeline.spec.tasks.length,
     );
@@ -291,21 +325,21 @@ describe('pipeline-utils ', () => {
   it('should append status to only pipeline tasks if isFinallyTasks is false', () => {
     const { pipeline, pipelineRuns } = pipelineTestData[PipelineExampleNames.PIPELINE_WITH_FINALLY];
     const pipelineRun = pipelineRuns[DataState.SUCCESS];
-    const taskList = appendPipelineRunStatus(pipeline, pipelineRun);
+    const taskList = appendPipelineRunStatus(pipeline, pipelineRun, []);
     expect(taskList).toHaveLength(2);
   });
 
   it('should append status to only finally tasks if isFinallyTasks is true', () => {
     const { pipeline, pipelineRuns } = pipelineTestData[PipelineExampleNames.PIPELINE_WITH_FINALLY];
     const pipelineRun = pipelineRuns[DataState.SUCCESS];
-    const taskList = appendPipelineRunStatus(pipeline, pipelineRun, true);
+    const taskList = appendPipelineRunStatus(pipeline, pipelineRun, [], true);
     expect(taskList).toHaveLength(1);
   });
 
   it('should return empty array if there are no finally tasks but isFinallyTasks is true', () => {
     const { pipeline, pipelineRuns } = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
     const pipelineRun = pipelineRuns[DataState.IN_PROGRESS];
-    const taskList = appendPipelineRunStatus(pipeline, pipelineRun, true);
+    const taskList = appendPipelineRunStatus(pipeline, pipelineRun, [], true);
     expect(taskList).toHaveLength(0);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
@@ -12,6 +12,7 @@ import {
   apiVersionForModel,
 } from '@console/internal/module/k8s';
 import { TektonResourceLabel } from '../components/pipelines/const';
+import { getTaskRuns } from '../components/taskruns/useTaskRuns';
 import {
   ClusterTaskModel,
   ClusterTriggerBindingModel,
@@ -19,7 +20,7 @@ import {
   TriggerBindingModel,
   PipelineModel,
 } from '../models';
-import { ComputedStatus, PipelineKind, PipelineRunKind, PipelineTask } from '../types';
+import { ComputedStatus, PipelineKind, PipelineRunKind, PipelineTask, TaskRunKind } from '../types';
 import { pipelineRunFilterReducer, SucceedConditionReason } from './pipeline-filter-reducer';
 
 interface Metadata {
@@ -161,13 +162,22 @@ export const totalPipelineRunTasks = (executedPipeline: PipelineKind): number =>
   return totalTasks + finallyTasks;
 };
 
-export const getTaskStatus = (pipelinerun: PipelineRunKind, pipeline: PipelineKind): TaskStatus => {
+export const getTaskStatus = (
+  pipelinerun: PipelineRunKind,
+  pipeline: PipelineKind,
+  taskRuns: TaskRunKind[],
+): TaskStatus => {
   const totalTasks = totalPipelineRunTasks(pipeline);
-  const plrTasks =
-    pipelinerun && pipelinerun.status && pipelinerun.status.taskRuns
-      ? Object.keys(pipelinerun.status.taskRuns)
-      : [];
-  const plrTaskLength = plrTasks.length;
+  const plrTasks = (): string[] => {
+    if (pipelinerun?.status?.taskRuns) {
+      return Object.keys(pipelinerun.status.taskRuns);
+    }
+    if (taskRuns) {
+      return taskRuns?.map((tRun) => tRun.metadata.name);
+    }
+    return [];
+  };
+  const plrTaskLength = plrTasks().length;
   const skippedTaskLength = (pipelinerun?.status?.skippedTasks || []).length;
   const taskStatus: TaskStatus = {
     PipelineNotStarted: 0,
@@ -179,9 +189,12 @@ export const getTaskStatus = (pipelinerun: PipelineRunKind, pipeline: PipelineKi
     Skipped: skippedTaskLength,
   };
 
-  if (pipelinerun?.status?.taskRuns) {
-    plrTasks.forEach((taskRun) => {
-      const status = pipelineRunFilterReducer(pipelinerun.status.taskRuns[taskRun]);
+  if (pipelinerun?.status?.taskRuns || taskRuns) {
+    plrTasks().forEach((taskRun) => {
+      const status = pipelineRunFilterReducer(
+        taskRuns?.find((tRun) => tRun.metadata.name === taskRun) ||
+          pipelinerun.status.taskRuns[taskRun],
+      );
       if (status === 'Succeeded') {
         taskStatus[ComputedStatus.Succeeded]++;
       } else if (status === 'Running') {
@@ -262,8 +275,14 @@ export const getModelReferenceFromTaskKind = (kind: string): GroupVersionKind =>
 };
 
 export const countRunningTasks = (pipelineRun: PipelineRunKind): number => {
-  const taskStatuses = getTaskStatus(pipelineRun, undefined);
-  return taskStatuses.Running;
+  let taskRuns: TaskRunKind[] = [];
+  getTaskRuns(pipelineRun.metadata.namespace, pipelineRun.metadata.name)
+    .then((response: TaskRunKind[]) => {
+      taskRuns = response;
+    })
+    .catch(() => {});
+  const taskStatuses = taskRuns && getTaskStatus(pipelineRun, undefined, taskRuns);
+  return taskStatuses?.Running;
 };
 
 export const shouldHidePipelineRunStop = (pipelineRun: PipelineRunKind): boolean =>


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/OCPBUGS-11099

Descriptions: Starting with OpenShift Pipelines 1.11 (tektoncd/pipeline >= v0.45), the format of status is going to change to minimal status. This means the way the console finds TaskRun from PipelineRun.

NOTE: No UI changes. All Pipelines features should work as before.