### PR TITLE
OCPBUGS-12732: fix buildconfig form ns

### DIFF
--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { match as Match } from 'react-router';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { K8sResourceKind, K8sResourceKindReference, referenceFor } from '../module/k8s';
@@ -215,7 +216,7 @@ export const BuildConfigsPage: React.FC<BuildConfigsPageProps> = (props) => {
     },
   ];
 
-  const namespace = props.namespace;
+  const namespace = props.namespace ?? props.match?.params?.ns;
   const createProps = {
     to: `/k8s/ns/${namespace || 'default'}/buildconfigs/~new/form`,
   };
@@ -246,6 +247,7 @@ export type BuildConfigsDetailsProps = {
 
 export type BuildConfigsPageProps = {
   namespace: string;
+  match?: Match<{ ns: string; name: string }>;
   canCreate?: boolean;
   filterLabel?: string;
   mock?: boolean;


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-12732

**Root analysis:**
BuildConfig in the dev console has the namespace info in the match params

**Solution description:**
Fetching namespace info also from the match params

**GIF:**
Before:
https://user-images.githubusercontent.com/22490998/234354079-e74c3abd-8a67-4bf1-99e4-6a7374167f06.mov

After:
https://user-images.githubusercontent.com/22490998/234356685-9310f016-27cf-40ee-ad66-db24b8df2758.mov



/kind bug
