### PR TITLE
OCPBUGS-22284: updating doc links for 4.14 GA

### DIFF
--- a/frontend/public/components/modals/configure-cluster-upstream-modal.tsx
+++ b/frontend/public/components/modals/configure-cluster-upstream-modal.tsx
@@ -15,6 +15,7 @@ import {
   getDocumentationURL,
   HandlePromiseProps,
   isManaged,
+  isUpstream,
   withHandlePromise,
 } from '../utils';
 import { useTranslation } from 'react-i18next';
@@ -61,7 +62,7 @@ export const ConfigureClusterUpstreamModal = withHandlePromise(
               'public~Select a configuration to receive updates. Updates can be configured to receive information from Red Hat or a custom update service.',
             )}
           </p>
-          {!isManaged() && (
+          {!isManaged() && !isUpstream() && (
             <p>
               <ExternalLink
                 href={updateURL}

--- a/frontend/public/components/utils/documentation.tsx
+++ b/frontend/public/components/utils/documentation.tsx
@@ -54,17 +54,18 @@ export const documentationURLs: documentationURLsType = {
   },
   understandingUpgradeChannels: {
     downstream:
-      'html/updating_clusters/understanding-upgrade-channels-releases#understanding-upgrade-channels_understanding-upgrade-channels-releases',
-    upstream: 'updating/index.html#updating-clusters-overview-upgrade-channels-and-releases',
+      'html/updating_clusters/understanding-openshift-updates-1#understanding-update-channels-releases',
+    upstream: 'updating/understanding_updates/intro-to-updates.html',
   },
   updateService: {
     downstream:
-      'html/updating_clusters/updating-restricted-network-cluster#update-service-overview_updating-restricted-network-cluster',
-    upstream: 'updating/understanding-openshift-updates.html',
+      'html/updating_clusters/performing-a-cluster-update#updating-a-cluster-in-a-disconnected-environment',
+    upstream: '', // intentionally blank as there is no upstream equivalent
   },
   updateUsingCustomMachineConfigPools: {
-    downstream: 'html/updating_clusters/update-using-custom-machine-config-pools.html',
-    upstream: 'updating/update-using-custom-machine-config-pools.html',
+    downstream:
+      'html/updating_clusters/performing-a-cluster-update#update-using-custom-machine-config-pools',
+    upstream: 'updating/updating_a_cluster/update-using-custom-machine-config-pools.html',
   },
   usingInsights: {
     downstream:


### PR DESCRIPTION
Based on the docs previews, some of the doc links will be different in 4.14. This PR reflects what the new links are most likely going to be for both the downstream and upstream changes.

Because of the difficulties in redirecting links in the access.redhat.com version of the docs, we'll need to update the console.

https://issues.redhat.com/browse/OSDOCS-8149

See https://redhat-internal.slack.com/archives/C6A3NV5J9/p1696863838391269 for some context.