### PR TITLE
OCPBUGS-12286: Fix missing console plugin control on CSV details page.

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
@@ -306,7 +306,11 @@ describe(ClusterServiceVersionDetails.displayName, () => {
     wrapper = shallow(
       <ClusterServiceVersionDetails
         obj={_.cloneDeep(testClusterServiceVersion)}
-        subscriptions={testSubscriptions}
+        customData={{
+          subscriptions: testSubscriptions,
+          subscription: testSubscription,
+          subscriptionsLoaded: true,
+        }}
       />,
     );
   });
@@ -433,7 +437,11 @@ describe(ClusterServiceVersionDetails.displayName, () => {
     wrapper = shallow(
       <ClusterServiceVersionDetails
         obj={emptyTestClusterServiceVersion}
-        subscriptions={testSubscriptions}
+        customData={{
+          subscriptions: testSubscriptions,
+          subscription: testSubscription,
+          subscriptionsLoaded: true,
+        }}
       />,
     );
     expect(emptyTestClusterServiceVersion.spec.install.spec.permissions.length).toEqual(0);
@@ -451,7 +459,11 @@ describe(ClusterServiceVersionDetails.displayName, () => {
     wrapper = shallow(
       <ClusterServiceVersionDetails
         obj={duplicateTestClusterServiceVersion}
-        subscriptions={testSubscriptions}
+        customData={{
+          subscriptions: testSubscriptions,
+          subscription: testSubscription,
+          subscriptionsLoaded: true,
+        }}
       />,
     );
     expect(duplicateTestClusterServiceVersion.spec.install.spec.permissions.length).toEqual(2);
@@ -473,10 +485,12 @@ describe(CSVSubscription.displayName, () => {
     wrapper = shallow(
       <CSVSubscription
         obj={testClusterServiceVersion}
-        subscription={undefined}
-        loaded
+        customData={{
+          subscriptions: [],
+          subscription: undefined,
+          subscriptionsLoaded: true,
+        }}
         packageManifests={[]}
-        subscriptions={[]}
         installPlans={[]}
       />,
     );
@@ -497,10 +511,12 @@ describe(CSVSubscription.displayName, () => {
     wrapper = shallow(
       <CSVSubscription
         obj={obj}
+        customData={{
+          subscription,
+          subscriptions: [testSubscription, subscription],
+          subscriptionsLoaded: true,
+        }}
         packageManifests={[testPackageManifest]}
-        subscription={subscription}
-        loaded
-        subscriptions={[testSubscription, subscription]}
         installPlans={[testInstallPlan]}
       />,
     );
@@ -532,10 +548,12 @@ describe(CSVSubscription.displayName, () => {
       <CSVSubscription
         obj={obj}
         packageManifests={[testPackageManifest, otherPkg]}
-        subscription={subscription}
-        loaded
-        subscriptions={[testSubscription, subscription]}
         installPlans={[testInstallPlan]}
+        customData={{
+          subscription,
+          subscriptionsLoaded: true,
+          subscriptions: [testSubscription, subscription],
+        }}
       />,
     );
 


### PR DESCRIPTION
ClusterServiceVersionDetails component expected a `subscriptions` prop which was removed in another bug fix. Update ClusterServiceVersionDetailsPage to pass `subscriptions, subscription, subscriptionsLoaded, subscriptionsLoadError` props through the `customData` prop of `DetailsPage` component. This will make these properties available to all tab pages on the CSV details page.