### PR TITLE
OU-286: add test-id to panel charts to ease e2e tests when titles change

### DIFF
--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -644,6 +644,7 @@ const Card: React.FC<CardProps> = React.memo(({ panel }) => {
         data-test={`${panel.title.toLowerCase().replace(/\s+/g, '-')}-chart`}
         isClickable
         isSelectable
+        data-test-id={panel.id ? `chart-${panel.id}` : undefined}
       >
         <CardHeader
           actions={{


### PR DESCRIPTION
This PR adds a test id to the dashboards panels so testing can assert using ids instead of dashboards titles as they might change.