### PR TITLE
[release-4.13] OCPBUGS-24591: ConsolePlugin metrics must no longer be grouped by the vendor

### DIFF
--- a/pkg/serverconfig/metrics.go
+++ b/pkg/serverconfig/metrics.go
@@ -28,10 +28,10 @@ type Metrics struct {
 	perspectivesInfo *prometheus.GaugeVec
 	pluginsInfo      *prometheus.GaugeVec
 	// Keep the last info so that it is possible to report zero for removed ConsolePlugins.
-	lastPluginInfo *map[PluginVendor]map[PluginState]int
+	lastPluginInfo *map[MappedPluginName]map[PluginState]int
 }
 
-// Reduce cardinality by grouping all perspectives by a 'group name' or a vendor.
+// Reduce cardinality by grouping all perspectives by a 'group name'.
 type PerspectiveGroup string
 
 const (
@@ -58,34 +58,31 @@ const (
 	PerspectiveMetricStateCustomPermissions    PerspectiveMetricState = "custom-permissions"
 )
 
-// Reduce cardinality by mapping known plugin names to a vendor name.
-type PluginVendor string
+// Reduce cardinality by mapping known plugin names, everything else is reported as "unknown".
+type MappedPluginName string
 
-const (
-	PluginVendorRedHat PluginVendor = "redhat"
-	PluginVendorDemo   PluginVendor = "demo"
-	PluginVendorOther  PluginVendor = "other"
-)
-
-var knownPluginVendors = map[string]PluginVendor{
+var knownPluginNames = map[string]MappedPluginName{
 	// Red Hat maintained plugins
 	// https://docs.google.com/spreadsheets/d/1wcCdc1s4ewzxtUJ42VdRhAJ9wFA8UwoTajGSftrr5fM/edit
-	"acm":                             PluginVendorRedHat,
-	"console-telemetry-plugin":        PluginVendorRedHat,
-	"crane-ui-plugin":                 PluginVendorRedHat,
-	"forklift-console-plugin":         PluginVendorRedHat,
-	"kubevirt-plugin":                 PluginVendorRedHat,
-	"logging-view-plugin":             PluginVendorRedHat,
-	"mce":                             PluginVendorRedHat,
-	"netobserv-plugin":                PluginVendorRedHat,
-	"nmstate-console-plugin":          PluginVendorRedHat,
-	"node-remediation-console-plugin": PluginVendorRedHat,
-	"odf-console":                     PluginVendorRedHat,
-	"odf-multicluster-console":        PluginVendorRedHat,
+	"acm":                             "acm",
+	"console-telemetry-plugin":        "telemetry",
+	"crane-ui-plugin":                 "crane",
+	"forklift-console-plugin":         "forklift",
+	"gitops-plugin":                   "gitops",
+	"kubevirt-plugin":                 "kubevirt",
+	"logging-view-plugin":             "logging-view",
+	"mce":                             "mce",
+	"monitoring-plugin":               "monitoring",
+	"netobserv-plugin":                "netobserv",
+	"nmstate-console-plugin":          "nmstate",
+	"node-remediation-console-plugin": "node-remediation",
+	"odf-console":                     "odf",
+	"odf-multicluster-console":        "odf-multicluster",
+	"pipeline-console-plugin":         "pipelines",
 
 	// Unchanged template name from https://github.com/openshift/console-plugin-template
-	"console-plugin-template": PluginVendorDemo,
-	"my-plugin":               PluginVendorDemo,
+	"console-plugin-template": "demo",
+	"my-plugin":               "demo",
 }
 
 type PluginState string
@@ -153,9 +150,9 @@ func (m *Metrics) updatePluginMetric(
 		time.Since(startTime),
 	)
 
-	for vendor, states := range *pluginInfo {
+	for mappedPluginName, states := range *pluginInfo {
 		for state, value := range states {
-			if gauge, err := m.pluginsInfo.GetMetricWithLabelValues(string(vendor), string(state)); gauge != nil && err == nil {
+			if gauge, err := m.pluginsInfo.GetMetricWithLabelValues(string(mappedPluginName), string(state)); gauge != nil && err == nil {
 				gauge.Set(float64(value))
 			}
 		}
@@ -187,17 +184,17 @@ func (m *Metrics) getConsolePlugins(
 // Create a new plugin info map that is based on the last report to report also removed ConsolePlugins.
 func (m *Metrics) calculatePluginInfo(
 	consolePlugins *[]unstructured.Unstructured,
-	lastPluginInfo *map[PluginVendor]map[PluginState]int,
-) *map[PluginVendor]map[PluginState]int {
-	pluginInfo := make(map[PluginVendor]map[PluginState]int)
+	lastPluginInfo *map[MappedPluginName]map[PluginState]int,
+) *map[MappedPluginName]map[PluginState]int {
+	pluginInfo := make(map[MappedPluginName]map[PluginState]int)
 
 	if lastPluginInfo != nil {
-		for lastPluginVendor, lastPluginStates := range *lastPluginInfo {
+		for lastPluginName, lastPluginStates := range *lastPluginInfo {
 			for lastPluginState, _ := range lastPluginStates {
-				if pluginInfo[lastPluginVendor] == nil {
-					pluginInfo[lastPluginVendor] = make(map[PluginState]int)
+				if pluginInfo[lastPluginName] == nil {
+					pluginInfo[lastPluginName] = make(map[PluginState]int)
 				}
-				pluginInfo[lastPluginVendor][lastPluginState] = 0
+				pluginInfo[lastPluginName][lastPluginState] = 0
 			}
 		}
 	}
@@ -207,9 +204,9 @@ func (m *Metrics) calculatePluginInfo(
 	if consolePlugins != nil {
 		for _, consolePlugin := range *consolePlugins {
 			pluginName := consolePlugin.GetName()
-			vendor := knownPluginVendors[pluginName]
-			if vendor == "" {
-				vendor = PluginVendorOther
+			mappedPluginName := knownPluginNames[pluginName]
+			if mappedPluginName == "" {
+				mappedPluginName = "unknown"
 			}
 			state := PluginStateDisabled
 			if m.config != nil && m.config.Plugins != nil {
@@ -217,10 +214,10 @@ func (m *Metrics) calculatePluginInfo(
 					state = PluginStateEnabled
 				}
 			}
-			if pluginInfo[vendor] == nil {
-				pluginInfo[vendor] = make(map[PluginState]int)
+			if pluginInfo[mappedPluginName] == nil {
+				pluginInfo[mappedPluginName] = make(map[PluginState]int)
 			}
-			pluginInfo[vendor][state]++
+			pluginInfo[mappedPluginName][state]++
 			consolePluginNames[pluginName] = true
 		}
 	}
@@ -228,15 +225,15 @@ func (m *Metrics) calculatePluginInfo(
 	if m.config != nil && m.config.Plugins != nil {
 		for pluginName, _ := range m.config.Plugins {
 			if found := consolePluginNames[pluginName]; !found {
-				vendor := knownPluginVendors[pluginName]
-				if vendor == "" {
-					vendor = PluginVendorOther
+				mappedPluginName := knownPluginNames[pluginName]
+				if mappedPluginName == "" {
+					mappedPluginName = "unknown"
 				}
 				state := PluginStateNotFound
-				if pluginInfo[vendor] == nil {
-					pluginInfo[vendor] = make(map[PluginState]int)
+				if pluginInfo[mappedPluginName] == nil {
+					pluginInfo[mappedPluginName] = make(map[PluginState]int)
 				}
-				pluginInfo[vendor][state]++
+				pluginInfo[mappedPluginName][state]++
 			}
 		}
 	}

--- a/pkg/serverconfig/metrics_test.go
+++ b/pkg/serverconfig/metrics_test.go
@@ -71,8 +71,9 @@ func TestPluginMetrics(t *testing.T) {
 			configuredPlugins: []string{"acm", "kubevirt-plugin", "my-plugin"},
 			consolePlugins:    []string{"acm", "kubevirt-plugin", "my-plugin"},
 			expectedMetrics: `
+			console_plugins_info{name="acm",state="enabled"} 1
 			console_plugins_info{name="demo",state="enabled"} 1
-			console_plugins_info{name="redhat",state="enabled"} 2
+			console_plugins_info{name="kubevirt",state="enabled"} 1
 			`,
 		},
 
@@ -82,7 +83,7 @@ func TestPluginMetrics(t *testing.T) {
 			configuredPlugins: []string{"an-enabled-plugin", "another-enabled-plugin"},
 			consolePlugins:    []string{"an-enabled-plugin", "another-enabled-plugin"},
 			expectedMetrics: `
-			console_plugins_info{name="other",state="enabled"} 2
+			console_plugins_info{name="unknown",state="enabled"} 2
 			`,
 		},
 
@@ -92,7 +93,7 @@ func TestPluginMetrics(t *testing.T) {
 			configuredPlugins: []string{},
 			consolePlugins:    []string{"a-disabed-plugin", "another-disabed-plugin"},
 			expectedMetrics: `
-			console_plugins_info{name="other",state="disabled"} 2
+			console_plugins_info{name="unknown",state="disabled"} 2
 			`,
 		},
 
@@ -102,7 +103,7 @@ func TestPluginMetrics(t *testing.T) {
 			configuredPlugins: []string{"a-missing-plugin", "another-missing-plugin"},
 			consolePlugins:    []string{},
 			expectedMetrics: `
-			console_plugins_info{name="other",state="notfound"} 2
+			console_plugins_info{name="unknown",state="notfound"} 2
 			`,
 		},
 	}
@@ -156,14 +157,17 @@ func TestPluginMetricsRunningTwice(t *testing.T) {
 			consolePluginsInitially: []string{"acm", "kubevirt-plugin", "my-plugin"},
 			consolePluginsUpdated:   []string{},
 			expectedMetricsInitially: `
+			console_plugins_info{name="acm",state="enabled"} 1
 			console_plugins_info{name="demo",state="enabled"} 1
-			console_plugins_info{name="redhat",state="enabled"} 2
+			console_plugins_info{name="kubevirt",state="enabled"} 1
 			`,
 			expectedMetricsAfterUpdate: `
+			console_plugins_info{name="acm",state="enabled"} 0
+			console_plugins_info{name="acm",state="notfound"} 1
 			console_plugins_info{name="demo",state="enabled"} 0
 			console_plugins_info{name="demo",state="notfound"} 1
-			console_plugins_info{name="redhat",state="enabled"} 0
-			console_plugins_info{name="redhat",state="notfound"} 2
+			console_plugins_info{name="kubevirt",state="enabled"} 0
+			console_plugins_info{name="kubevirt",state="notfound"} 1
 			`,
 		},
 
@@ -173,11 +177,11 @@ func TestPluginMetricsRunningTwice(t *testing.T) {
 			consolePluginsInitially: []string{"an-enabled-plugin", "another-enabled-plugin"},
 			consolePluginsUpdated:   []string{"an-enabled-plugin"},
 			expectedMetricsInitially: `
-			console_plugins_info{name="other",state="enabled"} 2
+			console_plugins_info{name="unknown",state="enabled"} 2
 			`,
 			expectedMetricsAfterUpdate: `
-			console_plugins_info{name="other",state="enabled"} 1
-			console_plugins_info{name="other",state="notfound"} 1
+			console_plugins_info{name="unknown",state="enabled"} 1
+			console_plugins_info{name="unknown",state="notfound"} 1
 			`,
 		},
 
@@ -187,10 +191,10 @@ func TestPluginMetricsRunningTwice(t *testing.T) {
 			consolePluginsInitially: []string{"a-disabed-plugin", "another-disabed-plugin"},
 			consolePluginsUpdated:   []string{"a-disabed-plugin"},
 			expectedMetricsInitially: `
-			console_plugins_info{name="other",state="disabled"} 2
+			console_plugins_info{name="unknown",state="disabled"} 2
 			`,
 			expectedMetricsAfterUpdate: `
-			console_plugins_info{name="other",state="disabled"} 1
+			console_plugins_info{name="unknown",state="disabled"} 1
 			`,
 		},
 
@@ -200,11 +204,11 @@ func TestPluginMetricsRunningTwice(t *testing.T) {
 			consolePluginsInitially: []string{},
 			consolePluginsUpdated:   []string{"another-plugin"},
 			expectedMetricsInitially: `
-			console_plugins_info{name="other",state="notfound"} 2
+			console_plugins_info{name="unknown",state="notfound"} 2
 			`,
 			expectedMetricsAfterUpdate: `
-			console_plugins_info{name="other",state="enabled"} 1
-			console_plugins_info{name="other",state="notfound"} 1
+			console_plugins_info{name="unknown",state="enabled"} 1
+			console_plugins_info{name="unknown",state="notfound"} 1
 			`,
 		},
 
@@ -214,16 +218,16 @@ func TestPluginMetricsRunningTwice(t *testing.T) {
 			consolePluginsInitially: []string{"an-first-enabled-plugin", "acm", "another-disabled-plugin"},
 			consolePluginsUpdated:   []string{"another-disabled-plugin", "acm", "my-plugin"},
 			expectedMetricsInitially: `
-			console_plugins_info{name="other",state="disabled"} 1
-			console_plugins_info{name="other",state="enabled"} 1
-			console_plugins_info{name="redhat",state="enabled"} 1
+			console_plugins_info{name="acm",state="enabled"} 1
+			console_plugins_info{name="unknown",state="disabled"} 1
+			console_plugins_info{name="unknown",state="enabled"} 1
 			`,
 			expectedMetricsAfterUpdate: `
+			console_plugins_info{name="acm",state="enabled"} 1
 			console_plugins_info{name="demo",state="disabled"} 1
-			console_plugins_info{name="other",state="disabled"} 1
-			console_plugins_info{name="other",state="enabled"} 0
-			console_plugins_info{name="other",state="notfound"} 1
-			console_plugins_info{name="redhat",state="enabled"} 1
+			console_plugins_info{name="unknown",state="disabled"} 1
+			console_plugins_info{name="unknown",state="enabled"} 0
+			console_plugins_info{name="unknown",state="notfound"} 1
 			`,
 		},
 	}


### PR DESCRIPTION
This is a manual cherry-pick of #13391

/cc @jhadvig 
/assign @jhadvig 
