### PR TITLE
OCPBUGS-17496: Bridge NAD should set "preserveDefaultVlan": false

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
@@ -58,6 +58,7 @@ const buildConfig = (
     config.vlan = parseInt(typeParamsData?.vlanTagNum?.value, 10) || undefined;
     config.macspoofchk = _.get(typeParamsData, 'macspoofchk.value', true);
     config.ipam = ipam;
+    config.preserveDefaultVlan = false;
   } else if (networkType === 'sriov') {
     config.ipam = ipam;
   } else if (networkType === ovnKubernetesNetworkType) {

--- a/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
@@ -27,6 +27,7 @@ export type NetworkAttachmentDefinitionConfig = {
   plugins?: NetworkAttachmentDefinitionPlugin[];
   topology?: string;
   netAttachDefName?: string;
+  preserveDefaultVlan?: boolean;
 };
 
 // The config is a JSON object with the NetworkAttachmentDefinitionConfig type stored as a string


### PR DESCRIPTION
Adding "preserveDefaultVlan": false to NAD's config when creating a bridged NAD with the UI

Before:

https://github.com/openshift/console/assets/67270715/5848f5b5-5c1f-4311-a8cf-0ed3473fe413

After:

https://github.com/openshift/console/assets/67270715/91c312ab-4746-476d-84f8-25881a9330ac

