### PR TITLE
CONSOLE-3758:  add support for new features annotations while preserv…

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
@@ -83,7 +83,16 @@ export enum OperatorHubCSVAnnotationKey {
   infrastructureFeatures = 'operators.openshift.io/infrastructure-features',
   validSubscription = 'operators.openshift.io/valid-subscription',
   tags = 'tags',
+  disconnected = 'features.operators.openshift.io/disconnected',
+  fipsCompliant = 'features.operators.openshift.io/fips-compliant',
+  proxyAware = 'features.operators.openshift.io/proxy-aware',
+  cnf = 'features.operators.openshift.io/cnf',
+  cni = 'features.operators.openshift.io/cni',
+  csi = 'features.operators.openshift.io/csi',
+  tlsProfiles = 'features.operators.openshift.io/tls-profiles',
   tokenAuthAWS = 'features.operators.openshift.io/token-auth-aws',
+  tokenAuthAzure = 'features.operators.openshift.io/token-auth-azure',
+  tokenAuthGCP = 'features.operators.openshift.io/token-auth-gcp',
 }
 
 export type OperatorHubCSVAnnotations = {
@@ -102,7 +111,16 @@ export type OperatorHubCSVAnnotations = {
   [OperatorHubCSVAnnotationKey.infrastructureFeatures]?: string;
   [OperatorHubCSVAnnotationKey.validSubscription]?: string;
   [OperatorHubCSVAnnotationKey.tags]?: string[];
+  [OperatorHubCSVAnnotationKey.disconnected]?: string;
+  [OperatorHubCSVAnnotationKey.fipsCompliant]?: string;
+  [OperatorHubCSVAnnotationKey.proxyAware]?: string;
+  [OperatorHubCSVAnnotationKey.cnf]?: string;
+  [OperatorHubCSVAnnotationKey.cni]?: string;
+  [OperatorHubCSVAnnotationKey.csi]?: string;
+  [OperatorHubCSVAnnotationKey.tlsProfiles]?: string;
   [OperatorHubCSVAnnotationKey.tokenAuthAWS]?: string;
+  [OperatorHubCSVAnnotationKey.tokenAuthAzure]?: string;
+  [OperatorHubCSVAnnotationKey.tokenAuthGCP]?: string;
 } & ObjectMetadata['annotations'];
 
 type OperatorHubSpec = {


### PR DESCRIPTION
…ing support for existing infrastructure-features annotation

Note I tested using `Kiali Operator` as it already includes the new features annotations.

Future work to be completed in linked stories:
* add handling for [`tlsProfiles`](https://issues.redhat.com/browse/CONSOLE-3774), [`tokenAuthAzure`](https://issues.redhat.com/browse/CONSOLE-3775), [`tokenAuthGCP`](https://issues.redhat.com/browse/CONSOLE-3776)