### PR TITLE
OCPBUGS-23480: Improve PipelineRun list view performance

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
@@ -25,6 +25,7 @@ const useRuns = <Kind extends K8sResourceCommon>(
     limit?: number;
     name?: string;
   },
+  cacheKey?: string,
 ): [Kind[], boolean, unknown, GetNextPage] => {
   const etcdRunsRef = React.useRef<Kind[]>([]);
   const optionsMemo = useDeepCompareMemoize(options);
@@ -96,7 +97,12 @@ const useRuns = <Kind extends K8sResourceCommon>(
   const [trResources, trLoaded, trError, trGetNextPage] = (groupVersionKind ===
     PipelineRunGroupVersionKind
     ? useTRPipelineRuns
-    : useTRTaskRuns)(queryTr ? namespace : null, trOptions) as [[], boolean, unknown, GetNextPage];
+    : useTRTaskRuns)(queryTr ? namespace : null, trOptions, cacheKey) as [
+    [],
+    boolean,
+    unknown,
+    GetNextPage,
+  ];
 
   return React.useMemo(() => {
     const rResources =
@@ -145,8 +151,9 @@ export const useTaskRuns = (
     selector?: Selector;
     limit?: number;
   },
+  cacheKey?: string,
 ): [TaskRunKind[], boolean, unknown, GetNextPage] =>
-  useRuns<TaskRunKind>(TaskRunGroupVersionKind, namespace, options);
+  useRuns<TaskRunKind>(TaskRunGroupVersionKind, namespace, options, cacheKey);
 
 export const usePipelineRun = (
   namespace: string,

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
@@ -105,7 +105,7 @@ const useRuns = <Kind extends K8sResourceCommon>(
         : runs || trResources;
     return [
       rResources,
-      !!rResources?.[0],
+      !!rResources?.[0] || (loaded && trLoaded),
       namespace
         ? queryTr
           ? isList
@@ -116,7 +116,18 @@ const useRuns = <Kind extends K8sResourceCommon>(
         : undefined,
       trGetNextPage,
     ];
-  }, [runs, trResources, trLoaded, namespace, queryTr, isList, trError, error, trGetNextPage]);
+  }, [
+    runs,
+    trResources,
+    trLoaded,
+    loaded,
+    namespace,
+    queryTr,
+    isList,
+    trError,
+    error,
+    trGetNextPage,
+  ]);
 };
 
 export const usePipelineRuns = (

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTaskRuns.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTaskRuns.ts
@@ -9,6 +9,7 @@ export const useTaskRuns = (
   namespace: string,
   pipelineRunName?: string,
   taskName?: string,
+  cacheKey?: string,
 ): [TaskRunKind[], boolean, unknown, GetNextPage] => {
   const selector: Selector = React.useMemo(() => {
     if (pipelineRunName) {
@@ -24,6 +25,7 @@ export const useTaskRuns = (
     selector && {
       selector,
     },
+    cacheKey,
   );
 
   const sortedTaskRuns = React.useMemo(

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
@@ -136,7 +136,7 @@ export const useGetPipelineRuns = (ns: string, options?: { name: string; kind: s
   });
   const mergedPlrs =
     (resultPlrsLoaded || k8sPlrsLoaded) && !k8sPlrsLoadError
-      ? uniqBy([...k8sPlrs, ...resultPlrs], (r) => r.metadata.name)
+      ? uniqBy([...k8sPlrs, ...resultPlrs], (r) => r.metadata.uid)
       : [];
   return [
     mergedPlrs,

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunList.tsx
@@ -10,7 +10,6 @@ import { PipelineRunModel } from '../../../models';
 import { PipelineRunKind } from '../../../types';
 import { usePipelineOperatorVersion } from '../../pipelines/utils/pipeline-operator';
 import { getPipelineRunVulnerabilities } from '../hooks/usePipelineRunVulnerabilities';
-import { useGetTaskRuns } from '../hooks/useTektonResults';
 import PipelineRunHeader from './PipelineRunHeader';
 import PipelineRunRow from './PipelineRunRow';
 
@@ -32,7 +31,6 @@ export const PipelineRunList: React.FC<PipelineRunListProps> = (props) => {
     PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY,
     'pipelines',
   );
-  const [taskRuns, taskRunsLoaded] = useGetTaskRuns(namespace);
   React.useEffect(() => {
     if (preferredTabLoaded && activePerspective === 'dev') {
       setPreferredTab('pipeline-runs');
@@ -72,7 +70,7 @@ export const PipelineRunList: React.FC<PipelineRunListProps> = (props) => {
             );
           },
         }}
-        customData={{ operatorVersion, taskRuns: taskRunsLoaded ? taskRuns : [], taskRunsLoaded }}
+        customData={{ operatorVersion }}
         onRowsRendered={onRowsRendered}
         virtualize
       />

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
@@ -151,7 +151,12 @@ const PipelineRunRowWithoutTaskRuns: React.FC<PipelineRunRowWithoutTaskRunsProps
 
 const PipelineRunRowWithTaskRuns: React.FC<PipelineRunRowWithTaskRunsProps> = React.memo(
   ({ obj, operatorVersion }) => {
-    const [PLRTaskRuns, taskRunsLoaded] = useTaskRuns(obj.metadata.namespace, obj.metadata.name);
+    const [PLRTaskRuns, taskRunsLoaded] = useTaskRuns(
+      obj.metadata.namespace,
+      obj.metadata.name,
+      undefined,
+      `${obj.metadata.namespace}-${obj.metadata.name}`,
+    );
     return (
       <PipelineRunRowTable
         obj={obj}
@@ -166,10 +171,10 @@ const PipelineRunRowWithTaskRuns: React.FC<PipelineRunRowWithTaskRunsProps> = Re
 
 const PipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj, customData }) => {
   const { operatorVersion } = customData;
-  const pieplineRunStatus = pipelineRunStatus(obj);
+  const plrStatus = pipelineRunStatus(obj);
   if (
-    pieplineRunStatus === ComputedStatus.Cancelled ||
-    pieplineRunStatus === ComputedStatus.Failed
+    (plrStatus === ComputedStatus.Cancelled || plrStatus === ComputedStatus.Failed) &&
+    (obj?.status?.childReferences ?? []).length > 0
   ) {
     return <PipelineRunRowWithTaskRuns obj={obj} operatorVersion={operatorVersion} />;
   }

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import { ArchiveIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
+import { SemVer } from 'semver';
 import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
 import { Timestamp, ResourceLink } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
@@ -11,15 +12,17 @@ import {
 } from '../../../const';
 import * as SignedPipelinerunIcon from '../../../images/signed-badge.svg';
 import { PipelineRunModel } from '../../../models';
-import { PipelineRunKind, TaskRunKind } from '../../../types';
+import { ComputedStatus, PipelineRunKind, TaskRunKind } from '../../../types';
 import { getPipelineRunKebabActions } from '../../../utils/pipeline-actions';
+import { TaskStatus } from '../../../utils/pipeline-augment';
 import {
   pipelineRunFilterReducer,
+  pipelineRunStatus,
   pipelineRunTitleFilterReducer,
 } from '../../../utils/pipeline-filter-reducer';
-import { pipelineRunDuration } from '../../../utils/pipeline-utils';
+import { getPipelineRunStatus, pipelineRunDuration } from '../../../utils/pipeline-utils';
 import { chainsSignedAnnotation } from '../../pipelines/const';
-import { getTaskRunsOfPipelineRun } from '../../taskruns/useTaskRuns';
+import { useTaskRuns } from '../hooks/useTaskRuns';
 import LinkedPipelineRunTaskStatus from '../status/LinkedPipelineRunTaskStatus';
 import PipelineRunStatus from '../status/PipelineRunStatus';
 import PipelineRunVulnerabilities from '../status/PipelineRunVulnerabilities';
@@ -34,7 +37,18 @@ type PLRStatusProps = {
   taskRunsLoaded: boolean;
 };
 
-const PLRStatus: React.FC<PLRStatusProps> = ({ obj, taskRuns, taskRunsLoaded }) => {
+type PipelineRunRowWithoutTaskRunsProps = {
+  obj: PipelineRunKind;
+  operatorVersion: SemVer;
+  taskRunStatusObj: TaskStatus;
+};
+
+type PipelineRunRowWithTaskRunsProps = {
+  obj: PipelineRunKind;
+  operatorVersion: SemVer;
+};
+
+const PLRStatus: React.FC<PLRStatusProps> = React.memo(({ obj, taskRuns, taskRunsLoaded }) => {
   return (
     <PipelineRunStatus
       status={pipelineRunFilterReducer(obj)}
@@ -44,12 +58,16 @@ const PLRStatus: React.FC<PLRStatusProps> = ({ obj, taskRuns, taskRunsLoaded }) 
       taskRunsLoaded={taskRunsLoaded}
     />
   );
-};
+});
 
-const PipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj, customData }) => {
+const PipelineRunRowTable = ({
+  obj,
+  PLRTaskRuns,
+  taskRunsLoaded,
+  taskRunStatusObj,
+  operatorVersion,
+}) => {
   const { t } = useTranslation();
-  const { operatorVersion, taskRuns, taskRunsLoaded } = customData;
-  const PLRTaskRuns = getTaskRunsOfPipelineRun(taskRuns, obj?.metadata?.name);
 
   return (
     <>
@@ -94,6 +112,7 @@ const PipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj, custo
           pipelineRun={obj}
           taskRuns={PLRTaskRuns}
           taskRunsLoaded={taskRunsLoaded}
+          taskRunStatusObj={taskRunStatusObj}
         />
       </TableData>
       <TableData className={tableColumnClasses.started}>
@@ -102,12 +121,65 @@ const PipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj, custo
       <TableData className={tableColumnClasses.duration}>{pipelineRunDuration(obj)}</TableData>
       <TableData className={tableColumnClasses.actions}>
         <ResourceKebabWithUserLabel
-          actions={getPipelineRunKebabActions(operatorVersion, taskRuns)}
+          actions={getPipelineRunKebabActions(
+            operatorVersion,
+            PLRTaskRuns,
+            undefined,
+            taskRunStatusObj,
+          )}
           kind={pipelinerunReference}
           resource={obj}
         />
       </TableData>
     </>
+  );
+};
+
+const PipelineRunRowWithoutTaskRuns: React.FC<PipelineRunRowWithoutTaskRunsProps> = React.memo(
+  ({ obj, operatorVersion, taskRunStatusObj }) => {
+    return (
+      <PipelineRunRowTable
+        obj={obj}
+        PLRTaskRuns={[]}
+        taskRunsLoaded
+        operatorVersion={operatorVersion}
+        taskRunStatusObj={taskRunStatusObj}
+      />
+    );
+  },
+);
+
+const PipelineRunRowWithTaskRuns: React.FC<PipelineRunRowWithTaskRunsProps> = React.memo(
+  ({ obj, operatorVersion }) => {
+    const [PLRTaskRuns, taskRunsLoaded] = useTaskRuns(obj.metadata.namespace, obj.metadata.name);
+    return (
+      <PipelineRunRowTable
+        obj={obj}
+        PLRTaskRuns={PLRTaskRuns}
+        taskRunsLoaded={taskRunsLoaded}
+        operatorVersion={operatorVersion}
+        taskRunStatusObj={undefined}
+      />
+    );
+  },
+);
+
+const PipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj, customData }) => {
+  const { operatorVersion } = customData;
+  const pieplineRunStatus = pipelineRunStatus(obj);
+  if (
+    pieplineRunStatus === ComputedStatus.Cancelled ||
+    pieplineRunStatus === ComputedStatus.Failed
+  ) {
+    return <PipelineRunRowWithTaskRuns obj={obj} operatorVersion={operatorVersion} />;
+  }
+  const taskRunStatusObj = getPipelineRunStatus(obj);
+  return (
+    <PipelineRunRowWithoutTaskRuns
+      obj={obj}
+      operatorVersion={operatorVersion}
+      taskRunStatusObj={taskRunStatusObj}
+    />
   );
 };
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/LinkedPipelineRunTaskStatus.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/LinkedPipelineRunTaskStatus.tsx
@@ -5,12 +5,14 @@ import { LoadingInline, resourcePathFromModel } from '@console/internal/componen
 import { DASH } from '@console/shared';
 import { PipelineRunModel } from '../../../models';
 import { PipelineRunKind, TaskRunKind } from '../../../types';
-import { PipelineBars } from './PipelineBars';
+import { TaskStatus } from '../../../utils/pipeline-augment';
+import { PipelineBars, PipelineBarsForTaskRunsStatus } from './PipelineBars';
 
 export interface LinkedPipelineRunTaskStatusProps {
   pipelineRun: PipelineRunKind;
   taskRuns: TaskRunKind[];
   taskRunsLoaded?: boolean;
+  taskRunStatusObj?: TaskStatus;
 }
 
 /**
@@ -21,20 +23,18 @@ const LinkedPipelineRunTaskStatus: React.FC<LinkedPipelineRunTaskStatusProps> = 
   pipelineRun,
   taskRuns,
   taskRunsLoaded,
+  taskRunStatusObj,
 }) => {
   const { t } = useTranslation();
-  const pipelineStatus =
-    taskRuns.length > 0 ? (
-      <PipelineBars
-        key={pipelineRun.metadata?.name}
-        pipelinerun={pipelineRun}
-        taskRuns={taskRuns}
-      />
-    ) : taskRunsLoaded && taskRuns.length === 0 ? (
-      <>{DASH}</>
-    ) : (
-      <LoadingInline />
-    );
+  const pipelineStatus = taskRunStatusObj ? (
+    <PipelineBarsForTaskRunsStatus taskRunStatusObj={taskRunStatusObj} />
+  ) : taskRunsLoaded && taskRuns?.length > 0 ? (
+    <PipelineBars key={pipelineRun.metadata?.name} pipelinerun={pipelineRun} taskRuns={taskRuns} />
+  ) : taskRunsLoaded && taskRuns?.length === 0 && !taskRunStatusObj ? (
+    <>{DASH}</>
+  ) : (
+    <LoadingInline />
+  );
 
   if (pipelineRun.metadata?.name && pipelineRun.metadata?.namespace) {
     return (

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/LinkedPipelineRunTaskStatus.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/LinkedPipelineRunTaskStatus.tsx
@@ -26,15 +26,22 @@ const LinkedPipelineRunTaskStatus: React.FC<LinkedPipelineRunTaskStatusProps> = 
   taskRunStatusObj,
 }) => {
   const { t } = useTranslation();
-  const pipelineStatus = taskRunStatusObj ? (
-    <PipelineBarsForTaskRunsStatus taskRunStatusObj={taskRunStatusObj} />
-  ) : taskRunsLoaded && taskRuns?.length > 0 ? (
-    <PipelineBars key={pipelineRun.metadata?.name} pipelinerun={pipelineRun} taskRuns={taskRuns} />
-  ) : taskRunsLoaded && taskRuns?.length === 0 && !taskRunStatusObj ? (
-    <>{DASH}</>
-  ) : (
-    <LoadingInline />
-  );
+  const pipelineStatus =
+    taskRunStatusObj && Object.values(taskRunStatusObj)?.every((value) => value === 0) ? (
+      <>{DASH}</>
+    ) : taskRunStatusObj ? (
+      <PipelineBarsForTaskRunsStatus taskRunStatusObj={taskRunStatusObj} />
+    ) : taskRunsLoaded && taskRuns?.length > 0 ? (
+      <PipelineBars
+        key={pipelineRun.metadata?.name}
+        pipelinerun={pipelineRun}
+        taskRuns={taskRuns}
+      />
+    ) : taskRunsLoaded && taskRuns?.length === 0 && !taskRunStatusObj ? (
+      <>{DASH}</>
+    ) : (
+      <LoadingInline />
+    );
 
   if (pipelineRun.metadata?.name && pipelineRun.metadata?.namespace) {
     return (

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineBars.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineBars.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import { ComputedStatus, PipelineRunKind, TaskRunKind } from '../../../types';
-import { getRunStatusColor } from '../../../utils/pipeline-augment';
+import { TaskStatus, getRunStatusColor } from '../../../utils/pipeline-augment';
 import HorizontalStackedBars from '../../charts/HorizontalStackedBars';
 import { useTaskStatus } from '../hooks/useTaskStatus';
 import TaskStatusToolTip from './TaskStatusTooltip';
@@ -9,6 +9,10 @@ import TaskStatusToolTip from './TaskStatusTooltip';
 export interface PipelineBarProps {
   pipelinerun: PipelineRunKind;
   taskRuns: TaskRunKind[];
+}
+
+export interface PipelineBarsForTaskRunsStatus {
+  taskRunStatusObj: TaskStatus;
 }
 
 export const PipelineBars: React.FC<PipelineBarProps> = ({ pipelinerun, taskRuns }) => {
@@ -27,3 +31,19 @@ export const PipelineBars: React.FC<PipelineBarProps> = ({ pipelinerun, taskRuns
     </Tooltip>
   );
 };
+
+export const PipelineBarsForTaskRunsStatus: React.FC<PipelineBarsForTaskRunsStatus> = ({
+  taskRunStatusObj,
+}) => (
+  <Tooltip content={<TaskStatusToolTip taskStatus={taskRunStatusObj} />}>
+    <HorizontalStackedBars
+      height="1em"
+      inline
+      values={Object.keys(ComputedStatus).map((status) => ({
+        color: getRunStatusColor(ComputedStatus[status]).pftoken.value,
+        name: status,
+        size: taskRunStatusObj[ComputedStatus[status]],
+      }))}
+    />
+  </Tooltip>
+);

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatus.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatus.tsx
@@ -25,7 +25,7 @@ const PipelineRunStatus: React.FC<PipelineRunStatusProps> = ({
 }) => {
   const { t } = useTranslation();
   return pipelineRun ? (
-    taskRuns.length > 0 || (taskRunsLoaded && taskRuns.length === 0) ? (
+    taskRunsLoaded ? (
       <PipelineResourceStatus status={status} title={title}>
         <StatusPopoverContent
           logDetails={getPLRLogSnippet(pipelineRun, taskRuns)}

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/utils/tekton-results.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/utils/tekton-results.ts
@@ -257,8 +257,6 @@ export const getFilteredRecord = async <R extends K8sResourceCommon>(
   nextPageToken?: string,
   cacheKey?: string,
 ): Promise<[R[], RecordsList, boolean?]> => {
-  const url = await createTektonResultsUrl(namespace, dataType, filter, options, nextPageToken);
-
   if (cacheKey) {
     const result = CACHE[cacheKey];
     if (result) {
@@ -278,6 +276,7 @@ export const getFilteredRecord = async <R extends K8sResourceCommon>(
   InFlightStore[cacheKey] = true;
   const value = await (async (): Promise<[R[], RecordsList]> => {
     try {
+      const url = await createTektonResultsUrl(namespace, dataType, filter, options, nextPageToken);
       let list: RecordsList = await consoleProxyFetchJSON({
         url,
         method: 'GET',

--- a/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
@@ -50,7 +50,7 @@ type CombinedPipelineTestData = {
 type PipelineTestData = { [key in PipelineExampleNames]?: CombinedPipelineTestData };
 type PipelineSpecData = { [key in PipelineExampleNames]?: PipelineSpec };
 
-const pipelineSpec: PipelineSpecData = {
+export const pipelineSpec: PipelineSpecData = {
   [PipelineExampleNames.SIMPLE_PIPELINE]: {
     tasks: [
       {

--- a/frontend/packages/pipelines-plugin/src/types/pipelineRun.ts
+++ b/frontend/packages/pipelines-plugin/src/types/pipelineRun.ts
@@ -94,6 +94,13 @@ export type Condition = {
   lastTransitionTime?: string;
 };
 
+export type ChildReferences = {
+  apiVersion: string;
+  kind: string;
+  name: string;
+  pipelineTaskName: string;
+};
+
 export type PipelineRunEmbeddedResourceParam = { name: string; value: string };
 export type PipelineRunEmbeddedResource = {
   name: string;
@@ -143,6 +150,7 @@ export type PipelineRunStatus = {
   }[];
   pipelineResults?: TektonResultsRun[]; // in tekton v1 pipelineResults is renamed to results
   results?: TektonResultsRun[];
+  childReferences?: ChildReferences[];
 };
 
 export type PipelineRunKind = K8sResourceCommon & {

--- a/frontend/packages/pipelines-plugin/src/types/taskRun.ts
+++ b/frontend/packages/pipelines-plugin/src/types/taskRun.ts
@@ -51,3 +51,15 @@ export const TaskRunGroupVersionKind: K8sGroupVersionKind = {
   version: 'v1',
   kind: 'TaskRun',
 };
+
+export type PipelineRunStatusType = {
+  Completed?: number;
+  Failed?: number;
+  Skipped?: number;
+  Cancelled?: number;
+  Incomplete?: number;
+  PipelineNotStarted?: number;
+  Pending?: number;
+  Running?: number;
+  Succeeded?: number;
+};

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
@@ -45,6 +45,8 @@ export interface TaskStatus {
   Cancelled: number;
   Failed: number;
   Skipped: number;
+  Completed?: number;
+  Cancelling?: number;
 }
 
 export const getLatestRun = (runs: PipelineRunKind[], field: string): PipelineRunKind => {
@@ -306,6 +308,16 @@ export const shouldHidePipelineRunStop = (
       pipelineRunFilterReducer(pipelineRun) === ComputedStatus.Running)
   );
 
+export const shouldHidePipelineRunStopForTaskRunStatus = (
+  pipelineRun: PipelineRunKind,
+  taskRunStatusObj: TaskStatus,
+): boolean =>
+  !(
+    pipelineRun &&
+    (taskRunStatusObj?.Running > 0 ||
+      pipelineRunFilterReducer(pipelineRun) === ComputedStatus.Running)
+  );
+
 export const shouldHidePipelineRunCancel = (
   pipelineRun: PipelineRunKind,
   taskRuns: TaskRunKind[],
@@ -313,5 +325,15 @@ export const shouldHidePipelineRunCancel = (
   !(
     pipelineRun &&
     countRunningTasks(pipelineRun, taskRuns) > 0 &&
+    pipelineRunFilterReducer(pipelineRun) !== ComputedStatus.Cancelled
+  );
+
+export const shouldHidePipelineRunCancelForTaskRunStatus = (
+  pipelineRun: PipelineRunKind,
+  taskRunStatusObj: TaskStatus,
+): boolean =>
+  !(
+    pipelineRun &&
+    taskRunStatusObj?.Running > 0 &&
     pipelineRunFilterReducer(pipelineRun) !== ComputedStatus.Cancelled
   );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-30575

**Analysis / Root cause**: 
PipelineRun list view contains Task status column, which shows the overall task status of the pipelinerurn. Inorder to render this column we fetch all the tasksruns of that pipelinerun.  Every pipelinerun row will have to have all the related TaskRuns information, which is causing performance issue in the pipelinerun list view.

**Solution Description**: 
Fetching TaskRuns only for Failed and Cancelled PipelineRuns. Now TaskRuns status will be calculated from the message value in `pipelinerun.status.conditions:
`
```
lastTransitionTime: '2023-11-15T07:51:42Z'
message: 'Tasks Completed: 3 (Failed: 0, Cancelled 0), Skipped: 0'
reason: Succeeded
status: 'True'
type: Succeeded
```

**Screen shots / Gifs for design review**: 

NA

**Unit test coverage report**: 
```
    ✓ should expect getPipelineRunStatus to return taskruns status object with 1 Succeeded, 1 Failed and 1 Skipped for Cancelled status
    ✓ should expect getPipelineRunStatus to return taskruns status object with 2 Succeeded for Succeeded status (1ms)
    ✓ should expect getPipelineRunStatus to return taskruns status object with 1 Failed for Failed status
    ✓ should expect getPipelineRunStatus to return taskruns status object all 0 values for cancelled status
```



**Test setup:**

1. Create few pipelineruns
2. Navigate to pipelineruns list view

     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge