### PR TITLE
OCPBUGS-14015: Create helm release page doesn't show a YAML editor when schema isn't available (httpd-imagestreams chart)

### DIFF
--- a/frontend/packages/helm-plugin/integration-tests/features/helm/helm-installation-view.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/helm-installation-view.feature
@@ -38,3 +38,11 @@ Feature: Helm Chart Installation View
               And user selects the YAML view
               And user comes back to Form view
              Then user will see Release Name, Replica count as "nodejs-release-3", "3" respectively
+
+        @regression
+        Scenario: When Helm Release is not configurable: HR-04-TC04
+            Given user is at Add page
+             When user selects "Helm Chart" card from add page
+              And user searches and selects "Httpd Imagestreams" card from catalog page
+              And user clicks on the Create button on side bar
+             Then user should see message "Helm release is not configurable since the Helm Chart doesn't define any values." 

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-installation-view.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-installation-view.ts
@@ -46,3 +46,7 @@ Then(
     cy.byLegacyTestID('reset-button').click();
   },
 );
+
+Then('user should see message {string}', (message: string) => {
+  cy.get('h4.pf-c-alert__title').should('contain.text', message).should('exist');
+});

--- a/frontend/packages/helm-plugin/locales/en/helm-plugin.json
+++ b/frontend/packages/helm-plugin/locales/en/helm-plugin.json
@@ -108,6 +108,7 @@
   "The Helm Chart is currently unavailable. {{chartError}}": "The Helm Chart is currently unavailable. {{chartError}}",
   "Release name": "Release name",
   "A unique name for the Helm Release.": "A unique name for the Helm Release.",
+  "Helm release is not configurable since the Helm Chart doesn't define any values.": "Helm release is not configurable since the Helm Chart doesn't define any values.",
   "Errors in the form - {{errorsText}}": "Errors in the form - {{errorsText}}",
   "Invalid Form Schema - {{errorText}}": "Invalid Form Schema - {{errorText}}",
   "Invalid YAML - {{errorText}}": "Invalid YAML - {{errorText}}",

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
@@ -162,16 +162,25 @@ const HelmInstallUpgradeForm: React.FC<
             </GridItem>
           </Grid>
         </FormSection>
-        {!chartError && (
-          <SyncedEditorField
-            name="editorType"
-            formContext={{ name: 'formData', editor: formEditor, isDisabled: !formSchema }}
-            yamlContext={{ name: 'yamlData', editor: yamlEditor }}
-            lastViewUserSettingKey={LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY}
-            prune={prune}
-            noMargin
-          />
-        )}
+        {!chartError &&
+          (!formSchema && !chartHasValues ? (
+            <Alert
+              variant="info"
+              title={t(
+                "helm-plugin~Helm release is not configurable since the Helm Chart doesn't define any values.",
+              )}
+              isInline
+            />
+          ) : (
+            <SyncedEditorField
+              name="editorType"
+              formContext={{ name: 'formData', editor: formEditor, isDisabled: !formSchema }}
+              yamlContext={{ name: 'yamlData', editor: yamlEditor }}
+              lastViewUserSettingKey={LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY}
+              prune={prune}
+              noMargin
+            />
+          ))}
       </FormBody>
       <FormFooter
         handleReset={handleReset}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-14015

**Analysis / Root cause**: 
YAML editor was not displayed due to helm chart was not configurable

**Solution Description**: 
If form type is disabled and helm chart don't provide any configuration option, then instead of showing disabled form view and YAML view an info alert is added with a message "Helm release is not configurable since the Helm Chart doesn't define any values." 

**Screen shots / Gifs for design review**: 

----BEFORE----
<img width="1431" alt="Screenshot 2023-06-20 at 1 25 25 PM" src="https://github.com/openshift/console/assets/102503482/375abbf0-4a95-4a39-8221-22d63eb5b2d0">



----AFTER----
<img width="1429" alt="Screenshot 2023-06-20 at 1 24 56 PM" src="https://github.com/openshift/console/assets/102503482/71b7b5f6-be18-4ba1-b484-392e0a729497">



**Unit test coverage report**: 
NA

**Test setup:**

1. Switch to the developer perspective
2. Navigate to Add > Helm Chart
3. Search and select "httpd-imagestreams", click the card and then Create to open the "Create Helm Release" page

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge