### PR TITLE
OCPBUGS-25722: Add support for custom segment domains (to load JS and make API calls)

### DIFF
--- a/frontend/packages/console-telemetry-plugin/src/listeners/const.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/const.ts
@@ -1,8 +1,3 @@
-export const SEGMENT_API_KEY =
-  window.SERVER_FLAGS?.telemetry?.DEVSANDBOX_SEGMENT_API_KEY ||
-  window.SERVER_FLAGS?.telemetry?.SEGMENT_API_KEY ||
-  '';
-
 export const TELEMETRY_DISABLED =
   window.SERVER_FLAGS?.telemetry?.DISABLED === 'true' ||
   window.SERVER_FLAGS?.telemetry?.DEVSANDBOX_DISABLED === 'true';


### PR DESCRIPTION
**Fixes:**
Epic: https://issues.redhat.com/browse/ODC-7460
Story/Bug: https://issues.redhat.com/browse/OCPBUGS-25722

With this PR the frontend code consumes three new, optional SERVER_FLAG variables to configure where Segment loads the analytics .js and where it sends the analytics events.

* `SEGMENT_API_HOST` (default: api.segment.io/v1)
* `SEGMENT_JS_HOST` (default: cdn.segment.com)
* `SEGMENT_JS_URL` (default: https://$SEGMENT_JS_HOST/analytics.js/v1/$SEGMENT_API_KEY/analytics.min.js)

This variables can be configured when starting the bridge locally with `-telemetry key=value`.

You can find a valid Segment API key in our documentation (last link, search for Staging).

Locally you can try this by setting up a proxy or changing your `/etc/hosts` ...

But please notice that the API calls might be blocked by default
* when you have an ad blocker installed
* when you setup a proxy with invalid SSLs certificates (when using `/etc/hosts` ...)
* Segment API works fine also when the hostname is changed, but the CDN doesn't deliver the JS. With a valid setup this shouldn't be an issue.

```sh
./bin/bridge \
  -telemetry SEGMENT_API_KEY=TODO \
  -telemetry SEGMENT_API_HOST=segment-api-proxy/v1 \
  -telemetry SEGMENT_JS_HOST=segment-cdn-proxy
```

or

```
./bin/bridge \
  -telemetry SEGMENT_API_KEY=TODO \
  -telemetry SEGMENT_API_HOST=segment-api-proxy/v1 \
  -telemetry SEGMENT_JS_URL=https://segment-cdn-proxy/analytics.js/v1/TODO/analytics.js
```

Or when running a cluster with these annotations can be set on the console "cluster" configuration:

* https://your-console/k8s/cluster/operator.openshift.io~v1~Console/cluster/yaml

```yaml
    telemetry.console.openshift.io/SEGMENT_API_KEY: checkout our documentation (last link, search for staging)
    telemetry.console.openshift.io/SEGMENT_API_HOST: my-proxy
    telemetry.console.openshift.io/SEGMENT_JS_HOST: my-proxy
    telemetry.console.openshift.io/SEGMENT_API_HOST: https://cdn.segment.com/analytics.js/v1
```

Documentation on the Segment side: [Self Hosting or Proxying Analytics.js
](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/custom-proxy/)

I've updated the [corresponding documentation](https://docs.google.com/document/d/1PgQvB1TKwRH9Peezbr7Fu-raj-zU4iDFK9SJ6bZqxhs/edit) as well. That doc contains also additional information and patch commands.

Here is a 9 min recording where I've tested different options on a cluster bot:

https://github.com/openshift/console/assets/139310/b1088cab-0a17-4d75-ac02-9a62d0fb217b
