### PR TITLE
OU-198: Revert "Disable broken monitoring-tests"

### DIFF
--- a/frontend/integration-tests/tests/alertmanager.scenario.ts
+++ b/frontend/integration-tests/tests/alertmanager.scenario.ts
@@ -25,10 +25,6 @@ const getGlobalsAndReceiverConfig = (configName: string, yamlStr: string) => {
 };
 
 describe('Alertmanager: PagerDuty Receiver Form', () => {
-  // Disabled to resolve https://issues.redhat.com/browse/OCPBUGS-14964
-  // Follow-up issue to fix the Alertmanager and reeanble this tests: https://issues.redhat.com/browse/OCPBUGS-15036
-  pending('Temporary disabled, see OCPBUGS-14964 and OCPBUGS-15036');
-
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
@@ -208,10 +204,6 @@ describe('Alertmanager: PagerDuty Receiver Form', () => {
 });
 
 describe('Alertmanager: Email Receiver Form', () => {
-  // Disabled to resolve https://issues.redhat.com/browse/OCPBUGS-14964
-  // Follow-up issue to fix the Alertmanager and reeanble this tests: https://issues.redhat.com/browse/OCPBUGS-15036
-  pending('Temporary disabled, see OCPBUGS-14964 and OCPBUGS-15036');
-
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
@@ -336,10 +328,6 @@ describe('Alertmanager: Email Receiver Form', () => {
 });
 
 describe('Alertmanager: Slack Receiver Form', () => {
-  // Disabled to resolve https://issues.redhat.com/browse/OCPBUGS-14964
-  // Follow-up issue to fix the Alertmanager and reeanble this tests: https://issues.redhat.com/browse/OCPBUGS-15036
-  pending('Temporary disabled, see OCPBUGS-14964 and OCPBUGS-15036');
-
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
@@ -453,10 +441,6 @@ describe('Alertmanager: Slack Receiver Form', () => {
 });
 
 describe('Alertmanager: Webhook Receiver Form', () => {
-  // Disabled to resolve https://issues.redhat.com/browse/OCPBUGS-14964
-  // Follow-up issue to fix the Alertmanager and reeanble this tests: https://issues.redhat.com/browse/OCPBUGS-15036
-  pending('Temporary disabled, see OCPBUGS-14964 and OCPBUGS-15036');
-
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,

--- a/frontend/integration-tests/tests/monitoring.scenario.ts
+++ b/frontend/integration-tests/tests/monitoring.scenario.ts
@@ -10,10 +10,6 @@ import * as horizontalnavView from '../views/horizontal-nav.view';
 import { execSync } from 'child_process';
 
 describe('Alertmanager: YAML', () => {
-  // Disabled to resolve https://issues.redhat.com/browse/OCPBUGS-14964
-  // Follow-up issue to fix the Alertmanager and reeanble this tests: https://issues.redhat.com/browse/OCPBUGS-15036
-  pending('Temporary disabled, see OCPBUGS-14964 and OCPBUGS-15036');
-
   afterEach(() => {
     checkLogs();
     checkErrors();
@@ -42,10 +38,6 @@ describe('Alertmanager: YAML', () => {
 });
 
 describe('Alertmanager: Configuration', () => {
-  // Disabled to resolve https://issues.redhat.com/browse/OCPBUGS-14964
-  // Follow-up issue to fix the Alertmanager and reeanble this tests: https://issues.redhat.com/browse/OCPBUGS-15036
-  pending('Temporary disabled, see OCPBUGS-14964 and OCPBUGS-15036');
-
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,


### PR DESCRIPTION
This reverts commit 743df8399ad4a69fa7e9db61009f191f3a55b494 (PR https://github.com/openshift/console/pull/12902).

These test failures were fixed by https://github.com/openshift/monitoring-plugin/pull/48