### PR TITLE
OCPBUGS-11996: Fixed Make Serverless Form Error

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -44,12 +44,13 @@ export const getKnativeServiceDepResource = (
       env,
       triggers: { image: imagePolicy },
     },
-    import: { selectedStrategy },
     healthChecks,
     resources,
     formType,
   } = formData;
   const { fileUpload } = formData as UploadJarFormData;
+  const selectedStrategy = formData?.import?.selectedStrategy;
+
   const contTargetPort = parseInt(unknownTargetPort, 10) || defaultUnknownPort;
   const imgPullPolicy = imagePolicy ? ImagePullPolicy.Always : ImagePullPolicy.IfNotPresent;
   const {
@@ -109,9 +110,10 @@ export const getKnativeServiceDepResource = (
         ...(((formData as GitImportFormData).pipeline?.enabled || generatedImageStreamName) && {
           'app.kubernetes.io/name': name,
         }),
-        ...(selectedStrategy.type === ImportStrategy.SERVERLESS_FUNCTION && {
-          'function.knative.dev': 'true',
-        }),
+        ...(selectedStrategy &&
+          selectedStrategy?.type === ImportStrategy.SERVERLESS_FUNCTION && {
+            'function.knative.dev': 'true',
+          }),
       },
       annotations: fileUpload ? { ...annotations, jarFileName: fileUpload.name } : annotations,
     },


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-11996

**Analysis / Root cause**: 
Make serverless form is not working

**Solution Description**: 
Issues caused due to not being able to find a particular key in the formData.

**Screen shots / Gifs for design review**: 

https://github.com/openshift/console/assets/47265560/16bcf2dc-2995-444c-99ac-8cd24fd78874


**Unit test coverage report**: 
<!-- Attach test coverage report -->
Not changed.

**Test setup:**
1. Create a deployment using a Container image flow
2. Select Make Serverless option from the topology actions menu of the created deployment

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge