### PR TITLE
OCPBUGS-21800: Dev console buildconfig got [the server does not allow this method on the requested resource] error when not setting metadate.namespace

### DIFF
--- a/frontend/packages/dev-console/src/components/buildconfig/EditBuildConfig.tsx
+++ b/frontend/packages/dev-console/src/components/buildconfig/EditBuildConfig.tsx
@@ -45,6 +45,9 @@ const EditBuildConfig: React.FC<EditBuildConfigProps> = ({
     try {
       // Use YAML also as base when submitting the form
       parsedBuildConfig = safeYAMLToJS(values.yamlData);
+      if (!parsedBuildConfig?.metadata?.namespace) {
+        parsedBuildConfig.metadata.namespace = namespace;
+      }
     } catch (err) {
       helpers.setStatus({
         submitSuccess: '',


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-21800

**Analysis / Root cause**: 
Namespace was not added to request payload if not added manually

**Solution Description**: 
Added `metadata.namepsace` with current namespace value if not added

**Screen shots / Gifs for design review**: 

----BEFORE----


https://github.com/openshift/console/assets/102503482/51cd43af-f3f9-4e50-81c5-604332d77ffd




----AFTER----


https://github.com/openshift/console/assets/102503482/c817c2ad-42dd-4d90-ab10-789644ddf718









**Unit test coverage report**: 
NA

**Test setup:**
    openshift console -> Developer -> Builds -> Create BuildConfig -> yaml view


  
```
~~~
apiVersion: build.openshift.io/v1
kind: BuildConfig
metadata:
  name: mywebsite
  labels:
    name: mywebsite
spec:
  triggers:
  - type: ImageChange
    imageChange: {}
  - type: ConfigChange
  source:
    type: Git
    git:
      uri: https://github.com/monodot/container-up
    contextDir: httpd-hello-world
  strategy:
    type: Docker
    dockerStrategy:
      dockerfilePath: Dockerfile
      from:
        kind: ImageStreamTag
        name: httpd:latest 
        namespace: testbuild
  output:
    to:
      kind: ImageStreamTag
      name: mywebsite:latest 
~~~
```
     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge