### PR TITLE
OCPBUGS-18832: change resource icon for FenceAgentRemediationTemplate…

### DIFF
--- a/frontend/public/module/k8s/get-resources.ts
+++ b/frontend/public/module/k8s/get-resources.ts
@@ -26,7 +26,7 @@ const ADMIN_RESOURCES = new Set([
   'secrets',
 ]);
 
-const abbrBlacklist = ['ASS'];
+const abbrBlacklist = ['ASS', 'FART'];
 export const kindToAbbr = (kind) => {
   const abbrKind = (kind.replace(/[^A-Z]/g, '') || kind.toUpperCase()).slice(0, 4);
   return abbrBlacklist.includes(abbrKind) ? abbrKind.slice(0, -1) : abbrKind;


### PR DESCRIPTION
… to FAR

After:
<img width="387" alt="Screenshot 2023-09-18 at 11 16 06 AM" src="https://github.com/openshift/console/assets/895728/e0baaf5f-7a10-41ac-af97-e8426258dd02">

Note resource icon needs to be limited to a max of four characters otherwise layout issues occur.  For example, using `shortName` results in
<img width="387" alt="Screenshot 2023-09-18 at 11 13 59 AM" src="https://github.com/openshift/console/assets/895728/f2af4bb7-caaa-4572-b64b-1d04fcda07c5">
