### PR TITLE
OCPBUGS-18406: Builds navigation item is missing in Developer perspective

### DIFF
--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -717,9 +717,6 @@
         "data-quickstart-id": "qs-nav-builds",
         "data-test-id": "build-header"
       }
-    },
-    "flags": {
-      "required": ["DEVCONSOLE_BUILDS"]
     }
   },
   {
@@ -728,9 +725,6 @@
       "exact": true,
       "path": ["/builds"],
       "component": { "$codeRef": "common.NamespaceRedirect" }
-    },
-    "flags": {
-      "required": ["DEVCONSOLE_BUILDS"]
     }
   },
   {
@@ -739,9 +733,6 @@
       "exact": false,
       "path": ["/builds/all-namespaces", "/builds/ns/:ns"],
       "component": { "$codeRef": "builds.BuildsTabListPage" }
-    },
-    "flags": {
-      "required": ["DEVCONSOLE_BUILDS"]
     }
   },
   {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-18406

**Analysis / Root cause**: 
Builds not showing up in Side Panel Nav

**Solution Description**: 
Removed the requirement of "DEVCONSOLE_BUILD" flags for now.

**Screen shots / Gifs for design review**: 
![image](https://github.com/openshift/console/assets/47265560/2d843c44-7a4d-4055-8c98-6583e2f46011)


**Unit test coverage report**: 
Not changed

**Test setup:**
1. Developer Perspective



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge