### PR TITLE
OCPBUGS-31558: Fix NAD creation defaulting to the default namespace

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
@@ -35,6 +35,7 @@ import {
 } from '@console/internal/module/k8s';
 import {
   RedExclamationCircleIcon,
+  useActiveNamespace,
   validateDNS1123SubdomainValue,
   ValidationErrorType,
 } from '@console/shared';
@@ -243,8 +244,8 @@ const NetworkAttachmentDefinitionFormBase = (props) => {
   // t('kubevirt-plugin~Network Type')
   // t('kubevirt-plugin~Edit YAML')
   // t('kubevirt-plugin~Networks are not project-bound. Using the same name creates a shared NAD.')
-  const { loaded, match, resources, hasSriovNetNodePolicyCRD, hasHyperConvergedCRD } = props;
-  const namespace = _.get(match, 'params.ns', 'default');
+  const { loaded, resources, hasSriovNetNodePolicyCRD, hasHyperConvergedCRD } = props;
+  const [activeNamespace] = useActiveNamespace();
   const sriovNetNodePoliciesData = _.get(resources, 'sriovnetworknodepolicies.data', []);
 
   const { t } = useTranslation();
@@ -296,7 +297,9 @@ const NetworkAttachmentDefinitionFormBase = (props) => {
         <div className="co-m-pane__name">{NET_ATTACH_DEF_HEADER_LABEL}</div>
         <div className="co-m-pane__heading-link">
           <Link
-            to={`/k8s/ns/${namespace}/${referenceForModel(NetworkAttachmentDefinitionModel)}/~new`}
+            to={`/k8s/ns/${activeNamespace}/${referenceForModel(
+              NetworkAttachmentDefinitionModel,
+            )}/~new`}
             id="yaml-link"
             replace
           >
@@ -328,7 +331,7 @@ const NetworkAttachmentDefinitionFormBase = (props) => {
             placeholder={name}
             id="network-attachment-definition-name"
             onChange={(_event, value) =>
-              handleNameChange(value, namespace, fieldErrors, setName, setFieldErrors)
+              handleNameChange(value, activeNamespace, fieldErrors, setName, setFieldErrors)
             }
             value={name}
           />
@@ -406,7 +409,7 @@ const NetworkAttachmentDefinitionFormBase = (props) => {
                   name,
                   networkType,
                   typeParamsData,
-                  namespace,
+                  activeNamespace,
                   setError,
                   setLoading,
                 )


### PR DESCRIPTION
## Description

This PR fixes a bug where creating a network attachment definition (NAD) in a namespace other than the default namespace still results in the NAD being created in the default namespace.

Jira: https://issues.redhat.com/browse/OCPBUGS-31558

## Demos

### Before

https://github.com/openshift/console/assets/8544299/c12f4d52-830c-4a01-b7d4-c2c2950d3e16


### After

https://github.com/openshift/console/assets/8544299/26e50ae3-8073-4b36-946d-04aeb27beddd

