### PR TITLE
OCPBUGS-30575,OCPBUGS-30052: PipelineRuns in Console show wrong status or load indefinitely

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunList.tsx
@@ -72,7 +72,7 @@ export const PipelineRunList: React.FC<PipelineRunListProps> = (props) => {
             );
           },
         }}
-        customData={{ operatorVersion, taskRuns: taskRunsLoaded ? taskRuns : [] }}
+        customData={{ operatorVersion, taskRuns: taskRunsLoaded ? taskRuns : [], taskRunsLoaded }}
         onRowsRendered={onRowsRendered}
         virtualize
       />

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
@@ -31,22 +31,24 @@ const pipelinerunReference = referenceForModel(PipelineRunModel);
 type PLRStatusProps = {
   obj: PipelineRunKind;
   taskRuns: TaskRunKind[];
+  taskRunsLoaded: boolean;
 };
 
-const PLRStatus: React.FC<PLRStatusProps> = ({ obj, taskRuns }) => {
+const PLRStatus: React.FC<PLRStatusProps> = ({ obj, taskRuns, taskRunsLoaded }) => {
   return (
     <PipelineRunStatus
       status={pipelineRunFilterReducer(obj)}
       title={pipelineRunTitleFilterReducer(obj)}
       pipelineRun={obj}
       taskRuns={taskRuns}
+      taskRunsLoaded={taskRunsLoaded}
     />
   );
 };
 
 const PipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj, customData }) => {
   const { t } = useTranslation();
-  const { operatorVersion, taskRuns } = customData;
+  const { operatorVersion, taskRuns, taskRunsLoaded } = customData;
   const PLRTaskRuns = getTaskRunsOfPipelineRun(taskRuns, obj?.metadata?.name);
 
   return (
@@ -85,10 +87,14 @@ const PipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj, custo
         <PipelineRunVulnerabilities pipelineRun={obj} condensed />
       </TableData>
       <TableData className={tableColumnClasses.status}>
-        <PLRStatus obj={obj} taskRuns={PLRTaskRuns} />
+        <PLRStatus obj={obj} taskRuns={PLRTaskRuns} taskRunsLoaded={taskRunsLoaded} />
       </TableData>
       <TableData className={tableColumnClasses.taskStatus}>
-        <LinkedPipelineRunTaskStatus pipelineRun={obj} taskRuns={PLRTaskRuns} />
+        <LinkedPipelineRunTaskStatus
+          pipelineRun={obj}
+          taskRuns={PLRTaskRuns}
+          taskRunsLoaded={taskRunsLoaded}
+        />
       </TableData>
       <TableData className={tableColumnClasses.started}>
         <Timestamp timestamp={obj.status && obj.status.startTime} />

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/LinkedPipelineRunTaskStatus.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/LinkedPipelineRunTaskStatus.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
 import { LoadingInline, resourcePathFromModel } from '@console/internal/components/utils';
+import { DASH } from '@console/shared';
 import { PipelineRunModel } from '../../../models';
 import { PipelineRunKind, TaskRunKind } from '../../../types';
 import { PipelineBars } from './PipelineBars';
@@ -9,6 +10,7 @@ import { PipelineBars } from './PipelineBars';
 export interface LinkedPipelineRunTaskStatusProps {
   pipelineRun: PipelineRunKind;
   taskRuns: TaskRunKind[];
+  taskRunsLoaded?: boolean;
 }
 
 /**
@@ -18,6 +20,7 @@ export interface LinkedPipelineRunTaskStatusProps {
 const LinkedPipelineRunTaskStatus: React.FC<LinkedPipelineRunTaskStatusProps> = ({
   pipelineRun,
   taskRuns,
+  taskRunsLoaded,
 }) => {
   const { t } = useTranslation();
   const pipelineStatus =
@@ -27,6 +30,8 @@ const LinkedPipelineRunTaskStatus: React.FC<LinkedPipelineRunTaskStatusProps> = 
         pipelinerun={pipelineRun}
         taskRuns={taskRuns}
       />
+    ) : taskRunsLoaded && taskRuns.length === 0 ? (
+      <>{DASH}</>
     ) : (
       <LoadingInline />
     );

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatus.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatus.tsx
@@ -14,16 +14,18 @@ type PipelineRunStatusProps = {
   pipelineRun: PipelineRunKind;
   title?: string;
   taskRuns: TaskRunKind[];
+  taskRunsLoaded?: boolean;
 };
 const PipelineRunStatus: React.FC<PipelineRunStatusProps> = ({
   status,
   pipelineRun,
   title,
   taskRuns,
+  taskRunsLoaded,
 }) => {
   const { t } = useTranslation();
   return pipelineRun ? (
-    taskRuns.length > 0 ? (
+    taskRuns.length > 0 || (taskRunsLoaded && taskRuns.length === 0) ? (
       <PipelineResourceStatus status={status} title={title}>
         <StatusPopoverContent
           logDetails={getPLRLogSnippet(pipelineRun, taskRuns)}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineList.tsx
@@ -24,7 +24,7 @@ const PipelineList: React.FC<PipelineListProps> = (props) => {
       aria-label={t(PipelineModel.labelPluralKey)}
       Header={PipelineHeader}
       Row={PipelineRow}
-      customData={{ taskRuns: taskRunsLoaded ? taskRuns : [] }}
+      customData={{ taskRuns: taskRunsLoaded ? taskRuns : [], taskRunsLoaded }}
       virtualize
     />
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
@@ -20,21 +20,23 @@ const pipelinerunReference = referenceForModel(PipelineRunModel);
 type PipelineStatusProps = {
   obj: PipelineWithLatest;
   taskRuns: TaskRunKind[];
+  taskRunsLoaded?: boolean;
 };
 
-const PipelineStatus: React.FC<PipelineStatusProps> = ({ obj, taskRuns }) => {
+const PipelineStatus: React.FC<PipelineStatusProps> = ({ obj, taskRuns, taskRunsLoaded }) => {
   return (
     <PipelineRunStatus
       status={pipelineFilterReducer(obj)}
       title={pipelineTitleFilterReducer(obj)}
       pipelineRun={obj.latestRun}
       taskRuns={taskRuns}
+      taskRunsLoaded={taskRunsLoaded}
     />
   );
 };
 
 const PipelineRow: React.FC<RowFunctionArgs<PipelineWithLatest>> = ({ obj, customData }) => {
-  const { taskRuns } = customData;
+  const { taskRuns, taskRunsLoaded } = customData;
   const PLRTaskRuns = getTaskRunsOfPipelineRun(taskRuns, obj?.latestRun?.metadata?.name);
   return (
     <>
@@ -61,13 +63,17 @@ const PipelineRow: React.FC<RowFunctionArgs<PipelineWithLatest>> = ({ obj, custo
       </TableData>
       <TableData className={tableColumnClasses[3]}>
         {obj.latestRun ? (
-          <LinkedPipelineRunTaskStatus pipelineRun={obj.latestRun} taskRuns={PLRTaskRuns} />
+          <LinkedPipelineRunTaskStatus
+            pipelineRun={obj.latestRun}
+            taskRuns={PLRTaskRuns}
+            taskRunsLoaded={taskRunsLoaded}
+          />
         ) : (
           '-'
         )}
       </TableData>
       <TableData className={tableColumnClasses[4]}>
-        <PipelineStatus obj={obj} taskRuns={PLRTaskRuns} />
+        <PipelineStatus obj={obj} taskRuns={PLRTaskRuns} taskRunsLoaded={taskRunsLoaded} />
       </TableData>
       <TableData className={tableColumnClasses[5]}>
         {(obj.latestRun?.status?.startTime && (

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunList.tsx
@@ -24,7 +24,11 @@ export const RepositoryPipelineRunList: React.FC<RepositoryPipelineRunListProps>
       defaultSortOrder={SortByDirection.desc}
       Header={RepositoryPipelineRunHeader}
       Row={RepositoryPipelineRunRow}
-      customData={{ operatorVersion, taskRuns: taskRunsLoaded ? taskRuns : [] }}
+      customData={{
+        operatorVersion,
+        taskRuns: taskRunsLoaded ? taskRuns : [],
+        taskRunsLoaded,
+      }}
       virtualize
     />
   );

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunRow.tsx
@@ -43,15 +43,17 @@ const pipelinerunReference = referenceForModel(PipelineRunModel);
 type PLRStatusProps = {
   obj: PipelineRunKind;
   taskRuns: TaskRunKind[];
+  taskRunsLoaded?: boolean;
 };
 
-const PLRStatus: React.FC<PLRStatusProps> = ({ obj, taskRuns }) => {
+const PLRStatus: React.FC<PLRStatusProps> = ({ obj, taskRuns, taskRunsLoaded }) => {
   return (
     <PipelineRunStatus
       status={pipelineRunFilterReducer(obj)}
       title={pipelineRunTitleFilterReducer(obj)}
       pipelineRun={obj}
       taskRuns={taskRuns}
+      taskRunsLoaded={taskRunsLoaded}
     />
   );
 };
@@ -63,7 +65,7 @@ const RepositoryPipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({
   const { t } = useTranslation();
   const plrLabels = obj.metadata.labels;
   const plrAnnotations = obj.metadata.annotations;
-  const { operatorVersion, taskRuns } = customData;
+  const { operatorVersion, taskRuns, taskRunsLoaded } = customData;
   const PLRTaskRuns = getTaskRunsOfPipelineRun(taskRuns, obj?.metadata?.name);
   return (
     <>
@@ -122,10 +124,14 @@ const RepositoryPipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({
         <PipelineRunVulnerabilities pipelineRun={obj} condensed />
       </TableData>
       <TableData className={tableColumnClasses[3]}>
-        <PLRStatus obj={obj} taskRuns={PLRTaskRuns} />
+        <PLRStatus obj={obj} taskRuns={PLRTaskRuns} taskRunsLoaded={taskRunsLoaded} />
       </TableData>
       <TableData className={tableColumnClasses[4]}>
-        <LinkedPipelineRunTaskStatus pipelineRun={obj} taskRuns={PLRTaskRuns} />
+        <LinkedPipelineRunTaskStatus
+          pipelineRun={obj}
+          taskRuns={PLRTaskRuns}
+          taskRunsLoaded={taskRunsLoaded}
+        />
       </TableData>
       <TableData className={tableColumnClasses[5]}>
         <Timestamp timestamp={obj.status && obj.status.startTime} />

--- a/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoryRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/list-page/RepositoryRow.tsx
@@ -28,10 +28,10 @@ const RepositoryRow: React.FC<RowFunctionArgs<RepositoryKind>> = ({ obj, customD
   const {
     metadata: { name, namespace },
   } = obj;
-  const { taskRuns, pipelineRuns } = customData;
+  const { taskRuns, pipelineRuns, taskRunsLoaded } = customData;
   const plrs = pipelineRuns.filter((plr) => {
     return (
-      plr.metadata?.labels[RepositoryLabels[RepositoryFields.REPOSITORY]] === obj.metadata.name
+      plr.metadata?.labels?.[RepositoryLabels[RepositoryFields.REPOSITORY]] === obj.metadata.name
     );
   });
   const latestRun = getLatestRun(plrs, 'creationTimestamp');
@@ -72,7 +72,11 @@ const RepositoryRow: React.FC<RowFunctionArgs<RepositoryKind>> = ({ obj, customD
       <TableData className={repositoriesTableColumnClasses[4]}>
         {}
         {latestRun ? (
-          <LinkedPipelineRunTaskStatus pipelineRun={latestRun} taskRuns={PLRTaskRuns} />
+          <LinkedPipelineRunTaskStatus
+            pipelineRun={latestRun}
+            taskRuns={PLRTaskRuns}
+            taskRunsLoaded={taskRunsLoaded}
+          />
         ) : (
           '-'
         )}
@@ -84,6 +88,7 @@ const RepositoryRow: React.FC<RowFunctionArgs<RepositoryKind>> = ({ obj, customD
             title={pipelineRunTitleFilterReducer(latestRun)}
             pipelineRun={latestRun}
             taskRuns={PLRTaskRuns}
+            taskRunsLoaded={taskRunsLoaded}
           />
         }
       </TableData>

--- a/frontend/packages/pipelines-plugin/src/components/repository/list-page/ReppositoryList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/list-page/ReppositoryList.tsx
@@ -24,6 +24,7 @@ const RepositoryList: React.FC<RepositoryListProps> = (props) => {
       customData={{
         taskRuns: taskRunsLoaded ? taskRuns : [],
         pipelineRuns: pipelineRunsLoaded ? pipelineRuns : [],
+        taskRunsLoaded,
       }}
       virtualize
     />


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-30575
https://issues.redhat.com/browse/OCPBUGS-30052

**Analysis / Root cause**: 
If there is no TaskRun, loading icon is added and for failed PLR and when there are no taskruns, it was showing Loading icon indefinitely

**Solution Description**: 
Updated component to check if taskRuns are loaded and if the resources are loaded then don't add loading icon indefinitely

**Screen shots / Gifs for design review**: 

----BEFORE----



https://github.com/openshift/console/assets/102503482/cd8a3e75-4a91-4448-a32e-fac711a26b17





----AFTER----




https://github.com/openshift/console/assets/102503482/64e3c71b-b717-4f68-9293-05241d68e243










**Unit test coverage report**: 
NA

**Test setup:**

1. Create Task hello, TaskRun hello-task-run from https://tekton.dev/docs/getting-started/tasks/
2. Create Task goodbye, Pipeline hello-goodbye and  PipelineRun hello-goodbye-run from https://tekton.dev/docs/getting-started/pipelines/
3. Create another Pipeline and use an invalid TaskRun ref name
4. For the pending PipelineRun, create another PipelineRun using below spec, https://tekton.dev/docs/pipelines/pipelineruns/#pending-pipelineruns

     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge