### PR TITLE
ODC-7435: Remove pf classes in pipelines package

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -42,7 +42,8 @@ export const gitPO = {
   },
   pipeline: {
     infoMessage: '[aria-label="Info Alert"]',
-    addPipeline: '#form-checkbox-pipeline-enabled-field',
+    buildDropdown: '[id="form-select-input-build-option-field"]',
+    addPipeline: '[id="select-option-build.option-PIPELINES"]',
     pipelineDropdown: '#form-dropdown-pipeline-templateSelected-field',
   },
   resourcesDropdown: '#form-select-input-resources-field',

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
@@ -191,7 +191,10 @@ export const gitPage = {
         break;
     }
   },
-  selectAddPipeline: () => cy.get(gitPO.pipeline.addPipeline).scrollIntoView().check(),
+  selectAddPipeline: () => {
+    cy.get(gitPO.pipeline.buildDropdown).scrollIntoView().click();
+    cy.get(gitPO.pipeline.addPipeline).should('be.visible').click();
+  },
   clickCreate: () => cy.get(gitPO.create).scrollIntoView().should('be.enabled').click(),
   clickCancel: () => cy.get(gitPO.cancel).should('be.enabled').click(),
   selectBuilderImageForGitUrl: (gitUrl: string) => {

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
@@ -72,23 +72,20 @@ Feature: Create the pipeline from builder page
 
     @un-verified
     #test data required
-        Scenario Outline: Create pipeline with "<resource_type>" as resource type from pipeline builder page: P-02-TC06
+        Scenario Outline: Create pipeline resource from pipeline builder page: P-02-TC06
             Given user is at Pipeline Builder page
              When user enters pipeline name as "<pipeline_name>"
               And user clicks on Add task
               And user searches "<cluster_task_name>" in quick search bar
               And user clicks on "Add" in "<cluster_task_name>" task
-              And user adds "<resource_type>" resource with name "<resource_name>" to the "<cluster_task_name>"
+              And user adds resource with name "<resource_name>" to the "<cluster_task_name>"
               And user clicks Create button on Pipeline Builder page
              Then user will be redirected to Pipeline Details page with header name "<pipeline_name>"
 
         Examples:
-            #For git and image resource apply ../../testData/pipelines-workspaces/demo-optional-resources.yaml
-                  | pipeline_name | cluster_task_name | resource_type | resource_name |
-                  | p-git         | openshift-client  | Git           | git repo      |
-                  | p-img         | buildah           | Image         | image repo    |
-    # | p-storage     | task-storage           | Storage       | storage repo  |
-    # | p-cluster     | task-cluster           | Cluster       | cluster repo  |
+                  | pipeline_name | cluster_task_name | resource_name |
+                  | p-git         | openshift-client  | git repo      |
+                  | p-img         | buildah           | image repo    |
 
 
         @regression

--- a/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
@@ -4,7 +4,6 @@ export const pipelineBuilderPO = {
   cancel: '[data-test-id="reset-button"]',
   pipeline: '#pipeline-link',
   repository: '#repository-link',
-  add: 'button.pf-v5-c-button.pf-m-link.pf-m-inline',
   configureVia: {
     pipelineBuilder: '#form-radiobutton-editorType-form-field',
     yamlView: '#form-radiobutton-editorType-yaml-field',
@@ -22,14 +21,14 @@ export const pipelineBuilderPO = {
     seriesTask: '[data-id^="has-run-after-"][data-kind="node"]',
     parallelTask: '[data-id^="shared-parallel-"][data-kind="node"]',
     sectionTitle: '.odc-pipeline-builder-page h2',
-    addResourcesLink: 'div.pf-v5-c-form__group button[type="button"]',
+    addResourcesLink: '[data-test="add-action"]',
     addParams: {
       name: '#form-input-formData-params-0-name-field',
       description: '#form-input-formData-params-0-description-field',
       defaultValue: '#form-input-formData-params-0-default-field',
     },
     addResources: {
-      name: '#form-input-formData-resources-0-name-field',
+      name: '#form-input-formData-workspaces-0-name-field',
       resourceType: '#form-dropdown-formData-resources-0-type-field',
     },
     sidePane: {
@@ -132,10 +131,10 @@ export const pipelineDetailsPO = {
     yamlEditor: '[data-mode-id="yaml"]',
   },
   metrics: {
-    emptyMessage: '.pf-v5-c-empty-state__body',
+    emptyMessage: '.loading-box.loading-box__loaded',
     timeRange: '',
     refreshInterval: '',
-    graphTitle: '.pf-v5-c-card__title',
+    graphTitle: '[class$="card__title"]',
   },
   pipelineRuns: {
     pipelineRunIcon: '[title="PipelineRun"]',
@@ -274,10 +273,10 @@ export const pipelinesPO = {
   addTrigger: {
     add: '#confirm-action',
     gitProviderType: '[id$="triggerBinding-name-field"]',
-    gitUrl: '#form-input-resources-0-data-params-url-field',
-    revision: '#form-input-resources-0-data-params-revision-field',
+    gitUrl: '#form-input-parameters-1-value-field',
+    revision: '#form-input-parameters-2-value-field',
     variablesMessage: 'p.odc-trigger-binding-section__variable-descriptor',
-    variablesLink: '.pf-v5-c-form button',
+    variablesLink: '[id^="expandable-section-toggle"]',
   },
   editPipeline: {
     title: 'h1.odc-pipeline-builder-header__title',
@@ -289,15 +288,14 @@ export const pipelinesPO = {
   },
   startPipeline: {
     sectionTitle: 'h2.odc-form-section__heading',
-    gitResourceDropdown: '[id*="dropdown-resources-0"]',
-    gitUrl: '#form-input-resources-0-data-params-url-field',
-    revision: '#form-input-resources-0-data-params-revision-field',
+    gitResourceDropdown: '[for="form-input-parameters-1-value-field"]', // '[id*="dropdown-resources-0"]',
+    gitUrl: '#form-input-parameters-1-value-field',
+    revision: '#form-input-parameters-2-value-field',
     sharedWorkspace: '#form-dropdown-workspaces-0-type-field',
     emptyDirectoryInfo: '[aria-label="Info Alert"]',
     start: '#confirm-action',
     workspaces: {
       workspaceType: '[id$="workspaces-0-type-field"]',
-      emptyDirectoryInfo: '.pf-v5-u-screen-reader',
       configMap: '.odc-multiple-key-selector button',
       secret: '.odc-multiple-key-selector button',
       pvc: '[id$=persistentVolumeClaim-claimName-field]',

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineBuilder-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineBuilder-page.ts
@@ -98,10 +98,9 @@ export const pipelineBuilderPage = {
     cy.get(pipelineBuilderPO.formView.addParams.description).type(description);
     cy.get(pipelineBuilderPO.formView.addParams.defaultValue).type(defaultValue);
   },
-  addResource: (resourceName: string, resourceType: string = 'Git') => {
+  addResource: (resourceName: string) => {
     cy.get(pipelineBuilderPO.formView.addResourcesLink).eq(1).click();
     cy.get(pipelineBuilderPO.formView.addResources.name).type(resourceName);
-    cy.get(pipelineBuilderPO.formView.addResources.resourceType).select(resourceType);
   },
   verifySection: () => {
     cy.get(pipelineBuilderPO.formView.sectionTitle).as('sectionTitle');

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelines-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelines-page.ts
@@ -219,11 +219,7 @@ export const pipelinesPage = {
   },
 
   verifyOptionInKebabMenu: (option: string) => {
-    cy.get('ul.pf-v5-c-dropdown__menu li button').each(($el) => {
-      if ($el.text().includes(option)) {
-        expect($el.text()).toMatch(option);
-      }
-    });
+    cy.byTestActionID(option).should('be.visible');
   },
 
   addTrigger: (gitProviderType: string = 'github-pullreq') => {
@@ -246,12 +242,12 @@ export const startPipelineInPipelinesPage = {
     cy.get(pipelinesPO.startPipeline.gitUrl).should('be.enabled').type(gitUrl);
   },
   verifyGitRepoUrlAndEnterGitUrl: (gitUrl: string) => {
-    cy.get(pipelinesPO.startPipeline.gitResourceDropdown).then(($btn) => {
-      if ($btn.attr('disabled')) {
+    cy.get('.modal-content').then(($btn) => {
+      if ($btn.find(pipelinesPO.startPipeline.gitResourceDropdown).length !== 0) {
         startPipelineInPipelinesPage.enterGitUrl(gitUrl);
-      } else {
-        cy.get(pipelinesPO.startPipeline.gitResourceDropdown).select('Create Pipeline resource');
-        startPipelineInPipelinesPage.enterGitUrl(gitUrl);
+        // } else {
+        // cy.get(pipelinesPO.startPipeline.gitResourceDropdown).select('Create Pipeline resource');
+        // startPipelineInPipelinesPage.enterGitUrl(gitUrl);
       }
     });
   },
@@ -277,14 +273,23 @@ export const startPipelineInPipelinesPage = {
     modal.shouldBeOpened();
     cy.get('form').within(() => {
       app.waitForLoad();
-      cy.get(pipelinesPO.startPipeline.gitResourceDropdown).then(($btn) => {
-        if ($btn.attr('disabled')) {
-          cy.log('Pipeline resource is not available, so adding a new git resource');
-        } else {
-          cy.get(pipelinesPO.startPipeline.gitResourceDropdown).select('Create Pipeline resource');
+      // cy.get(pipelinesPO.startPipeline.gitResourceDropdown).then(($btn) => {
+      //   if ($btn.attr('disabled')) {
+      //     cy.log('Pipeline resource is not available, so adding a new git resource');
+      //   } else {
+      //     cy.get(pipelinesPO.startPipeline.gitResourceDropdown).select('Create Pipeline resource');
+      //   }
+      //   startPipelineInPipelinesPage.enterGitUrl(gitUrl);
+      //   startPipelineInPipelinesPage.enterRevision(revision);
+      // });
+      cy.get('.modal-content').then(($btn) => {
+        if ($btn.find(pipelinesPO.startPipeline.gitResourceDropdown).length !== 0) {
+          startPipelineInPipelinesPage.enterGitUrl(gitUrl);
+          startPipelineInPipelinesPage.enterRevision(revision);
+          // } else {
+          // cy.get(pipelinesPO.startPipeline.gitResourceDropdown).select('Create Pipeline resource');
+          // startPipelineInPipelinesPage.enterGitUrl(gitUrl);
         }
-        startPipelineInPipelinesPage.enterGitUrl(gitUrl);
-        startPipelineInPipelinesPage.enterRevision(revision);
       });
     });
   },

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
@@ -83,12 +83,9 @@ When('user adds another task {string} in series', (taskName: string) => {
   pipelineBuilderPage.selectSeriesTask(taskName);
 });
 
-When(
-  'user adds {string} resource with name {string} to the {string}',
-  (resourceType: string, resourceName: string) => {
-    pipelineBuilderPage.addResource(resourceName, resourceType);
-  },
-);
+When('user adds resource with name {string} to the {string}', (resourceName: string) => {
+  pipelineBuilderPage.addResource(resourceName);
+});
 
 When('user adds the parameter details like Name, Description and Default Value', () => {
   pipelineBuilderPage.addParameters('param-1', 'description', 'openshift/hello-openshift');

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-task-runs-display.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-task-runs-display.ts
@@ -126,7 +126,7 @@ Then('user can see Details, Log, YAML and Events tab', () => {
 });
 
 Then('user is redirected to Task Run Details tab', () => {
-  cy.get('.pf-v5-c-breadcrumb').should('include.text', 'TaskRun details');
+  cy.get('[aria-label="Breadcrumb"] li').eq(1).should('include.text', 'TaskRun details');
 });
 
 When('user clicks on task run {string}', (pipelineRunsName: string) => {
@@ -136,7 +136,7 @@ When('user clicks on task run {string}', (pipelineRunsName: string) => {
 Given('user is at pipeline details page with pipeline runs {string}', (pipelineName: string) => {
   detailsPage.titleShouldContain(pageTitle.Pipelines);
   pipelinesPage.selectPipeline(pipelineName);
-  cy.get('.pf-v5-c-breadcrumb').should('include.text', 'Pipeline details');
+  cy.get('[aria-label="Breadcrumb"] li').eq(1).should('include.text', 'Pipeline details');
 });
 
 When('user clicks on pipeline runs tab', () => {

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-actions.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-actions.ts
@@ -207,8 +207,8 @@ Then('Name field will be disabled', () => {
 });
 
 Then('Add Parameters, Add Resources, Task should be displayed', () => {
-  cy.get(pipelineBuilderPO.add).eq(0).should('be.enabled');
-  cy.get(pipelineBuilderPO.add).eq(1).should('be.enabled');
+  cy.get(pipelineBuilderPO.formView.addResourcesLink).eq(0).should('be.enabled');
+  cy.get(pipelineBuilderPO.formView.addResourcesLink).eq(1).should('be.enabled');
   cy.get(pipelineBuilderPO.formView.task).should('be.visible');
 });
 

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-runs.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-runs.ts
@@ -541,7 +541,7 @@ When('user goes to failed pipeline run of pipeline {string}', (pipelineName: str
 });
 
 When('user opens pipeline run details', () => {
-  cy.get('.pf-v5-c-breadcrumb').should('include.text', 'PipelineRun details');
+  cy.get('[aria-label="Breadcrumb"] li').eq(1).should('include.text', 'PipelineRun details');
 });
 
 Then('user can see status as Failure', () => {


### PR DESCRIPTION
**Fix**: [ODC-7435](https://issues.redhat.com/browse/ODC-7435)

**Description**: 
Remove PatternFly classname selectors from pipeline integration tests

Command to execute:

    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.13-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p pipelines


**Browser**
Chrome 120

**Test Execution Screenshot:**
