### PR TITLE
OCPBUGS-23164: Cannot Edit Shipwright Build

### DIFF
--- a/frontend/packages/shipwright-plugin/src/components/build-details/BuildDetailsPage.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/build-details/BuildDetailsPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
-import { Page, navFactory, viewYamlComponent } from '@console/internal/components/utils';
+import { Page, navFactory } from '@console/internal/components/utils';
 import { referenceFor } from '@console/internal/module/k8s';
 import {
   ActionMenu,
@@ -28,7 +28,7 @@ const BuildDetailsPage: React.FC<DetailsPageProps> = (props) => {
 
   const pages: Page[] = [
     navFactory.details(BuildDetailsTab),
-    navFactory.editYaml(viewYamlComponent),
+    navFactory.editYaml(),
     {
       href: 'buildruns',
       // t('shipwright-plugin~BuildRuns')

--- a/frontend/packages/shipwright-plugin/src/components/buildrun-details/BuildRunDetailsPage.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/buildrun-details/BuildRunDetailsPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
-import { Page, navFactory, viewYamlComponent } from '@console/internal/components/utils';
+import { Page, navFactory } from '@console/internal/components/utils';
 import { referenceFor } from '@console/internal/module/k8s';
 import {
   ActionMenu,
@@ -29,7 +29,7 @@ const BuildRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
 
   const pages: Page[] = [
     navFactory.details(BuildRunDetailsTab),
-    navFactory.editYaml(viewYamlComponent),
+    navFactory.editYaml(),
     navFactory.logs(BuildRunLogsTab),
     navFactory.events(BuildRunEventsTab),
   ];


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-23164

**Analysis / Root cause**: 
Cannot Edit Shipwright Build/BuildRun by clicking the "Edit Build/BuildRun" from the Actions Menu.

**Solution Description**: 
Updated the setting to allow the respective resources to be edited in the YAML editor.

**Screen shots / Gifs for design review**: 

https://github.com/openshift/console/assets/47265560/65817b01-42c3-4b24-a6b6-479022123d21



**Unit test coverage report**: 
Not changed.

**Test setup:**
1. Create a SW Build
2. Click the "Edit Build" from the Actions Menu.



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge