### PR TITLE
OCPBUGS-31901: Patch PF dynamic module parser to exclude 'next' modules

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
@@ -227,6 +227,7 @@ export type ConsoleRemotePluginOptions = Partial<{
      * If not specified, the following packages will be included:
      * - `@patternfly/react-core`
      * - `@patternfly/react-icons`
+     * - `@patternfly/react-table`
      */
     packageSpecs: Record<
       string,
@@ -291,6 +292,7 @@ export class ConsoleRemotePlugin implements webpack.WebpackPluginInstance {
       this.adaptedOptions.sharedDynamicModuleSettings.packageSpecs ?? {
         '@patternfly/react-core': {},
         '@patternfly/react-icons': {},
+        '@patternfly/react-table': {},
       },
     ).reduce<Record<string, DynamicModuleMap>>(
       (acc, [pkgName, { indexModule = 'dist/esm/index.js', resolutionField = 'module' }]) => ({


### PR DESCRIPTION
This PR patches Console PF dynamic module parser for parity with patternfly/patternfly-react/pull/10046

- Ignore dynamic modules nested under `deprecated` or `next` directories
- Add `@patternfly/react-table` to the list of packages to scan for dynamic modules by default in `ConsoleRemotePlugin`

Once Console bumps PF packages to recent 5.3.x versions (#13770) we will update our dynamic module parser to try using `dist/dynamic-modules.json` files provided by these PF packages.