### PR TITLE
CONSOLE-3327: Expose useActiveNamespace within dynamic-core-api

### DIFF
--- a/frontend/packages/console-app/src/components/detect-cluster/cluster.ts
+++ b/frontend/packages/console-app/src/components/detect-cluster/cluster.ts
@@ -9,8 +9,8 @@ import { setActiveCluster } from '@console/dynamic-plugin-sdk/src/app/core/actio
 import { useActivePerspective } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { clearSSARFlags, detectFeatures } from '@console/internal/actions/features';
 import { formatNamespaceRoute } from '@console/internal/actions/ui';
-import { useActiveNamespace } from '@console/shared/src';
 import { LAST_CLUSTER_USER_SETTINGS_KEY, HUB_CLUSTER_NAME } from '@console/shared/src/constants';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useUserSettingsLocalStorage } from '@console/shared/src/hooks/useUserSettingsLocalStorage';
 import { ACM_PERSPECTIVE_ID, ADMIN_PERSPECTIVE_ID } from '../../consts';
 

--- a/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
@@ -21,7 +21,13 @@ export const NamespaceContext = React.createContext<NamespaceContextType>({});
 
 const useUrlNamespace = () => getNamespace(useLocation().pathname);
 
-export const useValuesForNamespaceContext = () => {
+type UseValuesForNamespaceContext = () => {
+  namespace: string;
+  setNamespace: (ns: string) => void;
+  loaded: boolean;
+};
+
+export const useValuesForNamespaceContext: UseValuesForNamespaceContext = () => {
   const urlNamespace = useUrlNamespace();
   const [activeNamespace, setActiveNamespace] = React.useState<string>(urlNamespace);
   const [preferredNamespace, , preferredNamespaceLoaded] = usePreferredNamespace();

--- a/frontend/packages/console-app/src/components/nav/NavItemHref.tsx
+++ b/frontend/packages/console-app/src/components/nav/NavItemHref.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { NavItem } from '@patternfly/react-core';
 import { HrefNavItem } from '@console/dynamic-plugin-sdk';
-import { useActiveNamespace } from '@console/dynamic-plugin-sdk/src/lib-internal';
 import { formatNamespacedRouteForHref, formatNamespacedRouteForResource } from '@console/shared';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useLocation } from '@console/shared/src/hooks/useLocation';
 import { NavLinkProps, NavLink } from './NavLink';
 import { navItemHrefIsActive, stripScopeFromPath } from './utils';

--- a/frontend/packages/console-app/src/components/nav/NavItemResource.tsx
+++ b/frontend/packages/console-app/src/components/nav/NavItemResource.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { NavItem } from '@patternfly/react-core';
 import { ResourceNSNavItem } from '@console/dynamic-plugin-sdk';
-import { useActiveNamespace } from '@console/dynamic-plugin-sdk/src/lib-internal';
 import { referenceForExtensionModel } from '@console/internal/module/k8s';
 import {
   formatNamespacedRouteForResource,
   LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
   ALL_NAMESPACES_KEY,
 } from '@console/shared';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { useLocation } from '@console/shared/src/hooks/useLocation';
 import { NavLink, NavLinkProps } from './NavLink';

--- a/frontend/packages/console-app/src/components/user-preferences/UserPreferenceCheckboxField.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/UserPreferenceCheckboxField.tsx
@@ -4,7 +4,8 @@ import {
   UserPreferenceCheckboxField as CheckboxFieldType,
   UserPreferenceCheckboxFieldValue,
 } from '@console/dynamic-plugin-sdk/src';
-import { useTelemetry, useUserSettings } from '@console/shared';
+import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
+import { useUserSettings } from '@console/shared/src/hooks/useUserSettings';
 import { UserPreferenceFieldProps } from './types';
 
 import './UserPreferenceField.scss';

--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -66,10 +66,11 @@
 64.  [useAnnotationsModal](#useannotationsmodal)
 65.  [useDeleteModal](#usedeletemodal)
 66.  [useLabelsModal](#uselabelsmodal)
-67. [DEPRECATED] [PerspectiveContext](#perspectivecontext)
-68. [DEPRECATED] [useAccessReviewAllowed](#useaccessreviewallowed)
-69. [DEPRECATED] [useSafetyFirst](#usesafetyfirst)
-70. [DEPRECATED] [YAMLEditor](#yamleditor)
+67.  [useActiveNamespace](#useactivenamespace)
+68. [DEPRECATED] [PerspectiveContext](#perspectivecontext)
+69. [DEPRECATED] [useAccessReviewAllowed](#useaccessreviewallowed)
+70. [DEPRECATED] [useSafetyFirst](#usesafetyfirst)
+71. [DEPRECATED] [YAMLEditor](#yamleditor)
 
 ---
 
@@ -2357,6 +2358,44 @@ const PodLabelsButton = ({ pod }) => {
 ### Returns
 
 A function which will launch a modal for editing a resource's labels.
+
+
+---
+
+## `useActiveNamespace`
+
+### Summary 
+
+Hook that provides the currently active namespace and a callback for setting the active namespace.
+
+
+
+### Example
+
+
+```tsx
+const Component: React.FC = (props) => {
+   const [activeNamespace, setActiveNamespace] = useActiveNamespace();
+   return <select
+     value={activeNamespace}
+     onChange={(e) => setActiveNamespace(e.target.value)}
+   >
+     {
+       // ...namespace options
+     }
+   </select>
+}
+```
+
+
+
+
+
+
+
+### Returns
+
+A tuple containing the current active namespace and setter callback.
 
 
 ---

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -33,6 +33,7 @@ import {
   UsePrometheusPoll,
   UseResolvedExtensions,
   VirtualizedTableFC,
+  UseActiveNamespace,
 } from '../extensions/console-types';
 import { StatusPopupSectionProps, StatusPopupItemProps } from '../extensions/dashboard-types';
 
@@ -829,6 +830,7 @@ export const useAnnotationsModal: UseAnnotationsModal = require('@console/shared
  * }
  */
 export const useDeleteModal: UseDeleteModal = require('@console/shared/src/hooks/useDeleteModal')
+
   .useDeleteModal;
 
 /**
@@ -846,3 +848,24 @@ export const useDeleteModal: UseDeleteModal = require('@console/shared/src/hooks
  * ```
  */
 export const useLabelsModal: UseLabelsModal = require('@console/shared/src/hooks/useLabelsModal');
+
+/**
+ * Hook that provides the currently active namespace and a callback for setting the active namespace.
+ * @returns A tuple containing the current active namespace and setter callback.
+ * @example
+ * ```tsx
+ * const Component: React.FC = (props) => {
+ *    const [activeNamespace, setActiveNamespace] = useActiveNamespace();
+ *    return <select
+ *      value={activeNamespace}
+ *      onChange={(e) => setActiveNamespace(e.target.value)}
+ *    >
+ *      {
+ *        // ...namespace options
+ *      }
+ *    </select>
+ * }
+ * ```
+ */
+export const useActiveNamespace: UseActiveNamespace = require('@console/shared/src/hooks/useActiveNamespace')
+  .useActiveNamespace;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
@@ -13,7 +13,6 @@ import {
   UtilizationBodyProps,
   UtilizationDurationDropdownProps,
   UseUtilizationDuration,
-  UseActiveNamespace,
   VirtualizedGridProps,
   LazyActionMenuProps,
   UseDashboardResources,
@@ -58,8 +57,6 @@ export const QuickStartsLoader: React.FC<QuickStartsLoaderProps> = require('@con
 
 export const useUtilizationDuration: UseUtilizationDuration = require('@console/shared/src/hooks/useUtilizationDuration')
   .useUtilizationDuration;
-export const useActiveNamespace: UseActiveNamespace = require('@console/shared/src/hooks/useActiveNamespace')
-  .useActiveNamespace;
 export const ServicesList = require('@console/internal/components/service').ServicesList;
 export const useDashboardResources: UseDashboardResources = require('@console/shared/src/hooks/useDashboardResources')
   .useDashboardResources;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
@@ -180,8 +180,6 @@ export type Options = {
   cluster?: string;
 };
 
-export type UseActiveNamespace = () => [string, (ns: string) => void];
-
 export type UseLastNamespace = () => [
   string,
   React.Dispatch<React.SetStateAction<string>>,

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -726,3 +726,11 @@ export type UseDeleteModal = (
 ) => () => void;
 
 export type UseLabelsModal = (resource: K8sResourceCommon) => () => void;
+
+export type UseValuesForNamespaceContext = () => {
+  namespace: string;
+  setNamespace: (ns: string) => void;
+  loaded: boolean;
+};
+
+export type UseActiveNamespace = () => [string, (ns: string) => void];

--- a/frontend/packages/console-shared/src/components/getting-started/__tests__/QuickStartGettingStartedCard.spec.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/__tests__/QuickStartGettingStartedCard.spec.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import QuickStartsLoader from '@console/app/src/components/quick-starts/loader/QuickStartsLoader';
-import { useActiveNamespace } from '@console/shared/src';
 import { GettingStartedCard } from '@console/shared/src/components/getting-started';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { QuickStartGettingStartedCard } from '../QuickStartGettingStartedCard';
 import { loadingQuickStarts, loadedQuickStarts } from './QuickStartGettingStartedCard.data';
 

--- a/frontend/packages/console-shared/src/hooks/useActiveNamespace.ts
+++ b/frontend/packages/console-shared/src/hooks/useActiveNamespace.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { NamespaceContext } from '@console/app/src/components/detect-namespace/namespace';
-import { UseActiveNamespace } from '@console/dynamic-plugin-sdk/src/api/internal-types';
+import { UseActiveNamespace } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 
 export const useActiveNamespace: UseActiveNamespace = () => {
   const { namespace, setNamespace } = useContext(NamespaceContext);

--- a/frontend/packages/helm-plugin/src/catalog/components/HelmCatalogTypeDescription.tsx
+++ b/frontend/packages/helm-plugin/src/catalog/components/HelmCatalogTypeDescription.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Trans } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { useAccessReview } from '@console/dynamic-plugin-sdk/src';
-import { useActiveNamespace } from '@console/dynamic-plugin-sdk/src/lib-internal';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { ProjectHelmChartRepositoryModel } from '../../models';
 
 const LinkToCreatePHCR: React.FC = () => {

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard-footer.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard-footer.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { Prompt } from 'react-router';
 import { getActiveNamespace } from '@console/internal/actions/ui';
-import { useActiveNamespace } from '@console/shared';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useShowErrorToggler } from '../../hooks/use-show-error-toggler';
 import { getDialogUIError, getSimpleDialogUIError } from '../../utils';
 import { iGetIsLoaded, iGetLoadError } from '../../utils/immutable';

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
@@ -6,7 +6,7 @@ import { useSafetyFirst } from '@console/dynamic-plugin-sdk';
 import { RowFunctionArgs, Table } from '@console/internal/components/factory';
 import { useAccessReview2 } from '@console/internal/components/utils';
 import { NetworkAttachmentDefinitionModel } from '@console/network-attachment-definition-plugin';
-import { useActiveNamespace } from '@console/shared/src';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { asVMILikeWrapper } from '../../k8s/wrapper/utils/convert';
 import { NetworkInterfaceWrapper } from '../../k8s/wrapper/vm/network-interface-wrapper';
 import { NetworkWrapper } from '../../k8s/wrapper/vm/network-wrapper';

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/vm-environment-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/vm-environment-page.tsx
@@ -26,7 +26,7 @@ import {
   ServiceAccountKind,
   TemplateKind,
 } from '@console/internal/module/k8s';
-import { useActiveNamespace } from '@console/shared/src';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { PatchBuilder } from '@console/shared/src/k8s/patch';
 import { getVMLikePatches } from '../../../k8s/patches/vm-template';
 import { VMWrapper } from '../../../k8s/wrapper/vm/vm-wrapper';

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-ssh-service.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-ssh-service.ts
@@ -5,7 +5,7 @@ import { useDispatch } from 'react-redux';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ServiceModel } from '@console/internal/models';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { useActiveNamespace } from '@console/shared';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { sshActions, SSHActionsNames } from '../components/ssh-service/redux/actions';
 import {
   createOrDeleteSSHService,

--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/PacInfoPanel.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/PacInfoPanel.tsx
@@ -7,7 +7,7 @@ import {
   Resources,
 } from '@console/dev-console/src/components/import/import-types';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
-import { useActiveNamespace } from '@console/shared/src';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import './PacSection.scss';
 
 const InfoPanel: React.FC = () => {

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -7,7 +7,7 @@ import { ActionGroup, Button } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import { ListPageBody } from '@console/dynamic-plugin-sdk';
 import { FLAGS } from '@console/shared/src/constants';
-import { useActiveNamespace } from '@console/shared';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { ClusterRoleBindingModel } from '../../models';
 import { getQN, k8sCreate, k8sPatch, referenceFor } from '../../module/k8s';
 import * as UIActions from '../../actions/ui';

--- a/frontend/public/components/start-guide.tsx
+++ b/frontend/public/components/start-guide.tsx
@@ -6,7 +6,7 @@ import { Button } from '@patternfly/react-core';
 import { useTranslation, Trans } from 'react-i18next';
 
 import { FLAGS } from '@console/shared/src/constants';
-import { useActiveNamespace } from '@console/shared';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { createProjectMessageStateToProps } from '../reducers/ui';
 import { Disabled, HintBlock, ExternalLink, openshiftHelpBase, LinkifyExternal } from './utils';

--- a/frontend/public/components/utils/namespace-redirect.tsx
+++ b/frontend/public/components/utils/namespace-redirect.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Redirect, RouteComponentProps } from 'react-router-dom';
-import { useActiveNamespace } from '@console/shared/src';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants';
 
 const appendActiveNamespace = (namespace: string, pathname: string): string => {


### PR DESCRIPTION
Includes changes from https://github.com/openshift/console/pull/13018, which should merge first as the commits it contains will get squashed on merge.