### PR TITLE
OCPBUGS-19783: Channel page shows "Required" message for the default name when navigate to create channel page

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/channels/ChannelForm.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/channels/ChannelForm.tsx
@@ -84,7 +84,9 @@ const ChannelForm: React.FC<FormikProps<FormikValues> & OwnProps> = ({
         }),
       );
       setFieldTouched('yamlData', true);
-      validateForm();
+      setTimeout(() => {
+        validateForm();
+      }, 0);
     },
     [setErrors, setStatus, setFieldValue, setFieldTouched, values.formData, validateForm],
   );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-19783

**Analysis / Root cause**: 
Form was not re-validated after updating form name

**Solution Description**: 
Added ValidateForm inside setTimeout method

**Screen shots / Gifs for design review**: 
----BEFORE---

https://github.com/openshift/console/assets/102503482/6b83d4a9-3bc0-4a4e-9feb-baf45a8f5819




----AFTER----


https://github.com/openshift/console/assets/102503482/2f40131a-b7a8-439d-a1bb-0d8c906034e2





**Unit test coverage report**: 
NA

**Test setup:**
1. Install serverless operator
2. Go to Add page in developer perspective
3. Click on the channel card

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge