### PR TITLE
OCPBUGS-29377: Routes created by devfiles do not always use HTTPS

### DIFF
--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -14,6 +14,7 @@ import DevfileStrategySection from './devfile/DevfileStrategySection';
 import GitSection from './git/GitSection';
 import { BuildOptions, GitImportFormProps, ImportTypes } from './import-types';
 import ImportStrategySection from './ImportStrategySection';
+import SecureRoute from './route/SecureRoute';
 import { BuildSection } from './section/BuildSection';
 
 const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = ({
@@ -48,6 +49,10 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
     importType !== ImportTypes.devfile &&
     values.import.selectedStrategy.type !== ImportStrategy.DEVFILE &&
     !isSample;
+  const showSecureRouteSectionForDevfile =
+    (importType === ImportTypes.devfile ||
+      values.import.selectedStrategy.type === ImportStrategy.DEVFILE) &&
+    values?.devfile?.devfileSuggestedResources?.route?.spec?.tls;
 
   return (
     <form onSubmit={handleSubmit} data-test-id="import-git-form">
@@ -89,6 +94,11 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
 
                     <AdvancedSection values={values} />
                   </>
+                )}
+                {showSecureRouteSectionForDevfile && (
+                  <div className="pf-v5-c-form co-m-pane__form">
+                    <SecureRoute />
+                  </div>
                 )}
               </>
             )}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-29377

**Analysis / Root cause**: 
tls settings defined for devfile is not considered while creating the route.

**Solution Description**: 
Updated Import flow to consider tls settings defined for route and provided user the checkbox to secure the route. The checkbox to secure route will only be displayed if tls setting is defined for the devfile or else route will be created with http.

**Screen shots / Gifs for design review**: 


https://github.com/openshift/console/assets/102503482/b81c834c-ccdc-478d-b2f6-b9315a34f667



**Unit test coverage report**: 
NA

**Test setup:**

1. Ensure that the User Preferences > Application > Secure Route option is enabled
2. Switch to developer perspective and navigate to Add 
3. Import a Sample, enter "Devfile" as filter, select one option and press "Create"
 or
4. Import from Git: https://github.com/devfile-samples/devfile-sample-go-basic.git and press "Create"
5. Check the Route YAML, route should be created with https.
6. Import from Git: https://github.com/lokanandaprabhu/devfile-sample-go-basic
7. Check the Route YAML, route should be created with http and Secure route section should not be visible.


     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge