### PR TITLE
OCPBUGS-23775: After PatternFly5 update: Form error is missing when import a container image

### DIFF
--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
@@ -187,15 +187,18 @@ const ImageSearch: React.FC = () => {
     [handleSearch, values.searchTerm],
   );
 
-  const getHelpText = () => {
+  const helpText = React.useMemo(() => {
     if (values.isSearchingForImage) {
       return `${t('devconsole~Validating')}...`;
     }
     if (!values.isSearchingForImage && validated === ValidatedOptions.success) {
       return t('devconsole~Validated');
     }
+    if (validated === ValidatedOptions.error) {
+      return values.searchTerm === '' ? t('devconsole~Required') : values.isi.status?.message;
+    }
     return '';
-  };
+  }, [t, validated, values.isSearchingForImage, values.searchTerm, values.isi.status?.message]);
 
   const resetFields = () => {
     if (values.formType === 'edit') {
@@ -211,12 +214,6 @@ const ImageSearch: React.FC = () => {
       !applicationNameTouched &&
       setFieldValue('application.name', '');
   };
-
-  const helpTextInvalid = validated === ValidatedOptions.error && (
-    <span className="odc-image-search__helper-text-invalid">
-      {values.searchTerm === '' ? 'Required' : values.isi.status?.message}
-    </span>
-  );
 
   React.useEffect(() => {
     !dirty && values.searchTerm && handleSearch(values.searchTerm);
@@ -248,8 +245,8 @@ const ImageSearch: React.FC = () => {
         placeholder={t(
           'devconsole~docker.io/openshift/hello-openshift or quay.io/<username>/<image-name>',
         )}
-        helpText={getHelpText()}
-        helpTextInvalid={helpTextInvalid}
+        helpText={helpText}
+        helpTextInvalid={helpText}
         validated={validated}
         onChange={(e: KeyboardEvent) => {
           resetFields();


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-23775

**Analysis / Root cause**: 
Due to PF5 upgrade 

**Solution Description**: 
Updated help text similar to other import flows 

**Screen shots / Gifs for design review**: 
----BEFORE---

https://drive.google.com/file/d/1aUfUefnF3IxVzNjn7D3Q05pK9z4prVtN/view

----AFTER----

<img width="1300" alt="Screenshot 2023-11-24 at 5 59 27 PM" src="https://github.com/openshift/console/assets/102503482/f83ab593-cbe8-4564-983c-662bd2d20d74">






**Unit test coverage report**: 
NA

**Test setup:**
 1.Go to dev perspective
 2.Select container images in Add page
 3.Enter wrong image
 
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge