### PR TITLE
OCPBUGS-36619: Switch to use annotations as labels from PipelineRuns created through Pipelines as Code is deprecated

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
@@ -6,7 +6,7 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../../models';
 import { PipelineRunKind, TaskRunKind } from '../../../types';
 import { TektonResourceLabel } from '../../pipelines/const';
-import { RepositoryFields, RepositoryLabels } from '../../repository/consts';
+import { RepositoryLabels, RepositoryFields } from '../../repository/consts';
 import { useTaskRuns } from '../../taskruns/useTaskRuns';
 import {
   getPipelineRuns,
@@ -120,7 +120,9 @@ export const useGetPipelineRuns = (ns: string, options?: { name: string; kind: s
     selector = { matchLabels: { 'tekton.dev/pipeline': options?.name } };
   }
   if (options?.kind === 'Repository') {
-    selector = { matchLabels: { [RepositoryLabels[RepositoryFields.REPOSITORY]]: options?.name } };
+    selector = {
+      matchLabels: { [RepositoryLabels[RepositoryFields.REPOSITORY]]: options?.name },
+    };
   }
   const [resultPlrs, resultPlrsLoaded, resultPlrsLoadError, getNextPage] = useTRPipelineRuns(
     ns,

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryLinkList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryLinkList.tsx
@@ -12,10 +12,10 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { RepositoryModel } from '../../models';
 import { PipelineRunKind } from '../../types';
 import {
-  RepositoryLabels,
-  RepositoryFields,
   RepositoryAnnotations,
   RepoAnnotationFields,
+  RepositoryFields,
+  RepositoryLabels,
 } from './consts';
 import { getGitProviderIcon, getLabelValue, sanitizeBranchName } from './repository-utils';
 
@@ -31,6 +31,9 @@ const RepositoryLinkList: React.FC<RepositoryLinkListProps> = ({ pipelineRun }) 
   const repoName = plrLabels?.[repoLabel];
   const repoURL = plrAnnotations?.[RepositoryAnnotations[RepoAnnotationFields.REPO_URL]];
   const shaURL = plrAnnotations?.[RepositoryAnnotations[RepoAnnotationFields.SHA_URL]];
+  const branchName =
+    plrLabels?.[RepositoryAnnotations[RepoAnnotationFields.BRANCH]] ||
+    plrAnnotations?.[RepositoryAnnotations[RepoAnnotationFields.BRANCH]];
 
   if (!repoName) return null;
 
@@ -58,12 +61,10 @@ const RepositoryLinkList: React.FC<RepositoryLinkListProps> = ({ pipelineRun }) 
           </ExternalLink>
         )}
       </dd>
-      {plrLabels?.[RepositoryLabels[RepositoryFields.BRANCH]] && (
+      {branchName && (
         <>
-          <dt>{t(getLabelValue(plrLabels[RepositoryLabels[RepositoryFields.BRANCH]]))}</dt>
-          <dd data-test="pl-repository-branch">
-            {sanitizeBranchName(plrLabels[RepositoryLabels[RepositoryFields.BRANCH]])}
-          </dd>
+          <dt>{t(getLabelValue(branchName))}</dt>
+          <dd data-test="pl-repository-branch">{sanitizeBranchName(branchName)}</dd>
         </>
       )}
       {plrLabels?.[RepositoryLabels[RepositoryFields.SHA]] && (

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunHeader.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunHeader.tsx
@@ -1,7 +1,12 @@
 import { sortable } from '@patternfly/react-table';
 import i18n from 'i18next';
 import { Kebab } from '@console/internal/components/utils';
-import { RepositoryLabels, RepositoryFields } from './consts';
+import {
+  RepoAnnotationFields,
+  RepositoryAnnotations,
+  RepositoryFields,
+  RepositoryLabels,
+} from './consts';
 
 export const tableColumnClasses = [
   'pf-v5-u-w-16-on-lg pf-v5-u-w-25-on-md',
@@ -68,7 +73,7 @@ const RepositoryPipelineRunHeader = () => {
     },
     {
       title: i18n.t('pipelines-plugin~Branch/Tag'),
-      sortField: `metadata.labels.${RepositoryLabels[RepositoryFields.BRANCH]}`,
+      sortField: `metadata.annotations.${RepositoryAnnotations[RepoAnnotationFields.BRANCH]}`,
       transforms: [sortable],
       props: { className: tableColumnClasses[7] },
     },

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunListPage.tsx
@@ -42,7 +42,9 @@ const RepositoryPipelineRunListPage: React.FC<RepositoryPipelineRunListPageProps
       kind={referenceForModel(PipelineRunModel)}
       namespace={obj.metadata.namespace}
       selector={{
-        matchLabels: { [RepositoryLabels[RepositoryFields.REPOSITORY]]: obj.metadata.name },
+        matchLabels: {
+          [RepositoryLabels[RepositoryFields.REPOSITORY]]: obj.metadata.name,
+        },
       }}
       ListComponent={RunList}
       rowFilters={runFilters(t)}

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunRow.tsx
@@ -30,10 +30,10 @@ import { ResourceKebabWithUserLabel } from '../pipelineruns/triggered-by';
 import { chainsSignedAnnotation } from '../pipelines/const';
 import { getTaskRunsOfPipelineRun } from '../taskruns/useTaskRuns';
 import {
-  RepositoryLabels,
-  RepositoryFields,
   RepoAnnotationFields,
   RepositoryAnnotations,
+  RepositoryFields,
+  RepositoryLabels,
 } from './consts';
 import { sanitizeBranchName } from './repository-utils';
 import { tableColumnClasses } from './RepositoryPipelineRunHeader';
@@ -67,6 +67,9 @@ const RepositoryPipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({
   const plrAnnotations = obj.metadata.annotations;
   const { operatorVersion, taskRuns, taskRunsLoaded } = customData;
   const PLRTaskRuns = getTaskRunsOfPipelineRun(taskRuns, obj?.metadata?.name);
+  const branchName =
+    plrLabels?.[RepositoryAnnotations[RepoAnnotationFields.BRANCH]] ||
+    plrAnnotations?.[RepositoryAnnotations[RepoAnnotationFields.BRANCH]];
   return (
     <>
       <TableData className={tableColumnClasses[0]}>
@@ -109,7 +112,7 @@ const RepositoryPipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({
           <ExternalLink
             href={plrAnnotations?.[RepositoryAnnotations[RepoAnnotationFields.SHA_URL]]}
           >
-            {truncateMiddle(plrLabels[RepositoryLabels[RepositoryFields.SHA]], {
+            {truncateMiddle(plrLabels?.[RepositoryLabels[RepositoryFields.SHA]], {
               length: 7,
               truncateEnd: true,
               omission: '',
@@ -137,9 +140,7 @@ const RepositoryPipelineRunRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({
         <Timestamp timestamp={obj.status && obj.status.startTime} />
       </TableData>
       <TableData className={tableColumnClasses[6]}>{pipelineRunDuration(obj)}</TableData>
-      <TableData className={tableColumnClasses[7]}>
-        {sanitizeBranchName(plrLabels?.[RepositoryLabels[RepositoryFields.BRANCH]])}
-      </TableData>
+      <TableData className={tableColumnClasses[7]}>{sanitizeBranchName(branchName)}</TableData>
       <TableData className={tableColumnClasses[8]}>
         <ResourceKebabWithUserLabel
           actions={getPipelineRunKebabActions(operatorVersion, PLRTaskRuns)}

--- a/frontend/packages/pipelines-plugin/src/components/repository/consts.ts
+++ b/frontend/packages/pipelines-plugin/src/components/repository/consts.ts
@@ -3,7 +3,6 @@ import { RepositoryFormValues } from './types';
 
 export enum RepositoryFields {
   REPOSITORY = 'Repository',
-  BRANCH = 'Branch',
   URL_REPO = 'RepoUrl',
   URL_ORG = 'RepoOrg',
   SHA = 'sha',
@@ -14,6 +13,7 @@ export enum RepoAnnotationFields {
   SHA_MESSAGE = 'sha_message',
   SHA_URL = 'sha_url',
   REPO_URL = 'repo_url',
+  BRANCH = 'Branch',
 }
 
 export enum RepositoryRuntimes {
@@ -25,7 +25,6 @@ export enum RepositoryRuntimes {
 
 export const RepositoryLabels: Record<RepositoryFields, string> = {
   [RepositoryFields.REPOSITORY]: 'pipelinesascode.tekton.dev/repository',
-  [RepositoryFields.BRANCH]: 'pipelinesascode.tekton.dev/branch',
   [RepositoryFields.URL_REPO]: 'pipelinesascode.tekton.dev/url-repository',
   [RepositoryFields.URL_ORG]: 'pipelinesascode.tekton.dev/url-org',
   [RepositoryFields.SHA]: 'pipelinesascode.tekton.dev/sha',
@@ -36,6 +35,7 @@ export const RepositoryAnnotations: Record<RepoAnnotationFields, string> = {
   [RepoAnnotationFields.SHA_MESSAGE]: 'pipelinesascode.tekton.dev/sha-title',
   [RepoAnnotationFields.SHA_URL]: 'pipelinesascode.tekton.dev/sha-url',
   [RepoAnnotationFields.REPO_URL]: 'pipelinesascode.tekton.dev/repo-url',
+  [RepoAnnotationFields.BRANCH]: 'pipelinesascode.tekton.dev/branch',
 };
 
 export const baseURL = 'https://github.com';

--- a/frontend/packages/pipelines-plugin/src/components/repository/repository-utils.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/repository-utils.tsx
@@ -41,30 +41,30 @@ export const getGitProviderIcon = (url: string) => {
 };
 
 export const getLabelValue = (branchName: string): string => {
-  if (branchName.startsWith('refs/heads/') || branchName.startsWith('refs-heads-')) {
+  if (branchName?.startsWith('refs/heads/') || branchName?.startsWith('refs-heads-')) {
     return 'pipelines-plugin~Branch';
   }
 
-  if (branchName.startsWith('refs/tags/') || branchName.startsWith('refs-tags-')) {
+  if (branchName?.startsWith('refs/tags/') || branchName?.startsWith('refs-tags-')) {
     return 'pipelines-plugin~Tag';
   }
   return 'pipelines-plugin~Branch';
 };
 
 export const sanitizeBranchName = (branchName: string): string => {
-  if (branchName.startsWith('refs/heads/')) {
+  if (branchName?.startsWith('refs/heads/')) {
     return branchName.replace('refs/heads/', '');
   }
 
-  if (branchName.startsWith('refs-heads-')) {
+  if (branchName?.startsWith('refs-heads-')) {
     return branchName.replace('refs-heads-', '');
   }
 
-  if (branchName.startsWith('refs/tags/')) {
+  if (branchName?.startsWith('refs/tags/')) {
     return branchName.replace('refs/tags/', '');
   }
 
-  if (branchName.startsWith('refs-tags-')) {
+  if (branchName?.startsWith('refs-tags-')) {
     return branchName.replace('refs-tags-', '');
   }
   return branchName;

--- a/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
@@ -3227,8 +3227,10 @@ export const PipeLineRunWithRepoMetadata: Record<string, PipelineRunKind> = {
     metadata: {
       name: 'pipeline-with-repo',
       labels: {
-        'pipelinesascode.tekton.dev/branch': 'main',
         'pipelinesascode.tekton.dev/url-repository': 'demoapp',
+      },
+      annotations: {
+        'pipelinesascode.tekton.dev/branch': 'main',
       },
       namespace: 'test',
     },
@@ -3253,6 +3255,8 @@ export const PipeLineRunWithRepoMetadata: Record<string, PipelineRunKind> = {
       name: 'pipeline-with-repo',
       labels: {
         'pipelinesascode.tekton.dev/repository': 'repo1',
+      },
+      annotations: {
         'pipelinesascode.tekton.dev/branch': 'main',
       },
       namespace: 'test',


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-36619

Descriptions: 
The labels added by PAC have been deprecated and added to PLR annotations. So, use annotations to get the value in the repository list page, repository PLRs list page, and on the PLR details page. 


Test steps:
- Check Repository list page
- PipelineRuns list page for repository
- PipelineRun details page
- Repository details page 
