### PR TITLE
OCPBUGS-12896: Corrected Labels for resolving the bug related to the Create Route Checkbox

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-utils.spec.ts
@@ -225,7 +225,7 @@ describe('getKsvcRouteData', () => {
 
   it('should return values of route(clusterlocal and ports) based on the resource', () => {
     const routeData = {
-      create: true,
+      create: false,
       unknownTargetPort: '8080',
       targetPort: '8080',
       defaultUnknownPort: 8080,

--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -16,7 +16,7 @@ import {
   KNATIVE_CONCURRENCYUTILIZATION_ANNOTATION,
   KNATIVE_MAXSCALE_ANNOTATION,
   KNATIVE_MINSCALE_ANNOTATION,
-  KNATIVE_SERVING_LABEL,
+  PRIVATE_KNATIVE_SERVING_LABEL,
   ServiceModel,
 } from '@console/knative-plugin';
 import { PipelineType } from '@console/pipelines-plugin/src/components/import/import-types';
@@ -170,7 +170,7 @@ export const getKsvcRouteData = (resource: K8sResourceKind) => {
   const containers = spec?.template?.spec?.containers ?? [];
   const port = containers?.[0]?.ports?.[0]?.containerPort ?? '';
   const routeData = {
-    create: metadata?.labels?.[`${KNATIVE_SERVING_LABEL}/visibility`] !== 'cluster-local',
+    create: metadata?.labels?.[PRIVATE_KNATIVE_SERVING_LABEL] !== 'cluster-local',
     unknownTargetPort: _.toString(port),
     targetPort: _.toString(port),
     defaultUnknownPort: 8080,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-12896

**Analysis / Root cause**: 
The label that was added to the service when it was made private, was not correct.

**Solution Description**: 
Corrected the label.

**Screen shots / Gifs for design review**: 

https://github.com/openshift/console/assets/47265560/8b7665f4-11a5-4495-975d-160a86515f59

**Unit test coverage report**: 
Not Changed.

**Test setup:**
1. Install Serverless Operator and Create KN Serving Instance
2. Create a Serverless Function and open the Edit form of the KSVC
3. Uncheck the Create Route option and save.
4. Reopen the Edit form again.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge