### PR TITLE
OCPBUGS-15427: Remove access review check for PipelineResource from Pipeline section

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/PipelineSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/PipelineSection.tsx
@@ -10,7 +10,7 @@ import { connectToFlags } from '@console/internal/reducers/connectToFlags';
 import { FlagsObject } from '@console/internal/reducers/features';
 import { TechPreviewBadge } from '@console/shared';
 import { FLAG_OPENSHIFT_PIPELINE, CLUSTER_PIPELINE_NS } from '../../../const';
-import { PipelineModel, PipelineResourceModel } from '../../../models';
+import { PipelineModel } from '../../../models';
 import { PipelineKind } from '../../../types';
 import { usePipelineTechPreviewBadge } from '../../../utils/hooks';
 import PipelineTemplate from './PipelineTemplate';
@@ -38,14 +38,7 @@ const usePipelineAccessReview = (): boolean => {
     verb: 'create',
   });
 
-  const canCreatePipelineResource = useAccessReview({
-    group: PipelineResourceModel.apiGroup,
-    resource: PipelineResourceModel.plural,
-    namespace: getActiveNamespace(),
-    verb: 'create',
-  });
-
-  return canListPipelines && canCreatePipelines && canCreatePipelineResource;
+  return canListPipelines && canCreatePipelines;
 };
 
 const PipelineSection: React.FC<PipelineSectionProps> = ({


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGS-15427

**Descriptions:**
Pipeline Section is not visible in Git from Import form for non-admin users as PipelineResource has been deprecated in Red Hat Pipeline operator 1.11 and access review checks on PipelineResource return false for non-admin users.

**Screenshots:** 
![image](https://github.com/openshift/console/assets/2561818/8826b6b9-d410-468b-b0d7-117e496d9bfa)
