### PR TITLE
Fix nil pointer deref in plugin metrics on vanilla clusters

### DIFF
--- a/pkg/serverconfig/metrics.go
+++ b/pkg/serverconfig/metrics.go
@@ -178,6 +178,9 @@ func (m *Metrics) getConsolePlugins(
 		return nil, err
 	}
 	resp, err := client.Resource(consolePluginResource).List(ctx, v1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
 	return &resp.Items, err
 }
 


### PR DESCRIPTION
This PR fixes a nil pointer deref when running on a vanilla Kubernetes cluster without the CRD.