### PR TITLE
OCPBUGS-14354: e2e: Enable Pipeline tests

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster.ts
@@ -99,7 +99,6 @@ export const waitForCRDs = (operator: operators) => {
         6,
       );
       cy.get('[data-test-id="TektonPipeline"]', { timeout: 80000 }).should('be.visible');
-      cy.get('[data-test-id="PipelineResource"]', { timeout: 80000 }).should('be.visible');
       cy.get('[data-test-id="PipelineRun"]', { timeout: 80000 }).should('be.visible');
       cy.get('[data-test-id="Pipeline"]', { timeout: 80000 }).should('be.visible');
       break;

--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -74,7 +74,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-helm-headless
   yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
-  #yarn run test-cypress-pipelines-headless
+  yarn run test-cypress-pipelines-headless
 #  yarn run test-cypress-shipwright-headless
   yarn run test-cypress-webterminal-headless
   exit;


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-14354

Descriptions: Red Hat Pipeline operator 1.11.0 has been released and it is available in OperatorHub now.