### PR TITLE
ODC-7489: automation for getting-started-tour-dev-perspective feature file

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/getting-started/getting-started-tour-dev-perspective.feature
+++ b/frontend/packages/dev-console/integration-tests/features/getting-started/getting-started-tour-dev-perspective.feature
@@ -2,78 +2,59 @@
 Feature: Getting Started tour of developer perspective
               As a user I want to take tour of developer perspective
 
-
-        @regression @to-do
+        @regression @manual
         Scenario: Quick tour when user logs in for the first time: GS-02-TC01
             Given user is on login page for the first time
              When user enters the credential
               And user clicks on the login button
-              And user switches to developer perspective if not already there
-              And the Getting Started experience is automatically displayed
-              And user can see first screen as 'Welcome to Dev perspective'
-              And user can see the button labels on the first screen are 'Get Started' & 'Skip tour'
-              And user clicks on Get started
-              And user can see next screen appears on Perspective switcher
-              And user can see the button labels as 'Next' & 'Back'
-              And user can clicks on Next button
-              And user can see next screen appears on Monitoring tab
-              And user can see the button labels as 'Next' & 'Back'
-              And user can clicks on Next button
-              And user can see next screen appears on Search tab
-              And user can see the button labels as 'Next' & 'Back'
-              And user can clicks on Next button
-              And user can see next screen appears on Help
-              And user can see the button labels as 'Next' & 'Back'
-              And user can clicks on Next button
-              And user can see next screen appears is Final Screen saying 'You are ready to go!'
-              And user can see the button labels as 'Okay, got it!' & 'Back'
-              And user can clicks on 'Okay, got it!' button
-             Then user is in the topology view in developer perspective
+              And user sees first screen as "Welcome to the Developer Perspective!"
+              And user clicks on "Get Started"
+              And user sees the next screen appears as "Perspective Switcher"
+              And user clicks on 'Next' button
+              And user sees the next screen appears as "Observe"
+              And user clicks on 'Next' button
+              And user sees the next screen appears as "Search"
+              And user clicks on 'Next' button
+              And user sees the next screen appears as "Help"
+              And user clicks on 'Next' button
+              And user sees the next screen appears as "User Preferences"
+              And user clicks on 'Next' button
+              And user sees the final screen appears as "You’re ready to go!"
+              And user clicks on "Okay, got it!" button
+             Then user is in the topology view in the developer perspective
 
-
-        @regression @to-do
+        @regression
         Scenario: Quick tour from help menu: GS-02-TC02
-            Given user is in developer perspective with Dev_Workspace is available
+            Given user is at developer perspective
              When user opens help menu on top right
-              And user clicks on 'Guided Tour' option
-              And user can see first screen as 'Welcome to Dev perspective'
-              And user can see the button labels on the first screen are 'Get Started' & 'Skip tour'
-              And user clicks on Get started
-              And user can see next screen appears on Perspective switcher
-              And user can see the button labels as 'Next' & 'Back'
-              And user can clicks on Next button
-              And user can see next screen appears on Monitoring tab
-              And user can see the button labels as 'Next' & 'Back'
-              And user can clicks on Next button
-              And user can see next screen appears on Search tab
-              And user can see the button labels as 'Next' & 'Back'
-              And user can clicks on Next button
-              And user can see next screen appears on Command Line Terminal
-              And user can see the button labels as 'Next' & 'Back'
-              And user can clicks on Next button
-              And user can see next screen appears on Help
-              And user can see the button labels as 'Next' & 'Back'
-              And user can clicks on Next button
-              And user can see next screen appears is Final Screen saying 'You are ready to go!'
-              And user can see the button labels as 'Okay, got it!' & 'Back'
-              And user can clicks on 'Okay, got it!' button
-             Then user is in the topology view in developer perspective
+              And user clicks on the 'Guided tour' option
+              And user sees first screen as 'Welcome to the Developer Perspective!'
+              And user clicks on the 'Get started' button on the guided tour modal
+              And user sees the next screen appears as "Perspective Switcher"
+              And user clicks on the 'Next' button
+              And user sees the next screen appears as "Observe"
+              And user clicks on the 'Next' button
+              And user sees the next screen appears as "Search"
+              And user clicks on the 'Next' button
+              And user sees the next screen appears as "Help"
+              And user clicks on the 'Next' button
+              And user sees the next screen appears as "User Preferences"
+              And user clicks on the 'Next' button
+              And user sees the final screen appears as "You’re ready to go!"
+              And user clicks on the "Okay, got it!" button on the guided tour modal
+             Then user is in the topology view in the developer perspective
 
-
-        @regression @to-do
+        @regression
         Scenario: Stopping Quick tour in mid of the tour: GS-02-TC03
             Given user is in developer perspective
              When user opens help menu on top right
-              And user clicks on 'Guided Tour' option
-              And user can see the first screen as 'Welcome to Dev perspective'
-              And user clicks on Get started
-              And user can see next screen appears on Perspective switcher
-              And user can see the button labels as 'Next' & 'Back' and 'X' button on top-right corner
-              And user clicks on X button
-              And closing out modal will open
-              And user can see button labels as 'Back to tour' and 'Close'
+              And user clicks on the "Guided tour" option
+              And user sees first screen as "Welcome to the Developer Perspective!"
+              And user clicks on Get started button
+              And user sees the next screen appears as "Perspective Switcher"
+              And user sees the button labels as "Back" & "Next" and "Close" button on top-right corner
               And user clicks on Close button
-              And user is in the topology view in developer perspective
+              And user is in the Add page in developer perspective
               And user opens help menu on top right
-              And user clicks on 'Guided Tour' option
+              And user clicks on the "Guided tour" option
              Then user is taken to the first screen again

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/gettingStarted-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/gettingStarted-po.ts
@@ -1,0 +1,9 @@
+export const gettingStartedPO = {
+  guidedTour: {
+    model: '#guided-tour-modal',
+    popover: '#guided-tour-popover',
+    secondaryFooterItem: '[data-test="tour-step-footer-secondary"]',
+    primaryFooterItem: '[data-test="tour-step-footer-primary"]',
+    closeButton: '[aria-label="Close"]',
+  },
+};

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/index.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/index.ts
@@ -1,5 +1,6 @@
 export * from './add-flow-po';
 export * from './addHealthChecks-po';
+export * from './gettingStarted-po';
 export * from './global-po';
 export * from './helm-po';
 export * from './monitoring-po';

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/getting-started/getting-started-tour-dev-perspective.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/getting-started/getting-started-tour-dev-perspective.ts
@@ -1,0 +1,65 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { devNavigationMenu, switchPerspective } from '../../constants/global';
+import { gettingStartedPO } from '../../pageObjects';
+import { navigateTo, perspective, topologyPage } from '../../pages';
+
+When('user sees first screen as {string}', (HeaderText: string) => {
+  cy.get(gettingStartedPO.guidedTour.model).contains(HeaderText);
+});
+
+When('user clicks on Get started button', () => {
+  cy.get(gettingStartedPO.guidedTour.primaryFooterItem).contains('Get started').click();
+});
+
+When('user sees the next screen appears as {string}', (HeaderText: string) => {
+  cy.get(gettingStartedPO.guidedTour.popover).contains(HeaderText);
+});
+
+When('user clicks on the {string} button on the guided tour modal', (buttonText: string) => {
+  cy.get(gettingStartedPO.guidedTour.model).find('button').contains(buttonText).click('center');
+});
+
+When('user clicks on the {string} button', (buttonText: string) => {
+  cy.get(gettingStartedPO.guidedTour.popover).find('button').contains(buttonText).click('center');
+});
+
+When('user sees the final screen appears as {string}', (HeaderText: string) => {
+  cy.get(gettingStartedPO.guidedTour.model).contains(HeaderText);
+});
+
+Then('user is in the topology view in the developer perspective', () => {
+  topologyPage.verifyTopologyPage();
+});
+
+Given('user is in developer perspective', () => {
+  perspective.switchTo(switchPerspective.Developer);
+});
+
+When(
+  'user sees the button labels as {string} & {string} and "Close" button on top-right corner',
+  (secondryLabel: string, primaryLabel: string) => {
+    cy.get(gettingStartedPO.guidedTour.primaryFooterItem).contains(primaryLabel);
+    cy.get(gettingStartedPO.guidedTour.secondaryFooterItem).contains(secondryLabel);
+    cy.get(gettingStartedPO.guidedTour.closeButton).should('be.visible');
+  },
+);
+
+When('user clicks on Close button', () => {
+  cy.get(gettingStartedPO.guidedTour.closeButton).click();
+});
+
+When('user is in the Add page in developer perspective', () => {
+  perspective.switchTo(switchPerspective.Developer);
+  navigateTo(devNavigationMenu.Add);
+});
+
+When('user opens help menu on top right', () => {
+  cy.byTestID('help-dropdown-toggle').should('be.visible').click();
+});
+When('user clicks on the {string} option', (menuOption: string) => {
+  cy.get('[role="menu"]').contains(menuOption).click();
+});
+
+Then('user is taken to the first screen again', () => {
+  cy.get(gettingStartedPO.guidedTour.model).contains('Welcome to the Developer Perspective!');
+});


### PR DESCRIPTION
**Description:**

- Automation of getting-started-tour-dev-perspective gherkin file in getting-started package

**Jira Id:**
- Story: 
      -  [ODC-7489](https://issues.redhat.com/browse/ODC-7489)

**Checks for approving Epic scenarios Automation PR:**
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.13-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p dev-console
```

**Screen shots**:

<img width="1234" alt="Screenshot 2024-03-06 at 10 57 16 PM" src="https://github.com/openshift/console/assets/51144829/e761253e-a7f4-4153-8f81-445fa372004c">




**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge