### PR TITLE
OCPBUGS-23779: Fix crash when user clicks on Show tooltips

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -624,8 +624,8 @@ const EditYAMLInner = (props) => {
     window.dispatchEvent(new Event('sidebar_toggle'));
   };
 
-  const toggleShowTooltips = (v) => {
-    props.setShowTooltips(v);
+  const toggleShowTooltips = (event, checked) => {
+    props.setShowTooltips(checked);
   };
 
   const sanitizeYamlContent = (id, yaml, kind) => {
@@ -679,9 +679,7 @@ const EditYAMLInner = (props) => {
       id="showTooltips"
       isChecked={showTooltips}
       data-checked-state={showTooltips}
-      onChange={(checked) => {
-        toggleShowTooltips(checked);
-      }}
+      onChange={toggleShowTooltips}
     />
   );
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-23779

**Analysis / Root cause**: 
UI crashes because it tries to save the `Checkbox` click event instead of the new value.

**Solution Description**: 
The PF5 updates the signature of the `onChange` callback, and returns now the event as well.

Just add and ignore the `event` parameter.

**Screen shots / Gifs for design review**: 
Before:

https://github.com/openshift/console/assets/139310/05a6c962-1698-45e6-bdeb-1be9e73b5a05

After:

https://github.com/openshift/console/assets/139310/436e88c6-6317-4d2b-9637-053213c59459

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Open the YAML import view
2. Click on the "Show tooltip" checkbox

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
