### PR TITLE
Add pvc+namespace based used-capacity query

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/queries/ceph-queries.ts
+++ b/frontend/packages/ceph-storage-plugin/src/queries/ceph-queries.ts
@@ -21,6 +21,8 @@ export enum StorageDashboardQuery {
   PROJECTS_BY_USED = 'PROJECTS_BY_USED',
   STORAGE_CLASSES_TOTAL_USED = 'STORAGE_CLASSES_TOTAL_USED',
   STORAGE_CLASSES_BY_USED = 'STORAGE_CLASSES_BY_USED',
+  PVC_NAMESPACES_BY_USED = 'PVC_NAMESPACES_BY_USED',
+  PVC_NAMESPACES_TOTAL_USED = 'PVC_NAMESPACES_TOTAL_USED',
   STORAGE_CEPH_CAPACITY_REQUESTED_QUERY = 'STORAGE_CEPH_CAPACITY_REQUESTED_QUERY',
   STORAGE_CEPH_CAPACITY_USED_QUERY = 'STORAGE_CEPH_CAPACITY_USED_QUERY',
   RESILIENCY_PROGRESS = 'RESILIENCY_PROGRESS',
@@ -113,6 +115,10 @@ export const CAPACITY_BREAKDOWN_QUERIES = {
     'sum(sum(kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass) group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)|(ceph.rook.io/block)"})) by (storageclass, provisioner))',
   [StorageDashboardQuery.STORAGE_CLASSES_BY_USED]:
     'sum(kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass) group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)|(ceph.rook.io/block)"})) by (storageclass, provisioner)',
+  [StorageDashboardQuery.PVC_NAMESPACES_TOTAL_USED]:
+    'sum(sum by (namespace, persistentvolumeclaim) (kubelet_volume_stats_used_bytes * on (namespace, persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass) group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)|(ceph.rook.io/block)"})))',
+  [StorageDashboardQuery.PVC_NAMESPACES_BY_USED]:
+    'sum by (namespace, persistentvolumeclaim) (kubelet_volume_stats_used_bytes * on (namespace, persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass) group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)|(ceph.rook.io/block)"}))',
   [StorageDashboardQuery.PODS_TOTAL_USED]:
     'sum (((max by(namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes)) * on (namespace,persistentvolumeclaim) group_right() ((kube_running_pod_ready*0+1) * on(namespace, pod)  group_right() kube_pod_spec_volumes_persistentvolumeclaims_info)) * on(namespace,persistentvolumeclaim) group_left(provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)|(ceph.rook.io/block)"}))',
   [StorageDashboardQuery.PODS_BY_USED]:


### PR DESCRIPTION
Adding a used-capacity query which sorts based on namespace and persistent-volume-claim (pvc)