### PR TITLE
OCPBUGS-9355: Fix translation bug 

### DIFF
--- a/frontend/public/components/modals/configure-update-strategy-modal.tsx
+++ b/frontend/public/components/modals/configure-update-strategy-modal.tsx
@@ -188,6 +188,7 @@ export const ConfigureUpdateStrategyModal = withHandlePromise(
             onChangeStrategyType={setStrategyType}
             onChangeMaxUnavailable={setMaxUnavailable}
             onChangeMaxSurge={setMaxSurge}
+            replicas={props.deployment.spec.replicas}
           />
         </ModalBody>
         <ModalSubmitFooter


### PR DESCRIPTION
The actual translated values exist for each language. The issue was the `props.replicas` value was missing, which caused the pluralization to fail and so the translation string fell back to English.

[scrnli_7_25_2023_4-12-23 PM.webm](https://github.com/openshift/console/assets/1874151/11dd7cbd-b123-4d16-bf77-fd52835a1a91)
