### PR TITLE
CONSOLE-4115: Add OLM v1 package

### DIFF
--- a/frontend/packages/console-app/package.json
+++ b/frontend/packages/console-app/package.json
@@ -21,6 +21,7 @@
     "@console/metal3-plugin": "0.0.0-fixed",
     "@console/network-attachment-definition-plugin": "0.0.0-fixed",
     "@console/operator-lifecycle-manager": "0.0.0-fixed",
+    "@console/operator-lifecycle-manager-v1": "0.0.0-fixed",
     "@console/patternfly": "0.0.0-fixed",
     "@console/pipelines-plugin": "0.0.0-fixed",
     "@console/shipwright-plugin": "0.0.0-fixed",

--- a/frontend/packages/operator-lifecycle-manager-v1/OWNERS
+++ b/frontend/packages/operator-lifecycle-manager-v1/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - TheRealJon
+  - rhamilto
+  - jhadvig
+approvers:
+  - TheRealJon
+  - rhamilto
+  - jhadvig
+labels:
+  - component/olm

--- a/frontend/packages/operator-lifecycle-manager-v1/console-extensions.json
+++ b/frontend/packages/operator-lifecycle-manager-v1/console-extensions.json
@@ -1,0 +1,39 @@
+[
+  {
+    "type": "console.flag/model",
+    "properties": {
+      "model": {
+        "group": "catalogd.operatorframework.io",
+        "version": "v1alpha1",
+        "kind": "Catalog"
+      },
+      "flag": "CONSOLE_OLM_V1"
+    }
+  },
+  {
+    "type": "console.navigation/section",
+    "properties": {
+      "id": "ecosystem",
+      "perspective": "admin",
+      "name": "%olm-v1~Ecosystem%",
+      "insertAfter": "usermanagement"
+    },
+    "flags": {
+      "required": ["CONSOLE_OLM_V1"]
+    }
+  },
+  {
+    "type": "console.navigation/resource-cluster",
+    "properties": {
+      "id": "installed-extensions",
+      "section": "ecosystem",
+      "name": "%olm-v1~Installed Extensions%",
+      "model": {
+        "kind": "ClusterExtension",
+        "version": "v1alpha1",
+        "group": "olm.operatorframework.io"
+      },
+      "startsWith": ["olm.operatorframework.io"]
+    }
+  }
+]

--- a/frontend/packages/operator-lifecycle-manager-v1/locales/OWNERS
+++ b/frontend/packages/operator-lifecycle-manager-v1/locales/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - kind/i18n

--- a/frontend/packages/operator-lifecycle-manager-v1/locales/en/olm-v1.json
+++ b/frontend/packages/operator-lifecycle-manager-v1/locales/en/olm-v1.json
@@ -1,0 +1,4 @@
+{
+  "Ecosystem": "Ecosystem",
+  "Installed Extensions": "Installed Extensions"
+}

--- a/frontend/packages/operator-lifecycle-manager-v1/package.json
+++ b/frontend/packages/operator-lifecycle-manager-v1/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@console/operator-lifecycle-manager-v1",
+  "version": "0.0.0-fixed",
+  "description": "A management framework for extending Kubernetes with Operators",
+  "private": true,
+  "consolePlugin": {
+    "entry": "src/plugin.tsx"
+  }
+}

--- a/frontend/packages/operator-lifecycle-manager-v1/src/plugin.tsx
+++ b/frontend/packages/operator-lifecycle-manager-v1/src/plugin.tsx
@@ -1,0 +1,5 @@
+import { Plugin } from '@console/plugin-sdk';
+
+const plugin: Plugin<any> = [];
+
+export default plugin;

--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -69,6 +69,7 @@ export const init = () => {
         'metal3-plugin',
         'notification-drawer',
         'olm',
+        'olm-v1',
         'pipelines-plugin',
         'shipwright-plugin',
         'public',

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -314,6 +314,9 @@ const config: Configuration = {
     new CopyWebpackPlugin([
       { from: './packages/operator-lifecycle-manager/locales', to: 'locales' },
     ]),
+    new CopyWebpackPlugin([
+      { from: './packages/operator-lifecycle-manager-v1/locales', to: 'locales' },
+    ]),
     new CopyWebpackPlugin([{ from: './packages/dev-console/locales', to: 'locales' }]),
     new CopyWebpackPlugin([{ from: './packages/knative-plugin/locales', to: 'locales' }]),
     new CopyWebpackPlugin([{ from: './packages/container-security/locales', to: 'locales' }]),


### PR DESCRIPTION
Requires [OLM v1 be installed on the cluster](https://docs.openshift.com/container-platform/4.16/operators/olm_v1/olmv1-installing-an-operator-from-a-catalog.html#prerequisites_olmv1-installing-an-operator-from-a-catalog) and a fresh run of `./build.sh`

![localhost_9000_dashboards (1)](https://github.com/openshift/console/assets/895728/6766f1da-93d3-40c8-ba22-a2ea7cc32ee9)
