### PR TITLE
CONSOLE-3706: Remove custom history.pushPath alias function

### DIFF
--- a/frontend/__tests__/actions/ui.spec.ts
+++ b/frontend/__tests__/actions/ui.spec.ts
@@ -80,7 +80,7 @@ describe('ui-actions', () => {
     });
 
     it('should redirect to list view if current path is "new" and setting to "all-namespaces"', () => {
-      const spy = spyOn(router.history, 'pushPath');
+      const spy = spyOn(router.history, 'push');
       window.location.pathname = '/k8s/ns/floorwax/pods/~new';
       setActiveNamespace(ALL_NAMESPACES_KEY);
       expect(spy.calls.argsFor(0)[0]).toEqual('/k8s/all-namespaces/pods');

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -207,7 +207,7 @@ export const setActiveNamespace = (namespace: string = '') => {
     const oldPath = window.location.pathname;
     const newPath = formatNamespaceRoute(namespace, oldPath, window.location);
     if (newPath !== oldPath) {
-      history.pushPath(newPath);
+      history.push(newPath);
     }
     // save last namespace in session storage (persisted only for current browser tab). Used to remember/restore if
     // "All Projects" was selected when returning to the list view (typically from details view) via breadcrumb or

--- a/frontend/public/components/utils/router.ts
+++ b/frontend/public/components/utils/router.ts
@@ -1,8 +1,6 @@
 import * as _ from 'lodash-es';
 import { createBrowserHistory, createMemoryHistory, History } from 'history';
 
-type AppHistory = History & { pushPath: History['push'] };
-
 let createHistory;
 
 try {
@@ -16,7 +14,7 @@ try {
   createHistory = createBrowserHistory;
 }
 
-export const history: AppHistory = createHistory({ basename: window.SERVER_FLAGS.basePath });
+export const history: History = createHistory({ basename: window.SERVER_FLAGS.basePath });
 
 const removeBasePath = (url = '/') =>
   _.startsWith(url, window.SERVER_FLAGS.basePath)
@@ -29,7 +27,6 @@ history.replace = (url: string) => (history as any).__replace__(removeBasePath(u
 
 (history as any).__push__ = history.push;
 history.push = (url: string) => (history as any).__push__(removeBasePath(url));
-(history as any).pushPath = (path) => (history as any).__push__(path);
 
 export const getQueryArgument = (arg: string) =>
   new URLSearchParams(window.location.search).get(arg);


### PR DESCRIPTION
Remove custom `pushPath` function, since it's just an alias to the standard `history.push` function.