### PR TITLE
OCPBUGS-13361: Update plural string dynamic demo plugin locales

### DIFF
--- a/dynamic-demo-plugin/locales/en/plugin__console-demo-plugin.json
+++ b/dynamic-demo-plugin/locales/en/plugin__console-demo-plugin.json
@@ -1,6 +1,6 @@
 {
   "{{count}} Worker Node": "{{count}} Worker Node",
-  "{{count}} Worker Node_plural": "{{count}} Worker Node",
+  "{{count}} Worker Node_plural": "{{count}} Worker Nodes",
   "Worker Nodes": "Worker Nodes",
   "Custom Overview Detail Info": "Custom Overview Detail Info",
   "Oops something went wrong in your dynamic plug-in": "Oops something went wrong in your dynamic plug-in",


### PR DESCRIPTION


Adding this change to help with the further validation of i18n dependencies update changes, and also the investigation of [Dynamic plugin translation support for plurals broken](https://issues.redhat.com/browse/OCPBUGS-11285) bug