### PR TITLE
CONSOLE-3997: Bump Yarn to v1 latest & add script to check PatternFly modules

### DIFF
--- a/dynamic-demo-plugin/.yarnrc
+++ b/dynamic-demo-plugin/.yarnrc
@@ -2,5 +2,6 @@
 # yarn lockfile v1
 
 
-yarn-path "../frontend/.yarn/releases/yarn-1.22.15.js"
+yarn-path "../frontend/.yarn/releases/yarn-1.22.22.js"
 network-timeout "600000"
+disable-self-update-check true

--- a/frontend/.yarnrc
+++ b/frontend/.yarnrc
@@ -2,5 +2,6 @@
 # yarn lockfile v1
 
 
-yarn-path ".yarn/releases/yarn-1.22.15.js"
+yarn-path ".yarn/releases/yarn-1.22.22.js"
 network-timeout "600000"
+disable-self-update-check true

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "integration-tests"
   ],
   "scripts": {
-    "postinstall": "yarn prepare-husky && yarn generate",
+    "postinstall": "./scripts/check-patternfly-modules.sh && yarn prepare-husky && yarn generate",
     "clean": "rm -rf ./public/dist",
     "dev": "yarn clean && yarn generate && REACT_REFRESH=true NODE_OPTIONS=--max-old-space-size=4096 yarn ts-node ./node_modules/.bin/webpack serve --mode=development --progress",
     "dev-once": "yarn clean && yarn generate && NODE_OPTIONS=--max-old-space-size=4096 yarn ts-node ./node_modules/.bin/webpack --mode=development",

--- a/frontend/scripts/check-patternfly-modules.sh
+++ b/frontend/scripts/check-patternfly-modules.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euo pipefail
+
+COL_RESET='\e[0m'
+COL_RED='\e[0;31m'
+COL_GREEN='\e[0;32m'
+COL_YELLOW='\e[0;33m'
+
+resolution_errors=false
+
+# Ensure that only one version resolution exists for PatternFly packages in yarn.lock file.
+# Having multiple version resolutions may lead to bugs and webpack build or performance issues.
+#
+# Note: this code relies on yarn.lock v1 format since `yarn why <query>` CLI does not support
+# proper JSON output. We should revisit this code once we upgrade to a newer Yarn version.
+check-resolution() {
+  local PKG_NAME="${1:?Provide package name to check}"
+  local RES_COUNT=$(grep -Pc "^\"${PKG_NAME}@" yarn.lock)
+
+  if [[ $RES_COUNT -eq 0 ]]; then
+    echo -e "${COL_RED}${PKG_NAME}${COL_RESET} has no version resolutions"
+    resolution_errors=true
+  elif [[ $RES_COUNT -ne 1 ]]; then
+    echo -e "${COL_RED}${PKG_NAME}${COL_RESET} has multiple version resolutions"
+    resolution_errors=true
+  fi
+}
+
+# These packages will be checked for version resolutions.
+# This list is explicit since we may want to skip checking certain packages.
+#
+# To see the current full list, run the following command:
+#   sed -nr 's/^\"(@patternfly\/[^@]+).*$/\1/p' yarn.lock | sort -u
+PKGS_TO_CHECK=$(echo \
+  '@patternfly/quickstarts' \
+  '@patternfly/react-catalog-view-extension' \
+  '@patternfly/react-charts' \
+  '@patternfly/react-component-groups' \
+  '@patternfly/react-console' \
+  '@patternfly/react-core' \
+  '@patternfly/react-icons' \
+  '@patternfly/react-log-viewer' \
+  '@patternfly/react-styles' \
+  '@patternfly/react-table' \
+  '@patternfly/react-tokens' \
+  '@patternfly/react-topology' \
+  '@patternfly/react-user-feedback' \
+  '@patternfly/react-virtualized-extension'
+)
+
+echo -e "Checking ${COL_YELLOW}yarn.lock${COL_RESET} file for PatternFly module resolutions"
+
+for pkg in $PKGS_TO_CHECK; do
+  check-resolution $pkg
+done
+
+if [[ "$resolution_errors" == "false" ]]; then
+  echo -e "${COL_GREEN}No issues detected${COL_RESET}"
+  exit 0
+else
+  echo -e "Run ${COL_YELLOW}yarn why <pkg-name>${COL_RESET} to inspect module resolution details"
+  exit 1
+fi

--- a/frontend/scripts/check-patternfly-modules.sh
+++ b/frontend/scripts/check-patternfly-modules.sh
@@ -31,26 +31,26 @@ check-resolution() {
 #
 # To see the current full list, run the following command:
 #   sed -nr 's/^\"(@patternfly\/[^@]+).*$/\1/p' yarn.lock | sort -u
-PKGS_TO_CHECK=$(echo \
-  '@patternfly/quickstarts' \
-  '@patternfly/react-catalog-view-extension' \
-  '@patternfly/react-charts' \
-  '@patternfly/react-component-groups' \
-  '@patternfly/react-console' \
-  '@patternfly/react-core' \
-  '@patternfly/react-icons' \
-  '@patternfly/react-log-viewer' \
-  '@patternfly/react-styles' \
-  '@patternfly/react-table' \
-  '@patternfly/react-tokens' \
-  '@patternfly/react-topology' \
-  '@patternfly/react-user-feedback' \
+PKGS_TO_CHECK=(
+  '@patternfly/quickstarts'
+  '@patternfly/react-catalog-view-extension'
+  '@patternfly/react-charts'
+  '@patternfly/react-component-groups'
+  '@patternfly/react-console'
+  '@patternfly/react-core'
+  '@patternfly/react-icons'
+  '@patternfly/react-log-viewer'
+  '@patternfly/react-styles'
+  '@patternfly/react-table'
+  '@patternfly/react-tokens'
+  '@patternfly/react-topology'
+  '@patternfly/react-user-feedback'
   '@patternfly/react-virtualized-extension'
 )
 
 echo -e "Checking ${COL_YELLOW}yarn.lock${COL_RESET} file for PatternFly module resolutions"
 
-for pkg in $PKGS_TO_CHECK; do
+for pkg in "${PKGS_TO_CHECK[@]}"; do
   check-resolution $pkg
 done
 


### PR DESCRIPTION
Follow-up to #13693

The aim of this PR is to avoid webpack build or performance issues due to multiple version resolutions of PatternFly packages.

- Upgrade Yarn from version `1.22.15` (2021-09-30) to `1.22.22` (2024-03-09)
- Check PatternFly package version resolutions as part of Console `postinstall` hook

#### Example - check resolutions on current Console code base

![x1](https://github.com/openshift/console/assets/648971/e8f7a1be-ebac-48cf-b23b-d924418f0ef0)

#### Example - add `@patternfly/patternfly` :exclamation: and another dummy package to the list

![x2](https://github.com/openshift/console/assets/648971/cb382979-9e16-4dd8-8b77-b38b30d3cf24)

:exclamation: `PKGS_TO_CHECK` lists all PatternFly v5 packages, except for `@patternfly/patternfly`.

`@patternfly/patternfly` is excluded because a v4 package gets pulled in via `@patternfly-4/react-console`.
```sh
$ yarn why @patternfly/patternfly
..
=> Found "@patternfly/patternfly@5.2.1"
..
=> Found "@patternfly-4/react-console#@patternfly/patternfly@4.139.2"
..
```
Having multiple `@patternfly/patternfly` resolutions should be OK since this package only contains style related assets.