### PR TITLE
OCPBUGS-19426: Edit the secret and add the Chinese in the web-console, garbled characters will be displayed

### DIFF
--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -157,7 +157,7 @@ export const SecretFormWrapper: React.FC<BaseEditSecretProps_> = (props) => {
   const [error, setError] = React.useState();
   const [stringData, setStringData] = React.useState(
     _.mapValues(_.get(props.obj, 'data'), (value) => {
-      return value ? Base64.atob(value) : '';
+      return value ? Base64.decode(value) : '';
     }),
   );
   const [base64StringData, setBase64StringData] = React.useState({});
@@ -186,7 +186,7 @@ export const SecretFormWrapper: React.FC<BaseEditSecretProps_> = (props) => {
     setInProgress(true);
     const data = {
       ..._.mapValues(stringData, (value) => {
-        return Base64.btoa(value);
+        return Base64.encode(value);
       }),
       ...base64StringData,
     };
@@ -1109,7 +1109,7 @@ class GenericSecretFormWithTranslation extends React.Component<
         uid: _.uniqueId(),
         entry: {
           key,
-          value: isBinary ? Base64.btoa(value) : value,
+          value: isBinary ? Base64.encode(value) : value,
           isBase64: isBinary,
           isBinary,
         },


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-19426

**Analysis / Root cause**: 
Edit the secret and add the Chinese in the web-console, garbled characters will be displayed

**Solution Description**: 
Reverted the change made in https://github.com/openshift/console/pull/11890
Also verified the revert does not break the fix proposed by the previous PR.


**Screen shots / Gifs for design review**: 

https://github.com/openshift/console/assets/47265560/171d3c07-9e21-47a5-b04f-630535b061e4



**Unit test coverage report**: 
Not Changed

**Test setup:**
1. Login to the web-console and change to the Developer role.
2. Secret --> Create --> Key/Value secret 
3. Add the Chinese to the Value, then save.
4. Edit the Value again and the Chinese garbled characters .



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge