### PR TITLE
CONSOLE-3969: Enable French and Spanish in the OCP Console

### DIFF
--- a/frontend/packages/console-app/src/components/user-preferences/language/const.ts
+++ b/frontend/packages/console-app/src/components/user-preferences/language/const.ts
@@ -1,8 +1,10 @@
 export const supportedLocales = {
   en: 'English',
-  'zh-CN': '中文',
+  es: 'Español',
+  fr: 'Français',
   ko: '한국어',
   ja: '日本語',
+  'zh-CN': '中文',
 };
 
 export const LAST_LANGUAGE_LOCAL_STORAGE_KEY = 'bridge/last-language';


### PR DESCRIPTION
This work is to add French and Spanish langs to the Languages dropdown in User Preferences. There would be a follow-on PR for the actual translations in French and Spanish langs. So selecting French or Spanish lang in the dropdown would default to English since their translations are not available at this time.

### Before:
<img width="1642" alt="Screenshot 2024-03-15 at 8 36 37 AM" src="https://github.com/openshift/console/assets/15249132/ccd46949-c78d-4036-a82a-4ca1cb9e2be4">

### After:
<img width="1673" alt="Screenshot 2024-03-15 at 8 34 56 AM" src="https://github.com/openshift/console/assets/15249132/703e4df1-c3b7-4b9a-9395-d98392dc870b">
