### PR TITLE
CONSOLE-3591: Remove directory listing for /static/*

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -206,6 +206,20 @@ func (s *Server) getLocalAuther() *auth.Authenticator {
 	return s.Authers[serverutils.LocalClusterName]
 }
 
+func disableDirectoryListing(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// If the request is for a directory, return a 404.
+		// Directory path is expected to end with a slash or be empty,
+		// since we are stripping the '/static/' prefix from the path.
+		if strings.HasSuffix(r.URL.Path, "/") || r.URL.Path == "" {
+
+			http.NotFound(w, r)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	})
+}
+
 func (s *Server) authDisabled() bool {
 	return s.getLocalAuther() == nil
 }
@@ -313,7 +327,7 @@ func (s *Server) HTTPHandler() http.Handler {
 
 	handleFunc("/api/", notFoundHandler)
 
-	staticHandler := http.StripPrefix(proxy.SingleJoiningSlash(s.BaseURL.Path, "/static/"), http.FileServer(http.Dir(s.PublicDir)))
+	staticHandler := http.StripPrefix(proxy.SingleJoiningSlash(s.BaseURL.Path, "/static/"), disableDirectoryListing(http.FileServer(http.Dir(s.PublicDir))))
 	handle("/static/", gzipHandler(securityHeadersMiddleware(staticHandler)))
 
 	if s.CustomLogoFile != "" {


### PR DESCRIPTION
Removing listing for both all the directories, mainly:
- `/static/`
-  `/static/assets/`

Instead console server will return 404

Screen:
<img width="1917" alt="Screenshot 2023-07-12 at 17 48 13" src="https://github.com/openshift/console/assets/1668218/3d57ee26-3c6d-483d-b250-a4a0f00da2cd">


/assign @TheRealJon 

@spadgett FYI