### PR TITLE
OCPBUGS-18485: Monitoring: Fix display of silenced alerts in dev console

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceAlert.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceAlert.tsx
@@ -24,16 +24,11 @@ type SilenceAlertProps = {
   namespace: string;
 };
 
-const SilenceUntil = ({ rule }) => {
-  if (!_.isEmpty(rule.silencedBy)) {
-    return (
-      <div onClick={(e) => e.preventDefault()} role="presentation">
-        <StateTimestamp text="Until" timestamp={_.max(_.map(rule.silencedBy, 'endsAt'))} />
-      </div>
-    );
-  }
-  return null;
-};
+const SilenceUntil = ({ rule }) => (
+  <div onClick={(e) => e.preventDefault()} role="presentation">
+    <StateTimestamp text="Until" timestamp={_.max(_.map(rule.silencedBy, 'endsAt'))} />
+  </div>
+);
 
 const SilenceAlert: React.FC<SilenceAlertProps> = ({ rule, namespace }) => {
   const [isChecked, setIsChecked] = React.useState(true);
@@ -41,10 +36,8 @@ const SilenceAlert: React.FC<SilenceAlertProps> = ({ rule, namespace }) => {
   const dispatch = useDispatch();
 
   React.useEffect(() => {
-    if (rule.state === RuleStates.Silenced) {
-      setIsChecked(false);
-    }
-  }, [rule]);
+    setIsChecked(rule.state !== RuleStates.Silenced);
+  }, [rule.state]);
 
   const handleChange = (checked: boolean) => {
     setIsChecked(checked);


### PR DESCRIPTION
After silencing an alert, it would fail to display as silenced on the alerts list page.

Also fixes an issue where the silenced "Until" timestamp could flicker.