### PR TITLE
OCPBUGS-31355: add readOnly option to ResourceYAMLEditor

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -1952,6 +1952,7 @@ A lazy loaded YAML editor for Kubernetes resources with hover help and completio
 | `initialResource` | YAML/Object representing a resource to be shown by the editor. This prop is used only during the inital render. |
 | `header` | Add a header on top of the YAML editor. |
 | `onSave` | Callback for the Save button. Passing it will override the default update performed on the resource by the editor. |
+| `readOnly` | Sets the YAML editor to read-only mode. |
 
 
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -640,6 +640,7 @@ export const CodeEditor: React.ForwardRefExoticComponent<
  * @param {ResourceYAMLEditorProps['initialResource']} initialResource - YAML/Object representing a resource to be shown by the editor. This prop is used only during the inital render.
  * @param {ResourceYAMLEditorProps['header']} header - Add a header on top of the YAML editor.
  * @param {ResourceYAMLEditorProps['onSave']} onSave - Callback for the Save button. Passing it will override the default update performed on the resource by the editor.
+ * @param {ResourceYAMLEditorProps['readOnly']} readOnly - Sets the YAML editor to read-only mode.
  */
 export const ResourceYAMLEditor: React.FC<ResourceYAMLEditorProps> = require('@console/internal/components/AsyncResourceYAMLEditor')
   .AsyncResourceYAMLEditor;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -677,6 +677,7 @@ export type ResourceYAMLEditorProps = {
   initialResource: string | { [key: string]: any };
   header?: string;
   onSave?: (content: string) => void;
+  readOnly?: boolean;
 };
 
 export type ResourceEventStreamProps = {

--- a/frontend/public/components/droppable-edit-yaml.tsx
+++ b/frontend/public/components/droppable-edit-yaml.tsx
@@ -38,7 +38,15 @@ export const ResourceYAMLEditor: React.FC<ResourceYAMLEditorProps> = ({
   initialResource,
   header,
   onSave,
-}) => <DroppableEditYAML initialResource={initialResource} header={header} onSave={onSave} />;
+  readOnly,
+}) => (
+  <DroppableEditYAML
+    initialResource={initialResource}
+    header={header}
+    onSave={onSave}
+    readOnly={readOnly}
+  />
+);
 
 export const DroppableEditYAML = withDragDropContext<DroppableEditYAMLProps>(
   class DroppableEditYAML extends React.Component<DroppableEditYAMLProps, DroppableEditYAMLState> {


### PR DESCRIPTION
Demo using [YAMLEditorPage](https://github.com/openshift/console/blob/master/dynamic-demo-plugin/src/components/YAMLEditorPage.tsx).

<img width="1997" alt="Screenshot 2024-03-25 at 10 45 56 AM" src="https://github.com/openshift/console/assets/895728/d6bfcb9f-9faf-4bb8-a494-730aacc10503">
