### PR TITLE
OCPBUGS-11668: Fix kebab actions on Installed Operators page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -724,6 +724,11 @@ export const ClusterServiceVersionList: React.FC<ClusterServiceVersionListProps>
 export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProps> = (props) => {
   const { t } = useTranslation();
   const [cluster] = useActiveCluster(); // TODO remove multicluster
+  const [canListAllSubscriptions] = useAccessReview({
+    group: SubscriptionModel.apiGroup,
+    resource: SubscriptionModel.plural,
+    verb: 'list',
+  });
   const title = t('olm~Installed Operators');
   const olmURL = getDocumentationURL(documentationURLs.operators);
   const helpText = (
@@ -785,6 +790,7 @@ export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProp
           {
             kind: referenceForModel(SubscriptionModel),
             prop: 'subscriptions',
+            namespace: canListAllSubscriptions ? undefined : props.namespace,
             optional: true,
           },
           {


### PR DESCRIPTION
Update the Installed Operators page to use the useAccessReview hook to determine whether to list all subscriptions or just those in the current namespace. For users who don't have permission to list all subscriptions, the page will now only attempt to list subscriptions in the current namespace, and will show the correct actions for operators the current user has permission to edit or uninstall.