### PR TITLE
OCPBUGS-11256: Topology UI doesn't recognize Serverless Rust function for proper UI icon

### DIFF
--- a/frontend/public/components/catalog/catalog-item-icon.tsx
+++ b/frontend/public/components/catalog/catalog-item-icon.tsx
@@ -82,6 +82,7 @@ import * as rhIntegrationImg from '../../imgs/logos/rh-integration.svg';
 import * as rhSpringBoot from '../../imgs/logos/rh-spring-boot.svg';
 import * as rhTomcatImg from '../../imgs/logos/rh-tomcat.svg';
 import * as rubyImg from '../../imgs/logos/ruby.svg';
+import * as rustImg from '../../imgs/logos/rust.svg';
 import * as scalaImg from '../../imgs/logos/scala.svg';
 import * as shadowmanImg from '../../imgs/logos/shadowman.svg';
 import * as springImg from '../../imgs/logos/spring.svg';
@@ -176,6 +177,7 @@ const logos = new Map<string, any>()
   .set('icon-redis', redisImg)
   .set('icon-rh-integration', rhIntegrationImg)
   .set('icon-rh-spring-boot', rhSpringBoot)
+  .set('icon-rust', rustImg)
   .set('icon-serverless-function', serverlessFuncImage)
   .set('icon-java', openjdkImg)
   // Use the upstream icon.

--- a/frontend/public/imgs/logos/rust.svg
+++ b/frontend/public/imgs/logos/rust.svg
@@ -1,0 +1,57 @@
+<svg version="1.1" height="106" width="106" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="logo" transform="translate(53, 53)">
+  <path id="r" transform="translate(0.5, 0.5)" stroke="black" stroke-width="1" stroke-linejoin="round" d="     M -9,-15 H 4 C 12,-15 12,-7 4,-7 H -9 Z     M -40,22 H 0 V 11 H -9 V 3 H 1 C 12,3 6,22 15,22 H 40     V 3 H 34 V 5 C 34,13 25,12 24,7 C 23,2 19,-2 18,-2 C 33,-10 24,-26 12,-26 H -35     V -15 H -25 V 11 H -40 Z"/>
+  <g id="gear" mask="url(#holes)">
+    <circle r="43" fill="none" stroke="black" stroke-width="9"/>
+    <g id="cogs">
+      <polygon id="cog" stroke="black" stroke-width="3" stroke-linejoin="round" points="46,3 51,0 46,-3"/>
+      <use xlink:href="#cog" transform="rotate(11.25)"/>
+      <use xlink:href="#cog" transform="rotate(22.50)"/>
+      <use xlink:href="#cog" transform="rotate(33.75)"/>
+      <use xlink:href="#cog" transform="rotate(45.00)"/>
+      <use xlink:href="#cog" transform="rotate(56.25)"/>
+      <use xlink:href="#cog" transform="rotate(67.50)"/>
+      <use xlink:href="#cog" transform="rotate(78.75)"/>
+      <use xlink:href="#cog" transform="rotate(90.00)"/>
+      <use xlink:href="#cog" transform="rotate(101.25)"/>
+      <use xlink:href="#cog" transform="rotate(112.50)"/>
+      <use xlink:href="#cog" transform="rotate(123.75)"/>
+      <use xlink:href="#cog" transform="rotate(135.00)"/>
+      <use xlink:href="#cog" transform="rotate(146.25)"/>
+      <use xlink:href="#cog" transform="rotate(157.50)"/>
+      <use xlink:href="#cog" transform="rotate(168.75)"/>
+      <use xlink:href="#cog" transform="rotate(180.00)"/>
+      <use xlink:href="#cog" transform="rotate(191.25)"/>
+      <use xlink:href="#cog" transform="rotate(202.50)"/>
+      <use xlink:href="#cog" transform="rotate(213.75)"/>
+      <use xlink:href="#cog" transform="rotate(225.00)"/>
+      <use xlink:href="#cog" transform="rotate(236.25)"/>
+      <use xlink:href="#cog" transform="rotate(247.50)"/>
+      <use xlink:href="#cog" transform="rotate(258.75)"/>
+      <use xlink:href="#cog" transform="rotate(270.00)"/>
+      <use xlink:href="#cog" transform="rotate(281.25)"/>
+      <use xlink:href="#cog" transform="rotate(292.50)"/>
+      <use xlink:href="#cog" transform="rotate(303.75)"/>
+      <use xlink:href="#cog" transform="rotate(315.00)"/>
+      <use xlink:href="#cog" transform="rotate(326.25)"/>
+      <use xlink:href="#cog" transform="rotate(337.50)"/>
+      <use xlink:href="#cog" transform="rotate(348.75)"/>
+    </g>
+    <g id="mounts">
+      <polygon id="mount" stroke="black" stroke-width="6" stroke-linejoin="round" points="-7,-42 0,-35 7,-42"/>
+      <use xlink:href="#mount" transform="rotate(72)"/>
+      <use xlink:href="#mount" transform="rotate(144)"/>
+      <use xlink:href="#mount" transform="rotate(216)"/>
+      <use xlink:href="#mount" transform="rotate(288)"/>
+    </g>
+  </g>
+  <mask id="holes">
+    <rect x="-60" y="-60" width="120" height="120" fill="white"/>
+    <circle id="hole" cy="-40" r="3"/>
+    <use xlink:href="#hole" transform="rotate(72)"/>
+    <use xlink:href="#hole" transform="rotate(144)"/>
+    <use xlink:href="#hole" transform="rotate(216)"/>
+    <use xlink:href="#hole" transform="rotate(288)"/>
+  </mask>
+</g>
+</svg>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-11256

**Analysis / Root cause**: 
Rust icon not available in the codebase

**Solution Description**: 
Added Rust Icon

**Screen shots / Gifs for design review**: 

![image](https://github.com/openshift/console/assets/47265560/9367e570-4fd3-4aa6-9fbf-36ca489f30eb)

**Unit test coverage report**: 
Not changed

**Test setup:**
1. Create a Deployment with label `app.openshift.io/runtime=rust` 



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge