### PR TITLE
Bug 2176216: VMs are listed twice in cluster inventory

### DIFF
--- a/frontend/packages/kubevirt-plugin/console-extensions.json
+++ b/frontend/packages/kubevirt-plugin/console-extensions.json
@@ -152,26 +152,6 @@
     }
   },
   {
-    "type": "console.dashboards/overview/inventory/item",
-    "properties": {
-      "mapper": { "$codeRef": "dashboardInventory.getVMStatusGroups" },
-      "model": { "$codeRef": "models.VirtualMachineModel" }
-    },
-    "flags": {
-      "required": ["KUBEVIRT"]
-    }
-  },
-  {
-    "type": "console.dashboards/project/overview/item",
-    "properties": {
-      "mapper": { "$codeRef": "dashboardInventory.getVMStatusGroups" },
-      "model": { "$codeRef": "models.VirtualMachineModel" }
-    },
-    "flags": {
-      "required": ["KUBEVIRT"]
-    }
-  },
-  {
     "type": "console.dashboards/overview/inventory/item/group",
     "properties": {
       "id": "vm-stopped",


### PR DESCRIPTION
removing dupe VM items in Home -> Overview

Before:
![one-vm-inventory-item-b4](https://user-images.githubusercontent.com/67270715/235880781-1ab67de4-3f81-4a0d-9e01-634b38aed406.png)


After:
![one-vm-inventory-item](https://user-images.githubusercontent.com/67270715/235880798-3305990b-7e40-4d49-bea4-48ca67fa0940.png)
