### PR TITLE
OCPBUGS-22853: Keep useActiveNamespace hook in the internal api

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
@@ -21,6 +21,7 @@ import {
   UseURLPoll,
   UseLastNamespace,
 } from './internal-types';
+import { UseActiveNamespace } from '../extensions'
 
 export const ActivityItem: React.FC<ActivityItemProps> = require('@console/shared/src/components/dashboard/activity-card/ActivityItem')
   .default;
@@ -57,6 +58,9 @@ export const QuickStartsLoader: React.FC<QuickStartsLoaderProps> = require('@con
 
 export const useUtilizationDuration: UseUtilizationDuration = require('@console/shared/src/hooks/useUtilizationDuration')
   .useUtilizationDuration;
+// useActiveNamespace is deprecated and is now exposed as shared hook.
+export const useActiveNamespace: UseActiveNamespace = require('@console/shared/src/hooks/useActiveNamespace')
+  .useActiveNamespace;
 export const ServicesList = require('@console/internal/components/service').ServicesList;
 export const useDashboardResources: UseDashboardResources = require('@console/shared/src/hooks/useDashboardResources')
   .useDashboardResources;


### PR DESCRIPTION
This change is to avoid a API breaking change.
KubeVirt plugin needed to do [following changes](https://github.com/kubevirt-ui/kubevirt-plugin/pull/1489) in order to get rid of[ the error](https://issues.redhat.com/browse/OCPBUGS-22853).

Since this was introduced in 4.14 we should be probably backporting this issue.

/assign @sg00dwin @vojtechszocs 