### PR TITLE
OCPBUGS-22199: Save also the location.search and .hash values in localStorage to restore them after login

### DIFF
--- a/frontend/public/co-fetch.ts
+++ b/frontend/public/co-fetch.ts
@@ -56,7 +56,8 @@ export const validateStatus = async (
   }
 
   if (response.status === 401 && shouldLogout(url)) {
-    authSvc.logout(window.location.pathname, getActiveCluster(storeHandler.getStore()?.getState())); // TODO remove multicluster
+    const next = window.location.pathname + window.location.search + window.location.hash;
+    authSvc.logout(next, getActiveCluster(storeHandler.getStore()?.getState())); // TODO remove multicluster
   }
 
   const contentType = response.headers.get('content-type');


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-22199

**Analysis / Root cause**: 
The page opened after the login is automatically saved in the "next" `localStorage` but contains only the latest `window.location.pathname`.

**Solution Description**: 
Save also `window.location.search` and `window.location.hash` in the "next" localStorage.

* `search` is at least an empty string and contains the `?` when a search/query parameter is used.
* `hash` is at least an empty string and contains the `#` when the hash parameter is used.

**Screen shots / Gifs for design review**: 

Before, tested on dev sandbox:

https://github.com/openshift/console/assets/139310/18ac0542-0081-4fd2-b11d-762e371f3094

With this PR, tested on a cluster bot:

https://github.com/openshift/console/assets/139310/01c53b67-3cef-44db-b09b-48df447c3f8f

**Test setup:**
1. Login
2. Switch to Developer perspective
3. Navigate to Add > Developer Catalog > Builder Images > Add filter for ".NET" (for example)
   
   Users are applied to different clusters, so the exact URL isn't known, but the Path and Query parameters should look like this: `/catalog/ns/cjerolim-dev?catalogType=BuilderImage&keyword=.NET`
   
   Save the full URL incl. these query parameters
4. Logout
5. Enter the full URL from above
6. Login