### PR TITLE
ODC-7565: Update owners files (remove reviewers and add Avik and Prabhu as approvers for ODC)

### DIFF
--- a/frontend/packages/console-telemetry-plugin/OWNERS
+++ b/frontend/packages/console-telemetry-plugin/OWNERS
@@ -1,16 +1,7 @@
 reviewers:
-  - abhinandan13jan
-  - debsmita1
-  - divyanshiGupta
-  - christianvogt
-  - invincibleJai
   - jerolimov
-  - karthikjeeyar
   - lokanandaprabhu
   - lucifergene
-  - rohitkrai03
-  - rottencandy
-  - sahil143
   - vikram-raj
 approvers:
   - debsmita1
@@ -18,6 +9,8 @@ approvers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - sahil143
   - vikram-raj

--- a/frontend/packages/console-telemetry-plugin/integration-tests/OWNERS
+++ b/frontend/packages/console-telemetry-plugin/integration-tests/OWNERS
@@ -1,5 +1,7 @@
 reviewers:
   - sanketpathak
+  - the-anton
 approvers:
+  - jrichter1
+  - psrna
   - sanketpathak
-  - vikram-raj

--- a/frontend/packages/dev-console/OWNERS
+++ b/frontend/packages/dev-console/OWNERS
@@ -1,16 +1,7 @@
 reviewers:
-  - abhinandan13jan
-  - debsmita1
-  - divyanshiGupta
-  - christianvogt
-  - invincibleJai
   - jerolimov
-  - karthikjeeyar
   - lokanandaprabhu
   - lucifergene
-  - rohitkrai03
-  - rottencandy
-  - sahil143
   - vikram-raj
 approvers:
   - debsmita1
@@ -18,6 +9,8 @@ approvers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - sahil143
   - vikram-raj

--- a/frontend/packages/dev-console/integration-tests/OWNERS
+++ b/frontend/packages/dev-console/integration-tests/OWNERS
@@ -1,5 +1,7 @@
 reviewers:
+  - sanketpathak
+  - the-anton
 approvers:
-  - psrna
   - jrichter1
+  - psrna
   - sanketpathak

--- a/frontend/packages/git-service/OWNERS
+++ b/frontend/packages/git-service/OWNERS
@@ -1,16 +1,7 @@
 reviewers:
-  - abhinandan13jan
-  - debsmita1
-  - divyanshiGupta
-  - christianvogt
-  - invincibleJai
   - jerolimov
-  - karthikjeeyar
   - lokanandaprabhu
   - lucifergene
-  - rohitkrai03
-  - rottencandy
-  - sahil143
   - vikram-raj
 approvers:
   - debsmita1
@@ -18,6 +9,8 @@ approvers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - sahil143
   - vikram-raj

--- a/frontend/packages/gitops-plugin/OWNERS
+++ b/frontend/packages/gitops-plugin/OWNERS
@@ -1,16 +1,7 @@
 reviewers:
-  - abhinandan13jan
-  - debsmita1
-  - divyanshiGupta
-  - christianvogt
-  - invincibleJai
   - jerolimov
-  - karthikjeeyar
   - lokanandaprabhu
   - lucifergene
-  - rohitkrai03
-  - rottencandy
-  - sahil143
   - vikram-raj
 approvers:
   - debsmita1
@@ -18,6 +9,8 @@ approvers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - sahil143
   - vikram-raj

--- a/frontend/packages/gitops-plugin/integration-tests/OWNERS
+++ b/frontend/packages/gitops-plugin/integration-tests/OWNERS
@@ -1,5 +1,7 @@
 reviewers:
+  - sanketpathak
+  - the-anton
 approvers:
-  - psrna
   - jrichter1
+  - psrna
   - sanketpathak

--- a/frontend/packages/helm-plugin/OWNERS
+++ b/frontend/packages/helm-plugin/OWNERS
@@ -1,16 +1,7 @@
 reviewers:
-  - abhinandan13jan
-  - debsmita1
-  - divyanshiGupta
-  - christianvogt
-  - invincibleJai
   - jerolimov
-  - karthikjeeyar
   - lokanandaprabhu
   - lucifergene
-  - rohitkrai03
-  - rottencandy
-  - sahil143
   - vikram-raj
 approvers:
   - debsmita1
@@ -18,6 +9,8 @@ approvers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - sahil143
   - vikram-raj

--- a/frontend/packages/helm-plugin/integration-tests/OWNERS
+++ b/frontend/packages/helm-plugin/integration-tests/OWNERS
@@ -1,5 +1,7 @@
 reviewers:
+  - sanketpathak
+  - the-anton
 approvers:
-  - psrna
   - jrichter1
+  - psrna
   - sanketpathak

--- a/frontend/packages/knative-plugin/OWNERS
+++ b/frontend/packages/knative-plugin/OWNERS
@@ -1,16 +1,7 @@
 reviewers:
-  - abhinandan13jan
-  - debsmita1
-  - divyanshiGupta
-  - christianvogt
-  - invincibleJai
   - jerolimov
-  - karthikjeeyar
   - lokanandaprabhu
   - lucifergene
-  - rohitkrai03
-  - rottencandy
-  - sahil143
   - vikram-raj
 approvers:
   - debsmita1
@@ -18,6 +9,8 @@ approvers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - sahil143
   - vikram-raj

--- a/frontend/packages/knative-plugin/integration-tests/OWNERS
+++ b/frontend/packages/knative-plugin/integration-tests/OWNERS
@@ -1,6 +1,7 @@
 reviewers:
-  - mgencur
+  - sanketpathak
+  - the-anton
 approvers:
-  - psrna
   - jrichter1
+  - psrna
   - sanketpathak

--- a/frontend/packages/pipelines-plugin/OWNERS
+++ b/frontend/packages/pipelines-plugin/OWNERS
@@ -1,17 +1,8 @@
 reviewers:
-  - andrewballantyne
-  - abhinandan13jan
-  - debsmita1
-  - divyanshiGupta
-  - christianvogt
-  - invincibleJai
   - jerolimov
   - karthikjeeyar
   - lokanandaprabhu
   - lucifergene
-  - rohitkrai03
-  - rottencandy
-  - sahil143
   - vikram-raj
 approvers:
   - debsmita1
@@ -19,6 +10,8 @@ approvers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - sahil143
   - vikram-raj

--- a/frontend/packages/pipelines-plugin/integration-tests/OWNERS
+++ b/frontend/packages/pipelines-plugin/integration-tests/OWNERS
@@ -1,7 +1,9 @@
 reviewers:
-  - VeereshAradhya
   - ppitonak
+  - sanketpathak
+  - VeereshAradhya
+  - the-anton
 approvers:
-  - psrna
   - jrichter1
+  - psrna
   - sanketpathak

--- a/frontend/packages/service-binding-plugin/OWNERS
+++ b/frontend/packages/service-binding-plugin/OWNERS
@@ -1,16 +1,7 @@
 reviewers:
-  - abhinandan13jan
-  - debsmita1
-  - divyanshiGupta
-  - christianvogt
-  - invincibleJai
   - jerolimov
-  - karthikjeeyar
   - lokanandaprabhu
   - lucifergene
-  - rohitkrai03
-  - rottencandy
-  - sahil143
   - vikram-raj
 approvers:
   - debsmita1
@@ -18,6 +9,8 @@ approvers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - sahil143
   - vikram-raj

--- a/frontend/packages/shipwright-plugin/OWNERS
+++ b/frontend/packages/shipwright-plugin/OWNERS
@@ -1,16 +1,7 @@
 reviewers:
-  - abhinandan13jan
-  - debsmita1
-  - divyanshiGupta
-  - christianvogt
-  - invincibleJai
   - jerolimov
-  - karthikjeeyar
   - lokanandaprabhu
   - lucifergene
-  - rohitkrai03
-  - rottencandy
-  - sahil143
   - vikram-raj
 approvers:
   - debsmita1
@@ -18,6 +9,8 @@ approvers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - sahil143
   - vikram-raj

--- a/frontend/packages/shipwright-plugin/integration-tests/OWNERS
+++ b/frontend/packages/shipwright-plugin/integration-tests/OWNERS
@@ -1,5 +1,7 @@
 reviewers:
+  - sanketpathak
+  - the-anton
 approvers:
-  - psrna
   - jrichter1
+  - psrna
   - sanketpathak

--- a/frontend/packages/topology/OWNERS
+++ b/frontend/packages/topology/OWNERS
@@ -1,17 +1,7 @@
 reviewers:
-  - abhinandan13jan
-  - debsmita1
-  - divyanshiGupta
-  - christianvogt
-  - invincibleJai
-  - jeff-phillips-18
   - jerolimov
-  - karthikjeeyar
   - lokanandaprabhu
   - lucifergene
-  - rohitkrai03
-  - rottencandy
-  - sahil143
   - vikram-raj
 approvers:
   - debsmita1
@@ -20,6 +10,8 @@ approvers:
   - jeff-phillips-18
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - sahil143
   - vikram-raj

--- a/frontend/packages/topology/integration-tests/OWNERS
+++ b/frontend/packages/topology/integration-tests/OWNERS
@@ -1,5 +1,7 @@
 reviewers:
+  - sanketpathak
+  - the-anton
 approvers:
-  - psrna
   - jrichter1
+  - psrna
   - sanketpathak

--- a/frontend/packages/webterminal-plugin/OWNERS
+++ b/frontend/packages/webterminal-plugin/OWNERS
@@ -1,16 +1,7 @@
 reviewers:
-  - abhinandan13jan
-  - debsmita1
-  - divyanshiGupta
-  - christianvogt
-  - invincibleJai
   - jerolimov
-  - karthikjeeyar
   - lokanandaprabhu
   - lucifergene
-  - rohitkrai03
-  - rottencandy
-  - sahil143
   - vikram-raj
 approvers:
   - debsmita1
@@ -18,6 +9,8 @@ approvers:
   - invincibleJai
   - jerolimov
   - karthikjeeyar
+  - lokanandaprabhu
+  - lucifergene
   - rohitkrai03
   - sahil143
   - vikram-raj

--- a/frontend/packages/webterminal-plugin/integration-tests/OWNERS
+++ b/frontend/packages/webterminal-plugin/integration-tests/OWNERS
@@ -1,6 +1,7 @@
 reviewers:
   - sanketpathak
+  - the-anton
 approvers:
-  - psrna
   - jrichter1
+  - psrna
   - sanketpathak


### PR DESCRIPTION
Changes for packages and plugins that are maintained by the ODC-team:

1. Add @lokanandaprabhu and @lucifergene to the approver list if a change only affects the ODC base
2. Add @The-Anton as a reviewer for all integration-tests folders
3. Remove people who don't work on the ODC code base every day anymore. You can still add an lgtm label, but we hope that this helps the ci bot assign the right people.

/cc @vikram-raj 