### PR TITLE
OCPBUGS-33587: Fix password set to Secret created through Start Pipeline form

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/SecretForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/SecretForm.tsx
@@ -123,14 +123,11 @@ const SecretForm: React.FC<FormikProps<SecretFormValues>> = ({
     [t],
   );
 
-  const setValues = (type: SecretType) => {
+  const setValues = (type: SecretType, data) => {
     if (type === SecretType.dockerconfigjson) {
-      setFieldValue(
-        'formData',
-        _.mapValues({ '.dockerconfigjson': stringData[type] }, JSON.stringify),
-      );
+      setFieldValue('formData', _.mapValues({ '.dockerconfigjson': data[type] }, JSON.stringify));
     } else {
-      setFieldValue('formData', stringData[type]);
+      setFieldValue('formData', data[type]);
     }
     if (values.type !== type) {
       clearServerURL();
@@ -138,8 +135,10 @@ const SecretForm: React.FC<FormikProps<SecretFormValues>> = ({
   };
 
   const onDataChanged = (value: string) => {
-    setStringData({ ...stringData, [values.type]: value });
-    setValues(values.type);
+    setStringData((prevState) => {
+      setValues(values.type, { ...prevState, [values.type]: value });
+      return { ...prevState, [values.type]: value };
+    });
   };
 
   return (
@@ -172,7 +171,7 @@ const SecretForm: React.FC<FormikProps<SecretFormValues>> = ({
           label={t('pipelines-plugin~Authentication type')}
           items={authTypes}
           title={authTypes[values.type]}
-          onChange={(type: SecretType) => setValues(type)}
+          onChange={(type: SecretType) => setValues(type, stringData)}
           fullWidth
           required
         />


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-33587

Description: The Secret password was not set correctly last character of the password was missing in the case of a Secret created through the Start Pipeline form. This PR fixes this issue using a callback of the state.

Before:
The password is qwerty, but the last character is missing in the password.

https://github.com/openshift/console/assets/2561818/c2ae95a2-ff0b-4b17-81ea-db5b798fdb66



After:

https://github.com/openshift/console/assets/2561818/32e91999-78d6-4429-88a5-6f5b9a65ea10

