### PR TITLE
WINC-1182: [node] Modify filesystem queries to include Windows metrics

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -404,12 +404,14 @@ const fetchNodeMetrics = (): Promise<NodeMetrics> => {
     {
       key: 'usedStorage',
       query:
-        'sum by (instance) ((max by (device, instance) (node_filesystem_size_bytes{device=~"/.*"})) - (max by (device, instance) (node_filesystem_free_bytes{device=~"/.*"})))',
+        'sum by (instance) ((max by (device, instance) (node_filesystem_size_bytes{device=~"/.*"})) - (max by (device, instance) (node_filesystem_free_bytes{device=~"/.*"}))) or ' +
+        'sum by (instance) ((max by (volume, instance) (windows_logical_disk_size_bytes)) - (max by (volume, instance) (windows_logical_disk_free_bytes)))',
     },
     {
       key: 'totalStorage',
       query:
-        'sum by (instance) (max by (device, instance) (node_filesystem_size_bytes{device=~"/.*"}))',
+        'sum by (instance) (max by (device, instance) (node_filesystem_size_bytes{device=~"/.*"})) or' +
+        'sum by (instance) (max by (volume, instance) (windows_logical_disk_size_bytes))',
     },
     {
       key: 'cpu',

--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/queries.ts
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/queries.ts
@@ -37,10 +37,11 @@ const queries = {
   [NodeQueries.MEMORY_TOTAL]: _.template(`node_memory_MemTotal_bytes{instance='<%= node %>'}`),
   [NodeQueries.POD_COUNT]: _.template(`kubelet_running_pods{instance=~'<%= ipAddress %>:.*'}`),
   [NodeQueries.FILESYSTEM_USAGE]: _.template(
-    `sum(max by (device) (node_filesystem_size_bytes{instance='<%= node %>', device=~"/.*"})) - sum(max by (device) (node_filesystem_avail_bytes{instance='<%= node %>', device=~"/.*"}))`,
+    `sum(max by (device) (node_filesystem_size_bytes{instance='<%= node %>', device=~"/.*"})) - sum(max by (device) (node_filesystem_avail_bytes{instance='<%= node %>', device=~"/.*"})) or
+    sum (max by (volume) (windows_logical_disk_size_bytes{instance='<%= node %>'})) - sum(max by (volume) (windows_logical_disk_free_bytes{instance='<%= node %>'}))`,
   ),
   [NodeQueries.FILESYSTEM_TOTAL]: _.template(
-    `sum(max by (device) (node_filesystem_size_bytes{instance='<%= node %>', device=~"/.*"}))`,
+    `sum(max by (device) (node_filesystem_size_bytes{instance='<%= node %>', device=~"/.*"})) or sum(max by (volume) (windows_logical_disk_size_bytes{instance='<%= node %>'}))`,
   ),
   [NodeQueries.NETWORK_IN_UTILIZATION]: _.template(
     `instance:node_network_receive_bytes:rate:sum{instance='<%= node %>'}`,


### PR DESCRIPTION
This commit modifies filesystem queries to account for Windows node metrics which are exported through windows_exporter when Windows nodes are present in a cluster.