### PR TITLE
ODC-7391: Add a new allowInsecure option to the internet proxy API

### DIFF
--- a/frontend/packages/console-shared/src/utils/proxy.ts
+++ b/frontend/packages/console-shared/src/utils/proxy.ts
@@ -5,6 +5,7 @@ import { HttpError } from '@console/dynamic-plugin-sdk/src/utils/error/http-erro
 export const API_PROXY_URL = '/api/dev-console/proxy/internet';
 
 type ProxyRequest = {
+  allowInsecure?: boolean;
   method: string;
   url: string;
   headers?: Record<string, string[]>;

--- a/pkg/devconsole/proxy/proxy.go
+++ b/pkg/devconsole/proxy/proxy.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -69,7 +70,17 @@ func serve(r *http.Request) (ProxyResponse, error) {
 	}
 	serviceRequest.URL.RawQuery = query.Encode()
 
-	serviceClient := &http.Client{}
+	var serviceClient *http.Client
+	if request.AllowInsecure {
+		serviceTransport := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		serviceClient = &http.Client{
+			Transport: serviceTransport,
+		}
+	} else {
+		serviceClient = &http.Client{}
+	}
 
 	serviceResponse, err := serviceClient.Do(serviceRequest)
 	if err != nil {

--- a/pkg/devconsole/proxy/types.go
+++ b/pkg/devconsole/proxy/types.go
@@ -6,11 +6,12 @@ import (
 )
 
 type ProxyRequest struct {
-	Method      string      `json:"method"`
-	Url         string      `json:"url"`
-	Headers     http.Header `json:"headers"`
-	Queryparams url.Values  `json:"queryparams"`
-	Body        string      `json:"body"`
+	AllowInsecure bool        `json:"allowInsecure,omitempty"`
+	Method        string      `json:"method"`
+	Url           string      `json:"url"`
+	Headers       http.Header `json:"headers"`
+	Queryparams   url.Values  `json:"queryparams"`
+	Body          string      `json:"body"`
 }
 
 type ProxyResponse struct {


### PR DESCRIPTION
**Fixes:**
Epic: [ODC-7347 Support to load PipelineRuns and Logs also from Tekton Results](https://issues.redhat.com/browse/ODC-7347)
Story: [ODC-7391 Workaround to bypass CORS and TLS issues to fetch data from the Tekton Results API](https://issues.redhat.com/browse/ODC-7391)

Adds a new option to allow insecure (disables the TLS cert validation) when fetching data with the "internet proxy".

This must not be used in the final implementation! It's a workaround to start the UI developing.