### PR TITLE
OCPBUGS-34533: Fix updating the "Until" field on the Silence > Edit page

### DIFF
--- a/frontend/public/components/monitoring/silence-form.tsx
+++ b/frontend/public/components/monitoring/silence-form.tsx
@@ -273,7 +273,7 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => 
                   <DatetimeTextInput
                     data-test="silence-from"
                     isRequired
-                    onChange={(v: string) => setStartsAt(v)}
+                    onChange={(_event, value: string) => setStartsAt(value)}
                     value={startsAt}
                   />
                 )}
@@ -299,7 +299,7 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => 
                   <DatetimeTextInput
                     data-test="silence-until"
                     isRequired
-                    onChange={(v: string) => setEndsAt(v)}
+                    onChange={(_event, value: string) => setEndsAt(value)}
                     value={endsAt}
                   />
                 ) : (


### PR DESCRIPTION
Currently the event is saved into the "Until" field as the value, leading to an [object Object] being displayed after trying to edit it. This PR looks to update the state with the actual value instead.