### PR TITLE
OCPBUGS-29601: Disabling pipeline tests to restore CI health

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -57,7 +57,8 @@ if [ -n "${nightly-}" ] && [ -z "${pkg-}" ]; then
 
   yarn run test-cypress-dev-console-nightly
   yarn run test-cypress-helm-nightly
-  yarn run test-cypress-pipelines-nightly
+  # disabling pipeline tests due to unavailablility of opertor in operator hub
+  # yarn run test-cypress-pipelines-nightly
   # yarn run test-cypress-shipwright-nightly
   yarn run test-cypress-topology-nightly
   yarn run test-cypress-knative-nightly
@@ -73,7 +74,8 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-helm-headless
   yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
-  yarn run test-cypress-pipelines-headless
+  # disabling pipeline tests due to unavailablility of opertor in operator hub
+  # yarn run test-cypress-pipelines-headless
   # yarn run test-cypress-shipwright-headless
   # yarn run test-cypress-webterminal-headless
   exit;


### PR DESCRIPTION
CI has failures due to pipeline operator unavailability in the operator hub:
https://search.ci.openshift.org/?search=Entire+pipeline+flow+from+Builder+page+%22before+all%22+hook+for+%22Background+Steps%22&maxAge=336h&context=1&type=junit&name=pull-ci-openshift-console-master-e2e-gcp-console&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job
Bug: https://issues.redhat.com/browse/OCPBUGS-29601