### PR TITLE
OCPBUGS-23776: After PatternFly5 update: Add page > more button dropdown is too wide

### DIFF
--- a/frontend/packages/console-shared/src/components/getting-started/GettingStartedGrid.scss
+++ b/frontend/packages/console-shared/src/components/getting-started/GettingStartedGrid.scss
@@ -14,10 +14,10 @@
   }
 
   &__action-dropdown {
-    .pf-c-dropdown__menu {
+    .pf-v5-c-dropdown__menu {
       width: 280px;
     }
-    .pf-c-dropdown__menu-item-description {
+    .pf-v5-c-dropdown__menu-item-description {
       white-space: pre-wrap;
     }
   }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-23776

**Analysis / Root cause**: 
Due to PF5 upgrade 

**Solution Description**: 
Updated the css

**Screen shots / Gifs for design review**: 
----BEFORE---

https://drive.google.com/file/d/1ce5Vj8ol2R2kbXA94Z_RT7iA7-mpxDT8/view?usp=drive_link
https://drive.google.com/file/d/1DXDnl-bmnSPXn99LxftS0hKKmVDM0FxN/view?usp=drive_link

----AFTER----

<img width="1424" alt="image" src="https://github.com/openshift/console/assets/102503482/21f93fee-565c-4ce3-95f0-bcb3d1a092e0">




**Unit test coverage report**: 
NA

**Test setup:**
 1.Go to add page
 2.Click on kebab menu in getting started section

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge