### PR TITLE
OCPBUGS-17083: Fix duplicate warnings on yaml update

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -582,7 +582,8 @@ const EditYAMLInner = (props) => {
     if (callbackCommand === 'saveall') {
       saveAllCallback();
     }
-  }, [saving, callbackCommand, saveCallback, saveAllCallback]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [saving, callbackCommand, saveAllCallback]);
 
   const download = () => {
     const data = getEditor().getValue();


### PR DESCRIPTION
`saveCallback` being a memoized function by a useCallback hook, was recreated due to changes in dependency array on save, which caused multiple calls of the function by the useEffect hook (which had it as a dependency itself).