### PR TITLE
OCPBUGS-20229: Service details page shows revisions and routes from other service also

### DIFF
--- a/frontend/packages/knative-plugin/src/components/services/ServiceDetailsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServiceDetailsPage.tsx
@@ -164,11 +164,7 @@ const ServiceDetailsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (
       breadcrumbsFor={() => breadcrumbs}
       pages={pages}
       customActionMenu={actionMenu}
-      customData={
-        serviceTypeValue === ServiceTypeValue.Function
-          ? { selectResourcesForName: match.params.name }
-          : undefined
-      }
+      customData={{ selectResourcesForName: match.params.name }}
     />
   );
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-20229

**Analysis / Root cause**: 
Revisions are Routes are not selected based on selected service name

**Solution Description**: 
Revisions are Routes are now selected based on selected service name


**Screen shots / Gifs for design review**: 
----BEFORE---

https://github.com/openshift/console/assets/102503482/e0e92fc3-ff16-419f-8505-fdb0a25be21c


----AFTER----


https://github.com/openshift/console/assets/102503482/1a31fa14-48c3-447e-beca-c708903da93a



**Unit test coverage report**: 
NA

**Test setup:**
1. install serverless operator
2. Create serving instance
3. create multiple service in a namespace
4. Click on any service and go to Revisions, Routes and Pods page

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge