### PR TITLE
[release-4.10] OCPBUGS-12245: disable operator-install-single-namespace.spec.ts to solve CI issues

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -17,7 +17,7 @@ const testOperand: TestOperandProps = {
   exampleName: `backend1-sample`,
 };
 
-describe(`Installing "${testOperator.name}" operator in ${testOperator.installedNamespace}`, () => {
+xdescribe(`Installing "${testOperator.name}" operator in ${testOperator.installedNamespace}`, () => {
   before(() => {
     cy.login();
     cy.visit('/');


### PR DESCRIPTION
This is a manual backport of #12751 after the automatic cherry-pick [failed here](https://github.com/openshift/console/pull/12624#issuecomment-1517570425)

Current 4.10 [ci jobs](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-console-release-4.10-e2e-gcp-console) are failing since Feb 25. :face_with_spiral_eyes: 

This issue was solved on the main branch after the operator tests were disabled with #12406. :eyes: