### PR TITLE
OCPBUGS-35928: Improve control over PatternFly shared modules used in Console plugins

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
@@ -345,11 +345,9 @@ export class ConsoleRemotePlugin implements webpack.WebpackPluginInstance {
           .map((p) => path.resolve(p, pkgName))
           .find((p) => fs.existsSync(p) && fs.statSync(p).isDirectory());
 
-        if (basePath) {
-          acc[pkgName] = getDynamicModuleMap(basePath, indexModule, resolutionField);
-        }
-
-        return acc;
+        return basePath
+          ? { ...acc, [pkgName]: getDynamicModuleMap(basePath, indexModule, resolutionField) }
+          : acc;
       },
       {},
     );

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import {
   DynamicRemotePlugin,
@@ -50,17 +51,34 @@ const getPackageDependencies = (pkg: readPkg.PackageJson) => ({
 const getPluginSDKPackageDependencies = () =>
   loadVendorPackageJSON('@openshift-console/dynamic-plugin-sdk').dependencies;
 
+const getPatternFlyMajorVersion = (pkg: ConsolePluginPackageJSON) => {
+  const pluginDeps = getPackageDependencies(pkg);
+  const pfCoreVersionRange = pluginDeps['@patternfly/react-core'];
+
+  return semver.validRange(pfCoreVersionRange)
+    ? semver.minVersion(pfCoreVersionRange)?.major
+    : undefined;
+};
+
 const getPatternFlyStyles = (baseDir: string) =>
   glob.sync(`${baseDir}/node_modules/@patternfly/react-styles/**/*.css`);
 
 // https://webpack.js.org/plugins/module-federation-plugin/#sharing-hints
-const getWebpackSharedModules = () => {
+const getWebpackSharedModules = (pkg: ConsolePluginPackageJSON) => {
+  const pfMajorVersion = getPatternFlyMajorVersion(pkg);
   const sdkPkgDeps = getPluginSDKPackageDependencies();
 
   return sharedPluginModules.reduce<WebpackSharedObject>((acc, moduleName) => {
     const { singleton, allowFallback } = getSharedModuleMetadata(moduleName);
     const providedVersionRange = sdkPkgDeps[moduleName];
     const moduleConfig: WebpackSharedConfig = { singleton };
+
+    // Console provides PatternFly 4 shared modules to its plugins for backwards compatibility.
+    // Plugins using PatternFly 5 and higher share the PatternFly code bits via dynamic modules.
+    // TODO(vojtech): remove this code when Console drops support for PatternFly 4
+    if (moduleName.startsWith('@patternfly/') && pfMajorVersion > 4) {
+      return acc;
+    }
 
     if (!allowFallback) {
       moduleConfig.import = false;
@@ -230,6 +248,18 @@ export type ConsoleRemotePluginOptions = Partial<{
    */
   sharedDynamicModuleSettings: Partial<{
     /**
+     * Paths to `node_modules` directories to search when parsing dynamic modules.
+     *
+     * Paths listed here _must_ be absolute.
+     *
+     * If not specified, the list will contain a single entry:
+     * ```ts
+     * path.resolve(process.cwd(), 'node_modules')
+     * ```
+     */
+    modulePaths: string[];
+
+    /**
      * Attempt to parse dynamic modules for these packages.
      *
      * Each package listed here should include a `dist/dynamic` directory containing `package.json`
@@ -299,6 +329,10 @@ export class ConsoleRemotePlugin implements webpack.WebpackPluginInstance {
       validateConsoleProvidedSharedModules(this.pkg).report();
     }
 
+    const resolvedModulePaths = this.adaptedOptions.sharedDynamicModuleSettings.modulePaths ?? [
+      path.resolve(process.cwd(), 'node_modules'),
+    ];
+
     this.sharedDynamicModuleMaps = Object.entries(
       this.adaptedOptions.sharedDynamicModuleSettings.packageSpecs ?? {
         '@patternfly/react-core': {},
@@ -306,14 +340,17 @@ export class ConsoleRemotePlugin implements webpack.WebpackPluginInstance {
         '@patternfly/react-table': {},
       },
     ).reduce<Record<string, DynamicModuleMap>>(
-      (acc, [pkgName, { indexModule = 'dist/esm/index.js', resolutionField = 'module' }]) => ({
-        ...acc,
-        [pkgName]: getDynamicModuleMap(
-          path.resolve(this.baseDir, 'node_modules', pkgName),
-          indexModule,
-          resolutionField,
-        ),
-      }),
+      (acc, [pkgName, { indexModule = 'dist/esm/index.js', resolutionField = 'module' }]) => {
+        const basePath = resolvedModulePaths
+          .map((p) => path.resolve(p, pkgName))
+          .find((p) => fs.existsSync(p) && fs.statSync(p).isDirectory());
+
+        if (basePath) {
+          acc[pkgName] = getDynamicModuleMap(basePath, indexModule, resolutionField);
+        }
+
+        return acc;
+      },
       {},
     );
   }
@@ -358,7 +395,9 @@ export class ConsoleRemotePlugin implements webpack.WebpackPluginInstance {
       }
     });
 
-    const allSharedDynamicModules = Object.entries(this.sharedDynamicModuleMaps).reduce<
+    const consoleProvidedSharedModules = getWebpackSharedModules(this.pkg);
+
+    const sharedDynamicModules = Object.entries(this.sharedDynamicModuleMaps).reduce<
       WebpackSharedObject
     >(
       (acc, [moduleName, dynamicModuleMap]) => ({
@@ -379,7 +418,7 @@ export class ConsoleRemotePlugin implements webpack.WebpackPluginInstance {
         exposedModules,
       },
       extensions,
-      sharedModules: { ...getWebpackSharedModules(), ...allSharedDynamicModules },
+      sharedModules: { ...consoleProvidedSharedModules, ...sharedDynamicModules },
       entryCallbackSettings: {
         name: 'loadPluginEntry',
         pluginID: `${name}@${version}`,


### PR DESCRIPTION
### 1. Customize `node_modules` directories to search when parsing dynamic modules

New `ConsoleRemotePlugin` option `sharedDynamicModuleSettings.modulePaths` can be used to customize `node_modules` directories to search when parsing dynamic modules. If not specified, the list will contain a single entry (as per existing logic):
```ts
path.resolve(process.cwd(), 'node_modules')
```

Taking [ODF Console Plugin](https://github.com/red-hat-storage/odf-console) as an example, their [webpack config](https://github.com/red-hat-storage/odf-console/blob/master/webpack.config.ts) changes the current work directory to accomodate for different plugin builds:
```ts
const processPath = path.resolve(__dirname, `plugins/${PLUGIN}`);
process.chdir(processPath);
```
However, this breaks the default assumption of vendor packages installed at `{process.cwd}/node_modules` and ultimately results in tons of dynamic module related warnings like:
```
<w> No dynamic module found for Button in @patternfly/react-core
```

To address this issue, plugins can now use the above mentioned option like so:
```ts
new ConsoleRemotePlugin({
  sharedDynamicModuleSettings: { modulePaths: [path.resolve(__dirname, 'node_modules')] }
})
```

### 2. Discard Console provided PatternFly 4.x shared module metadata when using PF 5+

Older plugins using PatternFly **4.x** rely on Console providing the following [shared modules](https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules-init.ts) at runtime:
- `@patternfly/react-core`
- `@patternfly/react-table`
- `@patternfly/quickstarts`

Newer plugins using PatternFly **5.x** do **NOT** utilize above shared modules. Instead, they share individual PatternFly code bits (components, icons, functions, etc.) via dynamic modules (introduced in #13521).

To improve build performance and allow for smaller production builds, we now discard the Console provided PatternFly 4.x shared module metadata when we detect that the plugin uses PF 5+ (detection is based on `@patternfly/react-core` dependency).