### PR TITLE
ODC-7329: Subsequent PipelineRuns take initial PipelineRun name into account

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/utils.ts
@@ -68,6 +68,14 @@ export const getPipelineName = (pipeline?: PipelineKind, latestRun?: PipelineRun
   return null;
 };
 
+export const getPipelineRunGenerateName = (pipelineRun: PipelineRunKind): string => {
+  if (pipelineRun.metadata.generateName) {
+    return pipelineRun.metadata.generateName;
+  }
+
+  return `${pipelineRun.metadata.name?.replace(/-[a-z0-9]{5,6}$/, '')}-`;
+};
+
 export const getPipelineRunData = (
   pipeline: PipelineKind = null,
   latestRun?: PipelineRunKind,
@@ -112,7 +120,10 @@ export const getPipelineRunData = (
             generateName: `${pipelineName}-`,
           }
         : {
-            name: `${pipelineName}-${getRandomChars()}`,
+            name:
+              latestRun?.metadata?.name !== undefined
+                ? `${getPipelineRunGenerateName(latestRun)}${getRandomChars()}`
+                : `${pipelineName}-${getRandomChars()}`,
           }),
       annotations,
       namespace: pipeline ? pipeline.metadata.namespace : latestRun.metadata.namespace,


### PR DESCRIPTION
**Story:** https://issues.redhat.com/browse/ODC-7329

**Descriptions:** Subsequent PipelineRuns should take the initial PipelineRun name into account

GIF:

https://github.com/openshift/console/assets/2561818/b2e1924c-942c-4b64-bdf5-9ddf7869ed6c

