### PR TITLE
OCPBUGS-23778: Apply the correct font-family for the page header action button and menu items.

### DIFF
--- a/frontend/public/components/_nav-title.scss
+++ b/frontend/public/components/_nav-title.scss
@@ -1,6 +1,7 @@
 .co-actions {
   align-items: flex-end;
   display: flex;
+  font-family: var(--pf-v5-global--FontFamily--text);
   @media (max-width: $screen-xs) {
     flex-direction: column;
   }


### PR DESCRIPTION
PF5 sets button elements to `font-family: inherit`. Our legacy pageheader component has this button inside an `<h1>` it gets set to RedHatDisplay instead of RedHatText font-family.

before
<img width="493" alt="Screenshot 2023-11-27 at 1 15 20 PM" src="https://github.com/openshift/console/assets/1874151/e5fc1368-2fa0-4c0e-bb7b-46746ff6a677">

after
<img width="470" alt="Screenshot 2023-11-27 at 1 15 11 PM" src="https://github.com/openshift/console/assets/1874151/5b49eea4-d2c3-4708-bae1-af7c0df380d5">

