### PR TITLE
OCPBUGS-24592: Fix CI tests in helm and devconsole packages

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-devfile.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-devfile.feature
@@ -9,7 +9,7 @@ Feature: Create Application from Devfile
               And user is at Add page
 
 
-        @regression @broken-test
+        @regression
         Scenario: Deploy git workload with devfile from topology page: A-04-TC01
             Given user is at the Topology page
              When user right clicks on topology empty graph
@@ -31,7 +31,7 @@ Feature: Create Application from Devfile
               And user is able to see workload "node-example" in topology page
 
 
-        @regression
+        @regression @broken-test
         Scenario: No service is shown in the node sidebar if it is not defined in the devfile : A-04-TC03
             Given user has created workload "node-example" with resource type "Deployment"
               And user is at Topology page
@@ -40,7 +40,7 @@ Feature: Create Application from Devfile
               And user can see under Services section "No Services found for this resource."
 
 
-        @regression
+        @regression @broken-test
         Scenario: No route is shown in the node sidebar if it is not defined in the devfile : A-04-TC04
             Given user has created workload "node-example" with resource type "Deployment"
               And user is at Topology page

--- a/frontend/packages/dev-console/integration-tests/features/e2e/add-flow-ci.feature
+++ b/frontend/packages/dev-console/integration-tests/features/e2e/add-flow-ci.feature
@@ -86,7 +86,6 @@ Feature: Create the different workloads from Add page
              Then user will be redirected to Topology page
               And user is able to see workload "mariadb" in topology page
 
-        @regression @broken-test
         Scenario: Deploy git workload with devfile from topology page: A-04-TC01
             Given user is at the Topology page
              When user right clicks on topology empty graph

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-devfile.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-devfile.ts
@@ -8,7 +8,9 @@ When('user right clicks on topology empty graph', () => {
 
 When('user selects {string} option from Add to Project context menu', (option: string) => {
   cy.get(topologyPO.graph.contextMenuOptions.addToProject).focus().trigger('mouseover');
-  cy.byTestActionID(option).click({ force: true });
+  cy.get(`[data-test-action="${option}"] button[role="menuitem"]`)
+    .should('be.visible')
+    .click({ force: true });
 });
 
 When('user enters Git Repo url {string} in Devfile page', (gitUrl: string) => {

--- a/frontend/packages/helm-plugin/integration-tests/features/helm-release.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm-release.feature
@@ -38,7 +38,7 @@ Feature: Helm Release
              Then user will be redirected to Topology page
               And Topology page have the helm chart workload "nodejs-release"
 
-        @regression @broken-test
+
         Scenario: Context menu options of helm release:  HR-01-TC01
             Given user is at the Topology page
              When user right clicks on the helm release "nodejs-release" to open the context menu

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-release.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-release.ts
@@ -42,7 +42,7 @@ Then(
 );
 
 Then('user is able to see the context menu with actions Upgrade and Delete Helm Release', () => {
-  cy.get('ul[role="menu"]').should('be.visible');
+  cy.get('div.odc-topology-context-menu').should('be.visible');
   cy.byTestActionID('Upgrade').should('be.visible');
   cy.byTestActionID('Delete Helm Release').should('be.visible');
 });

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -63,7 +63,7 @@ export const topologyPO = {
       showPodCount: '[id$=show-pod-count]',
     },
     contextMenuOptions: {
-      addToProject: '.pf-topology-context-sub-menu',
+      addToProject: 'button.pf-topology-context-sub-menu',
     },
     addLink: '[data-test="add-page"]',
     quickSearch: '[data-test="quick-search-bar"]',


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-24592

Descriptions:

- Fix tests in files.
    - Scenario: Deploy git workload with devfile from topology page: A-04-TC01 in frontend/packages/dev-console/integration-tests/features/e2e/add-flow-ci.feature and frontend/packages/dev-console/integration-tests/features/addFlow/create-from-devfile.feature 
    - Scenario: Context menu options of helm release: HR-01-TC01 in frontend/packages/helm-plugin/integration-tests/features/helm-release.feature and frontend/packages/helm-plugin/integration-tests/features/helm/actions-on-helm-release.feature