### PR TITLE
ODC-7574: Add e2e tests for QuickStart from Masthead in CI

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/e2e/add-flow-ci.feature
+++ b/frontend/packages/dev-console/integration-tests/features/e2e/add-flow-ci.feature
@@ -140,7 +140,7 @@ Feature: Create the different workloads from Add page
 
         @regression
         Scenario: Quick Starts page when no Quick Start has started: QS-03-TC02
-             When user clicks on the "View all quick starts" on Build with guided documentation card
+             When user selects QuickStarts from the help menu icon on the masthead
              Then user can see "Get started with a sample application", "Install Red Hat Developer Hub (RHDH) with a Helm Chart" and "Add health checks to your sample application" Quick Starts
               And user can see time taken to complete the tour on the card
 

--- a/frontend/packages/dev-console/integration-tests/features/guided-tour/quick-starts/quick-start-devperspective.feature
+++ b/frontend/packages/dev-console/integration-tests/features/guided-tour/quick-starts/quick-start-devperspective.feature
@@ -17,7 +17,7 @@ Feature: Build with guided documentation card in developer console
 
         @regression
         Scenario: Quick Starts page when no Quick Start has started: QS-03-TC02
-             When user clicks on the "View all quick starts" on Build with guided documentation card
+             When user selects QuickStarts from the help menu icon on the masthead
              Then user can see "Get started with a sample application", "Install Red Hat Developer Hub (RHDH) with a Helm Chart" and "Add health checks to your sample application" Quick Starts
               And user can see time taken to complete the tour on the card
 

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/global-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/global-po.ts
@@ -53,3 +53,4 @@ export const pagePO = {
   breadcrumb: '[aria-label="Breadcrumb"]',
 };
 export const resourceRow = '[data-test-rows="resource-row"]';
+export const helpDropdownMenu = '[data-test="help-dropdown-toggle"]';

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/quck-starts/quick-start-devperspective.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/quck-starts/quick-start-devperspective.ts
@@ -1,6 +1,7 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
 import {
   addPagePO,
+  helpDropdownMenu,
   quickStartCard,
   quickStartLeaveModalPO,
   quickStartSidebarPO,
@@ -22,8 +23,9 @@ Then('user can see the "View all quick starts" on the card', () => {
   cy.get(addPagePO.viewAllQuickStarts).should('be.visible');
 });
 
-When('user clicks on the "View all quick starts" on Build with guided documentation card', () => {
-  cy.get(addPagePO.viewAllQuickStarts).should('be.visible').click();
+When('user selects QuickStarts from the help menu icon on the masthead', () => {
+  cy.get(helpDropdownMenu).should('be.visible').click();
+  cy.get('a[role="menuitem"]').contains('Quick Starts').click();
 });
 
 Then(


### PR DESCRIPTION
Fix: [ODC-7574](https://issues.redhat.com/browse/ODC-7547)

**Description:**
Add e2e tests for QuickStarts for Masthead in CI