### PR TITLE
OCPBUGS-33199: The filepath including leading slash makes error during parsing devfile using Gitlab

### DIFF
--- a/frontend/packages/git-service/src/services/gitlab-service.ts
+++ b/frontend/packages/git-service/src/services/gitlab-service.ts
@@ -208,7 +208,8 @@ export class GitlabService extends BaseService {
     try {
       const projectID = await this.getProjectId();
       const ref = this.metadata.defaultBranch || (this.repo as any)?.default_branch;
-      return await this.client.RepositoryFiles.showRaw(projectID, path, ref);
+      const filePath = path.replace(/^\/+/, '');
+      return await this.client.RepositoryFiles.showRaw(projectID, filePath, ref);
     } catch (e) {
       return null;
     }


### PR DESCRIPTION
If including duplicated leading slashes in the file path during devfile processes, the URL evaluated with invalid at GitLab side, so remove the duplicated leading slash before communicating with the target GitLab server. Reference:
- https://issues.redhat.com/browse/OCPBUGS-33199