### PR TITLE
OCPBUGS-18267: 404 - not found will show on Knative-serving Details page

### DIFF
--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -681,7 +681,7 @@
       "namespace": "knative-serving"
     },
     "flags": {
-      "required": ["KNATIVE_SERVING"]
+      "required": ["KNATIVE_SERVING", "KNATIVE_SERVING_SERVICE"]
     }
   },
   {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-18267

**Analysis / Root cause**: 
Knative Service flag was not checked while adding KnativeServing global configuration

**Solution Description**: 
Added the check

**Screen shots / Gifs for design review**: 


https://github.com/openshift/console/assets/102503482/d14069bb-4c69-4829-ac9c-37339c4a95b4




**Unit test coverage report**: 
NA

**Test setup:**
1. Installed 'Serveless' Operator, make sure the operator has been installed successfully, and the Knative Serving instance is created without any error
2. Navigate to Administration -> Cluster Settings -> Global Configuration
3. Go to Knative-serving Details page, check if 404 not found message is there

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge