### PR TITLE
OCPBUGS-29479: fix asynccache improper initialization

### DIFF
--- a/pkg/auth/asyncccache_test.go
+++ b/pkg/auth/asyncccache_test.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsyncCache(t *testing.T) {
+	cacheTime := func(ctx context.Context) (time.Time, error) {
+		return time.Now(), nil
+	}
+
+	c, err := NewAsyncCache(context.Background(), 2*time.Second, cacheTime)
+	require.NoError(t, err)
+
+	// test that initialization was successful
+	item := c.GetItem()
+	if item.IsZero() {
+		t.Error("expected non-zero time")
+	}
+
+	timedCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c.Run(timedCtx)
+
+	// test the values get properly changed
+	var matches int
+	var changed bool
+	for i := 0; i < 3; i++ {
+		newItem := c.GetItem()
+		if newItem == item {
+			matches++
+		} else {
+			changed = true
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	require.Greater(t, matches, 0)
+	require.True(t, changed)
+	cancel()
+
+	// test that the cache returns error properly
+	errorCaching := func(ctx context.Context) (bool, error) {
+		return false, fmt.Errorf("test error")
+	}
+
+	_, err = NewAsyncCache(context.Background(), 2*time.Second, errorCaching)
+	require.Error(t, err)
+}

--- a/pkg/auth/auth_oidc.go
+++ b/pkg/auth/auth_oidc.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/openshift/console/pkg/auth/sessions"
+	"github.com/openshift/console/pkg/serverutils/asynccache"
 )
 
 type oauth2ConfigConstructor func(oauth2.Endpoint) *oauth2.Config
@@ -18,7 +19,7 @@ type oauth2ConfigConstructor func(oauth2.Endpoint) *oauth2.Config
 type oidcAuth struct {
 	*oidcConfig
 
-	providerCache *AsyncCache[*oidc.Provider]
+	providerCache *asynccache.AsyncCache[*oidc.Provider]
 
 	// This preserves the old logic of associating users with session keys
 	// and requires smart routing when running multiple backend instances.
@@ -38,7 +39,7 @@ type oidcConfig struct {
 
 func newOIDCAuth(ctx context.Context, sessionStore *sessions.CombinedSessionStore, c *oidcConfig) (*oidcAuth, error) {
 	// NewProvider attempts to do OIDC Discovery
-	providerCache, err := NewAsyncCache[*oidc.Provider](
+	providerCache, err := asynccache.NewAsyncCache[*oidc.Provider](
 		ctx, 5*time.Minute,
 		func(cacheCtx context.Context) (*oidc.Provider, error) {
 			oidcCtx := oidc.ClientContext(cacheCtx, c.getClient())

--- a/pkg/auth/auth_openshift.go
+++ b/pkg/auth/auth_openshift.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openshift/console/pkg/auth/sessions"
 	"github.com/openshift/console/pkg/proxy"
+	"github.com/openshift/console/pkg/serverutils/asynccache"
 )
 
 // openShiftAuth implements OpenShift Authentication as defined in:
@@ -22,7 +23,7 @@ type openShiftAuth struct {
 
 	k8sClient *http.Client
 
-	oauthEndpointCache *AsyncCache[*oidcDiscovery]
+	oauthEndpointCache *asynccache.AsyncCache[*oidcDiscovery]
 }
 
 type oidcDiscovery struct {
@@ -52,7 +53,7 @@ func newOpenShiftAuth(ctx context.Context, k8sClient *http.Client, c *oidcConfig
 
 	// TODO: repeat the discovery several times as in the auth.go logic
 	var err error
-	o.oauthEndpointCache, err = NewAsyncCache[*oidcDiscovery](ctx, 5*time.Minute, o.getOIDCDiscoveryInternal)
+	o.oauthEndpointCache, err = asynccache.NewAsyncCache[*oidcDiscovery](ctx, 5*time.Minute, o.getOIDCDiscoveryInternal)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct OAuth endpoint cache: %w", err)
 	}

--- a/pkg/serverutils/asynccache/asynccache.go
+++ b/pkg/serverutils/asynccache/asynccache.go
@@ -1,4 +1,4 @@
-package auth
+package asynccache
 
 import (
 	"context"

--- a/pkg/serverutils/asynccache/asynccache.go
+++ b/pkg/serverutils/asynccache/asynccache.go
@@ -10,10 +10,9 @@ import (
 	"k8s.io/klog"
 )
 
-const (
-	initializationRetryInterval = 10 * time.Second
+var ( // make these variable so that we can change them in unit tests
+	initializationRetryInterval = 5 * time.Second
 	initializationTimeout       = 5 * time.Minute
-	initializeImmediately       = true
 )
 
 type cachingFuncType[T any] func(ctx context.Context) (T, error)
@@ -33,12 +32,11 @@ func NewAsyncCache[T any](ctx context.Context, reloadPeriod time.Duration, cachi
 		cachingFunc:  cachingFunc,
 	}
 
-	var err error
-	wait.PollUntilContextTimeout(
+	err := wait.PollUntilContextTimeout(
 		ctx,
 		initializationRetryInterval,
 		initializationTimeout,
-		initializeImmediately,
+		true,
 		func(ctx context.Context) (bool, error) {
 			item, err := cachingFunc(ctx)
 			if err != nil {

--- a/pkg/serverutils/asynccache/asyncccache_test.go
+++ b/pkg/serverutils/asynccache/asyncccache_test.go
@@ -1,4 +1,4 @@
-package auth
+package asynccache
 
 import (
 	"context"

--- a/pkg/serverutils/asynccache/asyncccache_test.go
+++ b/pkg/serverutils/asynccache/asyncccache_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestAsyncCache(t *testing.T) {
+	initializationRetryInterval = time.Second
+	initializationTimeout = 5 * time.Second
+
 	cacheTime := func(ctx context.Context) (time.Time, error) {
 		return time.Now(), nil
 	}


### PR DESCRIPTION
There were two bugs in the async cache initialization:
1. the initialization never returns an error even if it fails to run the caching function
2. The context in the caching function is cancelled right after the polling returns. If the cached item makes use of the context (OIDC providers unfortunately do), it will start failing.

/assign @TheRealJon 
/cc @jhadvig 