### PR TITLE
OBSDOCS-986: Update the Monitoring topic used by the console team

### DIFF
--- a/frontend/public/components/utils/documentation.tsx
+++ b/frontend/public/components/utils/documentation.tsx
@@ -33,7 +33,7 @@ export const documentationURLs: documentationURLsType = {
     downstream:
       'html/monitoring/configuring-the-monitoring-stack#maintenance-and-support_configuring-the-monitoring-stack',
     upstream:
-      'monitoring/configuring-the-monitoring-stack.html#maintenance-and-support_configuring-monitoring',
+      'observability/monitoring/configuring-the-monitoring-stack.html#maintenance-and-support_configuring-monitoring',
   },
   networkPolicy: {
     downstream: 'html/networking/network-policy#about-network-policy',


### PR DESCRIPTION
The downstream monitoring documentation have been currently moved under the Observability folder. For this reason, the downstream link needs to be updated to reflect that change.

* For versions 4.12+

@rhamilto could you PTAL?