### PR TITLE
OCPBUGS-4418: Re-enable shipwright e2e tests

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -75,7 +75,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
   yarn run test-cypress-pipelines-headless
-  # yarn run test-cypress-shipwright-headless
+  yarn run test-cypress-shipwright-headless
   # yarn run test-cypress-webterminal-headless
   exit;
 fi


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGS-4418

Let see if this passes with master and how long it takes!

We can rerun this also after #12910 and #12960 are merged.