### PR TITLE
OCPBUGS-14890: Missing 'View details' link for several servicemonitors.spec.endpoints fields in YAML sidebar

### DIFF
--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -5,11 +5,11 @@ import { useTranslation } from 'react-i18next';
 import { CamelCaseWrap } from '@console/dynamic-plugin-sdk';
 import {
   getDefinitionKey,
-  getSwaggerDefinitions,
   getSwaggerPath,
   K8sKind,
   SwaggerDefinition,
   SwaggerDefinitions,
+  fetchSwagger,
 } from '../../module/k8s';
 import { EmptyBox, LinkifyExternal } from '../utils';
 
@@ -27,14 +27,27 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
   const [drilldownHistory, setDrilldownHistory] = React.useState([]);
   const { kindObj, schema } = props;
   const { t } = useTranslation();
+  const [allDefinitions, setAllDefinitions] = React.useState<SwaggerDefinitions>(null);
+
+  React.useEffect(() => {
+    if (kindObj) {
+      fetchSwagger()
+        .then((response) => {
+          setAllDefinitions(response);
+        })
+        .catch((err) => {
+          // eslint-disable-next-line no-console
+          console.error('Could not fetch swagger definitions', err);
+        });
+    } else if (schema) {
+      setAllDefinitions({ 'custom-schema': schema });
+    }
+  }, [kindObj, schema]);
 
   if (!kindObj && !schema) {
     return null;
   }
 
-  const allDefinitions: SwaggerDefinitions = kindObj
-    ? getSwaggerDefinitions()
-    : schema && { 'custom-schema': schema };
   if (!allDefinitions) {
     return null;
   }
@@ -81,8 +94,11 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
   // - Inline property declartions for array items
   const getDrilldownPath = (name: string): string[] => {
     const path = kindObj
-      ? getSwaggerPath(allDefinitions, currentPath, name, true)
+      ? currentDefinition.items
+        ? getSwaggerPath(allDefinitions, [...currentPath, 'items'], name, true)
+        : getSwaggerPath(allDefinitions, currentPath, name, true)
       : [...currentPath, 'properties', name];
+
     // Only allow drilldown if the reference has additional properties to explore.
     const child = _.get(allDefinitions, path) as SwaggerDefinition;
     return _.has(child, 'properties') || _.has(child, 'items.properties') ? path : null;


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-14890

Two issues are addressed in this bug fix:

1. Missing “view details” for endpoints fields in YAML sidebar. This issue is caused because the “endpoints” field is an array type, but items in this array can have array or object type fields. Within the currentDefinition object used to generate the sidebar, object type fields have a “properties” key that is used to find the current path and create the “view details” button, but array type fields have an “items” key that contains a “properties” key listing the properties each individual item can have. Solution was to check for the presence of the items field and adjust the currentPath accordingly.

2. When clicking on “view details” button, sidebar will occasionally display text “No properties found” when it should be displaying a list of properties. This is because allDefinitions will sometimes will be loaded with $ref fields instead of having these fields resolved. Solution was to fetch the data in ExploreType component and storing it in a state hook instead of receiving the data from swagger.ts, which may not be up-to-date with the user sidebar. 
