### PR TITLE
OCPBUGS-34901: ensure correct API version for OperandDetails

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/mocks.ts
+++ b/frontend/packages/operator-lifecycle-manager/mocks.ts
@@ -30,8 +30,8 @@ const prefixedCapabilities = new Set([
 ]);
 
 export const testConditionsDescriptor = {
-  path: 'testCondtions',
-  displayName: 'Test Condtions',
+  path: 'testConditions',
+  displayName: 'Test Conditions',
   description: '',
   'x-descriptors': [StatusCapability.conditions],
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -224,8 +224,9 @@ describe(OperandDetails.displayName, () => {
 
   beforeEach(() => {
     resourceDefinition = {
-      plural: testCRD.metadata.name.split('.')[0],
+      plural: testModel.plural,
       annotations: testCRD.metadata.annotations,
+      apiVersion: testModel.apiVersion,
     };
     wrapper = shallow(
       <OperandDetails.WrappedComponent

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -616,7 +616,9 @@ export const OperandDetails = connectToModel(({ crd, csv, kindObj, obj }: Operan
     [
       ...(csv?.spec?.customresourcedefinitions?.owned ?? []),
       ...(csv?.spec?.customresourcedefinitions?.required ?? []),
-    ].find((def) => def.name === crd?.metadata?.name) ?? {};
+    ].find((def) => {
+      return def.name === crd?.metadata?.name && def.version === kindObj?.apiVersion;
+    }) ?? {};
 
   const schema =
     crd?.spec?.versions?.find((v) => v.name === version)?.schema?.openAPIV3Schema ??


### PR DESCRIPTION
Previously, the OperandDetails was displaying information for the first CRD that matched by name.   After this fix, the OperandDetails page displays information for the CRD that matches by name *and* the version of the operand.

Before:
![console-openshift-console apps rhamilto devcluster openshift com_k8s_ns_default_clusterserviceversions_cryostat-operator v3 0 0-dev_operator cryostat io~v1beta2~Cryostat_cryostat-sample](https://github.com/openshift/console/assets/895728/ffb55517-8750-410e-b01d-bb74b9f8afe9)

After:
![localhost_9000_k8s_ns_default_clusterserviceversions_cryostat-operator v3 0 0-dev_operator cryostat io~v1beta2~Cryostat_cryostat-sample (1)](https://github.com/openshift/console/assets/895728/141d1cd9-95e5-4f05-9ce6-2ec55d011367)
