### PR TITLE
CONSOLE-3687: Convert components in utils folder from class component…

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
@@ -643,7 +643,7 @@ export type UninstallOperatorModalProps = {
     resource: K8sResourceKind,
     data: { op: string; path: string; value: any }[],
   ) => Promise<any>;
-  subscription: SubscriptionKind;
+  subscription: SubscriptionKind | K8sResourceKind;
   csv?: ClusterServiceVersionKind;
   blocking?: boolean;
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -18,6 +18,7 @@ import {
   RowFunctionArgs,
 } from '@console/internal/components/factory';
 import {
+  KebabAction,
   FieldLevelHelp,
   Kebab,
   LoadingInline,
@@ -190,7 +191,7 @@ export const SubscriptionStatus: React.FC<{ subscription: SubscriptionKind }> = 
   }
 };
 
-const menuActions = [
+const menuActions: KebabAction[] = [
   Kebab.factory.Edit,
   (kind, obj) => ({
     // t('olm~Remove Subscription')

--- a/frontend/public/components/volumes-table.tsx
+++ b/frontend/public/components/volumes-table.tsx
@@ -250,7 +250,9 @@ const VolumeKebab = connectToModel((props: VolumeKebabProps) => {
   return (
     <Kebab
       options={options}
-      isDisabled={isDisabled !== undefined ? isDisabled : resource?.metadata?.deletionTimestamp}
+      isDisabled={
+        isDisabled !== undefined ? isDisabled : resource?.metadata?.deletionTimestamp?.length > 0
+      }
     />
   );
 });


### PR DESCRIPTION
… to functional component

The following files in frontend/public/components/utils have been converted from a class component to a functional component in order to use react-router v6 hooks:

* dropdown.jsx
* kebab.tsx
* tile-view-page.jsx