### PR TITLE
OCPBUGS-23771: Manually backport changes to prevent editor crash with acm and mce plugins enabled. 

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
+++ b/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
@@ -182,7 +182,7 @@ export const enableYAMLValidation = (
 ) => {
   const pendingValidationRequests = new Map();
 
-  const getModel = () => monaco.editor.getModels()[0];
+  const getModel = () => monaco.editor?.getModels()[0];
 
   const cleanPendingValidation = (document) => {
     const request = pendingValidationRequests.get(document.uri);

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -199,7 +199,7 @@ const EditYAMLInner = (props) => {
           const notAll = !resp.status.allowed;
           setNotAllowed(notAll);
           if (monacoRef.current) {
-            monacoRef.current.editor.updateOptions({ readOnly: notAll });
+            monacoRef.current.editor?.updateOptions({ readOnly: notAll });
           }
         })
         .catch((e) => {
@@ -638,7 +638,7 @@ const EditYAMLInner = (props) => {
     'co-file-dropzone--drop-over': isOver,
   });
 
-  monacoRef.current?.editor.updateOptions({ hover: showTooltips });
+  monacoRef.current?.editor?.updateOptions({ hover: showTooltips });
 
   if (displayResults) {
     return (


### PR DESCRIPTION
These fixes are in association with https://github.com/openshift/console/pull/13541 to fix the issue.