### PR TITLE
OCPBUGS-14836: Updated BuildConfig and Shipwright Build lists shows runs from another namespace

### DIFF
--- a/frontend/packages/shipwright-plugin/src/components/build-list/BuildTable.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/build-list/BuildTable.tsx
@@ -77,7 +77,8 @@ export const BuildRow: React.FC<RowFunctionArgs<Build, CustomData>> = ({
   const kindReference = referenceFor(build);
   const context = { [kindReference]: build };
   const buildRunKindReference = referenceForModel(BuildRunModel);
-  const latestBuildRun = customData.buildRuns.latestByBuildName[build.metadata.name];
+  const latestBuildRun =
+    customData.buildRuns.latestByBuildName[`${build.metadata.name}-${build.metadata.namespace}`];
 
   return (
     <>
@@ -148,8 +149,11 @@ export const BuildTable: React.FC<BuildTableProps> = (props) => {
       buildRuns: {
         latestByBuildName: buildRuns.reduce<Record<string, BuildRun>>((acc, buildRun) => {
           const name = buildRun.metadata.labels?.[BUILDRUN_TO_BUILD_REFERENCE_LABEL];
-          if (!acc[name] || isBuildRunNewerThen(buildRun, acc[name])) {
-            acc[name] = buildRun;
+          if (
+            !acc[`${name}-${buildRun.metadata.namespace}`] ||
+            isBuildRunNewerThen(buildRun, acc[`${name}-${buildRun.metadata.namespace}`])
+          ) {
+            acc[`${name}-${buildRun.metadata.namespace}`] = buildRun;
           }
           return acc;
         }, {}),

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -161,7 +161,8 @@ const BuildConfigsTableRow: React.FC<RowFunctionArgs<K8sResourceKind, CustomData
   obj,
   customData,
 }) => {
-  const latestBuild = customData.builds.latestByBuildName[obj.metadata.name];
+  const latestBuild =
+    customData.builds.latestByBuildName[`${obj.metadata.name}-${obj.metadata.namespace}`];
 
   const duration = displayDurationInWords(
     latestBuild?.status?.startTimestamp,
@@ -270,8 +271,11 @@ export const BuildConfigsList: React.SFC<BuildConfigsListProps> = (props) => {
       builds: {
         latestByBuildName: builds.reduce<Record<string, K8sResourceKind>>((acc, build) => {
           const name = build.metadata.labels?.[BUILDCONFIG_TO_BUILD_REFERENCE_LABEL];
-          if (!acc[name] || isBuildNewerThen(build, acc[name])) {
-            acc[name] = build;
+          if (
+            !acc[`${name}-${build.metadata.namespace}`] ||
+            isBuildNewerThen(build, acc[`${name}-${build.metadata.namespace}`])
+          ) {
+            acc[`${name}-${build.metadata.namespace}`] = build;
           }
           return acc;
         }, {}),


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-14836

**Analysis / Root cause**: 
Namespace was not considered, it was adding the list based on name, since the name is same for different namespaces, it was adding only one details for both builds

**Solution Description**: 
Updated to consider the namespace as well along with name

**Screen shots / Gifs for design review**: 

----BEFORE-----
<img width="1437" alt="Screenshot 2023-06-14 at 2 56 52 PM" src="https://github.com/openshift/console/assets/102503482/de39c564-0af9-478a-8483-08c2f8efe145">
<img width="1437" alt="Screenshot 2023-06-14 at 2 56 38 PM" src="https://github.com/openshift/console/assets/102503482/4784f114-fe98-4497-be0a-059191c8f391">



----AFTER----
<img width="1436" alt="Screenshot 2023-06-14 at 12 53 59 PM" src="https://github.com/openshift/console/assets/102503482/b1e655a2-d621-425d-a195-d8cff4414f8c">
<img width="1436" alt="Screenshot 2023-06-14 at 12 54 30 PM" src="https://github.com/openshift/console/assets/102503482/1a0c0425-46a9-4e62-86cb-8362b6a5883f">







**Unit test coverage report**: 
NA

**Test setup:**

1. Create two namespaces
2. Create a BuildConfig with the same name in both namespaces
3. Start a Build for each BuildConfig
4. Navigate to Build > BuildConfigs and select "All namespaces"

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge