### PR TITLE
OCPBUGS-32707: Fix React Router useParams in dynamic demo plugin

### DIFF
--- a/dynamic-demo-plugin/package.json
+++ b/dynamic-demo-plugin/package.json
@@ -35,6 +35,7 @@
     "react-i18next": "^11.7.3",
     "react-router": "5.3.x",
     "react-router-dom": "5.3.x",
+    "react-router-dom-v5-compat": "^6.11.2",
     "style-loader": "0.23.1",
     "ts-loader": "9.x",
     "ts-node": "10.9.2",

--- a/dynamic-demo-plugin/src/components/ExampleNamespacedPage.tsx
+++ b/dynamic-demo-plugin/src/components/ExampleNamespacedPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { match as RMatch } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import {
   Card,
   CardBody,
@@ -39,8 +39,8 @@ const NamespacePageContent = ({ namespace }: { namespace?: string }) => {
   );
 };
 
-export const ExampleNamespacedPage: React.FC<ExampleNamespacedPageProps> = ({ match }) => {
-  const { ns } = match?.params;
+export const ExampleNamespacedPage: React.FC = () => {
+  const { ns } = useParams<'ns'>();
   const activeNamespace = ns || 'all-namespaces';
 
   return (
@@ -49,10 +49,4 @@ export const ExampleNamespacedPage: React.FC<ExampleNamespacedPageProps> = ({ ma
       <NamespacePageContent namespace={activeNamespace} />
     </>
   );
-};
-
-type ExampleNamespacedPageProps = {
-  match: RMatch<{
-    ns?: string;
-  }>;
 };

--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -204,10 +204,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-5.1.1.tgz#098b70b4ed4d05217004395abc7395a46acc9abe"
   integrity sha512-cHuNkzNA9IY9aDwfjSEkitQoVEvRhOJRKhH0yIRlRByEkbdoV9jJZ9xj20hNShE+bxmNuom+MCTQSkpkN1bV8A==
 
-"@remix-run/router@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.9.0.tgz#9033238b41c4cbe1e961eccb3f79e2c588328cf6"
-  integrity sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA==
+"@remix-run/router@1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.6.2.tgz#bbe75f8c59e0b7077584920ce2cc76f8f354934d"
+  integrity sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
@@ -3027,12 +3027,12 @@ react-redux@7.2.2:
     react-is "^16.13.1"
 
 react-router-dom-v5-compat@^6.11.2:
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.16.0.tgz#3033241ce206297bac95da1e7f0038089abb933a"
-  integrity sha512-MfjB9qYZVnWUEHENFa+XpVU5qbDPkqpGvjaF/8nHCnCkfy5pxYajrZrmRmaR4v6Ehtu7GAx59JFTSoQGhLu1+g==
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.11.2.tgz#832a6e7aeef05f3cac12c0147b7c2c11a1540e50"
+  integrity sha512-3EKqtVKqpHOdUgGJiDfPJpsvZpCF+fPw3NO1mFU8eovOKvuksy/Rz7/FWR2e/FknIOOz4wdomx3w046M3aXkNg==
   dependencies:
     history "^5.3.0"
-    react-router "6.16.0"
+    react-router "6.11.2"
 
 react-router-dom@5.3.x:
   version "5.3.4"
@@ -3062,12 +3062,12 @@ react-router@5.3.4, react-router@5.3.x:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@6.16.0:
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.16.0.tgz#abbf3d5bdc9c108c9b822a18be10ee004096fb81"
-  integrity sha512-VT4Mmc4jj5YyjpOi5jOf0I+TYzGpvzERy4ckNSvSh2RArv8LLoCxlsZ2D+tc7zgjxcY34oTz2hZaeX5RVprKqA==
+react-router@6.11.2:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.11.2.tgz#006301c4da1a173d7ad76b7ecd2da01b9dd3837a"
+  integrity sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==
   dependencies:
-    "@remix-run/router" "1.9.0"
+    "@remix-run/router" "1.6.2"
 
 react-side-effect@^2.1.0:
   version "2.1.1"


### PR DESCRIPTION
This PR fixes the following issues in Console dynamic demo plugin:

- Error in `ExampleNamespacedPage` component due to `match` prop being `undefined` :arrow_forward: use React Router v6 `useParams` hook instead. This error is due to Console using React Router v6 which no longer passes the `match` prop to components.
- Ensure that dynamic demo plugin uses the same version of `react-router-dom-v5-compat` as Console frontend.