### PR TITLE
OCPBUGS-23786: PatternFly5 update: fix code snippet color in quick start in dark mode

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -390,3 +390,8 @@ ul.pf-v5-c-tree-view__list {
     font-size: $font-size-base;
   }
 }
+
+:where(.pf-theme-dark) .pfext-quick-start-task__content .pfext-markdown-view pre code {
+  color: var(--pf-global--Color--100);
+  background-color: var(--pf-global--palette--black-600);
+}


### PR DESCRIPTION
**Fix:** https://issues.redhat.com/browse/OCPBUGS-23786

**Screenshots:**

**Before:**
https://drive.google.com/file/d/1hxh5VI2S7jLKRdNlDQsdlAXL_G7TxtME/view?usp=sharing

**After:**
![image](https://github.com/openshift/console/assets/2561818/ea4f9c1c-b66b-45f3-8bcb-d2f599b9bb5f)
