### PR TITLE
OCPBUGS-13257: propagate labels to pipeline resources

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
@@ -224,6 +224,7 @@ describe('Import Submit Utils', () => {
         mockData.docker.dockerfilePath,
         mockData.image.tag,
         mockData.build.env,
+        {},
       );
       expect(createPipelineRunResourceSpy).toHaveBeenCalledTimes(1);
       expect(createPipelineWebhookSpy).toHaveBeenCalledTimes(1);
@@ -255,6 +256,7 @@ describe('Import Submit Utils', () => {
         mockData.docker.dockerfilePath,
         mockData.image.tag,
         mockData.build.env,
+        {},
       );
       const pipelineRunResource = returnValue[1];
       expect(pipelineRunResource.metadata.name.includes(mockData.name)).toEqual(true);

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -480,8 +480,7 @@ export const managePipelineResources = async (
 ): Promise<K8sResourceKind[]> => {
   const pipelineResources = [];
   if (!formData) return Promise.resolve([]);
-
-  const { name, git, pipeline, project, docker, image, build } = formData;
+  const { name, git, pipeline, project, docker, image, build, labels } = formData;
   let managedPipeline: PipelineKind;
   const pipelineName = pipelineData?.metadata?.name;
 
@@ -497,6 +496,7 @@ export const managePipelineResources = async (
       docker.dockerfilePath,
       image.tag,
       build.env,
+      labels,
     );
   } else if (pipeline.template) {
     managedPipeline = await createPipelineForImportFlow(
@@ -509,6 +509,7 @@ export const managePipelineResources = async (
       docker.dockerfilePath,
       image.tag,
       build.env,
+      labels,
     );
     pipelineResources.push(managedPipeline);
     try {
@@ -711,7 +712,8 @@ export const createOrUpdateResources = async (
 
   if (pipeline.type === PipelineType.PAC) {
     const pacRepository = formData?.pac?.repository;
-    const repo = await createRepositoryResources(pacRepository, namespace, dryRun);
+    const labels = formData?.labels;
+    const repo = await createRepositoryResources(pacRepository, namespace, labels, dryRun);
     responses.push(repo);
   }
 

--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils.ts
@@ -96,6 +96,7 @@ export const createPipelineForImportFlow = async (
   dockerfilePath: string,
   tag: string,
   buildEnv: (NameValuePair | NameValueFromPair)[],
+  labels: { [key: string]: string } = {},
 ) => {
   const template = _.cloneDeep(pipeline.template);
 
@@ -104,6 +105,7 @@ export const createPipelineForImportFlow = async (
     namespace,
     labels: {
       ...template.metadata?.labels,
+      ...labels,
       'app.kubernetes.io/instance': name,
       'app.kubernetes.io/name': name,
       ...(!isDockerPipeline(template) && {
@@ -158,12 +160,13 @@ export const updatePipelineForImportFlow = async (
   dockerfilePath: string,
   tag: string,
   buildEnv: (NameValuePair | NameValueFromPair)[],
+  labels: { [key: string]: string } = {},
 ): Promise<PipelineKind> => {
   let updatedPipeline = _.cloneDeep(pipeline);
 
   if (!template) {
     updatedPipeline.metadata.labels = _.omit(
-      updatedPipeline.metadata.labels,
+      { ...updatedPipeline.metadata.labels, ...labels },
       'app.kubernetes.io/instance',
     );
   } else {
@@ -175,6 +178,7 @@ export const updatePipelineForImportFlow = async (
         namespace,
         labels: {
           ...template.metadata?.labels,
+          ...labels,
           'app.kubernetes.io/instance': name,
           'app.kubernetes.io/name': name,
           ...(!isDockerPipeline(template) && { [PIPELINE_RUNTIME_VERSION_LABEL]: tag }),

--- a/frontend/packages/pipelines-plugin/src/components/repository/repository-form-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/repository/repository-form-utils.ts
@@ -73,6 +73,7 @@ const createTokenSecret = async (
 export const createRepositoryResources = async (
   values: RepositoryFormValues,
   namespace: string,
+  labels: { [key: string]: string } = {},
   dryRun?: boolean,
 ): Promise<K8sResourceKind> => {
   const {
@@ -103,6 +104,7 @@ export const createRepositoryResources = async (
     metadata: {
       name,
       namespace,
+      ...(labels || {}),
     },
     spec: {
       url: gitUrl,


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-13257

**Root analysis:**
The Labels added while importing from git are not used when creating the pipeline resources

**Solution description:**
Using the added labels also when creating pipeline resources

**GIF:**
https://github.com/openshift/console/assets/22490998/54485a65-3b49-4b74-ad54-2b9b202c8a08

/kind bug