### PR TITLE
OCPBUGS-16148:  disable Save if Use existing claim is active and no …

### DIFF
--- a/frontend/public/components/storage/attach-pvc-storage.tsx
+++ b/frontend/public/components/storage/attach-pvc-storage.tsx
@@ -408,7 +408,12 @@ export const AttachStorageForm: React.FC<AttachStorageFormProps> = (props) => {
       )}
       <ButtonBar errorMessage={error} inProgress={inProgress}>
         <ActionGroup className="pf-c-form">
-          <Button type="submit" variant="primary" id="save-changes">
+          <Button
+            type="submit"
+            variant="primary"
+            id="save-changes"
+            isDisabled={showCreatePVC === 'existing' && !claimName}
+          >
             {t('public~Save')}
           </Button>
           <Button type="button" variant="secondary" onClick={history.goBack}>


### PR DESCRIPTION
…claim has been selected

The other required fields in the form are using browser-side validation, which isn't possible with the custom select we're using.  So the simplest fix is to disable the `Save` button to prevent submission of the form without an existing claim specified.

After:
<img width="735" alt="Screenshot 2023-07-13 at 11 43 47 AM" src="https://github.com/openshift/console/assets/895728/9fde63ef-bba3-4fd8-a558-f8f761c26a4a">
