### PR TITLE
OCPBUGS-12897: Knative Route Details Page should show the URL of the route as it is shown in the Openshift Routes Details page

### DIFF
--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -239,6 +239,7 @@
   "You cannot delete the last {{revlabel}} for the {{serviceLabel}}.": "You cannot delete the last {{revlabel}} for the {{serviceLabel}}.",
   "OK": "OK",
   "Reason": "Reason",
+  "Route details": "Route details",
   "URL": "URL",
   "Traffic": "Traffic",
   "Generation": "Generation",

--- a/frontend/packages/knative-plugin/src/components/routes/RouteDetailsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/RouteDetailsPage.tsx
@@ -1,8 +1,18 @@
 import * as React from 'react';
+import { ClipboardCopy } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';
-import { DetailsForKind } from '@console/internal/components/default-resource';
+import { Conditions } from '@console/internal/components/conditions';
 import { DetailsPage } from '@console/internal/components/factory';
-import { navFactory } from '@console/internal/components/utils';
+import { RoutesDetailsProps } from '@console/internal/components/routes';
+import {
+  DetailsItem,
+  detailsPage,
+  ExternalLink,
+  navFactory,
+  ResourceSummary,
+  SectionHeading,
+} from '@console/internal/components/utils';
 import { K8sKind, K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import {
   ActionMenu,
@@ -10,12 +20,57 @@ import {
   ActionServiceProvider,
   useTabbedTableBreadcrumbsFor,
 } from '@console/shared';
+import { PRIVATE_KNATIVE_SERVING_LABEL } from '../../const';
 import { serverlessTab } from '../../utils/serverless-tab-utils';
 
+const RouteDetails: React.FC<RoutesDetailsProps> = ({ obj: route }) => {
+  const { t } = useTranslation();
+  const isPrivateKSVC =
+    route?.metadata?.labels?.[PRIVATE_KNATIVE_SERVING_LABEL] === 'cluster-local';
+  return (
+    <>
+      <div className="co-m-pane__body">
+        <SectionHeading text={t('knative-plugin~Route details')} />
+        <div className="row">
+          <div className="col-sm-6">
+            <ResourceSummary resource={route} />
+          </div>
+          <div className="col-sm-6">
+            <dl>
+              <DetailsItem
+                label={t('knative-plugin~Location')}
+                obj={route}
+                path="status.url"
+                hideEmpty
+              >
+                {isPrivateKSVC ? (
+                  <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied">
+                    {route?.status?.url}
+                  </ClipboardCopy>
+                ) : (
+                  <ExternalLink
+                    href={route?.status?.url}
+                    additionalClassName="co-external-link--block"
+                    text={route?.status?.url}
+                  />
+                )}
+              </DetailsItem>
+            </dl>
+          </div>
+        </div>
+      </div>
+      <div className="co-m-pane__body">
+        <SectionHeading text={t('knative-plugin~Conditions')} />
+        <Conditions conditions={route?.status?.conditions} />
+      </div>
+    </>
+  );
+};
+
 const RouteDetailsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (props) => {
-  const { kindObj, match, kind } = props;
+  const { kindObj, match } = props;
   const isAdminPerspective = useActivePerspective()[0] === 'admin';
-  const pages = [navFactory.details(DetailsForKind(kind)), navFactory.editYaml()];
+  const pages = [navFactory.details(detailsPage(RouteDetails)), navFactory.editYaml()];
   const actionMenu = (kindObjData: K8sKind, obj: K8sResourceKind) => {
     const resourceKind = referenceForModel(kindObjData);
     const context = { [resourceKind]: obj };

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -622,6 +622,8 @@ export type RouteKind = {
   };
   status?: {
     ingress: RouteIngress[];
+    url?: string;
+    conditions?: K8sResourceCondition[];
   };
 } & K8sResourceCommon;
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-12897

**Analysis / Root cause**: 
Route link was not added in details page

**Solution Description**: 
Added Route link in details page

**Screen shots / Gifs for design review**: 

<img width="1291" alt="image" src="https://github.com/openshift/console/assets/102503482/bae59a6f-8880-4584-8302-f168bc24c63c">




**Unit test coverage report**: 
NA

**Test setup:**
1. Install Knative Serving (Serverless Operator)
2. Create a SF from the Add Page.
3. Navigate to the Knative Routes Details page

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge