### PR TITLE
OCPBUGS-24267: Cluster configuration fields are not visible

### DIFF
--- a/frontend/packages/console-app/src/components/cluster-configuration/ClusterConfigurationForm.tsx
+++ b/frontend/packages/console-app/src/components/cluster-configuration/ClusterConfigurationForm.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { Form } from '@patternfly/react-core';
+import ClusterConfigurationField from './ClusterConfigurationField';
+import { ResolvedClusterConfigurationItem } from './types';
+
+type ClusterConfigurationFormProps = {
+  items: ResolvedClusterConfigurationItem[];
+};
+
+const ClusterConfigurationForm: React.FC<ClusterConfigurationFormProps> = ({ items }) =>
+  items?.length > 0 ? (
+    <Form onSubmit={(event) => event.preventDefault()}>
+      {items.map((item) => (
+        <ClusterConfigurationField key={item.id} item={item} />
+      ))}
+    </Form>
+  ) : null;
+export default ClusterConfigurationForm;

--- a/frontend/packages/console-app/src/components/cluster-configuration/ClusterConfigurationPage.scss
+++ b/frontend/packages/console-app/src/components/cluster-configuration/ClusterConfigurationPage.scss
@@ -10,7 +10,7 @@
   }
 
   .ocs-page-layout__content {
-    display: flex;
+    display: inline;
   }
 
   .pf-v5-c-empty-state {
@@ -39,10 +39,33 @@
   .pf-v5-c-tabs__scroll-button {
     display: none;
   }
+}
 
-  .pf-v5-c-tab-content {
-    background-color: var(--pf-v5-global--BackgroundColor--100);
-    width: 100%;
-    padding: var(--pf-v5-global--spacer--lg);
+.co-cluster-configuration-page-content {
+  display: flex;
+  flex-direction: row;
+  background-color: var(--pf-v5-global--BackgroundColor--100);
+  min-height: 100%;
+  &__tabs {
+    @media (min-width: 769px) {
+      max-width: 100%;
+    }
+
+    @media (min-width: 992px) {
+      min-width: 220px;
+    }
+
+    @media (min-width: 1200px) {
+      max-width: 220px;
+    }
+  }
+  &__tab-content {
+    margin: var(--pf-v5-global--spacer--lg);
+    max-width: 100%;
+  }
+
+  //workaround for patternfly bug which causes the buttons to show even when isVertical prop is true
+  .pf-v5-c-tabs__scroll-button {
+    display: none;
   }
 }

--- a/frontend/packages/console-app/src/components/cluster-configuration/ClusterConfigurationPage.tsx
+++ b/frontend/packages/console-app/src/components/cluster-configuration/ClusterConfigurationPage.tsx
@@ -3,11 +3,13 @@ import {
   Tabs,
   Tab,
   TabProps,
-  Form,
   EmptyState,
   EmptyStateIcon,
   EmptyStateBody,
   EmptyStateHeader,
+  TabContent,
+  TabContentProps,
+  TabTitleText,
 } from '@patternfly/react-core';
 import { LockIcon } from '@patternfly/react-icons/dist/esm/icons/lock-icon';
 import Helmet from 'react-helmet';
@@ -15,9 +17,12 @@ import { useTranslation } from 'react-i18next';
 import { RouteComponentProps } from 'react-router';
 import { LoadingBox, history } from '@console/internal/components/utils';
 import { PageLayout, isModifiedEvent } from '@console/shared';
-import ClusterConfigurationField from './ClusterConfigurationField';
+import ClusterConfigurationForm from './ClusterConfigurationForm';
+import { getClusterConfigurationGroups } from './getClusterConfigurationGroups';
+import { ClusterConfigurationTabGroup } from './types';
 import useClusterConfigurationGroups from './useClusterConfigurationGroups';
 import useClusterConfigurationItems from './useClusterConfigurationItems';
+
 import './ClusterConfigurationPage.scss';
 
 export type ClusterConfigurationPageProps = RouteComponentProps<{ group: string }>;
@@ -25,12 +30,14 @@ export type ClusterConfigurationPageProps = RouteComponentProps<{ group: string 
 const ClusterConfigurationPage: React.FC<ClusterConfigurationPageProps> = ({ match }) => {
   const { t } = useTranslation();
 
-  const groupId = match.params.group || 'general';
+  const initialGroupId = match.params.group || 'general';
+  const [activeTabId, setActiveTabId] = React.useState<string>(initialGroupId);
   const onSelect = (event: React.MouseEvent<HTMLElement>, newGroupId: string) => {
     if (isModifiedEvent(event)) {
       return;
     }
     event.preventDefault();
+    setActiveTabId(newGroupId);
     const path = match.path.includes(':group')
       ? match.path.replace(':group', newGroupId)
       : `${match.path}/${newGroupId}`;
@@ -49,24 +56,49 @@ const ClusterConfigurationPage: React.FC<ClusterConfigurationPageProps> = ({ mat
 
   const loaded = clusterConfigurationGroupsResolved && clusterConfigurationItemsResolved;
 
-  const tabs: React.ReactElement<TabProps>[] = clusterConfigurationGroups
-    .filter((group) => clusterConfigurationItems.some((item) => group.id === item.groupId))
-    .map((group) => {
-      const items =
-        groupId === group.id
-          ? clusterConfigurationItems
-              .filter((item) => item.groupId === group.id)
-              .map((item) => <ClusterConfigurationField key={item.id} item={item} />)
-          : null;
+  const [clusterConfigurationTabs, clusterConfigurationTabContents] = React.useMemo<
+    [React.ReactElement<TabProps>[], React.ReactElement<TabContentProps>[]]
+  >(() => {
+    const populatedClusterCongigurationGroups: ClusterConfigurationTabGroup[] = getClusterConfigurationGroups(
+      clusterConfigurationGroups,
+      clusterConfigurationItems,
+    );
+    const [tabs, tabContents] = populatedClusterCongigurationGroups.reduce(
+      (acc, currGroup) => {
+        const { id, label, items } = currGroup;
+        const ref = React.createRef<HTMLElement>();
+        acc[0].push(
+          <Tab
+            key={id}
+            eventKey={id}
+            title={<TabTitleText>{label}</TabTitleText>}
+            href={`/cluster-configuration/${id}`}
+            tabContentId={id}
+            tabContentRef={ref}
+            data-test={`tab ${id}`}
+            translate="no"
+          />,
+        );
+        acc[1].push(
+          <TabContent
+            key={id}
+            eventKey={id}
+            id={id}
+            ref={ref}
+            data-test={`tab-content ${id}`}
+            hidden={id !== activeTabId}
+          >
+            <ClusterConfigurationForm items={items} />
+          </TabContent>,
+        );
+        return acc;
+      },
+      [[], []],
+    );
+    return [tabs, tabContents];
+  }, [activeTabId, clusterConfigurationGroups, clusterConfigurationItems]);
 
-      return (
-        <Tab key={group.id} eventKey={group.id} title={group.label} translate="no">
-          <Form onSubmit={(event) => event.preventDefault()}>{items}</Form>
-        </Tab>
-      );
-    });
-
-  const groupNotFound = !clusterConfigurationGroups.some((group) => group.id === groupId);
+  const groupNotFound = !clusterConfigurationGroups.some((group) => group.id === activeTabId);
 
   return (
     <div className="co-cluster-configuration-page">
@@ -81,7 +113,7 @@ const ClusterConfigurationPage: React.FC<ClusterConfigurationPageProps> = ({ mat
       >
         {!loaded ? (
           <LoadingBox />
-        ) : tabs.length === 0 ? (
+        ) : clusterConfigurationTabs.length === 0 ? (
           <EmptyState>
             <EmptyStateHeader
               titleText={<>{t('console-app~Insufficient permissions')}</>}
@@ -96,13 +128,25 @@ const ClusterConfigurationPage: React.FC<ClusterConfigurationPageProps> = ({ mat
           </EmptyState>
         ) : (
           <>
-            <Tabs isVertical activeKey={groupId} onSelect={onSelect}>
-              <>{tabs}</>
-            </Tabs>
+            <div className="co-cluster-configuration-page-content">
+              <div className="co-cluster-configuration-page-content__tabs">
+                <Tabs
+                  activeKey={activeTabId}
+                  onSelect={onSelect}
+                  isVertical
+                  data-test="user-preferences tabs"
+                >
+                  <>{clusterConfigurationTabs}</>
+                </Tabs>
+              </div>
+              <div className="co-cluster-configuration-page-content__tab-content">
+                {clusterConfigurationTabContents}
+              </div>
+            </div>
             {groupNotFound ? (
               /* Similar to a TabContent */
               <section className="co-cluster-configuration-page pf-v5-c-tab-content">
-                <h1>{t('console-app~{{section}} not found', { section: groupId })}</h1>
+                <h1>{t('console-app~{{section}} not found', { section: activeTabId })}</h1>
               </section>
             ) : null}
           </>

--- a/frontend/packages/console-app/src/components/cluster-configuration/getClusterConfigurationGroups.ts
+++ b/frontend/packages/console-app/src/components/cluster-configuration/getClusterConfigurationGroups.ts
@@ -1,0 +1,49 @@
+import {
+  ClusterConfigurationTabGroup,
+  ResolvedClusterConfigurationGroup,
+  ResolvedClusterConfigurationItem,
+} from './types';
+
+export const getClusterConfigurationGroups = (
+  clusterConfigurationGroups: ResolvedClusterConfigurationGroup[],
+  clusterConfigurationItems: ResolvedClusterConfigurationItem[],
+): ClusterConfigurationTabGroup[] => {
+  if (!clusterConfigurationItems?.length || !clusterConfigurationGroups?.length) {
+    return [];
+  }
+  const initialClusterConfigurationGroup: ClusterConfigurationTabGroup[] = clusterConfigurationGroups.map(
+    (clusterConfigurationGroup) => ({
+      ...clusterConfigurationGroup,
+      items: [],
+    }),
+  );
+  const populatedClusterConfigurationGroup: ClusterConfigurationTabGroup[] = clusterConfigurationItems
+    .filter((clusterConfigurationItem) =>
+      clusterConfigurationGroups.find(
+        (clusterConfigurationGroup) =>
+          clusterConfigurationGroup.id === clusterConfigurationItem.groupId,
+      ),
+    )
+    .reduce(
+      (
+        clusterConfigurationGroup: typeof initialClusterConfigurationGroup,
+        currClusterConfigurationItem,
+      ) => {
+        const clusterConfigurationGroupForCurrentItem = clusterConfigurationGroup.find(
+          (group) => currClusterConfigurationItem.groupId === group.id,
+        );
+        if (clusterConfigurationGroupForCurrentItem) {
+          clusterConfigurationGroupForCurrentItem.items.push(currClusterConfigurationItem);
+        } else {
+          clusterConfigurationGroup.push({
+            id: currClusterConfigurationItem.id,
+            label: currClusterConfigurationItem.label,
+            items: [currClusterConfigurationItem],
+          });
+        }
+        return clusterConfigurationGroup;
+      },
+      initialClusterConfigurationGroup,
+    );
+  return populatedClusterConfigurationGroup.filter((group) => group.items.length);
+};

--- a/frontend/packages/console-app/src/components/cluster-configuration/types.ts
+++ b/frontend/packages/console-app/src/components/cluster-configuration/types.ts
@@ -18,3 +18,9 @@ export type ResolvedClusterConfigurationItem = Omit<
   ResolvedExtension<ClusterConfigurationItem>['properties'],
   'insertBefore' | 'insertAfter' | 'readAccessReview' | 'writeAccessReview'
 > & { readonly: boolean };
+
+export type ClusterConfigurationTabGroup = {
+  id: string;
+  label: string;
+  items: ResolvedClusterConfigurationItem[];
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-24267

**Analysis / Root cause**: 
`TabContent` component was not expected before

**Solution Description**: 
Added `TabContent` component to display the tab contents 

**Screen shots / Gifs for design review**: 
----BEFORE---

https://drive.google.com/file/d/17TrZNE2dY-AH-vUwcsjvC4E8wxiyPb9n/view?usp=drive_link

----AFTER----


https://github.com/openshift/console/assets/102503482/98d27395-57e6-4576-9744-732a2082d0b6







**Unit test coverage report**: 
NA

**Test setup:**
 1.Open '/cluster-configuration' link
 2.Check all the tabs
 
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge