### PR TITLE
OCPBUGS-30077: Add additional search filters in the toolbar

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -840,15 +840,15 @@ Component that generates filter for list page.
   // See implementation for more details on RowFilter and FilterValue types
   const [staticData, filteredData, onFilterChange] = useListPageFilter(
     data,
-    rowFilters,
+    [...rowFilters, ...searchFilters],
     staticFilters,
   );
   // ListPageFilter updates filter state based on user interaction and resulting filtered data can be rendered in an independent component.
   return (
     <>
-      <ListPageHeader .../>
+      <ListPageHeader />
       <ListPagBody>
-        <ListPageFilter data={staticData} onFilterChange={onFilterChange} />
+        <ListPageFilter data={staticData} onFilterChange={onFilterChange} rowFilters={rowFilters} rowSearchFilters={searchFilters} />
         <List data={filteredData} />
       </ListPageBody>
     </>
@@ -877,6 +877,7 @@ Component that generates filter for list page.
 | `columnLayout` | (optional) column layout object |
 | `hideColumnManagement` | (optional) flag to hide the column management |
 | `nameFilter` | (optional) a unique name key for name filter. This may be useful if there are multiple `ListPageFilter` components rendered at once. |
+| `rowSearchFilters` | (optional) An array of RowSearchFilters elements that define search text filters added on top of Name and Label filters |
 
 
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -281,20 +281,21 @@ export const ListPageCreateDropdown: React.FC<ListPageCreateDropdownProps> = req
  * @param {ColumnLayout} [columnLayout] -  (optional) column layout object
  * @param {boolean} [hideColumnManagement] -  (optional) flag to hide the column management
  * @param {string} [nameFilter] - (optional) a unique name key for name filter. This may be useful if there are multiple `ListPageFilter` components rendered at once.
+ * @param {RowSearchFilter[]} [rowSearchFilters] - (optional) An array of RowSearchFilters elements that define search text filters added on top of Name and Label filters
  * @example
  * ```tsx
  *   // See implementation for more details on RowFilter and FilterValue types
  *   const [staticData, filteredData, onFilterChange] = useListPageFilter(
  *     data,
- *     rowFilters,
+ *     [...rowFilters, ...searchFilters],
  *     staticFilters,
  *   );
  *   // ListPageFilter updates filter state based on user interaction and resulting filtered data can be rendered in an independent component.
  *   return (
  *     <>
- *       <ListPageHeader .../>
+ *       <ListPageHeader />
  *       <ListPagBody>
- *         <ListPageFilter data={staticData} onFilterChange={onFilterChange} />
+ *         <ListPageFilter data={staticData} onFilterChange={onFilterChange} rowFilters={rowFilters} rowSearchFilters={searchFilters} />
  *         <List data={filteredData} />
  *       </ListPageBody>
  *     </>

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -401,6 +401,12 @@ export type RowReducerFilter<R = any> = RowFilterBase<R> & {
 
 export type RowFilter<R = any> = RowMatchFilter<R> | RowReducerFilter<R>;
 
+export type RowSearchFilter<R = any> = Omit<RowFilterBase<R>, 'items' | 'defaultSelected'> & {
+  placeholder?: string;
+};
+
+export type AnyRowFilter<R = any> = RowFilter<R> | RowSearchFilter<R>;
+
 export type ColumnLayout = {
   id: string;
   columns: ManagedColumn[];
@@ -420,7 +426,7 @@ export type OnFilterChange = (type: string, value: FilterValue) => void;
 export type ListPageFilterProps<D = any> = {
   data: D;
   loaded: boolean;
-  rowFilters?: RowFilter[];
+  rowFilters?: RowFilter<D>[];
   labelFilter?: string;
   labelPath?: string;
   nameFilterTitle?: string;
@@ -432,11 +438,12 @@ export type ListPageFilterProps<D = any> = {
   onFilterChange: OnFilterChange;
   hideColumnManagement?: boolean;
   nameFilter?: string;
+  rowSearchFilters?: RowSearchFilter<D>[];
 };
 
 export type UseListPageFilter = <D, R>(
   data: D[],
-  rowFilters?: RowFilter<R>[],
+  rowFilters?: AnyRowFilter<R>[],
   staticFilters?: { [key: string]: FilterValue },
 ) => [D[], D[], OnFilterChange];
 

--- a/frontend/public/components/factory/ListPage/ListPageFilter.tsx
+++ b/frontend/public/components/factory/ListPage/ListPageFilter.tsx
@@ -19,6 +19,7 @@ const ListPageFilter: React.FC<ListPageFilterProps> = ({
   onFilterChange,
   hideColumnManagement,
   nameFilter,
+  rowSearchFilters,
 }) =>
   loaded &&
   !_.isEmpty(data) && (
@@ -36,6 +37,7 @@ const ListPageFilter: React.FC<ListPageFilterProps> = ({
       columnLayout={columnLayout}
       hideColumnManagement={hideColumnManagement}
       textFilter={nameFilter}
+      rowSearchFilters={rowSearchFilters}
     />
   );
 

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as fuzzy from 'fuzzysearch';
 import { nodeStatus, volumeSnapshotStatus } from '@console/app/src/status';
 import { getNodeRoles, getLabelsAsString } from '@console/shared';
-import { Alert, FilterValue, RowFilter, Rule } from '@console/dynamic-plugin-sdk';
+import { Alert, AnyRowFilter, FilterValue, Rule } from '@console/dynamic-plugin-sdk';
 import { routeStatus } from '../routes';
 import { secretTypeFilterReducer } from '../secret';
 import { roleType } from '../RBAC';
@@ -235,13 +235,16 @@ export const tableFilters = (isExactSearch: boolean): FilterMap => {
     },
   };
 };
-const rowFiltersToFilterFuncs = (rowFilters: RowFilter[]): FilterMap => {
+const rowFiltersToFilterFuncs = (rowFilters: AnyRowFilter[]): FilterMap => {
   return (rowFilters || [])
     .filter((f) => f.type && _.isFunction(f.filter))
     .reduce((acc, f) => ({ ...acc, [f.type]: f.filter }), {} as FilterMap);
 };
 
-export const getAllTableFilters = (rowFilters: RowFilter[], isExactMatch?: boolean): FilterMap => ({
+export const getAllTableFilters = (
+  rowFilters: AnyRowFilter[],
+  isExactMatch?: boolean,
+): FilterMap => ({
   ...tableFilters(isExactMatch),
   ...rowFiltersToFilterFuncs(rowFilters),
 });

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -29,6 +29,7 @@ import {
   ColumnLayout,
   OnFilterChange,
   FilterValue,
+  RowSearchFilter,
 } from '@console/dynamic-plugin-sdk';
 import {
   Dropdown as DropdownInternal,
@@ -43,6 +44,7 @@ import { TextFilter } from './factory';
 import { filterList } from '@console/dynamic-plugin-sdk/src/app/k8s/actions/k8s';
 import useRowFilterFix from './useRowFilterFix';
 import useLabelSelectionFix from './useLabelSelectionFix';
+import useSearchFilters from './useSearchFilters';
 
 /**
  * Housing both the row filter and name/label filter in the same file.
@@ -82,6 +84,7 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
   reduxIDs,
   onFilterChange,
   labelPath,
+  rowSearchFilters = [],
 }) => {
   const dispatch = useDispatch();
   const location = useLocation();
@@ -90,6 +93,11 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
 
   const translatedNameFilterTitle = nameFilterTitle ?? t('public~Name');
 
+  const { searchFiltersObject, searchFiltersState, changeSearchFiltersState } = useSearchFilters(
+    rowSearchFilters,
+    uniqueFilterName,
+  );
+
   const translateFilterType = (value: string) => {
     switch (value) {
       case 'Name':
@@ -97,13 +105,27 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
       case 'Label':
         return t('public~Label');
       default:
-        return value;
+        return searchFiltersObject?.[value]?.filterGroupName || value;
     }
   };
-  const filterDropdownItems = {
-    NAME: translatedNameFilterTitle,
-    LABEL: t('public~Label'),
+
+  const filterDropdownItems: Record<string, string> = {
+    ...Object.keys(searchFiltersObject || {}).reduce(
+      (acc, key) => ({
+        ...acc,
+        [key]: searchFiltersObject[key].filterGroupName,
+      }),
+      {},
+    ),
   };
+
+  if (!hideLabelFilter && !hideNameLabelFilters) {
+    filterDropdownItems.LABEL = t('public~Label');
+  }
+
+  if (!hideNameLabelFilters) {
+    filterDropdownItems.NAME = translatedNameFilterTitle;
+  }
 
   // use unique name only when only when more than 1 table is in the view
   const nameFilterQueryArgumentKey = uniqueFilterName
@@ -112,13 +134,19 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
   const labelFilterQueryArgumentKey = uniqueFilterName
     ? `${uniqueFilterName}-${labelFilter}`
     : labelFilter;
+
   const params = new URLSearchParams(location.search);
-  const [filterType, setFilterType] = React.useState(FilterType.NAME);
   const [isOpen, setOpen] = React.useState(false);
   const [nameInputText, setNameInputText] = React.useState(
     params.get(nameFilterQueryArgumentKey) ?? '',
   );
   const [labelInputText, setLabelInputText] = React.useState('');
+
+  const [filterType, setFilterType] = React.useState(
+    nameInputText || !hideNameLabelFilters
+      ? FilterType.NAME
+      : Object.keys(searchFiltersState)?.[0] || rowSearchFilters?.[0]?.type,
+  );
 
   // Generate rowFilter items and counts. Memoize to minimize re-renders.
   const generatedRowFilters = useDeepCompareMemoize(
@@ -213,6 +241,27 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
     [onFilterChange, reduxIDs, dispatch],
   );
 
+  const applyTextFilter = React.useCallback(
+    (value: string, filterName: string) => {
+      applyFilters(filterName, { selected: [value] });
+    },
+    [applyFilters],
+  );
+
+  const searchRowFilters = rowSearchFilters.map((searchFilter) => (
+    <ToolbarFilter
+      key={searchFilter.type}
+      categoryName={translateFilterType(searchFilter.type)}
+      deleteChip={() => {
+        changeSearchFiltersState(searchFilter.type, '');
+        applyTextFilter('', searchFilter.type);
+      }}
+      chips={searchFiltersState[searchFilter.type] ? [searchFiltersState[searchFilter.type]] : []}
+    >
+      <></>
+    </ToolbarFilter>
+  ));
+
   const applyRowFilter = (selected: string[]) => {
     generatedRowFilters?.forEach?.(({ items, type }) => {
       const all = items?.map?.(({ id }) => id) ?? [];
@@ -250,6 +299,7 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
   );
 
   const debounceApplyNameFilter = useDebounceCallback(applyNameFilter, 250);
+  const debounceApplyTextFilter = useDebounceCallback(applyTextFilter, 250);
 
   const clearAll = () => {
     updateRowFilterSelected(selectedRowFilters);
@@ -261,6 +311,13 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
       setLabelInputText('');
       applyLabelFilters([]);
     }
+
+    if (rowSearchFilters.length > 0) {
+      Object.keys(searchFiltersState).forEach((key) => {
+        changeSearchFiltersState(key, '');
+        applyTextFilter('', key);
+      });
+    }
   };
 
   // Run once on mount to apply filters from query params
@@ -270,6 +327,12 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
     }
     if (!hideNameLabelFilters) {
       applyFilters(textFilter, { selected: [nameInputText] });
+    }
+
+    if (rowSearchFilters.length > 0) {
+      Object.keys(searchFiltersState).forEach((key) => {
+        applyFilters(key, { selected: [searchFiltersState[key]] });
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -287,6 +350,9 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rowFiltersInitialized, labelSelectionInitialized]);
 
+  const showSearchFilters = Object.keys(filterDropdownItems).length !== 0;
+
+  const showSearchFiltersDropdown = Object.keys(filterDropdownItems).length > 1;
   return (
     <Toolbar
       className="co-toolbar-no-padding pf-m-toggle-group-container"
@@ -347,8 +413,9 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
                 )}
               </ToolbarItem>
             )}
-            {!hideNameLabelFilters && (
+            {showSearchFilters && (
               <ToolbarItem className="co-filter-search--full-width">
+                {searchRowFilters}
                 <ToolbarFilter
                   deleteChipGroup={() => {
                     setLabelInputText('');
@@ -370,15 +437,15 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
                     categoryName={translatedNameFilterTitle}
                   >
                     <div className="pf-v5-c-input-group co-filter-group">
-                      {!hideLabelFilter && (
+                      {showSearchFiltersDropdown && (
                         <DropdownInternal
                           items={filterDropdownItems}
-                          onChange={(type) => setFilterType(FilterType[type])}
+                          onChange={(type) => setFilterType(FilterType[type] || type)}
                           selectedKey={filterType}
                           title={translateFilterType(filterType)}
                         />
                       )}
-                      {filterType === FilterType.LABEL ? (
+                      {filterType === FilterType.LABEL && (
                         <AutocompleteInput
                           className="co-text-node"
                           onSuggestionSelect={(selected) => {
@@ -391,7 +458,9 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
                           data={data}
                           labelPath={labelPath}
                         />
-                      ) : (
+                      )}
+
+                      {filterType === FilterType.NAME && (
                         <TextFilter
                           data-test="name-filter-input"
                           value={nameInputText}
@@ -400,6 +469,18 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
                             debounceApplyNameFilter(value);
                           }}
                           placeholder={nameFilterPlaceholder ?? t('public~Search by name...')}
+                        />
+                      )}
+
+                      {searchFiltersObject[filterType] && (
+                        <TextFilter
+                          data-test={`${filterType}-filter-input`}
+                          value={searchFiltersState[filterType]}
+                          onChange={(_event, value: string) => {
+                            changeSearchFiltersState(filterType, value);
+                            debounceApplyTextFilter(value, filterType);
+                          }}
+                          placeholder={searchFiltersObject[filterType].placeholder}
                         />
                       )}
                     </div>
@@ -471,6 +552,7 @@ type FilterToolbarProps = {
   // Used when multiple tables are in the same page
   uniqueFilterName?: string;
   onFilterChange?: OnFilterChange;
+  rowSearchFilters?: RowSearchFilter[];
 };
 
 FilterToolbar.displayName = 'FilterToolbar';

--- a/frontend/public/components/useSearchFilters.ts
+++ b/frontend/public/components/useSearchFilters.ts
@@ -1,0 +1,72 @@
+import { useDeepCompareMemoize } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useDeepCompareMemoize';
+import { useState, useMemo, useCallback } from 'react';
+import { setOrRemoveQueryArgument } from './utils';
+import { RowSearchFilter } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
+
+/**
+ * Handles a state management hack-fix around the label filters auto complete field.
+ * Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2070720
+ * TODO: Refactor FilterToolbar to use proper state management: https://issues.redhat.com/browse/CONSOLE-3147
+ *
+ * This is a hack fix due to the violation in state management in FilterToolbar. This hook should
+ * be deleted once proper React state management has been implemented.
+ */
+const useSearchFilters = (searchFilters: RowSearchFilter[], uniqueFilterName: string) => {
+  const searchFiltersObject = useMemo(
+    () =>
+      (searchFilters || []).reduce((acc, filter) => {
+        acc[filter?.type] = filter;
+        return acc;
+      }, {} as { [key: string]: RowSearchFilter }),
+    [searchFilters],
+  );
+
+  const queryParams = useDeepCompareMemoize(new URLSearchParams(location.search));
+
+  const searchFiltersValues: { [filterName: string]: string } = useMemo(
+    () =>
+      (searchFilters || []).reduce((acc, filter) => {
+        const queryKey = uniqueFilterName ? `${uniqueFilterName}-${filter?.type}` : filter?.type;
+        const queryValue = queryParams.get(queryKey);
+
+        if (queryValue) {
+          acc[filter?.type] = queryValue;
+        }
+        return acc;
+      }, {}),
+    [queryParams, uniqueFilterName, searchFilters],
+  );
+
+  const [searchFiltersState, setSearchFiltersState] = useState(searchFiltersValues);
+
+  const changeSearchFiltersState = useCallback(
+    (filterName: string, value: string) => {
+      setSearchFiltersState((state) => ({
+        ...state,
+        [filterName]: value,
+      }));
+      setTimeout(
+        () =>
+          setOrRemoveQueryArgument(
+            uniqueFilterName ? `${uniqueFilterName}-${filterName}` : filterName,
+            value,
+          ),
+        0,
+      );
+    },
+    [setSearchFiltersState, uniqueFilterName],
+  );
+
+  const flushSearchFiltersState = useCallback(() => {
+    setSearchFiltersState({});
+  }, []);
+
+  return {
+    searchFiltersObject,
+    searchFiltersState,
+    changeSearchFiltersState,
+    flushSearchFiltersState,
+  };
+};
+
+export default useSearchFilters;


### PR DESCRIPTION
@spadgett @vojtechszocs 

Hi guys this is the PR to add search filters to the `ListPageFilter` component.

I've added a new `RowSearchFilter` type to the `rowFilters` prop. The new type has a `placeholder` key and does not have the key `items` as in the search params there are no options but the user needs actually to type. It's not shown in the Filter popup but in the dropdown. 
For other things is treated as a normal `RowFilter`.

Another option would be to have a different prop for that kind of filter.

I have shared some screenshots with an example with pod list.


**With Name and Labels**

![Screenshot from 2023-10-12 09-43-54](https://github.com/openshift/console/assets/29160323/28744e1d-52a3-4139-a05a-44a97385511d)
![Screenshot from 2023-10-12 09-43-48](https://github.com/openshift/console/assets/29160323/16bf926a-a838-458a-ada9-5b7b3129e8d2)



**With no name and no labels**

![image](https://github.com/openshift/console/assets/29160323/b604814b-7ac2-4315-9224-4a6dd968db29)
