### PR TITLE
OCPBUGS-15060: "Duplicate RoleBinding" leads to "Unsupported value" error

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -455,9 +455,10 @@ class BaseEditRoleBindingWithTranslation extends React.Component {
       },
       subjects: [
         {
-          apiGroup: 'rbac.authorization.k8s.io',
           kind: subjectKind || 'User',
           name: subjectName || '',
+          apiGroup:
+            subjectKind === 'ServiceAccount' || !subjectKind ? '' : 'rbac.authorization.k8s.io',
         },
       ],
     });


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-15060

When specifying `ServiceAccount` subjects, there is no need to include the `apiGroup` field. Previously, the `apiGroup` attribute was being set to rbac.authorization.k8s.io for the `ServiceAccount` subject object due to it being passed through `defaultsDeep` along with other subject kinds. However, `ServiceAccount` subjects do not require this attribute.

To address this, a condition has been added to check if the `subjectKind` is equal to `ServiceAccount` or if it's null. If this condition is true, the `apiGroup` is set to an empty string, ensuring that the `apiGroup` for `ServiceAccount` or unspecified subject kinds is set to its values in `existingData`. This prevents any unwanted values from being assigned to the `apiGroup` attribute for `ServiceAccount` subjects.

Created `RoleBinding` with `ServiceAccount` kind
![image](https://github.com/openshift/console/assets/49416557/9f8a502f-fdcf-4479-82e5-9c0e70fa3352)

Duplicating the `RoleBinding` from above now causes a error for already existing name, which is correct. Previously there was an error as described in the issue.
![image](https://github.com/openshift/console/assets/49416557/13093662-f77b-46c3-9635-6b7aedbf6a84)

After renaming the `RoleBinding`, duplication is successful.
![image](https://github.com/openshift/console/assets/49416557/94491d39-be8c-45e3-bc03-0c3586268b49)
