### PR TITLE
CONSOLE-3612: User is warned when cluster is in STS mode

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -268,6 +268,8 @@
   "Valid Subscriptions": "Valid Subscriptions",
   "Repository": "Repository",
   "Container image": "Container image",
+  "Cluster in STS Mode": "Cluster in STS Mode",
+  "This cluster is using AWS Security Token Service to reach the cloud API. In order for this operator to take the actions it requires directly with the cloud API, you will need to provide a role ARN (with an attached policy) during installation. Please see the operator description for more details.": "This cluster is using AWS Security Token Service to reach the cloud API. In order for this operator to take the actions it requires directly with the cloud API, you will need to provide a role ARN (with an attached policy) during installation. Please see the operator description for more details.",
   "Installed": "Installed",
   "Not Installed": "Not Installed",
   "provided by {{provider}}": "provided by {{provider}}",

--- a/frontend/packages/operator-lifecycle-manager/mocks.ts
+++ b/frontend/packages/operator-lifecycle-manager/mocks.ts
@@ -2,6 +2,9 @@ import {
   K8sResourceKind,
   K8sKind,
   CustomResourceDefinitionKind,
+  CloudCredentialKind,
+  AuthenticationKind,
+  InfrastructureKind,
 } from '@console/internal/module/k8s';
 import { StatusCapability, SpecCapability } from './src/components/descriptors/types';
 import { OperatorHubItem } from './src/components/operator-hub';
@@ -616,6 +619,30 @@ const federationv2PackageManifest = {
   },
 };
 
+const manualCred: CloudCredentialKind = {
+  spec: {
+    credentialsMode: 'Manual',
+  },
+};
+
+const mintCred: CloudCredentialKind = {
+  spec: {
+    credentialsMode: 'Mint',
+  },
+};
+
+const infra: InfrastructureKind = {
+  status: {
+    platform: 'AWS',
+  },
+};
+
+const auth: AuthenticationKind = {
+  spec: {
+    serviceAccountIssuer: '',
+  },
+};
+
 const prometheusPackageManifest = {
   apiVersion: 'packages.operators.coreos.com/v1' as PackageManifestKind['apiVersion'],
   kind: 'PackageManifest' as PackageManifestKind['kind'],
@@ -728,6 +755,9 @@ export const operatorHubListPageProps = {
     ] as PackageManifestKind[],
   },
   clusterServiceVersions: null,
+  cloudCredentials: { loaded: true, data: manualCred },
+  infrastructure: { loaded: true, data: infra },
+  authentication: { loaded: true, data: auth },
 };
 
 export const operatorHubTileViewPageProps = {
@@ -759,6 +789,9 @@ export const operatorHubTileViewPageProps = {
       catalogSourceNamespace: 'openshift-marketplace',
       validSubscription: undefined,
       infraFeatures: undefined,
+      cloudCredentials: manualCred,
+      infrastructure: infra,
+      authentication: auth,
     },
     {
       obj: etcdPackageManifest,
@@ -786,6 +819,9 @@ export const operatorHubTileViewPageProps = {
       catalogSourceNamespace: 'openshift-marketplace',
       validSubscription: undefined,
       infraFeatures: undefined,
+      cloudCredentials: mintCred,
+      infrastructure: infra,
+      authentication: auth,
     },
     {
       obj: federationv2PackageManifest,
@@ -813,6 +849,9 @@ export const operatorHubTileViewPageProps = {
       catalogSourceNamespace: 'openshift-marketplace',
       validSubscription: undefined,
       infraFeatures: undefined,
+      cloudCredentials: manualCred,
+      infrastructure: infra,
+      authentication: auth,
     },
     {
       obj: prometheusPackageManifest,
@@ -839,6 +878,9 @@ export const operatorHubTileViewPageProps = {
       catalogSourceNamespace: 'openshift-marketplace',
       validSubscription: undefined,
       infraFeatures: undefined,
+      cloudCredentials: mintCred,
+      infrastructure: infra,
+      authentication: auth,
     },
   ] as OperatorHubItem[],
   openOverlay: null,
@@ -874,6 +916,9 @@ export const operatorHubTileViewPagePropsWithDummy = {
       catalogSourceNamespace: 'openshift-marketplace',
       validSubscription: undefined,
       infraFeatures: undefined,
+      cloudCredentials: manualCred,
+      infrastructure: infra,
+      authentication: auth,
     },
   ],
   openOverlay: null,
@@ -995,4 +1040,7 @@ export const itemWithLongDescription = {
   catalogSourceNamespace: 'openshift-marketplace',
   validSubscription: undefined,
   infraFeatures: undefined,
+  cloudCredentials: mintCred,
+  infrastructure: infra,
+  authentication: auth,
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
@@ -1,4 +1,10 @@
-import { K8sResourceKind, ObjectMetadata } from '@console/internal/module/k8s';
+import {
+  InfrastructureKind,
+  CloudCredentialKind,
+  AuthenticationKind,
+  K8sResourceKind,
+  ObjectMetadata,
+} from '@console/internal/module/k8s';
 import { PackageManifestKind, SubscriptionKind } from '../../types';
 
 export enum InstalledState {
@@ -54,6 +60,9 @@ export type OperatorHubItem = {
   [key: string]: any;
   validSubscription: string[];
   infraFeatures: InfraFeatures[];
+  cloudCredentials: CloudCredentialKind;
+  infrastructure: InfrastructureKind;
+  authentication: AuthenticationKind;
 };
 
 export enum OperatorHubCSVAnnotationKey {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -14,12 +14,22 @@ import {
   skeletonCatalog,
   StatusBox,
 } from '@console/internal/components/utils';
-import { referenceForModel } from '@console/internal/module/k8s';
+import {
+  referenceForModel,
+  CloudCredentialKind,
+  InfrastructureKind,
+  AuthenticationKind,
+} from '@console/internal/module/k8s';
 import { fromRequirements } from '@console/internal/module/k8s/selector';
 import { isCatalogTypeEnabled, useIsDeveloperCatalogEnabled } from '@console/shared';
 import { ErrorBoundaryFallbackPage, withFallback } from '@console/shared/src/components/error';
 import { parseJSONAnnotation } from '@console/shared/src/utils/annotations';
 import { iconFor } from '..';
+import {
+  CloudCredentialModel,
+  AuthenticationModel,
+  InfrastructureModel,
+} from '../../../../../public/models';
 import { OPERATOR_TYPE_ANNOTATION, NON_STANDALONE_ANNOTATION_VALUE } from '../../const';
 import {
   ClusterServiceVersionModel,
@@ -73,6 +83,9 @@ export const OperatorHubList: React.FC<OperatorHubListProps> = ({
   packageManifests,
   subscriptions,
   clusterServiceVersions,
+  cloudCredentials,
+  authentication,
+  infrastructure,
 }) => {
   const { t } = useTranslation();
   const items: OperatorHubItem[] = React.useMemo(() => {
@@ -155,6 +168,12 @@ export const OperatorHubList: React.FC<OperatorHubListProps> = ({
           const subscription =
             loaded && subscriptionFor(subscriptions?.data)(operatorGroups?.data)(pkg)(namespace);
 
+          const cloudCredential = loaded && cloudCredentials?.data;
+
+          const infra = loaded && infrastructure?.data;
+
+          const auth = loaded && authentication?.data;
+
           const clusterServiceVersion =
             loaded &&
             clusterServiceVersionFor(
@@ -203,6 +222,9 @@ export const OperatorHubList: React.FC<OperatorHubListProps> = ({
             validSubscriptionFilters,
             infraFeatures,
             keywords: currentCSVDesc?.keywords ?? [],
+            cloudCredentials: cloudCredential,
+            infrastructure: infra,
+            authentication: auth,
           };
         },
       );
@@ -214,6 +236,9 @@ export const OperatorHubList: React.FC<OperatorHubListProps> = ({
     operatorGroups,
     packageManifests,
     subscriptions,
+    cloudCredentials,
+    infrastructure,
+    authentication,
   ]);
 
   const uniqueItems = _.uniqBy(items, 'uid');
@@ -325,6 +350,21 @@ export const OperatorHubPage = withFallback((props: OperatorHubPageProps) => {
                   namespace: props.match.params.ns,
                   prop: 'clusterServiceVersions',
                 },
+                {
+                  kind: referenceForModel(CloudCredentialModel),
+                  prop: 'cloudCredentials',
+                  name: 'cluster',
+                },
+                {
+                  kind: referenceForModel(InfrastructureModel),
+                  prop: 'infrastructure',
+                  name: 'cluster',
+                },
+                {
+                  kind: referenceForModel(AuthenticationModel),
+                  prop: 'authentication',
+                  name: 'cluster',
+                },
               ]}
             >
               {/* FIXME(alecmerdler): Hack because `Firehose` injects props without TypeScript knowing about it */}
@@ -347,6 +387,9 @@ export type OperatorHubListProps = {
   packageManifests: { loaded: boolean; data?: PackageManifestKind[] };
   marketplacePackageManifests: { loaded: boolean; data?: PackageManifestKind[] };
   subscriptions: { loaded: boolean; data?: SubscriptionKind[] };
+  cloudCredentials: { loaded: boolean; data?: CloudCredentialKind };
+  infrastructure: { loaded: boolean; data?: InfrastructureKind };
+  authentication: { loaded: boolean; data?: AuthenticationKind };
   loaded: boolean;
   loadError?: string;
   clusterServiceVersions: { loaded: boolean; data?: ClusterServiceVersionKind[] };

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -1260,3 +1260,23 @@ export const ConsolePluginModel: K8sKind = {
   labelPluralKey: 'public~ConsolePlugins',
   crd: true,
 };
+
+export const CloudCredentialModel: K8sKind = {
+  kind: 'CloudCredential',
+  label: 'CloudCredential',
+  labelPlural: 'CloudCredentials',
+  apiGroup: 'operator.openshift.io',
+  apiVersion: 'v1',
+  abbr: 'CO',
+  plural: 'cloudcredentials',
+};
+
+export const AuthenticationModel: K8sKind = {
+  kind: 'Authentication',
+  label: 'Authentication',
+  labelPlural: 'Authentications',
+  apiGroup: 'config.openshift.io',
+  apiVersion: 'v1',
+  plural: 'authentications',
+  abbr: 'AU',
+};

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -627,6 +627,24 @@ export type RouteKind = {
   };
 } & K8sResourceCommon;
 
+export type CloudCredentialKind = {
+  spec: {
+    credentialsMode: string;
+  };
+} & K8sResourceCommon;
+
+export type InfrastructureKind = {
+  status: {
+    platform: string;
+  };
+} & K8sResourceCommon;
+
+export type AuthenticationKind = {
+  spec: {
+    serviceAccountIssuer: string;
+  };
+} & K8sResourceCommon;
+
 export type TemplateParameter = {
   name: string;
   value?: string;


### PR DESCRIPTION
Cluster is in STS mode when:

```# infrastructure platform is AWS
$ oc get infrastructure cluster -o jsonpath --template '{ .status.platform }'
AWS

# credentialsMode is "Manual"
$ oc get cloudcredential cluster -o jsonpath --template '{ .spec.credentialsMode }'
Manual

# serviceAccountIssuer is non empty
$ oc get authentication cluster -o jsonpath --template='{ .spec.serviceAccountIssuer }'
abutcher-oidc.s3.us-east-1.amazonaws.com
```

Screen Capture of the changes:

[Screencast from 2023-06-20 12-24-20.webm](https://github.com/openshift/console/assets/20077170/d3bfbbba-bfb5-4f19-a4f6-b4588cf66c28)

To reproduce:
1. Launch a cluster in AWS
2. `oc edit cloudcredential cluster` - change `spec.credentialsMode` to `Manual`
3. `oc edit authentication cluster` - change `spec.serviceAccountIssuer` to anything non-empty