### PR TITLE
OCPBUGS-16844: external link icon in `resource added` toast notification not linked

### DIFF
--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -109,12 +109,14 @@ export const ExternalLinkWithCopy: React.FC<ExternalLinkWithCopyProps> = ({
     <div className={classNames(additionalClassName)}>
       <a href={link} target="_blank" rel="noopener noreferrer" data-test-id={dataTestID}>
         {text ?? link}
+        <span className="co-icon-nowrap">
+          &nbsp;
+          <span className="co-external-link-with-copy__icon co-external-link-with-copy__externallinkicon">
+            <ExternalLinkAltIcon />
+          </span>
+        </span>
       </a>
       <span className="co-icon-nowrap">
-        &nbsp;
-        <span className="co-external-link-with-copy__icon co-external-link-with-copy__externallinkicon">
-          <ExternalLinkAltIcon />
-        </span>
         <Tooltip content={tooltipContent} trigger="click mouseenter focus" exitDelay={1250}>
           <CTC text={link} onCopy={() => setCopied(true)}>
             <span


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-16844

**Analysis / Root cause**: 
Icon was not under anchor tag

**Solution Description**: 
Added icon under anchor tag

**Screen shots / Gifs for design review**: 

----BEFORE----

https://github.com/openshift/console/assets/102503482/bef504e5-542c-4beb-8cd7-a0192259816a




----AFTER----


https://github.com/openshift/console/assets/102503482/cca0455a-f1ad-45cd-8de5-6c87c1aab8de



**Unit test coverage report**: 
NA

**Test setup:**
1. use the +Add page and import from git
2. after creating the app a toast notification will appear
3. Click the external link icon 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge