### PR TITLE
OCPBUGS-14660: Helm Repository "Edit" button results in 404

### DIFF
--- a/frontend/packages/helm-plugin/src/actions/creators.ts
+++ b/frontend/packages/helm-plugin/src/actions/creators.ts
@@ -68,8 +68,8 @@ export const editChartRepository = (
       hcr.kind === ProjectHelmChartRepositoryModel.kind
         ? `/ns/${hcr.metadata.namespace}/helmchartrepositories/${
             hcr.metadata.name
-          }/edit?kind=${referenceFor(hcr)}`
-        : `/k8s/cluster/helmchartrepositories/${hcr.metadata.name}/edit?kind=${referenceFor(hcr)}`,
+          }/form?kind=${referenceFor(hcr)}`
+        : `/k8s/cluster/helmchartrepositories/${hcr.metadata.name}/form?kind=${referenceFor(hcr)}`,
   },
   accessReview: {
     group: model.apiGroup,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-14660

**Analysis / Root cause**: 
Component path was not changed in kebab menu href

**Solution Description**: 
Updated the component path

**Screen shots / Gifs for design review**: 

----BEFORE-----
https://github.com/openshift/console/assets/102503482/67db01fe-642f-42a1-8a1e-c9530e86f574

----AFTER----
https://github.com/openshift/console/assets/102503482/0a9b24f4-05b8-4971-b25b-c215d86a3760






**Unit test coverage report**: 
NA

**Test setup:**
1. Create a new Helm chart repository 
2. Go to Helm repositories list page
3. Click three dots menu on the right of any chart repository and select "Edit ProjectHelmChartRepository" 
4. You land on 404 page

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge