### PR TITLE
OCPBUGS-28718: Revision tab and routes tab in serving details page showing no resource found

### DIFF
--- a/frontend/packages/knative-plugin/src/components/services/ServiceDetailsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServiceDetailsPage.tsx
@@ -124,6 +124,7 @@ const ServiceDetailsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (
         kind: referenceForModel(RevisionModel),
         namespace: params.ns,
         showTitle: false,
+        name: '',
       },
     },
     {
@@ -135,6 +136,7 @@ const ServiceDetailsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (
         kind: referenceForModel(RouteModel),
         namespace: params.ns,
         showTitle: false,
+        name: '',
       },
     },
     navFactory.pods(FunctionsPods),
@@ -156,7 +158,7 @@ const ServiceDetailsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (
     kindObj,
     location,
     params,
-    'serving',
+    serviceTypeValue === ServiceTypeValue.Function ? 'functions' : 'serving',
     serverlessTab(kindObj.kind),
     serviceTypeValue === ServiceTypeValue.Function ? t('knative-plugin~Functions') : undefined,
     serviceTypeValue === ServiceTypeValue.Function ? true : isAdminPerspective,
@@ -168,11 +170,7 @@ const ServiceDetailsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (
       breadcrumbsFor={() => breadcrumbs}
       pages={pages}
       customActionMenu={actionMenu}
-      customData={
-        serviceTypeValue === ServiceTypeValue.Function
-          ? { selectResourcesForName: params.name }
-          : undefined
-      }
+      customData={{ selectResourcesForName: params.name }}
     />
   );
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-28718

**Analysis / Root cause**: 
Issue caused due to changes in PR - https://github.com/openshift/console/pull/13216

**Solution Description**: 
Reverted the changes

**Screen shots / Gifs for design review**: 

----BEFORE----




https://github.com/openshift/console/assets/102503482/562f709f-29dd-40e4-b21f-043e5dd103ea




----AFTER----



https://github.com/openshift/console/assets/102503482/cc87ea2b-de67-4fa9-8751-cdb0330144db










**Unit test coverage report**: 
NA

**Test setup:**
    1.Install serverless operator
    2.Create serving instance
    3.Create knative service/ function
    4.Go to details page


     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge