### PR TITLE
OU-218: Monitoring: Use `useResolvedExtensions` instead of `useExtensions`

### DIFF
--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -38,7 +38,6 @@ import {
   VirtualizedTable,
 } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { consoleFetchJSON } from '@console/dynamic-plugin-sdk/src/utils/fetch';
-import { useExtensions } from '@console/plugin-sdk';
 import { withFallback } from '@console/shared/src/components/error';
 import { QueryBrowser } from '@console/shared/src/components/query-browser';
 import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
@@ -722,7 +721,9 @@ const AlertsDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
   const sourceId = rule?.sourceId;
 
   // Load alert metrics chart from plugin
-  const alertsChartExtensions = useExtensions<AlertingRuleChartExtension>(isAlertingRuleChart);
+  const [alertsChartExtensions] = useResolvedExtensions<AlertingRuleChartExtension>(
+    isAlertingRuleChart,
+  );
   const alertsChart = alertsChartExtensions
     .filter((extension) => extension.properties.sourceId === sourceId)
     .map((extension) => extension.properties.chart);
@@ -1022,7 +1023,9 @@ const AlertRulesDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
   const sourceId = rule?.sourceId;
 
   // Load alert metrics chart from plugin
-  const alertsChartExtensions = useExtensions<AlertingRuleChartExtension>(isAlertingRuleChart);
+  const [alertsChartExtensions] = useResolvedExtensions<AlertingRuleChartExtension>(
+    isAlertingRuleChart,
+  );
   const alertsChart = alertsChartExtensions
     .filter((extension) => extension.properties.sourceId === sourceId)
     .map((extension) => extension.properties.chart);

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -1,6 +1,10 @@
 import classNames from 'classnames';
 import * as _ from 'lodash-es';
-import { PrometheusEndpoint, RedExclamationCircleIcon } from '@console/dynamic-plugin-sdk';
+import {
+  PrometheusEndpoint,
+  RedExclamationCircleIcon,
+  useResolvedExtensions,
+} from '@console/dynamic-plugin-sdk';
 import {
   Button,
   Label,
@@ -70,7 +74,6 @@ import {
   getAllVariables,
 } from './monitoring-dashboard-utils';
 
-import { useExtensions } from '@console/plugin-sdk/src';
 import {
   isDataSource,
   DataSource as DataSourceExtension,
@@ -207,6 +210,7 @@ const VariableOption = ({ itemKey }) =>
 
 const VariableDropdown: React.FC<VariableDropdownProps> = ({ id, name, namespace }) => {
   const { t } = useTranslation();
+
   const activePerspective = getActivePerspective(namespace);
 
   const timespan = useSelector(({ observe }: RootState) =>
@@ -227,7 +231,7 @@ const VariableDropdown: React.FC<VariableDropdownProps> = ({ id, name, namespace
   const [isError, setIsError] = React.useState(false);
 
   const customDataSourceName = variable?.datasource?.name;
-  const extensions = useExtensions<DataSourceExtension>(isDataSource);
+  const [extensions] = useResolvedExtensions<DataSourceExtension>(isDataSource);
   const hasExtensions = !_.isEmpty(extensions);
 
   const getURL = React.useCallback(
@@ -239,7 +243,7 @@ const VariableDropdown: React.FC<VariableDropdownProps> = ({ id, name, namespace
           const extension = extensions.find(
             (ext) => ext?.properties?.contextId === 'monitoring-dashboards',
           );
-          const getDataSource = await extension?.properties?.getDataSource();
+          const getDataSource = extension?.properties?.getDataSource;
           const dataSource = await getDataSource(customDataSourceName);
           return getPrometheusURL(prometheusProps, dataSource?.basePath);
         }
@@ -418,6 +422,7 @@ const DashboardDropdown: React.FC<DashboardDropdownProps> = React.memo(
 
 export const PollIntervalDropdown: React.FC<TimeDropdownsProps> = ({ namespace }) => {
   const { t } = useTranslation();
+
   const refreshIntervalFromParams = getQueryArgument('refreshInterval');
   const activePerspective = getActivePerspective(namespace);
   const interval = useSelector(({ observe }: RootState) =>
@@ -476,6 +481,7 @@ const HeaderTop: React.FC<{}> = React.memo(() => {
 
 const QueryBrowserLink = ({ queries }) => {
   const { t } = useTranslation();
+
   const params = new URLSearchParams();
   queries.forEach((q, i) => params.set(`query${i}`, q));
   const namespace = React.useContext(NamespaceContext);
@@ -547,7 +553,7 @@ const Card: React.FC<CardProps> = React.memo(({ panel }) => {
   const [dataSourceInfoLoading, setDataSourceInfoLoading] = React.useState<boolean>(true);
   const [customDataSource, setCustomDataSource] = React.useState<CustomDataSource>(undefined);
   const customDataSourceName = panel.datasource?.name;
-  const extensions = useExtensions<DataSourceExtension>(isDataSource);
+  const [extensions] = useResolvedExtensions<DataSourceExtension>(isDataSource);
   const hasExtensions = !_.isEmpty(extensions);
 
   React.useEffect(() => {
@@ -560,7 +566,7 @@ const Card: React.FC<CardProps> = React.memo(({ panel }) => {
         const extension = extensions.find(
           (ext) => ext?.properties?.contextId === 'monitoring-dashboards',
         );
-        const getDataSource = await extension?.properties?.getDataSource();
+        const getDataSource = extension?.properties?.getDataSource;
         const dataSource = await getDataSource(customDataSourceName);
         setCustomDataSource(dataSource);
         setDataSourceInfoLoading(false);


### PR DESCRIPTION
Prefer `useResolvedExtensions` because it is available in the dynamic plugin SDK.