### PR TITLE
ODC-7623: Set Shipwright Builds as the default tab in Builds Page if the operator is installed

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/global.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/global.ts
@@ -5,6 +5,7 @@ export enum devNavigationMenu {
   Topology = 'Topology',
   Observe = 'Observe',
   Builds = 'Builds',
+  ShipwrightBuilds = 'Shipwright Builds',
   Search = 'Search',
   Helm = 'Helm',
   Project = 'Project',

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -122,6 +122,12 @@ export const navigateTo = (opt: devNavigationMenu) => {
       cy.testA11y('Builds Page in dev perspective');
       break;
     }
+    case devNavigationMenu.ShipwrightBuilds: {
+      cy.get(devNavigationMenuPO.builds).click();
+      detailsPage.titleShouldContain(pageTitle.Builds);
+      cy.testA11y('Builds Page in dev perspective for Shipwright Builds');
+      break;
+    }
     case devNavigationMenu.Pipelines: {
       cy.get(devNavigationMenuPO.pipelines, { timeout: 80000 }).click();
       detailsPage.titleShouldContain(pageTitle.Pipelines);

--- a/frontend/packages/dev-console/src/components/builds/BuildsTabListPage.tsx
+++ b/frontend/packages/dev-console/src/components/builds/BuildsTabListPage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useParams, useNavigate } from 'react-router-dom-v5-compat';
+import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { withStartGuide } from '@console/internal/components/start-guide';
 import { Page, AsyncComponent } from '@console/internal/components/utils';
 import { useFlag, MenuActions, MultiTabListPage, getBadgeFromType } from '@console/shared';
@@ -17,7 +18,9 @@ import CreateProjectListPage, { CreateAProjectButton } from '../projects/CreateP
 const BuildsTabListPage: React.FC = () => {
   const { t } = useTranslation();
   const params = useParams();
+  const navigate = useNavigate();
   const title = t('devconsole~Builds');
+  const activePerspective = useActivePerspective()[0];
   const namespace = params.ns;
   const menuActions: MenuActions = {};
   const pages: Page[] = [];
@@ -62,6 +65,15 @@ const BuildsTabListPage: React.FC = () => {
   const SHIPWRIGHT_BUILD_V1ALPHA1 = useFlag('SHIPWRIGHT_BUILD_V1ALPHA1');
 
   const shipwrightBuildEnabled = SHIPWRIGHT_BUILD || SHIPWRIGHT_BUILD_V1ALPHA1;
+
+  /* Redirect to Shipwright Builds tab if Shipwright Build is enabled */
+  React.useEffect(() => {
+    if (namespace && activePerspective === 'dev' && shipwrightBuildEnabled) {
+      navigate(`/builds/ns/${namespace}/shipwright-builds`, { replace: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shipwrightBuildEnabled, namespace]);
+
   const shipwrightKind = SHIPWRIGHT_BUILD
     ? 'shipwright.io~v1beta1~Build'
     : 'shipwright.io~v1alpha1~Build';

--- a/frontend/packages/shipwright-plugin/integration-tests/features/e2e/shipwright-ci.feature
+++ b/frontend/packages/shipwright-plugin/integration-tests/features/e2e/shipwright-ci.feature
@@ -14,7 +14,6 @@ Feature: Shipwright build details page
         @smoke
         Scenario: Shipwright build page in dev perspective: SWB-01-TC01
              When user navigates to Builds in Developer perspective
-              And user clicks on "Shipwright Builds" tab
              Then user will see Shipwright Builds
               And user will see "Succeeded", "Failed" and "Unknown" in Filter list
 
@@ -23,14 +22,12 @@ Feature: Shipwright build details page
         Scenario: Shipwright build page in admin perspective: SWB-01-TC02
              When user switches to Administrative perspective
               And user clicks on Builds navigation in Administrative perspective
-             Then user will see "Shipwright Builds" tab
              Then user will see "Shipwright BuildRuns" tab
 
 
         @regression
         Scenario: Shipwright build details page: SWB-01-TC03
             Given user is on Builds navigation in Developer perspective
-             When user clicks on "Shipwright Builds" tab
               And user clicks on "buildpack-nodejs-build-heroku" build
              Then user will see "Strategy", "Source URL" and "Output image"
               And user will see "Status" section

--- a/frontend/packages/shipwright-plugin/integration-tests/features/shipwright-table.feature
+++ b/frontend/packages/shipwright-plugin/integration-tests/features/shipwright-table.feature
@@ -8,12 +8,10 @@ Feature: Shipwright builds table view
               And user is at developer perspective
               And user has created or selected namespace "aut-shipwright-build-details"
               And user has created shipwright builds
-              And user is at Builds page
 
         @smoke
         Scenario: Shipwright Builds Table should contain all the required headers: SWB-03-TC01
-            Given user is at Builds page
-             When user clicks on "Shipwright Builds" tab
+            Given user is on Builds navigation in Developer perspective
              Then user will see "Name"
               And user will see "Output"
               And user will see "Last run"
@@ -24,15 +22,13 @@ Feature: Shipwright builds table view
 
         @smoke
         Scenario: Upon clicking name of a Build, it should go to appropriate Build details page: SWB-03-TC02
-            Given user is at Builds page
-             When user clicks on "Shipwright Builds" tab
+            Given user is on Builds navigation in Developer perspective
               And user clicks on "buildpack-nodejs-build-heroku" build
              Then user will see "buildpack-nodejs-build-heroku" Build details page
 
 
         @smoke
         Scenario: Upon clicking name of a BuildRun, it should go to appropriate BuildRun details page: SWB-03-TC03
-            Given user is at Builds page
-             When user clicks on "Shipwright Builds" tab
+            Given user is on Builds navigation in Developer perspective
               And user clicks on last run of "buildpack-nodejs-build-heroku" build
              Then user will see "buildpack-nodejs-build-heroku" BuildRun details page

--- a/frontend/packages/shipwright-plugin/integration-tests/support/step-definitions/builds/shipwright-build-detail-page.ts
+++ b/frontend/packages/shipwright-plugin/integration-tests/support/step-definitions/builds/shipwright-build-detail-page.ts
@@ -23,7 +23,7 @@ When('user has created shipwright builds', () => {
 });
 
 When('user navigates to Builds in Developer perspective', () => {
-  navigateTo(devNavigationMenu.Builds);
+  navigateTo(devNavigationMenu.ShipwrightBuilds);
 });
 
 When('user switches to Administrative perspective', () => {
@@ -39,7 +39,7 @@ Then('user will see {string} tab', (tab: string) => {
 });
 
 Given('user is on Builds navigation in Developer perspective', () => {
-  navigateTo(devNavigationMenu.Builds);
+  navigateTo(devNavigationMenu.ShipwrightBuilds);
 });
 
 Then('user will see {string}, {string} and {string} in Filter list', (el1, el2, el3: string) => {
@@ -72,7 +72,7 @@ Then('user will see events steaming', () => {
 });
 
 Given('user is at Shipwright Builds details page for build {string}', (buildName: string) => {
-  navigateTo(devNavigationMenu.Builds);
+  navigateTo(devNavigationMenu.ShipwrightBuilds);
   cy.get(buildPO.shipwrightBuild.shipwrightBuildsTab).should('be.visible').click();
   cy.get(`[data-test-id='${buildName}'][href*='Build/${buildName}']`).should('be.visible').click();
   cy.get('[aria-label="Breadcrumb"]').should('contain', 'Build details');
@@ -111,8 +111,7 @@ Then(
 );
 
 Given('user is at Shipwright Builds run page {string}', (buildName: string) => {
-  navigateTo(devNavigationMenu.Builds);
-  cy.get(buildPO.shipwrightBuild.shipwrightBuildsTab).should('be.visible').click();
+  navigateTo(devNavigationMenu.ShipwrightBuilds);
   cy.get(`[data-test-id='${buildName}'][href*='Build/${buildName}']`).should('be.visible').click();
   cy.get(buildPO.shipwrightBuild.shipwrightBuildRunsTab).should('be.visible').click();
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-7623

**Solution Description**: 
Set Shipwright Builds as the default tab in Builds Page if the operator is installed

**Screen shots / Gifs for design review**: 

https://github.com/openshift/console/assets/47265560/073a6a84-de79-478a-8090-8765f963dd5d



**Unit test coverage report**: 

- [x] E2E Tests Updated

**Test setup:**
1. Install the Shipwright Builds operator
2. Go to the Builds Page.
3. You will see that Shipwright Builds tab is selected by default


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox