### PR TITLE
ODC-7395, ODC-7382: add support for tektonresult api to load PipelineRuns

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -481,7 +481,18 @@
         "version": "v1beta1",
         "kind": "PipelineRun"
       },
-      "component": { "$codeRef": "pipelinesComponent.PipelineRunsResourceList" }
+      "component": { "$codeRef": "pipelinesComponent.PipelineRunsK8sResourceList" }
+    }
+  },
+  {
+    "type": "console.page/resource/list",
+    "properties": {
+      "model": {
+        "group": "tekton.dev",
+        "version": "v1",
+        "kind": "PipelineRun"
+      },
+      "component": { "$codeRef": "pipelinesComponent.PipelineRunsK8sResourceList" }
     }
   },
   {
@@ -493,17 +504,6 @@
         "kind": "Pipeline"
       },
       "component": { "$codeRef": "pipelinesComponent.PipelinesResourceList" }
-    }
-  },
-  {
-    "type": "console.page/resource/list",
-    "properties": {
-      "model": {
-        "group": "tekton.dev",
-        "version": "v1",
-        "kind": "PipelineRun"
-      },
-      "component": { "$codeRef": "pipelinesComponent.PipelineRunsResourceList" }
     }
   },
   {

--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -438,6 +438,8 @@
   "TektonConfigs": "TektonConfigs",
   "TektonHub": "TektonHub",
   "TektonHubs": "TektonHubs",
+  "TektonResult": "TektonResult",
+  "TektonResults": "TektonResults",
   "Pipeline {{status}}": "Pipeline {{status}}",
   "Pipeline status is {{status}}. View logs.": "Pipeline status is {{status}}. View logs.",
   "Pipeline not started. Start pipeline.": "Pipeline not started. Start pipeline.",

--- a/frontend/packages/pipelines-plugin/src/components/ListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/ListPage.tsx
@@ -1,0 +1,594 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import * as React from 'react';
+import { Button, TextInput, TextInputProps } from '@patternfly/react-core';
+import * as classNames from 'classnames';
+// eslint-disable-next-line no-restricted-imports
+import * as _ from 'lodash-es';
+import { useTranslation } from 'react-i18next';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { useDispatch } from 'react-redux';
+import { Link, match as RMatch } from 'react-router-dom';
+import { ColumnLayout } from '@console/dynamic-plugin-sdk';
+import { filterList } from '@console/dynamic-plugin-sdk/src/app/k8s/actions/k8s';
+import { ErrorPage404 } from '@console/internal/components/error';
+import { FilterToolbar, RowFilter } from '@console/internal/components/filter-toolbar';
+import { storagePrefix } from '@console/internal/components/row-filter';
+import {
+  Dropdown,
+  FirehoseResource,
+  FirehoseResourcesResult,
+  FirehoseResultObject,
+  history,
+  inject,
+  kindObj,
+  makeQuery,
+  makeReduxID,
+  PageHeading,
+  RequireCreatePermission,
+} from '@console/internal/components/utils';
+import {
+  K8sKind,
+  K8sResourceCommon,
+  referenceForModel,
+  Selector,
+} from '@console/internal/module/k8s';
+import { useDocumentListener, KEYBOARD_SHORTCUTS, useDeepCompareMemoize } from '@console/shared';
+import { withFallback, ErrorBoundaryFallbackPage } from '@console/shared/src/components/error';
+import ListPropProvider from './ListPropProvider';
+
+type CreateProps = {
+  action?: string;
+  createLink?: (item: string) => string;
+  to?: string;
+  items?: {
+    [key: string]: string;
+  };
+  onClick?: () => void;
+  isDisabled?: boolean;
+  id?: string;
+};
+
+type TextFilterProps = Omit<TextInputProps, 'type' | 'tabIndex'> & {
+  label?: string;
+  parentClassName?: string;
+};
+
+export const TextFilter: React.FC<TextFilterProps> = (props) => {
+  const {
+    label,
+    className,
+    placeholder,
+    autoFocus = false,
+    parentClassName,
+    ...otherInputProps
+  } = props;
+  const { ref } = useDocumentListener<HTMLInputElement>();
+  const { t } = useTranslation();
+  const placeholderText = placeholder ?? t('public~Filter {{label}}...', { label });
+
+  return (
+    <div className={classNames('has-feedback', parentClassName)}>
+      <TextInput
+        {...otherInputProps}
+        className={classNames('co-text-filter', className)}
+        data-test-id="item-filter"
+        aria-label={placeholderText}
+        placeholder={placeholderText}
+        ref={ref}
+        autoFocus={autoFocus}
+        tabIndex={0}
+        type="text"
+      />
+      <span className="co-text-filter-feedback">
+        <kbd className="co-kbd co-kbd__filter-input">{KEYBOARD_SHORTCUTS.focusFilterInput}</kbd>
+      </span>
+    </div>
+  );
+};
+TextFilter.displayName = 'TextFilter';
+
+// TODO (jon) make this into "withListPageFilters" HOC
+
+type ListPageWrapperProps<L = any, C = any> = {
+  ListComponent: React.ComponentType<L>;
+  kinds: string[];
+  filters?: any;
+  flatten?: Flatten;
+  rowFilters?: RowFilter[];
+  hideNameLabelFilters?: boolean;
+  hideLabelFilter?: boolean;
+  columnLayout?: ColumnLayout;
+  name?: string;
+  resources?: FirehoseResourcesResult;
+  reduxIDs?: string[];
+  textFilter?: string;
+  nameFilterPlaceholder?: string;
+  namespace?: string;
+  labelFilterPlaceholder?: string;
+  label?: string;
+  staticFilters?: { key: string; value: string }[];
+  customData?: C;
+  hideColumnManagement?: boolean;
+  nameFilter?: string;
+  data?: any;
+};
+
+export const ListPageWrapper: React.FC<ListPageWrapperProps> = (props) => {
+  const {
+    flatten,
+    ListComponent,
+    reduxIDs,
+    rowFilters,
+    textFilter,
+    nameFilterPlaceholder,
+    labelFilterPlaceholder,
+    hideNameLabelFilters,
+    hideLabelFilter,
+    columnLayout,
+    name,
+    nameFilter,
+    data,
+  } = props;
+  const dispatch = useDispatch();
+  const memoizedIds = useDeepCompareMemoize(reduxIDs);
+
+  React.useEffect(() => {
+    if (!_.isNil(nameFilter)) {
+      memoizedIds.forEach((id) => dispatch(filterList(id, 'name', { selected: [nameFilter] })));
+    }
+  }, [dispatch, nameFilter, memoizedIds]);
+
+  const dta = flatten ? flatten(data) : [];
+  const Filter = (
+    <FilterToolbar
+      rowFilters={rowFilters}
+      nameFilterPlaceholder={nameFilterPlaceholder}
+      labelFilterPlaceholder={labelFilterPlaceholder}
+      reduxIDs={reduxIDs}
+      textFilter={textFilter}
+      hideNameLabelFilters={hideNameLabelFilters}
+      hideLabelFilter={hideLabelFilter}
+      columnLayout={columnLayout}
+      uniqueFilterName={name}
+      {...props}
+      data={dta}
+    />
+  );
+
+  return (
+    <div>
+      {!_.isEmpty(dta) && Filter}
+      <div className="row">
+        <div className="col-xs-12">
+          <ListComponent {...props} data={dta} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+ListPageWrapper.displayName = 'ListPageWrapper_';
+
+export type FireManProps = {
+  canCreate?: boolean;
+  textFilter?: string;
+  createAccessReview?: {
+    model: K8sKind;
+    namespace?: string;
+  };
+  createButtonText?: string;
+  createProps?: CreateProps;
+  fieldSelector?: string;
+  filterLabel?: string;
+  resources: FirehoseResource[];
+  badge?: React.ReactNode;
+  helpText?: React.ReactNode;
+  title?: string;
+  autoFocus?: boolean;
+  cluster?: string; // TODO remove multicluster
+};
+
+export const FireMan: React.FC<FireManProps & { filterList?: typeof filterList }> = (props) => {
+  const {
+    cluster,
+    resources,
+    textFilter,
+    canCreate,
+    createAccessReview,
+    createButtonText,
+    createProps = {},
+    helpText,
+    badge,
+    title,
+  } = props;
+  const [reduxIDs, setReduxIDs] = React.useState([]);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [expand] = React.useState();
+
+  React.useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    params.forEach((v, k) => applyFilter(k, v));
+
+    const reduxId = resources.map((r) =>
+      makeReduxID(kindObj(r.kind), makeQuery(r.namespace, r.selector, r.fieldSelector, r.name)),
+    );
+    setReduxIDs(reduxId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  React.useEffect(() => {
+    const reduxId = resources.map((r) =>
+      makeReduxID(kindObj(r.kind), makeQuery(r.namespace, r.selector, r.fieldSelector, r.name)),
+    );
+
+    if (_.isEqual(reduxId, reduxIDs)) {
+      return;
+    }
+
+    // reapply filters to the new list...
+    setReduxIDs(reduxId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cluster, resources]);
+
+  const updateURL = (filterName: string, options: any) => {
+    if (filterName !== textFilter) {
+      // TODO (ggreer): support complex filters (objects, not just strings)
+      return;
+    }
+    const params = new URLSearchParams(window.location.search);
+    if (options) {
+      params.set(filterName, options);
+    } else {
+      params.delete(filterName);
+    }
+    const url = new URL(window.location.href);
+    history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+  };
+
+  const applyFilter = (filterName: string, options: any) => {
+    // TODO: (ggreer) lame blacklist of query args. Use a whitelist based on resource filters
+    if (['q', 'kind', 'orderBy', 'sortBy'].includes(filterName)) {
+      return;
+    }
+    if (filterName.indexOf(storagePrefix) === 0) {
+      return;
+    }
+    reduxIDs.forEach((id) => props.filterList(id, filterName, options));
+    updateURL(filterName, options);
+  };
+
+  const runOrNavigate = (itemName: string) => {
+    const action = _.isFunction(createProps.action) && createProps.action(itemName);
+    if (action) {
+      action();
+    } else if (_.isFunction(createProps.createLink)) {
+      history.push(createProps.createLink(itemName));
+    }
+  };
+
+  let createLink: any;
+
+  if (canCreate) {
+    if (createProps.to) {
+      createLink = (
+        <Link className="co-m-primary-action" to={createProps.to}>
+          <Button variant="primary" id="yaml-create" data-test="item-create">
+            {createButtonText}
+          </Button>
+        </Link>
+      );
+    } else if (createProps.items) {
+      createLink = (
+        <div className="co-m-primary-action">
+          <Dropdown
+            buttonClassName="pf-m-primary"
+            id="item-create"
+            dataTest="item-create"
+            menuClassName={classNames({ 'pf-m-align-right-on-md': title })}
+            title={createButtonText}
+            noSelection
+            items={createProps.items}
+            onChange={runOrNavigate}
+          />
+        </div>
+      );
+    } else {
+      createLink = (
+        <div className="co-m-primary-action">
+          <Button variant="primary" id="yaml-create" data-test="item-create" {...createProps}>
+            {createButtonText}
+          </Button>
+        </div>
+      );
+    }
+    if (!_.isEmpty(createAccessReview)) {
+      createLink = (
+        <RequireCreatePermission
+          model={createAccessReview.model}
+          namespace={createAccessReview.namespace}
+        >
+          {createLink}
+        </RequireCreatePermission>
+      );
+    }
+  }
+
+  return (
+    <>
+      {/* Badge rendered from PageHeading only when title is present */}
+      <PageHeading
+        title={title}
+        badge={title ? badge : null}
+        className={classNames({ 'co-m-nav-title--row': createLink })}
+      >
+        {createLink && (
+          <div className={classNames({ 'co-m-pane__createLink--no-title': !title })}>
+            {createLink}
+          </div>
+        )}
+        {!title && badge && <div>{badge}</div>}
+      </PageHeading>
+      {helpText && <p className="co-m-pane__help-text co-help-text">{helpText}</p>}
+      <div className="co-m-pane__body co-m-pane__body--no-top-margin">
+        {inject(props.children, {
+          resources,
+          expand,
+          reduxIDs,
+          applyFilter,
+        })}
+      </div>
+    </>
+  );
+};
+FireMan.displayName = 'FireMan';
+
+export type Flatten<
+  F extends FirehoseResultObject = { [key: string]: K8sResourceCommon | K8sResourceCommon[] },
+  R = any
+> = (resources: FirehoseResourcesResult<F>) => R;
+
+export type ListPageProps<L = any, C = any> = PageCommonProps<L, C> & {
+  kind: string;
+  helpText?: React.ReactNode;
+  selector?: Selector;
+  fieldSelector?: string;
+  createHandler?: () => void;
+  name?: string;
+  filters?: any;
+  limit?: number;
+  nameFilter?: string;
+  match?: RMatch<any>;
+  skipAccessReview?: boolean;
+  data?: any;
+};
+
+export const ListPage = withFallback<ListPageProps>((props) => {
+  const {
+    autoFocus,
+    canCreate,
+    createButtonText,
+    createHandler,
+    customData,
+    fieldSelector,
+    filterLabel,
+    labelFilterPlaceholder,
+    nameFilterPlaceholder,
+    filters,
+    helpText,
+    kind,
+    limit,
+    ListComponent,
+    mock,
+    name,
+    nameFilter,
+    namespace,
+    selector,
+    showTitle = true,
+    skipAccessReview,
+    textFilter,
+    match,
+    badge,
+    hideLabelFilter,
+    hideNameLabelFilters,
+    hideColumnManagement,
+    columnLayout,
+    data,
+    flatten = (_resources) => _.get(_resources, kind)?.data,
+  } = props;
+  const { t } = useTranslation();
+  let { createProps } = props;
+  const ko = kindObj(kind);
+  const { label, labelKey, labelPlural, labelPluralKey, namespaced, plural } = ko;
+  const title = props.title || t(labelPluralKey) || labelPlural;
+  const usedNamespace = !namespace && namespaced ? _.get(match, 'params.ns') : namespace;
+
+  let href = usedNamespace
+    ? `/k8s/ns/${usedNamespace || 'default'}/${plural}/~new`
+    : `/k8s/cluster/${plural}/~new`;
+  if (ko.crd) {
+    try {
+      const ref = referenceForModel(ko);
+      href = usedNamespace
+        ? `/k8s/ns/${usedNamespace || 'default'}/${ref}/~new`
+        : `/k8s/cluster/${ref}/~new`;
+    } catch (unused) {
+      /**/
+    }
+  }
+
+  createProps = createProps || (createHandler ? { onClick: createHandler } : { to: href });
+  const createAccessReview = skipAccessReview ? null : { model: ko, namespace: usedNamespace };
+  const resources = [
+    {
+      fieldSelector,
+      filters,
+      kind,
+      limit,
+      name,
+      namespaced,
+      selector,
+      prop: kind,
+    },
+  ];
+
+  // Don't show row filters if props.filters were passed. The content is already filtered and the row filters will have incorrect counts.
+  const rowFilters = _.isEmpty(filters) ? props.rowFilters : undefined;
+
+  if (!namespaced && usedNamespace) {
+    return <ErrorPage404 />;
+  }
+
+  return (
+    <MultiListPage
+      autoFocus={autoFocus}
+      canCreate={canCreate}
+      createAccessReview={createAccessReview}
+      createButtonText={
+        createButtonText || t('public~Create {{label}}', { label: t(labelKey) || label })
+      }
+      createProps={createProps}
+      customData={customData}
+      filterLabel={filterLabel || t('public~by name')}
+      nameFilterPlaceholder={nameFilterPlaceholder}
+      labelFilterPlaceholder={labelFilterPlaceholder}
+      flatten={flatten}
+      helpText={helpText}
+      label={t(labelPluralKey) || labelPlural}
+      ListComponent={ListComponent}
+      mock={mock}
+      namespace={usedNamespace}
+      resources={resources}
+      rowFilters={rowFilters}
+      showTitle={showTitle}
+      textFilter={textFilter}
+      title={title}
+      badge={badge}
+      hideLabelFilter={hideLabelFilter}
+      hideNameLabelFilters={hideNameLabelFilters}
+      hideColumnManagement={hideColumnManagement}
+      columnLayout={columnLayout}
+      nameFilter={nameFilter}
+      data={data}
+    />
+  );
+}, ErrorBoundaryFallbackPage);
+
+ListPage.displayName = 'ListPage';
+
+type PageCommonProps<L = any, C = any> = {
+  canCreate?: boolean;
+  createButtonText?: string;
+  createProps?: CreateProps;
+  flatten?: Flatten;
+  title?: string;
+  showTitle?: boolean;
+  filterLabel?: string;
+  textFilter?: string;
+  rowFilters?: RowFilter[];
+  ListComponent: React.ComponentType<L>;
+  namespace?: string;
+  customData?: C;
+  badge?: React.ReactNode;
+  hideNameLabelFilters?: boolean;
+  hideLabelFilter?: boolean;
+  columnLayout?: ColumnLayout;
+  hideColumnManagement?: boolean;
+  labelFilterPlaceholder?: string;
+  nameFilterPlaceholder?: string;
+  autoFocus?: boolean;
+  mock?: boolean;
+  data?: any;
+};
+
+export type MultiListPageProps<L = any, C = any> = PageCommonProps<L, C> & {
+  createAccessReview?: {
+    model: K8sKind;
+    namespace?: string;
+  };
+  label?: string;
+  hideTextFilter?: boolean;
+  helpText?: React.ReactNode;
+  resources: (Omit<FirehoseResource, 'prop'> & { prop?: FirehoseResource['prop'] })[];
+  staticFilters?: { key: string; value: string }[];
+  nameFilter?: string;
+};
+
+export const MultiListPage: React.FC<MultiListPageProps> = (props) => {
+  const {
+    autoFocus,
+    canCreate,
+    createAccessReview,
+    createButtonText,
+    createProps,
+    filterLabel,
+    nameFilterPlaceholder,
+    labelFilterPlaceholder,
+    flatten,
+    helpText,
+    label,
+    ListComponent,
+    mock,
+    namespace,
+    rowFilters,
+    showTitle = true,
+    staticFilters,
+    textFilter,
+    title,
+    customData,
+    badge,
+    hideLabelFilter,
+    hideNameLabelFilters,
+    hideColumnManagement,
+    columnLayout,
+    nameFilter,
+    data,
+  } = props;
+  const { t } = useTranslation();
+  const resources = _.map(props.resources, (r) => ({
+    ...r,
+    isList: r.isList !== undefined ? r.isList : true,
+    namespace: r.namespaced ? namespace : r.namespace,
+    prop: r.kind,
+  }));
+  return (
+    <FireMan
+      autoFocus={autoFocus}
+      canCreate={canCreate}
+      createAccessReview={createAccessReview}
+      createButtonText={createButtonText || t('public~Create')}
+      createProps={createProps}
+      filterLabel={filterLabel || t('public~by name')}
+      helpText={helpText}
+      resources={mock ? [] : resources}
+      textFilter={textFilter}
+      title={showTitle ? title : undefined}
+      badge={badge}
+    >
+      <ListPropProvider data={data}>
+        <ListPageWrapper
+          flatten={flatten}
+          kinds={_.map(resources, 'kind')}
+          label={label}
+          ListComponent={ListComponent}
+          textFilter={textFilter}
+          rowFilters={rowFilters}
+          staticFilters={staticFilters}
+          customData={customData}
+          hideLabelFilter={hideLabelFilter}
+          hideNameLabelFilters={hideNameLabelFilters}
+          hideColumnManagement={hideColumnManagement}
+          columnLayout={columnLayout}
+          nameFilterPlaceholder={nameFilterPlaceholder}
+          labelFilterPlaceholder={labelFilterPlaceholder}
+          nameFilter={nameFilter}
+          namespace={namespace}
+          resources={data}
+          data={data}
+        />
+      </ListPropProvider>
+    </FireMan>
+  );
+};
+
+MultiListPage.displayName = 'MultiListPage';

--- a/frontend/packages/pipelines-plugin/src/components/ListPropProvider.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/ListPropProvider.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { Map as ImmutableMap } from 'immutable';
+import * as _ from 'lodash';
+// FIXME upgrading redux types is causing many errors at this time
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { useSelector } from 'react-redux';
+import { inject, processReduxId } from '@console/internal/components/utils';
+
+const worstError = (errors) => {
+  let worst = errors && errors[0];
+  for (const e of errors) {
+    if (e.status === 403) {
+      return e;
+    }
+    if (e.status === 401) {
+      worst = e;
+    }
+    if (e.status > worst.status) {
+      worst = e;
+    }
+  }
+  return worst;
+};
+
+const ListPropProvider = (props) => {
+  const k8sData: ImmutableMap<string, any> = useSelector(({ k8s }) => k8s);
+  const reduxes = props.resources.map(({ prop, isList, filters, optional, kind }) => {
+    return {
+      reduxID: props.reduxIDs[0],
+      prop,
+      isList,
+      filters,
+      optional,
+      kind,
+    };
+  });
+  const resources: any = {};
+  reduxes.forEach((redux) => {
+    resources[redux.prop] = processReduxId({ k8s: k8sData }, redux);
+  });
+  const required = _.filter(resources, (r) => !r.optional);
+  const loaded = _.every(resources, (resource) =>
+    resource.optional ? resource.loaded || !_.isEmpty(resource.loadError) : resource.loaded,
+  );
+  const loadError = worstError(_.map(required, 'loadError').filter(Boolean));
+
+  const k8sResults = Object.assign({}, resources, {
+    filters: Object.assign({}, ..._.map(resources, 'filters')),
+    loaded,
+    loadError,
+    reduxIDs: _.map(reduxes, 'reduxID'),
+    resources,
+  });
+  return (
+    <>
+      {inject(props.children, {
+        ...props,
+        ...props?.data,
+        ...k8sResults,
+      })}
+    </>
+  );
+};
+
+export default ListPropProvider;

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsK8sResourceList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsK8sResourceList.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../models';
 import { usePipelineTechPreviewBadge } from '../../utils/hooks';
-import { ListPage } from '../ListPage';
 import { runFilters } from '../pipelines/detail-page-tabs/PipelineRuns';
-import { useGetPipelineRuns } from './hooks/useTektonResults';
 import PipelineRunsList from './list-page/PipelineRunList';
 
 interface PipelineRunsResourceListProps {
@@ -13,22 +12,12 @@ interface PipelineRunsResourceListProps {
   canCreate?: boolean;
 }
 
-const PipelineRunsResourceList: React.FC<
+const PipelineRunsK8sResourceList: React.FC<
   Omit<React.ComponentProps<typeof ListPage>, 'kind' | 'ListComponent' | 'rowFilters'> &
     PipelineRunsResourceListProps
 > = (props) => {
   const { t } = useTranslation();
-  const ns = props.namespace || props?.match?.params?.ns;
-  const badge = usePipelineTechPreviewBadge(ns);
-  const [pipelineRuns, pipelineRunsLoaded, pipelineRunsLoadError] = useGetPipelineRuns(ns);
-  const resources = {
-    [referenceForModel(PipelineRunModel)]: {
-      data: pipelineRuns,
-      kind: referenceForModel(PipelineRunModel),
-      loadError: pipelineRunsLoadError,
-      loaded: pipelineRunsLoaded,
-    },
-  };
+  const badge = usePipelineTechPreviewBadge(props.namespace);
   return (
     <ListPage
       {...props}
@@ -37,9 +26,8 @@ const PipelineRunsResourceList: React.FC<
       ListComponent={PipelineRunsList}
       rowFilters={runFilters(t)}
       badge={props.hideBadge ? null : badge}
-      data={resources}
     />
   );
 };
 
-export default PipelineRunsResourceList;
+export default PipelineRunsK8sResourceList;

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsResourceList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsResourceList.tsx
@@ -20,7 +20,9 @@ const PipelineRunsResourceList: React.FC<
   const { t } = useTranslation();
   const ns = props.namespace || props?.match?.params?.ns;
   const badge = usePipelineTechPreviewBadge(ns);
-  const [pipelineRuns, pipelineRunsLoaded, pipelineRunsLoadError] = useGetPipelineRuns(ns);
+  const [pipelineRuns, pipelineRunsLoaded, pipelineRunsLoadError, getNextPage] = useGetPipelineRuns(
+    ns,
+  );
   const resources = {
     [referenceForModel(PipelineRunModel)]: {
       data: pipelineRuns,
@@ -37,6 +39,7 @@ const PipelineRunsResourceList: React.FC<
       ListComponent={PipelineRunsList}
       rowFilters={runFilters(t)}
       badge={props.hideBadge ? null : badge}
+      customData={{ nextPage: getNextPage }}
       data={resources}
     />
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunsResourceList.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunsResourceList.spec.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import { shallow, ShallowWrapper } from 'enzyme';
-import { ListPage } from '@console/internal/components/factory';
+import { ListPage } from '../../ListPage';
 import { PIPELINE_GA_VERSION } from '../../pipelines/const';
 import * as operatorUtils from '../../pipelines/utils/pipeline-operator';
+import * as tektonResultsHooks from '../hooks/useTektonResults';
 import PipelineRunsResourceList from '../PipelineRunsResourceList';
 
 type PipelineRunsResourceListProps = React.ComponentProps<typeof PipelineRunsResourceList>;
@@ -11,6 +12,7 @@ type PipelineRunsResourceListProps = React.ComponentProps<typeof PipelineRunsRes
 describe('PipelineRunsResourceList:', () => {
   let pipelineRunsResourceListProps: PipelineRunsResourceListProps;
   let wrapper: ShallowWrapper<PipelineRunsResourceListProps>;
+  jest.spyOn(tektonResultsHooks, 'useGetPipelineRuns').mockReturnValue([[], true, '']);
 
   beforeEach(() => {
     pipelineRunsResourceListProps = {

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
@@ -1,0 +1,181 @@
+import * as React from 'react';
+import { uniqBy } from 'lodash';
+import { K8sResourceCommon, Selector } from '@console/dynamic-plugin-sdk/src';
+import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { PipelineRunModel } from '../../../models';
+import { PipelineRunKind, TaskRunKind } from '../../../types';
+import { RepositoryFields, RepositoryLabels } from '../../repository/consts';
+import { useTaskRuns } from '../../taskruns/useTaskRuns';
+import {
+  getPipelineRuns,
+  TektonResultsOptions,
+  getTaskRuns,
+  RecordsList,
+  // getTaskRunLog,
+} from '../utils/tekton-results';
+
+export type GetNextPage = () => void | undefined;
+
+const useTRRuns = <Kind extends K8sResourceCommon>(
+  getRuns: (
+    namespace: string,
+    options?: TektonResultsOptions,
+    nextPageToken?: string,
+    cacheKey?: string,
+  ) => Promise<[Kind[], RecordsList, boolean?]>,
+  namespace: string,
+  options?: TektonResultsOptions,
+  cacheKey?: string,
+): [Kind[], boolean, unknown, GetNextPage] => {
+  const [nextPageToken, setNextPageToken] = React.useState<string>(null);
+  const [localCacheKey, setLocalCacheKey] = React.useState(cacheKey);
+
+  if (cacheKey !== localCacheKey) {
+    // force update local cache key
+    setLocalCacheKey(cacheKey);
+  }
+
+  const [result, setResult] = React.useState<[Kind[], boolean, unknown, GetNextPage]>([
+    [],
+    false,
+    undefined,
+    undefined,
+  ]);
+
+  // reset token if namespace or options change
+  React.useEffect(() => {
+    setNextPageToken(null);
+  }, [namespace, options, cacheKey]);
+
+  // eslint-disable-next-line consistent-return
+  React.useEffect(() => {
+    let disposed = false;
+    if (namespace) {
+      (async () => {
+        try {
+          const tkPipelineRuns = await getRuns(namespace, options, nextPageToken, localCacheKey);
+          if (!disposed) {
+            const token = tkPipelineRuns[1].nextPageToken;
+            const callInflight = !!tkPipelineRuns?.[2];
+            const loaded = !callInflight;
+            if (!callInflight) {
+              setResult((cur) => [
+                nextPageToken ? [...cur[0], ...tkPipelineRuns[0]] : tkPipelineRuns[0],
+                loaded,
+                undefined,
+                token
+                  ? (() => {
+                      // ensure we can only call this once
+                      let executed = false;
+                      return () => {
+                        if (!disposed && !executed) {
+                          executed = true;
+                          // trigger the update
+                          setNextPageToken(token);
+                          return true;
+                        }
+                        return false;
+                      };
+                    })()
+                  : undefined,
+              ]);
+            }
+          }
+        } catch (e) {
+          if (!disposed) {
+            if (nextPageToken) {
+              setResult((cur) => [cur[0], cur[1], e, undefined]);
+            } else {
+              setResult([[], false, e, undefined]);
+            }
+          }
+        }
+      })();
+      return () => {
+        disposed = true;
+      };
+    }
+  }, [namespace, options, nextPageToken, localCacheKey, getRuns]);
+  return result;
+};
+
+export const useTRPipelineRuns = (
+  namespace: string,
+  options?: TektonResultsOptions,
+  cacheKey?: string,
+): [PipelineRunKind[], boolean, unknown, GetNextPage] =>
+  useTRRuns<PipelineRunKind>(getPipelineRuns, namespace, options, cacheKey);
+
+export const useTRTaskRuns = (
+  namespace: string,
+  options?: TektonResultsOptions,
+  cacheKey?: string,
+): [TaskRunKind[], boolean, unknown, GetNextPage] =>
+  useTRRuns<TaskRunKind>(getTaskRuns, namespace, options, cacheKey);
+
+export const useGetPipelineRuns = (ns: string, options?: { name: string; kind: string }) => {
+  let selector: Selector;
+
+  if (options?.kind === 'Pipeline') {
+    selector = { matchLabels: { 'tekton.dev/pipeline': options?.name } };
+  }
+  if (options?.kind === 'Repository') {
+    selector = { matchLabels: { [RepositoryLabels[RepositoryFields.REPOSITORY]]: options?.name } };
+  }
+  const [resultPlrs, resultPlrsLoaded, resultPlrsLoadError] = useTRPipelineRuns(
+    ns,
+    options && {
+      selector,
+    },
+  );
+  const [k8sPlrs, k8sPlrsLoaded, k8sPlrsLoadError] = useK8sWatchResource<PipelineRunKind[]>({
+    isList: true,
+    kind: referenceForModel(PipelineRunModel),
+    namespace: ns,
+    ...(options ? { selector } : {}),
+  });
+  const mergedPlrs =
+    (resultPlrsLoaded || k8sPlrsLoaded) && !k8sPlrsLoadError
+      ? uniqBy([...k8sPlrs, ...resultPlrs], (r) => r.metadata.name)
+      : [];
+  return [mergedPlrs, resultPlrsLoaded || k8sPlrsLoaded, resultPlrsLoadError || k8sPlrsLoadError];
+};
+
+export const useGetTaskRuns = (ns: string) => {
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(ns);
+  const [resultTaskRuns, resultTaskRunsLoaded] = useTRTaskRuns(ns);
+  const mergedTaskRuns =
+    resultTaskRunsLoaded || taskRunsLoaded
+      ? uniqBy([...taskRuns, ...resultTaskRuns], (r) => r.metadata.name)
+      : [];
+  return [mergedTaskRuns, resultTaskRunsLoaded || taskRunsLoaded];
+};
+
+// export const useTRTaskRunLog = (
+//   namespace: string,
+//   taskRunName: string,
+// ): [string, boolean, unknown] => {
+//   const [result, setResult] = React.useState<[string, boolean, unknown]>([null, false, undefined]);
+//   React.useEffect(() => {
+//     let disposed = false;
+//     if (namespace && taskRunName) {
+//       (async () => {
+//         try {
+//           const log = await getTaskRunLog(namespace, taskRunName);
+//           if (!disposed) {
+//             setResult([log, true, undefined]);
+//           }
+//         } catch (e) {
+//           if (!disposed) {
+//             setResult([null, false, e]);
+//           }
+//         }
+//       })();
+//     }
+//     return () => {
+//       disposed = true;
+//     };
+//   }, [namespace, taskRunName]);
+//   return result;
+// };

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
@@ -123,7 +123,7 @@ export const useGetPipelineRuns = (ns: string, options?: { name: string; kind: s
   if (options?.kind === 'Repository') {
     selector = { matchLabels: { [RepositoryLabels[RepositoryFields.REPOSITORY]]: options?.name } };
   }
-  const [resultPlrs, resultPlrsLoaded, resultPlrsLoadError] = useTRPipelineRuns(
+  const [resultPlrs, resultPlrsLoaded, resultPlrsLoadError, getNextPage] = useTRPipelineRuns(
     ns,
     options && {
       selector,
@@ -139,7 +139,12 @@ export const useGetPipelineRuns = (ns: string, options?: { name: string; kind: s
     (resultPlrsLoaded || k8sPlrsLoaded) && !k8sPlrsLoadError
       ? uniqBy([...k8sPlrs, ...resultPlrs], (r) => r.metadata.name)
       : [];
-  return [mergedPlrs, resultPlrsLoaded || k8sPlrsLoaded, resultPlrsLoadError || k8sPlrsLoadError];
+  return [
+    mergedPlrs,
+    resultPlrsLoaded || k8sPlrsLoaded,
+    resultPlrsLoadError || k8sPlrsLoadError,
+    getNextPage,
+  ];
 };
 
 export const useGetTaskRuns = (ns: string) => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/index.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/index.ts
@@ -1,3 +1,4 @@
 export { default as PipelineRunDetailsPage } from './PipelineRunDetailsPage';
 export { default as PipelineRunsResourceList } from './PipelineRunsResourceList';
+export { default as PipelineRunsK8sResourceList } from './PipelineRunsK8sResourceList';
 export { default as PipelineRunsPage } from './PipelineRunsPage';

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunList.tsx
@@ -18,22 +18,32 @@ import './PipelineRunList.scss';
 
 type PipelineRunListProps = {
   namespace: string;
+  loaded?: boolean;
+  data?: PipelineRunKind[];
+  customData?: any;
 };
 
 export const PipelineRunList: React.FC<PipelineRunListProps> = (props) => {
   const { t } = useTranslation();
-  const operatorVersion = usePipelineOperatorVersion(props.namespace);
+  const { namespace, loaded, data, customData } = props;
+  const operatorVersion = usePipelineOperatorVersion(namespace);
   const activePerspective = useActivePerspective()[0];
   const [, setPreferredTab, preferredTabLoaded] = useUserSettings<string>(
     PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY,
     'pipelines',
   );
-  const [taskRuns, taskRunsLoaded] = useGetTaskRuns(props.namespace);
+  const [taskRuns, taskRunsLoaded] = useGetTaskRuns(namespace);
   React.useEffect(() => {
     if (preferredTabLoaded && activePerspective === 'dev') {
       setPreferredTab('pipeline-runs');
     }
   }, [activePerspective, preferredTabLoaded, setPreferredTab]);
+
+  const onRowsRendered = ({ stopIndex }) => {
+    if (loaded && stopIndex === data.length - 1) {
+      customData?.nextPage?.();
+    }
+  };
 
   return (
     <>
@@ -63,6 +73,7 @@ export const PipelineRunList: React.FC<PipelineRunListProps> = (props) => {
           },
         }}
         customData={{ operatorVersion, taskRuns: taskRunsLoaded ? taskRuns : [] }}
+        onRowsRendered={onRowsRendered}
         virtualize
       />
     </>

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunList.tsx
@@ -9,8 +9,8 @@ import { PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY } from '../../../const
 import { PipelineRunModel } from '../../../models';
 import { PipelineRunKind } from '../../../types';
 import { usePipelineOperatorVersion } from '../../pipelines/utils/pipeline-operator';
-import { useTaskRuns } from '../../taskruns/useTaskRuns';
 import { getPipelineRunVulnerabilities } from '../hooks/usePipelineRunVulnerabilities';
+import { useGetTaskRuns } from '../hooks/useTektonResults';
 import PipelineRunHeader from './PipelineRunHeader';
 import PipelineRunRow from './PipelineRunRow';
 
@@ -28,8 +28,7 @@ export const PipelineRunList: React.FC<PipelineRunListProps> = (props) => {
     PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY,
     'pipelines',
   );
-  const [taskRuns, taskRunsLoaded] = useTaskRuns(props.namespace);
-
+  const [taskRuns, taskRunsLoaded] = useGetTaskRuns(props.namespace);
   React.useEffect(() => {
     if (preferredTabLoaded && activePerspective === 'dev') {
       setPreferredTab('pipeline-runs');

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/utils/tekton-results.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/utils/tekton-results.ts
@@ -1,0 +1,348 @@
+import {
+  K8sResourceCommon,
+  K8sResourceKind,
+  MatchExpression,
+  MatchLabels,
+  Selector,
+} from '@console/dynamic-plugin-sdk/src';
+import { k8sGetResource } from '@console/dynamic-plugin-sdk/src/utils/k8s';
+import { RouteModel } from '@console/internal/models';
+import { consoleProxyFetchJSON } from '@console/shared/src/utils/proxy';
+import { TektonResultModel } from '../../../models';
+import { PipelineRunKind, TaskRunKind } from '../../../types';
+
+// REST API spec
+// https://github.com/tektoncd/results/blob/main/docs/api/rest-api-spec.md
+
+// const URL_PREFIX = `/apis/results.tekton.dev/v1alpha2/parents/`;
+
+const MINIMUM_PAGE_SIZE = 5;
+const MAXIMUM_PAGE_SIZE = 10000;
+
+export type Record = {
+  name: string;
+  uid: string;
+  createTime: string;
+  updateTime: string;
+  etag: string;
+  data: {
+    // tekton.dev/v1beta1.PipelineRun | tekton.dev/v1beta1.TaskRun | results.tekton.dev/v1alpha2.Log
+    type: string;
+    value: string;
+  };
+};
+
+export type Log = {
+  result: {
+    name: string;
+    data: string;
+  };
+};
+
+export type RecordsList = {
+  nextPageToken?: string;
+  records: Record[];
+};
+
+export type TektonResultsOptions = {
+  pageSize?: number;
+  selector?: Selector;
+  // limit cannot be used in conjuction with pageSize and takes precedence
+  limit?: number;
+  filter?: string;
+};
+
+// const throw404 = () => {
+//   // eslint-disable-next-line no-throw-literal
+//   throw { code: 404 };
+// };
+
+// decoding result base64
+export const decodeValue = (value: string) => atob(value);
+export const decodeValueJson = (value: string) => (value ? JSON.parse(decodeValue(value)) : null);
+
+// filter functions
+export const AND = (...expressions: string[]) => expressions.filter((x) => x).join(' && ');
+export const OR = (...expressions: string[]) => {
+  const filteredExpressions = expressions.filter((x) => x);
+  const filter = filteredExpressions.join(' || ');
+  return filteredExpressions.length > 1 ? `(${filter})` : filter;
+};
+
+const EXP = (left: string, right: string, operator: string) => `${left} ${operator} ${right}`;
+export const EQ = (left: string, right: string) => EXP(left, `"${right}"`, '==');
+export const NEQ = (left: string, right: string) => EXP(left, `"${right}"`, '!=');
+
+export enum DataType {
+  PipelineRun = 'tekton.dev/v1beta1.PipelineRun',
+  TaskRun = 'tekton.dev/v1beta1.TaskRun',
+  Log = 'results.tekton.dev/v1alpha2.Log',
+}
+
+export const labelsToFilter = (labels?: MatchLabels): string =>
+  labels
+    ? AND(
+        ...Object.keys(labels).map((label) =>
+          EQ(`data.metadata.labels["${label}"]`, labels[label]),
+        ),
+      )
+    : '';
+
+export const nameFilter = (name?: string): string =>
+  name ? AND(`data.metadata.name.startsWith("${name.trim().toLowerCase()}")`) : '';
+
+export const expressionsToFilter = (expressions: Omit<MatchExpression, 'value'>[]): string =>
+  AND(
+    ...expressions
+      .map((expression) => {
+        switch (expression.operator) {
+          case 'Exists':
+            return `data.metadata.labels.contains("${expression.key}")`;
+          case 'DoesNotExist':
+            return `!data.metadata.labels.contains("${expression.key}")`;
+          case 'NotIn':
+            return expression.values?.length > 0
+              ? AND(
+                  ...expression.values.map((value) =>
+                    NEQ(`data.metadata.labels["${expression.key}"]`, value),
+                  ),
+                )
+              : '';
+          case 'In':
+            return expression.values?.length > 0
+              ? `data.metadata.labels["${expression.key}"] in [${expression.values.map(
+                  (value) => `"${value}"`,
+                )}]`
+              : '';
+          case 'Equals':
+            return expression.values?.[0]
+              ? EQ(`data.metadata.labels["${expression.key}"]`, expression.values?.[0])
+              : '';
+          case 'NotEquals':
+          case 'NotEqual':
+            return expression.values?.[0]
+              ? NEQ(`data.metadata.labels["${expression.key}"]`, expression.values?.[0])
+              : '';
+          case 'GreaterThan':
+            return expression.values?.[0]
+              ? EXP(`data.metadata.labels["${expression.key}"]`, expression.values?.[0], '>')
+              : '';
+          case 'LessThan':
+            return expression.values?.[0]
+              ? EXP(`data.metadata.labels["${expression.key}"]`, expression.values?.[0], '<')
+              : '';
+          default:
+            throw new Error(
+              `Tekton results operator '${expression.operator}' conversion not implemented.`,
+            );
+        }
+      })
+      .filter((x) => x),
+  );
+
+export const selectorToFilter = (selector) => {
+  let filter = '';
+  if (selector) {
+    const { matchLabels, matchExpressions, filterByName } = selector;
+
+    if (filterByName) {
+      filter = AND(filter, nameFilter(filterByName as string));
+    }
+
+    if (matchLabels || matchExpressions) {
+      if (matchLabels) {
+        filter = AND(filter, labelsToFilter(matchLabels));
+      }
+      if (matchExpressions) {
+        filter = AND(filter, expressionsToFilter(matchExpressions));
+      }
+    } else {
+      filter = labelsToFilter(selector as MatchLabels);
+    }
+  }
+  return filter;
+};
+
+// Devs should be careful to not cache a response that may not be complete.
+// In most situtations, caching is unnecessary.
+// Only cache a response that returns a single complete record as lists can change over time.
+let CACHE: { [key: string]: [any[], RecordsList] } = {};
+export const clearCache = () => {
+  CACHE = {};
+};
+const InFlightStore: { [key: string]: boolean } = {};
+
+let tektonResultUrl: string;
+
+export const createTektonResultsUrl = async (
+  namespace: string,
+  dataType: DataType,
+  filter?: string,
+  options?: TektonResultsOptions,
+  nextPageToken?: string,
+): Promise<string> => {
+  if (!tektonResultUrl) {
+    const tektonResult: K8sResourceKind = await k8sGetResource({
+      model: TektonResultModel,
+      name: 'result',
+    });
+    const targetNamespace = tektonResult?.spec?.targetNamespace;
+    const route: K8sResourceKind = await k8sGetResource({
+      model: RouteModel,
+      name: 'tekton-results-api-service',
+      ns: targetNamespace,
+    });
+    tektonResultUrl = route?.spec.host;
+    if (!tektonResultUrl) {
+      throw new Error('route.spec.host is undefined');
+    }
+  }
+  const url = `https://${tektonResultUrl}/apis/results.tekton.dev/v1alpha2/parents/${namespace}/results/-/records?${new URLSearchParams(
+    {
+      // default sort should always be by `create_time desc`
+      // order_by: 'create_time desc', not supported yet
+      page_size: `${Math.max(
+        MINIMUM_PAGE_SIZE,
+        Math.min(MAXIMUM_PAGE_SIZE, options?.limit >= 0 ? options.limit : options?.pageSize ?? 50),
+      )}`,
+      ...(nextPageToken ? { page_token: nextPageToken } : {}),
+      filter: AND(
+        EQ('data_type', dataType.toString()),
+        filter,
+        selectorToFilter(options?.selector),
+        options?.filter,
+      ),
+    },
+  ).toString()}`;
+  return url;
+};
+
+export const getFilteredRecord = async <R extends K8sResourceCommon>(
+  namespace: string,
+  dataType: DataType,
+  filter?: string,
+  options?: TektonResultsOptions,
+  nextPageToken?: string,
+  cacheKey?: string,
+): Promise<[R[], RecordsList, boolean?]> => {
+  const url = await createTektonResultsUrl(namespace, dataType, filter, options, nextPageToken);
+
+  if (cacheKey) {
+    const result = CACHE[cacheKey];
+    if (result) {
+      return result;
+    }
+    if (InFlightStore[cacheKey]) {
+      return [
+        [],
+        {
+          nextPageToken: null,
+          records: [],
+        },
+        true,
+      ];
+    }
+  }
+  InFlightStore[cacheKey] = true;
+  const value = await (async (): Promise<[R[], RecordsList]> => {
+    try {
+      let list: RecordsList = await consoleProxyFetchJSON({
+        url,
+        method: 'GET',
+        allowInsecure: true,
+      });
+      if (options?.limit >= 0) {
+        list = {
+          nextPageToken: null,
+          records: list.records.slice(0, options.limit),
+        };
+      }
+      return [list.records.map((result) => decodeValueJson(result.data.value)), list];
+    } catch (e) {
+      // return an empty response if we get a 404 error
+      if (e?.code === 404) {
+        return [
+          [],
+          {
+            nextPageToken: null,
+            records: [],
+          },
+        ] as [R[], RecordsList];
+      }
+      throw e;
+    }
+  })();
+
+  if (cacheKey) {
+    InFlightStore[cacheKey] = false;
+    CACHE[cacheKey] = value;
+  }
+  return value;
+};
+
+const getFilteredPipelineRuns = (
+  namespace: string,
+  filter: string,
+  options?: TektonResultsOptions,
+  nextPageToken?: string,
+  cacheKey?: string,
+) =>
+  getFilteredRecord<PipelineRunKind>(
+    namespace,
+    DataType.PipelineRun,
+    filter,
+    options,
+    nextPageToken,
+    cacheKey,
+  );
+
+const getFilteredTaskRuns = (
+  namespace: string,
+  filter: string,
+  options?: TektonResultsOptions,
+  nextPageToken?: string,
+  cacheKey?: string,
+) =>
+  getFilteredRecord<TaskRunKind>(
+    namespace,
+    DataType.TaskRun,
+    filter,
+    options,
+    nextPageToken,
+    cacheKey,
+  );
+
+export const getPipelineRuns = (
+  namespace: string,
+  options?: TektonResultsOptions,
+  nextPageToken?: string,
+  // supply a cacheKey only if the PipelineRun is complete and response will never change in the future
+  cacheKey?: string,
+) => getFilteredPipelineRuns(namespace, '', options, nextPageToken, cacheKey);
+
+export const getTaskRuns = (
+  namespace: string,
+  options?: TektonResultsOptions,
+  nextPageToken?: string,
+  // supply a cacheKey only if the TaskRun is complete and response will never change in the future
+  cacheKey?: string,
+) => getFilteredTaskRuns(namespace, '', options, nextPageToken, cacheKey);
+
+// const getLog = (taskRunPath: string) =>
+//   consoleProxyFetchJSON({
+//     url: `${getTRUrlPrefix()}/${taskRunPath.replace('/records/', '/logs/')}`,
+//     method: 'GET', allowInsecure: true
+//   });
+
+// export const getTaskRunLog = (namespace: string, taskRunName: string): Promise<string> =>
+//   getFilteredRecord<any>(
+//     namespace,
+//     DataType.Log,
+//     AND(EQ(`data.spec.resource.kind`, 'TaskRun'), EQ(`data.spec.resource.name`, taskRunName)),
+//     { limit: 1 },
+//   ).then((x) =>
+//     x?.[1]?.records.length > 0
+//       ? // eslint-disable-next-line promise/no-nesting
+//         getLog(x?.[1]?.records[0].name).then((response) => decodeValue(response.result.data))
+//       : throw404(),
+//   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineRuns.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineRuns.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
-import { ListPage } from '@console/internal/components/factory';
+// import { ListPage } from '@console/internal/components/factory';
 import { RowFilter } from '@console/internal/components/filter-toolbar';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../../models';
@@ -10,6 +10,8 @@ import {
   pipelineRunStatusFilter,
 } from '../../../utils/pipeline-filter-reducer';
 import { ListFilterId, ListFilterLabels } from '../../../utils/pipeline-utils';
+import { ListPage } from '../../ListPage';
+import { useGetPipelineRuns } from '../../pipelineruns/hooks/useTektonResults';
 import PipelineRunsList from '../../pipelineruns/list-page/PipelineRunList';
 import { PipelineDetailsTabProps } from './types';
 
@@ -32,6 +34,22 @@ export const runFilters = (t: TFunction): RowFilter[] => {
 
 const PipelineRuns: React.FC<PipelineDetailsTabProps> = ({ obj }) => {
   const { t } = useTranslation();
+  const [pipelineRuns, pipelineRunsLoaded, pipelineRunsLoadError] = useGetPipelineRuns(
+    obj.metadata.namespace,
+    { name: obj.metadata.name, kind: obj.kind },
+  );
+
+  const resources = React.useMemo(
+    () => ({
+      [referenceForModel(PipelineRunModel)]: {
+        data: pipelineRuns,
+        kind: referenceForModel(PipelineRunModel),
+        loadError: pipelineRunsLoadError,
+        loaded: pipelineRunsLoaded,
+      },
+    }),
+    [pipelineRunsLoadError, pipelineRunsLoaded, pipelineRuns],
+  );
   return (
     <ListPage
       showTitle={false}
@@ -43,6 +61,7 @@ const PipelineRuns: React.FC<PipelineDetailsTabProps> = ({ obj }) => {
       }}
       ListComponent={PipelineRunsList}
       rowFilters={runFilters(t)}
+      data={resources}
     />
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineRuns.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineRuns.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
-// import { ListPage } from '@console/internal/components/factory';
 import { RowFilter } from '@console/internal/components/filter-toolbar';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../../models';

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/PipelineRuns.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/PipelineRuns.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { ListPage } from '@console/internal/components/factory';
+import { ListPage } from '../../../ListPage';
+import * as tektonResultsHooks from '../../../pipelineruns/hooks/useTektonResults';
 import PipelineRuns from '../PipelineRuns';
 
 const pipelineRunProps: React.ComponentProps<typeof PipelineRuns> = {
@@ -20,6 +21,7 @@ const pipelineRunProps: React.ComponentProps<typeof PipelineRuns> = {
   },
 };
 
+jest.spyOn(tektonResultsHooks, 'useGetPipelineRuns').mockReturnValue([[], true, '']);
 const pipelineRunWrapper = shallow(<PipelineRuns {...pipelineRunProps} />);
 
 describe('Pipeline Run List', () => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineList.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Table } from '@console/internal/components/factory';
 import { PipelineModel } from '../../../models';
 import { PropPipelineData } from '../../../utils/pipeline-augment';
-import { useTaskRuns } from '../../taskruns/useTaskRuns';
+import { useGetTaskRuns } from '../../pipelineruns/hooks/useTektonResults';
 import PipelineHeader from './PipelineHeader';
 import PipelineRow from './PipelineRow';
 
@@ -15,7 +15,7 @@ export interface PipelineListProps {
 
 const PipelineList: React.FC<PipelineListProps> = (props) => {
   const { t } = useTranslation();
-  const [taskRuns, taskRunsLoaded] = useTaskRuns(props.namespace);
+  const [taskRuns, taskRunsLoaded] = useGetTaskRuns(props.namespace);
   return (
     <Table
       {...props}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/__tests__/PipelineAugmentRunsWrapper.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/__tests__/PipelineAugmentRunsWrapper.spec.tsx
@@ -4,6 +4,7 @@ import { ListPageWrapper } from '@console/internal/components/factory';
 import { EmptyBox, LoadingBox } from '@console/internal/components/utils';
 import { useUserSettings } from '@console/shared';
 import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
+import * as tektonResultsHooks from '../../../pipelineruns/hooks/useTektonResults';
 import PipelineAugmentRunsWrapper from '../PipelineAugmentRunsWrapper';
 
 const mockData = pipelineTestData[PipelineExampleNames.WORKSPACE_PIPELINE];
@@ -20,6 +21,8 @@ const mockUserSettings = useUserSettings as jest.Mock;
 describe('Pipeline Augment Run Wrapper', () => {
   let pipelineAugmentRunsWrapperProps: PipelineAugmentRunsWrapperProps;
   let wrapper: ShallowWrapper;
+  jest.spyOn(tektonResultsHooks, 'useGetPipelineRuns').mockReturnValue([[], true, '']);
+
   beforeEach(() => {
     mockUserSettings.mockReturnValue(['pipelines', jest.fn(), true]);
     pipelineAugmentRunsWrapperProps = {

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunListPage.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../models';
+import { ListPage } from '../ListPage';
+import { useGetPipelineRuns } from '../pipelineruns/hooks/useTektonResults';
 import { runFilters } from '../pipelines/detail-page-tabs/PipelineRuns';
-import { RepositoryLabels, RepositoryFields } from './consts';
+import { RepositoryFields, RepositoryLabels } from './consts';
 import RunList from './RepositoryPipelineRunList';
 import { RepositoryKind } from './types';
 
@@ -12,10 +13,24 @@ export interface RepositoryPipelineRunListPageProps {
   obj: RepositoryKind;
 }
 
-const RepositoryPipelineRunListPage: React.FC<RepositoryPipelineRunListPageProps> = ({ obj }) => {
+const RepositoryPipelineRunListPage: React.FC<RepositoryPipelineRunListPageProps> = (props) => {
   const { t } = useTranslation();
+  const { obj } = props;
+  const [pipelineRuns, pipelineRunsLoaded, pipelineRunsLoadError] = useGetPipelineRuns(
+    obj.metadata.namespace,
+    { name: obj.metadata.name, kind: obj.kind },
+  );
+  const resources = {
+    [referenceForModel(PipelineRunModel)]: {
+      data: pipelineRuns,
+      kind: referenceForModel(PipelineRunModel),
+      loadError: pipelineRunsLoadError,
+      loaded: pipelineRunsLoaded,
+    },
+  };
   return (
     <ListPage
+      {...props}
       showTitle={false}
       canCreate={false}
       kind={referenceForModel(PipelineRunModel)}
@@ -25,6 +40,7 @@ const RepositoryPipelineRunListPage: React.FC<RepositoryPipelineRunListPageProps
       }}
       ListComponent={RunList}
       rowFilters={runFilters(t)}
+      data={resources}
     />
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoryRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoryRow.tsx
@@ -10,16 +10,15 @@ import {
   resourcePath,
   Timestamp,
 } from '@console/internal/components/utils';
-import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { referenceFor, referenceForModel } from '@console/internal/module/k8s';
 import { getLatestRun } from '@console/pipelines-plugin/src/utils/pipeline-augment';
 import { PipelineRunModel, RepositoryModel } from '../../../models';
-import { PipelineRunKind } from '../../../types';
 import {
   pipelineRunFilterReducer,
   pipelineRunTitleFilterReducer,
 } from '../../../utils/pipeline-filter-reducer';
 import { pipelineRunDuration } from '../../../utils/pipeline-utils';
+import { useGetPipelineRuns } from '../../pipelineruns/hooks/useTektonResults';
 import LinkedPipelineRunTaskStatus from '../../pipelineruns/status/LinkedPipelineRunTaskStatus';
 import PipelineRunStatus from '../../pipelineruns/status/PipelineRunStatus';
 import { getTaskRunsOfPipelineRun } from '../../taskruns/useTaskRuns';
@@ -33,14 +32,9 @@ const RepositoryRow: React.FC<RowFunctionArgs<RepositoryKind>> = ({ obj, customD
   } = obj;
   const { taskRuns } = customData;
 
-  const [pipelineRun, loaded] = useK8sWatchResource<PipelineRunKind[]>({
-    kind: referenceForModel(PipelineRunModel),
-    namespace,
-    isList: true,
-    selector: { matchLabels: { [RepositoryLabels[RepositoryFields.REPOSITORY]]: name } },
-  });
+  const [pipelineRuns, loaded] = useGetPipelineRuns(namespace, { name, kind: obj.kind });
 
-  const latestRun = loaded && getLatestRun(pipelineRun, 'creationTimestamp');
+  const latestRun = loaded && getLatestRun(pipelineRuns, 'creationTimestamp');
 
   const latestPLREventType =
     latestRun && latestRun?.metadata?.labels[RepositoryLabels[RepositoryFields.EVENT_TYPE]];

--- a/frontend/packages/pipelines-plugin/src/components/repository/list-page/ReppositoryList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/list-page/ReppositoryList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Table } from '@console/internal/components/factory';
 import { RepositoryModel } from '../../../models';
-import { useTaskRuns } from '../../taskruns/useTaskRuns';
+import { useGetTaskRuns } from '../../pipelineruns/hooks/useTektonResults';
 import { RepositoryKind } from '../types';
 import RepositoryHeader from './RepositoryHeader';
 import RepositoryRow from './RepositoryRow';
@@ -12,7 +12,7 @@ export interface RepositoryListProps {
 }
 
 const RepositoryList: React.FC<RepositoryListProps> = (props) => {
-  const [taskRuns, taskRunsLoaded] = useTaskRuns(props.namespace);
+  const [taskRuns, taskRunsLoaded] = useGetTaskRuns(props.namespace);
 
   return (
     <Table

--- a/frontend/packages/pipelines-plugin/src/models/pipelines.ts
+++ b/frontend/packages/pipelines-plugin/src/models/pipelines.ts
@@ -324,3 +324,20 @@ export const TektonHubModel: K8sKind = {
   labelPlural: 'TektonHubs',
   crd: true,
 };
+
+export const TektonResultModel: K8sKind = {
+  apiGroup: 'operator.tekton.dev',
+  apiVersion: 'v1alpha1',
+  label: 'TektonResult',
+  // t('pipelines-plugin~TektonResult')
+  labelKey: 'pipelines-plugin~TektonResult',
+  // t('pipelines-plugin~TektonResults')
+  labelPluralKey: 'pipelines-plugin~TektonResults',
+  plural: 'tektonresults',
+  abbr: 'TR',
+  namespaced: false,
+  kind: 'TektonResult',
+  id: 'tektonresult',
+  labelPlural: 'TektonResults',
+  crd: true,
+};

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
@@ -20,7 +20,7 @@ import { getTaskRunsOfPipelineRun } from '../components/taskruns/useTaskRuns';
 import { EventListenerModel, PipelineModel, PipelineRunModel, TaskRunModel } from '../models';
 import { PipelineKind, PipelineRunKind, TaskRunKind } from '../types';
 import { shouldHidePipelineRunStop, shouldHidePipelineRunCancel } from './pipeline-augment';
-import { getSbomTaskRun } from './pipeline-utils';
+import { getSbomTaskRun, returnValidPipelineRunModel } from './pipeline-utils';
 
 export const handlePipelineRunSubmit = (pipelineRun: PipelineRunKind) => {
   history.push(
@@ -48,7 +48,7 @@ export const reRunPipelineRun: KebabAction = (kind: K8sKind, pipelineRun: Pipeli
     const namespace = _.get(pipelineRun, 'metadata.namespace');
     const { pipelineRef, pipelineSpec } = pipelineRun.spec;
     if (namespace && (pipelineRef?.name || pipelineSpec)) {
-      k8sCreate(PipelineRunModel, getPipelineRunData(null, pipelineRun));
+      k8sCreate(returnValidPipelineRunModel(pipelineRun), getPipelineRunData(null, pipelineRun));
     } else {
       errorModal({
         error: i18n.t(

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -253,6 +253,7 @@ const VirtualBody: React.FC<VirtualBodyProps> = (props) => {
     scrollTop,
     width,
     getRowProps,
+    onRowsRendered,
   } = props;
 
   const cellMeasurementCache = new CellMeasurerCache({
@@ -306,6 +307,7 @@ const VirtualBody: React.FC<VirtualBodyProps> = (props) => {
       rowRenderer={rowRenderer}
       scrollTop={scrollTop}
       width={width}
+      onRowsRendered={onRowsRendered}
     />
   );
 };
@@ -328,6 +330,12 @@ export type VirtualBodyProps<D = any, C = any> = {
   width: number;
   expand: boolean;
   getRowProps?: (obj: D) => Partial<Pick<TableRowProps, 'id' | 'className' | 'title'>>;
+  onRowsRendered?: (params: {
+    overscanStartIndex: number;
+    overscanStopIndex: number;
+    startIndex: number;
+    stopIndex: number;
+  }) => void;
 };
 
 type HeaderFunc = (componentProps: ComponentProps) => any[];
@@ -418,6 +426,7 @@ export const Table: React.FC<TableProps> = ({
   isPinned,
   defaultSortField,
   getRowProps,
+  onRowsRendered,
 }) => {
   const filters = useDeepCompareMemoize(initFilters);
   const Header = useDeepCompareMemoize(initHeader);
@@ -553,6 +562,7 @@ export const Table: React.FC<TableProps> = ({
                 width={width}
                 expand={expand}
                 getRowProps={getRowProps}
+                onRowsRendered={onRowsRendered}
               />
             </div>
           )}
@@ -657,6 +667,7 @@ export type TableProps<D = any, C = any> = Partial<ComponentProps<D>> & {
   expand?: boolean;
   scrollElement?: HTMLElement | (() => HTMLElement);
   getRowProps?: VirtualBodyProps<D>['getRowProps'];
+  onRowsRendered?: VirtualBodyProps<D>['onRowsRendered'];
 };
 
 export type ComponentProps<D = any> = {


### PR DESCRIPTION
Story: [ODC-7395](https://issues.redhat.com/browse/ODC-7395), [ODC-7382](https://issues.redhat.com/browse/ODC-7382)

Descriptions:
- Add support to fetch PipelineRuns using the TektonResults API endpoint in the PipelineRun list page, PipelineRuns list on the Pipeline and Repository details page, and on the Pipeline and Repository list to show the PipelineRun data.

Test setup:
- Install Red Hat Openshift Pipeline Operator in the console
- Install Tekton Results in the console using this gist https://gist.github.com/vikram-raj/257d672a38eb2159b0368eaed8f8970a
- Create Pipeline and PipelineRuns and try out all the features.