### PR TITLE
OCPBUGS-35879: Fix TypeError: Cannot read properties of null (reading 'metadata') in Topology view

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useRoutesWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/useRoutesWatcher.ts
@@ -7,18 +7,17 @@ import { useServicesWatcher } from './useServicesWatcher';
 export const useRoutesWatcher = (
   resource: K8sResourceKind,
 ): { loaded: boolean; loadError: string; routes: RouteKind[] } => {
-  const { namespace } = resource.metadata;
   const watchedServices = useServicesWatcher(resource);
   const [allRoutes, loaded, loadError] = useK8sWatchResource<RouteKind[]>({
     isList: true,
     kind: 'Route',
-    namespace,
+    namespace: resource?.metadata?.namespace,
   });
 
   const servicesNames = React.useMemo(
     () =>
       !watchedServices.loadError && watchedServices.loaded
-        ? watchedServices.services.map((s) => s.metadata.name)
+        ? watchedServices.services.map((s) => s.metadata?.name)
         : [],
     [watchedServices.loadError, watchedServices.loaded, watchedServices.services],
   );


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-35879

Descriptions: TypeError: Cannot read properties of null (reading 'metadata') in Topology view. So, get the namespace using optional chaining instead of directly extracting it from the metadata.