### PR TITLE
OCPBUGS-31431: Hide dev perspective Pipelines nav option if dynamic plugin nav option is enable

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -1172,7 +1172,8 @@
       }
     },
     "flags": {
-      "required": ["OPENSHIFT_PIPELINE"]
+      "required": ["OPENSHIFT_PIPELINE"],
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_NAV_OPTION"]
     }
   },
   {


### PR DESCRIPTION
Fixes: [OCPBUGS-31431](https://issues.redhat.com/browse/OCPBUGS-31431)

-  Hide dev perspective Pipelines nav option if dynamic plugin nav option is enable