### PR TITLE
OCPBUGS-11869: Pod Status Overlapping in Sidebar

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/Status.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/Status.tsx
@@ -123,7 +123,7 @@ const Status: React.FC<StatusProps> = ({
       return <StatusIconAndText {...statusProps} icon={<NotStartedIcon />} />;
 
     default:
-      return <>{status || DASH}</>;
+      return status ? <StatusIconAndText {...statusProps} /> : <>{DASH}</>;
   }
 };
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: [https://issues.redhat.com/browse/ODC-XXX](https://issues.redhat.com/browse/ODC-XXX) -->
https://issues.redhat.com/browse/OCPBUGS-11869

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
The pod status being shown had no styling associated with it i.e. was just a empty tag

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Reused a component with correct styling

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

--Before--
![Screenshot from 2023-04-17 23-17-21](https://user-images.githubusercontent.com/122968482/232569140-39d04c2a-38ce-4a8c-8ccb-e5b63fe076a2.png)

--After--
![Screenshot from 2023-04-17 23-15-39](https://user-images.githubusercontent.com/122968482/232569291-d8456fde-4da2-4914-b3af-de98ae7a68ab.png)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
 1. Create a Pod that gives CreateContainerConfigError/InvalidImageName or other similar status


Sample YAML:
```
apiVersion: v1
kind: Pod
metadata:
  name: example
  labels:
    app: httpd
  namespace: ane
spec:
  securityContext:
    runAsNonRoot: true
    seccompProfile:
      type: RuntimeDefault
  containers:
    - name: httpd
      image: docker.io/httpd:latest
      ports:
        - containerPort: 80
      securityContext:
        allowPrivilegeEscalation: true
        capabilities:
          drop:
            - ALL 
 ```
 Alternative YAML: ( for InvalidImageName status)
```
apiVersion: v1
kind: Pod
metadata:
  name: example
  labels:
    app: httpd
  namespace: ane
spec:
  securityContext:
    runAsNonRoot: true
    seccompProfile:
      type: RuntimeDefault
  containers:
    - name: httpd
      image: docker.io
      ports:
        - containerPort: 80
      securityContext:
        allowPrivilegeEscalation: true
        capabilities:
          drop:
            - ALL 
 ```
 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge