### PR TITLE
[release-4.12] OCPBUGS-12477: Users don't know what type of resource is being created by Import from Git or Deploy Image flows

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -44,6 +44,12 @@ export const gitPO = {
     addPipeline: '#form-checkbox-pipeline-enabled-field',
     pipelineDropdown: '#form-dropdown-pipeline-templateSelected-field',
   },
+  resourcesDropdown: '#form-select-input-resources-field',
+  resources: {
+    deployment: '#select-option-resources-kubernetes',
+    deploymentConfig: '#select-option-resources-openshift',
+    knative: '#select-option-resources-knative',
+  },
   advancedOptions: {
     createRoute: '#form-checkbox-route-create-field',
     routing: {
@@ -91,12 +97,6 @@ export const gitPO = {
       memoryLimitHelperText: 'div#form-resource-limit-limits-memory-limit-field-helper',
     },
     labels: 'input[data-test="labels"]',
-    resourcesDropdown: '#form-select-input-resources-field',
-    resources: {
-      deployment: '#select-option-resources-kubernetes',
-      deploymentConfig: '#select-option-resources-openshift',
-      knative: '#select-option-resources-knative',
-    },
   },
 };
 

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
@@ -148,28 +148,27 @@ export const gitPage = {
   verifyNodeName: (componentName: string) =>
     cy.get(gitPO.nodeName).should('have.value', componentName),
   selectResource: (resource: string = 'deployment') => {
-    gitPage.selectAdvancedOptions(gitAdvancedOptions.Resources);
-    cy.get(gitPO.advancedOptions.resourcesDropdown)
+    cy.get(gitPO.resourcesDropdown)
       .scrollIntoView()
       .click();
     switch (resource) {
       case 'deployment':
       case 'Deployment':
-        cy.get(gitPO.advancedOptions.resources.deployment)
+        cy.get(gitPO.resources.deployment)
           .scrollIntoView()
           .click();
         break;
       case 'deployment config':
       case 'Deployment Config':
       case 'DeploymentConfig':
-        cy.get(gitPO.advancedOptions.resources.deploymentConfig)
+        cy.get(gitPO.resources.deploymentConfig)
           .scrollIntoView()
           .click();
         break;
       case 'Knative':
       case 'Knative Service':
       case 'Serverless Deployment':
-        cy.get(gitPO.advancedOptions.resources.knative)
+        cy.get(gitPO.resources.knative)
           .scrollIntoView()
           .click();
         break;

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/userPreferences/user-preferences-dev-perspective.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/userPreferences/user-preferences-dev-perspective.ts
@@ -1,12 +1,7 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
 import { modal } from '@console/cypress-integration-tests/views/modal';
 import { nav } from '@console/cypress-integration-tests/views/nav';
-import {
-  addOptions,
-  devNavigationMenu,
-  gitAdvancedOptions,
-  switchPerspective,
-} from '../../constants';
+import { addOptions, devNavigationMenu, switchPerspective } from '../../constants';
 import { gitPO } from '../../pageObjects';
 import {
   getPreferenceDropdown,
@@ -242,6 +237,5 @@ When('user clicks on Container images', () => {
 });
 
 Then('user is able to see resources DeploymentConfig is selected', () => {
-  gitPage.selectAdvancedOptions(gitAdvancedOptions.Resources);
-  cy.get(gitPO.advancedOptions.resourcesDropdown).should('contain.text', 'DeploymentConfig');
+  cy.get(gitPO.resourcesDropdown).should('contain.text', 'DeploymentConfig');
 });

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -528,7 +528,7 @@
   "Select an icon": "Select an icon",
   "A {{deploymentLabel}} enables declarative updates for Pods and ReplicaSets.": "A {{deploymentLabel}} enables declarative updates for Pods and ReplicaSets.",
   "A {{deploymentConfigLabel}} defines the template for a Pod and manages deploying new Images or configuration changes.": "A {{deploymentConfigLabel}} defines the template for a Pod and manages deploying new Images or configuration changes.",
-  "Select the resource type to generate": "Select the resource type to generate",
+  "Resource type to generate. The default can be set in <2>User Preferences</2>.": "Resource type to generate. The default can be set in <2>User Preferences</2>.",
   "Domain mapping": "Domain mapping",
   "Add domain": "Add domain",
   "Enter custom domain to map to the Knative service": "Enter custom domain to map to the Knative service",

--- a/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
@@ -9,6 +9,7 @@ import AppSection from './app/AppSection';
 import ImageSearchSection from './image-search/ImageSearchSection';
 import { DeployImageFormProps } from './import-types';
 import IconSection from './section/IconSection';
+import ResourceSection from './section/ResourceSection';
 
 const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps> = ({
   values,
@@ -32,6 +33,7 @@ const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps
           project={values.project}
           noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
         />
+        <ResourceSection />
         <AdvancedSection values={values} />
       </FormBody>
       <FormFooter

--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -12,6 +12,7 @@ import DevfileStrategySection from './devfile/DevfileStrategySection';
 import GitSection from './git/GitSection';
 import { GitImportFormProps, ImportTypes } from './import-types';
 import ImportStrategySection from './ImportStrategySection';
+import ResourceSection from './section/ResourceSection';
 
 const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = ({
   values,
@@ -63,6 +64,7 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
             {importType !== ImportTypes.devfile &&
               values.import.selectedStrategy.type !== ImportStrategy.DEVFILE && (
                 <>
+                  <ResourceSection />
                   <PipelineSection builderImages={builderImages} />
                   <AdvancedSection values={values} />
                 </>

--- a/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
@@ -9,6 +9,7 @@ import AppSection from './app/AppSection';
 import BuilderSection from './builder/BuilderSection';
 import GitSection from './git/GitSection';
 import { SourceToImageFormProps } from './import-types';
+import ResourceSection from './section/ResourceSection';
 
 const SourceToImageForm: React.FC<FormikProps<FormikValues> & SourceToImageFormProps> = ({
   values,
@@ -34,6 +35,7 @@ const SourceToImageForm: React.FC<FormikProps<FormikValues> & SourceToImageFormP
           noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
         />
         <PipelineSection builderImages={builderImages} />
+        <ResourceSection />
         <AdvancedSection values={values} />
       </FormBody>
       <FormFooter

--- a/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormikValues, useFormikContext } from 'formik';
+import { FormikValues } from 'formik';
 import { Trans, useTranslation } from 'react-i18next';
 import { AppResources } from '../../edit-application/edit-application-types';
 import HealthChecks from '../../health-checks/HealthChecks';
@@ -7,8 +7,6 @@ import ProgressiveList from '../../progressive-list/ProgressiveList';
 import ProgressiveListItem from '../../progressive-list/ProgressiveListItem';
 import { Resources } from '../import-types';
 import FormSection from '../section/FormSection';
-import ResourceSection from '../section/ResourceSection';
-import { useResourceType } from '../section/useResourceType';
 import BuildConfigSection from './BuildConfigSection';
 import DeploymentConfigSection from './DeploymentConfigSection';
 import LabelSection from './LabelSection';
@@ -48,11 +46,6 @@ const List: React.FC<AdvancedSectionProps> = ({ appResources, values }) => {
       onVisibleItemChange={handleVisibleItemChange}
       Footer={Footer}
     >
-      {!['edit', 'knatify'].includes(values.formType) && (
-        <ProgressiveListItem name={t('devconsole~Resource type')}>
-          <ResourceSection />
-        </ProgressiveListItem>
-      )}
       <ProgressiveListItem name={t('devconsole~Health checks')}>
         <HealthChecks title={t('devconsole~Health checks')} resourceType={values.resources} />
       </ProgressiveListItem>
@@ -90,13 +83,6 @@ const List: React.FC<AdvancedSectionProps> = ({ appResources, values }) => {
 
 const AdvancedSection: React.FC<AdvancedSectionProps> = ({ values, appResources }) => {
   const { t } = useTranslation();
-  const [resourceType] = useResourceType();
-  const { setFieldValue } = useFormikContext<FormikValues>();
-
-  React.useEffect(() => {
-    !['edit', 'knatify'].includes(values.formType) && setFieldValue('resources', resourceType);
-  }, [resourceType, setFieldValue, values.formType]);
-
   return (
     <FormSection title={t('devconsole~Advanced options')}>
       <RouteSection route={values.route} resources={values.resources} />

--- a/frontend/packages/dev-console/src/components/import/advanced/__tests__/AdvancedSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/__tests__/AdvancedSection.spec.tsx
@@ -3,7 +3,6 @@ import { shallow } from 'enzyme';
 import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
 import HealthChecks from '../../../health-checks/HealthChecks';
 import { Resources } from '../../import-types';
-import ResourceSection from '../../section/ResourceSection';
 import AdvancedSection from '../AdvancedSection';
 import BuildConfigSection from '../BuildConfigSection';
 import DeploymentConfigSection from '../DeploymentConfigSection';
@@ -19,10 +18,6 @@ jest.mock('formik', () => ({
   useFormikContext: jest.fn(() => ({
     setFieldValue: jest.fn(),
   })),
-}));
-
-jest.mock('../../section/useResourceType', () => ({
-  useResourceType: () => ['', null],
 }));
 
 describe('AdvancedSection', () => {
@@ -57,7 +52,6 @@ describe('AdvancedSection', () => {
     expect(listItems.find(DeploymentConfigSection).exists()).toBe(true);
     expect(listItems.find(ScalingSection).exists()).toBe(true);
     expect(listItems.find(ResourceLimitSection).exists()).toBe(true);
-    expect(listItems.find(ResourceSection).exists()).toBe(true);
 
     expect(listItems.find(LabelSection).exists()).toBe(true);
     expect(listItems.find(ServerlessScalingSection).exists()).toBe(false);

--- a/frontend/packages/dev-console/src/components/import/jar/UploadJarForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/jar/UploadJarForm.tsx
@@ -13,6 +13,7 @@ import AppSection from '../app/AppSection';
 import BuilderImageTagSelector from '../builder/BuilderImageTagSelector';
 import FormSection from '../section/FormSection';
 import IconSection from '../section/IconSection';
+import ResourceSection from '../section/ResourceSection';
 import JarSection from './section/JarSection';
 
 export type UploadJarFormProps = {
@@ -64,6 +65,7 @@ const UploadJarForm: React.FunctionComponent<FormikProps<FormikValues> & UploadJ
           project={values.project}
           noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
         />
+        <ResourceSection />
         <AdvancedSection values={values} />
       </FormBody>
       <FormFooter

--- a/frontend/packages/git-service/src/types/git.ts
+++ b/frontend/packages/git-service/src/types/git.ts
@@ -28,4 +28,5 @@ export enum ImportStrategy {
   S2I,
   DOCKERFILE,
   DEVFILE,
+  SERVERLESS_FUNCTION,
 }

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/create-knative-workload.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/create-knative-workload.ts
@@ -5,7 +5,6 @@ import {
   catalogCards,
   catalogTypes,
   devNavigationMenu,
-  gitAdvancedOptions,
 } from '@console/dev-console/integration-tests/support/constants';
 import { gitPO, topologyPO } from '@console/dev-console/integration-tests/support/pageObjects';
 import {
@@ -79,11 +78,10 @@ Then('user will be redirected to page with header name {string}', (headerName: s
 Then('Knative Service option is displayed under Resources section', () => {
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(4000);
-  gitPage.selectAdvancedOptions(gitAdvancedOptions.Resources);
-  cy.get(gitPO.advancedOptions.resourcesDropdown)
+  cy.get(gitPO.resourcesDropdown)
     .scrollIntoView()
     .click();
-  cy.get(gitPO.advancedOptions.resources.knative)
+  cy.get(gitPO.resources.knative)
     .scrollIntoView()
     .should('be.visible');
 });


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-7395

**Analysis / Root cause:**
NA

**Solution Description:**
Moved Resource type selection out of Advanced section

**Screen shots / Gifs for design review:**


https://user-images.githubusercontent.com/102503482/233934744-c2d5657a-4fbb-475e-9488-a79324ff9e1f.mov



****Unit test coverage report:****
NA

**Test setup:**

NA

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
