### PR TITLE
OCPBUGS-29757: Use HTTP proxy configuration from environment variables in dev-console proxies, so that our backend proxies works fine on airgapped clusters

### DIFF
--- a/pkg/devconsole/proxy/proxy.go
+++ b/pkg/devconsole/proxy/proxy.go
@@ -70,16 +70,21 @@ func serve(r *http.Request) (ProxyResponse, error) {
 	}
 	serviceRequest.URL.RawQuery = query.Encode()
 
-	var serviceClient *http.Client
+	var serviceTransport *http.Transport
 	if request.AllowInsecure {
-		serviceTransport := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		serviceClient = &http.Client{
-			Transport: serviceTransport,
+		serviceTransport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
 		}
 	} else {
-		serviceClient = &http.Client{}
+		serviceTransport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		}
+	}
+	serviceClient := &http.Client{
+		Transport: serviceTransport,
 	}
 
 	serviceResponse, err := serviceClient.Do(serviceRequest)

--- a/pkg/knative/handler.go
+++ b/pkg/knative/handler.go
@@ -247,16 +247,21 @@ func sendPost(invokeRequest InvokeServiceRequestBody, endpoint string) (invokeRe
 		}
 	}
 
-	var serviceClient *http.Client
+	var serviceTransport *http.Transport
 	if invokeRequest.AllowInsecure {
-		serviceTransport := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		serviceClient = &http.Client{
-			Transport: serviceTransport,
+		serviceTransport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
 		}
 	} else {
-		serviceClient = &http.Client{}
+		serviceTransport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		}
+	}
+	serviceClient := &http.Client{
+		Transport: serviceTransport,
 	}
 
 	serviceResponse, err := serviceClient.Do(serviceRequest)


### PR DESCRIPTION
Issue: TODO

We noticed on an air-gapped cluster that the new Pipelines dashboard (developed as a dynamic plugin) couldn't access a Tekton Results API that is exposed with a Route

Now, the code consumes the HTTP proxy environment variables, which is optional, of course.

```mermaid
sequenceDiagram
    Browser->>Console backend (Route): http
    Console backend (Route)->>Cluster proxy (optional): http (when proxy is def.)
    Cluster proxy (optional)->>Tekton Results API (Route): http
    Console backend (Route)->>Tekton Results API (Route): http (without proxy)
```

/kind bug
/cc @vikram-raj @Lucifergene 