### PR TITLE
OCPBUGS-31745: TaskRun status is not displayed near the name

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/taskruns/TaskRunDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/TaskRunDetailsPage.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../const';
 import { TaskRunKind } from '../../types';
 import { usePipelineTechPreviewBadge } from '../../utils/hooks';
+import { taskRunFilterReducer } from '../../utils/pipeline-filter-reducer';
 import { useTaskRun } from '../pipelineruns/hooks/usePipelineRuns';
 import { useTasksBreadcrumbsFor } from '../pipelines/hooks';
 import TaskRunEvents from './events/TaskRunEvents';
@@ -49,6 +50,7 @@ const TaskRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
       badge={badge}
       breadcrumbsFor={() => breadcrumbsFor}
       titleFunc={resourceTitleFunc}
+      getResourceStatus={taskRunFilterReducer}
       pages={[
         navFactory.details(TaskRunDetails),
         navFactory.editYaml(viewYamlComponent),


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-31745

**Analysis / Root cause**: 
Status was not added for TaskRun details page heading

**Solution Description**: 
Added the status value in heading

**Screen shots / Gifs for design review**: 

---Before--
<img width="1439" alt="Screenshot 2024-04-10 at 12 16 18 PM" src="https://github.com/openshift/console/assets/102503482/9fd20c4c-49af-49a0-8d94-53fc3a466e82">



--After--
<img width="1440" alt="Screenshot 2024-04-10 at 12 09 12 PM" src="https://github.com/openshift/console/assets/102503482/350d9154-052c-46b4-a311-2ac78ced363e">


**Unit test coverage report**: 
NA

**Test setup:**

    1. Create a TaskRun and go to details page


     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge