### PR TITLE
OCPBUGS-19714: add correct Channel tooltip URLs for OSD and ROSA

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -453,7 +453,10 @@ export const CurrentVersionHeader: React.FC<CurrentVersionProps> = ({ cv }) => {
 };
 
 export const ChannelDocLink: React.FC<{}> = () => {
-  const upgradeURL = getDocumentationURL(documentationURLs.understandingUpgradeChannels);
+  const upgradeURL = getDocumentationURL(
+    documentationURLs.upgradeChannels,
+    window.SERVER_FLAGS.branding,
+  );
   const { t } = useTranslation();
   return (
     <ExternalLink href={upgradeURL} text={t('public~Learn more about OpenShift update channels')} />

--- a/frontend/public/components/utils/documentation.tsx
+++ b/frontend/public/components/utils/documentation.tsx
@@ -1,6 +1,10 @@
 const UPSTREAM_LATEST = 'https://docs.okd.io/latest/';
 
 // Prefer the documentation base URL passed as a flag, but fall back to the latest upstream docs if none was specified.
+// Expected values for openshiftHelpBase:
+// dedicated: https://docs.openshift.com/dedicated/
+// rosa: https://docs.openshift.com/rosa/
+// upstream: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.x/
 export const openshiftHelpBase = window.SERVER_FLAGS.documentationBaseURL || UPSTREAM_LATEST;
 
 export const DOC_URL_OPENSHIFT_WHATS_NEW = 'https://www.openshift.com/learn/whats-new';
@@ -52,9 +56,11 @@ export const documentationURLs: documentationURLsType = {
     downstream: 'html/post-installation_configuration/index',
     upstream: 'post_installation_configuration/machine-configuration-tasks.html',
   },
-  understandingUpgradeChannels: {
+  upgradeChannels: {
+    dedicated: 'upgrading/osd-upgrades.html',
     downstream:
       'html/updating_clusters/understanding-upgrade-channels-releases#understanding-upgrade-channels_understanding-upgrade-channels-releases',
+    rosa: 'upgrading/rosa-upgrading.html',
     upstream: 'updating/index.html#updating-clusters-overview-upgrade-channels-and-releases',
   },
   updateService: {
@@ -88,10 +94,18 @@ export const documentationURLs: documentationURLsType = {
 
 export const isUpstream = () => window.SERVER_FLAGS.branding === 'okd';
 
-export const getDocumentationURL = (docURLs: docURLs) =>
-  isUpstream()
-    ? `${UPSTREAM_LATEST}${docURLs.upstream}`
-    : `${window.SERVER_FLAGS.documentationBaseURL}${docURLs.downstream}`;
+export const getDocumentationURL = (docURLs: docURLs, branding?: string) => {
+  switch (branding) {
+    case 'dedicated':
+      return `${window.SERVER_FLAGS.documentationBaseURL}${docURLs.dedicated}`;
+    case 'rosa':
+      return `${window.SERVER_FLAGS.documentationBaseURL}${docURLs.rosa}`;
+    default:
+      return isUpstream()
+        ? `${UPSTREAM_LATEST}${docURLs.upstream}`
+        : `${window.SERVER_FLAGS.documentationBaseURL}${docURLs.downstream}`;
+  }
+};
 
 export const getNetworkPolicyDocURL = (openshiftFlag: boolean) => {
   const networkLink = getDocumentationURL(documentationURLs.networkPolicy);
@@ -104,7 +118,9 @@ type documentationURLsType = {
 };
 
 type docURLs = {
+  dedicated?: string;
   downstream: string;
   kube?: string;
+  rosa?: string;
   upstream: string;
 };


### PR DESCRIPTION
Important:
* In order for this fix to work for ROSA, the ROSA branding option added with https://github.com/openshift/console/pull/12889 and https://github.com/openshift/api/pull/1494 must be utilized when packaging ROSA (note the same is also true for https://github.com/openshift/console/pull/13184).
* It assumes the base urls for OSD and ROSA will continue to be:
  * OSD: https://docs.openshift.com/dedicated/
  * ROSA: https://docs.openshift.com/rosa/

cc: @dtaylor113, @spadgett, @wgordon17 