### PR TITLE
PatternFly5 update: Remove text decoration for task node on hover

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.scss
@@ -1,6 +1,6 @@
 .odc-pipeline-topology__task-node {
   &.is-link {
-    > a:hover {
+    >g a:hover {
       text-decoration: none;
     }
   }


### PR DESCRIPTION
**Fix:** https://issues.redhat.com/browse/OCPBUGS-23956

**Before:**

![image](https://github.com/openshift/console/assets/2561818/2788ed71-7ab2-474c-b79b-6ff1b9022925)


**After:** 

![image](https://github.com/openshift/console/assets/2561818/2c559477-8f89-4bf1-879f-13dee5b6b940)
