### PR TITLE
OCPBUGS-33345: Disable create button on NAD empty state for regular user

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/network-attachment-definition-plugin/locales/en/kubevirt-plugin.json
@@ -1,7 +1,7 @@
 {
-  "No network attachment definitions found": "No network attachment definitions found",
-  "Create network attachment definition": "Create network attachment definition",
-  "Learn how to use network attachment definitions": "Learn how to use network attachment definitions",
+  "No {{label}} found": "No {{label}} found",
+  "Create {{label}}": "Create {{label}}",
+  "Learn how to use {{label}}": "Learn how to use {{label}}",
   "NetworkAttachmentDefinition details": "NetworkAttachmentDefinition details",
   "Type": "Type",
   "Details": "Details",
@@ -14,6 +14,7 @@
   "Network Type": "Network Type",
   "Edit YAML": "Edit YAML",
   "Networks are not project-bound. Using the same name creates a shared NAD.": "Networks are not project-bound. Using the same name creates a shared NAD.",
+  "Create network attachment definition": "Create network attachment definition",
   "Name": "Name",
   "Description": "Description",
   "<0>OpenShift Virtualization Operator</0> or <3>SR-IOV Network Operator </3>needs to be installed on the cluster, in order to pick the Network Type.": "<0>OpenShift Virtualization Operator</0> or <3>SR-IOV Network Operator </3>needs to be installed on the cluster, in order to pick the Network Type.",

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
@@ -12,6 +12,7 @@ import { sortable } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom-v5-compat';
 import { QuickStartModel } from '@console/app/src/models';
+import { useAccessReview } from '@console/dynamic-plugin-sdk';
 import { ListPage, Table, TableData, RowFunctionArgs } from '@console/internal/components/factory';
 import { history, Kebab, ResourceKebab, ResourceLink } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
@@ -120,6 +121,12 @@ const NADListEmpty: React.FC = () => {
   const { t } = useTranslation();
   const [namespace] = useActiveNamespace();
 
+  const [canCreate] = useAccessReview({
+    group: NetworkAttachmentDefinitionModel.apiGroup,
+    resource: NetworkAttachmentDefinitionModel.plural,
+    verb: 'create',
+  });
+
   const searchText = 'network attachment definition';
   const [quickStarts, quickStartsLoaded] = useK8sWatchResource<QuickStart[]>({
     kind: referenceForModel(QuickStartModel),
@@ -136,7 +143,13 @@ const NADListEmpty: React.FC = () => {
   return (
     <EmptyState>
       <EmptyStateHeader
-        titleText={<>{t('kubevirt-plugin~No network attachment definitions found')}</>}
+        titleText={
+          <>
+            {t('kubevirt-plugin~No {{label}} found', {
+              label: NetworkAttachmentDefinitionModel.labelPlural,
+            })}
+          </>
+        }
         headingLevel="h4"
       />
       <EmptyStateFooter>
@@ -146,8 +159,9 @@ const NADListEmpty: React.FC = () => {
           onClick={() =>
             history.push(getCreateLink(namespace === ALL_NAMESPACES_KEY ? undefined : namespace))
           }
+          isDisabled={!canCreate}
         >
-          {t('kubevirt-plugin~Create network attachment definition')}
+          {t('kubevirt-plugin~Create {{label}}', { label: NetworkAttachmentDefinitionModel.label })}
         </Button>
         {hasQuickStarts && (
           <EmptyStateActions>
@@ -157,7 +171,9 @@ const NADListEmpty: React.FC = () => {
               onClick={() => history.push('/quickstart?keyword=network+attachment+definition')}
             >
               <RocketIcon className="nad-quickstart-icon" />
-              {t('kubevirt-plugin~Learn how to use network attachment definitions')}
+              {t('kubevirt-plugin~Learn how to use {{label}}', {
+                label: NetworkAttachmentDefinitionModel.labelPlural,
+              })}
             </Button>
           </EmptyStateActions>
         )}


### PR DESCRIPTION

- disable button
- Change text using standards. Don't use `network attachment definition` but `NetworkAttachmentDefinition`


![image](https://github.com/openshift/console/assets/29160323/d1022901-6209-4694-a843-cfa53ea4999f)


