### PR TITLE
OCPBUGS-15896: STS label not valid according to kube

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
@@ -83,7 +83,7 @@ export enum OperatorHubCSVAnnotationKey {
   infrastructureFeatures = 'operators.openshift.io/infrastructure-features',
   validSubscription = 'operators.openshift.io/valid-subscription',
   tags = 'tags',
-  tokenAuthAWS = 'operators.openshift.io/infrastructure-features/token-auth/aws',
+  tokenAuthAWS = 'features.operators.openshift.io/token-auth-aws',
 }
 
 export type OperatorHubCSVAnnotations = {


### PR DESCRIPTION
```
error creating csv ack-s3-controller.v1.0.3: ClusterServiceVersion.operators.coreos.com "ack-s3-controller.v1.0.3" is invalid: metadata.annotations: Invalid value: "operators.openshift.io/infrastructure-features/token-auth/aws": a qualified name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName', or 'my.name', or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
```