### PR TITLE
OCPBUGS-25936: fix copy-execute-demo.yaml inline syntax

### DIFF
--- a/frontend/packages/dev-console/integration-tests/testData/quick-start/copy-execute-demo.yaml
+++ b/frontend/packages/dev-console/integration-tests/testData/quick-start/copy-execute-demo.yaml
@@ -11,17 +11,36 @@ spec:
     - description: >
         ### Create a Project
 
-        Execute `oc new-project sample-sclorg-app`{{execute}} command to create
-        a new project
+        Execute
+
+
+        ```
+
+        oc new-project sample-sclorg-app
+
+        ```{{execute}}
+        command to create a new project
 
 
         In next step we will create a resource using
         `https://github.com/sclorg/ruby-ex.git`{{copy}}
 
 
-        Deploy app using commad `oc new-app
-        ruby~https://github.com/sclorg/ruby-ex.git`{{execute}}  
+        Deploy app using commad
 
 
-        Expose route using `oc expose svc/ruby-ex`{{execute}}
+        ```
+
+        oc new-app ruby~https://github.com/sclorg/ruby-ex.git
+
+        ```{{execute}}  
+
+        Expose route using
+
+
+        ```
+
+        oc expose svc/ruby-ex
+
+        ```{{execute}}
       title: Create Ruby App


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-25936

Before the PR: 

https://github.com/openshift/console/assets/51144829/90aa4f13-e611-48c4-a8c5-65c9fe0aa4fb


After: 

https://github.com/openshift/console/assets/51144829/e51d989d-b560-48e7-9424-afc03c584676


