### PR TITLE
OCPBUGS-19640: Dont render ARN mode role field and warning for HyperShift clusters

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -25,7 +25,7 @@ import {
   AuthenticationKind,
   referenceForModel,
 } from '@console/internal/module/k8s';
-import { RH_OPERATOR_SUPPORT_POLICY_LINK } from '@console/shared';
+import { RH_OPERATOR_SUPPORT_POLICY_LINK, isClusterExternallyManaged } from '@console/shared';
 import { DefaultCatalogSource } from '../../const';
 import { ClusterServiceVersionModel } from '../../models';
 import { ClusterServiceVersionKind, SubscriptionKind } from '../../types';
@@ -363,6 +363,7 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
             <div className="co-catalog-page__overlay-description">
               {isAWSSTSCluster(cloudCredentials, infrastructure, authentication) &&
                 showWarn &&
+                !isClusterExternallyManaged() &&
                 infraFeatures?.find((i) => i === InfraFeatures[shortLivedTokenAuth]) && (
                   <Alert
                     isInline

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -50,6 +50,7 @@ import {
   referenceForModel,
 } from '@console/internal/module/k8s';
 import { fromRequirements } from '@console/internal/module/k8s/selector';
+import { isClusterExternallyManaged } from '@console/shared';
 import { CONSOLE_OPERATOR_CONFIG_NAME } from '@console/shared/src/constants';
 import { parseJSONAnnotation } from '@console/shared/src/utils/annotations';
 import { SubscriptionModel, OperatorGroupModel, PackageManifestModel } from '../../models';
@@ -730,7 +731,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
         )}
       />
       <div className="co-m-pane__body">
-        {tokenizedAuth === 'AWS' && showSTSWarn && (
+        {tokenizedAuth === 'AWS' && !isClusterExternallyManaged() && showSTSWarn && (
           <Alert
             isInline
             variant="warning"
@@ -748,7 +749,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
         <div className="row">
           <div className="col-xs-6">
             <>
-              {tokenizedAuth === 'AWS' && (
+              {tokenizedAuth === 'AWS' && !isClusterExternallyManaged() && (
                 <div className="form-group">
                   <fieldset>
                     <label className="co-required">{t('olm~role ARN')}</label>


### PR DESCRIPTION
Based on https://redhat-internal.slack.com/archives/C01C8502FMM/p1695208537708359 disscusion, ARN role field and warning should be hidden in HyperShift clusters.

/assign @rhamilto @gallettilance 
