### PR TITLE
OCPBUGS-14149: account for single object in status.conditions instead…

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -120,7 +120,13 @@ const getOperandStatus = (obj: K8sResourceKind): OperandStatusType => {
     };
   }
 
-  const trueConditions = conditions?.filter((c: K8sResourceCondition) => c.status === 'True');
+  const conditionsIsObject =
+    typeof conditions === 'object' && !Array.isArray(conditions) && conditions !== null;
+  const formattedConditions = conditionsIsObject ? [conditions] : conditions;
+
+  const trueConditions = formattedConditions?.filter(
+    (c: K8sResourceCondition) => c.status === 'True',
+  );
   if (trueConditions?.length) {
     const types = trueConditions.map((c: K8sResourceCondition) => c.type);
     return {


### PR DESCRIPTION
… of an array of objects

Kepler operands return a single object for status.conditions [1] instead of an array of objects. This fix accounts for this unexpected behavior from the operand.

[1]
```
apiVersion: kepler.system.sustainable.computing.io/v1alpha1
kind: Kepler
metadata:
  creationTimestamp: '2023-05-30T18:04:03Z'
  generation: 1
  labels:
    app.kubernetes.io/created-by: kepler-operator
    app.kubernetes.io/instance: kepler
    app.kubernetes.io/managed-by: kustomize
    app.kubernetes.io/name: kepler
    app.kubernetes.io/part-of: kepler-operator
  managedFields:
    - apiVersion: kepler.system.sustainable.computing.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:labels':
            .: {}
            'f:app.kubernetes.io/created-by': {}
            'f:app.kubernetes.io/instance': {}
            'f:app.kubernetes.io/managed-by': {}
            'f:app.kubernetes.io/name': {}
            'f:app.kubernetes.io/part-of': {}
        'f:spec':
          .: {}
          'f:collector':
            .: {}
            'f:collectorPort': {}
            'f:image': {}
      manager: Mozilla
      operation: Update
      time: '2023-05-30T18:04:03Z'
    - apiVersion: kepler.system.sustainable.computing.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:status':
          .: {}
          'f:conditions':
            .: {}
            'f:lastTransitionTime': {}
            'f:message': {}
            'f:reason': {}
            'f:status': {}
            'f:type': {}
      manager: manager
      operation: Update
      subresource: status
      time: '2023-05-30T18:04:05Z'
  name: kepler
  namespace: openshift-operators
  resourceVersion: '10230'
  uid: 396ce277-db6c-4800-b87d-e8e278c6b68b
spec:
  collector:
    collectorPort: 9103
    image: 'quay.io/sustainable_computing_io/kepler:release-0.4'
status:
  conditions:
    lastTransitionTime: '2023-05-30T18:04:03Z'
    message: Reconcile complete
    reason: ReconcileComplete
    status: 'True'
    type: Reconciled
```
