### PR TITLE
[release-4.11] OCPBUGS-19359: Remove PipelineResource CRD check because it's not installed with PO 1.11 anymore

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster.ts
@@ -96,7 +96,6 @@ export const waitForCRDs = (operator: operators) => {
         6,
       );
       cy.get('[data-test-id="TektonPipeline"]', { timeout: 80000 }).should('be.visible');
-      cy.get('[data-test-id="PipelineResource"]', { timeout: 80000 }).should('be.visible');
       cy.get('[data-test-id="PipelineRun"]', { timeout: 80000 }).should('be.visible');
       cy.get('[data-test-id="Pipeline"]', { timeout: 80000 }).should('be.visible');
       break;


### PR DESCRIPTION
This is an manual cherry-pick of #12948