### PR TITLE
OCPBUGS-19875: Fix plugin proxy handler

### DIFF
--- a/pkg/plugins/handlers.go
+++ b/pkg/plugins/handlers.go
@@ -167,13 +167,6 @@ func (p *PluginsHandler) proxyPluginRequest(requestURL *url.URL, pluginName stri
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		errMsg := fmt.Sprintf("GET request for %q plugin failed with %d status code", pluginName, resp.StatusCode)
-		klog.Error(errMsg)
-		serverutils.SendResponse(w, resp.StatusCode, serverutils.ApiError{Err: errMsg})
-		return
-	}
-
 	// filter unwanted headers from the response
 	proxy.FilterHeaders(resp)
 	// copy headers from the plugin's server response


### PR DESCRIPTION
Do not intercept responses with non-200 status codes in the plugin proxy. Pass all responses on to the requester.