### PR TITLE
OCPBUGS-25881: remove "openshift-storage" namespace usage from the console

### DIFF
--- a/frontend/packages/console-shared/src/utils/storage-utils.ts
+++ b/frontend/packages/console-shared/src/utils/storage-utils.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { StorageClass } from '@console/internal/components/storage-class-form';
 
 export const cephStorageProvisioners = [
@@ -7,16 +6,11 @@ export const cephStorageProvisioners = [
   'rbd.csi.ceph.com',
 ];
 
-const objectStorageProvisioners = [
-  'openshift-storage.noobaa.io/obc',
-  'openshift-storage.ceph.rook.io/bucket',
-];
+const objectStorageProvisioners = ['noobaa.io/obc', 'ceph.rook.io/bucket'];
 
 // To check if the provisioner is OCS based
-export const isCephProvisioner = (scProvisioner: string): boolean => {
-  return cephStorageProvisioners.some((provisioner: string) =>
-    _.endsWith(scProvisioner, provisioner),
-  );
-};
+export const isCephProvisioner = (scProvisioner: string): boolean =>
+  cephStorageProvisioners.some((provisioner: string) => scProvisioner?.includes(provisioner));
 
-export const isObjectSC = (sc: StorageClass) => objectStorageProvisioners.includes(sc.provisioner);
+export const isObjectSC = (sc: StorageClass) =>
+  objectStorageProvisioners.some((provisioner: string) => sc.provisioner?.includes(provisioner));

--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -20,7 +20,7 @@ import { StorageClassDropdown } from '../utils/storage-class-dropdown';
 import { Checkbox } from '../checkbox';
 import { PersistentVolumeClaimModel } from '../../models';
 import { StorageClass } from '../storage-class-form';
-import { provisionerAccessModeMapping, initialAccessModes, dropdownUnits } from './shared';
+import { getProvisionerModeMapping, initialAccessModes, dropdownUnits } from './shared';
 
 const NameValueEditorComponent = (props) => (
   <AsyncComponent
@@ -116,7 +116,7 @@ export const CreatePVCForm: React.FC<CreatePVCFormProps> = (props) => {
   const handleStorageClass = (updatedStorageClass) => {
     const provisioner: string = updatedStorageClass?.provisioner || '';
     //setting message to display for various modes when a storage class of a know provisioner is selected
-    const displayMessage = provisionerAccessModeMapping[provisioner]
+    const displayMessage = getProvisionerModeMapping(provisioner)
       ? `${t('public~Access mode is set by StorageClass and cannot be changed')}`
       : `${t('public~Permissions to the mounted drive')}`;
     setAccessModeHelp(displayMessage);


### PR DESCRIPTION
- "openshift-storage" namespace is specific to "OpenShift Data Foundation" operator and should not be used in OCP console.
- We have also removed Ceph static plugin from OCP console repository (https://github.com/openshift/console/pull/13255), this PR can be regarded as further minor cleanup.
- ODF operator can now be installed in other namespaces as well, so csi provisioner will not always be pre-fixed with "openshift-storage".

<img width="814" alt="Screenshot 2023-12-07 at 3 37 41 PM" src="https://github.com/openshift/console/assets/39404641/9492ca23-77ca-4c2b-8f15-7746883a1ba1">
<img width="768" alt="Screenshot 2023-12-07 at 3 38 50 PM" src="https://github.com/openshift/console/assets/39404641/dcdb253b-e2d1-4f7c-bd96-869fa476a9a6">
<img width="725" alt="Screenshot 2023-12-07 at 3 40 04 PM" src="https://github.com/openshift/console/assets/39404641/dbaf255a-8e24-491b-9bc3-7a32a6cb6c55">
