### PR TITLE
OCPBUGS-34516: Improve catalog grid icon display and scaling

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/CatalogController.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/CatalogController.tsx
@@ -184,7 +184,7 @@ const CatalogController: React.FC<CatalogControllerProps> = ({
       <Helmet>
         <title>{title}</title>
       </Helmet>
-      <div className="co-m-page__body">
+      <div className="co-m-page__body co-catalog-controller">
         <div className="co-catalog">
           <PageHeading title={title} breadcrumbs={type ? breadcrumbs : null} />
           <p data-test-id="catalog-page-description" className="co-catalog-page__description">

--- a/frontend/packages/console-shared/src/components/catalog/CatalogController.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/CatalogController.tsx
@@ -184,7 +184,7 @@ const CatalogController: React.FC<CatalogControllerProps> = ({
       <Helmet>
         <title>{title}</title>
       </Helmet>
-      <div className="co-m-page__body co-catalog-controller">
+      <div className="co-m-page__body">
         <div className="co-catalog">
           <PageHeading title={title} breadcrumbs={type ? breadcrumbs : null} />
           <p data-test-id="catalog-page-description" className="co-catalog-page__description">

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -46,7 +46,7 @@ form.pf-v5-c-form {
   }
 }
 
-.co-catalog-page__grid {
+.co-catalog-controller {
   // Get rid of weird stretching of catalog grid items
   .pf-v5-c-card__header-main {
     flex: unset;

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -46,6 +46,18 @@ form.pf-v5-c-form {
   }
 }
 
+.co-catalog-page__grid {
+  // Get rid of weird stretching of catalog grid items
+  .pf-v5-c-card__header-main {
+    flex: unset;
+
+    // When images are too wide, scale them instead of squishing
+    img {
+      object-fit: contain;
+    }
+  }
+}
+
 .catalog-item-header-pf-icon {
   @include catalog-logo-background(var(--pf-v5-global--spacer--sm));
 }

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -46,7 +46,7 @@ form.pf-v5-c-form {
   }
 }
 
-.co-catalog-controller {
+.odc-catalog-tile {
   // Get rid of weird stretching of catalog grid items
   .pf-v5-c-card__header-main {
     flex: unset;


### PR DESCRIPTION
References Jira issue https://issues.redhat.com/projects/OCPBUGS/issues/OCPBUGS-34516

Adds some CSS overrides so that icons in CatalogGrids are not stretched/squished

Before:
![image](https://github.com/openshift/console/assets/18614559/7f0836f9-6fb2-406e-b364-021a94bdd536)

After:
![image](https://github.com/openshift/console/assets/18614559/cdbea001-62b0-4943-aba5-176a2a3c7894)
