### PR TITLE
OCPBUGS-23765: fix dark theme issue for helm release readme modal

### DIFF
--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
@@ -5,6 +5,7 @@ import { JSONSchema7 } from 'json-schema';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
+import { ThemeContext } from '@console/internal/components/ThemeProvider';
 import {
   InputField,
   FormFooter,
@@ -66,6 +67,7 @@ const HelmInstallUpgradeForm: React.FC<
   chartIndexEntry,
 }) => {
   const { t } = useTranslation();
+  const theme = React.useContext(ThemeContext);
   const { chartName, chartVersion, chartReadme, formData, formSchema, editorType } = values;
   const { type: helmAction, title, subTitle } = helmActionConfig;
 
@@ -111,6 +113,7 @@ const HelmInstallUpgradeForm: React.FC<
           helmReadmeModalLauncher({
             readme: chartReadme,
             modalClassName: 'modal-lg',
+            theme,
           })
         }
         isInline

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmReadmeModal.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmReadmeModal.tsx
@@ -10,16 +10,17 @@ import { SyncMarkdownView } from '@console/internal/components/markdown-view';
 
 type HelmReadmeModalProps = {
   readme: string;
+  theme?: string;
 };
 type Props = HelmReadmeModalProps & ModalComponentProps;
 
-const HelmReadmeModal: React.FunctionComponent<Props> = ({ readme, close }) => {
+const HelmReadmeModal: React.FunctionComponent<Props> = ({ readme, theme, close }) => {
   const { t } = useTranslation();
   return (
     <div className="modal-content">
       <ModalTitle close={close}>{t('helm-plugin~README')}</ModalTitle>
       <ModalBody>
-        <SyncMarkdownView content={readme} />
+        <SyncMarkdownView content={readme} theme={theme} />
       </ModalBody>
     </div>
   );

--- a/frontend/public/components/markdown-view.tsx
+++ b/frontend/public/components/markdown-view.tsx
@@ -5,13 +5,20 @@ import { ThemeContext, updateThemeClass } from './ThemeProvider';
 
 type SyncMarkdownProps = Omit<MarkdownProps, 'theme' | 'updateThemeClass' | 'emptyMsg'> & {
   emptyMsg?: string;
+  theme?: string;
 };
 
-export const SyncMarkdownView: React.FC<SyncMarkdownProps> = ({ emptyMsg, ...rest }) => {
+export const SyncMarkdownView: React.FC<SyncMarkdownProps> = ({ emptyMsg, theme, ...rest }) => {
   const { t } = useTranslation();
   emptyMsg = emptyMsg || t('public~Not available');
-  const theme = React.useContext(ThemeContext);
+  const contextTheme = React.useContext(ThemeContext);
+  const markDownTheme = theme || contextTheme;
   return (
-    <MarkdownView {...rest} emptyMsg={emptyMsg} theme={theme} updateThemeClass={updateThemeClass} />
+    <MarkdownView
+      {...rest}
+      emptyMsg={emptyMsg}
+      theme={markDownTheme}
+      updateThemeClass={updateThemeClass}
+    />
   );
 };


### PR DESCRIPTION
**Fix:** https://issues.redhat.com/browse/OCPBUGS-23765

**Descriptions:** 
- theme context is not available for the markdown in the modal so pass the theme as a prop to the markdown component.

**Screenshots:**
**Before:**
https://drive.google.com/file/d/1pYFsVxJrB4m2s7pYuw1QeTW3j38A_fRT/view?usp=drive_link

**After:**

https://github.com/openshift/console/assets/2561818/b1098060-5311-4b86-ad6f-af0b306f8cdb

