### PR TITLE
[release-4.13] OCPBUGS-22241: Save also the location.search and .hash values in localStorage to restore them after login

### DIFF
--- a/frontend/public/co-fetch.ts
+++ b/frontend/public/co-fetch.ts
@@ -74,7 +74,8 @@ export const validateStatus = async (
   }
 
   if (response.status === 401 && shouldLogout(url)) {
-    authSvc.logout(window.location.pathname, getActiveCluster(storeHandler.getStore()?.getState()));
+    const next = window.location.pathname + window.location.search + window.location.hash;
+    authSvc.logout(next, getActiveCluster(storeHandler.getStore()?.getState()));
   }
 
   const contentType = response.headers.get('content-type');


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGS-22241

This is a manual cherry-pick of #13270 because an automatic cherry-pick will not work because of a tiny conflict.

The comment `// TODO remove multicluster` wasn't part of 4.13. :laughing: 

/cc @lokanandaprabhu @sanketpathak @jhadvig 