### PR TITLE
OCPBUGS-14964: Disable broken monitoring-tests

### DIFF
--- a/frontend/integration-tests/tests/alertmanager.scenario.ts
+++ b/frontend/integration-tests/tests/alertmanager.scenario.ts
@@ -25,6 +25,10 @@ const getGlobalsAndReceiverConfig = (configName: string, yamlStr: string) => {
 };
 
 describe('Alertmanager: PagerDuty Receiver Form', () => {
+  // Disabled to resolve https://issues.redhat.com/browse/OCPBUGS-14964
+  // Follow-up issue to fix the Alertmanager and reeanble this tests: https://issues.redhat.com/browse/OCPBUGS-15036
+  pending('Temporary disabled, see OCPBUGS-14964 and OCPBUGS-15036');
+
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
@@ -204,6 +208,10 @@ describe('Alertmanager: PagerDuty Receiver Form', () => {
 });
 
 describe('Alertmanager: Email Receiver Form', () => {
+  // Disabled to resolve https://issues.redhat.com/browse/OCPBUGS-14964
+  // Follow-up issue to fix the Alertmanager and reeanble this tests: https://issues.redhat.com/browse/OCPBUGS-15036
+  pending('Temporary disabled, see OCPBUGS-14964 and OCPBUGS-15036');
+
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
@@ -328,6 +336,10 @@ describe('Alertmanager: Email Receiver Form', () => {
 });
 
 describe('Alertmanager: Slack Receiver Form', () => {
+  // Disabled to resolve https://issues.redhat.com/browse/OCPBUGS-14964
+  // Follow-up issue to fix the Alertmanager and reeanble this tests: https://issues.redhat.com/browse/OCPBUGS-15036
+  pending('Temporary disabled, see OCPBUGS-14964 and OCPBUGS-15036');
+
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
@@ -441,6 +453,10 @@ describe('Alertmanager: Slack Receiver Form', () => {
 });
 
 describe('Alertmanager: Webhook Receiver Form', () => {
+  // Disabled to resolve https://issues.redhat.com/browse/OCPBUGS-14964
+  // Follow-up issue to fix the Alertmanager and reeanble this tests: https://issues.redhat.com/browse/OCPBUGS-15036
+  pending('Temporary disabled, see OCPBUGS-14964 and OCPBUGS-15036');
+
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,

--- a/frontend/integration-tests/tests/monitoring.scenario.ts
+++ b/frontend/integration-tests/tests/monitoring.scenario.ts
@@ -10,6 +10,10 @@ import * as horizontalnavView from '../views/horizontal-nav.view';
 import { execSync } from 'child_process';
 
 describe('Alertmanager: YAML', () => {
+  // Disabled to resolve https://issues.redhat.com/browse/OCPBUGS-14964
+  // Follow-up issue to fix the Alertmanager and reeanble this tests: https://issues.redhat.com/browse/OCPBUGS-15036
+  pending('Temporary disabled, see OCPBUGS-14964 and OCPBUGS-15036');
+
   afterEach(() => {
     checkLogs();
     checkErrors();
@@ -38,6 +42,10 @@ describe('Alertmanager: YAML', () => {
 });
 
 describe('Alertmanager: Configuration', () => {
+  // Disabled to resolve https://issues.redhat.com/browse/OCPBUGS-14964
+  // Follow-up issue to fix the Alertmanager and reeanble this tests: https://issues.redhat.com/browse/OCPBUGS-15036
+  pending('Temporary disabled, see OCPBUGS-14964 and OCPBUGS-15036');
+
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,


### PR DESCRIPTION
Replaces https://github.com/openshift/console/pull/12901

Just disable the broken e2e tests to solve https://issues.redhat.com/browse/OCPBUGS-14964 and unblock our merge queue.

The page Cluster Settings > Configuration > Alertmanager shows an empty page when running on a cluster with installed `monitoring-plugin` (currently version 1.0.0).

For more details see: https://redhat-internal.slack.com/archives/C6A3NV5J9/p1686827297311749?thread_ts=1686666034.315849&cid=C6A3NV5J9

We should enable the tests again after we've fixed the underlying issue. This can be tracked here: https://issues.redhat.com/browse/OCPBUGS-15036