### PR TITLE
OCPBUGS-14481: update check for the 'provider' label on the PackageMa…

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -643,7 +643,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
             isChecked={enableMonitoring}
             data-checked-state={enableMonitoring}
           />
-          {props.packageManifest.data[0].metadata.labels['opsrc-provider'] !== 'redhat' && (
+          {!props.packageManifest.data[0].metadata.labels.provider?.includes('Red Hat') && (
             <Alert
               isInline
               className="co-alert pf-v5-c-alert--top-margin"


### PR DESCRIPTION
…nifest when installing operators

After:
![localhost_9000_operatorhub_subscribe_pkg=openshift-custom-metrics-autoscaler-operator catalog=redhat-operators catalogNamespace=openshift-marketplace targetNamespace=undefined channel=stable version=2 11 2-322 tokenizedAuth=null](https://github.com/openshift/console/assets/895728/bf50bf91-9f19-4c9e-97f8-f1cd0e9087cf)
