### PR TITLE
OCPBUGS-16433: Fixes location update issues

### DIFF
--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -14,6 +14,7 @@ import {
   matchPath,
   RouteComponentProps,
   useRouteMatch,
+  useLocation,
 } from 'react-router-dom';
 import {
   HorizontalNavTab as DynamicResourceNavTab,
@@ -182,6 +183,7 @@ export const navFactory: NavFactory = {
 export const NavBar: React.FC<NavBarProps> = ({ pages, baseURL, basePath }) => {
   const { t } = useTranslation();
   const { telemetryPrefix, titlePrefix } = React.useContext(PageTitleContext);
+  const location = useLocation();
 
   basePath = basePath.replace(/\/$/, '');
 


### PR DESCRIPTION
Currently for dynamic plugins the Horizontal Nav doesn't update the active tab after moving the recent changes of removing the `withRouter` HOC. This fixes that issue.