### PR TITLE
OCPBUGS-30841: Redirects to new PipelineRun logs URL from old PipelineRun logs URL

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -739,6 +739,17 @@
     "type": "console.page/route",
     "properties": {
       "exact": true,
+      "path": [
+        "/k8s/ns/:ns/tekton.dev~v1~PipelineRun/:plrName/logs/:taskName",
+        "/k8s/ns/:ns/tekton.dev~v1beta1~PipelineRun/:plrName/logs/:taskName"
+      ],
+      "component": { "$codeRef": "pipelinesComponent.LogURLRedirect" }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
       "path": "/k8s/ns/:ns/tekton.dev~v1~Pipeline/~new/builder",
       "component": {
         "$codeRef": "pipelinesComponent.PipelineBuilderPage"

--- a/frontend/packages/pipelines-plugin/src/components/LogURLRedirect.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/LogURLRedirect.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Navigate, useLocation, useParams } from 'react-router-dom-v5-compat';
+
+const createLogURL = (pathname: string, taskName: string): string => {
+  const basePath = pathname.replace(/\/$/, '');
+  const detailsURL = basePath.split('/logs/');
+  return `${detailsURL[0]}/logs?taskName=${taskName}`;
+};
+
+export const LogURLRedirect: React.FC = () => {
+  const location = useLocation();
+  const { taskName } = useParams();
+  return <Navigate to={createLogURL(location.pathname, taskName)} replace />;
+};

--- a/frontend/packages/pipelines-plugin/src/components/pipelines-index.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines-index.ts
@@ -4,3 +4,4 @@ export * from './conditions';
 export * from './pipelines-lists';
 export * from './repository';
 export { useIsTektonV1VersionPresent } from './pipelines/utils/pipeline-operator';
+export { LogURLRedirect } from './LogURLRedirect';


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-30841

Descriptions: Logs URL has been changed after the react-router package upgrade because of this change log URL provided by PAC is broken now. This change redirects the old PLR logs URL to a new one.

https://github.com/openshift/console/assets/2561818/bd58f998-cc21-4e57-8bd2-c2a92292a8bf


