### PR TITLE
OCPBUGS-32773: Values entered into the Instantiate Template form are automatically cleared

### DIFF
--- a/frontend/public/components/instantiate-template.tsx
+++ b/frontend/public/components/instantiate-template.tsx
@@ -136,16 +136,20 @@ const TemplateForm_: React.FC<TemplateFormProps> = (props) => {
   const [parameters, setParameters] = React.useState([]);
   const [inProgress, setInProgress] = React.useState(false);
   const [error, setError] = React.useState('');
+  const isInitialLoad = React.useRef(true);
 
   const { t } = useTranslation();
   const navigate = useNavigate();
 
   React.useEffect(() => {
-    const object = (obj.data.parameters || []).reduce((acc, { name, value }) => {
-      acc[name] = value;
-      return acc;
-    }, {});
-    setParameters(object);
+    if (isInitialLoad.current && obj.loaded) {
+      const object = (obj.data.parameters || []).reduce((acc, { name, value }) => {
+        acc[name] = value;
+        return acc;
+      }, {});
+      setParameters(object);
+      isInitialLoad.current = false;
+    }
   }, [obj]);
 
   const onParameterChanged: React.ReactEventHandler<HTMLInputElement> = (event) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-32773

**Analysis / Root cause**: 
The input fields are always populated based on the API response and user entered values are getting cleared out

**Solution Description**: 
Added the check to not load data after 1st load to keep user entered information

**Screen shots / Gifs for design review**: 


---BEFORE---


https://github.com/openshift/console/assets/102503482/c42d654a-bceb-48cb-9add-08fc7584d0c6



---AFTER---



https://github.com/openshift/console/assets/102503482/d93f83b7-5d0b-463e-b1cf-542251655adf



**Unit test coverage report**: 
NA

**Test setup:**

1. Log in with a non-administrator account.
2. Select a template from the developer catalog and click on Instantiate Template.
3. Enter values into the initially empty form.
4. Wait for several seconds, and the entered values will disappear.

    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge




