### PR TITLE
OCPBUGS-23378: Set min-width for PF popovers that are being overridden by an inline style

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -399,3 +399,8 @@ ul.pf-v5-c-tree-view__list {
   color: var(--pf-global--Color--100);
   background-color: var(--pf-global--palette--black-600);
 }
+
+// PF5 Popover component applies an new inline width:auto style that overrides it's own pf-v5-c-popover min-width: var(--pf-v5-c-popover--MinWidth). So the pf-v5-c-popover container is not a consistent size and can resize when additional content is loaded which causes the alignment to be incorrect.
+.pf-v5-c-popover {
+  min-width: var(--pf-v5-c-popover--MinWidth) !important;
+}


### PR DESCRIPTION
Because of a difference between PF4 and PF5, their `Popover` component is now adding an inline `width: auto` to the `pf-v5-c-popover` container, which is overriding their PF variable `min-width: var(--pf-v5-c-popover--MinWidth)` (which is calculated the same as `max-width: var(--pf-v5-c-popover--MaxWidth)` ).  So what happens is the `pf-v5-c-popover` container can load at smaller width and resize larger when delayed content is loaded, which is then not aligned correctly.

**Popover** with incorrect position and the inline `width: auto`
![popover-alignment-broken](https://github.com/openshift/console/assets/1874151/6153e4ab-c118-49e5-abea-5857c37e3f28)


**Popover** fixed when `min-width: var(--pf-v5-c-popover--MinWidth) !important;` applied
![popover-alignment-fix](https://github.com/openshift/console/assets/1874151/58f1721e-19ae-4388-bcf5-dddffd85ffc5)
