### PR TITLE
OCPBUGS-24408: fix runtime error on Node details Overview when Machin…

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -385,6 +385,7 @@
   "Reprovision pending": "Reprovision pending",
   "Only one {{ machineHealthCheckLabel }} resource should match this node.": "Only one {{ machineHealthCheckLabel }} resource should match this node.",
   "Not configured": "Not configured",
+  "No conditions": "No conditions",
   "CPU": "CPU",
   "Memory": "Memory",
   "Filesystem": "Filesystem",

--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/NodeHealth.tsx
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/NodeHealth.tsx
@@ -200,28 +200,34 @@ export const getMachineHealth = (
   }
   let failingConditions: number = 0;
   const conditions = _.flatten(
-    matchingHC.map((hc) =>
-      hc.spec.unhealthyConditions.map((c) => {
-        const failing = isConditionFailing(node, c);
-        if (failing) {
-          failingConditions++;
-        }
-        return {
-          ...c,
-          failing,
-        };
-      }),
+    matchingHC.map(
+      (hc) =>
+        hc.spec?.unhealthyConditions?.map((c) => {
+          const failing = isConditionFailing(node, c);
+          if (failing) {
+            failingConditions++;
+          }
+          return {
+            ...c,
+            failing,
+          };
+        }) ?? [],
     ),
   );
 
   return {
-    state: failingConditions || matchingHC.length > 1 ? HealthState.WARNING : HealthState.OK,
+    state:
+      failingConditions || matchingHC.length > 1 || conditions.length === 0
+        ? HealthState.WARNING
+        : HealthState.OK,
     details:
       matchingHC.length > 1
         ? 'Multiple resources'
         : failingConditions
         ? `${pluralize(failingConditions, 'condition')} failing`
-        : `${pluralize(conditions.length, 'condition')} passing`,
+        : conditions.length > 0
+        ? `${pluralize(conditions.length, 'condition')} passing`
+        : i18next.t('console-app~No conditions'),
     conditions,
     matchingHC,
   };


### PR DESCRIPTION
…eHealthCheck without conditions exists

After:
<img width="1049" alt="Screenshot 2023-12-07 at 11 34 18 AM" src="https://github.com/openshift/console/assets/895728/39eb38df-0d9f-42b4-8372-02a3f34bc95d">

Note I opted to *not* also update the popover contents since this seems like a corner case.
