### PR TITLE
[release-4.16] OCPBUGS-33433: UI should use type "bridge" instead of "cnv-bridge"

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
@@ -7,13 +7,13 @@ export const ELEMENT_TYPES = {
   TEXTAREA: 'textarea',
 };
 
-export const cnvBridgeNetworkType = 'cnv-bridge';
+export const cnvBridgeNetworkType = 'bridge';
 export const ovnKubernetesNetworkType = 'ovn-k8s-cni-overlay';
 export const ovnKubernetesSecondaryLocalnet = 'ovn-k8s-cni-overlay-localnet';
 
 export const networkTypes = {
   sriov: 'SR-IOV',
-  [cnvBridgeNetworkType]: 'CNV Linux bridge',
+  [cnvBridgeNetworkType]: 'Linux bridge',
   [ovnKubernetesNetworkType]: 'OVN Kubernetes L2 overlay network',
   [ovnKubernetesSecondaryLocalnet]: 'OVN Kubernetes secondary localnet network',
 };


### PR DESCRIPTION
Create NAD with type "bridge" instead of "cnv-bridge" and change the dropdown text.

Before:
![cnv-bridge-type2-415](https://github.com/openshift/console/assets/67270715/4c3ee828-716b-4b21-90be-2100abebed6f)
![cnv-bridge-type415](https://github.com/openshift/console/assets/67270715/4c9d4190-285e-4ded-9652-c2ee50266965)

After:
![bridge-type2-415](https://github.com/openshift/console/assets/67270715/c7f3ee75-c7f1-45b8-8a9c-e0ae73c56462)
![bridge-type415](https://github.com/openshift/console/assets/67270715/5a0106a1-b800-47c5-8a75-2a04f71706b1)
