### PR TITLE
OCPBUGS-18464: Hide the Builds NavItem if BuildConfig is not installed in the cluster

### DIFF
--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -717,6 +717,9 @@
         "data-quickstart-id": "qs-nav-builds",
         "data-test-id": "build-header"
       }
+    },
+    "flags": {
+      "required": ["OPENSHIFT_BUILDCONFIG"]
     }
   },
   {
@@ -725,6 +728,9 @@
       "exact": true,
       "path": ["/builds"],
       "component": { "$codeRef": "common.NamespaceRedirect" }
+    },
+    "flags": {
+      "required": ["OPENSHIFT_BUILDCONFIG"]
     }
   },
   {
@@ -733,6 +739,9 @@
       "exact": false,
       "path": ["/builds/all-namespaces", "/builds/ns/:ns"],
       "component": { "$codeRef": "builds.BuildsTabListPage" }
+    },
+    "flags": {
+      "required": ["OPENSHIFT_BUILDCONFIG"]
     }
   },
   {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-18464

**Solution Description**: 
Added respective required labels to the navitems

**Screen shots / Gifs for design review**: 

![image](https://github.com/openshift/console/assets/47265560/db363f79-8ea7-4008-843c-c427f3dcbc86)


**Unit test coverage report**: 
Not changed

**Test setup:**
1. Create a cluster without BC
2. Verify the Builds tab does not show in the Pre-pinned Nav Items


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge