### PR TITLE
[i18n] Initial value of top consumer options in kubevirt monitoring dashboard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/top-consumers-card/VirtOverviewTopConsumersCard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/top-consumers-card/VirtOverviewTopConsumersCard.tsx
@@ -35,9 +35,9 @@ const topAmountSelectOptions = (t: TFunction) => [
 
 export const VirtOverviewTopConsumersCard: React.FC = () => {
   const { t } = useTranslation();
-  const [numItemsToShow, setNumItemsToShow] = React.useState('Show top 5');
-  const numItemsOptionSelected = React.useMemo(() => (numItemsToShow === 'Show top 5' ? 5 : 10), [
-    numItemsToShow,
+  const [numItemsToShow, setNumItemsToShow] = React.useState(topAmountSelectOptions(t)[0]);
+  const numItemsOptionSelected = React.useMemo(() => (numItemsToShow.key === 'top-5' ? 5 : 10), [
+    numItemsToShow.key,
   ]);
 
   const onTopAmountSelect = (value) => setNumItemsToShow(value);
@@ -56,7 +56,7 @@ export const VirtOverviewTopConsumersCard: React.FC = () => {
                   <FormPFSelect
                     toggleId="kv-top-consumers-card-amount-select"
                     variant={SelectVariantDeprecated.single}
-                    selections={numItemsToShow}
+                    selections={numItemsToShow.value}
                     onSelect={(e, value) => onTopAmountSelect(value)}
                   >
                     {topAmountSelectOptions(t).map((opt) => (


### PR DESCRIPTION
When I use hco, the options in the consumer dashboard fail to implement internationalization functionality:
![image](https://github.com/openshift/console/assets/39036074/f2038874-ad9a-4c1b-9912-014a2ac1f8a4)
This modification makes use of the already defined array [topAmountSelectOptions](https://github.com/openshift/console/blob/master/frontend/packages/kubevirt-plugin/src/components/virtualization-overview/top-consumers-card/VirtOverviewTopConsumersCard.tsx#L25) and its internationalized values. The modified effect is as follows:
![image](https://github.com/openshift/console/assets/39036074/7bc42291-2ccd-4236-85a3-07d1ffe6c493)

