### PR TITLE
CONSOLE-3084: frontend/packages/console-shared/src/hooks/useCanClusterUpgrade: Not ROSA

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useCanClusterUpgrade.ts
+++ b/frontend/packages/console-shared/src/hooks/useCanClusterUpgrade.ts
@@ -13,8 +13,10 @@ export const useCanClusterUpgrade = (): boolean => {
     name: 'version',
   });
   const notExternallyManaged = !isClusterExternallyManaged();
-  const brandingNotDedicated = window.SERVER_FLAGS.branding !== 'dedicated';
-  const canPerformUpgrade = hasPermissionsToUpdate && brandingNotDedicated && notExternallyManaged;
+  const brandingManagedUpdates =
+    window.SERVER_FLAGS.branding === 'dedicated' || window.SERVER_FLAGS.branding === 'rosa';
+  const canPerformUpgrade =
+    hasPermissionsToUpdate && !brandingManagedUpdates && notExternallyManaged;
 
   return canPerformUpgrade;
 };


### PR DESCRIPTION
ROSA cluster updates are [via OCM][1]:

> There are three methods to upgrade Red Hat OpenShift Service on AWS (ROSA) clusters:
>
> * Individual upgrades through the ROSA CLI (`rosa`)
> * Individual upgrades through the OpenShift Cluster Manager Hybrid Cloud Console console
> * Recurring upgrades through the OpenShift Cluster Manager Hybrid Cloud Console console

This is similar to [OpenShift Dedicated (OSD)][2], although there is no OSD command-line client analogous to `rosa`.  This catches this one function up with f783d87981 (#12889), CC @rhamilto, although I have not audited to see if there are other branding consumers that might want similar updates.

[1]: https://docs.openshift.com/rosa/upgrading/rosa-upgrading.html#rosa-sts-upgrading-a-cluster
[2]: https://docs.openshift.com/dedicated/upgrading/osd-upgrades.html