### PR TITLE
OCPBUGS-19314: Hide the DeploymentConfig option in the User Preferences if that resource type isn't available

### DIFF
--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -955,7 +955,8 @@
       "insertBefore": "devconsole.routingOptions"
     },
     "flags": {
-      "disallowed": ["KNATIVE_SERVING_SERVICE"]
+      "disallowed": ["KNATIVE_SERVING_SERVICE"],
+      "required": ["OPENSHIFT_DEPLOYMENTCONFIG"]
     }
   },
   {
@@ -996,6 +997,74 @@
       "insertBefore": "devconsole.routingOptions"
     },
     "flags": {
+      "required": ["KNATIVE_SERVING_SERVICE", "OPENSHIFT_DEPLOYMENTCONFIG"]
+    }
+  },
+  {
+    "type": "console.user-preference/item",
+    "properties": {
+      "id": "devconsole.preferredResource",
+      "label": "%devconsole~Resource type%",
+      "groupId": "applications",
+      "description": "%devconsole~If resource type is not selected, the console default to the latest.%",
+      "field": {
+        "type": "dropdown",
+        "userSettingsKey": "devconsole.preferredResourceType",
+        "defaultValue": "kubernetes",
+        "description": "%devconsole~The defaults below will only apply to the Import from Git and Deploy Image forms when creating Deployments or Deployment Configs.%",
+        "options": [
+          {
+            "value": "latest",
+            "label": "%devconsole~Last used%",
+            "description": "%devconsole~The last resource type used when adding a resource.%"
+          },
+          {
+            "value": "kubernetes",
+            "label": "%devconsole~Deployment%",
+            "description": "%devconsole~A Deployment enables declarative updates for Pods and ReplicaSets.%"
+          }
+        ]
+      },
+      "insertBefore": "devconsole.routingOptions"
+    },
+    "flags": {
+      "disallowed": ["OPENSHIFT_DEPLOYMENTCONFIG", "KNATIVE_SERVING_SERVICE"]
+    }
+  },
+  {
+    "type": "console.user-preference/item",
+    "properties": {
+      "id": "devconsole.preferredResource",
+      "label": "%devconsole~Resource type%",
+      "groupId": "applications",
+      "description": "%devconsole~If resource type is not selected, the console default to the latest.%",
+      "field": {
+        "type": "dropdown",
+        "userSettingsKey": "devconsole.preferredResourceType",
+        "defaultValue": "kubernetes",
+        "description": "%devconsole~The defaults below will only apply to the Import from Git and Deploy Image forms when creating Deployments or Deployment Configs.%",
+        "options": [
+          {
+            "value": "latest",
+            "label": "%devconsole~Last used%",
+            "description": "%devconsole~The last resource type used when adding a resource.%"
+          },
+          {
+            "value": "kubernetes",
+            "label": "%devconsole~Deployment%",
+            "description": "%devconsole~A Deployment enables declarative updates for Pods and ReplicaSets.%"
+          },
+          {
+            "value": "knative",
+            "label": "%devconsole~Serverless Deployment%",
+            "description": "%devconsole~A type of deployment that enables Serverless scaling to 0 when idle.%"
+          }
+        ]
+      },
+      "insertBefore": "devconsole.routingOptions"
+    },
+    "flags": {
+      "disallowed": ["OPENSHIFT_DEPLOYMENTCONFIG"],
       "required": ["KNATIVE_SERVING_SERVICE"]
     }
   },


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-7376

**Solution Description**: 
Added a check that ensures that if there is DC in the cluster, only then show the option in User Preferences

**Screen shots / Gifs for design review**: 


https://github.com/openshift/console/assets/47265560/aa5f10d9-6129-47af-ab20-3f761c1707d7



**Unit test coverage report**: 
Not Changed

**Test setup:**
1. Create a Cluster without DC
2. Open User Preferences and go to Applications
3. You will not see DC in Resource Type



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge