### PR TITLE
ODC-7322: Implement a proxy to hit the Artifacthub.io API end point

### DIFF
--- a/pkg/devconsole/proxy/proxy.go
+++ b/pkg/devconsole/proxy/proxy.go
@@ -1,0 +1,89 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/openshift/console/pkg/serverutils"
+)
+
+func Handler(w http.ResponseWriter, r *http.Request) {
+	path := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+
+	if len(path) == 2 && path[0] == "proxy" && path[1] == "internet" {
+		// POST  /api/dev-console/proxy/internet
+		if r.Method == http.MethodPost {
+			response, err := serve(r)
+			if err != nil {
+				serverutils.SendResponse(w, http.StatusInternalServerError, serverutils.ApiError{Err: err.Error()})
+				return
+			}
+			serverutils.SendResponse(w, http.StatusOK, response)
+			return
+		} else {
+			serverutils.SendResponse(w, http.StatusMethodNotAllowed, serverutils.ApiError{Err: "Invalid method: only POST is allowed"})
+			return
+		}
+	} else {
+		serverutils.SendResponse(w, http.StatusNotFound, serverutils.ApiError{Err: "Invalid URL"})
+		return
+	}
+}
+
+func serve(r *http.Request) (ProxyResponse, error) {
+	var request ProxyRequest
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		return ProxyResponse{}, fmt.Errorf("Failed to parse request: %v", err)
+	}
+
+	if request.Method == "" {
+		request.Method = http.MethodGet
+	}
+
+	var serviceRequest *http.Request
+	if request.Body == "" {
+		serviceRequest, err = http.NewRequest(request.Method, request.Url, nil)
+	} else {
+		serviceRequest, err = http.NewRequest(request.Method, request.Url, strings.NewReader(request.Body))
+	}
+
+	if err != nil {
+		return ProxyResponse{}, fmt.Errorf("Failed to create request: %v", err)
+	}
+
+	for key, values := range request.Headers {
+		for _, value := range values {
+			serviceRequest.Header.Add(key, value)
+		}
+	}
+
+	query := serviceRequest.URL.Query()
+	for key, values := range request.Queryparams {
+		for _, value := range values {
+			query.Add(key, value)
+		}
+	}
+	serviceRequest.URL.RawQuery = query.Encode()
+
+	serviceClient := &http.Client{}
+
+	serviceResponse, err := serviceClient.Do(serviceRequest)
+	if err != nil {
+		return ProxyResponse{}, fmt.Errorf("Failed to send request: %v", err)
+	}
+	defer serviceResponse.Body.Close()
+	serviceResponseBody, err := io.ReadAll(serviceResponse.Body)
+	if err != nil {
+		return ProxyResponse{}, fmt.Errorf("Failed to read response body: %v", err)
+	}
+
+	return ProxyResponse{
+		StatusCode: serviceResponse.StatusCode,
+		Headers:    serviceResponse.Header,
+		Body:       string(serviceResponseBody),
+	}, nil
+}

--- a/pkg/devconsole/proxy/proxy_test.go
+++ b/pkg/devconsole/proxy/proxy_test.go
@@ -1,0 +1,80 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestProxyEndpoint(t *testing.T) {
+	tests := []struct {
+		testName         string
+		request          ProxyRequest
+		expectedResponse ProxyResponse
+	}{
+		{
+			testName: "valid GET",
+			request: ProxyRequest{
+				Url:    "testserver",
+				Method: http.MethodGet,
+			},
+			expectedResponse: ProxyResponse{
+				StatusCode: http.StatusOK,
+				Headers: http.Header{
+					"Content-Type":   {"application/json"},
+					"Content-Length": {"15"},
+				},
+				Body: "Mocked response",
+			},
+		},
+		{
+			testName: "valid GET without method",
+			request: ProxyRequest{
+				Url: "testserver",
+			},
+			expectedResponse: ProxyResponse{
+				StatusCode: http.StatusOK,
+				Headers: http.Header{
+					"Content-Type":   {"application/json"},
+					"Content-Length": {"15"},
+				},
+				Body: "Mocked response",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				rw.Header().Add("Content-Type", "application/json")
+				rw.WriteHeader(http.StatusOK)
+				rw.Write([]byte("Mocked response"))
+			}))
+			defer server.Close()
+
+			tt.request.Url = server.URL
+			body, err := json.Marshal(tt.request)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			req, err := http.NewRequest(http.MethodPost, "/proxy", bytes.NewBuffer(body))
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			actual, err := serve(req)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			actual.Headers.Del("Date")
+			if !reflect.DeepEqual(tt.expectedResponse, actual) {
+				t.Errorf("Response does not match expectation:\n%v\nbut got\n%v", tt.expectedResponse, actual)
+			}
+		})
+	}
+}

--- a/pkg/devconsole/proxy/types.go
+++ b/pkg/devconsole/proxy/types.go
@@ -1,0 +1,20 @@
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+)
+
+type ProxyRequest struct {
+	Method      string      `json:"method"`
+	Url         string      `json:"url"`
+	Headers     http.Header `json:"headers"`
+	Queryparams url.Values  `json:"queryparams"`
+	Body        string      `json:"body"`
+}
+
+type ProxyResponse struct {
+	StatusCode int         `json:"statusCode"`
+	Headers    http.Header `json:"headers"`
+	Body       string      `json:"body"`
+}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-7322

**Solution Description**: 
Added Proxy for calling the Search and Fetch Task Endpoints of ArtifactHub.io

**Screen shots / Gifs for design review**: 

**Search Endpoint**
![image](https://github.com/openshift/console/assets/47265560/6fc66562-e93f-4bd8-a026-f2425b659daa)

**Fetch Endpoint**
![image](https://github.com/openshift/console/assets/47265560/558673c1-c59c-4c2c-9268-9de755aa4ee9)



**Unit test coverage report**: 
![image](https://github.com/openshift/console/assets/47265560/d694f764-9b11-4ac9-9bf5-b1e3446d877c)