### PR TITLE
OCPBUGS-3239: Update spacing between elements on the add flows

### DIFF
--- a/frontend/packages/dev-console/src/components/import/GitImportForm.scss
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.scss
@@ -1,0 +1,3 @@
+.odc-git-import-form__section-heading {
+  margin-top: var(--pf-global--spacer--lg);
+}

--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -14,6 +14,8 @@ import { GitImportFormProps, ImportTypes } from './import-types';
 import ImportStrategySection from './ImportStrategySection';
 import ResourceSection from './section/ResourceSection';
 
+import './GitImportForm.scss';
+
 const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = ({
   values,
   errors,
@@ -57,16 +59,22 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
             ) : (
               <ImportStrategySection builderImages={builderImages} />
             )}
-            <AppSection
-              project={values.project}
-              noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
-            />
+            <div className="odc-git-import-form__section-heading">
+              <AppSection
+                project={values.project}
+                noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
+              />
+            </div>
             {importType !== ImportTypes.devfile &&
               values.import.selectedStrategy.type !== ImportStrategy.DEVFILE && (
                 <>
                   <ResourceSection />
-                  <PipelineSection builderImages={builderImages} />
-                  <AdvancedSection values={values} />
+                  <div className="odc-git-import-form__section-heading">
+                    <PipelineSection builderImages={builderImages} />
+                  </div>
+                  <div className="odc-git-import-form__section-heading">
+                    <AdvancedSection values={values} />
+                  </div>
                 </>
               )}
           </>

--- a/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
@@ -46,35 +46,83 @@ const List: React.FC<AdvancedSectionProps> = ({ appResources, values }) => {
       Footer={Footer}
     >
       <ProgressiveListItem name={t('devconsole~Health checks')}>
-        <HealthChecks title={t('devconsole~Health checks')} resourceType={values.resources} />
+        <div
+          style={
+            visibleItems[0] === 'Health checks'
+              ? { marginTop: 'var(--pf-global--spacer--lg)' }
+              : { marginTop: 'var(--pf-global--spacer--2xl)' }
+          }
+        >
+          <HealthChecks title={t('devconsole~Health checks')} resourceType={values.resources} />
+        </div>
       </ProgressiveListItem>
       {/* Hide Build for Deploy Image or when a Pipeline is added */}
       {values.isi || values.pipeline?.enabled ? null : (
         <ProgressiveListItem name={t('devconsole~Build configuration')}>
-          <BuildConfigSection
-            namespace={values.project.name}
-            resource={appResources?.buildConfig?.data}
-          />
+          <div
+            style={
+              visibleItems[0] === 'Build configuration'
+                ? { marginTop: 'var(--pf-global--spacer--lg)' }
+                : { marginTop: 'var(--pf-global--spacer--2xl)' }
+            }
+          >
+            <BuildConfigSection
+              namespace={values.project.name}
+              resource={appResources?.buildConfig?.data}
+            />
+          </div>
         </ProgressiveListItem>
       )}
       <ProgressiveListItem name={t('devconsole~Deployment')}>
-        <DeploymentConfigSection
-          namespace={values.project.name}
-          resource={appResources?.editAppResource?.data}
-        />
+        <div
+          style={
+            visibleItems[0] === 'Deployment'
+              ? { marginTop: 'var(--pf-global--spacer--lg)' }
+              : { marginTop: 'var(--pf-global--spacer--2xl)' }
+          }
+        >
+          <DeploymentConfigSection
+            namespace={values.project.name}
+            resource={appResources?.editAppResource?.data}
+          />
+        </div>
       </ProgressiveListItem>
       <ProgressiveListItem name={t('devconsole~Scaling')}>
-        {values.resources === Resources.KnativeService ? (
-          <ServerlessScalingSection />
-        ) : (
-          <ScalingSection name="deployment.replicas" />
-        )}
+        <div
+          style={
+            visibleItems[0] === 'Scaling'
+              ? { marginTop: 'var(--pf-global--spacer--lg)' }
+              : { marginTop: 'var(--pf-global--spacer--2xl)' }
+          }
+        >
+          {values.resources === Resources.KnativeService ? (
+            <ServerlessScalingSection />
+          ) : (
+            <ScalingSection name="deployment.replicas" />
+          )}
+        </div>
       </ProgressiveListItem>
       <ProgressiveListItem name={t('devconsole~Resource limits')}>
-        <ResourceLimitSection />
+        <div
+          style={
+            visibleItems[0] === 'Resource limits'
+              ? { marginTop: 'var(--pf-global--spacer--lg)' }
+              : { marginTop: 'var(--pf-global--spacer--2xl)' }
+          }
+        >
+          <ResourceLimitSection />
+        </div>
       </ProgressiveListItem>
       <ProgressiveListItem name={t('devconsole~Labels')}>
-        <LabelSection />
+        <div
+          style={
+            visibleItems[0] === 'Labels'
+              ? { marginTop: 'var(--pf-global--spacer--lg)' }
+              : { marginTop: 'var(--pf-global--spacer--2xl)' }
+          }
+        >
+          <LabelSection />
+        </div>
       </ProgressiveListItem>
     </ProgressiveList>
   );

--- a/frontend/packages/dev-console/src/components/import/builder/BuilderSection.scss
+++ b/frontend/packages/dev-console/src/components/import/builder/BuilderSection.scss
@@ -1,0 +1,6 @@
+.odc-import-strategy-section {
+  &__builder-tag-section {
+    margin-top: var(--pf-global--spacer--lg);
+    margin-bottom: var(--pf-global--spacer--sm);
+  }
+}

--- a/frontend/packages/dev-console/src/components/import/builder/BuilderSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/builder/BuilderSection.tsx
@@ -7,6 +7,8 @@ import FormSection from '../section/FormSection';
 import BuilderImageSelector from './BuilderImageSelector';
 import BuilderImageTagSelector from './BuilderImageTagSelector';
 
+import './BuilderSection.scss';
+
 export interface ImageSectionProps {
   builderImages: NormalizedBuilderImages;
   existingPipeline?: PipelineKind;
@@ -75,12 +77,14 @@ const BuilderSection: React.FC<ImageSectionProps> = ({ builderImages, existingPi
         />
       </FormSection>
       {builderImages[image.selected] && image.tag && (
-        <FormSection>
-          <BuilderImageTagSelector
-            selectedBuilderImage={builderImages[image.selected]}
-            selectedImageTag={image.tag}
-          />
-        </FormSection>
+        <div className="odc-import-strategy-section__builder-tag-section">
+          <FormSection>
+            <BuilderImageTagSelector
+              selectedBuilderImage={builderImages[image.selected]}
+              selectedImageTag={image.tag}
+            />
+          </FormSection>
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-3239

**Solution Description**: 
As per the recommendation from @jerolimov on the ticket comments, have worked on the following:

- added spacing above and below "Builder Image version"
- the padding above a section title should be bigger than below
- checked for other bad spacings

**Screen shots / Gifs for design review**: 

**Before:**
![screencapture-console-openshift-console-apps-rhoms-4-14-062304-dev-openshiftappsvc-org-import-ns-avik-2023-06-23-19_35_18 (1)](https://github.com/openshift/console/assets/47265560/2f6f6297-e39f-4851-8216-13a62840e2f3)

**After:**
![screencapture-localhost-9000-import-ns-avik-2023-06-23-19_33_50](https://github.com/openshift/console/assets/47265560/745b9549-fe57-4a54-b48d-d02e839b7c8c)


**Unit test coverage report**: 
Not changed

**Test setup:**
1. Add -> Import From Git



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge