### PR TITLE
OCPBUGS-31809: Pipeline details page Metrics tab crashed due to no custom data

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/types.ts
@@ -3,7 +3,7 @@ import { RouteTemplate } from '../utils/triggers';
 
 export type PipelineDetailsTabProps = {
   obj: PipelineKind;
-  customData: {
+  customData?: {
     templateNames: RouteTemplate[];
     queryPrefix: string;
     metricsLevel: string;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetrics.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetrics.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { PipelineMetricsLevel } from '../const';
 import { PipelineDetailsTabProps } from '../detail-page-tabs/types';
 import { useLatestPipelineRun } from '../hooks';
+import { usePipelineMetricsLevel } from '../utils/pipeline-operator';
 import { GraphData } from './pipeline-metrics-utils';
 import PipelineMetricsEmptyState from './PipelineMetricsEmptyState';
 import PipelineMetricsQuickstart from './PipelineMetricsQuickstart';
@@ -29,12 +30,12 @@ import PipelineSuccessRatioDonut from './PipelineSuccessRatioDonut';
 
 import './PipelineMetrics.scss';
 
-const PipelineMetrics: React.FC<PipelineDetailsTabProps> = ({ obj, customData }) => {
+const PipelineMetrics: React.FC<PipelineDetailsTabProps> = ({ obj }) => {
   const {
     metadata: { name, namespace },
   } = obj;
-  const { queryPrefix, metricsLevel, hasUpdatePermission } = customData;
   const { t } = useTranslation();
+  const { queryPrefix, metricsLevel, hasUpdatePermission } = usePipelineMetricsLevel(namespace);
   const latestPipelineRun = useLatestPipelineRun(name, namespace);
   const [timespan, setTimespan] = React.useState(parsePrometheusDuration('1w'));
   const [interval, setInterval] = React.useState(parsePrometheusDuration('30s'));

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineMetrics.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineMetrics.spec.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../../test-data/pipeline-data';
 import { PipelineMetricsLevel } from '../../const';
 import * as hookUtils from '../../hooks';
+import { usePipelineMetricsLevel } from '../../utils/pipeline-operator';
 import { MetricsQueryPrefix } from '../pipeline-metrics-utils';
 import PipelineMetrics from '../PipelineMetrics';
 import PipelineMetricsEmptyState from '../PipelineMetricsEmptyState';
@@ -24,6 +25,12 @@ jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
   useK8sGet: jest.fn(),
 }));
 
+jest.mock('../../utils/pipeline-operator', () => ({
+  usePipelineMetricsLevel: jest.fn(),
+}));
+
+const mockUsePipelineMetricsLevel = usePipelineMetricsLevel as jest.Mock;
+
 const latestPipelineRunSpy = jest.spyOn(hookUtils, 'useLatestPipelineRun');
 
 const mockData = pipelineTestData[PipelineExampleNames.WORKSPACE_PIPELINE];
@@ -34,15 +41,14 @@ type PipelineMetricsProps = React.ComponentProps<typeof PipelineMetrics>;
 
 describe('Pipeline Metrics', () => {
   let PipelineMetricsProps: PipelineMetricsProps;
+  mockUsePipelineMetricsLevel.mockReturnValue({
+    queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
+    metricsLevel: PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL,
+    hasUpdatePermission: true,
+  });
   beforeEach(() => {
     PipelineMetricsProps = {
       obj: pipeline,
-      customData: {
-        templateNames: [],
-        queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
-        metricsLevel: PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL,
-        hasUpdatePermission: true,
-      },
     };
   });
 
@@ -69,12 +75,12 @@ describe('Pipeline Metrics', () => {
 
   it('Should render only success ratio and number of pipeline runs charts if the metrics level is set to pipeline /task (default) level', () => {
     latestPipelineRunSpy.mockReturnValue(pipelineRun);
+    mockUsePipelineMetricsLevel.mockReturnValue({
+      queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
+      metricsLevel: PipelineMetricsLevel.PIPELINE_TASK_LEVEL,
+      hasUpdatePermission: true,
+    });
     const pipelineMetricsWrapper = shallow(<PipelineMetrics {...PipelineMetricsProps} />);
-    pipelineMetricsWrapper
-      .setProps({
-        customData: { metricsLevel: PipelineMetricsLevel.PIPELINE_TASK_LEVEL },
-      })
-      .update();
     expect(pipelineMetricsWrapper.find(PipelineMetricsEmptyState).exists()).toBe(false);
     expect(pipelineMetricsWrapper.find(Card)).toHaveLength(2);
 
@@ -89,75 +95,61 @@ describe('Pipeline Metrics', () => {
 
   it('Should contain quickstart link if the metrics level is set to pipeline /task (default) level', () => {
     latestPipelineRunSpy.mockReturnValue(pipelineRun);
+    mockUsePipelineMetricsLevel.mockReturnValue({
+      queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
+      metricsLevel: PipelineMetricsLevel.PIPELINE_TASK_LEVEL,
+      hasUpdatePermission: true,
+    });
     const pipelineMetricsWrapper = shallow(<PipelineMetrics {...PipelineMetricsProps} />);
-    pipelineMetricsWrapper
-      .setProps({
-        customData: {
-          metricsLevel: PipelineMetricsLevel.PIPELINE_TASK_LEVEL,
-          hasUpdatePermission: true,
-        },
-      })
-      .update();
 
     expect(pipelineMetricsWrapper.find(PipelineMetricsQuickstart).exists()).toBe(true);
   });
 
   it('Should contain quickstart link if the user has update permission', () => {
     latestPipelineRunSpy.mockReturnValue(pipelineRun);
+    mockUsePipelineMetricsLevel.mockReturnValue({
+      queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
+      metricsLevel: PipelineMetricsLevel.PIPELINE_TASK_LEVEL,
+      hasUpdatePermission: true,
+    });
     const pipelineMetricsWrapper = shallow(<PipelineMetrics {...PipelineMetricsProps} />);
-    pipelineMetricsWrapper
-      .setProps({
-        customData: {
-          metricsLevel: PipelineMetricsLevel.PIPELINE_TASK_LEVEL,
-          hasUpdatePermission: true,
-        },
-      })
-      .update();
 
     expect(pipelineMetricsWrapper.find(PipelineMetricsQuickstart).exists()).toBe(true);
   });
 
   it('Should not contain quickstart link if the user does not have update permission', () => {
     latestPipelineRunSpy.mockReturnValue(pipelineRun);
+    mockUsePipelineMetricsLevel.mockReturnValue({
+      queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
+      metricsLevel: PipelineMetricsLevel.PIPELINE_TASK_LEVEL,
+      hasUpdatePermission: false,
+    });
     const pipelineMetricsWrapper = shallow(<PipelineMetrics {...PipelineMetricsProps} />);
-    pipelineMetricsWrapper
-      .setProps({
-        customData: {
-          metricsLevel: PipelineMetricsLevel.PIPELINE_TASK_LEVEL,
-          hasUpdatePermission: false,
-        },
-      })
-      .update();
 
     expect(pipelineMetricsWrapper.find(PipelineMetricsQuickstart).exists()).toBe(false);
   });
 
   it('Should not contain quickstart link if the metrics level is set to pipelinerun /taskrun level', () => {
     latestPipelineRunSpy.mockReturnValue(pipelineRun);
+    mockUsePipelineMetricsLevel.mockReturnValue({
+      queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
+      metricsLevel: PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL,
+      hasUpdatePermission: true,
+    });
     const pipelineMetricsWrapper = shallow(<PipelineMetrics {...PipelineMetricsProps} />);
-    pipelineMetricsWrapper
-      .setProps({
-        customData: {
-          metricsLevel: PipelineMetricsLevel.PIPELINERUN_TASKRUN_LEVEL,
-          hasUpdatePermission: true,
-        },
-      })
-      .update();
 
     expect(pipelineMetricsWrapper.find(PipelineMetricsQuickstart).exists()).toBe(false);
   });
 
   it('Should render Pipeline Metrics Unsupported empty page', () => {
     latestPipelineRunSpy.mockReturnValue(pipelineRun);
+    mockUsePipelineMetricsLevel.mockReturnValue({
+      queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
+      metricsLevel: PipelineMetricsLevel.UNSUPPORTED_LEVEL,
+      hasUpdatePermission: true,
+    });
     const pipelineMetricsWrapper = shallow(<PipelineMetrics {...PipelineMetricsProps} />);
-    pipelineMetricsWrapper
-      .setProps({
-        customData: {
-          metricsLevel: PipelineMetricsLevel.UNSUPPORTED_LEVEL,
-          hasUpdatePermission: true,
-        },
-      })
-      .update();
+
     expect(pipelineMetricsWrapper.find(PipelineMetricsUnsupported).exists()).toBe(true);
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-31809

**Analysis / Root cause**: 
While doing the migration of Pipeline details page, Metrics page is expecting customData from Details page - https://github.com/openshift/console/blob/master/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetrics.tsx  but in horizontalnav component exposed to dynamic plugin, we don't have customData prop. https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/docs/api.md#horizontalnav

**Solution Description**: 
Calling customData values inside Metrics page

**Screen shots / Gifs for design review**: 

---Before--

<img width="1728" alt="Screenshot 2024-04-05 at 6 10 46 PM" src="https://github.com/openshift/console/assets/102503482/c45708b7-dd0e-40dc-b0cd-c329f1229581">


--After--
<img width="1728" alt="Screenshot 2024-04-05 at 6 02 03 PM" src="https://github.com/openshift/console/assets/102503482/1d83d1aa-0c7c-4fc6-bf46-e78543671f18">


**Unit test coverage report**: 
NA

**Test setup:**

    1. Pipeline details page PR to be up for testing this[WIP][Story - https://issues.redhat.com/browse/ODC-7525]
    2. Install Pipelines Operator and don't install Tekton result
    3. Enabled Pipeline details page in dynamic plugin
    4. create a pipeline and go to Metrics tab in details page


     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge