### PR TITLE
OCPBUGS-23768: After PatternFly5 update: Navigation: Extra space after divider

### DIFF
--- a/frontend/packages/console-app/src/components/nav/PerspectiveNav.scss
+++ b/frontend/packages/console-app/src/components/nav/PerspectiveNav.scss
@@ -12,7 +12,7 @@
   .pf-v5-c-nav__section.no-title {
     border-bottom: 1px solid var(--pf-v5-global--BackgroundColor--dark-200);
     padding-bottom: var(--pf-v5-global--spacer--sm);
-    --pf-v5-c-nav__section--MarginTop: 0;
+    --pf-v5-c-nav__section--section--MarginTop: var(--pf-v5-global--spacer--sm);
     .pf-v5-c-nav__section-title {
       --pf-v5-c-nav__section-title--PaddingBottom: 0;
     }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-23768

**Analysis / Root cause**: 
Due to PF5 upgrade 

**Solution Description**: 
Updated the css

**Screen shots / Gifs for design review**: 
----BEFORE---

https://drive.google.com/file/d/1ROcHXCLmPPhr30nGTUblMTL-JQqKEsCY/view?usp=drive_link

----AFTER----

<img width="780" alt="image" src="https://github.com/openshift/console/assets/102503482/2cc47cb0-2887-42d6-b4eb-7b9d2c227ae8">





**Unit test coverage report**: 
NA

**Test setup:**
 1.Go to dev perspective
 2.See left navigation

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge