### PR TITLE
OCPBUGS-37403, CNV-41506: Localnet NAD incorrectly displayed

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetails.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetails.tsx
@@ -2,14 +2,18 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import {
+  ResourceSummary,
   ScrollToTopOnMount,
   SectionHeading,
   StatusBox,
-  ResourceSummary,
 } from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { getName, getNamespace } from '@console/shared/src';
-import { networkTypes } from '../../constants/constants';
+import {
+  networkTypes,
+  ovnKubernetesNetworkType,
+  ovnKubernetesSecondaryLocalnet,
+} from '../../constants/constants';
 import { getConfigAsJSON, getType } from '../../selectors';
 import { NetworkAttachmentDefinitionKind } from '../../types';
 
@@ -41,7 +45,14 @@ export const NetAttachDefinitionSummary: React.FC<NetAttachDefinitionSummaryProp
   netAttachDef,
 }) => {
   const { t } = useTranslation();
-  const type = getType(getConfigAsJSON(netAttachDef));
+  const nadConfig = getConfigAsJSON(netAttachDef);
+  const type = getType(nadConfig);
+  const typeLabel = React.useMemo(() => {
+    if (type === ovnKubernetesNetworkType && nadConfig?.topology === 'localnet') {
+      return networkTypes[ovnKubernetesSecondaryLocalnet];
+    }
+    return _.get(networkTypes, [type], null) || type;
+  }, [nadConfig?.topology, type]);
   const id = getBasicID(netAttachDef);
 
   return (
@@ -61,7 +72,7 @@ export const NetAttachDefinitionSummary: React.FC<NetAttachDefinitionSummaryProp
                 idValue={prefixedID(id, 'type')}
                 isNotAvail={!type}
               >
-                {_.get(networkTypes, [type], null) || type}
+                {typeLabel}
               </DetailsItem>
             </dl>
           </div>


### PR DESCRIPTION
when creating a NAD of type secondary localnet, after creating in the NAD details it displays L2 overlay instead.

Before:
![localnetb4](https://github.com/openshift/console/assets/67270715/67caba5f-55b4-4bef-863e-6aaaf633d880)

After:
![localnet](https://github.com/openshift/console/assets/67270715/ce5a66d2-a31f-4ab8-a1bc-8b2398be8f0d)
