### PR TITLE
OCPBUGS-32950: Restore user toggle when authentification is disabled

### DIFF
--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -423,7 +423,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
     );
     const launchActions = getLaunchActions();
 
-    if (flagPending(openshiftFlag) || flagPending(authEnabledFlag) || !username) {
+    if (flagPending(openshiftFlag) || flagPending(authEnabledFlag)) {
       return null;
     }
 
@@ -512,7 +512,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
     const userToggle = (
       <span className="pf-v5-c-dropdown__toggle">
         <span className="co-username" data-test="username">
-          {username}
+          {authEnabledFlag ? username : t('public~Auth disabled')}
         </span>
         <CaretDownIcon className="pf-c-dropdown__toggle-icon" />
       </span>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -787,6 +787,7 @@
   "User Preferences": "User Preferences",
   "Log out": "Log out",
   "Utility menu": "Utility menu",
+  "Auth disabled": "Auth disabled",
   "User menu": "User menu",
   "Application launcher": "Application launcher",
   "Notification drawer": "Notification drawer",


### PR DESCRIPTION
**All versions up to 4.14 (local console without authentication):**

![image](https://github.com/openshift/console/assets/139310/45a5cb77-23a4-40d5-8655-7b878859d270)

**4.15 and 4.16 (local console without authentication):**

![image](https://github.com/openshift/console/assets/139310/fe6d2638-b7ce-4830-8b5d-740483d0ec4a)

**Local console with this PR (and without authentication):**

![image](https://github.com/openshift/console/assets/139310/e93decd0-c91c-4274-b466-4f4b6cd0d7f1)

/cc @jhadvig @TheRealJon @lokanandaprabhu @Lucifergene 