### PR TITLE
OCPBUGS-28836: AUTH-440: fix usersettings identifier creation

### DIFF
--- a/analyze.sh
+++ b/analyze.sh
@@ -14,7 +14,7 @@ if [ -d "$ARTIFACT_DIR" ]; then
   cp public/dist/report.html "${ARTIFACT_DIR}"
 fi
 
-MAX_BYTES=3670016 # ~3.5 MiB
+MAX_BYTES=3827302 # ~3.65 MiB
 VENDORS_MAIN_BYTES=$(du -b `find public/dist -type f -name 'vendors~main-chunk*js'` | cut -f1)
 DISPLAY_VALUE=$(awk "BEGIN {printf \"%.2f\n\", $VENDORS_MAIN_BYTES/1024/1024}")
 MAX_DISPLAY_VALUE=$(awk "BEGIN {printf \"%.2f\n\", $MAX_BYTES/1024/1024}")

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -167,6 +167,7 @@
     "apollo-link-ws": "^1.0.20",
     "axios": "^0.21.2",
     "classnames": "2.x",
+    "crypto-browserify": "3.12.0",
     "d3": "^5.16.0",
     "file-saver": "1.3.x",
     "focus-trap-react": "^6.0.0",

--- a/frontend/packages/console-shared/src/hooks/useUserSettings.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettings.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { createHash } from 'crypto-browserify';
 // FIXME upgrading redux types is causing many errors at this time
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -63,10 +64,26 @@ export const useUserSettings: UseUserSettings = <T>(key, defaultValue, sync = fa
   // Request counter
   const [isRequestPending, increaseRequest, decreaseRequest] = useCounterRef();
 
+  const hashNameOrKubeadmin = (name: string): string | null => {
+    if (!name) {
+      return null;
+    }
+
+    if (name === 'kube:admin') {
+      return 'kubeadmin';
+    }
+    const hash = createHash('sha256');
+    hash.update(name);
+    return hash.digest('hex');
+  };
+
   // User and impersonate
   const userUid = useSelector(
     (state: RootState) =>
-      getImpersonate(state)?.name ?? getUser(state)?.metadata?.uid ?? 'kubeadmin',
+      getImpersonate(state)?.name ??
+      getUser(state)?.metadata?.uid ??
+      hashNameOrKubeadmin(getUser(state).metadata?.name) ??
+      '',
   );
   const impersonate: boolean = useSelector((state: RootState) => !!getImpersonate(state));
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5886,9 +5886,10 @@ crypt@0.0.2:
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
-crypto-browserify@^3.0.0, crypto-browserify@^3.11.0:
+crypto-browserify@3.12.0, crypto-browserify@^3.0.0, crypto-browserify@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
+  integrity sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==
   dependencies:
     browserify-cipher "^1.0.0"
     browserify-sign "^4.0.0"


### PR DESCRIPTION
Usernames can contain all kinds of characters that are not allowed in resource names. Hash the name instead and use hex representation of the result to get a usable identifier.

/assign @jhadvig 