### PR TITLE
OCPBUGS-11971: When removing the project owner from the project in GUI, instead of that user, the group (the default group added as project admin through the project template) will be removed.

### DIFF
--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
@@ -62,7 +62,7 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({
     let removeRoles = getRemovedRoles(initialValues.projectAccess, values.projectAccess);
     const updateRoles = getRolesToUpdate(newRoles, removeRoles);
 
-    const updateRolesWithMultipleSubjects = getRolesWithMultipleSubjects(
+    const { updateRolesWithMultipleSubjects, removeRoleSubjectFlag } = getRolesWithMultipleSubjects(
       newRoles,
       removeRoles,
       updateRoles,
@@ -78,15 +78,20 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({
     }
     updateRoles.push(...updateRolesWithMultipleSubjects);
     const roleBindingRequests = [];
-
     if (updateRoles.length > 0) {
-      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Patch, updateRoles, namespace));
+      roleBindingRequests.push(
+        ...sendRoleBindingRequest(Verb.Patch, updateRoles, namespace, removeRoleSubjectFlag),
+      );
     }
     if (newRoles.length > 0) {
-      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Create, newRoles, namespace));
+      roleBindingRequests.push(
+        ...sendRoleBindingRequest(Verb.Create, newRoles, namespace, removeRoleSubjectFlag),
+      );
     }
     if (removeRoles.length > 0) {
-      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Remove, removeRoles, namespace));
+      roleBindingRequests.push(
+        ...sendRoleBindingRequest(Verb.Remove, removeRoles, namespace, removeRoleSubjectFlag),
+      );
     }
 
     return Promise.all(roleBindingRequests)

--- a/frontend/packages/dev-console/src/components/project-access/__tests__/project-access-form-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/project-access/__tests__/project-access-form-submit-utils.spec.ts
@@ -38,8 +38,12 @@ describe('Project Access handleSubmit Utils', () => {
     expect(rolesWithNameChange).toEqual(rolesWithNameChangeResult);
   });
   it('should get roles with multiple subjects', () => {
-    const result = getRolesWithMultipleSubjects(newRoles, removeRoles, updateRoles);
-    expect(result).toEqual([
+    const { updateRolesWithMultipleSubjects } = getRolesWithMultipleSubjects(
+      newRoles,
+      removeRoles,
+      updateRoles,
+    );
+    expect(updateRolesWithMultipleSubjects).toEqual([
       {
         role: 'admin',
         roleBindingName: 'admin-d',


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-11971

**Analysis / Root cause**: 
While removing the subjects were not properly considered

**Solution Description**: 
Proper subject to remove is considered

**Screen shots / Gifs for design review**: 




https://github.com/openshift/console/assets/102503482/6c293666-70bc-4324-b64c-738492fbd818




**Unit test coverage report**: 
NA

**Test setup:**

Follow steps to reproduce in https://issues.redhat.com/browse/OCPBUGS-11971 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge