### PR TITLE
[release-4.15] OCPBUGS-32793: Fix that telemetry events didn't incl. an userId anymore

### DIFF
--- a/dynamic-demo-plugin/src/utils/telemetry.ts
+++ b/dynamic-demo-plugin/src/utils/telemetry.ts
@@ -72,19 +72,27 @@ export const eventListener = async (eventType: string, properties?: any) => {
     },
   };
   switch (eventType) {
-    case 'identify':
+    case 'identify': {
       const { user, ...otherProperties } = properties;
-      const id = user.metadata.uid || `${location.host}-${user.metadata.name}`;
+      // With 4.15+ we can use the user object directly, but on older releases (<4.15)
+      // we need to extract the user object from the metadata.
+      // All properties are defined in the UserInfo interface and marked as optional.
+      const uid = user?.uid || user?.metadata?.uid;
+      const username = user?.username || user?.metadata?.name;
+      const id = uid || `${location.host}-${username}`;
       // Use SHA1 hash algorithm to anonymize the user
       const anonymousIdBuffer = await crypto.subtle.digest('SHA-1', new TextEncoder().encode(id));
       const anonymousIdArray = Array.from(new Uint8Array(anonymousIdBuffer));
       const anonymousId = anonymousIdArray.map((b) => b.toString(16).padStart(2, '0')).join('');
       (window as any).analytics.identify(anonymousId, otherProperties, anonymousIP);
       break;
-    case 'page':
+    }
+    case 'page': {
       (window as any).analytics.page(undefined, properties, anonymousIP);
       break;
-    default:
+    }
+    default: {
       (window as any).analytics.track(eventType, properties, anonymousIP);
+    }
   }
 };

--- a/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts
@@ -122,7 +122,7 @@ export const eventListener: TelemetryEventListener = async (
     case 'identify':
       {
         const { user, ...otherProperties } = properties;
-        const id = user?.metadata?.name;
+        const id = user?.username;
         if (id) {
           // Use SHA1 hash algorithm to anonymize the user
           const anonymousIdBuffer = await crypto.subtle.digest(

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -300,12 +300,12 @@ const CaptureTelemetry = React.memo(function CaptureTelemetry() {
   );
 
   React.useEffect(() => {
-    if (user.metadata?.uid || user.metadata?.name) {
+    if (user?.uid || user?.username) {
       fireTelemetryEvent('identify', { perspective, user });
     }
     // Only trigger identify event when the user identifier changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user.metadata?.uid || user.metadata?.name, fireTelemetryEvent]);
+  }, [user?.uid || user?.username, fireTelemetryEvent]);
 
   // notify url change events
   // Debouncing the url change events so that redirects don't fire multiple events.


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGS-32793

This is a manual backport of https://issues.redhat.com/browse/OCPBUGS-32791, the fix for that is included in #13786

## Cluster bot 4.14

By default, no telemetry communication happens.

After setting these annotations on the console cluster config (Console CR, not ConfigMap):

```
    telemetry.console.openshift.io/SEGMENT_API_KEY: ...
    telemetry.console.openshift.io/SEGMENT_API_HOST: console.redhat.com/connections/api/v1
    telemetry.console.openshift.io/SEGMENT_JS_HOST: console.redhat.com/connections/cdn
    telemetry.console.openshift.io/ORGANIZATION_ID: console-team-cluster-bot-test
```

I could confirm this network communication:

![image](https://github.com/openshift/console/assets/139310/1de5d494-7b53-4157-b53c-eb9d713f027e)

When also adding

```
    telemetry.console.openshift.io/DEBUG: 'true'
```

The scripts are still loaded, but the events are **not** sent.

The Segment `userId` is `sha1('kube:admin')`

## Cluster bot 4.15

By default, no telemetry communication happens.

After setting these annotations on the console cluster config (Console CR, not ConfigMap):

```
    telemetry.console.openshift.io/SEGMENT_API_KEY: ...
    telemetry.console.openshift.io/SEGMENT_API_HOST: console.redhat.com/connections/api/v1
    telemetry.console.openshift.io/SEGMENT_JS_HOST: console.redhat.com/connections/cdn
    telemetry.console.openshift.io/ORGANIZATION_ID: console-team-cluster-bot-test
```

I could confirm this network communication:

![image](https://github.com/openshift/console/assets/139310/6812ccb3-9d9b-4e8a-b0c7-f2eab53f8582)

When also adding

```
    telemetry.console.openshift.io/DEBUG: 'true'
```

The scripts are still loaded, but the events are **not** sent.

The Segment `userId` is picked up from the `ajs_user_id` cookie, or null if the cookie isn't there.
