### PR TITLE
OCPBUGS-32631: TaskRuns should not be fetched for Failed PLR's

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
@@ -24,7 +24,7 @@ import { getPipelineRunStatus, pipelineRunDuration } from '../../../utils/pipeli
 import { chainsSignedAnnotation } from '../../pipelines/const';
 import { useTaskRuns } from '../hooks/useTaskRuns';
 import LinkedPipelineRunTaskStatus from '../status/LinkedPipelineRunTaskStatus';
-import PipelineRunStatus from '../status/PipelineRunStatus';
+import PipelineRunStatusContent from '../status/PipelineRunStatusContent';
 import PipelineRunVulnerabilities from '../status/PipelineRunVulnerabilities';
 import { ResourceKebabWithUserLabel } from '../triggered-by';
 import { tableColumnClasses } from './pipelinerun-table';
@@ -33,8 +33,6 @@ const pipelinerunReference = referenceForModel(PipelineRunModel);
 
 type PLRStatusProps = {
   obj: PipelineRunKind;
-  taskRuns: TaskRunKind[];
-  taskRunsLoaded: boolean;
 };
 
 type PipelineRunRowWithoutTaskRunsProps = {
@@ -51,14 +49,12 @@ type PipelineRunRowWithTaskRunsProps = {
 const TASKRUNSFORPLRCACHE: { [key: string]: TaskRunKind[] } = {};
 const InFlightStoreForTaskRunsForPLR: { [key: string]: boolean } = {};
 
-const PLRStatus: React.FC<PLRStatusProps> = React.memo(({ obj, taskRuns, taskRunsLoaded }) => {
+const PLRStatus: React.FC<PLRStatusProps> = React.memo(({ obj }) => {
   return (
-    <PipelineRunStatus
+    <PipelineRunStatusContent
       status={pipelineRunFilterReducer(obj)}
       title={pipelineRunTitleFilterReducer(obj)}
       pipelineRun={obj}
-      taskRuns={taskRuns}
-      taskRunsLoaded={taskRunsLoaded}
     />
   );
 });
@@ -108,7 +104,7 @@ const PipelineRunRowTable = ({
         <PipelineRunVulnerabilities pipelineRun={obj} condensed />
       </TableData>
       <TableData className={tableColumnClasses.status}>
-        <PLRStatus obj={obj} taskRuns={PLRTaskRuns} taskRunsLoaded={taskRunsLoaded} />
+        <PLRStatus obj={obj} />
       </TableData>
       <TableData className={tableColumnClasses.taskStatus}>
         <LinkedPipelineRunTaskStatus
@@ -208,10 +204,7 @@ const PipelineRunRowWithTaskRuns: React.FC<PipelineRunRowWithTaskRunsProps> = Re
 const PipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj, customData }) => {
   const { operatorVersion } = customData;
   const plrStatus = pipelineRunStatus(obj);
-  if (
-    (plrStatus === ComputedStatus.Cancelled || plrStatus === ComputedStatus.Failed) &&
-    (obj?.status?.childReferences ?? []).length > 0
-  ) {
+  if (plrStatus === ComputedStatus.Cancelled && (obj?.status?.childReferences ?? []).length > 0) {
     return <PipelineRunRowWithTaskRuns obj={obj} operatorVersion={operatorVersion} />;
   }
   const taskRunStatusObj = getPipelineRunStatus(obj);

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatusContent.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatusContent.scss
@@ -1,0 +1,4 @@
+.odc-status-column-text {
+    padding: 0;
+    color: var(--pf-v5-c-button--m-link--Color) !important;
+}

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatusContent.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatusContent.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
+import { DASH } from '@console/shared';
+import { ComputedStatus, PipelineRunKind } from '../../../types';
+import PipelineResourceStatus from './PipelineResourceStatus';
+import PipelineRunStatusPopoverContent from './PipelineRunStatusPopoverContent';
+import './PipelineRunStatusContent.scss';
+
+type PipelineRunStatusProps = {
+  status: string;
+  pipelineRun: PipelineRunKind;
+  title?: string;
+};
+const PipelineRunStatusContent: React.FC<PipelineRunStatusProps> = ({
+  status,
+  pipelineRun,
+  title,
+}) => {
+  const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
+
+  const PopoverContent = () => {
+    return <>{isPopoverOpen && <PipelineRunStatusPopoverContent pipelineRun={pipelineRun} />}</>;
+  };
+  return (
+    <>
+      {pipelineRun ? (
+        status === ComputedStatus.Failed ? (
+          <Popover
+            bodyContent={PopoverContent}
+            isVisible={isPopoverOpen}
+            shouldClose={() => setIsPopoverOpen(false)}
+            shouldOpen={() => setIsPopoverOpen(true)}
+            position={PopoverPosition.auto}
+          >
+            <Button variant="plain" className="odc-status-column-text">
+              <PipelineResourceStatus status={status} title={title} />
+            </Button>
+          </Popover>
+        ) : (
+          <PipelineResourceStatus status={status} title={title} />
+        )
+      ) : (
+        <>{DASH}</>
+      )}
+    </>
+  );
+};
+
+export default PipelineRunStatusContent;

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatusPopoverContent.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatusPopoverContent.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom-v5-compat';
+import { LoadingInline, resourcePathFromModel } from '@console/internal/components/utils';
+import { PipelineRunModel } from '../../../models';
+import { PipelineRunKind } from '../../../types';
+import { useTaskRuns } from '../hooks/useTaskRuns';
+import LogSnippetBlock from '../logs/LogSnippetBlock';
+import { getPLRLogSnippet } from '../logs/pipelineRunLogSnippet';
+import './StatusPopoverContent.scss';
+
+type StatusPopoverContentProps = {
+  pipelineRun: PipelineRunKind;
+};
+const PipelineRunStatusPopoverContent: React.FC<StatusPopoverContentProps> = ({ pipelineRun }) => {
+  const { t } = useTranslation();
+  const [PLRTaskRuns, taskRunsLoaded] = useTaskRuns(
+    pipelineRun.metadata.namespace,
+    pipelineRun.metadata.name,
+  );
+
+  if (!taskRunsLoaded) {
+    return (
+      <div style={{ minHeight: '300px' }}>
+        <LoadingInline />
+      </div>
+    );
+  }
+
+  const logDetails = getPLRLogSnippet(pipelineRun, PLRTaskRuns);
+
+  return (
+    <div className="odc-statuspopover-content" style={{ minHeight: '300px' }}>
+      <LogSnippetBlock logDetails={logDetails} namespace={pipelineRun.metadata.namespace}>
+        {(logSnippet: string) => (
+          <>
+            <pre className="co-pre">{logSnippet}</pre>
+            <Link
+              to={`${resourcePathFromModel(
+                PipelineRunModel,
+                pipelineRun.metadata.name,
+                pipelineRun.metadata.namespace,
+              )}/logs`}
+            >
+              {t('pipelines-plugin~View logs')}
+            </Link>
+          </>
+        )}
+      </LogSnippetBlock>
+    </div>
+  );
+};
+
+export default PipelineRunStatusPopoverContent;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-32631

**Analysis / Root cause**: 
TaskRuns were fetched for Failed PipelineRuns. Due to this many API calls were happening and performance becoming slow.

**Solution Description**: 
Not fetching TaskRuns for Failed PipelineRuns. Now TaskRuns status will be calculated from the message value in `pipelinerun.status.conditions`. Only on click of Failed status to see the logs TaskRuns are fetched for that PipelineRun

**Screen shots / Gifs for design review**: 


https://github.com/openshift/console/assets/102503482/7fe90904-ff77-4fb4-8eaa-1631349fac2c







**Unit test coverage report**: 
NA

**Test setup:**

    1.Create 1000 PipelineRuns using https://github.com/openshift-dev-console/loadtests and test different scenarios 


     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge