### PR TITLE
OCPBUGS-31685: Revert - terminal: use username if uid is not present

### DIFF
--- a/pkg/terminal/proxy.go
+++ b/pkg/terminal/proxy.go
@@ -123,9 +123,13 @@ func (p *Proxy) HandleProxy(user *auth.User, w http.ResponseWriter, r *http.Requ
 			return
 		}
 
-		userId = string(userInfo.Status.UserInfo.UID) // TODO: are we cool rewriting this here?
+		userId = userInfo.Status.UserInfo.UID
 		if userId == "" {
-			userId = userInfo.Status.UserInfo.Username
+			// uid is missing. it must be kube:admin
+			if userInfo.Status.UserInfo.Username != "kube:admin" {
+				http.Error(w, "User must have UID to proceed authorization", http.StatusInternalServerError)
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
Reverts https://github.com/openshift/console/commit/e87dc6fc852d23e8fca211cd0d3862b07cefa79e
/assign @stlaz 