### PR TITLE
[release-4.13] OCPBUGS-31595: Fix operands list endpoint.

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -555,7 +555,7 @@ func (s *Server) HTTPHandler() http.Handler {
 
 	// List operator operands endpoint
 	operandsListHandler := &OperandsListHandler{
-		APIServerURL: s.KubeAPIServerURL,
+		APIServerURL: localK8sProxyConfig.Endpoint.String(),
 		Client:       s.LocalK8sClient,
 	}
 


### PR DESCRIPTION
The operands list endpoint was proxying to the public API server URL instead of the proxy endpoint configured at startup. This was causing mismatched TLS configuration when the console is running on-cluster.

Manual cherry-pick of https://github.com/openshift/console/pull/13625