### PR TITLE
[release-4.10] OCPBUGS-18014: When removing the project owner from the project in GUI, instead of that user, the group (the default group added as project admin through the project template) will be removed.

### DIFF
--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
@@ -56,7 +56,7 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({ namespace, roleBindings, 
     let removeRoles = getRemovedRoles(initialValues.projectAccess, values.projectAccess);
     const updateRoles = getRolesToUpdate(newRoles, removeRoles);
 
-    const updateRolesWithMultipleSubjects = getRolesWithMultipleSubjects(
+    const { updateRolesWithMultipleSubjects, removeRoleSubjectFlag } = getRolesWithMultipleSubjects(
       newRoles,
       removeRoles,
       updateRoles,
@@ -75,13 +75,19 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({ namespace, roleBindings, 
     roleBinding.metadata.namespace = namespace;
 
     if (updateRoles.length > 0) {
-      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Patch, updateRoles, roleBinding));
+      roleBindingRequests.push(
+        ...sendRoleBindingRequest(Verb.Patch, updateRoles, roleBinding, removeRoleSubjectFlag),
+      );
     }
     if (removeRoles.length > 0) {
-      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Remove, removeRoles, roleBinding));
+      roleBindingRequests.push(
+        ...sendRoleBindingRequest(Verb.Remove, removeRoles, roleBinding, removeRoleSubjectFlag),
+      );
     }
     if (newRoles.length > 0) {
-      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Create, newRoles, roleBinding));
+      roleBindingRequests.push(
+        ...sendRoleBindingRequest(Verb.Create, newRoles, roleBinding, removeRoleSubjectFlag),
+      );
     }
 
     return Promise.all(roleBindingRequests)

--- a/frontend/packages/dev-console/src/components/project-access/__tests__/project-access-form-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/project-access/__tests__/project-access-form-submit-utils.spec.ts
@@ -38,8 +38,12 @@ describe('Project Access handleSubmit Utils', () => {
     expect(rolesWithNameChange).toEqual(rolesWithNameChangeResult);
   });
   it('should get roles with multiple subjects', () => {
-    const result = getRolesWithMultipleSubjects(newRoles, removeRoles, updateRoles);
-    expect(result).toEqual([
+    const { updateRolesWithMultipleSubjects } = getRolesWithMultipleSubjects(
+      newRoles,
+      removeRoles,
+      updateRoles,
+    );
+    expect(updateRolesWithMultipleSubjects).toEqual([
       {
         role: 'admin',
         roleBindingName: 'admin-d',

--- a/frontend/packages/dev-console/src/components/project-access/project-access-form-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/project-access/project-access-form-submit-utils.ts
@@ -104,7 +104,8 @@ export const getRemovedRoles = (
           o1.subject.name === o2.subject.name &&
           o1.subject.kind === o2.subject.kind &&
           o1.role === o2.role &&
-          o1.subject.namespace === o2.subject.namespace,
+          o1.subject.namespace === o2.subject.namespace &&
+          o1.roleBindingName === o2.roleBindingName,
       ),
   );
   return removeRoles;
@@ -126,6 +127,7 @@ export const sendRoleBindingRequest = (
   verb: string,
   roles: UserRoleBinding[],
   roleBinding: RoleBinding,
+  removeRoleSubjectFlag: number,
 ) => {
   const rb = _.clone(roleBinding);
   const finalArray = [];
@@ -145,6 +147,8 @@ export const sendRoleBindingRequest = (
               name: user.subject.name,
             },
           ]
+        : removeRoleSubjectFlag === 1 && user.subjects.length > 0
+        ? getUpdatedSubjects(user.subjects)
         : user.subjects.length > 1
         ? getUpdatedSubjects(user.subjects)
         : getUpdatedSubjects([user.subject]);
@@ -160,6 +164,7 @@ export const getRolesWithMultipleSubjects = (
   removeRoles: UserRoleBinding[],
   updateRoles: UserRoleBinding[],
 ) => {
+  let removeRoleSubjectFlag = 0;
   const updateRolesWithMultipleSubjects: UserRoleBinding[] = [];
   _.remove(
     newRoles,
@@ -183,6 +188,7 @@ export const getRolesWithMultipleSubjects = (
       } else {
         const newSubs = removeRole.subjects.filter((sub) => sub.name !== removeRole.subject.name);
         updateRolesWithMultipleSubjects.push({ ...removeRole, subjects: newSubs });
+        removeRoleSubjectFlag = 1;
       }
       return true;
     }
@@ -199,5 +205,5 @@ export const getRolesWithMultipleSubjects = (
     }
     return false;
   });
-  return updateRolesWithMultipleSubjects;
+  return { updateRolesWithMultipleSubjects, removeRoleSubjectFlag };
 };


### PR DESCRIPTION
This is manual cherry-pick for PR - https://github.com/openshift/console/pull/13071