### PR TITLE
ODC-7383: add support for tektonresult api to load TaskRuns

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
@@ -1,0 +1,181 @@
+import * as React from 'react';
+import differenceBy from 'lodash-es/differenceBy';
+import uniqBy from 'lodash-es/uniqBy';
+import { Selector } from '@console/dynamic-plugin-sdk/src';
+import {
+  K8sGroupVersionKind,
+  K8sResourceCommon,
+} from '@console/dynamic-plugin-sdk/src/extensions/console-types';
+import { useDeepCompareMemoize } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useDeepCompareMemoize';
+import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource';
+import {
+  PipelineRunGroupVersionKind,
+  PipelineRunKind,
+  TaskRunGroupVersionKind,
+  TaskRunKind,
+} from '../../../types';
+import { EQ } from '../utils/tekton-results';
+import { GetNextPage, useTRPipelineRuns, useTRTaskRuns } from './useTektonResults';
+
+const useRuns = <Kind extends K8sResourceCommon>(
+  groupVersionKind: K8sGroupVersionKind,
+  namespace: string,
+  options?: {
+    selector?: Selector;
+    limit?: number;
+    name?: string;
+  },
+): [Kind[], boolean, unknown, GetNextPage] => {
+  const etcdRunsRef = React.useRef<Kind[]>([]);
+  const optionsMemo = useDeepCompareMemoize(options);
+  const isList = !optionsMemo?.name;
+  const limit = optionsMemo?.limit;
+  // do not include the limit when querying etcd because result order is not sorted
+  const watchOptions = React.useMemo(() => {
+    // reset cached runs as the options have changed
+    etcdRunsRef.current = [];
+    return namespace
+      ? {
+          groupVersionKind,
+          namespace,
+          isList,
+          selector: optionsMemo?.selector,
+          name: optionsMemo?.name,
+        }
+      : null;
+  }, [groupVersionKind, namespace, optionsMemo, isList]);
+
+  const [resources, loaded, error] = useK8sWatchResource(watchOptions);
+
+  // if a pipeline run was removed from etcd, we want to still include it in the return value without re-querying tekton-results
+  const etcdRuns = React.useMemo(() => {
+    if (!loaded || error) {
+      return [];
+    }
+    const resourcesArray = (isList ? resources : [resources]) as Kind[];
+
+    return resourcesArray;
+  }, [isList, resources, loaded, error]);
+
+  const runs = React.useMemo(() => {
+    if (!etcdRuns) {
+      return etcdRuns;
+    }
+    let value = etcdRunsRef.current
+      ? [
+          ...etcdRuns,
+          // identify the runs that were removed
+          ...differenceBy(etcdRunsRef.current, etcdRuns, (plr) => plr.metadata.name),
+        ]
+      : [...etcdRuns];
+    value.sort((a, b) => b.metadata.creationTimestamp.localeCompare(a.metadata.creationTimestamp));
+    if (limit && limit < value.length) {
+      value = value.slice(0, limit);
+    }
+    return value;
+  }, [etcdRuns, limit]);
+
+  // cache the last set to identify removed runs
+  etcdRunsRef.current = runs;
+
+  // Query tekton results if there's no limit or we received less items from etcd than the current limit
+  const queryTr =
+    !limit || (namespace && ((runs && loaded && optionsMemo.limit > runs.length) || error));
+
+  const trOptions: typeof optionsMemo = React.useMemo(() => {
+    if (optionsMemo?.name) {
+      const { name, ...rest } = optionsMemo;
+      return {
+        ...rest,
+        filter: EQ('data.metadata.name', name),
+      };
+    }
+    return optionsMemo;
+  }, [optionsMemo]);
+
+  // tekton-results includes items in etcd, therefore options must use the same limit
+  // these duplicates will later be de-duped
+  const [trResources, trLoaded, trError, trGetNextPage] = (groupVersionKind ===
+    PipelineRunGroupVersionKind
+    ? useTRPipelineRuns
+    : useTRTaskRuns)(queryTr ? namespace : null, trOptions) as [[], boolean, unknown, GetNextPage];
+
+  return React.useMemo(() => {
+    const rResources =
+      runs && trResources
+        ? uniqBy([...runs, ...trResources], (r) => r.metadata.name)
+        : runs || trResources;
+
+    return [
+      rResources,
+      namespace ? !!rResources?.[0] : false,
+      namespace
+        ? queryTr
+          ? isList
+            ? trError || error
+            : // when searching by name, return an error if we have no result
+              trError || (trLoaded && !trResources.length ? error : undefined)
+          : error
+        : undefined,
+      trGetNextPage,
+    ];
+  }, [error, trResources, trLoaded, trError, trGetNextPage, namespace, isList, queryTr, runs]);
+};
+
+export const usePipelineRuns = (
+  namespace: string,
+  options?: {
+    selector?: Selector;
+    limit?: number;
+  },
+): [PipelineRunKind[], boolean, unknown, GetNextPage] =>
+  useRuns<PipelineRunKind>(PipelineRunGroupVersionKind, namespace, options);
+
+export const useTaskRuns = (
+  namespace: string,
+  options?: {
+    selector?: Selector;
+    limit?: number;
+  },
+): [TaskRunKind[], boolean, unknown, GetNextPage] =>
+  useRuns<TaskRunKind>(TaskRunGroupVersionKind, namespace, options);
+
+export const usePipelineRun = (
+  namespace: string,
+  pipelineRunName: string,
+): [PipelineRunKind, boolean, string] => {
+  const result = (usePipelineRuns(
+    namespace,
+    React.useMemo(
+      () => ({
+        name: pipelineRunName,
+        limit: 1,
+      }),
+      [pipelineRunName],
+    ),
+  ) as unknown) as [PipelineRunKind[], boolean, string];
+
+  return React.useMemo(() => [result[0]?.[0], result[1], result[0]?.[0] ? undefined : result[2]], [
+    result,
+  ]);
+};
+
+export const useTaskRun = (
+  namespace: string,
+  taskRunName: string,
+): [TaskRunKind, boolean, string] => {
+  const result = (useTaskRuns(
+    namespace,
+    React.useMemo(
+      () => ({
+        name: taskRunName,
+        limit: 1,
+      }),
+      [taskRunName],
+    ),
+  ) as unknown) as [TaskRunKind[], boolean, string];
+
+  return React.useMemo(() => [result[0]?.[0], result[1], result[0]?.[0] ? undefined : result[2]], [
+    result,
+  ]);
+};

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTaskRuns.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTaskRuns.ts
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { Selector } from '@console/dynamic-plugin-sdk/src';
+import { TaskRunKind } from '../../../types';
+import { TektonResourceLabel } from '../../pipelines/const';
+import { useTaskRuns as useTaskRuns2 } from './usePipelineRuns';
+import { GetNextPage } from './useTektonResults';
+
+export const useTaskRuns = (
+  namespace: string,
+  pipelineRunName?: string,
+  taskName?: string,
+): [TaskRunKind[], boolean, unknown, GetNextPage] => {
+  const selector: Selector = React.useMemo(() => {
+    if (pipelineRunName) {
+      return { matchLabels: { [TektonResourceLabel.pipelinerun]: pipelineRunName } };
+    }
+    if (taskName) {
+      return { matchLabels: { [TektonResourceLabel.pipelineTask]: taskName } };
+    }
+    return undefined;
+  }, [taskName, pipelineRunName]);
+  const [taskRuns, loaded, error, getNextPage] = useTaskRuns2(
+    namespace,
+    selector && {
+      selector,
+    },
+  );
+
+  const sortedTaskRuns = React.useMemo(
+    () =>
+      taskRuns?.sort((a, b) => {
+        if (a?.status?.completionTime) {
+          return b?.status?.completionTime &&
+            new Date(a?.status?.completionTime) > new Date(b?.status?.completionTime)
+            ? 1
+            : -1;
+        }
+        return b?.status?.startTime ||
+          new Date(a?.status?.startTime) > new Date(b?.status?.startTime)
+          ? 1
+          : -1;
+      }),
+    [taskRuns],
+  );
+  return React.useMemo(() => [sortedTaskRuns, loaded, error, getNextPage], [
+    sortedTaskRuns,
+    loaded,
+    error,
+    getNextPage,
+  ]);
+};

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
@@ -5,6 +5,7 @@ import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/h
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../../models';
 import { PipelineRunKind, TaskRunKind } from '../../../types';
+import { TektonResourceLabel } from '../../pipelines/const';
 import { RepositoryFields, RepositoryLabels } from '../../repository/consts';
 import { useTaskRuns } from '../../taskruns/useTaskRuns';
 import {
@@ -147,14 +148,40 @@ export const useGetPipelineRuns = (ns: string, options?: { name: string; kind: s
   ];
 };
 
-export const useGetTaskRuns = (ns: string) => {
-  const [taskRuns, taskRunsLoaded] = useTaskRuns(ns);
-  const [resultTaskRuns, resultTaskRunsLoaded] = useTRTaskRuns(ns);
+export const useGetTaskRuns = (
+  ns: string,
+  pipelineRunName?: string,
+): [TaskRunKind[], boolean, unknown, GetNextPage] => {
+  let selector: Selector;
+  if (pipelineRunName) {
+    selector = {
+      matchLabels: {
+        [TektonResourceLabel.pipelinerun]: pipelineRunName,
+      },
+    };
+  }
+  const [k8sTaskRuns, k8sTaskRunsLoaded, k8sTaskRunsLoadError] = useTaskRuns(ns, pipelineRunName);
+  const [
+    resultTaskRuns,
+    resultTaskRunsLoaded,
+    resultTaskRunsLoadError,
+    getNextPage,
+  ] = useTRTaskRuns(
+    ns,
+    pipelineRunName && {
+      selector,
+    },
+  );
   const mergedTaskRuns =
-    resultTaskRunsLoaded || taskRunsLoaded
-      ? uniqBy([...taskRuns, ...resultTaskRuns], (r) => r.metadata.name)
+    resultTaskRunsLoaded || k8sTaskRunsLoaded
+      ? uniqBy([...k8sTaskRuns, ...resultTaskRuns], (r) => r.metadata.name)
       : [];
-  return [mergedTaskRuns, resultTaskRunsLoaded || taskRunsLoaded];
+  return [
+    mergedTaskRuns,
+    resultTaskRunsLoaded || k8sTaskRunsLoaded,
+    k8sTaskRunsLoadError || resultTaskRunsLoadError,
+    getNextPage,
+  ];
 };
 
 // export const useTRTaskRunLog = (

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsList.tsx
@@ -5,12 +5,15 @@ import { ColumnLayout } from '@console/dynamic-plugin-sdk';
 import { Table } from '@console/internal/components/factory';
 import { useActiveColumns } from '@console/internal/components/factory/Table/active-columns-hook';
 import { TaskRunModel } from '../../../models';
+import { TaskRunKind } from '../../../types';
 import TaskRunsHeader from './TaskRunsHeader';
 import TaskRunsRow from './TaskRunsRow';
 
 interface TaskRunsListProps {
   customData?: { [key: string]: any };
   columnLayout: ColumnLayout;
+  loaded?: boolean;
+  data?: TaskRunKind[];
 }
 
 const TaskRunsList: React.FC<TaskRunsListProps> = (props) => {
@@ -18,6 +21,8 @@ const TaskRunsList: React.FC<TaskRunsListProps> = (props) => {
   const {
     columnLayout: { columns, id },
     customData,
+    data,
+    loaded,
   } = props;
   const [activeColumns, userSettingsLoaded] = useActiveColumns({
     columns,
@@ -27,6 +32,11 @@ const TaskRunsList: React.FC<TaskRunsListProps> = (props) => {
     activeColumns,
   ]);
   const newCustomData = { ...customData, selectedColumns };
+  const onRowsRendered = ({ stopIndex }) => {
+    if (loaded && stopIndex === data.length - 1) {
+      customData?.nextPage?.();
+    }
+  };
   return (
     userSettingsLoaded && (
       <Table
@@ -39,6 +49,7 @@ const TaskRunsList: React.FC<TaskRunsListProps> = (props) => {
         virtualize
         activeColumns={selectedColumns}
         customData={newCustomData}
+        onRowsRendered={onRowsRendered}
       />
     )
   );

--- a/frontend/packages/pipelines-plugin/src/types/pipelineRun.ts
+++ b/frontend/packages/pipelines-plugin/src/types/pipelineRun.ts
@@ -1,4 +1,8 @@
-import { K8sResourceCommon, ObjectMetadata } from '@console/internal/module/k8s';
+import {
+  K8sGroupVersionKind,
+  K8sResourceCommon,
+  ObjectMetadata,
+} from '@console/internal/module/k8s';
 import { TektonResultsRun, TektonTaskSpec } from './coreTekton';
 import { PipelineKind, PipelineSpec } from './pipeline';
 
@@ -163,4 +167,10 @@ export type PipelineRunKind = K8sResourceCommon & {
 
 export type PipelineWithLatest = PipelineKind & {
   latestRun?: PipelineRunKind;
+};
+
+export const PipelineRunGroupVersionKind: K8sGroupVersionKind = {
+  group: 'tekton.dev',
+  version: 'v1',
+  kind: 'PipelineRun',
 };

--- a/frontend/packages/pipelines-plugin/src/types/taskRun.ts
+++ b/frontend/packages/pipelines-plugin/src/types/taskRun.ts
@@ -1,4 +1,8 @@
-import { K8sResourceCommon, PersistentVolumeClaimKind } from '@console/internal/module/k8s';
+import {
+  K8sGroupVersionKind,
+  K8sResourceCommon,
+  PersistentVolumeClaimKind,
+} from '@console/internal/module/k8s';
 import { TektonResource, TektonResultsRun, TektonTaskSpec } from './coreTekton';
 import { PipelineTaskParam, PipelineTaskRef } from './pipeline';
 import {
@@ -40,4 +44,10 @@ export type TaskRunKind = K8sResourceCommon & {
     workspaces?: TaskRunWorkspace[];
   };
   status?: TaskRunStatus;
+};
+
+export const TaskRunGroupVersionKind: K8sGroupVersionKind = {
+  group: 'tekton.dev',
+  version: 'v1',
+  kind: 'TaskRun',
 };


### PR DESCRIPTION
Story: https://issues.redhat.com/browse/ODC-7383

Descriptions:

Add support to fetch TaskRuns using the TektonResults API endpoint in the TaskRun list page, TaskRuns list on the PipelineRun details page.


Test setup:
1. Install Red Hat Openshift Pipeline Operator in the console
2. Install Tekton Results in the console using this gist https://gist.github.com/vikram-raj/257d672a38eb2159b0368eaed8f8970a
3. Create Pipeline and PipelineRuns and try out all the features.
