### PR TITLE
OCPBUGS-14002: Correct the alignment of yaml toolbar links

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/CodeEditorToolbar.scss
+++ b/frontend/packages/console-shared/src/components/editor/CodeEditorToolbar.scss
@@ -1,23 +1,16 @@
 @import '../../../../../public/style/vars';
 
-.ocs-yaml-editor-toolbar {
-  align-items: center;
-  display: flex;
-  flex-shrink: 0;
-  justify-content: flex-end;
-  margin: 2px;
-  z-index: 1;
-
-  @media(max-width: $screen-sm-max) {
-    display: none;
-  }
-}
-
-.ocs-yaml-editor-toolbar__link {
-  display: inline-block;
-}
-
 .ocs-yaml-editor-shortcut__text {
   color: var(--pf-global--Color--200);
   margin-left: var(--pf-global--spacer--sm);
+}
+
+.ocs-yaml-editor-toolbar {
+  align-items: center;
+}
+
+@media(max-width: $screen-sm-max) {
+  .ocs-yaml-editor-toolbar__link {
+      display: none;
+    }
 }

--- a/frontend/packages/console-shared/src/components/editor/CodeEditorToolbar.tsx
+++ b/frontend/packages/console-shared/src/components/editor/CodeEditorToolbar.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Divider } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { isMac, ShortcutCommand } from '../shortcuts/Shortcut';
 import ShortcutsLink from './ShortcutsLink';
@@ -14,30 +15,44 @@ const CodeEditorToolbar: React.FC<CodeEditorToolbarProps> = ({ showShortcuts, to
   const { t } = useTranslation();
   if (!showShortcuts && !toolbarLinks?.length) return null;
   return (
-    <div className="ocs-yaml-editor-toolbar">
-      <span className="ocs-yaml-editor-shortcut__command">
-        <ShortcutCommand>{isMac ? '⌥ Opt' : 'Alt'}</ShortcutCommand>
-        <ShortcutCommand>F1</ShortcutCommand>
-      </span>
-      <span className="ocs-yaml-editor-shortcut__text">
-        {t('console-shared~Accessibility help')}
-      </span>
-      <div className="co-action-divider">|</div>
-      {showShortcuts && (
+    <div className="co-toolbar__group co-toolbar__group--right">
+      <div className="ocs-yaml-editor-toolbar pf-u-pb-sm pf-l-flex">
         <div className="ocs-yaml-editor-toolbar__link">
-          <ShortcutsLink />
-        </div>
-      )}
-      {toolbarLinks &&
-        toolbarLinks.map((link, index) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <div key={`${index}`}>
-            {(showShortcuts || index > 0) && link ? (
-              <div className="co-action-divider">|</div>
-            ) : null}
-            <div className="ocs-yaml-editor-toolbar__link">{link}</div>
+          <div>
+            <span className="ocs-yaml-editor-shortcut__command">
+              <ShortcutCommand>{isMac ? '⌥ Opt' : 'Alt'}</ShortcutCommand>
+              <ShortcutCommand>F1</ShortcutCommand>
+            </span>
+            <span className="ocs-yaml-editor-shortcut__text">
+              {t('console-shared~Accessibility help')}
+            </span>
           </div>
-        ))}
+        </div>
+        {showShortcuts && (
+          <div className="ocs-yaml-editor-toolbar__link pf-l-flex">
+            <Divider
+              orientation={{
+                default: 'vertical',
+              }}
+            />
+            <ShortcutsLink />
+          </div>
+        )}
+        {toolbarLinks &&
+          toolbarLinks.map((link, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <div key={`${index}`} className="ocs-yaml-editor-toolbar__link pf-l-flex">
+              {(showShortcuts || index > 0) && link ? (
+                <Divider
+                  orientation={{
+                    default: 'vertical',
+                  }}
+                />
+              ) : null}
+              <div className="ocs-yaml-editor-toolbar__link">{link}</div>
+            </div>
+          ))}
+      </div>
     </div>
   );
 };

--- a/frontend/public/components/utils/resource-log.tsx
+++ b/frontend/public/components/utils/resource-log.tsx
@@ -9,6 +9,7 @@ import {
   AlertActionLink,
   Button,
   Checkbox,
+  Divider,
   Select,
   SelectOption,
   SelectVariant,
@@ -282,83 +283,96 @@ export const LogControls: React.FC<LogControlsProps> = ({
           </Tooltip>
         )}
       </div>
-      <div className="co-toolbar__group co-toolbar__group--right" data-test="log-links">
-        {!_.isEmpty(podLogLinks) &&
-          _.map(_.sortBy(podLogLinks, 'metadata.name'), (link) => {
-            const namespace = resource.metadata.namespace;
-            const namespaceFilter = link.spec.namespaceFilter;
-            if (namespaceFilter) {
-              try {
-                const namespaceRegExp = new RegExp(namespaceFilter, 'g');
-                if (namespace.search(namespaceRegExp)) {
+      <div
+        className="co-toolbar__group co-toolbar__group--right co-toolbar__group--right"
+        data-test="log-links"
+      >
+        <div className="pf-l-flex">
+          {!_.isEmpty(podLogLinks) &&
+            _.map(_.sortBy(podLogLinks, 'metadata.name'), (link) => {
+              const namespace = resource.metadata.namespace;
+              const namespaceFilter = link.spec.namespaceFilter;
+              if (namespaceFilter) {
+                try {
+                  const namespaceRegExp = new RegExp(namespaceFilter, 'g');
+                  if (namespace.search(namespaceRegExp)) {
+                    return null;
+                  }
+                } catch (e) {
+                  // eslint-disable-next-line no-console
+                  console.warn('invalid log link regex', namespaceFilter, e);
                   return null;
                 }
-              } catch (e) {
-                // eslint-disable-next-line no-console
-                console.warn('invalid log link regex', namespaceFilter, e);
-                return null;
               }
-            }
-            const url = replaceVariables(link.spec.hrefTemplate, {
-              resourceName: resource.metadata.name,
-              resourceUID: resource.metadata.uid,
-              containerName,
-              resourceNamespace: namespace,
-              resourceNamespaceUID: namespaceUID,
-              podLabels: JSON.stringify(resource.metadata.labels),
-            });
-            return (
-              <React.Fragment key={link.metadata.uid}>
-                <ExternalLink href={url} text={link.spec.text} dataTestID={link.metadata.name} />
-                <span aria-hidden="true" className="co-action-divider hidden-xs">
-                  |
-                </span>
-              </React.Fragment>
-            );
-          })}
-        <Checkbox
-          label={t('public~Wrap lines')}
-          id="wrapLogLines"
-          isChecked={isWrapLines}
-          data-checked-state={isWrapLines}
-          onChange={(checked: boolean) => {
-            toggleWrapLines(checked);
-          }}
-        />
-        <span aria-hidden="true" className="co-action-divider hidden-xs">
-          |
-        </span>
-        <a href={currentLogURL} target="_blank" rel="noopener noreferrer">
-          <OutlinedWindowRestoreIcon className="co-icon-space-r" />
-          {t('public~Raw')}
-        </a>
-        <span aria-hidden="true" className="co-action-divider hidden-xs">
-          |
-        </span>
-        <a href={currentLogURL} download={`${resource.metadata.name}-${containerName}.log`}>
-          <DownloadIcon className="co-icon-space-r" />
-          {t('public~Download')}
-        </a>
-        {screenfull.enabled && (
-          <>
-            <span aria-hidden="true" className="co-action-divider hidden-xs">
-              |
-            </span>
-            <Button variant="link" isInline onClick={toggleFullscreen}>
-              {isFullscreen ? (
-                <>
-                  <CompressIcon className="co-icon-space-r" />
-                  {t('public~Collapse')}
-                </>
-              ) : (
-                <>
-                  <ExpandIcon className="co-icon-space-r" />
-                  {t('public~Expand')}
-                </>
-              )}
-            </Button>
-          </>
-        )}
+              const url = replaceVariables(link.spec.hrefTemplate, {
+                resourceName: resource.metadata.name,
+                resourceUID: resource.metadata.uid,
+                containerName,
+                resourceNamespace: namespace,
+                resourceNamespaceUID: namespaceUID,
+                podLabels: JSON.stringify(resource.metadata.labels),
+              });
+              return (
+                <React.Fragment key={link.metadata.uid}>
+                  <ExternalLink href={url} text={link.spec.text} dataTestID={link.metadata.name} />
+                  <Divider
+                    orientation={{
+                      default: 'vertical',
+                    }}
+                  />
+                </React.Fragment>
+              );
+            })}
+          <Checkbox
+            label={t('public~Wrap lines')}
+            id="wrapLogLines"
+            isChecked={isWrapLines}
+            data-checked-state={isWrapLines}
+            onChange={(checked: boolean) => {
+              toggleWrapLines(checked);
+            }}
+          />
+          <Divider
+            orientation={{
+              default: 'vertical',
+            }}
+          />
+          <a href={currentLogURL} target="_blank" rel="noopener noreferrer">
+            <OutlinedWindowRestoreIcon className="co-icon-space-r" />
+            {t('public~Raw')}
+          </a>
+          <Divider
+            orientation={{
+              default: 'vertical',
+            }}
+          />
+          <a href={currentLogURL} download={`${resource.metadata.name}-${containerName}.log`}>
+            <DownloadIcon className="co-icon-space-r" />
+            {t('public~Download')}
+          </a>
+          {screenfull.enabled && (
+            <>
+              <Divider
+                orientation={{
+                  default: 'vertical',
+                }}
+              />
+              <Button variant="link" isInline onClick={toggleFullscreen}>
+                {isFullscreen ? (
+                  <>
+                    <CompressIcon className="co-icon-space-r" />
+                    {t('public~Collapse')}
+                  </>
+                ) : (
+                  <>
+                    <ExpandIcon className="co-icon-space-r" />
+                    {t('public~Expand')}
+                  </>
+                )}
+              </Button>
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -245,12 +245,6 @@ dl.co-inline {
   background-color: #d64456;
 }
 
-.co-action-divider {
-  color: $pf-color-black-600;
-  display: inline-block;
-  margin: 0 10px 0 10px;
-}
-
 .co-break-word {
   @include co-break-word;
 }


### PR DESCRIPTION
Also switch to use PatternFly Divider component for both YAML and Terminal toolbar links

https://issues.redhat.com/browse/OCPBUGS-14002
![Screenshot 2023-06-13 at 3 37 28 PM](https://github.com/openshift/console/assets/1874151/91283c76-d67a-4a9b-a1eb-f2538a4bc340)
![Screenshot 2023-06-13 at 2 34 37 PM](https://github.com/openshift/console/assets/1874151/41eb216e-8285-410d-8465-4acdbf82cc3a)



