### PR TITLE
OCPBUGS-13152: fetch TaskRuns without selector and reduces the get TaskRuns requests

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunDetailsPage.tsx
@@ -6,6 +6,7 @@ import { getPipelineRunKebabActions } from '../../utils/pipeline-actions';
 import { pipelineRunStatus } from '../../utils/pipeline-filter-reducer';
 import { useDevPipelinesBreadcrumbsFor } from '../pipelines/hooks';
 import { usePipelineOperatorVersion } from '../pipelines/utils/pipeline-operator';
+import { useTaskRuns } from '../taskruns/useTaskRuns';
 import { PipelineRunDetails } from './detail-page-tabs/PipelineRunDetails';
 import { PipelineRunLogsWithActiveTask } from './detail-page-tabs/PipelineRunLogs';
 import TaskRuns from './detail-page-tabs/TaskRuns';
@@ -16,8 +17,9 @@ import { useMenuActionsWithUserAnnotation } from './triggered-by';
 const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { kindObj, match } = props;
   const operatorVersion = usePipelineOperatorVersion(props.namespace);
+  const [taskRuns] = useTaskRuns(props.namespace);
   const menuActions: KebabAction[] = useMenuActionsWithUserAnnotation(
-    getPipelineRunKebabActions(operatorVersion, true),
+    getPipelineRunKebabActions(operatorVersion, taskRuns, true),
   );
   const breadcrumbsFor = useDevPipelinesBreadcrumbsFor(kindObj, match);
   const badge = usePipelineTechPreviewBadge(props.namespace);

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunDetailsPage.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunDetailsPage.spec.tsx
@@ -6,6 +6,7 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../../models';
 import { getPipelineRunKebabActions } from '../../../utils/pipeline-actions';
 import * as hookUtils from '../../pipelines/hooks';
+import * as taskRunUtils from '../../taskruns/useTaskRuns';
 import TaskRuns from '../detail-page-tabs/TaskRuns';
 import PipelineRunEvents from '../events/PipelineRunEvents';
 import PipelineRunDetailsPage from '../PipelineRunDetailsPage';
@@ -13,6 +14,7 @@ import * as triggerHooksModule from '../triggered-by/hooks';
 
 const menuActions = jest.spyOn(triggerHooksModule, 'useMenuActionsWithUserAnnotation');
 const breadCrumbs = jest.spyOn(hookUtils, 'useDevPipelinesBreadcrumbsFor');
+const taskRuns = jest.spyOn(taskRunUtils, 'useTaskRuns');
 type PipelineRunDetailsPageProps = React.ComponentProps<typeof PipelineRunDetailsPage>;
 const i18nNS = 'public';
 const i18nPipelineNS = 'pipelines-plugin';
@@ -33,8 +35,9 @@ describe('PipelineRunDetailsPage:', () => {
         },
       },
     };
-    menuActions.mockReturnValue([getPipelineRunKebabActions(new SemVer('1.9.0'), true)]);
+    menuActions.mockReturnValue([getPipelineRunKebabActions(new SemVer('1.9.0'), [], true)]);
     breadCrumbs.mockReturnValue([{ label: 'PipelineRuns' }, { label: 'PipelineRuns Details' }]);
+    taskRuns.mockReturnValue([]);
     wrapper = shallow(<PipelineRunDetailsPage {...pipelineRunDetailsPageProps} />);
   });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunList.tsx
@@ -8,6 +8,7 @@ import { useUserSettings } from '@console/shared/src';
 import { PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY } from '../../../const';
 import { PipelineRunModel } from '../../../models';
 import { usePipelineOperatorVersion } from '../../pipelines/utils/pipeline-operator';
+import { useTaskRuns } from '../../taskruns/useTaskRuns';
 import PipelineRunHeader from './PipelineRunHeader';
 import PipelineRunRow from './PipelineRunRow';
 
@@ -23,6 +24,7 @@ export const PipelineRunList: React.FC<PipelineRunListProps> = (props) => {
     PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY,
     'pipelines',
   );
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(props.namespace);
 
   React.useEffect(() => {
     if (preferredTabLoaded && activePerspective === 'dev') {
@@ -42,7 +44,7 @@ export const PipelineRunList: React.FC<PipelineRunListProps> = (props) => {
         defaultSortOrder={SortByDirection.desc}
         Header={PipelineRunHeader}
         Row={PipelineRunRow}
-        customData={operatorVersion}
+        customData={{ operatorVersion, taskRuns: taskRunsLoaded ? taskRuns : [] }}
         virtualize
       />
     </>

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
@@ -3,13 +3,14 @@ import { TableData, RowFunctionArgs } from '@console/internal/components/factory
 import { ResourceLink, Timestamp } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../../models';
-import { PipelineRunKind } from '../../../types';
+import { PipelineRunKind, TaskRunKind } from '../../../types';
 import { getPipelineRunKebabActions } from '../../../utils/pipeline-actions';
 import {
   pipelineRunFilterReducer,
   pipelineRunTitleFilterReducer,
 } from '../../../utils/pipeline-filter-reducer';
 import { pipelineRunDuration } from '../../../utils/pipeline-utils';
+import { getTaskRunsOfPipelineRun } from '../../taskruns/useTaskRuns';
 import LinkedPipelineRunTaskStatus from '../status/LinkedPipelineRunTaskStatus';
 import PipelineRunStatus from '../status/PipelineRunStatus';
 import { ResourceKebabWithUserLabel } from '../triggered-by';
@@ -19,22 +20,23 @@ const pipelinerunReference = referenceForModel(PipelineRunModel);
 
 type PLRStatusProps = {
   obj: PipelineRunKind;
+  taskRuns: TaskRunKind[];
 };
 
-const PLRStatus: React.FC<PLRStatusProps> = ({ obj }) => {
+const PLRStatus: React.FC<PLRStatusProps> = ({ obj, taskRuns }) => {
   return (
     <PipelineRunStatus
       status={pipelineRunFilterReducer(obj)}
       title={pipelineRunTitleFilterReducer(obj)}
       pipelineRun={obj}
+      taskRuns={taskRuns}
     />
   );
 };
 
-const PipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({
-  obj,
-  customData: operatorVersion,
-}) => {
+const PipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj, customData }) => {
+  const { operatorVersion, taskRuns } = customData;
+  const PLRTaskRuns = getTaskRunsOfPipelineRun(taskRuns, obj?.metadata?.name);
   return (
     <>
       <TableData className={tableColumnClasses[0]}>
@@ -49,10 +51,10 @@ const PipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
-        <PLRStatus obj={obj} />
+        <PLRStatus obj={obj} taskRuns={PLRTaskRuns} />
       </TableData>
       <TableData className={tableColumnClasses[3]}>
-        <LinkedPipelineRunTaskStatus pipelineRun={obj} />
+        <LinkedPipelineRunTaskStatus pipelineRun={obj} taskRuns={PLRTaskRuns} />
       </TableData>
       <TableData className={tableColumnClasses[4]}>
         <Timestamp timestamp={obj.status && obj.status.startTime} />
@@ -60,7 +62,7 @@ const PipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({
       <TableData className={tableColumnClasses[5]}>{pipelineRunDuration(obj)}</TableData>
       <TableData className={tableColumnClasses[6]}>
         <ResourceKebabWithUserLabel
-          actions={getPipelineRunKebabActions(operatorVersion)}
+          actions={getPipelineRunKebabActions(operatorVersion, taskRuns)}
           kind={pipelinerunReference}
           resource={obj}
         />

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/LinkedPipelineRunTaskStatus.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/LinkedPipelineRunTaskStatus.tsx
@@ -3,12 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { LoadingInline, resourcePathFromModel } from '@console/internal/components/utils';
 import { PipelineRunModel } from '../../../models';
-import { PipelineRunKind } from '../../../types';
-import { useTaskRuns } from '../../taskruns/useTaskRuns';
+import { PipelineRunKind, TaskRunKind } from '../../../types';
 import { PipelineBars } from './PipelineBars';
 
 export interface LinkedPipelineRunTaskStatusProps {
   pipelineRun: PipelineRunKind;
+  taskRuns: TaskRunKind[];
 }
 
 /**
@@ -17,17 +17,19 @@ export interface LinkedPipelineRunTaskStatusProps {
  */
 const LinkedPipelineRunTaskStatus: React.FC<LinkedPipelineRunTaskStatusProps> = ({
   pipelineRun,
+  taskRuns,
 }) => {
   const { t } = useTranslation();
-  const [taskRuns, taskRunsLoaded] = useTaskRuns(
-    pipelineRun.metadata.namespace,
-    pipelineRun.metadata.name,
-  );
-  const pipelineStatus = taskRunsLoaded ? (
-    <PipelineBars key={pipelineRun.metadata?.name} pipelinerun={pipelineRun} taskRuns={taskRuns} />
-  ) : (
-    <LoadingInline />
-  );
+  const pipelineStatus =
+    taskRuns.length > 0 ? (
+      <PipelineBars
+        key={pipelineRun.metadata?.name}
+        pipelinerun={pipelineRun}
+        taskRuns={taskRuns}
+      />
+    ) : (
+      <LoadingInline />
+    );
 
   if (pipelineRun.metadata?.name && pipelineRun.metadata?.namespace) {
     return (

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatus.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatus.tsx
@@ -4,8 +4,7 @@ import { Link } from 'react-router-dom';
 import { LoadingInline, resourcePathFromModel } from '@console/internal/components/utils';
 import { DASH } from '@console/shared';
 import { PipelineRunModel } from '../../../models';
-import { PipelineRunKind } from '../../../types';
-import { useTaskRuns } from '../../taskruns/useTaskRuns';
+import { PipelineRunKind, TaskRunKind } from '../../../types';
 import { getPLRLogSnippet } from '../logs/pipelineRunLogSnippet';
 import PipelineResourceStatus from './PipelineResourceStatus';
 import StatusPopoverContent from './StatusPopoverContent';
@@ -14,15 +13,17 @@ type PipelineRunStatusProps = {
   status: string;
   pipelineRun: PipelineRunKind;
   title?: string;
+  taskRuns: TaskRunKind[];
 };
-const PipelineRunStatus: React.FC<PipelineRunStatusProps> = ({ status, pipelineRun, title }) => {
+const PipelineRunStatus: React.FC<PipelineRunStatusProps> = ({
+  status,
+  pipelineRun,
+  title,
+  taskRuns,
+}) => {
   const { t } = useTranslation();
-  const [taskRuns, taskRunsLoaded] = useTaskRuns(
-    pipelineRun?.metadata?.namespace,
-    pipelineRun?.metadata?.name,
-  );
   return pipelineRun ? (
-    taskRunsLoaded ? (
+    taskRuns.length > 0 ? (
       <PipelineResourceStatus status={status} title={title}>
         <StatusPopoverContent
           logDetails={getPLRLogSnippet(pipelineRun, taskRuns)}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineList.tsx
@@ -4,15 +4,18 @@ import { useTranslation } from 'react-i18next';
 import { Table } from '@console/internal/components/factory';
 import { PipelineModel } from '../../../models';
 import { PropPipelineData } from '../../../utils/pipeline-augment';
+import { useTaskRuns } from '../../taskruns/useTaskRuns';
 import PipelineHeader from './PipelineHeader';
 import PipelineRow from './PipelineRow';
 
 export interface PipelineListProps {
   data?: PropPipelineData[];
+  namespace: string;
 }
 
 const PipelineList: React.FC<PipelineListProps> = (props) => {
   const { t } = useTranslation();
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(props.namespace);
   return (
     <Table
       {...props}
@@ -21,6 +24,7 @@ const PipelineList: React.FC<PipelineListProps> = (props) => {
       aria-label={t(PipelineModel.labelPluralKey)}
       Header={PipelineHeader}
       Row={PipelineRow}
+      customData={{ taskRuns: taskRunsLoaded ? taskRuns : [] }}
       virtualize
     />
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
@@ -3,13 +3,14 @@ import { RowFunctionArgs, TableData } from '@console/internal/components/factory
 import { ResourceLink, Timestamp } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineModel, PipelineRunModel } from '../../../models';
-import { PipelineWithLatest } from '../../../types';
+import { PipelineWithLatest, TaskRunKind } from '../../../types';
 import {
   pipelineFilterReducer,
   pipelineTitleFilterReducer,
 } from '../../../utils/pipeline-filter-reducer';
 import LinkedPipelineRunTaskStatus from '../../pipelineruns/status/LinkedPipelineRunTaskStatus';
 import PipelineRunStatus from '../../pipelineruns/status/PipelineRunStatus';
+import { getTaskRunsOfPipelineRun } from '../../taskruns/useTaskRuns';
 import { tableColumnClasses } from './pipeline-table';
 import PipelineRowKebabActions from './PipelineRowKebabActions';
 
@@ -18,19 +19,23 @@ const pipelinerunReference = referenceForModel(PipelineRunModel);
 
 type PipelineStatusProps = {
   obj: PipelineWithLatest;
+  taskRuns: TaskRunKind[];
 };
 
-const PipelineStatus: React.FC<PipelineStatusProps> = ({ obj }) => {
+const PipelineStatus: React.FC<PipelineStatusProps> = ({ obj, taskRuns }) => {
   return (
     <PipelineRunStatus
       status={pipelineFilterReducer(obj)}
       title={pipelineTitleFilterReducer(obj)}
       pipelineRun={obj.latestRun}
+      taskRuns={taskRuns}
     />
   );
 };
 
-const PipelineRow: React.FC<RowFunctionArgs<PipelineWithLatest>> = ({ obj }) => {
+const PipelineRow: React.FC<RowFunctionArgs<PipelineWithLatest>> = ({ obj, customData }) => {
+  const { taskRuns } = customData;
+  const PLRTaskRuns = getTaskRunsOfPipelineRun(taskRuns, obj?.latestRun?.metadata?.name);
   return (
     <>
       <TableData className={tableColumnClasses[0]}>
@@ -55,10 +60,14 @@ const PipelineRow: React.FC<RowFunctionArgs<PipelineWithLatest>> = ({ obj }) => 
         )}
       </TableData>
       <TableData className={tableColumnClasses[3]}>
-        {obj.latestRun ? <LinkedPipelineRunTaskStatus pipelineRun={obj.latestRun} /> : '-'}
+        {obj.latestRun ? (
+          <LinkedPipelineRunTaskStatus pipelineRun={obj.latestRun} taskRuns={PLRTaskRuns} />
+        ) : (
+          '-'
+        )}
       </TableData>
       <TableData className={tableColumnClasses[4]}>
-        <PipelineStatus obj={obj} />
+        <PipelineStatus obj={obj} taskRuns={PLRTaskRuns} />
       </TableData>
       <TableData className={tableColumnClasses[5]}>
         {(obj.latestRun?.status?.startTime && (

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunList.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Table } from '@console/internal/components/factory';
 import { PipelineRunModel } from '../../models';
 import { usePipelineOperatorVersion } from '../pipelines/utils/pipeline-operator';
+import { useTaskRuns } from '../taskruns/useTaskRuns';
 import RepositoryPipelineRunHeader from './RepositoryPipelineRunHeader';
 import RepositoryPipelineRunRow from './RepositoryPipelineRunRow';
 
@@ -14,6 +15,7 @@ type RepositoryPipelineRunListProps = {
 export const RepositoryPipelineRunList: React.FC<RepositoryPipelineRunListProps> = (props) => {
   const { t } = useTranslation();
   const operatorVersion = usePipelineOperatorVersion(props.namespace);
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(props.namespace);
   return (
     <Table
       {...props}
@@ -22,7 +24,7 @@ export const RepositoryPipelineRunList: React.FC<RepositoryPipelineRunListProps>
       defaultSortOrder={SortByDirection.desc}
       Header={RepositoryPipelineRunHeader}
       Row={RepositoryPipelineRunRow}
-      customData={operatorVersion}
+      customData={{ operatorVersion, taskRuns: taskRunsLoaded ? taskRuns : [] }}
       virtualize
     />
   );

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunRow.tsx
@@ -9,7 +9,7 @@ import {
 } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../models';
-import { PipelineRunKind } from '../../types';
+import { PipelineRunKind, TaskRunKind } from '../../types';
 import { getPipelineRunKebabActions } from '../../utils/pipeline-actions';
 import {
   pipelineRunFilterReducer,
@@ -19,6 +19,7 @@ import { pipelineRunDuration } from '../../utils/pipeline-utils';
 import LinkedPipelineRunTaskStatus from '../pipelineruns/status/LinkedPipelineRunTaskStatus';
 import PipelineRunStatus from '../pipelineruns/status/PipelineRunStatus';
 import { ResourceKebabWithUserLabel } from '../pipelineruns/triggered-by';
+import { getTaskRunsOfPipelineRun } from '../taskruns/useTaskRuns';
 import {
   RepositoryLabels,
   RepositoryFields,
@@ -32,14 +33,16 @@ const pipelinerunReference = referenceForModel(PipelineRunModel);
 
 type PLRStatusProps = {
   obj: PipelineRunKind;
+  taskRuns: TaskRunKind[];
 };
 
-const PLRStatus: React.FC<PLRStatusProps> = ({ obj }) => {
+const PLRStatus: React.FC<PLRStatusProps> = ({ obj, taskRuns }) => {
   return (
     <PipelineRunStatus
       status={pipelineRunFilterReducer(obj)}
       title={pipelineRunTitleFilterReducer(obj)}
       pipelineRun={obj}
+      taskRuns={taskRuns}
     />
   );
 };
@@ -50,7 +53,8 @@ const RepositoryPipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({
 }) => {
   const plrLabels = obj.metadata.labels;
   const plrAnnotations = obj.metadata.annotations;
-
+  const { operatorVersion, taskRuns } = customData;
+  const PLRTaskRuns = getTaskRunsOfPipelineRun(taskRuns, obj?.metadata?.name);
   return (
     <>
       <TableData className={tableColumnClasses[0]}>
@@ -86,10 +90,10 @@ const RepositoryPipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[3]}>
-        <PLRStatus obj={obj} />
+        <PLRStatus obj={obj} taskRuns={PLRTaskRuns} />
       </TableData>
       <TableData className={tableColumnClasses[4]}>
-        <LinkedPipelineRunTaskStatus pipelineRun={obj} />
+        <LinkedPipelineRunTaskStatus pipelineRun={obj} taskRuns={PLRTaskRuns} />
       </TableData>
       <TableData className={tableColumnClasses[5]}>
         <Timestamp timestamp={obj.status && obj.status.startTime} />
@@ -100,7 +104,7 @@ const RepositoryPipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({
       </TableData>
       <TableData className={tableColumnClasses[8]}>
         <ResourceKebabWithUserLabel
-          actions={getPipelineRunKebabActions(customData)}
+          actions={getPipelineRunKebabActions(operatorVersion, PLRTaskRuns)}
           kind={pipelinerunReference}
           resource={obj}
         />

--- a/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoryRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoryRow.tsx
@@ -22,14 +22,16 @@ import {
 import { pipelineRunDuration } from '../../../utils/pipeline-utils';
 import LinkedPipelineRunTaskStatus from '../../pipelineruns/status/LinkedPipelineRunTaskStatus';
 import PipelineRunStatus from '../../pipelineruns/status/PipelineRunStatus';
+import { getTaskRunsOfPipelineRun } from '../../taskruns/useTaskRuns';
 import { RepositoryFields, RepositoryLabels } from '../consts';
 import { RepositoryKind } from '../types';
 import { repositoriesTableColumnClasses } from './RepositoryHeader';
 
-const RepositoryRow: React.FC<RowFunctionArgs<RepositoryKind>> = ({ obj }) => {
+const RepositoryRow: React.FC<RowFunctionArgs<RepositoryKind>> = ({ obj, customData }) => {
   const {
     metadata: { name, namespace },
   } = obj;
+  const { taskRuns } = customData;
 
   const [pipelineRun, loaded] = useK8sWatchResource<PipelineRunKind[]>({
     kind: referenceForModel(PipelineRunModel),
@@ -42,6 +44,8 @@ const RepositoryRow: React.FC<RowFunctionArgs<RepositoryKind>> = ({ obj }) => {
 
   const latestPLREventType =
     latestRun && latestRun?.metadata?.labels[RepositoryLabels[RepositoryFields.EVENT_TYPE]];
+
+  const PLRTaskRuns = getTaskRunsOfPipelineRun(taskRuns, latestRun?.metadata?.name);
   return (
     <>
       <TableData className={repositoriesTableColumnClasses[0]}>
@@ -79,7 +83,7 @@ const RepositoryRow: React.FC<RowFunctionArgs<RepositoryKind>> = ({ obj }) => {
         {}
         {loaded ? (
           latestRun ? (
-            <LinkedPipelineRunTaskStatus pipelineRun={latestRun} />
+            <LinkedPipelineRunTaskStatus pipelineRun={latestRun} taskRuns={PLRTaskRuns} />
           ) : (
             '-'
           )
@@ -93,6 +97,7 @@ const RepositoryRow: React.FC<RowFunctionArgs<RepositoryKind>> = ({ obj }) => {
             status={pipelineRunFilterReducer(latestRun)}
             title={pipelineRunTitleFilterReducer(latestRun)}
             pipelineRun={latestRun}
+            taskRuns={PLRTaskRuns}
           />
         ) : (
           <LoadingInline />

--- a/frontend/packages/pipelines-plugin/src/components/repository/list-page/ReppositoryList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/list-page/ReppositoryList.tsx
@@ -1,22 +1,29 @@
 import * as React from 'react';
 import { Table } from '@console/internal/components/factory';
 import { RepositoryModel } from '../../../models';
+import { useTaskRuns } from '../../taskruns/useTaskRuns';
 import { RepositoryKind } from '../types';
 import RepositoryHeader from './RepositoryHeader';
 import RepositoryRow from './RepositoryRow';
 
 export interface RepositoryListProps {
   data?: RepositoryKind[];
+  namespace: string;
 }
 
-const RepositoryList: React.FC<RepositoryListProps> = (props) => (
-  <Table
-    {...props}
-    aria-label={RepositoryModel.labelPluralKey}
-    Header={RepositoryHeader}
-    Row={RepositoryRow}
-    virtualize
-  />
-);
+const RepositoryList: React.FC<RepositoryListProps> = (props) => {
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(props.namespace);
+
+  return (
+    <Table
+      {...props}
+      aria-label={RepositoryModel.labelPluralKey}
+      Header={RepositoryHeader}
+      Row={RepositoryRow}
+      customData={{ taskRuns: taskRunsLoaded ? taskRuns : [] }}
+      virtualize
+    />
+  );
+};
 
 export default RepositoryList;

--- a/frontend/packages/pipelines-plugin/src/topology/build-decorators/PipelineRunDecorator.tsx
+++ b/frontend/packages/pipelines-plugin/src/topology/build-decorators/PipelineRunDecorator.tsx
@@ -11,7 +11,7 @@ import { getLatestPipelineRunStatus } from '@console/pipelines-plugin/src/utils/
 import { Status } from '@console/shared';
 import { BuildDecoratorBubble } from '@console/topology/src/components/graph-view';
 import { startPipelineModal } from '../../components/pipelines/modals';
-import { useTaskRuns } from '../../components/taskruns/useTaskRuns';
+import { getTaskRunsOfPipelineRun, useTaskRuns } from '../../components/taskruns/useTaskRuns';
 import { PipelineRunModel } from '../../models';
 import { PipelineKind, PipelineRunKind } from '../../types';
 
@@ -41,10 +41,8 @@ export const ConnectedPipelineRunDecorator: React.FC<PipelineRunDecoratorProps &
 }) => {
   const { t } = useTranslation();
   const { latestPipelineRun, status } = getLatestPipelineRunStatus(pipelineRuns);
-  const [taskRuns, taskRunsLoaded] = useTaskRuns(
-    latestPipelineRun?.metadata?.namespace,
-    latestPipelineRun?.metadata?.name,
-  );
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(latestPipelineRun?.metadata?.namespace);
+  const PLRTaskRuns = getTaskRunsOfPipelineRun(taskRuns, latestPipelineRun?.metadata?.namespace);
   const statusIcon = <Status status={status} iconOnly noTooltip />;
 
   const defaultAccessReview: AccessReviewResourceAttributes = {
@@ -64,7 +62,7 @@ export const ConnectedPipelineRunDecorator: React.FC<PipelineRunDecoratorProps &
       <PipelineBuildDecoratorTooltip
         pipelineRun={latestPipelineRun}
         status={status}
-        taskRuns={taskRuns}
+        taskRuns={PLRTaskRuns}
       />
     );
     const link = `${resourcePathFromModel(

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-actions.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-actions.spec.ts
@@ -1,3 +1,4 @@
+import { SemVer } from 'semver';
 import { PipelineModel, PipelineRunModel } from '../../models';
 import { pipelineTestData, PipelineExampleNames, DataState } from '../../test-data/pipeline-data';
 import {
@@ -47,24 +48,34 @@ describe('PipelineAction testing startPipeline to check the pipelinerun access r
 
 describe('PipelineAction testing stopPipelineRun create correct labels and callbacks', () => {
   it('expect label to be "Stop" with hidden flag as false when latest Run is running', () => {
-    const stopAction = stopPipelineRun(PipelineRunModel, {
-      ...samplePipelineRun,
-      status: {
-        conditions: [
-          {
-            ...samplePipelineRun.status.conditions[0],
-            status: 'Unknown',
-          },
-        ],
+    const stopAction = stopPipelineRun(
+      PipelineRunModel,
+      {
+        ...samplePipelineRun,
+        status: {
+          conditions: [
+            {
+              ...samplePipelineRun.status.conditions[0],
+              status: 'Unknown',
+            },
+          ],
+        },
       },
-    });
+      new SemVer('1.9.0'),
+      [],
+    );
     expect(stopAction.labelKey).toBe(`${i18nNS}~Stop`);
     expect(stopAction.callback).not.toBeNull();
     expect(stopAction.hidden).toBeFalsy();
   });
 
   it('expect label to be "Stop" with hidden flag as true when latest Run is not running', () => {
-    const stopAction = stopPipelineRun(PipelineRunModel, samplePipelineRun);
+    const stopAction = stopPipelineRun(
+      PipelineRunModel,
+      samplePipelineRun,
+      new SemVer('1.9.0'),
+      [],
+    );
     expect(stopAction.labelKey).toBe(`${i18nNS}~Stop`);
     expect(stopAction.callback).not.toBeNull();
     expect(stopAction.hidden).not.toBeFalsy();
@@ -75,26 +86,30 @@ describe('PipelineAction testing cancelPipelineRunFinally create correct labels 
   it('expect label to be "Cancel" with hidden flag as false when latest Run is running', () => {
     const pipelineRun =
       pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipelineRuns[DataState.IN_PROGRESS];
-    const cancelAction = cancelPipelineRunFinally(PipelineRunModel, pipelineRun);
+    const cancelAction = cancelPipelineRunFinally(PipelineRunModel, pipelineRun, []);
     expect(cancelAction.labelKey).toBe(`${i18nNS}~Cancel`);
     expect(cancelAction.callback).not.toBeNull();
     expect(cancelAction.hidden).toBeFalsy();
   });
 
   it('expect label to be "Cancel" with hidden flag as true when latest Run is not running', () => {
-    const cancelAction = cancelPipelineRunFinally(PipelineRunModel, samplePipelineRun);
+    const cancelAction = cancelPipelineRunFinally(PipelineRunModel, samplePipelineRun, []);
     expect(cancelAction.labelKey).toBe(`${i18nNS}~Cancel`);
     expect(cancelAction.callback).not.toBeNull();
     expect(cancelAction.hidden).not.toBeFalsy();
   });
 
   it('"Cancel" action should be present for the Stopped latest Run', () => {
-    const cancelAction = cancelPipelineRunFinally(PipelineRunModel, {
-      ...samplePipelineRun,
-      spec: {
-        status: 'StoppedRunFinally',
+    const cancelAction = cancelPipelineRunFinally(
+      PipelineRunModel,
+      {
+        ...samplePipelineRun,
+        spec: {
+          status: 'StoppedRunFinally',
+        },
       },
-    });
+      [],
+    );
     expect(cancelAction.labelKey).toBe(`${i18nNS}~Cancel`);
     expect(cancelAction.callback).not.toBeNull();
     expect(cancelAction.hidden).not.toBeFalsy();

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
@@ -184,7 +184,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
         pipelineTestData[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].pipelineRuns[
           DataState.IN_PROGRESS
         ];
-      expect(shouldHidePipelineRunStop(pipelineRun)).toEqual(false);
+      expect(shouldHidePipelineRunStop(pipelineRun, [])).toEqual(false);
     });
 
     it('should hide the pipelinerun stop action ', () => {
@@ -192,7 +192,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
         pipelineTestData[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].pipelineRuns[
           DataState.SUCCESS
         ];
-      expect(shouldHidePipelineRunStop(pipelineRun)).toEqual(true);
+      expect(shouldHidePipelineRunStop(pipelineRun, [])).toEqual(true);
     });
 
     it('should hide the pipelinerun cancel action ', () => {
@@ -200,7 +200,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
         pipelineTestData[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].pipelineRuns[
           DataState.SUCCESS
         ];
-      expect(shouldHidePipelineRunCancel(pipelineRun)).toEqual(true);
+      expect(shouldHidePipelineRunCancel(pipelineRun, [])).toEqual(true);
     });
 
     it('should not hide the pipelinerun cancel action ', () => {
@@ -208,7 +208,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
         pipelineTestData[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].pipelineRuns[
           DataState.IN_PROGRESS
         ];
-      expect(shouldHidePipelineRunCancel(pipelineRun)).toEqual(false);
+      expect(shouldHidePipelineRunCancel(pipelineRun, [])).toEqual(false);
     });
 
     it('should hide the pipelinerun cancel action ', () => {
@@ -216,7 +216,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
         pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipelineRuns[
           DataState.PIPELINE_RUN_STOPPED
         ];
-      expect(shouldHidePipelineRunCancel(pipelineRun)).toEqual(true);
+      expect(shouldHidePipelineRunCancel(pipelineRun, [])).toEqual(true);
     });
   });
 

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
@@ -12,7 +12,6 @@ import {
   apiVersionForModel,
 } from '@console/internal/module/k8s';
 import { TektonResourceLabel } from '../components/pipelines/const';
-import { getTaskRuns } from '../components/taskruns/useTaskRuns';
 import {
   ClusterTaskModel,
   ClusterTriggerBindingModel,
@@ -274,27 +273,30 @@ export const getModelReferenceFromTaskKind = (kind: string): GroupVersionKind =>
   return referenceForModel(model);
 };
 
-export const countRunningTasks = (pipelineRun: PipelineRunKind): number => {
-  let taskRuns: TaskRunKind[] = [];
-  getTaskRuns(pipelineRun.metadata.namespace, pipelineRun.metadata.name)
-    .then((response: TaskRunKind[]) => {
-      taskRuns = response;
-    })
-    .catch(() => {});
+export const countRunningTasks = (
+  pipelineRun: PipelineRunKind,
+  taskRuns: TaskRunKind[],
+): number => {
   const taskStatuses = taskRuns && getTaskStatus(pipelineRun, undefined, taskRuns);
   return taskStatuses?.Running;
 };
 
-export const shouldHidePipelineRunStop = (pipelineRun: PipelineRunKind): boolean =>
+export const shouldHidePipelineRunStop = (
+  pipelineRun: PipelineRunKind,
+  taskRuns: TaskRunKind[],
+): boolean =>
   !(
     pipelineRun &&
-    (countRunningTasks(pipelineRun) > 0 ||
+    (countRunningTasks(pipelineRun, taskRuns) > 0 ||
       pipelineRunFilterReducer(pipelineRun) === ComputedStatus.Running)
   );
 
-export const shouldHidePipelineRunCancel = (pipelineRun: PipelineRunKind): boolean =>
+export const shouldHidePipelineRunCancel = (
+  pipelineRun: PipelineRunKind,
+  taskRuns: TaskRunKind[],
+): boolean =>
   !(
     pipelineRun &&
-    countRunningTasks(pipelineRun) > 0 &&
+    countRunningTasks(pipelineRun, taskRuns) > 0 &&
     pipelineRunFilterReducer(pipelineRun) !== ComputedStatus.Cancelled
   );


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGS-13152

**Descriptions:** Fetch TaskRuns without selector and also remove the fetching of TaskRuns per Rows of Pipeline, PipelineRun and Repository

**Before:**

https://github.com/openshift/console/assets/2561818/642eec90-e4e8-4c7e-945b-176c3533ed9e

**After:**

https://github.com/openshift/console/assets/2561818/40da6fa6-5e62-4af6-83c7-2a90f7b201f9

