### PR TITLE
WIP: STS support for Operators

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -271,6 +271,7 @@
   "No Operators available": "No Operators available",
   "There are no Operators that match operating system {{os}} and architecture {{arch}}.": "There are no Operators that match operating system {{os}} and architecture {{arch}}.",
   "Install state": "Install state",
+  "Short Lived Token Enabled": "Short Lived Token Enabled",
   "Valid subscription": "Valid subscription",
   "No Results Match the Filter Criteria": "No Results Match the Filter Criteria",
   "No OperatorHub items are being shown due to the filters being applied.": "No OperatorHub items are being shown due to the filters being applied.",

--- a/frontend/packages/operator-lifecycle-manager/mocks.ts
+++ b/frontend/packages/operator-lifecycle-manager/mocks.ts
@@ -5,6 +5,7 @@ import {
 } from '@console/internal/module/k8s';
 import { StatusCapability, SpecCapability } from './src/components/descriptors/types';
 import { OperatorHubItem } from './src/components/operator-hub';
+import { CloudCredentialKind } from '@console/internal/module/k8s';
 import {
   OperatorGroupKind,
   PackageManifestKind,
@@ -616,6 +617,14 @@ const federationv2PackageManifest = {
   },
 };
 
+const cred : CloudCredentialKind = {
+  spec: {
+    credentialsMode: "Manual",
+  }
+}
+
+const testCredentials = cred
+
 const prometheusPackageManifest = {
   apiVersion: 'packages.operators.coreos.com/v1' as PackageManifestKind['apiVersion'],
   kind: 'PackageManifest' as PackageManifestKind['kind'],
@@ -728,6 +737,7 @@ export const operatorHubListPageProps = {
     ] as PackageManifestKind[],
   },
   clusterServiceVersions: null,
+  cloudcredentials: { loaded: true, data: cred},
 };
 
 export const operatorHubTileViewPageProps = {
@@ -759,6 +769,8 @@ export const operatorHubTileViewPageProps = {
       catalogSourceNamespace: 'openshift-marketplace',
       validSubscription: undefined,
       infraFeatures: undefined,
+      shortLivedTokenEnabled: 'false',
+      cloudcredentials: testCredentials,
     },
     {
       obj: etcdPackageManifest,
@@ -786,6 +798,8 @@ export const operatorHubTileViewPageProps = {
       catalogSourceNamespace: 'openshift-marketplace',
       validSubscription: undefined,
       infraFeatures: undefined,
+      shortLivedTokenEnabled: 'false',
+      cloudcredentials: testCredentials,
     },
     {
       obj: federationv2PackageManifest,
@@ -813,6 +827,8 @@ export const operatorHubTileViewPageProps = {
       catalogSourceNamespace: 'openshift-marketplace',
       validSubscription: undefined,
       infraFeatures: undefined,
+      shortLivedTokenEnabled: 'false',
+      cloudcredentials: testCredentials,
     },
     {
       obj: prometheusPackageManifest,
@@ -839,6 +855,8 @@ export const operatorHubTileViewPageProps = {
       catalogSourceNamespace: 'openshift-marketplace',
       validSubscription: undefined,
       infraFeatures: undefined,
+      shortLivedTokenEnabled: 'false',
+      cloudcredentials: testCredentials,
     },
   ] as OperatorHubItem[],
   openOverlay: null,
@@ -874,6 +892,8 @@ export const operatorHubTileViewPagePropsWithDummy = {
       catalogSourceNamespace: 'openshift-marketplace',
       validSubscription: undefined,
       infraFeatures: undefined,
+      shortLivedTokenEnabled: 'false',
+      cloudcredentials: testCredentials,
     },
   ],
   openOverlay: null,
@@ -991,4 +1011,6 @@ export const itemWithLongDescription = {
   catalogSourceNamespace: 'openshift-marketplace',
   validSubscription: undefined,
   infraFeatures: undefined,
+  shortLivedTokenEnabled: 'false',
+  cloudcredentials: testCredentials,
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
@@ -1,4 +1,4 @@
-import { K8sResourceKind, ObjectMetadata } from '@console/internal/module/k8s';
+import { CloudCredentialKind, K8sResourceKind, ObjectMetadata } from '@console/internal/module/k8s';
 import { PackageManifestKind, SubscriptionKind } from '../../types';
 
 export enum InstalledState {
@@ -53,6 +53,8 @@ export type OperatorHubItem = {
   [key: string]: any;
   validSubscription: string[];
   infraFeatures: InfraFeatures[];
+  shortLivedTokenEnabled: string;
+  cloudcredentials: CloudCredentialKind;
 };
 
 export enum OperatorHubCSVAnnotationKey {
@@ -71,6 +73,7 @@ export enum OperatorHubCSVAnnotationKey {
   infrastructureFeatures = 'operators.openshift.io/infrastructure-features',
   validSubscription = 'operators.openshift.io/valid-subscription',
   tags = 'tags',
+  shortLivedTokenEnabled = 'cloudTokenEnabled',
 }
 
 export type OperatorHubCSVAnnotations = {
@@ -89,6 +92,7 @@ export type OperatorHubCSVAnnotations = {
   [OperatorHubCSVAnnotationKey.infrastructureFeatures]?: string;
   [OperatorHubCSVAnnotationKey.validSubscription]?: string;
   [OperatorHubCSVAnnotationKey.tags]?: string[];
+  [OperatorHubCSVAnnotationKey.shortLivedTokenEnabled]?: string;
 } & ObjectMetadata['annotations'];
 
 type OperatorHubSpec = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -6,7 +6,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { ExternalLink, HintBlock, Timestamp } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
-import { referenceForModel } from '@console/internal/module/k8s';
+import { CloudCredentialKind, referenceForModel } from '@console/internal/module/k8s';
 import { RH_OPERATOR_SUPPORT_POLICY_LINK } from '@console/shared';
 import { DefaultCatalogSource } from '../../const';
 import { ClusterServiceVersionModel } from '../../models';
@@ -128,15 +128,28 @@ const InstallingHintBlock: React.FC<OperatorHubItemDetailsHintBlockProps> = ({ s
   );
 };
 
+
 const OperatorHubItemDetailsHintBlock: React.FC<OperatorHubItemDetailsHintBlockProps> = (props) => {
   const { t } = useTranslation();
-  const { installed, isInstalling, catalogSource } = props;
+  const { installed, isInstalling, catalogSource, cloudcredentials } = props;
   if (isInstalling) {
     return <InstallingHintBlock {...props} />;
   }
 
   if (installed) {
     return <InstalledHintBlock {...props} />;
+  }
+
+  if ( cloudcredentials?.spec?.credentialsMode == "Token") {
+    return (
+      <HintBlock className="co-catalog-page__hint" title={t('olm~CLUSTER IS IN STS MODE')}>
+        <p>
+          {t(
+            'olm~The cluster is in STS mode!!',
+          )}
+        </p>
+      </HintBlock>
+    )
   }
 
   if (catalogSource === DefaultCatalogSource.CommunityOperators) {
@@ -200,6 +213,8 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({ 
     support,
     validSubscription,
     version,
+    shortLivedTokenEnabled,
+    cloudcredentials,
   } = item;
   const notAvailable = (
     <span className="properties-side-panel-pf-property-label">{t('olm~N/A')}</span>
@@ -241,6 +256,10 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({ 
                     notAvailable
                   )
                 }
+              />
+              <PropertyItem
+                label={t('olm~Short Lived Token Enabled')}
+                value={shortLivedTokenEnabled || notAvailable}
               />
               <PropertyItem
                 label={t('olm~Source')}
@@ -294,6 +313,7 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({ 
                 latestVersion={version}
                 catalogSource={catalogSource}
                 subscription={subscription}
+                cloudcredentials={cloudcredentials}
               />
               {longDescription ? <MarkdownView content={longDescription} /> : description}
             </div>
@@ -313,6 +333,7 @@ type OperatorHubItemDetailsHintBlockProps = {
   latestVersion: string;
   catalogSource: string;
   subscription: SubscriptionKind;
+  cloudcredentials: CloudCredentialKind;
 };
 
 export type OperatorHubItemDetailsProps = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -107,6 +107,7 @@ const operatorHubFilterGroups = [
   'capabilityLevel',
   'infraFeatures',
   'validSubscriptionFilters',
+  'shortLivedTokenEnabled',
 ];
 
 const ignoredProviderTails = [', Inc.', ', Inc', ' Inc.', ' Inc', ', LLC', ' LLC'];
@@ -236,6 +237,10 @@ const validSubscriptionSort = (validSubscription) => {
   }
 };
 
+const shortLivedTokenEnabledSort = (shortLivedTokenEnabled) => {
+  return shortLivedTokenEnabled.value
+};
+
 const sortFilterValues = (values, field) => {
   let sorter: any = ['value'];
 
@@ -261,6 +266,10 @@ const sortFilterValues = (values, field) => {
 
   if (field === 'validSubscriptionFilters') {
     sorter = validSubscriptionSort;
+  }
+
+  if (field === 'shortLivedTokenEnabled') {
+    sorter = shortLivedTokenEnabledSort;
   }
 
   return _.sortBy(values, sorter);
@@ -505,6 +514,7 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
     capabilityLevel: t('olm~Capability level'),
     infraFeatures: t('olm~Infrastructure features'),
     validSubscriptionFilters: t('olm~Valid subscription'),
+    shortLivedTokenEnabled: t('olm~Short Lived Token Enabled'),
   };
 
   return (

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -6,6 +6,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { match } from 'react-router';
 import { Link } from 'react-router-dom';
 import { RadioGroup, RadioInput } from '@console/internal/components/radio';
+import { TextInput } from '@patternfly/react-core';
 import {
   documentationURLs,
   Dropdown,
@@ -71,6 +72,7 @@ import {
 import { installedFor, supports, providedAPIsForOperatorGroup, isGlobal } from '../operator-group';
 
 export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> = (props) => {
+  const [filterText, setFilterText] = React.useState('');
   const { catalogNamespace, pkg } = getURLSearchParams();
   const [targetNamespace, setTargetNamespace] = React.useState(null);
   const [installMode, setInstallMode] = React.useState(null);
@@ -389,7 +391,14 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
         startingCSV: channels.find((ch) => ch.name === selectedUpdateChannel).currentCSV,
         channel: selectedUpdateChannel,
         installPlanApproval: selectedApproval,
-      },
+        config: {
+          env: [
+            {
+              name: "roleARN",
+              value: filterText,
+            },]
+          }
+        },
     };
 
     try {
@@ -700,6 +709,8 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
     selectedTargetNamespace,
   );
 
+  const tokenType = "role ARN"
+
   return (
     <>
       <Helmet>
@@ -719,6 +730,24 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
         <div className="row">
           <div className="col-xs-6">
             <>
+              {(
+                <div className="form-group">
+                <fieldset>
+                  <div className="co-toolbar__item">
+                    <TextInput
+                      autoFocus
+                      placeholder={tokenType}
+                      aria-label={tokenType}
+                      type="text"
+                      value={filterText}
+                      onChange={(value) => {
+                        setFilterText(value);
+                      }}
+                    />
+                  </div>
+                </fieldset>
+              </div>
+              )}
               <div className="form-group">
                 <fieldset>
                   <label className="co-required">{t('olm~Update channel')}</label>

--- a/frontend/packages/operator-lifecycle-manager/src/models.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/models.ts
@@ -32,6 +32,16 @@ export const CatalogSourceModel: K8sKind = {
   plural: 'catalogsources',
 };
 
+export const CloudCredentialModel: K8sKind = {
+  kind: 'CloudCredential',
+  label: 'CloudCredential',
+  labelPlural: 'CloudCredentials',
+  apiGroup: 'operator.openshift.io',
+  apiVersion: 'v1',
+  abbr: 'CO',
+  plural: 'cloudcredentials',
+}
+
 export const PackageManifestModel: K8sKind = {
   kind: 'PackageManifest',
   label: 'PackageManifest',

--- a/frontend/packages/operator-lifecycle-manager/src/types.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/types.ts
@@ -182,6 +182,11 @@ export type InstallPlanKind = {
   };
 } & K8sResourceCommon;
 
+export type Env = {
+  name: string
+  value: string
+}
+
 export type SubscriptionKind = {
   apiVersion: 'operators.coreos.com/v1alpha1';
   kind: 'Subscription';
@@ -192,6 +197,9 @@ export type SubscriptionKind = {
     startingCSV?: string;
     sourceNamespace?: string;
     installPlanApproval?: InstallPlanApproval;
+    config?: {
+      env?: Env[]
+    }
   };
   status?: {
     catalogHealth?: {

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -625,6 +625,12 @@ export type RouteKind = {
   };
 } & K8sResourceCommon;
 
+export type CloudCredentialKind = {
+  spec: {
+    credentialsMode: string;
+  };
+} & K8sResourceCommon;
+
 export type TemplateParameter = {
   name: string;
   value?: string;


### PR DESCRIPTION
### User Stories

1. As a users, can use a filter to know which Operators in OperatorHub support Tokenized Authentication 
    - Technically: this is done by parsing the annotation on the CSV `cloudTokenEnabled: "true"`

2. User install flow includes STS configuration 
    - Technically: this is done by adding a text field (required when the operator claims support for Tokenized Auth)
    - Technically: the install mode should default to `Manual` and have an explanation as to why 'Automatic` subscriptions are not recommended (it's because we can't currently tell if the permissions required to run the next operator version of the operator are different)

3. User is informed in the OperatorHub UI that the cluster is in STS mode
    - Technically: the cluster is in STS mode when:

```
# infrastructure platform is AWS
$ oc get infrastructure cluster -o jsonpath --template '{ .status.platform }'
AWS

# credentialsMode is "Manual"
$ oc get cloudcredential cluster -o jsonpath --template '{ .spec.credentialsMode }'
Manual

# serviceAccountIssuer is non empty
$ oc get authentication cluster -o jsonpath --template='{ .spec.serviceAccountIssuer }'
abutcher-oidc.s3.us-east-1.amazonaws.com
```
Note: this should work more broadly for any cloud provider's short-term token authentication method. We expect to support Azure and GCP next so the above detection should account for that.


https://user-images.githubusercontent.com/20077170/234570075-1a13b9d7-efcf-431a-8a5b-3c8d654b52be.mp4

