### PR TITLE
OCPBUGS-22778: Fix for yaml editor that crashes with MCE and ACM plugins enabled

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/CodeEditor.tsx
+++ b/frontend/packages/console-shared/src/components/editor/CodeEditor.tsx
@@ -37,7 +37,7 @@ const CodeEditor = React.forwardRef<MonacoEditor, CodeEditorProps>((props, ref) 
         default:
           break;
       }
-      monaco.editor.getModels()[0].updateOptions({ tabSize: 2 });
+      monaco.editor.getModels()[0]?.updateOptions({ tabSize: 2 });
       onSave && editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S, onSave); // eslint-disable-line no-bitwise
     },
     [onSave, usesValue],


### PR DESCRIPTION
TypeError
`Cannot read properties of undefined (reading 'updateOptions')`

![yaml-bug-fix2](https://github.com/openshift/console/assets/1874151/c076322d-2be8-45b5-9a2a-808f2c5750f5)
