### PR TITLE
CONSOLE-3907: add actions extension point to Events

### DIFF
--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -81,7 +81,14 @@
   width: 100%;
 }
 
+.co-sysevent__count-and-actions {
+  align-items: flex-end;
+  display: flex;
+  flex-direction: column;
+}
+
 .co-sysevent__details {
+  column-gap: 8px;
   display: flex;
   justify-content: space-between;
 }

--- a/frontend/public/components/utils/event-stream.tsx
+++ b/frontend/public/components/utils/event-stream.tsx
@@ -39,7 +39,7 @@ class SysEvent extends React.Component<SysEventProps> {
   }
 
   render() {
-    const { EventComponent, index, style, event, className } = this.props;
+    const { EventComponent, index, style, event, className, list } = this.props;
 
     let shouldAnimate: boolean;
     const key = event.metadata.uid;
@@ -61,7 +61,7 @@ class SysEvent extends React.Component<SysEventProps> {
         >
           {(status) => (
             <div className={`slide-${status}`}>
-              <EventComponent event={event} />
+              <EventComponent event={event} list={list} cache={measurementCache} index={index} />
             </div>
           )}
         </CSSTransition>
@@ -94,6 +94,7 @@ export const EventStreamList: React.FC<EventStreamListProps> = ({
           <SysEvent
             className={className}
             event={events[index]}
+            list={list}
             EventComponent={EventComponent}
             onLoad={measure}
             onEntered={print}
@@ -104,7 +105,7 @@ export const EventStreamList: React.FC<EventStreamListProps> = ({
         )}
       </CellMeasurer>
     ),
-    [events, className, EventComponent],
+    [events, className, EventComponent, list],
   );
 
   const renderVirtualizedTable = (scrollContainer) => (
@@ -146,6 +147,9 @@ type EventStreamListProps = {
 
 export type EventComponentProps = {
   event: EventKind;
+  list: VirtualList;
+  cache: CellMeasurerCache;
+  index: number;
 };
 
 type SysEventProps = {
@@ -156,4 +160,5 @@ type SysEventProps = {
   style: React.CSSProperties;
   index: number;
   className?: string;
+  list: VirtualList;
 };


### PR DESCRIPTION
Update Events to render actions provided via [console.action/resource-provider](https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md#consoleactionresource-provider).  See example below.

If there is 1 action, render it as a button:
![localhost_9000_k8s_all-namespaces_events (1)](https://github.com/openshift/console/assets/895728/6d4eec73-bab1-44e1-bc72-cad3fb2191b2)

If there is more than 1 action, render an actions dropdown:
![localhost_9000_k8s_all-namespaces_events (2)](https://github.com/openshift/console/assets/895728/fc3f116f-5eb5-4612-9207-45831db5d699)

### To test:

Add the following to https://github.com/openshift/console/blob/6935c3fce1cf3d0a185e20ed8ca29547c9f0930f/frontend/packages/console-app/console-extensions.json#L1835
```json
  {
    "type": "console.action/resource-provider",
    "properties": {
      "model": {
        "version": "v1",
        "kind": "Event"
      },
      "provider": {
        "$codeRef": "eventActions.useEventActions"
      }
    }
```

Add the following to https://github.com/openshift/console/blob/6935c3fce1cf3d0a185e20ed8ca29547c9f0930f/frontend/packages/console-app/package.json#L52

```json
      "eventActions": "src/components/events/menu-actions.tsx"
```

Add the following as https://github.com/openshift/console/tree/master/frontend/packages/console-app/src/components/events/menu-actions.tsx

```tsx
import * as React from 'react';
import { Action } from '@console/dynamic-plugin-sdk';
import { EventKind, ExtensionHook } from '@console/internal/module/k8s';

export const useEventActions: ExtensionHook<Action[], EventKind> = (event) => {
  const eventActions = React.useMemo<Action[]>(() => {
    const actions: Action[] = [
      {
        id: 'test',
        label: 'Explain', // but use i18n in your code
        // eslint-disable-next-line no-console
        cta: () => console.log('Will open a modal for', event),
      },
      // {
      //   id: 'test2',
      //   label: 'A second action', // but use i18n in your code
      //   // eslint-disable-next-line no-console
      //   cta: () => console.log('Will open a modal for', event),
      // },
    ];
    return actions;
  }, [event]);

  return [eventActions, true, undefined];
};
```