### PR TITLE
OCPBUGS-8682: Fix empty create dropdown on provided APIs page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -404,7 +404,7 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
   const createItems =
     providedAPIs.length > 1
       ? providedAPIs.reduce(
-          (acc, api) => ({ ...acc, [referenceForProvidedAPI(api)]: api.displayName }),
+          (acc, api) => ({ ...acc, [referenceForProvidedAPI(api)]: api.displayName || api.kind }),
           {},
         )
       : {};


### PR DESCRIPTION
The provided APIs page was using the displayName of the provided API which is not always set. This change falls back to the kind of the provided API if the displayName is not set.