### PR TITLE
ODC-7433: Remove PatternFly classes from helm integration tests

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
@@ -7,7 +7,8 @@ export const helmPO = {
   resourcesTab: '[data-test-id="horizontal-link-Resources"]',
   revisionHistoryTab: '[data-test-id="horizontal-link-Revision history"]',
   releaseNotesTab: '[data-test-id="horizontal-link-Release notes"]',
-  filterDropdown: '[data-test-id="filter-dropdown-toggle"] button',
+  filterDropdown: '[data-test-id="filter-dropdown-toggle"] button[aria-label="Options menu"]',
+  filterDropdownDialog: '[class$="menu-group"]',
   filterDropdownItem: '.co-filter-dropdown-item__name',
   filter: {
     pendingInstall: '[data-test-row-filter="pending-install"]',

--- a/frontend/packages/helm-plugin/integration-tests/features/helm/helm-installation-view.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/helm-installation-view.feature
@@ -8,10 +8,11 @@ Feature: Helm Chart Installation View
 
 
         # This test is broken because now there is only on version of nodejs chart.
-        @regression @broken-test
+        @regression
         Scenario: Grouping of Helm multiple chart versions together in developer catalog: HR-04-TC01
             Given user is at Add page
              When user selects "Helm Chart" card from add page
+              And user clicks on "open-shift-helm-charts" chart repository
               And user searches and selects "Nodejs" card from catalog page
               And user clicks on the Create button on side bar
               And user clicks on the chart versions dropdown menu
@@ -45,4 +46,4 @@ Feature: Helm Chart Installation View
              When user selects "Helm Chart" card from add page
               And user searches and selects "Httpd Imagestreams" card from catalog page
               And user clicks on the Create button on side bar
-             Then user should see message "Helm release is not configurable since the Helm Chart doesn't define any values." 
+             Then user should see message "Helm release is not configurable since the Helm Chart doesn't define any values."

--- a/frontend/packages/helm-plugin/integration-tests/features/helm/helm-page-tabs.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/helm-page-tabs.feature
@@ -1,10 +1,10 @@
 @helm @odc-6685
 Feature: Add repositories tab in Helm navigation item
-        As a user, I want to navigate to different tabs related to Helm in the Helm page
+              As a user, I want to navigate to different tabs related to Helm in the Helm page
 
         Background:
             Given user has created or selected namespace "aut-helm"
-            
+
 
         @regression
         Scenario: Helm Page on developer perspective: HR-09-TC01
@@ -12,9 +12,9 @@ Feature: Add repositories tab in Helm navigation item
              When user clicks on the Helm tab
              Then user is able to see Helm Releases and Repositories Tabs
               And user is able to see the message "No Helm Releases found"
-              And user is able to see the link "Browse the catalog to discover and install Helm Charts"
+              And user is able to see the link "Browse the catalog to discover available Helm Charts"
               And user is able to see the Create drop down menu with Helm Release and Repository options
-        
+
 
         @regression
         Scenario: Repositories Tab on Helm Page: HR-09-TC02
@@ -42,10 +42,10 @@ Feature: Add repositories tab in Helm navigation item
         Scenario: Create Project Helm Chart Repository: HR-09-TC04
             Given user is at the Helm page
              When user clicks on Repository in create action menu to see the "Create Helm Chart Repository" form
-               And user enters Chart repository name as "helm-test1"
-               And user enters Description as "test"
-               And user enters URL as "https://raw.githubusercontent.com/IBM/charts/master/repo/community/index.yaml"
-               And user clicks on Create button
+              And user enters Chart repository name as "helm-test1"
+              And user enters Description as "test"
+              And user enters URL as "https://raw.githubusercontent.com/IBM/charts/master/repo/community/index.yaml"
+              And user clicks on Create button
              Then user can see "ProjectHelmChartRepository" "helm-test1" details page
 
 
@@ -53,33 +53,33 @@ Feature: Add repositories tab in Helm navigation item
         Scenario: Edit Project Helm Chart Repository: HR-09-TC05
             Given user is at the Helm page
              When user clicks on Repositories tab
-               And user edits "helm-test1" "ProjectHelmChartRepository"
-               And user enters Display name as "My charts"
-               And user clicks on Save button to see the "ProjectHelmChartRepository" "helm-test1" details page
-               And user navigates to Helm page
-               And user clicks on Repositories tab
+              And user edits "helm-test1" "ProjectHelmChartRepository"
+              And user enters Display name as "My charts"
+              And user clicks on Save button to see the "ProjectHelmChartRepository" "helm-test1" details page
+              And user navigates to Helm page
+              And user clicks on Repositories tab
              Then user can see "ProjectHelmChartRepository" "helm-test1" updated with "My charts" in the list page
 
         @regression
         Scenario: Create Helm Chart Repository: HR-09-TC06
             Given user is at the Helm page
              When user clicks on Repository in create action menu to see the "Create Helm Chart Repository" form
-               And user selects cluster-scoped scope type
-               And user enters Chart repository name as "helm-test2"
-               And user enters URL as "https://raw.githubusercontent.com/Azure-Samples/helm-charts/master"
-               And user clicks on Create button
+              And user selects cluster-scoped scope type
+              And user enters Chart repository name as "helm-test2"
+              And user enters URL as "https://raw.githubusercontent.com/Azure-Samples/helm-charts/master"
+              And user clicks on Create button
              Then user can see "HelmChartRepository" "helm-test2" details page
 
-        
+
         @regression
         Scenario: Edit Helm Chart Repository: HR-09-TC07
             Given user is at the Helm page
              When user clicks on Repositories tab
-               And user edits "helm-test2" "HelmChartRepository"
-               And user enters URL as "https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs/index.yaml"
-               And user clicks on Save button to see the "HelmChartRepository" "helm-test2" details page
-               And user navigates to Helm page
-               And user clicks on Repositories tab
+              And user edits "helm-test2" "HelmChartRepository"
+              And user enters URL as "https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs/index.yaml"
+              And user clicks on Save button to see the "HelmChartRepository" "helm-test2" details page
+              And user navigates to Helm page
+              And user clicks on Repositories tab
              Then user can see "HelmChartRepository" "helm-test2" updated with "https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs/index.yaml" in the list page
 
 

--- a/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-details-page.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-details-page.ts
@@ -60,6 +60,8 @@ export const helmDetailsPage = {
     cy.byLegacyTestID('dropdown-menu').contains(createMenuOption).click();
   },
   clickHelmChartRepository: (repoName: string) => cy.byLegacyTestID(repoName).click(),
+  selectHelmChartRepository: (repoName: string) =>
+    cy.byTestID(`chartRepositoryTitle-${repoName}`).click(),
   clickCreateHelmRelease: () => {
     cy.byLegacyTestID('dropdown-button').click();
     cy.byLegacyTestID('dropdown-menu').contains('Helm Release').click();

--- a/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-page.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-page.ts
@@ -141,8 +141,8 @@ export const helmPage = {
   clearAllFilter: () => {
     // eslint-disable-next-line promise/catch-or-return
     cy.get(helmPO.filterToolBar).then((body) => {
-      if (body.find(helmPO.clearAllFilter).length >= 0) {
-        cy.get(helmPO.clearAllFilter).eq(1).click();
+      if (body.find(`button`).text().includes('Clear all filters')) {
+        cy.get('[data-test="filter-toolbar"] button').contains('Clear all filters').click();
       }
     });
   },

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-installation-view.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-installation-view.ts
@@ -8,7 +8,7 @@ When('user searches and selects {string} helm chart from catalog page', (helmCha
 });
 
 Then('user will see the information of all the chart versions', () => {
-  cy.get('ul.pf-v5-c-dropdown__menu').find('li button').should('have.length.gte', 1);
+  cy.get('[data-test-id="dropdown-menu"]').should('have.length.gte', 1);
   cy.byLegacyTestID('reset-button').click();
 });
 
@@ -48,5 +48,5 @@ Then(
 );
 
 Then('user should see message {string}', (message: string) => {
-  cy.get('h4.pf-v5-c-alert__title').should('contain.text', message).should('exist');
+  cy.get('h4[class$="alert__title"]').should('contain.text', message).should('exist');
 });

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-navigation.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-navigation.ts
@@ -26,7 +26,7 @@ const deleteChartRepositoryFromDetailsPage = (name: string, type: string) => {
   cy.byLegacyTestID('kebab-button').click();
   cy.byTestActionID(`Delete ${type}`).click();
   createForm.clickConfirm();
-  cy.byTestID('no-repositories-found').should('be.visible');
+  cy.get('[class~="loading-box"] h4').contains('No repositories found'); // should('have.value', 'No repositories found');
 };
 
 Given('user is at developer perspective', () => {
@@ -59,7 +59,7 @@ When('user searches and selects {string} card from catalog page', (cardName: str
 });
 
 Then('Create Helm Release page is displayed', () => {
-  cy.get('h1.pf-v5-c-title').should('have.text', pageTitle.CreateHelmRelease);
+  cy.get('[data-test="form-title"]').should('have.text', pageTitle.CreateHelmRelease);
 });
 
 Then('release name displays as {string}', (name: string) => {
@@ -220,6 +220,10 @@ Then(
 
 Then('user clicks on {string} repository', (repoName: string) => {
   helmDetailsPage.clickHelmChartRepository(repoName);
+});
+
+Then('user clicks on {string} chart repository', (repoName: string) => {
+  helmDetailsPage.selectHelmChartRepository(repoName);
 });
 
 Then('Repositories breadcrumbs is visible', () => {


### PR DESCRIPTION
**Fix**: [ODC-7433](https://issues.redhat.com/browse/ODC-7433)

**Description**: 
Remove PatternFly classname selectors from helm-plugin integration tests

Command to execute:

    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.13-042801.devcluster.openshift.com/
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p helm


**Browser**
Chrome 120

**Test Execution Screenshot:**
