### PR TITLE
OCPBUGS-16717: Fix name validation regex

### DIFF
--- a/frontend/packages/metal3-plugin/locales/en/metal3-plugin.json
+++ b/frontend/packages/metal3-plugin/locales/en/metal3-plugin.json
@@ -202,5 +202,8 @@
   "This host was provisioned outside of this cluster and added manually.": "This host was provisioned outside of this cluster and added manually.",
   "Power operations cannot be performed on this host until Baseboard Management Controller (BMC) credentials are provided.": "Power operations cannot be performed on this host until Baseboard Management Controller (BMC) credentials are provided.",
   "Under maintenance": "Under maintenance",
-  "Stopping maintenance": "Stopping maintenance"
+  "Stopping maintenance": "Stopping maintenance",
+  "Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.": "Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.",
+  "Cannot be longer than {{characterCount}} characters.": "Cannot be longer than {{characterCount}} characters.",
+  "Required": "Required"
 }

--- a/frontend/packages/metal3-plugin/src/validations/__tests__/regex.spec.ts
+++ b/frontend/packages/metal3-plugin/src/validations/__tests__/regex.spec.ts
@@ -1,0 +1,50 @@
+import { MAC_REGEX, RESOURCE_NAME_REGEX } from '../regex';
+
+describe('resource name regex', () => {
+  it('should match valid resource names', () => {
+    const validNames = [
+      'appname',
+      'app-name',
+      'app-name123',
+      'app-name123-app',
+      'app.name',
+      'app.name.foo',
+      'app.name123',
+    ];
+    validNames.forEach((name) => expect(name).toMatch(RESOURCE_NAME_REGEX));
+  });
+
+  it('should not match invalid resource names', () => {
+    const invalidNames = [
+      'AppName',
+      '-app-name',
+      'app$name!',
+      'app name',
+      '',
+      '-',
+      'app_name',
+      'app..name',
+    ];
+    invalidNames.forEach((name) => expect(name).not.toMatch(RESOURCE_NAME_REGEX));
+  });
+});
+
+describe('MAC address regex', () => {
+  it('should match valid MAC address', () => {
+    const validMAC = ['00:B0:D0:63:C2:26'];
+    validMAC.forEach((mac) => expect(mac).toMatch(MAC_REGEX));
+  });
+
+  it('should not match invalid resource names', () => {
+    const invalidNames = [
+      '00-B0-D0-63-C2-26',
+      '00-B0-D0-63-C2',
+      '00:B0:D0:63:C2',
+      '00-B0-D0-63-C2-26-ea',
+      '00:B0:D0:63:C2:26:ea',
+      '003-B0-D0-63-C2-26',
+      '003:B0:D0:63:C2:26',
+    ];
+    invalidNames.forEach((name) => expect(name).not.toMatch(RESOURCE_NAME_REGEX));
+  });
+});

--- a/frontend/packages/metal3-plugin/src/validations/regex.tsx
+++ b/frontend/packages/metal3-plugin/src/validations/regex.tsx
@@ -1,28 +1,4 @@
-const HEXCH_REGEX = '[0-9A-Fa-f]';
-export const MAC_REGEX_COLON_DELIMITER = new RegExp(
-  `^((${HEXCH_REGEX}{2}[:]){19}${HEXCH_REGEX}{2})$|` + // 01:23:45:67:89:ab:cd:ef:00:00:01:23:45:67:89:ab:cd:ef:00:00
-  `^((${HEXCH_REGEX}{2}[:]){7}${HEXCH_REGEX}{2})$|` + // 01:23:45:67:89:ab:cd:ef
-    `^((${HEXCH_REGEX}{2}[:]){5}${HEXCH_REGEX}{2})$`, // 01:23:45:67:89:ab
-);
-
-export const MAC_REGEX_DASH_DELIMITER = new RegExp(
-  `^((${HEXCH_REGEX}{2}[-]){19}${HEXCH_REGEX}{2})$|` + // 01-23-45-67-89-ab-cd-ef-00-00-01-23-45-67-89-ab-cd-ef-00-00
-  `^((${HEXCH_REGEX}{2}[-]){7}${HEXCH_REGEX}{2})$|` + // 01-23-45-67-89-ab-cd-ef
-    `^((${HEXCH_REGEX}{2}[-]){5}${HEXCH_REGEX}{2})$`, // 01-23-45-67-89-ab
-);
-
-export const MAC_REGEX_PERIOD_DELIMITER = new RegExp(
-  `^((${HEXCH_REGEX}{4}.){9}${HEXCH_REGEX}{4})$|` + // 0123.4567.89ab.cdef.0000.0123.4567.89ab.cdef.0000
-  `^((${HEXCH_REGEX}{4}.){3}${HEXCH_REGEX}{4})$|` + // 0123.4567.89ab.cdef
-    `^((${HEXCH_REGEX}{4}.){2}${HEXCH_REGEX}{4})$`, // 0123.4567.89ab
-);
-
-// Validates that the provided MAC address meets one of following formats supported by the golang ParseMAC function:
-// IEEE 802 MAC-48, EUI-48, EUI-64, or a 20-octet IP over InfiniBand link-layer address
-// https://golang.org/pkg/net/#ParseMAC
-export const MAC_REGEX = new RegExp(
-  `^(${MAC_REGEX_COLON_DELIMITER.source}|${MAC_REGEX_DASH_DELIMITER.source}|${MAC_REGEX_PERIOD_DELIMITER.source})$`,
-);
+export const MAC_REGEX = /^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$/;
 
 export const IPV6_ADDRESS = new RegExp(
   /^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$/,
@@ -35,3 +11,5 @@ export const URL_REGEX = new RegExp(
 export const BMC_ADDRESS_REGEX = new RegExp(
   /^((ipmi|idrac|idrac\+http|idrac-virtualmedia|irmc|redfish|redfish\+http|redfish-virtualmedia|ilo5-virtualmedia|https?|ftp):(\/\/([a-z0-9\-._~%!$&'()*+,;=]+@)?([a-z0-9\-._~%]+|\[[a-f0-9:.]+\]|\[v[a-f0-9][a-z0-9\-._~%!$&'()*+,;=:]+\])(:[0-9]+)?(\/[a-z0-9\-._~%!$&'()*+,;=:@]+)*\/?|(\/?[a-z0-9\-._~%!$&'()*+,;=:@]+(\/[a-z0-9\-._~%!$&'()*+,;=:@]+)*\/?)?)|([a-z0-9\-._~%!$&'()*+,;=@]+(\/[a-z0-9\-._~%!$&'()*+,;=:@]+)*\/?|(\/[a-z0-9\-._~%!$&'()*+,;=:@]+)+\/?))(\?[a-z0-9\-._~%!$&'()*+,;=:@/?]*)?(#[a-z0-9\-._~%!$&'()*+,;=:@/?]*)?$/i,
 );
+
+export const RESOURCE_NAME_REGEX = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;

--- a/frontend/packages/metal3-plugin/src/validations/validations.tsx
+++ b/frontend/packages/metal3-plugin/src/validations/validations.tsx
@@ -1,0 +1,21 @@
+import { TFunction } from 'react-i18next';
+import * as yup from 'yup';
+import { RESOURCE_NAME_REGEX } from './regex';
+
+export const nameValidationSchema = (t: TFunction<'metal3-plugin'>, maxLength = 263) =>
+  yup
+    .string()
+    .matches(RESOURCE_NAME_REGEX, {
+      message: t(
+        'metal3-plugin~Name must consist of lower case alphanumeric characters, hyphens or dots, and must start and end with an alphanumeric character.',
+      ),
+      excludeEmptyString: true,
+    })
+    .max(
+      maxLength,
+      // see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+      t('metal3-plugin~Cannot be longer than {{characterCount}} characters.', {
+        characterCount: maxLength,
+      }),
+    )
+    .required(t('metal3-plugin~Required'));


### PR DESCRIPTION
Fix MAC address validation regex
Improve reload form logic


Beside the obvious name validation, i also noticed that the MAC address regex does not match the one that is used by backend - so I fixed it too.

When editing BMH, i've made sure that the validation errors are visible right away (by setting touched=true on all fields)