### PR TITLE
OCPBUGS-20362: Delete results.tekton.dev annotations before rerun the pipelineRun

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/utils.ts
@@ -110,6 +110,9 @@ export const getPipelineRunData = (
   );
   delete annotations['kubectl.kubernetes.io/last-applied-configuration'];
   delete annotations['tekton.dev/v1beta1TaskRuns'];
+  delete annotations['results.tekton.dev/log'];
+  delete annotations['results.tekton.dev/record'];
+  delete annotations['results.tekton.dev/result'];
 
   const newPipelineRun = {
     apiVersion: pipeline ? pipeline.apiVersion : latestRun.apiVersion,


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-20362

Descriptions: Creating a PipelineRun with previous annotations leads to the result not being created. But records are updated with new TaskRuns. This PR deletes the results.tekton.dev annotations from the previous PipelineRun.

GIF:

https://github.com/openshift/console/assets/2561818/b533279e-1142-443c-8e0c-4588b1ce4fca

