### PR TITLE
[release-4.11] OCPBUGS-13214: the name of the object (imagestream-name) does not match the name on the URL (deployment_name)

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-deployment/utils/edit-deployment-types.ts
+++ b/frontend/packages/dev-console/src/components/edit-deployment/utils/edit-deployment-types.ts
@@ -88,6 +88,7 @@ export interface EditDeploymentFormData extends TriggersAndImageStreamFormData {
   imagePullSecret?: string;
   paused?: boolean;
   replicas?: number;
+  formType?: string;
 }
 
 export interface EditDeploymentData {

--- a/frontend/packages/dev-console/src/components/edit-deployment/utils/edit-deployment-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-deployment/utils/edit-deployment-utils.ts
@@ -280,6 +280,7 @@ export const convertDeploymentToEditForm = (
 ): EditDeploymentFormData => {
   const resourceType = getResourcesType(deployment);
   return {
+    formType: deployment.metadata.name ? 'edit' : 'create',
     name: deployment.metadata.name ?? '',
     resourceVersion: deployment.metadata.resourceVersion ?? '',
     deploymentStrategy: getStrategy(deployment, resourceType),


### PR DESCRIPTION
Manual cherry-pick of PR - https://github.com/openshift/console/pull/12024

**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-13214

**Analysis / Root cause**: 
Edit deployment is treated as create, so the resource name is getting changed on change of Image stream.

**Solution Description**: 
If deployment name is present formType is added as edit or else create

**Screen shots / Gifs for design review**: 


https://github.com/openshift/console/assets/102503482/8032ea39-8e1c-4b3f-b44c-d0b8567b5758




**Unit test coverage report**: 
NA

**Test setup:**
Follow steps to reproduce in ticket - https://issues.redhat.com/browse/OCPBUGS-13214

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge