### PR TITLE
OCPBUGS-27473: Error in displaying BuildRun logs in Console

### DIFF
--- a/frontend/packages/shipwright-plugin/src/components/buildrun-details/BuildRunLogsTab.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/buildrun-details/BuildRunLogsTab.tsx
@@ -9,6 +9,7 @@ import TaskRunLog from '@console/pipelines-plugin/src/components/taskruns/TaskRu
 import { TaskRunModel } from '@console/pipelines-plugin/src/models/pipelines';
 import { TaskRunKind } from '@console/pipelines-plugin/src/types';
 import { BuildRun } from '../../types';
+import { isV1Alpha1Resource } from '../../utils';
 
 type BuildRunLogsTabProps = {
   obj: BuildRun;
@@ -18,7 +19,9 @@ const BuildRunLogsTab: React.FC<BuildRunLogsTabProps> = ({ obj: buildRun }) => {
   const { t } = useTranslation();
   const { ns: namespace } = useParams();
 
-  const taskRunRef = buildRun.status?.latestTaskRunRef;
+  const taskRunRef = isV1Alpha1Resource(buildRun)
+    ? buildRun.status?.latestTaskRunRef
+    : buildRun.status?.taskRunName;
   const [taskRun, taskRunLoaded, taskRunLoadError] = useK8sWatchResource<TaskRunKind>(
     taskRunRef
       ? {

--- a/frontend/packages/shipwright-plugin/src/types.ts
+++ b/frontend/packages/shipwright-plugin/src/types.ts
@@ -16,10 +16,10 @@ export type BuildStatus = IBuildV1Alpha1['status'] & IBuildV1Beta1['status'];
 // Make status.conditions compatible with @console/internal/components/conditions props
 export type BuildRun =
   | (IBuildRunV1Alpha1 & {
-      status?: { conditions?: K8sResourceCondition[] };
+      status?: { conditions?: K8sResourceCondition[]; latestTaskRunRef?: string };
     })
   | (IBuildRunV1Beta1 & {
-      status?: { conditions?: K8sResourceCondition[]; latestTaskRunRef?: string };
+      status?: { conditions?: K8sResourceCondition[]; taskRunName?: string };
     });
 
 // The enum values need to match the dynamic-plugin `Status` `status` prop.


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-27473

**Analysis / Root cause**: 
BuildRun logs cannot be displayed in the console and shows the error.

**Solution Description**: 
Updated the code according to the latest v1beta1 API Version.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Screenshot from 2024-02-06 20-24-21](https://github.com/openshift/console/assets/47265560/4a4bf498-f421-4856-ac4e-35de21c355f8)


**Unit test coverage report**: 
Not Changed.

**Test setup:**
1. Install the Builds Operator and start a Build.
2. Check the Logs page of the BuildRun.



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge