### PR TITLE
OCPBUGS-32189: Fix PatternFly version resolution check script for MacOS

### DIFF
--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -119,7 +119,7 @@
 "@openshift-console/dynamic-plugin-sdk-webpack@file:../frontend/packages/console-dynamic-plugin-sdk/dist/webpack":
   version "0.0.0-fixed"
   dependencies:
-    "@openshift/dynamic-plugin-sdk-webpack" "^4.0.1"
+    "@openshift/dynamic-plugin-sdk-webpack" "^4.0.2"
     ajv "^6.12.3"
     chalk "2.4.x"
     comment-json "4.x"
@@ -156,10 +156,10 @@
     sanitize-html "^2.3.2"
     showdown "1.8.6"
 
-"@openshift/dynamic-plugin-sdk-webpack@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@openshift/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-4.0.1.tgz#5d9956f12234fd50854868744b947a4a1009406a"
-  integrity sha512-ZlY57t1WIl8B8XNPoq+CuU/+Ll4/ZX/7IO/dxn+7dp1S/NUmdvgwv01mXpUcjviOUhhgWl/dK2WvCQTzz6CoZg==
+"@openshift/dynamic-plugin-sdk-webpack@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@openshift/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-4.0.2.tgz#0304911c9c27ecff7ba5d2df5ca24f781fd445ec"
+  integrity sha512-zgRLt9WM63aGYygrQEtd8QtWoP5zYWr67kzlRKzGcHeRbWDgiHnY7FOiDUM04bYeb4lL6qv3iErEnrtvVpyh0Q==
   dependencies:
     lodash "^4.17.21"
     semver "^7.3.7"

--- a/frontend/scripts/check-patternfly-modules.sh
+++ b/frontend/scripts/check-patternfly-modules.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-COL_RESET='\e[0m'
-COL_RED='\e[0;31m'
-COL_GREEN='\e[0;32m'
-COL_YELLOW='\e[0;33m'
+COL_RESET='\033[0m'
+COL_RED='\033[31m'
+COL_GREEN='\033[32m'
+COL_YELLOW='\033[33m'
 
 resolution_errors=false
 
@@ -15,7 +15,7 @@ resolution_errors=false
 # proper JSON output. We should revisit this code once we upgrade to a newer Yarn version.
 check-resolution() {
   local PKG_NAME="${1:?Provide package name to check}"
-  local RES_COUNT=$(grep -Pc "^\"${PKG_NAME}@" yarn.lock)
+  local RES_COUNT=$(grep -c "^\"${PKG_NAME}@" yarn.lock)
 
   if [[ $RES_COUNT -eq 0 ]]; then
     echo -e "${COL_RED}${PKG_NAME}${COL_RESET} has no version resolutions"


### PR DESCRIPTION
Modified the grep command not to use `-P, --perl-regexp` option (Perl-compatible regex aka PCRE) since that seems to be [unsupported](https://stackoverflow.com/questions/77662026/grep-invalid-option-p-error-when-doing-regex-in-bash-script) by MacOS version of the grep binary.

The pattern `^\"${PKG_NAME}@` is very simple and therefore no need for neither `-P, --perl-regexp` nor `-E, --extended-regexp` options to be enabled.

Also modified color escape sequences - the `\033[XXXm` format should be ANSI compatible and should work on MacOS.

This PR also updates the `yarn.lock` file of dynamic demo plugin to match the current dependency resolutions.