### PR TITLE
CONSOLE-3853: Prevent PatternFly styles from being included in plugin compilation

### DIFF
--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -99,6 +99,7 @@
     chalk "2.4.x"
     comment-json "4.x"
     find-up "4.x"
+    glob "7.x"
     lodash "^4.17.21"
     read-pkg "5.x"
     semver "6.x"
@@ -1563,6 +1564,18 @@ glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
 
+glob@7.x:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.1.1:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
@@ -2221,6 +2234,13 @@ mimic-fn@^1.0.0:
 minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
@@ -158,7 +158,7 @@ export const getWebpackPackage: GetPackageDefinition = (
       ),
       ...parseDeps(
         rootPackage,
-        ['ajv', 'chalk', 'comment-json', 'find-up', 'read-pkg', 'semver'],
+        ['ajv', 'chalk', 'comment-json', 'find-up', 'glob', 'read-pkg', 'semver'],
         missingDepCallback,
       ),
       ...parseDepsAs(rootPackage, { 'lodash-es': 'lodash' }, missingDepCallback),

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -54,7 +54,7 @@ const extractCSS = new MiniCssExtractPlugin({
 const virtualModules = new VirtualModulesPlugin();
 
 const getVendorModuleRegExp = (vendorModules: string[]) =>
-  new RegExp(`node_modules\\/(${vendorModules.map((m) => _.escapeRegExp(m)).join('|')})\\/`);
+  new RegExp(`node_modules\\/(${vendorModules.map(_.escapeRegExp).join('|')})\\/`);
 
 const overpassTest = /overpass-.*\.(woff2?|ttf|eot|otf)(\?.*$|$)/;
 


### PR DESCRIPTION
This PR patches `ConsoleRemotePlugin` to ensure that PatternFly styles are **not** included when building a dynamic plugin.

This should reduce the risk of having styling related bugs, i.e. some plugin overriding PatternFly styles provided by Console.

Reference:
- [webpack `resolve.alias` option](https://webpack.js.org/configuration/resolve/#resolvealias)
- [frontend-components `searchIgnoredStyles` function](https://github.com/RedHatInsights/frontend-components/blob/master/packages/config-utils/src/search-ignored-styles.ts)

---

#### How to verify changes in this PR

1. Switch to latest `master` branch:
```sh
git checkout master
git fetch upstream && git rebase upstream/master # upstream => https://github.com/openshift/console.git
```
2. Rebuild Console dynamic plugin SDK and Console demo plugin (dev build for more readable output):
```sh
(cd frontend ; yarn) # rebuild frontend/packages/console-dynamic-plugin-sdk/dist
(cd dynamic-demo-plugin ; rm -rf node_modules ; yarn ; yarn build-dev) # rebuild dynamic-demo-plugin/dist
```
3. Keep the original Console demo plugin output:
```sh
(cd dynamic-demo-plugin ; mv dist dist-before)
```
4. Apply this PR on top of your local branch and then repeat step 2. above.
5. Keep the modified Console demo plugin output:
```sh
(cd dynamic-demo-plugin ; mv dist dist-after)
```

You can now use a visual diff tool like [Meld](https://meldmerge.org/) to compare before vs. after build output:
- there will be additional chunks containing ignored (empty) PatternFly CSS modules
- `vendors-node_modules_patternfly_react-core_dist_esm_index_js-chunk.js` will refer to these empty CSS modules, for example:
```diff
-__webpack_require__(/*! ./alert.css */ "../node_modules/@patternfly/react-styles/css/components/Alert/alert.css");
+__webpack_require__(/*! ./alert.css */ "?9b90");
```
