### PR TITLE
ODC-7614: Port exposed in Dockerfile not observed in the Ports Dropdown in Git Import Form

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-docker-file.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-docker-file.feature
@@ -43,3 +43,15 @@ Feature: Create Application from Docker file
               And user selects "Deployment" in Resource type section
               And user clicks Cancel button on Add page
              Then user will be redirected to Add page
+
+
+        @regression @odc-7614
+        Scenario: Create workload from Dockerfile and verify the Exposed Port in the Target Port section: A-05-TC04
+            Given user is on Import from Git form
+             When user enters Git Repo URL as "https://github.com/rohitkrai03/flask-dockerfile-example"
+              And user enters Name as "dockerfile-5000" in Docker file page
+              And user selects "Deployment" in Resource type section
+              And user selects "5000" in Target Port section
+              And user clicks Create button on Add page
+             Then user will be redirected to Topology page
+              And user is able to see workload "dockerfile-5000" in topology page

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -57,6 +57,7 @@ export const gitPO = {
     routing: {
       hostname: '#form-input-route-hostname-field',
       path: '#form-input-route-path-field',
+      targetPortDropdown: '#form-select-input-route-unknownTargetPort-field',
       targetPort: 'input[placeholder="8080"]',
       secureRoute: 'input#form-checkbox-route-secure-field',
       tlsTermination: 'button#form-dropdown-route-tls-termination-field',

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
@@ -289,6 +289,10 @@ export const gitPage = {
   selectTargetPortForRouting: () => {
     cy.get(gitPO.advancedOptions.routing.targetPort).scrollIntoView().clear().type('8080');
   },
+  selectTargetPortForRoutingWithPort: (port: string) => {
+    cy.get(gitPO.advancedOptions.routing.targetPortDropdown).click();
+    cy.get(`[id="select-option-route.unknownTargetPort-${port}"]`).click();
+  },
   enterRoutingHostName: (hostName: string) =>
     cy.get(gitPO.advancedOptions.routing.hostname).type(hostName),
   enterRoutingPath: (path: string) => cy.get(gitPO.advancedOptions.routing.path).type(path),

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-docker-file.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-docker-file.ts
@@ -20,6 +20,10 @@ When('user selects {string} in Resource type section', (resourceType: string) =>
   gitPage.selectResource(resourceType);
 });
 
+When('user selects {string} in Target Port section', (targetPort: string) => {
+  gitPage.selectTargetPortForRoutingWithPort(targetPort);
+});
+
 When('user clicks Cancel button on Add page', () => {
   gitPage.clickCancel();
 });

--- a/frontend/packages/dev-console/src/components/import/route/PortInputField.tsx
+++ b/frontend/packages/dev-console/src/components/import/route/PortInputField.tsx
@@ -16,8 +16,10 @@ const PortInputField: React.FC<PortInputFieldProps> = ({ defaultPort }) => {
       image: { ports },
     },
   } = useFormikContext<DeployImageFormData | GitImportFormData | UploadJarFormData>();
-  const portOptions: SelectInputOption[] = ports.map((port) => ({
-    value: port.containerPort.toString(),
+  const portOptions: SelectInputOption[] = Array.from(
+    new Set(ports.map((port) => port.containerPort.toString())),
+  ).map((value) => ({
+    value,
     disabled: false,
   }));
   const placeholderPort = ports[0]?.containerPort || defaultPort;

--- a/frontend/packages/git-service/src/utils/dockerfile-parser.ts
+++ b/frontend/packages/git-service/src/utils/dockerfile-parser.ts
@@ -11,14 +11,18 @@ export class DockerFileParser {
   }
 
   parse(): CommandEntry[] {
-    return parse(this.content);
+    let parsedContent: CommandEntry[] = [];
+    try {
+      parsedContent = parse(this.content);
+    } catch {} // eslint-disable-line no-empty
+    return parsedContent;
   }
 
   getContainerPort(): number {
     const cmd = this.parsedCommands.filter((c: CommandEntry) => c.name === 'EXPOSE');
     if (cmd.length > 0) {
       const exposeCommand = cmd[0];
-      if (exposeCommand.args.length > 0) return Number(exposeCommand.args[0]);
+      if ((exposeCommand.args.length as number) > 0) return Number(exposeCommand.args[0]);
     }
     return null;
   }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-7614

**Solution Description**: 

- [x]  Port exposed in Dockerfile added in the Target Ports Dropdown in Git Import Form

**Screen shots / Gifs for design review**: 

https://github.com/openshift/console/assets/47265560/9bc0599f-c54a-4f82-9ed3-10360b4c24ba



**Unit test coverage report**: 

- [x] E2E tests added

**Test setup:**
1. Git Import Form -> https://github.com/Lucifergene/knative-do-demo
2. In the Target Port dropdown in Advanced section, you will find 5000 listed.
3. Check thoroughly if the console crashes.



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge