### PR TITLE
OCPBUGS-23787: PatternFly5 update: fix Quickstarts catalog item count alignment

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartCatalogPage.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartCatalogPage.scss
@@ -7,3 +7,7 @@
 .pfext-quick-start-footer {
   background-color: var(--pf-v5-global--BackgroundColor--100);
 }
+
+.pfext-quick-start-catalog-filter__count {
+  align-self: center;
+}


### PR DESCRIPTION
Fix: [OCPBUGS-23787](https://issues.redhat.com/browse/OCPBUGS-23787)

Screenshots:

![image](https://github.com/openshift/console/assets/2561818/c0404158-b1c7-4a3f-b103-4a831ab3eceb)
