### PR TITLE
OCPBUGS-33523: restrict Masthead logo to max-height

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/app/masthead.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/masthead.cy.ts
@@ -17,6 +17,14 @@ describe('Masthead', () => {
     cy.visit('/');
   });
 
+  describe('Logo', () => {
+    it('should be restricted to a max-height of 60px', () => {
+      cy.byTestID('brand-image').should('be.visible');
+      cy.byTestID('brand-image').should('have.css', 'max-height', '60px');
+      cy.byTestID('brand-image').invoke('height').should('be.lte', 60);
+    });
+  });
+
   describe('User dropdown', () => {
     it('should render the correct copy login command link', () => {
       cy.window().then((win: any) => {

--- a/frontend/public/components/masthead.jsx
+++ b/frontend/public/components/masthead.jsx
@@ -82,7 +82,7 @@ export const Masthead = React.memo(({ isMastheadStacked, isNavOpen, onNavToggle 
       </MastheadToggle>
       <MastheadMain>
         <MastheadBrand component="a" {...logoProps}>
-          <Brand src={details.logoImg} alt={details.productName} />
+          <Brand src={details.logoImg} alt={details.productName} data-test="brand-image" />
         </MastheadBrand>
       </MastheadMain>
       <MastheadContent>

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -205,9 +205,15 @@ form.pf-v5-c-form {
   &__main.default-overflow {
     z-index: calc(var(--pf-v5-c-page__header--ZIndex) + 50);
   }
+
   // Default light background for our content
   .co-page-backdrop {
     background-color: var(--pf-global--BackgroundColor--100) !important;
+  }
+
+  // Restore the max-height from PageHeader to maintain backwards compatibility
+  .pf-v5-c-brand {
+    max-height: var(--pf-c-page__header-brand-link--c-brand--MaxHeight);
   }
 
   // Apply to primary content section to prevent yaml editor and topology sections from collapsing


### PR DESCRIPTION
Before/After

https://github.com/openshift/console/assets/895728/ec5dbcc7-3aa8-4bca-a565-1130c294a09f

