### PR TITLE
OCPBUGS-35497: Update Go prereq in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The console is a more friendly `kubectl` in the form of a single page webapp. It
 ### Dependencies:
 
 1. [node.js](https://nodejs.org/) >= 18 & [yarn](https://yarnpkg.com/en/docs/install) >= 1.20
-2. [go](https://golang.org/) >= 1.18+
+2. [go](https://golang.org/) >= 1.22+
 3. [oc](https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/) or [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and an OpenShift or Kubernetes cluster
 4. [jq](https://stedolan.github.io/jq/download/) (for `contrib/environment.sh`)
 


### PR DESCRIPTION
Per https://issues.redhat.com/browse/OCPBUGS-35497 product builds now use go 1.22, so update the README to match that