### PR TITLE
OCPBUGS-33631: show "Debug container" link for pods with status.phase…

### DIFF
--- a/frontend/public/components/debug-terminal.tsx
+++ b/frontend/public/components/debug-terminal.tsx
@@ -46,6 +46,7 @@ const getDebugPod = (debugPodName: string, podToDebug: PodKind, containerName: s
     container.stdin = true;
     container.stdinOnce = true;
     container.tty = true;
+    delete container?.args;
     delete container?.readinessProbe;
     delete container?.livenessProbe;
   });

--- a/frontend/public/components/utils/resource-log.tsx
+++ b/frontend/public/components/utils/resource-log.tsx
@@ -146,9 +146,6 @@ const showDebugAction = (pod: PodKind, containerName: string) => {
     return false;
   }
   const containerStatus = pod?.status?.containerStatuses?.find((c) => c.name === containerName);
-  if (pod?.status?.phase === 'Succeeded') {
-    return false;
-  }
   if (pod?.metadata?.annotations?.['openshift.io/build.name']) {
     return false;
   }


### PR DESCRIPTION
… of "Succeeded"

This aligns 4.16 with the behavior in 3.x.  See https://github.com/openshift/origin-web-console/blob/c37982397087036321312172282e139da378eff2/app/scripts/directives/resources.js#L33-L53 and note 'Completed' is not a valid value for `pod.status.phase` (see https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase)


https://github.com/openshift/console/assets/895728/6e0afa50-3e61-4d30-9442-a4327aa69b42

