### PR TITLE
OCPBUGS-4469: Updating image in "Deploy Image" edit form doesn't actually use new ImageStreamTag

### DIFF
--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -363,8 +363,6 @@ export const createOrUpdateDeployImageResources = async (
   const imageStreamData = _.orderBy(imageStreamList, ['metadata.resourceVersion'], ['desc']);
   const originalImageStream = (imageStreamData.length && imageStreamData[0]) || {};
   if (formData.resources !== Resources.KnativeService) {
-    registry === RegistryType.External &&
-      (await createOrUpdateImageStream(formData, dryRun, originalImageStream, verb));
     if (formData.resources === Resources.Kubernetes) {
       requests.push(
         createOrUpdateDeployment(
@@ -402,6 +400,8 @@ export const createOrUpdateDeployImageResources = async (
         requests.push(k8sCreate(RouteModel, route, dryRun ? dryRunOpt : {}));
       }
     }
+    registry === RegistryType.External &&
+      (await createOrUpdateImageStream(formData, dryRun, originalImageStream, verb));
   } else if (formData.resources === Resources.KnativeService) {
     let imageStreamUrl: string = image?.dockerImageReference;
     let generatedImageStreamName: string = '';


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: [https://issues.redhat.com/browse/ODC-XXX](https://issues.redhat.com/browse/ODC-XXX) -->
https://issues.redhat.com/browse/OCPBUGS-4469

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
On submitting the Deploy Image form , there would be 4 network calls made, out of which the first one would cause unwanted changes making the 2nd call fail

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Reordered the network calls so that such a clash does not occur

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
--Before--

https://user-images.githubusercontent.com/122968482/233328927-59874656-b201-44f7-a696-a420933b2335.mp4

--After--

https://user-images.githubusercontent.com/122968482/233328909-2e9f26e6-411a-4ba1-b10a-bd16ec313fdb.mp4


**Unit test coverage report**: 
<!-- Attach test coverage report -->
NA

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
- In Developer Perspective, go to Container Images
- In the field below Image name from external registry, use the following repo: aneeshmbhat/nodejs-test:v1 & click create, wait a bit to make sure all resources are updated
- Check the url of the Deployment to see version
- Afterwards go the the Deployment Kebab Menu & click Edit <deployment-name>
- Change the tag of aneeshmbhat/nodejs-test:v1 to v2 ( i.e. aneeshmbhat/nodejs-test:v2 ) & Save
- Now go to url again of Deployment & it should be v2 
- Try the same for any other Image having multiple tags

Additional Resource:
quay.io/rh_ee_anebhat/node-test:v1 (v1 & v2 tags)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge