### PR TITLE
OCPBUGS-23923: fix PipelineRun task logs switcher

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.scss
@@ -4,6 +4,7 @@
   width: 100%;
   padding: var(--pf-v5-global--spacer--xl) 0;
   &__nav {
+    padding-top: 0;
     list-style-type: none;
   }
   &__nav .co-icon-and-text {

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
@@ -107,7 +107,7 @@ const useRuns = <Kind extends K8sResourceCommon>(
         : runs || trResources;
     return [
       rResources,
-      loaded || trLoaded,
+      !!rResources?.[0],
       namespace
         ? queryTr
           ? isList
@@ -118,18 +118,7 @@ const useRuns = <Kind extends K8sResourceCommon>(
         : undefined,
       trGetNextPage,
     ];
-  }, [
-    runs,
-    trResources,
-    loaded,
-    trLoaded,
-    namespace,
-    queryTr,
-    isList,
-    trError,
-    error,
-    trGetNextPage,
-  ]);
+  }, [runs, trResources, trLoaded, namespace, queryTr, isList, trError, error, trGetNextPage]);
 };
 
 export const usePipelineRuns = (

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/LogsWrapperComponent.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/LogsWrapperComponent.tsx
@@ -23,6 +23,7 @@ type LogsWrapperComponentProps = {
 const LogsWrapperComponent: React.FC<LogsWrapperComponentProps> = ({
   resource,
   taskRun,
+  taskName,
   onDownloadAll,
   downloadAllLabel = 'Download all',
   ...props
@@ -33,8 +34,6 @@ const LogsWrapperComponent: React.FC<LogsWrapperComponentProps> = ({
   const [isFullscreen, fullscreenRef, fullscreenToggle] = useFullscreen<HTMLDivElement>();
   const [downloadAllStatus, setDownloadAllStatus] = React.useState(false);
   const currentLogGetterRef = React.useRef<() => string>();
-
-  const taskName = taskRun?.spec.taskRef?.name ?? taskRun?.metadata.name;
 
   if (loaded && !error && resource.name === obj.metadata.name) {
     resourceRef.current = obj;
@@ -114,26 +113,15 @@ const LogsWrapperComponent: React.FC<LogsWrapperComponentProps> = ({
           </FlexItem>
         )}
       </Flex>
-      {loaded || error ? (
-        <>
-          {!error ? (
-            <MultiStreamLogs
-              {...props}
-              taskRun={taskRun}
-              resource={resourceRef.current}
-              setCurrentLogsGetter={setLogGetter}
-            />
-          ) : (
-            <TektonTaskRunLog taskRun={taskRun} setCurrentLogsGetter={setLogGetter} />
-          )}
-        </>
+      {!error ? (
+        <MultiStreamLogs
+          {...props}
+          taskName={taskName}
+          resource={resourceRef.current}
+          setCurrentLogsGetter={setLogGetter}
+        />
       ) : (
-        <span
-          className="odc-multi-stream-logs__taskName__loading-indicator"
-          data-test-id="loading-indicator"
-        >
-          <LoadingInline />
-        </span>
+        <TektonTaskRunLog taskRun={taskRun} setCurrentLogsGetter={setLogGetter} />
       )}
     </div>
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/MultiStreamLogs.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/MultiStreamLogs.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { LoadingInline, LOG_SOURCE_WAITING } from '@console/internal/components/utils';
 import { ContainerStatus, PodKind, ContainerSpec } from '@console/internal/module/k8s';
 import { useScrollDirection, ScrollDirection } from '@console/shared';
-import { TaskRunKind } from '../../../types';
 import { containerToLogSourceStatus } from '../../../utils/pipeline-utils';
 import Logs from './Logs';
 import { getRenderContainers } from './logs-utils';
@@ -12,13 +11,12 @@ import './MultiStreamLogs.scss';
 type MultiStreamLogsProps = {
   resource: PodKind;
   taskName?: string;
-  taskRun?: TaskRunKind;
   setCurrentLogsGetter?: (getter: () => string) => void;
 };
 
 export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
   resource,
-  taskRun,
+  taskName,
   setCurrentLogsGetter,
 }) => {
   const scrollPane = React.useRef<HTMLDivElement>();
@@ -28,7 +26,6 @@ export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
   const { containers, stillFetching } = getRenderContainers(resource);
   const dataRef = React.useRef<ContainerSpec[]>(null);
   dataRef.current = containers;
-  const taskName = taskRun?.spec.taskRef?.name ?? taskRun?.metadata.name;
 
   React.useEffect(() => {
     setCurrentLogsGetter(() => {
@@ -50,7 +47,7 @@ export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
   const autoScroll =
     scrollDirection == null || scrollDirection === ScrollDirection.scrolledToBottom;
 
-  const containerStatus: ContainerStatus[] = resource.status?.containerStatuses ?? [];
+  const containerStatus: ContainerStatus[] = resource?.status?.containerStatuses ?? [];
   return (
     <>
       <div className="odc-multi-stream-logs__taskName" data-test-id="logs-taskName">

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/TektonTaskRunLog.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/TektonTaskRunLog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { HttpError } from '@console/dynamic-plugin-sdk/src/utils/error/http-error';
 import { LoadingInline } from '@console/internal/components/utils';
 import { TaskRunKind } from '../../../types';
+import { TektonResourceLabel } from '../../pipelines/const';
 import { useTRTaskRunLog } from '../hooks/useTektonResults';
 
 import './Logs.scss';
@@ -17,7 +18,7 @@ export const TektonTaskRunLog: React.FC<TektonTaskRunLogProps> = ({
   setCurrentLogsGetter,
 }) => {
   const scrollPane = React.useRef<HTMLDivElement>();
-  const taskName = taskRun?.spec.taskRef?.name ?? taskRun?.metadata.name;
+  const taskName = taskRun?.metadata?.labels?.[TektonResourceLabel.pipelineTask] || '-';
   const [trResults, trLoaded, trError] = useTRTaskRunLog(
     taskRun.metadata.namespace,
     taskRun.metadata.name,

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/__tests__/MultiStreamLogs.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/__tests__/MultiStreamLogs.spec.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { cloneDeep } from 'lodash';
-import { taskRunWithResults } from '../../../taskruns/__tests__/taskrun-test-data';
 import Logs from '../Logs';
 import { MultiStreamLogs } from '../MultiStreamLogs';
 import { podData } from './logs-test-data';
@@ -23,9 +22,9 @@ describe('MultiStreamLogs', () => {
   });
 
   it('should render inline loading based on logs completion', () => {
-    const wrapper = shallow(<MultiStreamLogs {...props} taskRun={taskRunWithResults} />);
+    const wrapper = shallow(<MultiStreamLogs {...props} />);
     expect(wrapper.find('.odc-multi-stream-logs__taskName--loading').exists()).toBe(false);
-    expect(wrapper.find('.odc-multi-stream-logs__taskName').text()).toBe('add-task');
+    expect(wrapper.find('.odc-multi-stream-logs__taskName').text()).toBe('step-oc');
   });
 
   it('should render number of logs equal to number of containers', () => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/logs-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/logs-utils.ts
@@ -35,8 +35,8 @@ const getSortedContainerStatus = (
 export const getRenderContainers = (
   pod: PodKind,
 ): { containers: ContainerSpec[]; stillFetching: boolean } => {
-  const containers: ContainerSpec[] = pod.spec?.containers ?? [];
-  const containerStatuses: ContainerStatus[] = pod.status?.containerStatuses ?? [];
+  const containers: ContainerSpec[] = pod?.spec?.containers ?? [];
+  const containerStatuses: ContainerStatus[] = pod?.status?.containerStatuses ?? [];
 
   const sortedContainerStatuses = getSortedContainerStatus(containers, containerStatuses);
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

https://issues.redhat.com/browse/OCPBUGS-23923
https://issues.redhat.com/browse/OCPBUGS-23948


**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

Pipelinerun log switcher was not clickable and so users are not able to view the logs for different tasks.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Make the pipelinerun task navigation list clickable and on clicking on the task it should load the relevant log in the logs window.





**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Before:**
![log_switcher_before](https://github.com/openshift/console/assets/9964343/0d9ed336-886a-43a9-9eb9-20ba4087e13d)


**After:**

![logs_switcher](https://github.com/openshift/console/assets/9964343/a59e4a87-30f5-4f7b-b930-8be639cfa9d9)



PipelineRun details page loading correct status:


https://github.com/openshift/console/assets/9964343/f836926a-d5a1-4353-9152-785ff8704b77




**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge