### PR TITLE
OCPBUGS-36260: Tooltip on Pipeline when expression is not shows

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineTaskNode.tsx
@@ -29,6 +29,7 @@ import {
 } from '../detail-page-tabs/pipeline-details/pipeline-step-utils';
 import { PipelineVisualizationStepList } from '../detail-page-tabs/pipeline-details/PipelineVisualizationStepList';
 import { NodeType } from './const';
+import { getTooltipContent } from './utils';
 
 import './PipelineTaskNode.scss';
 
@@ -73,8 +74,8 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
   const isSkipped = !!(
     computedTask &&
     data.pipelineRun?.status?.skippedTasks?.some(
-      (t) => t.name === data.task.name,
-      (t) => t.name === computedTask.name,
+      (skippedTask) => skippedTask.name === data.task.name,
+      (skippedTask) => skippedTask.name === computedTask.name,
     )
   );
 
@@ -119,6 +120,7 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
   }, [data]);
 
   const hasTaskIcon = !!(data.taskIconClass || data.taskIcon);
+  const tooltipContent = getTooltipContent(data.task?.status?.reason);
   const whenDecorator = data.whenStatus ? (
     <WhenDecorator
       element={element}
@@ -128,6 +130,7 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
           ? DEFAULT_WHEN_OFFSET + (element.getBounds().height - 4) * 0.75
           : DEFAULT_WHEN_OFFSET
       }
+      toolTip={tooltipContent}
     />
   ) : null;
 
@@ -175,8 +178,7 @@ const PipelineTaskNode: React.FunctionComponent<PipelineTaskNodeProps> = ({
     >
       <g data-test={`task ${element.getLabel()}`} className={classes} ref={hoverRef}>
         <Tooltip
-          position="bottom"
-          enableFlip={false}
+          enableFlip
           triggerRef={taskRef}
           content={
             <PipelineVisualizationStepList

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
@@ -661,3 +661,15 @@ export const getWhenExpressionDiamondState = (
   }
   return { tooltipContent, diamondColor };
 };
+
+export const getTooltipContent = (statusReason: ComputedStatus): string => {
+  switch (statusReason) {
+    case ComputedStatus.Succeeded:
+    case ComputedStatus.Failed:
+      return i18n.t('pipelines-plugin~When expression was met');
+    case ComputedStatus.Skipped:
+      return i18n.t('pipelines-plugin~When expression was not met');
+    default:
+      return i18n.t('pipelines-plugin~When expression');
+  }
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-36260

**Analysis / Root cause**: 
`toolTip` prop was not passed to `WhenDecorator` of react-topology

**Solution Description**: 
Added toolTip prop

**Screen shots / Gifs for design review**: 

https://github.com/openshift/console/assets/102503482/a8f2ba18-78fe-49e1-be05-8a900ecd1c9a




**Unit test coverage report**: 
NA

**Test setup:**

1. Create a Pipeline with whenExpression
2. navigate to the Pipeline details page
3. hover over the whenExpression diamond shape

    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge




