### PR TITLE
OCPBUGS-26566: Page fails to return to the Secrets list after clicking 'Cancel' on any Secret creation page

### DIFF
--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -138,6 +138,7 @@ export const SecretFormWrapper: React.FC<BaseEditSecretProps_> = (props) => {
   const { isCreate, modal, onCancel } = props;
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const params = useParams();
 
   const existingSecret = _.pick(props.obj, ['metadata', 'type']);
   const defaultSecretType = toDefaultSecretType(props.secretTypeAbstraction);
@@ -163,7 +164,7 @@ export const SecretFormWrapper: React.FC<BaseEditSecretProps_> = (props) => {
   const [base64StringData, setBase64StringData] = React.useState({});
   const [disableForm, setDisableForm] = React.useState(false);
 
-  const defaultCancel = () => navigate(-1);
+  const cancel = () => navigate(`/k8s/ns/${params.ns}/core~v1~Secret`);
 
   const onDataChanged = (secretsData) => {
     setStringData({ ...secretsData?.stringData });
@@ -272,7 +273,7 @@ export const SecretFormWrapper: React.FC<BaseEditSecretProps_> = (props) => {
         errorMessage={error || ''}
         inProgress={inProgress}
         submitText={t('public~Create')}
-        cancel={props.onCancel || defaultCancel}
+        cancel={onCancel || cancel}
       />
     </form>
   ) : (
@@ -295,12 +296,7 @@ export const SecretFormWrapper: React.FC<BaseEditSecretProps_> = (props) => {
               >
                 {props.saveButtonText || t('public~Create')}
               </Button>
-              <Button
-                type="button"
-                variant="secondary"
-                id="cancel"
-                onClick={onCancel || defaultCancel}
-              >
+              <Button type="button" variant="secondary" id="cancel" onClick={onCancel || cancel}>
                 {t('public~Cancel')}
               </Button>
             </ActionGroup>


### PR DESCRIPTION

### Before:

![Screenshot 2024-01-12 at 8 56 26 AM](https://github.com/openshift/console/assets/15249132/3601200e-c94e-407e-9941-10d5a3da6547)
![Screenshot 2024-01-12 at 8 56 42 AM](https://github.com/openshift/console/assets/15249132/ee83a7ac-45d1-4cc0-a920-eb4dfdde376c)

### After:

![Screenshot 2024-01-12 at 8 54 30 AM](https://github.com/openshift/console/assets/15249132/839f7b3c-2392-4fbf-8c1f-c33fe57cde66)
![Screenshot 2024-01-12 at 8 54 54 AM](https://github.com/openshift/console/assets/15249132/b1978955-386c-49f8-8f24-4503b1c2ccbf)
