### PR TITLE
OCPBUGS-17948: Fix that Devconsole plugin show essential features like add page and topology also when Builds and DeploymentConfigs capabilities are disabled

### DIFF
--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -27,11 +27,55 @@
     "type": "console.flag/model",
     "properties": {
       "model": {
+        "group": "build.openshift.io",
+        "version": "v1",
+        "kind": "BuildConfig"
+      },
+      "flag": "OPENSHIFT_BUILDCONFIG"
+    }
+  },
+  {
+    "type": "console.flag/model",
+    "properties": {
+      "model": {
         "group": "console.openshift.io",
         "version": "v1",
         "kind": "ConsoleSample"
       },
-      "flag": "CONSOLESAMPLES"
+      "flag": "CONSOLESAMPLE"
+    }
+  },
+  {
+    "type": "console.flag/model",
+    "properties": {
+      "model": {
+        "group": "apps.openshift.io",
+        "version": "v1",
+        "kind": "DeploymentConfig"
+      },
+      "flag": "OPENSHIFT_DEPLOYMENTCONFIG"
+    }
+  },
+  {
+    "type": "console.flag/model",
+    "properties": {
+      "model": {
+        "group": "image.openshift.io",
+        "version": "v1",
+        "kind": "ImageStream"
+      },
+      "flag": "OPENSHIFT_IMAGESTREAM"
+    }
+  },
+  {
+    "type": "console.flag/model",
+    "properties": {
+      "model": {
+        "group": "template.openshift.io",
+        "version": "v1",
+        "kind": "Template"
+      },
+      "flag": "OPENSHIFT_TEMPLATE"
     }
   },
 
@@ -285,6 +329,9 @@
         { "group": "route.openshift.io", "resource": "routes", "verb": "create" },
         { "group": "", "resource": "services", "verb": "create" }
       ]
+    },
+    "flags": {
+      "required": ["OPENSHIFT_BUILDCONFIG", "OPENSHIFT_IMAGESTREAM"]
     }
   },
   {
@@ -445,7 +492,7 @@
       "typeDescription": "%devconsole~**Builder Images** are container images that build source code for a particular language or framework.%"
     },
     "flags": {
-      "required": ["OPENSHIFT"]
+      "required": ["OPENSHIFT_IMAGESTREAM"]
     }
   },
   {
@@ -457,7 +504,7 @@
       "provider": { "$codeRef": "catalog.builderImageProvider" }
     },
     "flags": {
-      "required": ["OPENSHIFT"]
+      "required": ["OPENSHIFT_IMAGESTREAM"]
     }
   },
   {
@@ -469,7 +516,7 @@
       "typeDescription": "%devconsole~**Templates** are sets of objects for creating services, build configurations, and anything you have permission to create within a Project.%"
     },
     "flags": {
-      "required": ["OPENSHIFT"]
+      "required": ["OPENSHIFT_TEMPLATE"]
     }
   },
   {
@@ -481,7 +528,7 @@
       "provider": { "$codeRef": "catalog.templateProvider" }
     },
     "flags": {
-      "required": ["OPENSHIFT"]
+      "required": ["OPENSHIFT_TEMPLATE"]
     }
   },
   {
@@ -491,9 +538,6 @@
       "title": "%devconsole~Devfiles%",
       "catalogDescription": "%devconsole~Browse for devfiles that support a particular language or framework. Cluster administrators can customize the content made available in the catalog.%",
       "typeDescription": "%devconsole~**Devfiles** are sets of objects for creating services, build configurations, and anything you have permission to create within a Project.%"
-    },
-    "flags": {
-      "required": ["OPENSHIFT"]
     }
   },
   {
@@ -503,9 +547,6 @@
       "type": "Devfile",
       "title": "%devconsole~Devfiles%",
       "provider": { "$codeRef": "catalog.devfileProvider" }
-    },
-    "flags": {
-      "required": ["OPENSHIFT"]
     }
   },
   {
@@ -540,9 +581,6 @@
     "properties": {
       "type": "Sample",
       "title": "%devconsole~Samples%"
-    },
-    "flags": {
-      "required": ["OPENSHIFT"]
     }
   },
   {
@@ -554,7 +592,7 @@
       "provider": { "$codeRef": "catalog.useConsoleSamplesCatalogProvider" }
     },
     "flags": {
-      "required": ["OPENSHIFT", "CONSOLESAMPLES"]
+      "required": ["CONSOLESAMPLE"]
     }
   },
   {
@@ -566,7 +604,7 @@
       "provider": { "$codeRef": "catalog.builderImageSamplesProvider" }
     },
     "flags": {
-      "required": ["OPENSHIFT"]
+      "required": ["OPENSHIFT_IMAGESTREAM"]
     }
   },
   {
@@ -576,9 +614,6 @@
       "type": "Devfile",
       "title": "%devconsole~Devfile%",
       "provider": { "$codeRef": "catalog.devfileSamplesProvider" }
-    },
-    "flags": {
-      "required": ["OPENSHIFT"]
     }
   },
   {
@@ -601,9 +636,6 @@
         "data-quickstart-id": "qs-nav-add",
         "data-test-id": "+Add-header"
       }
-    },
-    "flags": {
-      "required": ["OPENSHIFT"]
     }
   },
   {
@@ -619,9 +651,6 @@
         "data-quickstart-id": "qs-nav-topology",
         "data-test-id": "topology-header"
       }
-    },
-    "flags": {
-      "required": ["OPENSHIFT"]
     }
   },
   {
@@ -640,7 +669,7 @@
       }
     },
     "flags": {
-      "required": ["OPENSHIFT", "MONITORING"]
+      "required": ["MONITORING"]
     }
   },
   {
@@ -657,9 +686,6 @@
         "data-tour-id": "tour-search-nav",
         "data-test-id": "search-header"
       }
-    },
-    "flags": {
-      "required": ["OPENSHIFT"]
     }
   },
   {
@@ -675,9 +701,6 @@
         "data-quickstart-id": "qs-nav-project",
         "data-test-id": "project-details-header"
       }
-    },
-    "flags": {
-      "required": ["OPENSHIFT"]
     }
   },
   {
@@ -696,7 +719,7 @@
       }
     },
     "flags": {
-      "required": ["OPENSHIFT"]
+      "required": ["DEVCONSOLE_BUILDS"]
     }
   },
   {
@@ -707,7 +730,7 @@
       "component": { "$codeRef": "common.NamespaceRedirect" }
     },
     "flags": {
-      "required": ["OPENSHIFT"]
+      "required": ["DEVCONSOLE_BUILDS"]
     }
   },
   {
@@ -718,7 +741,7 @@
       "component": { "$codeRef": "builds.BuildsTabListPage" }
     },
     "flags": {
-      "required": ["OPENSHIFT"]
+      "required": ["DEVCONSOLE_BUILDS"]
     }
   },
   {
@@ -822,7 +845,7 @@
       "insertAfter": "topology-side-bar-tab-resource"
     },
     "flags": {
-      "required": ["OPENSHIFT", "MONITORING"]
+      "required": ["MONITORING"]
     }
   },
   {
@@ -1022,7 +1045,6 @@
       "exact": true,
       "path": [
         "/add",
-        "/import",
         "/import-sample",
         "/catalog",
         "/samples",
@@ -1036,6 +1058,17 @@
         "/builds"
       ],
       "component": { "$codeRef": "common.NamespaceRedirect" }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
+      "path": ["/import"],
+      "component": { "$codeRef": "common.NamespaceRedirect" }
+    },
+    "flags": {
+      "required": ["OPENSHIFT_BUILDCONFIG", "OPENSHIFT_IMAGESTREAM"]
     }
   },
   {
@@ -1087,6 +1120,9 @@
         "/k8s/ns/:ns/deploymentconfigs/:name/form"
       ],
       "component": { "$codeRef": "deployment.DeploymentConfigPage" }
+    },
+    "flags": {
+      "required": ["OPENSHIFT_DEPLOYMENTCONFIG"]
     }
   },
   {
@@ -1095,6 +1131,9 @@
       "exact": true,
       "path": ["/import/all-namespaces", "/import/ns/:ns"],
       "component": { "$codeRef": "import.ImportPage" }
+    },
+    "flags": {
+      "required": ["OPENSHIFT_BUILDCONFIG", "OPENSHIFT_IMAGESTREAM"]
     }
   },
   {

--- a/frontend/public/actions/features.ts
+++ b/frontend/public/actions/features.ts
@@ -164,7 +164,8 @@ export type FeatureAction = Action<
   typeof featureActions | typeof receivedResources | typeof clearFlags
 >;
 
-const openshiftPath = '/apis/apps.openshift.io/v1';
+// This config API contains the OpenShift Project, and other mandatory resources
+const openshiftPath = '/apis/config.openshift.io/v1';
 const detectOpenShift = (dispatch) =>
   fetchURL(openshiftPath).then(
     (res) => dispatch(setFlag(FLAGS.OPENSHIFT, _.size(res.resources) > 0)),


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-17948

**Analysis / Root cause**: 
When Samples, Builds and DeploymentConfigs are disabled, the `OPENSHIFT` flag stays disabled.

**Solution Description**: 
Use different smaller feature flags for different resources instead of using one big flag for everything.

This is similar to #13089, I aligned the flag names to that PR, but both PRs could be merged separately!

1. Added new flags for the related CRDs:
   * `OPENSHIFT_BUILDCONFIG`
   * `OPENSHIFT_DEPLOYMENTCONFIG`
   * `OPENSHIFT_IMAGESTREAM`
   * `OPENSHIFT_TEMPLATE`
3. Removed OPENSHIFT dependency for pages that don't require that feature flag, esp. the add page (with the cards), the extendable topology, search, and project page.
4. Update FLAG.OPENSHIFT to check the API group `config.openshift.io` instead of `apps.openshift.io`.

**Screen shots / Gifs for design review**: 
Before:

![image](https://github.com/openshift/console/assets/139310/439f82e2-0285-4659-9084-e9f227b2ed02)

With this PR:

![image](https://github.com/openshift/console/assets/139310/1b4cda6f-169a-4e6a-b17e-8184d13cf6f2)

**Unit test coverage report**: 


**Test setup:**


**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
