### PR TITLE
OCPBUGS-14550: Use proxy with web socket connection and monitoring d…

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -21,10 +21,11 @@ var websocketPingInterval = 30 * time.Second
 var websocketTimeout = 30 * time.Second
 
 type Config struct {
-	HeaderBlacklist []string
-	Endpoint        *url.URL
-	TLSClientConfig *tls.Config
-	Origin          string
+	HeaderBlacklist         []string
+	Endpoint                *url.URL
+	TLSClientConfig         *tls.Config
+	Origin                  string
+	UseProxyFromEnvironment bool
 }
 
 type Proxy struct {
@@ -219,6 +220,9 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	dialer := &websocket.Dialer{
 		TLSClientConfig: p.config.TLSClientConfig,
+	}
+	if p.config.UseProxyFromEnvironment == true {
+		dialer.Proxy = http.ProxyFromEnvironment
 	}
 
 	backend, resp, err := dialer.Dial(r.URL.String(), proxiedHeader)


### PR DESCRIPTION
This PR is to demonstrate a change that enables new backplane to render a working monitoring dashboard and successful web socket connection.

**Note:** Blocking PR merge because this is intended to communicate the issue. Best design decisions are left to the console team.