### PR TITLE
OCPBUGS-24280: view sbom link redirection should be based on taskrun annotation

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/testData/sbom-pipelinerun/pipelinerun-with-sbom-link.yaml
+++ b/frontend/packages/pipelines-plugin/integration-tests/testData/sbom-pipelinerun/pipelinerun-with-sbom-link.yaml
@@ -9,6 +9,6 @@ spec:
         taskRef:
           name: sbom-task
     results:
-      - name: LINK_TO_SBOM
+      - name: IMAGE_URL
         description: Contains the SBOM link
         value: $(tasks.sbom-task.results.LINK_TO_SBOM)

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunCustomDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunCustomDetails.tsx
@@ -11,7 +11,13 @@ import {
   pipelineRunFilterReducer,
   pipelineRunTitleFilterReducer,
 } from '../../../utils/pipeline-filter-reducer';
-import { getSbomLink, getSbomTaskRun, pipelineRunDuration } from '../../../utils/pipeline-utils';
+import {
+  getImageUrl,
+  getSbomLink,
+  getSbomTaskRun,
+  hasExternalLink,
+  pipelineRunDuration,
+} from '../../../utils/pipeline-utils';
 import {
   convertBackingPipelineToPipelineResourceRefProps,
   getPipelineResourceLinks,
@@ -42,7 +48,9 @@ const PipelineRunCustomDetails: React.FC<PipelineRunCustomDetailsProps> = ({ pip
   );
 
   const sbomTaskRun = taskRunsLoaded ? getSbomTaskRun(taskRuns) : null;
-  const buildImage = getSbomLink(sbomTaskRun);
+  const buildImage = getImageUrl(pipelineRun);
+  const linkToSbom = getSbomLink(sbomTaskRun);
+  const isExternalLink = hasExternalLink(sbomTaskRun);
   return (
     <>
       <dl>
@@ -71,7 +79,7 @@ const PipelineRunCustomDetails: React.FC<PipelineRunCustomDetailsProps> = ({ pip
         <dd>
           <PipelineResourceRef {...convertBackingPipelineToPipelineResourceRefProps(pipelineRun)} />
         </dd>
-        {buildImage && (
+        {buildImage && sbomTaskRun && (
           <>
             <dt data-test="download-sbom">{t('pipelines-plugin~Download SBOM')}</dt>
             <dd>
@@ -92,13 +100,17 @@ const PipelineRunCustomDetails: React.FC<PipelineRunCustomDetailsProps> = ({ pip
           <>
             <dt data-test="view-sbom">{t('pipelines-plugin~SBOM')}</dt>
             <dd>
-              <Link
-                to={`/k8s/ns/${sbomTaskRun.metadata.namespace}/${referenceForModel(TaskRunModel)}/${
-                  sbomTaskRun.metadata.name
-                }/logs`}
-              >
-                {t('pipelines-plugin~View SBOM')}
-              </Link>
+              {isExternalLink && !!linkToSbom ? (
+                <ExternalLink href={linkToSbom}>{t('pipelines-plugin~View SBOM')}</ExternalLink>
+              ) : (
+                <Link
+                  to={`/k8s/ns/${sbomTaskRun.metadata.namespace}/${referenceForModel(
+                    TaskRunModel,
+                  )}/${sbomTaskRun.metadata.name}/logs`}
+                >
+                  {t('pipelines-plugin~View SBOM')}
+                </Link>
+              )}
             </dd>
           </>
         )}

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/__tests__/PipelineRunCustomDetails.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/__tests__/PipelineRunCustomDetails.spec.tsx
@@ -6,6 +6,7 @@ import store from '@console/internal/redux';
 import {
   DataState,
   PipelineExampleNames,
+  PipelineRunWithSBOM,
   pipelineTestData,
 } from '../../../../test-data/pipeline-data';
 import {
@@ -64,7 +65,7 @@ describe('PipelineRunCustomDetails', () => {
     useTaskRunsMock.mockReturnValue([[taskRunWithSBOMResult], true]);
     const wrapper = render(
       <Wrapper>
-        <PipelineRunCustomDetails pipelineRun={pipelineRun} />
+        <PipelineRunCustomDetails pipelineRun={PipelineRunWithSBOM} />
       </Wrapper>,
       {
         wrapper: BrowserRouter,

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/__tests__/taskrun-test-data.ts
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/__tests__/taskrun-test-data.ts
@@ -143,6 +143,56 @@ export const taskRunWithSBOMResult = {
     ],
   },
 };
+
+export const taskRunWithSBOMResultExternalLink = {
+  apiVersion: 'tekton.dev/v1',
+  kind: 'TaskRun',
+  metadata: {
+    annotations: {
+      'chains.tekton.dev/signed': 'true',
+      'pipeline.openshift.io/preferredName': 'pipelinerun-with-sbom-task',
+      'pipeline.openshift.io/started-by': 'kube:admin',
+      'pipeline.tekton.dev/release': 'a2f17f6',
+      'task.output.location': 'results',
+      'task.results.format': 'application/text',
+      'task.results.type': 'external-link',
+      'task.results.key': 'LINK_TO_SBOM',
+    },
+    resourceVersion: '197373',
+    name: 'pipelinerun-with-sbom-task-t237ev-sbom-task',
+    uid: '764d0a6c-a4f6-419c-a3c3-585c2a9eb67c',
+    creationTimestamp: '2023-11-08T08:18:18Z',
+    generation: 1,
+  },
+  spec: {
+    serviceAccountName: 'pipeline',
+    taskRef: {
+      kind: 'Task',
+      name: 'sbom-task',
+    },
+    timeout: '1h0m0s',
+  },
+  status: {
+    completionTime: '2023-11-08T08:18:25Z',
+    conditions: [
+      {
+        lastTransitionTime: '2023-11-08T08:18:25Z',
+        message: 'All Steps have completed executing',
+        reason: 'Succeeded',
+        status: 'True',
+        type: 'Succeeded',
+      },
+    ],
+    podName: 'pipelinerun-with-sbom-task-t237ev-sbom-task-pod',
+    results: [
+      {
+        name: 'LINK_TO_SBOM',
+        type: 'string',
+        value: 'quay.io/test/image:build-8e536-1692702836',
+      },
+    ],
+  },
+};
 export const taskRunWithWorkspaces: TaskRunKind[] = [
   {
     apiVersion: 'tekton.dev/v1beta1',

--- a/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
@@ -3213,6 +3213,67 @@ export enum PipeLineRunWithVulnerabilitiesNames {
   MultipleScanOutput = 'multiple-scan-output',
 }
 
+export enum PipelineRunwithSBOMType {
+  ExternalLink = 'external-link',
+  InternalLink = 'internal-link',
+}
+
+export const PipelineRunWithSBOM: PipelineRunKind = {
+  apiVersion: 'tekton.dev/v1',
+  kind: 'PipelineRun',
+  metadata: {
+    name: 'pipelinerun-with-sbom-task',
+    namespace: 'test-ns',
+  },
+  spec: {
+    pipelineSpec: {
+      results: [
+        {
+          description: 'Contains the SBOM link',
+          name: 'IMAGE_URL',
+          value: '$(tasks.sbom-task.results.IMAGE_URL)',
+        },
+      ],
+      tasks: [
+        {
+          name: 'sbom-task',
+          taskRef: {
+            kind: 'Task',
+            name: 'sbom-task',
+          },
+        },
+      ],
+    },
+  },
+  status: {
+    pipelineSpec: {
+      results: [
+        {
+          description: 'Contains the SBOM link',
+          name: 'IMAGE_URL',
+          value: '$(tasks.sbom-task.results.IMAGE_URL)',
+        },
+      ],
+      tasks: [
+        {
+          name: 'sbom-task',
+          taskRef: {
+            kind: 'Task',
+            name: 'sbom-task',
+          },
+        },
+      ],
+    },
+    results: [
+      {
+        name: 'IMAGE_URL',
+        value:
+          'quay.io/redhat-user-workloads/karthik-jk-tenant/node-express-hello/node-express-hello:build-8e536-1692702836',
+      },
+    ],
+  },
+};
+
 export const PipeLineRunWithVulnerabilitiesData: Record<string, PipelineRunKind> = {
   [PipeLineRunWithVulnerabilitiesNames.ScanOutput]: {
     kind: 'PipelineRun',

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
@@ -11,9 +11,15 @@ import { SecretAnnotationId, TektonResourceLabel } from '../../components/pipeli
 import {
   taskRunWithResults,
   taskRunWithSBOMResult,
+  taskRunWithSBOMResultExternalLink,
 } from '../../components/taskruns/__tests__/taskrun-test-data';
 import { PipelineRunModel } from '../../models';
-import { DataState, PipelineExampleNames, pipelineTestData } from '../../test-data/pipeline-data';
+import {
+  DataState,
+  PipelineExampleNames,
+  PipelineRunWithSBOM,
+  pipelineTestData,
+} from '../../test-data/pipeline-data';
 import { ComputedStatus } from '../../types';
 import {
   getPipelineTasks,
@@ -29,6 +35,8 @@ import {
   getMatchedPVCs,
   getSbomTaskRun,
   getSbomLink,
+  getImageUrl,
+  hasExternalLink,
 } from '../pipeline-utils';
 import { mockPipelineServiceAccount } from './pipeline-serviceaccount-test-data';
 import {
@@ -366,5 +374,37 @@ describe('pipeline-utils ', () => {
 
   it('should return the SBOM link', () => {
     expect(getSbomLink(taskRunWithSBOMResult)).toBe('quay.io/test/image:build-8e536-1692702836');
+  });
+
+  it('should undefined for the pipelinerun without IMAGE_URL', () => {
+    const { pipelineRuns } = pipelineTestData[PipelineExampleNames.PIPELINE_WITH_FINALLY];
+    const pipelineRun = pipelineRuns[DataState.SUCCESS];
+    expect(getImageUrl(pipelineRun)).toBeUndefined();
+  });
+
+  it('should return the SBOM image registry url', () => {
+    expect(getImageUrl(PipelineRunWithSBOM)).toBe(
+      'quay.io/redhat-user-workloads/karthik-jk-tenant/node-express-hello/node-express-hello:build-8e536-1692702836',
+    );
+  });
+
+  it('should false if the taskrun is missing annotations', () => {
+    expect(
+      hasExternalLink({
+        ...taskRunWithSBOMResultExternalLink,
+        metadata: {
+          ...taskRunWithSBOMResultExternalLink.metadata,
+          annotations: undefined,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('should false if the taskrun is missing external-link type annotation', () => {
+    expect(hasExternalLink(taskRunWithSBOMResult)).toBe(false);
+  });
+
+  it('should true if the taskrun has external-link type annotation', () => {
+    expect(hasExternalLink(taskRunWithSBOMResultExternalLink)).toBe(true);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
@@ -532,9 +532,15 @@ export const returnValidTaskModel = (task: TaskKind): K8sModel => {
 
 export enum TaskRunResultsAnnotations {
   KEY = 'task.results.key',
+  TYPE = 'task.results.type',
+}
+
+export enum TaskRunResultsAnnotationValue {
+  EXTERNAL_LINK = 'external-link',
 }
 
 export enum TaskRunResults {
+  IMAGE_REPOSITORY = 'IMAGE_URL',
   SBOM = 'LINK_TO_SBOM',
   SCAN_OUTPUT = 'SCAN_OUTPUT',
   TEST_OUTPUT = 'TEST_OUTPUT',
@@ -545,10 +551,20 @@ export const getSbomTaskRun = (taskruns: TaskRunKind[]): TaskRunKind =>
     (tr) => tr?.metadata?.annotations?.[TaskRunResultsAnnotations.KEY] === TaskRunResults.SBOM,
   );
 
+export const hasExternalLink = (sbomTaskRun: TaskRunKind): boolean =>
+  sbomTaskRun?.metadata?.annotations?.[TaskRunResultsAnnotations.TYPE] ===
+  TaskRunResultsAnnotationValue.EXTERNAL_LINK;
+
 export const getSbomLink = (sbomTaskRun: TaskRunKind): string | undefined =>
   (sbomTaskRun?.status?.results || sbomTaskRun?.status?.taskResults)?.find(
-    (r) => r.name === 'LINK_TO_SBOM',
+    (r) => r.name === TaskRunResults.SBOM,
   )?.value;
+
+export const getImageUrl = (PipelineRun: PipelineRunKind): string | undefined =>
+  (PipelineRun?.status?.results || PipelineRun?.status?.pipelineResults)?.find(
+    (r) => r.name === TaskRunResults.IMAGE_REPOSITORY,
+  )?.value;
+
 export const taskRunStatus = (taskRun: TaskRunKind | PLRTaskRunData): ComputedStatus => {
   if (!taskRun?.status?.conditions?.length) {
     return ComputedStatus.Pending;


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/OCPBUGS-24280

**Problem:**

View sbom link should be redirecting to external page if the taskrun annotation 

**Solution:**

`View Sbom` link should be redirecting to external page if taskrun annotation`task.results.type: external-link` is set. Use `IMAGE_URL` to show the download sbom section.


**Steps to test:**

use this task/pipelineRun - https://gist.github.com/karthikjeeyar/4ad15a67115f82d4320ac52663f2b07a

**Screenshots:**

External link:

<img width="732" alt="image" src="https://github.com/openshift/console/assets/9964343/4f2d1653-776b-46f6-b07e-87e047fde827">