### PR TITLE
OCPBUGS-11464: Availability requirement update is initially disabled …

### DIFF
--- a/frontend/packages/console-app/src/components/pdb/PDBForm.tsx
+++ b/frontend/packages/console-app/src/components/pdb/PDBForm.tsx
@@ -79,6 +79,10 @@ const PDBForm: React.FC<PodDisruptionBudgetFormProps> = ({
   React.useEffect(() => {
     setRequirement(formValues.requirement);
 
+    if (formValues.requirement !== i18next.t('console-app~Requirement')) {
+      setDisabled(false);
+    }
+
     if (!_.isEmpty(existingResource) && _.isEmpty(formValues.name)) {
       onFormValuesChange(initialValuesFromK8sResource(existingResource));
     }


### PR DESCRIPTION
…on Edit PodDisruptionBudget page

Fixes: https://issues.redhat.com/browse/OCPBUGS-11464

When editing PDB, form loaded with current value and user can edit values by default