### PR TITLE
OCPBUGS-20305: Extra space is in the translation text(Chinese) of 'Create rolebinding' and 'replicate rolebinding'

### DIFF
--- a/frontend/public/locales/zh/public.json
+++ b/frontend/public/locales/zh/public.json
@@ -1365,7 +1365,7 @@
   "Create Pod": "创建 Pod",
   "Service monitor selector": "服务监控选择器",
   "Promethesuses": "Promethesuses",
-  "Duplicate {{kindLabel}}": "重复 {{kindLabel}}",
+  "Duplicate {{kindLabel}}": "重复{{kindLabel}}",
   "Edit {{kindLabel}} subject": "编辑{{kindLabel}}主题",
   "Delete {{label}} subject": "删除 {{label}} 主题",
   "Are you sure you want to delete subject {{name}} of type {{kind}}?": "确定要删除类型 {{kind}} 的主题 {{name}}？",


### PR DESCRIPTION
Manually removed extra space in the chinese translation of 'Duplicate` option from the kebab menu in rolebindings page. As the the change from PR https://github.com/openshift/console/pull/12099 for some reason is not included into the master/release4.12-4.14 branch. 
<img width="397" alt="image" src="https://github.com/openshift/console/assets/49416557/b4b89ce6-3f6a-46b6-8cea-7043c8f19de8">
