### PR TITLE
OCPBUGS-34200: fix bug where textarea is not resizable

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/metrics/QueryInput.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/metrics/QueryInput.tsx
@@ -220,7 +220,7 @@ export const QueryInput: React.FC<QueryInputProps> = ({ index }) => {
     <div className="query-browser__query pf-v5-c-dropdown">
       <textarea
         aria-label={placeholder}
-        className="pf-v5-c-form-control query-browser__query-input"
+        className="pf-v5-c-form-control pf-m-resize-both query-browser__query-input"
         onBlur={onBlur}
         onChange={onChange}
         onKeyDown={onKeyDown}

--- a/frontend/public/components/modals/create-namespace-modal.jsx
+++ b/frontend/public/components/modals/create-namespace-modal.jsx
@@ -228,7 +228,7 @@ const CreateNamespaceModalWithTranslation_ = (props) => {
               <textarea
                 id="input-description"
                 name="description"
-                className="pf-v5-c-form-control"
+                className="pf-v5-c-form-control pf-m-resize-both"
                 onChange={(e) => setDescription(e.target.value)}
                 value={description || ''}
               />

--- a/frontend/public/components/utils/file-input.tsx
+++ b/frontend/public/components/utils/file-input.tsx
@@ -119,7 +119,7 @@ class FileInputWithTranslation extends React.Component<FileInputProps, FileInput
                 data-test-id={
                   this.props['data-test-id'] ? this.props['data-test-id'] : 'file-input-textarea'
                 }
-                className="pf-v5-c-form-control co-file-dropzone__textarea"
+                className="pf-v5-c-form-control pf-m-resize-both co-file-dropzone__textarea"
                 onChange={this.onDataChange}
                 value={this.props.inputFileData}
                 aria-label={this.props.label}


### PR DESCRIPTION
This regression was introduced with the PatternFly 5 upgrade as PatternFly 5 turns off resizing for `<textarea>` without the addition of `pf-m-resize-both`.

After
<img width="629" alt="Screenshot 2024-05-23 at 9 14 12 AM" src="https://github.com/openshift/console/assets/895728/5a98984e-59b8-495d-bec4-0c67164eb870">
<img width="694" alt="Screenshot 2024-05-23 at 9 14 29 AM" src="https://github.com/openshift/console/assets/895728/404e1f72-4adb-45a2-ad1d-3f3f4dc7e4b6">
<img width="996" alt="Screenshot 2024-05-23 at 9 19 50 AM" src="https://github.com/openshift/console/assets/895728/5bbc5921-0e9d-4111-b9e2-3a1cdb66c5b7">
