### PR TITLE
CONSOLE-3633: Add ability to show/hide tooltips in the yaml editor

### DIFF
--- a/frontend/packages/console-shared/src/constants/common.ts
+++ b/frontend/packages/console-shared/src/constants/common.ts
@@ -46,7 +46,8 @@ export const COMMUNITY_PROVIDERS_WARNING_USERSETTINGS_KEY = `${USERSETTINGS_PREF
 export const PINNED_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/pinned-resources`;
 export const COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/table-columns`;
 export const LOG_WRAP_LINES_USERSETTINGS_KEY = `${USERSETTINGS_PREFIX}.log.wrapLines`;
-
+export const SHOW_YAML_EDITOR_TOOLTIPS_USER_SETTING_KEY = `${USERSETTINGS_PREFIX}.showYAMLEditorTooltips`;
+export const SHOW_YAML_EDITOR_TOOLTIPS_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/showYAMLEditorTooltips`;
 // Bootstrap user for OpenShift 4.0 clusters (kube:admin)
 export const KUBE_ADMIN_USERNAMES = ['kube:admin'];
 

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -94,6 +94,7 @@ export const EditYAML_ = connect(stateToProps)(
             stale: false,
             sampleObj: props.sampleObj,
             showSidebar: !!props.create,
+            hover: true,
             owner: null,
           };
           this.monacoRef = React.createRef();
@@ -569,6 +570,15 @@ export const EditYAML_ = connect(stateToProps)(
           window.dispatchEvent(new Event('sidebar_toggle'));
         };
 
+        toggleHover = () => {
+          this.setState(
+            (state) => {
+              return { hover: !state.hover };
+            },
+            () => this.monacoRef.current.editor.updateOptions({ hover: this.state.hover }),
+          );
+        };
+
         sanitizeYamlContent = (id, yaml, kind) => {
           const contentObj = this.getYamlContent_(id, yaml, kind);
           const sanitizedYaml = this.convertObjToYAMLString(contentObj);
@@ -599,6 +609,7 @@ export const EditYAML_ = connect(stateToProps)(
 
           const {
             errors,
+            hover,
             success,
             stale,
             showSidebar,
@@ -641,6 +652,11 @@ export const EditYAML_ = connect(stateToProps)(
                 {t('public~View sidebar')}
               </Button>
             ) : null;
+          const hoverLink = (
+            <Button type="button" variant="link" isInline onClick={this.toggleHover}>
+              {hover ? t('public~Hide tooltips') : t('public~Show tooltips')}
+            </Button>
+          );
 
           const editYamlComponent = (
             <div className="co-file-dropzone co-file-dropzone__flex">
@@ -682,7 +698,7 @@ export const EditYAML_ = connect(stateToProps)(
                         options={options}
                         showShortcuts={!genericYAML}
                         minHeight="100px"
-                        toolbarLinks={sidebarLink ? [sidebarLink] : []}
+                        toolbarLinks={sidebarLink ? [hoverLink, sidebarLink] : [hoverLink]}
                         onChange={onChange}
                         onSave={() => (allowMultiple ? this.saveAll() : this.save())}
                       />

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -475,7 +475,6 @@
   "Failed to parse YAML sample": "Failed to parse YAML sample",
   "An error occurred.": "An error occurred.",
   "View sidebar": "View sidebar",
-  "Hide tooltips": "Hide tooltips",
   "Show tooltips": "Show tooltips",
   "Drop file here": "Drop file here",
   "Drag and drop YAML or JSON files into the editor, or manually enter files and use <1>---</1> to separate each definition.": "Drag and drop YAML or JSON files into the editor, or manually enter files and use <1>---</1> to separate each definition.",

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -475,6 +475,8 @@
   "Failed to parse YAML sample": "Failed to parse YAML sample",
   "An error occurred.": "An error occurred.",
   "View sidebar": "View sidebar",
+  "Hide tooltips": "Hide tooltips",
+  "Show tooltips": "Show tooltips",
   "Drop file here": "Drop file here",
   "Drag and drop YAML or JSON files into the editor, or manually enter files and use <1>---</1> to separate each definition.": "Drag and drop YAML or JSON files into the editor, or manually enter files and use <1>---</1> to separate each definition.",
   "Create by manually entering YAML or JSON definitions, or by dragging and dropping a file into the editor.": "Create by manually entering YAML or JSON definitions, or by dragging and dropping a file into the editor.",


### PR DESCRIPTION
Fix for customer issue with having tooltips appear while trying to edit yaml in the editor. 


https://user-images.githubusercontent.com/35978579/235978193-572b3b8d-ba8c-421a-bef4-75d4f7fde49f.mov


