### PR TITLE
CONSOLE-3610: User can filter on STS enabled clusters for Operators that claim support for STS

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
@@ -31,6 +31,8 @@ export enum InfraFeatures {
   cni = 'Container Network Interface',
   csi = 'Container Storage Interface',
   sno = 'Single Node Clusters',
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  'Short-lived token authentication' = 'Short-lived token authentication',
 }
 
 export enum ValidSubscriptionValue {
@@ -81,6 +83,7 @@ export enum OperatorHubCSVAnnotationKey {
   infrastructureFeatures = 'operators.openshift.io/infrastructure-features',
   validSubscription = 'operators.openshift.io/valid-subscription',
   tags = 'tags',
+  tokenAuthAWS = 'operators.openshift.io/infrastructure-features/token-auth/aws',
 }
 
 export type OperatorHubCSVAnnotations = {
@@ -99,6 +102,7 @@ export type OperatorHubCSVAnnotations = {
   [OperatorHubCSVAnnotationKey.infrastructureFeatures]?: string;
   [OperatorHubCSVAnnotationKey.validSubscription]?: string;
   [OperatorHubCSVAnnotationKey.tags]?: string[];
+  [OperatorHubCSVAnnotationKey.tokenAuthAWS]?: string;
 } & ObjectMetadata['annotations'];
 
 type OperatorHubSpec = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -32,7 +32,8 @@ import { ClusterServiceVersionKind, SubscriptionKind } from '../../types';
 import { MarkdownView } from '../clusterserviceversion';
 import { defaultChannelNameFor } from '../index';
 import { OperatorChannelSelect, OperatorVersionSelect } from './operator-channel-version-select';
-import { OperatorHubItem } from './index';
+import { shortLivedTokenAuth, isAWSSTSCluster } from './operator-hub-utils';
+import { InfraFeatures, OperatorHubItem } from './index';
 
 // t('olm~Basic Install'),
 // t('olm~Seamless Upgrades'),
@@ -150,18 +151,6 @@ const InstallingHintBlock: React.FC<OperatorHubItemDetailsHintBlockProps> = ({ s
         <Link to={to}>{t('olm~View it here.')}</Link>
       </p>
     </HintBlock>
-  );
-};
-
-const isAWSSTSCluster = (
-  cloudcreds: CloudCredentialKind,
-  infra: InfrastructureKind,
-  auth: AuthenticationKind,
-) => {
-  return (
-    cloudcreds?.spec?.credentialsMode === 'Manual' &&
-    infra?.status?.platform === 'AWS' &&
-    auth?.spec?.serviceAccountIssuer !== ''
   );
 };
 
@@ -372,21 +361,23 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
               />
             </PropertiesSidePanel>
             <div className="co-catalog-page__overlay-description">
-              {isAWSSTSCluster(cloudCredentials, infrastructure, authentication) && showWarn && (
-                <Alert
-                  isInline
-                  variant="warning"
-                  title={t('olm~Cluster in STS Mode')}
-                  actionClose={<AlertActionCloseButton onClose={() => setShowWarn(false)} />}
-                  className="pf-u-mb-lg"
-                >
-                  <p>
-                    {t(
-                      'olm~This cluster is using AWS Security Token Service to reach the cloud API. In order for this operator to take the actions it requires directly with the cloud API, you will need to provide a role ARN (with an attached policy) during installation. Please see the operator description for more details.',
-                    )}
-                  </p>
-                </Alert>
-              )}
+              {isAWSSTSCluster(cloudCredentials, infrastructure, authentication) &&
+                showWarn &&
+                infraFeatures?.find((i) => i === InfraFeatures[shortLivedTokenAuth]) && (
+                  <Alert
+                    isInline
+                    variant="warning"
+                    title={t('olm~Cluster in STS Mode')}
+                    actionClose={<AlertActionCloseButton onClose={() => setShowWarn(false)} />}
+                    className="pf-u-mb-lg"
+                  >
+                    <p>
+                      {t(
+                        'olm~This cluster is using AWS Security Token Service to reach the cloud API. In order for this operator to take the actions it requires directly with the cloud API, you will need to provide a role ARN (with an attached policy) during installation. Please see the operator description for more details.',
+                      )}
+                    </p>
+                  </Alert>
+                )}
               <OperatorHubItemDetailsHintBlock
                 installed={installed}
                 isInstalling={isInstalling}

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -31,6 +31,7 @@ import { DefaultCatalogSource, DefaultCatalogSourceDisplayName } from '../../con
 import { SubscriptionModel } from '../../models';
 import { communityOperatorWarningModal } from './operator-hub-community-provider-modal';
 import { OperatorHubItemDetails } from './operator-hub-item-details';
+import { shortLivedTokenAuth } from './operator-hub-utils';
 import {
   OperatorHubItem,
   InstalledState,
@@ -216,8 +217,10 @@ const infraFeaturesSort = (infrastructure) => {
       return 1;
     case InfraFeatures.FipsMode:
       return 2;
-    default:
+    case InfraFeatures[shortLivedTokenAuth]:
       return 3;
+    default:
+      return 4;
   }
 };
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -45,7 +45,11 @@ import {
 } from '../../types';
 import { subscriptionFor } from '../operator-group';
 import { OperatorHubTileView } from './operator-hub-items';
-import { getCatalogSourceDisplayName } from './operator-hub-utils';
+import {
+  getCatalogSourceDisplayName,
+  shortLivedTokenAuth,
+  isAWSSTSCluster,
+} from './operator-hub-utils';
 import {
   OperatorHubItem,
   OperatorHubCSVAnnotations,
@@ -160,6 +164,7 @@ export const OperatorHubList: React.FC<OperatorHubListProps> = ({
             createdAt,
             support,
             capabilities: capabilityLevel,
+            [OperatorHubCSVAnnotationKey.tokenAuthAWS]: tokenAuthAWS,
             [OperatorHubCSVAnnotationKey.actionText]: marketplaceActionText,
             [OperatorHubCSVAnnotationKey.remoteWorkflow]: marketplaceRemoteWorkflow,
             [OperatorHubCSVAnnotationKey.supportWorkflow]: marketplaceSupportWorkflow,
@@ -173,6 +178,13 @@ export const OperatorHubList: React.FC<OperatorHubListProps> = ({
           const infra = loaded && infrastructure?.data;
 
           const auth = loaded && authentication?.data;
+
+          // FIXME: this is a temporary hack and should be fixed as part of
+          // a refactor to include the new style of infrastructure features
+          // tracked in PORTENABLE-525
+          if (tokenAuthAWS === 'true' && isAWSSTSCluster(cloudCredential, infra, auth)) {
+            infraFeatures.push(shortLivedTokenAuth);
+          }
 
           const clusterServiceVersion =
             loaded &&

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.ts
@@ -1,3 +1,8 @@
+import {
+  CloudCredentialKind,
+  InfrastructureKind,
+  AuthenticationKind,
+} from '@console/internal/module/k8s';
 import { DefaultCatalogSource, DefaultCatalogSourceDisplayName } from '../../const';
 import { PackageManifestKind } from '../../types';
 
@@ -12,5 +17,19 @@ export const getCatalogSourceDisplayName = (packageManifest: PackageManifestKind
   const { catalogSource, catalogSourceDisplayName } = packageManifest.status;
   return (
     defaultCatalogSourceDisplayNameMap?.[catalogSource] || catalogSourceDisplayName || catalogSource
+  );
+};
+
+export const shortLivedTokenAuth = 'Short-lived token authentication';
+
+export const isAWSSTSCluster = (
+  cloudcreds: CloudCredentialKind,
+  infra: InfrastructureKind,
+  auth: AuthenticationKind,
+) => {
+  return (
+    cloudcreds?.spec?.credentialsMode === 'Manual' &&
+    infra?.status?.platform === 'AWS' &&
+    auth?.spec?.serviceAccountIssuer !== ''
   );
 };


### PR DESCRIPTION
Add support for filtering for operators that support tokenized auth. The filter is triggered on the presence of the following annotation in the csv:

```yaml
metadata:
  annotations:
    operators.openshift.io/infrastructure-features/token-auth/aws: "true"
```

STS warning is only visible if the annotation is set to true AND the cluster is in STS mode.

Filter is only visible on STS mode clusters.

[Screencast from 2023-06-28 11-47-33.webm](https://github.com/openshift/console/assets/20077170/7263d708-6d94-419d-8ec5-c05046608219)
