### PR TITLE
OCPBUGS-3495: Add cacheBuster query string when requesting plugin entry scripts

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/__tests__/url.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/__tests__/url.spec.ts
@@ -1,18 +1,56 @@
+import * as _ from 'lodash';
 import { resolveURL } from '../url';
 
 describe('resolveURL', () => {
-  const getDocumentOrigin = () => 'https://example:1234';
+  const getDocumentOrigin = jest.fn(() => 'https://example:1234');
 
   it('uses the base URL as-is if it has the protocol', () => {
-    expect(resolveURL('http://test', 'foo', getDocumentOrigin)).toBe('http://test/foo');
-    expect(resolveURL('http://test/', 'foo', getDocumentOrigin)).toBe('http://test/foo');
-    expect(resolveURL('http://test/foo', 'bar', getDocumentOrigin)).toBe('http://test/bar');
-    expect(resolveURL('http://test/foo/', 'bar', getDocumentOrigin)).toBe('http://test/foo/bar');
+    expect(resolveURL('http://test', 'foobar', _.identity, getDocumentOrigin)).toBe(
+      'http://test/foobar',
+    );
+    expect(resolveURL('http://test/', 'foobar', _.identity, getDocumentOrigin)).toBe(
+      'http://test/foobar',
+    );
+    expect(resolveURL('http://test/foo', 'bar', _.identity, getDocumentOrigin)).toBe(
+      'http://test/bar',
+    );
+    expect(resolveURL('http://test/foo/', 'bar', _.identity, getDocumentOrigin)).toBe(
+      'http://test/foo/bar',
+    );
+
+    expect(getDocumentOrigin).not.toHaveBeenCalled();
   });
 
   it("makes the base URL relative to document origin if it's missing the protocol", () => {
-    expect(resolveURL('/', 'foo', getDocumentOrigin)).toBe('https://example:1234/foo');
-    expect(resolveURL('/foo', 'bar', getDocumentOrigin)).toBe('https://example:1234/bar');
-    expect(resolveURL('/foo/', 'bar', getDocumentOrigin)).toBe('https://example:1234/foo/bar');
+    expect(resolveURL('/', 'foobar', _.identity, getDocumentOrigin)).toBe(
+      'https://example:1234/foobar',
+    );
+    expect(resolveURL('/foo', 'bar', _.identity, getDocumentOrigin)).toBe(
+      'https://example:1234/bar',
+    );
+    expect(resolveURL('/foo/', 'bar', _.identity, getDocumentOrigin)).toBe(
+      'https://example:1234/foo/bar',
+    );
+
+    expect(getDocumentOrigin).toHaveBeenCalledTimes(3);
+  });
+
+  it('calls the URL processing callback before returning the URL string', () => {
+    const processURL = jest.fn((url: URL) => {
+      const newURL = new URL(url);
+
+      newURL.protocol = 'http';
+      newURL.hostname = 'custom-host';
+      newURL.port = '8080';
+      newURL.search = '?test=true';
+
+      return newURL;
+    });
+
+    expect(resolveURL('/', 'foobar', processURL, getDocumentOrigin)).toBe(
+      'http://custom-host:8080/foobar?test=true',
+    );
+
+    expect(processURL).toHaveBeenCalledWith(new URL('https://example:1234/foobar'));
   });
 });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/url.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/url.ts
@@ -7,13 +7,14 @@ import * as _ from 'lodash';
  *
  * @param base Base URL.
  * @param to Target resource URL.
- * @param options Resolution options.
+ * @param processURL Custom URL processing callback.
  */
 export const resolveURL = (
   base: string,
   to: string,
+  processURL: (url: URL) => URL = _.identity,
   getDocumentOrigin: () => string = _.constant(window.location.origin),
 ) => {
   const baseAbsoluteURL = base.indexOf('://') === -1 ? getDocumentOrigin() + base : base;
-  return new URL(to, baseAbsoluteURL).toString();
+  return processURL(new URL(to, baseAbsoluteURL)).toString();
 };


### PR DESCRIPTION
This PR adds `?cacheBuster=${getRandomChars()}` query string when requesting `plugin-entry.js` resources.

This is a backport of OpenShift dynamic plugin SDK [`PluginLoader`](https://github.com/openshift/dynamic-plugin-sdk/blob/main/packages/lib-core/src/runtime/PluginLoader.ts) script URL resolution code:
```ts
resolveURL(manifest.baseURL, scriptName, (url) => {
  url.searchParams.set('cacheBuster', uuidv4());
  return url;
})
```

Implementation notes:
- using the existing Console `getRandomChars` helper function (long term, we will adopt `PluginLoader` in Console)
- setting the query string via `url.search` instead of `url.searchParams` due to `jsdom` missing polyfill for the latter

How to verify:
1. build Console frontend
  ```
  cd /path/to/console/frontend
  yarn
  yarn build-dev
  ```
2. build Console demo plugin and host it on a local server
  ```
  cd /path/to/console/dynamic-demo-plugin
  rm -rf node_modules ; yarn
  yarn build-dev
  yarn http-server
  ```
3. start Bridge server
  ```
  oc login ...
  oc-run-bridge -plugins console-demo-plugin=http://localhost:9001
  ```
4. open Console in browser and switch to developer tools / network tab
  - any requests for `plugin-entry.js` should include `?cacheBuster=<random-chars>`

![network-script](https://github.com/openshift/console/assets/648971/159b6885-107d-4c32-b153-12cc25c2bf11)
