### PR TITLE
OCPBUGS-22894: adjusting documentation links for 4.15

### DIFF
--- a/frontend/public/components/utils/documentation.tsx
+++ b/frontend/public/components/utils/documentation.tsx
@@ -49,7 +49,7 @@ export const documentationURLs: documentationURLsType = {
     upstream: '', // intentionally blank as there is no upstream equivalent
   },
   postInstallationMachineConfigurationTasks: {
-    downstream: 'html/post-installation_configuration/index',
+    downstream: 'html/postinstallation_configuration/index',
     upstream: 'post_installation_configuration/machine-configuration-tasks.html',
   },
   understandingUpgradeChannels: {


### PR DESCRIPTION
I reviewed the downstream documentation links in the stage instance of access.redhat.com and found that one of the links has changed. I confirmed that the upstream link for this page is still correct.

The [stage version of this page](https://dxp-docp-prod.apps.ext-waf.spoke.prod.us-west-2.aws.paas.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/post-installation_configuration/index?lb_target=stage) can be accessed if you log in to access.redhat.com with the correct credentials.

@rhamilto, PTAL? 