### PR TITLE
OCPBUGS-11057: Importing a kn Service shows a non-working Open URL decorator also when the Add Route checkbox was unselected

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/KSRoutesOverviewListItem.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KSRoutesOverviewListItem.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
+import { ClipboardCopy } from '@patternfly/react-core/dist/esm/components/ClipboardCopy';
 import { useTranslation } from 'react-i18next';
 import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
+import { PRIVATE_KNATIVE_SERVING_LABEL } from '../../const';
 import { RouteModel } from '../../models';
 
 type KSRoutesOverviewListItemProps = {
@@ -14,19 +16,29 @@ const KSRoutesOverviewListItem: React.FC<KSRoutesOverviewListItemProps> = ({ ksr
     metadata: { name, namespace },
     status,
   } = ksroute;
+
+  const isPrivateKSVC =
+    ksroute?.metadata?.labels?.[PRIVATE_KNATIVE_SERVING_LABEL] === 'cluster-local';
+
   return (
     <li className="list-group-item">
       <div className="row">
-        <div className="col-xs-10">
+        <div className="col-xs-12">
           <ResourceLink kind={referenceForModel(RouteModel)} name={name} namespace={namespace} />
           {status?.url?.length > 0 && (
             <>
               <span className="text-muted">{t('knative-plugin~Location:')} </span>
-              <ExternalLink
-                href={status.url}
-                additionalClassName="co-external-link--block"
-                text={status.url}
-              />
+              {isPrivateKSVC ? (
+                <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied">
+                  {status.url}
+                </ClipboardCopy>
+              ) : (
+                <ExternalLink
+                  href={status.url}
+                  additionalClassName="co-external-link--block"
+                  text={status.url}
+                />
+              )}
             </>
           )}
         </div>

--- a/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewListItem.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewListItem.tsx
@@ -23,15 +23,15 @@ const RoutesOverviewListItem: React.FC<RoutesOverviewListItemProps> = ({
       <div className="row">
         <div className="col-xs-10">
           <ResourceLink kind={referenceForModel(RouteModel)} name={name} namespace={namespace} />
-          {url.length > 0 && <RoutesUrlLink urls={[url]} title={t('knative-plugin~Location')} />}
-          {uniqueRoutes?.length > 0 && (
-            <RoutesUrlLink urls={uniqueRoutes} title={t('knative-plugin~Unique Route')} />
-          )}
         </div>
         {percent.length > 0 && (
           <span className="col-xs-2 pf-u-text-align-right">{totalPercent || percent}</span>
         )}
       </div>
+      {url.length > 0 && <RoutesUrlLink urls={[url]} title={t('knative-plugin~Location')} />}
+      {uniqueRoutes?.length > 0 && (
+        <RoutesUrlLink urls={uniqueRoutes} title={t('knative-plugin~Unique Route')} />
+      )}
     </li>
   );
 };

--- a/frontend/packages/knative-plugin/src/components/overview/RoutesUrlLink.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RoutesUrlLink.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { ClipboardCopy } from '@patternfly/react-core/dist/esm/components/ClipboardCopy';
 import { ExternalLink } from '@console/internal/components/utils';
 
 export type RoutesUrlLinkProps = {
@@ -10,14 +11,20 @@ const RoutesUrlLink: React.FC<RoutesUrlLinkProps> = ({ urls = [], title }) =>
   urls.length > 0 && (
     <>
       {title && <span className="text-muted">{title}: </span>}
-      {urls.map((url) => (
-        <ExternalLink
-          key={url}
-          href={url}
-          text={url}
-          additionalClassName="co-external-link--block"
-        />
-      ))}
+      {urls.map((url) =>
+        url?.endsWith('svc.cluster.local') ? (
+          <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied">
+            {url}
+          </ClipboardCopy>
+        ) : (
+          <ExternalLink
+            key={url}
+            href={url}
+            text={url}
+            additionalClassName="co-external-link--block"
+          />
+        ),
+      )}
     </>
   );
 

--- a/frontend/packages/knative-plugin/src/const.ts
+++ b/frontend/packages/knative-plugin/src/const.ts
@@ -5,6 +5,7 @@ export const FLAG_KNATIVE_SERVING_REVISION = 'KNATIVE_SERVING_REVISION';
 export const FLAG_KNATIVE_SERVING_ROUTE = 'KNATIVE_SERVING_ROUTE';
 export const FLAG_KNATIVE_SERVING_SERVICE = 'KNATIVE_SERVING_SERVICE';
 export const KNATIVE_SERVING_LABEL = 'serving.knative.dev/service';
+export const PRIVATE_KNATIVE_SERVING_LABEL = 'networking.knative.dev/visibility';
 export const KNATIVE_SERVING_APIGROUP = 'serving.knative.dev';
 export const KNATIVE_EVENTING_APIGROUP = 'eventing.knative.dev';
 export const KNATIVE_EVENT_MESSAGE_APIGROUP = 'messaging.knative.dev';

--- a/frontend/packages/knative-plugin/src/topology/components/decorators/getServiceRouteDecorator.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/decorators/getServiceRouteDecorator.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Node } from '@patternfly/react-topology/src/types';
 import { ROUTE_DISABLED_ANNOTATION, ROUTE_URL_ANNOTATION } from '@console/topology/src/const';
 import { getResource } from '@console/topology/src/utils';
+import { PRIVATE_KNATIVE_SERVING_LABEL } from '../../../const';
 import { TYPE_KNATIVE_SERVICE } from '../../const';
 import ServiceRouteDecorator from './ServiceRouteDecorator';
 
@@ -13,10 +14,17 @@ export const getServiceRouteDecorator = (element: Node, radius: number, x: numbe
   const { data } = element.getData();
 
   const disabled = resourceObj?.metadata?.annotations?.[ROUTE_DISABLED_ANNOTATION] === 'true';
+  const isPrivateRoute =
+    resourceObj?.metadata?.labels?.[PRIVATE_KNATIVE_SERVING_LABEL] === 'cluster-local';
   const annotationURL = resourceObj?.metadata?.annotations?.[ROUTE_URL_ANNOTATION];
   const url = annotationURL || data.url;
 
-  if (disabled || !url || !(url.startsWith('http://') || url.startsWith('https://'))) {
+  if (
+    isPrivateRoute ||
+    disabled ||
+    !url ||
+    !(url.startsWith('http://') || url.startsWith('https://'))
+  ) {
     return null;
   }
   return <ServiceRouteDecorator key="service-route" url={url} radius={radius} x={x} y={y} />;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-11057

**Analysis / Root cause**: 
When importing a Serverless Service from a git repository the topology shows an Open URL decorator also when the "Add Route" checkbox was unselected (which is selected by default).

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Hidden the decorator and changed the Pvt Service link in Topology Sidebar to Clipboard component.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/47265560/232134716-ea2c104d-8fe2-4898-b22a-3ba57aec30a4.png)

**Unit test coverage report**: 
No change

**Test setup:**

1. Install the OpenShift Serverless operator and create the required kn Serving resource.
2. Navigate to the Developer perspective > Add > Import from Git
3. Enter a git repository (like https://gitlab.com/jerolimov/nodeinfo
4. Unselect "Add Route" and press Create




**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge