### PR TITLE
OCPBUGS-27152: Fix popover jump in Tables

### DIFF
--- a/frontend/public/components/factory/Table/VirtualizedTableBody.tsx
+++ b/frontend/public/components/factory/Table/VirtualizedTableBody.tsx
@@ -20,8 +20,20 @@ type VirtualizedTableBodyProps<D, R = {}> = {
   getRowClassName?: (obj: D) => string;
 };
 
-const RowMemo = React.memo<RowProps<any, any> & { Row: React.ComponentType<RowProps<any, any>> }>(
-  ({ Row, ...props }) => <Row {...props} />,
+const RowMemo = React.memo<
+  RowProps<any, any> & {
+    Row: React.ComponentType<RowProps<any, any>>;
+    isScrolling: boolean;
+    style: React.CSSProperties;
+  }
+>(
+  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+  ({ Row, isScrolling, style, ...props }) => <Row {...props} />,
+  (_, nextProps) => {
+    if (nextProps.isScrolling) {
+      return true;
+    }
+  },
 );
 
 const VirtualizedTableBody = <D extends any, R extends any = {}>({
@@ -73,7 +85,7 @@ const VirtualizedTableBody = <D extends any, R extends any = {}>({
           title={getRowTitle?.(rowArgs.obj)}
           className={getRowClassName?.(rowArgs.obj)}
         >
-          <RowMemo Row={Row} {...rowArgs} />
+          <RowMemo Row={Row} {...rowArgs} style={style} isScrolling={isScrolling} />
         </TableRow>
       </CellMeasurer>
     );


### PR DESCRIPTION
the issue is not limited to Nodes table, it appears or any page using VirtualizedTable component.
The root cause is the way how react-virtualized works and its combination with memoizing Rows.

react-virtualized renders each row twice (first to measure it and determine if it is visible). When rendering the row first time, the position is set to 0. This is picked up by popover which is moved to 0 position. 
The second rendering sets the correct position, but due to row being memoized, the new position wont get to the popover, thus it is not properly updated.

A fix is to pass `style` to memoized Row to make sure that when position of the row changes, it updates the popover too.