### PR TITLE
OCPBUGS-34752: Forward selected key prop in IconDropdown component

### DIFF
--- a/frontend/packages/dev-console/src/components/import/icon/IconDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/icon/IconDropdown.tsx
@@ -54,6 +54,7 @@ const IconDropdown: React.FC<IconDropdownProps> = ({ placeholder, value, onChang
       dropDownClassName="dropdown--full-width odc-icon-dropdown"
       menuClassName="odc-icon-dropdown__menu"
       onChange={onChanged}
+      selectedKey={value || 'openshift'}
     />
   );
 };


### PR DESCRIPTION
Corresponds to Jira issue https://issues.redhat.com/browse/OCPBUGS-34752

Minor UX improvement to improve visibility of system status.

Forwards the default icon to the dropdown component, so that it is checked upon first load when selecting an icon (e.g., when deploying an image or uploading a jar file)

before:
![dropdown menu with an option selected, but without the checkmark indicating selection](https://github.com/openshift/console/assets/18614559/4834ef4e-3148-4b3f-a952-12e53c57765f)


after:
![dropdown with checkmark next to default option](https://github.com/openshift/console/assets/18614559/3b221e3a-4cd9-4843-ab68-916ed41f37c2)
