### PR TITLE
ODC-7588: Automatically select new Deployments or Knative Services in Topology after creating them with the Import from Git or Import image container flow

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md
@@ -812,7 +812,7 @@ This extension contributes a new perspective to the console which enables custom
 | `name` | `string` | no | The perspective display name. |
 | `icon` | `CodeRef<LazyComponent>` | no | The perspective display icon. |
 | `landingPageURL` | `CodeRef<(flags: { [key: string]: boolean; }, isFirstVisit: boolean) => string>` | no | The function to get perspective landing page URL. |
-| `importRedirectURL` | `CodeRef<(namespace: string) => string>` | no | The function to get redirect URL for import flow. |
+| `importRedirectURL` | `CodeRef<(namespace: string) => string>` | no | The function to get a relative redirect URL for import flow. |
 | `default` | `boolean` | yes | Whether the perspective is the default. There can only be one default. |
 | `defaultPins` | `ExtensionK8sModel[]` | yes | Default pinned resources on the nav |
 | `usePerspectiveDetection` | `CodeRef<() => [boolean, boolean]>` | yes | The hook to detect default perspective |

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/perspectives.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/perspectives.ts
@@ -21,7 +21,7 @@ export type Perspective = ExtensionDeclaration<
     defaultPins?: ExtensionK8sModel[];
     /** The function to get perspective landing page URL. */
     landingPageURL: CodeRef<(flags: { [key: string]: boolean }, isFirstVisit: boolean) => string>;
-    /** The function to get redirect URL for import flow. */
+    /** The function to get a relative redirect URL for import flow. */
     importRedirectURL: CodeRef<(namespace: string) => string>;
     /** The hook to detect default perspective */
     usePerspectiveDetection?: CodeRef<() => [boolean, boolean]>; // [enablePerspective: boolean, loading: boolean]

--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-devfile.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-devfile.feature
@@ -29,6 +29,7 @@ Feature: Create Application from Devfile
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
               And user is able to see workload "node-example" in topology page
+              And user will see sidebar in topology page with title "node-example"
 
 
         @regression @broken-test

--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-docker-file.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-docker-file.feature
@@ -29,6 +29,7 @@ Feature: Create Application from Docker file
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
               And user is able to see workload "<name>" in topology page
+              And user will see sidebar in topology page with title "<name>"
 
         Examples:
                   | resource_type     | name         |

--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
@@ -40,9 +40,9 @@ Feature: Create Application from git form
               And user selects resource type as "Deployment Config"
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
-              And user will see sidebar in topology page with title "dancer-ex-git-2"
               And user can see toast notification saying "DeploymentConfig" created successfully
               And user can see the created workload "dancer-ex-git-2" is linked to existing application "nodejs-ex-git-app"
+              And user will see sidebar in topology page with title "dancer-ex-git-2"
 
 
         @regression
@@ -150,8 +150,8 @@ Feature: Create Application from git form
               And user enters label as "app=frontend"
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
-              And user will see sidebar in topology page with title "git-labels"
               And verify the label "app=frontend" in side bar of application node "git-labels"
+              And user will see sidebar in topology page with title "git-labels"
 
 
         @regression

--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
@@ -40,6 +40,7 @@ Feature: Create Application from git form
               And user selects resource type as "Deployment Config"
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user will see sidebar in topology page with title "dancer-ex-git-2"
               And user can see toast notification saying "DeploymentConfig" created successfully
               And user can see the created workload "dancer-ex-git-2" is linked to existing application "nodejs-ex-git-app"
 
@@ -61,6 +62,7 @@ Feature: Create Application from git form
               And user unselects the advanced option Create a route to the application
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user will see sidebar in topology page with title "name-no-route"
               And public url is not created for node "name-no-route" in the workload sidebar
 
 
@@ -76,6 +78,7 @@ Feature: Create Application from git form
               And user selects default Target Port
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user will see sidebar in topology page with title "git-route"
               And user can see the toast notification containg the route value "home"
               And the route of application "git-route" contains "home" in the Routes section of the workload sidebar
               And user is able to see label "route=testRoute1" in Route details page for deployment "git-route"
@@ -94,6 +97,7 @@ Feature: Create Application from git form
               And user enters Value as "value" in Environment Variables section
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user will see sidebar in topology page with title "git-build"
               And build does not get started for "git-build"
 
 
@@ -108,6 +112,7 @@ Feature: Create Application from git form
               And user enters Value as "value" in Environment Variables Runtime only section
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user will see sidebar in topology page with title "git-deploy"
 
 
         @regression
@@ -122,6 +127,7 @@ Feature: Create Application from git form
               And user enters Memory Limit as "300" in Memory section
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user will see sidebar in topology page with title "git-resource"
 
 # Marked below test as broken due to issue https://issues.redhat.com/browse/OCPBUGS-30205
         @regression @broken-test
@@ -144,6 +150,7 @@ Feature: Create Application from git form
               And user enters label as "app=frontend"
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user will see sidebar in topology page with title "git-labels"
               And verify the label "app=frontend" in side bar of application node "git-labels"
 
 
@@ -158,6 +165,7 @@ Feature: Create Application from git form
               And user fills the Startup Probe details
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user will see sidebar in topology page with title "git-healthchecks"
 
 
         # Marking this scenario as @manual, because due to git-rate limit issue, below scenarios are failing

--- a/frontend/packages/dev-console/integration-tests/features/addFlow/upload-jar-file.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/upload-jar-file.feature
@@ -29,6 +29,7 @@ Feature: Upload JAR file
               And user selects resource type as "<resource_type>"
               And user clicks create button
              Then user will be redirected to Topology page
+              And user will see sidebar in topology page with title "sample-upload-app"
               And user can see a toast notification of JAR file uploading with link to build logs
               And user can see "<resource_type>" "<name>" in application "sample-upload-app" is created in topology
 
@@ -48,6 +49,7 @@ Feature: Upload JAR file
               And user selects resource type as "<resource_type>"
               And user clicks create button
              Then user will be redirected to Topology page
+              And user will see sidebar in topology page with title "sample-upload-app"
               And user can see a toast notification of JAR file uploading with link to build logs
               And user can see "<resource_type>" "<name>" in application "sample-upload-app" is created in topology
 
@@ -69,6 +71,7 @@ Feature: Upload JAR file
               And user fills the Startup Probe details
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user will see sidebar in topology page with title "sample-upload-app"
 
 
         @regression @to-do
@@ -80,6 +83,7 @@ Feature: Upload JAR file
               And user unselects the advanced option Create a route to the application
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user will see sidebar in topology page with title "sample-upload-app"
               And public url is not created for node "sample-yaml-upload" in the workload sidebar
 
 
@@ -95,6 +99,7 @@ Feature: Upload JAR file
               And user selects default Target Port
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user will see sidebar in topology page with title "sample-upload-app"
               And the route of application "sample-yaml-upload" contains "home" in the Routes section of the workload sidebar
 
 
@@ -110,7 +115,7 @@ Feature: Upload JAR file
               And user enters Value as "value" in Environment Variables Runtime only section
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
-
+              And user will see sidebar in topology page with title "sample-upload-app"
 
         @regression @to-do
         Scenario: Upload JAR file with advanced option "Resource Limits": A-10-TC08
@@ -125,7 +130,7 @@ Feature: Upload JAR file
               And user enters Memory Limit as "300" in Memory section
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
-
+              And user will see sidebar in topology page with title "sample-upload-app"
 
         @regression @to-do
         Scenario: Upload JAR file with advanced option "Scaling": A-10-TC09
@@ -137,7 +142,7 @@ Feature: Upload JAR file
               And user enters number of replicas as "5" in Replicas section
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
-
+              And user will see sidebar in topology page with title "sample-upload-app"
 
         @regression @to-do
         Scenario: Upload JAR file with advanced option "Labels": A-10-TC10
@@ -149,4 +154,5 @@ Feature: Upload JAR file
               And user enters label as "app=frontend"
               And user clicks Create button on Add page
              Then user will be redirected to Topology page
+              And user will see sidebar in topology page with title "sample-upload-app"
               And verify the label "app=frontend" in side bar of application node "sample-yaml-upload"

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-git.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-git.ts
@@ -137,8 +137,7 @@ When('user enters Value as {string} in Environment Variables section', (envValue
 });
 
 Then('build does not get started for {string}', (nodeName: string) => {
-  topologyPage.componentNode(nodeName).click({ force: true });
-  topologySidePane.verify();
+  topologyPage.verifyOrOpenSidebar(nodeName);
   cy.get('div.build-overview li.list-group-item > span').should(
     'contain.text',
     'No Builds found for this Build Config.',
@@ -205,7 +204,7 @@ Then('user can see the toast notification containg the route value {string}', (m
 
 Then('public url is not created for node {string} in the workload sidebar', (nodeName: string) => {
   topologyPage.verifyWorkloadInTopologyPage(nodeName);
-  topologyPage.componentNode(nodeName).click({ force: true });
+  topologyPage.verifyOrOpenSidebar(nodeName);
   topologySidePane.selectTab('Resources');
   topologySidePane.verifySection('Routes');
   cy.get('[role="dialog"] h2')
@@ -218,7 +217,7 @@ Then(
   'the route of application {string} contains {string} in the Routes section of the workload sidebar',
   (nodeName: string, routeName: string) => {
     topologyPage.verifyWorkloadInTopologyPage(nodeName);
-    topologyPage.componentNode(nodeName).click({ force: true });
+    topologyPage.verifyOrOpenSidebar(nodeName);
     topologySidePane.selectTab('Resources');
     topologySidePane.verifySection('Routes');
     // cy.get('a.co-external-link.co-external-link--block').should('contain.text', routeName);
@@ -229,7 +228,7 @@ Then(
 Then(
   'verify the label {string} in side bar of application node {string}',
   (labelName: string, nodeName: string) => {
-    topologyPage.componentNode(nodeName).click({ force: true });
+    topologyPage.verifyOrOpenSidebar(nodeName);
     topologySidePane.selectTab('Details');
     topologySidePane.verifyLabel(labelName);
     topologySidePane.close();

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/topology/create-workloads.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/topology/create-workloads.ts
@@ -1,7 +1,10 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
 import { guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
 import { nav } from '@console/cypress-integration-tests/views/nav';
-import { topologyPage } from '@console/topology/integration-tests/support/pages/topology';
+import {
+  topologyPage,
+  topologySidePane,
+} from '@console/topology/integration-tests/support/pages/topology';
 import { switchPerspective, devNavigationMenu } from '../../constants';
 import { perspective, navigateTo } from '../../pages';
 
@@ -41,4 +44,9 @@ Then('user will see pod with name {string} on topology page', (name: string) => 
   guidedTour.close();
   nav.sidenav.switcher.shouldHaveText(switchPerspective.Developer);
   topologyPage.verifyWorkloadInTopologyPage(`${name}`);
+});
+
+Then('user will see sidebar in topology page with title {string}', (title: string) => {
+  topologySidePane.verify();
+  topologySidePane.verifyTitle(title);
 });

--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -13,6 +13,7 @@ import { healthChecksProbeInitialData } from '../health-checks/health-checks-pro
 import { createOrUpdateDeployImageResources } from './deployImage-submit-utils';
 import { deployValidationSchema } from './deployImage-validation-utils';
 import DeployImageForm from './DeployImageForm';
+import { filterDeployedResources } from './import-submit-utils';
 import { DeployImageFormData, FirehoseList, Resources } from './import-types';
 import { useUpdateKnScalingDefaultValues } from './serverless/useUpdateKnScalingDefaultValues';
 
@@ -181,8 +182,10 @@ const DeployImage: React.FC<Props> = ({
       });
 
     return resourceActions
-      .then(() => {
-        history.push(`/topology/ns/${projectName}`);
+      .then((res) => {
+        const selectId = filterDeployedResources(res)[0]?.metadata?.uid;
+
+        history.push(`/topology/ns/${projectName}${selectId ? `?selectId=${selectId}` : ''}`);
       })
       .catch((err) => {
         helpers.setStatus({ submitError: err.message });

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -23,7 +23,10 @@ import {
   useTelemetry,
 } from '@console/shared';
 import { useToast } from '@console/shared/src/components/toast';
-import { UNASSIGNED_KEY } from '@console/topology/src/const';
+import {
+  LAST_TOPOLOGY_OVERVIEW_OPEN_STORAGE_KEY,
+  UNASSIGNED_KEY,
+} from '@console/topology/src/const';
 import { sanitizeApplicationValue } from '@console/topology/src/utils/application-utils';
 import { NormalizedBuilderImages, normalizeBuilderImages } from '../../utils/imagestream-utils';
 import { getBaseInitialValues } from './form-initial-values';
@@ -215,6 +218,9 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
         }
 
         fireTelemetryEvent('Git Import', getTelemetryImport(values));
+
+        sessionStorage.removeItem(LAST_TOPOLOGY_OVERVIEW_OPEN_STORAGE_KEY);
+
         handleRedirect(projectName, perspective, perspectiveExtensions, redirectSearchParams);
       })
       .catch((err) => {

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -195,6 +195,9 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
             (resource.kind === knSvcModel.kind &&
               resource.apiVersion === `${knSvcModel.apiGroup}/${knSvcModel.apiVersion}`),
         );
+
+        const redirectSearchParams = new URLSearchParams();
+
         const route = resources.find((resource) => resource.kind === RouteModel.kind) as RouteKind;
         if (deployedResources.length > 0) {
           toastContext.addToast({
@@ -207,10 +210,12 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
             timeout: true,
             dismissible: true,
           });
+
+          redirectSearchParams.set('selectId', deployedResources[0].metadata.uid);
         }
 
         fireTelemetryEvent('Git Import', getTelemetryImport(values));
-        handleRedirect(projectName, perspective, perspectiveExtensions);
+        handleRedirect(projectName, perspective, perspectiveExtensions, redirectSearchParams);
       })
       .catch((err) => {
         // eslint-disable-next-line no-console

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -22,10 +22,7 @@ import {
   useTelemetry,
 } from '@console/shared';
 import { useToast } from '@console/shared/src/components/toast';
-import {
-  LAST_TOPOLOGY_OVERVIEW_OPEN_STORAGE_KEY,
-  UNASSIGNED_KEY,
-} from '@console/topology/src/const';
+import { UNASSIGNED_KEY } from '@console/topology/src/const';
 import { sanitizeApplicationValue } from '@console/topology/src/utils/application-utils';
 import { NormalizedBuilderImages, normalizeBuilderImages } from '../../utils/imagestream-utils';
 import { getBaseInitialValues } from './form-initial-values';
@@ -218,8 +215,6 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
         }
 
         fireTelemetryEvent('Git Import', getTelemetryImport(values));
-
-        sessionStorage.removeItem(LAST_TOPOLOGY_OVERVIEW_OPEN_STORAGE_KEY);
 
         handleRedirect(projectName, perspective, perspectiveExtensions, redirectSearchParams);
       })

--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
@@ -26,7 +26,12 @@ import {
   sampleDevfileFormData,
 } from './import-submit-utils-data';
 
-const { createOrUpdateDeployment, createOrUpdateResources, createDevfileResources } = submitUtils;
+const {
+  createOrUpdateDeployment,
+  createOrUpdateResources,
+  createDevfileResources,
+  addSearchParamsToRelativeURL,
+} = submitUtils;
 
 describe('Import Submit Utils', () => {
   const t = jest.fn();
@@ -651,6 +656,47 @@ describe('Import Submit Utils', () => {
         devFileLanguage: 'python',
         devFileProjectType: 'python',
       });
+    });
+  });
+
+  describe('addSearchParamsToRelativeURL tests', () => {
+    it('should work when the URL already has a search param', () => {
+      expect(
+        addSearchParamsToRelativeURL(
+          '/foo/bar?param=true',
+          new URLSearchParams({ newParam: 'new' }),
+        ),
+      ).toEqual('/foo/bar?param=true&newParam=new');
+    });
+
+    it('should override existing search params', () => {
+      expect(
+        addSearchParamsToRelativeURL(
+          '/foo/bar?param=true',
+          new URLSearchParams({ param: 'false' }),
+        ),
+      ).toEqual('/foo/bar?param=false');
+    });
+
+    it('should work when there is a section in the URL', () => {
+      expect(
+        addSearchParamsToRelativeURL('/foo/bar#section', new URLSearchParams({ param: 'true' })),
+      ).toEqual('/foo/bar?param=true#section');
+    });
+
+    it('should work when the URL has no search params', () => {
+      expect(
+        addSearchParamsToRelativeURL('/foo/bar', new URLSearchParams({ param: 'true' })),
+      ).toEqual('/foo/bar?param=true');
+    });
+
+    it('should override search params, work when there are sections', () => {
+      expect(
+        addSearchParamsToRelativeURL(
+          '/foo/bar?param=true#section',
+          new URLSearchParams({ param: 'false' }),
+        ),
+      ).toEqual('/foo/bar?param=false#section');
     });
   });
 });

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -24,9 +24,7 @@ import {
   k8sUpdate,
   K8sVerb,
 } from '@console/internal/module/k8s';
-import {
-  ServiceModel as KnServiceModel,
-} from '@console/knative-plugin';
+import { ServiceModel as KnServiceModel } from '@console/knative-plugin';
 import {
   getDomainMappingRequests,
   getKnativeServiceDepResource,
@@ -863,7 +861,10 @@ export const filterDeployedResources = (resources: K8sResourceKind[]) =>
         resource.apiVersion === `${KnServiceModel.apiGroup}/${KnServiceModel.apiVersion}`),
   );
 
-const addSearchParamsToRelativeURL = (url: string, searchParams?: URLSearchParams): string => {
+export const addSearchParamsToRelativeURL = (
+  url: string,
+  searchParams?: URLSearchParams,
+): string => {
   const urlObj = new URL(url, 'thismessage:/'); // ITEF RFC 2557 section 5 (e)
 
   urlObj.search = new URLSearchParams({

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -852,12 +852,12 @@ export const createOrUpdateResources = async (
   return responses;
 };
 
-const addSearchParamsToRelativeURL = (url: string, searchParams: URLSearchParams): string => {
+const addSearchParamsToRelativeURL = (url: string, searchParams?: URLSearchParams): string => {
   const urlObj = new URL(url, 'thismessage:/'); // ITEF RFC 2557 section 5 (e)
 
   urlObj.search = new URLSearchParams({
     ...Object.fromEntries(urlObj.searchParams),
-    ...Object.fromEntries(searchParams),
+    ...(searchParams ? Object.fromEntries(searchParams) : {}),
   }).toString();
 
   return urlObj.toString().replace(urlObj.protocol, '');

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -852,14 +852,27 @@ export const createOrUpdateResources = async (
   return responses;
 };
 
+const addSearchParamsToRelativeURL = (url: string, searchParams: URLSearchParams): string => {
+  const urlObj = new URL(url, 'thismessage:/'); // ITEF RFC 2557 section 5 (e)
+
+  urlObj.search = new URLSearchParams({
+    ...Object.fromEntries(urlObj.searchParams),
+    ...Object.fromEntries(searchParams),
+  }).toString();
+
+  return urlObj.toString().replace(urlObj.protocol, '');
+};
+
 export const handleRedirect = async (
   project: string,
   perspective: string,
   perspectiveExtensions: Perspective[],
+  searchParamOverrides?: URLSearchParams,
 ) => {
   const perspectiveData = perspectiveExtensions.find((item) => item.properties.id === perspective);
   const redirectURL = (await perspectiveData.properties.importRedirectURL())(project);
-  history.push(redirectURL);
+
+  history.push(addSearchParamsToRelativeURL(redirectURL, searchParamOverrides));
 };
 
 export const isRouteAdvOptionsUsed = (

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -859,8 +859,8 @@ export const filterDeployedResources = (resources: K8sResourceKind[]) =>
     (resource) =>
       resource.kind === DeploymentModel.kind ||
       resource.kind === DeploymentConfigModel.kind ||
-      (resource.kind === knSvcModel.kind &&
-        resource.apiVersion === `${knSvcModel.apiGroup}/${knSvcModel.apiVersion}`),
+      (resource.kind === KnServiceModel.kind &&
+        resource.apiVersion === `${KnServiceModel.apiGroup}/${KnServiceModel.apiVersion}`),
   );
 
 const addSearchParamsToRelativeURL = (url: string, searchParams?: URLSearchParams): string => {

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -872,7 +872,11 @@ export const handleRedirect = async (
   const perspectiveData = perspectiveExtensions.find((item) => item.properties.id === perspective);
   const redirectURL = (await perspectiveData.properties.importRedirectURL())(project);
 
-  history.push(addSearchParamsToRelativeURL(redirectURL, searchParamOverrides));
+  if (searchParamOverrides) {
+    history.push(addSearchParamsToRelativeURL(redirectURL, searchParamOverrides));
+  } else {
+    history.push(redirectURL);
+  }
 };
 
 export const isRouteAdvOptionsUsed = (

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -24,7 +24,10 @@ import {
   k8sUpdate,
   K8sVerb,
 } from '@console/internal/module/k8s';
-import { ServiceModel as KnServiceModel } from '@console/knative-plugin';
+import {
+  ServiceModel as KnServiceModel,
+  ServiceModel as knSvcModel,
+} from '@console/knative-plugin';
 import {
   getDomainMappingRequests,
   getKnativeServiceDepResource,
@@ -851,6 +854,15 @@ export const createOrUpdateResources = async (
 
   return responses;
 };
+
+export const filterDeployedResources = (resources: K8sResourceKind[]) =>
+  resources.filter(
+    (resource) =>
+      resource.kind === DeploymentModel.kind ||
+      resource.kind === DeploymentConfigModel.kind ||
+      (resource.kind === knSvcModel.kind &&
+        resource.apiVersion === `${knSvcModel.apiGroup}/${knSvcModel.apiVersion}`),
+  );
 
 const addSearchParamsToRelativeURL = (url: string, searchParams?: URLSearchParams): string => {
   const urlObj = new URL(url, 'thismessage:/'); // ITEF RFC 2557 section 5 (e)

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -26,7 +26,6 @@ import {
 } from '@console/internal/module/k8s';
 import {
   ServiceModel as KnServiceModel,
-  ServiceModel as knSvcModel,
 } from '@console/knative-plugin';
 import {
   getDomainMappingRequests,

--- a/frontend/packages/dev-console/src/components/import/jar/UploadJar.tsx
+++ b/frontend/packages/dev-console/src/components/import/jar/UploadJar.tsx
@@ -10,10 +10,11 @@ import {
   usePerspectives,
   usePostFormSubmitAction,
 } from '@console/shared/src';
+import { LAST_TOPOLOGY_OVERVIEW_OPEN_STORAGE_KEY } from '@console/topology/src/const';
 import { sanitizeApplicationValue } from '@console/topology/src/utils';
 import { BuilderImage } from '../../../utils/imagestream-utils';
 import { getBaseInitialValues } from '../form-initial-values';
-import { handleRedirect } from '../import-submit-utils';
+import { filterDeployedResources, handleRedirect } from '../import-submit-utils';
 import { BaseFormData, Resources, UploadJarFormData } from '../import-types';
 import { createOrUpdateJarFile } from '../upload-jar-submit-utils';
 import { validationSchema } from '../upload-jar-validation-utils';
@@ -85,7 +86,15 @@ const UploadJar: React.FunctionComponent<UploadJarProps> = ({
       .then((resp) => {
         postFormCallback(resp);
         toastCallback(resp);
-        handleRedirect(projectName, perspective, perspectiveExtensions);
+        sessionStorage.removeItem(LAST_TOPOLOGY_OVERVIEW_OPEN_STORAGE_KEY);
+        handleRedirect(
+          projectName,
+          perspective,
+          perspectiveExtensions,
+          new URLSearchParams({
+            selectId: filterDeployedResources(resp)[0]?.metadata?.uid,
+          }),
+        );
       })
       .catch((err) => {
         actions.setStatus({ submitError: err.message });

--- a/frontend/packages/dev-console/src/components/import/jar/UploadJar.tsx
+++ b/frontend/packages/dev-console/src/components/import/jar/UploadJar.tsx
@@ -10,7 +10,6 @@ import {
   usePerspectives,
   usePostFormSubmitAction,
 } from '@console/shared/src';
-import { LAST_TOPOLOGY_OVERVIEW_OPEN_STORAGE_KEY } from '@console/topology/src/const';
 import { sanitizeApplicationValue } from '@console/topology/src/utils';
 import { BuilderImage } from '../../../utils/imagestream-utils';
 import { getBaseInitialValues } from '../form-initial-values';
@@ -86,7 +85,6 @@ const UploadJar: React.FunctionComponent<UploadJarProps> = ({
       .then((resp) => {
         postFormCallback(resp);
         toastCallback(resp);
-        sessionStorage.removeItem(LAST_TOPOLOGY_OVERVIEW_OPEN_STORAGE_KEY);
         handleRedirect(
           projectName,
           perspective,

--- a/frontend/packages/dev-console/src/components/import/serverless-function/AddServerlessFunction.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless-function/AddServerlessFunction.tsx
@@ -23,7 +23,11 @@ import {
 import { sanitizeApplicationValue } from '@console/topology/src/utils/application-utils';
 import { normalizeBuilderImages, NormalizedBuilderImages } from '../../../utils/imagestream-utils';
 import { getBaseInitialValues } from '../form-initial-values';
-import { createOrUpdateResources, handleRedirect } from '../import-submit-utils';
+import {
+  createOrUpdateResources,
+  handleRedirect,
+  filterDeployedResources,
+} from '../import-submit-utils';
 import { BaseFormData, BuildOptions, Resources } from '../import-types';
 import { validationSchema } from '../import-validation-utils';
 import { useUpdateKnScalingDefaultValues } from '../serverless/useUpdateKnScalingDefaultValues';
@@ -160,8 +164,15 @@ const AddServerlessFunction: React.FC<AddServerlessFunctionProps> = ({
       .catch(() => {});
     fireTelemetryEvent('Serverless Function being created');
     return resourceActions
-      .then(() => {
-        handleRedirect(projectName, perspective, perspectiveExtensions);
+      .then((res) => {
+        const selectId = filterDeployedResources(res)[0]?.metadata?.uid || undefined;
+
+        handleRedirect(
+          projectName,
+          perspective,
+          perspectiveExtensions,
+          new URLSearchParams({ selectId }),
+        );
       })
       .catch((err) => {
         // eslint-disable-next-line no-console

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -16,6 +16,11 @@ import { gitPage } from '@console/dev-console/integration-tests/support/pages/ad
 import { topologyHelper } from './topology-helper-page';
 
 export const topologyPage = {
+  verifyOrOpenSidebar: (nodeName: string) => {
+    if (!cy.get(topologyPO.sidePane.dialog)) {
+      topologyPage.componentNode(nodeName).click({ force: true });
+    }
+  },
   verifyUserIsInGraphView: () => {
     cy.byLegacyTestID('topology-view-shortcuts').should('be.visible');
     // eslint-disable-next-line promise/catch-or-return

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -17,9 +17,13 @@ import { topologyHelper } from './topology-helper-page';
 
 export const topologyPage = {
   verifyOrOpenSidebar: (nodeName: string) => {
-    if (!cy.get(topologyPO.sidePane.dialog)) {
-      topologyPage.componentNode(nodeName).click({ force: true });
-    }
+    cy.get(topologyPO.sidePane.dialog).then((dialog) => {
+      if (dialog.length !== 0) {
+        topologyPage.componentNode(nodeName).click({ force: true });
+      } else {
+        cy.log(`Sidebar is already open`);
+      }
+    });
   },
   verifyUserIsInGraphView: () => {
     cy.byLegacyTestID('topology-view-shortcuts').should('be.visible');

--- a/frontend/packages/topology/src/components/page/TopologyPage.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyPage.tsx
@@ -8,7 +8,11 @@ import CreateProjectListPage, {
   CreateAProjectButton,
 } from '@console/dev-console/src/components/projects/CreateProjectListPage';
 import { withStartGuide } from '@console/internal/components/start-guide';
-import { removeQueryArgument, setQueryArgument } from '@console/internal/components/utils';
+import {
+  getQueryArgument,
+  removeQueryArgument,
+  setQueryArgument,
+} from '@console/internal/components/utils';
 import { useQueryParams, useUserSettingsCompatibility } from '@console/shared';
 import { ErrorBoundaryFallbackPage, withFallback } from '@console/shared/src/components/error';
 import {
@@ -94,7 +98,7 @@ export const TopologyPage: React.FC<TopologyPageProps> = ({
     const lastOverviewOpen = JSON.parse(
       sessionStorage.getItem(LAST_TOPOLOGY_OVERVIEW_OPEN_STORAGE_KEY) ?? '{}',
     );
-    if (loaded && namespace in lastOverviewOpen) {
+    if (loaded && namespace in lastOverviewOpen && !getQueryArgument('selectId')) {
       setQueryArgument('selectId', lastOverviewOpen[namespace]);
     }
   }, [loaded, namespace]);


### PR DESCRIPTION
From Jira issue https://issues.redhat.com/browse/ODC-7588

**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
n/a

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Adds option of adding search params to `handleRedirect`, then passes the required `selectId` upon creation of a service by filtering only deployment resources.

Needed to make a `addSearchParamsToRelativeURL` helper to include this feature, as the URL returned by `importRedirectURL` has no guarantee of not already including search params or url fragments, and naive string concatenation would result in bugs in that case. I applied [ITEF RFC 2257](https://datatracker.ietf.org/doc/html/rfc2557#section-5) spec to implement the helper that adds search params to the URL

I also updated the jsdoc for `importRedirectURL` to explicitly indicate that it returns a relative URL as a postcondition. This was already assumed by the `handleRedirect` helper, but was not explicitly written (i.e., if an absolute url were returned, it would not redirect the user to the correct url).   

I also had to modify the topology page to ignore the last opened sidebar in favor of the new id I'm giving it, which may have consequences I'm not aware of. Testing indicates that the page just saves the new ID as the new previously viewed deployment

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://github.com/openshift/console/assets/18614559/7be4226e-76f2-49bb-bdce-d830cec6ec2d

This screen recording was taken on a new installation of Chromium (OzonePlatform set to Wayland) 125.0.6422.141 on Fedora CSB 40 with no saved cookies or site data. No operators were installed on OpenShift

**Unit test coverage report**: 
<!-- Attach test coverage report -->
Not changed.

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

No additional setup is required aside from already having an OpenShift cluster :p

Here are the URLs/container image ids I used for easy copy/pasting:
- https://github.com/sclorg/nodejs-ex.git
- https://github.com/sclorg/golang-ex.git
- https://github.com/sclorg/ruby-ex.git
- openshift/hello-openshift
- [server.jar](https://piston-data.mojang.com/v1/objects/145ff0858209bcfc164859ba735d4199aafa1eea/server.jar) (it can be any jar) 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge - not needed as edge is now chromium based