### PR TITLE
OCPBUGS-33487: Fix tsconfig so that VSCode can autocomplete imports correctly

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,7 +12,41 @@
     "sourceMap": true,
     "noUnusedLocals": true,
     "typeRoots": ["node_modules/@types", "@types"],
-    "types": ["node", "jest", "cypress-axe", "console"]
+    "types": ["node", "jest", "cypress-axe", "console"],
+    "paths": {
+      "@console/internal/*": ["./public/*"],
+      "@console/app/*": ["./packages/console-app/*"],
+      "@console/demo-plugin/*": ["./packages/console-demo-plugin/*"],
+      "@console/dynamic-plugin-sdk/*": ["./packages/console-dynamic-plugin-sdk/*"],
+      "@console/plugin-sdk/*": ["./packages/console-plugin-sdk/*"],
+      "@console/plugin-shared/*": ["./packages/console-plugin-shared/*"],
+      "@console/shared/*": ["./packages/console-shared/*"],
+      "@console/telemetry-plugin/*": ["./packages/console-telemetry-plugin/*"],
+      "@console/container-security/*": ["./packages/container-security/*"],
+      "@console/dev-console/*": ["./packages/dev-console/*"],
+      "@console/eslint-plugin-console/*": ["./packages/eslint-plugin-console/*"],
+      "@console/git-service/*": ["./packages/git-service/*"],
+      "@console/gitops-plugin/*": ["./packages/gitops-plugin/*"],
+      "@console/helm-plugin/*": ["./packages/helm-plugin/*"],
+      "@console/insights-plugin/*": ["./packages/insights-plugin/*"],
+      "@console/cypress-integration-tests/*": ["./packages/integration-tests-cypress/*"],
+      "@console/knative-plugin/*": ["./packages/knative-plugin/*"],
+      "@console/kubevirt-plugin/*": ["./packages/kubevirt-plugin/*"],
+      "@console/local-storage-operator-plugin/*": ["./packages/local-storage-operator-plugin/*"],
+      "@console/metal3-plugin/*": ["./packages/metal3-plugin/*"],
+      "@console/network-attachment-definition-plugin/*": [
+        "./packages/network-attachment-definition-plugin/*"
+      ],
+      "@console/operator-lifecycle-manager/*": ["./packages/operator-lifecycle-manager/*"],
+      "@console/patternfly/*": ["./packages/patternfly/*"],
+      "@console/pipelines-plugin/*": ["./packages/pipelines-plugin/*"],
+      "@console/rhoas-plugin/*": ["./packages/rhoas-plugin/*"],
+      "@console/service-binding-plugin/*": ["./packages/service-binding-plugin/*"],
+      "@console/shipwright-plugin/*": ["./packages/shipwright-plugin/*"],
+      "@console/topology/*": ["./packages/topology/*"],
+      "@console/vsphere-plugin/*": ["./packages/vsphere-plugin/*"],
+      "@console/webterminal-plugin/*": ["./packages/webterminal-plugin/*"]
+    }
   },
   "exclude": [
     ".yarn",


### PR DESCRIPTION
This is a nit that has bothered me for a while. Hopefully it improves the developer experience in our repo.