### PR TITLE
OCPBUGS-27779:  fix bug where Expand PVC modal assumes pvc.spec.resou…

### DIFF
--- a/frontend/public/components/modals/expand-pvc-modal.tsx
+++ b/frontend/public/components/modals/expand-pvc-modal.tsx
@@ -9,13 +9,16 @@ import {
   validate,
   withHandlePromise,
   HandlePromiseProps,
+  convertToBaseValue,
+  humanizeBinaryBytesWithoutB,
 } from '../utils';
 import { k8sPatch, referenceFor, K8sKind, K8sResourceKind } from '../../module/k8s/';
 import { getRequestedPVCSize } from '@console/shared';
 
 // Modal for expanding persistent volume claims
 const ExpandPVCModal = withHandlePromise((props: ExpandPVCModalProps) => {
-  const defaultSize = validate.split(getRequestedPVCSize(props.resource));
+  const baseValue = convertToBaseValue(getRequestedPVCSize(props.resource));
+  const defaultSize = validate.split(humanizeBinaryBytesWithoutB(baseValue).string);
   const [requestSizeValue, setRequestSizeValue] = React.useState(defaultSize[0] || '');
   const [requestSizeUnit, setRequestSizeUnit] = React.useState(defaultSize[1] || 'Gi');
   const [errorMessage, setErrorMessage] = React.useState<string>();


### PR DESCRIPTION
…rces.requests.storage value includes a unit

After:

https://github.com/openshift/console/assets/895728/5842b6d7-e230-4709-8680-b03df000b66c
