### PR TITLE
OCPBUGS-32476: Import from Git allow users to import an app with Build option Pipeline also when no Pipeline is available

### DIFF
--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -19,6 +19,7 @@ import {
   gitUrlRegex,
   resourcesValidationSchema,
   devfileValidationSchema,
+  importFlowPipelineTemplateValidationSchema,
 } from './validation-schema';
 
 export const validationSchema = (t: TFunction) =>
@@ -38,6 +39,7 @@ export const validationSchema = (t: TFunction) =>
     resources: resourcesValidationSchema,
     healthChecks: healthChecksProbesValidationSchema(t),
     pac: importFlowRepositoryValidationSchema(t),
+    pipeline: importFlowPipelineTemplateValidationSchema,
   });
 
 const hasDomain = (url: string, domain: string): boolean => {

--- a/frontend/packages/dev-console/src/components/import/validation-schema.ts
+++ b/frontend/packages/dev-console/src/components/import/validation-schema.ts
@@ -2,9 +2,10 @@ import { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import * as yup from 'yup';
 import { convertToBaseValue } from '@console/internal/components/utils';
+import { PipelineType } from '@console/pipelines-plugin/src/components/import/import-types';
 import { CREATE_APPLICATION_KEY } from '@console/topology/src/const';
 import { isInteger } from '../../utils/yup-validation-util';
-import { Resources } from './import-types';
+import { BuildOptions, Resources } from './import-types';
 import { removeKsvcInfoFromDomainMapping } from './serverless/serverless-utils';
 
 const hostnameRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
@@ -345,4 +346,15 @@ export const isiValidationSchema = (t: TFunction) =>
     image: yup.object().required(t('devconsole~Required')),
     tag: yup.string(),
     status: yup.string().required(t('devconsole~Required')),
+  });
+
+export const importFlowPipelineTemplateValidationSchema = yup
+  .object()
+  .when(['enabled', 'build.option', 'type'], {
+    is: (isPipelineEnabled, buildOption, pipelineType) =>
+      (isPipelineEnabled || buildOption === BuildOptions.PIPELINES) &&
+      pipelineType !== PipelineType.PAC,
+    then: yup.object().shape({
+      templateSelected: yup.string().required(),
+    }),
   });

--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/PipelineTemplate.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/PipelineTemplate.tsx
@@ -193,7 +193,6 @@ const PipelineTemplate: React.FC<PipelineTemplateProps> = ({ builderImages, exis
       } else {
         setFieldValue('pipeline.template', null);
         setFieldValue('pipeline.templateSelected', '');
-        setFieldValue('pipeline.enabled', false);
         setNoTemplateForRuntime(true);
       }
     };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-32476

**Analysis / Root cause**: 
Validation was not added to check if any pipeline template is selected if user choose Pipeline from the cluster

**Solution Description**: 
Added the validation to check if build type is Pipeline and pipeline type is not PAC to check whether pipeline template is selected or not. If not create button will be disabled

**Screen shots / Gifs for design review**: 


----When Just after Pipeline operator is installed---

https://github.com/openshift/console/assets/102503482/009b8199-4ed8-4509-b1b9-a5fb88b990c8

--- Import from Git form---
https://github.com/openshift/console/assets/102503482/ef7d7127-795a-4ff8-bdbf-4563f78ccfed



---Adding serverless function without Pipeline template created---
https://github.com/openshift/console/assets/102503482/f87d01e6-32e9-4aa8-b5c2-835b16b50462

---Create serverless function form---
https://github.com/openshift/console/assets/102503482/e7c4ce2a-e4b8-4b2c-9542-15f6cd048ab2







**Unit test coverage report**: 
NA

**Test setup:**

1. Install OpenShift Local
2. Install Pipelines Opeartor
3. Import from Git and select Pipeline as option

     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


