### PR TITLE
OCPBUGS-23554: Fix for monaco editor that happens with yaml is being edited

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
+++ b/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
@@ -221,20 +221,18 @@ export const enableYAMLValidation = (
     tryFolding();
   }
 
-  setTimeout(() => {
-    getModel()?.onDidChangeContent(() => {
-      tryFolding();
+  getModel()?.onDidChangeContent(() => {
+    tryFolding();
 
-      const document = createDocument(getModel());
-      cleanPendingValidation(document);
-      pendingValidationRequests.set(
-        document.uri,
-        setTimeout(() => {
-          pendingValidationRequests.delete(document.uri);
-          doValidate(document);
-        }),
-      );
-    });
+    const document = createDocument(getModel());
+    cleanPendingValidation(document);
+    pendingValidationRequests.set(
+      document.uri,
+      setTimeout(() => {
+        pendingValidationRequests.delete(document.uri);
+        doValidate(document);
+      }),
+    );
   });
 };
 


### PR DESCRIPTION
Revert of the [setTimeout that was added to address the yaml editor crash](https://github.com/openshift/console/pull/13195) when ACM and MCE plugins are enabled. This ended up not fixing that bug and caused this new bug.



