### PR TITLE
Added disallowed flag to gitops static plugin

### DIFF
--- a/frontend/packages/gitops-plugin/console-extensions.json
+++ b/frontend/packages/gitops-plugin/console-extensions.json
@@ -14,7 +14,8 @@
       }
     },
     "flags": {
-      "required": ["OPENSHIFT_GITOPS"]
+      "required": ["OPENSHIFT_GITOPS"],
+      "disallowed": ["GITOPS_DYNAMIC"]
     }
   }
 ]


### PR DESCRIPTION
Purpose of PR: Disable gitops static plugin when dynamic plugin is enabled with disallowed flag.
Resolves [GITOPS-3575](https://issues.redhat.com/browse/GITOPS-3575), and it works along with [gitops-console-plugin PR](https://github.com/redhat-developer/gitops-console-plugin/pull/25)