### PR TITLE
[WIP] CONSOLE-3568: Expose DeleteModal component in console-dynamic-plugin-sdk

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/index.ts
@@ -5,6 +5,7 @@ export { default as PopoverStatus } from './status/PopoverStatus';
 export { default as StatusComponent } from './status/Status';
 export { default as StatusIconAndText } from './status/StatusIconAndText';
 export { default as ResourceStatus } from './utils/resource-status';
+export { default as ResourceDeleteModal } from './modals/ResourceDeleteModal';
 
 export * from './status/icons';
 export * from './status/statuses';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/modals/ResourceDeleteModal.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/modals/ResourceDeleteModal.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { Alert, Button, Modal, ModalVariant, Text } from '@patternfly/react-core';
+import * as _ from 'lodash';
+import { resourceListPathFromModel } from '@console/internal/components/utils';
+import { history } from '@console/internal/components/utils/router';
+import { ResourceDeleteModalProps } from '../../../extensions/console-types';
+import { k8sDeleteResource } from '../../../utils/k8s/k8s-resource';
+
+const ResourceDeleteModal = (props: ResourceDeleteModalProps) => {
+  const { kind, resource, btnText, isOpen, onClose } = props;
+  const [error, setError] = React.useState<string>(null);
+
+  const submit = (event) => {
+    event.preventDefault();
+    k8sDeleteResource({ model: kind, resource })
+      .then(() => {
+        const url = resourceListPathFromModel(kind, _.get(resource, 'metadata.namespace'));
+        onClose();
+        history.push(url);
+      })
+      .catch((err) => {
+        setError(err.message);
+      });
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.default}
+      title={`Delete ${kind}?`}
+      isOpen={isOpen}
+      onClose={onClose}
+      titleIconVariant="warning"
+      actions={[
+        <Button key="delete" variant="danger" onClick={submit}>
+          {btnText || 'Delete'}
+        </Button>,
+        <Button key="cancel" variant="link" onClick={onClose}>
+          Cancel
+        </Button>,
+      ]}
+    >
+      <Text>
+        Are you sure you want to delete{' '}
+        <strong className="co-break-word">{{ resourceName: resource.metadata.name }}</strong>?
+      </Text>
+      {error && (
+        <Alert
+          isInline
+          className="co-alert co-alert--scrollable"
+          variant="danger"
+          title="public~An error occurred"
+        >
+          <div className="co-pre-line">{error}</div>
+        </Alert>
+      )}
+    </Modal>
+  );
+};
+
+export default ResourceDeleteModal;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -59,6 +59,14 @@ export type K8sResourceCommon = {
   metadata?: ObjectMetadata;
 };
 
+export type K8sResourceKind = K8sResourceCommon & {
+  spec?: {
+    [key: string]: any;
+  };
+  status?: { [key: string]: any };
+  data?: { [key: string]: any };
+};
+
 export type K8sVerb =
   | 'create'
   | 'get'
@@ -669,4 +677,12 @@ export type ErrorBoundaryFallbackProps = {
   componentStack: string;
   stack: string;
   title: string;
+};
+
+export type ResourceDeleteModalProps = {
+  isOpen: boolean;
+  kind: K8sModel;
+  resource: K8sResourceCommon;
+  onClose: () => void;
+  btnText?: string;
 };


### PR DESCRIPTION
Exposing a minimal version of the `DeleteModal` as a `ResourceDeleteModa` so it does not conflict with original component. This new component only handles a single resource and is not as robust as the original `DeleteModal`.

Action items:
- [ ] Expose the [DeleteModal](https://github.com/openshift/console/blob/master/frontend/public/components/modals/delete-modal.tsx#L26-L159) component in our  [console-dynamic-plugin-sdk](https://github.com/openshift/console/tree/master/frontend/packages/console-dynamic-plugin-sdk) as a `ResourceDeleteModal`
- [ ] Decouple the functionality console internal codebase.
- [ ] Use the new ResourceDeleteModal in parts of the code base where it would make delete action over a single resource
- [ ] Review the new component's API before merge
- [ ] Add TS docs the migrated DeleteModal component

/assign @vojtechszocs @TheRealJon 