### PR TITLE
OCPBUGS-26039: Make editor sidebar width consistent

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/CodeEditorField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/CodeEditorField.scss
@@ -27,7 +27,7 @@
   }
   &__sidebar {
     display: flex;
-    flex: 1 0 0;
+    width: 34%;
     margin-top: -$pf-v5-global-gutter--md;
     @media screen and (max-width: $pf-v5-global--breakpoint--lg) {
       display: none;

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -42,7 +42,7 @@ body,
   height: 100%;
 
   &__body {
-    flex: 1 1 auto;
+    flex: 2;
   }
 
   &__close-button {


### PR DESCRIPTION
In effect, these changes divide the yaml editor view into thirds and when its sidebar is displayed, the editor has 2/3rds width and the sidebar 1/3rd width of the available content area.

fixes [bug](https://issues.redhat.com/browse/OCPBUGS-26039) 

**Before**
<img width="1836" alt="Screenshot 2024-01-09 at 6 18 16 PM" src="https://github.com/openshift/console/assets/1874151/d5389bb4-7cb0-4a6a-99bb-80b1405cb92c">
<img width="1836" alt="Screenshot 2024-01-09 at 6 18 07 PM" src="https://github.com/openshift/console/assets/1874151/2b3b0585-f207-43c6-8d97-04bf5574c16a">

---

**After**
<img width="1830" alt="Screenshot 2024-01-09 at 6 15 55 PM" src="https://github.com/openshift/console/assets/1874151/5ae3bf5c-9618-4d82-8a0e-6b4b8d141f15">
<img width="1837" alt="Screenshot 2024-01-09 at 6 16 04 PM" src="https://github.com/openshift/console/assets/1874151/e5d2808a-9973-4c25-be3a-69d729ed35f4">

