### PR TITLE
OCPBUGS-15299: Create Serverless Function Form is Broken

### DIFF
--- a/frontend/packages/dev-console/src/components/import/serverless-function/AddServerlessFunction.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless-function/AddServerlessFunction.tsx
@@ -13,6 +13,7 @@ import { LoadingBox, history } from '@console/internal/components/utils';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { ImageStreamModel, ProjectModel } from '@console/internal/models';
 import { K8sResourceKind } from '@console/internal/module/k8s';
+import { defaultRepositoryFormValues } from '@console/pipelines-plugin/src/components/repository/consts';
 import {
   ALL_APPLICATIONS_KEY,
   usePerspectives,
@@ -91,6 +92,12 @@ const AddServerlessFunction: React.FC<AddServerlessFunctionProps> = ({
     },
     pipeline: {
       enabled: false,
+    },
+    pac: {
+      pacHasError: false,
+      repository: {
+        ...defaultRepositoryFormValues,
+      },
     },
   };
 

--- a/frontend/packages/knative-plugin/integration-tests/features/e2e/knative-ci.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/e2e/knative-ci.feature
@@ -130,3 +130,20 @@ Feature: Perform actions on knative service and revision
              When user selects "Delete Service" context menu option of knative service "kn-service"
               And user clicks Delete button on Delete Service modal
              Then "kn-service" service should not be displayed in project
+
+        Scenario Outline: Create serverless function using Create Serverless function form with Builder Images: SF-01-TC06
+            Given user is at Add page
+             When user clicks on Create Serverless function card
+              And user enters git url "<git_url>"
+              And user is able to see builder image version dropdown
+              And user is able to see the runtime details
+              And user clicks on Create button on Create Serverless function
+             Then user will be redirected to Topology page
+              And user is able to see workload "<workload_name>" in topology page
+              And user clicks on the Knative Service workload "<workload_name>"
+              And user switches to the "Details" tab
+              And user is able to see Type as Function
+
+        Examples:
+                  | git_url                                           | workload_name       |
+                  | https://github.com/vikram-raj/hello-func-node-env | hello-func-node-env |


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-15299

**Analysis / Root cause**: 
Default values for PAC was not added

**Solution Description**: 
Added default values for PAC in Add serverless function page

**Screen shots / Gifs for design review**: 

-------BEFORE---

https://drive.google.com/file/d/1uyzGHktfr8tEGWPyYkv9ISYI6BhdnK6f/view?usp=sharing

-------AFTER-----

https://github.com/openshift/console/assets/102503482/7faa40c2-74cb-4e06-8e27-c99503db8f8e




**Unit test coverage report**: 
NA

**Test setup:**

1. Go to Add Page
2. Click Create Serverless Function form

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge