### PR TITLE
OCPBUGS-13693: Fix RTE in bridge.

### DIFF
--- a/pkg/serverconfig/metrics.go
+++ b/pkg/serverconfig/metrics.go
@@ -178,6 +178,9 @@ func (m *Metrics) getConsolePlugins(
 		return nil, err
 	}
 	resp, err := client.Resource(consolePluginResource).List(ctx, v1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
 	return &resp.Items, err
 }
 


### PR DESCRIPTION
Fix pkg/serverconfig/metrics.go b/pkg/serverconfig/metrics.go getConsolePlugins func that can throw a runtime exception if console plugins request fails.