### PR TITLE
ODC-7436: shipwright test package update concerning pf5 update

### DIFF
--- a/frontend/packages/shipwright-plugin/integration-tests/features/shipwright-build-in-topology.feature
+++ b/frontend/packages/shipwright-plugin/integration-tests/features/shipwright-build-in-topology.feature
@@ -32,7 +32,7 @@ Feature: Shipwright build in topolgy
         Scenario Outline: BuildRun Section in Topology Sidebar: SWB-02-TC02
              When user navigates to Topology in Developer perspective
               And user filters the workload "<workload_name>" by name and sets the workload type to "<workload_type>"
-              And user clicks on the workload of type "<workload_type>"
+              And user clicks on the workload with name "<workload_name>" and of type "<workload_type>"
              Then user will clicks on the Resources tab on the topology sidebar for "<workload_name>"
               And user will verify BuildRuns section is visible
 
@@ -49,7 +49,7 @@ Feature: Shipwright build in topolgy
              When user selects "Start" option from Actions menu
               And user navigates to Topology in Developer perspective
               And user filters the workload "<workload_name>" by name and sets the workload type to "<workload_type>"
-             Then user will see build running for "<workload_type>"
+             Then user will see build running for "<workload_name>" of type "<workload_type>"
 
         Examples:
                   | build_name                        | workload_name               | workload_type    |
@@ -62,7 +62,7 @@ Feature: Shipwright build in topolgy
         Scenario Outline: View logs for shipwright buildrun: SWB-02-TC04
              When user navigates to Topology in Developer perspective
               And user filters the workload "<workload_name>" by name and sets the workload type to "<workload_type>"
-              And user clicks on View logs button for buildrun for workload type "<workload_type>" from the sidebar
+              And user clicks on View logs button for buildrun for workload with name "<workload_name>" and of type "<workload_type>" from the sidebar
              Then user will be able to see the buildRun logs
 
         Examples:

--- a/frontend/packages/shipwright-plugin/integration-tests/support/step-definitions/builds/shipwright-build-in-topology.ts
+++ b/frontend/packages/shipwright-plugin/integration-tests/support/step-definitions/builds/shipwright-build-in-topology.ts
@@ -66,15 +66,16 @@ Then('user will be able to see the buildRun logs', () => {
   cy.get(buildPO.shipwrightBuild.buildrunLogs).should('be.visible');
 });
 
-When('user clicks on the workload of type {string}', (type: string) => {
-  if (type === 'Service') {
-    cy.get('g.odc-knative-service__label > text').first().click({ force: true });
-  } else {
-    cy.get(topologyPO.highlightNode).within(() => {
-      cy.get('g.pf-topology__node__label > text').click({ force: true });
-    });
-  }
-});
+When(
+  'user clicks on the workload with name {string} and of type {string}',
+  (name: string, type: string) => {
+    if (type === 'Service') {
+      cy.get('[data-type="knative-service"]').contains(name).click({ force: true });
+    } else {
+      cy.byLegacyTestID(name).click('center');
+    }
+  },
+);
 
 Then(
   'user will clicks on the Resources tab on the topology sidebar for {string}',
@@ -89,7 +90,7 @@ Then('user will verify BuildRuns section is visible', () => {
   topologySidePane.verifySection('BuildRuns');
 });
 
-Then('user will see build running for {string}', (type: string) => {
+Then('user will see build running for {string} of type {string}', (name: string, type: string) => {
   if (type === 'Service') {
     cy.get('g.odc-knative-service__label > text').click({ force: true });
 
@@ -97,7 +98,7 @@ Then('user will see build running for {string}', (type: string) => {
       .find('ul.list-group > li.so-build-run-item')
       .should('have.length.greaterThan', 1);
   } else {
-    cy.get('g.pf-topology__node__label > text').click({ force: true });
+    cy.byLegacyTestID(name).click('center');
     cy.get('div.ocs-sidebar-tabsection:nth-child(5)')
       .find('ul.list-group > li.so-build-run-item')
       .should('have.length.greaterThan', 1);
@@ -105,15 +106,15 @@ Then('user will see build running for {string}', (type: string) => {
 });
 
 When(
-  'user clicks on View logs button for buildrun for workload type {string} from the sidebar',
-  (type: string) => {
+  'user clicks on View logs button for buildrun for workload with name {string} and of type {string} from the sidebar',
+  (name: string, type: string) => {
     if (type === 'Service') {
       cy.get('g.odc-knative-service__label > text').click({ force: true });
 
       cy.get('div.ocs-sidebar-tabsection:nth-child(6)').should('be.visible');
       cy.get('ul.list-group > li.so-build-run-item').contains('View logs').click({ force: true });
     } else {
-      cy.get('g.pf-topology__node__label > text').click({ force: true });
+      cy.byLegacyTestID(name).click('center');
 
       cy.get('div.ocs-sidebar-tabsection:nth-child(5)').should('be.visible');
       cy.get('ul.list-group > li.so-build-run-item').contains('View logs').click({ force: true });


### PR DESCRIPTION
Fix: [ODC-7436](https://issues.redhat.com/browse/ODC-7434)

**Description:**
Remove PatternFly classname selectors from shipwright integration tests

**Test Setup:**

Check the TAGS in frontend/packages/shipwright/integration-tests/cypress.config.js file be: 

```
(@smoke or @regression) and not (@manual or @to-do or @un-verified or @broken-test)
```

**Command to execute:**

Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.13-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p dev-console
```

**Browser**
Chrome 116
