### PR TITLE
OCPBUGS-31430: Re-enable Pipelines e2e tests

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -57,8 +57,7 @@ if [ -n "${nightly-}" ] && [ -z "${pkg-}" ]; then
 
   yarn run test-cypress-dev-console-nightly
   yarn run test-cypress-helm-nightly
-  # disabling pipeline tests due to unavailablility of opertor in operator hub
-  # yarn run test-cypress-pipelines-nightly
+  yarn run test-cypress-pipelines-nightly
   # yarn run test-cypress-shipwright-nightly
   yarn run test-cypress-topology-nightly
   yarn run test-cypress-knative-nightly
@@ -74,8 +73,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-helm-headless
   yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
-  # disabling pipeline tests due to unavailablility of opertor in operator hub
-  # yarn run test-cypress-pipelines-headless
+  yarn run test-cypress-pipelines-headless
   # yarn run test-cypress-shipwright-headless
   # yarn run test-cypress-webterminal-headless
   exit;


### PR DESCRIPTION
Re-enable e2e tests Red Hat Openshift Pipelines operator is now available in the operator hub.