### PR TITLE
OCPBUGS-15419: Title on Overview page has changed to "Cluster · Red Hat OpenShift"

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/dashboards.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/dashboards.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
-import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 
 import { ClusterDashboard } from './cluster-dashboard/cluster-dashboard';
@@ -10,6 +9,7 @@ import { HorizontalNav, PageHeading, LoadingBox, Page, AsyncComponent } from '..
 import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
 import DashboardGrid from '@console/shared/src/components/dashboard/DashboardGrid';
 import { RestoreGettingStartedButton } from '@console/shared/src/components/getting-started';
+import { PageTitleContext } from '@console/shared/src/components/pagetitle/PageTitleContext';
 import {
   useExtensions,
   DashboardsCard,
@@ -97,7 +97,8 @@ const DashboardsPage_: React.FC<DashboardsPageProps> = ({ match, kindsInFlight, 
     () => [
       {
         href: '',
-        name: t('public~Cluster'),
+        // t('public~Cluster')
+        nameKey: 'public~Cluster',
         component: ClusterDashboard,
         badge: <RestoreGettingStartedButton userSettingsKey={USER_SETTINGS_KEY} />,
       },
@@ -110,16 +111,19 @@ const DashboardsPage_: React.FC<DashboardsPageProps> = ({ match, kindsInFlight, 
     () => allPages.find((page) => `/dashboards${page.href}` === match.path)?.badge,
     [allPages, match],
   );
+  const titleProviderValues = {
+    telemetryPrefix: 'Overview',
+    titlePrefix: title,
+  };
 
   return kindsInFlight && k8sModels.size === 0 ? (
     <LoadingBox />
   ) : (
     <>
-      <Helmet>
-        <title>{title}</title>
-      </Helmet>
-      <PageHeading title={title} detail={true} badge={badge} />
-      <HorizontalNav match={match} pages={allPages} noStatusBox />
+      <PageTitleContext.Provider value={titleProviderValues}>
+        <PageHeading title={title} detail={true} badge={badge} />
+        <HorizontalNav match={match} pages={allPages} noStatusBox />
+      </PageTitleContext.Provider>
     </>
   );
 };

--- a/frontend/public/components/dashboard/project-dashboard/project-dashboard.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/project-dashboard.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Helmet from 'react-helmet';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
+import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
 import DashboardGrid from '@console/shared/src/components/dashboard/DashboardGrid';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
@@ -48,6 +49,7 @@ export const getNamespaceDashboardConsoleLinks = (
 
 export const ProjectDashboard: React.FC<ProjectDashboardProps> = ({ obj }) => {
   const { t } = useTranslation();
+  const [perspective] = useActivePerspective();
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     kind: referenceForModel(ConsoleLinkModel),
@@ -68,9 +70,11 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = ({ obj }) => {
 
   return (
     <>
-      <Helmet>
-        <title>{t('public~Project overview')}</title>
-      </Helmet>
+      {perspective === 'dev' && (
+        <Helmet>
+          <title>{t('public~Project overview')}</title>
+        </Helmet>
+      )}
       <ProjectDashboardContext.Provider value={context}>
         <Dashboard>
           <DashboardGrid mainCards={mainCards} leftCards={leftCards} rightCards={rc} />

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -45,7 +45,7 @@ import {
 } from '@console/shared';
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 import * as k8sActions from '@console/dynamic-plugin-sdk/src/app/k8s/actions/k8s';
-
+import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import {
   ConsoleLinkModel,
   NamespaceModel,
@@ -1048,6 +1048,7 @@ export const NamespaceSummary = ({ ns }) => {
 
 export const NamespaceDetails = ({ obj: ns, customData }) => {
   const { t } = useTranslation();
+  const [perspective] = useActivePerspective();
   const [consoleLinks] = useK8sWatchResource({
     isList: true,
     kind: referenceForModel(ConsoleLinkModel),
@@ -1056,9 +1057,11 @@ export const NamespaceDetails = ({ obj: ns, customData }) => {
   const links = getNamespaceDashboardConsoleLinks(ns, consoleLinks);
   return (
     <div>
-      <Helmet>
-        <title>{t('public~Project details')}</title>
-      </Helmet>
+      {perspective === 'dev' && (
+        <Helmet>
+          <title>{t('public~Project details')}</title>
+        </Helmet>
+      )}
       <div className="co-m-pane__body">
         {!customData?.hideHeading && (
           <SectionHeading text={t('public~{{kind}} details', { kind: ns.kind })} />


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-15419

**Analysis / Root cause**: 
Overview prefix is missed in page title

**Solution Description**: 
Changed page title to Overview · Cluster · OKD (Overview · Cluster · {product-name})

**Screen shots / Gifs for design review**: 



https://github.com/openshift/console/assets/102503482/5be1a206-857f-4b33-b250-aec7a9a6ae77

https://github.com/openshift/console/assets/102503482/fc1c0f24-23bc-4b20-8b76-dcedbf65b36f




**Unit test coverage report**: 
NA

**Test setup:**

1. Install OpenShift 4.14 
2. login to management console 
3. Navigate to Home / Overview 
4. Load the HTML DOM and verify the HTML node <title>; title is also visible when hovering on the opened tab in Chrome or Firefox

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge