### PR TITLE
OCPBUGS-20016: account for `useK8sWatchResource` returning `{}` like it does f…

### DIFF
--- a/frontend/public/components/modals/labels-modal.tsx
+++ b/frontend/public/components/modals/labels-modal.tsx
@@ -46,7 +46,7 @@ const BaseLabelsModal: React.FC<BaseLabelsModalProps> = ({
   const { t } = useTranslation();
 
   React.useEffect(() => {
-    if (watchedResourceLoaded) {
+    if (watchedResourceLoaded && !_.isEmpty(watchedResource)) {
       setStale(!_.isEqual(resource?.metadata?.labels, watchedResource?.metadata?.labels));
     }
   }, [path, resource, watchedResource, watchedResourceLoaded]);

--- a/frontend/public/components/modals/tags.tsx
+++ b/frontend/public/components/modals/tags.tsx
@@ -44,7 +44,7 @@ export const TagsModal = withHandlePromise<TagsModalProps & HandlePromiseProps>(
   const { t } = useTranslation();
 
   React.useEffect(() => {
-    if (watchedResourceLoaded) {
+    if (watchedResourceLoaded && !_.isEmpty(watchedResource)) {
       setStale(!_.isEqual(props.tags, watchedResource?.metadata?.annotations));
     }
   }, [props.tags, watchedResource, watchedResourceLoaded]);


### PR DESCRIPTION
…or users and groups