### PR TITLE
OCPBUGS-32117: Add flag to hide Output tab contributed by pipelines-plugin

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -1298,7 +1298,7 @@
     },
     "flags": {
       "required": ["OPENSHIFT_PIPELINE"],
-      "disallowed": ["CONSOLE_PIPELINE_PLUGIN"]
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINERUN_DETAIL_OUTPUT_TAB"]
     }
   },
   {
@@ -1320,7 +1320,7 @@
     },
     "flags": {
       "required": ["OPENSHIFT_PIPELINE"],
-      "disallowed": ["CONSOLE_PIPELINE_PLUGIN"]
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINERUN_DETAIL_OUTPUT_TAB"]
     }
   }
 ]


### PR DESCRIPTION
Descriptions: Add a flag to hide the Output tab on PipelineRun details page contributed by pipelines-plugin