### PR TITLE
OCPBUGS-9422: Telemetry- Current page was sometimes not tracked when reloading the current page

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -281,9 +281,21 @@ const AppRouter = () => {
 const CaptureTelemetry = React.memo(function CaptureTelemetry() {
   const [perspective] = useActivePerspective();
   const fireTelemetryEvent = useTelemetry();
-
+  const [debounceTime, setDebounceTime] = React.useState(5000);
+  const [titleOnLoad, setTitleOnLoad] = React.useState('');
   // notify of identity change
   const user = useSelector(getUser);
+  const telemetryTitle = getTelemetryTitle();
+
+  React.useEffect(
+    () =>
+      setTimeout(() => {
+        setTitleOnLoad(telemetryTitle);
+        setDebounceTime(500);
+      }, 5000),
+    [],
+  );
+
   React.useEffect(() => {
     if (user.metadata?.uid || user.metadata?.name) {
       fireTelemetryEvent('identify', { perspective, user });
@@ -301,8 +313,11 @@ const CaptureTelemetry = React.memo(function CaptureTelemetry() {
       title: getTelemetryTitle(),
       ...withoutSensitiveInformations(location),
     });
-  });
+  }, debounceTime);
   React.useEffect(() => {
+    if (!titleOnLoad) {
+      return;
+    }
     fireUrlChangeEvent(history.location);
     let { pathname, search } = history.location;
     const unlisten = history.listen((location) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-9422

**Analysis / Root cause**: 
Reload time was more but the page event sent before complete page load

**Solution Description**: 
Added timeout of 5 sec for page reload 

**Screen shots / Gifs for design review**: 

----AFTER----


https://github.com/openshift/console/assets/102503482/9f40886e-bed1-47b6-813e-1b123df513c8



**Unit test coverage report**: 
NA

**Test setup:**
1. Open the browser network inspector and filter for segment
2. Open the developer console

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge