### PR TITLE
OCPBUGS-30218: fix pseudolocalization

### DIFF
--- a/INTERNATIONALIZATION.md
+++ b/INTERNATIONALIZATION.md
@@ -47,7 +47,7 @@ Good: t('public~Hello, it is now {{date}}', { date: new Date() })
 ```
 
 * `aria-label`, `aria-placeholder`, `aria-roledescription`, and `aria-valuetext` should be internationalized.
-* Use the query parameter `?pseudolocalization=true&lng=en` to see pseudolocalization on strings you've marked for internationalization.
+* Use the query parameter `?pseudolocalization=true&lng=en-US` to see pseudolocalization on strings you've marked for internationalization.  *Note:* if `en-US` is not your browser's first preferred language, change that value to match the language that is.
     * Pseudolocalization adds brackets around the text and makes it longer so you can test components with different text lengths.
 * Make sure there are no missing key warnings in your browser's developer tools - missing keys will trigger errors in integration tests. The warning will show up as an error in the JavaScript console.
 * When displaying a resource kind, you can hard-code it directly in the internationalized text or use the predefined label on the model for the kind.

--- a/frontend/packages/integration-tests-cypress/tests/i18n/pseudolocalization.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/i18n/pseudolocalization.cy.ts
@@ -1,6 +1,8 @@
 import { checkErrors } from '../../support';
 import { masthead } from '../../views/masthead';
 
+const url = '/dashboards?pseudolocalization=true&lng=en';
+
 describe('Localization', () => {
   before(() => {
     cy.login();
@@ -12,7 +14,7 @@ describe('Localization', () => {
 
   it('pseudolocalizes masthead', () => {
     cy.log('test masthead');
-    cy.visitWithDefaultLang('/dashboards?pseudolocalization=true');
+    cy.visitWithDefaultLang(url);
     masthead.clickMastheadLink('help-dropdown-toggle');
     cy.byTestID('help-dropdown-toggle').within(() => {
       // wait for both console help menu items and additionalHelpActions items to load
@@ -24,13 +26,13 @@ describe('Localization', () => {
 
   it('pseudolocalizes navigation', () => {
     cy.log('test navigation');
-    cy.visitWithDefaultLang('/dashboards?pseudolocalization=true');
+    cy.visitWithDefaultLang(url);
     cy.byTestID('nav').isPseudoLocalized();
   });
 
   it('pseudolocalizes activity card', () => {
     cy.log('test activity card components');
-    cy.visitWithDefaultLang('/dashboards?pseudolocalization=true');
+    cy.visitWithDefaultLang(url);
     cy.byTestID('activity').isPseudoLocalized();
     cy.byTestID('activity-recent-title').isPseudoLocalized();
     cy.byTestID('ongoing-title').isPseudoLocalized();
@@ -40,7 +42,7 @@ describe('Localization', () => {
 
   it('pseudolocalizes utilization card', () => {
     cy.log('test utilization card components');
-    cy.visitWithDefaultLang('/dashboards?pseudolocalization=true');
+    cy.visitWithDefaultLang(url);
     cy.byLegacyTestID('utilization-card').within(() => {
       cy.byTestID('utilization-card__title').isPseudoLocalized();
       cy.byTestID('utilization-card-item-text').isPseudoLocalized();

--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -11,6 +11,7 @@ import { dateTimeFormatter, fromNow } from './components/utils/datetime';
 
 const params = new URLSearchParams(window.location.search);
 const pseudolocalizationEnabled = params.get('pseudolocalization') === 'true';
+const language = params.get('lng');
 
 let resolvedLoading;
 
@@ -20,7 +21,9 @@ export const loading = new Promise((resolve) => {
 
 export const init = () => {
   i18n
-    .use(new Pseudo({ enabled: pseudolocalizationEnabled, wrapped: true }))
+    .use(
+      new Pseudo({ enabled: pseudolocalizationEnabled, languageToPseudo: language, wrapped: true }),
+    )
     // fetch json files
     // learn more: https://github.com/i18next/i18next-http-backend
     .use(httpBackend)


### PR DESCRIPTION
Implements workaround mentioned in https://github.com/MattBoatman/i18next-pseudo/issues/4#issuecomment-1118709400

Note the value of `lng` in the query string should match the browser's first preferred language.  For example, if the browser's first preferred language is `en-US`, use `?pseudolocalization=true&lng=en-US`.