### PR TITLE
OCPBUGS-14419: Remove tech preview badge from Pipeline repository pages

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoriesList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoriesList.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { getBadgeFromType, useUserSettings } from '@console/shared/src';
+import { useUserSettings } from '@console/shared/src';
 import { PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY } from '../../../const';
 import { RepositoryModel } from '../../../models';
 import RepositoryList from './ReppositoryList';
@@ -37,7 +37,6 @@ const RepositoriesList: React.FC<React.ComponentProps<typeof ListPage>> = (props
         canCreate={props.canCreate ?? true}
         kind={referenceForModel(RepositoryModel)}
         ListComponent={RepositoryList}
-        badge={getBadgeFromType(RepositoryModel.badge)}
       />
     </>
   );

--- a/frontend/packages/pipelines-plugin/src/models/pipelines.ts
+++ b/frontend/packages/pipelines-plugin/src/models/pipelines.ts
@@ -1,6 +1,5 @@
 import { chart_color_green_400 as tektonGroupColor } from '@patternfly/react-tokens/dist/js/chart_color_green_400';
 import { K8sKind } from '@console/internal/module/k8s';
-import { BadgeType } from '@console/shared/src/components/badges/badge-factory';
 
 const color = tektonGroupColor.value;
 
@@ -289,7 +288,6 @@ export const RepositoryModel: K8sKind = {
   id: 'repository',
   labelPlural: 'Repositories',
   crd: true,
-  badge: BadgeType.TECH,
   color,
 };
 


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGS-14419

**Descriptions:** Remove the Tech preview badge from the repository List and details page

**GIF**

https://github.com/openshift/console/assets/2561818/8b0e8aa5-d2ce-4ed1-8c4b-5c2ea74d05f9

