### PR TITLE
OCPBUGS-13808: Console SDK components should be using GroupVersionKin…

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -676,7 +676,7 @@ const exampleList: React.FC<MyProps> = () => {
   return (
     <>
       <ListPageHeader title="Example Pod List Page"/>
-        <ListPageCreate groupVersionKind="Pod">Create Pod</ListPageCreate>
+        <ListPageCreate groupVersionKind={{ group: 'app'; version: 'v1'; kind: 'Deployment' }}>Create Pod</ListPageCreate>
       </ListPageHeader>
     </>
   );
@@ -691,7 +691,7 @@ const exampleList: React.FC<MyProps> = () => {
 
 | Parameter Name | Description |
 | -------------- | ----------- |
-| `groupVersionKind` | the resource group/version/kind to represent |
+| `groupVersionKind` | group, version, kind of k8s resource {@link K8sGroupVersionKind} is preferred alternatively can pass reference for group, version, kind which is deprecated i.e `group~version~kind` {@link K8sResourceKindReference}. |
 
 
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -175,14 +175,14 @@ export const ListPageHeader: React.FC<ListPageHeaderProps> = require('@console/i
 
 /**
  * Component for adding a create button for a specific resource kind that automatically generates a link to the create YAML for this resource
- * @param {GroupVersionKind} groupVersionKind - the resource group/version/kind to represent
+ * @param groupVersionKind group, version, kind of k8s resource {@link K8sGroupVersionKind} is preferred alternatively can pass reference for group, version, kind which is deprecated i.e `group~version~kind` {@link K8sResourceKindReference}.
  * @example
  * ```ts
  * const exampleList: React.FC<MyProps> = () => {
  *   return (
  *     <>
  *       <ListPageHeader title="Example Pod List Page"/>
- *         <ListPageCreate groupVersionKind="Pod">Create Pod</ListPageCreate>
+ *         <ListPageCreate groupVersionKind={{ group: 'app'; version: 'v1'; kind: 'Deployment' }}>Create Pod</ListPageCreate>
  *       </ListPageHeader>
  *     </>
  *   );
@@ -585,9 +585,9 @@ export { useFlag } from '../utils/flags';
  * @param {YAMLEditorProps['onSave']} onSave - Callback called when the command CTRL / CMD + S is triggered.
  * @param {YAMLEditorRef} ref - React reference to `{ editor?: IStandaloneCodeEditor }`. Using the 'editor' property, you are able to access to all methods to control the editor. For more information, visit https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneCodeEditor.html.
  */
-export const YAMLEditor: React.ForwardRefExoticComponent<CodeEditorProps &
-  React.RefAttributes<CodeEditorRef>> = require('@console/internal/components/AsyncCodeEditor')
-  .AsyncCodeEditor;
+export const YAMLEditor: React.ForwardRefExoticComponent<
+  CodeEditorProps & React.RefAttributes<CodeEditorRef>
+> = require('@console/internal/components/AsyncCodeEditor').AsyncCodeEditor;
 
 /**
  * A basic lazy loaded Code editor with hover help and completion.
@@ -610,9 +610,9 @@ export const YAMLEditor: React.ForwardRefExoticComponent<CodeEditorProps &
  * @param {CodeEditorProps['onSave']} onSave - Callback called when the command CTRL / CMD + S is triggered.
  * @param {CodeEditorRef} ref - React reference to `{ editor?: IStandaloneCodeEditor }`. Using the 'editor' property, you are able to access to all methods to control the editor. For more information, visit https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneCodeEditor.html.
  */
-export const CodeEditor: React.ForwardRefExoticComponent<CodeEditorProps &
-  React.RefAttributes<CodeEditorRef>> = require('@console/internal/components/AsyncCodeEditor')
-  .AsyncCodeEditor;
+export const CodeEditor: React.ForwardRefExoticComponent<
+  CodeEditorProps & React.RefAttributes<CodeEditorRef>
+> = require('@console/internal/components/AsyncCodeEditor').AsyncCodeEditor;
 
 /**
  * A lazy loaded YAML editor for Kubernetes resources with hover help and completion.

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -91,7 +91,7 @@ export type GroupVersionKind = string;
  * The canonical, unique identifier for a Kubernetes resource type.
  * Maintains backwards-compatibility with references using the `kind` string field.
  */
-export type K8sResourceKindReference = GroupVersionKind | string;
+export type K8sResourceKindReference = string;
 
 export type K8sGroupVersionKind = { group?: string; version: string; kind: string };
 
@@ -370,13 +370,13 @@ export type ListPageHeaderProps = {
 
 export type CreateWithPermissionsProps = {
   createAccessReview?: {
-    groupVersionKind: GroupVersionKind;
+    groupVersionKind: K8sResourceKindReference | K8sGroupVersionKind;
     namespace?: string;
   };
 };
 
 export type ListPageCreateProps = CreateWithPermissionsProps & {
-  groupVersionKind: GroupVersionKind;
+  groupVersionKind: K8sResourceKindReference | K8sGroupVersionKind;
 };
 
 export type ListPageCreateLinkProps = CreateWithPermissionsProps & {

--- a/frontend/public/components/factory/ListPage/ListPageCreate.tsx
+++ b/frontend/public/components/factory/ListPage/ListPageCreate.tsx
@@ -97,7 +97,9 @@ const ListPageCreate: React.FC<ListPageCreateProps> = ({
   groupVersionKind,
   children,
 }) => {
-  const [k8sModel] = useK8sModel(groupVersionKind);
+  const kind = typeof groupVersionKind !== 'string' ? groupVersionKind.kind : groupVersionKind;
+
+  const [k8sModel] = useK8sModel(kind);
   const [namespace] = useActiveNamespace();
   let to: string;
   if (k8sModel) {
@@ -111,8 +113,8 @@ const ListPageCreate: React.FC<ListPageCreateProps> = ({
       : `/k8s/cluster/${k8sModel.plural}/~new`;
     if (k8sModel.crd) {
       to = usedNamespace
-        ? `/k8s/ns/${usedNamespace || 'default'}/${groupVersionKind}/~new`
-        : `/k8s/cluster/${groupVersionKind}/~new`;
+        ? `/k8s/ns/${usedNamespace || 'default'}/${kind}/~new`
+        : `/k8s/cluster/${kind}/~new`;
     }
   }
 


### PR DESCRIPTION
…d object

Fixes https://issues.redhat.com/browse/OCPBUGS-13808

Components in Console Dynamic Plugin SDK use new `K8sGroupVersionKind` object. Reference string still supported for backwards compatibility.