### PR TITLE
OCPBUGS-35908: fix flaking crd-extension tests

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-cli-download.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-cli-download.cy.ts
@@ -40,6 +40,7 @@ describe(`${crd} CRD`, () => {
 
   it(`creates, displays, and deletes a new ${crd} instance`, () => {
     cy.visit(`/k8s/cluster/customresourcedefinitions?custom-resource-definition-name=${crd}`);
+    listPage.isCreateButtonVisible();
     listPage.rows.shouldBeLoaded();
     listPage.rows.clickKebabAction(crd, 'View instances');
     listPage.titleShouldHaveText(crd);

--- a/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-link.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-link.cy.ts
@@ -47,6 +47,7 @@ describe(`${crd} CRD`, () => {
     ({ name: instanceName, dropdownMenuName, dropdownToggle, menuLinkLocation, menuLinkText }) => {
       it(`creates, displays, and deletes a new ${crd} ${dropdownMenuName} instance`, () => {
         cy.visit(`/k8s/cluster/customresourcedefinitions?custom-resource-definition-name=${crd}`);
+        listPage.isCreateButtonVisible();
         listPage.rows.shouldBeLoaded();
         listPage.rows.clickKebabAction(crd, 'View instances');
         listPage.titleShouldHaveText(crd);

--- a/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-notification.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-notification.cy.ts
@@ -31,6 +31,7 @@ describe(`${crd} CRD`, () => {
 
   it(`creates, displays, modifies, and deletes a new ${crd} instance`, () => {
     cy.visit(`/k8s/cluster/customresourcedefinitions?custom-resource-definition-name=${crd}`);
+    listPage.isCreateButtonVisible();
     listPage.rows.shouldBeLoaded();
     listPage.rows.clickKebabAction(crd, 'View instances');
     listPage.titleShouldHaveText(crd);

--- a/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-yaml-sample.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-yaml-sample.cy.ts
@@ -61,6 +61,7 @@ metadata:
 
   it(`creates, displays, tests and deletes a new ${crd} instance`, () => {
     cy.visit(`/k8s/cluster/customresourcedefinitions?custom-resource-definition-name=${crd}`);
+    listPage.isCreateButtonVisible();
     listPage.rows.shouldBeLoaded();
     listPage.rows.clickKebabAction(crd, 'View instances');
     listPage.titleShouldHaveText(crd);

--- a/frontend/packages/integration-tests-cypress/tests/crud/customresourcedefinition.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/customresourcedefinition.cy.ts
@@ -96,6 +96,7 @@ describe('CustomResourceDefinitions', () => {
         });
       });
       cy.visit(`/k8s/cluster/customresourcedefinitions?name=${name}`);
+      listPage.isCreateButtonVisible();
       listPage.rows.shouldBeLoaded();
       listPage.rows.clickKebabAction(`CRD${testName}`, 'View instances');
       listPage.clickCreateYAMLbutton();
@@ -108,6 +109,7 @@ describe('CustomResourceDefinitions', () => {
         });
       });
       cy.visit(`/k8s/cluster/customresourcedefinitions?name=${name}`);
+      listPage.isCreateButtonVisible();
       listPage.rows.shouldBeLoaded();
       listPage.rows.clickKebabAction(`CRD${testName}`, 'Delete CustomResourceDefinition');
       cy.resourceShouldBeDeleted(testName, 'CustomResourceDefinition', `CRD${testName}`);


### PR DESCRIPTION
Flakes occur in CI because CustomResourceDefinitions list page can initially render without the create button and then re-render with the create button, thus breaking the test (see video below).  By waiting for the create button to be present, we should no longer see these flakes.

https://github.com/openshift/console/assets/895728/8a35b2ea-50b2-44f1-8c94-c243b4505cc8

