### PR TITLE
RHSTOR-4533: added a mutator property for the storage class extension

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -695,3 +695,11 @@ export type QueryBrowserProps = {
   timespan?: number;
   units?: string;
 };
+
+export type StorageClass = K8sResourceCommon & {
+  provisioner: string;
+  parameters: object;
+  reclaimPolicy?: string;
+  volumeBindingMode?: string;
+  allowVolumeExpansion?: boolean;
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/storage-class-provisioner.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/storage-class-provisioner.ts
@@ -1,5 +1,6 @@
 import { Extension } from '@console/plugin-sdk/src/typings/base';
 import { CodeRef, ExtensionDeclaration } from '../types';
+import { StorageClass } from './console-types';
 
 export type ProvisionerProps = {
   onParamChange: (id: string, paramName: string, checkbox: boolean) => void;
@@ -35,6 +36,7 @@ export type ProvisionerDetails = {
       validationMsg?: string;
     };
   };
+  mutator?: CodeRef<(storageClass: StorageClass) => StorageClass>;
 };
 
 /** Adds a new storage class provisioner as an option during storage class creation. */

--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -249,7 +249,7 @@ const StorageClassFormWithTranslation = withTranslation()(
         } = this.state.newStorageClass;
         const dataParameters = this.getFormParams();
         const annotations = description ? { description } : {};
-        const data: StorageClass = {
+        let data: StorageClass = {
           metadata: {
             name: this.state.newStorageClass.name,
             annotations,
@@ -272,6 +272,10 @@ const StorageClassFormWithTranslation = withTranslation()(
           : allowVolumeExpansion;
         if (shouldAllowVolumeExpansion) {
           data.allowVolumeExpansion = expansion;
+        }
+        const { mutator } = this.storageTypes[type];
+        if (_.isFunction(mutator)) {
+          data = mutator(data);
         }
 
         k8sCreate(StorageClassModel, data)


### PR DESCRIPTION
story - https://issues.redhat.com/browse/RHSTOR-4533

able to see the mutated storage class object before creation for encrypted rbd storage class 

![image](https://github.com/openshift/console/assets/22158580/7dcfd66f-2f51-40c4-b23a-6679dd82c241)

annotations not added for non encrypted 

![image](https://github.com/openshift/console/assets/22158580/43a71b70-28a8-42b1-a227-6b187ef5c819)

