### PR TITLE
OCPBUGS-28216: Adjust width and spacing so that warning icons are not clipped.

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/EventItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/EventItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionContent, AccordionItem, AccordionToggle } from '@patternfly/react-core';
+import { AccordionContent, AccordionItem, AccordionToggle, Icon } from '@patternfly/react-core';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { typeFilter, getLastTime } from '@console/internal/components/events';
@@ -42,10 +42,12 @@ const EventItem: React.FC<EventItemProps> = React.memo(({ event, isExpanded, onT
             </div>
             <div className="co-recent-item__title-message">
               {isWarning && (
-                <YellowExclamationTriangleIcon
-                  title={t('public~Warning')}
-                  className="co-dashboard-icon co-recent-item__icon--warning"
-                />
+                <Icon iconSize="md" className="co-recent-item__icon">
+                  <YellowExclamationTriangleIcon
+                    title={t('public~Warning')}
+                    className="co-recent-item__icon--warning"
+                  />
+                </Icon>
               )}
               {!expanded && (
                 <>

--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
@@ -126,17 +126,19 @@
   }
 }
 
+.co-recent-item__icon {
+  height: 18px !important;
+  margin-right: var(--pf-v5-global--spacer--xs);
+  min-width: 18px;
+}
+
 .co-recent-item__icon--warning {
-  align-items: center;
-  display: flex;
-  margin-right: 0.3rem;
-  margin-top: 0;
-  flex: 0 0 auto;
+  font-size: 1.1rem;
 }
 
 .co-recent-item__title {
-  display: flex;
   align-items: center;
+  display: flex;
 }
 
 .co-recent-item__title-message {
@@ -151,7 +153,7 @@
 }
 
 .co-recent-item__title-timestamp {
-  min-width: 65px;
+  min-width: 60px;
   padding-right: 0.3rem;
   text-align: left;
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-28216
<img width="553" alt="Screenshot 2024-01-25 at 12 14 04 PM" src="https://github.com/openshift/console/assets/1874151/aee015da-fc43-4575-a2a1-c6ea35577252">


**After** updated


![Screenshot 2024-01-26 at 2 37 05 PM](https://github.com/openshift/console/assets/1874151/3760c921-cbad-4229-b8b2-d490979957ef)
![Screenshot 2024-01-26 at 2 37 18 PM](https://github.com/openshift/console/assets/1874151/72d1251a-ca67-4e3f-9dd2-d464dc38aae6)
