### PR TITLE
OCPBUGS-32405: Create Serverless form does not create BuildConfig

### DIFF
--- a/frontend/packages/dev-console/src/components/import/serverless-function/AddServerlessFunction.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless-function/AddServerlessFunction.tsx
@@ -24,7 +24,7 @@ import { sanitizeApplicationValue } from '@console/topology/src/utils/applicatio
 import { normalizeBuilderImages, NormalizedBuilderImages } from '../../../utils/imagestream-utils';
 import { getBaseInitialValues } from '../form-initial-values';
 import { createOrUpdateResources, handleRedirect } from '../import-submit-utils';
-import { BaseFormData, Resources } from '../import-types';
+import { BaseFormData, BuildOptions, Resources } from '../import-types';
 import { validationSchema } from '../import-validation-utils';
 import { useUpdateKnScalingDefaultValues } from '../serverless/useUpdateKnScalingDefaultValues';
 import AddServerlessFunctionForm from './AddServerlessFunctionForm';
@@ -135,15 +135,23 @@ const AddServerlessFunction: React.FC<AddServerlessFunctionProps> = ({
       resourcesData.projects.loaded && _.isEmpty(resourcesData.projects.data);
     const {
       project: { name: projectName },
+      pipeline: { enabled: isPipelineOptionChecked },
     } = values;
 
+    const updatedFormData = {
+      ...values,
+      build: {
+        ...values.build,
+        option: isPipelineOptionChecked ? BuildOptions.PIPELINES : BuildOptions.BUILDS,
+      },
+    };
     const resourceActions = createOrUpdateResources(
       t,
-      values,
+      updatedFormData,
       imageStream,
       createNewProject,
       true,
-    ).then(() => createOrUpdateResources(t, values, imageStream));
+    ).then(() => createOrUpdateResources(t, updatedFormData, imageStream));
 
     resourceActions
       .then((resources) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-32405

**Analysis / Root cause**: 
When pipeline operator is not installed and Pipeline resource is not created for that particular serverless function then BuildConfig is not created

**Solution Description**: 
Updated to consider build option as BUILDS when pipeline is not checked and if pipeline is checked, build option will be PIPELINES.

**Screen shots / Gifs for design review**: 

----Without pipeline operator installed----
https://github.com/openshift/console/assets/102503482/6391cd11-b582-497a-9ca0-4ed1eab8e3ef


----With pipeline operator installed and without Pipeline resource----

https://github.com/openshift/console/assets/102503482/ad81ee1a-e5ff-42ee-8616-5c661d7407d0


----With pipeline operator installed and with Pipeline resource----

https://github.com/openshift/console/assets/102503482/792e8161-dd1e-469d-999f-12c5712fac1c

----With pipeline operator installed and with Pipeline resource but unchecked add pipeline----

https://github.com/openshift/console/assets/102503482/85dcf4fa-90a4-4d30-a652-754a6b2f155f

---with Samples----
https://github.com/openshift/console/assets/102503482/b49ba0a7-638a-4d2e-b5d5-daace0329e51





**Unit test coverage report**: 
NA

**Test setup:**

    1.Install serverless operator and knative instances
    2. Don't install pipelines operator
    3. Create serverless function, then BuildConfig should be created
    4. Install Pipelines operator but don't create Pipeline resource for particular serverless function and create serverless function, then also BuildConfig should be created
    5. Create Pipeline resource using https://gist.github.com/vikram-raj/386b4eca5193036b0ca29471f6e513a5 and create serverless function, then if you select add pipelines then Pipeline/Repository will be created and if you don't add pipeline, then BuildConfig will be created


     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge