### PR TITLE
OCPBUGS-14874,OCPBUGS-14875,OCPBUGS-14665: Helm Chart installation form hangs on create if JSON-schema is using 2019-09 or 2020-20 standard revisions

### DIFF
--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -97,6 +97,7 @@
   "Expressions": "Expressions",
   "Select {{title}}": "Select {{title}}",
   "A form is not available for this resource. Please use the YAML view.": "A form is not available for this resource. Please use the YAML view.",
+  "There is some issue in this form view. Please select \"YAML view\" for full control.": "There is some issue in this form view. Please select \"YAML view\" for full control.",
   "Create": "Create",
   "Cancel": "Cancel",
   "Advanced configuration": "Advanced configuration",

--- a/frontend/packages/console-shared/src/components/dynamic-form/index.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/index.tsx
@@ -3,7 +3,9 @@ import { Accordion, ActionGroup, Button, Alert } from '@patternfly/react-core';
 import Form, { FormProps } from '@rjsf/core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { ErrorBoundaryFallbackProps } from '@console/dynamic-plugin-sdk';
 import { history } from '@console/internal/components/utils';
+import { ErrorBoundary } from '@console/shared/src/components/error';
 import { K8S_UI_SCHEMA } from './const';
 import defaultFields from './fields';
 import {
@@ -55,6 +57,19 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
       />
     );
   }
+  const FormErrorFallbackComponent: React.FC<ErrorBoundaryFallbackProps> = () => {
+    return (
+      <Alert
+        isInline
+        className="co-alert co-break-word"
+        variant="danger"
+        title={t(
+          'console-shared~There is some issue in this form view. Please select "YAML view" for full control.',
+        )}
+      />
+    );
+  };
+
   return (
     <>
       {showAlert && (
@@ -68,40 +83,42 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
         />
       )}
       <Accordion asDefinitionList={false} className="co-dynamic-form__accordion">
-        <Form
-          {...restProps}
-          className="co-dynamic-form"
-          noValidate={noValidate}
-          ArrayFieldTemplate={ArrayFieldTemplate}
-          fields={{ ...defaultFields, ...fields }}
-          FieldTemplate={FieldTemplate}
-          formContext={{ ...formContext, formData }}
-          formData={formData}
-          noHtml5Validate
-          ObjectFieldTemplate={ObjectFieldTemplate}
-          onChange={(next) => onChange(next.formData)}
-          onError={(newErrors) => onError(_.map(newErrors, (error) => error.stack))}
-          onSubmit={onSubmit}
-          schema={schema}
-          // Don't show the react-jsonschema-form error list at top
-          showErrorList={false}
-          uiSchema={customUISchema ? uiSchema : _.defaultsDeep({}, K8S_UI_SCHEMA, uiSchema)}
-          widgets={{ ...defaultWidgets, ...widgets }}
-        >
-          {errors.length > 0 && <ErrorTemplate errors={errors} />}
-          {!noActions && (
-            <div style={{ paddingBottom: '30px' }}>
-              <ActionGroup className="pf-c-form">
-                <Button type="submit" variant="primary" data-test="create-dynamic-form">
-                  {t('console-shared~Create')}
-                </Button>
-                <Button onClick={onCancel || history.goBack} variant="secondary">
-                  {t('console-shared~Cancel')}
-                </Button>
-              </ActionGroup>
-            </div>
-          )}
-        </Form>
+        <ErrorBoundary FallbackComponent={FormErrorFallbackComponent}>
+          <Form
+            {...restProps}
+            className="co-dynamic-form"
+            noValidate={noValidate}
+            ArrayFieldTemplate={ArrayFieldTemplate}
+            fields={{ ...defaultFields, ...fields }}
+            FieldTemplate={FieldTemplate}
+            formContext={{ ...formContext, formData }}
+            formData={formData}
+            noHtml5Validate
+            ObjectFieldTemplate={ObjectFieldTemplate}
+            onChange={(next) => onChange(next.formData)}
+            onError={(newErrors) => onError(_.map(newErrors, (error) => error.stack))}
+            onSubmit={onSubmit}
+            schema={schema}
+            // Don't show the react-jsonschema-form error list at top
+            showErrorList={false}
+            uiSchema={customUISchema ? uiSchema : _.defaultsDeep({}, K8S_UI_SCHEMA, uiSchema)}
+            widgets={{ ...defaultWidgets, ...widgets }}
+          >
+            {errors.length > 0 && <ErrorTemplate errors={errors} />}
+            {!noActions && (
+              <div style={{ paddingBottom: '30px' }}>
+                <ActionGroup className="pf-c-form">
+                  <Button type="submit" variant="primary" data-test="create-dynamic-form">
+                    {t('console-shared~Create')}
+                  </Button>
+                  <Button onClick={onCancel || history.goBack} variant="secondary">
+                    {t('console-shared~Cancel')}
+                  </Button>
+                </ActionGroup>
+              </div>
+            )}
+          </Form>
+        </ErrorBoundary>
       </Accordion>
     </>
   );

--- a/frontend/packages/helm-plugin/locales/en/helm-plugin.json
+++ b/frontend/packages/helm-plugin/locales/en/helm-plugin.json
@@ -109,7 +109,7 @@
   "Release name": "Release name",
   "A unique name for the Helm Release.": "A unique name for the Helm Release.",
   "Helm release is not configurable since the Helm Chart doesn't define any values.": "Helm release is not configurable since the Helm Chart doesn't define any values.",
-  "Errors in the form - {{errorsText}}": "Errors in the form - {{errorsText}}",
+  "Errors in the form data.": "Errors in the form data.",
   "Invalid Form Schema - {{errorText}}": "Invalid Form Schema - {{errorText}}",
   "Invalid YAML - {{errorText}}": "Invalid YAML - {{errorText}}",
   "Select the version to rollback <1>{{releaseName}}</1> to, from the table below:": "Select the version to rollback <1>{{releaseName}}</1> to, from the table below:",

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as Ajv from 'ajv';
 import { Formik } from 'formik';
 import { safeDump, safeLoad } from 'js-yaml';
 import { JSONSchema7 } from 'json-schema';
@@ -141,26 +140,18 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
       chartIndexEntry,
       yamlData,
       formData,
-      formSchema,
       editorType,
     }: HelmInstallUpgradeFormData = values;
     let valuesObj;
 
     if (editorType === EditorType.Form) {
-      const ajv = new Ajv({ schemaId: 'auto' });
-      // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-      ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
       try {
-        const validSchema = ajv.validateSchema(formSchema);
         const prunedFormData = prune(formData);
-        const validFormData = validSchema && ajv.validate(formSchema, prunedFormData);
-        if (validFormData) {
+        if (prunedFormData) {
           valuesObj = prunedFormData;
         } else {
           actions.setStatus({
-            submitError: t('helm-plugin~Errors in the form - {{errorsText}}', {
-              errorsText: ajv.errorsText(),
-            }),
+            submitError: t('helm-plugin~Errors in the form data.'),
           });
           return Promise.resolve();
         }
@@ -170,7 +161,7 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
             errorText: err.toString(),
           }),
         });
-        return Promise.reject(err);
+        return Promise.resolve();
       }
     } else if (yamlData) {
       try {
@@ -179,7 +170,7 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
         actions.setStatus({
           submitError: t('helm-plugin~Invalid YAML - {{errorText}}', { errorText: err.toString() }),
         });
-        return Promise.reject(err);
+        return Promise.resolve();
       }
     }
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-14874
https://issues.redhat.com/browse/OCPBUGS-14875
https://issues.redhat.com/browse/OCPBUGS-14665

**Solution Description**:
OCPBUGS-14874 - Validation of schema is removed from frontend since the validation is already happening in backend
OCPBUGS-14875 - Validation of schema is removed from frontend since the validation is already happening in backend
OCPBUGS-14665 - Added error boundary around Form component and error is shown in UI.

**Screen shots / Gifs for design review**: 

-------BEFORE---

https://github.com/openshift/console/assets/102503482/abab5378-c059-40ee-ad4c-798ccbeaa5f3


https://github.com/openshift/console/assets/102503482/29edd5bc-9376-4b2a-83f0-1cf29f8922c8


https://github.com/openshift/console/assets/102503482/39e9831c-9978-4542-89b1-29bdfd895a6d




-------AFTER-----


https://github.com/openshift/console/assets/102503482/fc4649d2-4d30-4997-a5e2-2a7e265efe9c


https://github.com/openshift/console/assets/102503482/948fbfca-9a10-43ae-88d4-0e8d2267fa48

https://github.com/openshift/console/assets/102503482/b58bba9b-a8b2-481e-a3d4-d4b984030209







**Unit test coverage report**: 
NA

**Test setup:**

Follow the steps to reproduce mentioned in 
https://issues.redhat.com/browse/OCPBUGS-14874
https://issues.redhat.com/browse/OCPBUGS-14875
https://issues.redhat.com/browse/OCPBUGS-14665

**Additional Information:**
Test charts are added in https://github.com/openshift-dev-console/helm-charts repo and the package files are available in gh-pages branch. To test with these charts add https://openshift-dev-console.github.io/helm-charts as helm chart repository. 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge