### PR TITLE
CONSOLE-1756: replace PodIP with PodIPs or HostIP with HostIPs if mor…

### DIFF
--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -811,6 +811,8 @@ export const PodStatus: React.FC<PodStatusProps> = ({ pod }) => {
 
 export const PodDetailsList: React.FC<PodDetailsListProps> = ({ pod }) => {
   const { t } = useTranslation();
+  const moreThanOnePodIPs = pod.status?.podIPs?.length > 1;
+  const moreThanOneHostIPs = pod.status?.hostIPs?.length > 1;
   return (
     <dl className="co-m-pane__details">
       <dt>{t('public~Status')}</dt>
@@ -829,8 +831,24 @@ export const PodDetailsList: React.FC<PodDetailsListProps> = ({ pod }) => {
           ? t('public~{{count}} second', { count: pod.spec.activeDeadlineSeconds })
           : t('public~Not configured')}
       </DetailsItem>
-      <DetailsItem label={t('public~Pod IP')} obj={pod} path="status.podIP" />
-      <DetailsItem label={t('public~Host IP')} obj={pod} path="status.hostIP" />
+      <DetailsItem
+        label={moreThanOnePodIPs ? t('public~Pod IPs') : t('public~Pod IP')}
+        obj={pod}
+        path={moreThanOnePodIPs ? 'status.podIPs' : 'status.podIP'}
+      >
+        {moreThanOnePodIPs
+          ? pod.status.podIPs.map((podIP) => podIP.ip).join(', ')
+          : pod.status.podIP}
+      </DetailsItem>
+      <DetailsItem
+        label={moreThanOneHostIPs ? t('public~Host IPs') : t('public~Host IP')}
+        obj={pod}
+        path={moreThanOneHostIPs ? 'status.hostIPs' : 'status.hostIP'}
+      >
+        {moreThanOneHostIPs
+          ? pod.status.hostIPs.map((hostIP) => hostIP.ip).join(', ')
+          : pod.status.hostIP}
+      </DetailsItem>
       <DetailsItem label={t('public~Node')} obj={pod} path="spec.nodeName" hideEmpty>
         <NodeLink name={pod.spec.nodeName} />
       </DetailsItem>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1344,6 +1344,8 @@
   "To troubleshoot, view logs and events, then debug in terminal.": "To troubleshoot, view logs and events, then debug in terminal.",
   "Debug container {{name}}": "Debug container {{name}}",
   "Restart policy": "Restart policy",
+  "Pod IPs": "Pod IPs",
+  "Host IPs": "Host IPs",
   "Host IP": "Host IP",
   "Image pull secret": "Image pull secret",
   "Pod details": "Pod details",


### PR DESCRIPTION
…e than one PodIPs or HostIPs is present

To test, follow [these instructions](https://gist.github.com/rhamilto/3d7ec3bac1ca5eb79a634a48657a6dc1) for creating a `dual-stack` cluster.

When cluster is configured for `dual-stack`:
![console-openshift-console apps ostest test metalkube org_k8s_ns_openshift-monitoring_pods_alertmanager-main-0](https://github.com/openshift/console/assets/895728/771d9fa8-88f8-4d0c-b625-4f8e6b6cbd41)
![console-openshift-console apps ostest test metalkube org_k8s_ns_openshift-monitoring_pods_alertmanager-main-0 (1)](https://github.com/openshift/console/assets/895728/5808a6ac-5e73-4d26-b64a-dcc9148db4a2)
![console-openshift-console apps ostest test metalkube org_k8s_ns_openshift-monitoring_pods_alertmanager-main-0 (2)](https://github.com/openshift/console/assets/895728/83a773b2-9977-4a0d-b3b0-d332979baca2)
