### PR TITLE
OCPBUGS-28856: make getGroupVersionKindForResource null safe

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-ref.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-ref.ts
@@ -48,18 +48,21 @@ export const getAPIVersionForModel: GetAPIVersionForModel = (model) =>
  * If the resource has an invalid apiVersion then it'll throw Error.
  * */
 export const getGroupVersionKindForResource: GetGroupVersionKindForResource = (resource) => {
-  const { apiVersion, kind } = resource;
-  const apiVersionSplit = apiVersion.split('/');
-  const apiVersionSplitLen = apiVersionSplit.length;
+  const apiVersion = resource?.apiVersion;
+  const kind = resource?.kind;
+  const apiVersionSplit = apiVersion?.split('/');
+  const apiVersionSplitLen = apiVersionSplit?.length;
   if (apiVersionSplitLen > 2) throw new Error('Provided resource has invalid apiVersion.');
 
-  return {
-    ...(apiVersionSplitLen === 2 && {
-      group: apiVersionSplit[0],
-    }),
-    version: apiVersionSplitLen === 2 ? apiVersionSplit[1] : apiVersion,
-    kind,
-  };
+  return !apiVersion || !kind
+    ? undefined
+    : {
+        ...(apiVersionSplitLen === 2 && {
+          group: apiVersionSplit[0],
+        }),
+        version: apiVersionSplitLen === 2 ? apiVersionSplit[1] : resource?.apiVersion,
+        kind,
+      };
 };
 
 /**


### PR DESCRIPTION
Demo:

`getGroupVersionKindForResource` is now null safe and will return `undefined` if `apiVersion` or `kind` are `undefined`.  `useDeleteModal` will not work with an `undefined` resource, but the run time error no longer occurs.

https://github.com/openshift/console/assets/895728/432a34dd-bc71-470a-8f7a-287700bbfa26

