### PR TITLE
OCPBUGS-28383: Activity card event has expanded content that is not correctly left aligned with the rest of the card content

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
@@ -36,15 +36,20 @@
     margin: 0;
   }
 
-  .co-recent-item__content .pf-v5-c-accordion {
-    --pf-v5-c-accordion__expanded-content-body--PaddingRight: var(
-      --pf-v5-c-card--child--PaddingRight
-    );
-    --pf-v5-c-accordion__expanded-content-body--PaddingLeft: var(
-      --pf-v5-c-card--child--PaddingLeft
-    );
+  .co-recent-item__content {
+    .pf-v5-c-accordion {
+      --pf-v5-c-accordion__expanded-content-body--PaddingRight: var(
+        --pf-v5-c-card--child--PaddingRight
+      );
+      --pf-v5-c-accordion__expanded-content-body--PaddingLeft: var(
+        --pf-v5-c-card--child--PaddingLeft
+      );
+    }
+    .pf-v5-c-accordion__expandable-content-body {
+      padding-inline-start: var(--pf-v5-c-card--child--PaddingLeft);
+      padding-inline-end: var(--pf-v5-c-card--child--PaddingRight);
+    }
   }
-
   .co-recent-item__toggle.pf-v5-c-accordion__toggle {
     --pf-v5-c-accordion__toggle--PaddingRight: var(--pf-v5-c-card--child--PaddingRight);
     --pf-v5-c-accordion__toggle--PaddingLeft: var(--pf-v5-c-card--child--PaddingLeft);


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-28383

**before**

![Screenshot 2024-01-26 at 3 55 39 PM](https://github.com/openshift/console/assets/1874151/2c05a315-76a2-41e6-bbe9-d79efb971402)


**after**
![Screenshot 2024-01-26 at 4 03 12 PM](https://github.com/openshift/console/assets/1874151/f608c330-12c6-47e7-84a7-2e636ff7662a)
