### PR TITLE
OCPBUGS-16025,OCPBUGS-14837: Hide the Duplicate Pipelines Card in the DevConsole Add Page

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -715,6 +715,12 @@
     }
   },
   {
+    "type": "console.flag/hookProvider",
+    "properties": {
+      "handler": { "$codeRef": "pipelinesComponent.useIsTektonV1VersionPresent" }
+    }
+  },
+  {
     "type": "dev-console.add/action-group",
     "properties": {
       "id": "pipelines",
@@ -726,7 +732,8 @@
   {
     "type": "dev-console.add/action",
     "flags": {
-      "required": ["OPENSHIFT_PIPELINE_V1BETA1"]
+      "required": ["OPENSHIFT_PIPELINE_V1BETA1"],
+      "disallowed": ["FLAG_TEKTON_V1_ENABLED"]
     },
     "properties": {
       "id": "pipeline",
@@ -747,7 +754,7 @@
   {
     "type": "dev-console.add/action",
     "flags": {
-      "required": ["OPENSHIFT_PIPELINE"]
+      "required": ["OPENSHIFT_PIPELINE", "FLAG_TEKTON_V1_ENABLED"]
     },
     "properties": {
       "id": "pipeline",
@@ -781,7 +788,27 @@
       }
     },
     "flags": {
-      "required": ["OPENSHIFT_PIPELINE"]
+      "required": ["OPENSHIFT_PIPELINE", "FLAG_TEKTON_V1_ENABLED"]
+    }
+  },
+  {
+    "type": "console.navigation/href",
+    "properties": {
+      "id": "pipelines",
+      "perspective": "dev",
+      "section": "resources",
+      "insertAfter": "builds",
+      "name": "%pipelines-plugin~Pipelines%",
+      "href": "/dev-pipelines",
+      "namespaced": true,
+      "dataAttributes": {
+        "data-quickstart-id": "qs-nav-pipelines",
+        "data-test-id": "pipeline-header"
+      }
+    },
+    "flags": {
+      "required": ["OPENSHIFT_PIPELINE_V1BETA1"],
+      "disallowed": ["FLAG_TEKTON_V1_ENABLED"]
     }
   },
   {
@@ -798,7 +825,7 @@
       }
     },
     "flags": {
-      "required": ["OPENSHIFT_PIPELINE"]
+      "required": ["OPENSHIFT_PIPELINE", "FLAG_TEKTON_V1_ENABLED"]
     }
   },
   {
@@ -812,7 +839,7 @@
       "namespaced": true
     },
     "flags": {
-      "required": ["OPENSHIFT_PIPELINE"]
+      "required": ["OPENSHIFT_PIPELINE", "FLAG_TEKTON_V1_ENABLED"]
     }
   },
   {
@@ -826,7 +853,55 @@
       "namespaced": true
     },
     "flags": {
-      "required": ["OPENSHIFT_PIPELINE"]
+      "required": ["OPENSHIFT_PIPELINE", "FLAG_TEKTON_V1_ENABLED"]
+    }
+  },
+  {
+    "type": "console.navigation/href",
+    "properties": {
+      "id": "pipelines",
+      "perspective": "admin",
+      "section": "pipelines",
+      "name": "%pipelines-plugin~Pipelines%",
+      "href": "/pipelines",
+      "namespaced": true,
+      "dataAttributes": {
+        "data-quickstart-id": "qs-nav-pipelines"
+      }
+    },
+    "flags": {
+      "required": ["OPENSHIFT_PIPELINE_V1BETA1"],
+      "disallowed": ["FLAG_TEKTON_V1_ENABLED"]
+    }
+  },
+  {
+    "type": "console.navigation/href",
+    "properties": {
+      "id": "pipelinetasks",
+      "perspective": "admin",
+      "section": "pipelines",
+      "name": "%pipelines-plugin~Tasks%",
+      "href": "/tasks",
+      "namespaced": true
+    },
+    "flags": {
+      "required": ["OPENSHIFT_PIPELINE_V1BETA1"],
+      "disallowed": ["FLAG_TEKTON_V1_ENABLED"]
+    }
+  },
+  {
+    "type": "console.navigation/href",
+    "properties": {
+      "id": "pipelinetriggers",
+      "perspective": "admin",
+      "section": "pipelines",
+      "name": "%pipelines-plugin~Triggers%",
+      "href": "/triggers",
+      "namespaced": true
+    },
+    "flags": {
+      "required": ["OPENSHIFT_PIPELINE_V1BETA1"],
+      "disallowed": ["FLAG_TEKTON_V1_ENABLED"]
     }
   },
   {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines-index.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines-index.ts
@@ -3,3 +3,4 @@ export * from './pipelineruns';
 export * from './conditions';
 export * from './pipelines-lists';
 export * from './repository';
+export { useIsTektonV1VersionPresent } from './pipelines/utils/pipeline-operator';

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
@@ -76,3 +76,5 @@ export enum PipelineMetricsLevel {
   UNSUPPORTED_LEVEL = 'unsupported',
   UNSIMPLIFIED_METRICS_LEVEL = 'unsimplified',
 }
+
+export const FLAG_TEKTON_V1_ENABLED = 'FLAG_TEKTON_V1_ENABLED';

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/utils/pipeline-operator.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/utils/pipeline-operator.ts
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { compare, gt, gte, parse, SemVer } from 'semver';
-import { useAccessReview } from '@console/dynamic-plugin-sdk';
+import { SetFeatureFlag, useAccessReview } from '@console/dynamic-plugin-sdk';
 import { k8sList } from '@console/dynamic-plugin-sdk/src/utils/k8s';
 import {
   ClusterServiceVersionKind,
   ClusterServiceVersionModel,
   ClusterServiceVersionPhase,
 } from '@console/operator-lifecycle-manager';
+import { useActiveNamespace } from '@console/shared/src';
 import { TektonConfigModel } from '../../../models';
 import {
   PIPELINE_UNSIMPLIFIED_METRICS_VERSION,
@@ -14,6 +15,7 @@ import {
   TRIGGERS_GA_VERSION,
   PipelineMetricsLevel,
   PIPELINE_NAMESPACE,
+  FLAG_TEKTON_V1_ENABLED,
 } from '../const';
 import { MetricsQueryPrefix } from '../pipeline-metrics/pipeline-metrics-utils';
 import { getPipelineMetricsLevel, usePipelineConfig } from './pipeline-config';
@@ -91,4 +93,11 @@ export const usePipelineMetricsLevel = (namespace: string) => {
     queryPrefix,
     hasUpdatePermission,
   };
+};
+
+export const useIsTektonV1VersionPresent = (setFeatureFlag: SetFeatureFlag) => {
+  const [activeNamespace] = useActiveNamespace();
+  const operatorVersion = usePipelineOperatorVersion(activeNamespace);
+  const isTektonV1VersionPresent = operatorVersion?.major === 1 && operatorVersion?.minor >= 11;
+  setFeatureFlag(FLAG_TEKTON_V1_ENABLED, isTektonV1VersionPresent);
 };


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-14837 and https://issues.redhat.com/browse/OCPBUGS-16025

Descriptions: 
- Previously duplicate was shown on the add page when Openshift Pipeline operator 1.11 is installed as both the API versions v1 and v1beta1 are enabled. Fixed it by introducing a new flag that checks for the operator version.
- Pipeline tab was not visible on the 4.14 cluster if older than 1.11 Pipeline Operator is installed. Fixed by making entries for the v1beta1 API version in the console-extension.