### PR TITLE
OCPBUGS-36424: DeploymentConfigs deprecation info alert should not present on the Edit deployment page

### DIFF
--- a/frontend/packages/dev-console/src/components/deployments/DeploymentForm.tsx
+++ b/frontend/packages/dev-console/src/components/deployments/DeploymentForm.tsx
@@ -53,8 +53,7 @@ const EditDeploymentForm: React.FC<
 
   const yamlEditor = (
     <>
-      <DeploymentConfigDeprecationAlert />
-      <br />
+      {resource.kind === DeploymentConfigModel.kind && <DeploymentConfigDeprecationAlert />}
       <CodeEditorField
         name="yamlData"
         model={resourceType === Resources.OpenShift ? DeploymentConfigModel : DeploymentModel}

--- a/frontend/packages/dev-console/src/components/deployments/DeploymentFormEditor.tsx
+++ b/frontend/packages/dev-console/src/components/deployments/DeploymentFormEditor.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DeploymentConfigDeprecationAlert } from '@console/internal/components/deployment-config';
+import { DeploymentConfigModel } from '@console/internal/models';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import SwitchToYAMLAlert from '@console/shared/src/components/alerts/SwitchToYAMLAlert';
 import NameSection from '../buildconfig/sections/NameSection';
@@ -21,7 +22,7 @@ const EditDeploymentFormEditor: React.FC<EditDeploymentFormEditorProps> = ({
   const [showYAMLAlert, setShowYAMLAlert] = React.useState<boolean>(true);
   return (
     <>
-      <DeploymentConfigDeprecationAlert />
+      {resourceObj.kind === DeploymentConfigModel.kind && <DeploymentConfigDeprecationAlert />}
       {showYAMLAlert && <SwitchToYAMLAlert onClose={() => setShowYAMLAlert(false)} />}
       <NameSection />
       <DeploymentStrategySection resourceType={resourceType} resourceObj={resourceObj} />


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-36424

**Analysis / Root cause**: 
Edit Deployment and DeploymentConfig used the same form and kind check was not added

**Solution Description**: 
Added the check to display info alert only if kind is DeploymentConfig

**Screen shots / Gifs for design review**: 


https://github.com/openshift/console/assets/102503482/8b648999-3e7b-4af0-8b02-d28ecda5071b





**Unit test coverage report**: 
NA

**Test setup:**

    1. Create a deployment
    2. Open Edit deployment form from the actions menu

    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge




