### PR TITLE
OCPBUGS-26415: Application creation fail when manually entering input scaling value in local setup

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/NumberSpinnerField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/NumberSpinnerField.tsx
@@ -8,7 +8,16 @@ import { RedExclamationCircleIcon } from '../status';
 import { FieldProps } from './field-types';
 import { getFieldId } from './field-utils';
 
-const NumberSpinnerField: React.FC<FieldProps> = ({ label, helpText, required, ...props }) => {
+interface NumberSpinnerFieldProps extends FieldProps {
+  setOutputAsIntegerFlag?: boolean;
+}
+
+const NumberSpinnerField: React.FC<NumberSpinnerFieldProps> = ({
+  label,
+  helpText,
+  required,
+  ...props
+}) => {
   const [field, { touched, error }] = useField(props.name);
   const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
   const fieldId = getFieldId(props.name, 'number-spinner');
@@ -20,9 +29,14 @@ const NumberSpinnerField: React.FC<FieldProps> = ({ label, helpText, required, .
   const handleChange: React.ReactEventHandler<HTMLInputElement> = React.useCallback(
     (event) => {
       field.onChange(event);
-      setFieldValue(props.name, event.currentTarget.value);
+      setFieldValue(
+        props.name,
+        props?.setOutputAsIntegerFlag
+          ? _.toInteger(event.currentTarget.value)
+          : event.currentTarget.value,
+      );
     },
-    [field, props.name, setFieldValue],
+    [field, props.name, setFieldValue, props?.setOutputAsIntegerFlag],
   );
 
   return (

--- a/frontend/packages/dev-console/src/components/import/advanced/ScalingSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/ScalingSection.tsx
@@ -15,6 +15,7 @@ const ScalingSection: React.FC<{ name: string }> = ({ name }) => {
         name={name}
         label={t('devconsole~Replicas')}
         helpText={t('devconsole~The number of instances of your Image.')}
+        setOutputAsIntegerFlag
       />
     </FormSection>
   );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-26415

**Analysis / Root cause**: 
When user type the number, the value is set as string. On click of + and - sign, the value is set as integer.

**Solution Description**: 
Modified `NumberSpinnerField` to set the output to integer, when new prop `setOutputAsIntegerFlag` is true

**Screen shots / Gifs for design review**: 

----BEFORE----

https://github.com/openshift/console/assets/102503482/984cbaec-2e47-4a51-b4eb-7177e1a55979



----AFTER----


https://github.com/openshift/console/assets/102503482/dd448d5b-7888-468f-b1ed-b8c2fdaa6c3c







**Unit test coverage report**: 
NA

**Test setup:**
    1. Enter a git repo and select deployment as the resource type
    2. In scaling enter the value as '5' and click on Create button
     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge