### PR TITLE
OCPBUGS-15927: Error page when fresh normal user visiting BuildConfigs page of 'default' project

### DIFF
--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { match as Match } from 'react-router';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
+import * as _ from 'lodash-es';
 import {
   K8sResourceKind,
   K8sResourceKindReference,
@@ -288,13 +289,17 @@ export const BuildConfigsList: React.SFC<BuildConfigsListProps> = (props) => {
     [builds, buildsLoaded, buildsLoadError],
   );
 
-  const buildResource = props.data.map((buildConfig) => {
-    buildConfig.latestBuild =
-      data.builds.latestByBuildName[
-        `${buildConfig.metadata.name}-${buildConfig.metadata.namespace}`
-      ];
-    return buildConfig;
-  });
+  const buildResource = _.isUndefined(props.data)
+    ? []
+    : props.data.map((buildConfig) => {
+        if (props.data) {
+          buildConfig.latestBuild =
+            data.builds.latestByBuildName[
+              `${buildConfig.metadata.name}-${buildConfig.metadata.namespace}`
+            ];
+        }
+        return buildConfig;
+      });
 
   return (
     <Table

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { match as Match } from 'react-router';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import * as _ from 'lodash-es';
 import {
   K8sResourceKind,
   K8sResourceKindReference,
@@ -289,17 +288,15 @@ export const BuildConfigsList: React.SFC<BuildConfigsListProps> = (props) => {
     [builds, buildsLoaded, buildsLoadError],
   );
 
-  const buildResource = _.isUndefined(props.data)
-    ? []
-    : props.data.map((buildConfig) => {
-        if (props.data) {
-          buildConfig.latestBuild =
-            data.builds.latestByBuildName[
-              `${buildConfig.metadata.name}-${buildConfig.metadata.namespace}`
-            ];
-        }
+  const buildResource = props.data
+    ? props.data.map((buildConfig) => {
+        buildConfig.latestBuild =
+          data.builds.latestByBuildName[
+            `${buildConfig.metadata.name}-${buildConfig.metadata.namespace}`
+          ];
         return buildConfig;
-      });
+      })
+    : [];
 
   return (
     <Table


### PR DESCRIPTION
Links to: https://issues.redhat.com/browse/OCPBUGS-15927

Added undefined condition in BuildResources to fix issue where normal user with no projects encountered errors when accessing BuildConfigs page.

When normal user without projects tried accessing the BuildConfigs page error  occured. It was likely caused by the fact user didn’t have access to any project. The straight forward fix to this issue is to check for undefined value of props.data and in case it is undefined pass empty list. This result in the page showing No BuildConfigs found similarly as its in the /k8s/ns/default/route.openshift.io~v1~Route.

Before: 
<img width="1154" alt="image" src="https://github.com/openshift/console/assets/49416557/4b07482a-f309-493e-9ecb-a83d5bf8ef50">

After:
<img width="1068" alt="image" src="https://github.com/openshift/console/assets/49416557/1f9a2855-1e31-4b7f-9f2e-2bbeb57af65a">
