### PR TITLE
OCPBUGS-33383: Fix Admission webhook warning for Route and BuildConfig creation via import flow

### DIFF
--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -278,7 +278,6 @@ export const createOrUpdateBuildConfig = (
         git: {
           uri: repository,
           ref,
-          type: 'Git',
         },
         ...(secretName ? { sourceSecret: { name: secretName } } : {}),
       },

--- a/frontend/packages/dev-console/src/utils/__tests__/__snapshots__/shared-submit-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/utils/__tests__/__snapshots__/shared-submit-utils.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "apiVersion": "route.openshift.io/v1",
   "kind": "Route",
   "metadata": Object {
-    "defaultAnnotations": Object {
+    "annotations": Object {
       "openshift.io/generated-by": "OpenShiftWebConsole",
     },
     "labels": Object {
@@ -40,7 +40,7 @@ Object {
   "apiVersion": "route.openshift.io/v1",
   "kind": "Route",
   "metadata": Object {
-    "defaultAnnotations": Object {
+    "annotations": Object {
       "app.openshift.io/vcs-ref": "",
       "app.openshift.io/vcs-uri": "https://github.com/test/repo",
       "openshift.io/generated-by": "OpenShiftWebConsole",

--- a/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
+++ b/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
@@ -175,7 +175,7 @@ export const createRoute = (
       name,
       namespace,
       labels: { ...defaultLabels, ...userLabels, ...routeLabels },
-      defaultAnnotations,
+      annotations: defaultAnnotations,
     },
     spec: {
       to: {

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -155,6 +155,16 @@ export const getKnativeServiceDepResource = (
                 ],
               }),
               imagePullPolicy: imgPullPolicy,
+              securityContext: {
+                allowPrivilegeEscalation: false,
+                capabilities: {
+                  drop: ['ALL'],
+                },
+                runAsNonRoot: true,
+                seccompProfile: {
+                  type: 'RuntimeDefault',
+                },
+              },
               env,
               resources: {
                 ...((cpuLimit || memoryLimit) && {


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/OCPBUGS-33383

Descriptions: The unknown field gets added to Route and BuildConfig while creating using the import from git flow. This PR fixes and removes the unknown field from the Route and BuidConfig.

Before: 

https://github.com/openshift/console/assets/2561818/6b8ed418-dc20-4776-9b75-19ea80121c22

After:

https://github.com/openshift/console/assets/2561818/d0e5854f-a7d9-4a49-aaf5-0a843e860419

