### PR TITLE
OCPBUGS-23378: Prevent text overlap with popover close button on Create NetworkPolicy form

### DIFF
--- a/frontend/packages/console-app/src/components/network-policies/network-policy-selector-preview.tsx
+++ b/frontend/packages/console-app/src/components/network-policies/network-policy-selector-preview.tsx
@@ -31,7 +31,6 @@ export const NetworkPolicySelectorPreview: React.FC<NetworkPolicySelectorPreview
     <>
       <Popover
         aria-label="pods-list"
-        headerContent={<p />}
         data-test={props.dataTest ? `${props.dataTest}-popover` : `pods-preview-popover`}
         bodyContent={
           props.namespaceSelector ? (


### PR DESCRIPTION

**before**
<img width="456" alt="Screenshot 2023-12-08 at 1 27 36 PM" src="https://github.com/openshift/console/assets/1874151/c1b4971d-bf39-4a0d-99a1-1888a5e7c939">


**after**
<img width="494" alt="Screenshot 2023-12-08 at 1 18 09 PM" src="https://github.com/openshift/console/assets/1874151/b7830689-e4d3-44a8-9605-d622a5270998">

