### PR TITLE
OCPBUGS-29363: TaskRuns list page is loading constantly for all projects

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
@@ -34,15 +34,13 @@ const useRuns = <Kind extends K8sResourceCommon>(
   const watchOptions = React.useMemo(() => {
     // reset cached runs as the options have changed
     etcdRunsRef.current = [];
-    return namespace
-      ? {
-          groupVersionKind,
-          namespace,
-          isList,
-          selector: optionsMemo?.selector,
-          name: optionsMemo?.name,
-        }
-      : null;
+    return {
+      groupVersionKind,
+      namespace: namespace || undefined,
+      isList,
+      selector: optionsMemo?.selector,
+      name: optionsMemo?.name,
+    };
   }, [groupVersionKind, namespace, optionsMemo, isList]);
 
   const [resources, loaded, error] = useK8sWatchResource(watchOptions);

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
@@ -52,51 +52,49 @@ const useTRRuns = <Kind extends K8sResourceCommon>(
   // eslint-disable-next-line consistent-return
   React.useEffect(() => {
     let disposed = false;
-    if (namespace) {
-      (async () => {
-        try {
-          const tkPipelineRuns = await getRuns(namespace, options, nextPageToken, localCacheKey);
-          if (!disposed) {
-            const token = tkPipelineRuns[1].nextPageToken;
-            const callInflight = !!tkPipelineRuns?.[2];
-            const loaded = !callInflight;
-            if (!callInflight) {
-              setResult((cur) => [
-                nextPageToken ? [...cur[0], ...tkPipelineRuns[0]] : tkPipelineRuns[0],
-                loaded,
-                undefined,
-                token
-                  ? (() => {
-                      // ensure we can only call this once
-                      let executed = false;
-                      return () => {
-                        if (!disposed && !executed) {
-                          executed = true;
-                          // trigger the update
-                          setNextPageToken(token);
-                          return true;
-                        }
-                        return false;
-                      };
-                    })()
-                  : undefined,
-              ]);
-            }
-          }
-        } catch (e) {
-          if (!disposed) {
-            if (nextPageToken) {
-              setResult((cur) => [cur[0], cur[1], e, undefined]);
-            } else {
-              setResult([[], false, e, undefined]);
-            }
+    (async () => {
+      try {
+        const tkPipelineRuns = await getRuns(namespace, options, nextPageToken, localCacheKey);
+        if (!disposed) {
+          const token = tkPipelineRuns[1].nextPageToken;
+          const callInflight = !!tkPipelineRuns?.[2];
+          const loaded = !callInflight;
+          if (!callInflight) {
+            setResult((cur) => [
+              nextPageToken ? [...cur[0], ...tkPipelineRuns[0]] : tkPipelineRuns[0],
+              loaded,
+              undefined,
+              token
+                ? (() => {
+                    // ensure we can only call this once
+                    let executed = false;
+                    return () => {
+                      if (!disposed && !executed) {
+                        executed = true;
+                        // trigger the update
+                        setNextPageToken(token);
+                        return true;
+                      }
+                      return false;
+                    };
+                  })()
+                : undefined,
+            ]);
           }
         }
-      })();
-      return () => {
-        disposed = true;
-      };
-    }
+      } catch (e) {
+        if (!disposed) {
+          if (nextPageToken) {
+            setResult((cur) => [cur[0], cur[1], e, undefined]);
+          } else {
+            setResult([[], false, e, undefined]);
+          }
+        }
+      }
+    })();
+    return () => {
+      disposed = true;
+    };
   }, [namespace, options, nextPageToken, localCacheKey, getRuns]);
   return result;
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/utils/tekton-results.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/utils/tekton-results.ts
@@ -7,6 +7,7 @@ import {
 } from '@console/dynamic-plugin-sdk/src';
 import { RouteModel } from '@console/internal/models';
 import { k8sGet } from '@console/internal/module/k8s';
+import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants';
 import { consoleProxyFetch, consoleProxyFetchJSON } from '@console/shared/src/utils/proxy';
 import {
   DELETED_RESOURCE_IN_K8S_ANNOTATION,
@@ -224,7 +225,8 @@ export const createTektonResultsUrl = async (
   if (!tektonResultUrl) {
     throw new Error('route.spec.host is undefined');
   }
-  const url = `https://${tektonResultUrl}/apis/results.tekton.dev/v1alpha2/parents/${namespace}/results/-/records?${new URLSearchParams(
+  const namespaceToSearch = namespace && namespace !== ALL_NAMESPACES_KEY ? namespace : '-';
+  const url = `https://${tektonResultUrl}/apis/results.tekton.dev/v1alpha2/parents/${namespaceToSearch}/results/-/records?${new URLSearchParams(
     {
       // default sort should always be by `create_time desc`
       // order_by: 'create_time desc', not supported yet

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunRow.tsx
@@ -10,7 +10,10 @@ import {
   ExternalLink,
 } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { DELETED_RESOURCE_IN_K8S_ANNOTATION } from '../../const';
+import {
+  DELETED_RESOURCE_IN_K8S_ANNOTATION,
+  RESOURCE_LOADED_FROM_RESULTS_ANNOTATION,
+} from '../../const';
 import * as SignedPipelinerunIcon from '../../images/signed-badge.svg';
 import { PipelineRunModel } from '../../models';
 import { PipelineRunKind, TaskRunKind } from '../../types';
@@ -79,7 +82,8 @@ const RepositoryPipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({
                   </div>
                 </Tooltip>
               ) : null}
-              {obj?.metadata?.annotations?.[DELETED_RESOURCE_IN_K8S_ANNOTATION] === 'true' ? (
+              {obj?.metadata?.annotations?.[DELETED_RESOURCE_IN_K8S_ANNOTATION] === 'true' ||
+              obj?.metadata?.annotations?.[RESOURCE_LOADED_FROM_RESULTS_ANNOTATION] === 'true' ? (
                 <Tooltip content={t('pipelines-plugin~Archived in Tekton results')}>
                   <div className="opp-pipeline-run-list__results-indicator">
                     <ArchiveIcon />

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
@@ -5,7 +5,10 @@ import { useTranslation } from 'react-i18next';
 import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
 import { ResourceLink, Timestamp } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { DELETED_RESOURCE_IN_K8S_ANNOTATION } from '../../../const';
+import {
+  DELETED_RESOURCE_IN_K8S_ANNOTATION,
+  RESOURCE_LOADED_FROM_RESULTS_ANNOTATION,
+} from '../../../const';
 import { TaskRunModel, PipelineModel } from '../../../models';
 import { TaskRunKind } from '../../../types';
 import { getTaskRunKebabActions } from '../../../utils/pipeline-actions';
@@ -35,7 +38,8 @@ const TaskRunsRow: React.FC<RowFunctionArgs<TaskRunKind>> = ({ obj, customData }
           data-test-id={obj.metadata.name}
           nameSuffix={
             <>
-              {obj?.metadata?.annotations?.[DELETED_RESOURCE_IN_K8S_ANNOTATION] === 'true' ? (
+              {obj?.metadata?.annotations?.[DELETED_RESOURCE_IN_K8S_ANNOTATION] === 'true' ||
+              obj?.metadata?.annotations?.[RESOURCE_LOADED_FROM_RESULTS_ANNOTATION] === 'true' ? (
                 <Tooltip content={t('pipelines-plugin~Archived in Tekton results')}>
                   <div className="opp-task-run-list__results-indicator">
                     <ArchiveIcon />


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-29363

**Analysis / Root cause**: 
When namespace is change to all projects, the cases are not handled properly

**Solution Description**: 
Updated PipelineRun and TaskRun list page to handle all project value
Added Archive icon for all task in TaskRun list page

**Screen shots / Gifs for design review**: 

----BEFORE----

https://github.com/openshift/console/assets/102503482/5be0ece2-721f-4e65-bca0-d4fa293a956a




https://github.com/openshift/console/assets/102503482/d07e3139-2a4e-4f12-b89e-af40957bb5d9




----AFTER----


https://github.com/openshift/console/assets/102503482/f1114b33-d5dd-4ed4-9f54-1e2a13cf2fd9











**Unit test coverage report**: 
NA

**Test setup:**
    1.Create some TaskRun
    2.Go to TaskRun list page
    3.Select all project in project dropdown
    4.Check PipelineRun list page also for multiple projects and for all projects
    5.Check Archive icon for resources deleted in k8s

  

     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge