### PR TITLE
TRT-1708: Revert #13944 "(chore) Update tectonic builder image to use golang-1.21"

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: tectonic-console-builder
   namespace: ci
-  tag: v27
+  tag: v26

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -8,7 +8,7 @@
 # You can test the image using `./builder-run.sh`. For instance:
 #   $ ./builder-run.sh ./build-backend.sh
 
-FROM golang:1.21-bullseye
+FROM golang:1.20-bullseye
 
 MAINTAINER Ed Rooth - CoreOS
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 # Dockerfile to build console image from pre-built front end.
 
-FROM quay.io/coreos/tectonic-console-builder:v27 AS build
+FROM quay.io/coreos/tectonic-console-builder:v26 AS build
 RUN mkdir -p /go/src/github.com/openshift/console/
 ADD . /go/src/github.com/openshift/console/
 WORKDIR /go/src/github.com/openshift/console/

--- a/builder-run.sh
+++ b/builder-run.sh
@@ -11,7 +11,7 @@ set -e
 # Without env vars:
 #   ./builder-run.sh ./my-script --my-script-arg1 --my-script-arg2
 
-BUILDER_IMAGE="quay.io/coreos/tectonic-console-builder:v27"
+BUILDER_IMAGE="quay.io/coreos/tectonic-console-builder:v26"
 
 # forward whitelisted env variables to docker
 ENV_STR=()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/console
 
-go 1.21
+go 1.20
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.15.2


### PR DESCRIPTION
Reverts #13944 ; tracked by [TRT-1708](https://issues.redhat.com//browse/TRT-1708)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Hypershift is permafailing on 4.16. This is the only PR relevant, and the errors are on the console-operator.  Opening to test.

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job 
periodic-ci-openshift-hypershift-release-4.16-periodics-e2e-aws-ovn-conformance should pass
```

CC: @jhadvig

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
