### PR TITLE
OCPBUGS-29355: Output image url link leads to 404 for Shipwright Builds

### DIFF
--- a/frontend/packages/shipwright-plugin/src/components/build-list/BuildOutput.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/build-list/BuildOutput.tsx
@@ -13,7 +13,10 @@ const BuildOutput: React.FC<BuildOutputProps> = ({ buildSpec }) => {
   const outputImage = buildSpec?.output?.image;
 
   if (outputImage?.startsWith(BUILD_OUTPUT_IMAGESTREAM_URL)) {
-    const imageStreamName = outputImage?.split('/')?.pop();
+    let imageStreamName = outputImage?.split('/')?.pop();
+    if (imageStreamName?.includes(':')) {
+      imageStreamName = imageStreamName?.split(':')[0];
+    }
     const imageStreamNamespace = outputImage?.split('/')[1];
     return (
       <ResourceLink


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-29355

**Analysis / Root cause**: 
When clicking on the output image link on a Shipwright BuildRun details page, the link leads to the imagestream details page but shows 404 error.

**Solution Description**: 
Fixed Build Output issue with Image Tags

**Screen shots / Gifs for design review**: 

https://github.com/openshift/console/assets/47265560/aefda6c5-938e-4402-95f0-3aa0b12bb5e5

**Unit test coverage report**: 
Not changed

**Test setup:**
1. Install Builds Operator and start a BuildRun.
2. Click the Build Output link



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge