### PR TITLE
OCPBUGS-32698: Remove TELEMETRY_DISABLED check from console telemetry…

### DIFF
--- a/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts
@@ -110,11 +110,11 @@ export const eventListener: TelemetryEventListener = async (
   eventType: string,
   properties?: any,
 ) => {
-  if (TELEMETRY_DISABLED || !apiKey) {
+  if (!apiKey) {
     if (TELEMETRY_DEBUG) {
       // eslint-disable-next-line no-console
       console.debug(
-        'console-telemetry-plugin: telemetry disabled - ignoring telemetry event:',
+        'console-telemetry-plugin: missing Segment API key - ignoring telemetry event:',
         eventType,
         properties,
       );


### PR DESCRIPTION
… plugin listener.

The extension will not be loaded when TELEMETRY_DISABLED is set to true, so the check is redundant.