### PR TITLE
[release-4.13] OCPBUGS-15335: Delete annotation 'tekton.dev/v1beta1TaskRuns' when rerun the PLR

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/utils.ts
@@ -102,6 +102,7 @@ export const getPipelineRunData = (
       },
   );
   delete annotations['kubectl.kubernetes.io/last-applied-configuration'];
+  delete annotations['tekton.dev/v1beta1TaskRuns'];
 
   const newPipelineRun = {
     apiVersion: pipeline ? pipeline.apiVersion : latestRun.apiVersion,


### PR DESCRIPTION
**Descriptions:** When we import an app via "Import from Git", select "Add Pipeline" and then Rerun the automatically started PipelineRun, the new PipelineRun doesn't run successfully while the first one was fine. It looks like the annotation `tekton.dev/v1beta1TaskRuns` is copied and includes an old status. So we need to remove it when rerunning a PLR. 

We already resolved this issue as part of the PR https://github.com/openshift/console/pull/12729, So backporting only that part of the code to 4.13.z.