### PR TITLE
[release-4.16] OCPBUGS-35481: fix crash if helm chart metadata is nil

### DIFF
--- a/pkg/helm/chartproxy/proxy.go
+++ b/pkg/helm/chartproxy/proxy.go
@@ -92,25 +92,30 @@ func (p *proxy) IndexFile(onlyCompatible bool, namespace string) (*repo.IndexFil
 				continue
 			}
 
-			for key, entry := range idxFile.Entries {
-				for i := len(entry) - 1; i >= 0; i-- {
-					if entry[i].Type == "library" {
-						entry = append(entry[:i], entry[i+1:]...)
+			for key, entries := range idxFile.Entries {
+				for i := len(entries) - 1; i >= 0; i-- {
+					if entries[i] == nil || entries[i].Metadata == nil {
+						klog.Warningf("Helm chart %v from repository %v has an invalid entry at index %v", key, helmRepo.Name, i)
+						entries = append(entries[:i], entries[i+1:]...)
 						continue
 					}
-					if onlyCompatible && entry[i].Metadata.KubeVersion != "" && p.kubeVersion != "" {
-						if !chartutil.IsCompatibleRange(entry[i].Metadata.KubeVersion, p.kubeVersion) {
-							entry = append(entry[:i], entry[i+1:]...)
+					if entries[i].Type == "library" {
+						entries = append(entries[:i], entries[i+1:]...)
+						continue
+					}
+					if onlyCompatible && entries[i].Metadata.KubeVersion != "" && p.kubeVersion != "" {
+						if !chartutil.IsCompatibleRange(entries[i].Metadata.KubeVersion, p.kubeVersion) {
+							entries = append(entries[:i], entries[i+1:]...)
 						}
 					}
 				}
-				if len(entry) > 0 {
+				if len(entries) > 0 {
 					if overwrites != "" {
 						// Adding potential duplicates to the list
-						delKeys = append(delKeys, entry[0].Name+"--"+overwrites)
+						delKeys = append(delKeys, entries[0].Name+"--"+overwrites)
 					}
 
-					indexFile.Entries[key+"--"+helmRepo.Name] = entry
+					indexFile.Entries[key+"--"+helmRepo.Name] = entries
 				}
 			}
 		}


### PR DESCRIPTION
Fixes:
Fixes an internal crash related to https://issues.redhat.com/browse/OCPBUGS-29804 without updating the helm library.

Related to https://github.com/openshift/console/pull/13816

I added just one new nil check:

if entries[i] == nil || entries[i].Metadata == nil {
  klog.Warningf("Helm chart %v from repository %v has an invalid entry at index %v", key, helmRepo.Name, i)
  entries = append(entries[:i], entries[i+1:]...)
  continue
}
The rest of the change is only because I renamed the array entry to entries.

Test setup:

Open the console and switch to the developer perspective
Navigate to Helm
Add this helm repository: https://jerolimov.github.io/helm-cve-2024-26147-test/
Repo source code: https://github.com/jerolimov/helm-cve-2024-26147-test
Broken repository: https://github.com/jerolimov/helm-cve-2024-26147-test/commit/f96fc8247455dbc96550f415f32722163f5cd1ad
Click Create > Helm Release to search for available helm charts.
Previously the page showed an error.

With this change the page works fine also with this broken helm repository.