### PR TITLE
OCPBUGS-27016: fix resizeObserver limit exceed for dev-console

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/dev-console/integration-tests/support/commands/hooks.ts
@@ -1,5 +1,16 @@
 import { guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
 
+//  To ignore the resizeObserverLoopErrors on CI, adding below code
+const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
+/* eslint-disable consistent-return */
+Cypress.on('uncaught:exception', (err, runnable, promise) => {
+  /* returning false here prevents Cypress from failing the test */
+  if (resizeObserverLoopErrRe.test(err.message)) {
+    return false;
+  }
+  cy.log('uncaught:exception', err, runnable, promise);
+});
+
 before(() => {
   cy.exec('../../../../contrib/create-user.sh');
   const bridgePasswordIDP: string = Cypress.env('BRIDGE_HTPASSWD_IDP') || 'test';


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/OCPBUGS-27016

Description:
Currently dev-console package don't handle `uncaught: exceptions` which causes test to fail but on the other hand UI is working as expected.
