### PR TITLE
OCPBUGS-31482: oidc: use our own pre-configured client for token refreshes

### DIFF
--- a/pkg/auth/auth_oidc.go
+++ b/pkg/auth/auth_oidc.go
@@ -91,7 +91,10 @@ func (o *oidcAuth) refreshSession(ctx context.Context, w http.ResponseWriter, r 
 		return session, nil
 	}
 
-	newTokens, err := oauthConfig.TokenSource(ctx, &oauth2.Token{RefreshToken: cookieRefreshToken}).Token()
+	newTokens, err := oauthConfig.TokenSource(
+		context.WithValue(ctx, oauth2.HTTPClient, o.getClient()), // supply our client with custom trust
+		&oauth2.Token{RefreshToken: cookieRefreshToken},
+	).Token()
 	if err != nil {
 		return nil, fmt.Errorf("failed to refresh a token %s: %w", cookieRefreshToken, err)
 	}


### PR DESCRIPTION
/assign @jhadvig 