### PR TITLE
OCPBUGS-33090: UI inconsistency in topology when application grouping is collapsed

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/components/groups/GroupNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/groups/GroupNode.tsx
@@ -63,6 +63,7 @@ const GroupNode: React.FC<GroupNodeProps> = ({
   typeIconClass,
   ...rest
 }) => {
+  const ref = React.useRef();
   const [filtered] = useSearchFilter(element.getLabel());
   const [textHover, textHoverRef] = useHover();
   const [iconSize, iconRef] = useSize([badge]);
@@ -124,23 +125,26 @@ const GroupNode: React.FC<GroupNodeProps> = ({
             badgeColor={badgeColor}
           />
           {title && (
-            <Tooltip
-              content={title}
-              position={TooltipPosition.top}
-              trigger="manual"
-              isVisible={textHover && shouldTruncate(title)}
-            >
-              <text
-                ref={textHoverRef}
-                className="odc-group-node__title"
-                x={LEFT_MARGIN + iconWidth + TEXT_MARGIN}
-                y={TOP_MARGIN + iconHeight}
-                textAnchor="start"
-                dy="-0.25em"
+            <g ref={textHoverRef}>
+              <Tooltip
+                content={title}
+                position={TooltipPosition.top}
+                trigger="manual"
+                isVisible={textHover && shouldTruncate(title, truncateOptions)}
+                triggerRef={ref}
               >
-                {truncateMiddle(title, truncateOptions)}
-              </text>
-            </Tooltip>
+                <text
+                  ref={ref}
+                  className="odc-group-node__title"
+                  x={LEFT_MARGIN + iconWidth + TEXT_MARGIN}
+                  y={TOP_MARGIN + iconHeight}
+                  textAnchor="start"
+                  dy="-0.25em"
+                >
+                  {truncateMiddle(title, truncateOptions)}
+                </text>
+              </Tooltip>
+            </g>
           )}
           {(children || groupResources || emptyValue) && (
             <g transform={`translate(${LEFT_MARGIN}, ${TOP_MARGIN + iconHeight})`}>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-33090

**Analysis / Root cause**: 
triggerRef was not added to the Tooltip component

**Solution Description**: 
Added triggerRef to the Tooltip component


**Screen shots / Gifs for design review**: 

--- Before---

<img width="1439" alt="Screenshot 2024-05-16 at 11 44 08 AM" src="https://github.com/openshift/console/assets/102503482/e1ca3ace-f94b-4858-8f14-ccb6ed422b8d">




---After---

<img width="1439" alt="Screenshot 2024-05-16 at 11 44 20 AM" src="https://github.com/openshift/console/assets/102503482/226898f5-80c6-4e1b-9d92-375a2eec2cb2">




**Unit test coverage report**: 
NA

**Test setup:**

    1. Have some deployments
    2. In topology unselect the application grouping in the display filter 

     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


