### PR TITLE
OCPBUGS-23543: Deployment option is missing in 'Deploy Image'

### DIFF
--- a/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
@@ -7,10 +7,10 @@ import { FormFooter, FlexForm, FormBody } from '@console/shared/src/components/f
 import { hasSampleQueryParameter } from '../../utils/samples';
 import AdvancedSection from './advanced/AdvancedSection';
 import AppSection from './app/AppSection';
+import { DeploySection } from './DeploySection';
 import ImageSearchSection from './image-search/ImageSearchSection';
 import { DeployImageFormProps } from './import-types';
 import IconSection from './section/IconSection';
-import ResourceSection from './section/ResourceSection';
 
 const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps> = ({
   values,
@@ -39,7 +39,7 @@ const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps
         />
         {showAdvancedSections && (
           <>
-            <ResourceSection />
+            <DeploySection values={values} />
             <AdvancedSection values={values} />
           </>
         )}

--- a/frontend/packages/dev-console/src/components/import/DeploySection.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeploySection.tsx
@@ -18,7 +18,10 @@ export const DeploySection: React.FC<DeploySectionProps> = ({ values, appResourc
     <FormSection title={t('devconsole~Deploy')} fullWidth>
       <ResourceSection />
 
-      <ExpandableSection toggleText={t('devconsole~Show advanced Deployment option')}>
+      <ExpandableSection
+        isWidthLimited
+        toggleText={t('devconsole~Show advanced Deployment option')}
+      >
         <DeploymentConfigSection
           namespace={values.project.name}
           resource={appResources?.editAppResource?.data}

--- a/frontend/packages/dev-console/src/components/import/__tests__/DeployImage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/__tests__/DeployImage.spec.tsx
@@ -13,8 +13,8 @@ import AdvancedSection from '../advanced/AdvancedSection';
 import AppSection from '../app/AppSection';
 import DeployImage from '../DeployImage';
 import DeployImagePage from '../DeployImagePage';
+import { DeploySection } from '../DeploySection';
 import ImageSearchSection from '../image-search/ImageSearchSection';
-import ResourceSection from '../section/ResourceSection';
 
 jest.mock('@console/shared/src/hooks/post-form-submit-action', () => ({
   usePostFormSubmitAction: () => () => {},
@@ -135,8 +135,8 @@ describe('Deploy Image Test', () => {
   it('should load  correct app section', () => {
     expect(deployImageWrapper.find(AppSection).exists()).toBe(true);
   });
-  it('should load  correct resource section', () => {
-    expect(deployImageWrapper.find(ResourceSection).exists()).toBe(true);
+  it('should load  correct Deploy section', () => {
+    expect(deployImageWrapper.find(DeploySection).exists()).toBe(true);
   });
   it('should load  correct advanced section', () => {
     expect(deployImageWrapper.find(AdvancedSection).exists()).toBe(true);

--- a/frontend/packages/dev-console/src/components/import/__tests__/DeployImageForm.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/__tests__/DeployImageForm.spec.tsx
@@ -5,6 +5,7 @@ import { formikFormProps } from '@console/shared/src/test-utils/formik-props-uti
 import AdvancedSection from '../advanced/AdvancedSection';
 import AppSection from '../app/AppSection';
 import DeployImageForm from '../DeployImageForm';
+import { DeploySection } from '../DeploySection';
 import ImageSearchSection from '../image-search/ImageSearchSection';
 import IconSection from '../section/IconSection';
 
@@ -26,6 +27,7 @@ describe('DeployImageForm', () => {
     expect(wrapper.find(ImageSearchSection).exists()).toBe(true);
     expect(wrapper.find(IconSection).exists()).toBe(true);
     expect(wrapper.find(AppSection).exists()).toBe(true);
+    expect(wrapper.find(DeploySection).exists()).toBe(true);
     expect(wrapper.find(AdvancedSection).exists()).toBe(true);
     expect(wrapper.find(FormFooter).exists()).toBe(true);
   });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-23543

**Analysis / Root cause**: 
The Deployment option is missing in 'Click on the names to access advanced options' list in Deploy image page, user cannot set up ENV related function anymore

**Solution Description**: 
Replaced the `ResourceSection` with the new `DeploySection`. Now users can create env vars directly from the Deploy Section rather than the Advanced Section.

**Screen shots / Gifs for design review**: 

![image](https://github.com/openshift/console/assets/47265560/df033d9e-4a8c-4dcb-8c71-278b85be917b)


**Unit test coverage report**: 
Tests updated.

**Test setup:**
1. Login OCP, and change to Developer perspective, navigate to Deploy Image page (+Add -> Container image)
   /deploy-image/ns/default
2. Scroll down and check if 'deployment' is list in the advance list



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge