### PR TITLE
OCPBUGS-26772: fix bug where Clone PVC modal assumes pvc.spec.resourc…

### DIFF
--- a/frontend/packages/console-app/src/components/modals/clone/clone-pvc-modal.tsx
+++ b/frontend/packages/console-app/src/components/modals/clone/clone-pvc-modal.tsx
@@ -30,6 +30,7 @@ import {
   validate,
   resourceObjPath,
   convertToBaseValue,
+  humanizeBinaryBytesWithoutB,
 } from '@console/internal/components/utils';
 import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
 import { HandlePromiseProps } from '@console/internal/components/utils/promise-component';
@@ -54,8 +55,9 @@ const ClonePVCModal = withHandlePromise((props: ClonePVCModalProps) => {
   const { t } = useTranslation();
   const { close, cancel, resource, handlePromise, errorMessage, inProgress } = props;
   const { name: pvcName, namespace } = resource?.metadata;
-  const defaultSize: string[] = validate.split(getRequestedPVCSize(resource));
-  const pvcRequestedSize = `${defaultSize[0]} ${dropdownUnits[defaultSize[1]]}`;
+  const baseValue = convertToBaseValue(getRequestedPVCSize(resource));
+  const defaultSize: string[] = validate.split(humanizeBinaryBytesWithoutB(baseValue).string);
+  const pvcRequestedSize = humanizeBinaryBytes(baseValue).string;
 
   const [clonePVCName, setClonePVCName] = React.useState(`${pvcName}-clone`);
   const [requestedSize, setRequestedSize] = React.useState(defaultSize[0] || '');


### PR DESCRIPTION
…es.requests.storage value includes a unit

After:

https://github.com/openshift/console/assets/895728/88628355-4d99-4cd9-80f6-a8b4c2b9be0b

