### PR TITLE
OCPBUGS-34052: Include English Translations text for Supported Languages in User Preference Dropdown

### DIFF
--- a/frontend/packages/console-app/src/components/user-preferences/language/const.ts
+++ b/frontend/packages/console-app/src/components/user-preferences/language/const.ts
@@ -1,10 +1,10 @@
 export const supportedLocales = {
   en: 'English',
-  es: 'Español',
-  fr: 'Français',
-  ko: '한국어',
-  ja: '日本語',
-  'zh-CN': '中文',
+  es: 'Español - Spanish',
+  fr: 'Français - French',
+  ko: '한국어 - Korean',
+  ja: '日本語 - Japanese',
+  'zh-CN': '中文 - Chinese (Simplified)',
 };
 
 export const LAST_LANGUAGE_LOCAL_STORAGE_KEY = 'bridge/last-language';


### PR DESCRIPTION
### Before:
<img width="1827" alt="Screenshot 2024-05-21 at 1 06 13 PM" src="https://github.com/openshift/console/assets/15249132/70b13d88-5f1a-4b5f-9a6e-469a1f66345e">

### After:
<img width="934" alt="Screenshot 2024-05-21 at 1 23 11 PM" src="https://github.com/openshift/console/assets/15249132/8ecf3b08-f05e-4aaa-b842-def104b80fea">

