### PR TITLE
[release-4.14] OCPBUGS-32697: Routes created by devfiles do not always use HTTPS

### DIFF
--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -13,8 +13,10 @@ import DevfileStrategySection from './devfile/DevfileStrategySection';
 import GitSection from './git/GitSection';
 import { GitImportFormProps, ImportTypes } from './import-types';
 import ImportStrategySection from './ImportStrategySection';
+import SecureRoute from './route/SecureRoute';
 import ResourceSection from './section/ResourceSection';
 import ExtensionCards from './serverless-function/ExtensionCards';
+
 import './serverless-function/AddServerlessFunctionForm.scss';
 
 const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = ({
@@ -51,6 +53,11 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
   const showExtensionCards =
     values.import.selectedStrategy.type === ImportStrategy.SERVERLESS_FUNCTION && isSample;
 
+  const showSecureRouteSectionForDevfile =
+    (importType === ImportTypes.devfile ||
+      values.import.selectedStrategy.type === ImportStrategy.DEVFILE) &&
+    values?.devfile?.devfileSuggestedResources?.route?.spec?.tls;
+
   return (
     <form onSubmit={handleSubmit} data-test-id="import-git-form">
       <Flex direction={{ default: 'column', sm: 'row' }}>
@@ -85,6 +92,11 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
                     <PipelineSection builderImages={builderImages} />
                     <AdvancedSection values={values} />
                   </>
+                )}
+                {showSecureRouteSectionForDevfile && (
+                  <div className="pf-c-form co-m-pane__form">
+                    <SecureRoute />
+                  </div>
                 )}
               </>
             )}


### PR DESCRIPTION
This is manual cherry pick for PR - https://github.com/openshift/console/pull/13771

Video:


https://github.com/openshift/console/assets/102503482/a50543c8-d655-42b3-9f13-2177a4f14b96

