### PR TITLE
CONSOLE-3944: Disable segment analytics when cluster telemetry is disabled

### DIFF
--- a/frontend/packages/console-telemetry-plugin/src/listeners/const.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/const.ts
@@ -1,6 +1,6 @@
 export const TELEMETRY_DISABLED =
   window.SERVER_FLAGS?.telemetry?.DISABLED === 'true' ||
   window.SERVER_FLAGS?.telemetry?.DEVSANDBOX_DISABLED === 'true' ||
-  window.SERVER_FLAGS?.telemetry?.telemeterClientDisabled === 'true';
+  window.SERVER_FLAGS?.telemetry?.TELEMETER_CLIENT_DISABLED === 'true';
 
 export const TELEMETRY_DEBUG = window.SERVER_FLAGS?.telemetry?.DEBUG === 'true';

--- a/frontend/packages/console-telemetry-plugin/src/listeners/const.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/const.ts
@@ -1,5 +1,6 @@
 export const TELEMETRY_DISABLED =
   window.SERVER_FLAGS?.telemetry?.DISABLED === 'true' ||
-  window.SERVER_FLAGS?.telemetry?.DEVSANDBOX_DISABLED === 'true';
+  window.SERVER_FLAGS?.telemetry?.DEVSANDBOX_DISABLED === 'true' ||
+  window.SERVER_FLAGS?.telemetry?.telemeterClientDisabled === 'true';
 
 export const TELEMETRY_DEBUG = window.SERVER_FLAGS?.telemetry?.DEBUG === 'true';

--- a/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts
@@ -110,12 +110,18 @@ export const eventListener: TelemetryEventListener = async (
   eventType: string,
   properties?: any,
 ) => {
+  if (TELEMETRY_DISABLED || !apiKey) {
+    // eslint-disable-next-line no-console
+    console.debug(
+      'console-telemetry-plugin: telemetry disabled - ignoring telemetry event:',
+      eventType,
+      properties,
+    );
+    return;
+  }
   if (TELEMETRY_DEBUG) {
     // eslint-disable-next-line no-console
     console.debug('console-telemetry-plugin: received telemetry event:', eventType, properties);
-    return;
-  }
-  if (TELEMETRY_DISABLED || !apiKey) {
     return;
   }
   switch (eventType) {


### PR DESCRIPTION
Disable console-telemetry-plugin segment analytics when `window.SERVER_FLAGS.telemetry.TELEMETER_CLIENT_DISABLED` flag is set