### PR TITLE
OCPBUGS-17370: Installed Operators page crashed with TypeError: "Cann…

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -754,7 +754,7 @@ export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProp
         isCSV(obj) ||
         _.isUndefined(
           all.find(({ metadata }) =>
-            [obj?.status?.currentCSV, obj?.spec?.startingCSV].includes(metadata.name),
+            [obj?.status?.currentCSV, obj?.spec?.startingCSV].includes(metadata?.name),
           ),
         ),
     );


### PR DESCRIPTION
…ot read properties of undefined (reading 'name')" when navigated from the StorageSystems page

Fixes https://issues.redhat.com/browse/OCPBUGS-17370.

Page no longer crashes when navigated from StorageSystems page.