### PR TITLE
NO-JIRA: revert "Add username/uid label and annotation for the user setting ConfigMap, Role and RoleBinding"

### DIFF
--- a/pkg/usersettings/helpers.go
+++ b/pkg/usersettings/helpers.go
@@ -18,7 +18,6 @@ func newUserSettingMeta(userInfo authenticationv1.UserInfo) (*UserSettingMeta, e
 	if uid != "" {
 		resourceIdentifier = uid
 	} else if username == "kube:admin" {
-		uid = "kubeadmin"
 		resourceIdentifier = "kubeadmin"
 	} else {
 		// to avoid issues when the username contains special characters like '@'

--- a/pkg/usersettings/helpers.go
+++ b/pkg/usersettings/helpers.go
@@ -11,13 +11,10 @@ import (
 )
 
 func newUserSettingMeta(userInfo authenticationv1.UserInfo) (*UserSettingMeta, error) {
-	uid := userInfo.UID
-	username := userInfo.Username
 	var resourceIdentifier string
-
-	if uid != "" {
-		resourceIdentifier = uid
-	} else if username == "kube:admin" {
+	if userInfo.UID != "" {
+		resourceIdentifier = userInfo.UID
+	} else if userInfo.Username == "kube:admin" {
 		resourceIdentifier = "kubeadmin"
 	} else {
 		// to avoid issues when the username contains special characters like '@'
@@ -30,8 +27,8 @@ func newUserSettingMeta(userInfo authenticationv1.UserInfo) (*UserSettingMeta, e
 	}
 
 	return &UserSettingMeta{
-		Username:           username,
-		UID:                uid,
+		Username:           userInfo.Username,
+		UID:                userInfo.UID,
 		ResourceIdentifier: resourceIdentifier,
 	}, nil
 }

--- a/pkg/usersettings/helpers.go
+++ b/pkg/usersettings/helpers.go
@@ -11,10 +11,13 @@ import (
 )
 
 func newUserSettingMeta(userInfo authenticationv1.UserInfo) (*UserSettingMeta, error) {
-	var resourceIdentifier string
-	if userInfo.UID != "" {
-		resourceIdentifier = userInfo.UID
-	} else if userInfo.Username == "kube:admin" {
+	uid := userInfo.UID
+	name := userInfo.Username
+	resourceIdentifier := name
+
+	if uid != "" {
+		resourceIdentifier = string(uid)
+	} else if name == "kube:admin" {
 		resourceIdentifier = "kubeadmin"
 	} else {
 		// to avoid issues when the username contains special characters like '@'
@@ -27,8 +30,8 @@ func newUserSettingMeta(userInfo authenticationv1.UserInfo) (*UserSettingMeta, e
 	}
 
 	return &UserSettingMeta{
-		Username:           userInfo.Username,
-		UID:                userInfo.UID,
+		Username:           name,
+		UID:                string(uid),
 		ResourceIdentifier: resourceIdentifier,
 	}, nil
 }

--- a/pkg/usersettings/helpers.go
+++ b/pkg/usersettings/helpers.go
@@ -40,9 +40,7 @@ func createRole(userSettingMeta *UserSettingMeta) *rbac.Role {
 			Kind:       "Role",
 		},
 		ObjectMeta: meta.ObjectMeta{
-			Name:        userSettingMeta.getRoleName(),
-			Labels:      userSettingMeta.getLabels(),
-			Annotations: userSettingMeta.getAnnotations(),
+			Name: userSettingMeta.getRoleName(),
 		},
 		Rules: []rbac.PolicyRule{
 			{
@@ -74,9 +72,7 @@ func createRoleBinding(userSettingMeta *UserSettingMeta) *rbac.RoleBinding {
 			Kind:       "RoleBinding",
 		},
 		ObjectMeta: meta.ObjectMeta{
-			Name:        userSettingMeta.getRoleBindingName(),
-			Labels:      userSettingMeta.getLabels(),
-			Annotations: userSettingMeta.getAnnotations(),
+			Name: userSettingMeta.getRoleBindingName(),
 		},
 		Subjects: []rbac.Subject{
 			{
@@ -100,9 +96,7 @@ func createConfigMap(userSettingMeta *UserSettingMeta) *core.ConfigMap {
 			Kind:       "ConfigMap",
 		},
 		ObjectMeta: meta.ObjectMeta{
-			Name:        userSettingMeta.getConfigMapName(),
-			Labels:      userSettingMeta.getLabels(),
-			Annotations: userSettingMeta.getAnnotations(),
+			Name: userSettingMeta.getConfigMapName(),
 		},
 	}
 }

--- a/pkg/usersettings/helpers_test.go
+++ b/pkg/usersettings/helpers_test.go
@@ -83,6 +83,7 @@ func TestCreateUserSettingsResources(t *testing.T) {
 			testcase: "for kubeadmin",
 			userInfo: authenticationv1.UserInfo{
 				Username: "kube:admin",
+				UID:      "",
 			},
 			expectedRole: rbac.Role{
 				TypeMeta: meta.TypeMeta{
@@ -273,71 +274,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234",
-				},
-			},
-		},
-		{
-			testcase: "for users with email addresses as username",
-			userInfo: authenticationv1.UserInfo{
-				Username: "openshift@redhat.com",
-			},
-			expectedRole: rbac.Role{
-				TypeMeta: meta.TypeMeta{
-					APIVersion: "rbac.authorization.k8s.io/v1",
-					Kind:       "Role",
-				},
-				ObjectMeta: meta.ObjectMeta{
-					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-role",
-				},
-				Rules: []rbac.PolicyRule{
-					{
-						APIGroups: []string{
-							"", // Core group, not "v1"
-						},
-						Resources: []string{
-							"configmaps", // Not "ConfigMap"
-						},
-						Verbs: []string{
-							"get",
-							"list",
-							"patch",
-							"update",
-							"watch",
-						},
-						ResourceNames: []string{
-							"user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-						},
-					},
-				},
-			},
-			expectedRoleBinding: rbac.RoleBinding{
-				TypeMeta: meta.TypeMeta{
-					APIVersion: "rbac.authorization.k8s.io/v1",
-					Kind:       "RoleBinding",
-				},
-				ObjectMeta: meta.ObjectMeta{
-					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-rolebinding",
-				},
-				Subjects: []rbac.Subject{
-					{
-						APIGroup: "rbac.authorization.k8s.io",
-						Kind:     "User",
-						Name:     "openshift@redhat.com",
-					},
-				},
-				RoleRef: rbac.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Role",
-					Name:     "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-role",
-				},
-			},
-			expectedConfigMap: core.ConfigMap{
-				TypeMeta: meta.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "ConfigMap",
-				},
-				ObjectMeta: meta.ObjectMeta{
-					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 				},
 			},
 		},

--- a/pkg/usersettings/helpers_test.go
+++ b/pkg/usersettings/helpers_test.go
@@ -5,9 +5,6 @@ import (
 	"testing"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
-	core "k8s.io/api/core/v1"
-	rbac "k8s.io/api/rbac/v1"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNewUserSettingsMeta(t *testing.T) {
@@ -73,11 +70,11 @@ func TestNewUserSettingsMeta(t *testing.T) {
 
 func TestCreateUserSettingsResources(t *testing.T) {
 	tests := []struct {
-		testcase            string
-		userInfo            authenticationv1.UserInfo
-		expectedRole        rbac.Role
-		expectedRoleBinding rbac.RoleBinding
-		expectedConfigMap   core.ConfigMap
+		testcase                string
+		userInfo                authenticationv1.UserInfo
+		expectedRoleName        string
+		expectedRoleBindingName string
+		expectedConfigMapName   string
 	}{
 		{
 			testcase: "for kubeadmin",
@@ -85,65 +82,9 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				Username: "kube:admin",
 				UID:      "",
 			},
-			expectedRole: rbac.Role{
-				TypeMeta: meta.TypeMeta{
-					APIVersion: "rbac.authorization.k8s.io/v1",
-					Kind:       "Role",
-				},
-				ObjectMeta: meta.ObjectMeta{
-					Name: "user-settings-kubeadmin-role",
-				},
-				Rules: []rbac.PolicyRule{
-					{
-						APIGroups: []string{
-							"", // Core group, not "v1"
-						},
-						Resources: []string{
-							"configmaps", // Not "ConfigMap"
-						},
-						Verbs: []string{
-							"get",
-							"list",
-							"patch",
-							"update",
-							"watch",
-						},
-						ResourceNames: []string{
-							"user-settings-kubeadmin",
-						},
-					},
-				},
-			},
-			expectedRoleBinding: rbac.RoleBinding{
-				TypeMeta: meta.TypeMeta{
-					APIVersion: "rbac.authorization.k8s.io/v1",
-					Kind:       "RoleBinding",
-				},
-				ObjectMeta: meta.ObjectMeta{
-					Name: "user-settings-kubeadmin-rolebinding",
-				},
-				Subjects: []rbac.Subject{
-					{
-						APIGroup: "rbac.authorization.k8s.io",
-						Kind:     "User",
-						Name:     "kube:admin",
-					},
-				},
-				RoleRef: rbac.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Role",
-					Name:     "user-settings-kubeadmin-role",
-				},
-			},
-			expectedConfigMap: core.ConfigMap{
-				TypeMeta: meta.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "ConfigMap",
-				},
-				ObjectMeta: meta.ObjectMeta{
-					Name: "user-settings-kubeadmin",
-				},
-			},
+			expectedConfigMapName:   "user-settings-kubeadmin",
+			expectedRoleName:        "user-settings-kubeadmin-role",
+			expectedRoleBindingName: "user-settings-kubeadmin-rolebinding",
 		},
 		{
 			testcase: "for fake kubeadmin we use uid",
@@ -151,65 +92,9 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				Username: "kube:admin",
 				UID:      "1234",
 			},
-			expectedRole: rbac.Role{
-				TypeMeta: meta.TypeMeta{
-					APIVersion: "rbac.authorization.k8s.io/v1",
-					Kind:       "Role",
-				},
-				ObjectMeta: meta.ObjectMeta{
-					Name: "user-settings-1234-role",
-				},
-				Rules: []rbac.PolicyRule{
-					{
-						APIGroups: []string{
-							"", // Core group, not "v1"
-						},
-						Resources: []string{
-							"configmaps", // Not "ConfigMap"
-						},
-						Verbs: []string{
-							"get",
-							"list",
-							"patch",
-							"update",
-							"watch",
-						},
-						ResourceNames: []string{
-							"user-settings-1234",
-						},
-					},
-				},
-			},
-			expectedRoleBinding: rbac.RoleBinding{
-				TypeMeta: meta.TypeMeta{
-					APIVersion: "rbac.authorization.k8s.io/v1",
-					Kind:       "RoleBinding",
-				},
-				ObjectMeta: meta.ObjectMeta{
-					Name: "user-settings-1234-rolebinding",
-				},
-				Subjects: []rbac.Subject{
-					{
-						APIGroup: "rbac.authorization.k8s.io",
-						Kind:     "User",
-						Name:     "kube:admin",
-					},
-				},
-				RoleRef: rbac.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Role",
-					Name:     "user-settings-1234-role",
-				},
-			},
-			expectedConfigMap: core.ConfigMap{
-				TypeMeta: meta.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "ConfigMap",
-				},
-				ObjectMeta: meta.ObjectMeta{
-					Name: "user-settings-1234",
-				},
-			},
+			expectedConfigMapName:   "user-settings-1234",
+			expectedRoleName:        "user-settings-1234-role",
+			expectedRoleBindingName: "user-settings-1234-rolebinding",
 		},
 		{
 			testcase: "for non kubeadmin",
@@ -217,65 +102,9 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				Username: "developer",
 				UID:      "1234",
 			},
-			expectedRole: rbac.Role{
-				TypeMeta: meta.TypeMeta{
-					APIVersion: "rbac.authorization.k8s.io/v1",
-					Kind:       "Role",
-				},
-				ObjectMeta: meta.ObjectMeta{
-					Name: "user-settings-1234-role",
-				},
-				Rules: []rbac.PolicyRule{
-					{
-						APIGroups: []string{
-							"", // Core group, not "v1"
-						},
-						Resources: []string{
-							"configmaps", // Not "ConfigMap"
-						},
-						Verbs: []string{
-							"get",
-							"list",
-							"patch",
-							"update",
-							"watch",
-						},
-						ResourceNames: []string{
-							"user-settings-1234",
-						},
-					},
-				},
-			},
-			expectedRoleBinding: rbac.RoleBinding{
-				TypeMeta: meta.TypeMeta{
-					APIVersion: "rbac.authorization.k8s.io/v1",
-					Kind:       "RoleBinding",
-				},
-				ObjectMeta: meta.ObjectMeta{
-					Name: "user-settings-1234-rolebinding",
-				},
-				Subjects: []rbac.Subject{
-					{
-						APIGroup: "rbac.authorization.k8s.io",
-						Kind:     "User",
-						Name:     "developer",
-					},
-				},
-				RoleRef: rbac.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Role",
-					Name:     "user-settings-1234-role",
-				},
-			},
-			expectedConfigMap: core.ConfigMap{
-				TypeMeta: meta.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "ConfigMap",
-				},
-				ObjectMeta: meta.ObjectMeta{
-					Name: "user-settings-1234",
-				},
-			},
+			expectedConfigMapName:   "user-settings-1234",
+			expectedRoleName:        "user-settings-1234-role",
+			expectedRoleBindingName: "user-settings-1234-rolebinding",
 		},
 	}
 
@@ -290,14 +119,28 @@ func TestCreateUserSettingsResources(t *testing.T) {
 			roleBinding := createRoleBinding(userSettingMeta)
 			configMap := createConfigMap(userSettingMeta)
 
-			if !reflect.DeepEqual(&tt.expectedRole, role) {
-				t.Errorf("Role does not match expectation:\n%v\nbut got\n%v", &tt.expectedRole, role)
+			// Role
+			if role.ObjectMeta.Name != tt.expectedRoleName {
+				t.Errorf("Role name does not match:\n%v\nbut got\n%v", tt.expectedRoleName, role.ObjectMeta.Name)
 			}
-			if !reflect.DeepEqual(&tt.expectedRoleBinding, roleBinding) {
-				t.Errorf("RoleBinding does not match expectation:\n%v\nbut got\n%v", &tt.expectedRoleBinding, roleBinding)
+			if role.Rules[0].ResourceNames[0] != tt.expectedConfigMapName {
+				t.Errorf("Role configmap ref does not match:\n%v\nbut got\n%v", tt.expectedConfigMapName, role.Rules[0].ResourceNames[0])
 			}
-			if !reflect.DeepEqual(&tt.expectedConfigMap, configMap) {
-				t.Errorf("ConfigMap does not match expectation:\n%v\nbut got\n%v", &tt.expectedConfigMap, configMap)
+
+			// RoleBinding
+			if roleBinding.ObjectMeta.Name != tt.expectedRoleBindingName {
+				t.Errorf("RoleBinding name does not match:\n%v\nbut got\n%v", tt.expectedRoleBindingName, roleBinding.ObjectMeta.Name)
+			}
+			if roleBinding.Subjects[0].Name != tt.userInfo.Username {
+				t.Errorf("RoleBinding username ref does not match:\n%v\nbut got\n%v", tt.userInfo.Username, roleBinding.Subjects[0].Name)
+			}
+			if roleBinding.RoleRef.Name != tt.expectedRoleName {
+				t.Errorf("RoleBinding role ref does not match:\n%v\nbut got\n%v", tt.expectedRoleName, roleBinding.RoleRef.Name)
+			}
+
+			// ConfigMap
+			if configMap.ObjectMeta.Name != tt.expectedConfigMapName {
+				t.Errorf("ConfigMap name does not match:\n%v\nbut got\n%v", tt.expectedConfigMapName, configMap.ObjectMeta.Name)
 			}
 		})
 	}

--- a/pkg/usersettings/helpers_test.go
+++ b/pkg/usersettings/helpers_test.go
@@ -83,7 +83,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 			testcase: "for kubeadmin",
 			userInfo: authenticationv1.UserInfo{
 				Username: "kube:admin",
-				UID:      "",
 			},
 			expectedRole: rbac.Role{
 				TypeMeta: meta.TypeMeta{
@@ -92,15 +91,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-kubeadmin-role",
-					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "",
-						resourceIdentifierLabel: "kubeadmin",
-					},
-					Annotations: map[string]string{
-						uidAnnotation:      "",
-						usernameAnnotation: "kube:admin",
-					},
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -130,15 +120,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-kubeadmin-rolebinding",
-					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "",
-						resourceIdentifierLabel: "kubeadmin",
-					},
-					Annotations: map[string]string{
-						uidAnnotation:      "",
-						usernameAnnotation: "kube:admin",
-					},
 				},
 				Subjects: []rbac.Subject{
 					{
@@ -160,15 +141,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-kubeadmin",
-					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "",
-						resourceIdentifierLabel: "kubeadmin",
-					},
-					Annotations: map[string]string{
-						uidAnnotation:      "",
-						usernameAnnotation: "kube:admin",
-					},
 				},
 			},
 		},
@@ -185,15 +157,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-role",
-					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "1234",
-						resourceIdentifierLabel: "1234",
-					},
-					Annotations: map[string]string{
-						uidAnnotation:      "1234",
-						usernameAnnotation: "kube:admin",
-					},
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -223,15 +186,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-rolebinding",
-					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "1234",
-						resourceIdentifierLabel: "1234",
-					},
-					Annotations: map[string]string{
-						uidAnnotation:      "1234",
-						usernameAnnotation: "kube:admin",
-					},
 				},
 				Subjects: []rbac.Subject{
 					{
@@ -253,15 +207,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234",
-					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "1234",
-						resourceIdentifierLabel: "1234",
-					},
-					Annotations: map[string]string{
-						uidAnnotation:      "1234",
-						usernameAnnotation: "kube:admin",
-					},
 				},
 			},
 		},
@@ -278,15 +223,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-role",
-					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "1234",
-						resourceIdentifierLabel: "1234",
-					},
-					Annotations: map[string]string{
-						uidAnnotation:      "1234",
-						usernameAnnotation: "developer",
-					},
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -316,15 +252,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-rolebinding",
-					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "1234",
-						resourceIdentifierLabel: "1234",
-					},
-					Annotations: map[string]string{
-						uidAnnotation:      "1234",
-						usernameAnnotation: "developer",
-					},
 				},
 				Subjects: []rbac.Subject{
 					{
@@ -346,15 +273,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234",
-					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "1234",
-						resourceIdentifierLabel: "1234",
-					},
-					Annotations: map[string]string{
-						uidAnnotation:      "1234",
-						usernameAnnotation: "developer",
-					},
 				},
 			},
 		},
@@ -370,15 +288,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-role",
-					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "",
-						resourceIdentifierLabel: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-					},
-					Annotations: map[string]string{
-						uidAnnotation:      "",
-						usernameAnnotation: "openshift@redhat.com",
-					},
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -408,15 +317,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-rolebinding",
-					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "",
-						resourceIdentifierLabel: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-					},
-					Annotations: map[string]string{
-						uidAnnotation:      "",
-						usernameAnnotation: "openshift@redhat.com",
-					},
 				},
 				Subjects: []rbac.Subject{
 					{
@@ -438,15 +338,6 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-					Labels: map[string]string{
-						userSettingsLabel:       "true",
-						uidLabel:                "",
-						resourceIdentifierLabel: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-					},
-					Annotations: map[string]string{
-						uidAnnotation:      "",
-						usernameAnnotation: "openshift@redhat.com",
-					},
 				},
 			},
 		},

--- a/pkg/usersettings/helpers_test.go
+++ b/pkg/usersettings/helpers_test.go
@@ -18,7 +18,7 @@ func TestNewUserSettingsMeta(t *testing.T) {
 		expectedData  *UserSettingMeta
 	}{
 		{
-			testcase: "returns kubeadmin for kube:admin",
+			testcase: "returns -kubeadmin for kube:admin",
 			userInfo: authenticationv1.UserInfo{
 				Username: "kube:admin",
 				UID:      "",
@@ -26,12 +26,12 @@ func TestNewUserSettingsMeta(t *testing.T) {
 			expectedError: nil,
 			expectedData: &UserSettingMeta{
 				Username:           "kube:admin",
-				UID:                "kubeadmin",
+				UID:                "",
 				ResourceIdentifier: "kubeadmin",
 			},
 		},
 		{
-			testcase: "returns kubeadmin for fake kube:admin with uid",
+			testcase: "returns -kubeadmin for fake kube:admin with uid",
 			userInfo: authenticationv1.UserInfo{
 				Username: "kube:admin",
 				UID:      "1234",
@@ -93,10 +93,12 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-kubeadmin-role",
 					Labels: map[string]string{
-						userSettingsLabel: "true",
-						uidLabel:          "kubeadmin",
+						userSettingsLabel:       "true",
+						uidLabel:                "",
+						resourceIdentifierLabel: "kubeadmin",
 					},
 					Annotations: map[string]string{
+						uidAnnotation:      "",
 						usernameAnnotation: "kube:admin",
 					},
 				},
@@ -129,10 +131,12 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-kubeadmin-rolebinding",
 					Labels: map[string]string{
-						userSettingsLabel: "true",
-						uidLabel:          "kubeadmin",
+						userSettingsLabel:       "true",
+						uidLabel:                "",
+						resourceIdentifierLabel: "kubeadmin",
 					},
 					Annotations: map[string]string{
+						uidAnnotation:      "",
 						usernameAnnotation: "kube:admin",
 					},
 				},
@@ -157,10 +161,12 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-kubeadmin",
 					Labels: map[string]string{
-						userSettingsLabel: "true",
-						uidLabel:          "kubeadmin",
+						userSettingsLabel:       "true",
+						uidLabel:                "",
+						resourceIdentifierLabel: "kubeadmin",
 					},
 					Annotations: map[string]string{
+						uidAnnotation:      "",
 						usernameAnnotation: "kube:admin",
 					},
 				},
@@ -180,10 +186,12 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-role",
 					Labels: map[string]string{
-						userSettingsLabel: "true",
-						uidLabel:          "1234",
+						userSettingsLabel:       "true",
+						uidLabel:                "1234",
+						resourceIdentifierLabel: "1234",
 					},
 					Annotations: map[string]string{
+						uidAnnotation:      "1234",
 						usernameAnnotation: "kube:admin",
 					},
 				},
@@ -216,10 +224,12 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-rolebinding",
 					Labels: map[string]string{
-						userSettingsLabel: "true",
-						uidLabel:          "1234",
+						userSettingsLabel:       "true",
+						uidLabel:                "1234",
+						resourceIdentifierLabel: "1234",
 					},
 					Annotations: map[string]string{
+						uidAnnotation:      "1234",
 						usernameAnnotation: "kube:admin",
 					},
 				},
@@ -244,10 +254,12 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234",
 					Labels: map[string]string{
-						userSettingsLabel: "true",
-						uidLabel:          "1234",
+						userSettingsLabel:       "true",
+						uidLabel:                "1234",
+						resourceIdentifierLabel: "1234",
 					},
 					Annotations: map[string]string{
+						uidAnnotation:      "1234",
 						usernameAnnotation: "kube:admin",
 					},
 				},
@@ -267,10 +279,12 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-role",
 					Labels: map[string]string{
-						userSettingsLabel: "true",
-						uidLabel:          "1234",
+						userSettingsLabel:       "true",
+						uidLabel:                "1234",
+						resourceIdentifierLabel: "1234",
 					},
 					Annotations: map[string]string{
+						uidAnnotation:      "1234",
 						usernameAnnotation: "developer",
 					},
 				},
@@ -303,10 +317,12 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234-rolebinding",
 					Labels: map[string]string{
-						userSettingsLabel: "true",
-						uidLabel:          "1234",
+						userSettingsLabel:       "true",
+						uidLabel:                "1234",
+						resourceIdentifierLabel: "1234",
 					},
 					Annotations: map[string]string{
+						uidAnnotation:      "1234",
 						usernameAnnotation: "developer",
 					},
 				},
@@ -331,10 +347,12 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-1234",
 					Labels: map[string]string{
-						userSettingsLabel: "true",
-						uidLabel:          "1234",
+						userSettingsLabel:       "true",
+						uidLabel:                "1234",
+						resourceIdentifierLabel: "1234",
 					},
 					Annotations: map[string]string{
+						uidAnnotation:      "1234",
 						usernameAnnotation: "developer",
 					},
 				},
@@ -353,10 +371,12 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-role",
 					Labels: map[string]string{
-						userSettingsLabel: "true",
-						uidLabel:          "",
+						userSettingsLabel:       "true",
+						uidLabel:                "",
+						resourceIdentifierLabel: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					},
 					Annotations: map[string]string{
+						uidAnnotation:      "",
 						usernameAnnotation: "openshift@redhat.com",
 					},
 				},
@@ -389,10 +409,12 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-rolebinding",
 					Labels: map[string]string{
-						userSettingsLabel: "true",
-						uidLabel:          "",
+						userSettingsLabel:       "true",
+						uidLabel:                "",
+						resourceIdentifierLabel: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					},
 					Annotations: map[string]string{
+						uidAnnotation:      "",
 						usernameAnnotation: "openshift@redhat.com",
 					},
 				},
@@ -417,10 +439,12 @@ func TestCreateUserSettingsResources(t *testing.T) {
 				ObjectMeta: meta.ObjectMeta{
 					Name: "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					Labels: map[string]string{
-						userSettingsLabel: "true",
-						uidLabel:          "",
+						userSettingsLabel:       "true",
+						uidLabel:                "",
+						resourceIdentifierLabel: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					},
 					Annotations: map[string]string{
+						uidAnnotation:      "",
 						usernameAnnotation: "openshift@redhat.com",
 					},
 				},

--- a/pkg/usersettings/types.go
+++ b/pkg/usersettings/types.go
@@ -1,11 +1,5 @@
 package usersettings
 
-const userSettingsLabel = "console.openshift.io/user-settings"
-const uidLabel = "console.openshift.io/user-settings-uid"
-const resourceIdentifierLabel = "console.openshift.io/user-settings-resource-identifier"
-const uidAnnotation = "console.openshift.io/user-settings-uid"
-const usernameAnnotation = "console.openshift.io/user-settings-username"
-
 type UserSettingMeta struct {
 	Username string
 	UID      string
@@ -23,19 +17,4 @@ func (r *UserSettingMeta) getRoleName() string {
 
 func (r *UserSettingMeta) getRoleBindingName() string {
 	return "user-settings-" + r.ResourceIdentifier + "-rolebinding"
-}
-
-func (r *UserSettingMeta) getLabels() map[string]string {
-	return map[string]string{
-		userSettingsLabel:       "true",
-		uidLabel:                r.UID,
-		resourceIdentifierLabel: r.ResourceIdentifier,
-	}
-}
-
-func (r *UserSettingMeta) getAnnotations() map[string]string {
-	return map[string]string{
-		uidAnnotation:      r.UID,
-		usernameAnnotation: r.Username,
-	}
 }

--- a/pkg/usersettings/types.go
+++ b/pkg/usersettings/types.go
@@ -2,6 +2,8 @@ package usersettings
 
 const userSettingsLabel = "console.openshift.io/user-settings"
 const uidLabel = "console.openshift.io/user-settings-uid"
+const resourceIdentifierLabel = "console.openshift.io/user-settings-resource-identifier"
+const uidAnnotation = "console.openshift.io/user-settings-uid"
 const usernameAnnotation = "console.openshift.io/user-settings-username"
 
 type UserSettingMeta struct {
@@ -25,13 +27,15 @@ func (r *UserSettingMeta) getRoleBindingName() string {
 
 func (r *UserSettingMeta) getLabels() map[string]string {
 	return map[string]string{
-		userSettingsLabel: "true",
-		uidLabel:          r.UID,
+		userSettingsLabel:       "true",
+		uidLabel:                r.UID,
+		resourceIdentifierLabel: r.ResourceIdentifier,
 	}
 }
 
 func (r *UserSettingMeta) getAnnotations() map[string]string {
 	return map[string]string{
+		uidAnnotation:      r.UID,
 		usernameAnnotation: r.Username,
 	}
 }


### PR DESCRIPTION
https://github.com/openshift/console/pull/13798 broke the console in OIDC clusters

Bug report:
Upon entering the console page, the user is properly redirected to the OIDC page.
After a successful log in, the user gets redirected back to console only to see a blank page. The console logs:
```
I0603 11:02:57.836280       1 main.go:208] The following console plugins are enabled:
I0603 11:02:57.836299       1 main.go:210]  - monitoring-plugin
W0603 11:02:57.836309       1 authoptions.go:112] Flag inactivity-timeout is set to less then 300 seconds and will be ignored!
I0603 11:02:57.867114       1 main.go:605] Binding to [::]:8443...
I0603 11:02:57.867145       1 main.go:607] using TLS
I0603 11:03:00.870003       1 metrics.go:128] serverconfig.Metrics: Update ConsolePlugin metrics...
I0603 11:03:00.898621       1 metrics.go:138] serverconfig.Metrics: Update ConsolePlugin metrics: &map[monitoring:map[enabled:1]] (took 28.598204ms)
I0603 11:03:02.867557       1 metrics.go:80] usage.Metrics: Count console users...
I0603 11:03:03.578203       1 metrics.go:156] usage.Metrics: Update console users metrics: 0 kubeadmin, 0 cluster-admins, 3 developers, 0 unknown/errors (took 710.61853ms)
I0603 11:06:26.768394       1 auth.go:368] oauth success, redirecting to: "https://console-openshift-console.apps.sl-ad.group-b.devcluster.openshift.com/"
2024/06/03 11:06:29 CheckOrigin: Proxy has no configured Origin. Allowing origin [https://console-openshift-console.apps.sl-ad.group-b.devcluster.openshift.com] to wss://kubernetes.default.svc/api/v1/namespaces/openshift-console-user-settings/configmaps?watch=true&fieldSelector=metadata.name%3Duser-settings-b56a431c2d45809444fd952dbd0fd0aa45f47ae938583771e6c6be41fb608414
I0603 11:06:29.050584       1 handlers.go:114] User settings ConfigMap "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" already exist, will return existing data.
I0603 11:06:29.050656       1 handlers.go:114] User settings ConfigMap "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" already exist, will return existing data.
I0603 11:06:29.051654       1 handlers.go:114] User settings ConfigMap "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" already exist, will return existing data.
I0603 11:06:59.037643       1 handlers.go:114] User settings ConfigMap "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" already exist, will return existing data.
I0603 11:06:59.038732       1 handlers.go:114] User settings ConfigMap "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" already exist, will return existing data.
I0603 11:06:59.044581       1 handlers.go:114] User settings ConfigMap "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" already exist, will return existing data.
I0603 11:06:59.051800       1 handlers.go:114] User settings ConfigMap "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" already exist, will return existing data.
I0603 11:07:29.093244       1 handlers.go:114] User settings ConfigMap "user-settings-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" already exist, will return existing data.
```
and the browser logs
```
consoleFetch failed for url /api/kubernetes/api/v1/namespaces/openshift-console-user-settings/configmaps/user-settings-b56a431c2d45809444fd952dbd0fd0aa45f47ae938583771e6c6be41fb608414 r: configmaps "user-settings-b56a431c2d45809444fd952dbd0fd0aa45f47ae938583771e6c6be41fb608414" not found
```

/cc @jerolimov 
/assign @jhadvig 