### PR TITLE
ODC-7425: Add serverless function icon in Add page group header

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md
@@ -1334,6 +1334,7 @@ This extension allows plugins to contibute a group in the add page of developer 
 | `name` | `string` | no | The title of the action group |
 | `insertBefore` | `string` | yes | ID of action group before which this group should be placed |
 | `insertAfter` | `string` | yes | ID of action group after which this group should be placed |
+| `icon` | `string \| CodeRef<React.ReactNode>` | yes | The perspective display icon. |
 
 ---
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/add-actions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/add-actions.ts
@@ -41,6 +41,8 @@ export type AddActionGroup = ExtensionDeclaration<
     insertBefore?: string;
     /** ID of action group after which this group should be placed */
     insertAfter?: string;
+    /** The perspective display icon. */
+    icon?: CodeRef<React.ReactNode> | string;
   }
 >;
 

--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -276,7 +276,7 @@
       "name": "%devconsole~Serverless function%",
       "insertAfter": "eventing",
       "insertBefore": "git-repository",
-      "icon": { "$codeRef": "icons.serverlessFunctionSVG" }
+      "icon": "icon-serverless-function"
     }
   },
   {

--- a/frontend/packages/dev-console/src/components/add/AddCard.scss
+++ b/frontend/packages/dev-console/src/components/add/AddCard.scss
@@ -6,6 +6,19 @@
   &__title {
     margin: var(--pf-global--spacer--lg) 0px 0px var(--pf-global--spacer--lg);
   }
+
+  &__icon {
+    max-width: var(--pf-global--spacer--lg);
+    min-width: var(--pf-global--spacer--md);
+    color: var(--pf-global--Color--100) !important;
+    // temporary fix since --pf-global--FontSize--md is being computed to 14px instead of 16px
+    font-size: var(--pf-global--FontSize--md);
+    margin-right: var(--pf-global--spacer--sm);
+  }
+
+  &__img-icon {
+    vertical-align: -0.3em;
+  }
 }
 
 .pf-c-simple-list ul {

--- a/frontend/packages/dev-console/src/components/add/AddCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/AddCard.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { Card, SimpleList, Title } from '@patternfly/react-core';
 import { ResolvedExtension, AddAction } from '@console/dynamic-plugin-sdk';
+import { CodeRef } from '@console/dynamic-plugin-sdk/src/types';
+import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
+import { isValidUrl } from '@console/shared';
 import AddCardItem from './AddCardItem';
 import './AddCard.scss';
 
@@ -9,14 +12,36 @@ type AddCardProps = {
   title: string;
   items: ResolvedExtension<AddAction>[];
   namespace: string;
+  icon?: CodeRef<React.ReactNode> | string;
 };
 
-const AddCard: React.FC<AddCardProps> = ({ id, title, items, namespace }) => {
+const AddCard: React.FC<AddCardProps> = ({ id, title, items, namespace, icon }) => {
   const isTitleFromItem: boolean = items?.length === 1 && items[0].properties.label === title;
+  const actionIcon = (): JSX.Element => {
+    if (typeof icon === 'string') {
+      return (
+        <img
+          className="odc-add-card__icon odc-add-card__img-icon"
+          src={isValidUrl(icon) ? icon : getImageForIconClass(icon)}
+          aria-hidden="true"
+          alt={title}
+        />
+      );
+    }
+    if (typeof icon !== 'string' && React.isValidElement(icon)) {
+      return (
+        <span className="odc-add-card__icon" aria-hidden="true">
+          {icon}
+        </span>
+      );
+    }
+    return null;
+  };
   return items?.length > 0 ? (
     <Card key={title} className="odc-add-card" data-test={`card ${id}`}>
       {!isTitleFromItem && (
         <Title size="lg" headingLevel="h2" className="odc-add-card__title" data-test="title">
+          {actionIcon()}
           {title}
         </Title>
       )}

--- a/frontend/packages/dev-console/src/components/add/AddCardSection.tsx
+++ b/frontend/packages/dev-console/src/components/add/AddCardSection.tsx
@@ -41,8 +41,8 @@ const AddCardSection: React.FC<AddCardSectionProps> = ({
 
     const addGroups: AddGroup[] = getAddGroups(addActionExtensions, sortedActionGroup);
 
-    return addGroups.map(({ id, name, items }) => (
-      <AddCard key={id} id={id} title={name} items={items} namespace={namespace} />
+    return addGroups.map(({ id, name, items, icon }) => (
+      <AddCard key={id} id={id} title={name} items={items} namespace={namespace} icon={icon} />
     ));
   };
 

--- a/frontend/packages/dev-console/src/components/types.ts
+++ b/frontend/packages/dev-console/src/components/types.ts
@@ -1,7 +1,9 @@
 import { AddAction, ResolvedExtension } from '@console/dynamic-plugin-sdk';
+import { CodeRef } from '@console/dynamic-plugin-sdk/src/types';
 
 export type AddGroup = {
   id: string;
   name: string;
   items: ResolvedExtension<AddAction>[];
+  icon?: CodeRef<React.ReactNode> | string;
 };


### PR DESCRIPTION
**Story**: https://issues.redhat.com/browse/ODC-7425

**Screenshots:** 

<img width="1728" alt="Screenshot 2023-11-17 at 11 27 18 AM" src="https://github.com/openshift/console/assets/102503482/77885194-f8ff-42a4-9fa5-86423f9324c1">
<img width="1725" alt="Screenshot 2023-11-17 at 11 26 53 AM" src="https://github.com/openshift/console/assets/102503482/c6f156b9-e3e3-4892-8de2-d6d0687516bd">
