### PR TITLE
OCPBUGS-29813: Backport of missing change

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
+++ b/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
@@ -226,7 +226,7 @@ export const enableYAMLValidation = (
     tryFolding();
   }
 
-  getModel().onDidChangeContent(() => {
+  getModel()?.onDidChangeContent(() => {
     tryFolding();
 
     const document = createDocument(getModel());


### PR DESCRIPTION
This change is needed to prevent TypeError `Cannot read properties of undefined (reading 'onDidChangeContent')`
https://issues.redhat.com/browse/OCPBUGS-29813

_Change in master_
https://github.com/openshift/console/blob/master/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts#L229

_Change in 4.15_
https://github.com/openshift/console/blob/release-4.15/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts#L224

fix
![yaml-editor-mac-chrome-Version 122 0 6261 94(Official Build)(arm64)03052024](https://github.com/openshift/console/assets/1874151/6ddf5dfb-e7f0-417f-a2f1-341531a9c9b7)

