### PR TITLE
Add dynamic plugin SDK package changelogs & update plugin docs

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
@@ -3,6 +3,12 @@
 Refer to [Console dynamic plugins README][README] for OpenShift Console version vs SDK package
 version and PatternFly version compatibility.
 
+## 1.4.0 - 2024-07-02
+
+- Expose `useUserSettings` hook ([OCPBUGS-33567], [#13843])
+- Add `sortColumnIndex` and `sortDirection` props to `VirtualizedTable` component ([OCPBUGS-33539], [#13916])
+- Document Console 4.16 shared module changes ([OCPBUGS-34538], [CONSOLE-3662], [CONSOLE-4097], [#13900])
+
 ## 1.3.0 - 2024-04-09
 
 - Add new props to `ResourceYAMLEditor` component ([OCPBUGS-31703], [#13722])
@@ -15,7 +21,7 @@ version and PatternFly version compatibility.
 ## 1.1.0 - 2024-03-19
 
 - Add search filter functionality to `ListPageFilter` component ([OCPBUGS-30077], [#13233])
-- Improve dynamic plugin SDK documentation and add PatternFly upgrade notes ([CONSOLE-3883], [#13637])
+- Improve plugin SDK documentation and add PatternFly upgrade notes ([CONSOLE-3883], [#13637])
 
 ## 1.0.0 - 2024-02-09
 
@@ -27,14 +33,19 @@ version and PatternFly version compatibility.
 - Add new extension type `console.node/status` ([CONSOLE-3899], [#13493])
 
 [README]: ./README.md
+[CONSOLE-3662]: https://issues.redhat.com/browse/CONSOLE-3662
 [CONSOLE-3693]: https://issues.redhat.com/browse/CONSOLE-3693
 [CONSOLE-3695]: https://issues.redhat.com/browse/CONSOLE-3695
 [CONSOLE-3883]: https://issues.redhat.com/browse/CONSOLE-3883
 [CONSOLE-3899]: https://issues.redhat.com/browse/CONSOLE-3899
 [CONSOLE-3949]: https://issues.redhat.com/browse/CONSOLE-3949
+[CONSOLE-4097]: https://issues.redhat.com/browse/CONSOLE-4097
 [OCPBUGS-30077]: https://issues.redhat.com/browse/OCPBUGS-30077
 [OCPBUGS-31355]: https://issues.redhat.com/browse/OCPBUGS-31355
 [OCPBUGS-31703]: https://issues.redhat.com/browse/OCPBUGS-31703
+[OCPBUGS-33539]: https://issues.redhat.com/browse/OCPBUGS-33539
+[OCPBUGS-33567]: https://issues.redhat.com/browse/OCPBUGS-33567
+[OCPBUGS-34538]: https://issues.redhat.com/browse/OCPBUGS-34538
 [ODC-7425]: https://issues.redhat.com/browse/ODC-7425
 [#12983]: https://github.com/openshift/console/pull/12983
 [#13233]: https://github.com/openshift/console/pull/13233
@@ -45,3 +56,6 @@ version and PatternFly version compatibility.
 [#13637]: https://github.com/openshift/console/pull/13637
 [#13694]: https://github.com/openshift/console/pull/13694
 [#13722]: https://github.com/openshift/console/pull/13722
+[#13843]: https://github.com/openshift/console/pull/13843
+[#13900]: https://github.com/openshift/console/pull/13900
+[#13916]: https://github.com/openshift/console/pull/13916

--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
@@ -1,0 +1,47 @@
+# Changelog for `@openshift-console/dynamic-plugin-sdk`
+
+Refer to [Console dynamic plugins README][README] for OpenShift Console version vs SDK package
+version and PatternFly version compatibility.
+
+## 1.3.0 - 2024-04-09
+
+- Add new props to `ResourceYAMLEditor` component ([OCPBUGS-31703], [#13722])
+
+## 1.2.0 - 2024-04-03
+
+- Support returning entire response body in `consoleFetchJSON` and `consoleFetchText` ([CONSOLE-3949], [#13623])
+- Add `readOnly` prop in `ResourceYAMLEditor` component ([OCPBUGS-31355], [#13694])
+
+## 1.1.0 - 2024-03-19
+
+- Add search filter functionality to `ListPageFilter` component ([OCPBUGS-30077], [#13233])
+- Improve dynamic plugin SDK documentation and add PatternFly upgrade notes ([CONSOLE-3883], [#13637])
+
+## 1.0.0 - 2024-02-09
+
+> Initial v1 release. Changes listed here refer to the latest 0.0.x version (0.0.21) of this package.
+
+- Add new extension type `console.resource/details-item` ([CONSOLE-3695], [#13240])
+- Allow custom perspective display icon in extension type `dev-console.add/action-group` ([ODC-7425], [#13338])
+- Use PatternFly 5 in Console and relax singleton config of PatternFly shared modules ([CONSOLE-3693], [#12983])
+- Add new extension type `console.node/status` ([CONSOLE-3899], [#13493])
+
+[README]: ./README.md
+[CONSOLE-3693]: https://issues.redhat.com/browse/CONSOLE-3693
+[CONSOLE-3695]: https://issues.redhat.com/browse/CONSOLE-3695
+[CONSOLE-3883]: https://issues.redhat.com/browse/CONSOLE-3883
+[CONSOLE-3899]: https://issues.redhat.com/browse/CONSOLE-3899
+[CONSOLE-3949]: https://issues.redhat.com/browse/CONSOLE-3949
+[OCPBUGS-30077]: https://issues.redhat.com/browse/OCPBUGS-30077
+[OCPBUGS-31355]: https://issues.redhat.com/browse/OCPBUGS-31355
+[OCPBUGS-31703]: https://issues.redhat.com/browse/OCPBUGS-31703
+[ODC-7425]: https://issues.redhat.com/browse/ODC-7425
+[#12983]: https://github.com/openshift/console/pull/12983
+[#13233]: https://github.com/openshift/console/pull/13233
+[#13240]: https://github.com/openshift/console/pull/13240
+[#13338]: https://github.com/openshift/console/pull/13338
+[#13493]: https://github.com/openshift/console/pull/13493
+[#13623]: https://github.com/openshift/console/pull/13623
+[#13637]: https://github.com/openshift/console/pull/13637
+[#13694]: https://github.com/openshift/console/pull/13694
+[#13722]: https://github.com/openshift/console/pull/13722

--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-webpack.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-webpack.md
@@ -3,6 +3,11 @@
 Refer to [Console dynamic plugins README][README] for OpenShift Console version vs SDK package
 version and PatternFly version compatibility.
 
+## 1.1.1 - 2024-07-02
+
+- Patch dynamic module parser to exclude PatternFly "next" modules ([OCPBUGS-31901], [#13832])
+- Ensure `requiredVersion` is set for Console provided shared modules ([OCPBUGS-34683], [#13893])
+
 ## 1.1.0 - 2024-04-03
 
 - Remove `react-helmet` from Console provided shared modules ([OCPBUGS-30824], [#13687])
@@ -28,10 +33,14 @@ version and PatternFly version compatibility.
 [CONSOLE-3853]: https://issues.redhat.com/browse/CONSOLE-3853
 [OCPBUGS-30762]: https://issues.redhat.com/browse/OCPBUGS-30762
 [OCPBUGS-30824]: https://issues.redhat.com/browse/OCPBUGS-30824
+[OCPBUGS-31901]: https://issues.redhat.com/browse/OCPBUGS-31901
 [OCPBUGS-33642]: https://issues.redhat.com/browse/OCPBUGS-33642
+[OCPBUGS-34683]: https://issues.redhat.com/browse/OCPBUGS-34683
 [#13188]: https://github.com/openshift/console/pull/13188
 [#13388]: https://github.com/openshift/console/pull/13388
 [#13521]: https://github.com/openshift/console/pull/13521
 [#13657]: https://github.com/openshift/console/pull/13657
 [#13687]: https://github.com/openshift/console/pull/13687
+[#13832]: https://github.com/openshift/console/pull/13832
 [#13849]: https://github.com/openshift/console/pull/13849
+[#13893]: https://github.com/openshift/console/pull/13893

--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-webpack.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-webpack.md
@@ -1,0 +1,37 @@
+# Changelog for `@openshift-console/dynamic-plugin-sdk-webpack`
+
+Refer to [Console dynamic plugins README][README] for OpenShift Console version vs SDK package
+version and PatternFly version compatibility.
+
+## 1.1.0 - 2024-04-03
+
+- Remove `react-helmet` from Console provided shared modules ([OCPBUGS-30824], [#13687])
+
+## 1.0.2 - 2024-06-27
+
+- Patch dynamic module parser to exclude PatternFly "next" modules ([OCPBUGS-33642], [#13849])
+
+## 1.0.1 - 2024-03-19
+
+- Fix bugs in `ConsoleRemotePlugin` found in kubevirt-ui/kubevirt-plugin#1804 ([OCPBUGS-30762], [#13657])
+
+## 1.0.0 - 2024-02-09
+
+> Initial v1 release. Changes listed here refer to the latest 0.0.x version (0.0.11) of this package.
+
+- Update build-time infra to use webpack code from OpenShift Dynamic Plugin SDK ([CONSOLE-3705], [#13188])
+- Prevent PatternFly styles from being included in plugin builds ([CONSOLE-3853], [#13388])
+- Optimize module federation of PatternFly packages via dynamic modules ([CONSOLE-3853], [#13521])
+
+[README]: ./README.md
+[CONSOLE-3705]: https://issues.redhat.com/browse/CONSOLE-3705
+[CONSOLE-3853]: https://issues.redhat.com/browse/CONSOLE-3853
+[OCPBUGS-30762]: https://issues.redhat.com/browse/OCPBUGS-30762
+[OCPBUGS-30824]: https://issues.redhat.com/browse/OCPBUGS-30824
+[OCPBUGS-33642]: https://issues.redhat.com/browse/OCPBUGS-33642
+[#13188]: https://github.com/openshift/console/pull/13188
+[#13388]: https://github.com/openshift/console/pull/13388
+[#13521]: https://github.com/openshift/console/pull/13521
+[#13657]: https://github.com/openshift/console/pull/13657
+[#13687]: https://github.com/openshift/console/pull/13687
+[#13849]: https://github.com/openshift/console/pull/13849

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -417,7 +417,7 @@ yarn publish dist/<pkg> --no-git-tag-version --new-version <version>
 
 If the given package doesn't exist in npm registry, add `--access public` to `yarn publish` command.
 
-If the newly published version is lesser than the latest published version in terms of semver rules
+If the newly published version comes before the latest published version in terms of semver rules
 (e.g. hotfix release 1.0.2 for an older minor version stream 1.0.x), ensure the `latest` dist-tag
 still applies to the appropriate package version:
 

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -338,12 +338,13 @@ provide the same content:
 - http://localhost:9000/api/plugins/foo-plugin/plugin-manifest.json
 - http://localhost:9001/plugin-manifest.json
 
-Open the Console in your web browser and inspect the value of `window.SERVER_FLAGS.consolePlugins` to see the
-list of dynamic plugins the Console loads at runtime. For local development, this should only
+Open the Console in your web browser and inspect the value of `window.SERVER_FLAGS.consolePlugins` to
+see the list of dynamic plugins the Console loads at runtime. For local development, this should only
 include plugin(s) listed via `-plugins` Bridge argument.
 
-Console development builds allow you to interact with the `PluginStore` object that manages
-all plugins and their extensions directly in your web browser with `window.pluginStore`.
+Console development builds allow you to interact with the `PluginStore` object that manages all
+plugins and their extensions directly in your web browser with `window.pluginStore`. Please note
+that this is _not_ a public API and is meant only for debugging local Console development builds.
 
 ### Using local Console plugin SDK code
 

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -49,8 +49,8 @@ compatible versions of distributable SDK packages to versions of the OpenShift C
 | ----------------- | ----------------------------------------------- | -------------------- |
 | 4.17.x            | `@openshift-console/dynamic-plugin-sdk`         | Latest               |
 |                   | `@openshift-console/dynamic-plugin-sdk-webpack` | Latest               |
-| 4.16.x            | `@openshift-console/dynamic-plugin-sdk`         | 1.3.0                |
-|                   | `@openshift-console/dynamic-plugin-sdk-webpack` | 1.1.0                |
+| 4.16.x            | `@openshift-console/dynamic-plugin-sdk`         | 1.4.0                |
+|                   | `@openshift-console/dynamic-plugin-sdk-webpack` | 1.1.1                |
 | 4.15.x            | `@openshift-console/dynamic-plugin-sdk`         | 1.0.0                |
 |                   | `@openshift-console/dynamic-plugin-sdk-webpack` | 1.0.2                |
 | 4.14.x            | `@openshift-console/dynamic-plugin-sdk`         | 0.0.21               |

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -342,8 +342,8 @@ Open the Console in your web browser and inspect the value of `window.SERVER_FLA
 list of dynamic plugins the Console loads at runtime. For local development, this should only
 include plugin(s) listed via `-plugins` Bridge argument.
 
-Console development builds also allow you to interact with the `PluginStore` object that manages
-all plugins and their extensions directly in your web browser via `window.pluginStore`.
+Console development builds allow you to interact with the `PluginStore` object that manages
+all plugins and their extensions directly in your web browser with `window.pluginStore`.
 
 ### Using local Console plugin SDK code
 
@@ -418,7 +418,7 @@ yarn publish dist/<pkg> --no-git-tag-version --new-version <version>
 If the given package doesn't exist in npm registry, add `--access public` to `yarn publish` command.
 
 If the newly published version is lesser than the latest published version in terms of semver rules
-(e.g. hotfix release 1.0.2 for an older minor version stream 1.0.x), make sure that the `latest` dist-tag
+(e.g. hotfix release 1.0.2 for an older minor version stream 1.0.x), ensure the `latest` dist-tag
 still applies to the appropriate package version:
 
 ```sh

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -47,10 +47,12 @@ compatible versions of distributable SDK packages to versions of the OpenShift C
 
 | Console Version   | SDK Package                                     | Last Package Version |
 | ----------------- | ----------------------------------------------- | -------------------- |
-| 4.16.x            | `@openshift-console/dynamic-plugin-sdk`         | Latest               |
+| 4.17.x            | `@openshift-console/dynamic-plugin-sdk`         | Latest               |
 |                   | `@openshift-console/dynamic-plugin-sdk-webpack` | Latest               |
+| 4.16.x            | `@openshift-console/dynamic-plugin-sdk`         | 1.3.0                |
+|                   | `@openshift-console/dynamic-plugin-sdk-webpack` | 1.1.0                |
 | 4.15.x            | `@openshift-console/dynamic-plugin-sdk`         | 1.0.0                |
-|                   | `@openshift-console/dynamic-plugin-sdk-webpack` | 1.0.0                |
+|                   | `@openshift-console/dynamic-plugin-sdk-webpack` | 1.0.2                |
 | 4.14.x            | `@openshift-console/dynamic-plugin-sdk`         | 0.0.21               |
 |                   | `@openshift-console/dynamic-plugin-sdk-webpack` | 0.0.11               |
 | 4.13.x            | `@openshift-console/dynamic-plugin-sdk`         | 0.0.19               |
@@ -340,6 +342,9 @@ Open the Console in your web browser and inspect the value of `window.SERVER_FLA
 list of dynamic plugins the Console loads at runtime. For local development, this should only
 include plugin(s) listed via `-plugins` Bridge argument.
 
+Console development builds also allow you to interact with the `PluginStore` object that manages
+all plugins and their extensions directly in your web browser via `window.pluginStore`.
+
 ### Using local Console plugin SDK code
 
 If you need to make modifications to Console dynamic plugin SDK code and reflect them in your
@@ -411,6 +416,14 @@ yarn publish dist/<pkg> --no-git-tag-version --new-version <version>
 ```
 
 If the given package doesn't exist in npm registry, add `--access public` to `yarn publish` command.
+
+If the newly published version is lesser than the latest published version in terms of semver rules
+(e.g. hotfix release 1.0.2 for an older minor version stream 1.0.x), make sure that the `latest` dist-tag
+still applies to the appropriate package version:
+
+```sh
+npm dist-tag add <package-name>@<version> latest
+```
 
 ## Future Deprecations in Shared Plugin Dependencies
 

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
@@ -120,6 +120,7 @@ export const getCorePackage: GetPackageDefinition = (
     ...commonFiles,
     ...docFiles,
     ...getReferencedAssets('dist/core'),
+    'CHANGELOG-core.md': 'CHANGELOG.md',
   },
 });
 
@@ -175,5 +176,6 @@ export const getWebpackPackage: GetPackageDefinition = (
   filesToCopy: {
     ...commonFiles,
     'generated/schema': 'schema',
+    'CHANGELOG-webpack.md': 'CHANGELOG.md',
   },
 });


### PR DESCRIPTION
- Add changelog for core & webpack plugin SDK packages, based on [Common Changelog](https://common-changelog.org/)
  - :memo: Tracking changes since version 1.0.0 of each package
- Copy changelog when building core & webpack plugin SDK packages as `CHANGELOG.md` file
- Update dynamic plugins README
  - :hash: Section "OpenShift Console Versions vs SDK Versions" updated for Console 4.15 and 4.16
  - :lady_beetle: Add note about `window.pluginStore` available in Console development builds
