### PR TITLE
OCPBUGS-14434: Running `yarn dev` results in the build running on a loop

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,6 +14,6 @@
     "typeRoots": ["node_modules/@types", "@types"],
     "types": ["node", "jest", "cypress", "cypress-axe", "cypress-file-upload", "console"]
   },
-  "exclude": [".yarn", "**/node_modules", "**/dist", "packages/console-dynamic-plugin-sdk/scripts"],
+  "exclude": [".yarn", "**/node_modules", "public/dist", "packages/console-dynamic-plugin-sdk/scripts"],
   "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "**/*.json"]
 }


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/OCPBUGS-14434

Internal logging of `ForkTsCheckerWebpackPlugin` has shown that after the change of any file, many if not all built files in the dist folder were marked as changed thus triggering the rebuild and the loop. After explicitly excluding the dist folder without use of `**` the issue seems to be fixed.

Here are screenshots with internal logging of `ForkTsCheckerWebpackPlugin` turned on:
This screenshot shows state before the changes. The files marked as changed are visibly from the `dist` directory, triggering the loop.
![image](https://github.com/openshift/console/assets/49416557/8bb5f97d-436c-48c5-ae51-8a7aca35d6f7)

After changes the build files are not marked as changed anymore and the loop does not occur.
![image](https://github.com/openshift/console/assets/49416557/8674a278-aac6-41ca-9f0f-b46ebbc310ba)
