### PR TITLE
ODC-7569: Automation of the Recently Used Resources Section in the Search Resource page Dropdown

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/search/search-devperspective.feature
+++ b/frontend/packages/dev-console/integration-tests/features/search/search-devperspective.feature
@@ -1,0 +1,38 @@
+@search-page @dev-console
+Feature: Search page
+              As a user, I need to see the last 5 resources that have been seen in the past so can quickly view their details without any further actions.
+
+
+
+        Background:
+            Given user is at developer perspective
+              And user has created or selected namespace "aut-search-enhancement"
+              And user is at Search page
+
+
+        @smoke
+        Scenario: Recently Searched Section in Search Resource Page Dropdown: SR-01-TC01
+             When user searches and selects for "AlertingRule"
+              And user navigates to Topology page
+              And user navigates to Search page
+              And user clicks on Resources filter
+             Then user can see "AlertingRule" in Recently used
+
+
+        @regression
+        Scenario: 5 Recently search items in Search Resource Page Dropdown: SR-01-TC02
+             When user searches for "AlertingRule", "Deployment", "DeploymentConfig", "ConfigMap", and "BuildConfig"
+              And user navigates to Topology page
+              And user navigates to Search page
+              And user clicks on Resources filter
+             Then user can see "AlertingRule", "Deployment", "DeploymentConfig", "ConfigMap", and "BuildConfig" in Recently used
+
+
+        @regression
+        Scenario: Clear history for recently searched resource: SR-01-TC02
+             When user searches and selects for "AlertingRule"
+              And user navigates to Topology page
+              And user navigates to Search page
+              And user clicks on Resources filter
+              And user clicks on clear history
+             Then user can not see Recently used

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -130,7 +130,7 @@ export const navigateTo = (opt: devNavigationMenu) => {
     }
     case devNavigationMenu.Search: {
       cy.get(devNavigationMenuPO.search).click();
-      detailsPage.titleShouldContain(pageTitle.Search);
+      cy.get('h1').contains(pageTitle.Search);
       cy.testA11y('Search Page in dev perspective');
       break;
     }

--- a/frontend/packages/dev-console/integration-tests/support/pages/search-resources/search-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/search-resources/search-page.ts
@@ -5,7 +5,7 @@ import { navigateToAdminMenu } from '../app';
 
 const dataTestIdPref: string = 'data-test-id';
 
-function performResourceSearching(resourceName: string) {
+export function performResourceSearching(resourceName: string) {
   cy.get('div').contains('Resources').click();
   cy.get('input[placeholder="Select Resource"]').clear().type(resourceName);
   cy.get(`input[id$=${resourceName}]`).click();

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/search/search-devperspective.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/search/search-devperspective.ts
@@ -1,0 +1,60 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { devNavigationMenu } from '../../constants';
+import { navigateTo } from '../../pages';
+import { performResourceSearching, searchResource } from '../../pages/search-resources/search-page';
+
+Given('user is at Search page', () => {
+  navigateTo(devNavigationMenu.Search);
+});
+
+When('user searches and selects for {string}', (resourceName: string) => {
+  performResourceSearching(resourceName);
+});
+
+When('user navigates to Search page', () => {
+  navigateTo(devNavigationMenu.Search);
+});
+
+When('user clicks on Resources filter', () => {
+  cy.get('[aria-label="Options menu"]').should('be.visible').click();
+});
+
+When('user can see {string} in Recently used', (recourceName: string) => {
+  cy.get('[aria-labelledby="Recently-used"]')
+    .find(`[data-filter-text="AR${recourceName}"]`)
+    .should('be.visible');
+});
+
+When(
+  'user searches for {string}, {string}, {string}, {string}, and {string}',
+  (el1, el2, el3, el4, el5: string) => {
+    const sample = [el1, el2, el3, el4, el5];
+    for (let i = 0; i < 5; i++) {
+      searchResource.searchResourceByNameAsDev(sample[i]);
+      navigateTo(devNavigationMenu.Topology);
+    }
+  },
+);
+
+Then(
+  'user can see {string}, {string}, {string}, {string}, and {string} in Recently used',
+  (el1, el2, el3, el4, el5: string) => {
+    cy.get('[aria-labelledby="Recently-used"]').each(($resource) => {
+      cy.wrap($resource)
+        .find('label')
+        .should('contains.text', el1)
+        .and('contains.text', el2)
+        .and('contains.text', el3)
+        .and('contains.text', el4)
+        .and('contains.text', el5);
+    });
+  },
+);
+
+When('user clicks on clear history', () => {
+  cy.byLegacyTestID('close-icon').should('be.visible').click({ force: true });
+});
+
+Then('user can not see Recently used', () => {
+  cy.get('[aria-labelledby="Recently-used"]').should('not.exist');
+});


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-7463
Story: https://issues.redhat.com/browse/ODC-7569

Acceptance criteria:

- Automating the ACs for epic [ODC-7480](https://issues.redhat.com/browse/ODC-7480)

**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]

**Fix**: https://issues.redhat.com/browse/ODC-7569


**Test Setup**:

Command to execute:

Run a cluster locally and execute the command  `npm run test-cypress-dev-console` simultaneously

Execute the search-devperspective.feature file

**Browser**
Chrome 120

**Test Execution Screenshot:**
<img width="1784" alt="Screenshot 2024-04-24 at 3 42 05 AM" src="https://github.com/openshift/console/assets/10252230/85612dc4-f1e3-4959-bd37-71b59eb30c26">


