### PR TITLE
OCPBUGS-30073: Upload Jar form's Clear button is not functioning

### DIFF
--- a/frontend/packages/dev-console/src/components/import/jar/section/JarSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/jar/section/JarSection.tsx
@@ -57,6 +57,14 @@ const JarSection: React.FunctionComponent = () => {
     }
   }, [fileUpload, updatedJarFile, setFileUpload, fileName]);
 
+  const handleClear = () => {
+    setFieldValue('fileUpload.value', '');
+    setFieldValue('fileUpload.name', '');
+    setTimeout(() => {
+      setFieldTouched('fileUpload.name', true);
+    }, 0);
+  };
+
   return (
     <FormSection title={t('devconsole~JAR')}>
       <FileUpload
@@ -73,7 +81,8 @@ const JarSection: React.FunctionComponent = () => {
         dropzoneProps={{
           accept: { 'application/java-archive': ['.jar', '.JAR'] },
         }}
-        required
+        isRequired
+        onClearClick={handleClear}
       />
       <InputField
         type={TextInputTypes.text}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-30073

**Analysis / Root cause**: 
Happened due to PF5 upgrade

**Solution Description**: 
Added `handleClear` function on click of clear 

**Screen shots / Gifs for design review**: 





https://github.com/openshift/console/assets/102503482/c8df2f4d-4eae-4bdf-ad52-397f6b3a0eb2













**Unit test coverage report**: 
NA

**Test setup:**
    1. Open Upload Jar File form from Add Page
    2. Upload a JAR file
    3. Remove the JAR the file by using clear button

  

     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge