### PR TITLE
[release-4.13] OCPBUGS-15228: Create helm release page doesn't show a YAML editor when schema isn't available (httpd-imagestreams chart)

### DIFF
--- a/frontend/packages/helm-plugin/integration-tests/features/helm/helm-installation-view.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/helm-installation-view.feature
@@ -38,3 +38,11 @@ Feature: Helm Chart Installation View
               And user selects the YAML view
               And user comes back to Form view
              Then user will see Release Name, Replica count as "nodejs-release-3", "3" respectively
+
+        @regression
+        Scenario: When Helm Release is not configurable: HR-04-TC04
+            Given user is at Add page
+             When user selects "Helm Chart" card from add page
+              And user searches and selects "Httpd Imagestreams" card from catalog page
+              And user clicks on the Create button on side bar
+             Then user should see message "Helm release is not configurable since the Helm Chart doesn't define any values." 

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-installation-view.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-installation-view.ts
@@ -50,3 +50,9 @@ Then(
     cy.byLegacyTestID('reset-button').click();
   },
 );
+
+Then('user should see message {string}', (message: string) => {
+  cy.get('h4.pf-c-alert__title')
+    .should('contain.text', message)
+    .should('exist');
+});

--- a/frontend/packages/helm-plugin/locales/en/helm-plugin.json
+++ b/frontend/packages/helm-plugin/locales/en/helm-plugin.json
@@ -108,6 +108,7 @@
   "The Helm Chart is currently unavailable. {{chartError}}": "The Helm Chart is currently unavailable. {{chartError}}",
   "Release name": "Release name",
   "A unique name for the Helm Release.": "A unique name for the Helm Release.",
+  "Helm release is not configurable since the Helm Chart doesn't define any values.": "Helm release is not configurable since the Helm Chart doesn't define any values.",
   "Errors in the form - {{errorsText}}": "Errors in the form - {{errorsText}}",
   "Select the version to rollback <1>{{releaseName}}</1> to, from the table below:": "Select the version to rollback <1>{{releaseName}}</1> to, from the table below:",
   "CustomResources": "CustomResources",

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
@@ -143,16 +143,25 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
             </GridItem>
           </Grid>
         </FormSection>
-        {!chartError && (
-          <SyncedEditorField
-            name="editorType"
-            formContext={{ name: 'formData', editor: formEditor, isDisabled: !formSchema }}
-            yamlContext={{ name: 'yamlData', editor: yamlEditor }}
-            lastViewUserSettingKey={LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY}
-            prune={prune}
-            noMargin
-          />
-        )}
+        {!chartError &&
+          (!formSchema && !chartHasValues ? (
+            <Alert
+              variant="info"
+              title={t(
+                "helm-plugin~Helm release is not configurable since the Helm Chart doesn't define any values.",
+              )}
+              isInline
+            />
+          ) : (
+            <SyncedEditorField
+              name="editorType"
+              formContext={{ name: 'formData', editor: formEditor, isDisabled: !formSchema }}
+              yamlContext={{ name: 'yamlData', editor: yamlEditor }}
+              lastViewUserSettingKey={LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY}
+              prune={prune}
+              noMargin
+            />
+          ))}
       </FormBody>
       <FormFooter
         handleReset={handleReset}


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/openshift/console/pull/12914

Automated cherry-pick PR https://github.com/openshift/console/pull/12919 frontend test is failing, creating manual cherry-pick PR to analyse and update. 