### PR TITLE
OCPBUGS-12267: Fix OLM k8sResourcePrefix descriptor dropdown behavior

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/widgets.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/widgets.tsx
@@ -121,7 +121,7 @@ export const K8sResourceWidget: React.FC<K8sResourceWidgetProps> = ({
   const { t } = useTranslation();
   const { model, groupVersionKind } = options;
   const { namespace } = formContext;
-  const selectedKey = value ? `${value}-${model.kind}` : null;
+  const selectedKey = value ? `${value}-${groupVersionKind}` : null;
 
   return (
     <div>


### PR DESCRIPTION
The selectedKey prop passed into the ListDropdown component was incorrectly formatted. Update to use  `name-group~version~kind` rather than just `name-kind`.