### PR TITLE
ODC-7409: Use @kubernetes-models/shipwright types in shipwright-plugin

### DIFF
--- a/frontend/packages/shipwright-plugin/package.json
+++ b/frontend/packages/shipwright-plugin/package.json
@@ -8,7 +8,9 @@
     "lint": "yarn --cwd ../.. eslint packages/shipwright-plugin",
     "test": "yarn --cwd ../.. test packages/shipwright-plugin"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@kubernetes-models/shipwright": "^0.2.0"
+  },
   "consolePlugin": {
     "entry": "src/plugin.ts",
     "exposedModules": {

--- a/frontend/packages/shipwright-plugin/src/__tests__/api.spec.ts
+++ b/frontend/packages/shipwright-plugin/src/__tests__/api.spec.ts
@@ -159,7 +159,17 @@ describe('rerunBuildRun', () => {
         generateName: 'buildrun3-33333-',
       },
       spec: {
-        buildSpec: {},
+        buildSpec: {
+          output: {
+            image: '',
+          },
+          source: {
+            url: '',
+          },
+          strategy: {
+            name: '',
+          },
+        },
       },
     };
 
@@ -181,7 +191,17 @@ describe('rerunBuildRun', () => {
         generateName: 'buildrun4-',
       },
       spec: {
-        buildSpec: {},
+        buildSpec: {
+          output: {
+            image: '',
+          },
+          source: {
+            url: '',
+          },
+          strategy: {
+            name: '',
+          },
+        },
       },
     };
 
@@ -194,7 +214,7 @@ describe('rerunBuildRun', () => {
   });
 
   it('should fail when try to rerun an incomplete BuildRun without buildRef and without buildSpec', async () => {
-    const buildRun: BuildRun = incompleteBuildRun;
+    const buildRun = incompleteBuildRun;
 
     await expect(rerunBuildRun(buildRun)).rejects.toEqual(
       new Error('Could not rerun BuildRun without buildRef.name or inline buildSpec.'),

--- a/frontend/packages/shipwright-plugin/src/__tests__/mock-data.ts
+++ b/frontend/packages/shipwright-plugin/src/__tests__/mock-data.ts
@@ -1,13 +1,13 @@
 import { Build, BuildRun } from '../types';
 
-export const incompleteBuild: Build = {
+export const incompleteBuild = {
   apiVersion: 'shipwright.io/v1alpha1',
   kind: 'Build',
   metadata: {
     namespace: 'a-namespace',
     name: 'incomplete-build',
   },
-};
+} as Build;
 
 export const buildWithLabels: Build = {
   apiVersion: 'shipwright.io/v1alpha1',
@@ -35,14 +35,14 @@ export const buildWithLabels: Build = {
   },
 };
 
-export const incompleteBuildRun: BuildRun = {
+export const incompleteBuildRun = {
   apiVersion: 'shipwright.io/v1alpha1',
   kind: 'BuildRun',
   metadata: {
     namespace: 'a-namespace',
     name: 'incomplete-buildrun',
   },
-};
+} as BuildRun;
 
 export const buildRunWithLabels: BuildRun = {
   apiVersion: 'shipwright.io/v1alpha1',
@@ -100,7 +100,17 @@ export const buildRunContainsIncompleteBuildSpecWithoutGenerateName: BuildRun = 
     name: 'buildrun3-33333',
   },
   spec: {
-    buildSpec: {},
+    buildSpec: {
+      output: {
+        image: '',
+      },
+      source: {
+        url: '',
+      },
+      strategy: {
+        name: '',
+      },
+    },
   },
 };
 
@@ -113,7 +123,17 @@ export const buildRunContainsIncompleteBuildSpecWithGenerateName: BuildRun = {
     name: 'buildrun4-44444',
   },
   spec: {
-    buildSpec: {},
+    buildSpec: {
+      output: {
+        image: '',
+      },
+      source: {
+        url: '',
+      },
+      strategy: {
+        name: '',
+      },
+    },
   },
 };
 
@@ -124,6 +144,7 @@ export const pendingBuildRun: BuildRun = {
     namespace: 'a-namespace',
     name: 'pending-buildrun',
   },
+  spec: {},
   status: {
     conditions: [
       {
@@ -131,6 +152,7 @@ export const pendingBuildRun: BuildRun = {
         status: 'Unknown',
         reason: 'Pending',
         message: '',
+        lastTransitionTime: '',
       },
     ],
   },
@@ -143,6 +165,7 @@ export const runningBuildRun: BuildRun = {
     namespace: 'a-namespace',
     name: 'running-buildrun',
   },
+  spec: {},
   status: {
     conditions: [
       {
@@ -150,6 +173,7 @@ export const runningBuildRun: BuildRun = {
         status: 'Unknown',
         reason: 'Running',
         message: '',
+        lastTransitionTime: '',
       },
     ],
   },
@@ -162,6 +186,7 @@ export const succeededBuildRun: BuildRun = {
     namespace: 'a-namespace',
     name: 'Succeeded-buildrun',
   },
+  spec: {},
   status: {
     conditions: [
       {
@@ -169,6 +194,7 @@ export const succeededBuildRun: BuildRun = {
         status: 'True',
         reason: '',
         message: '',
+        lastTransitionTime: '',
       },
     ],
   },
@@ -181,6 +207,7 @@ export const failedBuildRun: BuildRun = {
     namespace: 'a-namespace',
     name: 'failed-buildrun',
   },
+  spec: {},
   status: {
     conditions: [
       {
@@ -188,6 +215,7 @@ export const failedBuildRun: BuildRun = {
         status: 'False',
         reason: '',
         message: '',
+        lastTransitionTime: '',
       },
     ],
   },

--- a/frontend/packages/shipwright-plugin/src/components/buildrun-duration/__tests__/BuildRunDuration.spec.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/buildrun-duration/__tests__/BuildRunDuration.spec.tsx
@@ -46,6 +46,7 @@ describe('BuildRunDuration', () => {
         namespace: 'a-namespace',
         name: 'incomplete-buildrun',
       },
+      spec: {},
       status: {
         startTime: '2022-06-06T13:52:34Z',
         completionTime: '2022-06-06T13:53:26Z',
@@ -63,6 +64,7 @@ describe('BuildRunDuration', () => {
         namespace: 'a-namespace',
         name: 'incomplete-buildrun',
       },
+      spec: {},
       status: {
         startTime: '2022-06-06T13:52:34Z',
       },

--- a/frontend/packages/shipwright-plugin/src/types.ts
+++ b/frontend/packages/shipwright-plugin/src/types.ts
@@ -1,86 +1,16 @@
-import { K8sResourceCommon, K8sResourceCondition } from '@console/internal/module/k8s';
+import { IBuild } from '@kubernetes-models/shipwright/shipwright.io/v1alpha1/Build';
+import { IBuildRun } from '@kubernetes-models/shipwright/shipwright.io/v1alpha1/BuildRun';
+import { K8sResourceCondition } from '@console/internal/module/k8s';
 
-export type BuildStrategyRef = {
-  name: string;
-  kind: string;
-};
+// Add missing latestBuild to Build
+export type Build = IBuild & { latestBuild?: BuildRun };
 
-export type BuildSource = {
-  url: string;
-  contextDir?: string;
-  credentials?: {
-    name: string;
-  };
-};
+export type BuildSpec = IBuild['spec'];
 
-export type BuildSources = {
-  name: string;
-  url: string;
-}[];
+export type BuildStatus = IBuild['status'];
 
-export type BuildBuilder = {
-  image: string;
-};
-
-export type BuildOutput = {
-  image: string;
-  credentials?: {
-    name: string;
-  };
-};
-
-/** @deprecated */
-type BuildRuntime = any;
-
-export type Build = K8sResourceCommon & {
-  apiVersion: 'shipwright.io/v1alpha1';
-  kind: 'Build';
-  spec?: BuildSpec;
-  status?: BuildStatus;
-  latestBuild?: BuildRun;
-};
-
-export type BuildSpec = {
-  strategy?: BuildStrategyRef;
-  source?: BuildSource;
-  sources?: BuildSources;
-  dockerfile?: string;
-  builder?: BuildBuilder;
-  output?: BuildOutput;
-  /** @deprecated */
-  runtime?: BuildRuntime;
-};
-
-export type BuildStatus = {
-  registered?: string;
-  reason?: string;
-  message?: string;
-};
-
-export type BuildRef = {
-  name: string;
-};
-
-export type BuildRun = K8sResourceCommon & {
-  apiVersion: 'shipwright.io/v1alpha1';
-  kind: 'BuildRun';
-  spec?: {
-    buildRef?: BuildRef;
-    buildSpec?: BuildSpec;
-    serviceAccount?: {
-      name: string;
-    };
-  };
-  status?: {
-    buildSpec?: BuildSpec;
-    conditions?: BuildRunCondition[];
-    startTime?: string;
-    completionTime?: string;
-    latestTaskRunRef?: string;
-  };
-};
-
-export type BuildRunCondition = K8sResourceCondition;
+// Make status.conditions compatible with @console/internal/components/conditions props
+export type BuildRun = IBuildRun & { status?: { conditions?: K8sResourceCondition[] } };
 
 // The enum values need to match the dynamic-plugin `Status` `status` prop.
 // A translation (title) is added in the BuildRunStatus component.

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1977,6 +1977,44 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@kubernetes-models/apimachinery@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@kubernetes-models/apimachinery/-/apimachinery-1.2.1.tgz#39725bf5e1f50972475ee6e614d5d70e41876b13"
+  integrity sha512-mURvFnel3gaMXFchp8YeFmPBWuYifakuJnmRK1ad0Y7bxcPbcEntcb1rjdwitnHE0qTq3JZ2kBzpNqGO3+YJUw==
+  dependencies:
+    "@kubernetes-models/base" "^4.0.3"
+    "@kubernetes-models/validate" "^3.1.1"
+    tslib "^2.4.0"
+
+"@kubernetes-models/base@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@kubernetes-models/base/-/base-4.0.3.tgz#e973dfb60bb6d2fa29cbb281e2a74979d40efc9d"
+  integrity sha512-9Uo/RzB1ZvvPmnnpAE6yWPaFerMkpBxIHLuObexVDF813ZwVPdn56mmOOFfA6RyZtPdIT1AlhMozlHKOX16AGQ==
+  dependencies:
+    "@kubernetes-models/validate" "^3.1.1"
+    is-plain-object "^5.0.0"
+    tslib "^2.4.0"
+
+"@kubernetes-models/shipwright@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@kubernetes-models/shipwright/-/shipwright-0.2.0.tgz#4fc082f23c9537f8084c3e0ec36774d026405629"
+  integrity sha512-r0WjZIr7BDZ3qfGusLMxpMP218k81g0WDvKq3GyyY3qJfWrlEABvA8Quw9t8Gb2b4gKto3N3Zn752bzENaEAqw==
+  dependencies:
+    "@kubernetes-models/apimachinery" "^1.2.1"
+    "@kubernetes-models/base" "^4.0.3"
+    "@kubernetes-models/validate" "^3.1.1"
+    tslib "^2.4.0"
+
+"@kubernetes-models/validate@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@kubernetes-models/validate/-/validate-3.1.1.tgz#952362caf93d8e5d6b863c15558fd359d08346c2"
+  integrity sha512-s1YMn5+9jLG0S0441Tca8aukt05UqyqlloW6seJ43gdjBHWOYhfaG7ppw8Lmw0jvxF69yNV6wtYfXCTULXIfLw==
+  dependencies:
+    ajv "^8.12.0"
+    ajv-formats "^2.1.1"
+    ajv-formats-draft2019 "^1.6.1"
+    tslib "^2.4.0"
+
 "@lezer/common@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.0.0.tgz#1c95ae53ec17706aa3cbcc88b52c23f22ed56096"
@@ -3955,6 +3993,23 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
+ajv-formats-draft2019@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats-draft2019/-/ajv-formats-draft2019-1.6.1.tgz#6affe2220e7828360793776f1976de0420acccfb"
+  integrity sha512-JQPvavpkWDvIsBp2Z33UkYCtXCSpW4HD3tAZ+oL4iEFOk9obQZffx0yANwECt6vzr6ET+7HN5czRyqXbnq/u0Q==
+  dependencies:
+    punycode "^2.1.1"
+    schemes "^1.4.0"
+    smtp-address-parser "^1.0.3"
+    uri-js "^4.4.1"
+
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
@@ -4024,6 +4079,16 @@ ajv@^6.9.1:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.12.0:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 align-text@^0.1.1, align-text@^0.1.3:
@@ -6146,7 +6211,7 @@ commander@^2.11.0, commander@^2.18.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
-commander@^2.15.1, commander@^2.20.0, commander@^2.9.0:
+commander@^2.15.1, commander@^2.19.0, commander@^2.20.0, commander@^2.9.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -12460,6 +12525,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -13826,6 +13896,11 @@ monaco-languageclient@^0.13.0:
     vscode-languageclient "^6.0.0"
     vscode-uri "^2.1.1"
 
+moo@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
+  integrity sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -13908,10 +13983,10 @@ nanoid@^2.1.0:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
   integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
 
-nanoid@^3.1.22:
-  version "3.1.22"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844"
-  integrity sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
+nanoid@^3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
+  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -13944,6 +14019,16 @@ ncname@1.0.x:
   resolved "https://registry.yarnpkg.com/ncname/-/ncname-1.0.0.tgz#5b57ad18b1ca092864ef62b0b1ed8194f383b71c"
   dependencies:
     xml-char-classes "^1.0.0"
+
+nearley@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.20.1.tgz#246cd33eff0d012faf197ff6774d7ac78acdd474"
+  integrity sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
 
 nearley@^2.7.10:
   version "2.13.0"
@@ -15065,6 +15150,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
@@ -15219,13 +15309,13 @@ postcss-value-parser@^4.1.0:
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
 postcss@^8.0.2, postcss@^8.2.13, postcss@^8.2.15:
-  version "8.2.13"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.13.tgz#dbe043e26e3c068e45113b1ed6375d2d37e2129f"
-  integrity sha512-FCE5xLH+hjbzRdpbRb1IMCvPv9yZx2QnDarBEYSN0N0HYk+TcXsEhwdFcFb+SRWOKzKGErhIEbBK2ogyLdTtfQ==
+  version "8.4.31"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
+  integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
   dependencies:
-    colorette "^1.2.2"
-    nanoid "^3.1.22"
-    source-map "^0.6.1"
+    nanoid "^3.3.6"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -16627,7 +16717,7 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
-require-from-string@^2.0.1:
+require-from-string@^2.0.1, require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
@@ -17074,6 +17164,13 @@ schema-utils@^3.0.0, schema-utils@^3.1.0, schema-utils@^3.1.1:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
+schemes@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/schemes/-/schemes-1.4.0.tgz#9d03302275e562488dd3afa7b654ed42e00569ec"
+  integrity sha512-ImFy9FbCsQlVgnE3TCWmLPCFnVzx0lHL/l+umHplDqAKd0dzFpnS6lFZIpagBlYhKwzVmlV36ec0Y1XTu8JBAQ==
+  dependencies:
+    extend "^3.0.0"
+
 screenfull@4.x:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-4.0.0.tgz#86f3c26a2e516c8143884d8af16d07f0cb653394"
@@ -17434,6 +17531,13 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+smtp-address-parser@^1.0.3:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/smtp-address-parser/-/smtp-address-parser-1.0.10.tgz#9fc4ed6021f13dc3d8f591e0ad0d50454073025e"
+  integrity sha512-Osg9LmvGeAG/hyao4mldbflLOkkr3a+h4m1lwKCK5U8M6ZAr7tdXEz/+/vr752TSGE4MNUlUl9cIK2cB8cgzXg==
+  dependencies:
+    nearley "^2.20.1"
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -17497,6 +17601,11 @@ source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.3"
@@ -18690,6 +18799,11 @@ tslib@^2.0.0, tslib@~2.0.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
   integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
 
+tslib@^2.4.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
 tsutils@3.21.0, tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -18796,9 +18910,9 @@ typescript@^4.2.4:
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 ua-parser-js@^0.7.18, ua-parser-js@^0.7.24:
-  version "0.7.26"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.26.tgz#b3731860e241419abd5b542b1a0881070d92e0ce"
-  integrity sha512-VwIvGlFNmpKbjzRt51jpbbFTrKIEgGHxIwA8Y69K1Bqc6bTIV7TaGGABOkghSFQWsLmcRB4drGvpfv9z2szqoQ==
+  version "0.7.36"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.36.tgz#382c5d6fc09141b6541be2cae446ecfcec284db2"
+  integrity sha512-CPPLoCts2p7D8VbybttE3P2ylv0OBZEAy7a12DsulIEcAiMtWJy+PBgMXgWDI80D5UwqE8oQPHYnk13tm38M2Q==
 
 uc.micro@^1.0.1:
   version "1.0.6"
@@ -19020,7 +19134,7 @@ upper-case@^1.0.3, upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
-uri-js@^4.2.2:
+uri-js@^4.2.2, uri-js@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==


### PR DESCRIPTION
Use CRD-generated types instead of manual written types in the shipwright-plugin.

See:

* https://github.com/tommy351/kubernetes-models-ts
* https://github.com/tommy351/kubernetes-models-ts/tree/master/third-party/shipwright
* https://www.npmjs.com/package/@kubernetes-models/shipwright

`@kubernetes-models/shipwright` 0.2.0 types are generated based on the shipwright 0.12.0 CRDs:

* https://github.com/tommy351/kubernetes-models-ts/pull/140
* https://github.com/tommy351/kubernetes-models-ts/pull/145

/cc @Lucifergene @lokanandaprabhu @vikram-raj @spadgett @jhadvig 