### PR TITLE
OCPBUGS-23388: Pipeline Name gets changed to "new-pipeline" on the Edit Pipeline YAML/Builder

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/utils.ts
@@ -348,7 +348,7 @@ export const convertBuilderFormToPipeline = (
     kind: PipelineModel.kind,
     metadata: {
       ...existingPipeline?.metadata,
-      name,
+      name: existingPipeline?.metadata?.name ? existingPipeline?.metadata?.name : name,
       namespace,
     },
     spec: {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-23388

**Analysis / Root cause**: 
On edit pipeline, in yaml editor, existing pipeline name was not considered

**Solution Description**: 
Updated edit pipeline to not not change name while edit in YAML editor

**Screen shots / Gifs for design review**: 
----BEFORE---

https://drive.google.com/file/d/19-dI8lSdH6tAZm3T8CQHw78P2AzdSIRv/view?usp=sharing



----AFTER----

https://github.com/openshift/console/assets/102503482/b7433e96-5546-43f4-8af7-6ec389c738c3





**Unit test coverage report**: 
NA

**Test setup:**
1. Create Task 1: https://tekton.dev/docs/getting-started/tasks/#create-and-run-a-basic-task
2. Create Task 2: https://tekton.dev/docs/getting-started/pipelines/#create-and-run-a-second-task
3. Create Pipeline: https://tekton.dev/docs/getting-started/pipelines/#create-and-run-a-pipeline
4. Click "Edit Pipeline" from the Actions Menu 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge