### PR TITLE
OCPBUGS-30762: Fix bugs in Console dynamic plugin SDK webpack code

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/package.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@microsoft/tsdoc": "0.14.2",
-    "@openshift/dynamic-plugin-sdk-webpack": "^4.0.1",
+    "@openshift/dynamic-plugin-sdk-webpack": "^4.0.2",
     "@types/ejs": "3.x",
     "@types/fs-extra": "9.x",
     "ejs": "3.x",

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/Status.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/Status.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { BanIcon } from '@patternfly/react-icons/dist/esm/icons/ban-icon';
-import { ClipboardListIcon } from '@patternfly/react-icons/dist/esm/icons/clipboard-list-icon';
-import { HourglassHalfIcon } from '@patternfly/react-icons/dist/esm/icons/hourglass-half-icon';
-import { HourglassStartIcon } from '@patternfly/react-icons/dist/esm/icons/hourglass-start-icon';
-import { NotStartedIcon } from '@patternfly/react-icons/dist/esm/icons/not-started-icon';
-import { SyncAltIcon } from '@patternfly/react-icons/dist/esm/icons/sync-alt-icon';
-import { UnknownIcon } from '@patternfly/react-icons/dist/esm/icons/unknown-icon';
+import {
+  BanIcon,
+  ClipboardListIcon,
+  HourglassHalfIcon,
+  HourglassStartIcon,
+  NotStartedIcon,
+  SyncAltIcon,
+  UnknownIcon,
+} from '@patternfly/react-icons';
 import { StatusComponentProps } from '../../../extensions/console-types';
 import { DASH } from '../../constants';
 import { YellowExclamationTriangleIcon } from './icons';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { Icon } from '@patternfly/react-core';
-import { CheckCircleIcon } from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
-import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
-import { InfoCircleIcon } from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InfoCircleIcon,
+} from '@patternfly/react-icons';
 import * as classNames from 'classnames';
 
 import './icons.scss';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/statuses.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/statuses.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { InProgressIcon } from '@patternfly/react-icons/dist/esm/icons/in-progress-icon';
+import { InProgressIcon } from '@patternfly/react-icons';
 import { StatusComponentProps } from '../../../extensions/console-types';
 import GenericStatus from './GenericStatus';
 import { RedExclamationCircleIcon, GreenCheckCircleIcon, BlueInfoCircleIcon } from './icons';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1670,10 +1670,10 @@
     once "^1.4.0"
     universal-user-agent "^4.0.0"
 
-"@openshift/dynamic-plugin-sdk-webpack@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@openshift/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-4.0.1.tgz#5d9956f12234fd50854868744b947a4a1009406a"
-  integrity sha512-ZlY57t1WIl8B8XNPoq+CuU/+Ll4/ZX/7IO/dxn+7dp1S/NUmdvgwv01mXpUcjviOUhhgWl/dK2WvCQTzz6CoZg==
+"@openshift/dynamic-plugin-sdk-webpack@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@openshift/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-4.0.2.tgz#0304911c9c27ecff7ba5d2df5ca24f781fd445ec"
+  integrity sha512-zgRLt9WM63aGYygrQEtd8QtWoP5zYWr67kzlRKzGcHeRbWDgiHnY7FOiDUM04bYeb4lL6qv3iErEnrtvVpyh0Q==
   dependencies:
     lodash "^4.17.21"
     semver "^7.3.7"


### PR DESCRIPTION
This PR addresses several bugs in Console dynamic plugin SDK discovered as part of kubevirt-ui/kubevirt-plugin#1804

---

### 1. Build errors related to [Hot Module Replacement](https://webpack.js.org/concepts/hot-module-replacement/) chunk files
```
ERROR in [entry] [initial] kubevirt-plugin.494371abc020603eb01f.hot-update.js
Missing call to loadPluginEntry
```
:ballot_box_with_check: Fixed in openshift/dynamic-plugin-sdk#256 - updated `@openshift/dynamic-plugin-sdk-webpack` dependency.

---

### 2. Build warnings issued by `dynamic-module-import-loader`
```
LOG from @openshift-console/dynamic-plugin-sdk-webpack/lib/webpack/loaders/dynamic-module-import-loader ../node_modules/ts-loader/index.js??ruleSet[1].rules[0].use[0]!./utils/hooks/useKubevirtWatchResource.ts
<w> Detected parse errors in /home/vszocs/work/kubevirt-plugin/src/utils/hooks/useKubevirtWatchResource.ts
```
:information_source: Not all valid `.ts` files can be parsed using `ScriptKind.TSX` - this is an inherent TS language limitation.
:ballot_box_with_check: Fixed by using `ScriptKind.TSX` only when parsing modules that end with `.jsx` or `.tsx`.

---

### 3. Build warnings related to PatternFly shared modules

```
WARNING in shared module @patternfly/react-core
No required version specified and unable to automatically determine one. Unable to find required version for "@patternfly/react-core" in description file (/home/vszocs/work/kubevirt-plugin/node_modules/@openshift-console/dynamic-plugin-sdk/package.json). It need to be in dependencies, devDependencies or peerDependencies.
```
:ballot_box_with_check: Fixed by allowing `@openshift-console/*` packages to have their code processed by `dynamic-module-import-loader`.

---

This PR also improves the performance of `dynamic-module-import-loader` to minimize the module parse overhead:
```ts
if (!sourceContainsDynamicModuleReference) {
  return source;
}
```