### PR TITLE
OCPBUGS-30824: Remove react-helmet from Console provided shared modules

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules-init.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules-init.ts
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
 /* eslint-disable @typescript-eslint/no-require-imports */
 
+import { SharedModuleNames } from './shared-modules';
 import { RemoteEntryModule } from './types';
 
 type SharedScopeObject = {
@@ -19,7 +20,7 @@ const initSharedScope = () => {
   // If version range is '*' it means "this shared module matches all requested versions",
   // i.e. make sure that the plugin always uses the given shared module implementation
   const addModule = (
-    moduleName: string,
+    moduleName: SharedModuleNames,
     getModule: () => Promise<() => any>,
     versionRange = '*',
   ) => {
@@ -61,14 +62,6 @@ const initSharedScope = () => {
     async () => () => require('@patternfly-4/quickstarts'),
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     require('@patternfly-4/quickstarts/package.json').version,
-  );
-
-  // Deprecated modules to be removed from Console shared scope in future
-  addModule(
-    'react-helmet',
-    async () => () => require('react-helmet'),
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    require('react-helmet/package.json').version,
   );
 
   return scope;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules.ts
@@ -28,7 +28,6 @@ export const sharedPluginModules = [
   '@patternfly/react-table',
   '@patternfly/quickstarts',
   'react',
-  'react-helmet',
   'react-i18next',
   'react-router',
   'react-router-dom',
@@ -38,7 +37,7 @@ export const sharedPluginModules = [
   'redux-thunk',
 ] as const;
 
-type SharedModuleNames = typeof sharedPluginModules[number];
+export type SharedModuleNames = typeof sharedPluginModules[number];
 
 /**
  * Metadata associated with the shared modules.
@@ -50,7 +49,6 @@ const sharedPluginModulesMetadata: Record<SharedModuleNames, SharedModuleMetadat
   '@patternfly/react-table': {},
   '@patternfly/quickstarts': {},
   react: { singleton: true, allowFallback: false },
-  'react-helmet': {}, // Deprecated, to be removed in future release
   'react-i18next': { singleton: true, allowFallback: false },
   'react-router': { singleton: true, allowFallback: false },
   'react-router-dom': { singleton: true, allowFallback: false },


### PR DESCRIPTION
This PR removes `react-helmet` from the initial Console shared scope object.

There should be no impact on existing dynamic plugins.

`react-helmet` was effectively configured as `singleton: false, allowFallback: true` so dynamic plugins can still bring in their own `react-helmet` code, if they need to do so.