### PR TITLE
OCPBUGS-15135: Make knative routes copyable similar to openshift routes

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/KSRoutesOverviewListItem.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KSRoutesOverviewListItem.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ClipboardCopy } from '@patternfly/react-core/dist/esm/components/ClipboardCopy';
 import { useTranslation } from 'react-i18next';
-import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
+import { ResourceLink, ExternalLinkWithCopy } from '@console/internal/components/utils';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { PRIVATE_KNATIVE_SERVING_LABEL } from '../../const';
 import { RouteModel } from '../../models';
@@ -33,10 +33,10 @@ const KSRoutesOverviewListItem: React.FC<KSRoutesOverviewListItemProps> = ({ ksr
                   {status.url}
                 </ClipboardCopy>
               ) : (
-                <ExternalLink
-                  href={status.url}
-                  additionalClassName="co-external-link--block"
+                <ExternalLinkWithCopy
+                  link={status.url}
                   text={status.url}
+                  additionalClassName="co-external-link--block"
                 />
               )}
             </>

--- a/frontend/packages/knative-plugin/src/components/overview/RoutesUrlLink.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RoutesUrlLink.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ClipboardCopy } from '@patternfly/react-core/dist/esm/components/ClipboardCopy';
-import { ExternalLink } from '@console/internal/components/utils';
+import { ExternalLinkWithCopy } from '@console/internal/components/utils';
 
 export type RoutesUrlLinkProps = {
   urls: string[];
@@ -17,9 +17,9 @@ const RoutesUrlLink: React.FC<RoutesUrlLinkProps> = ({ urls = [], title }) =>
             {url}
           </ClipboardCopy>
         ) : (
-          <ExternalLink
+          <ExternalLinkWithCopy
             key={url}
-            href={url}
+            link={url}
             text={url}
             additionalClassName="co-external-link--block"
           />

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KSRoutesOverviewListItem.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KSRoutesOverviewListItem.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';
-import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
+import { ResourceLink, ExternalLinkWithCopy } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { RouteModel } from '../../../models';
 import { MockKnativeResources } from '../../../topology/__tests__/topology-knative-test-data';
@@ -27,8 +27,11 @@ describe('KSRoutesOverviewListItem', () => {
   });
 
   it('should have route ExternalLink with proper href', () => {
-    expect(wrapper.find(ExternalLink)).toHaveLength(1);
-    expect(wrapper.find(ExternalLink).at(0).props().href).toEqual(
+    expect(wrapper.find(ExternalLinkWithCopy)).toHaveLength(1);
+    expect(wrapper.find(ExternalLinkWithCopy).at(0).props().link).toEqual(
+      'http://overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com',
+    );
+    expect(wrapper.find(ExternalLinkWithCopy).at(0).props().text).toEqual(
       'http://overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com',
     );
   });
@@ -37,7 +40,7 @@ describe('KSRoutesOverviewListItem', () => {
     const ksroute = { ...MockKnativeResources.ksroutes.data[0], status: { url: '' } };
     wrapper.setProps({ ksroute });
     expect(wrapper.find(ResourceLink)).toHaveLength(1);
-    expect(wrapper.find(ExternalLink)).toHaveLength(0);
+    expect(wrapper.find(ExternalLinkWithCopy)).toHaveLength(0);
   });
 
   it('should have ResourceLink with proper kind and not external link if status is not preset on route', () => {
@@ -45,6 +48,6 @@ describe('KSRoutesOverviewListItem', () => {
     wrapper.setProps({ ksroute });
     expect(wrapper.find(ResourceLink).exists()).toBe(true);
     expect(wrapper.find(ResourceLink).at(0).props().kind).toEqual(referenceForModel(RouteModel));
-    expect(wrapper.find(ExternalLink).exists()).toBe(false);
+    expect(wrapper.find(ExternalLinkWithCopy).exists()).toBe(false);
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/domain-mapping/DomainMappingOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/domain-mapping/DomainMappingOverviewList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  ExternalLink,
+  ExternalLinkWithCopy,
   ResourceLink,
   SidebarSectionHeading,
 } from '@console/internal/components/utils';
@@ -37,10 +37,10 @@ const DomainMappingOverviewList: React.FC<DomainMappingOverviewListProps> = ({
               {status?.url?.length > 0 && (
                 <>
                   <span className="text-muted">{t('knative-plugin~Location:')}</span>
-                  <ExternalLink
-                    href={status.url}
-                    additionalClassName="co-external-link--block"
+                  <ExternalLinkWithCopy
+                    link={status.url}
                     text={status.url}
+                    additionalClassName="co-external-link--block"
                   />
                 </>
               )}

--- a/frontend/packages/knative-plugin/src/components/routes/RouteDetailsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/RouteDetailsPage.tsx
@@ -8,7 +8,7 @@ import { RoutesDetailsProps } from '@console/internal/components/routes';
 import {
   DetailsItem,
   detailsPage,
-  ExternalLink,
+  ExternalLinkWithCopy,
   navFactory,
   ResourceSummary,
   SectionHeading,
@@ -48,10 +48,10 @@ const RouteDetails: React.FC<RoutesDetailsProps> = ({ obj: route }) => {
                     {route?.status?.url}
                   </ClipboardCopy>
                 ) : (
-                  <ExternalLink
-                    href={route?.status?.url}
-                    additionalClassName="co-external-link--block"
+                  <ExternalLinkWithCopy
+                    link={route?.status?.url}
                     text={route?.status?.url}
+                    additionalClassName="co-external-link--block"
                   />
                 )}
               </DetailsItem>

--- a/frontend/packages/knative-plugin/src/components/routes/RouteRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/RouteRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as cx from 'classnames';
 import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
-import { ResourceLink, Timestamp, ExternalLink } from '@console/internal/components/utils';
+import { ResourceLink, Timestamp, ExternalLinkWithCopy } from '@console/internal/components/utils';
 import { referenceFor, referenceForModel } from '@console/internal/module/k8s';
 import { LazyActionMenu } from '@console/shared/src';
 import { RevisionModel, RouteModel } from '../../models';
@@ -29,10 +29,10 @@ const RouteRow: React.FC<RowFunctionArgs<RouteKind>> = ({ obj }) => {
       </TableData>
       <TableData className={tableColumnClasses[2]}>
         {(obj.status && obj.status.url && (
-          <ExternalLink
-            href={obj.status.url}
-            additionalClassName="co-external-link--block"
+          <ExternalLinkWithCopy
+            link={obj.status.url}
             text={obj.status.url}
+            additionalClassName="co-external-link--block"
           />
         )) ||
           '-'}

--- a/frontend/packages/knative-plugin/src/components/routes/__tests__/RouteRow.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/__tests__/RouteRow.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import * as _ from 'lodash';
 import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
-import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
+import { ResourceLink, ExternalLinkWithCopy } from '@console/internal/components/utils';
 import { knativeRouteObj } from '../../../topology/__tests__/topology-knative-test-data';
 import { RouteKind } from '../../../types';
 import RouteRow from '../RouteRow';
@@ -20,8 +20,11 @@ describe('RouteRow', () => {
     const wrapper = shallow(<RouteRow {...routeData} />);
     const serviceDataTable = wrapper.find(TableData).at(2);
     expect(wrapper.find(TableData)).toHaveLength(7);
-    expect(serviceDataTable.find(ExternalLink)).toHaveLength(1);
-    expect(serviceDataTable.find(ExternalLink).props().href).toEqual(
+    expect(serviceDataTable.find(ExternalLinkWithCopy)).toHaveLength(1);
+    expect(serviceDataTable.find(ExternalLinkWithCopy).props().link).toEqual(
+      'http://overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com',
+    );
+    expect(serviceDataTable.find(ExternalLinkWithCopy).props().text).toEqual(
       'http://overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com',
     );
   });
@@ -30,7 +33,7 @@ describe('RouteRow', () => {
     routeData = _.omit(routeData, 'obj.status');
     const wrapper = shallow(<RouteRow {...routeData} />);
     const serviceDataTable = wrapper.find(TableData).at(2);
-    expect(serviceDataTable.find(ExternalLink)).toHaveLength(0);
+    expect(serviceDataTable.find(ExternalLinkWithCopy)).toHaveLength(0);
   });
 
   it('should show appropriate conditions', () => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-15135

**Analysis / Root cause**: 
@vikram-raj noticed in https://github.com/openshift/console/pull/12853#issuecomment-1594829827 that the new Route link wasn't clickable. But it was also not copyable on many other Knative routes screens, while it was copyable in all the places when an OpenShift Route was disabled.

**Solution Description**: 
Updated multiple `ExternalLink` with `ExternalLinkWithCopy`

**Screen shots / Gifs for design review**: 

Left side before, but with #12853 --- this PR on the right side

## Topology

### Deployment (for comparison)

![topology-deployment-public-route](https://github.com/openshift/console/assets/139310/d77b77a0-08fa-4779-b543-9a40cda03054)

### Knative Service with a public route (added copy button)

![topology-knative-service-public-route](https://github.com/openshift/console/assets/139310/21a0d555-754f-424d-94cb-116462677703)

### Knative Revision with a public route (added copy button)

![topology-knative-revision-public-route](https://github.com/openshift/console/assets/139310/d5aff1a2-02c4-42da-adf8-2cf2ebcbdadb)

### Knative Service with a private route (unchanged)

![topology-knative-service-private-route](https://github.com/openshift/console/assets/139310/0672b1f3-3c06-4020-885e-ba690a11b368)

### Knative Revision with a private route (unchanged)

![topology-knative-revision-private-route](https://github.com/openshift/console/assets/139310/daffac30-b83e-406c-b0af-384d769d53de)

## List view

### OpenShift Route (for comparison)

![openshift-route-list-public-route](https://github.com/openshift/console/assets/139310/40494c07-1a10-4ca9-bcc8-945887e868e1)

### Knative route with public route (added copy button)

![knative-route-list-public-route](https://github.com/openshift/console/assets/139310/26d44749-a99d-49bf-84e1-527807a108bd)

### Knative route with private route (added copy button)

![knative-routes-list-private-route](https://github.com/openshift/console/assets/139310/6b3f992f-41b5-4495-9dc6-f5b2923676c7)

## Detail view

### OpenShift Route (for comparison)

![openshift-route-detail-public-route](https://github.com/openshift/console/assets/139310/b8f4b3a9-5b10-42d2-9bda-698c2041641e)

### Knative route with public route (added copy button)

![knative-route-detail-public-route](https://github.com/openshift/console/assets/139310/e64faa84-91d3-4716-a5b5-2bf046d72cde)

### Knative route with private route (unchanged)

![knative-route-detail-page-private-route](https://github.com/openshift/console/assets/139310/dd92ea1e-9eb5-4729-81ae-97c274fd132c)

**Test setup:**
1. Install Serverless operator and create the Serverless serving resource
2. Import an application as a Deployment and Knative Service
3. Checkout and compare
   * Topology sidebar (Deployment vs Knative Service)
   * Route list view (OpenShift Route vs Knative Route)
   * Route detail view (OpenShift Route vs Knative Route)

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
