### PR TITLE
OCPBUGS-7485: When Creating Sample Devfile from the Samples Page, Topology Icon is not set

### DIFF
--- a/frontend/packages/dev-console/src/components/import/devfile/DevfileStrategySection.tsx
+++ b/frontend/packages/dev-console/src/components/import/devfile/DevfileStrategySection.tsx
@@ -6,7 +6,7 @@ import { getGitService, ImportStrategy, GitProvider } from '@console/git-service
 import { InputField } from '@console/shared/src';
 import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 import { safeYAMLToJS } from '@console/shared/src/utils/yaml';
-import { ImportTypes } from '../import-types';
+import { ImportTypes, SampleRuntime } from '../import-types';
 import FormSection from '../section/FormSection';
 import { useDevfileServer, useDevfileSource, useSelectedDevfileSample } from './devfileHooks';
 import DevfileInfo from './DevfileInfo';
@@ -30,8 +30,10 @@ const DevfileStrategySection: React.FC = () => {
 
   const devfileInfo = React.useMemo(() => {
     let info;
-    if (selectedSample) info = selectedSample;
-    else if (devfile.devfileContent) {
+    if (selectedSample) {
+      info = selectedSample;
+      setFieldValue('devfile.devfileProjectType', SampleRuntime[selectedSample.projectType]);
+    } else if (devfile.devfileContent) {
       const devfileJSON = safeYAMLToJS(devfile.devfileContent);
       info = {
         displayName: devfileJSON.metadata?.name || 'Devfile',
@@ -40,7 +42,7 @@ const DevfileStrategySection: React.FC = () => {
       };
     }
     return info;
-  }, [selectedSample, devfile]);
+  }, [selectedSample, devfile.devfileContent, setFieldValue]);
 
   const handleDevfileChange = React.useCallback(async () => {
     const gitService = getGitService(url, type, ref, dir, secretResource, devfile.devfilePath);

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -48,6 +48,7 @@ import { LimitsData } from '@console/shared/src/types';
 import { getRandomChars, getResourceLimitsData } from '@console/shared/src/utils';
 import { safeYAMLToJS } from '@console/shared/src/utils/yaml';
 import { CREATE_APPLICATION_KEY } from '@console/topology/src/const';
+import { RUNTIME_LABEL } from '../../const';
 import {
   getAppLabels,
   getPodLabels,
@@ -331,7 +332,14 @@ export const createOrUpdateDeployment = (
   } = formData;
 
   const imageStreamName = imageStream && imageStream.metadata.name;
-  const defaultLabels = getAppLabels({ name, applicationName, imageStreamName, selectedTag });
+  const runtimeIcon = imageStream && imageStream.metadata.labels?.[RUNTIME_LABEL];
+  const defaultLabels = getAppLabels({
+    name,
+    applicationName,
+    imageStreamName,
+    selectedTag,
+    runtimeIcon,
+  });
   const imageName = name;
   const defaultAnnotations = {
     ...getCommonAnnotations(),
@@ -559,7 +567,7 @@ export const createDevfileResources = async (
   const {
     name,
     project: { name: namespace },
-    devfile: { devfileSuggestedResources },
+    devfile: { devfileSuggestedResources, devfileProjectType },
   } = formData;
 
   const devfileResourceObjects: DevfileSuggestedResources = Object.keys(
@@ -583,6 +591,7 @@ export const createDevfileResources = async (
           namespace,
           labels: {
             ...resource.metadata?.labels,
+            ...(devfileProjectType ? { [RUNTIME_LABEL]: devfileProjectType } : {}),
           },
         },
       },

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -191,6 +191,7 @@ export type DevfileData = {
   devfileSourceUrl?: string;
   devfileHasError: boolean;
   devfileSuggestedResources?: DevfileSuggestedResources;
+  devfileProjectType?: string;
 };
 
 export type PacData = {
@@ -307,6 +308,15 @@ export enum SupportedRuntime {
 }
 
 export const notSupportedRuntime = ['go', 'rust', 'springboot', 'python'];
+
+export enum SampleRuntime {
+  'Node.js' = 'nodejs',
+  Quarkus = 'quarkus',
+  dotnet = 'dotnet',
+  Python = 'python',
+  Go = 'golang',
+  springboot = 'spring-boot',
+}
 
 export const ReadableResourcesNames: Record<Resources, string> = {
   [Resources.OpenShift]: DeploymentConfigModel.labelKey,

--- a/frontend/packages/dev-console/src/const.ts
+++ b/frontend/packages/dev-console/src/const.ts
@@ -26,6 +26,7 @@ export const LAST_RESOURCE_TYPE_STORAGE_KEY = `devconsole.last.resource-type`;
 
 export const NAME_LABEL = 'app.kubernetes.io/name';
 export const INSTANCE_LABEL = 'app.kubernetes.io/instance';
+export const RUNTIME_LABEL = 'app.openshift.io/runtime';
 export const FLAG_DEVELOPER_CATALOG = 'DEVELOPER_CATALOG';
 export const FLAG_OPERATOR_BACKED_SERVICE_CATALOG_TYPE = 'OPERATOR_BACKED_SERVICE_CATALOG_TYPE';
 export const FLAG_SAMPLE_CATALOG_TYPE = 'SAMPLE_CATALOG_TYPE';


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-7485

**Analysis / Root cause**: 
When Creating Sample Devfile from the Samples Page, corresponding Topology Icon for the app is not set. This issue is not observed when we create a BuildImage from the Samples page.

**Solution Description**: 
Current label: `app.openshift.io/runtime=dotnet-basic`
Change to: `app.openshift.io/runtime=dotnet`

**Screenshots / Gifs for design review**: 

![Screenshot from 2023-04-14 20-00-55](https://user-images.githubusercontent.com/47265560/232089171-a91252dc-ed42-40f3-87af-b66095141d6c.png)

**Unit test coverage report**:
No Changes 

**Test setup:**
1. Create a Sample Devfile App from the Samples Page
2. Go to the Topology Page and check the icon of the app created.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge