### PR TITLE
OCPBUGS-19855: Validate watchK8sObject query must have name and namespace for namespaced resources

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResource.spec.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResource.spec.tsx
@@ -157,6 +157,7 @@ describe('useK8sWatchResource', () => {
     const initResource: WatchK8sResource = {
       kind: 'Pod',
       name: 'my-pod',
+      namespace: 'foo',
     };
     render(
       <Wrapper>
@@ -173,7 +174,7 @@ describe('useK8sWatchResource', () => {
 
     // Assert API calls
     expect(k8sGetMock).toHaveBeenCalledTimes(1);
-    expect(k8sGetMock.mock.calls[0]).toEqual([PodModel, 'my-pod', undefined, {}, {}]);
+    expect(k8sGetMock.mock.calls[0]).toEqual([PodModel, 'my-pod', 'foo', {}, {}]);
     k8sGetMock.mockClear();
 
     await act(async () => jest.runAllTimers());
@@ -182,7 +183,7 @@ describe('useK8sWatchResource', () => {
     expect(k8sWatchMock).toHaveBeenCalledTimes(1);
     expect(k8sWatchMock.mock.calls[0]).toEqual([
       PodModel,
-      { fieldSelector: 'metadata.name=my-pod' },
+      { fieldSelector: 'metadata.name=my-pod', ns: 'foo' },
       { subprotocols: undefined },
     ]);
     k8sWatchMock.mockClear();
@@ -227,6 +228,7 @@ describe('useK8sWatchResource', () => {
     const initResource: WatchK8sResource = {
       kind: 'Pod',
       name: 'my-pod',
+      namespace: 'foo',
     };
     render(
       <Wrapper>
@@ -243,14 +245,14 @@ describe('useK8sWatchResource', () => {
 
     // Assert API calls
     expect(k8sGetMock).toHaveBeenCalledTimes(1);
-    expect(k8sGetMock.mock.calls[0]).toEqual([PodModel, 'my-pod', undefined, {}, {}]);
+    expect(k8sGetMock.mock.calls[0]).toEqual([PodModel, 'my-pod', 'foo', {}, {}]);
     k8sGetMock.mockClear();
 
     // TODO: Unexpected watch call! The watch call was not triggered when watching a list
     expect(k8sWatchMock).toHaveBeenCalledTimes(1);
     expect(k8sWatchMock.mock.calls[0]).toEqual([
       PodModel,
-      { fieldSelector: 'metadata.name=my-pod' },
+      { fieldSelector: 'metadata.name=my-pod', ns: 'foo' },
       { subprotocols: undefined },
     ]);
     k8sWatchMock.mockClear();
@@ -347,6 +349,7 @@ describe('useK8sWatchResource', () => {
     const initResource: WatchK8sResource = {
       kind: 'Pod',
       name: 'my-pod',
+      namespace: 'foo',
     };
     render(
       <Wrapper>
@@ -368,7 +371,7 @@ describe('useK8sWatchResource', () => {
 
     // Assert API calls
     expect(k8sGetMock).toHaveBeenCalledTimes(1);
-    expect(k8sGetMock.mock.calls[0]).toEqual([PodModel, 'my-pod', undefined, {}, {}]);
+    expect(k8sGetMock.mock.calls[0]).toEqual([PodModel, 'my-pod', 'foo', {}, {}]);
     k8sGetMock.mockClear();
 
     await act(async () => jest.runAllTimers());
@@ -377,7 +380,7 @@ describe('useK8sWatchResource', () => {
     expect(k8sWatchMock).toHaveBeenCalledTimes(1);
     expect(k8sWatchMock.mock.calls[0]).toEqual([
       PodModel,
-      { fieldSelector: 'metadata.name=my-pod' },
+      { fieldSelector: 'metadata.name=my-pod', ns: 'foo' },
       { subprotocols: undefined },
     ]);
     k8sWatchMock.mockClear();

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResources.spec.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResources.spec.tsx
@@ -172,6 +172,7 @@ describe('useK8sWatchResource', () => {
       pod: {
         kind: 'Pod',
         name: 'my-pod',
+        namespace: 'my-namespace',
       },
     };
     render(
@@ -205,7 +206,7 @@ describe('useK8sWatchResource', () => {
 
     // Assert API calls
     expect(k8sGetMock).toHaveBeenCalledTimes(1);
-    expect(k8sGetMock.mock.calls[0]).toEqual([PodModel, 'my-pod', undefined, {}, {}]);
+    expect(k8sGetMock.mock.calls[0]).toEqual([PodModel, 'my-pod', 'my-namespace', {}, {}]);
     k8sGetMock.mockClear();
 
     await act(async () => jest.runAllTimers());
@@ -214,7 +215,7 @@ describe('useK8sWatchResource', () => {
     expect(k8sWatchMock).toHaveBeenCalledTimes(1);
     expect(k8sWatchMock.mock.calls[0]).toEqual([
       PodModel,
-      { fieldSelector: 'metadata.name=my-pod' },
+      { fieldSelector: 'metadata.name=my-pod', ns: 'my-namespace' },
       { subprotocols: undefined },
     ]);
     k8sWatchMock.mockClear();
@@ -286,6 +287,7 @@ describe('useK8sWatchResource', () => {
       pod: {
         kind: 'Pod',
         name: 'my-pod',
+        namespace: 'my-namespace',
       },
     };
     render(
@@ -319,14 +321,14 @@ describe('useK8sWatchResource', () => {
 
     // Assert API calls
     expect(k8sGetMock).toHaveBeenCalledTimes(1);
-    expect(k8sGetMock.mock.calls[0]).toEqual([PodModel, 'my-pod', undefined, {}, {}]);
+    expect(k8sGetMock.mock.calls[0]).toEqual([PodModel, 'my-pod', 'my-namespace', {}, {}]);
     k8sGetMock.mockClear();
 
     // TODO: Unexpected watch call! The watch call was not triggered when watching a list
     expect(k8sWatchMock).toHaveBeenCalledTimes(1);
     expect(k8sWatchMock.mock.calls[0]).toEqual([
       PodModel,
-      { fieldSelector: 'metadata.name=my-pod' },
+      { fieldSelector: 'metadata.name=my-pod', ns: 'my-namespace' },
       { subprotocols: undefined },
     ]);
     k8sWatchMock.mockClear();
@@ -478,6 +480,7 @@ describe('useK8sWatchResource', () => {
       pod: {
         kind: 'Pod',
         name: 'my-pod',
+        namespace: 'my-namespace',
       },
     };
     render(
@@ -532,7 +535,7 @@ describe('useK8sWatchResource', () => {
 
     // Assert API calls
     expect(k8sGetMock).toHaveBeenCalledTimes(1);
-    expect(k8sGetMock.mock.calls[0]).toEqual([PodModel, 'my-pod', undefined, {}, {}]);
+    expect(k8sGetMock.mock.calls[0]).toEqual([PodModel, 'my-pod', 'my-namespace', {}, {}]);
     k8sGetMock.mockClear();
 
     await act(async () => jest.runAllTimers());
@@ -541,7 +544,7 @@ describe('useK8sWatchResource', () => {
     expect(k8sWatchMock).toHaveBeenCalledTimes(1);
     expect(k8sWatchMock.mock.calls[0]).toEqual([
       PodModel,
-      { fieldSelector: 'metadata.name=my-pod' },
+      { fieldSelector: 'metadata.name=my-pod', ns: 'my-namespace' },
       { subprotocols: undefined },
     ]);
     k8sWatchMock.mockClear();


### PR DESCRIPTION
This has to be validated on the frontend since we use field selectors to watch the list endppoint. Allowing a watch request for a namespaced resource without a namespace creates an edge case where we might unintentionally watch a resource in a different namespace than desired.