### PR TITLE
OCPBUGS-27247: improve empty state message for Machines and MachineSets page

### DIFF
--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -404,6 +404,7 @@ export const MachineSetList: React.FC<MachineSetListProps> = (props) => {
     <VirtualizedTable<MachineSetKind>
       {...props}
       aria-label={t('public~MachineSets')}
+      label={t('public~MachineSets')}
       columns={machineSetTableColumn}
       Row={MachineSetTableRow}
     />

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -259,6 +259,7 @@ export const MachineList: React.FC<MachineListProps> = (props) => {
     <VirtualizedTable<MachineKind>
       {...props}
       aria-label={t('public~Machines')}
+      label={t('public~Machines')}
       columns={columns}
       Row={MachineTableRow}
     />


### PR DESCRIPTION
### Before:

![Screenshot 2024-02-05 at 2 08 37 PM](https://github.com/openshift/console/assets/15249132/4c45fa0f-aad7-4296-8463-7b280fae4456)

![Screenshot 2024-02-05 at 2 08 49 PM](https://github.com/openshift/console/assets/15249132/35d5fe83-9689-4367-8fd1-e93e117ad7df)

### After:

![Screenshot 2024-02-05 at 2 09 06 PM](https://github.com/openshift/console/assets/15249132/161fc504-d049-4876-aed0-bb3f4cdda619)
![Screenshot 2024-02-05 at 2 09 18 PM](https://github.com/openshift/console/assets/15249132/9b5b2f31-27d0-4dec-b8a8-b778c42adc92)
