### PR TITLE
ODC-7341: Show Build output in Shipwright Build list and details page

### DIFF
--- a/frontend/packages/shipwright-plugin/integration-tests/features/shipwright-table.feature
+++ b/frontend/packages/shipwright-plugin/integration-tests/features/shipwright-table.feature
@@ -4,7 +4,7 @@ Feature: Shipwright builds table view
 
         Background:
             Given user has installed OpenShift Pipelines Operator
-              And user has installed Shipwright Operator    
+              And user has installed Shipwright Operator
               And user is at developer perspective
               And user has created or selected namespace "aut-shipwright-build-details"
               And user has created shipwright builds
@@ -15,9 +15,10 @@ Feature: Shipwright builds table view
             Given user is at Builds page
              When user clicks on "Shipwright Builds" tab
              Then user will see "Name"
+              And user will see "Output"
               And user will see "Last run"
               And user will see "Last run status"
-              And user will see "Last run time"  
+              And user will see "Last run time"
               And user will see "Last run duration"
 
 

--- a/frontend/packages/shipwright-plugin/locales/en/shipwright-plugin.json
+++ b/frontend/packages/shipwright-plugin/locales/en/shipwright-plugin.json
@@ -32,6 +32,7 @@
   "Unknown": "Unknown",
   "Name": "Name",
   "Namespace": "Namespace",
+  "Output": "Output",
   "Last run": "Last run",
   "Last run status": "Last run status",
   "Last run time": "Last run time",

--- a/frontend/packages/shipwright-plugin/src/components/build-details/BuildSpecSection.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/build-details/BuildSpecSection.tsx
@@ -6,6 +6,7 @@ import { ResourceLink, DetailsItem, ExternalLink } from '@console/internal/compo
 import { SecretModel } from '@console/internal/models';
 import { ClusterBuildStrategyModel, BuildStrategyModel } from '../../models';
 import { Build, BuildRun, BuildSpec } from '../../types';
+import BuildOutput from '../build-list/BuildOutput';
 
 type BuildSpecSectionProps = {
   obj: Build | BuildRun;
@@ -123,9 +124,7 @@ const BuildSpecSection: React.FC<BuildSpecSectionProps> = ({ obj, buildSpec, pat
           obj={obj}
           path={`${path}.output.image`}
         >
-          <ClipboardCopy variant={ClipboardCopyVariant.inlineCompact}>
-            {buildSpec.output.image}
-          </ClipboardCopy>
+          <BuildOutput buildSpec={buildSpec} />
         </DetailsItem>
       ) : null}
 

--- a/frontend/packages/shipwright-plugin/src/components/build-list/BuildOutput.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/build-list/BuildOutput.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { getGroupVersionKindForModel } from '@console/dynamic-plugin-sdk/src/lib-core';
+import { ExternalLinkWithCopy, ResourceLink } from '@console/internal/components/utils';
+import { ImageStreamModel } from '@console/internal/models';
+import { BUILD_OUTPUT_IMAGESTREAM_URL, BUILD_OUTPUT_QUAY_URL } from '../../const';
+import { BuildSpec } from '../../types';
+
+type BuildOutputProps = {
+  buildSpec: BuildSpec;
+};
+
+const BuildOutput: React.FC<BuildOutputProps> = ({ buildSpec }) => {
+  const outputImage = buildSpec?.output?.image;
+
+  if (outputImage?.startsWith(BUILD_OUTPUT_IMAGESTREAM_URL)) {
+    const imageStreamName = outputImage?.split('/')?.pop();
+    const imageStreamNamespace = outputImage?.split('/')[1];
+    return (
+      <ResourceLink
+        name={imageStreamName}
+        namespace={imageStreamNamespace}
+        groupVersionKind={getGroupVersionKindForModel(ImageStreamModel)}
+      />
+    );
+  }
+  if (outputImage?.startsWith(BUILD_OUTPUT_QUAY_URL)) {
+    const outputImageName = outputImage?.split('/')?.slice(1)?.join('/');
+    return <ExternalLinkWithCopy link={`https://${outputImage}`} text={outputImageName} />;
+  }
+  return <>{outputImage}</>;
+};
+
+export default BuildOutput;

--- a/frontend/packages/shipwright-plugin/src/components/build-list/BuildTable.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/build-list/BuildTable.tsx
@@ -18,10 +18,12 @@ import { Build, BuildRun } from '../../types';
 import { isBuildRunNewerThen } from '../../utils';
 import BuildRunDuration, { getBuildRunDuration } from '../buildrun-duration/BuildRunDuration';
 import BuildRunStatus, { getBuildRunStatus } from '../buildrun-status/BuildRunStatus';
+import BuildOutput from './BuildOutput';
 
 const columnClassNames = [
   '', // name
   '', // namespace
+  '', // output
   'pf-m-hidden pf-m-visible-on-lg', // last run
   'pf-m-hidden pf-m-visible-on-lg', // last run status
   'pf-m-hidden pf-m-visible-on-lg', // last run time
@@ -48,32 +50,36 @@ export const BuildHeader = () => {
       props: { className: columnClassNames[1] },
     },
     {
+      title: t('shipwright-plugin~Output'),
+      props: { className: columnClassNames[2] },
+    },
+    {
       title: t('shipwright-plugin~Last run'),
       transforms: [sortable],
       sortField: 'latestBuild.metadata.name',
-      props: { className: columnClassNames[2] },
+      props: { className: columnClassNames[3] },
     },
     {
       title: t('shipwright-plugin~Last run status'),
       transforms: [sortable],
       sortFunc: 'latestBuildStatus',
-      props: { className: columnClassNames[3] },
+      props: { className: columnClassNames[4] },
     },
     {
       title: t('shipwright-plugin~Last run time'),
       transforms: [sortable],
       sortField: 'latestBuild.status.completionTime',
-      props: { className: columnClassNames[4] },
+      props: { className: columnClassNames[5] },
     },
     {
       title: t('shipwright-plugin~Last run duration'),
       transforms: [sortable],
       sortFunc: 'latestRunDuration',
-      props: { className: columnClassNames[5] },
+      props: { className: columnClassNames[6] },
     },
     {
       title: '',
-      props: { className: columnClassNames[6] },
+      props: { className: columnClassNames[7] },
     },
   ];
 };
@@ -96,6 +102,9 @@ export const BuildRow: React.FC<RowFunctionArgs<Build>> = ({ obj: build }) => {
         <ResourceLink kind="Namespace" name={build.metadata.namespace} />
       </TableData>
       <TableData className={columnClassNames[2]}>
+        <BuildOutput buildSpec={build.spec} />
+      </TableData>
+      <TableData className={columnClassNames[3]}>
         {build.latestBuild ? (
           <ResourceLink
             kind={buildRunKindReference}
@@ -106,20 +115,20 @@ export const BuildRow: React.FC<RowFunctionArgs<Build>> = ({ obj: build }) => {
           '-'
         )}
       </TableData>
-      <TableData className={columnClassNames[3]}>
+      <TableData className={columnClassNames[4]}>
         {build.latestBuild ? <BuildRunStatus buildRun={build.latestBuild} /> : '-'}
       </TableData>
-      <TableData className={columnClassNames[4]}>
+      <TableData className={columnClassNames[5]}>
         {build.latestBuild ? (
           <Timestamp timestamp={build?.latestBuild.metadata?.creationTimestamp} />
         ) : (
           '-'
         )}
       </TableData>
-      <TableData className={columnClassNames[5]}>
+      <TableData className={columnClassNames[6]}>
         {build?.latestBuild ? <BuildRunDuration buildRun={build.latestBuild} /> : '-'}
       </TableData>
-      <TableData className={columnClassNames[6]}>
+      <TableData className={columnClassNames[7]}>
         <LazyActionMenu context={context} />
       </TableData>
     </>

--- a/frontend/packages/shipwright-plugin/src/const.ts
+++ b/frontend/packages/shipwright-plugin/src/const.ts
@@ -3,3 +3,6 @@ export const API_VERSION = 'v1alpha1';
 
 export const BUILDRUN_TO_BUILD_REFERENCE_LABEL = 'build.shipwright.io/name';
 export const BUILDRUN_TO_RESOURCE_MAP_LABEL = 'app.kubernetes.io/part-of';
+
+export const BUILD_OUTPUT_IMAGESTREAM_URL = 'image-registry.openshift-image-registry.svc:5000';
+export const BUILD_OUTPUT_QUAY_URL = 'quay.io';


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-7341

**Solution Description**: 
- Added the Output Column to the Build List Page
- Changed the component displaying the Build Output in the Build/BuildRun Details Page

**Screenshots / Gifs for design review**: 

**List Page:**
![image](https://github.com/openshift/console/assets/47265560/c3ca4559-352c-4e19-93e9-16c58d1443bc)

**Details Page:**
![image](https://github.com/openshift/console/assets/47265560/488e11d2-4498-4b31-aabd-d618dbe8897e)


**Unit test coverage report**: 
Not changed

**Test setup:**
1. Install SW operator
2. Create some Sample Builds.


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge