### PR TITLE
Reduce i18n missing key error logging

### DIFF
--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -99,8 +99,13 @@ export const init = () => {
       saveMissing: true,
       missingKeyHandler: function (lng, ns, key) {
         window.windowError = `Missing i18n key "${key}" in namespace "${ns}" and language "${lng}."`;
-        // eslint-disable-next-line no-console
-        console.error(window.windowError);
+
+        window.missingKeyNotified = window.missingKeyNotified ?? new Set();
+        if (!window.missingKeyNotified.has(window.windowError)) {
+          window.missingKeyNotified.add(window.windowError);
+          // eslint-disable-next-line no-console
+          console.error(window.windowError);
+        }
       },
     })
     // Update loading promise and pass values and errors to the caller


### PR DESCRIPTION
When the console is running in dev mode, the number of missing key errors which also include stack traces, will pollute the browser console.  Reconfigure the i18n `missingKeyHandler()` to log each error only once.  This improves developer experience.