### PR TITLE
OCPBUGS-17676: Enable white space retain in resource logs 

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -149,7 +149,7 @@
     "@patternfly/react-catalog-view-extension": "4.96.0",
     "@patternfly/react-charts": "6.94.19",
     "@patternfly/react-core": "4.276.11",
-    "@patternfly/react-log-viewer": "4.87.100",
+    "@patternfly/react-log-viewer": "4.87.101",
     "@patternfly/react-table": "4.113.0",
     "@patternfly/react-tokens": "4.94.6",
     "@patternfly/react-topology": "4.93.6",

--- a/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
@@ -363,6 +363,7 @@ const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
         ) : (
           <LogViewer
             isTextWrapped={isWrapLines}
+            retainWhitespace
             data={trimmedContent || content}
             toolbar={logControls}
             theme="dark"

--- a/frontend/public/components/utils/resource-log.tsx
+++ b/frontend/public/components/utils/resource-log.tsx
@@ -691,6 +691,7 @@ export const ResourceLog: React.FC<ResourceLogProps> = ({
             ref={logViewerRef}
             height="100%"
             isTextWrapped={wrapLinesCheckbox}
+            retainWhitespace
             toolbar={logControls}
             footer={
               <FooterButton

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2032,7 +2032,7 @@
     xterm "^4.8.1"
     xterm-addon-fit "^0.2.1"
 
-"@patternfly/react-core@4.276.11", "@patternfly/react-core@^4.160.2", "@patternfly/react-core@^4.273.1", "@patternfly/react-core@^4.276.6", "@patternfly/react-core@^4.276.8":
+"@patternfly/react-core@4.276.11", "@patternfly/react-core@^4.160.2", "@patternfly/react-core@^4.276.6", "@patternfly/react-core@^4.276.8":
   version "4.276.11"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.276.11.tgz#df59cff4386caf9d0443f9cb4a30922702df5b53"
   integrity sha512-ApoBNo0g5GioS4ezCERf13vuVi8aO6rjHnjQr5ogQR2lYR93sBq0FDt60kG+rVwAraKbtjJBjFNAYhKEhER9sQ==
@@ -2045,7 +2045,7 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-icons@4.93.6", "@patternfly/react-icons@^4.93.4", "@patternfly/react-icons@^4.93.6":
+"@patternfly/react-icons@4.93.6", "@patternfly/react-icons@^4.93.6":
   version "4.93.6"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.93.6.tgz#4aff18724afa30157e3ffd6a6414951dbb39dcb3"
   integrity sha512-ZrXegc/81oiuTIeWvoHb3nG/eZODbB4rYmekBEsrbiysyO7m/sUFoi/RLvgFINrRoh6YCJqL5fj06Jg6d7jX1g==
@@ -2055,19 +2055,18 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.93.7.tgz#130acbcda4835cf0f26802aaddbb75664709ad4b"
   integrity sha512-3kr35dgba7Qz5CSzmfH0rIjSvBC5xkmiknf3SvVUVxaiVA7KRowID8viYHeZlf3v/Oa3sEewaH830Q0t+nWsZQ==
 
-"@patternfly/react-log-viewer@4.87.100":
-  version "4.87.100"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-log-viewer/-/react-log-viewer-4.87.100.tgz#7cc81c886ad805fb7bce3640f69aaeeb31bcbb25"
-  integrity sha512-FG+oZDnymvtWNTSSNSQ573NCikpCKr1Iq0Fz5FOSeqW/rLxvuJPqBnlK+A4nUORvxvYc3DhBri2ycCaZMoZfPg==
+"@patternfly/react-log-viewer@4.87.101":
+  version "4.87.101"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-log-viewer/-/react-log-viewer-4.87.101.tgz#546375fa7f3a62cca1b176acb56f99afba7f1df5"
+  integrity sha512-JSV1PEDIRZ3ffzfXGhz7x3wA8VlTcypnYGQZ7OEng7Kv91TiaThlVDr2j/uZ2LPaTam/PvH6bdxpFXXVslqqWw==
   dependencies:
-    "@patternfly/react-core" "^4.273.1"
-    "@patternfly/react-icons" "^4.93.4"
-    "@patternfly/react-styles" "^4.92.4"
+    "@patternfly/react-core" "^4.276.6"
+    "@patternfly/react-icons" "^4.93.6"
+    "@patternfly/react-styles" "^4.92.6"
     memoize-one "^5.1.0"
-    resize-observer-polyfill "^1.5.1"
-    tslib "^2.0.0"
+    monaco-editor "^0.33.0"
 
-"@patternfly/react-styles@^4.92.4", "@patternfly/react-styles@^4.92.6":
+"@patternfly/react-styles@^4.92.6":
   version "4.92.6"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.92.6.tgz#a72c5f0b7896ce1c419d1db79f8e39ba6632057d"
   integrity sha512-b8uQdEReMyeoMzjpMri845QxqtupY/tIFFYfVeKoB2neno8gkcW1RvDdDe62LF88q45OktCwAe/8A99ker10Iw==
@@ -13607,6 +13606,11 @@ monaco-editor@*:
   resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.20.0.tgz#5d5009343a550124426cb4d965a4d27a348b4dea"
   integrity sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ==
 
+monaco-editor@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.33.0.tgz#842e244f3750a2482f8a29c676b5684e75ff34af"
+  integrity sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw==
+
 monaco-languageclient@^0.13.0:
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/monaco-languageclient/-/monaco-languageclient-0.13.0.tgz#59b68b42fb7633171502d6557f597c2752f6c266"
@@ -16411,7 +16415,7 @@ reselect@4.x:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
-resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
+resize-observer-polyfill@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
   integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==


### PR DESCRIPTION
PF4 Log Viewer component currently does not have the option to enable white space retaining (with text wrap disabled) in resource logs so turning it on by default. This results in mangled tables and other white-space sensitive formatting.

This change makes the Log Viewer component output consistent with the output of `oc logs` command.