### PR TITLE
OCPBUGS-15011: Upload JAR file does not work if the Cluster Samples Operator is disabled

### DIFF
--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -365,6 +365,9 @@
         { "group": "route.openshift.io", "resource": "routes", "verb": "create" },
         { "group": "", "resource": "services", "verb": "create" }
       ]
+    },
+    "flags": {
+      "required": ["JAVA_IMAGE_STREAM_ENABLED"]
     }
   },
   {

--- a/frontend/packages/dev-console/src/components/import/jar/UploadJarPage.tsx
+++ b/frontend/packages/dev-console/src/components/import/jar/UploadJarPage.tsx
@@ -7,7 +7,7 @@ import { LoadingBox, PageHeading } from '@console/internal/components/utils';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { ImageStreamModel, ProjectModel } from '@console/internal/models';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { QUERY_PROPERTIES } from '../../../const';
+import { IMAGESTREAM_NAMESPACE, JAVA_IMAGESTREAM_NAME, QUERY_PROPERTIES } from '../../../const';
 import { normalizeBuilderImages, NormalizedBuilderImages } from '../../../utils/imagestream-utils';
 import NamespacedPage, { NamespacedPageVariants } from '../../NamespacedPage';
 import QueryFocusApplication from '../../QueryFocusApplication';
@@ -22,7 +22,6 @@ type WatchResource = {
 const UploadJarPage: React.FunctionComponent<UploadJarPageProps> = ({ match, location }) => {
   const { t } = useTranslation();
   const namespace = match.params.ns;
-  const imageStreamName = 'java';
   const params = new URLSearchParams(location.search);
 
   const resources: WatchK8sResults<WatchResource> = useK8sWatchResources<WatchResource>({
@@ -32,8 +31,8 @@ const UploadJarPage: React.FunctionComponent<UploadJarPageProps> = ({ match, loc
     },
     imagestream: {
       kind: ImageStreamModel.kind,
-      name: imageStreamName,
-      namespace: 'openshift',
+      name: JAVA_IMAGESTREAM_NAME,
+      namespace: IMAGESTREAM_NAMESPACE,
     },
   });
 
@@ -63,7 +62,7 @@ const UploadJarPage: React.FunctionComponent<UploadJarPageProps> = ({ match, loc
             forApplication={desiredApplication}
             namespace={namespace}
             projects={resources.projects as WatchK8sResultsObject<K8sResourceKind[]>}
-            builderImage={normalizedJavaImages?.[imageStreamName]}
+            builderImage={normalizedJavaImages?.[JAVA_IMAGESTREAM_NAME]}
             contextualSource={params.get(QUERY_PROPERTIES.CONTEXT_SOURCE)}
           />
         )}

--- a/frontend/packages/dev-console/src/components/import/jar/useJavaImageStreamEnabled.ts
+++ b/frontend/packages/dev-console/src/components/import/jar/useJavaImageStreamEnabled.ts
@@ -1,0 +1,12 @@
+import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
+import { ImageStreamModel } from '@console/internal/models';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
+export const useJavaImageStreamEnabled = (): boolean => {
+  const [resource, loaded] = useK8sGet<K8sResourceKind>(ImageStreamModel, 'java', 'openshift');
+
+  if (!loaded || !resource) {
+    return false;
+  }
+  return true;
+};

--- a/frontend/packages/dev-console/src/const.ts
+++ b/frontend/packages/dev-console/src/const.ts
@@ -33,3 +33,7 @@ export const FLAG_SAMPLE_CATALOG_TYPE = 'SAMPLE_CATALOG_TYPE';
 export const OPERATOR_BACKED_SERVICE_CATALOG_TYPE_ID = 'OperatorBackedService';
 export const SAMPLE_CATALOG_TYPE_ID = 'Sample';
 export const ADD_TO_PROJECT = 'add-to-project';
+
+export const FLAG_JAVA_IMAGE_STREAM_ENABLED = 'JAVA_IMAGE_STREAM_ENABLED';
+export const IMAGESTREAM_NAMESPACE = 'openshift';
+export const JAVA_IMAGESTREAM_NAME = 'java';


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-15011

**Analysis / Root cause**: 
Import JAR is not working when Java Builder Image is absent.

**Solution Description**: 
Hide the Import JAR option when Java Builder Image is absent.

**Screen shots / Gifs for design review**: 

https://github.com/openshift/console/assets/47265560/fd6bd359-e24e-4b8c-8e7b-111041c7c87e


**Unit test coverage report**: 
Not Changed.

**Test setup:**
1. Go to `/k8s/cluster/samples.operator.openshift.io~v1~Config/cluster/yaml` and change the `spec.managementState` to `Removed`.
2. Come to the Add Page and **Refresh**
3. You will see the Import JAR Option is not shown.
4. Also in the Topology Page, upon right-clicking to create resources, you will not find the Import JAR option.
5. Now, create a Java ImageStream with the following attached YAML.
6. Come to the Add Page and **Refresh**
7. You will see the Import JAR Option is back.

**Java IS Yaml:**
```yaml
﻿kind: ImageStream
apiVersion: image.openshift.io/v1
metadata:
  annotations:
    openshift.io/display-name: Red Hat OpenJDK
    openshift.io/provider-display-name: 'Red Hat, Inc.'
    samples.operator.openshift.io/version: 4.13.4
    version: 1.4.17
  name: java
  namespace: openshift
  labels:
    samples.operator.openshift.io/managed: 'true'
    xpaas: 1.4.17
spec:
  lookupPolicy:
    local: false
  tags:
    - name: '11'
      annotations:
        description: Build and run Java applications using Maven and OpenJDK 11.
        iconClass: icon-rh-openjdk
        openshift.io/display-name: Red Hat OpenJDK 11
        sampleContextDir: undertow-servlet
        sampleRepo: 'https://github.com/jboss-openshift/openshift-quickstarts'
        supports: 'java:11,java'
        tags: 'builder,java,openjdk,hidden'
        version: '11'
      from:
        kind: DockerImage
        name: 'registry.redhat.io/openjdk/openjdk-11-rhel7:latest'
      generation: 2
      importPolicy:
        importMode: Legacy
      referencePolicy:
        type: Local
    - name: '8'
      annotations:
        description: Build and run Java applications using Maven and OpenJDK 8.
        iconClass: icon-rh-openjdk
        openshift.io/display-name: Red Hat OpenJDK 8
        sampleContextDir: undertow-servlet
        sampleRepo: 'https://github.com/jboss-openshift/openshift-quickstarts'
        supports: 'java:8,java'
        tags: 'builder,java,openjdk,hidden'
        version: '8'
      from:
        kind: DockerImage
        name: 'registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest'
      generation: 2
      importPolicy:
        importMode: Legacy
      referencePolicy:
        type: Local
    - name: latest
      annotations:
        description: Build and run Java applications using Maven.
        iconClass: icon-rh-openjdk
        openshift.io/display-name: Java (Latest)
        sampleContextDir: undertow-servlet
        sampleRepo: 'https://github.com/jboss-openshift/openshift-quickstarts'
        supports: java
        tags: 'builder,java,openjdk'
        version: latest
      from:
        kind: ImageStreamTag
        name: openjdk-17-ubi8
      generation: 1
      importPolicy:
        importMode: Legacy
      referencePolicy:
        type: Local
    - name: openjdk-11-el7
      annotations:
        description: Build and run Java applications using Maven and OpenJDK 11.
        iconClass: icon-rh-openjdk
        openshift.io/display-name: Red Hat OpenJDK 11 (RHEL 7)
        sampleContextDir: undertow-servlet
        sampleRepo: 'https://github.com/jboss-openshift/openshift-quickstarts'
        supports: 'java:11,java'
        tags: 'builder,java,openjdk'
        version: '11'
      from:
        kind: DockerImage
        name: 'registry.redhat.io/openjdk/openjdk-11-rhel7:latest'
      generation: 2
      importPolicy:
        importMode: Legacy
      referencePolicy:
        type: Local
    - name: openjdk-11-ubi8
      annotations:
        description: Build and run Java applications using Maven and OpenJDK 11.
        iconClass: icon-rh-openjdk
        openshift.io/display-name: Red Hat OpenJDK 11 (UBI 8)
        sampleContextDir: undertow-servlet
        sampleRepo: 'https://github.com/jboss-openshift/openshift-quickstarts'
        supports: 'java:11,java'
        tags: 'builder,java,openjdk'
        version: '11'
      from:
        kind: DockerImage
        name: 'registry.redhat.io/ubi8/openjdk-11:latest'
      generation: 2
      importPolicy:
        importMode: Legacy
      referencePolicy:
        type: Local
    - name: openjdk-17-ubi8
      annotations:
        description: Build and run Java applications using Maven and OpenJDK 17.
        iconClass: icon-rh-openjdk
        openshift.io/display-name: Red Hat OpenJDK 17 (UBI 8)
        sampleContextDir: undertow-servlet
        sampleRepo: 'https://github.com/jboss-openshift/openshift-quickstarts'
        supports: 'java:17,java'
        tags: 'builder,java,openjdk'
        version: '17'
      from:
        kind: DockerImage
        name: 'registry.redhat.io/ubi8/openjdk-17:latest'
      generation: 2
      importPolicy:
        importMode: Legacy
      referencePolicy:
        type: Local
    - name: openjdk-8-el7
      annotations:
        description: Build and run Java applications using Maven and OpenJDK 8.
        iconClass: icon-rh-openjdk
        openshift.io/display-name: Red Hat OpenJDK 8 (RHEL 7)
        sampleContextDir: undertow-servlet
        sampleRepo: 'https://github.com/jboss-openshift/openshift-quickstarts'
        supports: 'java:8,java'
        tags: 'builder,java,openjdk'
        version: '8'
      from:
        kind: DockerImage
        name: 'registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest'
      generation: 2
      importPolicy:
        importMode: Legacy
      referencePolicy:
        type: Local
    - name: openjdk-8-ubi8
      annotations:
        description: Build and run Java applications using Maven and OpenJDK 8.
        iconClass: icon-rh-openjdk
        openshift.io/display-name: Red Hat OpenJDK 8 (UBI 8)
        sampleContextDir: undertow-servlet
        sampleRepo: 'https://github.com/jboss-openshift/openshift-quickstarts'
        supports: 'java:8,java'
        tags: 'builder,java,openjdk'
        version: '8'
      from:
        kind: DockerImage
        name: 'registry.redhat.io/ubi8/openjdk-8:latest'
      generation: 2
      importPolicy:
        importMode: Legacy
      referencePolicy:
        type: Local
```



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge