### PR TITLE
CONSOLE-4058: add user-impersonation to QuickStartGettingStartedCard,…

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/explore-admin-features-getting-started-card.spec.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/explore-admin-features-getting-started-card.spec.tsx
@@ -35,15 +35,13 @@ describe('ExploreAdminFeaturesGettingStartedCard', () => {
     expect(wrapper.find(GettingStartedCard).props().title).toEqual(
       'Explore new features and capabilities',
     );
-    expect(wrapper.find(GettingStartedCard).props().links).toEqual([
-      {
-        id: 'openshift-ai',
-        title: 'OpenShift AI',
-        description: 'Build, deploy, and manage AI-enabled applications.',
-        href:
-          '/operatorhub/all-namespaces?keyword=openshift+ai&details-item=rhods-operator-redhat-operators-openshift-marketplace',
-      },
-    ]);
+    expect(wrapper.find(GettingStartedCard).props().links).toContainEqual({
+      id: 'openshift-ai',
+      title: 'OpenShift AI',
+      description: 'Build, deploy, and manage AI-enabled applications.',
+      href:
+        '/operatorhub/all-namespaces?keyword=openshift+ai&details-item=rhods-operator-redhat-operators-openshift-marketplace',
+    });
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
       id: 'whats-new',
       title: "See what's new in OpenShift 4.16",

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
@@ -43,6 +43,12 @@ export const ExploreAdminFeaturesGettingStartedCard: React.FC = () => {
         href:
           '/operatorhub/all-namespaces?keyword=openshift+ai&details-item=rhods-operator-redhat-operators-openshift-marketplace',
       },
+      {
+        id: 'new-translations',
+        title: t('public~French and Spanish now available'),
+        description: t('public~Console language options now include French and Spanish.'),
+        href: '/user-preferences/language',
+      },
     ],
     [t],
   );
@@ -50,7 +56,7 @@ export const ExploreAdminFeaturesGettingStartedCard: React.FC = () => {
   React.useEffect(() => {
     const addLinkIfLightSpeedIsAvailable = async () => {
       if (await getLightSpeedAvailability()) {
-        links.push({
+        links.splice(1, 1, {
           id: 'lightspeed',
           title: t('public~OpenShift LightSpeed'),
           description: t('public~Your personal AI helper.'),

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/getting-started-section.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/getting-started-section.tsx
@@ -38,6 +38,8 @@ export const GettingStartedSection: React.FC = () => {
         <QuickStartGettingStartedCard
           featured={[
             // All part of the console-operator:
+            // - Impersonate a user
+            'user-impersonation',
             // - Monitor your sample application
             'monitor-sampleapp',
             // - Install the Red Hat Developer Hub (RHDH) operator (and create a RHDH instance)

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -402,6 +402,8 @@
   "Add identity providers": "Add identity providers",
   "OpenShift AI": "OpenShift AI",
   "Build, deploy, and manage AI-enabled applications.": "Build, deploy, and manage AI-enabled applications.",
+  "French and Spanish now available": "French and Spanish now available",
+  "Console language options now include French and Spanish.": "Console language options now include French and Spanish.",
   "OpenShift LightSpeed": "OpenShift LightSpeed",
   "Your personal AI helper.": "Your personal AI helper.",
   "See what's new in OpenShift {{version}}": "See what's new in OpenShift {{version}}",


### PR DESCRIPTION
… new langs to ExploreAdminFeaturesGettingStartedCard

https://github.com/openshift/console/assets/895728/f333cc02-7d0f-498a-9fcc-3b3465efdf65

Once LightSpeed is available in OperatorHub, the new languages option in ExploreAdminFeaturesGettingStartedCard changes:

<img width="1341" alt="Screenshot 2024-05-16 at 11 35 27 AM" src="https://github.com/openshift/console/assets/895728/23b5f9af-786a-4133-89ef-9c40491dc879">

