### PR TITLE
OCPBUGS-14118: No need to supply 'User workload notifications' option on 'User Preference' page for normal user

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -635,6 +635,9 @@
         "falseValue": false,
         "defaultValue": false
       }
+    },
+    "flags": {
+      "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
     }
   },
   {


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-14118

Screenshot:

![image](https://github.com/openshift/console/assets/2561818/e8392972-11a7-4145-b122-b74c3c81550a)
