### PR TITLE
OCPBUGS-15773: The upgrade Helm Release tab in OpenShift GUI Developer console is not refreshing with updated values.

### DIFF
--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartVersionDropdown.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartVersionDropdown.tsx
@@ -58,7 +58,7 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
   const [helmChartEntries, setHelmChartEntries] = React.useState<HelmChartMetaData[]>([]);
   const [initialYamlData, setInitialYamlData] = React.useState<string>('');
   const [initialFormData, setInitialFormData] = React.useState<object>();
-
+  const [helmChartRepos, setHelmChartRepos] = React.useState<HelmChartEntries>({});
   const resourceSelector: WatchK8sResource = {
     isList: true,
     kind: referenceForModel(HelmChartRepositoryModel),
@@ -134,6 +134,7 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
           getChartIndexEntry(json?.entries, chartName, chartEntries[0].repoName),
         );
       }
+      setHelmChartRepos(json?.entries);
       setHelmChartEntries(chartEntries);
       setHelmChartVersions(getChartVersions(chartEntries, t));
     };
@@ -145,15 +146,15 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
 
   const onChartVersionChange = (value: string) => {
     const [version, repoName] = value.split('--');
-
     const chartURL = getChartURL(helmChartEntries, version, repoName);
+    const chartRepoIndex = getChartIndexEntry(helmChartRepos, chartName, repoName);
 
     setFieldValue('chartVersion', value);
     setFieldValue('chartURL', chartURL);
     coFetchJSON(
       `/api/helm/chart?url=${encodeURIComponent(
         chartURL,
-      )}&namespace=${namespace}&indexEntry=${encodeURIComponent(chartIndexEntry)}`,
+      )}&namespace=${namespace}&indexEntry=${encodeURIComponent(chartRepoIndex)}`,
     )
       .then((res: HelmChart) => {
         onVersionChange(res);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-15773

**Analysis / Root cause**: 
indexEntry url param was null for upgrade so on change of version API call was getting failed

**Solution Description**: 
Added Chart index value to indexEntry url param

**Screen shots / Gifs for design review**: 
-----BEFORE----


https://github.com/openshift/console/assets/102503482/6a02684a-cd71-47c5-bc27-e13f8a3f01cc




-----AFTER-----

https://github.com/openshift/console/assets/102503482/60f4cd30-c261-4fab-9bbf-7841563147c9




**Unit test coverage report**: 
NA

**Test setup:**

1. Install a helm chart by changing some values different from default yaml values
2. Click on Upgrade in kebab menu in Helm Release list page
3. Change Chart version in drop down
4. After changing the chart version, updated values for previous chart should be replaced by new default values

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge