### PR TITLE
OCPBUGS-18996: fix issues with refactored "Create StorageClass" form

### DIFF
--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -201,7 +201,7 @@ const StorageClassFormInner: React.FC<StorageClassFormProps> = (props) => {
       return false;
     }
 
-    const allParamsForType = storageTypes.current[storageType].parameters;
+    const allParamsForType = storageTypes.current[storageType]?.parameters;
 
     const requiredKeys = _.keys(allParamsForType).filter((key) => paramIsRequired(key));
     const allReqdFieldsEntered = _.every(requiredKeys, (key) => {
@@ -365,7 +365,7 @@ const StorageClassFormInner: React.FC<StorageClassFormProps> = (props) => {
     const dataParameters = _.pickBy(
       _.mapValues(newStorageClass.parameters, (value, key) => {
         let finalValue = value.value;
-        if (storageTypes.current[type].parameters[key]?.format) {
+        if (storageTypes.current[type]?.parameters[key]?.format) {
           finalValue = storageTypes.current[type].parameters[key].format(value.value);
         }
         return finalValue;

--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -360,10 +360,10 @@ const StorageClassFormInner: React.FC<StorageClassFormProps> = (props) => {
     return _.fromPairs(c);
   };
 
-  const getFormParams = () => {
-    const type = newStorageClass.type;
+  const getFormParams = (newStorageClassBeforeCreation) => {
+    const type = newStorageClassBeforeCreation.type;
     const dataParameters = _.pickBy(
-      _.mapValues(newStorageClass.parameters, (value, key) => {
+      _.mapValues(newStorageClassBeforeCreation.parameters, (value, key) => {
         let finalValue = value.value;
         if (storageTypes.current[type]?.parameters[key]?.format) {
           finalValue = storageTypes.current[type].parameters[key].format(value.value);
@@ -383,10 +383,9 @@ const StorageClassFormInner: React.FC<StorageClassFormProps> = (props) => {
     setError(null);
 
     const newStorage = addDefaultParams();
-    setNewStorageClass(newStorage);
 
     const { name, description, type, reclaim, expansion, volumeBindingMode } = newStorage;
-    const dataParameters = getFormParams();
+    const dataParameters = getFormParams(newStorage);
     const annotations = description ? { description } : {};
     let data: StorageClass = {
       metadata: {

--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -253,6 +253,10 @@ const StorageClassFormInner: React.FC<StorageClassFormProps> = (props) => {
       const csiLoaded = props.resources?.csi?.loaded;
       const scData = (props.resources?.sc?.data || []) as K8sResourceKind[];
       const csiData = (props.resources?.csi?.data || []) as K8sResourceKind[];
+      // making sure csi provisioners are added to "storageTypes" (if loaded) before running "validateForm"
+      if (csiLoaded) {
+        csiProvisionerMap(csiData);
+      }
       if (loaded) {
         resources.current = {
           data: scData,
@@ -260,9 +264,6 @@ const StorageClassFormInner: React.FC<StorageClassFormProps> = (props) => {
           loaded,
         };
         validateForm();
-      }
-      if (csiLoaded) {
-        csiProvisionerMap(csiData);
       }
     }
 


### PR DESCRIPTION
This resolves 3 issues with new refactored StorageClassForm FC (Needs to be backported to OCP 4.14 as well):
1. Added minor `?.` optional chaining as form was sometimes giving TypeError at runtime.

> Caught error in a child component: TypeError: Cannot read properties of undefined (reading 'parameters')
>     at allRequiredFieldsFilled (storage-class-form.tsx:204:1)

2. Fixed the issue where default params added via extension points were not getting populated in final created StorageClass CR.

> "getFormParams" (https://github.com/openshift/console/blob/master/frontend/public/components/storage-class-form.tsx#L389) had access to older storage class state obj (without the updates of "addDefaultParams").

3. Fixed the issue with the validations of the form's params (added by provisioner extension).

> "validateForm" was being executed (https://github.com/openshift/console/blob/master/frontend/public/components/storage-class-form.tsx#L262) before running "csiProvisionerMap" (even though "csiLoaded" was true), which was causing issues with params added by "CSI" extensions.


https://github.com/openshift/console/assets/39404641/3545d73b-0daf-4513-ae0f-c49da38484fb


