### PR TITLE
OCPBUGS-31703: Resource yaml with create

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -1953,6 +1953,9 @@ A lazy loaded YAML editor for Kubernetes resources with hover help and completio
 | `header` | Add a header on top of the YAML editor. |
 | `onSave` | Callback for the Save button. Passing it will override the default update performed on the resource by the editor. |
 | `readOnly` | Sets the YAML editor to read-only mode. |
+| `create` | Editor will be on creation mode. Create button will replace the Save and Cancel buttons. If no onSave method defined, the 'Create' button will trigger the creation of the defined resource. Default: false |
+| `onChange` | Callback triggered at any editor change. |
+| `hideHeader` | On creation mode the editor by default show an header that can be hided with this property |
 
 
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -641,6 +641,9 @@ export const CodeEditor: React.ForwardRefExoticComponent<
  * @param {ResourceYAMLEditorProps['header']} header - Add a header on top of the YAML editor.
  * @param {ResourceYAMLEditorProps['onSave']} onSave - Callback for the Save button. Passing it will override the default update performed on the resource by the editor.
  * @param {ResourceYAMLEditorProps['readOnly']} readOnly - Sets the YAML editor to read-only mode.
+ * @param {ResourceYAMLEditorProps['create']} create - Editor will be on creation mode. Create button will replace the Save and Cancel buttons. If no onSave method defined, the 'Create' button will trigger the creation of the defined resource. Default: false
+ * @param {ResourceYAMLEditorProps['onChange']} onChange - Callback triggered at any editor change.
+ * @param {ResourceYAMLEditorProps['hideHeader']} hideHeader - On creation mode the editor by default show an header that can be hided with this property
  */
 export const ResourceYAMLEditor: React.FC<ResourceYAMLEditorProps> = require('@console/internal/components/AsyncResourceYAMLEditor')
   .AsyncResourceYAMLEditor;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -678,6 +678,9 @@ export type ResourceYAMLEditorProps = {
   header?: string;
   onSave?: (content: string) => void;
   readOnly?: boolean;
+  create?: boolean;
+  onChange?: (content: string) => void;
+  hideHeader?: boolean;
 };
 
 export type ResourceEventStreamProps = {

--- a/frontend/public/components/droppable-edit-yaml.tsx
+++ b/frontend/public/components/droppable-edit-yaml.tsx
@@ -39,12 +39,18 @@ export const ResourceYAMLEditor: React.FC<ResourceYAMLEditorProps> = ({
   header,
   onSave,
   readOnly,
+  create,
+  onChange,
+  hideHeader,
 }) => (
   <DroppableEditYAML
     initialResource={initialResource}
     header={header}
     onSave={onSave}
     readOnly={readOnly}
+    create={create}
+    onChange={onChange}
+    hideHeader={hideHeader}
   />
 );
 
@@ -118,7 +124,13 @@ export const DroppableEditYAML = withDragDropContext<DroppableEditYAMLProps>(
     }
 
     render() {
-      const { allowMultiple, initialResource } = this.props;
+      const {
+        allowMultiple,
+        initialResource,
+        create = false,
+        onChange = () => null,
+        hideHeader = false,
+      } = this.props;
       const { errors, fileUpload } = this.state;
       return (
         <EditYAMLComponent
@@ -129,6 +141,9 @@ export const DroppableEditYAML = withDragDropContext<DroppableEditYAMLProps>(
           error={errors.join('\n')}
           onDrop={this.handleFileDrop}
           clearFileUpload={this.clearFileUpload}
+          create={create}
+          onChange={onChange}
+          hideHeader={hideHeader}
         />
       );
     }
@@ -142,6 +157,9 @@ type EditYAMLProps = {
   error: string;
   onDrop: (item: any, monitor: DropTargetMonitor) => void;
   clearFileUpload: () => void;
+  create?: boolean;
+  onChange?: (content: string) => void;
+  hideHeader?: boolean;
 };
 
 export type DroppedFile = {


### PR DESCRIPTION
ResourceYAMLEditor is always used in the resource details page to edit objects, but when it's used to create objects there is no "Create" button and no samples show up. 
There is no option to do that but it's actually easy to add this functionality

**Before**

![image](https://github.com/openshift/console/assets/29160323/c8c39f2c-56c2-456e-9e53-1ceb32c438c0)



**After**

with `<ResourceYAMLEditor initialResource={obj} create />;`

![image](https://github.com/openshift/console/assets/29160323/bf4d4561-3947-49d0-8242-8bf2b91115e8)
