### PR TITLE
OCPBUGS-18439: use active namespace in Create cta href of create action for operator backed

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersions.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersions.tsx
@@ -44,6 +44,7 @@ export const ExpandCollapseDescription: React.FC<ExpandCollapseDescriptionProps>
 
 const normalizeClusterServiceVersions = (
   clusterServiceVersions: ClusterServiceVersionKind[],
+  namespace: string,
   t: TFunction,
 ): CatalogItem[] => {
   const formatTileDescription = (csvDescription: string): string =>
@@ -125,7 +126,7 @@ const normalizeClusterServiceVersions = (
         },
         cta: {
           label: t('public~Create'),
-          href: `/k8s/ns/${desc.csv.metadata.namespace}/clusterserviceversions/${
+          href: `/k8s/ns/${namespace}/clusterserviceversions/${
             desc.csv.metadata.name
           }/${referenceForProvidedAPI(desc)}/~new`,
         },
@@ -175,9 +176,10 @@ const useClusterServiceVersions: ExtensionHook<CatalogItem[]> = ({
     () =>
       normalizeClusterServiceVersions(
         [...(csvsResources.csvs?.data ?? []), ...(csvsResources.globalCsvs?.data ?? [])],
+        namespace,
         t,
       ),
-    [csvsResources, t],
+    [csvsResources, namespace, t],
   );
 
   return [normalizedCSVs, csvsResources.csvs?.loaded, csvsResources.csvs?.loadError];


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-18439

Descriptions: 
- Use active namespace instead of reading the namespace from the csv metadata as if `disableCopiedCSVs` is true then we get the csvs from the Openshift namespace. 

GIF:

https://github.com/openshift/console/assets/2561818/d5868c18-82b5-4ee0-8d9e-2f0c1cec01e9


Test steps:
1. Install Camel-k operator (community version, stable channel)
2. Disable copies of CSV by setting 'OLMConfig.spec.features.disableCopiedCSVs' to 'true'
3. Create a new namespace/project
4. Go to Developer Catalog -> Operator backed
5. Select operator backed Integration card and click on create 
6. Click on Create 
7. On the Search page select the Integration resource. and You will see the Integration is being created in the active namespace
