### PR TITLE
OCPBUGS-17196: Fix nad ovn type - annotation and netAttachName

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
@@ -2,7 +2,7 @@ import { K8sResourceKind } from '@console/internal/module/k8s';
 
 export type NetworkAttachmentDefinitionAnnotations = {
   description?: string;
-  'k8s.v1.cni.cncf.io/resourceName': string;
+  'k8s.v1.cni.cncf.io/resourceName'?: string;
 };
 
 export type IPAMConfig = {


### PR DESCRIPTION
OVN type NetworkAttachmentDefinition - fix netAttachName fields order, namespace/name 
Remove annotation for this type

https://issues.redhat.com/browse/CNV-31358