### PR TITLE
OCPBUGS-24339: Do not depend on a global installed lint-staged

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,12 +193,6 @@ go 1.18+, nodejs/yarn, kubectl
 
 All frontend code lives in the `frontend/` directory. The frontend uses node, yarn, and webpack to compile dependencies into self contained bundles which are loaded dynamically at run time in the browser. These bundles are not committed to git. Tasks are defined in `package.json` in the `scripts` section and are aliased to `yarn run <cmd>` (in the frontend directory).
 
-#### Git hooks and PATH
-
-In order to make a commit, the PATH env var in the terminal session where the commit command is executed must include `./node_modules/.bin`. We use a git pre-commit hook to lint changes before they are committed. This will fail if the commands used in the hook cannot be found in PATH.
-
-It is also possible to skip the pre-commit hook by passing the `-n` or `--no-verify` flag in the git commit command. This will allow commits to include lint errors. Use this sparingly as the pre-commit hook is intended to save time by catching lint errors before they make it into a PR and fail CI.
-
 #### Install Dependencies
 
 To install the build tools and dependencies:

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -3,4 +3,5 @@
 
 echo "Running husky pre-commit hook..."
 cd frontend
-lint-staged
+yarn run lint-staged
+


### PR DESCRIPTION
Follow up on #13320 and #13396

Could you commit changes on the latest master (with #13320) without installing lint-staged globally???

I got this error when I commit a change:

```
Running husky pre-commit hook...
frontend/.husky/pre-commit: line 6: lint-staged: command not found
husky - pre-commit hook exited with code 127 (error)
husky - command not found in PATH=my path that doesn't include the current project
```

Please take a look if this change makes sense for you.

/cc @TheRealJon @jhadvig @vikram-raj @lokanandaprabhu @Lucifergene 