### PR TITLE
CONSOLE-3565: Expose annotations modal in dynamic plugins sdk

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -2051,7 +2051,7 @@ A hook to launch Modals.
 
 ```tsx
 const AppPage: React.FC = () => {
- const [launchModal] = useModal();
+ const launchModal = useModal();
  const onClick = () => launchModal(ModalComponent);
  return (
    <Button onClick={onClick}>Launch a Modal</Button>

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
@@ -21,6 +21,8 @@ import {
   QuickStartsLoaderProps,
   UseURLPoll,
   UseLastNamespace,
+  AnnotationsModalProps,
+  ModalWrapperProps,
 } from './internal-types';
 
 export const ActivityItem: React.FC<ActivityItemProps> = require('@console/shared/src/components/dashboard/activity-card/ActivityItem')
@@ -69,4 +71,7 @@ export const useURLPoll: UseURLPoll = require('@console/internal/components/util
   .useURLPoll;
 export const useLastNamespace: UseLastNamespace = require('@console/app/src/components/detect-namespace/useLastNamespace')
   .useLastNamespace;
-
+export const ModalWrapper: React.FC<ModalWrapperProps> = require('@console/internal/components/factory/modal')
+  .ModalWrapper;
+export const AnnotationsModal: React.FC<AnnotationsModalProps> = require('@console/internal/components/modals/tags')
+  .AnnotationsModal;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
@@ -294,3 +294,21 @@ export type UseURLPoll = <R>(
   delay?: number,
   ...dependencies: any[]
 ) => [R, any, boolean];
+
+export type ModalWrapperProps = {
+  blocking?: boolean;
+  className?: string;
+  onClose?: (event?: React.SyntheticEvent) => void;
+};
+
+export type TagsModalProps = {
+  cancel?: () => void;
+  close?: () => void;
+  kind: K8sModel;
+  path: string;
+  resource: K8sResourceCommon;
+  tags?: { [key: string]: string };
+  titleKey: string;
+};
+
+export type AnnotationsModalProps = Omit<TagsModalProps, 'path' | 'tags' | 'titleKey'>;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/modals/useAnnotationsModal.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/modals/useAnnotationsModal.tsx
@@ -27,8 +27,9 @@ const AnnotationsModalComponent: ModalComponent<AnnotationsModalProps> = ({
  * @returns a function which will launch a modal for editing a resource's annotations.
  * @example
  * const PodAnnotationsButton = ({ pod }) => {
+ *   const { t } = useTranslation();
  *   const launchAnnotationsModal = useAnnotationsModal<PodKind>(pod);
- *   return <button onClick={launchAnnotationsModal}>Edit Pod Annotations</button>
+ *   return <button onClick={launchAnnotationsModal}>{t('Edit Pod Annotations')}</button>
  * }
  */
 export const useAnnotationsModal: UseAnnotationsModal = (resource) => {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/modals/useAnnotationsModal.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/modals/useAnnotationsModal.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { AnnotationsModalProps } from '../../../api/internal-types';
+import { K8sResourceCommon, getGroupVersionKindForResource, useK8sModel } from '../../../lib-core';
+import { AnnotationsModal, ModalWrapper } from '../../../lib-internal';
+import { ModalComponent } from '../../modal-support/ModalProvider';
+import { useModal } from '../../modal-support/useModal';
+
+type UseAnnotationsModal = (resource: K8sResourceCommon) => () => void;
+
+const AnnotationsModalComponent: ModalComponent<AnnotationsModalProps> = ({
+  closeModal,
+  kind,
+  resource,
+}) => {
+  return (
+    <ModalWrapper blocking onClose={closeModal}>
+      <AnnotationsModal cancel={closeModal} close={closeModal} kind={kind} resource={resource} />
+    </ModalWrapper>
+  );
+};
+
+/**
+ * A hook for launching a modal for editing a resource's annotations.
+ *
+ * @hook useAnnotationsModal
+ * @argument resource - The resource to edit annotations for.
+ * @returns a function which will launch a modal for editing a resource's annotations.
+ * @example
+ * const PodAnnotationsButton = ({ pod }) => {
+ *   const launchAnnotationsModal = useAnnotationsModal<PodKind>(pod);
+ *   return <button onClick={launchAnnotationsModal}>Edit Pod Annotations</button>
+ * }
+ */
+export const useAnnotationsModal: UseAnnotationsModal = (resource) => {
+  const launcher = useModal();
+  const groupVersionKind = getGroupVersionKindForResource(resource);
+  const [kind] = useK8sModel(groupVersionKind);
+  return React.useCallback(
+    () =>
+      resource &&
+      kind &&
+      launcher<AnnotationsModalProps>(AnnotationsModalComponent, { kind, resource }),
+    [launcher, kind, resource],
+  );
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/modal-support/useModal.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/modal-support/useModal.ts
@@ -8,7 +8,7 @@ type UseModalLauncher = () => LaunchModal;
  * @example
  *```tsx
  * const AppPage: React.FC = () => {
- *  const [launchModal] = useModal();
+ *  const launchModal = useModal();
  *  const onClick = () => launchModal(ModalComponent);
  *  return (
  *    <Button onClick={onClick}>Launch a Modal</Button>

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/states.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/states.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { InProgressIcon } from '@patternfly/react-icons';
 import { TFunction } from 'i18next';
-import { HealthState } from '@console/dynamic-plugin-sdk';
+import { HealthState } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import {
   GreenCheckCircleIcon,
   RedExclamationCircleIcon,

--- a/frontend/public/components/modals/tags.tsx
+++ b/frontend/public/components/modals/tags.tsx
@@ -2,7 +2,11 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { k8sPatch, K8sResourceKind, K8sKind } from '../../module/k8s';
+import {
+  AnnotationsModalProps,
+  TagsModalProps,
+} from '@console/dynamic-plugin-sdk/src/api/internal-types';
+import { k8sPatch } from '../../module/k8s';
 import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
 import { NameValueEditorPair, withHandlePromise, HandlePromiseProps } from '../utils';
 import { AsyncComponent } from '../utils/async';
@@ -18,7 +22,7 @@ const NameValueEditorComponent = (props) => (
   />
 );
 
-export const TagsModal = withHandlePromise((props: TagsModalProps) => {
+export const TagsModal = withHandlePromise((props: TagsModalProps & HandlePromiseProps) => {
   // Track tags as an array instead of an object / Map so we can preserve the order during editing and so we can have
   // duplicate keys during editing. However, the ordering and any duplicate keys are lost when the form is submitted.
   const [tags, setTags] = React.useState(
@@ -66,7 +70,7 @@ export const TagsModal = withHandlePromise((props: TagsModalProps) => {
   );
 });
 
-export const annotationsModal = createModalLauncher((props: AnnotationsModalProps) => (
+export const AnnotationsModal: React.FC<AnnotationsModalProps> = (props) => (
   <TagsModal
     path="/metadata/annotations"
     tags={props.resource.metadata.annotations}
@@ -74,20 +78,8 @@ export const annotationsModal = createModalLauncher((props: AnnotationsModalProp
     titleKey="public~Edit annotations"
     {...props}
   />
-));
+);
 
-type TagsModalProps = {
-  tags?: { [key: string]: string };
-  path: string;
-  titleKey: string;
-  kind: K8sKind;
-  resource: K8sResourceKind;
-  inProgress: boolean;
-  errorMessage: string;
-  cancel?: () => void;
-  close?: () => void;
-} & HandlePromiseProps;
-
-type AnnotationsModalProps = Omit<TagsModalProps, 'path' | 'tags'>;
+export const annotationsModal = createModalLauncher(AnnotationsModal);
 
 TagsModal.displayName = 'TagsModal';

--- a/frontend/public/components/service.jsx
+++ b/frontend/public/components/service.jsx
@@ -273,12 +273,11 @@ const Details = ({ obj: s }) => {
   );
 };
 
-const { details, pods, editYaml } = navFactory;
 const ServicesDetailsPage = (props) => (
   <DetailsPage
     {...props}
     menuActions={menuActions}
-    pages={[details(Details), editYaml(), pods()]}
+    pages={[navFactory.details(Details), navFactory.editYaml(), navFactory.pods()]}
   />
 );
 

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -4,7 +4,7 @@ import * as _ from 'lodash-es';
 import { Button } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { useCanClusterUpgrade } from '@console/shared';
-
+import { useAnnotationsModal } from '@console/dynamic-plugin-sdk/src/app/components/modals/useAnnotationsModal';
 import { DetailsItem } from './details-item';
 import { Kebab } from './kebab';
 import { LabelList } from './label-list';
@@ -67,6 +67,7 @@ export const ResourceSummary: React.FC<ResourceSummaryProps> = ({
   const model = modelFor(reference);
   const tolerationsPath = getTolerationsPath(resource);
   const tolerations: Toleration[] = _.get(resource, tolerationsPath);
+  const annotationsModalLauncher = useAnnotationsModal(resource);
   const canUpdateAccess = useAccessReview({
     group: model.apiGroup,
     resource: model.plural,
@@ -141,7 +142,7 @@ export const ResourceSummary: React.FC<ResourceSummaryProps> = ({
               data-test="edit-annotations"
               type="button"
               isInline
-              onClick={Kebab.factory.ModifyAnnotations(model, resource).callback}
+              onClick={annotationsModalLauncher}
               variant="link"
             >
               {t('public~{{count}} annotation', { count: _.size(metadata.annotations) })}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -560,6 +560,7 @@
   "Create {{label}}": "Create {{label}}",
   "by name": "by name",
   "Modal": "Modal",
+  "Submit": "Submit",
   "Reset": "Reset",
   "Back": "Back",
   "Bug Reported": "Bug Reported",


### PR DESCRIPTION
- Factor out AnnotationsModal component from annotationsModal launcher
- Factor out ModalWrapper from createModalLauncher and export as internal API from SDK
- Move ModalWrapperProps, TagsModalProps, and AnnotationsModalProps to SDK internal types
- Implement useAnnotationsModal hook in dynamic plugin SDK and use in core details page component
- Improve SDK ModalComponent prop types
- Fix useModal hook example in SDK docs
- Address some minor tech debt issues in modal factory