### PR TITLE
OCPBUGS-25931: fix for execute inline markdown syntax issue

### DIFF
--- a/frontend/packages/console-shared/src/components/markdown-extensions/inline-clipboard-extension.ts
+++ b/frontend/packages/console-shared/src/components/markdown-extensions/inline-clipboard-extension.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MARKDOWN_COPY_BUTTON_ID, MARKDOWN_SNIPPET_ID } from './const';
-import { removeTemplateWhitespace } from './utils';
 
 import './showdown-extension.scss';
 
@@ -19,20 +18,25 @@ const useInlineCopyClipboardShowdownExtension = () => {
         groupId: string,
       ): string => {
         if (!group || !subGroup || !groupType || !groupId) return text;
-        return removeTemplateWhitespace(
-          `<span class="pf-v5-c-clipboard-copy pf-m-inline">
-              <span class="pf-v5-c-clipboard-copy__text" ${MARKDOWN_SNIPPET_ID}="${groupType}">${group}</span>
-              <span class="pf-v5-c-clipboard-copy__actions">
-                <span class="pf-v5-c-clipboard-copy__actions-item">
-                  <button class="pf-v5-c-button pf-m-plain" aria-label="${t(
-                    'console-shared~Copy to clipboard',
-                  )}" ${MARKDOWN_COPY_BUTTON_ID}="${groupType}">
-                    <i class="fas fa-copy" />
-                  </button>
-                </span>
-              </span>
-            </span>`,
-        );
+        return `<b><div class="pf-v5-c-code-block">
+        <div class="pf-v5-c-code-block__header">
+          <div class="pf-v5-c-code-block__actions">
+            <div class="pf-v5-c-code-block__actions-item">
+              <button class="pf-v5-c-button pf-m-plain" type="button" aria-label="${t(
+                'console-shared~Copy to clipboard',
+              )}" ${MARKDOWN_COPY_BUTTON_ID}="${groupType}">
+                <i class="fas fa-copy" aria-hidden="true"></i>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div class="pf-v5-c-code-block__content">
+          <pre class="pf-v5-c-code-block__pre ocs-code-block__pre">
+            <code class="pf-v5-c-code-block__code" 
+              ${MARKDOWN_SNIPPET_ID}="${groupType}">${group.trim()}</code>
+          </pre>
+        </div>
+      </div></b>`;
       },
     }),
     [t],

--- a/frontend/packages/console-shared/src/components/markdown-extensions/inline-execute-extension.ts
+++ b/frontend/packages/console-shared/src/components/markdown-extensions/inline-execute-extension.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import useCloudShellAvailable from '@console/webterminal-plugin/src/components/cloud-shell/useCloudShellAvailable';
 import { MARKDOWN_COPY_BUTTON_ID, MARKDOWN_EXECUTE_BUTTON_ID, MARKDOWN_SNIPPET_ID } from './const';
-import { removeTemplateWhitespace } from './utils';
 
 import './showdown-extension.scss';
 
@@ -21,32 +20,36 @@ const useInlineExecuteCommandShowdownExtension = () => {
         groupId: string,
       ): string => {
         if (!group || !subGroup || !groupType || !groupId) return text;
-        return removeTemplateWhitespace(
-          `<span class="pf-v5-c-clipboard-copy pf-m-inline">
-              <span class="pf-v5-c-clipboard-copy__text" ${MARKDOWN_SNIPPET_ID}="${groupId}">${group.trim()}</span>
-              <span class="pf-v5-c-clipboard-copy__actions">
-                <span class="pf-v5-c-clipboard-copy__actions-item">
-                  <button class="pf-v5-c-button pf-m-plain" aria-label="${t(
-                    'console-shared~Copy to clipboard',
-                  )}" ${MARKDOWN_COPY_BUTTON_ID}="${groupId}">
-                    <i class="fas fa-copy" aria-hidden="true"></i>
-                  </button>
-                </span>
-                ${
-                  showExecuteButton
-                    ? `<span class="pf-v5-c-clipboard-copy__actions-item ocs-markdown-execute-snippet__action">
-                    <button class="pf-v5-c-button pf-m-plain ocs-markdown-execute-snippet__button" aria-label="${t(
-                      'console-shared~Run in Web Terminal',
-                    )}" ${MARKDOWN_EXECUTE_BUTTON_ID}="${groupId}">
-                      <i class="fas fa-play" aria-hidden="true"></i>
-                      <i class="fas fa-check" aria-hidden="true"></i>
-                    </button>
-                  </span>`
-                    : ''
-                }
-              </span>
-            </span>`,
-        );
+        return `<div class="pf-v5-c-code-block">
+        <div class="pf-v5-c-code-block__header">
+          <div class="pf-v5-c-code-block__actions">
+            <div class="pf-v5-c-code-block__actions-item">
+              <button class="pf-v5-c-button pf-m-plain" type="button" aria-label="${t(
+                'console-shared~Copy to clipboard',
+              )}" ${MARKDOWN_COPY_BUTTON_ID}="${groupType}">
+                <i class="fas fa-copy" aria-hidden="true"></i>
+              </button>
+            </div>
+            ${
+              showExecuteButton
+                ? `<div class="pf-v5-c-code-block__actions-item ocs-markdown-execute-snippet__action">
+                <button class="pf-v5-c-button pf-m-plain ocs-markdown-execute-snippet__button" type="button" aria-label="${t(
+                  'console-shared~Run in Web Terminal',
+                )}" ${MARKDOWN_EXECUTE_BUTTON_ID}="${groupType}">
+                  <i class="fas fa-play" aria-hidden="true"></i>
+                  <i class="fas fa-check" aria-hidden="true"></i>
+                </button>
+              </div>`
+                : ''
+            }
+          </div>
+        </div>
+        <div class="pf-v5-c-code-block__content">
+          <pre class="pf-v5-c-code-block__pre pfext-code-block__pre">
+            <code class="pf-v5-c-code-block__code" ${MARKDOWN_SNIPPET_ID}="${groupType}">${group.trim()}</code>
+          </pre>
+        </div>
+      </div>`;
       },
     }),
     [showExecuteButton, t],


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/OCPBUGS-25931

Screen shots / Gifs for design review:

----BEFORE----
![image](https://github.com/openshift/console/assets/51144829/06ded6d4-c0c0-4de5-851b-42dec1b5037c)

----AFTER----
<img width="1792" alt="Screenshot 2024-02-06 at 12 58 14 PM" src="https://github.com/openshift/console/assets/51144829/c7636e30-9e68-4231-82e9-a57942ef922c">


Unit test coverage report:
NA

Test setup:
1.Install web terminal operator
2.Create a ConsoleQuickStart resource using "[copy-execute-demo.yaml](https://drive.google.com/file/d/1Zw3LJxQCS9ZK1xa4reGFeDmG9nQiEHrk/view?usp=sharing)" file
3.Open "Sample Quick Start" from quick start catalog page

Browser conformance:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge