### PR TITLE
ODC-7480: Recently Searched Section in Search Resource Page Dropdown

### DIFF
--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -65,7 +65,7 @@
   .pf-v5-c-select__menu {
     min-width: 290px;
     @media (min-width: 480px) {
-      min-width: 350px;
+      min-width: 420px;
     }
     .co-resource-item__tech-dev-preview {
       color: red;
@@ -76,4 +76,19 @@
 
 .span--icon__right-margin {
   margin-right: 6px;
+}
+
+.co-select-group-close-button {
+  margin-left: 360px;
+  top: 2px;
+  z-index: 1;
+}
+
+.co-select-group-dismissible {
+  top: -32px;
+  position: relative;
+}
+
+.co-select-group-divider {
+  margin-top: -22px !important;
 }

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -253,6 +253,7 @@ const SearchPage_: React.FC<SearchProps> = (props) => {
                 <ResourceListDropdown
                   selected={[...selectedItems]}
                   onChange={updateSelectedItems}
+                  recentList={true}
                 />
               </ToolbarFilter>
             </ToolbarItem>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1414,6 +1414,8 @@
   "ReplicationController details": "ReplicationController details",
   "{{statusReplicas}} of {{specReplicas}} pods": "{{statusReplicas}} of {{specReplicas}} pods",
   "Tech Preview": "Tech Preview",
+  "Clear history": "Clear history",
+  "Recently used": "Recently used",
   "Select Resource": "Select Resource",
   "Edit AppliedClusterResourceQuota": "Edit AppliedClusterResourceQuota",
   "Affects pods that have an active deadline. These pods usually include builds, deployers, and jobs.": "Affects pods that have an active deadline. These pods usually include builds, deployers, and jobs.",


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-7480


**Solution Description**: 
This PR introduces a "Recently Searched" Section to the Search Page Drop-down.
Whenever a user searches some resources from the drop-down, it will be automatically shown in this new section. 
This will help users who don't wish to pin every resource they would search, while also allowing them to visit the recently searched resource without typing anything again.
Also, there is a provision to clear all the recently searched resources beside this new group.

**Screenshots / GIFs for design review**: 

https://github.com/openshift/console/assets/47265560/5ef6dfde-fa26-48ad-b7fe-4b7f4838c67e

![image](https://github.com/openshift/console/assets/47265560/c0ada1c7-f383-4002-b25d-fbbc73d933eb)



**Unit test coverage report**: 
Not Changed

**Test setup:**
1. Go to the Search Page and search for some resources.
2. Go to any other page and come back.



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge