### PR TITLE
OCPBUGS-29760: Dev console: Observe > Dashboard page should be called "Dashboards" (OU-260)

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/monitoring/changing-context-monitoring-dashboard.feature
+++ b/frontend/packages/dev-console/integration-tests/features/monitoring/changing-context-monitoring-dashboard.feature
@@ -10,10 +10,10 @@ Feature: Changing context in Observe Dashboard
 
 
         @regression
-        Scenario: Charts display in observe dashboard for specific workload: M-01-TC01
+        Scenario: Charts display in observe dashboards for specific workload: M-01-TC01
             Given user is at the Topology page
              When user selects the workload "nodejs-ex-git" to open the topology sidebar
-              And user navigates to observe dashboard from toplogy sidebar
+              And user navigates to observe dashboards from toplogy sidebar
              Then user is able to see the workload "nodejs-ex-git" in workloads dropdown
               And user will see "CPU Usage" chart
               And user will see "CPU Quota" chart

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/monitoring/changing-context-dashboard.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/monitoring/changing-context-dashboard.ts
@@ -6,9 +6,9 @@ When('user selects the workload {string} to open the topology sidebar', (workloa
   topologyPage.clickOnNode(workloadName);
 });
 
-When('user navigates to observe dashboard from toplogy sidebar', () => {
+When('user navigates to observe dashboards from toplogy sidebar', () => {
   topologySidePane.selectTab('Observe');
-  cy.get(topologyPO.sidePane.monitoringTab.viewMonitoringDashBoardLink).click({ force: true });
+  cy.get(topologyPO.sidePane.monitoringTab.viewMonitoringDashBoardsLink).click({ force: true });
 });
 
 Then('user is able to see the workload {string} in workloads dropdown', (workloadName: string) => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/monitoring/topology-sidebar-actions.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/monitoring/topology-sidebar-actions.ts
@@ -54,7 +54,7 @@ When('user selects {string} from Context Menu', (menuOption: string) => {
 });
 
 When('user clicks on View dashboard link', () => {
-  cy.get(topologyPO.sidePane.monitoringTab.viewMonitoringDashBoardLink).click({ force: true });
+  cy.get(topologyPO.sidePane.monitoringTab.viewMonitoringDashBoardsLink).click({ force: true });
 });
 
 When('user selects {string} from topology sidebar Actions dropdown', (menuOption: string) => {
@@ -189,7 +189,7 @@ Then('user wont see Monitoring tab', () => {
 });
 
 Then('user will see View dashboard link', () => {
-  cy.get(topologyPO.sidePane.monitoringTab.viewMonitoringDashBoardLink).should('be.visible');
+  cy.get(topologyPO.sidePane.monitoringTab.viewMonitoringDashBoardsLink).should('be.visible');
 });
 
 Then('user will see CPU Usage Metrics', () => {

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -627,7 +627,7 @@
   "Select query": "Select query",
   "Hide PromQL": "Hide PromQL",
   "Show PromQL": "Show PromQL",
-  "Dashboard": "Dashboard",
+  "Dashboards": "Dashboards",
   "Metrics": "Metrics",
   "Silences": "Silences",
   "Events": "Events",

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -634,7 +634,7 @@
   "Select a Project to view monitoring metrics<1></1>.": "Select a Project to view monitoring metrics<1></1>.",
   "No metrics found": "No metrics found",
   "Deployment Configuration metrics are not yet supported.": "Deployment Configuration metrics are not yet supported.",
-  "View dashboard": "View dashboard",
+  "View dashboards": "View dashboards",
   "All events": "All events",
   "There are no recent events.": "There are no recent events.",
   "CPU usage": "CPU usage",

--- a/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
@@ -39,8 +39,8 @@ export const PageContents: React.FC = () => {
   const pages = [
     {
       href: '',
-      // t('devconsole~Dashboard')
-      nameKey: 'devconsole~Dashboard',
+      // t('devconsole~Dashboards')
+      nameKey: 'devconsole~Dashboards',
       component: MonitoringDashboardsPage,
     },
     {

--- a/frontend/packages/dev-console/src/components/monitoring/__tests__/MonitoringPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/__tests__/MonitoringPage.spec.tsx
@@ -32,7 +32,7 @@ describe('Monitoring Page ', () => {
 
   it('should render all Tabs of Monitoring page for selected project', () => {
     spyUseAccessReview.mockReturnValue(true);
-    const expectedTabs: string[] = ['Dashboard', 'Metrics', 'Alerts', 'Silences', 'Events'];
+    const expectedTabs: string[] = ['Dashboards', 'Metrics', 'Alerts', 'Silences', 'Events'];
 
     jest.spyOn(Router, 'useParams').mockReturnValue({
       ns: 'test-proj',
@@ -50,7 +50,7 @@ describe('Monitoring Page ', () => {
 
   it('should not render the Alerts tab if user has no access to get prometheousRule resource', () => {
     spyUseAccessReview.mockReturnValue(false);
-    const expectedTabs: string[] = ['Dashboard', 'Metrics', 'Events'];
+    const expectedTabs: string[] = ['Dashboards', 'Metrics', 'Events'];
     jest.spyOn(Router, 'useParams').mockReturnValue({
       ns: 'test-proj',
     });

--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.scss
@@ -15,7 +15,7 @@
       --pf-v5-c-accordion__expanded-content-body--PaddingLeft: 0;
     }
   }
-  &__view-monitoring-dashboard {
+  &__view-monitoring-dashboards {
     margin: var(--pf-v5-global--spacer--sm) 0;
     text-align: right;
   }

--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.tsx
@@ -135,7 +135,7 @@ const MonitoringOverview: React.FC<MonitoringOverviewProps> = (props) => {
               </EmptyState>
             ) : (
               <>
-                <div className="odc-monitoring-overview__view-monitoring-dashboard">
+                <div className="odc-monitoring-overview__view-monitoring-dashboards">
                   <Link
                     to={`/dev-monitoring/ns/${
                       resource?.metadata?.namespace

--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.tsx
@@ -144,7 +144,7 @@ const MonitoringOverview: React.FC<MonitoringOverviewProps> = (props) => {
                     }&type=${resource?.kind?.toLowerCase()}`}
                     data-test="observe-dashboard-link"
                   >
-                    {t('devconsole~View dashboard')}
+                    {t('devconsole~View dashboards')}
                   </Link>
                 </div>
                 <WorkloadGraphs resource={resource} />

--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.tsx
@@ -142,7 +142,7 @@ const MonitoringOverview: React.FC<MonitoringOverviewProps> = (props) => {
                     }?dashboard=grafana-dashboard-k8s-resources-workload&workload=${
                       resource?.metadata?.name
                     }&type=${resource?.kind?.toLowerCase()}`}
-                    data-test="observe-dashboard-link"
+                    data-test="observe-dashboards-link"
                   >
                     {t('devconsole~View dashboards')}
                   </Link>

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -113,7 +113,7 @@ export const topologyPO = {
       podTrafficStatus: 'div[data-test="pod-traffic-status',
     },
     monitoringTab: {
-      viewMonitoringDashBoardLink: '[data-test="observe-dashboard-link"]',
+      viewMonitoringDashBoardsLink: '[data-test="observe-dashboards-link"]',
     },
     releaseNotesTab: {},
   },


### PR DESCRIPTION
Story: https://issues.redhat.com/browse/OU-260

Description: The dashboard tab contains a number of dashboards, and should be renamed to dashboards to be more accurate. This will bring this page in line with the admin console version.

Screenshot:
<img width="1721" alt="Screenshot 2024-02-09 at 11 39 05 AM" src="https://github.com/openshift/console/assets/47438010/0c76ae94-7d4b-4c7d-810c-8376a7444f44">
