### PR TITLE
OCPBUGS-23780,OCPBUGS-23794,OCPBUGS-23977,OCPBUGS-23783: Bring back the Decorators and Pod Rings around resources in Topology

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodStatus.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodStatus.tsx
@@ -57,6 +57,7 @@ const PodStatus: React.FC<PodStatusProps> = ({
   subTitleComponent,
   data,
 }) => {
+  const ref = React.useRef();
   const [updateOnEnd, setUpdateOnEnd] = React.useState<boolean>(false);
   const forceUpdate = useForceUpdate();
   const prevVData = React.useRef<PodData[]>(null);
@@ -165,7 +166,11 @@ const PodStatus: React.FC<PodStatusProps> = ({
         })}
       </div>
     );
-    return <Tooltip content={tipContent}>{chartDonut}</Tooltip>;
+    return (
+      <Tooltip triggerRef={ref} content={tipContent}>
+        <g ref={ref}>{chartDonut}</g>
+      </Tooltip>
+    );
   }
   return chartDonut;
 };

--- a/frontend/packages/helm-plugin/src/topology/components/HelmReleaseStatusDecorator.tsx
+++ b/frontend/packages/helm-plugin/src/topology/components/HelmReleaseStatusDecorator.tsx
@@ -19,6 +19,7 @@ const HelmReleaseStatusDecorator: React.FC<HelmReleaseStatusDecoratorProps> = ({
   x,
   y,
 }) => {
+  const ref = React.useRef();
   const { t } = useTranslation();
   const { data } = element.getData();
 
@@ -29,10 +30,12 @@ const HelmReleaseStatusDecorator: React.FC<HelmReleaseStatusDecoratorProps> = ({
   const label = t('helm-plugin~Helm release is {{status}}', { status });
 
   return (
-    <Tooltip content={label} position={TooltipPosition.left}>
-      <BuildDecoratorBubble x={x} y={y} radius={radius} ariaLabel={label}>
-        <Status status={status} iconOnly noTooltip />
-      </BuildDecoratorBubble>
+    <Tooltip triggerRef={ref} content={label} position={TooltipPosition.left}>
+      <g ref={ref}>
+        <BuildDecoratorBubble x={x} y={y} radius={radius} ariaLabel={label}>
+          <Status status={status} iconOnly noTooltip />
+        </BuildDecoratorBubble>
+      </g>
     </Tooltip>
   );
 };

--- a/frontend/packages/knative-plugin/src/topology/components/decorators/RevisionRouteDecorator.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/decorators/RevisionRouteDecorator.tsx
@@ -20,6 +20,7 @@ const RevisionRouteDecorator: React.FC<RevisionRouteDecoratorProps> = ({
   x,
   y,
 }) => {
+  const ref = React.useRef();
   const { t } = useTranslation();
   const resourceObj = getResource(element);
   const url = useRoutesURL(resourceObj);
@@ -28,12 +29,22 @@ const RevisionRouteDecorator: React.FC<RevisionRouteDecoratorProps> = ({
     return null;
   }
   return (
-    <Tooltip key="route" content={t('knative-plugin~Open URL')} position={TooltipPosition.right}>
-      <Decorator x={x} y={y} radius={radius} href={url} external>
-        <g transform={`translate(-${radius / 2}, -${radius / 2})`}>
-          <ExternalLinkAltIcon style={{ fontSize: radius }} title={t('knative-plugin~Open URL')} />
-        </g>
-      </Decorator>
+    <Tooltip
+      triggerRef={ref}
+      key="route"
+      content={t('knative-plugin~Open URL')}
+      position={TooltipPosition.right}
+    >
+      <g ref={ref}>
+        <Decorator x={x} y={y} radius={radius} href={url} external>
+          <g transform={`translate(-${radius / 2}, -${radius / 2})`}>
+            <ExternalLinkAltIcon
+              style={{ fontSize: radius }}
+              title={t('knative-plugin~Open URL')}
+            />
+          </g>
+        </Decorator>
+      </g>
     </Tooltip>
   );
 };

--- a/frontend/packages/knative-plugin/src/topology/components/decorators/ServiceRouteDecorator.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/decorators/ServiceRouteDecorator.tsx
@@ -12,14 +12,25 @@ type ServiceRouteDecoratorProps = {
 };
 
 const ServiceRouteDecorator: React.FC<ServiceRouteDecoratorProps> = ({ url, radius, x, y }) => {
+  const ref = React.useRef();
   const { t } = useTranslation();
   return (
-    <Tooltip key="route" content={t('knative-plugin~Open URL')} position={TooltipPosition.right}>
-      <Decorator x={x} y={y} radius={radius} href={url} external>
-        <g transform="translate(-6.5, -6.5)">
-          <ExternalLinkAltIcon style={{ fontSize: radius }} title={t('knative-plugin~Open URL')} />
-        </g>
-      </Decorator>
+    <Tooltip
+      triggerRef={ref}
+      key="route"
+      content={t('knative-plugin~Open URL')}
+      position={TooltipPosition.right}
+    >
+      <g ref={ref}>
+        <Decorator x={x} y={y} radius={radius} href={url} external>
+          <g transform="translate(-6.5, -6.5)">
+            <ExternalLinkAltIcon
+              style={{ fontSize: radius }}
+              title={t('knative-plugin~Open URL')}
+            />
+          </g>
+        </Decorator>
+      </g>
     </Tooltip>
   );
 };

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
@@ -78,6 +78,7 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
   onShowCreateConnector,
   createConnectorDrag,
 }) => {
+  const ref = React.useRef();
   const { t } = useTranslation();
   const [hoverChange, setHoverChange] = React.useState<boolean>(false);
   const [hover, hoverRef] = useHover(200, 200, [hoverChange]);
@@ -138,85 +139,88 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
 
   return (
     <Tooltip
+      triggerRef={ref}
       content={tooltipLabel}
       trigger="manual"
       isVisible={dropTarget && canDrop}
       animationDuration={0}
     >
-      <g
-        ref={hoverRef}
-        onClick={onSelect}
-        onContextMenu={onContextMenu}
-        className={classNames('odc-knative-service', {
-          'pf-m-dragging': dragging || labelDragging,
-          'pf-m-highlight': canDrop || edgeDragging,
-          'is-filtered': filtered,
-        })}
-      >
-        <NodeShadows />
-        <Layer
-          id={
-            (dragging || labelDragging) && (regrouping || labelRegrouping) ? undefined : 'groups2'
-          }
+      <g ref={ref}>
+        <g
+          ref={hoverRef}
+          onClick={onSelect}
+          onContextMenu={onContextMenu}
+          className={classNames('odc-knative-service', {
+            'pf-m-dragging': dragging || labelDragging,
+            'pf-m-highlight': canDrop || edgeDragging,
+            'is-filtered': filtered,
+          })}
         >
-          <g
-            ref={nodeRefs}
-            className={classNames('odc-knative-service', {
-              'pf-m-selected': selected,
-              'pf-m-dragging': dragging || labelDragging,
-              'pf-m-highlight': canDrop || edgeDragging,
-              'pf-m-drop-target': canDrop && dropTarget,
-              'is-filtered': filtered,
-              'is-function': isServerlessFunction(getResource(element)),
-            })}
+          <NodeShadows />
+          <Layer
+            id={
+              (dragging || labelDragging) && (regrouping || labelRegrouping) ? undefined : 'groups2'
+            }
           >
-            <rect
-              key={
-                hover || innerHover || dragging || labelDragging || contextMenuOpen || dropTarget
-                  ? 'rect-hover'
-                  : 'rect'
-              }
-              ref={dndDropRef}
-              className="odc-knative-service__bg"
-              x={x}
-              y={y}
-              width={width}
-              height={height}
-              rx="5"
-              ry="5"
-              filter={createSvgIdUrl(
-                hover || innerHover || dragging || labelDragging || contextMenuOpen || dropTarget
-                  ? NODE_SHADOW_FILTER_ID_HOVER
-                  : NODE_SHADOW_FILTER_ID,
+            <g
+              ref={nodeRefs}
+              className={classNames('odc-knative-service', {
+                'pf-m-selected': selected,
+                'pf-m-dragging': dragging || labelDragging,
+                'pf-m-highlight': canDrop || edgeDragging,
+                'pf-m-drop-target': canDrop && dropTarget,
+                'is-filtered': filtered,
+                'is-function': isServerlessFunction(getResource(element)),
+              })}
+            >
+              <rect
+                key={
+                  hover || innerHover || dragging || labelDragging || contextMenuOpen || dropTarget
+                    ? 'rect-hover'
+                    : 'rect'
+                }
+                ref={dndDropRef}
+                className="odc-knative-service__bg"
+                x={x}
+                y={y}
+                width={width}
+                height={height}
+                rx="5"
+                ry="5"
+                filter={createSvgIdUrl(
+                  hover || innerHover || dragging || labelDragging || contextMenuOpen || dropTarget
+                    ? NODE_SHADOW_FILTER_ID_HOVER
+                    : NODE_SHADOW_FILTER_ID,
+                )}
+              />
+              {!hasChildren && (
+                <text x={x + width / 2} y={y + height / 2} dy="0.35em" textAnchor="middle">
+                  {t('knative-plugin~No Revisions')}
+                </text>
               )}
-            />
-            {!hasChildren && (
-              <text x={x + width / 2} y={y + height / 2} dy="0.35em" textAnchor="middle">
-                {t('knative-plugin~No Revisions')}
-              </text>
-            )}
-          </g>
-        </Layer>
-        {decorators}
-        {showLabel && (data.kind || element.getLabel()) && (
-          <NodeLabel
-            className="pf-topology__group__label odc-knative-service__label odc-base-node__label"
-            onContextMenu={onContextMenu}
-            contextMenuOpen={contextMenuOpen}
-            x={x + width / 2}
-            y={y + height + 20}
-            paddingX={8}
-            paddingY={4}
-            labelIconClass={getImageForIconClass(typeIconClass) || typeIconClass}
-            badge={badge}
-            badgeColor={badgeColor}
-            badgeClassName={badgeClassName}
-            dragRef={dragLabelRef}
-          >
-            {element.getLabel()}
-          </NodeLabel>
-        )}
-        {children}
+            </g>
+          </Layer>
+          {decorators}
+          {showLabel && (data.kind || element.getLabel()) && (
+            <NodeLabel
+              className="pf-topology__group__label odc-knative-service__label odc-base-node__label"
+              onContextMenu={onContextMenu}
+              contextMenuOpen={contextMenuOpen}
+              x={x + width / 2}
+              y={y + height + 20}
+              paddingX={8}
+              paddingY={4}
+              labelIconClass={getImageForIconClass(typeIconClass) || typeIconClass}
+              badge={badge}
+              badgeColor={badgeColor}
+              badgeClassName={badgeClassName}
+              dragRef={dragLabelRef}
+            >
+              {element.getLabel()}
+            </NodeLabel>
+          )}
+          {children}
+        </g>
       </g>
     </Tooltip>
   );

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSink.tsx
@@ -60,6 +60,7 @@ const EventSink: React.FC<EventSinkProps> = ({
   ...rest
 }) => {
   useAnchor(EventSinkTargetAnchor, AnchorEnd.target, TYPE_EVENT_SINK_LINK);
+  const ref = React.useRef();
   const { t } = useTranslation();
   const [hover, hoverRef] = useHover();
   const groupRefs = useCombineRefs(dragNodeRef, dndDropRef);
@@ -129,48 +130,50 @@ const EventSink: React.FC<EventSinkProps> = ({
       isVisible={dropTarget && canDrop}
       animationDuration={0}
     >
-      <BaseNode
-        className="odc-event-source"
-        onShowCreateConnector={isKafkaConnectionLinkPresent && onShowCreateConnector}
-        kind={data.kind}
-        element={element}
-        hoverRef={hoverRef}
-        dragNodeRef={groupRefs}
-        dropTarget={dropTarget}
-        canDrop={canDrop}
-        labelIcon={<EventSinkIcon />}
-        {...rest}
-      >
-        {donutStatus && showDetails && !isKafkaSink && (
-          <PodSet size={size * 0.75} x={width / 2} y={height / 2} data={donutStatus} />
-        )}
-        <circle
-          cx={width * 0.5}
-          cy={height * 0.5}
-          r={width * 0.25}
-          fill="var(--pf-v5-global--palette--white)"
-        />
-        {typeof getEventSourceIcon(data.kind, resources.obj) === 'string' ? (
-          <image
-            x={width * 0.33}
-            y={height * 0.33}
-            width={size * 0.35}
-            height={size * 0.35}
-            xlinkHref={getEventSourceIcon(data.kind, resources.obj, element.getType()) as string}
+      <g ref={ref}>
+        <BaseNode
+          className="odc-event-source"
+          onShowCreateConnector={isKafkaConnectionLinkPresent && onShowCreateConnector}
+          kind={data.kind}
+          element={element}
+          hoverRef={hoverRef}
+          dragNodeRef={groupRefs}
+          dropTarget={dropTarget}
+          canDrop={canDrop}
+          labelIcon={<EventSinkIcon />}
+          {...rest}
+        >
+          {donutStatus && showDetails && !isKafkaSink && (
+            <PodSet size={size * 0.75} x={width / 2} y={height / 2} data={donutStatus} />
+          )}
+          <circle
+            cx={width * 0.5}
+            cy={height * 0.5}
+            r={width * 0.25}
+            fill="var(--pf-v5-global--palette--white)"
           />
-        ) : (
-          <foreignObject
-            x={width * 0.33}
-            y={height * 0.33}
-            width={size * 0.35}
-            height={size * 0.35}
-            className="odc-event-source__svg-icon"
-          >
-            {getEventSourceIcon(data.kind, resources.obj, element.getType())}
-          </foreignObject>
-        )}
-        {children}
-      </BaseNode>
+          {typeof getEventSourceIcon(data.kind, resources.obj) === 'string' ? (
+            <image
+              x={width * 0.33}
+              y={height * 0.33}
+              width={size * 0.35}
+              height={size * 0.35}
+              xlinkHref={getEventSourceIcon(data.kind, resources.obj, element.getType()) as string}
+            />
+          ) : (
+            <foreignObject
+              x={width * 0.33}
+              y={height * 0.33}
+              width={size * 0.35}
+              height={size * 0.35}
+              className="odc-event-source__svg-icon"
+            >
+              {getEventSourceIcon(data.kind, resources.obj, element.getType())}
+            </foreignObject>
+          )}
+          {children}
+        </BaseNode>
+      </g>
     </Tooltip>
   );
 };

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
@@ -49,6 +49,7 @@ const EventingPubSubNode: React.FC<EventingPubSubNodeProps> = ({
   useAnchor(RectAnchor, AnchorEnd.target, TYPE_AGGREGATE_EDGE);
   useAnchor(EventSinkSourceAnchor, AnchorEnd.source, TYPE_EVENT_SINK_LINK);
 
+  const ref = React.useRef();
   const { t } = useTranslation();
   const { data } = element.getData();
   const { width } = element.getBounds();
@@ -57,6 +58,7 @@ const EventingPubSubNode: React.FC<EventingPubSubNodeProps> = ({
 
   return (
     <Tooltip
+      triggerRef={ref}
       content={t('knative-plugin~Move sink to {{resourceObjKind}}', {
         resourceObjKind: resourceObj.kind,
       })}
@@ -64,25 +66,27 @@ const EventingPubSubNode: React.FC<EventingPubSubNodeProps> = ({
       isVisible={dropTarget && canDrop}
       animationDuration={0}
     >
-      <BaseNode
-        className="odc-eventing-pubsub"
-        createConnectorAccessVerb="create"
-        kind={data.kind}
-        element={element}
-        dropTarget={dropTarget}
-        canDrop={canDrop}
-        {...rest}
-      >
-        <image
-          x={width * 0.1}
-          y={0}
-          width={width * 0.8}
-          height={width * 0.5}
-          xlinkHref={eventPubSubImg}
-          className="odc-eventing-pubsub--image"
-        />
-        {children}
-      </BaseNode>
+      <g ref={ref}>
+        <BaseNode
+          className="odc-eventing-pubsub"
+          createConnectorAccessVerb="create"
+          kind={data.kind}
+          element={element}
+          dropTarget={dropTarget}
+          canDrop={canDrop}
+          {...rest}
+        >
+          <image
+            x={width * 0.1}
+            y={0}
+            width={width * 0.8}
+            height={width * 0.5}
+            xlinkHref={eventPubSubImg}
+            className="odc-eventing-pubsub--image"
+          />
+          {children}
+        </BaseNode>
+      </g>
     </Tooltip>
   );
 };

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/SinkUriNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/SinkUriNode.tsx
@@ -38,6 +38,8 @@ const SinkUriNode: React.FC<SinkUriNodeProps> = ({
   contextMenuOpen,
   ...rest
 }) => {
+  const ref = React.useRef();
+  const sinkRef = React.useRef();
   const { t } = useTranslation();
   const { width, height } = element.getDimensions();
   const [hover, hoverRef] = useHover();
@@ -57,44 +59,50 @@ const SinkUriNode: React.FC<SinkUriNodeProps> = ({
             key="URI"
             content={t('knative-plugin~Open URI')}
             position={TooltipPosition.right}
+            triggerRef={sinkRef}
           >
-            <Decorator
-              x={cx + radius - DECORATOR_RADIUS * 0.7}
-              y={cy - radius + DECORATOR_RADIUS * 0.7}
-              radius={DECORATOR_RADIUS}
-              href={sinkData.sinkUri}
-              external
-            >
-              <g transform={`translate(-${DECORATOR_RADIUS / 2}, -${DECORATOR_RADIUS / 2})`}>
-                <ExternalLinkAltIcon style={{ fontSize: DECORATOR_RADIUS }} title="Open URL" />
-              </g>
-            </Decorator>
+            <g ref={sinkRef}>
+              <Decorator
+                x={cx + radius - DECORATOR_RADIUS * 0.7}
+                y={cy - radius + DECORATOR_RADIUS * 0.7}
+                radius={DECORATOR_RADIUS}
+                href={sinkData.sinkUri}
+                external
+              >
+                <g transform={`translate(-${DECORATOR_RADIUS / 2}, -${DECORATOR_RADIUS / 2})`}>
+                  <ExternalLinkAltIcon style={{ fontSize: DECORATOR_RADIUS }} title="Open URL" />
+                </g>
+              </Decorator>
+            </g>
           </Tooltip>,
         ]
       : undefined;
 
   return (
     <Tooltip
+      triggerRef={ref}
       content={t('knative-plugin~Move sink to URI')}
       trigger="manual"
       isVisible={dropTarget && canDrop}
       animationDuration={0}
     >
-      <BaseNode
-        className="odc-sink-uri"
-        hoverRef={hoverRef}
-        createConnectorAccessVerb="create"
-        kind={sinkData.kind}
-        element={element}
-        dropTarget={dropTarget}
-        canDrop={canDrop}
-        attachments={decorators}
-        {...rest}
-      >
-        <g transform={`translate(${cx / 2}, ${cy / 2})`}>
-          <LinkIcon style={{ fontSize: radius }} />
-        </g>
-      </BaseNode>
+      <g ref={ref}>
+        <BaseNode
+          className="odc-sink-uri"
+          hoverRef={hoverRef}
+          createConnectorAccessVerb="create"
+          kind={sinkData.kind}
+          element={element}
+          dropTarget={dropTarget}
+          canDrop={canDrop}
+          attachments={decorators}
+          {...rest}
+        >
+          <g transform={`translate(${cx / 2}, ${cy / 2})`}>
+            <LinkIcon style={{ fontSize: radius }} />
+          </g>
+        </BaseNode>
+      </g>
     </Tooltip>
   );
 };

--- a/frontend/packages/kubevirt-plugin/src/topology/components/nodes/VmNode.tsx
+++ b/frontend/packages/kubevirt-plugin/src/topology/components/nodes/VmNode.tsx
@@ -47,6 +47,7 @@ const ObservedVmNode: React.FC<VmNodeProps> = ({
   children,
   ...rest
 }) => {
+  const ref = React.useRef();
   useAnchor(RectAnchor);
   const { width, height } = element.getBounds();
   const vmData = element.getData().data;
@@ -123,30 +124,33 @@ const ObservedVmNode: React.FC<VmNodeProps> = ({
   return (
     <g>
       <Tooltip
+        triggerRef={ref}
         content={tipContent}
         trigger="manual"
         isVisible={dropTarget && canDrop}
         animationDuration={0}
       >
-        <BaseNode
-          className={classNames('kubevirt-vm-node', statusClass)}
-          kind={kind}
-          element={element}
-          dropTarget={dropTarget}
-          canDrop={canDrop}
-          {...rest}
-        >
-          {statusMessage ? <Tooltip content={statusMessage}>{statusRect}</Tooltip> : statusRect}
-          <rect
-            className="kubevirt-vm-node__bg"
-            x={VM_STATUS_GAP + VM_STATUS_WIDTH}
-            y={VM_STATUS_GAP + VM_STATUS_WIDTH}
-            width={width - (VM_STATUS_GAP + VM_STATUS_WIDTH) * 2}
-            height={height - (VM_STATUS_GAP + VM_STATUS_WIDTH) * 2}
-          />
-          {imageComponent}
-          {children}
-        </BaseNode>
+        <g ref={ref}>
+          <BaseNode
+            className={classNames('kubevirt-vm-node', statusClass)}
+            kind={kind}
+            element={element}
+            dropTarget={dropTarget}
+            canDrop={canDrop}
+            {...rest}
+          >
+            {statusMessage ? <Tooltip content={statusMessage}>{statusRect}</Tooltip> : statusRect}
+            <rect
+              className="kubevirt-vm-node__bg"
+              x={VM_STATUS_GAP + VM_STATUS_WIDTH}
+              y={VM_STATUS_GAP + VM_STATUS_WIDTH}
+              width={width - (VM_STATUS_GAP + VM_STATUS_WIDTH) * 2}
+              height={height - (VM_STATUS_GAP + VM_STATUS_WIDTH) * 2}
+            />
+            {imageComponent}
+            {children}
+          </BaseNode>
+        </g>
       </Tooltip>
     </g>
   );

--- a/frontend/packages/pipelines-plugin/src/topology/build-decorators/PipelineRunDecorator.tsx
+++ b/frontend/packages/pipelines-plugin/src/topology/build-decorators/PipelineRunDecorator.tsx
@@ -39,6 +39,7 @@ export const ConnectedPipelineRunDecorator: React.FC<PipelineRunDecoratorProps &
   y,
   impersonate,
 }) => {
+  const ref = React.useRef();
   const { t } = useTranslation();
   const { latestPipelineRun, status } = getLatestPipelineRunStatus(pipelineRuns);
   const [taskRuns, taskRunsLoaded] = useTaskRuns(latestPipelineRun?.metadata?.namespace);
@@ -99,8 +100,8 @@ export const ConnectedPipelineRunDecorator: React.FC<PipelineRunDecoratorProps &
   }
 
   return (
-    <Tooltip content={tooltipContent} position={TooltipPosition.left}>
-      {decoratorContent}
+    <Tooltip triggerRef={ref} content={tooltipContent} position={TooltipPosition.left}>
+      <g ref={ref}>{decoratorContent}</g>
     </Tooltip>
   );
 };

--- a/frontend/packages/shipwright-plugin/src/components/build-decorators/ShipwrightBuildDecorator.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/build-decorators/ShipwrightBuildDecorator.tsx
@@ -37,6 +37,7 @@ export const ConnectedBuildRunDecorator: React.FC<BuildRunDecoratorProps & State
   x,
   y,
 }) => {
+  const ref = React.useRef();
   const { t } = useTranslation();
   const { latestBuildRun, status } = getLatestBuildRunStatusforDeployment(buildRuns, resource);
 
@@ -78,8 +79,8 @@ export const ConnectedBuildRunDecorator: React.FC<BuildRunDecoratorProps & State
   }
 
   return (
-    <Tooltip content={tooltipContent} position={TooltipPosition.left}>
-      {decoratorContent}
+    <Tooltip triggerRef={ref} content={tooltipContent} position={TooltipPosition.left}>
+      <g ref={ref}>{decoratorContent}</g>
     </Tooltip>
   );
 };

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/BuildDecorator.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/BuildDecorator.tsx
@@ -16,6 +16,7 @@ interface BuildDecoratorProps {
 }
 
 const BuildDecorator: React.FC<BuildDecoratorProps> = ({ element, radius, x, y }) => {
+  const ref = React.useRef();
   const { t } = useTranslation();
   const resource = getResource(element);
   const { buildConfigs } = useBuildConfigsWatcher(resource);
@@ -34,10 +35,12 @@ const BuildDecorator: React.FC<BuildDecoratorProps> = ({ element, radius, x, y }
   )}/logs`;
 
   return (
-    <Tooltip content={label} position={TooltipPosition.left}>
-      <BuildDecoratorBubble x={x} y={y} radius={radius} ariaLabel={label} href={link}>
-        <Status status={build.status.phase} iconOnly noTooltip />
-      </BuildDecoratorBubble>
+    <Tooltip triggerRef={ref} content={label} position={TooltipPosition.left}>
+      <g ref={ref}>
+        <BuildDecoratorBubble x={x} y={y} radius={radius} ariaLabel={label} href={link}>
+          <Status status={build.status.phase} iconOnly noTooltip />
+        </BuildDecoratorBubble>
+      </g>
     </Tooltip>
   );
 };

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/EditDecorator.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/EditDecorator.tsx
@@ -17,6 +17,7 @@ interface DefaultDecoratorProps {
 }
 
 const EditDecorator: React.FC<DefaultDecoratorProps> = ({ element, radius, x, y }) => {
+  const ref = React.useRef();
   const { t } = useTranslation();
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
@@ -35,10 +36,12 @@ const EditDecorator: React.FC<DefaultDecoratorProps> = ({ element, radius, x, y 
   }
   const label = t('topology~Edit source code');
   return (
-    <Tooltip content={label} position={TooltipPosition.right}>
-      <Decorator x={x} y={y} radius={radius} href={editUrl} external ariaLabel={label}>
-        <g transform={`translate(-${radius / 2}, -${radius / 2})`}>{repoIcon}</g>
-      </Decorator>
+    <Tooltip triggerRef={ref} content={label} position={TooltipPosition.right}>
+      <g ref={ref}>
+        <Decorator x={x} y={y} radius={radius} href={editUrl} external ariaLabel={label}>
+          <g transform={`translate(-${radius / 2}, -${radius / 2})`}>{repoIcon}</g>
+        </Decorator>
+      </g>
     </Tooltip>
   );
 };

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/MonitoringAlertsDecorator.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/MonitoringAlertsDecorator.tsx
@@ -37,6 +37,7 @@ const MonitoringAlertsDecorator: React.FC<MonitoringAlertsDecoratorType> = ({
   y,
   showMonitoringOverview,
 }) => {
+  const ref = React.useRef();
   const { t } = useTranslation();
   const workloadData = element.getData().data;
   const { monitoringAlerts } = workloadData;
@@ -53,12 +54,14 @@ const MonitoringAlertsDecorator: React.FC<MonitoringAlertsDecoratorType> = ({
 
   const label = t('topology~Monitoring alert');
   return (
-    <Tooltip key="monitoringAlert" content={label} position={TooltipPosition.left}>
-      <Decorator x={x} y={y} radius={radius} onClick={showSidebar} ariaLabel={label}>
-        <g transform={`translate(-${radius / 2}, -${radius / 2})`}>
-          <AlertSeverityIcon severityAlertType={severityAlertType} fontSize={radius} />
-        </g>
-      </Decorator>
+    <Tooltip triggerRef={ref} key="monitoringAlert" content={label} position={TooltipPosition.left}>
+      <g ref={ref}>
+        <Decorator x={x} y={y} radius={radius} onClick={showSidebar} ariaLabel={label}>
+          <g transform={`translate(-${radius / 2}, -${radius / 2})`}>
+            <AlertSeverityIcon severityAlertType={severityAlertType} fontSize={radius} />
+          </g>
+        </Decorator>
+      </g>
     </Tooltip>
   );
 };

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/UrlDecorator.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/UrlDecorator.tsx
@@ -15,6 +15,7 @@ interface DefaultDecoratorProps {
 }
 
 const UrlDecorator: React.FC<DefaultDecoratorProps> = ({ element, radius, x, y }) => {
+  const ref = React.useRef();
   const { t } = useTranslation();
   const resourceObj = getResource(element);
   const url = useRoutesURL(resourceObj);
@@ -23,12 +24,14 @@ const UrlDecorator: React.FC<DefaultDecoratorProps> = ({ element, radius, x, y }
   }
   const label = t('topology~Open URL');
   return (
-    <Tooltip key="route" content={label} position={TooltipPosition.right}>
-      <Decorator x={x} y={y} radius={radius} href={url} external ariaLabel={label}>
-        <g transform={`translate(-${radius / 2}, -${radius / 2})`}>
-          <ExternalLinkAltIcon style={{ fontSize: radius }} title={label} />
-        </g>
-      </Decorator>
+    <Tooltip triggerRef={ref} key="route" content={label} position={TooltipPosition.right}>
+      <g ref={ref}>
+        <Decorator x={x} y={y} radius={radius} href={url} external ariaLabel={label}>
+          <g transform={`translate(-${radius / 2}, -${radius / 2})`}>
+            <ExternalLinkAltIcon style={{ fontSize: radius }} title={label} />
+          </g>
+        </Decorator>
+      </g>
     </Tooltip>
   );
 };

--- a/frontend/packages/topology/src/operators/components/OperatorBackedServiceGroup.tsx
+++ b/frontend/packages/topology/src/operators/components/OperatorBackedServiceGroup.tsx
@@ -59,6 +59,7 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
   onContextMenu,
   contextMenuOpen,
 }) => {
+  const ref = React.useRef();
   const { t } = useTranslation();
   const [hover, hoverRef] = useHover();
   const [innerHover, innerHoverRef] = useHover();
@@ -85,47 +86,50 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
       <NodeShadows />
       <Layer id={dragging || labelDragging ? undefined : 'groups2'}>
         <Tooltip
+          triggerRef={ref}
           content={t('topology~Create Service Binding')}
           trigger="manual"
           isVisible={dropTarget && canDrop}
           animationDuration={0}
           position="top"
         >
-          <g
-            ref={nodeRefs}
-            className={classNames('odc-operator-backed-service', {
-              'pf-m-selected': selected,
-              'pf-m-highlight': canDrop,
-              'pf-m-dragging': dragging || labelDragging,
-              'is-filtered': filtered,
-              'pf-m-drop-target': canDrop && dropTarget,
-            })}
-          >
-            <rect
-              key={
-                hover || innerHover || contextMenuOpen || dragging || labelDragging
-                  ? 'rect-hover'
-                  : 'rect'
-              }
-              ref={dndDropRef}
-              className="odc-operator-backed-service__bg"
-              x={x}
-              y={y}
-              width={width}
-              height={height}
-              rx="5"
-              ry="5"
-              filter={createSvgIdUrl(
-                hover || innerHover || contextMenuOpen || dragging || labelDragging
-                  ? NODE_SHADOW_FILTER_ID_HOVER
-                  : NODE_SHADOW_FILTER_ID,
+          <g ref={ref}>
+            <g
+              ref={nodeRefs}
+              className={classNames('odc-operator-backed-service', {
+                'pf-m-selected': selected,
+                'pf-m-highlight': canDrop,
+                'pf-m-dragging': dragging || labelDragging,
+                'is-filtered': filtered,
+                'pf-m-drop-target': canDrop && dropTarget,
+              })}
+            >
+              <rect
+                key={
+                  hover || innerHover || contextMenuOpen || dragging || labelDragging
+                    ? 'rect-hover'
+                    : 'rect'
+                }
+                ref={dndDropRef}
+                className="odc-operator-backed-service__bg"
+                x={x}
+                y={y}
+                width={width}
+                height={height}
+                rx="5"
+                ry="5"
+                filter={createSvgIdUrl(
+                  hover || innerHover || contextMenuOpen || dragging || labelDragging
+                    ? NODE_SHADOW_FILTER_ID_HOVER
+                    : NODE_SHADOW_FILTER_ID,
+                )}
+              />
+              {!hasChildren && (
+                <text x={x + width / 2} y={y + height / 2} dy="0.35em" textAnchor="middle">
+                  No Resources
+                </text>
               )}
-            />
-            {!hasChildren && (
-              <text x={x + width / 2} y={y + height / 2} dy="0.35em" textAnchor="middle">
-                No Resources
-              </text>
-            )}
+            </g>
           </g>
         </Tooltip>
       </Layer>

--- a/frontend/packages/topology/src/operators/components/OperatorBackedServiceNode.tsx
+++ b/frontend/packages/topology/src/operators/components/OperatorBackedServiceNode.tsx
@@ -30,16 +30,20 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
   dropTarget,
   ...rest
 }) => {
+  const ref = React.useRef();
   const { t } = useTranslation();
   return (
     <Tooltip
+      triggerRef={ref}
       content={t('topology~Create Service Binding')}
       trigger="manual"
       isVisible={dropTarget && canDrop}
       animationDuration={0}
       position="top"
     >
-      <GroupNode bgClassName="odc-operator-backed-service__bg" {...rest} />
+      <g ref={ref}>
+        <GroupNode bgClassName="odc-operator-backed-service__bg" {...rest} />
+      </g>
     </Tooltip>
   );
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-23780
https://issues.redhat.com/browse/OCPBUGS-23794
https://issues.redhat.com/browse/OCPBUGS-23977
https://issues.redhat.com/browse/OCPBUGS-23783

**Analysis / Root cause**: 
The decorators and Pod Rings around the resources in the Topology view were not visible after the PF upgrade.

**Solution Description**: 
Added `triggerRef` to the ToolTip components to bring back the same

**Screen shots / Gifs for design review**: 

https://github.com/openshift/console/assets/47265560/5b5e9723-f827-43e5-a16c-60e9f148f727

![image](https://github.com/openshift/console/assets/47265560/bb2ec69c-40d3-49d8-bfc3-06d2a62e865a)



**Unit test coverage report**: 
Not Changed.

**Test setup:**
1. Create respective applications to test the Pod Rings/ Decorators in the Topology View



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge