### PR TITLE
OCPBUGS-24280: Add missing https:// check for an external link

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -1117,7 +1117,7 @@
     }
   },
   {
-    "type": "console.tab/horizontalNav",   
+    "type": "console.tab/horizontalNav",
     "properties": {
       "id": "Output",
       "name": "Output",
@@ -1130,15 +1130,15 @@
         "name": "%pipelines-plugin~Output%",
         "href": "output"
       },
-      "component": { "$codeRef": "ResultsComponent.OutputTab" }
-    } ,  
+      "component": { "$codeRef": "resultsComponent.OutputTab" }
+    },
     "flags": {
       "required": ["OPENSHIFT_PIPELINE"],
       "disallowed": ["CONSOLE_PIPELINE_PLUGIN"]
     }
   },
   {
-    "type": "console.tab/horizontalNav",   
+    "type": "console.tab/horizontalNav",
     "properties": {
       "id": "Output",
       "name": "Output",
@@ -1152,8 +1152,8 @@
         "name": "%pipelines-plugin~Output%",
         "href": "output"
       },
-      "component": { "$codeRef": "ResultsComponent.OutputTab" }
-    } ,  
+      "component": { "$codeRef": "resultsComponent.OutputTab" }
+    },
     "flags": {
       "required": ["OPENSHIFT_PIPELINE"],
       "disallowed": ["CONSOLE_PIPELINE_PLUGIN"]

--- a/frontend/packages/pipelines-plugin/package.json
+++ b/frontend/packages/pipelines-plugin/package.json
@@ -24,7 +24,7 @@
       "tasksComponent": "src/components/tasks-index.ts",
       "triggersComponent": "src/components/triggers-index.ts",
       "pacComponent": "src/components/pac/index.ts",
-      "ResultsComponent": "src/components/shared/results"
+      "resultsComponent": "src/components/shared/results"
     }
   }
 }

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunCustomDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunCustomDetails.tsx
@@ -100,7 +100,9 @@ const PipelineRunCustomDetails: React.FC<PipelineRunCustomDetailsProps> = ({ pip
           <>
             <dt data-test="view-sbom">{t('pipelines-plugin~SBOM')}</dt>
             <dd>
-              {isExternalLink && !!linkToSbom ? (
+              {isExternalLink &&
+              linkToSbom &&
+              (linkToSbom.startsWith('http://') || linkToSbom.startsWith('https://')) ? (
                 <ExternalLink href={linkToSbom}>{t('pipelines-plugin~View SBOM')}</ExternalLink>
               ) : (
                 <Link


### PR DESCRIPTION
Follow up on #13387

Also if the JavaScript isn't executed because the ExternalLink component uses target=_blank I would be happy if we could check that the URL is a valid https:// link.

```yaml
apiVersion: tekton.dev/v1
kind: Task
metadata:
  name: sbom-task-js
  annotations: 
    task.output.location: results
    task.results.format: application/text
    task.results.type: external-link
    task.results.key: LINK_TO_SBOM
spec:
  results:
      - name: LINK_TO_SBOM
        description: Contains the SBOM link
  steps:
    - name: print-sbom-results
      image: quay.io/redhat-appstudio/syft:v0.96.0
      script: |
        #!/bin/sh
        syft version
        syft quay.io/bsutter/quarkus-demo:v2 --output cyclonedx-json=sbom-image.json
        echo 'BEGIN SBOM'
        cat sbom-image.json
        echo 'END SBOM'
        echo 'javascript:alert(1)' | tee $(results.LINK_TO_SBOM.path)
---
apiVersion: tekton.dev/v1
kind: PipelineRun
metadata:
  name: pipelinerun-with-sbom-task-js
spec:
  pipelineSpec:
    tasks:
      - name: sbom-task
        taskRef:
          name: sbom-task-js
    results:
    - name: IMAGE_URL
      description:  Contains the SBOM link
      value: $(tasks.sbom-task.results.LINK_TO_SBOM)
```

/cc @karthikjeeyar @Lucifergene 