### PR TITLE
OCPBUGS-32550: Fix placement of icons on WebKit

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.tsx
@@ -26,15 +26,19 @@ export type ColoredIconProps = {
  * <GreenCheckCircleIcon title="Healthy" />
  * ```
  */
-export const GreenCheckCircleIcon: React.FC<ColoredIconProps> = ({ className, title, size }) => (
-  <Icon size={size}>
+export const GreenCheckCircleIcon: React.FC<ColoredIconProps> = ({ className, title, size }) => {
+  const icon = (
     <CheckCircleIcon
       data-test="success-icon"
       className={classNames('dps-icons__green-check-icon', className)}
       title={title}
     />
-  </Icon>
-);
+  );
+  if (size) {
+    return <Icon size={size}>{icon}</Icon>;
+  }
+  return icon;
+};
 
 /**
  * Component for displaying a red exclamation mark circle icon.
@@ -50,14 +54,19 @@ export const RedExclamationCircleIcon: React.FC<ColoredIconProps> = ({
   className,
   title,
   size,
-}) => (
-  <Icon size={size}>
+}) => {
+  const icon = (
     <ExclamationCircleIcon
       className={classNames('dps-icons__red-exclamation-icon', className)}
       title={title}
     />
-  </Icon>
-);
+  );
+
+  if (size) {
+    return <Icon size={size}>{icon}</Icon>;
+  }
+  return icon;
+};
 
 /**
  * Component for displaying a yellow triangle exclamation icon.
@@ -73,14 +82,19 @@ export const YellowExclamationTriangleIcon: React.FC<ColoredIconProps> = ({
   className,
   title,
   size,
-}) => (
-  <Icon size={size}>
+}) => {
+  const icon = (
     <ExclamationTriangleIcon
       className={classNames('dps-icons__yellow-exclamation-icon', className)}
       title={title}
     />
-  </Icon>
-);
+  );
+
+  if (size) {
+    return <Icon size={size}>{icon}</Icon>;
+  }
+  return icon;
+};
 
 /**
  * Component for displaying a blue info circle icon.
@@ -92,8 +106,13 @@ export const YellowExclamationTriangleIcon: React.FC<ColoredIconProps> = ({
  * <BlueInfoCircleIcon title="Info" />
  * ```
  */
-export const BlueInfoCircleIcon: React.FC<ColoredIconProps> = ({ className, title, size }) => (
-  <Icon size={size}>
+export const BlueInfoCircleIcon: React.FC<ColoredIconProps> = ({ className, title, size }) => {
+  const icon = (
     <InfoCircleIcon className={classNames('dps-icons__blue-info-icon', className)} title={title} />
-  </Icon>
-);
+  );
+
+  if (size) {
+    return <Icon size={size}>{icon}</Icon>;
+  }
+  return icon;
+};


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGS-32550 

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

On WebKit, there is a styling issue that causes the icons to be misplaced in the topology when wrapped around two `spans`, which is done internally in patternfly

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Do not include the pf `Icon` container if the `size` prop is not specified (the `Icon` component just wraps its children two spans, and seems to only be needed if the size is changed)

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

before:
![image](https://github.com/openshift/console/assets/18614559/ff6b9e7b-aacb-4af8-8021-f65c2805ca65)


after:
![image](https://github.com/openshift/console/assets/18614559/6952c2ce-0c46-44b8-a104-ddfd1d1b74a9)

**Unit test coverage report**: 
<!-- Attach test coverage report -->
unchanged

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
set up some services and then look at the topology page

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] ~~Safari~~ GNOME Epiphany 46.0

