### PR TITLE
OCPBUGS-18844: Replace the old sr-only class to the patternfly pf-v5-u-screen-reader class

### DIFF
--- a/frontend/public/components/configmap-and-secret-data.tsx
+++ b/frontend/public/components/configmap-and-secret-data.tsx
@@ -12,7 +12,7 @@ export const MaskedData: React.FC<{}> = () => {
   const { t } = useTranslation();
   return (
     <>
-      <span className="sr-only">{t('public~Value hidden')}</span>
+      <span className="pf-v5-u-screen-reader">{t('public~Value hidden')}</span>
       <span aria-hidden="true">&bull;&bull;&bull;&bull;&bull;</span>
     </>
   );

--- a/frontend/public/components/utils/copy-to-clipboard.tsx
+++ b/frontend/public/components/utils/copy-to-clipboard.tsx
@@ -30,7 +30,7 @@ export const CopyToClipboard: React.FC<CopyToClipboardProps> = React.memo((props
             type="button"
           >
             <CopyIcon />
-            <span className="sr-only">{t('public~Copy to clipboard')}</span>
+            <span className="pf-v5-u-screen-reader">{t('public~Copy to clipboard')}</span>
           </Button>
         </CTC>
       </Tooltip>

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -125,7 +125,7 @@ export const ExternalLinkWithCopy: React.FC<ExternalLinkWithCopyProps> = ({
               className="co-external-link-with-copy__icon co-external-link-with-copy__copyicon"
             >
               <CopyIcon />
-              <span className="sr-only">{t('public~Copy to clipboard')}</span>
+              <span className="pf-v5-u-screen-reader">{t('public~Copy to clipboard')}</span>
             </span>
           </CTC>
         </Tooltip>

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -481,7 +481,7 @@ const PairElement_ = DragSource(
         const deleteIcon = (
           <>
             <MinusCircleIcon className="pairs-list__side-btn pairs-list__delete-icon" />
-            <span className="sr-only">{t('public~Delete')}</span>
+            <span className="pf-v5-u-screen-reader">{t('public~Delete')}</span>
           </>
         );
         const dragButton = (
@@ -642,7 +642,7 @@ const EnvFromPairElement_ = DragSource(
         const deleteButton = (
           <>
             <MinusCircleIcon className="pairs-list__side-btn pairs-list__delete-icon" />
-            <span className="sr-only">{t('public~Delete')}</span>
+            <span className="pf-v5-u-screen-reader">{t('public~Delete')}</span>
           </>
         );
         return connectDropTarget(

--- a/frontend/public/components/utils/resource-icon.tsx
+++ b/frontend/public/components/utils/resource-icon.tsx
@@ -32,7 +32,7 @@ export const ResourceIcon: React.SFC<ResourceIconProps> = ({
 
   const rendered = (
     <>
-      <span className="sr-only">{kindStr}</span>
+      <span className="pf-v5-u-screen-reader">{kindStr}</span>
       <span className={klass} title={kindStr} style={{ backgroundColor }}>
         {iconLabel}
       </span>


### PR DESCRIPTION
This prevents a strange bug that appeared within the flex layout because of it's absolute position.

![screen-reader-sr-only-bug](https://github.com/openshift/console/assets/1874151/9a404d82-d9e2-4972-9e44-3669a85ef1e9)
