### PR TITLE
OCPBUGS-32222: Add warning about service binding operator will not be supported from 4.15

### DIFF
--- a/frontend/packages/console-app/src/components/modals/service-binding/CreateServiceBindingForm.tsx
+++ b/frontend/packages/console-app/src/components/modals/service-binding/CreateServiceBindingForm.tsx
@@ -10,6 +10,7 @@ import {
   ModalSubmitFooter,
 } from '@console/internal/components/factory/modal';
 import { K8sResourceKind } from '@console/internal/module/k8s';
+import { ServiceBindingDeprecationAlertForModals } from '@console/service-binding-plugin/src/components/service-binding-utils/ServiceBindingAlerts';
 import { InputField } from '@console/shared';
 import BindableServices from './BindableServices';
 
@@ -39,6 +40,8 @@ const CreateServiceBindingForm: React.FC<
     <form onSubmit={handleSubmit} className="modal-content">
       <ModalTitle>{t('console-app~Create Service Binding')}</ModalTitle>
       <ModalBody>
+        <ServiceBindingDeprecationAlertForModals />
+        <br />
         <Title headingLevel="h2" size="md" className="co-m-form-row">
           {title}
         </Title>

--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogFilters.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogFilters.tsx
@@ -73,7 +73,9 @@ const CatalogFilters: React.FC<CatalogFiltersProps> = ({
             <>
               {filterGroupMap[groupName].label || groupName}
               {filterGroupMap[groupName].description && (
-                <FieldLevelHelp>{filterGroupMap[groupName].description}</FieldLevelHelp>
+                <FieldLevelHelp>
+                  <p style={{ whiteSpace: 'pre-line' }}>{filterGroupMap[groupName].description}</p>
+                </FieldLevelHelp>
               )}
             </>
           }

--- a/frontend/packages/console-shared/src/components/catalog/details/CatalogDetailsModal.scss
+++ b/frontend/packages/console-shared/src/components/catalog/details/CatalogDetailsModal.scss
@@ -2,4 +2,10 @@
   &__header {
     align-items: baseline;
   }
+
+  &__sbo_alert {
+    margin-left: var(--pf-v5-global--spacer--lg);
+    margin-right: var(--pf-v5-global--spacer--lg);
+    margin-bottom: var(--pf-v5-global--spacer--md);
+  }
 }

--- a/frontend/packages/console-shared/src/components/catalog/details/CatalogDetailsModal.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/details/CatalogDetailsModal.tsx
@@ -4,6 +4,7 @@ import { Split, SplitItem } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
 import { CatalogItem } from '@console/dynamic-plugin-sdk/src/extensions';
+import { ServiceBindingDeprecationAlertForModals } from '@console/service-binding-plugin/src/components/service-binding-utils/ServiceBindingAlerts';
 import { Modal } from '../../modal';
 import CatalogBadges from '../CatalogBadges';
 import useCtaLink from '../hooks/useCtaLink';
@@ -25,13 +26,14 @@ const CatalogDetailsModal: React.FC<CatalogDetailsModalProps> = ({ item, onClose
     return null;
   }
 
-  const { name, title, badges } = item;
+  const { name, title, badges, tags } = item;
 
   const provider = item.provider
     ? t('console-shared~Provided by {{provider}}', { provider: item.provider })
     : null;
 
   const vendor = <div>{provider}</div>;
+  const isBindable = tags?.includes('bindable');
 
   const modalHeader = (
     <>
@@ -70,6 +72,11 @@ const CatalogDetailsModal: React.FC<CatalogDetailsModalProps> = ({ item, onClose
       title={item.name}
       aria-label={item.name}
     >
+      {isBindable && (
+        <div className="odc-catalog-details-modal__sbo_alert">
+          <ServiceBindingDeprecationAlertForModals />
+        </div>
+      )}
       <CatalogDetailsPanel item={item} />
     </Modal>
   );

--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -554,7 +554,7 @@
         {
           "label": "%devconsole~Service binding%",
           "attribute": "bindable",
-          "description": "%devconsole~Bindable services can be easily consumed by applications because they expose their binding data (credentials, connection details, volume mounts, secrets, etc.) in a standard way.%"
+          "description": "%devconsole~Bindable services can be easily consumed by applications because they expose their binding data (credentials, connection details, volume mounts, secrets, etc.) in a standard way.\n\nService Bindings is deprecated with OpenShift 4.15.\n\nService Bindings can still be created and show in the OpenShift web console, but will be removed from a future release, currently planned as OpenShift Container Platform 4.18. You should migrate wherever it is possible.%"
         }
       ]
     },

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -46,7 +46,6 @@
   "Browse for devfiles that support a particular language or framework. Cluster administrators can customize the content made available in the catalog.": "Browse for devfiles that support a particular language or framework. Cluster administrators can customize the content made available in the catalog.",
   "**Devfiles** are sets of objects for creating services, build configurations, and anything you have permission to create within a Project.": "**Devfiles** are sets of objects for creating services, build configurations, and anything you have permission to create within a Project.",
   "Service binding": "Service binding",
-  "Bindable services can be easily consumed by applications because they expose their binding data (credentials, connection details, volume mounts, secrets, etc.) in a standard way.": "Bindable services can be easily consumed by applications because they expose their binding data (credentials, connection details, volume mounts, secrets, etc.) in a standard way.",
   "Console sample": "Console sample",
   "Builder Image": "Builder Image",
   "Devfile": "Devfile",

--- a/frontend/packages/service-binding-plugin/locales/en/service-binding-plugin.json
+++ b/frontend/packages/service-binding-plugin/locales/en/service-binding-plugin.json
@@ -11,5 +11,11 @@
   "Error": "Error",
   "Name": "Name",
   "Namespace": "Namespace",
-  "Created": "Created"
+  "Created": "Created",
+  "Service Bindings is deprecated with OpenShift 4.15 and will be removed from a future release, currently planned as {{productName}} 4.18.": "Service Bindings is deprecated with OpenShift 4.15 and will be removed from a future release, currently planned as {{productName}} 4.18.",
+  "Service Bindings are deprecated": "Service Bindings are deprecated",
+  "Service Bindings is deprecated with {{productName}} 4.15": "Service Bindings is deprecated with {{productName}} 4.15",
+  "Feature development of Service Binding Operator is deprecated in {{productName}} 4.15.": "Feature development of Service Binding Operator is deprecated in {{productName}} 4.15.",
+  "Service Bindings can still be created and shown in the OpenShift web console, but will be removed from a future release, currently planned as {{productName}} 4.18. You should migrate wherever it is possible.": "Service Bindings can still be created and shown in the OpenShift web console, but will be removed from a future release, currently planned as {{productName}} 4.18. You should migrate wherever it is possible.",
+  "Web console support will be removed from a future release, currently planned as {{productName}} 4.18. You should migrate wherever it is possible.": "Web console support will be removed from a future release, currently planned as {{productName}} 4.18. You should migrate wherever it is possible."
 }

--- a/frontend/packages/service-binding-plugin/src/components/service-binding-details/ServiceBindingDetailsPage.tsx
+++ b/frontend/packages/service-binding-plugin/src/components/service-binding-details/ServiceBindingDetailsPage.tsx
@@ -8,6 +8,7 @@ import {
   ActionServiceProvider,
 } from '@console/shared/src/components/actions';
 import { getComputedServiceBindingStatus } from '../../utils';
+import { ServiceBindingDeprecationAlert } from '../service-binding-utils/ServiceBindingAlerts';
 import ServiceBindingDetailsTab from './ServiceBindingDetailsTab';
 
 const ServiceBindingDetailsPage: React.FC<DetailsPageProps> = (props) => {
@@ -36,7 +37,10 @@ const ServiceBindingDetailsPage: React.FC<DetailsPageProps> = (props) => {
       getResourceStatus={getComputedServiceBindingStatus}
       customActionMenu={customActionMenu}
       pages={pages}
-    />
+    >
+      <ServiceBindingDeprecationAlert />
+      <br />
+    </DetailsPage>
   );
 };
 

--- a/frontend/packages/service-binding-plugin/src/components/service-binding-list/ServiceBindingListPage.tsx
+++ b/frontend/packages/service-binding-plugin/src/components/service-binding-list/ServiceBindingListPage.tsx
@@ -7,6 +7,7 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { ServiceBindingModel } from '../../models';
 import { ServiceBinding } from '../../types';
 import { getComputedServiceBindingStatus } from '../../utils';
+import { ServiceBindingDeprecationAlert } from '../service-binding-utils/ServiceBindingAlerts';
 import ServiceBindingTable from './ServiceBindingTable';
 
 type ListPageProps = React.ComponentProps<typeof ListPage>;
@@ -45,6 +46,7 @@ const ServiceBindingListPage: React.FC<ServiceBindingListPageProps> = (props) =>
       ListComponent={ServiceBindingTable}
       rowFilters={filters}
       canCreate
+      helpText={<ServiceBindingDeprecationAlert />}
       {...propsWithoutName}
     />
   );

--- a/frontend/packages/service-binding-plugin/src/components/service-binding-utils/ServiceBindingAlerts.scss
+++ b/frontend/packages/service-binding-plugin/src/components/service-binding-utils/ServiceBindingAlerts.scss
@@ -1,0 +1,5 @@
+.service-binding-alert-modal {  
+    :where(.pf-v5-theme-dark) & {
+      background-color: var(--pf-v5-global--BackgroundColor--400) !important;
+    }
+  }

--- a/frontend/packages/service-binding-plugin/src/components/service-binding-utils/ServiceBindingAlerts.tsx
+++ b/frontend/packages/service-binding-plugin/src/components/service-binding-utils/ServiceBindingAlerts.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { Alert, Label, Popover } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/api/core-api';
+import { K8sResourceCommon } from '@console/internal/module/k8s';
+import { YellowExclamationTriangleIcon } from '@console/shared';
+import { ServiceBindingModel } from '../../models';
+import { getBrandingDetails } from '../../utils';
+import './ServiceBindingAlerts.scss';
+
+export interface ServiceBindingWarningProps {
+  namespace: string;
+}
+
+export const ServiceBindingDeprecationAlertForTopology: React.FC = () => {
+  const { t } = useTranslation();
+  const productDetails = getBrandingDetails();
+  return (
+    <p>
+      {t(
+        'service-binding-plugin~Service Bindings is deprecated with OpenShift 4.15 and will be removed from a future release, currently planned as {{productName}} 4.18.',
+        { productName: productDetails.productName },
+      )}
+    </p>
+  );
+};
+
+export const ServiceBindingWarningForTopology: React.FC<ServiceBindingWarningProps> = ({
+  namespace,
+}) => {
+  const { t } = useTranslation();
+
+  const [serviceBindings, serviceBindingsLoaded] = useK8sWatchResource<K8sResourceCommon[]>({
+    groupVersionKind: {
+      group: ServiceBindingModel.apiGroup,
+      kind: ServiceBindingModel.kind,
+      version: ServiceBindingModel.apiVersion,
+    },
+    isList: true,
+    namespaced: true,
+    namespace,
+  });
+
+  return (
+    <>
+      {serviceBindingsLoaded && serviceBindings?.length > 0 && (
+        <Popover bodyContent={<ServiceBindingDeprecationAlertForTopology />} triggerAction="hover">
+          <Label color="orange" icon={<YellowExclamationTriangleIcon />}>
+            {t('service-binding-plugin~Service Bindings are deprecated')}
+          </Label>
+        </Popover>
+      )}
+    </>
+  );
+};
+
+export const ServiceBindingDeprecationAlert: React.FC = () => {
+  const { t } = useTranslation();
+  const productDetails = getBrandingDetails();
+  return (
+    <Alert
+      isInline
+      variant="info"
+      title={t('service-binding-plugin~Service Bindings is deprecated with {{productName}} 4.15', {
+        productName: window.SERVER_FLAGS.branding === 'OKD' ? 'OKD' : 'OpenShift',
+      })}
+    >
+      <p>
+        {t(
+          'service-binding-plugin~Feature development of Service Binding Operator is deprecated in {{productName}} 4.15.',
+          { productName: productDetails.productName },
+        )}
+      </p>
+      <p>
+        {t(
+          'service-binding-plugin~Service Bindings can still be created and shown in the OpenShift web console, but will be removed from a future release, currently planned as {{productName}} 4.18. You should migrate wherever it is possible.',
+          { productName: productDetails.productName },
+        )}
+      </p>
+    </Alert>
+  );
+};
+
+export const ServiceBindingDeprecationAlertForModals: React.FC = () => {
+  const { t } = useTranslation();
+  const productDetails = getBrandingDetails();
+  return (
+    <Alert
+      isInline
+      variant="info"
+      title={t('service-binding-plugin~Service Bindings is deprecated with {{productName}} 4.15', {
+        productName: window.SERVER_FLAGS.branding === 'OKD' ? 'OKD' : 'OpenShift',
+      })}
+      className="service-binding-alert-modal"
+    >
+      <p>
+        {t(
+          'service-binding-plugin~Web console support will be removed from a future release, currently planned as {{productName}} 4.18. You should migrate wherever it is possible.',
+          { productName: productDetails.productName },
+        )}
+      </p>
+    </Alert>
+  );
+};

--- a/frontend/packages/service-binding-plugin/src/utils.ts
+++ b/frontend/packages/service-binding-plugin/src/utils.ts
@@ -29,3 +29,33 @@ export const getFirstServiceBindingError = (
   );
   return firstError || null;
 };
+
+export const getBrandingDetails = () => {
+  let productName;
+  switch (window.SERVER_FLAGS.branding) {
+    case 'openshift':
+      productName = 'Red Hat OpenShift';
+      break;
+    case 'ocp':
+      productName = 'Red Hat OpenShift';
+      break;
+    case 'online':
+      productName = 'Red Hat OpenShift Online';
+      break;
+    case 'dedicated':
+      productName = 'Red Hat OpenShift Dedicated';
+      break;
+    case 'azure':
+      productName = 'Azure Red Hat OpenShift';
+      break;
+    case 'rosa':
+      productName = 'Red Hat OpenShift Service on AWS';
+      break;
+    default:
+      productName = 'OKD';
+  }
+  if (window.SERVER_FLAGS.customProductName) {
+    productName = window.SERVER_FLAGS.customProductName;
+  }
+  return { productName };
+};

--- a/frontend/packages/topology/src/filters/TopologyFilterBar.tsx
+++ b/frontend/packages/topology/src/filters/TopologyFilterBar.tsx
@@ -21,6 +21,7 @@ import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s
 import { requirementFromString } from '@console/internal/module/k8s/selector-requirement';
 import { getActiveNamespace } from '@console/internal/reducers/ui';
 import { RootState } from '@console/internal/redux';
+import { ServiceBindingWarningForTopology } from '@console/service-binding-plugin/src/components/service-binding-utils/ServiceBindingAlerts';
 import { useFlag, useQueryParams } from '@console/shared';
 import ExportApplication from '../components/export-app/ExportApplication';
 import TopologyQuickSearchButton from '../components/quick-search/TopologyQuickSearchButton';
@@ -199,6 +200,9 @@ const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
           variant={ToolbarGroupVariant['button-group']}
           align={{ default: 'alignRight' }}
         >
+          <ToolbarItem>
+            <ServiceBindingWarningForTopology namespace={namespace} />
+          </ToolbarItem>
           <ToolbarItem
             className={
               isExportApplicationEnabled || kialiLink


### PR DESCRIPTION
**Issue**: https://issues.redhat.com/browse/OCPBUGS-32222

**To Test**:
You can test the product name using window.SERVER_FLAGS.branding or in local using `./bin/bridge -branding 'openshift'` 

**Screenshots**:

---Topology Page---

<img width="1439" alt="Screenshot 2024-04-17 at 11 27 03 AM" src="https://github.com/openshift/console/assets/102503482/001627e6-77f3-49f3-8e74-a947e6e1a714">
<img width="1440" alt="Screenshot 2024-04-17 at 11 27 23 AM" src="https://github.com/openshift/console/assets/102503482/3ff21a43-2341-4894-a3dd-96e12caf05f4">
<img width="1443" alt="Screenshot 2024-04-17 at 11 28 40 AM" src="https://github.com/openshift/console/assets/102503482/9af492dd-3156-4874-ac64-c3c77d0f23ef">
<img width="1445" alt="Screenshot 2024-04-17 at 11 29 21 AM" src="https://github.com/openshift/console/assets/102503482/7e3d2384-07f3-4a9b-baef-1951cd3e479b">

---Service Binding list page---

<img width="1728" alt="Screenshot 2024-04-17 at 11 29 41 AM" src="https://github.com/openshift/console/assets/102503482/30cc4978-1c74-43ad-95b0-38fdfb3b9237">

---Service Binding details page---


<img width="1726" alt="Screenshot 2024-04-17 at 11 29 51 AM" src="https://github.com/openshift/console/assets/102503482/6ea90ca7-1108-48a6-b2a1-1b983ecc3169">

---Catalog details side panel---

<img width="1442" alt="Screenshot 2024-04-17 at 11 30 16 AM" src="https://github.com/openshift/console/assets/102503482/86ce8685-d67e-4eb2-b329-4c2e70bdae5d">

---Create Service Binding modal---
<img width="673" alt="Screenshot 2024-04-17 at 11 30 39 AM" src="https://github.com/openshift/console/assets/102503482/066f612f-8e8b-4563-a3f7-c6aa0b206171">

---Developer catalog page help text---
<img width="1125" alt="Screenshot 2024-04-17 at 12 54 01 PM" src="https://github.com/openshift/console/assets/102503482/ba0540e8-050d-4f10-af64-de565b89bbdd">