### PR TITLE
OCPBUGS-16108: Fix DeploymentConfig list performance issues by lazy loading their ReplicationControllers

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -200,6 +200,8 @@
   "Are you sure you want to cancel this rollout?": "Are you sure you want to cancel this rollout?",
   "Yes, cancel": "Yes, cancel",
   "No, don't cancel": "No, don't cancel",
+  "Retry rollout": "Retry rollout",
+  "This action is only enabled when the latest revision of the ReplicationController resource is in a failed state.": "This action is only enabled when the latest revision of the ReplicationController resource is in a failed state.",
   "Access mode": "Access mode",
   "Cluster configuration": "Cluster configuration",
   "Set cluster-wide configuration for the console experience. Your changes will be autosaved and will affect after a refresh.": "Set cluster-wide configuration for the console experience. Your changes will be autosaved and will affect after a refresh.",

--- a/frontend/packages/console-app/src/actions/creators/hpa-factory.ts
+++ b/frontend/packages/console-app/src/actions/creators/hpa-factory.ts
@@ -119,7 +119,7 @@ export const useHPAActions = (kindObj: K8sKind, resource: K8sResourceKind) => {
     [extraResources.csvs.data, resource],
   );
 
-  const result = React.useMemo(() => {
+  const result = React.useMemo<[Action[], HorizontalPodAutoscalerKind[]]>(() => {
     return [supportsHPA ? getHpaActions(kindObj, resource, relatedHPAs) : [], relatedHPAs];
   }, [kindObj, relatedHPAs, resource, supportsHPA]);
 

--- a/frontend/packages/console-app/src/actions/providers/deploymentconfig-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/deploymentconfig-provider.ts
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { DeleteResourceAction } from '@console/dev-console/src/actions/context-menu';
+import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/dist/core/lib/lib-core';
+import { Action, K8sResourceCommon } from '@console/dynamic-plugin-sdk/src';
+import { errorModal } from '@console/internal/components/modals';
+import { DeploymentConfigKind, referenceFor } from '@console/internal/module/k8s';
+import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
+import { CommonActionFactory } from '../creators/common-factory';
+import { DeploymentActionFactory, retryRollout } from '../creators/deployment-factory';
+import { getHealthChecksAction } from '../creators/health-checks-factory';
+import { useHPAActions } from '../creators/hpa-factory';
+import { usePDBActions } from '../creators/pdb-factory';
+
+const useReplicationController = (resource: DeploymentConfigKind) => {
+  const [rcModel, rcModelInFlight] = useK8sModel('ReplicationController');
+
+  const watch = !resource.spec?.paused && !rcModelInFlight;
+
+  return useK8sWatchResource<K8sResourceCommon>(
+    watch
+      ? {
+          kind: rcModel.kind,
+          namespace: resource.metadata.namespace,
+          namespaced: true,
+          selector: {
+            matchLabels: {
+              'openshift.io/deployment-config.name': resource.metadata.name,
+            },
+          },
+        }
+      : null,
+  );
+};
+
+const useRetryRolloutAction = (resource: DeploymentConfigKind): Action => {
+  const { t } = useTranslation();
+  const [dcModel] = useK8sModel(referenceFor(resource));
+  const [rcModel] = useK8sModel('ReplicationController');
+  const [rc] = useReplicationController(resource);
+
+  const canRetry =
+    !resource.spec?.paused &&
+    rc?.metadata?.annotations?.['openshift.io/deployment.phase'] === 'Failed' &&
+    resource.status?.latestVersion !== 0;
+
+  return React.useMemo<Action>(
+    () => ({
+      id: 'retry-rollout',
+      label: t('console-app~Retry rollout'),
+      cta: () => retryRollout(rcModel, rc).catch((err) => errorModal({ error: err.message })),
+      insertAfter: 'start-rollout',
+      disabled: !canRetry,
+      disabledTooltip: !canRetry
+        ? t(
+            'console-app~This action is only enabled when the latest revision of the ReplicationController resource is in a failed state.',
+          )
+        : null,
+      accessReview: {
+        group: dcModel.apiGroup,
+        resource: dcModel.plural,
+        name: resource.metadata.name,
+        namespace: resource.metadata.namespace,
+        verb: 'patch',
+      },
+    }),
+    [t, dcModel, rcModel, rc, canRetry, resource],
+  );
+};
+
+export const useDeploymentConfigActionsProvider = (resource: DeploymentConfigKind) => {
+  const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
+  const [hpaActions, relatedHPAs] = useHPAActions(kindObj, resource);
+  const [pdbActions] = usePDBActions(kindObj, resource);
+  const retryRolloutAction = useRetryRolloutAction(resource);
+
+  const deploymentConfigActions = React.useMemo(() => {
+    const actions = [
+      ...(relatedHPAs?.length === 0 ? [CommonActionFactory.ModifyCount(kindObj, resource)] : []),
+      ...hpaActions,
+      ...pdbActions,
+      getHealthChecksAction(kindObj, resource),
+      DeploymentActionFactory.StartDCRollout(kindObj, resource),
+      retryRolloutAction,
+      DeploymentActionFactory.PauseRollout(kindObj, resource),
+      CommonActionFactory.AddStorage(kindObj, resource),
+      DeploymentActionFactory.EditResourceLimits(kindObj, resource),
+      CommonActionFactory.ModifyLabels(kindObj, resource),
+      CommonActionFactory.ModifyAnnotations(kindObj, resource),
+      DeploymentActionFactory.EditDeployment(kindObj, resource),
+      ...(resource.metadata.annotations?.['openshift.io/generated-by'] === 'OpenShiftWebConsole'
+        ? [DeleteResourceAction(kindObj, resource)]
+        : [CommonActionFactory.Delete(kindObj, resource)]),
+    ];
+    return actions;
+  }, [resource, kindObj, hpaActions, pdbActions, relatedHPAs, retryRolloutAction]);
+
+  return [deploymentConfigActions, !inFlight, undefined];
+};

--- a/frontend/packages/console-app/src/actions/providers/index.ts
+++ b/frontend/packages/console-app/src/actions/providers/index.ts
@@ -1,4 +1,5 @@
 export * from './deployment-provider';
+export * from './deploymentconfig-provider';
 export * from './stateful-set-provider';
 export * from './daemon-set-provider';
 export * from './job-provider';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
@@ -229,7 +229,6 @@ export type LazyActionMenuProps = {
   variant?: ActionMenuVariant;
   label?: string;
   isDisabled?: boolean;
-  extra?: any;
 };
 
 export type ActionContext = {

--- a/frontend/packages/console-shared/src/components/actions/LazyActionMenu.tsx
+++ b/frontend/packages/console-shared/src/components/actions/LazyActionMenu.tsx
@@ -62,7 +62,6 @@ const LazyActionMenu: React.FC<LazyActionMenuProps> = ({
   variant = ActionMenuVariant.KEBAB,
   label,
   isDisabled,
-  extra,
 }) => {
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const [initActionLoader, setInitActionLoader] = React.useState<boolean>(false);
@@ -91,23 +90,19 @@ const LazyActionMenu: React.FC<LazyActionMenuProps> = ({
       />
       {initActionLoader && (
         <ActionServiceProvider context={context}>
-          {({ actions, options, loaded }) => {
-            const menuActions = [...actions, extra];
-            const menuOptions = [...options, extra];
-            return (
-              loaded && (
-                <LazyMenuRenderer
-                  isOpen={isOpen}
-                  actions={extra ? menuActions : actions}
-                  options={extra ? menuOptions : options}
-                  menuRef={menuRef}
-                  toggleRef={toggleRef}
-                  onClick={hideMenu}
-                  focusItem={options[0]}
-                />
-              )
-            );
-          }}
+          {({ actions, options, loaded }) =>
+            loaded && (
+              <LazyMenuRenderer
+                isOpen={isOpen}
+                actions={actions}
+                options={options}
+                menuRef={menuRef}
+                toggleRef={toggleRef}
+                onClick={hideMenu}
+                focusItem={options[0]}
+              />
+            )
+          }
         </ActionServiceProvider>
       )}
     </>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -470,7 +470,6 @@
   "Triggers": "Triggers",
   "DeploymentConfig details": "DeploymentConfig details",
   "ReplicationControllers": "ReplicationControllers",
-  "Retry rollout": "Retry rollout",
   "DeploymentConfigs": "DeploymentConfigs",
   "Edit update strategy": "Edit update strategy",
   "Progress deadline seconds": "Progress deadline seconds",

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -324,6 +324,25 @@ export type DeploymentKind = {
   };
 } & K8sResourceCommon;
 
+export type DeploymentConfigKind = {
+  spec: {
+    paused?: boolean;
+    replicas?: number;
+    selector: Selector;
+    strategy?: {
+      rollingUpdate?: {
+        maxSurge: number | string;
+        maxUnavailable: number | string;
+      };
+      type?: string;
+    };
+    template: PodTemplate;
+  };
+  status?: {
+    latestVersion?: number;
+  };
+} & K8sResourceCommon;
+
 export type ResourceQuotaKind = {
   spec?: {
     hard?: { [key: string]: string };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-16108

**Analysis / Root cause**: 
Web console is slow when visiting a DeploymentConfig list with many workloads on the admin perspective on Workloads > DeploymentConfigs or via Search or a pinned resource.

The reason is that the `DeploymentConfigTableRow` loads the `ReplicationController` for any rendered row. This was added in #11725 to show a "Retry rollout" action and detect if the action should be enabled or disabled.

**Solution Description**: 
Moved the code for the "Retry rollout" action from the `DeploymentConfigTableRow` into the `useDeploymentConfigActionsProvider`. This actions are already loaded lazy when the user hovers over the action menu button (or opens it).

Wth this change this action is also available in the topology (right-click on a DC) and in the topology sidebar.

**Screen shots / Gifs for design review**: 
Before:

https://github.com/openshift/console/assets/139310/699d18ae-ed73-48d8-acad-0ab6e26a1c2d

With this PR:

https://github.com/openshift/console/assets/139310/d1b23f33-cb9e-47c7-85a0-a92ab9860dd0

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Create multiple Deployments and DeploymentConfigs
2. Open the network inspector and filter the network calls for "replicationcontrollers"
3. In the admin perspective: Check Deployment and DeploymentConfig list pages and their actions
4. In the developer perspective: Check topology actions

If needed, script to create N deployments:

```bash
#!/bin/bash
set -e

namespace="loadtest-dc"
oc new-project "$namespace"

start=1
end=100
for i in $(seq $start $end); do
    oc -n "$namespace" create deploymentconfig "dc-$i" "--image=jerolimov/nodeinfo"
done
```

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
