### PR TITLE
[release-4.12] OCPBUGS-12476: Pipelines repository list and creation form doesn't show Tech Preview status

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoriesList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoriesList.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
+import { getBadgeFromType } from '@console/shared/src';
 import { RepositoryModel } from '../../../models';
 import RepositoryList from './ReppositoryList';
 
@@ -13,6 +14,7 @@ const RepositoriesList: React.FC<React.ComponentProps<typeof ListPage>> = (props
     canCreate={props.canCreate ?? true}
     kind={referenceForModel(RepositoryModel)}
     ListComponent={RepositoryList}
+    badge={getBadgeFromType(RepositoryModel.badge)}
   />
 );
 

--- a/frontend/packages/pipelines-plugin/src/components/repository/sections/RepositoryFormSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/sections/RepositoryFormSection.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { TextInputTypes } from '@patternfly/react-core';
+import { Flex, FlexItem, TextInputTypes, Title } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 import { getGitService, ImportStrategy } from '@console/git-service/src';
 import { detectImportStrategies } from '@console/git-service/src/utils/import-strategy-detector';
-import { FormHeader, InputField, useDebounceCallback } from '@console/shared';
+import { FormHeader, getBadgeFromType, InputField, useDebounceCallback } from '@console/shared';
+import { RepositoryModel } from '../../../models';
 import { useBuilderImages } from '../hooks/useBuilderImages';
 import {
   recommendRepositoryName,
@@ -56,9 +57,18 @@ const RepositoryFormSection = () => {
   };
   const debouncedHandleGitUrlChange = useDebounceCallback(handleGitUrlChange);
 
+  const title = (
+    <Flex className="odc-pipeline-builder-header__content">
+      <FlexItem grow={{ default: 'grow' }}>
+        <Title headingLevel="h1">{t('pipelines-plugin~Add Git Repository')}</Title>
+      </FlexItem>
+      <FlexItem>{getBadgeFromType(RepositoryModel.badge)}</FlexItem>
+    </Flex>
+  );
+
   return (
     <>
-      <FormHeader title={t('pipelines-plugin~Add Git Repository')} />
+      <FormHeader title={title} />
       <FormSection>
         <InputField
           label={t('pipelines-plugin~Git Repo URL')}


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-7031

**Analysis / Root cause:**
Tech preview label was not added

**Solution Description:**
Added Tech preview label for pipeline repository list and create page

**Screen shots / Gifs for design review:**
<img width="1434" alt="Screenshot 2023-04-24 at 12 51 12 PM" src="https://user-images.githubusercontent.com/102503482/233926830-a11f9e82-c0fa-4339-b2c1-d50391370435.png">

<img width="1029" alt="Screenshot 2023-04-24 at 12 51 22 PM" src="https://user-images.githubusercontent.com/102503482/233926844-153145c5-8573-4692-99ce-b72dabee9fd1.png">



****Unit test coverage report:****
NA

**Test setup:**

1. Install OpenShift Pipelines operator
2. Navigate to Pipelines > Repository tab
3. Select Create > Repository

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
