### PR TITLE
[release-4.9] OCPBUGS-12695: Fix that topology sidebar actions shows outdated data (Edit Pod Count, Edit labels, Edit annotations, etc.)

### DIFF
--- a/frontend/packages/helm-plugin/src/actions/providers.ts
+++ b/frontend/packages/helm-plugin/src/actions/providers.ts
@@ -24,11 +24,11 @@ export const useHelmActionProvider = (scope: HelmActionsScope) => {
 };
 
 export const useHelmActionProviderForTopology = (element: GraphElement) => {
-  const nodeType = element.getType();
+  const resource = getResource(element);
   const scope = React.useMemo(() => {
+    const nodeType = element.getType();
     if (nodeType !== TYPE_HELM_RELEASE) return undefined;
     const releaseName = element.getLabel();
-    const resource = getResource(element);
     if (!resource?.metadata) return null;
     const {
       namespace,
@@ -42,7 +42,7 @@ export const useHelmActionProviderForTopology = (element: GraphElement) => {
       },
       actionOrigin: 'topology',
     };
-  }, [element, nodeType]);
+  }, [element, resource]);
   const result = useHelmActionProvider(scope);
   return result;
 };

--- a/frontend/packages/topology/console-extensions.json
+++ b/frontend/packages/topology/console-extensions.json
@@ -162,7 +162,7 @@
     "type": "console.action/provider",
     "properties": {
       "contextId": "topology-actions",
-      "provider": { "$codeRef": "actions.useTopologyWorloadActionProvider" }
+      "provider": { "$codeRef": "actions.useTopologyWorkloadActionProvider" }
     }
   },
   {

--- a/frontend/packages/topology/src/actions/TopologyActions.tsx
+++ b/frontend/packages/topology/src/actions/TopologyActions.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { GraphElement } from '@patternfly/react-topology';
+import { observer, GraphElement } from '@patternfly/react-topology';
 import { referenceFor } from '@console/internal/module/k8s';
 import { ActionMenu, ActionMenuVariant, ActionServiceProvider } from '@console/shared';
 import { getResource } from '../utils';
@@ -9,13 +9,13 @@ type TopologyActionsProps = {
 };
 
 const TopologyActions: React.FC<TopologyActionsProps> = ({ element }) => {
+  const resource = getResource(element);
   const context = React.useMemo(() => {
-    const resource = getResource(element);
     return {
       'topology-actions': element,
       [referenceFor(resource)]: resource,
     };
-  }, [element]);
+  }, [element, resource]);
   return (
     <ActionServiceProvider key={element.getId()} context={context}>
       {({ actions, options, loaded }) => {
@@ -29,4 +29,4 @@ const TopologyActions: React.FC<TopologyActionsProps> = ({ element }) => {
   );
 };
 
-export default TopologyActions;
+export default observer(TopologyActions);

--- a/frontend/packages/topology/src/actions/provider.ts
+++ b/frontend/packages/topology/src/actions/provider.ts
@@ -5,12 +5,12 @@ import { TYPE_WORKLOAD } from '../const';
 import { getResource } from '../utils';
 import { getModifyApplicationAction } from './modify-application';
 
-export const useTopologyWorloadActionProvider = (element: GraphElement) => {
+export const useTopologyWorkloadActionProvider = (element: GraphElement) => {
+  const resource = getResource(element);
   const actions = useMemo(() => {
-    const resource = getResource(element);
     const k8sKind = modelFor(referenceFor(resource));
     return [getModifyApplicationAction(k8sKind, resource)];
-  }, [element]);
+  }, [resource]);
 
   return useMemo(() => {
     if (element.getType() !== TYPE_WORKLOAD) return [[], true, undefined];


### PR DESCRIPTION
**Fixes** https://issues.redhat.com/browse/OCPBUGS-12695

This is a manual backport of #12533

**Before** the sidebar action dropdown uses the old data:

https://user-images.githubusercontent.com/139310/234228637-ca657156-fead-426c-ab62-8e94ed8c5b03.mp4

**With this PR** the sidebar action dropdown uses the latest data:

https://user-images.githubusercontent.com/139310/234229727-42a802e5-bdca-4e48-a8ac-cfb9bd5e2772.mp4
