### PR TITLE
OCPBUGS-31732: Hide the cluster configuration for analytics

### DIFF
--- a/frontend/packages/console-telemetry-plugin/console-extensions.json
+++ b/frontend/packages/console-telemetry-plugin/console-extensions.json
@@ -65,7 +65,8 @@
           "name": "cluster"
         }
       ]
-    }
+    },
+    "flags": { "required": ["TELEMETRY_CLUSTER_CONFIGURATION"] }
   },
   {
     "type": "console.user-preference/item",


### PR DESCRIPTION
Based on a discussion with Ali and Parag yesterday, we want to hide the analytics option from the cluster configuration. We keep the option for a cluster admin to activate the opt-in or opt-out banner in the UI.

/cc @lokanandaprabhu @jhadvig @spadgett 