### PR TITLE
[release-4.12] OCPBUGS-12232: Fix for broken Create key/value secrets e2e tests

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crud/secrets.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/secrets.spec.ts
@@ -34,12 +34,20 @@ describe('Create key/value secrets', () => {
   });
 
   beforeEach(() => {
+    // ensure the test project is selected to avoid flakes
+    cy.visit(`/k8s/cluster/projects/${testName}`);
     nav.sidenav.clickNavLink(['Workloads', 'Secrets']);
     listPage.titleShouldHaveText('Secrets');
     secrets.clickCreateKeyValSecretDropdownButton();
   });
 
   afterEach(() => {
+    cy.exec(
+      `oc delete secret -n ${testName} ${binarySecretName} ${asciiSecretName} ${unicodeSecretName}`,
+      {
+        failOnNonZeroExit: false,
+      },
+    );
     checkErrors();
   });
 
@@ -53,7 +61,9 @@ describe('Create key/value secrets', () => {
     cy.byLegacyTestID('file-input-textarea').should('not.exist');
     cy.get(infoMessage).should('exist');
     cy.byTestID('save-changes').click();
+    cy.byTestID('loading-indicator').should('not.exist');
     detailsPage.isLoaded();
+    detailsPage.titleShouldContain(binarySecretName);
     cy.exec(
       `oc get secret -n ${testName} ${binarySecretName} --template '{{.data.${secretKey}}}' | base64 -d`,
       {
@@ -71,7 +81,9 @@ describe('Create key/value secrets', () => {
     cy.byLegacyTestID('file-input-textarea').should('exist');
     cy.get(infoMessage).should('not.exist');
     cy.byTestID('save-changes').click();
+    cy.byTestID('loading-indicator').should('not.exist');
     detailsPage.isLoaded();
+    detailsPage.titleShouldContain(asciiSecretName);
     cy.exec(
       `oc get secret -n ${testName} ${asciiSecretName} --template '{{.data.${secretKey}}}' | base64 -d`,
       {
@@ -89,7 +101,9 @@ describe('Create key/value secrets', () => {
     cy.byLegacyTestID('file-input-textarea').should('exist');
     cy.get(infoMessage).should('not.exist');
     cy.byTestID('save-changes').click();
+    cy.byTestID('loading-indicator').should('not.exist');
     detailsPage.isLoaded();
+    detailsPage.titleShouldContain(unicodeSecretName);
     cy.exec(
       `oc get secret -n ${testName} ${unicodeSecretName} --template '{{.data.${secretKey}}}' | base64 -d`,
       {

--- a/frontend/packages/integration-tests-cypress/tests/crud/secrets.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/secrets.spec.ts
@@ -78,19 +78,19 @@ describe('Create key/value secrets', () => {
 
   it(`Validate a key/value secret whose value is an ascii file`, () => {
     populateSecretForm(asciiSecretName, secretKey, asciiFilename);
-    cy.byLegacyTestID('file-input-textarea').should('exist');
-    cy.get(infoMessage).should('not.exist');
-    cy.byTestID('save-changes').click();
-    cy.byTestID('loading-indicator').should('not.exist');
-    detailsPage.isLoaded();
-    detailsPage.titleShouldContain(asciiSecretName);
-    cy.exec(
-      `oc get secret -n ${testName} ${asciiSecretName} --template '{{.data.${secretKey}}}' | base64 -d`,
-      {
-        failOnNonZeroExit: false,
-      },
-    ).then((value) => {
-      cy.fixture(asciiFilename, 'ascii').then((asciiSecret) => {
+    cy.fixture(asciiFilename, 'ascii').then((asciiSecret) => {
+      cy.byLegacyTestID('file-input-textarea').should('contain.text', asciiSecret);
+      cy.get(infoMessage).should('not.exist');
+      cy.byTestID('save-changes').click();
+      cy.byTestID('loading-indicator').should('not.exist');
+      detailsPage.isLoaded();
+      detailsPage.titleShouldContain(asciiSecretName);
+      cy.exec(
+        `oc get secret -n ${testName} ${asciiSecretName} --template '{{.data.${secretKey}}}' | base64 -d`,
+        {
+          failOnNonZeroExit: false,
+        },
+      ).then((value) => {
         expect(asciiSecret).toEqual(value.stdout);
       });
     });
@@ -98,19 +98,19 @@ describe('Create key/value secrets', () => {
 
   it(`Validate a key/value secret whose value is a unicode file`, () => {
     populateSecretForm(unicodeSecretName, secretKey, unicodeFilename);
-    cy.byLegacyTestID('file-input-textarea').should('exist');
-    cy.get(infoMessage).should('not.exist');
-    cy.byTestID('save-changes').click();
-    cy.byTestID('loading-indicator').should('not.exist');
-    detailsPage.isLoaded();
-    detailsPage.titleShouldContain(unicodeSecretName);
-    cy.exec(
-      `oc get secret -n ${testName} ${unicodeSecretName} --template '{{.data.${secretKey}}}' | base64 -d`,
-      {
-        failOnNonZeroExit: false,
-      },
-    ).then((value) => {
-      cy.fixture(unicodeFilename, 'utf8').then((unicodeSecret) => {
+    cy.fixture(unicodeFilename, 'utf8').then((unicodeSecret) => {
+      cy.byLegacyTestID('file-input-textarea').should('contain.text', unicodeSecret);
+      cy.get(infoMessage).should('not.exist');
+      cy.byTestID('save-changes').click();
+      cy.byTestID('loading-indicator').should('not.exist');
+      detailsPage.isLoaded();
+      detailsPage.titleShouldContain(unicodeSecretName);
+      cy.exec(
+        `oc get secret -n ${testName} ${unicodeSecretName} --template '{{.data.${secretKey}}}' | base64 -d`,
+        {
+          failOnNonZeroExit: false,
+        },
+      ).then((value) => {
         expect(unicodeSecret).toEqual(value.stdout);
       });
     });


### PR DESCRIPTION
I got this issue on 4.9 and 4.10, so I started a backporting the fix for:

![image](https://user-images.githubusercontent.com/139310/233572771-64f53678-d8d5-4f1e-8bed-bf9533b425e2.png)
From one of this error logs:

```
1) Create key/value secrets
       Validate a key/value secret whose value is an ascii file :

      AssertionError: expected 'This is ascii' to equal ''
      + expected - actual

      -'This is ascii'
      
      at Proxy.toEqual (https://console-openshift-console.apps.ci-op-s12pmyst-b5642.xxxxxxxxxxxxxxxxxxxxxx/__cypress/tests?p=tests/crud/secrets.spec.ts:12150:30697)
      at Context.eval (https://console-openshift-console.apps.ci-op-s12pmyst-b5642.xxxxxxxxxxxxxxxxxxxxxx/__cypress/tests?p=tests/crud/secrets.spec.ts:14448:37)

  2) Create key/value secrets
       Validate a key/value secret whose value is a unicode file :

      AssertionError: expected 'ȹȻɣʄɣɱɰ' to equal ''
      + expected - actual

      -'ȹȻɣʄɣɱɰ'
      
      at Proxy.toEqual (https://console-openshift-console.apps.ci-op-s12pmyst-b5642.xxxxxxxxxxxxxxxxxxxxxx/__cypress/tests?p=tests/crud/secrets.spec.ts:12150:30697)
      at Context.eval (https://console-openshift-console.apps.ci-op-s12pmyst-b5642.xxxxxxxxxxxxxxxxxxxxxx/__cypress/tests?p=tests/crud/secrets.spec.ts:14462:39)

  3) Create key/value secrets
       "after all" hook for "Validate a key/value secret whose value is a unicode file ":
     CypressError: `cy.click()` failed because it requires a DOM element.

The subject received was:

  > `undefined`

The previous command that ran was:

  > `cy.get()`

Because this error occurred during a `after all` hook we are skipping the remaining tests in the current suite: `Create key/value secrets`

Although you have test retries enabled, we do not retry tests when `before all` or `after all` hooks fail
      at ensureElement (https://console-openshift-console.apps.ci-op-s12pmyst-b5642.xxxxxxxxxxxxxxxxxxxxxx/__cypress/runner/cypress_runner.js:160549:85)
      at validateType (https://console-openshift-console.apps.ci-op-s12pmyst-b5642.xxxxxxxxxxxxxxxxxxxxxx/__cypress/runner/cypress_runner.js:160386:18)
      at Object.ensureSubjectByType (https://console-openshift-console.apps.ci-op-s12pmyst-b5642.xxxxxxxxxxxxxxxxxxxxxx/__cypress/runner/cypress_runner.js:160422:11)
      at pushSubjectAndValidate (https://console-openshift-console.apps.ci-op-s12pmyst-b5642.xxxxxxxxxxxxxxxxxxxxxx/__cypress/runner/cypress_runner.js:169527:17)
      at Context.<anonymous> (https://console-openshift-console.apps.ci-op-s12pmyst-b5642.xxxxxxxxxxxxxxxxxxxxxx/__cypress/runner/cypress_runner.js:169856:20)
  From Your Spec Code:
      at Object.clickPageActionFromDropdown (https://console-openshift-console.apps.ci-op-s12pmyst-b5642.xxxxxxxxxxxxxxxxxxxxxx/__cypress/tests?p=tests/crud/secrets.spec.ts:14487:50)
      at Context.eval (https://console-openshift-console.apps.ci-op-s12pmyst-b5642.xxxxxxxxxxxxxxxxxxxxxx/__cypress/tests?p=tests/crud/secrets.spec.ts:14284:69)
```

This is a manual backport of @rhamilto and @TheRealJon 4.13 work.

* #12345
* #12407

Thanks for that. I also looked into

* #12316
* #12405

which was linked in the origin issue, but these were reverted with both PRs above.