### PR TITLE
OCPBUGS-19541: Console Operand not working for clusterwide CRDs

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -616,7 +616,9 @@ export const OperandDetails = connectToModel(({ crd, csv, kindObj, obj }: Operan
     [
       ...(csv?.spec?.customresourcedefinitions?.owned ?? []),
       ...(csv?.spec?.customresourcedefinitions?.required ?? []),
-    ].find((def) => def.name === crd?.metadata?.name) ?? {};
+    ].find(
+      (def) => def.name === crd?.metadata?.name && obj.apiVersion.endsWith(`/${def.version}`),
+    ) ?? {};
 
   const schema =
     crd?.spec?.versions?.find((v) => v.name === version)?.schema?.openAPIV3Schema ??

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -772,7 +772,9 @@ const DefaultOperandDetailsPage = ({ k8sModel }: DefaultOperandDetailsPageProps)
       breadcrumbsFor={() => [
         {
           name: t('olm~Installed Operators'),
-          path: `/k8s/ns/${match.params.ns}/${ClusterServiceVersionModel.plural}`,
+          path: `/k8s/${match.params.ns ? `ns/${match.params.ns}` : 'all-namespaces'}/${
+            ClusterServiceVersionModel.plural
+          }`,
         },
         {
           name: match.params.appName,

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-link.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-link.tsx
@@ -19,9 +19,9 @@ export const OperandLink: React.FC<OperandLinkProps> = (props) => {
   const csvName = props.csvName || csvNameFromWindow();
 
   const reference = referenceFor(props.obj);
-  const to = namespace
-    ? `/k8s/ns/${namespace}/${ClusterServiceVersionModel.plural}/${csvName}/${reference}/${name}`
-    : `/k8s/cluster/${reference}/${name}`;
+  const to = `/k8s/${namespace ? `ns/${namespace}` : 'cluster'}/${
+    ClusterServiceVersionModel.plural
+  }/${csvName}/${reference}/${name}`;
   const classes = classNames('co-resource-item', {
     'co-resource-item--inline': props.inline,
   });

--- a/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
@@ -86,6 +86,37 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: `/k8s/cluster/${models.ClusterServiceVersionModel.plural}/:csvName/:plural/~new`,
+      loader: async () =>
+        (
+          await import(
+            './components/operand/create-operand' /* webpackChunkName: "create-operand" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      path: `/k8s/cluster/${models.ClusterServiceVersionModel.plural}/:appName/:plural/:name`,
+      loader: async () =>
+        (await import('./components/operand' /* webpackChunkName: "operand" */)).OperandDetailsPage,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      path: `/k8s/cluster/${referenceForModel(
+        models.ClusterServiceVersionModel,
+      )}/:appName/:plural/:name`,
+      loader: async () =>
+        (await import('./components/operand' /* webpackChunkName: "operand" */)).OperandDetailsPage,
+    },
+  },
+  {
     type: 'Page/Resource/List',
     properties: {
       model: models.SubscriptionModel,


### PR DESCRIPTION
This PR allows using descriptors for clusterwide CRDs.
Check https://issues.redhat.com/browse/OCPBUGS-19541 for details

Before:
![image](https://github.com/openshift/console/assets/91894519/cc0dafab-5d47-4eb4-930c-a67c2699daf9)
After:
![image](https://github.com/openshift/console/assets/91894519/b413062a-6197-4da3-a593-f0067688140a)
