### PR TITLE
OCPBUGS-8274: Fix copy login command regression

### DIFF
--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -37,7 +37,6 @@ declare interface Window {
     prometheusTenancyBaseURL: string;
     quickStarts: string;
     releaseVersion: string;
-    requestTokenURL: string;
     inactivityTimeout: number;
     statuspageID: string;
     GOARCH: string;

--- a/frontend/packages/console-shared/src/hooks/useRequestTokenURL.ts
+++ b/frontend/packages/console-shared/src/hooks/useRequestTokenURL.ts
@@ -4,19 +4,21 @@ import { useActiveCluster } from '@console/shared/src/hooks/useActiveCluster';
 import { FLAGS } from '../constants';
 import { useFlag } from './flag';
 
+const REQUEST_TOKEN_ENDPOINT = '/api/request-token';
+
 export const useRequestTokenURL = (): [string] => {
   const [clusterName] = useActiveCluster(); // TODO remove multicluster
   const [requestTokenURL, setRequestTokenURL] = React.useState<string>();
   const authEnabled = useFlag(FLAGS.AUTH_ENABLED);
   React.useEffect(() => {
-    if (authEnabled && window.SERVER_FLAGS.requestTokenURL) {
-      coFetchJSON(window.SERVER_FLAGS.requestTokenURL, 'GET', {}, 5000, clusterName)
+    if (authEnabled) {
+      coFetchJSON(REQUEST_TOKEN_ENDPOINT, 'GET', {}, 5000, clusterName)
         .then((resp) => {
           setRequestTokenURL(resp?.requestTokenURL);
         })
         .catch((err) => {
           // eslint-disable-next-line no-console
-          console.warn(`Could not get request token URL for ${clusterName}: ${err}`);
+          console.warn(`Could not get request token URL: ${err}`);
           setRequestTokenURL('');
         });
     }

--- a/frontend/packages/integration-tests-cypress/tests/app/masthead.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/masthead.spec.ts
@@ -1,0 +1,34 @@
+import { checkErrors } from '../../support';
+import { masthead } from '../../views/masthead';
+
+describe('Masthead', () => {
+  before(() => {
+    cy.login();
+  });
+
+  afterEach(() => {
+    checkErrors();
+  });
+
+  after(() => {
+    cy.visit('/');
+    cy.logout();
+  });
+  describe('User dropdown', () => {
+    it('should render the correct copy login command link', () => {
+      cy.window().then((win: any) => {
+        if (win.SERVER_FLAGS?.authDisabled) {
+          cy.log('Skipping test, auth is disabled');
+        } else {
+          masthead.userDropdown().click();
+          masthead.copyLoginCommand().should('be.visible').invoke('removeAttr', 'target');
+          masthead.copyLoginCommand().click();
+          cy.url().should('include', '/oauth/token/display');
+          cy.get('body').should('include.text', 'Display Token');
+        }
+      });
+    });
+    // TODO: Add more tests for user dropdown
+  });
+  // TODO Add more tests for masthead
+});

--- a/frontend/packages/integration-tests-cypress/views/masthead.ts
+++ b/frontend/packages/integration-tests-cypress/views/masthead.ts
@@ -9,6 +9,8 @@ export const masthead = {
         .byTestID(Cypress.env('BRIDGE_KUBEADMIN_PASSWORD') ? 'user-dropdown' : 'username')
         .should('have.text', text),
   },
+  userDropdown: () => cy.byTestID('user-dropdown'),
+  copyLoginCommand: () => cy.byTestID('copy-login-command'),
   clickMastheadLink: (path: string) => {
     return cy.byTestID(path).click();
   },

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -584,6 +584,7 @@ class MastheadToolbarContents_ extends React.Component {
           label: t('public~Copy login command'),
           href: requestTokenURL,
           externalLink: true,
+          dataTest: 'copy-login-command',
         });
       }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -129,7 +129,6 @@ type jsGlobals struct {
 	PrometheusTenancyBaseURL        string                     `json:"prometheusTenancyBaseURL"`
 	QuickStarts                     string                     `json:"quickStarts"`
 	ReleaseVersion                  string                     `json:"releaseVersion"`
-	RequestTokenURL                 string                     `json:"requestTokenURL"`
 	StatuspageID                    string                     `json:"statuspageID"`
 	Telemetry                       serverconfig.MultiKeyValue `json:"telemetry"`
 	ThanosPublicURL                 string                     `json:"thanosPublicURL"`
@@ -807,7 +806,6 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 
 	if !s.authDisabled() {
 		specialAuthURLs := localAuther.GetSpecialURLs()
-		jsg.RequestTokenURL = specialAuthURLs.RequestToken
 		jsg.KubeAdminLogoutURL = specialAuthURLs.KubeAdminLogout
 	}
 


### PR DESCRIPTION
- Update `useRequestTokenURL` hook to fetch the request token URL from `/api/request-token` endpoint instead of the `window.SERVER_FLAGS.requestTokenURL`, which was incorrect.
- Remove unused requestTokenURL server flag from frontend and backend