### PR TITLE
OCPBUGS-19970: Home-Projects-Default-workloads-AddPage: upload JAR file's i18n misses

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -499,6 +499,8 @@
   "JAR": "JAR",
   "JAR file": "JAR file",
   "Drag a file here or browse to upload": "Drag a file here or browse to upload",
+  "Browse...": "Browse...",
+  "Clear": "Clear",
   "Optional Java arguments": "Optional Java arguments",
   "Optional Java arguments are saved as JAVA_ARGS environment variable to customize your application.": "Optional Java arguments are saved as JAVA_ARGS environment variable to customize your application.",
   "JAVA_ARGS": "JAVA_ARGS",

--- a/frontend/packages/dev-console/src/components/import/jar/section/JarSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/jar/section/JarSection.tsx
@@ -66,6 +66,8 @@ const JarSection: React.FunctionComponent = () => {
         filename={fileName}
         label={t('devconsole~JAR file')}
         filenamePlaceholder={t('devconsole~Drag a file here or browse to upload')}
+        browseButtonText={t('devconsole~Browse...')}
+        clearButtonText={t('devconsole~Clear')}
         onChange={updatedJarFile}
         hideDefaultPreview
         dropzoneProps={{


### PR DESCRIPTION
### Before:
![Screenshot 2023-10-03 at 8 15 59 AM](https://github.com/openshift/console/assets/15249132/3d9fd64e-91ca-4b6d-9308-0fd7b3ed7627)

### After
![Screenshot 2023-10-03 at 8 41 11 AM](https://github.com/openshift/console/assets/15249132/6f753dfd-e3a8-4b16-b9cc-7c258adf5b1e)

**FYI: The actual translations in supported languages would be available in the next Memsource upload/download task.** 