### PR TITLE
CNV-30298: Add UI for OVN Secondary Localnet Network

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/network-attachment-definition-plugin/locales/en/kubevirt-plugin.json
@@ -11,12 +11,21 @@
   "Network attachment definition name cannot contain uppercase characters": "Network attachment definition name cannot contain uppercase characters",
   "Network attachment definition name is too long": "Network attachment definition name is too long",
   "Network attachment definition name is too short": "Network attachment definition name is too short",
+  "Network Type": "Network Type",
   "Create Network Attachment Definition": "Create Network Attachment Definition",
   "Edit YAML": "Edit YAML",
   "Name": "Name",
   "Description": "Description",
-  "Network Type": "Network Type",
   "<0>OpenShift Virtualization Operator</0> or <3>SR-IOV Network Operator </3>needs to be installed on the cluster, in order to pick the Network Type.": "<0>OpenShift Virtualization Operator</0> or <3>SR-IOV Network Operator </3>needs to be installed on the cluster, in order to pick the Network Type.",
   "Create": "Create",
-  "Cancel": "Cancel"
+  "Cancel": "Cancel",
+  "Resource name": "Resource name",
+  "VLAN tag number": "VLAN tag number",
+  "IP address management": "IP address management",
+  "Bridge name": "Bridge name",
+  "MAC spoof check": "MAC spoof check",
+  "Bridge mapping": "Bridge mapping",
+  "Physical network name. A bridge mapping must be configured on cluster nodes to map between physical network names and Open vSwitch bridges.": "Physical network name. A bridge mapping must be configured on cluster nodes to map between physical network names and Open vSwitch bridges.",
+  "MTU": "MTU",
+  "VLAN": "VLAN"
 }

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.scss
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.scss
@@ -9,3 +9,7 @@
 .kv-nad-form-checkbox--alignment {
   height: 100%;
 }
+
+.network-type-options--help-icon {
+  cursor: pointer;
+}

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkTypeOptions.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkTypeOptions.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { FormGroup, TextArea, TextInput } from '@patternfly/react-core';
+import { FormGroup, Popover, PopoverPosition, TextArea, TextInput } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
 import * as classNames from 'classnames';
 import { isEmpty } from 'lodash';
 import { Dropdown } from '@console/internal/components/utils';
@@ -164,7 +165,12 @@ const NetworkTypeOptions = (props) => {
               })}
               id={`network-type-params-${key}-label`}
             >
-              {name}
+              {name}{' '}
+              {parameter?.hintText && (
+                <Popover bodyContent={parameter.hintText} position={PopoverPosition.right}>
+                  <HelpIcon className="network-type-options--help-icon" />
+                </Popover>
+              )}
             </label>
             <TextInput
               type="text"

--- a/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
@@ -9,11 +9,13 @@ export const ELEMENT_TYPES = {
 
 export const cnvBridgeNetworkType = 'cnv-bridge';
 export const ovnKubernetesNetworkType = 'ovn-k8s-cni-overlay';
+export const ovnKubernetesSecondaryLocalnet = 'ovn-k8s-cni-overlay-localnet';
 
 export const networkTypes = {
   sriov: 'SR-IOV',
   [cnvBridgeNetworkType]: 'CNV Linux bridge',
   [ovnKubernetesNetworkType]: 'OVN Kubernetes L2 overlay network',
+  [ovnKubernetesSecondaryLocalnet]: 'OVN Kubernetes secondary localnet network',
 };
 
 export enum NetworkTypes {
@@ -22,39 +24,66 @@ export enum NetworkTypes {
   'CNV-Bridge' = 'CNV Linux bridge',
 }
 
+// t('kubevirt-plugin~Resource name')
+// t('kubevirt-plugin~VLAN tag number')
+// t('kubevirt-plugin~IP address management')
+// t('kubevirt-plugin~Bridge name')
+// t('kubevirt-plugin~MAC spoof check')
+// t('kubevirt-plugin~Bridge mapping')
+// t('kubevirt-plugin~Physical network name. A bridge mapping must be configured on cluster nodes to map between physical network names and Open vSwitch bridges.')
+// t('kubevirt-plugin~MTU')
+// t('kubevirt-plugin~VLAN')
+
 export const networkTypeParams: NetworkTypeParamsList = {
   sriov: {
     resourceName: {
-      name: 'Resource Name',
+      name: 'Resource name',
       values: {},
       required: true,
       type: ELEMENT_TYPES.DROPDOWN,
     },
     vlanTagNum: {
-      name: 'VLAN Tag Number',
+      name: 'VLAN tag number',
       hintText: 'Ex: 100',
       type: ELEMENT_TYPES.TEXT,
     },
     ipam: {
-      name: 'IP Address Management',
+      name: 'IP address management',
       type: ELEMENT_TYPES.TEXTAREA,
     },
   },
   [cnvBridgeNetworkType]: {
     bridge: {
-      name: 'Bridge Name',
+      name: 'Bridge name',
       required: true,
       type: ELEMENT_TYPES.TEXT,
     },
     vlanTagNum: {
-      name: 'VLAN Tag Number',
+      name: 'VLAN tag number',
       hintText: 'Ex: 100',
       type: ELEMENT_TYPES.TEXT,
     },
     macspoofchk: {
-      name: 'MAC Spoof Check',
+      name: 'MAC spoof check',
       type: ELEMENT_TYPES.CHECKBOX,
       initValue: true,
+    },
+  },
+  [ovnKubernetesSecondaryLocalnet]: {
+    bridgeMapping: {
+      name: 'Bridge mapping',
+      type: ELEMENT_TYPES.TEXT,
+      required: true,
+      hintText:
+        'Physical network name. A bridge mapping must be configured on cluster nodes to map between physical network names and Open vSwitch bridges.',
+    },
+    mtu: {
+      name: 'MTU',
+      type: ELEMENT_TYPES.TEXT,
+    },
+    vlanID: {
+      name: 'VLAN',
+      type: ELEMENT_TYPES.TEXT,
     },
   },
 };

--- a/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
@@ -28,6 +28,8 @@ export type NetworkAttachmentDefinitionConfig = {
   topology?: string;
   netAttachDefName?: string;
   preserveDefaultVlan?: boolean;
+  vlanID?: number;
+  mtu?: number;
 };
 
 // The config is a JSON object with the NetworkAttachmentDefinitionConfig type stored as a string


### PR DESCRIPTION
**Fixes**:
 https://issues.redhat.com/browse/CNV-30298

 **Solution Description**:
Add new _OVN Kubernetes secondary localnet network_ drop down item as another _Network Type_ in the Create NAD form. If the mentioned item is selected, display three additional fields:
- "Bridge Mapping"
- "MTU" (optional)
- "VLAN" (optional)

When the fields are filled in and _Create_ button clicked, create the new NAD with the config according to the newly added fields.

Add tooltip for "Bridge mapping" field:
_Physical network name. A bridge mapping must be configured on cluster nodes to map between physical network names and Open vSwitch bridges._

Additionally, use sentence case in the related page for fields' titles, such as "Resource name", "VLAN tag number", "IP address management", "Bridge name", "MAC spoof check". Also add missing translation support for those fields.

_Draft of the localnet documentation:_
https://github.com/openshift/openshift-docs/blob/0fe4ec0bcc31afd4ba5060fb87dc9c347da34603/modules/configuring-localnet-switched-topology.adoc#L92

_Some more doc related to the feature:_
https://github.com/openshift/openshift-docs/pull/61110

_Note:_
There isn't any related design doc for this feature, unfortunately.

**Screen shots / Gifs for design review**:
_Before:_
![ovn_before](https://github.com/openshift/console/assets/13417815/6e2a7f1b-e93e-4c5d-9019-f780c984b6af)

_After:_
New _OVN Kubernetes secondary localnet network_ drop down item added:
![ovn1](https://github.com/openshift/console/assets/13417815/6ccf72c1-4992-4484-aabb-bf608482e027)
![ovn2](https://github.com/openshift/console/assets/13417815/932a4bfb-664e-469f-b397-4092cac13989)
NAD creation, clicking on Create button with the new additional fields filled in:
![ovn3](https://github.com/openshift/console/assets/13417815/dffd5239-78c5-45cc-a5fd-c308ee0340f0)
New NAD's config (yaml):
![ovn4](https://github.com/openshift/console/assets/13417815/39d295dc-ba09-4399-bfca-aa9c81631562)

