### PR TITLE
OCPBUGS-25929: Fix: Quick Start "next" button requires double click to move to next step

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.tsx
@@ -7,7 +7,6 @@ import {
   QuickStartStatus,
   QuickStartTaskStatus,
   getTaskStatusKey,
-  QUICKSTART_TASKS_INITIAL_STATES,
 } from '@patternfly/quickstarts';
 import Pseudo from 'i18next-pseudo';
 import { useTranslation } from 'react-i18next';
@@ -120,7 +119,6 @@ export const useValuesForQuickStartContext = (): QuickStartContextValues => {
         const quickStart = qs[activeQuickStartID];
         const status = quickStart?.status;
         const taskNumber = quickStart?.taskNumber;
-        const taskStatus = quickStart[getTaskStatusKey(taskNumber)];
 
         let updatedStatus;
         let updatedTaskNumber;
@@ -132,11 +130,7 @@ export const useValuesForQuickStartContext = (): QuickStartContextValues => {
             type: 'start',
           });
           updatedStatus = QuickStartStatus.IN_PROGRESS;
-        } else if (
-          status === QuickStartStatus.IN_PROGRESS &&
-          !QUICKSTART_TASKS_INITIAL_STATES.includes(taskStatus) &&
-          taskNumber === totalTasks - 1
-        ) {
+        } else if (status === QuickStartStatus.IN_PROGRESS && taskNumber === totalTasks - 1) {
           fireTelemetryEvent('Quick Start Completed', {
             id: activeQuickStartID,
           });

--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.tsx
@@ -143,10 +143,6 @@ export const useValuesForQuickStartContext = (): QuickStartContextValues => {
           updatedStatus = QuickStartStatus.COMPLETE;
         }
 
-        if (taskStatus === QuickStartTaskStatus.VISITED) {
-          updatedTaskStatus = QuickStartTaskStatus.REVIEW;
-        }
-
         if (taskNumber < totalTasks && !updatedTaskStatus) {
           updatedTaskNumber = taskNumber + 1;
         }


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
Fixes https://issues.redhat.com/browse/OCPBUGS-25929

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

There was an unnecessary if statement when clicking next that changes status from visited to review that was probably there so that users can complete the quick start without needing to click "yes" to all the check your works. 

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
I removed this if statement along with removing the check the status of "check your works" statuses in the "finish" button 

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://github.com/openshift/console/assets/18614559/8a927af6-990a-467f-84fb-bb7858aee215

(not shown but it also works if you click yes to all the "check your works")

**Unit test coverage report**: 
<!-- Attach test coverage report -->
Unchanged

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
You just need openshift

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
