### PR TITLE
ODC-7627: Move test-cypress script into a frontend sub-folder to make it easier to approve changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,22 +268,23 @@ This will launch the Cypress Test Runner UI in the `console` package, where you 
 
 #### Execute Cypress in different packages
 
-An alternate way to execute cypress tests is via [test-cypress.sh](test-cypress.sh) which takes a `-p <package>` parameter to allow execution in different packages. It also can run Cypress tests in the Test Runner UI or in `-- headless` mode:
+An alternate way to execute cypress tests is via [frontend/integration-tests/test-cypress.sh](frontend/integration-tests/test-cypress.sh) which takes a `-p <package>` parameter to allow execution in different packages. It also can run Cypress tests in the Test Runner UI or in `-- headless` mode:
 
 ```
-console>./test-cypress.sh
+console/frontend > ./integration-tests/test-cypress.sh
+
 Runs Cypress tests in Test Runner or headless mode
 Usage: test-cypress [-p] <package> [-s] <filemask> [-h true]
   '-p <package>' may be 'console, 'olm' or 'devconsole'
   '-s <specmask>' is a file mask for spec test files, such as 'tests/monitoring/*'. Used only in headless mode when '-p' is specified.
   '-h true' runs Cypress in headless mode. When omitted, launches Cypress Test Runner
 Examples:
-  test-cypress.sh                                       // displays this help text
-  test-cypress.sh -p console                            // opens Cypress Test Runner for console tests
-  test-cypress.sh -p olm                                // opens Cypress Test Runner for OLM tests
-  test-cypress.sh -h true                               // runs all packages in headless mode
-  test-cypress.sh -p olm -h true                        // runs OLM tests in headless mode
-  test-cypress.sh -p console -s 'tests/crud/*' -h true  // runs console CRUD tests in headless mode
+  ./integration-tests/test-cypress.sh                                       // displays this help text
+  ./integration-tests/test-cypress.sh -p console                            // opens Cypress Test Runner for console tests
+  ./integration-tests/test-cypress.sh -p olm                                // opens Cypress Test Runner for OLM tests
+  ./integration-tests/test-cypress.sh -h true                               // runs all packages in headless mode
+  ./integration-tests/test-cypress.sh -p olm -h true                        // runs OLM tests in headless mode
+  ./integration-tests/test-cypress.sh -p console -s 'tests/crud/*' -h true  // runs console CRUD tests in headless mode
 ```
 
 When running in headless mode, Cypress will test using its integrated Electron browser, but if you want to use Chrome or Firefox instead, set `BRIDGE_E2E_BROWSER_NAME` environment variable in your shell with the value `chrome` or `firefox`.
@@ -298,9 +299,9 @@ The end-to-end tests run against pull requests using [ci-operator](https://githu
 The tests are defined in [this manifest](https://github.com/openshift/release/blob/master/ci-operator/jobs/openshift/console/openshift-console-master-presubmits.yaml)
 in the [openshift/release](https://github.com/openshift/release) repo and were generated with [ci-operator-prowgen](https://github.com/openshift/ci-operator-prowgen).
 
-CI runs the [test-prow-e2e.sh](test-prow-e2e.sh) script, which runs [test-cypress.sh](test-cypress.sh).
+CI runs the [test-prow-e2e.sh](test-prow-e2e.sh) script, which runs [frontend/integration-tests/test-cypress.sh](frontend/integration-tests/test-cypress.sh).
 
-[test-cypress.sh](test-cypress.sh) runs all Cypress tests, in all 'packages' (console, olm, and devconsole), in `-- headless` mode via:
+`test-cypress.sh` runs all Cypress tests, in all 'packages' (console, olm, and devconsole), in `-- headless` mode via:
 
 `test-cypress.sh -h true`
 

--- a/frontend/integration-tests/OWNERS
+++ b/frontend/integration-tests/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - sanketpathak
+  - the-anton
+  - yapei
+approvers:
+  - jrichter1
+  - psrna
+  - sanketpathak

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -2,52 +2,40 @@
 
 set -exuo pipefail
 
-ARTIFACT_DIR=${ARTIFACT_DIR:=/tmp/artifacts}
-SCREENSHOTS_DIR=frontend/gui_test_screenshots
 INSTALLER_DIR=${INSTALLER_DIR:=${ARTIFACT_DIR}/installer}
-
-function copyArtifacts {
-  if [ -d "$ARTIFACT_DIR" ] && [ -d "$SCREENSHOTS_DIR" ]; then
-    echo "Copying artifacts from $(pwd)..."
-    cp -r "$SCREENSHOTS_DIR" "${ARTIFACT_DIR}/gui_test_screenshots"
-  fi
-}
-
-trap copyArtifacts EXIT
 
 # don't log kubeadmin-password
 set +x
-BRIDGE_KUBEADMIN_PASSWORD="$(cat "${KUBEADMIN_PASSWORD_FILE:-${INSTALLER_DIR}/auth/kubeadmin-password}")"
-export BRIDGE_KUBEADMIN_PASSWORD
+export BRIDGE_KUBEADMIN_PASSWORD="$(cat "${KUBEADMIN_PASSWORD_FILE:-${INSTALLER_DIR}/auth/kubeadmin-password}")"
 set -x
-BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"
-export BRIDGE_BASE_ADDRESS
+export BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"
 
 ./contrib/create-user.sh
 
+pushd frontend
+
 SCENARIO="${1:-e2e}"
 
-# Disable color codes in Cypress since they do not render well CI test logs.
-# https://docs.cypress.io/guides/guides/continuous-integration.html#Colors
-export NO_COLOR=1
 if [ "$SCENARIO" == "nightly-cypress" ]; then
   PACKAGE=""
   if [ $# -gt 1 ]; then
     PACKAGE="-p $2"
   fi
-  ./test-cypress.sh -n true $PACKAGE
+  ./integration-tests/test-cypress.sh -n true $PACKAGE
 elif [ "$SCENARIO" == "e2e" ] || [ "$SCENARIO" == "release" ]; then
-  ./test-cypress.sh -h true
+  ./integration-tests/test-cypress.sh -h true
 elif [ "$SCENARIO" == "login" ]; then
-  ./test-cypress.sh -p console -s 'tests/app/auth-multiuser-login.cy.ts' -h true
+  ./integration-tests/test-cypress.sh -p console -s 'tests/app/auth-multiuser-login.cy.ts' -h true
 elif [ "$SCENARIO" == "olmFull" ]; then
-  ./test-cypress.sh -p olm -h true
+  ./integration-tests/test-cypress.sh -p olm -h true
 elif [ "$SCENARIO" == "dev-console" ]; then
-  ./test-cypress.sh -p dev-console -h true
+  ./integration-tests/test-cypress.sh -p dev-console -h true
 elif [ "$SCENARIO" == "pipelines" ]; then
-  ./test-cypress.sh -p pipelines -h true
+  ./integration-tests/test-cypress.sh -p pipelines -h true
 # elif [ "$SCENARIO" == "gitops" ]; then
-#  ./test-cypress.sh -p gitops -h true
+#  ./integration-tests/test-cypress.sh -p gitops -h true
 elif [ "$SCENARIO" == "knative" ]; then
-  ./test-cypress.sh -p knative -h true
+  ./integration-tests/test-cypress.sh -p knative -h true
 fi
+
+popd


### PR DESCRIPTION
Follow-up / based on #13931, please ignore the first commit.

This PR moves the `test-cypress.sh` into the `frontend/integration-tests` folder to allow more people to approve changes in the `test-cypress.sh` script.

So that everyone with approval rights on frontend can approve that change, esp. @vikram-raj 

I also added another OWNERS file to allow our QE team, esp. @sanketpathak, to approve changes in that file. This file is aligned with other `integration-tests/OWNERS` files.

This is needed because it's common to disable and enable some tests if there is trouble with an operator (update).