### PR TITLE
OCPBUGS-33636: Updating the secrets using Form editor displays an unknown warning message

### DIFF
--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -1322,7 +1322,8 @@ export const SecretLoadingWrapper = withTranslation()(
       if (!secretTypeAbstraction) {
         return <LoadingBox />;
       }
-      const fixed = _.reduce(fixedKeys, (acc, k) => ({ ...acc, k: _.get(obj.data, k) }), {});
+      const fixed = fixedKeys?.reduce((acc, k) => ({ ...acc, [k]: obj.data?.[k] || '' }), {});
+
       return (
         <StatusBox {...obj}>
           <SecretFormWrapper


### PR DESCRIPTION
### Before:
<img width="1862" alt="Screenshot 2024-05-14 at 4 41 35 PM" src="https://github.com/openshift/console/assets/15249132/76cc890c-fe50-4488-a4db-f12887ec673b">

### After:
<img width="1826" alt="Screenshot 2024-05-14 at 4 43 35 PM" src="https://github.com/openshift/console/assets/15249132/11766ec4-692a-4ed5-8898-7cfd16f94870">
<img width="1852" alt="Screenshot 2024-05-14 at 4 43 44 PM" src="https://github.com/openshift/console/assets/15249132/4bda6c52-ca9a-42bb-9a32-b2daffe034d3">

