### PR TITLE
OCPBUGS-16736: Addition of optional chaining to prevent yaml crash

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/CodeEditor.tsx
+++ b/frontend/packages/console-shared/src/components/editor/CodeEditor.tsx
@@ -24,7 +24,7 @@ const CodeEditor = React.forwardRef<MonacoEditor, CodeEditorProps>((props, ref) 
   const [usesValue] = React.useState<boolean>(value !== undefined);
   const editorDidMount = React.useCallback(
     (editor, monaco) => {
-      const currentLanguage = editor.getModel().getModeId();
+      const currentLanguage = editor.getModel()?.getModeId();
       editor.layout();
       editor.focus();
       switch (currentLanguage) {

--- a/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
+++ b/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
@@ -16,7 +16,12 @@ const MODEL_URI = 'inmemory://model.yaml';
 const MONACO_URI = monaco.Uri.parse(MODEL_URI);
 
 const createDocument = (model) => {
-  return TextDocument.create(MODEL_URI, model.getModeId(), model.getVersionId(), model.getValue());
+  return TextDocument.create(
+    MODEL_URI,
+    model?.getModeId(),
+    model?.getVersionId(),
+    model?.getValue(),
+  );
 };
 
 // Unfortunately, `editor.focus()` doesn't work when hiding the shortcuts


### PR DESCRIPTION
fix for yaml error `Cannot read properties of undefined (reading 'getModeId')`