### PR TITLE
OCPBUGS-35376: sessions: fix sessions pruning

### DIFF
--- a/pkg/auth/oauth2/auth_oidc.go
+++ b/pkg/auth/oauth2/auth_oidc.go
@@ -70,7 +70,6 @@ func (o *oidcAuth) login(w http.ResponseWriter, r *http.Request, token *oauth2.T
 		return nil, err
 	}
 
-	o.sessions.PruneSessions()
 	return ls, nil
 }
 
@@ -134,7 +133,7 @@ func (o *oidcAuth) getLoginState(w http.ResponseWriter, r *http.Request) (*sessi
 		return nil, fmt.Errorf("failed to retrieve login state: %v", err)
 	}
 
-	if ls == nil || ls.IsExpired() {
+	if ls == nil || ls.ShouldRotate() {
 		if refreshToken := o.sessions.GetCookieRefreshToken(r); refreshToken != "" {
 			return o.refreshSession(r.Context(), w, r, o.oauth2Config(), refreshToken)
 		}

--- a/pkg/auth/sessions/combined_sessions.go
+++ b/pkg/auth/sessions/combined_sessions.go
@@ -185,8 +185,3 @@ func (cs *CombinedSessionStore) DeleteSession(w http.ResponseWriter, r *http.Req
 
 	return nil
 }
-
-// FIXME: do this regulary in a separate goroutine on background
-func (cs *CombinedSessionStore) PruneSessions() {
-	cs.serverStore.PruneSessions()
-}

--- a/pkg/auth/sessions/combined_sessions_test.go
+++ b/pkg/auth/sessions/combined_sessions_test.go
@@ -417,10 +417,16 @@ func TestCombinedSessionStore_DeleteSession(t *testing.T) {
 
 	setupServerStore := func() *SessionStore {
 		testServerSessions := NewServerSessionStore(10)
+		// lock the sessions lock to prevent data race check being
+		// triggered in the test setup
+		testServerSessions.mux.Lock()
+		defer testServerSessions.mux.Unlock()
+
 		for i := 0; i < 5; i++ {
 			sessionToken := strconv.Itoa(i)
-			testServerSessions.byToken[sessionToken] = &LoginState{sessionToken: sessionToken}
+			testServerSessions.byToken[sessionToken] = &LoginState{sessionToken: sessionToken, exp: time.Now().Add(5 * time.Minute), now: time.Now}
 			testServerSessions.byAge = append(testServerSessions.byAge, testServerSessions.byToken[sessionToken])
+
 		}
 
 		refreshedSession := testServerSessions.byToken["4"]

--- a/pkg/auth/sessions/server_session_test.go
+++ b/pkg/auth/sessions/server_session_test.go
@@ -4,10 +4,14 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func checkSessions(t *testing.T, ss *SessionStore) {
@@ -53,7 +57,7 @@ func TestSessions(t *testing.T) {
 		t.Fatal("ss.byAge != 4")
 	}
 
-	ss.PruneSessions()
+	ss.pruneSessions()
 
 	if len(ss.byAge) != 3 {
 		t.Fatal("ss.byAge != 3")
@@ -125,5 +129,215 @@ func TestSessionStore_GetSession(t *testing.T) {
 				t.Errorf("SessionStore.GetSession() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSessionStore_pruneSessions(t *testing.T) {
+	tests := []struct {
+		name                  string
+		modifyStorage         func(*SessionStore)
+		expectedSessionTokens sets.Set[string]
+		expectedRefreshTokens sets.Set[string]
+		expectedByAgeLen      int
+	}{
+		{
+			name: "no sessions",
+		},
+		{
+			name: "single, expired session",
+			modifyStorage: withServerSessions(
+				&LoginState{
+					sessionToken: "session-1",
+					refreshToken: "refresh-1",
+					exp:          time.Now().Add(-time.Minute * 5),
+				},
+			),
+			expectedByAgeLen: 0,
+		},
+		{
+			name: "expired session among others",
+			modifyStorage: withServerSessions(
+				&LoginState{
+					sessionToken: "s1",
+					refreshToken: "r1",
+					exp:          time.Now().Add(time.Minute * 12),
+				},
+				&LoginState{
+					sessionToken: "session-expired",
+					refreshToken: "refresh-expired",
+					exp:          time.Now().Add(-time.Minute * 5),
+				},
+				&LoginState{
+					sessionToken: "s2",
+					refreshToken: "r2",
+					exp:          time.Now().Add(time.Minute * 5),
+				},
+				&LoginState{
+					sessionToken: "s3",
+					refreshToken: "r3",
+					exp:          time.Now().Add(time.Minute * 7),
+				},
+			),
+			expectedSessionTokens: sets.New("s1", "s2", "s3"),
+			expectedRefreshTokens: sets.New("r1", "r2", "r3"),
+			expectedByAgeLen:      3,
+		},
+		{
+			name: "picking sessions that are still valid",
+			modifyStorage: withServerSessions(
+				&LoginState{
+					sessionToken: "s1",
+					refreshToken: "r1",
+					exp:          time.Now().Add(time.Minute * 12),
+				},
+				&LoginState{
+					sessionToken: "s2",
+					refreshToken: "r2",
+					exp:          time.Now().Add(time.Minute * 5),
+				},
+				&LoginState{
+					sessionToken: "s3",
+					refreshToken: "r3",
+					exp:          time.Now().Add(time.Minute * 7),
+				},
+				&LoginState{
+					sessionToken: "s4",
+					refreshToken: "r4",
+					exp:          time.Now().Add(time.Minute * 15),
+				},
+				&LoginState{
+					sessionToken: "s5",
+					refreshToken: "r5",
+					exp:          time.Now().Add(time.Minute * 3),
+				},
+			),
+			expectedSessionTokens: sets.New("s1", "s3", "s4"),
+			expectedRefreshTokens: sets.New("r1", "r3", "r4"),
+			expectedByAgeLen:      3,
+		},
+		{
+			name: "noop at limit",
+			modifyStorage: withServerSessions(
+				&LoginState{
+					sessionToken: "s1",
+					refreshToken: "r1",
+					exp:          time.Now().Add(time.Minute * 12),
+				},
+				&LoginState{
+					sessionToken: "s2",
+					refreshToken: "r2",
+					exp:          time.Now().Add(time.Minute * 5),
+				},
+				&LoginState{
+					sessionToken: "s3",
+					refreshToken: "r3",
+					exp:          time.Now().Add(time.Minute * 7),
+				},
+			),
+			expectedSessionTokens: sets.New("s1", "s2", "s3"),
+			expectedRefreshTokens: sets.New("r1", "r2", "r3"),
+			expectedByAgeLen:      3,
+		},
+		{
+			name: "noop",
+			modifyStorage: withServerSessions(
+				&LoginState{
+					sessionToken: "s1",
+					refreshToken: "r1",
+					exp:          time.Now().Add(time.Minute * 12),
+				},
+				&LoginState{
+					sessionToken: "s2",
+					refreshToken: "r2",
+					exp:          time.Now().Add(time.Minute * 5),
+				},
+			),
+			expectedSessionTokens: sets.New("s1", "s2"),
+			expectedRefreshTokens: sets.New("r1", "r2"),
+			expectedByAgeLen:      2,
+		},
+		{
+			name: "picking valid and expired sessions",
+			modifyStorage: withServerSessions(
+				&LoginState{
+					sessionToken: "s1",
+					refreshToken: "r1",
+					exp:          time.Now().Add(time.Minute * 12),
+				},
+				&LoginState{
+					sessionToken: "s2",
+					refreshToken: "r2",
+					exp:          time.Now().Add(time.Minute * 5),
+				},
+				&LoginState{
+					sessionToken: "s3",
+					refreshToken: "r3",
+					exp:          time.Now().Add(-time.Minute * 7),
+				},
+				&LoginState{
+					sessionToken: "s4",
+					refreshToken: "r4",
+					exp:          time.Now().Add(time.Minute * 15),
+				},
+				&LoginState{
+					sessionToken: "s5",
+					refreshToken: "r5",
+					exp:          time.Now().Add(-time.Minute * 1),
+				},
+				&LoginState{
+					sessionToken: "s6",
+					refreshToken: "r6",
+					exp:          time.Now().Add(time.Minute * 1),
+				},
+				&LoginState{
+					sessionToken: "s7",
+					refreshToken: "r7",
+					exp:          time.Now().Add(time.Minute * 14),
+				},
+			),
+			expectedSessionTokens: sets.New("s1", "s4", "s7"),
+			expectedRefreshTokens: sets.New("r1", "r4", "r7"),
+			expectedByAgeLen:      3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ss := &SessionStore{
+				byToken:        map[string]*LoginState{},
+				byRefreshToken: map[string]*LoginState{},
+				byAge:          []*LoginState{},
+				maxSessions:    3,
+				now:            time.Now,
+				mux:            sync.Mutex{},
+			}
+			if tt.modifyStorage != nil {
+				tt.modifyStorage(ss)
+			}
+			ss.pruneSessions()
+
+			require.Equal(t, tt.expectedByAgeLen, len(ss.byAge))
+			refreshKeys, sessionKeys := sets.New[string](), sets.New[string]()
+			for k := range ss.byRefreshToken {
+				refreshKeys.Insert(k)
+			}
+			for k := range ss.byToken {
+				sessionKeys.Insert(k)
+			}
+			require.True(t, tt.expectedRefreshTokens.Equal(refreshKeys), "remaining refresh tokens: %v", refreshKeys)
+			require.True(t, tt.expectedSessionTokens.Equal(sessionKeys), "remaining session tokens: %v", sessionKeys)
+
+		})
+	}
+}
+
+func withServerSessions(sessions ...*LoginState) func(ss *SessionStore) {
+	return func(ss *SessionStore) {
+		for _, s := range sessions {
+			s := s
+			s.now = time.Now
+			ss.byToken[s.sessionToken] = s
+			ss.byRefreshToken[s.refreshToken] = s
+			ss.byAge = append(ss.byAge, s)
+		}
 	}
 }


### PR DESCRIPTION
Given the sessions can now modify their expiration during their lifetime (by going through the token refresh process), the current pruning mechanism might randomly remove active sessions.

This PR is fixing that behavior by ordering the `byAge` index of the session storage by expiration and only removing the sessions that are either really expired or close to expiration.

/assign @jhadvig 