### PR TITLE
[release-4.16] OCPBUGS-35571: Update Go prereq in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The console is a more friendly `kubectl` in the form of a single page webapp. It
 ### Dependencies:
 
 1. [node.js](https://nodejs.org/) >= 18 & [yarn](https://yarnpkg.com/en/docs/install) >= 1.20
-2. [go](https://golang.org/) >= 1.18+
+2. [go](https://golang.org/) >= 1.21+
 3. [oc](https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.4/) or [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and an OpenShift or Kubernetes cluster
 4. [jq](https://stedolan.github.io/jq/download/) (for `contrib/environment.sh`)
 5. Google Chrome/Chromium or Firefox for integration tests


### PR DESCRIPTION
Per [issues.redhat.com/browse/OCPBUGS-35497](https://issues.redhat.com/browse/OCPBUGS-35497) and #13979, correct the go prereq README for release v4.16