### PR TITLE
[release-4.13] OCPBUGS-12785: Project admin can update and view subscription from operator details page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
@@ -473,6 +473,8 @@ describe(CSVSubscription.displayName, () => {
     wrapper = shallow(
       <CSVSubscription
         obj={testClusterServiceVersion}
+        subscription={undefined}
+        loaded
         packageManifests={[]}
         subscriptions={[]}
         catalogSources={[]}
@@ -497,6 +499,8 @@ describe(CSVSubscription.displayName, () => {
       <CSVSubscription
         obj={obj}
         packageManifests={[testPackageManifest]}
+        subscription={subscription}
+        loaded
         subscriptions={[testSubscription, subscription]}
         catalogSources={[testCatalogSource]}
         installPlans={[testInstallPlan]}
@@ -530,6 +534,8 @@ describe(CSVSubscription.displayName, () => {
       <CSVSubscription
         obj={obj}
         packageManifests={[testPackageManifest, otherPkg]}
+        subscription={subscription}
+        loaded
         subscriptions={[testSubscription, subscription]}
         catalogSources={[testCatalogSource]}
         installPlans={[testInstallPlan]}

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
@@ -306,7 +306,11 @@ describe(ClusterServiceVersionDetails.displayName, () => {
     wrapper = shallow(
       <ClusterServiceVersionDetails
         obj={_.cloneDeep(testClusterServiceVersion)}
-        subscriptions={testSubscriptions}
+        customData={{
+          subscriptions: testSubscriptions,
+          subscription: testSubscription,
+          subscriptionsLoaded: true,
+        }}
       />,
     );
   });
@@ -433,7 +437,11 @@ describe(ClusterServiceVersionDetails.displayName, () => {
     wrapper = shallow(
       <ClusterServiceVersionDetails
         obj={emptyTestClusterServiceVersion}
-        subscriptions={testSubscriptions}
+        customData={{
+          subscriptions: testSubscriptions,
+          subscription: testSubscription,
+          subscriptionsLoaded: true,
+        }}
       />,
     );
     expect(emptyTestClusterServiceVersion.spec.install.spec.permissions.length).toEqual(0);
@@ -451,7 +459,11 @@ describe(ClusterServiceVersionDetails.displayName, () => {
     wrapper = shallow(
       <ClusterServiceVersionDetails
         obj={duplicateTestClusterServiceVersion}
-        subscriptions={testSubscriptions}
+        customData={{
+          subscriptions: testSubscriptions,
+          subscription: testSubscription,
+          subscriptionsLoaded: true,
+        }}
       />,
     );
     expect(duplicateTestClusterServiceVersion.spec.install.spec.permissions.length).toEqual(2);
@@ -473,11 +485,12 @@ describe(CSVSubscription.displayName, () => {
     wrapper = shallow(
       <CSVSubscription
         obj={testClusterServiceVersion}
-        subscription={undefined}
-        loaded
+        customData={{
+          subscriptions: [],
+          subscription: undefined,
+          subscriptionsLoaded: true,
+        }}
         packageManifests={[]}
-        subscriptions={[]}
-        catalogSources={[]}
         installPlans={[]}
       />,
     );
@@ -498,11 +511,12 @@ describe(CSVSubscription.displayName, () => {
     wrapper = shallow(
       <CSVSubscription
         obj={obj}
+        customData={{
+          subscription,
+          subscriptions: [testSubscription, subscription],
+          subscriptionsLoaded: true,
+        }}
         packageManifests={[testPackageManifest]}
-        subscription={subscription}
-        loaded
-        subscriptions={[testSubscription, subscription]}
-        catalogSources={[testCatalogSource]}
         installPlans={[testInstallPlan]}
       />,
     );
@@ -534,11 +548,12 @@ describe(CSVSubscription.displayName, () => {
       <CSVSubscription
         obj={obj}
         packageManifests={[testPackageManifest, otherPkg]}
-        subscription={subscription}
-        loaded
-        subscriptions={[testSubscription, subscription]}
-        catalogSources={[testCatalogSource]}
         installPlans={[testInstallPlan]}
+        customData={{
+          subscription,
+          subscriptionsLoaded: true,
+          subscriptions: [testSubscription, subscription],
+        }}
       />,
     );
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -936,6 +936,7 @@ export const ClusterServiceVersionDetails: React.FC<ClusterServiceVersionDetails
 ) => {
   const { t } = useTranslation();
   const { spec, metadata, status } = props.obj;
+  const { subscription } = props.customData;
   const providedAPIs = providedAPIsForCSV(props.obj);
   const {
     'marketplace.openshift.io/support-workflow': marketplaceSupportWorkflow,
@@ -970,7 +971,6 @@ export const ClusterServiceVersionDetails: React.FC<ClusterServiceVersionDetails
   }, [marketplaceSupportWorkflow]);
 
   const csvPlugins = getClusterServiceVersionPlugins(metadata?.annotations);
-  const subscription = subscriptionForCSV(props.subscriptions, props.obj);
   const permissions = _.uniqBy(spec?.install?.spec?.permissions, 'serviceAccountName');
 
   return (
@@ -1175,14 +1175,10 @@ export const ClusterServiceVersionDetails: React.FC<ClusterServiceVersionDetails
   );
 };
 
-export const CSVSubscription: React.FC<CSVSubscriptionProps> = ({
-  obj,
-  subscription,
-  loaded,
-  loadError,
-  ...rest
-}) => {
+export const CSVSubscription: React.FC<CSVSubscriptionProps> = ({ obj, customData, ...rest }) => {
   const { t } = useTranslation();
+  const { subscription, subscriptions, subscriptionsLoaded, subscriptionsLoadError } =
+    customData ?? {};
   const EmptyMsg = () => (
     <MsgBox
       title={t('olm~No Operator Subscription')}
@@ -1191,8 +1187,18 @@ export const CSVSubscription: React.FC<CSVSubscriptionProps> = ({
   );
 
   return (
-    <StatusBox EmptyMsg={EmptyMsg} loaded={loaded} loadError={loadError} data={subscription}>
-      <SubscriptionDetails {...rest} obj={subscription} clusterServiceVersions={[obj]} />
+    <StatusBox
+      EmptyMsg={EmptyMsg}
+      loaded={subscriptionsLoaded}
+      loadError={subscriptionsLoadError}
+      data={subscription}
+    >
+      <SubscriptionDetails
+        {...rest}
+        obj={subscription}
+        clusterServiceVersions={[obj]}
+        subscriptions={subscriptions}
+      />
     </StatusBox>
   );
 };
@@ -1229,55 +1235,47 @@ export const ClusterServiceVersionDetailsPage: React.FC<ClusterServiceVersionsDe
     [subscription],
   );
 
-  const pagesFor = React.useCallback(
-    (obj: ClusterServiceVersionKind) => {
-      const providedAPIs = providedAPIsForCSV(obj);
-      return [
-        navFactory.details(ClusterServiceVersionDetails),
-        navFactory.editYaml(),
-        {
-          href: 'subscription',
-          // t('olm~Subscription')
-          nameKey: 'olm~Subscription',
-          component: CSVSubscription,
-          pageData: {
-            subscriptions,
-            subscription,
-            loaded: subscriptionsLoaded,
-            loadError: subscriptionsLoadError,
-          },
+  const pagesFor = React.useCallback((obj: ClusterServiceVersionKind) => {
+    const providedAPIs = providedAPIsForCSV(obj);
+    return [
+      navFactory.details(ClusterServiceVersionDetails),
+      navFactory.editYaml(),
+      {
+        href: 'subscription',
+        // t('olm~Subscription')
+        nameKey: 'olm~Subscription',
+        component: CSVSubscription,
+      },
+      navFactory.events(ResourceEventStream),
+      ...(providedAPIs.length > 1
+        ? [
+            {
+              href: 'instances',
+              // t('olm~All instances')
+              nameKey: 'olm~All instances',
+              component: ProvidedAPIsPage,
+            },
+          ]
+        : []),
+      ...providedAPIs.map<Page<ProvidedAPIPageProps>>((api: CRDDescription) => ({
+        href: referenceForProvidedAPI(api),
+        name: ['Details', 'YAML', 'Subscription', 'Events'].includes(api.displayName)
+          ? `${api.displayName} Operand`
+          : api.displayName || api.kind,
+        component: ProvidedAPIPage,
+        pageData: {
+          csv: obj,
+          kind: referenceForProvidedAPI(api),
         },
-        navFactory.events(ResourceEventStream),
-        ...(providedAPIs.length > 1
-          ? [
-              {
-                href: 'instances',
-                // t('olm~All instances')
-                nameKey: 'olm~All instances',
-                component: ProvidedAPIsPage,
-              },
-            ]
-          : []),
-        ...providedAPIs.map<Page<ProvidedAPIPageProps>>((api: CRDDescription) => ({
-          href: referenceForProvidedAPI(api),
-          name: ['Details', 'YAML', 'Subscription', 'Events'].includes(api.displayName)
-            ? `${api.displayName} Operand`
-            : api.displayName || api.kind,
-          component: ProvidedAPIPage,
-          pageData: {
-            csv: obj,
-            kind: referenceForProvidedAPI(api),
-          },
-        })),
-      ];
-    },
-    [subscription, subscriptions, subscriptionsLoadError, subscriptionsLoaded],
-  );
+      })),
+    ];
+  }, []);
 
   return (
     <DetailsPage
       {...props}
       obj={{ data: csv, loaded: csvLoaded, loadError: csvLoadError }}
+      customData={{ subscriptions, subscription, subscriptionsLoaded, subscriptionsLoadError }}
       breadcrumbsFor={() => [
         {
           name: t('olm~Installed Operators'),
@@ -1350,7 +1348,12 @@ export type ClusterServiceVersionsDetailsPageProps = {
 
 export type ClusterServiceVersionDetailsProps = {
   obj: ClusterServiceVersionKind;
-  subscriptions: SubscriptionKind[];
+  customData: {
+    subscriptions: SubscriptionKind[];
+    subscription: SubscriptionKind;
+    subscriptionsLoaded: boolean;
+    subscriptionsLoadError?: any;
+  };
 };
 
 type ConsolePluginsProps = {
@@ -1391,13 +1394,9 @@ type ManagedNamespacesProps = {
 
 export type CSVSubscriptionProps = Omit<
   SubscriptionDetailsProps,
-  'obj' | 'clusterServiceVersions'
-> & {
-  obj: ClusterServiceVersionKind;
-  subscription: SubscriptionKind;
-  loaded: boolean;
-  loadError?: any;
-};
+  'obj' | 'clusterServiceVersions' | 'subscriptions'
+> &
+  ClusterServiceVersionDetailsProps;
 
 type InitializationResourceAlertProps = {
   csv: ClusterServiceVersionKind;

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
@@ -11,6 +11,7 @@ import {
   referenceForModel,
   referenceForGroupVersionKind,
 } from '@console/internal/module/k8s';
+import { OPERATOR_NAMESPACE_ANNOTATION } from '../const';
 import { OperatorGroupModel } from '../models';
 import {
   OperatorGroupKind,
@@ -20,11 +21,11 @@ import {
 } from '../types';
 
 export const targetNamespacesFor = (obj: K8sResourceKind) =>
-  obj?.metadata?.annotations?.['olm.targetNamespaces'];
+  obj?.metadata?.annotations?.['olm.targetNamespaces']; // FIXME magic string
 export const operatorNamespaceFor = (obj: K8sResourceKind) =>
-  obj?.metadata?.annotations?.['olm.operatorNamespace'];
+  obj?.metadata?.annotations?.[OPERATOR_NAMESPACE_ANNOTATION];
 export const operatorGroupFor = (obj: K8sResourceKind) =>
-  obj?.metadata?.annotations?.['olm.operatorGroup'];
+  obj?.metadata?.annotations?.['olm.operatorGroup']; // FIXME magic string
 
 export const NoOperatorGroupMsg: React.FC = () => {
   const { t } = useTranslation();

--- a/frontend/packages/operator-lifecycle-manager/src/const.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/const.ts
@@ -19,14 +19,16 @@ export enum DefaultCatalogSourceDisplayName {
   Custom = 'Custom',
 }
 
-export const OPERATOR_UNINSTALL_MESSAGE_ANNOTATION = 'operator.openshift.io/uninstall-message';
-export const OPERATOR_TYPE_ANNOTATION = 'operators.operatorframework.io/operator-type';
-export const NON_STANDALONE_ANNOTATION_VALUE = 'non-standalone';
-export const INTERNAL_OBJECTS_ANNOTATION = 'operators.operatorframework.io/internal-objects';
-export const DEFAULT_SOURCE_NAMESPACE = 'openshift-marketplace';
-export const OPERATOR_PLUGINS_ANNOTATION = 'console.openshift.io/plugins';
 export const DEFAULT_GLOBAL_OPERATOR_INSTALLATION_NAMESPACE = 'openshift-operators';
+export const DEFAULT_SOURCE_NAMESPACE = 'openshift-marketplace';
 export const GLOBAL_COPIED_CSV_NAMESPACE = 'openshift';
+export const INTERNAL_OBJECTS_ANNOTATION = 'operators.operatorframework.io/internal-objects';
+export const NON_STANDALONE_ANNOTATION_VALUE = 'non-standalone';
+export const OPERATOR_NAMESPACE_ANNOTATION = 'olm.operatorNamespace';
+export const OPERATOR_PLUGINS_ANNOTATION = 'console.openshift.io/plugins';
+export const OPERATOR_TYPE_ANNOTATION = 'operators.operatorframework.io/operator-type';
+export const OPERATOR_UNINSTALL_MESSAGE_ANNOTATION = 'operator.openshift.io/uninstall-message';
+
 export const GLOBAL_OPERATOR_NAMESPACES = [
   DEFAULT_GLOBAL_OPERATOR_INSTALLATION_NAMESPACE,
   GLOBAL_COPIED_CSV_NAMESPACE,

--- a/frontend/packages/operator-lifecycle-manager/src/status/csv-status.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/status/csv-status.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import i18n from '@console/internal/i18n';
 import { getName } from '@console/shared/src/selectors/common';
+import { operatorNamespaceFor } from '../components/operator-group';
 import {
   ClusterServiceVersionKind,
   SubscriptionKind,
@@ -22,16 +23,14 @@ export const subscriptionForCSV = (
   csv: ClusterServiceVersionKind,
 ): SubscriptionKind =>
   // TODO Replace _.find with Array.prototype.find
-  _.find(subscriptions, {
+  _.find<SubscriptionKind>(subscriptions, {
     metadata: {
-      // FIXME Magic string. Make a constant.
-      namespace: csv?.metadata?.annotations?.['olm.operatorNamespace'],
+      namespace: operatorNamespaceFor(csv),
     },
     status: {
       installedCSV: getName(csv),
     },
-    // TODO Imporove this type def
-  } as any); // 'as any' to supress typescript error caused by lodash;
+  });
 
 export const getCSVStatus = (
   csv: ClusterServiceVersionKind,


### PR DESCRIPTION
Manual cherry-pick of:
#12716 - Do not list subscriptions in all namespaces on CSV details page.
#12766 - Fix missing console plugin control on CSV details page (regression introduced by former #12716)