### PR TITLE
ODC-7479: automation of quick-starts-cluster-overview.feature

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/guided-tour/quick-starts/quick-starts-cluster-overview.feature
+++ b/frontend/packages/dev-console/integration-tests/features/guided-tour/quick-starts/quick-starts-cluster-overview.feature
@@ -4,57 +4,38 @@ Feature: Build with guided documentation card on cluster overview
 
         Background:
             Given user is at administrator perspective
-              And sample-application Quick Start CR is available
-              And explore-serverless Quick Start CR is available
-              And explore-pipeline Quick Start CR is available
-              And add-healthchecks Quick Start CR is available
 
 
-        @regression @to-do
+        @regression
         Scenario: Build with guided documentation card on Cluster Overview: QS-04-TC01
             Given user is at developer perspective
              When user switches to administrator perspective
               And user goes to Cluster Overview page
              Then user can see Build with guided documentation card
               And user can see two Quick Starts link present on it
-              And user can see the "View all quick starts"
+              And user can see the "View all quick starts" on the card
 
 
-        @regression @to-do
+        @regression
         Scenario: Quick Starts links with status as in progress: QS-04-TC02
             Given user is at Cluster Overview page
              When user clicks on first Quick Starts link on the Build with guided documentation card
               And user clicks on the Start button
               And user clicks on close button
               And user clicks on Leave button in Leave quick start modal box
-             Then user can see the first Quick Start link present
+             Then user can see the first Quick Starts link
 
 
-        @regression @to-do
+        @regression
         Scenario: Build with guided documentation card when one Quick Start has completed: QS-04-TC03
             Given user is at Cluster Overview page
              When user completes first Quick Starts from the card
              Then user can see completed Quick Starts link is replaced with another quick start link in the card
 
 
-        @regression @to-do
+        @regression @manual
         Scenario: Build with guided documentation card when all Quick Start has completed: QS-04-TC04
             Given user is at Cluster Overview page
              When user completes all the Quick Starts present
              Then user can see Build with guided documentation card is removed from the Cluster Overview page
 
-
-        @regression @to-do
-        Scenario: Remove Build with guided documentation card from Cluster Overview page: QS-04-TC05
-            Given user is at Cluster Overview page
-             When user clicks on the kebab menu at the Getting Started resources card
-              And user clicks on Hide from the view
-             Then Build with guided documentation card will be removed from Cluster Overview page
-
-
-        @regression @to-do
-        Scenario: Removed Build with guided documentation card from Cluster Overview page can be seen in Add page: QS-04-TC06
-            Given user removed Build with guided documentation card from Cluster Overview page
-             When user goes to developer perspective
-              And user goes to Add page
-             Then Build with guided documentation card will be displayed in Add page

--- a/frontend/packages/dev-console/integration-tests/support/pages/quickStartsPage.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/quickStartsPage.ts
@@ -94,4 +94,17 @@ export const quickStartsPage = {
     cy.get(quickStartSidebarPO.quickStartSidebarBody).find(quickStartSidebarPO.startButton).click();
     closeQuickStart();
   },
+  finishFirstQuickStart: () => {
+    cy.get(addPagePO.buildWithGuidedDocumentationItems).first().click();
+    cy.get(quickStartSidebarPO.restartSideNoteAction).click();
+    cy.get('li[class*=nav-item]  h3').then(($elements) => {
+      const noOfsteps = $elements.length;
+      cy.get(quickStartSidebarPO.startButton).click();
+      for (let currentStep = 0; currentStep < noOfsteps; currentStep++) {
+        cy.get(quickStartSidebarPO.yesOptionCheckInput).click();
+        cy.get(quickStartSidebarPO.nextButton).click();
+      }
+      cy.get(quickStartSidebarPO.closeButton).click();
+    });
+  },
 };

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/quck-starts/quick-starts-cluster-overview.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/quck-starts/quick-starts-cluster-overview.ts
@@ -1,0 +1,59 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { adminNavigationBar, switchPerspective } from '../../constants';
+import { addPagePO } from '../../pageObjects';
+import { quickStartLeaveModalPO, quickStartSidebarPO } from '../../pageObjects/quickStarts-po';
+import { navigateToAdminMenu, perspective, quickStartsPage } from '../../pages';
+
+let quickStartLink: string;
+
+Given('user is at administrator perspective', () => {
+  perspective.switchTo(switchPerspective.Administrator);
+});
+
+When('user switches to administrator perspective', () => {
+  perspective.switchTo(switchPerspective.Administrator);
+});
+
+When('user goes to Cluster Overview page', () => {
+  navigateToAdminMenu(adminNavigationBar.Home);
+});
+
+Given('user is at Cluster Overview page', () => {
+  navigateToAdminMenu(adminNavigationBar.Home);
+});
+
+When('user clicks on the Start button', () => {
+  cy.get(quickStartSidebarPO.quickStartSidebarBody).find(quickStartSidebarPO.startButton).click();
+});
+When('user clicks on close button', () => {
+  cy.get(quickStartSidebarPO.closePanel).should('be.visible').click();
+});
+When('user clicks on Leave button in Leave quick start modal box', () => {
+  cy.get(quickStartLeaveModalPO.leaveModal).should('be.visible');
+  cy.get(quickStartLeaveModalPO.leaveButton).should('be.visible').click();
+});
+
+When('user completes first Quick Starts from the card', () => {
+  cy.get(addPagePO.buildWithGuidedDocumentationItems)
+    .first()
+    .then(($link) => {
+      quickStartLink = $link.get(0).innerText;
+    });
+
+  quickStartsPage.finishFirstQuickStart();
+});
+
+Then(
+  'user can see completed Quick Starts link is replaced with another quick start link in the card',
+  () => {
+    cy.get(addPagePO.buildWithGuidedDocumentationItems)
+      .first()
+      .then(($link) => {
+        const newQuickStartLink = $link.get(0).innerText;
+        if (newQuickStartLink !== quickStartLink) {
+          return true;
+        }
+        return false;
+      });
+  },
+);


### PR DESCRIPTION
**Description:**

- Automation of quick-starts-cluster-overview gherkin file in dev-console package

**Jira Id:**
- Story: 
      -  [ODC-7479](https://issues.redhat.com/browse/ODC-7479)

**Checks for approving Epic scenarios Automation PR:**
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.13-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p dev-console
```

**Screen shots**:

![Screenshot 2024-04-02 at 2 30 30 PM](https://github.com/openshift/console/assets/51144829/2377de35-da93-463b-bcb4-83811722c6b0)
