### PR TITLE
Allowed Import from Git form to show up if Pipelines is enabled

### DIFF
--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -78,6 +78,17 @@
       "flag": "OPENSHIFT_TEMPLATE"
     }
   },
+  {
+    "type": "console.flag/model",
+    "properties": {
+      "model": {
+        "group": "tekton.dev",
+        "version": "v1",
+        "kind": "Pipeline"
+      },
+      "flag": "OPENSHIFT_PIPELINE"
+    }
+  },
 
   {
     "type": "console.cluster-configuration/item",
@@ -332,6 +343,28 @@
     },
     "flags": {
       "required": ["OPENSHIFT_BUILDCONFIG", "OPENSHIFT_IMAGESTREAM"]
+    }
+  },
+  {
+    "type": "dev-console.add/action",
+    "properties": {
+      "id": "import-from-git",
+      "groupId": "git-repository",
+      "href": "/import/ns/:namespace",
+      "label": "%devconsole~Import from Git%",
+      "description": "%devconsole~Import code from your Git repository to be built and deployed%",
+      "icon": { "$codeRef": "icons.gitIconElement" },
+      "accessReview": [
+        { "group": "apps.openshift.io", "resource": "deploymentconfigs", "verb": "create" },
+        { "group": "", "resource": "secrets", "verb": "create" },
+        { "group": "route.openshift.io", "resource": "routes", "verb": "create" },
+        { "group": "", "resource": "services", "verb": "create" },
+        { "group": "tekton.dev", "resource": "pipelines", "verb": "create" }
+      ]
+    },
+    "flags": {
+      "required": ["OPENSHIFT_PIPELINE"],
+      "disallowed": ["OPENSHIFT_BUILDCONFIG"]
     }
   },
   {
@@ -1125,6 +1158,17 @@
     },
     "flags": {
       "required": ["OPENSHIFT_BUILDCONFIG", "OPENSHIFT_IMAGESTREAM"]
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
+      "path": ["/import/all-namespaces", "/import/ns/:ns"],
+      "component": { "$codeRef": "import.ImportPage" }
+    },
+    "flags": {
+      "required": ["OPENSHIFT_PIPELINE"]
     }
   },
   {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-7379

**Solution Description**: 
Allowed the Import from Git form to show up even if BuildConfig is not installed in the cluster but Pipelines Operator is installed.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://github.com/openshift/console/assets/47265560/e0851890-9938-4b71-9bfd-5e86c4666b2a


**Test setup:**
1. Create a cluster without BC
2. Verify the Import from Git does not show up in the Add Page
3. Now, install the Pipelines Operator
4. Verify that it now shows up in the Add page.


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge