### PR TITLE
OCPBUGS-4242: Fix CSV list and details page managed namespaces for copied CSVs.

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/types.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/types.ts
@@ -139,6 +139,7 @@ export type ClusterServiceVersionKind = {
   status?: {
     phase: ClusterServiceVersionPhase;
     reason: CSVConditionReason;
+    message?: string;
     requirementStatus?: RequirementStatus[];
   };
 } & K8sResourceKind;


### PR DESCRIPTION
Display copied CSV namespace in the "Managed Namespace" field with muted `status.message` content underneath.