### PR TITLE
OCPBUGS-32059: Helm Plugin's Catalog incorrectly renders a single index entry into multiple tiles

### DIFF
--- a/frontend/packages/helm-plugin/src/catalog/utils/catalog-utils.tsx
+++ b/frontend/packages/helm-plugin/src/catalog/utils/catalog-utils.tsx
@@ -173,8 +173,9 @@ export const normalizeHelmCharts = (
         // group Helm chart with same name and different version together
         const existingChartIndex = normalizedCharts.findIndex((currentChart) => {
           return (
-            currentChart.attributes?.name === name &&
-            currentChart.attributes?.chartRepositoryTitle === chartRepositoryTitle
+            (currentChart.attributes?.name === name &&
+              currentChart.attributes?.chartRepositoryTitle === chartRepositoryTitle) ||
+            (currentChart.name === annotatedName && currentChart.provider === providerName)
           );
         });
 

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartVersionDropdown.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartVersionDropdown.tsx
@@ -37,6 +37,8 @@ export type HelmChartVersionDropdownProps = {
   onVersionChange: (chart: HelmChart) => void;
   namespace: string;
   chartIndexEntry: string;
+  annotatedName?: string;
+  providerName?: string;
 };
 type ModalCallback = () => void;
 
@@ -47,6 +49,8 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
   onVersionChange,
   namespace,
   chartIndexEntry,
+  annotatedName,
+  providerName,
 }) => {
   const { t } = useTranslation();
   const {
@@ -127,6 +131,8 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
         chartName,
         chartRepoName,
         chartRepositories,
+        annotatedName,
+        providerName,
       );
       if (!chartIndexEntry) {
         setFieldValue(
@@ -142,7 +148,17 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
     return () => {
       ignore = true;
     };
-  }, [chartName, chartRepoName, chartRepositories, t, namespace, chartIndexEntry, setFieldValue]);
+  }, [
+    chartName,
+    chartRepoName,
+    chartRepositories,
+    t,
+    namespace,
+    chartIndexEntry,
+    setFieldValue,
+    annotatedName,
+    providerName,
+  ]);
 
   const onChartVersionChange = (value: string) => {
     const [version, repoName] = value.split('--');

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
@@ -46,6 +46,8 @@ export interface HelmInstallUpgradeFormProps {
   chartError: Error;
   namespace: string;
   chartIndexEntry?: string;
+  annotatedName?: string;
+  providerName?: string;
 }
 
 const HelmInstallUpgradeForm: React.FC<
@@ -65,6 +67,8 @@ const HelmInstallUpgradeForm: React.FC<
   chartError,
   namespace,
   chartIndexEntry,
+  annotatedName,
+  providerName,
 }) => {
   const { t } = useTranslation();
   const theme = React.useContext(ThemeContext);
@@ -161,6 +165,8 @@ const HelmInstallUpgradeForm: React.FC<
                 onVersionChange={onVersionChange}
                 namespace={namespace}
                 chartIndexEntry={chartIndexEntry}
+                annotatedName={annotatedName}
+                providerName={providerName}
               />
             </GridItem>
           </Grid>

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
@@ -13,6 +13,7 @@ import { coFetchJSON } from '@console/internal/co-fetch';
 import { history, LoadingBox } from '@console/internal/components/utils';
 import { prune } from '@console/shared/src/components/dynamic-form/utils';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+import { CHART_NAME_ANNOTATION, PROVIDER_NAME_ANNOTATION } from '../../../catalog/utils/const';
 import {
   HelmActionType,
   HelmChart,
@@ -208,6 +209,8 @@ const HelmInstallUpgradePage: React.FunctionComponent = () => {
   if (!chartData && !chartError) {
     return <LoadingBox />;
   }
+  const annotatedName = chartData?.metadata?.annotations?.[CHART_NAME_ANNOTATION] ?? '';
+  const providerName = chartData?.metadata?.annotations?.[PROVIDER_NAME_ANNOTATION] ?? '';
 
   const chartMetaDescription = <HelmChartMetaDescription chart={chartData} />;
 
@@ -232,6 +235,8 @@ const HelmInstallUpgradePage: React.FunctionComponent = () => {
             chartError={chartError}
             namespace={namespace}
             chartIndexEntry={indexEntry}
+            annotatedName={annotatedName}
+            providerName={providerName}
           />
         )}
       </Formik>

--- a/frontend/packages/helm-plugin/src/utils/helm-utils.ts
+++ b/frontend/packages/helm-plugin/src/utils/helm-utils.ts
@@ -7,6 +7,7 @@ import { Flatten } from '@console/internal/components/factory/list-page';
 import { RowFilter } from '@console/internal/components/filter-toolbar';
 import { K8sResourceKind, modelFor, referenceFor } from '@console/internal/module/k8s';
 import { toTitleCase, WORKLOAD_TYPES } from '@console/shared';
+import { CHART_NAME_ANNOTATION, PROVIDER_NAME_ANNOTATION } from '../catalog/utils/const';
 import {
   HelmRelease,
   HelmChart,
@@ -139,6 +140,8 @@ export const getChartEntriesByName = (
   chartName: string,
   chartRepoName?: string,
   chartRepositories?: K8sResourceKind[],
+  annotatedName?: string,
+  providerName?: string,
 ): HelmChartMetaData[] => {
   if (chartName && chartRepoName) {
     const chartRepositoryTitle = getChartRepositoryTitle(chartRepositories, chartRepoName);
@@ -156,7 +159,13 @@ export const getChartEntriesByName = (
       const repoName = key.split('--').pop();
       const chartRepositoryTitle = getChartRepositoryTitle(chartRepositories, repoName);
       charts.forEach((chart: HelmChartMetaData) => {
-        if (chart.name === chartName) {
+        if (
+          chart.name === chartName ||
+          (annotatedName &&
+            providerName &&
+            chart?.annotations?.[CHART_NAME_ANNOTATION] === annotatedName &&
+            chart?.annotations?.[PROVIDER_NAME_ANNOTATION] === providerName)
+        ) {
           acc.push({ ...chart, repoName: chartRepositoryTitle });
         }
       });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-32059

**Analysis / Root cause**: 
Since the name of the chart got changed, while adding up the versions for the particular index, chart name was used. So it created 2 tiles one for old name and other for new name

**Solution Description**: 
Used `charts.openshift.io/name` and `charts.openshift.io/provider` annotations along with existing chart name to group the charts.

**Screen shots / Gifs for design review**: 

https://drive.google.com/file/d/1IU-6bA9oSavUZa4enrzrcX5yb-VztVbK/view?usp=drive_link


**Unit test coverage report**: 
NA

**Test setup:**

    1.Open the Developer Console, Helm Plugin
    2. Select a namespace and Click to create a helm release
    3. Search for the developer-hub chart in the catalog and create
    4. Create multiple helm charts and try upgrade and rollback options

     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge