### PR TITLE
OCPBUGS-14909: Disabling web-terminal tests in CI

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -75,8 +75,8 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
   yarn run test-cypress-pipelines-headless
-#  yarn run test-cypress-shipwright-headless
-  yarn run test-cypress-webterminal-headless
+  # yarn run test-cypress-shipwright-headless
+  # yarn run test-cypress-webterminal-headless
   exit;
 fi
 


### PR DESCRIPTION
Failure:  https://search.ci.openshift.org/?search=Web+Terminal+for+Admin+user&maxAge=336h&context=1&type=junit&name=pull-ci-openshift-console-master-e2e-gcp-console&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job
Bug:  https://issues.redhat.com/browse/OCPBUGS-14909 