### PR TITLE
MULTIARCH-4148: Add the CPU architecture column to the NodeList and filter properties for all cpu archs

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -796,6 +796,7 @@ export type NodeKind = {
     phase?: string;
     nodeInfo?: {
       operatingSystem: string;
+      architecture: string;
     };
     addresses?: NodeAddress[];
   };

--- a/frontend/packages/console-shared/src/promql/resource-metrics.ts
+++ b/frontend/packages/console-shared/src/promql/resource-metrics.ts
@@ -5,6 +5,7 @@ import { useK8sModel } from '../hooks/useK8sModel';
 export enum ResourceUtilizationQuery {
   MEMORY = 'MEMORY',
   CPU = 'CPU',
+  CPU_ARCH = 'CPU_ARCH',
   FILESYSTEM = 'FILESYSTEM',
   NETWORK_IN = 'NETWORK_IN',
   NETWORK_OUT = 'NETWORK_OUT',
@@ -40,6 +41,9 @@ const podControllerMetricsQueries = {
   ),
   [ResourceUtilizationQuery.CPU]: _.template(
     "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{} * on(pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
+  ),
+  [ResourceUtilizationQuery.CPU_ARCH]: _.template(
+    "sum by(node) (kube_node_info{node='<%= name %>'})",
   ),
   [ResourceUtilizationQuery.FILESYSTEM]: _.template(
     "sum(pod:container_fs_usage_bytes:sum * on(pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",

--- a/frontend/packages/console-shared/src/selectors/node.ts
+++ b/frontend/packages/console-shared/src/selectors/node.ts
@@ -54,3 +54,7 @@ export const isWindowsNode = (node): boolean =>
 export const getNodeUptime = (node: NodeKind): string =>
   node?.status?.conditions?.find(({ type, status }) => type === 'Ready' && status === 'True')
     ?.lastTransitionTime;
+
+export const getNodeArchitecture = (node: NodeKind) => {
+  return node?.status?.nodeInfo?.architecture ?? '';
+};

--- a/frontend/packages/console-shared/src/sorts/nodes.ts
+++ b/frontend/packages/console-shared/src/sorts/nodes.ts
@@ -17,6 +17,7 @@ export const nodeFS = (node: NodeKind): number => {
   return total === 0 ? 0 : used / total;
 };
 export const nodeCPU = (node: NodeKind): number => Number(UIActions.getNodeMetric(node, 'cpu'));
+export const nodeArch = (node: NodeKind): string => node?.status?.nodeInfo?.architecture;
 export const nodePods = (node: NodeKind): number => Number(UIActions.getNodeMetric(node, 'pods'));
 export const nodeMachine = (node: NodeKind): string => getNodeMachineName(node);
 export const nodeInstanceType = (node: NodeKind): string =>

--- a/frontend/public/components/utils/resource-metrics.tsx
+++ b/frontend/public/components/utils/resource-metrics.tsx
@@ -62,6 +62,13 @@ export const ResourceMetricsDashboard: React.FC<ResourceMetricsDashboardProps> =
             title={t('public~Network out')}
           />
         </GridItem>
+        <GridItem xl={6} lg={12}>
+          <ResourceMetricsDashboardCard
+            namespace={obj.metadata.namespace}
+            queries={queries[ResourceUtilizationQuery.CPU_ARCH]}
+            title={t('public~Architecture')}
+          />
+        </GridItem>
       </Grid>
     </Dashboard>
   ) : null;


### PR DESCRIPTION
This will have CPU arch column to console and filter properties for all CPU archs . 
Here are some screenshot of it . 

<img width="1700" alt="Screenshot 2024-04-01 at 3 32 07 PM" src="https://github.com/openshift/console/assets/13777279/950f4263-63c0-4cde-aa59-4ea68dac46ba">
<img width="1700" alt="Screenshot 2024-04-01 at 3 33 06 PM" src="https://github.com/openshift/console/assets/13777279/9c5ebb3a-af50-4f81-8aed-b9a82b3c4bc4">
<img width="1700" alt="Screenshot 2024-04-01 at 3 33 54 PM" src="https://github.com/openshift/console/assets/13777279/c6e2b63b-083f-4714-97f5-774bb3727976">


