### PR TITLE
[release-4.12] OCPBUGS-18366: Fix DeploymentConfig list performance issues by lazy loading their ReplicationControllers

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -202,6 +202,8 @@
   "Are you sure you want to cancel this rollout?": "Are you sure you want to cancel this rollout?",
   "Yes, cancel": "Yes, cancel",
   "No, don't cancel": "No, don't cancel",
+  "Retry rollout": "Retry rollout",
+  "This action is only enabled when the latest revision of the ReplicationController resource is in a failed state.": "This action is only enabled when the latest revision of the ReplicationController resource is in a failed state.",
   "Access mode": "Access mode",
   "Close terminal?": "Close terminal?",
   "This will close the terminal session. Content in the terminal will not be restored on next session.": "This will close the terminal session. Content in the terminal will not be restored on next session.",

--- a/frontend/packages/console-app/src/actions/creators/hpa-factory.ts
+++ b/frontend/packages/console-app/src/actions/creators/hpa-factory.ts
@@ -119,7 +119,7 @@ export const useHPAActions = (kindObj: K8sKind, resource: K8sResourceKind) => {
     [extraResources.csvs.data, resource],
   );
 
-  const result = React.useMemo(() => {
+  const result = React.useMemo<[Action[], HorizontalPodAutoscalerKind[]]>(() => {
     return [supportsHPA ? getHpaActions(kindObj, resource, relatedHPAs) : [], relatedHPAs];
   }, [kindObj, relatedHPAs, resource, supportsHPA]);
 

--- a/frontend/packages/console-app/src/actions/providers/deploymentconfig-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/deploymentconfig-provider.ts
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { DeleteResourceAction } from '@console/dev-console/src/actions/context-menu';
+import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/dist/core/lib/lib-core';
+import { Action, K8sResourceCommon } from '@console/dynamic-plugin-sdk/src';
+import { errorModal } from '@console/internal/components/modals';
+import { DeploymentConfigKind, referenceFor } from '@console/internal/module/k8s';
+import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
+import { CommonActionFactory } from '../creators/common-factory';
+import { DeploymentActionFactory, retryRollout } from '../creators/deployment-factory';
+import { getHealthChecksAction } from '../creators/health-checks-factory';
+import { useHPAActions } from '../creators/hpa-factory';
+import { usePDBActions } from '../creators/pdb-factory';
+
+const useReplicationController = (resource: DeploymentConfigKind) => {
+  const [rcModel, rcModelInFlight] = useK8sModel('ReplicationController');
+
+  const watch = !resource.spec?.paused && !rcModelInFlight;
+
+  return useK8sWatchResource<K8sResourceCommon>(
+    watch
+      ? {
+          kind: rcModel.kind,
+          namespace: resource.metadata.namespace,
+          namespaced: true,
+          selector: {
+            matchLabels: {
+              'openshift.io/deployment-config.name': resource.metadata.name,
+            },
+          },
+        }
+      : null,
+  );
+};
+
+const useRetryRolloutAction = (resource: DeploymentConfigKind): Action => {
+  const { t } = useTranslation();
+  const [dcModel] = useK8sModel(referenceFor(resource));
+  const [rcModel] = useK8sModel('ReplicationController');
+  const [rc] = useReplicationController(resource);
+
+  const canRetry =
+    !resource.spec?.paused &&
+    rc?.metadata?.annotations?.['openshift.io/deployment.phase'] === 'Failed' &&
+    resource.status?.latestVersion !== 0;
+
+  return React.useMemo<Action>(
+    () => ({
+      id: 'retry-rollout',
+      label: t('console-app~Retry rollout'),
+      cta: () => retryRollout(rcModel, rc).catch((err) => errorModal({ error: err.message })),
+      insertAfter: 'start-rollout',
+      disabled: !canRetry,
+      disabledTooltip: !canRetry
+        ? t(
+            'console-app~This action is only enabled when the latest revision of the ReplicationController resource is in a failed state.',
+          )
+        : null,
+      accessReview: {
+        group: dcModel.apiGroup,
+        resource: dcModel.plural,
+        name: resource.metadata.name,
+        namespace: resource.metadata.namespace,
+        verb: 'patch',
+      },
+    }),
+    [t, dcModel, rcModel, rc, canRetry, resource],
+  );
+};
+
+export const useDeploymentConfigActionsProvider = (resource: DeploymentConfigKind) => {
+  const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
+  const [hpaActions, relatedHPAs] = useHPAActions(kindObj, resource);
+  const [pdbActions] = usePDBActions(kindObj, resource);
+  const retryRolloutAction = useRetryRolloutAction(resource);
+
+  const deploymentConfigActions = React.useMemo(() => {
+    const actions = [
+      ...(relatedHPAs?.length === 0 ? [CommonActionFactory.ModifyCount(kindObj, resource)] : []),
+      ...hpaActions,
+      ...pdbActions,
+      getHealthChecksAction(kindObj, resource),
+      DeploymentActionFactory.StartDCRollout(kindObj, resource),
+      retryRolloutAction,
+      DeploymentActionFactory.PauseRollout(kindObj, resource),
+      CommonActionFactory.AddStorage(kindObj, resource),
+      DeploymentActionFactory.EditResourceLimits(kindObj, resource),
+      CommonActionFactory.ModifyLabels(kindObj, resource),
+      CommonActionFactory.ModifyAnnotations(kindObj, resource),
+      DeploymentActionFactory.EditDeployment(kindObj, resource),
+      ...(resource.metadata.annotations?.['openshift.io/generated-by'] === 'OpenShiftWebConsole'
+        ? [DeleteResourceAction(kindObj, resource)]
+        : [CommonActionFactory.Delete(kindObj, resource)]),
+    ];
+    return actions;
+  }, [resource, kindObj, hpaActions, pdbActions, relatedHPAs, retryRolloutAction]);
+
+  return [deploymentConfigActions, !inFlight, undefined];
+};

--- a/frontend/packages/console-app/src/actions/providers/index.ts
+++ b/frontend/packages/console-app/src/actions/providers/index.ts
@@ -1,4 +1,5 @@
 export * from './deployment-provider';
+export * from './deploymentconfig-provider';
 export * from './stateful-set-provider';
 export * from './daemon-set-provider';
 export * from './job-provider';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-types.ts
@@ -231,7 +231,6 @@ export type LazyActionMenuProps = {
   variant?: ActionMenuVariant;
   label?: string;
   isDisabled?: boolean;
-  extra?: any;
 };
 
 export type ActionContext = {

--- a/frontend/packages/console-shared/src/components/actions/LazyActionMenu.tsx
+++ b/frontend/packages/console-shared/src/components/actions/LazyActionMenu.tsx
@@ -62,7 +62,6 @@ const LazyActionMenu: React.FC<LazyActionMenuProps> = ({
   variant = ActionMenuVariant.KEBAB,
   label,
   isDisabled,
-  extra,
 }) => {
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const [initActionLoader, setInitActionLoader] = React.useState<boolean>(false);
@@ -91,23 +90,19 @@ const LazyActionMenu: React.FC<LazyActionMenuProps> = ({
       />
       {initActionLoader && (
         <ActionServiceProvider context={context}>
-          {({ actions, options, loaded }) => {
-            const menuActions = [...actions, extra];
-            const menuOptions = [...options, extra];
-            return (
-              loaded && (
-                <LazyMenuRenderer
-                  isOpen={isOpen}
-                  actions={extra ? menuActions : actions}
-                  options={extra ? menuOptions : options}
-                  menuRef={menuRef}
-                  toggleRef={toggleRef}
-                  onClick={hideMenu}
-                  focusItem={options[0]}
-                />
-              )
-            );
-          }}
+          {({ actions, options, loaded }) =>
+            loaded && (
+              <LazyMenuRenderer
+                isOpen={isOpen}
+                actions={actions}
+                options={options}
+                menuRef={menuRef}
+                toggleRef={toggleRef}
+                onClick={hideMenu}
+                focusItem={options[0]}
+              />
+            )
+          }
         </ActionServiceProvider>
       )}
     </>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -449,7 +449,6 @@
   "Triggers": "Triggers",
   "DeploymentConfig details": "DeploymentConfig details",
   "ReplicationControllers": "ReplicationControllers",
-  "Retry rollout": "Retry rollout",
   "DeploymentConfigs": "DeploymentConfigs",
   "Edit update strategy": "Edit update strategy",
   "Progress deadline seconds": "Progress deadline seconds",

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -324,6 +324,25 @@ export type DeploymentKind = {
   };
 } & K8sResourceCommon;
 
+export type DeploymentConfigKind = {
+  spec: {
+    paused?: boolean;
+    replicas?: number;
+    selector: Selector;
+    strategy?: {
+      rollingUpdate?: {
+        maxSurge: number | string;
+        maxUnavailable: number | string;
+      };
+      type?: string;
+    };
+    template: PodTemplate;
+  };
+  status?: {
+    latestVersion?: number;
+  };
+} & K8sResourceCommon;
+
 export type ResourceQuotaKind = {
   spec?: {
     hard?: { [key: string]: string };


### PR DESCRIPTION
This is a cherry-pick of #13120

I did this to run the tests before the 4.13 PR was merged. The cherry-pick worked fine:

```
➜  ~/git/openshift/console-4.12/frontend git:(cherry-pick-13120-to-release-4.12) git cherry-pick c8e598fc7727ef58127d60f20af9c437c76a2768
Auto-merging frontend/packages/console-app/locales/en/console-app.json
Auto-merging frontend/packages/console-app/src/actions/providers/index.ts
Auto-merging frontend/public/components/deployment-config.tsx
Auto-merging frontend/public/locales/en/public.json
Auto-merging frontend/public/module/k8s/types.ts
[cherry-pick-13120-to-release-4.12 de0229ce4f] Lazy load RC for each DC row when list all DCs
 Date: Tue Aug 29 23:20:32 2023 +0200
 10 files changed, 144 insertions(+), 152 deletions(-)
 create mode 100644 frontend/packages/console-app/src/actions/providers/deploymentconfig-provider.ts
```

/kind bug
/cc @jerolimov @vikram-raj @sanketpathak 
/label backport-risk-assessed