### PR TITLE
OCPBUGS-17410: Fix that "Delete application" doesn't work in topology when Pipelines operator is not installed

### DIFF
--- a/frontend/packages/dev-console/src/components/add/__tests__/GettingStartedSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/GettingStartedSection.spec.tsx
@@ -45,7 +45,7 @@ describe('GettingStartedSection', () => {
     expect(wrapper.find(GettingStartedGrid).props().children.length).toEqual(3);
   });
 
-  it('should render nothing when useFlags(FLAGS.OPENSHIFT) return false', () => {
+  it('should render nothing when useFlag(FLAGS.OPENSHIFT) return false', () => {
     useFlagMock.mockReturnValue(false);
     useGettingStartedShowStateMock.mockReturnValue([GettingStartedShowState.SHOW, jest.fn(), true]);
 

--- a/frontend/packages/topology/src/components/export-app/ExportApplicationModal.tsx
+++ b/frontend/packages/topology/src/components/export-app/ExportApplicationModal.tsx
@@ -257,7 +257,7 @@ export const handleExportApplication = async (
     });
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.warn(err, 'Resource not found');
+    console.warn('Error while getting export resource:', err);
     exportApplicationModal({
       name,
       namespace,

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/getting-started-section.spec.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/getting-started-section.spec.tsx
@@ -48,7 +48,7 @@ describe('GettingStartedSection', () => {
     expect(wrapper.find(GettingStartedGrid).props().children.length).toEqual(3);
   });
 
-  it('should render nothing when useFlags(FLAGS.OPENSHIFT) return false', () => {
+  it('should render nothing when useFlag(FLAGS.OPENSHIFT) return false', () => {
     useFlagMock.mockReturnValue(false);
     useGettingStartedShowStateMock.mockReturnValue([GettingStartedShowState.SHOW, jest.fn(), true]);
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-17410

**Analysis / Root cause**: 
The `cleanUpWorkload` function in `packages/topology/src/utils/application-utils.ts` failed silently when the Pipelines operator is not installed. The new try-catch was added in #12587 and was backported to older versions.

**Solution Description**: 
1. Removed the try-catch block so that errors are visible again in the UI.
2. Added a new function `safeLoadList` that ignores 404 Not found errors while loading resources. (Similar to the already existing `safeKill` function.)

**Screen shots / Gifs for design review**: 
Before:

https://github.com/openshift/console/assets/139310/0072392d-cacd-421c-84a3-44a22cc7122d

After:

https://github.com/openshift/console/assets/139310/a06157a2-f625-4cde-9ec1-cd71b5817fc0

**Unit test coverage report**: 
Untouched.

**Test setup:**
1. Setup a cluster without Pipelines operator
2. Navigate to developer perspective
3. Import an application (from git or a container image)
4. Delete the application **group**

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
