### PR TITLE
OCPBUGS-17595: Updating YAML from console shows error

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -582,7 +582,9 @@ const EditYAMLInner = (props) => {
     if (callbackCommand === 'saveall') {
       saveAllCallback();
     }
-  }, [saving, callbackCommand, saveCallback, saveAllCallback]);
+    // removed callback functions from deps array to prevent stream of errors after save
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [saving, callbackCommand]);
 
   const download = () => {
     const data = getEditor().getValue();


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-17595

Editing YAML component does not cause stream of errors.