### PR TITLE
ODC-7419: Feature new Quickstarts (RHDH on the admin dashboard and Pipelines/Serverless on the dev add page)

### DIFF
--- a/frontend/packages/dev-console/src/components/add/GettingStartedSection.tsx
+++ b/frontend/packages/dev-console/src/components/add/GettingStartedSection.tsx
@@ -27,7 +27,23 @@ export const GettingStartedSection: React.FC = () => {
     <div className="odc-add-page-getting-started-section">
       <GettingStartedGrid onHide={() => setShowState(GettingStartedShowState.HIDE)}>
         <SampleGettingStartedCard featured={['code-with-quarkus', 'java-springboot-basic']} />
-        <QuickStartGettingStartedCard featured={['quarkus-with-s2i', 'spring-with-s2i']} />
+        <QuickStartGettingStartedCard
+          featured={[
+            // Available when the Red Hat OpenShift Pipelines operator is installed:
+            // - Deploying an application with a pipeline
+            'install-app-and-associate-pipeline',
+
+            // Available when the Red Hat OpenShift Serverless operator is installed:
+            // - Exploring Serverless applications
+            'serverless-application',
+
+            // All part of the console-operator:
+            // - Get started with Quarkus using s2i
+            'quarkus-with-s2i',
+            // - Get started with Spring
+            'spring-with-s2i',
+          ]}
+        />
         <DeveloperFeaturesGettingStartedCard />
       </GettingStartedGrid>
     </div>

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/getting-started-section.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/getting-started-section.tsx
@@ -27,7 +27,19 @@ export const GettingStartedSection: React.FC = () => {
     <div className="co-dashboard-getting-started-section">
       <GettingStartedGrid onHide={() => setShowState(GettingStartedShowState.HIDE)}>
         <ClusterSetupGettingStartedCard />
-        <QuickStartGettingStartedCard featured={['monitor-sampleapp', 'quarkus-with-helm']} />
+        <QuickStartGettingStartedCard
+          featured={[
+            // All part of the console-operator:
+            // - Monitor your sample application
+            'monitor-sampleapp',
+            // - Install the Red Hat Developer Hub (RHDH) operator (and create a RHDH instance)
+            'rhdh-installation-via-operator',
+            // - Install the Red Hat OpenShift Pipelines operator
+            'explore-pipelines',
+            // - Install the Red Hat OpenShift Serverless operator
+            'install-serverless',
+          ]}
+        />
         <ExploreAdminFeaturesGettingStartedCard />
       </GettingStartedGrid>
     </div>


### PR DESCRIPTION
**Implements**: 
https://issues.redhat.com/browse/ODC-7419

## Admin perspective > Overview dashboard change

Removed the developer focus "Get started with Quarkus using a Helm Chart" Quickstart and added these with a focus on RHDH and installing the Pipelines/Serverless operator:

**Before:**

- Monitor your sample application
- Get started with Quarkus using a Helm Chart

**With this PR:**

- Monitor your sample application
- Install the Red Hat Developer Hub (RHDH) operator (and create a RHDH instance)
- Install the Red Hat OpenShift Pipelines operator
- Install the Red Hat OpenShift Serverless operator

Note: Only the first two, not-completed Quickstarts are shown, as before. But when the cluster admin finish the RHDH Quickstart, the next one is shown.

**Before:**

![image](https://github.com/openshift/console/assets/139310/ec031ba7-316f-4970-988a-ecee4860de69)

**With this PR:**

![image](https://github.com/openshift/console/assets/139310/4761ee2c-2859-4404-b9cb-9a6f51abf3a3)

## Developer perspective > Add page change

Change: Prefer two QuickStarts around Pipelines and Serverless when their operator is installed. Kept the Quarkus s2i and Sprint Quickstarts for the case that one or both operators are not installed.

**Before:**

- Get started with Quarkus using s2i
- Get started with Spring

**With this PR:**

- Deploying an application with a pipeline &nbsp; (but only when the Pipelines operator is installed)
- Exploring Serverless applications &nbsp; &nbsp; &nbsp; (but only when the Serverless operator is installed)
- Get started with Quarkus using s2i
- Get started with Spring

**With this PR:**

![image](https://github.com/openshift/console/assets/139310/9100b6a4-87d4-4bd2-8666-01ec931741d4)

**With this PR:**

![image](https://github.com/openshift/console/assets/139310/fb761482-b30d-4ece-becb-4865546c74b6)

**Test setup:**
1. To see the RHDH Quickstarts, please install the resources from https://github.com/openshift/console-operator/pull/806
2. Open the Administrator perspective, Home > Overview and check the Getting started section
3. Open the Developer perspective, Add page and check the Getting started section

Note: Featured quick starts are shown until the user has completed them. Then the next quickstarts will be shown.

fyi @jhadvig 

/cc @vikram-raj @invincibleJai @pdaverh @alimobrem 