### PR TITLE
[WIP] OU-175: Monitoring: Add "Silences" tab to Developer console

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { match as RMatch } from 'react-router';
+import { SilencesPage } from '@console/internal/components/monitoring/alerting';
 import MonitoringDashboardsPage from '@console/internal/components/monitoring/dashboards';
 import { withStartGuide } from '@console/internal/components/start-guide';
 import {
@@ -60,6 +61,12 @@ export const PageContents: React.FC<MonitoringPageProps> = ({ match }) => {
             // t('devconsole~Alerts')
             nameKey: 'devconsole~Alerts',
             component: ConnectedMonitoringAlerts,
+          },
+          {
+            href: 'silences',
+            // t('public~Silences')
+            nameKey: 'public~Silences',
+            component: SilencesPage,
           },
         ]
       : []),

--- a/frontend/public/components/monitoring/types.ts
+++ b/frontend/public/components/monitoring/types.ts
@@ -1,4 +1,4 @@
-import { Alert, PrometheusLabels, Rule, Silence } from '@console/dynamic-plugin-sdk';
+import { Alert, PrometheusLabels, Silence } from '@console/dynamic-plugin-sdk';
 
 export const enum AlertSource {
   Platform = 'platform',
@@ -20,12 +20,6 @@ export type Silences = {
 
 export type Alerts = {
   data: Alert[];
-  loaded: boolean;
-  loadError?: string | Error;
-};
-
-export type Rules = {
-  data: Rule[];
   loaded: boolean;
   loadError?: string | Error;
 };


### PR DESCRIPTION
This page has exactly the same behaviour as the "Silences" tab in the Administrator console, except that it filters the silences to only show those from the current namespace.

Also fixes the props types for `SilencesPage` and `AlertsPage`.

Also removes the unused `Rules` type.