### PR TITLE
OCPBUGS-18604: [knative] Don't rely on openshift/hello-openshift as a sample image

### DIFF
--- a/frontend/packages/knative-plugin/integration-tests/features/e2e/knative-ci.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/e2e/knative-ci.feature
@@ -20,8 +20,8 @@ Feature: Perform actions on knative service and revision
               And user is able to see workload "<workload_name>" in topology page
 
         Examples:
-                  | image_name                | workload_name |
-                  | openshift/hello-openshift | kn-service    |
+                  | image_name                         | workload_name |
+                  | quay.io/openshift-knative/showcase | kn-service    |
 
 
         Scenario: knative service menu options: KN-02-TC01

--- a/frontend/packages/knative-plugin/integration-tests/features/eventing/create-event-sources.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/eventing/create-event-sources.feature
@@ -73,7 +73,7 @@ Feature: Create event sources
         Scenario: Create ContainerSource event source: KE-02-TC07
              When user selects event source type "Container Source"
               And user selects Create Event Source
-              And user enters Container Image as "openshift/hello-openshift"
+              And user enters Container Image as "quay.io/openshift-knative/showcase"
               And user selects an "kn-event" option from knative service field
               And user clicks on Create button
              Then user will be redirected to Topology page

--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/actions-on-knative-service.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/actions-on-knative-service.feature
@@ -19,8 +19,8 @@ Feature: Perform actions on knative service
               And user is able to see workload "<workload_name>" in topology page
 
         Examples:
-                  | image_name                | workload_name |
-                  | openshift/hello-openshift | kn-service    |
+                  | image_name                         | workload_name |
+                  | quay.io/openshift-knative/showcase | kn-service    |
 
 
         @smoke

--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/create-knative-workload.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/create-knative-workload.feature
@@ -57,8 +57,8 @@ Feature: Create a workload of 'knative Service' type resource
               And user is able to see workload "<workload_name>" in topology page
 
         Examples:
-                  | image_name                | workload_name       |
-                  | openshift/hello-openshift | knative-ex-registry |
+                  | image_name                         | workload_name       |
+                  | quay.io/openshift-knative/showcase | knative-ex-registry |
 
 
         @regression

--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/side-bar-of-knative-revision-and-service.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/side-bar-of-knative-revision-and-service.feature
@@ -23,8 +23,8 @@ Feature: side bar details
               And user is able to see Knative Revision
 
         Examples:
-                  | name         | image_name                | runtime_icon |
-                  | hello-secure | openshift/hello-openshift | fedora       |
+                  | name         | image_name                         | runtime_icon |
+                  | hello-secure | quay.io/openshift-knative/showcase | fedora       |
 
 
         @smoke

--- a/frontend/packages/knative-plugin/src/utils/__mocks__/knatify-mock.ts
+++ b/frontend/packages/knative-plugin/src/utils/__mocks__/knatify-mock.ts
@@ -21,7 +21,7 @@ export const ksvcData: K8sResourceKind = {
         containers: [
           {
             name: 'overlayimage',
-            image: 'openshift/hello-openshift',
+            image: 'quay.io/openshift-knative/showcase',
             ports: [{ containerPort: 8080 }],
             imagePullPolicy: 'Always',
             resources: {},

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knatify-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knatify-utils.spec.ts
@@ -46,7 +46,7 @@ describe('knatify-utils', () => {
     const knatifyFormInitialVal = {
       ...knatifyFormCommonInitialValues,
       runtimeIcon: null,
-      searchTerm: 'openshift/hello-openshift',
+      searchTerm: 'quay.io/openshift-knative/showcase',
       registry: 'external',
       allowInsecureRegistry: false,
       imageStream: { image: '', tag: '', namespace: '' },

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
@@ -157,7 +157,7 @@ export const deploymentData: K8sResourceKind = {
         containers: [
           {
             name: 'hello-openshift',
-            image: 'openshift/hello-openshift',
+            image: 'quay.io/openshift-knative/showcase',
             ports: [{ containerPort: 8080, protocol: 'TCP' }],
             resources: {},
             terminationMessagePath: '/dev/termination-log',
@@ -306,7 +306,7 @@ export const deploymentKnativeData: K8sResourceKind = {
         containers: [
           {
             name: 'hello-openshift',
-            image: 'openshift/hello-openshift',
+            image: 'quay.io/openshift-knative/showcase',
             ports: [{ containerPort: 8080, protocol: 'TCP' }],
             resources: {},
             terminationMessagePath: '/dev/termination-log',
@@ -465,7 +465,7 @@ export const getEventSourceDeploymentData = (EventSourceModel: K8sKind): K8sReso
           containers: [
             {
               name: 'hello-openshift',
-              image: 'openshift/hello-openshift',
+              image: 'quay.io/openshift-knative/showcase',
               ports: [{ containerPort: 8080, protocol: 'TCP' }],
               resources: {},
               terminationMessagePath: '/dev/termination-log',

--- a/frontend/packages/knative-plugin/src/yaml-templates.ts
+++ b/frontend/packages/knative-plugin/src/yaml-templates.ts
@@ -4,11 +4,11 @@ export const defaultYamlTemplate = `
 apiVersion: ${ServiceModel.apiGroup}/${ServiceModel.apiVersion}
 kind: ${ServiceModel.kind}
 metadata:
-  name: sample
+  name: showcase
   namespace: default
 spec:
   template:
     spec:
       containers:
-      - image: openshift/hello-openshift
+      - image: quay.io/openshift-knative/showcase
 `;


### PR DESCRIPTION
Fixes https://issues.redhat.com//browse/OCPBUGS-18604

The docs have been migrated already: https://github.com/openshift/openshift-docs/pull/60772. This is for the samples in the OCP Web console.