### PR TITLE
NO-JIRA: Remove Edge from devconsole_pr.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/devconsole_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/devconsole_pr.md
@@ -21,4 +21,3 @@
 - [ ] Chrome
 - [ ] Firefox
 - [ ] Safari
-- [ ] Edge


### PR DESCRIPTION
This PR removes Microsoft Edge from the Browser conformance section of the Dev Console PR template.

The last update to this file was made in 2019 December, where it made sense to include Edge, since it used its in-house EdgeHTML rendering engine. However, since then, the new version of Edge based on Chromium was released in 2020 January.

The [legacy version of Edge ended support in 2021](https://blogs.windows.com/msedgedev/2021/03/09/microsoft-edge-legacy-end-of-support/), and the EdgeHTML version [was subsequently removed from all up-to-date Windows 10 installations](https://gscitsolutions.com/news/an-upcoming-windows-10-update-will-remove-the-old-microsoft-edge/). 
Windows 11 never included the legacy version of Edge.

As a result, this makes Microsoft Edge's rendering engine (now Blink) downstream of Chromium, akin to Opera, Brave, and Chrome. Therefore I believe makes Edge conformance automatic when Chrome/Chromium is tested, since I don't think Microsoft makes many rendering engine changes to Edge.

It's not like Opera, Brave, or the other Chromium-based browsers at the time were included in the template either

What does everyone think?