### PR TITLE
[release-4.13] OCPBUGS-16040: fix bug where binary secret values are corrupted on edit and add test coverage

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crud/secrets.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/secrets.spec.ts
@@ -16,6 +16,14 @@ const populateSecretForm = (name: string, key: string, fileName: string) => {
   cy.byTestID('file-input').attachFile(fileName);
 };
 
+const modifySecretForm = (key: string) => {
+  detailsPage.clickPageActionFromDropdown('Edit Secret');
+  cy.get('.co-m-pane__heading').contains('Edit key/value secret');
+  cy.byTestID('secret-key')
+    .clear()
+    .type(key);
+};
+
 describe('Create key/value secrets', () => {
   const binarySecretName = `${testName}binarysecretname`;
   const asciiSecretName = `${testName}asciisecretname`;
@@ -24,6 +32,7 @@ describe('Create key/value secrets', () => {
   const asciiFilename = 'asciisecret.txt';
   const unicodeFilename = 'unicodesecret.utf8';
   const secretKey = `secretkey`;
+  const modifiedSecretKey = 'modifiedsecretkey';
 
   before(() => {
     cy.login();
@@ -56,7 +65,7 @@ describe('Create key/value secrets', () => {
     cy.logout();
   });
 
-  it(`Validate a key/value secret whose value is a binary file`, () => {
+  it(`Validate create and edit of a key/value secret whose value is a binary file`, () => {
     populateSecretForm(binarySecretName, secretKey, binaryFilename);
     cy.byLegacyTestID('file-input-textarea').should('not.exist');
     cy.get(infoMessage).should('exist');
@@ -66,6 +75,21 @@ describe('Create key/value secrets', () => {
     detailsPage.titleShouldContain(binarySecretName);
     cy.exec(
       `oc get secret -n ${testName} ${binarySecretName} --template '{{.data.${secretKey}}}' | base64 -d`,
+      {
+        failOnNonZeroExit: false,
+      },
+    ).then((value) => {
+      cy.fixture(binaryFilename, 'binary').then((binarySecret) => {
+        expect(binarySecret).toEqual(value.stdout);
+      });
+    });
+    modifySecretForm(modifiedSecretKey);
+    cy.byTestID('save-changes').click();
+    cy.byTestID('loading-indicator').should('not.exist');
+    detailsPage.isLoaded();
+    detailsPage.titleShouldContain(binarySecretName);
+    cy.exec(
+      `oc get secret -n ${testName} ${binarySecretName} --template '{{.data.${modifiedSecretKey}}}' | base64 -d`,
       {
         failOnNonZeroExit: false,
       },

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -22,6 +22,7 @@ import { ModalBody, ModalTitle, ModalSubmitFooter } from '../factory/modal';
 import { AsyncComponent } from '../utils/async';
 import { SecretModel } from '../../models';
 import { WebHookSecretKey } from '../secret';
+import { containsNonPrintableCharacters } from '../utils/file-input';
 
 export enum SecretTypeAbstraction {
   generic = 'generic',
@@ -1056,6 +1057,7 @@ export const SSHAuthSubform = withTranslation()(SSHAuthSubformWithTranslation);
 
 type KeyValueEntryFormState = {
   isBase64?: boolean;
+  isBinary?: boolean;
   key: string;
   value: string;
 };
@@ -1105,20 +1107,26 @@ class GenericSecretFormWithTranslation extends React.Component<
     if (_.isEmpty(genericSecretObject)) {
       return [this.newGenericSecretEntry()];
     }
-    return _.map(genericSecretObject, (value, key) => ({
-      uid: _.uniqueId(),
-      entry: {
-        key,
-        value,
-      },
-    }));
+    return _.map(genericSecretObject, (value, key) => {
+      const isBinary = containsNonPrintableCharacters(value);
+      return {
+        uid: _.uniqueId(),
+        entry: {
+          key,
+          value: isBinary ? Base64.btoa(value) : value,
+          isBase64: isBinary,
+          isBinary,
+        },
+      };
+    });
   }
   genericSecretArrayToObject(genericSecretArray) {
     return _.reduce(
       genericSecretArray,
       (acc, k) =>
         _.assign(acc, {
-          [k.entry.key]: k.entry?.isBase64 ? k.entry.value : Base64.encode(k.entry.value),
+          [k.entry.key]:
+            k.entry?.isBase64 || k.entry?.isBinary ? k.entry.value : Base64.encode(k.entry.value),
         }),
       {},
     );
@@ -1209,6 +1217,7 @@ class KeyValueEntryFormWithTranslation extends React.Component<
     this.state = {
       key: props.entry.key,
       value: props.entry.value,
+      isBinary: props.entry.isBinary,
     };
     this.onValueChange = this.onValueChange.bind(this);
     this.onKeyChange = this.onKeyChange.bind(this);
@@ -1261,6 +1270,7 @@ class KeyValueEntryFormWithTranslation extends React.Component<
               inputFieldHelpText={t(
                 'public~Drag and drop file with your value here or browse to upload it.',
               )}
+              inputFileIsBinary={this.state.isBinary}
             />
           </div>
         </div>

--- a/frontend/public/components/utils/file-input.tsx
+++ b/frontend/public/components/utils/file-input.tsx
@@ -175,7 +175,8 @@ const DroppableFileInputWithTranslation = withDragDropContext(
       this.state = {
         inputFileName: '',
         inputFileData: this.props.inputFileData || '',
-        inputFileIsBinary: containsNonPrintableCharacters(this.props.inputFileData),
+        inputFileIsBinary:
+          this.props.inputFileIsBinary || containsNonPrintableCharacters(this.props.inputFileData),
       };
       this.handleFileDrop = this.handleFileDrop.bind(this);
       this.onDataChange = this.onDataChange.bind(this);
@@ -256,6 +257,7 @@ export type DroppableFileInputProps = WithTranslation & {
   textareaFieldHelpText: string;
   isRequired: boolean;
   hideContents?: boolean;
+  inputFileIsBinary?: boolean;
 };
 
 export type DroppableFileInputState = {


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-16040

Backport from 4.14: https://github.com/openshift/console/pull/12986