### PR TITLE
[release-4.12] OCPBUGS-15482: Remove PipelineResource CRD check because it's not installed with PO 1.11 anymore

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster.ts
@@ -100,7 +100,6 @@ export const waitForCRDs = (operator: operators) => {
         6,
       );
       cy.get('[data-test-id="TektonPipeline"]', { timeout: 80000 }).should('be.visible');
-      cy.get('[data-test-id="PipelineResource"]', { timeout: 80000 }).should('be.visible');
       cy.get('[data-test-id="PipelineRun"]', { timeout: 80000 }).should('be.visible');
       cy.get('[data-test-id="Pipeline"]', { timeout: 80000 }).should('be.visible');
       break;


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-15482

**4.12 builds are blocked:**

* https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-console-release-4.12-e2e-gcp-console
* https://search.ci.openshift.org/?search=Expected+to+find+element&maxAge=336h&context=1&type=all&name=pull-ci-openshift-console-release-4.12-e2e-gcp-console&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job (not exact match, but couldn't create a better filter)

**Failing e2e test:**:

```
  Running:  e2e/pipeline-ci.feature                                                         (1 of 1)
Couldn't determine Mocha version


  Logging in as kubeadmin
      Installing operator: "Red Hat OpenShift Pipelines"
      Operator Red Hat OpenShift Pipelines was not yet installed.
      Performing Pipelines post-installation steps
      Verify the CRD's for the "Red Hat OpenShift Pipelines"
  1) "before all" hook for "Background Steps"
      Deleting "" namespace

  0 passing (3m)
  1 failing

  1) Entire pipeline flow from Builder page
       "before all" hook for "Background Steps":
     AssertionError: Timed out retrying after 80000ms: Expected to find element: `[data-test-id="PipelineResource"]`, but never found it.

Because this error occurred during a `before all` hook we are skipping all of the remaining tests.
      at ../../dev-console/integration-tests/support/pages/functions/installOperatorOnCluster.ts.exports.waitForCRDs (https://console-openshift-console.apps.ci-op-why3n0t9-690b9.XXXXXXXXXXXXXXXXXXXXXX/__cypress/tests?p=support/commands/index.ts:17016:77)
      at performPostInstallationSteps (https://console-openshift-console.apps.ci-op-why3n0t9-690b9.XXXXXXXXXXXXXXXXXXXXXX/__cypress/tests?p=support/commands/index.ts:17101:21)
      at ../../dev-console/integration-tests/support/pages/functions/installOperatorOnCluster.ts.exports.verifyAndInstallOperator (https://console-openshift-console.apps.ci-op-why3n0t9-690b9.XXXXXXXXXXXXXXXXXXXXXX/__cypress/tests?p=support/commands/index.ts:17127:5)
      at ../../dev-console/integration-tests/support/pages/functions/installOperatorOnCluster.ts.exports.verifyAndInstallPipelinesOperator (https://console-openshift-console.apps.ci-op-why3n0t9-690b9.XXXXXXXXXXXXXXXXXXXXXX/__cypress/tests?p=support/commands/index.ts:17131:13)
      at Context.eval (https://console-openshift-console.apps.ci-op-why3n0t9-690b9.XXXXXXXXXXXXXXXXXXXXXX/__cypress/tests?p=support/commands/index.ts:20668:13)
```

This CRD is not installed with Pipelines operator 1.11 anymore.

**Solution**: 
Remove the check that the "PipelineResource" CRD is installed.

Tested the 4.12 console (4.12.0-0.nightly-2023-06-26-100619) with the latest Pipelines operator (1.11.0).

* Import from Git with Pipeline works fine
* Creating a Pipeline with the Pipeline Builder works fine
  * Admission controller shows an error when adding "Resources" to the pipeline.

https://github.com/openshift/console/assets/139310/5d1067da-f929-4144-98c9-da8b8cbce631
