### PR TITLE
OCPBUGS-26073: setting correct image trigger annotation

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -360,7 +360,7 @@ export const getDeploymentData = (resource: K8sResourceKind) => {
       return {
         env,
         triggers: {
-          image: imageTrigger?.pause === 'false',
+          image: imageTrigger?.paused === 'false',
         },
         replicas: resource.spec?.replicas ?? 1,
       };

--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
@@ -53,7 +53,7 @@ describe('Import Submit Utils', () => {
             namespace: 'gijohn',
           },
           fieldPath: 'spec.template.spec.containers[?(@.name=="nodejs-ex-git")].image',
-          pause: 'false',
+          paused: 'false',
         },
       ]);
       done();
@@ -426,7 +426,7 @@ describe('Import Submit Utils', () => {
             'app.openshift.io/vcs-ref': 'master',
             'app.openshift.io/vcs-uri': 'https://github.com/redhat-developer/devfile-sample',
             'image.openshift.io/triggers':
-              '[{"from":{"kind":"ImageStreamTag","name":"devfile-sample:latest","namespace":"gijohn"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"devfile-sample\\")].image","pause":"false"}]',
+              '[{"from":{"kind":"ImageStreamTag","name":"devfile-sample:latest","namespace":"gijohn"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"devfile-sample\\")].image","paused":"false"}]',
             isFromDevfile: 'true',
             'openshift.io/generated-by': 'OpenShiftWebConsole',
             'app.openshift.io/route-disabled': 'false',

--- a/frontend/packages/dev-console/src/components/import/__tests__/upload-jar-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/upload-jar-submit-utils.spec.ts
@@ -44,7 +44,7 @@ describe('Upload Jar Submit Utils', () => {
             namespace: 'my-app',
           },
           fieldPath: 'spec.template.spec.containers[?(@.name=="java-ex-git")].image',
-          pause: 'false',
+          paused: 'false',
         },
       ]);
       done();

--- a/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils-data.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils-data.ts
@@ -7,7 +7,7 @@ export const originalDeployment = {
       'app.openshift.io/vcs-ref': 'master',
       'app.openshift.io/vcs-uri': 'https://github.com/divyanshiGupta/nationalparks-py',
       'image.openshift.io/triggers':
-        '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","pause":"false"}]',
+        '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","paused":"false"}]',
       'openshift.io/generated-by': 'OpenShiftWebConsole',
       'app.openshift.io/connects-to': 'database',
       'deployment.kubernetes.io/revision': '4',
@@ -104,7 +104,7 @@ export const newDeployment = {
       'app.openshift.io/vcs-ref': 'master',
       'app.openshift.io/vcs-uri': 'https://github.com/divyanshiGupta/nationalparks-py',
       'image.openshift.io/triggers':
-        '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","pause":"true"}]',
+        '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","paused":"true"}]',
       'openshift.io/generated-by': 'OpenShiftWebConsole',
     },
     name: 'nationalparks-py',
@@ -169,7 +169,7 @@ export const devfileDeployment = {
       'app.openshift.io/vcs-ref': 'master',
       'app.openshift.io/vcs-uri': 'https://github.com/divyanshiGupta/nationalparks-py',
       'image.openshift.io/triggers':
-        '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","pause":"true"}]',
+        '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","paused":"true"}]',
       'openshift.io/generated-by': 'OpenShiftWebConsole',
       isFromDevfile: 'true',
     },

--- a/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils.spec.tsx
+++ b/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils.spec.tsx
@@ -36,7 +36,7 @@ describe('resource-label-utils', () => {
         'app.openshift.io/vcs-ref': 'master',
         'app.openshift.io/vcs-uri': 'https://github.com/divyanshiGupta/nationalparks-py',
         'image.openshift.io/triggers':
-          '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","pause":"true"}]',
+          '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","paused":"true"}]',
         'openshift.io/generated-by': 'OpenShiftWebConsole',
         'app.openshift.io/connects-to': 'database',
         'deployment.kubernetes.io/revision': '4',
@@ -125,12 +125,12 @@ describe('resource-label-utils', () => {
       let annotation = getTriggerAnnotation('test', 'python', 'div', true);
       expect(annotation).toEqual({
         'image.openshift.io/triggers':
-          '[{"from":{"kind":"ImageStreamTag","name":"python:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"test\\")].image","pause":"false"}]',
+          '[{"from":{"kind":"ImageStreamTag","name":"python:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"test\\")].image","paused":"false"}]',
       });
       annotation = getTriggerAnnotation('test', 'test', 'div', false);
       expect(annotation).toEqual({
         'image.openshift.io/triggers':
-          '[{"from":{"kind":"ImageStreamTag","name":"test:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"test\\")].image","pause":"true"}]',
+          '[{"from":{"kind":"ImageStreamTag","name":"test:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"test\\")].image","paused":"true"}]',
       });
     });
   });

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -75,7 +75,7 @@ export const getTriggerAnnotation = (
     {
       from: { kind: 'ImageStreamTag', name: `${imageName}:${imageTag}`, namespace: imageNamespace },
       fieldPath: `spec.template.spec.containers[?(@.name=="${containerName}")].image`,
-      pause: `${!imageTrigger}`,
+      paused: `${!imageTrigger}`,
     },
   ]),
 });


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/OCPBUGS-26073

Description:
We want to update trigger from auto to manual or vice versa. We can do it with CLI 'oc set triggers deployment/<name> --manual'. It normally changes to deployment annotation metadata.annotations.image.openshift.io/triggers to "paused: true" or "paused: false" when set to auto. But when we enable or disable auto trigger by editing deployment from the web console, it overrides annotation to "pause: false" or "pause: true" without 'd'.


https://github.com/openshift/console/assets/2561818/25287a9d-fd64-41cf-95f2-ce0bb994c36a

