### PR TITLE
OCPBUGS-19546: Set unlimited line width in YAML editor

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -225,7 +225,7 @@ const EditYAMLInner = (props) => {
           yaml = allowMultiple ? appendYAMLString(obj) : obj;
         } else {
           try {
-            yaml = safeDump(obj);
+            yaml = safeDump(obj, { lineWidth: -1 });
             checkEditAccess(obj);
           } catch (e) {
             yaml = t('public~Error getting YAML: {{e}}', { e });


### PR DESCRIPTION
Before:

<img width="1609" alt="Screenshot 2023-09-21 at 14 15 59" src="https://github.com/openshift/console/assets/1668218/1ee6dd9e-0b71-46ff-a6fc-808541ef3c2e">

After:

<img width="1209" alt="Screenshot 2023-09-21 at 14 17 07" src="https://github.com/openshift/console/assets/1668218/8a355f3e-356e-4a5d-a470-e13b54cee2b6">

/assign @rhamilto 