### PR TITLE
OCPBUGS-30297: TaskRun with same name in different project don't show 2 entries when listing in all namespace

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
@@ -101,7 +101,7 @@ const useRuns = <Kind extends K8sResourceCommon>(
   return React.useMemo(() => {
     const rResources =
       runs && trResources
-        ? uniqBy([...runs, ...trResources], (r) => r.metadata.name)
+        ? uniqBy([...runs, ...trResources], (r) => r.metadata.uid)
         : runs || trResources;
     return [
       rResources,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-30297

**Analysis / Root cause**: 
`uniqBy` was based on name. So if there is a resource with same name it was ignoring other

**Solution Description**: 
Used uid instead of name while doing `uniqBy`

**Screen shots / Gifs for design review**: 

----BEFORE----


https://github.com/openshift/console/assets/102503482/38f4ae7d-0650-46f4-ba0a-e3093130084b




----AFTER----



https://github.com/openshift/console/assets/102503482/edc6ac22-f994-4af6-aa5d-04482f6e8948









**Unit test coverage report**: 
NA

**Test setup:**

    1. Create TaskRun using https://gist.github.com/karthikjeeyar/eb1bbdf9157431f5c875eb55ce47580c in 2 different namespace
    2. Go to TaskRun list page
    3. Select All Projects

     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge