### PR TITLE
CONSOLE-3774: Enable OperatorHub filter by TLSProfiles annotation 

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
@@ -27,6 +27,7 @@ export enum InfraFeatures {
   'proxy-aware' = 'Proxy-aware',
   FipsMode = 'FIPS Mode',
   fips = 'FIPS Mode',
+  tlsProfiles = 'Configurable TLS ciphers',
   cnf = 'Cloud-Native Network Function',
   cni = 'Container Network Interface',
   csi = 'Container Storage Interface',
@@ -114,6 +115,7 @@ export type OperatorHubCSVAnnotations = {
   [OperatorHubCSVAnnotationKey.disconnected]?: string;
   [OperatorHubCSVAnnotationKey.fipsCompliant]?: string;
   [OperatorHubCSVAnnotationKey.proxyAware]?: string;
+  [OperatorHubCSVAnnotationKey.tlsProfiles]?: string;
   [OperatorHubCSVAnnotationKey.cnf]?: string;
   [OperatorHubCSVAnnotationKey.cni]?: string;
   [OperatorHubCSVAnnotationKey.csi]?: string;

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -219,8 +219,10 @@ const infraFeaturesSort = (infrastructure) => {
       return 2;
     case InfraFeatures.TokenAuth:
       return 3;
-    default:
+    case InfraFeatures.tlsProfiles:
       return 4;
+    default:
+      return 5;
   }
 };
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -164,8 +164,7 @@ export const OperatorHubList: React.FC<OperatorHubListProps> = ({
             [OperatorHubCSVAnnotationKey.cnf]: cnf,
             [OperatorHubCSVAnnotationKey.cni]: cni,
             [OperatorHubCSVAnnotationKey.csi]: csi,
-            // tlsProfiles requires addtional changes
-            // [OperatorHubCSVAnnotationKey.tlsProfiles]: tlsProfiles,
+            [OperatorHubCSVAnnotationKey.tlsProfiles]: tlsProfiles,
             [OperatorHubCSVAnnotationKey.tokenAuthAWS]: tokenAuthAWS,
             [OperatorHubCSVAnnotationKey.tokenAuthAzure]: tokenAuthAzure,
             // tokenAuthGCP requires additional changes
@@ -197,6 +196,7 @@ export const OperatorHubList: React.FC<OperatorHubListProps> = ({
             { key: InfraFeatures.cnf, value: cnf },
             { key: InfraFeatures.cni, value: cni },
             { key: InfraFeatures.csi, value: csi },
+            { key: InfraFeatures.tlsProfiles, value: tlsProfiles },
           ];
 
           // override old with new


### PR DESCRIPTION
https://issues.redhat.com/browse/CONSOLE-3774

![Screenshot 2024-01-30 at 3 12 46 PM](https://github.com/openshift/console/assets/1874151/269e4760-9c3a-4fd6-a3d1-016331b5ad83)
