### PR TITLE
OCPBUGS-34764: Ensure envs are initted upon first load

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/EnvironmentField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/EnvironmentField.tsx
@@ -26,7 +26,7 @@ const EnvironmentField: React.FC<EnvironmentFieldProps> = ({
   const { t } = useTranslation();
   const fieldId = getFieldId(props.name, 'env-input');
   const environmentVariables = React.useMemo(() => {
-    return !_.isEmpty(envs) ? envs.map((env) => _.values(env)) : [['', '']];
+    return _.isEmpty(envs) ? [['', '']] : envs.map((env) => _.values(env));
   }, [envs]);
   const [nameValue, setNameValue] = React.useState(environmentVariables);
   const [configMaps, setConfigMaps] = React.useState({});
@@ -50,19 +50,13 @@ const EnvironmentField: React.FC<EnvironmentFieldProps> = ({
     [props.name, setFieldValue],
   );
 
-  const [updatedEnv, setUpdatedEnv] = React.useState(false);
-
   React.useEffect(() => {
     if (values.formReloadCount) {
       setNameValue(environmentVariables);
     }
-
-    // reset name values when envs are loaded from file, only once
-    if (!updatedEnv && (environmentVariables[0][0] || environmentVariables[0][1])) {
-      setNameValue(environmentVariables);
-      setUpdatedEnv(true);
-    }
-  }, [values.formReloadCount, environmentVariables, updatedEnv]);
+    // this effect only handles reload, so we disable dep on environmentVariables
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [values.formReloadCount]);
 
   React.useEffect(() => {
     Promise.all([k8sGet(ConfigMapModel, null, namespace), k8sGet(SecretModel, null, namespace)])

--- a/frontend/packages/console-shared/src/components/formik-fields/EnvironmentField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/EnvironmentField.tsx
@@ -50,13 +50,19 @@ const EnvironmentField: React.FC<EnvironmentFieldProps> = ({
     [props.name, setFieldValue],
   );
 
+  const [updatedEnv, setUpdatedEnv] = React.useState(false);
+
   React.useEffect(() => {
     if (values.formReloadCount) {
       setNameValue(environmentVariables);
     }
-    // this effect only handles reload, so we disable dep on environmentVariables
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [values.formReloadCount]);
+
+    // reset name values when envs are loaded from file, only once
+    if (!updatedEnv && (environmentVariables[0][0] || environmentVariables[0][1])) {
+      setNameValue(environmentVariables);
+      setUpdatedEnv(true);
+    }
+  }, [values.formReloadCount, environmentVariables, updatedEnv]);
 
   React.useEffect(() => {
     Promise.all([k8sGet(ConfigMapModel, null, namespace), k8sGet(SecretModel, null, namespace)])

--- a/frontend/packages/dev-console/integration-tests/features/e2e/knative-service-workload.feature
+++ b/frontend/packages/dev-console/integration-tests/features/e2e/knative-service-workload.feature
@@ -1,23 +1,26 @@
-@e2e
+@e2e @smoke
 Feature: OpenShift Serverless Operator E2E
               As a user, I should be able to perform end to end scenarios related to OpenShift Serverless Operator
 
 
         Background:
-            Given user is at developer perspective
-              And user installed OpenShift Serverless Operator
-              And user has selected namespace "aut-serverless-e2e"
+            Given user has created or selected namespace "aut-serverless-e2e"
+              And user has installed OpenShift Serverless Operator
+              And user is at developer perspective
 
 
-        @to-do
-        Scenario: Create knative work load from Import From Git card on Add page: EE-02-TC01
-            Given user is on "Import from Git" form page
-             When user enters Git Repo url as "https://github.com/gajanan-more/knative-demo"
-              And user enters name as "knative-demo"
-              And user selects "Knative Service" as resource type
-              And user clicks Create button
+        Scenario: Create knative workload from Import From Git card on Add page: EE-02-TC01
+            Given user is at Add page
+              And user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/logonoff/oc-node-func-with-env"
+              And user enters Name as "node-knative"
+              And user clicks "Show advanced Build option" link in Advanced Options section
+              And user clicks "Show advanced Deployment option" link in Advanced Options section
+             Then the environment variable "MY_BUILD_KEY" has value "tests" in the advanced options of the Build section in the Import from Git page
+             Then the environment variable "MY_API_KEY" has value "{{ env:API_KEY }}" in the advanced options of the Deployment section in the Import from Git page
+              And user clicks Create button on Add page
              Then user will be redirected to Topology page
-              And user is able to see workload "knative-demo" in topology page list view
+              And user is able to see workload "node-knative" in topology page list view
 
 
         @to-do

--- a/frontend/packages/dev-console/integration-tests/features/e2e/knative-service-workload.feature
+++ b/frontend/packages/dev-console/integration-tests/features/e2e/knative-service-workload.feature
@@ -9,7 +9,7 @@ Feature: OpenShift Serverless Operator E2E
               And user is at developer perspective
 
 
-        Scenario: Create knative workload from Import From Git card on Add page: EE-02-TC01
+        Scenario: Check environment variable initialisation in git form : EE-02-TC01
             Given user is at Add page
               And user is at Import from Git form
              When user enters Git Repo URL as "https://github.com/logonoff/oc-node-func-with-env"
@@ -17,10 +17,7 @@ Feature: OpenShift Serverless Operator E2E
               And user clicks "Show advanced Build option" link in Advanced Options section
               And user clicks "Show advanced Deployment option" link in Advanced Options section
              Then the environment variable "MY_BUILD_KEY" has value "tests" in the advanced options of the Build section in the Import from Git page
-             Then the environment variable "MY_API_KEY" has value "{{ env:API_KEY }}" in the advanced options of the Deployment section in the Import from Git page
-              And user clicks Create button on Add page
-             Then user will be redirected to Topology page
-              And user is able to see workload "node-knative" in topology page list view
+              And the environment variable "MY_API_KEY" has value "{{ env:API_KEY }}" in the advanced options of the Deployment section in the Import from Git page
 
 
         @to-do

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
@@ -412,6 +412,16 @@ export const gitPage = {
       .parent()
       .find(gitPO.advancedOptions.buildConfig.envValue)
       .type(envValue),
+  verifyBuildConfigEnv: (envName: string, envValue: string) => {
+    cy.get(gitPO.sectionTitle)
+      .contains('Build')
+      .parent()
+      .find(`${gitPO.advancedOptions.buildConfig.envName}[value="${envName}"]`)
+      .parent()
+      .parent()
+      .find(gitPO.advancedOptions.buildConfig.envValue)
+      .should('have.value', envValue);
+  },
   verifyDeploymentOptionIsChecked: () => {
     cy.get(gitPO.advancedOptions.deployment.deploymentTriggerImage).should('be.checked');
   },
@@ -429,6 +439,16 @@ export const gitPage = {
       .parent()
       .find(gitPO.advancedOptions.deployment.envValue)
       .type(envValue),
+  verifyDeploymentEnv: (envName: string, envValue: string) => {
+    cy.get(gitPO.sectionTitle)
+      .contains('Deploy')
+      .parent()
+      .find(`${gitPO.advancedOptions.deployment.envName}[value="${envName}"]`)
+      .parent()
+      .parent()
+      .find(gitPO.advancedOptions.deployment.envValue)
+      .should('have.value', envValue);
+  },
   enterResourceLimitCPURequest: (cpuRequestValue: string) =>
     cy.get(gitPO.advancedOptions.resourceLimit.cpuRequest).type(cpuRequestValue),
   enterResourceLimitCPULimit: (cpuLimitValue: string) =>

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/common/addFlow.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/common/addFlow.ts
@@ -120,6 +120,20 @@ And(
   },
 );
 
+Then(
+  'the environment variable {string} has value {string} in the advanced options of the Build section in the Import from Git page',
+  (envKey: string, envVal: string) => {
+    gitPage.verifyBuildConfigEnv(envKey, envVal);
+  },
+);
+
+Then(
+  'the environment variable {string} has value {string} in the advanced options of the Deployment section in the Import from Git page',
+  (envKey: string, envVal: string) => {
+    gitPage.verifyDeploymentEnv(envKey, envVal);
+  },
+);
+
 Given('user has installed Gitops primer Operator', () => {
   verifyAndInstallGitopsPrimerOperator();
 });

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -127,7 +127,6 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
     },
     build: {
       ...initialBaseValues.build,
-      loaded: false,
       triggers: {
         webhook: true,
         image: true,

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -138,7 +138,7 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
     },
     import: {
       loaded: false,
-      funcLoaded: false,
+      kNativeFuncLoaded: false,
       loadError: null,
       strategies: [],
       selectedStrategy: {

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -138,7 +138,7 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
     },
     import: {
       loaded: false,
-      kNativeFuncLoaded: false,
+      knativeFuncLoaded: false,
       loadError: null,
       strategies: [],
       selectedStrategy: {

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -138,6 +138,7 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
     },
     import: {
       loaded: false,
+      funcLoaded: false,
       loadError: null,
       strategies: [],
       selectedStrategy: {

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -127,6 +127,7 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
     },
     build: {
       ...initialBaseValues.build,
+      loaded: false,
       triggers: {
         webhook: true,
         image: true,

--- a/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
@@ -24,7 +24,7 @@ const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
     values: {
       resources,
       deployment: { env },
-      import: { selectedStrategy, funcLoaded },
+      import: { selectedStrategy, kNativeFuncLoaded: funcLoaded },
     },
   } = useFormikContext<FormikValues>();
   const deploymentConfigObj = resource || {
@@ -46,7 +46,9 @@ const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
           label={t('devconsole~Auto deploy when deployment configuration changes')}
         />
       )}
-      {(selectedStrategy.type === ImportStrategy.SERVERLESS_FUNCTION ? funcLoaded : true) ? (
+      {(
+        selectedStrategy.type === ImportStrategy.SERVERLESS_FUNCTION ? funcLoaded ?? false : true
+      ) ? (
         <EnvironmentField
           name="deployment.env"
           label={t('devconsole~Environment variables (runtime only)')}

--- a/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
@@ -46,12 +46,7 @@ const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
           label={t('devconsole~Auto deploy when deployment configuration changes')}
         />
       )}
-      {(
-        typeof selectedStrategy === 'undefined' ||
-        selectedStrategy.type === ImportStrategy.SERVERLESS_FUNCTION
-          ? funcLoaded
-          : true
-      ) ? (
+      {(selectedStrategy.type === ImportStrategy.SERVERLESS_FUNCTION ? funcLoaded : true) ? (
         <EnvironmentField
           name="deployment.env"
           label={t('devconsole~Environment variables (runtime only)')}

--- a/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { useFormikContext, FormikValues } from 'formik';
 import { useTranslation } from 'react-i18next';
+import { ImportStrategy } from '@console/git-service/src';
+import { LoadingBox } from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { CheckboxField, EnvironmentField } from '@console/shared';
 import { Resources } from '../import-types';
@@ -22,6 +24,8 @@ const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
     values: {
       resources,
       deployment: { env },
+      serverless: { funcLoaded },
+      import: { selectedStrategy },
     },
   } = useFormikContext<FormikValues>();
   const deploymentConfigObj = resource || {
@@ -43,12 +47,16 @@ const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
           label={t('devconsole~Auto deploy when deployment configuration changes')}
         />
       )}
-      <EnvironmentField
-        name="deployment.env"
-        label={t('devconsole~Environment variables (runtime only)')}
-        envs={env}
-        obj={deploymentConfigObj}
-      />
+      {(selectedStrategy.type === ImportStrategy.SERVERLESS_FUNCTION ? funcLoaded : true) ? (
+        <EnvironmentField
+          name="deployment.env"
+          label={t('devconsole~Environment variables (runtime only)')}
+          envs={env}
+          obj={deploymentConfigObj}
+        />
+      ) : (
+        <LoadingBox />
+      )}
     </FormSection>
   );
 };

--- a/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
@@ -24,7 +24,7 @@ const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
     values: {
       resources,
       deployment: { env },
-      import: { selectedStrategy, kNativeFuncLoaded: funcLoaded },
+      import: { selectedStrategy, knativeFuncLoaded: funcLoaded },
     },
   } = useFormikContext<FormikValues>();
   const deploymentConfigObj = resource || {

--- a/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
@@ -24,8 +24,7 @@ const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
     values: {
       resources,
       deployment: { env },
-      serverless: { funcLoaded },
-      import: { selectedStrategy },
+      import: { selectedStrategy, funcLoaded },
     },
   } = useFormikContext<FormikValues>();
   const deploymentConfigObj = resource || {
@@ -47,7 +46,12 @@ const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
           label={t('devconsole~Auto deploy when deployment configuration changes')}
         />
       )}
-      {(selectedStrategy.type === ImportStrategy.SERVERLESS_FUNCTION ? funcLoaded : true) ? (
+      {(
+        typeof selectedStrategy === 'undefined' ||
+        selectedStrategy.type === ImportStrategy.SERVERLESS_FUNCTION
+          ? funcLoaded
+          : true
+      ) ? (
         <EnvironmentField
           name="deployment.env"
           label={t('devconsole~Environment variables (runtime only)')}

--- a/frontend/packages/dev-console/src/components/import/advanced/__tests__/DeploymentConfigSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/__tests__/DeploymentConfigSection.spec.tsx
@@ -20,6 +20,9 @@ jest.mock('formik', () => ({
           },
         ],
       },
+      import: {
+        selectedStrategy: 1, // dockerfile
+      },
     },
   })),
 }));

--- a/frontend/packages/dev-console/src/components/import/form-initial-values.ts
+++ b/frontend/packages/dev-console/src/components/import/form-initial-values.ts
@@ -44,7 +44,6 @@ export const getBaseInitialValues = (
         concurrencyutilization: '',
       },
       domainMapping: [],
-      funcLoaded: false,
     },
     route: {
       disable: false,

--- a/frontend/packages/dev-console/src/components/import/form-initial-values.ts
+++ b/frontend/packages/dev-console/src/components/import/form-initial-values.ts
@@ -44,6 +44,7 @@ export const getBaseInitialValues = (
         concurrencyutilization: '',
       },
       domainMapping: [],
+      funcLoaded: false,
     },
     route: {
       disable: false,

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -250,6 +250,7 @@ export interface DetectedStrategyFormData extends DetectedStrategy {
 
 export interface ImportStrategyData {
   loaded?: boolean;
+  funcLoaded?: boolean;
   loadError?: string;
   strategies?: DetectedStrategy[];
   recommendedStrategy?: DetectedStrategyFormData;

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -250,7 +250,7 @@ export interface DetectedStrategyFormData extends DetectedStrategy {
 
 export interface ImportStrategyData {
   loaded?: boolean;
-  kNativeFuncLoaded?: boolean;
+  knativeFuncLoaded?: boolean;
   loadError?: string;
   strategies?: DetectedStrategy[];
   recommendedStrategy?: DetectedStrategyFormData;

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -250,7 +250,7 @@ export interface DetectedStrategyFormData extends DetectedStrategy {
 
 export interface ImportStrategyData {
   loaded?: boolean;
-  funcLoaded?: boolean;
+  kNativeFuncLoaded?: boolean;
   loadError?: string;
   strategies?: DetectedStrategy[];
   recommendedStrategy?: DetectedStrategyFormData;

--- a/frontend/packages/dev-console/src/components/import/section/build-section/BuildSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/build-section/BuildSection.tsx
@@ -30,7 +30,7 @@ export const BuildSection: React.FC<BuildSectionProps> = ({ values, appResources
     project: { name: namespace },
     build: { option: buildOption, env: buildEnv },
     image: { selected: selectedImage, tag: selectedTag },
-    import: { selectedStrategy, kNativeFuncLoaded: funcLoaded },
+    import: { selectedStrategy, knativeFuncLoaded: funcLoaded },
   } = values;
   const { setFieldValue } = useFormikContext<FormikValues>();
   const isRepositoryEnabled = useFlag(FLAG_OPENSHIFT_PIPELINE_AS_CODE);

--- a/frontend/packages/dev-console/src/components/import/section/build-section/BuildSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/build-section/BuildSection.tsx
@@ -30,7 +30,7 @@ export const BuildSection: React.FC<BuildSectionProps> = ({ values, appResources
     project: { name: namespace },
     build: { option: buildOption, env: buildEnv },
     image: { selected: selectedImage, tag: selectedTag },
-    import: { selectedStrategy },
+    import: { selectedStrategy, kNativeFuncLoaded: funcLoaded },
   } = values;
   const { setFieldValue } = useFormikContext<FormikValues>();
   const isRepositoryEnabled = useFlag(FLAG_OPENSHIFT_PIPELINE_AS_CODE);
@@ -158,7 +158,11 @@ export const BuildSection: React.FC<BuildSectionProps> = ({ values, appResources
           {values.build?.option === BuildOptions.BUILDS && (
             <BuildConfigSection showHeader={false} />
           )}
-          {envsLoaded ? (
+          {(
+            selectedStrategy.type === ImportStrategy.SERVERLESS_FUNCTION
+              ? funcLoaded ?? false
+              : envsLoaded
+          ) ? (
             <EnvironmentField
               name="build.env"
               label={t('devconsole~Environment variables (build and runtime)')}

--- a/frontend/packages/dev-console/src/components/import/section/build-section/__tests__/BuildSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/build-section/__tests__/BuildSection.spec.tsx
@@ -102,7 +102,7 @@ describe('BuildSection', () => {
         values={{
           ...componentProps.values,
           import: {
-            kNativeFuncLoaded: true, // env already loaded
+            knativeFuncLoaded: true, // env already loaded
             selectedStrategy: {
               type: 3,
             } as DetectedStrategyFormData,

--- a/frontend/packages/dev-console/src/components/import/section/build-section/__tests__/BuildSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/build-section/__tests__/BuildSection.spec.tsx
@@ -102,6 +102,7 @@ describe('BuildSection', () => {
         values={{
           ...componentProps.values,
           import: {
+            kNativeFuncLoaded: true, // env already loaded
             selectedStrategy: {
               type: 3,
             } as DetectedStrategyFormData,

--- a/frontend/packages/dev-console/src/components/import/serverless-function/ServerlessFunctionSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless-function/ServerlessFunctionSection.tsx
@@ -60,7 +60,7 @@ const ServerlessFunctionSection = ({ builderImages }) => {
         })
         .finally(() => {
           setLoaded(true);
-          setFieldValue('serverless.funcLoaded', true);
+          setFieldValue('import.kNativeFuncLoaded', true);
         });
   }, [
     setFieldValue,

--- a/frontend/packages/dev-console/src/components/import/serverless-function/ServerlessFunctionSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless-function/ServerlessFunctionSection.tsx
@@ -60,7 +60,7 @@ const ServerlessFunctionSection = ({ builderImages }) => {
         })
         .finally(() => {
           setLoaded(true);
-          setFieldValue('import.kNativeFuncLoaded', true);
+          setFieldValue('import.knativeFuncLoaded', true);
         });
   }, [
     setFieldValue,

--- a/frontend/packages/dev-console/src/components/import/serverless-function/ServerlessFunctionSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless-function/ServerlessFunctionSection.tsx
@@ -58,7 +58,10 @@ const ServerlessFunctionSection = ({ builderImages }) => {
           console.warn('Error fetching Serverless Function YAML: ', err);
           setFieldError('ServerlessFunction', err.message);
         })
-        .finally(() => setLoaded(true));
+        .finally(() => {
+          setLoaded(true);
+          setFieldValue('build.loaded', true);
+        });
   }, [
     setFieldValue,
     setFieldError,

--- a/frontend/packages/dev-console/src/components/import/serverless-function/ServerlessFunctionSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless-function/ServerlessFunctionSection.tsx
@@ -60,7 +60,7 @@ const ServerlessFunctionSection = ({ builderImages }) => {
         })
         .finally(() => {
           setLoaded(true);
-          setFieldValue('build.loaded', true);
+          setFieldValue('serverless.funcLoaded', true);
         });
   }, [
     setFieldValue,


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
Maps with JIRA issue https://issues.redhat.com/browse/OCPBUGS-34764

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

There is a data race between the environment variable editor component (which only takes the initial value) and the knative yaml parser. The env variable component loads first which sets the initial value as blank since the parser is still working. Then the parser is done, updates the prop, but is ignored because the env variable component is already loaded. 

Delaying loading the env list for 1 second also fixes the issue...

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Block the env selector from loading until the func.yaml is finished fetching and parsing


**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

n/a

**Unit test coverage report**: 
<!-- Attach test coverage report -->

unchanged

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Install the Red Hat OpenShift Serverless and setup a Knative service

Then use @Lucifergene 's serverless example https://github.com/Lucifergene/oc-func

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
