### PR TITLE
OCPBUGS-31082: Remove deprecated resources from spec of the Pipeline

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineForm.tsx
@@ -22,7 +22,6 @@ const PipelineForm: React.FC<PipelineFormProps> = ({
   const { t } = useTranslation();
   const initialValues = {
     parameters: _.get(obj.spec, 'params', []),
-    resources: _.get(obj.spec, 'resources', []),
   };
 
   const handleSubmit = (values, actions) => {
@@ -33,7 +32,6 @@ const PipelineForm: React.FC<PipelineFormProps> = ({
         spec: {
           ...obj.spec,
           params: sanitizePipelineParams(values.parameters),
-          resources: values.resources,
         },
       },
       obj.metadata.namespace,
@@ -43,7 +41,6 @@ const PipelineForm: React.FC<PipelineFormProps> = ({
         actions.resetForm({
           values: {
             parameters: _.get(newObj.spec, 'params', []),
-            resources: _.get(newObj.spec, 'resources', []),
           },
           status: {
             success: t('pipelines-plugin~Successfully updated the pipeline {{formName}}.', {


### PR DESCRIPTION
Fixes: [OCPBUGS-31082](https://issues.redhat.com/browse/OCPBUGS-31082)

Descriptions: Remove `resources` properties from spec as it is deprecated and failed on patch request of updating the Pipeline parameters.