### PR TITLE
OCPBUGS-23980: Fix logs streaming auto scroll issue

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/Logs.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/Logs.tsx
@@ -48,7 +48,7 @@ const Logs: React.FC<LogsProps> = ({
         scrollToRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
       }
       blockContentRef.current = '';
-    }, 300),
+    }, 1000),
     [],
   );
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/MultiStreamLogs.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/MultiStreamLogs.tsx
@@ -48,7 +48,7 @@ export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
   }, []);
 
   const autoScroll =
-    scrollDirection == null || scrollDirection === ScrollDirection.scrolledToBottom;
+    scrollDirection == null || scrollDirection !== ScrollDirection.scrolledToBottom;
 
   const containerStatus: ContainerStatus[] = resource.status?.containerStatuses ?? [];
   return (


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/OCPBUGS-23980

**Problem:**

logs container is not auto scrolling to the bottom of the page.

**Solution:**

Increase the throttle timeout to address the performance issue on high volume logs and set the autoscroll prop to true by default

**Before:**

Autoscroll feature is not working after few scroll operation. 

![logs_streaming_before_fix](https://github.com/openshift/console/assets/9964343/897feda1-9539-44dd-815b-da99240f6185)



**After:**

![log_streaming_after_fix](https://github.com/openshift/console/assets/9964343/43be4855-7369-4f82-b12a-689254738df6)


**Steps to test/reproduce:**

1. Use this pipelinerun - https://gist.github.com/karthikjeeyar/eb1bbdf9157431f5c875eb55ce47580c
2. navigate to logs page
