### PR TITLE
ODC-7547: Add e2e tests for QuickStarts in CI

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/e2e/add-flow-ci.feature
+++ b/frontend/packages/dev-console/integration-tests/features/e2e/add-flow-ci.feature
@@ -137,3 +137,17 @@ Feature: Create the different workloads from Add page
                   | card_name | form_header               | workload_name |
                   | Httpd     | Create Sample application | httpd-sample  |
                   | Basic Go  | Import from Git           | go-basic      |
+
+        @regression
+        Scenario: Quick Starts page when no Quick Start has started: QS-03-TC02
+             When user clicks on the "View all quick starts" on Build with guided documentation card
+             Then user can see "Get started with a sample application", "Install Red Hat Developer Hub (RHDH) with a Helm Chart" and "Add health checks to your sample application" Quick Starts
+              And user can see time taken to complete the tour on the card
+
+
+        @regression
+        Scenario: Quick Starts page when Quick Start has completed: QS-03-TC03
+            Given user is at Quick Starts catalog page
+              And user has completed "Get started with a sample application" Quick Start
+             Then user can see time taken to complete the "Get started with a sample application" tour on the card
+              And user can see Complete label on "Get started with a sample application" card

--- a/frontend/packages/dev-console/integration-tests/features/guided-tour/quick-starts/quick-start-devperspective.feature
+++ b/frontend/packages/dev-console/integration-tests/features/guided-tour/quick-starts/quick-start-devperspective.feature
@@ -18,7 +18,7 @@ Feature: Build with guided documentation card in developer console
         @regression
         Scenario: Quick Starts page when no Quick Start has started: QS-03-TC02
              When user clicks on the "View all quick starts" on Build with guided documentation card
-             Then user can see "Get started with a sample application", "Install the OpenShift Pipelines Operator" and "Add health checks to your sample application" Quick Starts
+             Then user can see "Get started with a sample application", "Install Red Hat Developer Hub (RHDH) with a Helm Chart" and "Add health checks to your sample application" Quick Starts
               And user can see time taken to complete the tour on the card
 
 

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/quck-starts/quick-start-devperspective.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/quck-starts/quick-start-devperspective.ts
@@ -29,20 +29,23 @@ When('user clicks on the "View all quick starts" on Build with guided documentat
 Then(
   'user can see {string}, {string} and {string} Quick Starts',
   (quickStartDisplayName1, quickStartDisplayName2, quickStartDisplayName3) => {
-    cy.get(quickStartCard(quickStartDisplayName1)).should('be.visible');
-    cy.get(quickStartCard(quickStartDisplayName2)).should('be.visible');
-    cy.get(quickStartCard(quickStartDisplayName3)).should('be.visible');
+    cy.get(quickStartCard(quickStartDisplayName1)).scrollIntoView().should('be.visible');
+    cy.get(quickStartCard(quickStartDisplayName2)).scrollIntoView().should('be.visible');
+    cy.get(quickStartCard(quickStartDisplayName3)).scrollIntoView().should('be.visible');
   },
 );
 
 Then('user can see time taken to complete the tour on the card', () => {
   cy.get(quickStartCard('Get started with a sample application'))
+    .scrollIntoView()
     .find(quickStartsPO.duration)
     .should('be.visible');
-  cy.get(quickStartCard('Install the OpenShift Pipelines Operator'))
+  cy.get(quickStartCard('Install Red Hat Developer Hub (RHDH) with a Helm Chart'))
+    .scrollIntoView()
     .find(quickStartsPO.duration)
     .should('be.visible');
   cy.get(quickStartCard('Add health checks to your sample application'))
+    .scrollIntoView()
     .find(quickStartsPO.duration)
     .should('be.visible');
 });


### PR DESCRIPTION
Fix:[ODC-7547](https://issues.redhat.com/browse/ODC-7547)

Description:
Add e2e tests for QuickStarts in CI