### PR TITLE
OCPBUGS-29744: Removed nested label component

### DIFF
--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.tsx
@@ -140,7 +140,7 @@ const QuickSearchList: React.FC<QuickSearchListProps> = ({
                             </SplitItem>
                             {item?.secondaryLabel && (
                               <SplitItem className="ocs-quick-search-list__secondary-label">
-                                <Label>{item.secondaryLabel}</Label>
+                                {item.secondaryLabel}
                               </SplitItem>
                             )}
                           </Split>


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

https://issues.redhat.com/browse/OCPBUGS-29744

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

`item.secondaryLabel` was already a React child per the typescript type, not a string, so it did not need another Label container

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Remove the redundant label container

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

Before:

https://github.com/openshift/console/assets/18614559/3e98b45b-176b-4800-a901-640ddac53d52

After:

https://github.com/openshift/console/assets/18614559/a529318c-e079-41d8-a416-b80e9ad6a0af

**Unit test coverage report**: 
<!-- Attach test coverage report -->
Unchanged

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

Install the following operators
- Red Hat OpenShift Pipelines
- Operator Certification Operator

Sometimes you may need to spam the following in your browser devtools console (thanks @vikram-raj):
```js
window.SERVER_FLAGS.GOARCH = 'amd64';
window.SERVER_FLAGS.GOOS = "linux";
```

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari

