### PR TITLE
ODC-7490: Add TaskRun tab in PLR details page using plugin

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -1235,6 +1235,42 @@
   {
     "type": "console.tab/horizontalNav",
     "properties": {
+      "model": {
+        "group": "tekton.dev",
+        "version": "v1",
+        "kind": "PipelineRun"
+      },
+      "page": {
+        "name": "%pipelines-plugin~TaskRuns%",
+        "href": "task-runs"
+      },
+      "component": { "$codeRef": "pipelinesComponent.TaskRuns" }
+    },
+    "flags": {
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINERUN_DETAIL_TASKRUNS_TAB"]
+    }
+  },
+  {
+    "type": "console.tab/horizontalNav",
+    "properties": {
+      "model": {
+        "group": "tekton.dev",
+        "version": "v1beta1",
+        "kind": "PipelineRun"
+      },
+      "page": {
+        "name": "%pipelines-plugin~TaskRuns%",
+        "href": "task-runs"
+      },
+      "component": { "$codeRef": "pipelinesComponent.TaskRuns" }
+    },
+    "flags": {
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINERUN_DETAIL_TASKRUNS_TAB"]
+    }
+  },
+  {
+    "type": "console.tab/horizontalNav",
+    "properties": {
       "id": "Output",
       "name": "Output",
       "model": {

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunDetailsPage.tsx
@@ -18,7 +18,6 @@ import { useDevPipelinesBreadcrumbsFor } from '../pipelines/hooks';
 import { usePipelineOperatorVersion } from '../pipelines/utils/pipeline-operator';
 import { PipelineRunDetails } from './detail-page-tabs/PipelineRunDetails';
 import { PipelineRunLogsWithActiveTask } from './detail-page-tabs/PipelineRunLogs';
-import TaskRuns from './detail-page-tabs/TaskRuns';
 import PipelineRunEvents from './events/PipelineRunEvents';
 import { usePipelineRun } from './hooks/usePipelineRuns';
 import { useTaskRuns } from './hooks/useTaskRuns';
@@ -74,12 +73,6 @@ const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
       pages={[
         navFactory.details(PipelineRunDetails),
         navFactory.editYaml(viewYamlComponent),
-        {
-          href: 'task-runs',
-          // t('pipelines-plugin~TaskRuns')
-          nameKey: 'pipelines-plugin~TaskRuns',
-          component: TaskRuns,
-        },
         {
           href: 'parameters',
           // t('pipelines-plugin~Parameters')

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunDetailsPage.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunDetailsPage.spec.tsx
@@ -7,7 +7,6 @@ import { PipelineRunModel } from '../../../models';
 import { getPipelineRunKebabActions } from '../../../utils/pipeline-actions';
 import * as hookUtils from '../../pipelines/hooks';
 import * as taskRunUtils from '../../taskruns/useTaskRuns';
-import TaskRuns from '../detail-page-tabs/TaskRuns';
 import PipelineRunEvents from '../events/PipelineRunEvents';
 import PipelineRunDetailsPage from '../PipelineRunDetailsPage';
 import * as triggerHooksModule from '../triggered-by/hooks';
@@ -44,7 +43,7 @@ describe('PipelineRunDetailsPage:', () => {
 
   it('Should contain five tabs in the details page', () => {
     const { pages } = wrapper.props();
-    expect(pages).toHaveLength(6);
+    expect(pages).toHaveLength(5);
   });
 
   it('Should contain events page', () => {
@@ -52,14 +51,6 @@ describe('PipelineRunDetailsPage:', () => {
     const eventPage = pages.find((page) => page.nameKey === `${i18nNS}~Events`);
     expect(eventPage).toBeDefined();
     expect(eventPage.component).toBe(PipelineRunEvents);
-  });
-
-  it('Should contain task runs page', () => {
-    const { pages } = wrapper.props();
-
-    const taskRunsPage = pages.find((page) => page.nameKey.includes('TaskRuns'));
-    expect(taskRunsPage).toBeDefined();
-    expect(taskRunsPage.component).toBe(TaskRuns);
   });
 
   it('Should contain Parameters page', () => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/index.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/index.ts
@@ -2,3 +2,4 @@ export { default as PipelineRunDetailsPage } from './PipelineRunDetailsPage';
 export { default as PipelineRunsResourceList } from './PipelineRunsResourceList';
 export { default as PipelineRunsK8sResourceList } from './PipelineRunsK8sResourceList';
 export { default as PipelineRunsPage } from './PipelineRunsPage';
+export { default as TaskRuns } from './detail-page-tabs/TaskRuns';


### PR DESCRIPTION
**Story**: https://issues.redhat.com/browse/ODC-7490

**Description**: In PipelineRunDetails page, there is a TaskRuns tab, this tab is now can be added from Dynamic plugin using flag `HIDE_STATIC_PIPELINE_PLUGIN_PIPELINERUN_DETAIL_TASKRUNS_TAB`