### PR TITLE
CONSOLE-3740: remove references to removed packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,8 +487,6 @@ We support the latest versions of the following browsers:
 IE 11 and earlier is not supported.
 
 ## Frontend Packages
-- [ceph-storage-plugin](./frontend/packages/ceph-storage-plugin/README.md)
-
 - [console-dynamic-plugin-sdk](./frontend/packages/console-dynamic-plugin-sdk/README.md)
 [[API]](./frontend/packages/console-dynamic-plugin-sdk/docs/api.md)
 [[Console Extensions]](./frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md)

--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -27,7 +27,7 @@ done
 if [ $# -eq 0 ]; then
     echo "Runs Cypress tests in Test Runner or headless mode"
     echo "Usage: test-cypress [-p] <package> [-s] <filemask> [-h true] [-n true/false]"
-    echo "  '-p <package>' may be 'console, 'olm', 'ceph' or 'devconsole'"
+    echo "  '-p <package>' may be 'console, 'olm', 'devconsole'"
     echo "  '-s <specmask>' is a file mask for spec test files, such as 'tests/monitoring/*'. Used only in headless mode when '-p' is specified."
     echo "  '-h true' runs Cypress in headless mode. When omitted, launches Cypress Test Runner"
     echo "  '-n true' runs the 'nightly' suite, all specs from selected packages in headless mode"
@@ -35,7 +35,6 @@ if [ $# -eq 0 ]; then
     echo "  test-cypress.sh                                       // displays this help text"
     echo "  test-cypress.sh -p console                            // opens Cypress Test Runner for console tests"
     echo "  test-cypress.sh -p olm                                // opens Cypress Test Runner for OLM tests"
-    echo "  test-cypress.sh -p ceph                               // opens Cypress Test Runner for Ceph tests"
     echo "  test-cypress.sh -p dev-console                        // opens Cypress Test Runner for Dev-Console tests"
     echo "  test-cypress.sh -p gitops                             // opens Cypress Test Runner for gitops tests"
     echo "  test-cypress.sh -p knative                            // opens Cypress Test Runner for knative tests"

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -33,7 +33,7 @@ export DBUS_SESSION_BUS_ADDRESS
 SCENARIO="${1:-e2e}"
 
 case $SCENARIO in
-  login|olmFull|ceph|kubevirt-gating|nightly-cypress) ;; # no protractor tests
+  login|olmFull|nightly-cypress) ;; # no protractor tests
   *) CHROME_VERSION=$(google-chrome --version) ./test-protractor.sh "$SCENARIO";;
 esac
 
@@ -52,10 +52,6 @@ elif [ "$SCENARIO" == "login" ]; then
   ./test-cypress.sh -p console -s 'tests/app/auth-multiuser-login.cy.ts' -h true
 elif [ "$SCENARIO" == "olmFull" ]; then
   ./test-cypress.sh -p olm -h true
-# elif [ "$SCENARIO" == "ceph" ]; then
-#   ./test-cypress.sh -p ceph -h true
-# elif [ "$SCENARIO" == "kubevirt-gating" ]; then
-#   ./test-cypress.sh -p kubevirt -h true
 elif [ "$SCENARIO" == "dev-console" ]; then
   ./test-cypress.sh -p dev-console -h true
 elif [ "$SCENARIO" == "pipelines" ]; then


### PR DESCRIPTION
Follow on clean up.  `ceph` was removed with https://github.com/openshift/console/pull/13255.  `kubevirt` tests will be removed with https://github.com/openshift/console/pull/13280.