### PR TITLE
OCPBUGS-18371: Searching for items in quick search is confusing

### DIFF
--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.scss
@@ -56,4 +56,7 @@
     display: flex;
     flex-direction: column;
   }
+  &__secondary-label {
+    margin-left: var(--pf-v5-global--BorderWidth--md);
+  }
 }

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.tsx
@@ -134,16 +134,23 @@ const QuickSearchList: React.FC<QuickSearchListProps> = ({
                       </span>
                       <Split style={{ alignItems: 'center' }} hasGutter>
                         <SplitItem>
-                          <Label>{itemType}</Label>
+                          <Split>
+                            <SplitItem>
+                              <Label>{itemType}</Label>
+                            </SplitItem>
+                            {item?.secondaryLabel && (
+                              <SplitItem className="ocs-quick-search-list__secondary-label">
+                                <Label>{item.secondaryLabel}</Label>
+                              </SplitItem>
+                            )}
+                          </Split>
                         </SplitItem>
                         <SplitItem>
-                          {item.secondaryLabel ?? (
-                            <TextContent
-                              data-test={`item-name-${item.name}-${item.provider}-secondary-label`}
-                            >
-                              <Text component={TextVariants.small}>{item.provider}</Text>
-                            </TextContent>
-                          )}
+                          <TextContent
+                            data-test={`item-name-${item.name}-${item.provider}-secondary-label`}
+                          >
+                            <Text component={TextVariants.small}>{item.provider}</Text>
+                          </TextContent>
                         </SplitItem>
                       </Split>
                     </DataListCell>,

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -201,6 +201,7 @@
   "A <1>DeploymentConfig</1> to rollout new revisions when the Image changes.": "A <1>DeploymentConfig</1> to rollout new revisions when the Image changes.",
   "A <1>Service</1> to expose your workload inside the Cluster.": "A <1>Service</1> to expose your workload inside the Cluster.",
   "An optional <1>Route</1> to expose your workload outside the Cluster.": "An optional <1>Route</1> to expose your workload outside the Cluster.",
+  "Create Builder Image Sample": "Create Builder Image Sample",
   "Create Devfile Sample": "Create Devfile Sample",
   "Instantiate Template": "Instantiate Template",
   "Pause rollouts": "Pause rollouts",

--- a/frontend/packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.data.ts
+++ b/frontend/packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.data.ts
@@ -66,6 +66,7 @@ export const expectedCatalogItems: CatalogItem[] = [
     type: 'Devfile',
     name: 'Basic Node.js',
     provider: undefined,
+    secondaryLabel: 'Samples',
     description: 'A simple Hello World Node.js application',
     tags: ['NodeJS', 'Express'],
     cta: {
@@ -80,6 +81,7 @@ export const expectedCatalogItems: CatalogItem[] = [
     type: 'Devfile',
     name: 'Basic Quarkus',
     provider: undefined,
+    secondaryLabel: 'Samples',
     description: 'A simple Hello World Java application using Quarkus',
     tags: ['Java', 'Quarkus'],
     cta: {
@@ -94,6 +96,7 @@ export const expectedCatalogItems: CatalogItem[] = [
     type: 'Devfile',
     name: 'Basic Spring Boot',
     provider: undefined,
+    secondaryLabel: 'Samples',
     description: 'A simple Hello World Java Spring Boot application using Maven',
     tags: ['Java', 'Spring'],
     cta: {
@@ -108,6 +111,7 @@ export const expectedCatalogItems: CatalogItem[] = [
     type: 'Devfile',
     name: 'Basic Python',
     provider: undefined,
+    secondaryLabel: 'Samples',
     description: 'A simple Hello World application using Python',
     tags: ['Python'],
     cta: {

--- a/frontend/packages/dev-console/src/components/catalog/providers/useBuilderImageSamples.ts
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useBuilderImageSamples.ts
@@ -30,13 +30,14 @@ const normalizeBuilderImages = (
     const provider = annotations?.[ANNOTATIONS.providerDisplayName] ?? '';
     const creationTimestamp = imageStream.metadata?.creationTimestamp;
     const href = `/samples/ns/${activeNamespace}/${name}/${imageStreamNS}`;
-    const createLabel = t('devconsole~Create');
+    const createLabel = t('devconsole~Create Builder Image Sample');
     const type = 'BuilderImage';
 
     const item: CatalogItem = {
       uid: `${type}-${uid}`,
       type,
       name: title,
+      secondaryLabel: 'Samples',
       provider,
       description,
       creationTimestamp,

--- a/frontend/packages/dev-console/src/components/catalog/providers/useDevfileSamples.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useDevfileSamples.tsx
@@ -29,6 +29,7 @@ const normalizeDevfileSamples = (
       uid,
       type: 'Devfile',
       name: displayName,
+      secondaryLabel: 'Samples',
       description,
       tags,
       provider,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-18371

**Analysis / Root cause**: 
In the quick search, if you search for word net you can see two options with the same name and description, one is for the source to image option and the other is for the sample option
but there is no way to differentiate in quick search

**Solution Description**: 
Added Labels to the Samples in Quicksearch and updated the button name

**Screen shots / Gifs for design review**: 

![image](https://github.com/openshift/console/assets/47265560/ea02a094-8e5f-4049-b88a-cc5cdbedcf65)


**Unit test coverage report**: 
Updated

**Test setup:**
1. Go to topology or Add page and select quick search
2. Search for net or node you will see confusing options



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge