### PR TITLE
OCPBUGS-32321: Add username/uid label and annotation for the user setting ConfigMap, Role and RoleBinding

### DIFF
--- a/pkg/usersettings/helpers.go
+++ b/pkg/usersettings/helpers.go
@@ -40,7 +40,9 @@ func createRole(userSettingMeta *UserSettingMeta) *rbac.Role {
 			Kind:       "Role",
 		},
 		ObjectMeta: meta.ObjectMeta{
-			Name: userSettingMeta.getRoleName(),
+			Name:        userSettingMeta.getRoleName(),
+			Labels:      userSettingMeta.getLabels(),
+			Annotations: userSettingMeta.getAnnotations(),
 		},
 		Rules: []rbac.PolicyRule{
 			{
@@ -72,7 +74,9 @@ func createRoleBinding(userSettingMeta *UserSettingMeta) *rbac.RoleBinding {
 			Kind:       "RoleBinding",
 		},
 		ObjectMeta: meta.ObjectMeta{
-			Name: userSettingMeta.getRoleBindingName(),
+			Name:        userSettingMeta.getRoleBindingName(),
+			Labels:      userSettingMeta.getLabels(),
+			Annotations: userSettingMeta.getAnnotations(),
 		},
 		Subjects: []rbac.Subject{
 			{
@@ -96,7 +100,9 @@ func createConfigMap(userSettingMeta *UserSettingMeta) *core.ConfigMap {
 			Kind:       "ConfigMap",
 		},
 		ObjectMeta: meta.ObjectMeta{
-			Name: userSettingMeta.getConfigMapName(),
+			Name:        userSettingMeta.getConfigMapName(),
+			Labels:      userSettingMeta.getLabels(),
+			Annotations: userSettingMeta.getAnnotations(),
 		},
 	}
 }

--- a/pkg/usersettings/helpers.go
+++ b/pkg/usersettings/helpers.go
@@ -11,13 +11,10 @@ import (
 )
 
 func newUserSettingMeta(userInfo authenticationv1.UserInfo) (*UserSettingMeta, error) {
-	uid := userInfo.UID
-	name := userInfo.Username
-	resourceIdentifier := name
-
-	if uid != "" {
-		resourceIdentifier = string(uid)
-	} else if name == "kube:admin" {
+	var resourceIdentifier string
+	if userInfo.UID != "" {
+		resourceIdentifier = userInfo.UID
+	} else if userInfo.Username == "kube:admin" {
 		resourceIdentifier = "kubeadmin"
 	} else {
 		// to avoid issues when the username contains special characters like '@'
@@ -30,8 +27,8 @@ func newUserSettingMeta(userInfo authenticationv1.UserInfo) (*UserSettingMeta, e
 	}
 
 	return &UserSettingMeta{
-		Username:           name,
-		UID:                string(uid),
+		Username:           userInfo.Username,
+		UID:                userInfo.UID,
 		ResourceIdentifier: resourceIdentifier,
 	}, nil
 }

--- a/pkg/usersettings/helpers.go
+++ b/pkg/usersettings/helpers.go
@@ -11,10 +11,13 @@ import (
 )
 
 func newUserSettingMeta(userInfo authenticationv1.UserInfo) (*UserSettingMeta, error) {
+	uid := userInfo.UID
+	username := userInfo.Username
 	var resourceIdentifier string
-	if userInfo.UID != "" {
-		resourceIdentifier = userInfo.UID
-	} else if userInfo.Username == "kube:admin" {
+
+	if uid != "" {
+		resourceIdentifier = uid
+	} else if username == "kube:admin" {
 		resourceIdentifier = "kubeadmin"
 	} else {
 		// to avoid issues when the username contains special characters like '@'
@@ -27,8 +30,8 @@ func newUserSettingMeta(userInfo authenticationv1.UserInfo) (*UserSettingMeta, e
 	}
 
 	return &UserSettingMeta{
-		Username:           userInfo.Username,
-		UID:                userInfo.UID,
+		Username:           username,
+		UID:                uid,
 		ResourceIdentifier: resourceIdentifier,
 	}, nil
 }

--- a/pkg/usersettings/helpers.go
+++ b/pkg/usersettings/helpers.go
@@ -18,6 +18,7 @@ func newUserSettingMeta(userInfo authenticationv1.UserInfo) (*UserSettingMeta, e
 	if uid != "" {
 		resourceIdentifier = uid
 	} else if username == "kube:admin" {
+		uid = "kubeadmin"
 		resourceIdentifier = "kubeadmin"
 	} else {
 		// to avoid issues when the username contains special characters like '@'

--- a/pkg/usersettings/helpers_test.go
+++ b/pkg/usersettings/helpers_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
+	core "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNewUserSettingsMeta(t *testing.T) {
@@ -70,11 +73,11 @@ func TestNewUserSettingsMeta(t *testing.T) {
 
 func TestCreateUserSettingsResources(t *testing.T) {
 	tests := []struct {
-		testcase                string
-		userInfo                authenticationv1.UserInfo
-		expectedRoleName        string
-		expectedRoleBindingName string
-		expectedConfigMapName   string
+		testcase            string
+		userInfo            authenticationv1.UserInfo
+		expectedRole        rbac.Role
+		expectedRoleBinding rbac.RoleBinding
+		expectedConfigMap   core.ConfigMap
 	}{
 		{
 			testcase: "for kubeadmin",
@@ -82,9 +85,65 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				Username: "kube:admin",
 				UID:      "",
 			},
-			expectedConfigMapName:   "user-settings-kubeadmin",
-			expectedRoleName:        "user-settings-kubeadmin-role",
-			expectedRoleBindingName: "user-settings-kubeadmin-rolebinding",
+			expectedRole: rbac.Role{
+				TypeMeta: meta.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "Role",
+				},
+				ObjectMeta: meta.ObjectMeta{
+					Name: "user-settings-kubeadmin-role",
+				},
+				Rules: []rbac.PolicyRule{
+					{
+						APIGroups: []string{
+							"", // Core group, not "v1"
+						},
+						Resources: []string{
+							"configmaps", // Not "ConfigMap"
+						},
+						Verbs: []string{
+							"get",
+							"list",
+							"patch",
+							"update",
+							"watch",
+						},
+						ResourceNames: []string{
+							"user-settings-kubeadmin",
+						},
+					},
+				},
+			},
+			expectedRoleBinding: rbac.RoleBinding{
+				TypeMeta: meta.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "RoleBinding",
+				},
+				ObjectMeta: meta.ObjectMeta{
+					Name: "user-settings-kubeadmin-rolebinding",
+				},
+				Subjects: []rbac.Subject{
+					{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     "kube:admin",
+					},
+				},
+				RoleRef: rbac.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Role",
+					Name:     "user-settings-kubeadmin-role",
+				},
+			},
+			expectedConfigMap: core.ConfigMap{
+				TypeMeta: meta.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: meta.ObjectMeta{
+					Name: "user-settings-kubeadmin",
+				},
+			},
 		},
 		{
 			testcase: "for fake kubeadmin we use uid",
@@ -92,9 +151,65 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				Username: "kube:admin",
 				UID:      "1234",
 			},
-			expectedConfigMapName:   "user-settings-1234",
-			expectedRoleName:        "user-settings-1234-role",
-			expectedRoleBindingName: "user-settings-1234-rolebinding",
+			expectedRole: rbac.Role{
+				TypeMeta: meta.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "Role",
+				},
+				ObjectMeta: meta.ObjectMeta{
+					Name: "user-settings-1234-role",
+				},
+				Rules: []rbac.PolicyRule{
+					{
+						APIGroups: []string{
+							"", // Core group, not "v1"
+						},
+						Resources: []string{
+							"configmaps", // Not "ConfigMap"
+						},
+						Verbs: []string{
+							"get",
+							"list",
+							"patch",
+							"update",
+							"watch",
+						},
+						ResourceNames: []string{
+							"user-settings-1234",
+						},
+					},
+				},
+			},
+			expectedRoleBinding: rbac.RoleBinding{
+				TypeMeta: meta.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "RoleBinding",
+				},
+				ObjectMeta: meta.ObjectMeta{
+					Name: "user-settings-1234-rolebinding",
+				},
+				Subjects: []rbac.Subject{
+					{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     "kube:admin",
+					},
+				},
+				RoleRef: rbac.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Role",
+					Name:     "user-settings-1234-role",
+				},
+			},
+			expectedConfigMap: core.ConfigMap{
+				TypeMeta: meta.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: meta.ObjectMeta{
+					Name: "user-settings-1234",
+				},
+			},
 		},
 		{
 			testcase: "for non kubeadmin",
@@ -102,9 +217,65 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				Username: "developer",
 				UID:      "1234",
 			},
-			expectedConfigMapName:   "user-settings-1234",
-			expectedRoleName:        "user-settings-1234-role",
-			expectedRoleBindingName: "user-settings-1234-rolebinding",
+			expectedRole: rbac.Role{
+				TypeMeta: meta.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "Role",
+				},
+				ObjectMeta: meta.ObjectMeta{
+					Name: "user-settings-1234-role",
+				},
+				Rules: []rbac.PolicyRule{
+					{
+						APIGroups: []string{
+							"", // Core group, not "v1"
+						},
+						Resources: []string{
+							"configmaps", // Not "ConfigMap"
+						},
+						Verbs: []string{
+							"get",
+							"list",
+							"patch",
+							"update",
+							"watch",
+						},
+						ResourceNames: []string{
+							"user-settings-1234",
+						},
+					},
+				},
+			},
+			expectedRoleBinding: rbac.RoleBinding{
+				TypeMeta: meta.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "RoleBinding",
+				},
+				ObjectMeta: meta.ObjectMeta{
+					Name: "user-settings-1234-rolebinding",
+				},
+				Subjects: []rbac.Subject{
+					{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     "developer",
+					},
+				},
+				RoleRef: rbac.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Role",
+					Name:     "user-settings-1234-role",
+				},
+			},
+			expectedConfigMap: core.ConfigMap{
+				TypeMeta: meta.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: meta.ObjectMeta{
+					Name: "user-settings-1234",
+				},
+			},
 		},
 	}
 
@@ -119,28 +290,14 @@ func TestCreateUserSettingsResources(t *testing.T) {
 			roleBinding := createRoleBinding(userSettingMeta)
 			configMap := createConfigMap(userSettingMeta)
 
-			// Role
-			if role.ObjectMeta.Name != tt.expectedRoleName {
-				t.Errorf("Role name does not match:\n%v\nbut got\n%v", tt.expectedRoleName, role.ObjectMeta.Name)
+			if !reflect.DeepEqual(&tt.expectedRole, role) {
+				t.Errorf("Role does not match expectation:\n%v\nbut got\n%v", &tt.expectedRole, role)
 			}
-			if role.Rules[0].ResourceNames[0] != tt.expectedConfigMapName {
-				t.Errorf("Role configmap ref does not match:\n%v\nbut got\n%v", tt.expectedConfigMapName, role.Rules[0].ResourceNames[0])
+			if !reflect.DeepEqual(&tt.expectedRoleBinding, roleBinding) {
+				t.Errorf("RoleBinding does not match expectation:\n%v\nbut got\n%v", &tt.expectedRoleBinding, roleBinding)
 			}
-
-			// RoleBinding
-			if roleBinding.ObjectMeta.Name != tt.expectedRoleBindingName {
-				t.Errorf("RoleBinding name does not match:\n%v\nbut got\n%v", tt.expectedRoleBindingName, roleBinding.ObjectMeta.Name)
-			}
-			if roleBinding.Subjects[0].Name != tt.userInfo.Username {
-				t.Errorf("RoleBinding username ref does not match:\n%v\nbut got\n%v", tt.userInfo.Username, roleBinding.Subjects[0].Name)
-			}
-			if roleBinding.RoleRef.Name != tt.expectedRoleName {
-				t.Errorf("RoleBinding role ref does not match:\n%v\nbut got\n%v", tt.expectedRoleName, roleBinding.RoleRef.Name)
-			}
-
-			// ConfigMap
-			if configMap.ObjectMeta.Name != tt.expectedConfigMapName {
-				t.Errorf("ConfigMap name does not match:\n%v\nbut got\n%v", tt.expectedConfigMapName, configMap.ObjectMeta.Name)
+			if !reflect.DeepEqual(&tt.expectedConfigMap, configMap) {
+				t.Errorf("ConfigMap does not match expectation:\n%v\nbut got\n%v", &tt.expectedConfigMap, configMap)
 			}
 		})
 	}

--- a/pkg/usersettings/helpers_test.go
+++ b/pkg/usersettings/helpers_test.go
@@ -83,6 +83,7 @@ func TestCreateUserSettingsResources(t *testing.T) {
 			testcase: "for kubeadmin",
 			userInfo: authenticationv1.UserInfo{
 				Username: "kube:admin",
+				UID:      "",
 			},
 			expectedRole: rbac.Role{
 				TypeMeta: meta.TypeMeta{
@@ -91,6 +92,15 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-kubeadmin-role",
+					Labels: map[string]string{
+						userSettingsLabel:       "true",
+						uidLabel:                "",
+						resourceIdentifierLabel: "kubeadmin",
+					},
+					Annotations: map[string]string{
+						uidAnnotation:      "",
+						usernameAnnotation: "kube:admin",
+					},
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -120,6 +130,15 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-kubeadmin-rolebinding",
+					Labels: map[string]string{
+						userSettingsLabel:       "true",
+						uidLabel:                "",
+						resourceIdentifierLabel: "kubeadmin",
+					},
+					Annotations: map[string]string{
+						uidAnnotation:      "",
+						usernameAnnotation: "kube:admin",
+					},
 				},
 				Subjects: []rbac.Subject{
 					{
@@ -141,6 +160,15 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-kubeadmin",
+					Labels: map[string]string{
+						userSettingsLabel:       "true",
+						uidLabel:                "",
+						resourceIdentifierLabel: "kubeadmin",
+					},
+					Annotations: map[string]string{
+						uidAnnotation:      "",
+						usernameAnnotation: "kube:admin",
+					},
 				},
 			},
 		},
@@ -157,6 +185,15 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-role",
+					Labels: map[string]string{
+						userSettingsLabel:       "true",
+						uidLabel:                "1234",
+						resourceIdentifierLabel: "1234",
+					},
+					Annotations: map[string]string{
+						uidAnnotation:      "1234",
+						usernameAnnotation: "kube:admin",
+					},
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -186,6 +223,15 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-rolebinding",
+					Labels: map[string]string{
+						userSettingsLabel:       "true",
+						uidLabel:                "1234",
+						resourceIdentifierLabel: "1234",
+					},
+					Annotations: map[string]string{
+						uidAnnotation:      "1234",
+						usernameAnnotation: "kube:admin",
+					},
 				},
 				Subjects: []rbac.Subject{
 					{
@@ -207,6 +253,15 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234",
+					Labels: map[string]string{
+						userSettingsLabel:       "true",
+						uidLabel:                "1234",
+						resourceIdentifierLabel: "1234",
+					},
+					Annotations: map[string]string{
+						uidAnnotation:      "1234",
+						usernameAnnotation: "kube:admin",
+					},
 				},
 			},
 		},
@@ -223,6 +278,15 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-role",
+					Labels: map[string]string{
+						userSettingsLabel:       "true",
+						uidLabel:                "1234",
+						resourceIdentifierLabel: "1234",
+					},
+					Annotations: map[string]string{
+						uidAnnotation:      "1234",
+						usernameAnnotation: "developer",
+					},
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -252,6 +316,15 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-rolebinding",
+					Labels: map[string]string{
+						userSettingsLabel:       "true",
+						uidLabel:                "1234",
+						resourceIdentifierLabel: "1234",
+					},
+					Annotations: map[string]string{
+						uidAnnotation:      "1234",
+						usernameAnnotation: "developer",
+					},
 				},
 				Subjects: []rbac.Subject{
 					{
@@ -273,6 +346,15 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234",
+					Labels: map[string]string{
+						userSettingsLabel:       "true",
+						uidLabel:                "1234",
+						resourceIdentifierLabel: "1234",
+					},
+					Annotations: map[string]string{
+						uidAnnotation:      "1234",
+						usernameAnnotation: "developer",
+					},
 				},
 			},
 		},
@@ -288,6 +370,15 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-role",
+					Labels: map[string]string{
+						userSettingsLabel:       "true",
+						uidLabel:                "",
+						resourceIdentifierLabel: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+					},
+					Annotations: map[string]string{
+						uidAnnotation:      "",
+						usernameAnnotation: "openshift@redhat.com",
+					},
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -317,6 +408,15 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-rolebinding",
+					Labels: map[string]string{
+						userSettingsLabel:       "true",
+						uidLabel:                "",
+						resourceIdentifierLabel: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+					},
+					Annotations: map[string]string{
+						uidAnnotation:      "",
+						usernameAnnotation: "openshift@redhat.com",
+					},
 				},
 				Subjects: []rbac.Subject{
 					{
@@ -338,6 +438,15 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+					Labels: map[string]string{
+						userSettingsLabel:       "true",
+						uidLabel:                "",
+						resourceIdentifierLabel: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+					},
+					Annotations: map[string]string{
+						uidAnnotation:      "",
+						usernameAnnotation: "openshift@redhat.com",
+					},
 				},
 			},
 		},

--- a/pkg/usersettings/helpers_test.go
+++ b/pkg/usersettings/helpers_test.go
@@ -83,7 +83,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 			testcase: "for kubeadmin",
 			userInfo: authenticationv1.UserInfo{
 				Username: "kube:admin",
-				UID:      "",
 			},
 			expectedRole: rbac.Role{
 				TypeMeta: meta.TypeMeta{
@@ -274,6 +273,71 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234",
+				},
+			},
+		},
+		{
+			testcase: "for users with email addresses as username",
+			userInfo: authenticationv1.UserInfo{
+				Username: "openshift@redhat.com",
+			},
+			expectedRole: rbac.Role{
+				TypeMeta: meta.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "Role",
+				},
+				ObjectMeta: meta.ObjectMeta{
+					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-role",
+				},
+				Rules: []rbac.PolicyRule{
+					{
+						APIGroups: []string{
+							"", // Core group, not "v1"
+						},
+						Resources: []string{
+							"configmaps", // Not "ConfigMap"
+						},
+						Verbs: []string{
+							"get",
+							"list",
+							"patch",
+							"update",
+							"watch",
+						},
+						ResourceNames: []string{
+							"user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+						},
+					},
+				},
+			},
+			expectedRoleBinding: rbac.RoleBinding{
+				TypeMeta: meta.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "RoleBinding",
+				},
+				ObjectMeta: meta.ObjectMeta{
+					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-rolebinding",
+				},
+				Subjects: []rbac.Subject{
+					{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     "openshift@redhat.com",
+					},
+				},
+				RoleRef: rbac.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Role",
+					Name:     "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-role",
+				},
+			},
+			expectedConfigMap: core.ConfigMap{
+				TypeMeta: meta.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: meta.ObjectMeta{
+					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 				},
 			},
 		},

--- a/pkg/usersettings/helpers_test.go
+++ b/pkg/usersettings/helpers_test.go
@@ -18,7 +18,7 @@ func TestNewUserSettingsMeta(t *testing.T) {
 		expectedData  *UserSettingMeta
 	}{
 		{
-			testcase: "returns -kubeadmin for kube:admin",
+			testcase: "returns kubeadmin for kube:admin",
 			userInfo: authenticationv1.UserInfo{
 				Username: "kube:admin",
 				UID:      "",
@@ -26,12 +26,12 @@ func TestNewUserSettingsMeta(t *testing.T) {
 			expectedError: nil,
 			expectedData: &UserSettingMeta{
 				Username:           "kube:admin",
-				UID:                "",
+				UID:                "kubeadmin",
 				ResourceIdentifier: "kubeadmin",
 			},
 		},
 		{
-			testcase: "returns -kubeadmin for fake kube:admin with uid",
+			testcase: "returns kubeadmin for fake kube:admin with uid",
 			userInfo: authenticationv1.UserInfo{
 				Username: "kube:admin",
 				UID:      "1234",
@@ -93,12 +93,10 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-kubeadmin-role",
 					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "",
-						resourceIdentifierLabel: "kubeadmin",
+						userSettingsLabel: "true",
+						uidLabel:          "kubeadmin",
 					},
 					Annotations: map[string]string{
-						uidAnnotation:      "",
 						usernameAnnotation: "kube:admin",
 					},
 				},
@@ -131,12 +129,10 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-kubeadmin-rolebinding",
 					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "",
-						resourceIdentifierLabel: "kubeadmin",
+						userSettingsLabel: "true",
+						uidLabel:          "kubeadmin",
 					},
 					Annotations: map[string]string{
-						uidAnnotation:      "",
 						usernameAnnotation: "kube:admin",
 					},
 				},
@@ -161,12 +157,10 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-kubeadmin",
 					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "",
-						resourceIdentifierLabel: "kubeadmin",
+						userSettingsLabel: "true",
+						uidLabel:          "kubeadmin",
 					},
 					Annotations: map[string]string{
-						uidAnnotation:      "",
 						usernameAnnotation: "kube:admin",
 					},
 				},
@@ -186,12 +180,10 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-role",
 					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "1234",
-						resourceIdentifierLabel: "1234",
+						userSettingsLabel: "true",
+						uidLabel:          "1234",
 					},
 					Annotations: map[string]string{
-						uidAnnotation:      "1234",
 						usernameAnnotation: "kube:admin",
 					},
 				},
@@ -224,12 +216,10 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-rolebinding",
 					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "1234",
-						resourceIdentifierLabel: "1234",
+						userSettingsLabel: "true",
+						uidLabel:          "1234",
 					},
 					Annotations: map[string]string{
-						uidAnnotation:      "1234",
 						usernameAnnotation: "kube:admin",
 					},
 				},
@@ -254,12 +244,10 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234",
 					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "1234",
-						resourceIdentifierLabel: "1234",
+						userSettingsLabel: "true",
+						uidLabel:          "1234",
 					},
 					Annotations: map[string]string{
-						uidAnnotation:      "1234",
 						usernameAnnotation: "kube:admin",
 					},
 				},
@@ -279,12 +267,10 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-role",
 					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "1234",
-						resourceIdentifierLabel: "1234",
+						userSettingsLabel: "true",
+						uidLabel:          "1234",
 					},
 					Annotations: map[string]string{
-						uidAnnotation:      "1234",
 						usernameAnnotation: "developer",
 					},
 				},
@@ -317,12 +303,10 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-rolebinding",
 					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "1234",
-						resourceIdentifierLabel: "1234",
+						userSettingsLabel: "true",
+						uidLabel:          "1234",
 					},
 					Annotations: map[string]string{
-						uidAnnotation:      "1234",
 						usernameAnnotation: "developer",
 					},
 				},
@@ -347,12 +331,10 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234",
 					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "1234",
-						resourceIdentifierLabel: "1234",
+						userSettingsLabel: "true",
+						uidLabel:          "1234",
 					},
 					Annotations: map[string]string{
-						uidAnnotation:      "1234",
 						usernameAnnotation: "developer",
 					},
 				},
@@ -371,12 +353,10 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-role",
 					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "",
-						resourceIdentifierLabel: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+						userSettingsLabel: "true",
+						uidLabel:          "",
 					},
 					Annotations: map[string]string{
-						uidAnnotation:      "",
 						usernameAnnotation: "openshift@redhat.com",
 					},
 				},
@@ -409,12 +389,10 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-rolebinding",
 					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "",
-						resourceIdentifierLabel: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+						userSettingsLabel: "true",
+						uidLabel:          "",
 					},
 					Annotations: map[string]string{
-						uidAnnotation:      "",
 						usernameAnnotation: "openshift@redhat.com",
 					},
 				},
@@ -439,12 +417,10 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "",
-						resourceIdentifierLabel: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+						userSettingsLabel: "true",
+						uidLabel:          "",
 					},
 					Annotations: map[string]string{
-						uidAnnotation:      "",
 						usernameAnnotation: "openshift@redhat.com",
 					},
 				},

--- a/pkg/usersettings/types.go
+++ b/pkg/usersettings/types.go
@@ -1,5 +1,11 @@
 package usersettings
 
+const userSettingsLabel = "console.openshift.io/user-settings"
+const uidLabel = "console.openshift.io/user-settings-uid"
+const resourceIdentifierLabel = "console.openshift.io/user-settings-resource-identifier"
+const uidAnnotation = "console.openshift.io/user-settings-uid"
+const usernameAnnotation = "console.openshift.io/user-settings-username"
+
 type UserSettingMeta struct {
 	Username string
 	UID      string
@@ -17,4 +23,19 @@ func (r *UserSettingMeta) getRoleName() string {
 
 func (r *UserSettingMeta) getRoleBindingName() string {
 	return "user-settings-" + r.ResourceIdentifier + "-rolebinding"
+}
+
+func (r *UserSettingMeta) getLabels() map[string]string {
+	return map[string]string{
+		userSettingsLabel:       "true",
+		uidLabel:                r.UID,
+		resourceIdentifierLabel: r.ResourceIdentifier,
+	}
+}
+
+func (r *UserSettingMeta) getAnnotations() map[string]string {
+	return map[string]string{
+		uidAnnotation:      r.UID,
+		usernameAnnotation: r.Username,
+	}
 }

--- a/pkg/usersettings/types.go
+++ b/pkg/usersettings/types.go
@@ -2,8 +2,6 @@ package usersettings
 
 const userSettingsLabel = "console.openshift.io/user-settings"
 const uidLabel = "console.openshift.io/user-settings-uid"
-const resourceIdentifierLabel = "console.openshift.io/user-settings-resource-identifier"
-const uidAnnotation = "console.openshift.io/user-settings-uid"
 const usernameAnnotation = "console.openshift.io/user-settings-username"
 
 type UserSettingMeta struct {
@@ -27,15 +25,13 @@ func (r *UserSettingMeta) getRoleBindingName() string {
 
 func (r *UserSettingMeta) getLabels() map[string]string {
 	return map[string]string{
-		userSettingsLabel:       "true",
-		uidLabel:                r.UID,
-		resourceIdentifierLabel: r.ResourceIdentifier,
+		userSettingsLabel: "true",
+		uidLabel:          r.UID,
 	}
 }
 
 func (r *UserSettingMeta) getAnnotations() map[string]string {
 	return map[string]string{
-		uidAnnotation:      r.UID,
 		usernameAnnotation: r.Username,
 	}
 }


### PR DESCRIPTION
This change adds 3 new labels and 2 annotations for newly created user settings resources.

* Labels
  1. A new label that identifies this resource is a user-settings resource.
  2. A new label with the UID, if the user-settings refers a local OpenShift user, `kubeadmin`, or empty for OIDC users.
* Annotations:
  2. The origin username, as annotations also allow email addresses when an OIDC user is used.

@stlaz this should work for the different auth variants we support, or?

For example for a **kube:admin** ConfigMap:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: user-settings-kubeadmin
  labels:
    console.openshift.io/user-settings: "true"
    console.openshift.io/user-settings-uid: "kubeadmin"
  annotations:
    console.openshift.io/user-settings-username: "kube:admin"
```

For a **local User with a UID**:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: user-settings-1234-1234...
  labels:
    console.openshift.io/user-settings: "true"
    console.openshift.io/user-settings-uid: "1234-1234..."
  annotations:
    console.openshift.io/user-settings-username: "consoledeveloper"
```

For an **OIDC user without an UID but with an email as username**:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: user-settings-e3b0c442...
  labels:
    console.openshift.io/user-settings: "true"
    console.openshift.io/user-settings-uid: ""
  annotations:
    console.openshift.io/user-settings-username: "openshift@redhat.com"
```

/cc @stlaz @jhadvig @TheRealJon