### PR TITLE
OCPBUGS-24203: ConsolePlugin metrics must no longer be grouped by the vendor

### DIFF
--- a/pkg/serverconfig/metrics_test.go
+++ b/pkg/serverconfig/metrics_test.go
@@ -71,8 +71,9 @@ func TestPluginMetrics(t *testing.T) {
 			configuredPlugins: []string{"acm", "kubevirt-plugin", "my-plugin"},
 			consolePlugins:    []string{"acm", "kubevirt-plugin", "my-plugin"},
 			expectedMetrics: `
+			console_plugins_info{name="acm",state="enabled"} 1
 			console_plugins_info{name="demo",state="enabled"} 1
-			console_plugins_info{name="redhat",state="enabled"} 2
+			console_plugins_info{name="kubevirt",state="enabled"} 1
 			`,
 		},
 
@@ -82,7 +83,7 @@ func TestPluginMetrics(t *testing.T) {
 			configuredPlugins: []string{"an-enabled-plugin", "another-enabled-plugin"},
 			consolePlugins:    []string{"an-enabled-plugin", "another-enabled-plugin"},
 			expectedMetrics: `
-			console_plugins_info{name="other",state="enabled"} 2
+			console_plugins_info{name="unknown",state="enabled"} 2
 			`,
 		},
 
@@ -92,7 +93,7 @@ func TestPluginMetrics(t *testing.T) {
 			configuredPlugins: []string{},
 			consolePlugins:    []string{"a-disabed-plugin", "another-disabed-plugin"},
 			expectedMetrics: `
-			console_plugins_info{name="other",state="disabled"} 2
+			console_plugins_info{name="unknown",state="disabled"} 2
 			`,
 		},
 
@@ -102,7 +103,7 @@ func TestPluginMetrics(t *testing.T) {
 			configuredPlugins: []string{"a-missing-plugin", "another-missing-plugin"},
 			consolePlugins:    []string{},
 			expectedMetrics: `
-			console_plugins_info{name="other",state="notfound"} 2
+			console_plugins_info{name="unknown",state="notfound"} 2
 			`,
 		},
 	}
@@ -156,14 +157,17 @@ func TestPluginMetricsRunningTwice(t *testing.T) {
 			consolePluginsInitially: []string{"acm", "kubevirt-plugin", "my-plugin"},
 			consolePluginsUpdated:   []string{},
 			expectedMetricsInitially: `
+			console_plugins_info{name="acm",state="enabled"} 1
 			console_plugins_info{name="demo",state="enabled"} 1
-			console_plugins_info{name="redhat",state="enabled"} 2
+			console_plugins_info{name="kubevirt",state="enabled"} 1
 			`,
 			expectedMetricsAfterUpdate: `
+			console_plugins_info{name="acm",state="enabled"} 0
+			console_plugins_info{name="acm",state="notfound"} 1
 			console_plugins_info{name="demo",state="enabled"} 0
 			console_plugins_info{name="demo",state="notfound"} 1
-			console_plugins_info{name="redhat",state="enabled"} 0
-			console_plugins_info{name="redhat",state="notfound"} 2
+			console_plugins_info{name="kubevirt",state="enabled"} 0
+			console_plugins_info{name="kubevirt",state="notfound"} 1
 			`,
 		},
 
@@ -173,11 +177,11 @@ func TestPluginMetricsRunningTwice(t *testing.T) {
 			consolePluginsInitially: []string{"an-enabled-plugin", "another-enabled-plugin"},
 			consolePluginsUpdated:   []string{"an-enabled-plugin"},
 			expectedMetricsInitially: `
-			console_plugins_info{name="other",state="enabled"} 2
+			console_plugins_info{name="unknown",state="enabled"} 2
 			`,
 			expectedMetricsAfterUpdate: `
-			console_plugins_info{name="other",state="enabled"} 1
-			console_plugins_info{name="other",state="notfound"} 1
+			console_plugins_info{name="unknown",state="enabled"} 1
+			console_plugins_info{name="unknown",state="notfound"} 1
 			`,
 		},
 
@@ -187,10 +191,10 @@ func TestPluginMetricsRunningTwice(t *testing.T) {
 			consolePluginsInitially: []string{"a-disabed-plugin", "another-disabed-plugin"},
 			consolePluginsUpdated:   []string{"a-disabed-plugin"},
 			expectedMetricsInitially: `
-			console_plugins_info{name="other",state="disabled"} 2
+			console_plugins_info{name="unknown",state="disabled"} 2
 			`,
 			expectedMetricsAfterUpdate: `
-			console_plugins_info{name="other",state="disabled"} 1
+			console_plugins_info{name="unknown",state="disabled"} 1
 			`,
 		},
 
@@ -200,11 +204,11 @@ func TestPluginMetricsRunningTwice(t *testing.T) {
 			consolePluginsInitially: []string{},
 			consolePluginsUpdated:   []string{"another-plugin"},
 			expectedMetricsInitially: `
-			console_plugins_info{name="other",state="notfound"} 2
+			console_plugins_info{name="unknown",state="notfound"} 2
 			`,
 			expectedMetricsAfterUpdate: `
-			console_plugins_info{name="other",state="enabled"} 1
-			console_plugins_info{name="other",state="notfound"} 1
+			console_plugins_info{name="unknown",state="enabled"} 1
+			console_plugins_info{name="unknown",state="notfound"} 1
 			`,
 		},
 
@@ -214,16 +218,16 @@ func TestPluginMetricsRunningTwice(t *testing.T) {
 			consolePluginsInitially: []string{"an-first-enabled-plugin", "acm", "another-disabled-plugin"},
 			consolePluginsUpdated:   []string{"another-disabled-plugin", "acm", "my-plugin"},
 			expectedMetricsInitially: `
-			console_plugins_info{name="other",state="disabled"} 1
-			console_plugins_info{name="other",state="enabled"} 1
-			console_plugins_info{name="redhat",state="enabled"} 1
+			console_plugins_info{name="acm",state="enabled"} 1
+			console_plugins_info{name="unknown",state="disabled"} 1
+			console_plugins_info{name="unknown",state="enabled"} 1
 			`,
 			expectedMetricsAfterUpdate: `
+			console_plugins_info{name="acm",state="enabled"} 1
 			console_plugins_info{name="demo",state="disabled"} 1
-			console_plugins_info{name="other",state="disabled"} 1
-			console_plugins_info{name="other",state="enabled"} 0
-			console_plugins_info{name="other",state="notfound"} 1
-			console_plugins_info{name="redhat",state="enabled"} 1
+			console_plugins_info{name="unknown",state="disabled"} 1
+			console_plugins_info{name="unknown",state="enabled"} 0
+			console_plugins_info{name="unknown",state="notfound"} 1
 			`,
 		},
 	}


### PR DESCRIPTION
The monitoring team is fine that we save all installed, known RH plugin names in our metrics/promtheus, instead of grouping them by "redhat" and "others".

To this PR

* [x] Changes the type and variable from "vendor" to "mapped plugin name" (only visible within our code base)
* [x] Updated the existing mapping and changed the mapping to the plugin names. It still maps the plugin names so that they naming is bit more aligned since we had at least 3 naming schemas there:
  * `acm` = acm
  * `gitops-plugin` => gitops
  * `forklift-console-plugin` => forklift
* [x] Added:
  * `monitoring-plugin` (reported as monitoring)
  * `gitops-plugin` (reported as gitops)
  * `pipeline-console-plugin` (reported as pipelines)

This PR requires that https://github.com/openshift/console-operator/pull/819 gets also merged into the same release!

We want to backport both to 4.13 and 4.14 as well.