### PR TITLE
CONSOLE-2501: Update builder image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
-  name: release
-  namespace: openshift
-  tag: tectonic-console-builder-v24
+  name: tectonic-console-builder
+  namespace: ci
+  tag: v25

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -8,7 +8,7 @@
 # You can test the image using `./builder-run.sh`. For instance:
 #   $ ./builder-run.sh ./build-backend.sh
 
-FROM golang:1.18-stretch
+FROM golang:1.20-bullseye
 
 MAINTAINER Ed Rooth - CoreOS
 
@@ -16,7 +16,7 @@ MAINTAINER Ed Rooth - CoreOS
 RUN go install github.com/jstemmer/go-junit-report@latest
 
 ### Install NodeJS and yarn
-ENV NODE_VERSION="v14.16.0"
+ENV NODE_VERSION="v14.21.3"
 ENV YARN_VERSION="v1.22.10"
 
 # yarn needs a home writable by any user running the container
@@ -30,7 +30,7 @@ RUN apt-get update \
     libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
     # ^^ additional Cypress dependencies: https://docs.cypress.io/guides/guides/continuous-integration.html#Dependencies
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.4/bin/linux/$(go env GOARCH)/kubectl && \
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.27.1/bin/linux/$(go env GOARCH)/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 # Dockerfile to build console image from pre-built front end.
 
-FROM quay.io/coreos/tectonic-console-builder:v24 AS build
+FROM quay.io/coreos/tectonic-console-builder:v25 AS build
 RUN mkdir -p /go/src/github.com/openshift/console/
 ADD . /go/src/github.com/openshift/console/
 WORKDIR /go/src/github.com/openshift/console/

--- a/Dockerfile.plugins.demo
+++ b/Dockerfile.plugins.demo
@@ -3,7 +3,7 @@
 # See dynamic-demo-plugin/README.md for details.
 
 # Stage 0: build the demo plugin
-FROM quay.io/coreos/tectonic-console-builder:v24 AS build
+FROM quay.io/coreos/tectonic-console-builder:v25 AS build
 
 RUN mkdir -p /src/console
 COPY . /src/console

--- a/builder-run.sh
+++ b/builder-run.sh
@@ -11,7 +11,7 @@ set -e
 # Without env vars:
 #   ./builder-run.sh ./my-script --my-script-arg1 --my-script-arg2
 
-BUILDER_IMAGE="quay.io/coreos/tectonic-console-builder:v24"
+BUILDER_IMAGE="quay.io/coreos/tectonic-console-builder:v25"
 
 # forward whitelisted env variables to docker
 ENV_STR=()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/console
 
-go 1.18
+go 1.20
 
 require (
 	github.com/coreos/go-oidc v2.1.0+incompatible

--- a/pkg/server/resource_lister.go
+++ b/pkg/server/resource_lister.go
@@ -27,7 +27,7 @@ type resourceLister struct {
 	responseFilter FilterFunction
 }
 
-//HandleResources handles resource requests
+// HandleResources handles resource requests
 func (l *resourceLister) HandleResources(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "GET" {
 		serverutils.SendResponse(w, http.StatusMethodNotAllowed, serverutils.ApiError{Err: "invalid method: only GET is allowed"})

--- a/pkg/serverconfig/metrics.go
+++ b/pkg/serverconfig/metrics.go
@@ -190,7 +190,7 @@ func (m *Metrics) calculatePluginInfo(
 
 	if lastPluginInfo != nil {
 		for lastPluginVendor, lastPluginStates := range *lastPluginInfo {
-			for lastPluginState, _ := range lastPluginStates {
+			for lastPluginState := range lastPluginStates {
 				if pluginInfo[lastPluginVendor] == nil {
 					pluginInfo[lastPluginVendor] = make(map[PluginState]int)
 				}
@@ -223,7 +223,7 @@ func (m *Metrics) calculatePluginInfo(
 	}
 
 	if m.config != nil && m.config.Plugins != nil {
-		for pluginName, _ := range m.config.Plugins {
+		for pluginName := range m.config.Plugins {
 			if found := consolePluginNames[pluginName]; !found {
 				vendor := knownPluginVendors[pluginName]
 				if vendor == "" {

--- a/pkg/usersettings/helpers.go
+++ b/pkg/usersettings/helpers.go
@@ -18,7 +18,7 @@ func newUserSettingMeta(userInfo *unstructured.Unstructured) (*UserSettingMeta, 
 	if uid != "" {
 		resourceIdentifier = string(uid)
 		ownerReferences = []meta.OwnerReference{
-			meta.OwnerReference{
+			{
 				APIVersion: userInfo.GetAPIVersion(),
 				Kind:       userInfo.GetKind(),
 				Name:       name,
@@ -51,7 +51,7 @@ func createRole(userSettingMeta *UserSettingMeta) *rbac.Role {
 			OwnerReferences: userSettingMeta.OwnerReferences,
 		},
 		Rules: []rbac.PolicyRule{
-			rbac.PolicyRule{
+			{
 				APIGroups: []string{
 					"", // Core group, not "v1"
 				},
@@ -84,7 +84,7 @@ func createRoleBinding(userSettingMeta *UserSettingMeta) *rbac.RoleBinding {
 			OwnerReferences: userSettingMeta.OwnerReferences,
 		},
 		Subjects: []rbac.Subject{
-			rbac.Subject{
+			{
 				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "User",
 				Name:     userSettingMeta.Username,

--- a/pkg/usersettings/helpers_test.go
+++ b/pkg/usersettings/helpers_test.go
@@ -54,7 +54,7 @@ func TestNewUserSettingsMeta(t *testing.T) {
 				UID:                "1234",
 				ResourceIdentifier: "1234",
 				OwnerReferences: []meta.OwnerReference{
-					meta.OwnerReference{
+					{
 						APIVersion: "user.openshift.io/v1",
 						Kind:       "User",
 						Name:       "kube:admin",
@@ -81,7 +81,7 @@ func TestNewUserSettingsMeta(t *testing.T) {
 				UID:                "1234",
 				ResourceIdentifier: "1234",
 				OwnerReferences: []meta.OwnerReference{
-					meta.OwnerReference{
+					{
 						APIVersion: "user.openshift.io/v1",
 						Kind:       "User",
 						Name:       "developer",


### PR DESCRIPTION
* go 1.18 -> 1.20
* node 4.16.0 -> 4.21.3
* kubectl 1.20.4 -> 1.27.1

Requires https://github.com/openshift/release/pull/39443
Blocks https://github.com/openshift/console/pull/12821