### PR TITLE
OCPBUGS-25771: Enable catalog source badge to truncate for long names

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -7,6 +7,7 @@ import {
   EmptyStateVariant,
   EmptyStateHeader,
   EmptyStateFooter,
+  Truncate,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import * as classNames from 'classnames';
@@ -93,7 +94,7 @@ const filterByArchAndOS = (items: OperatorHubItem[]): OperatorHubItem[] => {
 
 const Badge = ({ text }) => (
   <span key={text} className="pf-v5-c-badge pf-m-read">
-    {text}
+    <Truncate className="pf-v5-c-truncate--no-min-width" content={text} />
   </span>
 );
 

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -401,3 +401,7 @@ ul {
 .pf-v5-c-popover {
   min-width: var(--pf-v5-c-popover--MinWidth) !important;
 }
+
+.pf-v5-c-truncate--no-min-width {
+  --pf-v5-c-truncate--MinWidth: 0 !important;
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-25771
Allows badge widths to vary but still truncate without a min-width.

**After**
<img width="605" alt="Screenshot 2024-01-02 at 1 24 30 PM" src="https://github.com/openshift/console/assets/1874151/860754ae-e36b-4d57-9fe8-77d5821f067a">
