### PR TITLE
OCPBUGS-33202: Pipeline list page is crashed when navigating from Search page

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesResourceList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesResourceList.tsx
@@ -29,7 +29,7 @@ const PipelinesResourceList: React.FC<PipelinesResourceListProps> = (props) => {
       kind: referenceForModel(PipelineModel),
       namespace,
       prop: PipelineModel.id,
-      filters: { ...filters(t), name: nameFilter },
+      filters: { ...filters(t), ...(nameFilter && { name: nameFilter }) },
       selector,
       name,
     },


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-33202

**Analysis / Root cause**: 
name filter is used irrespective of filter value is present or not

**Solution Description**: 
If name filter value is there, then only send filter value

**Screen shots / Gifs for design review**: 

----Before----

https://github.com/openshift/console/assets/102503482/0b0e3807-c8b0-444b-a4c0-603328080580




----After----


https://github.com/openshift/console/assets/102503482/07d3e213-cc9f-4a4d-8538-a832c53741b0








**Unit test coverage report**: 
NA

**Test setup:**

    1.Install Pipelines Operator
    2.Go to Developer perspective
    3.Go to search menu, select Pipeline


     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge