### PR TITLE
OCPBUGS-22747: Display "With Data upload form" in Create PVC drop down once

### DIFF
--- a/frontend/packages/kubevirt-plugin/console-extensions.json
+++ b/frontend/packages/kubevirt-plugin/console-extensions.json
@@ -91,16 +91,6 @@
     }
   },
   {
-    "type": "console.pvc/create-prop",
-    "properties": {
-      "label": "%kubevirt-plugin~With Data upload form%",
-      "path": "~new/data"
-    },
-    "flags": {
-      "required": ["KUBEVIRT"]
-    }
-  },
-  {
     "type": "console.pvc/alert",
     "properties": {
       "alert": { "$codeRef": "pvcAlert.PVCAlertExtension" }

--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -4,7 +4,6 @@
   "**Virtual Machines** have templates for quickly creating a virtual machine.": "**Virtual Machines** have templates for quickly creating a virtual machine.",
   "Template Providers": "Template Providers",
   "VM templates": "VM templates",
-  "With Data upload form": "With Data upload form",
   "Access mode": "Access mode",
   "Add": "Add",
   "Access and Volume modes should follow storage feature matrix": "Access and Volume modes should follow storage feature matrix",


### PR DESCRIPTION
 **Fixes**:
https://issues.redhat.com/browse/OCPBUGS-22747

**Analysis / Root cause**:
The _With Data upload form_ was probably not removed from the console repo when we moved to the new [kubevirt-ui](https://github.com/kubevirt-ui/kubevirt-plugin) one, so the option "With Data upload form" was displayed twice when deploying a cluster with both OCP and CNV, in the _Create PersistentVolumeClaim_ drop down present in the PVCs list page.

 **Solution Description**:
Remove the form in this repo to achieve displaying _With Data upload form_ drop down item only once.

**Screen shots / Gifs for design review**:
_Before:_ _With Data upload form_ displayed twice when deploying a cluster with both OCP and CNV:
![pvc_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/18dd44e2-f260-437b-8c5b-deddbf98bbc7)

_After:_
![pvc_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/1a6d33c6-61fa-4aae-ac5e-1a26eb27230a)

