### PR TITLE
OCPBUGS-19313: Hide DeploymentConfig option from forms when it's not installed in the cluster

### DIFF
--- a/frontend/packages/dev-console/src/components/import/section/ResourceSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/ResourceSection.tsx
@@ -4,6 +4,7 @@ import { FormikValues, useField, useFormikContext } from 'formik';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { FLAG_OPENSHIFT_DEPLOYMENTCONFIG } from '@console/dev-console/src/const';
 import { ImportStrategy } from '@console/git-service/src';
 import { getActiveNamespace } from '@console/internal/actions/ui';
 import { useAccessReview } from '@console/internal/components/utils';
@@ -46,6 +47,9 @@ const ResourceSection: React.FC<ResourceSectionProps> = ({ flags }) => {
     flags[FLAG_KNATIVE_SERVING_SERVICE] &&
     knativeServiceAccess;
 
+  const canIncludeDeploymentConfig =
+    !invalidTypes.includes(Resources.OpenShift) && flags[FLAG_OPENSHIFT_DEPLOYMENTCONFIG];
+
   const [, setResourceType] = useResourceType();
 
   const onChange = React.useCallback(
@@ -69,7 +73,7 @@ const ResourceSection: React.FC<ResourceSectionProps> = ({ flags }) => {
         ),
       });
     }
-    if (!invalidTypes.includes(Resources.OpenShift)) {
+    if (canIncludeDeploymentConfig) {
       options.push({
         label: t(ReadableResourcesNames[Resources.OpenShift]),
         value: Resources.OpenShift,
@@ -90,7 +94,7 @@ const ResourceSection: React.FC<ResourceSectionProps> = ({ flags }) => {
       });
     }
     return options;
-  }, [invalidTypes, canIncludeKnative, t]);
+  }, [invalidTypes, canIncludeDeploymentConfig, canIncludeKnative, t]);
 
   if (
     !['edit', 'knatify'].includes(values.formType) &&
@@ -122,4 +126,7 @@ const ResourceSection: React.FC<ResourceSectionProps> = ({ flags }) => {
   return null;
 };
 
-export default connectToFlags(FLAG_KNATIVE_SERVING_SERVICE)(ResourceSection);
+export default connectToFlags(
+  FLAG_KNATIVE_SERVING_SERVICE,
+  FLAG_OPENSHIFT_DEPLOYMENTCONFIG,
+)(ResourceSection);

--- a/frontend/packages/dev-console/src/const.ts
+++ b/frontend/packages/dev-console/src/const.ts
@@ -37,3 +37,5 @@ export const ADD_TO_PROJECT = 'add-to-project';
 export const FLAG_JAVA_IMAGE_STREAM_ENABLED = 'JAVA_IMAGE_STREAM_ENABLED';
 export const IMAGESTREAM_NAMESPACE = 'openshift';
 export const JAVA_IMAGESTREAM_NAME = 'java';
+
+export const FLAG_OPENSHIFT_DEPLOYMENTCONFIG = 'OPENSHIFT_DEPLOYMENTCONFIG';


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-7375

**Solution Description**: 
Added a check which ensures that if there is DC in the cluster, only then show the option under the Resource Type

**Screen shots / Gifs for design review**: 

https://github.com/openshift/console/assets/47265560/7e4b683d-2be2-41ae-96b7-939bf3f96535

**Unit test coverage report**: 
Not Changed

**Test setup:**
1. Create a Cluster without DC
2. Open the Import forms to verify that the DC option is not shown under the Resources Type



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge