### PR TITLE
OCPBUGS-15008: update the KnativeServing API version to v1beta1 for global-config extension

### DIFF
--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -675,7 +675,7 @@
       "name": "knative-serving",
       "model": {
         "group": "operator.knative.dev",
-        "version": "v1alpha1",
+        "version": "v1beta1",
         "kind": "KnativeServing"
       },
       "namespace": "knative-serving"


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGS-15008

**Descriptions:**
Update the KnativeServing API version to v1beta1 for global-config extension as v1alpha1 support has been removed from the Red Hat Serverless Operator 1.29 and was deprecated in 1.27.

**GIF:**

https://github.com/openshift/console/assets/2561818/4afd6630-4d92-42de-aa2e-ed4ee9e00c33



