### PR TITLE
ODC-7336: automation for customization-of-catalog-add-page-form feature file

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/customization/customization-of-catalog-addPage-form-view.feature
+++ b/frontend/packages/dev-console/integration-tests/features/customization/customization-of-catalog-addPage-form-view.feature
@@ -7,7 +7,7 @@ Feature: Customization of catalogs and Add page through form view
               And user has created or selected namespace "aut-developer-catalog"
 
 
-        @regression @to-do
+        @regression
         Scenario: When all the sub-catalogs are disabled: DC-01-TC01
             Given user is at console tab
              When user clicks on cluster
@@ -19,25 +19,25 @@ Feature: Customization of catalogs and Add page through form view
               And user will not get any entry point to catalog page in add page, topology actions, empty states, quick search, and the catalog itself
 
 
-        @regression @to-do
+        @regression
         Scenario: When specific sub-catalog is disabled: DC-01-TC02
             Given user is at customization
               And user clicks on Developer tab
-              And user disables "HelmChart" the items in Developer Catalog
+              And user disables "Helm Charts" the item in Developer Catalog
              Then user will see Save message
               And user will see "Developer Catalog" and all the sub-catalogs in Add page and Topology page except "HelmChart"
 
 
-        @regression @to-do
+        @regression
         Scenario: When specific sub-catalog is enabled: DC-01-TC03
             Given user is at customization
               And user clicks on Developer tab
-              And user "HelmChart" in enabled and disables everything
+              And user enabled "Helm Charts" and disables everything
              Then user will see Save message
               And user will only see "Developer Catalog" and "HelmChart" type in Add page and Topology page
 
 
-        @regression @to-do
+        @regression
         Scenario: When all the Add page items are disabled: DC-01-TC04
             Given user is at customization
               And user clicks on Developer tab
@@ -46,10 +46,10 @@ Feature: Customization of catalogs and Add page through form view
               And user will not see any cards in Add page except Getting Started
 
 
-        @regression @to-do
-        Scenario: When all the Add page items are disabled: DC-01-TC05
+        @regression
+        Scenario: When specific Add page item is disabled: DC-01-TC05
             Given user is at customization
               And user clicks on Developer tab
-              And user disables "Import from Git" the items in Developer Catalog
+              And user disables "Import from Git" the item in Add page
              Then user will see Save message
               And user will not see any "Import from Git" card in Add page

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/customization.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/customization.ts
@@ -1,0 +1,28 @@
+export const customizationPO = {
+  developerCatalog: {
+    formSection: 'catalog-types form-section',
+    availableSearchInput: '[aria-label="Available search input"]',
+    choosenSearchInput: '[aria-label="Chosen search input"]',
+    addAllAction: '[aria-label="Add all"]',
+    addSelectedAction: '[aria-label="Add selected"]',
+    removeAllAction: '[aria-label="Remove all"]',
+    removeSelectedAction: '[aria-label="Remove selected"]',
+  },
+  addPage: {
+    formSection: 'add-page form-section',
+    availableSearchInput: '[aria-label="Available search input"]',
+    choosenSearchInput: '[aria-label="Chosen search input"]',
+    addAllAction: '[aria-label="Add all"]',
+    addSelectedAction: '[aria-label="Add selected"]',
+    removeAllAction: '[aria-label="Remove all"]',
+    removeSelectedAction: '[aria-label="Remove selected"]',
+  },
+  role: {
+    presentation: '[role="presentation"]',
+    option: '[role="option"]',
+  },
+  successAlert: '[aria-label="Success Alert"]',
+  resourceSearch: '[placeholder="Select Resource"]',
+  filter: '[aria-label="Options menu"]',
+  consoleItems: '[data-filter-text="CConsole"]',
+};

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -215,7 +215,7 @@ export const navigateTo = (opt: devNavigationMenu) => {
     case devNavigationMenu.Consoles: {
       cy.get('body').then(($body) => {
         if ($body.text().includes('Consoles')) {
-          cy.byTestID('nav').contains('Consoles').click();
+          cy.byLegacyTestID('dev-perspective-nav').contains('Consoles').click();
           cy.byTestID('cluster').should('be.visible').click();
         } else {
           cy.get(devNavigationMenuPO.search).click();

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/customization/customization-of-catalog-addPage-form-view.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/customization/customization-of-catalog-addPage-form-view.ts
@@ -1,0 +1,229 @@
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { devNavigationMenu, switchPerspective } from '../../constants';
+import { devNavigationMenuPO } from '../../pageObjects';
+import { customizationPO } from '../../pageObjects/customization';
+import { app, navigateTo, perspective } from '../../pages';
+
+Given('user is at console tab', () => {
+  cy.get('body').then(($body) => {
+    if ($body.text().includes('Consoles')) {
+      cy.byLegacyTestID('dev-perspective-nav').contains('Consoles').click();
+    } else {
+      cy.get(devNavigationMenuPO.search).click();
+      cy.get(customizationPO.filter).click();
+      cy.get(customizationPO.resourceSearch).should('be.visible').type('console');
+      cy.get(customizationPO.consoleItems).then(($el) => {
+        if ($el.text().includes('operator.openshift.io')) {
+          cy.wrap($el).contains('operator.openshift.io').click();
+        } else {
+          cy.wrap($el).click();
+        }
+      });
+      cy.get('.co-search-group__pin-toggle').should('be.visible').click();
+    }
+  });
+});
+
+When('user clicks on cluster', () => {
+  cy.byTestID('cluster').should('be.visible').click();
+});
+
+When('user opens customization', () => {
+  cy.byLegacyTestID('actions-menu-button').should('be.visible').click();
+  cy.byTestActionID('Customize').should('be.visible').click();
+});
+
+Given('user is at customization', () => {
+  navigateTo(devNavigationMenu.Consoles);
+  cy.byLegacyTestID('actions-menu-button').should('be.visible').click();
+  cy.byTestActionID('Customize').should('be.visible').click();
+});
+
+When('user clicks on Developer tab', () => {
+  cy.get(customizationPO.role.presentation).contains('Developer').should('be.visible').click();
+});
+
+When('user disables all the items in Developer Catalog', () => {
+  cy.byTestID(customizationPO.developerCatalog.formSection)
+    .find(customizationPO.developerCatalog.removeAllAction)
+    .scrollIntoView()
+    .then(($el) => {
+      if ($el.is(':enabled')) {
+        cy.wrap($el).click();
+      }
+    });
+
+  cy.byTestID(customizationPO.developerCatalog.formSection)
+    .find(customizationPO.developerCatalog.addAllAction)
+    .scrollIntoView()
+    .click();
+});
+
+When('user disables {string} the item in Developer Catalog', (actionName: string) => {
+  cy.byTestID(customizationPO.developerCatalog.formSection)
+    .find(customizationPO.developerCatalog.removeAllAction)
+    .click();
+
+  cy.byTestID(customizationPO.developerCatalog.formSection)
+    .find(customizationPO.developerCatalog.availableSearchInput)
+    .type(actionName);
+
+  cy.byTestID(customizationPO.developerCatalog.formSection)
+    .find(customizationPO.role.option)
+    .contains(actionName)
+    .scrollIntoView()
+    .click();
+
+  cy.byTestID(customizationPO.developerCatalog.formSection)
+    .find(customizationPO.developerCatalog.addSelectedAction)
+    .scrollIntoView()
+    .click();
+});
+
+Given('user enabled {string} and disables everything', (actionName: string) => {
+  cy.byTestID(customizationPO.developerCatalog.formSection)
+    .find(customizationPO.developerCatalog.addAllAction)
+    .click();
+
+  cy.byTestID(customizationPO.developerCatalog.formSection)
+    .find(customizationPO.developerCatalog.choosenSearchInput)
+    .type(actionName);
+
+  cy.byTestID(customizationPO.developerCatalog.formSection)
+    .find(customizationPO.role.option)
+    .contains(actionName)
+    .click();
+
+  cy.byTestID(customizationPO.developerCatalog.formSection)
+    .find(customizationPO.developerCatalog.removeSelectedAction)
+    .click();
+});
+
+Given('user disables all the items in Add page', () => {
+  cy.byTestID(customizationPO.addPage.formSection)
+    .find(customizationPO.addPage.addAllAction)
+    .scrollIntoView()
+    .click();
+});
+
+Given('user disables {string} the item in Add page', (actionName: string) => {
+  cy.byTestID(customizationPO.addPage.formSection)
+    .find(customizationPO.addPage.removeAllAction)
+    .click();
+
+  cy.byTestID(customizationPO.addPage.formSection)
+    .find(customizationPO.addPage.availableSearchInput)
+    .type(actionName);
+
+  cy.byTestID(customizationPO.addPage.formSection)
+    .find(customizationPO.role.option)
+    .contains(actionName)
+    .scrollIntoView()
+    .click();
+
+  cy.byTestID(customizationPO.addPage.formSection)
+    .find(customizationPO.addPage.addSelectedAction)
+    .scrollIntoView()
+    .click();
+});
+
+Then('user will see Save message', () => {
+  cy.get(customizationPO.successAlert).scrollIntoView().should('be.visible').click();
+});
+
+Then(
+  'user will not see "Developer Catalog" and all the sub-catalogs in Add page and Topology page',
+  () => {
+    perspective.switchTo(switchPerspective.Administrator);
+    perspective.switchTo(switchPerspective.Developer);
+    navigateTo(devNavigationMenu.Add);
+    cy.exec('oc -n openshift-console rollout status deployment/console --timeout=1m').then(() => {
+      cy.reload();
+      app.waitForDocumentLoad();
+      cy.byTestID('card developer-catalog').should('not.exist');
+    });
+  },
+);
+
+Then(
+  'user will not get any entry point to catalog page in add page, topology actions, empty states, quick search, and the catalog itself',
+  () => {
+    navigateTo(devNavigationMenu.Add);
+    cy.reload();
+    app.waitForDocumentLoad();
+    cy.byTestID('card developer-catalog').should('not.exist');
+
+    navigateTo(devNavigationMenu.Topology);
+    cy.byTestID('quick-search').click();
+    cy.byTestID('quick-search-bar').find('input').type('node');
+    cy.get('#devCatalog').should('not.exist');
+  },
+);
+
+Then(
+  'user will see "Developer Catalog" and all the sub-catalogs in Add page and Topology page except "HelmChart"',
+  () => {
+    perspective.switchTo(switchPerspective.Administrator);
+    perspective.switchTo(switchPerspective.Developer);
+    navigateTo(devNavigationMenu.Add);
+    cy.exec('oc -n openshift-console rollout status deployment/console --timeout=2m').then(() => {
+      cy.get('body')
+        .then(($body) => {
+          if (!$body.find('card developer-catalog').length) {
+            cy.wait(30000);
+            cy.reload();
+            app.waitForDocumentLoad();
+          }
+        })
+        .then(() => {
+          cy.byTestID('card developer-catalog').should('be.visible');
+          cy.byTestID('item operator-backed').should('be.visible');
+          cy.byTestID('item dev-catalog').should('be.visible');
+          cy.byTestID('item helm').should('not.exist');
+        });
+    });
+  },
+);
+
+Then(
+  'user will only see "Developer Catalog" and "HelmChart" type in Add page and Topology page',
+  () => {
+    perspective.switchTo(switchPerspective.Administrator);
+    perspective.switchTo(switchPerspective.Developer);
+    navigateTo(devNavigationMenu.Add);
+    cy.exec('oc -n openshift-console rollout status deployment/console --timeout=2m').then(() => {
+      cy.get('body')
+        .then(($body) => {
+          if (!$body.find('item helm').length) {
+            cy.wait(30000);
+            cy.reload();
+            app.waitForDocumentLoad();
+          }
+        })
+        .then(() => {
+          cy.byTestID('card developer-catalog').should('be.visible');
+          cy.byTestID('item helm').should('be.visible');
+          cy.byTestID('item operator-backed').should('not.exist');
+        });
+    });
+  },
+);
+
+Then('user will not see any cards in Add page except Getting Started', () => {
+  navigateTo(devNavigationMenu.Add);
+  cy.exec('oc -n openshift-console rollout status deployment/console --timeout=1m').then(() => {
+    cy.reload();
+    app.waitForDocumentLoad();
+    cy.byTestID('getting-started').should('be.visible');
+    cy.byTestID('add-page').find('[data-test^=card]').should('have.length', 2);
+  });
+});
+
+Then('user will not see any "Import from Git" card in Add page', () => {
+  navigateTo(devNavigationMenu.Add);
+  cy.exec('oc -n openshift-console rollout status deployment/console --timeout=1m').then(() => {
+    cy.reload();
+    app.waitForDocumentLoad();
+    cy.byTestID('card git-repository').should('not.exist');
+  });
+});


### PR DESCRIPTION
**Description:**

- Automation of customization-of-catalog-addPage-form-view feature file

**Jira Id:**
- Story: 
      -  [[ODC-7336](https://issues.redhat.com/browse/ODC-7336))

**Checks for approving Epic scenarios Automation PR:**
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
BRIDGE_KUBEADMIN_PASSWORD=BrCQB-qAJti-7GkZg-GA2bd
export BRIDGE_KUBEADMIN_PASSWORD
BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.ci-ln-c41px9b-72292.origin-ci-int-gce.dev.rhcloud.com/
export BRIDGE_BASE_ADDRESS
oc login https://api.ci-ln-c41px9b-72292.origin-ci-int-gce.dev.rhcloud.com:6443 -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
./test-cypress.sh -p dev-console
```

**Screen shots**:

<img width="1792" alt="Screenshot 2023-07-20 at 3 31 27 PM" src="https://github.com/openshift/console/assets/51144829/9eafcd28-223c-4126-a4fc-7832a2276a56">



**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge