### PR TITLE
OCPBUGS-23761: PatternFly5 update: Fix quick search input background color in dark mode

### DIFF
--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.scss
@@ -1,5 +1,5 @@
 .ocs-quick-search-bar {
-  .pf-v5-c-input-group {
+  &.pf-v5-c-input-group {
     background-color: var(--pf-v5-global--BackgroundColor--400);
     &__item.pf-m-box {
       border: none;


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/OCPBUGS-23761

Before:
<img width="1171" alt="image" src="https://github.com/openshift/console/assets/2561818/b87ce628-1a38-4c51-a38c-3a4db7d30314">


After:

https://github.com/openshift/console/assets/2561818/cf16badc-3634-4452-bb27-5147a3c5ec37

