### PR TITLE
OCPBUGS-12637: update helm release empty state text

### DIFF
--- a/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-page.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-page.ts
@@ -7,7 +7,7 @@ export const helmPage = {
   verifyInstallHelmLink: () =>
     cy
       .get('a')
-      .contains('Browse the catalog to discover and install Helm Charts')
+      .contains('Browse the catalog to discover available Helm Charts')
       .should('be.visible'),
   search: (name: string) => {
     cy.get(helmPO.search)

--- a/frontend/packages/helm-plugin/locales/en/helm-plugin.json
+++ b/frontend/packages/helm-plugin/locales/en/helm-plugin.json
@@ -120,6 +120,7 @@
   "False": "False",
   "Unable to load Helm Releases": "Unable to load Helm Releases",
   "No Helm Releases found": "No Helm Releases found",
+  "Browse the catalog to discover available Helm Charts": "Browse the catalog to discover available Helm Charts",
   "Repositories": "Repositories",
   "Select a Project to view its details<1></1>.": "Select a Project to view its details<1></1>.",
   "No repositories found": "No repositories found",

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
@@ -128,7 +128,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = (props) => {
         {isHelmEnabled ? (
           <EmptyStateSecondaryActions>
             <Link to={installURL}>
-              {t('helm-plugin~Browse the catalog to discover and install Helm Charts')}
+              {t('helm-plugin~Browse the catalog to discover available Helm Charts')}
             </Link>
           </EmptyStateSecondaryActions>
         ) : null}


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-12637

**Solution description:**
Updated the helm release empty state text to "Browse the catalog to discover available Helm Charts"

**Screenshot:**
<img width="1703" alt="Screenshot 2023-04-25 at 12 08 03 PM" src="https://user-images.githubusercontent.com/22490998/234196534-801b8ce7-9ffd-4433-a77a-520c6ee18164.png">

/kind bug