### PR TITLE
OCPBUGS-497: frontend: fix kube-apiserver availability query

### DIFF
--- a/frontend/packages/console-app/src/queries.ts
+++ b/frontend/packages/console-app/src/queries.ts
@@ -1,6 +1,18 @@
 import { PodModel } from '@console/internal/models';
 
-export const API_SERVERS_UP = '(sum(up{job="apiserver"} == 1) / count(up{job="apiserver"})) * 100';
+// The query used to compute the number of kube-apiserver instances that are up
+// is a bit different than the ones used for the other control plane components
+// because of how Kubernetes deal with the kube-apiserver Service endpoints.
+// When a node is down, the kube-apiserver address on that node is removed from
+// its Endpoint object which results in metrics for that kube-apiserver
+// instance to not be scraped anymore. Meaning that the `up` timeserie for that
+// kube-apiserver instance will not exist anymore and if we were to use the
+// same query as the other components we will always see the kube-apiserver
+// being 100% available when a node is down.  The solution to that problem is
+// to rely on the number of kube-apiserver pods instead of the number of
+// Prometheus targets it has.
+export const API_SERVERS_UP =
+  '(sum(up{job="apiserver"} == 1) / count(kube_pod_labels{label_app="openshift-kube-apiserver",label_apiserver="true",namespace="openshift-kube-apiserver"})) * 100';
 export const CONTROLLER_MANAGERS_UP =
   '(sum(up{job="kube-controller-manager"} == 1) / count(up{job="kube-controller-manager"})) * 100';
 export const SCHEDULERS_UP = '(sum(up{job="scheduler"} == 1) / count(up{job="scheduler"})) * 100';


### PR DESCRIPTION
The original kube-apiserver query used to report 100% availability even when a node was down whilst other control-plane components reported 66%. This is caused by the fact that the query relied on the number of Prometheus targets of the kube-apiserver. However, when a node is down, there is a controller in Kubernetes that removes the kube-apiserver address on that node from the Endpoint that Prometheus scrapes. So Prometheus is never able to detect scrape failures on that target since it disappeared before becoming unavailable.

We found 3 different ways to resolve this issue:
1. Fix the upstream controller to keep the address around as a not ready address like it is done for the other components. This is by far the best solution, but this is a very fragile part of the Kubernetes codebase and the cost of such a change is enormous.
2. Change the Prometheus target for the kube-apiserver from the default Kubernetes Service to the kube-apiserver Service. This is a very nice and easy solution but it comes with one drawback which is that we won't monitor the endpoint that users are sending requests to.
3. Update the query to rely on the number of kube-apiserver pods instead of the Prometheus targets. This is also a nice and easy solution but this one doesn't seems to have any drawbacks, so that's the one we chose to go with after weighting cost vs value. (kudos to @s-urbaniak for suggesting this path :100:)

/cc @s-urbaniak @p0lyn0mial 