### PR TITLE
ODC-7359: Fix shipwright build e2e tests

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -117,7 +117,7 @@ export const navigateTo = (opt: devNavigationMenu) => {
     }
     case devNavigationMenu.Builds: {
       cy.get(devNavigationMenuPO.builds).click();
-      detailsPage.titleShouldContain(pageTitle.BuildConfigs);
+      detailsPage.titleShouldContain(pageTitle.Builds);
       cy.testA11y('Builds Page in dev perspective');
       break;
     }

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster.ts
@@ -142,7 +142,7 @@ const waitForPipelineTasks = (retries: number = 30) => {
 };
 
 const createShipwrightBuild = () => {
-  projectNameSpace.selectProject(Cypress.env('NAMESPACE'));
+  projectNameSpace.selectOrCreateProject(Cypress.env('NAMESPACE'));
   cy.get('body').then(($body) => {
     if ($body.find(operatorsPO.installOperators.search)) {
       cy.get(operatorsPO.installOperators.search).clear().type(operators.ShipwrightOperator);

--- a/frontend/packages/shipwright-plugin/integration-tests/features/shipwright-build-in-topology.feature
+++ b/frontend/packages/shipwright-plugin/integration-tests/features/shipwright-build-in-topology.feature
@@ -60,7 +60,7 @@ Feature: Shipwright build in topolgy
 
         @regression
         Scenario Outline: View logs for shipwright buildrun: SWB-02-TC04
-            When user navigates to Topology in Developer perspective
+             When user navigates to Topology in Developer perspective
               And user filters the workload "<workload_name>" by name and sets the workload type to "<workload_type>"
               And user clicks on View logs button for buildrun for workload type "<workload_type>" from the sidebar
              Then user will be able to see the buildRun logs

--- a/frontend/packages/shipwright-plugin/integration-tests/support/pageObjects/build-po.ts
+++ b/frontend/packages/shipwright-plugin/integration-tests/support/pageObjects/build-po.ts
@@ -4,7 +4,7 @@ export const buildPO = {
     nav: '[data-test="nav"]',
   },
   filter: '[aria-label="Options menu"]',
-  filterList: '[aria-labelledby="Status"]',
+  filterList: '[aria-labelledby="BuildRun-status"]',
   pane: '.co-m-pane__body',
   eventTab: '[data-test-id="horizontal-link-Events"]',
   eventStream: '.co-sysevent-stream',
@@ -15,6 +15,7 @@ export const buildPO = {
   },
   decorator: '[data-test="build-decorator"]',
   shipwrightBuild: {
+    filterList: '[aria-labelledby="Status"]',
     shipwrightBuildsTab: '[data-test-id="horizontal-link-Shipwright Builds"]',
     shipwrightBuildRunsTab: '[data-test-id="horizontal-link-BuildRuns"]',
     statusText: '[data-test="status-text"]',

--- a/frontend/packages/shipwright-plugin/integration-tests/support/step-definitions/builds/shipwright-build-detail-page.ts
+++ b/frontend/packages/shipwright-plugin/integration-tests/support/step-definitions/builds/shipwright-build-detail-page.ts
@@ -60,7 +60,7 @@ When('user will see Shipwright Builds', () => {
 });
 
 When('user clicks on {string} build', (build: string) => {
-  cy.byLegacyTestID(`${build}`).should('be.visible').click();
+  cy.get(`[data-test-id='${build}'][href*='Build/${build}']`).should('be.visible').click();
 });
 
 When('user will see {string}, {string} and {string}', (el1, el2, el3: string) => {
@@ -74,7 +74,7 @@ Then('user will see events steaming', () => {
 Given('user is at Shipwright Builds details page for build {string}', (buildName: string) => {
   navigateTo(devNavigationMenu.Builds);
   cy.get(buildPO.shipwrightBuild.shipwrightBuildsTab).should('be.visible').click();
-  cy.byLegacyTestID(`${buildName}`).should('be.visible').click();
+  cy.get(`[data-test-id='${buildName}'][href*='Build/${buildName}']`).should('be.visible').click();
   cy.get('[aria-label="Breadcrumb"]').should('contain', 'Build details');
   cy.get('[data-test-id="actions-menu-button"]', { timeout: 10000 }).should('be.visible');
 });
@@ -86,7 +86,7 @@ When('user clicks on Filter', () => {
 When(
   'user will see {string}, {string}, {string}, {string} and {string} options',
   (el1, el2, el3, el4, el5: string) => {
-    cy.get(buildPO.filterList)
+    cy.get(buildPO.shipwrightBuild.filterList)
       .should('contain', el1)
       .and('contain', el2)
       .and('contain', el3)
@@ -113,19 +113,21 @@ Then(
 Given('user is at Shipwright Builds run page {string}', (buildName: string) => {
   navigateTo(devNavigationMenu.Builds);
   cy.get(buildPO.shipwrightBuild.shipwrightBuildsTab).should('be.visible').click();
-  cy.byLegacyTestID(`${buildName}`).should('be.visible').click();
+  cy.get(`[data-test-id='${buildName}'][href*='Build/${buildName}']`).should('be.visible').click();
   cy.get(buildPO.shipwrightBuild.shipwrightBuildRunsTab).should('be.visible').click();
 });
 
 When('user has a failed build run', () => {
   cy.exec(`oc apply -n ${Cypress.env('NAMESPACE')} -f testData/builds/shipwrightBuildRun.yaml`, {
     failOnNonZeroExit: false,
+  }).then(function (result) {
+    cy.log(result.stdout);
   });
   cy.byLegacyTestID('buildpack-nodejs-build-heroku-1').should('be.visible').click();
   cy.byLegacyTestID('breadcrumb-link-0').should('be.visible').click();
   cy.get(buildPO.filter).should('be.visible').click();
   cy.get(buildPO.failedFilter).should('be.visible').click();
-  cy.get(resourceRow).should('be.visible');
+  cy.get(resourceRow, { timeout: 20000 }).should('be.visible');
 });
 
 When('user clicks on Failed Status', () => {

--- a/frontend/packages/shipwright-plugin/integration-tests/support/step-definitions/builds/shipwright-build-in-topology.ts
+++ b/frontend/packages/shipwright-plugin/integration-tests/support/step-definitions/builds/shipwright-build-in-topology.ts
@@ -94,12 +94,12 @@ Then('user will see build running for {string}', (type: string) => {
     cy.get('g.odc-knative-service__label > text').click({ force: true });
 
     cy.get('div.ocs-sidebar-tabsection:nth-child(6)')
-      .find('ul.list-group > li.odc-build-run-item')
+      .find('ul.list-group > li.so-build-run-item')
       .should('have.length.greaterThan', 1);
   } else {
     cy.get('g.pf-topology__node__label > text').click({ force: true });
     cy.get('div.ocs-sidebar-tabsection:nth-child(5)')
-      .find('ul.list-group > li.odc-build-run-item')
+      .find('ul.list-group > li.so-build-run-item')
       .should('have.length.greaterThan', 1);
   }
 });
@@ -111,12 +111,12 @@ When(
       cy.get('g.odc-knative-service__label > text').click({ force: true });
 
       cy.get('div.ocs-sidebar-tabsection:nth-child(6)').should('be.visible');
-      cy.get('ul.list-group > li.odc-build-run-item').contains('View logs').click({ force: true });
+      cy.get('ul.list-group > li.so-build-run-item').contains('View logs').click({ force: true });
     } else {
       cy.get('g.pf-topology__node__label > text').click({ force: true });
 
       cy.get('div.ocs-sidebar-tabsection:nth-child(5)').should('be.visible');
-      cy.get('ul.list-group > li.odc-build-run-item').contains('View logs').click({ force: true });
+      cy.get('ul.list-group > li.so-build-run-item').contains('View logs').click({ force: true });
     }
   },
 );

--- a/frontend/packages/shipwright-plugin/integration-tests/testData/builds/shipwrightBuild.yaml
+++ b/frontend/packages/shipwright-plugin/integration-tests/testData/builds/shipwrightBuild.yaml
@@ -1,12 +1,10 @@
-apiVersion: shipwright.io/v1beta1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpack-nodejs-build-heroku
 spec:
   source:
-    type: Git
-    git:
-      url: https://github.com/shipwright-io/sample-nodejs
+    url: https://github.com/shipwright-io/sample-nodejs
     contextDir: source-build
   strategy:
     name: buildpacks-v3-heroku
@@ -14,18 +12,18 @@ spec:
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/buildpack-nodejs-build-heroku
 ---
-apiVersion: shipwright.io/v1beta1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpack-nodejs-build-heroku-1
 spec:
-  build:
+  buildRef:
     name: buildpack-nodejs-build-heroku
 ---
-apiVersion: shipwright.io/v1beta1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpack-nodejs-build-heroku-2
 spec:
-  build:
+  buildRef:
     name: buildpack-nodejs-build-heroku

--- a/frontend/packages/shipwright-plugin/integration-tests/testData/builds/shipwrightBuildRun.yaml
+++ b/frontend/packages/shipwright-plugin/integration-tests/testData/builds/shipwrightBuildRun.yaml
@@ -1,14 +1,12 @@
-apiVersion: shipwright.io/v1beta1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpack-nodejs-buildrun-123
 spec:
-  build:
-    spec:
+  buildSpec:
       source:
         type: Git
-        git:
-          url: https://github.com/shipwright-io/sample-nodejs
+        url: https://github.com/shipwright-io/sample-nodejs
         contextDir: source-build
       strategy:
         kind: BuildStrategy

--- a/frontend/packages/shipwright-plugin/integration-tests/testData/builds/shipwrightBuildStrategies.yaml
+++ b/frontend/packages/shipwright-plugin/integration-tests/testData/builds/shipwrightBuildStrategies.yaml
@@ -11,7 +11,7 @@
 #
 
 ---
-apiVersion: shipwright.io/v1beta1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   name: buildah
@@ -192,7 +192,7 @@ spec:
         - quay.io
 
 ---
-apiVersion: shipwright.io/v1beta1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   name: buildkit
@@ -340,7 +340,7 @@ spec:
         - $(params.secrets[*])
 
 ---
-apiVersion: shipwright.io/v1beta1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   name: buildpacks-v3-heroku
@@ -376,7 +376,7 @@ spec:
           memory: 65Mi
 
 ---
-apiVersion: shipwright.io/v1beta1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   name: buildpacks-v3
@@ -416,7 +416,7 @@ spec:
 # This Build Strategy will intentionally fail if the image has any
 # critical CVEs. It will not be pushed into the destination registry
 # if any critical vulnerabilities are found.
-apiVersion: shipwright.io/v1beta1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   name: kaniko-trivy
@@ -517,7 +517,7 @@ spec:
           mountPath: /kaniko/oci-image-layout
 
 ---
-apiVersion: shipwright.io/v1beta1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   name: kaniko
@@ -579,7 +579,7 @@ spec:
           mountPath: /kaniko/oci-image-layout
 
 ---
-apiVersion: shipwright.io/v1beta1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   name: ko
@@ -694,7 +694,7 @@ spec:
           memory: 65Mi
 
 ---
-apiVersion: shipwright.io/v1beta1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   name: source-to-image-redhat
@@ -826,7 +826,7 @@ spec:
         - quay.io
 
 ---
-apiVersion: shipwright.io/v1beta1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   name: source-to-image


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ODC-7359
Epic: https://issues.redhat.com/browse/ODC-7358

Test Setup:
```
export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.jephilli-4-11-02-23-0643.devcluster.openshift.com/
export BRIDGE_KUBEADMIN_PASSWORD
export BRIDGE_BASE_ADDRESS
oc login https://api.jephilli-4-10-02-23-0643.devcluster.openshift.com:6443/ -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
  
#Execute below commands under console folder
oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
  
./test-cypress.sh -p shipwright
```

Test Execution Screenshot:
<img width="1774" alt="Screenshot 2023-10-31 at 2 59 43 AM" src="https://github.com/openshift/console/assets/10252230/8d00871b-459b-4a1d-966c-2c7562a4a4a2">
<img width="1774" alt="Screenshot 2023-10-29 at 4 58 19 AM" src="https://github.com/openshift/console/assets/10252230/dd4eb8f8-6153-458f-9949-aa19017bd633">
