### PR TITLE
OCPBUGS-16141: Fix ArtifactHub integration e2e test

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
@@ -13,6 +13,27 @@ Feature: Create the pipeline from builder page
              Then user redirects to Pipeline Builder page
 
 
+        # Issue with install tasks provided by ArtifactHub
+        @regression @odc-7246
+        Scenario: Install task provided by ArtifactHub and add create a Pipeline: P-02-TC25
+            Given user is at Pipeline Builder page
+             When user enters pipeline name as "pl-task-from-artifacthub"
+              And user clicks Add task button under Tasks section
+              And user searches "git-clone" in quick search bar
+              And user selects "git-clone" from Artifacthub
+              And user clicks on Add button
+              And user selects the "git-clone" node
+              And user adds the git url in the url Parameter in cluster task sidebar
+              And user clicks on Add workspace
+              And user adds the Workspace name as "git-opt"
+              And user clicks on Optional Workspace checkbox
+              And user selects the "git-clone" node
+              And user selects the "git-opt" workspace in the Output of Workspaces in cluster task sidebar
+              And user clicks Create button on Pipeline Builder page
+             Then user will be redirected to Pipeline Details page with header name "pl-task-from-artifacthub"
+              And user will see workspace mentioned as "git-opt (optional)" in the Workspaces section of Pipeline Details page
+
+
         @regression
         Scenario: Pipeline Builder page: P-02-TC02
             Given user is at pipelines page
@@ -357,23 +378,3 @@ Feature: Create the pipeline from builder page
         Examples:
                   | pipeline_yaml                                | pipeline_name                 |
                   | testData/pipelineWithParameterTypeArray.yaml | pipeline-with-array-parameter |
-
-        # Issue with install tasks provided by ArtifactHub
-        @regression @broken-test @odc-7246
-        Scenario: Install task provided by ArtifactHub and add create a Pipeline: P-02-TC25
-            Given user is at Pipeline Builder page
-             When user enters pipeline name as "pl-task-from-artifacthub"
-              And user clicks Add task button under Tasks section
-              And user searches "git-clone" in quick search bar
-              And user selects "git-clone" from Artifacthub
-              And user clicks on Add button
-              And user selects the "git-clone" node
-              And user adds the git url in the url Parameter in cluster task sidebar
-              And user clicks on Add workspace
-              And user adds the Workspace name as "git-opt"
-              And user clicks on Optional Workspace checkbox
-              And user selects the "git-clone" node
-              And user selects the "git-opt" workspace in the Output of Workspaces in cluster task sidebar
-              And user clicks Create button on Pipeline Builder page
-             Then user will be redirected to Pipeline Details page with header name "pl-task-from-artifacthub"
-              And user will see workspace mentioned as "git-opt (optional)" in the Workspaces section of Pipeline Details page

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
@@ -20,7 +20,6 @@ Feature: Create the pipeline from builder page
              When user enters pipeline name as "pl-task-from-artifacthub"
               And user clicks Add task button under Tasks section
               And user searches "git-clone" in quick search bar
-              And user waits for "5" seconds
               And user selects "git-clone" from Artifacthub
               And user clicks on Add button
               And user selects the "git-clone" node

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
@@ -20,6 +20,7 @@ Feature: Create the pipeline from builder page
              When user enters pipeline name as "pl-task-from-artifacthub"
               And user clicks Add task button under Tasks section
               And user searches "git-clone" in quick search bar
+              And user waits for "5" seconds
               And user selects "git-clone" from Artifacthub
               And user clicks on Add button
               And user selects the "git-clone" node

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
@@ -659,7 +659,3 @@ When('user selects {string} from Artifacthub', (taskName: string) => {
     .should('have.text', 'ArtifactHub')
     .click();
 });
-
-And('user waits for {string} seconds', (seconds: string) => {
-  cy.wait(parseInt(seconds, 10) * 1000);
-});

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
@@ -659,3 +659,7 @@ When('user selects {string} from Artifacthub', (taskName: string) => {
     .should('have.text', 'ArtifactHub')
     .click();
 });
+
+And('user waits for {string} seconds', (seconds: string) => {
+  cy.wait(parseInt(seconds, 10) * 1000);
+});

--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/PipelineQuickSearchDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/PipelineQuickSearchDetails.tsx
@@ -51,6 +51,7 @@ const PipelineQuickSearchDetails: React.FC<QuickSearchDetailsRendererProps> = ({
     setSelectedVersion(selectedItem?.attributes?.installed ?? '');
     setHasInstalledVersion(isOneVersionInstalled(selectedItem));
   }, [selectedItem]);
+  const [artifactHubDataLoaded, setArtifactHubDataLoaded] = React.useState<boolean>(false);
 
   const onChangeVersion = React.useCallback(
     (key) => {
@@ -107,6 +108,7 @@ const PipelineQuickSearchDetails: React.FC<QuickSearchDetailsRendererProps> = ({
     if (isArtifactHubTask(selectedItem)) {
       const debouncedLoadDetails = debounce(async () => {
         if (mounted) {
+          setArtifactHubDataLoaded(false);
           try {
             const item = await getArtifactHubTaskDetails(selectedItem);
             selectedItem.attributes.versions = item.available_versions;
@@ -120,6 +122,8 @@ const PipelineQuickSearchDetails: React.FC<QuickSearchDetailsRendererProps> = ({
             if (mounted) {
               resetVersions();
             }
+          } finally {
+            setArtifactHubDataLoaded(true);
           }
         }
       }, 10);
@@ -162,7 +166,10 @@ const PipelineQuickSearchDetails: React.FC<QuickSearchDetailsRendererProps> = ({
           <Split hasGutter>
             <SplitItem>
               <Button
-                isDisabled={isTektonHubTaskWithoutVersions(selectedItem)}
+                isDisabled={
+                  isTektonHubTaskWithoutVersions(selectedItem) ||
+                  (isArtifactHubTask(selectedItem) && !artifactHubDataLoaded)
+                }
                 data-test="task-cta"
                 variant={ButtonVariant.primary}
                 className="opp-quick-search-details__form-button"


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGS-16141

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

The `git-clone` information in ArtifactHub probably wasn't done loading yet as cypress clicks on it quickly

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Disable the add button until it loads

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![image](https://github.com/openshift/console/assets/18614559/eff564f8-317d-4d5c-8cb3-ff80376b9d3f)

**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
n/a

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

**Additional notes:**
<!-- If any setup required to test this PR, mention the details -->