### PR TITLE
OCPBUGS-14959: Error for DuplicateClusterRoleBinding and Edit ClusterRoleBinding subject in RHOCP4 Web Console

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -78,13 +78,14 @@ const getKindLabel = (kind) => (kind.labelKey ? i18next.t(kind.labelKey) : kind.
 
 const menuActions = ({ subjectIndex, subjects }, startImpersonate) => {
   const subject = subjects[subjectIndex];
-
   const actions = [
     (kind, obj) => ({
       label: i18next.t('public~Duplicate {{kindLabel}}', {
         kindLabel: getKindLabel(kind),
       }),
-      href: `${resourceObjPath(obj, kind.kind)}/copy?subjectIndex=${subjectIndex}`,
+      href: `${decodeURIComponent(
+        resourceObjPath(obj, kind.kind),
+      )}/copy?subjectIndex=${subjectIndex}`,
       // Only perform access checks when duplicating cluster role bindings.
       // It's not practical to check namespace role bindings since we don't know what namespace the user will pick in the form.
       accessReview: _.get(obj, 'metadata.namespace')
@@ -95,7 +96,9 @@ const menuActions = ({ subjectIndex, subjects }, startImpersonate) => {
       label: i18next.t('public~Edit {{kindLabel}} subject', {
         kindLabel: getKindLabel(kind),
       }),
-      href: `${resourceObjPath(obj, kind.kind)}/edit?subjectIndex=${subjectIndex}`,
+      href: `${decodeURIComponent(
+        resourceObjPath(obj, kind.kind),
+      )}/edit?subjectIndex=${subjectIndex}`,
       accessReview: {
         group: kind.apiGroup,
         resource: kind.plural,

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -78,6 +78,7 @@ const getKindLabel = (kind) => (kind.labelKey ? i18next.t(kind.labelKey) : kind.
 
 const menuActions = ({ subjectIndex, subjects }, startImpersonate) => {
   const subject = subjects[subjectIndex];
+  
   const actions = [
     (kind, obj) => ({
       label: i18next.t('public~Duplicate {{kindLabel}}', {

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -78,7 +78,7 @@ const getKindLabel = (kind) => (kind.labelKey ? i18next.t(kind.labelKey) : kind.
 
 const menuActions = ({ subjectIndex, subjects }, startImpersonate) => {
   const subject = subjects[subjectIndex];
-  
+
   const actions = [
     (kind, obj) => ({
       label: i18next.t('public~Duplicate {{kindLabel}}', {
@@ -91,7 +91,11 @@ const menuActions = ({ subjectIndex, subjects }, startImpersonate) => {
       // It's not practical to check namespace role bindings since we don't know what namespace the user will pick in the form.
       accessReview: _.get(obj, 'metadata.namespace')
         ? null
-        : { group: kind.apiGroup, resource: kind.plural, verb: 'create' },
+        : {
+            group: kind.apiGroup,
+            resource: kind.plural,
+            verb: 'create',
+          },
     }),
     (kind, obj) => ({
       label: i18next.t('public~Edit {{kindLabel}} subject', {
@@ -121,7 +125,12 @@ const menuActions = ({ subjectIndex, subjects }, startImpersonate) => {
               ),
               btnText: i18next.t('public~Delete subject'),
               executeFn: () =>
-                k8sPatch(kind, binding, [{ op: 'remove', path: `/subjects/${subjectIndex}` }]),
+                k8sPatch(kind, binding, [
+                  {
+                    op: 'remove',
+                    path: `/subjects/${subjectIndex}`,
+                  },
+                ]),
             }),
           accessReview: {
             group: kind.apiGroup,

--- a/frontend/public/components/utils/resource-link.tsx
+++ b/frontend/public/components/utils/resource-link.tsx
@@ -65,9 +65,8 @@ export const resourcePath = (kind: K8sResourceKindReference, name?: string, name
   return resourcePathFromModel(model, name, namespace);
 };
 
-export const resourceObjPath = (obj: K8sResourceKind, kind: K8sResourceKindReference) => {
-  return resourcePath(kind, _.get(obj, 'metadata.name'), _.get(obj, 'metadata.namespace'));
-};
+export const resourceObjPath = (obj: K8sResourceKind, kind: K8sResourceKindReference) =>
+  resourcePath(kind, _.get(obj, 'metadata.name'), _.get(obj, 'metadata.namespace'));
 
 export const ResourceLink: React.FC<ResourceLinkProps> = ({
   className,

--- a/frontend/public/components/utils/resource-link.tsx
+++ b/frontend/public/components/utils/resource-link.tsx
@@ -65,8 +65,9 @@ export const resourcePath = (kind: K8sResourceKindReference, name?: string, name
   return resourcePathFromModel(model, name, namespace);
 };
 
-export const resourceObjPath = (obj: K8sResourceKind, kind: K8sResourceKindReference) =>
-  resourcePath(kind, _.get(obj, 'metadata.name'), _.get(obj, 'metadata.namespace'));
+export const resourceObjPath = (obj: K8sResourceKind, kind: K8sResourceKindReference) => {
+  return resourcePath(kind, _.get(obj, 'metadata.name'), _.get(obj, 'metadata.namespace'));
+};
 
 export const ResourceLink: React.FC<ResourceLinkProps> = ({
   className,


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-15060

When user tries to duplicate or edit `ClusterRoleBinding` subject in console causes "Error Loading : Name parameter invalid: "system%3Acontroller%3A<name-of-role-ref>": may not contain '%' ". This error happens only in  `ClusterRoleBindings` containing special characters as ':' that are encoded as '%3A'. 

To address this, decoding the special characters using `decodeURIComponent` fixes this error.

Screenshots:

- Before
![Screenshot 2023-06-26 at 18 01 22](https://github.com/openshift/console/assets/49416557/2ca17ef4-c36e-4b92-84c7-1b2cfcb99474)




- After
![Screenshot 2023-06-26 at 17 59 08](https://github.com/openshift/console/assets/49416557/a95d2110-9e76-4d2d-9a08-3360e52fe281)
