### PR TITLE
OCPBUGS-28723: Improve Create serverless function error message

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -562,7 +562,7 @@
   "A {{deploymentConfigLabel}} defines the template for a Pod and manages deploying new Images or configuration changes.": "A {{deploymentConfigLabel}} defines the template for a Pod and manages deploying new Images or configuration changes.",
   "Resource type to generate. The default can be set in <2>User Preferences</2>.": "Resource type to generate. The default can be set in <2>User Preferences</2>.",
   "func.yaml is not present and builder strategy is not s2i": "func.yaml is not present and builder strategy is not s2i",
-  "func.yaml must be present and builder strategy should be s2i to create a Serverless function": "func.yaml must be present and builder strategy should be s2i to create a Serverless function",
+  "The Function cannot be built from this repository since it is not created with <2>kn func create</2> command.": "The Function cannot be built from this repository since it is not created with <2>kn func create</2> command.",
   "Support for {{runtime}} is not yet available.": "Support for {{runtime}} is not yet available.",
   "Unsupported Runtime detected. Please update the Repository URL or change the Build Strategy to continue.": "Unsupported Runtime detected. Please update the Repository URL or change the Build Strategy to continue.",
   "Builder Image {{image}} is not present.": "Builder Image {{image}} is not present.",

--- a/frontend/packages/dev-console/src/components/import/serverless-function/AddServerlessFunctionForm.scss
+++ b/frontend/packages/dev-console/src/components/import/serverless-function/AddServerlessFunctionForm.scss
@@ -1,0 +1,3 @@
+.odc-func-form-link {
+  margin-top: var(--pf-v5-global--spacer--md);
+}

--- a/frontend/packages/dev-console/src/components/import/serverless-function/AddServerlessFunctionForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless-function/AddServerlessFunctionForm.tsx
@@ -2,11 +2,12 @@ import * as React from 'react';
 import { Alert, Flex, FlexItem, ValidatedOptions } from '@patternfly/react-core';
 import { FormikProps, FormikValues } from 'formik';
 import * as _ from 'lodash';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { WatchK8sResultsObject } from '@console/dynamic-plugin-sdk';
 import { k8sListResourceItems } from '@console/dynamic-plugin-sdk/src/utils/k8s';
 import { getGitService, GitProvider } from '@console/git-service/src';
 import { evaluateFunc } from '@console/git-service/src/utils/serverless-strategy-detector';
+import { ExternalLink } from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { ServerlessBuildStrategyType } from '@console/knative-plugin/src/types';
 import PipelineSection from '@console/pipelines-plugin/src/components/import/pipeline/PipelineSection';
@@ -26,6 +27,8 @@ import AppSection from '../app/AppSection';
 import GitSection from '../git/GitSection';
 import ServerlessFunctionStrategySection from './ServerlessFunctionStrategySection';
 
+import './AddServerlessFunctionForm.scss';
+
 type AddServerlessFunctionFormProps = {
   builderImages?: NormalizedBuilderImages;
   projects: WatchK8sResultsObject<K8sResourceKind[]>;
@@ -37,6 +40,9 @@ enum SupportedRuntime {
   typescript = 'nodejs',
   quarkus = 'java',
 }
+
+export const SERVERLESS_FUNCTION_DOCS_URL =
+  'https://docs.openshift.com/serverless/latest/functions/serverless-functions-getting-started.html';
 
 const AddServerlessFunctionForm: React.FC<
   FormikProps<FormikValues> & AddServerlessFunctionFormProps
@@ -147,10 +153,16 @@ const AddServerlessFunctionForm: React.FC<
                   title={t('devconsole~func.yaml is not present and builder strategy is not s2i')}
                 >
                   <p>
-                    {t(
-                      'devconsole~func.yaml must be present and builder strategy should be s2i to create a Serverless function',
-                    )}
+                    <Trans t={t} ns="devconsole">
+                      The Function cannot be built from this repository since it is not created with{' '}
+                      <code className="co-code">kn func create</code> command.
+                    </Trans>
                   </p>
+                  <ExternalLink
+                    additionalClassName="odc-func-form-link"
+                    href={SERVERLESS_FUNCTION_DOCS_URL}
+                    text={t('devconsole~Learn more')}
+                  />
                 </Alert>
               )}
           </FormBody>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-28723

**Analysis / Root cause**: 
The requirement of `func.yaml` was not clear and had no info about it.

**Solution Description**: 
Added a proper reason and link to explore the Func CLI.

**Screen shots / Gifs for design review**: 
![image](https://github.com/openshift/console/assets/47265560/123e1a2d-472d-4952-a79a-43759be19ec9)

**Unit test coverage report**: 
Not changed

**Test setup:**
1. Install Serverless operator
2. Paste a random Git Repo URL in the Create Serverless Function Form.



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge