### PR TITLE
OCPBUGS-18494: Upgrade DomainMapping apiVersion to v1beta1

### DIFF
--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -1473,7 +1473,7 @@
     "properties": {
       "model": {
         "group": "serving.knative.dev",
-        "version": "v1alpha1",
+        "version": "v1beta1",
         "kind": "DomainMapping"
       },
       "label": "%knative-plugin~DomainMapping%",

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -103,7 +103,7 @@ export const ServiceModel: K8sKind = {
 
 export const DomainMappingModel: K8sKind = {
   apiGroup: KNATIVE_SERVING_APIGROUP,
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1beta1',
   kind: 'DomainMapping',
   label: 'DomainMapping',
   // t('knative-plugin~DomainMapping')

--- a/frontend/packages/knative-plugin/src/utils/__tests__/get-knative-resources.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/get-knative-resources.spec.ts
@@ -202,7 +202,7 @@ describe('Get knative resources', () => {
       const domainMappingResource = knativeCamelDomainMappingResourceWatchers(SAMPLE_NAMESPACE);
       expect(domainMappingResource.domainmappings).toEqual({
         isList: true,
-        kind: 'serving.knative.dev~v1alpha1~DomainMapping',
+        kind: 'serving.knative.dev~v1beta1~DomainMapping',
         namespace: 'mynamespace',
         optional: true,
       });


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-18494

Descriptions: Upgrade DomainMapping apiVersion to v1beta1 as v1alpha1 is going to be removed in Serverless Operator 1.33


https://github.com/openshift/console/assets/2561818/2b5054a6-5059-4a10-8fd0-dcda05679a5f

