### PR TITLE
OCPBUGS-32218: fix runtime error on Pending pod details page

### DIFF
--- a/frontend/public/module/k8s/container.ts
+++ b/frontend/public/module/k8s/container.ts
@@ -34,7 +34,7 @@ export const getContainerStatus = (pod: PodKind, containerName: string): Contain
 };
 
 export const getContainerRestartCount = (status: ContainerStatus): number =>
-  status.restartCount ?? 0;
+  status?.restartCount ?? 0;
 
 const getPullPolicy = (container: ContainerSpec) => {
   const pullPolicy = {


### PR DESCRIPTION
After:
![localhost_9000_k8s_ns_robb_pods_nginx](https://github.com/openshift/console/assets/895728/81c4ef38-e1cb-46f1-b974-3329fe707869)
