### PR TITLE
OCPBUGS-19743: Fix Invalid URL crash

### DIFF
--- a/frontend/public/module/auth.js
+++ b/frontend/public/module/auth.js
@@ -3,11 +3,10 @@ import { coFetch } from '../co-fetch';
 import { stripBasePath } from '../components/utils/link';
 
 export const LOGIN_ERROR_PATH = window.SERVER_FLAGS.loginErrorURL
-  ? new URL(window.SERVER_FLAGS.loginErrorURL).pathname
+  ? new URL(window.SERVER_FLAGS.loginErrorURL, window.location.href).pathname
   : '';
 
-const isLoginErrorPath = (path) =>
-  path && LOGIN_ERROR_PATH.pathname && path === LOGIN_ERROR_PATH.pathname;
+const isLoginErrorPath = (path) => path && path === LOGIN_ERROR_PATH;
 
 const loginState = (key) => localStorage.getItem(key);
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-19743

**Analysis / Root cause**: 
After #13102 got merged, it wasn't possible to start the local console bridge anymore.

The UI crashes with this error:

```
Uncaught TypeError: Failed to construct 'URL': Invalid URL
    at ./public/module/auth.js (main-c115e44b78283c32bc69.js:81514:7)
    at __webpack_require__ (runtime~main-bundle.js:90:30)
```

The loginErrorURL is a string that couldn't get parsed with new URL:

```
window.SERVER_FLAGS.loginErrorURL
'/auth/error'

new URL(window.SERVER_FLAGS.loginErrorURL)
VM55:1 Uncaught TypeError: Failed to construct 'URL': Invalid URL
```

**Solution Description**: 
1. Added the current URL as base URL as second parameter to the [URL constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL).
2. Updated `isLoginErrorPath` because `LOGIN_ERROR_PATH` is a string, no an URL object.

To be honest, I didn't retested #13102 yet.

**Test setup:**
1. Start a local console with `./bin/bridge`

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
