### PR TITLE
[release-4.12] OCPBUGS-16139: The upgrade Helm Release tab in OpenShift GUI Developer console is not refreshing with updated values.

### DIFF
--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartVersionDropdown.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartVersionDropdown.tsx
@@ -58,7 +58,7 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
   const [helmChartEntries, setHelmChartEntries] = React.useState<HelmChartMetaData[]>([]);
   const [initialYamlData, setInitialYamlData] = React.useState<string>('');
   const [initialFormData, setInitialFormData] = React.useState<object>();
-
+  const [helmChartRepos, setHelmChartRepos] = React.useState<HelmChartEntries>({});
   const resourceSelector: WatchK8sResource = {
     isList: true,
     kind: referenceForModel(HelmChartRepositoryModel),
@@ -134,6 +134,7 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
           getChartIndexEntry(json?.entries, chartName, chartEntries[0].repoName),
         );
       }
+      setHelmChartRepos(json?.entries);
       setHelmChartEntries(chartEntries);
       setHelmChartVersions(getChartVersions(chartEntries, t));
     };
@@ -145,15 +146,15 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
 
   const onChartVersionChange = (value: string) => {
     const [version, repoName] = value.split('--');
-
     const chartURL = getChartURL(helmChartEntries, version, repoName);
+    const chartRepoIndex = getChartIndexEntry(helmChartRepos, chartName, repoName);
 
     setFieldValue('chartVersion', value);
     setFieldValue('chartURL', chartURL);
     coFetchJSON(
       `/api/helm/chart?url=${encodeURIComponent(
         chartURL,
-      )}&namespace=${namespace}&indexEntry=${encodeURIComponent(chartIndexEntry)}`,
+      )}&namespace=${namespace}&indexEntry=${encodeURIComponent(chartRepoIndex)}`,
     )
       .then((res: HelmChart) => {
         onVersionChange(res);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator.view.ts
@@ -70,7 +70,7 @@ export const operator = {
     nav.sidenav.clickNavLink(['Operators', 'Installed Operators']);
     listPage.titleShouldHaveText('Installed Operators');
     listPage.filter.byName(operatorName);
-    cy.byTestOperatorRow(operatorName, { timeout: 180000 }).should('exist'); // 3 minutes
+    cy.byTestOperatorRow(operatorName, { timeout: 720000 }).should('exist'); // 12 minutes
     listPage.rows.countShouldBe(1);
     cy.byTestID('status-text', { timeout: 720000 }).should('contain.text', 'Succeeded'); // 12 minutes
   },


### PR DESCRIPTION
This is an Manual cherry-pick of https://github.com/openshift/console/pull/12976