### PR TITLE
CONSOLE-3740: check that user dropdown is present to verify logged in

### DIFF
--- a/frontend/packages/integration-tests-cypress/support/login.ts
+++ b/frontend/packages/integration-tests-cypress/support/login.ts
@@ -72,8 +72,8 @@ Cypress.Commands.add(
       {
         cacheAcrossSpecs: true,
         validate() {
-          // If unable to visit the baseURL, login has failed, and the session will be re-created.
           cy.visit(Cypress.config('baseUrl'));
+          cy.byTestID('user-dropdown').should('exist');
         },
       },
     );


### PR DESCRIPTION
The fix in https://github.com/openshift/console/pull/13242 does not appear to resolve the issue since there is no failure.  Add check for `user-dropdown` so we get a failure.