### PR TITLE
OCPBUGS-6513: Fixed Edit Application form for Knative Services

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -182,6 +182,7 @@ export const getKnativeServiceDepResource = (
     knativeServiceUpdated = _.omit(originalKnativeService, [
       'status',
       'spec.template.metadata.name',
+      'spec.template.spec.containers',
     ]);
   }
   const knativeDeployResource = mergeData(knativeServiceUpdated || {}, newKnativeDeployResource);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-6513

**Analysis / Root cause**: 
The Edit form for Knative Services was broken. This was caused due to the presence of the health probes where it was not required. This caused the form to break.

**Solution Description**: 
Removed the health probe details from the place it was causing errors while preserving it in another place.

**Screenshots / Gifs for design review**: 

https://github.com/openshift/console/assets/47265560/6b639612-543f-4c98-b691-dfea0ad15382



**Unit test coverage report**: 
<!-- Attach test coverage report -->
Not changed

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Install Serverless Operator and Knative Serving instance
2. Paste the Following Yaml in the Import Yaml Editor:
```
apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  name: greeter
spec:
  template:
    spec:
      containers:
      - image: quay.io/rhdevelopers/knative-tutorial-greeter:quarkus
        livenessProbe:
          httpGet:
            path: /healthz
        readinessProbe:
          httpGet:
            path: /healthz
```
3. Go to the Topology View and right-click on the Service and click "Edit greeter".
4. Change the Runtime Icon in the Edit Application Form and Save.
5. Come to the Topology Page and see if the new runtime label has been added to the service.

**NOTE:** The Runtime Icon will not replace the Default Openshift Logo as currently the Runtime Label set in Knative Service is not auto-propagated to the Knative Revisions. To see the Runtime Icon in Knative Revision, you need to add the label to the Revision itself.


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge