### PR TITLE
OCPBUGS-32791,CONSOLE-4014: Consume telemetry CLUSTER_ID and use it together with orgId as segment identifier

### DIFF
--- a/dynamic-demo-plugin/src/utils/telemetry.ts
+++ b/dynamic-demo-plugin/src/utils/telemetry.ts
@@ -72,19 +72,27 @@ export const eventListener = async (eventType: string, properties?: any) => {
     },
   };
   switch (eventType) {
-    case 'identify':
+    case 'identify': {
       const { user, ...otherProperties } = properties;
-      const id = user.metadata.uid || `${location.host}-${user.metadata.name}`;
+      // With 4.15+ we can use the user object directly, but on older releases (<4.15)
+      // we need to extract the user object from the metadata.
+      // All properties are defined in the UserInfo interface and marked as optional.
+      const uid = user?.uid || user?.metadata?.uid;
+      const username = user?.username || user?.metadata?.name;
+      const id = uid || `${location.host}-${username}`;
       // Use SHA1 hash algorithm to anonymize the user
       const anonymousIdBuffer = await crypto.subtle.digest('SHA-1', new TextEncoder().encode(id));
       const anonymousIdArray = Array.from(new Uint8Array(anonymousIdBuffer));
       const anonymousId = anonymousIdArray.map((b) => b.toString(16).padStart(2, '0')).join('');
       (window as any).analytics.identify(anonymousId, otherProperties, anonymousIP);
       break;
-    case 'page':
+    }
+    case 'page': {
       (window as any).analytics.page(undefined, properties, anonymousIP);
       break;
-    default:
+    }
+    default: {
       (window as any).analytics.track(eventType, properties, anonymousIP);
+    }
   }
 };

--- a/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
@@ -10,9 +10,8 @@ import {
 } from '@console/shared';
 import { testHook } from '../../../../../__tests__/utils/hooks-utils';
 import {
-  getConsoleVersion,
-  getClusterType,
-  updateServerFlagsFromTests,
+  getClusterProperties,
+  updateClusterPropertiesFromTests,
   useTelemetry,
 } from '../useTelemetry';
 
@@ -39,34 +38,32 @@ afterAll(() => {
   window.SERVER_FLAGS = originServerFlags;
 });
 
-describe('getConsoleVersion', () => {
+describe('getClusterProperties', () => {
   it('returns undefined when consoleVersion is not configured', () => {
     window.SERVER_FLAGS = { ...originServerFlags };
     delete window.SERVER_FLAGS.consoleVersion;
-    expect(getConsoleVersion()).toBe(undefined);
+    expect(getClusterProperties().consoleVersion).toBe(undefined);
   });
 
   it('returns the right version when it is configured', () => {
     window.SERVER_FLAGS = { ...originServerFlags, consoleVersion: 'x.y.z' };
-    expect(getConsoleVersion()).toBe('x.y.z');
+    expect(getClusterProperties().consoleVersion).toBe('x.y.z');
   });
-});
 
-describe('getClusterType', () => {
   it('returns undefined when telemetry is missing at all', () => {
     window.SERVER_FLAGS = { ...originServerFlags };
     delete window.SERVER_FLAGS.telemetry;
-    expect(getClusterType()).toBe(undefined);
+    expect(getClusterProperties().clusterType).toBe(undefined);
   });
 
   it('returns undefined when telemetry configuration is empty', () => {
     window.SERVER_FLAGS = { ...originServerFlags, telemetry: {} };
-    expect(getClusterType()).toBe(undefined);
+    expect(getClusterProperties().clusterType).toBe(undefined);
   });
 
   it('returns the clusterType that it is configured', () => {
     window.SERVER_FLAGS = { ...originServerFlags, telemetry: { CLUSTER_TYPE: 'TEST' } };
-    expect(getClusterType()).toBe('TEST');
+    expect(getClusterProperties().clusterType).toBe('TEST');
   });
 
   it('returns DEVSANDBOX when CLUSTER_TYPE is "OSD" but and DEVSANDBOX is "true"', () => {
@@ -74,7 +71,7 @@ describe('getClusterType', () => {
       ...originServerFlags,
       telemetry: { CLUSTER_TYPE: 'OSD', DEVSANDBOX: 'true' },
     };
-    expect(getClusterType()).toBe('DEVSANDBOX');
+    expect(getClusterProperties().clusterType).toBe('DEVSANDBOX');
   });
 
   it('returns the clusterType that it is configured if CLUSTER_TYPE is not OSD (in the future) but DEVSANDBOX is still "true"', () => {
@@ -82,7 +79,7 @@ describe('getClusterType', () => {
       ...originServerFlags,
       telemetry: { CLUSTER_TYPE: 'a_FUTURE_DEVSANDBOX_KEY', DEVSANDBOX: 'true' },
     };
-    expect(getClusterType()).toBe('a_FUTURE_DEVSANDBOX_KEY');
+    expect(getClusterProperties().clusterType).toBe('a_FUTURE_DEVSANDBOX_KEY');
   });
 
   it('returns the clusterType that it is configured if CLUSTER_TYPE is OSD but DEVSANDBOX is not exactly "true"', () => {
@@ -90,7 +87,7 @@ describe('getClusterType', () => {
       ...originServerFlags,
       telemetry: { CLUSTER_TYPE: 'OSD', DEVSANDBOX: 'false' },
     };
-    expect(getClusterType()).toBe('OSD');
+    expect(getClusterProperties().clusterType).toBe('OSD');
   });
 });
 
@@ -122,7 +119,7 @@ describe('useTelemetry', () => {
       ...window.SERVER_FLAGS,
       telemetry: { STATE: CLUSTER_TELEMETRY_ANALYTICS.ENFORCE },
     };
-    updateServerFlagsFromTests();
+    updateClusterPropertiesFromTests();
     const { result } = testHook(() => useTelemetry());
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 1');
@@ -139,7 +136,7 @@ describe('useTelemetry', () => {
       consoleVersion: 'x.y.z',
       telemetry: { CLUSTER_TYPE: 'OSD', STATE: CLUSTER_TELEMETRY_ANALYTICS.ENFORCE },
     };
-    updateServerFlagsFromTests();
+    updateClusterPropertiesFromTests();
     const { result } = testHook(() => useTelemetry());
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 2');
@@ -156,7 +153,7 @@ describe('useTelemetry', () => {
       consoleVersion: 'x.y.z',
       telemetry: { CLUSTER_TYPE: 'OSD', STATE: CLUSTER_TELEMETRY_ANALYTICS.ENFORCE },
     };
-    updateServerFlagsFromTests();
+    updateClusterPropertiesFromTests();
     const { result } = testHook(() => useTelemetry());
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 3', { 'a-string': 'works fine', 'a-boolean': true });
@@ -179,7 +176,7 @@ describe('useTelemetry', () => {
         STATE: CLUSTER_TELEMETRY_ANALYTICS.ENFORCE,
       },
     };
-    updateServerFlagsFromTests();
+    updateClusterPropertiesFromTests();
     const { result } = testHook(() => useTelemetry());
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 4');
@@ -200,7 +197,7 @@ describe('useTelemetry', () => {
         STATE: CLUSTER_TELEMETRY_ANALYTICS.DISABLED,
       },
     };
-    updateServerFlagsFromTests();
+    updateClusterPropertiesFromTests();
     const { result } = testHook(() => useTelemetry());
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 5');
@@ -218,7 +215,7 @@ describe('useTelemetry', () => {
       },
     };
     mockUserSettings.mockReturnValue([USER_TELEMETRY_ANALYTICS.ALLOW, jest.fn(), true]);
-    updateServerFlagsFromTests();
+    updateClusterPropertiesFromTests();
     const { result } = testHook(() => useTelemetry());
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 6');
@@ -236,7 +233,7 @@ describe('useTelemetry', () => {
       },
     };
     mockUserSettings.mockReturnValue([USER_TELEMETRY_ANALYTICS.DENY, jest.fn(), true]);
-    updateServerFlagsFromTests();
+    updateClusterPropertiesFromTests();
     const { result } = testHook(() => useTelemetry());
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 7');
@@ -254,7 +251,7 @@ describe('useTelemetry', () => {
       },
     };
     mockUserSettings.mockReturnValue([USER_TELEMETRY_ANALYTICS.ALLOW, jest.fn(), true]);
-    updateServerFlagsFromTests();
+    updateClusterPropertiesFromTests();
     const { result } = testHook(() => useTelemetry());
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 8');
@@ -272,7 +269,7 @@ describe('useTelemetry', () => {
       },
     };
     mockUserSettings.mockReturnValue([USER_TELEMETRY_ANALYTICS.DENY, jest.fn(), true]);
-    updateServerFlagsFromTests();
+    updateClusterPropertiesFromTests();
     const { result } = testHook(() => useTelemetry());
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 9');
@@ -290,7 +287,7 @@ describe('useTelemetry', () => {
       },
     };
     mockUserSettings.mockReturnValue(['', jest.fn(), true]);
-    updateServerFlagsFromTests();
+    updateClusterPropertiesFromTests();
     const { result } = testHook(() => useTelemetry());
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 10');
@@ -307,7 +304,7 @@ describe('useTelemetry', () => {
         STATE: CLUSTER_TELEMETRY_ANALYTICS.ENFORCE,
       },
     };
-    updateServerFlagsFromTests();
+    updateClusterPropertiesFromTests();
     const { result } = testHook(() => useTelemetry());
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 11');

--- a/frontend/packages/console-shared/src/hooks/useTelemetry.ts
+++ b/frontend/packages/console-shared/src/hooks/useTelemetry.ts
@@ -14,29 +14,31 @@ import { useUserSettings } from './useUserSettings';
 
 let telemetryEvents: { eventType: string; event: Record<string, any> }[] = [];
 
-export const getClusterType = () => {
+interface ClusterProperties {
+  clusterId?: string;
+  clusterType?: string;
+  consoleVersion?: string;
+  organizationId?: string;
+}
+
+export const getClusterProperties = () => {
+  const clusterProperties: ClusterProperties = {};
+  clusterProperties.clusterId = window.SERVER_FLAGS?.telemetry?.CLUSTER_ID;
+  clusterProperties.clusterType = window.SERVER_FLAGS?.telemetry?.CLUSTER_TYPE;
   if (
     window.SERVER_FLAGS?.telemetry?.CLUSTER_TYPE === 'OSD' &&
     window.SERVER_FLAGS?.telemetry?.DEVSANDBOX === 'true'
   ) {
-    return 'DEVSANDBOX';
+    clusterProperties.clusterType = 'DEVSANDBOX';
   }
-  return window.SERVER_FLAGS?.telemetry?.CLUSTER_TYPE;
+  clusterProperties.consoleVersion = window.SERVER_FLAGS?.consoleVersion;
+  clusterProperties.organizationId = window.SERVER_FLAGS?.telemetry?.ORGANIZATION_ID;
+  return clusterProperties;
 };
 
-export const getConsoleVersion = () => window.SERVER_FLAGS?.consoleVersion;
+let clusterProperties = getClusterProperties();
 
-export const getOrganizationId = () => window.SERVER_FLAGS?.telemetry?.ORGANIZATION_ID;
-
-let clusterType = getClusterType();
-let consoleVersion = getConsoleVersion();
-let organizationId = getOrganizationId();
-
-export const updateServerFlagsFromTests = () => {
-  clusterType = getClusterType();
-  consoleVersion = getConsoleVersion();
-  organizationId = getOrganizationId();
-};
+export const updateClusterPropertiesFromTests = () => (clusterProperties = getClusterProperties());
 
 export const useTelemetry = () => {
   // TODO use useDynamicPluginInfo() hook to tell whether all dynamic plugins have been processed
@@ -67,9 +69,7 @@ export const useTelemetry = () => {
   return React.useCallback<TelemetryEventListener>(
     (eventType, properties: Record<string, any>) => {
       const event = {
-        clusterType,
-        consoleVersion,
-        organizationId,
+        ...clusterProperties,
         ...properties,
         // This is required to ensure that the replayed events uses the right path.
         path: properties?.pathname,

--- a/frontend/packages/console-telemetry-plugin/console-extensions.json
+++ b/frontend/packages/console-telemetry-plugin/console-extensions.json
@@ -9,6 +9,15 @@
     "type": "console.telemetry/listener",
     "properties": {
       "listener": {
+        "$codeRef": "telemetryListeners.debug"
+      }
+    },
+    "flags": { "required": ["TELEMETRY_DEBUG"] }
+  },
+  {
+    "type": "console.telemetry/listener",
+    "properties": {
+      "listener": {
         "$codeRef": "telemetryListeners.usage"
       }
     },

--- a/frontend/packages/console-telemetry-plugin/src/flags/detect-telemetry.ts
+++ b/frontend/packages/console-telemetry-plugin/src/flags/detect-telemetry.ts
@@ -1,6 +1,7 @@
 import { SetFeatureFlag } from '@console/dynamic-plugin-sdk';
-import { TELEMETRY_DISABLED } from '../listeners/const';
+import { TELEMETRY_DEBUG, TELEMETRY_DISABLED } from '../listeners/const';
 
 export const detectTelemetry = (setFeatureFlag: SetFeatureFlag) => {
+  setFeatureFlag('TELEMETRY_DEBUG', TELEMETRY_DEBUG);
   setFeatureFlag('TELEMETRY', !TELEMETRY_DISABLED);
 };

--- a/frontend/packages/console-telemetry-plugin/src/listeners/debug.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/debug.ts
@@ -1,0 +1,9 @@
+import { TelemetryEventListener } from '@console/dynamic-plugin-sdk/src';
+import { TELEMETRY_DEBUG } from './const';
+
+export const eventListener: TelemetryEventListener = (eventType: string, properties?: any) => {
+  if (TELEMETRY_DEBUG) {
+    // eslint-disable-next-line no-console
+    console.debug('console-telemetry-plugin: received telemetry event:', eventType, properties);
+  }
+};

--- a/frontend/packages/console-telemetry-plugin/src/listeners/index.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/index.ts
@@ -1,2 +1,3 @@
+export { eventListener as debug } from './debug';
 export { eventListener as usage } from './usage';
 export { eventListener as segment } from './segment';

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -300,12 +300,12 @@ const CaptureTelemetry = React.memo(function CaptureTelemetry() {
   );
 
   React.useEffect(() => {
-    if (user.metadata?.uid || user.metadata?.name) {
+    if (user?.uid || user?.username) {
       fireTelemetryEvent('identify', { perspective, user });
     }
     // Only trigger identify event when the user identifier changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user.metadata?.uid || user.metadata?.name, fireTelemetryEvent]);
+  }, [user?.uid || user?.username, fireTelemetryEvent]);
 
   // notify url change events
   // Debouncing the url change events so that redirects don't fire multiple events.


### PR DESCRIPTION
This is the frontend part related to https://github.com/openshift/console-operator/pull/889

1. Consume `SERVER_FLAGS.telemetry.CLUSTER_ID` and pass it together with other `clusterProperties` to segment.
2. Use the `clusterId` and `organizationId` to calculate the anonymized user identifier for segment.
3. Extract the "debug" feature for log every event into a separate listener extension.

I've tested this together with 889 on a cluster bot:

https://github.com/openshift/console-operator/assets/139310/31dcc3b1-f03f-462b-b111-571a08da40ef

/cc @jhadvig @TheRealJon 