### PR TITLE
OCPBUGS-29745: Fix Pipeline details page with when expression using CEL expression

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
@@ -485,10 +485,12 @@ export const getGraphDataModel = (
     }
     if (task?.when) {
       task.when.forEach(({ input, values }) => {
-        depsFromContextVariables.push(...extractDepsFromContextVariables(input));
-        values.forEach((whenValue) => {
-          depsFromContextVariables.push(...extractDepsFromContextVariables(whenValue));
-        });
+        if (values) {
+          depsFromContextVariables.push(...extractDepsFromContextVariables(input));
+          values.forEach((whenValue) => {
+            depsFromContextVariables.push(...extractDepsFromContextVariables(whenValue));
+          });
+        }
       });
     }
     const dependancies = _.uniq([...vertex.dependancyNames]);


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-29745

Descriptions: This PR prevents the Pipeline details page from crashing when the `when` expression using the `CEL` expression

https://github.com/openshift/console/assets/2561818/3fbcf08c-8dc4-4e89-978c-0dea8d8a218a


Tests: 
1. Enable the flag `enable-cel-in-whenexpression` in TektonConfig `config`
2. Add when expression using CEL expression in a Pipeline. CEL expression doc: https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#use-cel-expression-in-whenexpression
