### PR TITLE
OCPBUGS-24582: Updated functions list page to use new hook useParams

### DIFF
--- a/frontend/packages/knative-plugin/src/components/functions/FunctionsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/functions/FunctionsPage.tsx
@@ -24,7 +24,7 @@ import './FunctionsPage.scss';
 const FunctionsListPage: React.FC<React.ComponentProps<typeof ListPage>> = (props) => {
   const { t } = useTranslation();
   const params = useParams();
-  return params.namespace ? (
+  return params.ns ? (
     <KnativeServiceTypeContext.Provider value={ServiceTypeValue.Function}>
       <Helmet>
         <title>{t('knative-plugin~Functions')}</title>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-24582

**Analysis / Root cause**: 
Due to changes done in PR - https://github.com/openshift/console/commit/50d83648b0ff0f7c27c678483b7739c1461bc572#diff-2bb307d5f75a2ec91ac8f742a9b2d9f353c2e1fd104914aa7977603f7c339246 

**Solution Description**: 
used `params.ns` instead of `params.namespace`

**Screen shots / Gifs for design review**: 
----BEFORE---

https://github.com/openshift/console/assets/102503482/66ed95c6-07f9-4e87-8dff-3a5822260f5b



----AFTER----

<img width="1727" alt="Screenshot 2023-12-07 at 4 19 47 PM" src="https://github.com/openshift/console/assets/102503482/710f0b2d-234c-4578-9ef2-4e5dcf2dbe05">








**Unit test coverage report**: 
NA

**Test setup:**
 1. Install serverless operator
 2. Navigate to Functions tab in dev perspective
 
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge