### PR TITLE
OCPBUGS-16756: Cluster dropdown items are not marked for i18n when ACM/MCE installed

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -270,6 +270,7 @@
   "Required": "Required",
   "Service binding already exists. Select a different service to connect to.": "Service binding already exists. Select a different service to connect to.",
   "All Clusters": "All Clusters",
+  "local-cluster": "local-cluster",
   "Remove from navigation?": "Remove from navigation?",
   "Remove": "Remove",
   "Nav": "Nav",

--- a/frontend/packages/console-app/src/components/nav/ClusterMenu.tsx
+++ b/frontend/packages/console-app/src/components/nav/ClusterMenu.tsx
@@ -65,18 +65,18 @@ const ClusterMenu = () => {
         ? [
             {
               key: ACM_PERSPECTIVE_ID,
-              title: 'All Clusters',
+              title: t('console-app~All Clusters'),
               onClick: onAllClustersClick,
             },
           ]
         : []),
       {
         key: 'local-cluster',
-        title: 'local-cluster',
+        title: t('console-app~local-cluster'),
         onClick: () => onClusterClick('local-cluster'),
       },
     ],
-    [acmPerspectiveExtension, onAllClustersClick, onClusterClick],
+    [t, acmPerspectiveExtension, onAllClustersClick, onClusterClick],
   );
 
   const clusterMenu: JSX.Element = (


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-16756

No translation existed for local-cluster