### PR TITLE
AUTH-440: expand options for the OIDC authenticator

### DIFF
--- a/cmd/bridge/config/auth/authoptions.go
+++ b/cmd/bridge/config/auth/authoptions.go
@@ -240,7 +240,7 @@ func (c *completedOptions) getAuthenticator(
 	)
 
 	var scopes []string
-	authSource := auth.AuthSourceTectonic
+	authSource := auth.AuthSourceOIDC
 
 	if c.AuthType == "openshift" {
 		scopes = []string{"user:full"}

--- a/cmd/bridge/config/auth/authoptions.go
+++ b/cmd/bridge/config/auth/authoptions.go
@@ -73,13 +73,19 @@ func (c *AuthOptions) AddFlags(fs *flag.FlagSet) {
 }
 
 func (c *AuthOptions) ApplyConfig(config *serverconfig.Auth) {
+	setIfUnset(&c.AuthType, config.AuthType)
 	setIfUnset(&c.ClientID, config.ClientID)
+	setIfUnset(&c.IssuerURL, config.OIDCIssuer)
 	setIfUnset(&c.ClientSecretFilePath, config.ClientSecretFile)
 	setIfUnset(&c.CAFilePath, config.OAuthEndpointCAFile)
 	setIfUnset(&c.LogoutRedirect, config.LogoutRedirect)
 
 	if c.InactivityTimeoutSeconds == 0 {
 		c.InactivityTimeoutSeconds = config.InactivityTimeoutSeconds
+	}
+
+	if len(c.ExtraScopes) == 0 {
+		c.ExtraScopes = config.OIDCExtraScopes
 	}
 }
 

--- a/pkg/auth/asynccache.go
+++ b/pkg/auth/asynccache.go
@@ -1,0 +1,60 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+)
+
+type cachingFuncType[T any] func(ctx context.Context) (T, error)
+
+type AsyncCache[T any] struct {
+	reloadPeriod time.Duration
+
+	itemRWLock  sync.RWMutex
+	cachedItem  T
+	cachingFunc cachingFuncType[T]
+}
+
+func NewAsyncCache[T any](ctx context.Context, reloadPeriod time.Duration, cachingFunc cachingFuncType[T]) (*AsyncCache[T], error) {
+	c := &AsyncCache[T]{
+		reloadPeriod: reloadPeriod,
+		itemRWLock:   sync.RWMutex{},
+		cachingFunc:  cachingFunc,
+	}
+
+	item, err := cachingFunc(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup an async cache - caching func returned error: %w", err)
+	}
+
+	c.cachedItem = item
+
+	return c, nil
+}
+
+func (c *AsyncCache[T]) runCache(ctx context.Context) {
+	item, err := c.cachingFunc(ctx)
+	if err != nil {
+		klog.Errorf("failed a caching attempt: %v", err)
+		return
+	}
+
+	c.itemRWLock.Lock()
+	defer c.itemRWLock.Unlock()
+	c.cachedItem = item
+}
+
+func (c *AsyncCache[T]) GetItem() T {
+	c.itemRWLock.RLock()
+	defer c.itemRWLock.RUnlock()
+	return c.cachedItem
+}
+
+func (c *AsyncCache[T]) Run(ctx context.Context) {
+	go wait.UntilWithContext(ctx, c.runCache, c.reloadPeriod)
+}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -102,7 +102,7 @@ type loginMethod interface {
 type AuthSource int
 
 const (
-	AuthSourceTectonic  AuthSource = 0
+	AuthSourceOIDC      AuthSource = 0
 	AuthSourceOpenShift AuthSource = 1
 )
 
@@ -213,12 +213,14 @@ func NewAuthenticator(ctx context.Context, c *Config) (*Authenticator, error) {
 		if err != nil {
 			return nil, err
 		}
-	default:
+	case AuthSourceOIDC:
 		sessionStore := NewSessionStore(32768)
 		tokenHandler, err = newOIDCAuth(ctx, sessionStore, authConfig)
 		if err != nil {
 			return nil, err
 		}
+	default:
+		return nil, fmt.Errorf("unknown auth source: %v", c.AuthSource)
 	}
 	a.loginMethod = tokenHandler
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -189,7 +189,7 @@ func NewAuthenticator(ctx context.Context, c *Config) (*Authenticator, error) {
 	}
 
 	authConfig := &oidcConfig{
-		client:        a.clientFunc(),
+		getClient:     a.clientFunc,
 		issuerURL:     c.IssuerURL,
 		clientID:      c.ClientID,
 		cookiePath:    c.CookiePath,
@@ -199,6 +199,10 @@ func NewAuthenticator(ctx context.Context, c *Config) (*Authenticator, error) {
 	var tokenHandler loginMethod
 	switch c.AuthSource {
 	case AuthSourceOpenShift:
+		// TODO: once https://github.com/kubernetes/kubernetes/issues/11948 is fixed,
+		// copy the transport config from c.k8sConfig with rest.CopyConfig,
+		// add the c.K8SCA to it and use the roundtripper created from that config
+		//
 		// Use the k8s CA for OAuth metadata discovery.
 		k8sClient, errK8Client := newHTTPClient(c.K8sCA, true)
 		if errK8Client != nil {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -241,11 +241,13 @@ func NewAuthenticator(ctx context.Context, c *Config) (*Authenticator, error) {
 
 		a.safeOAuth2ConfigGetter = func(ctx context.Context) *oauth2.Config {
 			// rebuild non-pointer struct each time to prevent any mutation
+			scopesCopy := make([]string, len(c.Scope))
+			copy(scopesCopy, c.Scope)
 			baseOAuth2Config := oauth2.Config{
 				ClientID:     c.ClientID,
 				ClientSecret: c.ClientSecret,
 				RedirectURL:  c.RedirectURL,
-				Scopes:       c.Scope,
+				Scopes:       scopesCopy,
 				Endpoint:     fallbackEndpoint,
 			}
 

--- a/pkg/auth/auth_oidc.go
+++ b/pkg/auth/auth_oidc.go
@@ -99,7 +99,7 @@ func (o *oidcAuth) verify(ctx context.Context, rawIDToken string) (*oidc.IDToken
 	return provider.Verifier(&oidc.Config{ClientID: o.clientID}).Verify(ctx, rawIDToken)
 }
 
-func (o *oidcAuth) deleteCookie(w http.ResponseWriter, r *http.Request) {
+func (o *oidcAuth) DeleteCookie(w http.ResponseWriter, r *http.Request) {
 	// The returned login state can be nil even if err == nil.
 	if ls, _ := o.getLoginState(r); ls != nil {
 		o.sessions.deleteSession(ls.sessionToken)
@@ -118,7 +118,7 @@ func (o *oidcAuth) deleteCookie(w http.ResponseWriter, r *http.Request) {
 }
 
 func (o *oidcAuth) logout(w http.ResponseWriter, r *http.Request) {
-	o.deleteCookie(w, r)
+	o.DeleteCookie(w, r)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -139,7 +139,7 @@ func (o *oidcAuth) getLoginState(r *http.Request) (*loginState, error) {
 	return ls, nil
 }
 
-func (o *oidcAuth) getUser(r *http.Request) (*User, error) {
+func (o *oidcAuth) Authenticate(r *http.Request) (*User, error) {
 	ls, err := o.getLoginState(r)
 	if err != nil {
 		return nil, err

--- a/pkg/auth/auth_openshift.go
+++ b/pkg/auth/auth_openshift.go
@@ -21,7 +21,7 @@ type openShiftAuth struct {
 	cookiePath    string
 	secureCookies bool
 	k8sClient     *http.Client
-	client        *http.Client
+	getClient     func() *http.Client
 
 	oauthEndpointCache *AsyncCache[*oidcDiscovery]
 }
@@ -51,7 +51,7 @@ func newOpenShiftAuth(ctx context.Context, k8sClient *http.Client, c *oidcConfig
 		cookiePath:    c.cookiePath,
 		secureCookies: c.secureCookies,
 		k8sClient:     k8sClient,
-		client:        c.client,
+		getClient:     c.getClient,
 	}
 
 	// TODO: repeat the discovery several times as in the auth.go logic
@@ -114,7 +114,7 @@ func (o *openShiftAuth) getOIDCDiscoveryInternal(ctx context.Context) (*oidcDisc
 		return nil, err
 	}
 
-	resp, err = o.client.Do(req.WithContext(ctx))
+	resp, err = o.getClient().Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("request to OAuth issuer endpoint %s failed: %v",
 			metadata.Token, err)

--- a/pkg/auth/auth_openshift.go
+++ b/pkg/auth/auth_openshift.go
@@ -161,7 +161,7 @@ func (o *openShiftAuth) login(w http.ResponseWriter, token *oauth2.Token) (*logi
 }
 
 // NOTE: cookies are going away, this should be removed in the future
-func (o *openShiftAuth) deleteCookie(w http.ResponseWriter, r *http.Request) {
+func (o *openShiftAuth) DeleteCookie(w http.ResponseWriter, r *http.Request) {
 	// Delete session cookie
 	cookie := http.Cookie{
 		Name:     openshiftAccessTokenCookieName,
@@ -175,11 +175,11 @@ func (o *openShiftAuth) deleteCookie(w http.ResponseWriter, r *http.Request) {
 }
 
 func (o *openShiftAuth) logout(w http.ResponseWriter, r *http.Request) {
-	o.deleteCookie(w, r)
+	o.DeleteCookie(w, r)
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (o *openShiftAuth) getUser(r *http.Request) (*User, error) {
+func (o *openShiftAuth) Authenticate(r *http.Request) (*User, error) {
 	// TODO: This doesn't do any validation of the cookie with the assumption that the
 	// API server will reject tokens it doesn't recognize. If we want to keep some backend
 	// state we should sign this cookie. If not there's not much we can do.

--- a/pkg/auth/metrics.go
+++ b/pkg/auth/metrics.go
@@ -151,7 +151,7 @@ func (m *Metrics) isKubeAdmin(ctx context.Context, config *rest.Config) (bool, e
 		klog.Errorf("Error in auth.metrics isKubeAdmin: %v\n", err)
 		return false, err
 	}
-	userInfo, err := client.Resource(userResource).Get(ctx, "~", metav1.GetOptions{})
+	userInfo, err := client.Resource(userResource).Get(ctx, "~", metav1.GetOptions{}) // FIXME: fix this for the world where the userapi does not exist
 	if err != nil {
 		klog.Errorf("Error in auth.metrics isKubeAdmin: %v\n", err)
 		return false, err

--- a/pkg/auth/session.go
+++ b/pkg/auth/session.go
@@ -23,6 +23,7 @@ type SessionStore struct {
 	mux         sync.Mutex
 }
 
+// TODO: how is this shared between console instances? I doubt it is, we may want to use encrypted cookies instead
 func NewSessionStore(maxSessions int) *SessionStore {
 	return &SessionStore{
 		byToken:     make(map[string]*loginState),

--- a/pkg/metrics/handler.go
+++ b/pkg/metrics/handler.go
@@ -8,7 +8,7 @@ func AddHeaderAsCookieMiddleware(next http.Handler) http.Handler {
 		// This allows metric requests with proper tokens in either headers or cookies.
 		if r.URL.Path == "/metrics" {
 			openshiftSessionCookieName := "openshift-session-token"
-			openshiftSessionCookieValue := r.Header.Get("Authorization")
+			openshiftSessionCookieValue := r.Header.Get("Authorization") // FIXME: in OIDC setup, this actually ends up checking the token "Bearer <jwt>" to the underlying auth layer - instead of `<jwt>`.
 			r.AddCookie(&http.Cookie{Name: openshiftSessionCookieName, Value: openshiftSessionCookieValue})
 		}
 		next.ServeHTTP(w, r)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -716,12 +716,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !s.authDisabled() {
-		specialAuthURLs, err := s.Authenticator.GetSpecialURLs(r.Context())
-		if err != nil {
-			klog.Errorf("failed to determine KubeAdminLogoutURL: %v", err)
-			http.Error(w, "failed to determine KubeAdminLogoutURL", http.StatusInternalServerError)
-			return
-		}
+		specialAuthURLs := s.Authenticator.GetSpecialURLs()
 		jsg.KubeAdminLogoutURL = specialAuthURLs.KubeAdminLogout
 	}
 
@@ -775,12 +770,7 @@ func (s *Server) handleClusterTokenURL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	specialAuthURLs, err := s.Authenticator.GetSpecialURLs(r.Context())
-	if err != nil {
-		klog.Errorf("failed to determine RequestToken URL: %v", err)
-		http.Error(w, "failed to determine RequestToken URL", http.StatusInternalServerError)
-		return
-	}
+	specialAuthURLs := s.Authenticator.GetSpecialURLs()
 
 	serverutils.SendResponse(w, http.StatusOK, struct {
 		RequestTokenURL string `json:"requestTokenURL"`

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -285,6 +285,7 @@ func (s *Server) HTTPHandler() http.Handler {
 		handleFunc(authLogoutEndpoint, allowMethod(http.MethodPost, s.handleLogout))
 		handleFunc(AuthLoginCallbackEndpoint, s.Authenticator.CallbackFunc(fn))
 		handle(requestTokenEndpoint, authHandler(s.handleClusterTokenURL))
+		// TODO: only add the following in case the auth type is openshift?
 		handleFunc(deleteOpenshiftTokenEndpoint, allowMethod(http.MethodPost, authHandlerWithUser(s.handleOpenShiftTokenDeletion)))
 	}
 

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -79,11 +79,14 @@ type ClusterInfo struct {
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".
 type Auth struct {
-	ClientID                 string `yaml:"clientID,omitempty"`
-	ClientSecretFile         string `yaml:"clientSecretFile,omitempty"`
-	OAuthEndpointCAFile      string `yaml:"oauthEndpointCAFile,omitempty"`
-	LogoutRedirect           string `yaml:"logoutRedirect,omitempty"`
-	InactivityTimeoutSeconds int    `yaml:"inactivityTimeoutSeconds,omitempty"`
+	AuthType                 string   `yaml:"authType,omitempty"`
+	OIDCIssuer               string   `yaml:"oidcIssuer,omitempty"`
+	OIDCExtraScopes          []string `yaml:"oidcExtraScopes,omitempty"`
+	ClientID                 string   `yaml:"clientID,omitempty"`
+	ClientSecretFile         string   `yaml:"clientSecretFile,omitempty"`
+	OAuthEndpointCAFile      string   `yaml:"oauthEndpointCAFile,omitempty"`
+	LogoutRedirect           string   `yaml:"logoutRedirect,omitempty"`
+	InactivityTimeoutSeconds int      `yaml:"inactivityTimeoutSeconds,omitempty"`
 }
 
 // Customization holds configuration such as what logo to use.


### PR DESCRIPTION
This PR:
- allow setting scopes different from `openid` via options
- add the extra scopes and issuer to the config struct
- unify both OIDC provider and the OpenShift provider in how the OIDC discovery is queried (continuously in time compared to just during OIDC provider creation)

TODO:
- [x] - don't rely on username claims in the token
        - if necessary, consume the username from the [Self-Subject Review API](https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3325-self-subject-attributes-review-api#kep-3325-self-subject-review-api)