### PR TITLE
OCPBUGS-33219: Fix StatusItem layout when no timestamp is present

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
@@ -48,12 +48,14 @@ export const StatusItem: React.FC<StatusItemProps> = ({
       <div className="co-status-card__alert-item-text">
         <div className="co-status-card__alert-item-message">
           {name && <span className="co-status-card__alert-item-header">{name}</span>}
-          <div
-            className="co-health-card__alert-item-timestamp co-status-card__health-item-text text-secondary"
-            data-test="timestamp"
-          >
-            {timestamp && <Timestamp simple timestamp={timestamp} />}
-          </div>
+          {timestamp && (
+            <div
+              className="co-health-card__alert-item-timestamp co-status-card__health-item-text text-secondary"
+              data-test="timestamp"
+            >
+              <Timestamp simple timestamp={timestamp} />
+            </div>
+          )}
           <span className="co-status-card__health-item-text co-break-word">{message}</span>
           {documentationLink && (
             <ExternalLink


### PR DESCRIPTION
Before:
<img width="1623" alt="Screenshot 2024-05-02 at 1 20 40 PM" src="https://github.com/openshift/console/assets/895728/498a6934-f0cf-42c3-a320-daaf92f15048">

After:
<img width="642" alt="Screenshot 2024-05-02 at 1 17 43 PM" src="https://github.com/openshift/console/assets/895728/a3dcbab1-815d-4ed2-8bee-f7326bc04346">
