### PR TITLE
OCPBUGS-25843: Fixed bug with user feedback where inform the direction of RedHat was not showing up

### DIFF
--- a/frontend/public/components/feedback-local.jsx
+++ b/frontend/public/components/feedback-local.jsx
@@ -30,7 +30,7 @@ export function useFeedbackLocal(reportBug) {
     informDirectionDescription: t(
       'public~By participating in feedback sessions, usability tests, and interviews with our',
     ),
-    informRedhatDirection: t('public~Inform the direction of Red Hat'),
+    informDirection: t('public~Inform the direction of Red Hat'),
     learnAboutResearchOpportunities: t(
       'public~Learn about opportunities to share your feedback with our User Research Team.',
     ),

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -48,6 +48,7 @@ import ClusterMenu from '@console/app/src/components/nav/ClusterMenu';
 import { ACM_PERSPECTIVE_ID } from '@console/app/src/consts';
 import { FeedbackModal } from '@patternfly/react-user-feedback';
 import { useFeedbackLocal } from './feedback-local';
+import feedbackImage from '@patternfly/react-user-feedback/dist/esm/images/rh_feedback.svg';
 
 const defaultHelpLinks = [
   {
@@ -83,6 +84,7 @@ const FeedbackModalLocalized = ({ isOpen, onClose, reportBugLink }) => {
       onOpenSupportCase={reportBugLink.href}
       feedbackLocale={feedbackLocales}
       onJoinMailingList="https://console.redhat.com/self-managed-research-form?source=openshift"
+      feedbackImg={feedbackImage}
       isOpen={isOpen}
       onClose={onClose}
     />


### PR DESCRIPTION
Fixed bug with user feedback where inform the direction of RedHat was not showing up  Also updated with the correct image for redhat brand.  User feedback is now displaying the correct image and the missing text has been restored.

<img width="1204" alt="Screenshot 2024-01-04 at 4 29 23 PM" src="https://github.com/openshift/console/assets/6126356/dd1bccc4-2ec2-4c58-8248-907deadfb04f">
