### PR TITLE
CONSOLE-3624: Increase proxy dialer timeout to 5 minutes.

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -67,6 +67,8 @@ func NewProxy(cfg *Config) *Proxy {
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			ctx, cancel := context.WithTimeout(ctx, dialerTimeout)
+			defer cancel()
 			return dialer.DialContext(ctx, network, addr)
 		},
 		TLSClientConfig:     cfg.TLSClientConfig,


### PR DESCRIPTION
Increase backend proxy timeout to match browser maximum so that frontend request timeouts take precedence.