### PR TITLE
CONSOLE-3939: Display a warning message from kube-apiserver when creating / updating workloads resource

### DIFF
--- a/frontend/packages/console-app/src/components/admission-webhook-warnings/AdmissionWebhookWarningNotifications.tsx
+++ b/frontend/packages/console-app/src/components/admission-webhook-warnings/AdmissionWebhookWarningNotifications.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { AlertVariant } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore-next-line
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  AdmissionWebhookWarning,
+  CoreState,
+  getAdmissionWebhookWarnings,
+  removeAdmissionWebhookWarning,
+} from '@console/dynamic-plugin-sdk/src';
+import { documentationURLs, getDocumentationURL } from '@console/internal/components/utils';
+import { useToast } from '@console/shared/src';
+
+type UseAdmissionWebhookWarnings = () => Map<string, AdmissionWebhookWarning>;
+const useAdmissionWebhookWarnings: UseAdmissionWebhookWarnings = () =>
+  useSelector<CoreState, Map<string, AdmissionWebhookWarning>>(getAdmissionWebhookWarnings);
+
+export const AdmissionWebhookWarningNotifications = () => {
+  const { t } = useTranslation();
+  const toastContext = useToast();
+  const dispatch = useDispatch();
+  const admissionWebhookWarnings = useAdmissionWebhookWarnings();
+  React.useEffect(() => {
+    const docURL = getDocumentationURL(documentationURLs.admissionWebhookWarning);
+    admissionWebhookWarnings.forEach((warning, id) => {
+      toastContext.addToast({
+        variant: AlertVariant.warning,
+        title: t('public~Admission Webhook Warning'),
+        content: t(`{{kind}} {{name}} violates policy {{warning}}`, {
+          kind: warning.kind,
+          name: warning.name,
+          warning: warning.warning,
+        }),
+        actions: [
+          {
+            dismiss: true,
+            label: t('public~Learn more'),
+            callback: () => {
+              window.open(docURL, '_blank');
+            },
+            component: 'a',
+            dataTest: 'admission-webhook-warning-learn-more',
+          },
+        ],
+        timeout: true,
+        dismissible: true,
+      });
+      dispatch(removeAdmissionWebhookWarning(id));
+    });
+  }, [dispatch, admissionWebhookWarnings, t, toastContext]);
+
+  return null;
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -1203,13 +1203,12 @@ A custom wrapper around `fetch` that adds console-specific headers and allows fo
 | `method` | The HTTP method to use. Defaults to GET |
 | `options` | The options to pass to fetch |
 | `timeout` | The timeout in milliseconds |
-| `isEntireResponse` | The flag to control whether to return the entire content of the response or response body. The default is the response body. |
 
 
 
 ### Returns
 
-A promise that resolves to the response as text, response JSON object or entire content of the HTTP response.
+A promise that resolves to the response as text or JSON object.
 
 
 ---
@@ -1230,13 +1229,12 @@ A custom wrapper around `fetch` that adds console-specific headers and allows fo
 | `url` | The URL to fetch |
 | `options` | The options to pass to fetch |
 | `timeout` | The timeout in milliseconds |
-| `isEntireResponse` | The flag to control whether to return the entire content of the response or response body. The default is the response body. |
 
 
 
 ### Returns
 
-A promise that resolves to the response as text, response JSON object or entire content of the HTTP response.
+A promise that resolves to the response as text or JSON object.
 
 
 ---

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/actions/core.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/actions/core.ts
@@ -1,22 +1,30 @@
 import { action, ActionType as Action } from 'typesafe-actions';
 import { UserInfo } from '../../../extensions';
+import { AdmissionWebhookWarning } from '../../redux-types';
 
 export enum ActionType {
   SetUser = 'setUser',
   BeginImpersonate = 'beginImpersonate',
   EndImpersonate = 'endImpersonate',
   SetActiveCluster = 'setActiveCluster',
+  SetAdmissionWebhookWarning = 'setAdmissionWebhookWarning',
+  RemoveAdmissionWebhookWarning = 'removeAdmissionWebhookWarning',
 }
 
 export const setUser = (userInfo: UserInfo) => action(ActionType.SetUser, { userInfo });
 export const beginImpersonate = (kind: string, name: string, subprotocols: string[]) =>
   action(ActionType.BeginImpersonate, { kind, name, subprotocols });
 export const endImpersonate = () => action(ActionType.EndImpersonate);
-
+export const setAdmissionWebhookWarning = (id: string, warning: AdmissionWebhookWarning) =>
+  action(ActionType.SetAdmissionWebhookWarning, { id, warning });
+export const removeAdmissionWebhookWarning = (id) =>
+  action(ActionType.RemoveAdmissionWebhookWarning, { id });
 const coreActions = {
   setUser,
   beginImpersonate,
   endImpersonate,
+  setAdmissionWebhookWarning,
+  removeAdmissionWebhookWarning,
 };
 
 export type CoreAction = Action<typeof coreActions>;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/__tests__/core.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/__tests__/core.spec.ts
@@ -1,16 +1,22 @@
-import { CoreState } from '../../../redux-types';
+import { Map as ImmutableMap } from 'immutable';
+import { AdmissionWebhookWarning, CoreState } from '../../../redux-types';
 import { setUser, beginImpersonate, endImpersonate } from '../../actions/core';
 import { coreReducer } from '../core';
 import reducerTest from './utils/reducerTest';
 
 describe('Core Reducer', () => {
-  const state: CoreState = {};
+  const state: CoreState = {
+    user: {},
+    admissionWebhookWarnings: ImmutableMap<string, AdmissionWebhookWarning>(),
+  };
+  const mockAdmissionWebhookWarnings = ImmutableMap({});
 
   it('set user', () => {
     const mockUser = {
       username: 'kube:admin',
     };
     reducerTest(coreReducer, state, setUser(mockUser)).expectVal({
+      admissionWebhookWarnings: mockAdmissionWebhookWarnings,
       user: mockUser,
     });
   });
@@ -21,6 +27,8 @@ describe('Core Reducer', () => {
       state,
       beginImpersonate('User', 'developer', ['Impersonate-User.Y29uc29sZWRldmVsb3Blcg__']),
     ).expectVal({
+      user: {},
+      admissionWebhookWarnings: mockAdmissionWebhookWarnings,
       impersonate: {
         kind: 'User',
         name: 'developer',
@@ -30,6 +38,9 @@ describe('Core Reducer', () => {
   });
 
   it('end Impersonate', () => {
-    reducerTest(coreReducer, state, endImpersonate()).expectVal({});
+    reducerTest(coreReducer, state, endImpersonate()).expectVal({
+      admissionWebhookWarnings: mockAdmissionWebhookWarnings,
+      user: {},
+    });
   });
 });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/core.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/core.ts
@@ -1,4 +1,5 @@
-import { CoreState } from '../../redux-types';
+import { Map as ImmutableMap } from 'immutable';
+import { AdmissionWebhookWarning, CoreState } from '../../redux-types';
 import { ActionType, CoreAction } from '../actions/core';
 
 /**
@@ -10,7 +11,13 @@ import { ActionType, CoreAction } from '../actions/core';
  * @see CoreAction
  * @returns The the updated state.
  */
-export const coreReducer = (state: CoreState = { user: {} }, action: CoreAction): CoreState => {
+export const coreReducer = (
+  state: CoreState = {
+    user: {},
+    admissionWebhookWarnings: ImmutableMap<string, AdmissionWebhookWarning>(),
+  },
+  action: CoreAction,
+): CoreState => {
   switch (action.type) {
     case ActionType.BeginImpersonate:
       return {
@@ -21,7 +28,6 @@ export const coreReducer = (state: CoreState = { user: {} }, action: CoreAction)
           subprotocols: action.payload.subprotocols,
         },
       };
-
     case ActionType.EndImpersonate: {
       const stateKeys = Object.keys(state);
       return stateKeys.reduce((acc, key) => {
@@ -41,6 +47,19 @@ export const coreReducer = (state: CoreState = { user: {} }, action: CoreAction)
         user: action.payload.userInfo,
       };
 
+    case ActionType.SetAdmissionWebhookWarning:
+      return {
+        ...state,
+        admissionWebhookWarnings: state.admissionWebhookWarnings.set(
+          action.payload.id,
+          action.payload.warning,
+        ),
+      };
+    case ActionType.RemoveAdmissionWebhookWarning:
+      return {
+        ...state,
+        admissionWebhookWarnings: state.admissionWebhookWarnings.remove(action.payload.id),
+      };
     default:
       return state;
   }

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/coreSelectors.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/coreSelectors.ts
@@ -1,8 +1,12 @@
+import { Map as ImmutableMap } from 'immutable';
 import { UserInfo } from '../../../extensions';
-import { ImpersonateKind, SDKStoreState } from '../../redux-types';
+import { ImpersonateKind, SDKStoreState, AdmissionWebhookWarning } from '../../redux-types';
 
 type GetImpersonate = (state: SDKStoreState) => ImpersonateKind;
 type GetUser = (state: SDKStoreState) => UserInfo;
+type GetAdmissionWebhookWarnings = (
+  state: SDKStoreState,
+) => ImmutableMap<string, AdmissionWebhookWarning>;
 
 /**
  * It provides impersonation details from the redux store.
@@ -26,3 +30,11 @@ export const impersonateStateToProps = (state: SDKStoreState) => {
  * @returns The the user state.
  */
 export const getUser: GetUser = (state) => state.sdkCore.user;
+
+/**
+ * It provides admission webhook warning data from the redux store.
+ * @param state the root state
+ * @returns The the admissionWebhookWarning state.
+ */
+export const getAdmissionWebhookWarnings: GetAdmissionWebhookWarnings = (state) =>
+  state.sdkCore.admissionWebhookWarnings;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/redux-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/redux-types.ts
@@ -3,6 +3,11 @@ import { UserInfo } from '../extensions/console-types';
 
 export type K8sState = ImmutableMap<string, any>;
 
+export type AdmissionWebhookWarning = {
+  kind: string;
+  name: string;
+  warning: string;
+};
 export type ImpersonateKind = {
   kind: string;
   name: string;
@@ -12,6 +17,7 @@ export type ImpersonateKind = {
 export type CoreState = {
   user?: UserInfo;
   impersonate?: ImpersonateKind;
+  admissionWebhookWarnings?: ImmutableMap<string, AdmissionWebhookWarning>;
 };
 
 export type SDKStoreState = {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -266,39 +266,14 @@ export type ConsoleFetch = (
   url: string,
   options?: RequestInit,
   timeout?: number,
-  isEntireResponse?: boolean,
 ) => Promise<Response>;
 
 export type ConsoleFetchJSON<T = any> = {
-  (
-    url: string,
-    method?: string,
-    options?: RequestInit,
-    timeout?: number,
-    isEntireResponse?: boolean,
-  ): Promise<T>;
+  (url: string, method?: string, options?: RequestInit, timeout?: number): Promise<T>;
   delete(url: string, json?: any, options?: RequestInit, timeout?: number): Promise<T>;
-  post(
-    url: string,
-    json: any,
-    options?: RequestInit,
-    timeout?: number,
-    isEntireResponse?: boolean,
-  ): Promise<T>;
-  put(
-    url: string,
-    json: any,
-    options?: RequestInit,
-    timeout?: number,
-    isEntireResponse?: boolean,
-  ): Promise<T>;
-  patch(
-    url: string,
-    json: any,
-    options?: RequestInit,
-    timeout?: number,
-    isEntireResponse?: boolean,
-  ): Promise<T>;
+  post(url: string, json: any, options?: RequestInit, timeout?: number): Promise<T>;
+  put(url: string, json: any, options?: RequestInit, timeout?: number): Promise<T>;
+  patch(url: string, json: any, options?: RequestInit, timeout?: number): Promise<T>;
 };
 
 export type ConsoleFetchText<T = any> = (...args: Parameters<ConsoleFetch>) => Promise<T>;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-resource.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-resource.ts
@@ -51,7 +51,6 @@ const adapterFunc: AdapterFunc = (func: Function, knownArgs: string[]) => {
  * @param ns The namespace to look into, should not be specified for cluster-scoped resources.
  * @param opts The options to pass
  * @param requestInit The fetch init object to use. This can have request headers, method, redirect, etc.
- * @param isEntireResponse The flag to cotrol whether to return full or partial response. The default is partial.
  * See more at https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.requestinit.html
  * @returns A promise that resolves to the response as JSON object with a resource if the name is provided
  * else it returns all the resouces matching the model. In case of failure, the promise gets rejected with HTTP error response.
@@ -97,7 +96,6 @@ export const k8sGetResource: K8sGetResource = adapterFunc(k8sGet, [
  * @param model Kubernetes model
  * @param data The payload for the resource to be created.
  * @param opts The options to pass.
- * @param isEntireResponse The flag to control whether to return the entire content of the response or response body. The default is the response body.
  * @returns A promise that resolves to the response of the resource created.
  * In case of failure promise gets rejected with HTTP error response.
  */
@@ -105,14 +103,12 @@ export const k8sCreate = <R extends K8sResourceCommon>(
   model: K8sModel,
   data: R,
   opts: Options = {},
-  isEntireResponse?: boolean,
 ) => {
   return coFetchJSON.post(
     resourceURL(model, Object.assign({ ns: data?.metadata?.namespace }, opts)),
     data,
     null,
     null,
-    isEntireResponse,
   );
 };
 
@@ -149,7 +145,6 @@ export const k8sCreateResource: K8sCreateResource = adapterFunc(k8sCreate, [
  * @param ns namespace to look into, it should not be specified for cluster-scoped resources.
  * @param name resource name to be updated.
  * @param opts The options to pass
- * @param isEntireResponse The flag to control whether to return the entire content of the response or response body. The default is the response body.
  * @returns A promise that resolves to the response of the resource updated.
  * In case of failure promise gets rejected with HTTP error response.
  */
@@ -159,7 +154,6 @@ export const k8sUpdate = <R extends K8sResourceCommon>(
   ns?: string,
   name?: string,
   opts?: Options,
-  isEntireResponse?: boolean,
 ): Promise<R> =>
   coFetchJSON.put(
     resourceURL(model, {
@@ -170,7 +164,6 @@ export const k8sUpdate = <R extends K8sResourceCommon>(
     data,
     null,
     null,
-    isEntireResponse,
   );
 
 type OptionsUpdate<R> = BaseOptions & {
@@ -211,7 +204,6 @@ export const k8sUpdateResource: K8sUpdateResource = adapterFunc(k8sUpdate, [
  * @param resource The resource to be patched
  * @param data Only the data to be patched on existing resource with the operation, path, and value
  * @param opts The options to pass
- * @param isEntireResponse The flag to control whether to return the entire content of the response or response body. The default is the response body.
  * @returns A promise that resolves to the response of the resource patched.
  * In case of failure promise gets rejected with HTTP error response.
  */
@@ -220,7 +212,6 @@ export const k8sPatch = <R extends K8sResourceCommon>(
   resource: R,
   data: Patch[],
   opts: Options = {},
-  isEntireResponse?: boolean,
 ) => {
   const patches = _.compact(data);
 
@@ -242,7 +233,6 @@ export const k8sPatch = <R extends K8sResourceCommon>(
     patches,
     null,
     null,
-    isEntireResponse,
   );
 };
 

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -69,6 +69,7 @@ const NOTIFICATION_DRAWER_BREAKPOINT = 1800;
 import 'url-search-params-polyfill';
 import { withoutSensitiveInformations, getTelemetryTitle } from './utils/telemetry';
 import { graphQLReady } from '../graphql/client';
+import { AdmissionWebhookWarningNotifications } from '@console/app/src/components/admission-webhook-warnings/AdmissionWebhookWarningNotifications';
 
 initI18n();
 
@@ -597,6 +598,7 @@ graphQLReady.onReady(() => {
           >
             <ToastProvider>
               <PollConsoleUpdates />
+              <AdmissionWebhookWarningNotifications />
               <AppRouter />
             </ToastProvider>
           </AppInitSDK>

--- a/frontend/public/components/utils/documentation.tsx
+++ b/frontend/public/components/utils/documentation.tsx
@@ -85,6 +85,11 @@ export const documentationURLs: documentationURLsType = {
     downstream: 'html/building_applications/deployments',
     upstream: 'applications/deployments/what-deployments-are.html',
   },
+  admissionWebhookWarning: {
+    downstream: 'html/architecture/admission-plug-ins',
+    kube: `${KUBE_DOCS}/reference/access-authn-authz/extensible-admission-controllers/#response`,
+    upstream: 'architecture/index.html#about-admission-plug-ins',
+  },
 };
 
 export const isUpstream = () => window.SERVER_FLAGS.branding === 'okd';

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1952,6 +1952,8 @@
   "HTTP GET": "HTTP GET",
   "TCP socket (port)": "TCP socket (port)",
   "Default pull Secret_plural": "Default pull Secret_plural",
+  "Admission Webhook Warning": "Admission Webhook Warning",
+  "{{kind}} {{name}} violates policy {{warning}}": "{{kind}} {{name}} violates policy {{warning}}",
   "Are you sure you want to remove <1>{{label}}</1> from navigation?": "Are you sure you want to remove <1>{{label}}</1> from navigation?",
   "Refer to your cluster administrator to know which network provider is used.": "Refer to your cluster administrator to know which network provider is used.",
   "Input error: selectors must start and end by a letter or number, and can only contain -, _, / or . Offending value: {{offendingSelector}}": "Input error: selectors must start and end by a letter or number, and can only contain -, _, / or . Offending value: {{offendingSelector}}",


### PR DESCRIPTION

Steps to verify the warn policy.
1.  Create a Validation Admission Webhook to enforce a warn policy for resource i.e. Pod . For example, you can follow the steps in my [GIst](https://gist.github.com/cyril-ui-developer/8af3a0e20cb0a743ec07178e40d3a717)
2. Create the resource specified in the warn policy in step 1  i.e. Pod using Create YAML editor to see the notification alert.
Note: This change covers Import YAML editor for all resources and certain resources i.e. Pod that fully makes use of the Create YAML Editor code implementation in - https://github.com/openshift/console/blob/master/frontend/public/components/edit-yaml.jsx. 

### After:

**Scenario 1:**
![Screenshot 2024-04-01 at 2 29 53 PM](https://github.com/openshift/console/assets/15249132/2eb12012-f880-4abd-abaf-3b036eda967b)
![Screenshot 2024-04-01 at 2 30 02 PM](https://github.com/openshift/console/assets/15249132/af08bec6-3ff0-4154-8f89-9a7bce8b29ba)

**Scenario 2:**
![Screenshot 2024-04-01 at 2 34 47 PM](https://github.com/openshift/console/assets/15249132/2ff6a818-ef55-4c1b-8b65-c88321b22525)
![Screenshot 2024-04-01 at 2 34 57 PM](https://github.com/openshift/console/assets/15249132/eaa5c753-9080-4eba-8f2c-8f592bb50525)


**Scenario 3:**

<img width="1823" alt="Screenshot 2024-04-18 at 12 24 48 PM" src="https://github.com/openshift/console/assets/15249132/81da982a-3ab4-4dbc-b5ae-9439f24913f8">
<img width="1055" alt="Screenshot 2024-04-18 at 12 25 14 PM" src="https://github.com/openshift/console/assets/15249132/fda8da82-5d82-43ad-871b-5a724665c3bf">


**Scenario 4:**

<img width="1320" alt="Screenshot 2024-04-18 at 12 32 48 PM" src="https://github.com/openshift/console/assets/15249132/9208231a-8fd3-4981-abd5-2434f8a7d411">
<img width="1100" alt="Screenshot 2024-04-18 at 12 32 56 PM" src="https://github.com/openshift/console/assets/15249132/2968e668-169a-4555-877c-d38184b50f13">





**Scenario 5:**
![Screenshot 2024-04-22 at 10 22 58 AM](https://github.com/openshift/console/assets/15249132/08b7089c-e584-48b6-9500-6179e7df135c)
![Screenshot 2024-04-22 at 10 23 07 AM](https://github.com/openshift/console/assets/15249132/3fa2d687-73c1-4f88-8f6b-27f7d928eeeb)


### Update a resource
**Scenario 6:**
![Screenshot 2024-04-22 at 10 59 20 AM](https://github.com/openshift/console/assets/15249132/eaf11f9e-8614-4824-8c32-449a20413cc8)
![Screenshot 2024-04-22 at 10 59 27 AM](https://github.com/openshift/console/assets/15249132/041455e6-2920-4959-937f-e799956d3d00)

**Scenario 7:**

![Screenshot 2024-04-22 at 11 01 53 AM](https://github.com/openshift/console/assets/15249132/cb02abe4-77b6-426f-9846-5b5e976d0422)
![Screenshot 2024-04-22 at 11 02 02 AM](https://github.com/openshift/console/assets/15249132/b447e533-9288-42fa-9410-e8453bce05d9)
