### PR TITLE
OCPBUGS-11620: [Openshift Pipelines] Stop option for pipelinerun is not working

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunDetailsPage.tsx
@@ -6,6 +6,7 @@ import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 import { getPipelineRunKebabActions } from '../../utils/pipeline-actions';
 import { pipelineRunStatus } from '../../utils/pipeline-filter-reducer';
 import { usePipelinesBreadcrumbsFor } from '../pipelines/hooks';
+import { usePipelineOperatorVersion } from '../pipelines/utils/pipeline-operator';
 import { PipelineRunDetails } from './detail-page-tabs/PipelineRunDetails';
 import { PipelineRunLogsWithActiveTask } from './detail-page-tabs/PipelineRunLogs';
 import TaskRuns from './detail-page-tabs/TaskRuns';
@@ -15,8 +16,9 @@ import { useMenuActionsWithUserAnnotation } from './triggered-by';
 const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { t } = useTranslation();
   const { kindObj, match } = props;
+  const version = usePipelineOperatorVersion(props.namespace)?.version;
   const menuActions: KebabAction[] = useMenuActionsWithUserAnnotation(
-    getPipelineRunKebabActions(true),
+    getPipelineRunKebabActions(version, true),
   );
   const breadcrumbsFor = usePipelinesBreadcrumbsFor(kindObj, match);
   const badge = usePipelineTechPreviewBadge(props.namespace);

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
@@ -10,6 +10,7 @@ import {
   pipelineRunTitleFilterReducer,
 } from '../../../utils/pipeline-filter-reducer';
 import { pipelineRunDuration } from '../../../utils/pipeline-utils';
+import { usePipelineOperatorVersion } from '../../pipelines/utils/pipeline-operator';
 import LinkedPipelineRunTaskStatus from '../status/LinkedPipelineRunTaskStatus';
 import PipelineRunStatus from '../status/PipelineRunStatus';
 import { ResourceKebabWithUserLabel } from '../triggered-by';
@@ -32,6 +33,7 @@ const PLRStatus: React.FC<PLRStatusProps> = ({ obj }) => {
 };
 
 const PipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj }) => {
+  const version = usePipelineOperatorVersion(obj.metadata.namespace);
   return (
     <>
       <TableData className={tableColumnClasses[0]}>
@@ -57,7 +59,7 @@ const PipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj }) => 
       <TableData className={tableColumnClasses[5]}>{pipelineRunDuration(obj)}</TableData>
       <TableData className={tableColumnClasses[6]}>
         <ResourceKebabWithUserLabel
-          actions={getPipelineRunKebabActions()}
+          actions={getPipelineRunKebabActions(version)}
           kind={pipelinerunReference}
           resource={obj}
         />

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunRow.tsx
@@ -19,6 +19,7 @@ import { pipelineRunDuration } from '../../utils/pipeline-utils';
 import LinkedPipelineRunTaskStatus from '../pipelineruns/status/LinkedPipelineRunTaskStatus';
 import PipelineRunStatus from '../pipelineruns/status/PipelineRunStatus';
 import { ResourceKebabWithUserLabel } from '../pipelineruns/triggered-by';
+import { usePipelineOperatorVersion } from '../pipelines/utils/pipeline-operator';
 import {
   RepositoryLabels,
   RepositoryFields,
@@ -46,6 +47,7 @@ const PLRStatus: React.FC<PLRStatusProps> = ({ obj }) => {
 const RepositoryPipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj }) => {
   const plrLabels = obj.metadata.labels;
   const plrAnnotations = obj.metadata.annotations;
+  const version = usePipelineOperatorVersion(obj.metadata.namespace);
 
   return (
     <>
@@ -96,7 +98,7 @@ const RepositoryPipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ 
       </TableData>
       <TableData className={tableColumnClasses[8]}>
         <ResourceKebabWithUserLabel
-          actions={getPipelineRunKebabActions()}
+          actions={getPipelineRunKebabActions(version)}
           kind={pipelinerunReference}
           resource={obj}
         />

--- a/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
@@ -17,6 +17,7 @@ export enum DataState {
   SKIPPED = 'Skipped',
   PIPELINE_RUN_PENDING = 'PipelineRunPending',
   PIPELINE_RUN_CANCELLED = 'PipelineRunCancelled',
+  STOPPED_RUN_FINALLY = 'StoppedRunFinally',
 }
 
 export enum PipelineExampleNames {

--- a/frontend/packages/pipelines-plugin/src/types/pipelineRun.ts
+++ b/frontend/packages/pipelines-plugin/src/types/pipelineRun.ts
@@ -149,7 +149,7 @@ export type PipelineRunKind = K8sResourceCommon & {
     serviceAccountName?: string;
     timeout?: string;
     // Only used in a single case - cancelling a pipeline; should not be copied between PLRs
-    status?: 'PipelineRunCancelled' | 'PipelineRunPending';
+    status?: 'PipelineRunCancelled' | 'PipelineRunPending' | 'StoppedRunFinally';
   };
   status?: PipelineRunStatus;
 };

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
@@ -16,6 +16,7 @@ import {
 } from '../components/pipelines/modals';
 import { getPipelineRunData } from '../components/pipelines/modals/common/utils';
 import { EventListenerModel, PipelineModel, PipelineRunModel } from '../models';
+import { DataState } from '../test-data/pipeline-data';
 import { PipelineKind, PipelineRunKind } from '../types';
 import { shouldHidePipelineRunStop } from './pipeline-augment';
 
@@ -177,8 +178,11 @@ export const rerunPipelineRunAndRedirect: KebabAction = (
   });
 };
 
-export const stopPipelineRun: KebabAction = (kind: K8sKind, pipelineRun: PipelineRunKind) => {
-  // The returned function will be called using the 'kind' and 'obj' in Kebab Actions
+export const stopPipelineRun: KebabAction = (
+  kind: K8sKind,
+  pipelineRun: PipelineRunKind,
+  version,
+) => {
   return {
     // t('pipelines-plugin~Stop')
     labelKey: 'pipelines-plugin~Stop',
@@ -192,7 +196,10 @@ export const stopPipelineRun: KebabAction = (kind: K8sKind, pipelineRun: Pipelin
           {
             op: 'replace',
             path: `/spec/status`,
-            value: 'PipelineRunCancelled',
+            value:
+              version.major === 1 && version.minor < 9
+                ? DataState.PIPELINE_RUN_CANCELLED
+                : DataState.STOPPED_RUN_FINALLY,
           },
         ],
       );
@@ -258,11 +265,11 @@ export const getPipelineKebabActions = (
   Kebab.factory.Delete,
 ];
 
-export const getPipelineRunKebabActions = (redirectReRun?: boolean): KebabAction[] => [
+export const getPipelineRunKebabActions = (version, redirectReRun?: boolean): KebabAction[] => [
   redirectReRun
     ? (model, pipelineRun) => rerunPipelineRunAndRedirect(model, pipelineRun)
     : (model, pipelineRun) => reRunPipelineRun(model, pipelineRun),
-  (model, pipelineRun) => stopPipelineRun(model, pipelineRun),
+  (model, pipelineRun) => stopPipelineRun(model, pipelineRun, version),
   Kebab.factory.Delete,
 ];
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: [https://issues.redhat.com/browse/ODC-XXX](https://issues.redhat.com/browse/ODC-XXX) -->
https://issues.redhat.com/browse/OCPBUGS-11620

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
PipelineRunCancelled status was removed from 1.9.x Pipeline Operator

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Added a conditional status based on version of pipeline operator

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
--BEFORE--

https://user-images.githubusercontent.com/122968482/236275436-c6155a79-eeda-4882-a059-51d2d415807d.mp4

--AFTER--

https://user-images.githubusercontent.com/122968482/236275421-dc11dddc-a5ab-4ff9-b209-1d662e5e8464.mp4

**Unit test coverage report**: 
<!-- Attach test coverage report -->
NA

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Make sure to Install 1.9.x Pipelines Operator

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge