### PR TITLE
[release-4.12] OCPBUGS-11989: Modified git import flow module to handle create button enable-disable issue

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
@@ -244,5 +244,17 @@ Feature: Create Application from git form
              Then user is able to see Secure Route checkbox is checked
               And user is able to see Edge value is selected in "TLS termination"
               And user is able to see Redirect value is selected in "Insecure traffic"
+     
+        @regression @ocp-43404
+        Scenario: Disable devfile import strategy for git type - other: A-06-TC18
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "https://mysupersecretgit.example.com/org/repo"
+             Then devfile import strategy is disabled
 
-
+        @regression @ocp-43404
+        Scenario: When devfile path is not detected: A-06-TC19
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/nodeshift-starters/devfile-sample"
+              And user clicks on Edit import strategy
+              And user enters Devfile Path as "devfile1"
+             Then user see message "Devfile not detected"

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -98,6 +98,12 @@ export const gitPO = {
       knative: '#select-option-resources-knative',
     },
   },
+  importStrategy: {
+    devFileStrategy: '[data-test=import-strategy-Devfile]',
+    editImportStrategyBtn: '[data-test=import-strategy-button]',
+    devFilePathInput: '[data-test=git-form-devfile-path-input]',
+    devFileHelperText: '.pf-c-form__helper-text',
+  },
 };
 
 export const catalogPO = {

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
@@ -370,4 +370,17 @@ export const gitPage = {
     cy.get(gitPO.advancedOptions.routing.labels).type(labelRouteName),
   notificationVerify: (message: string) =>
     cy.get(gitPO.pipeline.infoMessage).should('contain.text', message),
+  checkIfDevfileImportStrategyDisabled: () =>
+    cy.get(gitPO.importStrategy.devFileStrategy).should('have.attr', 'aria-disabled', 'true'),
+  clickEditImportStrategy: () => cy.get(gitPO.importStrategy.editImportStrategyBtn).click(),
+  enterDevfilePath: (devfilePath: string) => {
+    cy.get(gitPO.importStrategy.devFilePathInput)
+      .clear()
+      .type(devfilePath);
+  },
+  checkDevFileHelpText: (message: string) => {
+    cy.get(gitPO.importStrategy.devFileHelperText)
+      .contains(message)
+      .should('exist');
+  },
 };

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-git.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-git.ts
@@ -256,3 +256,19 @@ Then('user is able to see {string} value is selected in TLS termination', (value
 Then('user is able to see {string} value is selected in Insecure traffic', (value: string) => {
   cy.get(gitPO.advancedOptions.routing.insecureTraffic).should('have.text', value);
 });
+
+Then('devfile import strategy is disabled', () => {
+  gitPage.checkIfDevfileImportStrategyDisabled();
+});
+
+When('user clicks on Edit import strategy', () => {
+  gitPage.clickEditImportStrategy();
+});
+
+When('user enters Devfile Path as {string}', (devfilePath: string) => {
+  gitPage.enterDevfilePath(devfilePath);
+});
+
+Then('user see message {string}', (message: string) => {
+  gitPage.checkDevFileHelpText(message);
+});

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -409,6 +409,7 @@
   "Could not fetch devfile resources.": "Could not fetch devfile resources.",
   "The Devfile in your Git repository is invalid.": "The Devfile in your Git repository is invalid.",
   "Validated": "Validated",
+  "Could not get Devfile for an unknown Git type": "Could not get Devfile for an unknown Git type",
   "Devfile not detected": "Devfile not detected",
   "Allows the builds to use a different path to locate your Devfile, relative to the Context Dir field": "Allows the builds to use a different path to locate your Devfile, relative to the Context Dir field",
   "Import is not possible.": "Import is not possible.",

--- a/frontend/packages/dev-console/src/components/import/ImportStrategySection.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportStrategySection.tsx
@@ -134,6 +134,7 @@ const ImportStrategySection: React.FC<ImportStrategySectionProps> = ({ builderIm
                 className="odc-import-strategy-section__edit-strategy-button"
                 onClick={handleEditStrategy}
                 icon={!showEditImportStrategy ? <PencilAltIcon /> : <UndoIcon />}
+                data-test="import-strategy-button"
               >
                 {!showEditImportStrategy
                   ? t('devconsole~Edit Import Strategy')

--- a/frontend/packages/dev-console/src/components/import/ImportStrategySelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportStrategySelector.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { FormGroup, Grid, GridItem, Tile } from '@patternfly/react-core';
+import { FormGroup, Grid, GridItem, Tile, Tooltip } from '@patternfly/react-core';
 import { LayerGroupIcon, CubeIcon, GitAltIcon, StarIcon } from '@patternfly/react-icons';
 import { FormikValues, useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
-import { ImportStrategy } from '@console/git-service/src';
+import { GitProvider, ImportStrategy } from '@console/git-service/src';
 import { BuildStrategyType } from '@console/internal/components/build';
 import { getFieldId, useFormikValidationFix } from '@console/shared/src';
 import './ImportStrategySelector.scss';
@@ -14,6 +14,7 @@ const ImportStrategySelector: React.FC = () => {
     values: {
       import: { recommendedStrategy, selectedStrategy },
       build: { strategy },
+      git: { type },
     },
     setFieldValue,
   } = useFormikContext<FormikValues>();
@@ -27,6 +28,11 @@ const ImportStrategySelector: React.FC = () => {
       priority: 2,
       detectedFiles: [],
       icon: <LayerGroupIcon />,
+      isDisabled: type === GitProvider.UNSURE,
+      disabledReason:
+        type === GitProvider.UNSURE
+          ? t('devconsole~Could not get Devfile for an unknown Git type')
+          : null,
     },
     {
       name: 'Dockerfile',
@@ -63,24 +69,47 @@ const ImportStrategySelector: React.FC = () => {
   return (
     <FormGroup fieldId={fieldId} label={t('devconsole~Import Strategy')}>
       <Grid hasGutter>
-        {itemList.map((item) => (
-          <GridItem span={4} key={item.name}>
-            <Tile
-              className="odc-import-strategy-selector__tile"
-              data-test={`import-strategy ${item.name}`}
-              title={item.name}
-              icon={item.icon}
-              onClick={() => onSelect(item)}
-              isSelected={selectedStrategy.type === item.type}
-            >
-              {recommendedStrategy?.type === item.type && (
-                <span className="odc-import-strategy-selector__recommended">
-                  <StarIcon />
-                </span>
-              )}
-            </Tile>
-          </GridItem>
-        ))}
+        {itemList.map((item) =>
+          item.disabledReason ? (
+            <Tooltip content={item.disabledReason}>
+              <GridItem span={4} key={item.name}>
+                <Tile
+                  className="odc-import-strategy-selector__tile"
+                  data-test={`import-strategy-${item.name}`}
+                  title={item.name}
+                  icon={item.icon}
+                  onClick={() => onSelect(item)}
+                  isSelected={selectedStrategy.type === item.type}
+                  isDisabled={item.isDisabled}
+                >
+                  {recommendedStrategy?.type === item.type && (
+                    <span className="odc-import-strategy-selector__recommended">
+                      <StarIcon />
+                    </span>
+                  )}
+                </Tile>
+              </GridItem>
+            </Tooltip>
+          ) : (
+            <GridItem span={4} key={item.name}>
+              <Tile
+                className="odc-import-strategy-selector__tile"
+                data-test={`import-strategy-${item.name}`}
+                title={item.name}
+                icon={item.icon}
+                onClick={() => onSelect(item)}
+                isSelected={selectedStrategy.type === item.type}
+                isDisabled={item.isDisabled}
+              >
+                {recommendedStrategy?.type === item.type && (
+                  <span className="odc-import-strategy-selector__recommended">
+                    <StarIcon />
+                  </span>
+                )}
+              </Tile>
+            </GridItem>
+          ),
+        )}
       </Grid>
     </FormGroup>
   );

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -291,6 +291,7 @@ const GitSection: React.FC<GitSectionProps> = ({
           recommendedStrategy: null,
           showEditImportStrategy: true,
         });
+        setFieldValue('build.strategy', BuildStrategyType.Source);
         return;
       }
 
@@ -535,6 +536,7 @@ const GitSection: React.FC<GitSectionProps> = ({
             title={GitReadableTypes[values.git.type]}
             fullWidth
             required
+            dataTest="git-type"
           />
           {values.git.detectedType === GitProvider.UNSURE && (
             <Alert isInline variant="info" title={t('devconsole~Defaulting Git type to other')}>


### PR DESCRIPTION
**Fixes**: 
manual cherry-pick PR https://github.com/openshift/console/pull/11493

**Analysis / Root cause**: 
Build starategy was not update when builder image is selected by default, so the create button was not getting enabled.


**Solution Description**: 
Updated Build starategy to 'Source'.

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/102503482/234543014-cc50f4b3-1778-4671-823b-bddb3daccdeb.mov



**Unit test coverage report**: 
NA

**Test setup:**
CASE A
1. Switch to developer perspective, add page > import from Git
2. Enter URL https://mysupersecretgit.example.com/org/repo
3. Select Builder image (node.js for example), enter a name. Now all required fields are filled.

CASE B
1. Switch to developer perspective, add page > import from Git
2. Enter URL https://mysupersecretgit.example.com/org/repo
3. Select Devfile, enter "Devfile", a name. Now all required fields are filled.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge