### PR TITLE
OCPBUGS-16374: Fix topology crash when a console.topology/data/factory extension tries to resolve a resource with version from the CRDs which doesn't exists

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources.ts
@@ -86,8 +86,9 @@ export const useK8sWatchResources: UseK8sWatchResources = (initResources) => {
             );
 
             const resourceModel =
-              k8sModels.get(modelReference) ||
-              k8sModels.get(getGroupVersionKindForReference(modelReference).kind);
+              modelReference &&
+              (k8sModels.get(modelReference) ||
+                k8sModels.get(getGroupVersionKindForReference(modelReference).kind));
             if (!resourceModel) {
               ids[key] = {
                 noModel: true,

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsPage.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsPage.tsx
@@ -36,15 +36,12 @@ const flattenResources = (resources: Resources) => {
   const loaded = _.every(resources, (resource) =>
     resource.optional ? resource.loaded || !_.isEmpty(resource.loadError) : resource.loaded,
   );
-  const {
-    hosts: { data: hostsData },
-    machines: { data: machinesData },
-    machineSets,
-    nodes,
-    nodeMaintenances,
-  } = resources;
 
   if (loaded) {
+    const { hosts, machines, machineSets, nodes, nodeMaintenances } = resources;
+    const hostsData = hosts?.data || [];
+    const machinesData = machines?.data || [];
+
     const maintenancesByNodeName = createLookup(nodeMaintenances, getNodeMaintenanceNodeName);
     const nodesByMachineName = createLookup(nodes, getNodeMachineName);
     const machineSetByUID = createLookup(machineSets);


### PR DESCRIPTION
## Fixes
https://issues.redhat.com/browse/OCPBUGS-16374

## Analysis / Root cause
The crash happened in `getGroupVersionKindForReference` because the given reference string was null.

1. It was called in `useK8sWatchResources` where one of the resources had no kind.
2. The underlying issue was that the topology `DataModelProvider` builds these resources dynamically based on three extensions:

```tsx
  const modelFactories = useExtensions<TopologyDataModelFactory>(isTopologyDataModelFactory);

  const dynamicModelFactories = useExtensions<DynamicTopologyDataModelFactory>(
    isDynamicTopologyDataModelFactory,
  );

  const namespacedDynamicFactories = React.useMemo(
    () => getNamespacedDynamicModelFactories(dynamicModelFactories),
    [dynamicModelFactories],
  );
```

These extensions could provide a list of resources they want to monitor with an group, kind and optional version. If the version is not defined the console tries to resolve it from the known models (CRDs).

If these aren't defined resource (returned from flattenResource) might have no kind and the console crashes.

## Solution Description
1. Added a null check to `useK8sWatchResources` before calling `getGroupVersionKindForReference`.
   * I was thinking about adding a new Error to `getGroupVersionKindForReference` as well but wasn't sure if it could have negative side effects if it would fail also for empty strings. So I decided do just address the bug fix here.
2. Updated `flattenResource` to detect when `modelForGroupKind` doesn't return a model (CRD). The code know logs a warning and returns null which was then ignored in the updated `getNamespacedDynamicModelFactories` function.

## Screen shots / Gifs for design review
Topology without this PR (and the recreated edge-case, see below how to reproduce this):

![image](https://github.com/openshift/console/assets/139310/5966adc4-3395-4cb0-a17a-aca3b1ebaa6a)

Fixed topology:

![image](https://github.com/openshift/console/assets/139310/a38918a6-4479-4ca1-8bb0-512470ce24e0)

While testing this, I also noticed a never finish loading page on "Compute > Bare Metal Hosts" page when the CRD isn't there (edge-case):

![image](https://github.com/openshift/console/assets/139310/1a07b693-ee0a-4934-99e0-57bdd4d03d5b)

I fixed this by expecting that not all data are available in `BareMetalHostsPage.tsx`:

![image](https://github.com/openshift/console/assets/139310/e6df864a-ea55-4308-9bd1-7aeba41c33a1)

## Test setup
### Steps to reproduce this error on a **developer machine:

Edit `packages/console-plugin-sdk/src/store.ts` to drop all "required flags" ... aka, enable all plugins.

```diff
export const sanitizeExtension = <E extends Extension>(e: E): E => {
  e.flags = e.flags || {};
-  e.flags.required = _.uniq(e.flags.required || []);
-  e.flags.disallowed = _.uniq(e.flags.disallowed || []);
+  e.flags.required = [];
+  e.flags.disallowed = [];
  return e;
};
```

Yes, the result is a console that show some pages that doesn't work and some duplications in the navigation but that's fine to reproduce this issue.

### Steps to reproduce this error on a cluster bot instance:

1. Install KubeVirt operator (Community or OpenShift Virtualization)
4. Create a HyperConvergeds resource and wait until the status shows "ReconcileComplete, Available"
5. Uninstall the KubeVirt operator (the CRDs of that operator stays)
6. Delete the VirtualMachineInstance CRD (the VirtualMachine CRD enables the KubeVirt plugin, but it requires this CRD as well)
7. Switch to Developer perspective and navigate to the Topology page

## Browser conformance
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
