### PR TITLE
ODC-7535,ODC-7438: web-terminal automation improvement

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/webterminal-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/webterminal-po.ts
@@ -3,16 +3,17 @@ export const webTerminalPO = {
   terminalWindow: 'canvas.xterm-cursor-layer',
   terminalWindowWithEnabledMouseEvent: 'div.xterm-screen>canvas.xterm-cursor-layer',
   terminalOpenInNewTabBtn: "a[href='/terminal']",
-  terminalCloseWindowBtn: "button[aria-label='Close terminal']",
+  terminalCloseWindowBtn: "button[data-test='close-terminal-icon']",
   terminalInnactivityMessageArea: 'div.co-cloudshell-exec__error-msg',
   createProjectMenu: {
-    createProjectDropdownMenu: 'button#form-ns-dropdown-namespace-field',
-    createProjectButton: 'button#\\#CREATE_NAMESPACE_KEY\\#-link',
+    createProjectDropdownMenu: '[data-test-id="namespace-bar-dropdown"] [type="button"]',
+    createProjectButton: '[data-test-dropdown-menu="#CREATE_RESOURCE_ACTION#"]',
     selectProjectField: 'input#form-input-newNamespace-field',
+    inputField: 'dropdown-text-filter',
   },
 
   projectNameMenu: {
-    projectNameField: 'input#form-input-newNamespace-field',
+    projectNameField: '[data-test="input-name"]',
   },
   closeTerminalDialog: {},
 };

--- a/frontend/packages/webterminal-plugin/integration-tests/features/web-terminal/web-teminal-basic.feature
+++ b/frontend/packages/webterminal-plugin/integration-tests/features/web-terminal/web-teminal-basic.feature
@@ -8,20 +8,23 @@ Feature: Web Terminal
               And user has logged in as basic user
               And user has created or selected namespace "aut-terminal-basic"
 
-        @regression @to-do
+        @regression
         Scenario: Open existing Web Terminal instance: WT-01-TC01
              When user clicks on the Web Terminal icon on the Masthead
+              And user clicks advanced option for Timeout
+              And user sets timeout to 1 Minute
+              And user clicks on Start button
              Then user will see the terminal window
               And user close current Web Terminal session
 
-        @regression @to-do
+        @regression
         Scenario: Web Terminal in new tab: WT-01-TC02
             Given user can see terminal icon on masthead
              When user clicks on the Web Terminal icon on the Masthead
               And user clicks on Open Terminal in new tab button on the terminal window
              Then user will see the terminal window opened in new tab
 
-        @regression @to-do
+        @regression
         Scenario: Web Terminal is stopped by inactivity: WT-01-TC03
             Given user can see terminal icon on masthead
              When user clicks on the Web Terminal icon on the Masthead

--- a/frontend/packages/webterminal-plugin/integration-tests/features/web-terminal/web-terminal-devuser.feature
+++ b/frontend/packages/webterminal-plugin/integration-tests/features/web-terminal/web-terminal-devuser.feature
@@ -13,21 +13,22 @@ Feature: Web Terminal for Developer user
               # in existed project
               And user has created or selected namespace "aut-terminal-testuser-existed"
 
-        @regression @to-do @odc-6745
+        @regression @odc-6745
         Scenario: Create new project and use Web Terminal: WT-03-TC01
             Given user can see terminal icon on masthead
-             When user clicks on the Web Terminal icon on the Masthead
-              And user selects Create Project from Project drop down menu
+             When user selects Create Project from Project drop down menu
               And user enters project name "aut-terminal-testuser"
+              And user clicks on the Web Terminal icon on the Masthead
               And user clicks advanced option for Timeout
               And user sets timeout to 1 Minute
               And user clicks on Start button
              Then user will see the terminal window
              Then user will see the terminal instance for developer namespace "aut-terminal-testuser"
 
-        @regression @to-do
+        @regression
         Scenario: Open Web Terminal for existing project WT-03-TC02
             Given user can see terminal icon on masthead
              When user clicks on the Web Terminal icon on the Masthead
+              And user clicks on Start button
               And user selects "aut-terminal-testuser-existed" from Project drop down menu
              Then user will see the terminal instance for developer namespace "aut-terminal-testuser-existed"

--- a/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/pages/web-terminal/initTerminal-page.ts
+++ b/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/pages/web-terminal/initTerminal-page.ts
@@ -1,9 +1,11 @@
 import { formPO } from '@console/dev-console/integration-tests/support/pageObjects';
 import { webTerminalPO } from '@console/dev-console/integration-tests/support/pageObjects/webterminal-po';
+import { app } from '@console/dev-console/integration-tests/support/pages/app';
 
 export const initTerminalPage = {
-  clickOnProjectDropDawn: () => {
-    cy.get(webTerminalPO.createProjectMenu.createProjectDropdownMenu).click();
+  clickOnProjectDropDown: () => {
+    app.waitForDocumentLoad();
+    cy.get(webTerminalPO.createProjectMenu.createProjectDropdownMenu).click('center');
   },
 
   selectCreateProjectButton: () => {
@@ -19,18 +21,21 @@ export const initTerminalPage = {
   },
 
   selectProject: (projectName: string) => {
-    cy.get(`a#${projectName}-link`).click();
+    cy.byTestID(webTerminalPO.createProjectMenu.inputField)
+      .type(projectName)
+      .should('have.value', projectName);
+    cy.byTestID('dropdown-menu-item-link').contains(projectName).click();
   },
 
   createAndStartTerminalInNewProject: (projectName: string) => {
-    initTerminalPage.clickOnProjectDropDawn();
+    initTerminalPage.clickOnProjectDropDown();
     initTerminalPage.selectCreateProjectButton();
     initTerminalPage.typeProjectName(projectName);
     initTerminalPage.clickStartButton();
   },
 
   startTerminalInExistedProject: (projectName: string) => {
-    initTerminalPage.clickOnProjectDropDawn();
+    initTerminalPage.clickOnProjectDropDown();
     initTerminalPage.selectProject(projectName);
     initTerminalPage.clickStartButton();
   },

--- a/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/web-terminal/web-Terminal-devuser.ts
+++ b/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/web-terminal/web-Terminal-devuser.ts
@@ -3,32 +3,37 @@ import {
   devWorkspaceStatuses,
   switchPerspective,
 } from '@console/dev-console/integration-tests/support/constants';
-import {
-  projectNameSpace,
-  perspective,
-} from '@console/dev-console/integration-tests/support/pages';
+import { webTerminalPO } from '@console/dev-console/integration-tests/support/pageObjects/webterminal-po';
+import { perspective } from '@console/dev-console/integration-tests/support/pages';
 import { devWorkspacePage } from '@console/dev-console/integration-tests/support/pages/devworspace/devworkspacePage';
 import { searchResource } from '@console/dev-console/integration-tests/support/pages/search-resources/search-page';
 import { initTerminalPage } from '@console/webterminal-plugin/integration-tests/support/step-definitions/pages/web-terminal/initTerminal-page';
 
 When('user selects Create Project from Project drop down menu', () => {
-  initTerminalPage.clickOnProjectDropDawn();
+  initTerminalPage.clickOnProjectDropDown();
   initTerminalPage.selectCreateProjectButton();
 });
 
 When('user enters project name {string}', (projectName: string) => {
   initTerminalPage.typeProjectName(projectName);
+  cy.byTestID('confirm-action').click();
 });
 
 When('user clicks on Start button', () => {
   initTerminalPage.clickStartButton();
 });
+
 Then(
   'user will see the terminal instance for developer namespace {string}',
   (nameSpace: string) => {
-    projectNameSpace.selectProject(nameSpace);
+    initTerminalPage.clickOnProjectDropDown();
+    cy.byTestID(webTerminalPO.createProjectMenu.inputField)
+      .type(nameSpace)
+      .should('have.value', nameSpace);
+    cy.byTestID('dropdown-menu-item-link').contains(nameSpace).click();
     perspective.switchTo(switchPerspective.Administrator);
     searchResource.searchResourceByNameAsAdmin('DevWorkspace');
+    cy.get('div').contains('Resources').click();
     searchResource.selectSearchedItem('terminal');
     devWorkspacePage.verifyDevWsResourceStatus(devWorkspaceStatuses.running);
     cy.exec(`oc delete namespace ${nameSpace}`, { failOnNonZeroExit: true });
@@ -36,7 +41,6 @@ Then(
 );
 
 When('user selects {string} from Project drop down menu', (projectName: string) => {
-  initTerminalPage.clickOnProjectDropDawn();
+  initTerminalPage.clickOnProjectDropDown();
   initTerminalPage.selectProject(projectName);
-  initTerminalPage.clickStartButton();
 });

--- a/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/web-terminal/web-teminal-basic.ts
+++ b/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/web-terminal/web-teminal-basic.ts
@@ -1,5 +1,10 @@
-import { When, Then, And } from 'cypress-cucumber-preprocessor/steps';
+import { When, Then, And, Given } from 'cypress-cucumber-preprocessor/steps';
+import { verifyAndInstallWebTerminalOperator } from '@console/dev-console/integration-tests/support/pages';
 import { webTerminalPage } from '@console/webterminal-plugin/integration-tests/support/step-definitions/pages/web-terminal/webTerminal-page';
+
+Given('user with basic rights has installed Web Terminal operator', () => {
+  verifyAndInstallWebTerminalOperator();
+});
 
 When('user clicks on Open Terminal in new tab button on the terminal window', () => {
   webTerminalPage.verifyOpenInNewTabButton();

--- a/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/web-terminal/web-terminal-adminuser.ts
+++ b/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/web-terminal/web-terminal-adminuser.ts
@@ -33,9 +33,7 @@ When('user clicks on the Web Terminal icon on the Masthead', () => {
 });
 
 When('user clicks advanced option for Timeout', () => {
-  cy.get('[role="tabpanel"] button.pf-v5-c-button.pf-m-link.pf-m-inline')
-    .contains('Timeout')
-    .click();
+  cy.get('[role="tabpanel"] button').contains('Timeout').click();
 });
 
 When('user sets timeout to 1 Minute', () => {


### PR DESCRIPTION
**Description:**

- Automation improvement for web-terminal package

**Jira Id:**
- Story: 
      -  [ODC-7535](https://issues.redhat.com/browse/ODC-7535) [ODC-7438](https://issues.redhat.com/browse/ODC-7438)

**Checks for approving Epic scenarios Automation PR:**
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.13-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p webterminal
```

**Screen shots**:
![Screenshot 2024-04-11 at 12 19 30 PM](https://github.com/openshift/console/assets/51144829/e7369644-6676-43b1-a896-6ac489a2c763)

