### PR TITLE
OCPBUGS-19048: Fix perspective detection for dynamic route extensions and url query params

### DIFF
--- a/frontend/@types/console/react.d.ts
+++ b/frontend/@types/console/react.d.ts
@@ -5,4 +5,7 @@ declare module 'react' {
   interface ImgHTMLAttributes<T> extends HTMLAttributes<T> {
     loading?: 'lazy' | 'eager' | 'auto';
   }
+
+  // Type def for a childless FunctionComponent
+  type FCC<P> = (props: P) => ReactElement | null;
 }

--- a/frontend/packages/console-app/src/components/detect-perspective/DetectPerspective.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/DetectPerspective.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useLocation } from 'react-router-dom-v5-compat';
 import { Perspective, PerspectiveContext } from '@console/dynamic-plugin-sdk';
 import { usePerspectives } from '@console/shared/src';
 import PerspectiveDetector from './PerspectiveDetector';
@@ -22,11 +23,12 @@ const DetectPerspective: React.FC<DetectPerspectiveProps> = ({ children }) => {
   const [activePerspective, setActivePerspective, loaded] = useValuesForPerspectiveContext();
   const perspectiveExtensions = usePerspectives();
   const perspectiveParam = getPerspectiveURLParam(perspectiveExtensions);
+  const location = useLocation();
   React.useEffect(() => {
     if (perspectiveParam && perspectiveParam !== activePerspective) {
-      setActivePerspective(perspectiveParam);
+      setActivePerspective(perspectiveParam, location.pathname);
     }
-  }, [perspectiveParam, activePerspective, setActivePerspective]);
+  }, [perspectiveParam, activePerspective, setActivePerspective, location]);
   return loaded ? (
     activePerspective ? (
       <PerspectiveContext.Provider value={{ activePerspective, setActivePerspective }}>

--- a/frontend/packages/console-app/src/components/detect-perspective/__tests__/DetectPerspective.spec.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/__tests__/DetectPerspective.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { useLocation } from 'react-router-dom-v5-compat';
 import { usePerspectives } from '@console/shared/src';
 import DetectPerspective from '../DetectPerspective';
 import PerspectiveDetector from '../PerspectiveDetector';
@@ -14,13 +15,20 @@ jest.mock('../useValuesForPerspectiveContext', () => ({
 jest.mock('@console/shared/src', () => ({
   usePerspectives: jest.fn(),
 }));
+
+jest.mock('react-router-dom-v5-compat', () => ({
+  useLocation: jest.fn(),
+}));
+
 const useValuesForPerspectiveContextMock = useValuesForPerspectiveContext as jest.Mock;
 const usePerspectivesMock = usePerspectives as jest.Mock;
+const useLocationMock = useLocation as jest.Mock;
 
 describe('DetectPerspective', () => {
   beforeEach(() => {
     useValuesForPerspectiveContextMock.mockClear();
     usePerspectivesMock.mockClear();
+    useLocationMock.mockClear();
   });
   it('should render children if there is an activePerspective', () => {
     useValuesForPerspectiveContextMock.mockReturnValue(['dev', () => {}, true]);

--- a/frontend/packages/console-app/src/components/detect-perspective/__tests__/useValuesForPerspectiveContext.spec.ts
+++ b/frontend/packages/console-app/src/components/detect-perspective/__tests__/useValuesForPerspectiveContext.spec.ts
@@ -31,12 +31,15 @@ jest.mock('react', () => {
   };
 });
 
+jest.mock('react-router-dom-v5-compat', () => ({
+  useNavigate: jest.fn(),
+}));
+
 const useStateMock = React.useState as jest.Mock;
 const usePerspectiveExtensionMock = usePerspectiveExtension as jest.Mock;
 const usePerspectivesMock = usePerspectives as jest.Mock;
 const useLastPerspectiveMock = useLastPerspective as jest.Mock;
 const usePreferredPerspectiveMock = usePreferredPerspective as jest.Mock;
-
 describe('useValuesForPerspectiveContext', () => {
   afterEach(() => {
     jest.resetAllMocks();

--- a/frontend/packages/console-app/src/components/detect-perspective/useValuesForPerspectiveContext.ts
+++ b/frontend/packages/console-app/src/components/detect-perspective/useValuesForPerspectiveContext.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { PerspectiveType } from '@console/dynamic-plugin-sdk';
-import { history } from '@console/internal/components/utils';
 import { usePerspectiveExtension, usePerspectives, useTelemetry } from '@console/shared';
 import { ACM_PERSPECTIVE_ID } from '../../consts';
 import { usePreferredPerspective } from '../user-preferences';
@@ -8,9 +8,10 @@ import { useLastPerspective } from './useLastPerspective';
 
 export const useValuesForPerspectiveContext = (): [
   PerspectiveType,
-  (newPerspective: string) => void,
+  (newPerspective: string, next?: string) => void,
   boolean,
 ] => {
+  const navigate = useNavigate();
   const fireTelemetryEvent = useTelemetry();
   const perspectiveExtensions = usePerspectives();
   const [lastPerspective, setLastPerspective, lastPerspectiveLoaded] = useLastPerspective();
@@ -25,12 +26,14 @@ export const useValuesForPerspectiveContext = (): [
   const isValidPerspective =
     loaded && perspectiveExtensions.some((p) => p.properties.id === perspective);
 
-  const setPerspective = (newPerspective: string) => {
+  const setPerspective = (newPerspective: string, next?: string) => {
     setLastPerspective(newPerspective);
     setActivePerspective(newPerspective);
-    // Navigate to root and let the default page determine where to go to next
-    history.push('/');
+    // Navigate to next or root and let the default page determine where to go to next
+    navigate(next || '/');
     fireTelemetryEvent('Perspective Changed', { perspective: newPerspective });
+    // eslint-disable-next-line no-console
+    console.log('DEBUG: setting perspective', newPerspective, next);
   };
 
   return [isValidPerspective ? perspective : undefined, setPerspective, loaded];

--- a/frontend/packages/console-app/src/hooks/usePluginRoutes.tsx
+++ b/frontend/packages/console-app/src/hooks/usePluginRoutes.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react';
+import { Route } from 'react-router-dom-v5-compat';
+import {
+  useActivePerspective,
+  RoutePage as DynamicRoutePageExtension,
+  isRoutePage as isDynamicRoutePageExtension,
+} from '@console/dynamic-plugin-sdk';
+import { AsyncComponent } from '@console/internal/components/utils';
+import {
+  RoutePage as StaticRoutePageExtension,
+  isRoutePage as isStaticRoutePageExtension,
+  useExtensions,
+  LoadedExtension,
+} from '@console/plugin-sdk';
+
+const isRoutePageExtensionActive: IsRouteExtensionActive = (extension, activePerspective) =>
+  (extension.properties.perspective ?? activePerspective) === activePerspective;
+
+const LazyDynamicRoutePage: React.FCC<LazyDynamicRoutePageProps> = ({ component }) => {
+  const LazyComponent = React.useMemo(
+    () =>
+      React.lazy(async () => {
+        const Component = await component();
+        // TODO do not wrap as `default` when we support module code refs
+        return { default: Component };
+      }),
+    [component],
+  );
+  return <LazyComponent />;
+};
+
+const LazyRoutePage: React.FCC<LazyRoutePageProps> = ({ extension }) => {
+  if (isStaticRoutePageExtension(extension)) {
+    return extension.properties.loader ? (
+      <AsyncComponent loader={extension.properties.loader} />
+    ) : null;
+  }
+  return <LazyDynamicRoutePage component={extension.properties.component} />;
+};
+
+const InactiveRoutePage: React.FCC<InactiveRoutePageProps> = ({
+  extension,
+  path,
+  setActivePerspective,
+}) => {
+  React.useEffect(() => {
+    setActivePerspective(extension.properties.perspective, path);
+  });
+  return null;
+};
+
+const RoutePage: React.FCC<RoutePageProps> = ({
+  path,
+  extension,
+  activePerspective,
+  setActivePerspective,
+}) => {
+  const active = isRoutePageExtensionActive(extension, activePerspective);
+  return active ? (
+    <LazyRoutePage extension={extension} />
+  ) : (
+    <InactiveRoutePage
+      extension={extension}
+      path={path}
+      setActivePerspective={setActivePerspective}
+    />
+  );
+};
+
+export const usePluginRoutes: UsePluginRoutes = () => {
+  const staticExtensions = useExtensions<StaticRoutePageExtension>(isStaticRoutePageExtension);
+  const dynamicExtensions = useExtensions<DynamicRoutePageExtension>(isDynamicRoutePageExtension);
+  const [activePerspective, setActivePerspective] = useActivePerspective();
+  const getRoutesForExtension = React.useCallback(
+    (extension: LoadedRoutePageExtension): React.ReactElement[] => {
+      if (Array.isArray(extension.properties.path)) {
+        return extension.properties.path.map((path) => (
+          <Route
+            {...extension.properties}
+            path={`${path}${extension.properties.exact ? '' : '/*'}`}
+            key={path}
+            element={
+              <RoutePage
+                extension={extension}
+                path={path}
+                activePerspective={activePerspective}
+                setActivePerspective={setActivePerspective}
+              />
+            }
+          />
+        ));
+      }
+      return [
+        <Route
+          {...extension.properties}
+          path={`${extension.properties.path}${extension.properties.exact ? '' : '/*'}`}
+          key={extension.properties.path}
+          element={
+            <RoutePage
+              extension={extension}
+              path={extension.properties.path}
+              activePerspective={activePerspective}
+              setActivePerspective={setActivePerspective}
+            />
+          }
+        />,
+      ];
+    },
+    [activePerspective, setActivePerspective],
+  );
+
+  return React.useMemo(
+    () =>
+      [...staticExtensions, ...dynamicExtensions].reduce(
+        ([activeAcc, inactiveAcc], extension) => {
+          const active = isRoutePageExtensionActive(extension, activePerspective);
+          const routes = getRoutesForExtension(extension);
+          return active
+            ? [[...activeAcc, ...routes], inactiveAcc]
+            : [activeAcc, [...inactiveAcc, ...routes]];
+        },
+        [[], []],
+      ),
+    [staticExtensions, dynamicExtensions, getRoutesForExtension, activePerspective],
+  );
+};
+
+type RoutePageExtension = StaticRoutePageExtension | DynamicRoutePageExtension;
+
+type LoadedRoutePageExtension = LoadedExtension<RoutePageExtension>;
+
+type SetActivePerspective = (perspective: string, next: string) => void;
+
+type IsRouteExtensionActive = (
+  extension: LoadedRoutePageExtension,
+  activePerspective: string,
+) => boolean;
+
+type LazyDynamicRoutePageProps = {
+  component: DynamicRoutePageExtension['properties']['component'];
+};
+
+type LazyRoutePageProps = { extension: LoadedRoutePageExtension };
+
+type InactiveRoutePageProps = {
+  extension: LoadedRoutePageExtension;
+  path: string;
+  setActivePerspective: SetActivePerspective;
+};
+
+type RoutePageProps = {
+  path: string;
+  extension: LoadedRoutePageExtension;
+  activePerspective: string;
+  setActivePerspective: SetActivePerspective;
+};
+
+type UsePluginRoutes = () => [React.ReactElement[], React.ReactElement[]];

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -508,7 +508,7 @@ export type PerspectiveType = string;
 
 export type UseActivePerspective = () => [
   PerspectiveType,
-  React.Dispatch<React.SetStateAction<PerspectiveType>>,
+  (perspective: string, next?: string) => void,
 ];
 
 export type QueryParams = {


### PR DESCRIPTION
- Update useActivePerspective hook. SetActivePerspective callback accepts a second argument, "next". If passed, we use it in place of "/" as the navigate destination after updating the perspective.
- Update DetectPerspective to use the current location pathname as the second argument to setActivePerspective when a "perspective" URL query param is defined. This means that we redirect to the same location after changing the perspective, rather than the base path.
- Update app-content route page extension handling for better separation and readability.
- Update inactive route page extensions to use the second arg to set active perspective. They now pass their path property into setActivePerspective so that after changing the perspective, the app redirects back to the route that caused the change, which is now an active route page plugin.