### PR TITLE
ODC-7318: Update ODC owners, May 2023 edition

### DIFF
--- a/frontend/OWNERS
+++ b/frontend/OWNERS
@@ -9,7 +9,6 @@ reviewers:
   - TheRealJon
   - zherman0
 approvers:
-  - andrewballantyne
   - bparees
   - christianvogt
   - invincibleJai
@@ -20,4 +19,5 @@ approvers:
   - rhamilto
   - rohitkrai03
   - spadgett
+  - vikram-raj
   - vojtechszocs

--- a/frontend/packages/rhoas-plugin/OWNERS
+++ b/frontend/packages/rhoas-plugin/OWNERS
@@ -1,13 +1,8 @@
 reviewers:
-  - andrewballantyne
   - christianvogt
   - invincibleJai
   - jeff-phillips-18
   - vikram-raj
 approvers:
-  - andrewballantyne
-  - christianvogt
-  - invincibleJai
-  - rohitkrai03
 labels:
   - component/rhoas


### PR DESCRIPTION
* Added @vikram-raj as overall frontend approver.
* Dropped Andrew and the approvers from `rhoas-plugin` because all of them are part of the frontend/OWNERS file already.

/cc @jhadvig @invincibleJai 