### PR TITLE
RHSTOR-4130: Cross storage class clone /restore

### DIFF
--- a/frontend/packages/console-shared/src/selectors/storage.ts
+++ b/frontend/packages/console-shared/src/selectors/storage.ts
@@ -1,4 +1,14 @@
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, StorageClassResourceKind } from '@console/internal/module/k8s';
 
 export const getRequestedPVCSize = (pvc: K8sResourceKind): string =>
   pvc?.spec?.resources?.requests?.storage;
+
+export const onlyPvcSCs = (
+  scObj: StorageClassResourceKind,
+  scResourceLoadError: boolean,
+  scResource: StorageClassResourceKind | null,
+) =>
+  !scResourceLoadError
+    ? scObj.provisioner.includes(scResource?.provisioner) &&
+      scObj.parameters?.encrypted === scResource?.parameters?.encrypted
+    : true;

--- a/frontend/packages/integration-tests-cypress/mocks/snapshot.ts
+++ b/frontend/packages/integration-tests-cypress/mocks/snapshot.ts
@@ -73,6 +73,23 @@ export const PVC = {
   },
 };
 
+export const PVCGP3 = {
+  apiVersion: PVC.apiVersion,
+  kind: PVC.kind,
+  metadata: {
+    name: 'testpvcgp3',
+  },
+  spec: {
+    storageClassName: 'gp3-csi',
+    accessModes: PVC.spec.accessModes,
+    resources: {
+      requests: {
+        storage: PVC.spec.resources.requests.storage,
+      },
+    },
+  },
+};
+
 export const SnapshotClass = {
   apiVersion: 'snapshot.storage.k8s.io/v1',
   kind: 'VolumeSnapshotClass',

--- a/frontend/packages/integration-tests-cypress/tests/storage/clone.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/storage/clone.cy.ts
@@ -1,4 +1,4 @@
-import { PVC, testerDeployment } from '../../mocks/snapshot';
+import { PVC, PVCGP3, testerDeployment } from '../../mocks/snapshot';
 import { testName, checkErrors } from '../../support';
 import { resourceStatusShouldContain } from '../../views/common';
 import { detailsPage, DetailsPageSelector } from '../../views/details-page';
@@ -8,6 +8,16 @@ import { nav } from '../../views/nav';
 
 const cloneName = `${PVC.metadata.name}-clone`;
 const cloneSize = '2';
+const deletePVCClone = (pvcName: string) => {
+  nav.sidenav.clickNavLink(['PersistentVolumeClaims']);
+  listPage.filter.byName(pvcName);
+  listPage.rows.clickKebabAction(pvcName, 'Delete PersistentVolumeClaim');
+  modal.shouldBeOpened();
+  modal.submitShouldBeEnabled();
+  modal.submit();
+  modal.shouldBeClosed();
+  listPage.rows.shouldNotExist(pvcName);
+};
 
 if (Cypress.env('BRIDGE_AWS')) {
   describe('Clone Tests', () => {
@@ -15,6 +25,7 @@ if (Cypress.env('BRIDGE_AWS')) {
       cy.login();
       cy.createProjectWithCLI(testName);
       cy.exec(`echo '${JSON.stringify(PVC)}' | oc apply -n ${testName} -f -`);
+      cy.exec(`echo '${JSON.stringify(PVCGP3)}' | oc apply -n ${testName} -f -`);
       cy.exec(`echo '${JSON.stringify(testerDeployment)}' | oc apply -n ${testName} -f -`);
       nav.sidenav.clickNavLink(['Storage', 'PersistentVolumeClaims']);
       listPage.filter.byName(PVC.metadata.name);
@@ -28,6 +39,7 @@ if (Cypress.env('BRIDGE_AWS')) {
     after(() => {
       cy.exec(`echo '${JSON.stringify(testerDeployment)}' | oc delete -n ${testName} -f -`);
       cy.exec(`echo '${JSON.stringify(PVC)}' | oc delete -n ${testName} -f -`);
+      cy.exec(`echo '${JSON.stringify(PVCGP3)}' | oc delete -n ${testName} -f -`);
       cy.deleteProjectWithCLI(testName);
     });
 
@@ -60,13 +72,36 @@ if (Cypress.env('BRIDGE_AWS')) {
     });
 
     it('Deletes PVC Clone', () => {
-      listPage.filter.byName(cloneName);
-      listPage.rows.clickKebabAction(cloneName, 'Delete PersistentVolumeClaim');
+      deletePVCClone(cloneName);
+    });
+
+    it('Creates PVC Clone with different storage cluster', () => {
+      listPage.filter.byName(PVC.metadata.name);
+      listPage.rows.clickKebabAction(PVC.metadata.name, 'Clone PVC');
       modal.shouldBeOpened();
       modal.submitShouldBeEnabled();
+      cy.byTestID('input-request-size').clear().type(cloneSize);
+      cy.byTestID('storage-class-dropdown').click();
+      cy.byTestID('dropdown-menu-item-link').contains('gp3-csi').click();
       modal.submit();
       modal.shouldBeClosed();
-      listPage.rows.shouldNotExist(cloneName);
+      cy.location('pathname').should(
+        'include',
+        `persistentvolumeclaims/${PVC.metadata.name}-clone`,
+      );
+      detailsPage.titleShouldContain(`${PVC.metadata.name}-clone`);
+      cy.exec(`oc get pvc ${PVC.metadata.name}-clone -n ${testName} -o json`)
+        .its('stdout')
+        .then((res) => {
+          const pvc = JSON.parse(res);
+          cy.get(DetailsPageSelector.name).contains(pvc.metadata.name);
+          cy.get(DetailsPageSelector.namespace).contains(pvc.metadata.namespace);
+          cy.byTestID('pvc-requested-capacity').contains(`${cloneSize} GiB`);
+        });
+    });
+
+    it('Deletes PVC Clone', () => {
+      deletePVCClone(cloneName);
     });
   });
 } else {

--- a/frontend/public/components/utils/storage-class-dropdown.tsx
+++ b/frontend/public/components/utils/storage-class-dropdown.tsx
@@ -63,6 +63,7 @@ export class StorageClassDropdownInnerWithTranslation extends React.Component<
           '',
         ),
         provisioner: resource.provisioner,
+        parameters: resource.parameters,
         type: _.get(resource, 'parameters.type', ''),
         zone: _.get(resource, 'parameters.zone', ''),
         resource,


### PR DESCRIPTION
This patch provides the following feature:
1) Storage Class Selection:
Users can now choose a storage class from the same provider when cloning or restoring.
This flexibility allows seamless transitions between storage classes with different replica counts (e.g., moving from SC with 3 replicas to 2/1 replicas).
2) Managed Service Improvement:
Managed services can now clone Persistent Volumes (PVs) from slow to fast storage classes.
This enhancement ensures efficient data movement and optimisation.
Epic link:  https://issues.redhat.com/browse/RHSTOR-4130