### PR TITLE
OCPBUGS-26049: Tab VolumeSnapshots crashed on PVC page

### DIFF
--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
@@ -209,7 +209,7 @@ const VolumeSnapshotPage: React.FC<VolumeSnapshotPageProps> = (props) => {
 };
 
 const checkPVCSnapshot: CheckPVCSnapshot = (volumeSnapshots, pvc) =>
-  volumeSnapshots.filter(
+  volumeSnapshots?.filter(
     (snapshot) =>
       snapshot?.spec?.source?.persistentVolumeClaimName === getName(pvc) &&
       getNamespace(snapshot) === getNamespace(pvc),


### PR DESCRIPTION

### Before:

![Screenshot 2024-01-04 at 11 38 36 AM](https://github.com/openshift/console/assets/15249132/16748d8a-8c59-4979-8c1f-093dd70dd4d3)

### After:

![Screenshot 2024-01-04 at 11 39 10 AM](https://github.com/openshift/console/assets/15249132/543e8720-b54a-4402-851a-f7b5d4e60df4)
