### PR TITLE
ODC-7620: Use PatternFly Button progress indicator for all Create buttons that shows a loading indicator

### DIFF
--- a/frontend/packages/console-shared/src/components/form-utils/FormFooter.tsx
+++ b/frontend/packages/console-shared/src/components/form-utils/FormFooter.tsx
@@ -66,6 +66,7 @@ const FormFooter: React.FC<FormFooterProps> = ({
               {...(handleSubmit && { onClick: handleSubmit })}
               variant={ButtonVariant.primary}
               isDisabled={disableSubmit}
+              isLoading={isSubmitting}
               data-test-id="submit-button"
               data-test="save-changes"
             >

--- a/frontend/packages/console-shared/src/components/form-utils/FormFooter.tsx
+++ b/frontend/packages/console-shared/src/components/form-utils/FormFooter.tsx
@@ -41,7 +41,7 @@ const FormFooter: React.FC<FormFooterProps> = ({
       ref={footerElementRef}
     >
       <ButtonBar
-        inProgress={isSubmitting}
+        inProgress={isSubmitting && hideSubmit}
         errorMessage={errorMessage}
         successMessage={successMessage}
       >

--- a/frontend/packages/dev-console/src/components/deployments/__tests__/DeploymentForm.spec.tsx
+++ b/frontend/packages/dev-console/src/components/deployments/__tests__/DeploymentForm.spec.tsx
@@ -149,7 +149,9 @@ describe('EditDeploymentForm', () => {
     fireEvent.click(saveButton);
 
     expect(saveButton.hasAttribute('disabled')).toBeTruthy();
-    expect(screen.queryByTestId('loading-indicator')).not.toBeNull();
+    expect(
+      screen.queryByTestId('submit-button').querySelector('[aria-valuetext="Loading"]'),
+    ).not.toBeNull();
     await waitFor(() => {
       expect(handleSubmit).toHaveBeenCalledTimes(1);
     });

--- a/frontend/packages/dev-console/src/components/deployments/__tests__/DeploymentForm.spec.tsx
+++ b/frontend/packages/dev-console/src/components/deployments/__tests__/DeploymentForm.spec.tsx
@@ -149,9 +149,7 @@ describe('EditDeploymentForm', () => {
     fireEvent.click(saveButton);
 
     expect(saveButton.hasAttribute('disabled')).toBeTruthy();
-    expect(
-      screen.queryByTestId('submit-button').querySelector('[aria-valuetext="Loading"]'),
-    ).not.toBeNull();
+    expect(saveButton.querySelector('.pf-v5-c-button__progress')).not.toBeNull();
     await waitFor(() => {
       expect(handleSubmit).toHaveBeenCalledTimes(1);
     });

--- a/frontend/public/components/instantiate-template.tsx
+++ b/frontend/public/components/instantiate-template.tsx
@@ -313,13 +313,9 @@ const TemplateForm_: React.FC<TemplateFormProps> = (props) => {
               );
             },
           )}
-          <ButtonBar
-            className="co-instantiate-template-form__button-bar"
-            errorMessage={error}
-            inProgress={inProgress}
-          >
+          <ButtonBar className="co-instantiate-template-form__button-bar" errorMessage={error}>
             <ActionGroup className="pf-v5-c-form">
-              <Button type="submit" variant="primary">
+              <Button type="submit" variant="primary" isLoading={inProgress}>
                 {t('public~Create')}
               </Button>
               <Button type="button" variant="secondary" onClick={() => navigate(-1)}>


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

https://issues.redhat.com/browse/ODC-7620

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

When the submit button is not hidden, use the `isLoading` PF button prop instead of the `inProgress` prop in our `ButtonBar` component

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://github.com/openshift/console/assets/18614559/30096fc7-d865-4b0b-840d-9e391d3b4eb7

**Unit test coverage report**: 
<!-- Attach test coverage report -->
Unchanged

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
n/a

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
