### PR TITLE
OCPBUGS-27246: Unhealthy conditions table should put Type as first column on MachineHealthCheck details page

### DIFF
--- a/frontend/public/components/machine-health-check.tsx
+++ b/frontend/public/components/machine-health-check.tsx
@@ -102,17 +102,17 @@ const UnhealthyConditionsTable: React.FC<{ obj: K8sResourceKind }> = ({ obj }) =
     <table className="pf-v5-c-table pf-m-compact pf-m-border-rows">
       <thead className="pf-v5-c-table__thead">
         <tr className="pf-v5-c-table__tr">
+          <th className="pf-v5-c-table__th">{t('public~Type')}</th>
           <th className="pf-v5-c-table__th">{t('public~Status')}</th>
           <th className="pf-v5-c-table__th">{t('public~Timeout')}</th>
-          <th className="pf-v5-c-table__th">{t('public~Type')}</th>
         </tr>
       </thead>
       <tbody className="pf-v5-c-table__tbody">
         {obj.spec.unhealthyConditions.map(({ status, timeout, type }, i: number) => (
           <tr className="pf-v5-c-table__tr" key={i}>
+            <td className="pf-v5-c-table__td">{type}</td>
             <td className="pf-v5-c-table__td">{status}</td>
             <td className="pf-v5-c-table__td">{timeout}</td>
-            <td className="pf-v5-c-table__td">{type}</td>
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
### Before:

![Screenshot 2024-02-05 at 1 49 44 PM](https://github.com/openshift/console/assets/15249132/2ff40e97-775e-4cb2-ad5b-f86089556058)

### After:

![Screenshot 2024-02-05 at 1 49 56 PM](https://github.com/openshift/console/assets/15249132/6caee46c-5201-44b2-b737-a4146bd845a4)
