### PR TITLE
OCPBUGS-33222: List DeploymentConfig triggers a warning notification which is not required for Display warning policy feature

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch.ts
@@ -59,7 +59,7 @@ const consoleFetchCommon = async (
   const warning = response.headers.get('Warning');
 
   // If the response has a warning header, store it in the redux store.
-  if (response.ok && warning) {
+  if (response.ok && warning && method !== 'GET') {
     // Do nothing on error since this is a side-effect. Caller will handle the error.
     dataPromise
       .then((data) => handleAdmissionWebhookWarning(warning, data.kind, data.metadata?.name))


### PR DESCRIPTION
### Before:
<img width="1822" alt="Screenshot 2024-05-03 at 12 07 16 PM" src="https://github.com/openshift/console/assets/15249132/abe6f713-b5d2-4bf9-9726-78b52cc2e310">
<img width="1835" alt="Screenshot 2024-05-03 at 12 07 24 PM" src="https://github.com/openshift/console/assets/15249132/bd780e1f-34ad-4d54-afd1-d3cfd3cc59b1">

### After:
![Screenshot 2024-05-03 at 12 05 03 PM](https://github.com/openshift/console/assets/15249132/c50859e0-d4e3-4e8e-8e5a-29b8ad23d1b1)
![Screenshot 2024-05-03 at 12 05 13 PM](https://github.com/openshift/console/assets/15249132/639664d8-078b-43b0-8764-987a6ab05a23)
