### PR TITLE
OCPBUGS-9063: Remove frontend validation from legacy operand form gen…

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -215,7 +215,6 @@
   "Add {{item}}": "Add {{item}}",
   "Advanced configuration": "Advanced configuration",
   "Note: Some fields may not be represented in this form. Please select \"YAML View\" for full control of object creation.": "Note: Some fields may not be represented in this form. Please select \"YAML View\" for full control of object creation.",
-  "Fix above errors": "Fix above errors",
   "No provided APIs defined": "No provided APIs defined",
   "This application was not properly installed or configured.": "This application was not properly installed or configured.",
   "No operands found": "No operands found",


### PR DESCRIPTION
…erator.

We rely on backend validation pretty much everywhere else in the repo, so brings the legacy form generator into alignment with convention.