### PR TITLE
OCPBUGS-36173: Disable edit Secret forms with binary data

### DIFF
--- a/frontend/public/components/secrets/create-secret/KeyValueEntryForm.tsx
+++ b/frontend/public/components/secrets/create-secret/KeyValueEntryForm.tsx
@@ -1,78 +1,65 @@
 import * as React from 'react';
-import { withTranslation } from 'react-i18next';
-import { WithT } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { DroppableFileInput } from './DropableFileInput';
-import { KeyValueEntryFormState, KeyValueEntryFormProps } from './types';
+import { KeyValueEntry } from './types';
 
-export class KeyValueEntryFormWithTranslation extends React.Component<
-  KeyValueEntryFormProps & WithT,
-  KeyValueEntryFormState
-> {
-  constructor(props) {
-    super(props);
-    this.state = {
-      key: props.entry.key,
-      value: props.entry.value,
-      isBinary: props.entry.isBinary,
-    };
-    this.onValueChange = this.onValueChange.bind(this);
-    this.onKeyChange = this.onKeyChange.bind(this);
-  }
-  onValueChange(fileData, isBinary) {
-    this.setState(
-      {
-        value: fileData,
-        isBase64: isBinary,
-      },
-      () => this.props.onChange(this.state, this.props.id),
-    );
-  }
-  onKeyChange(event) {
-    this.setState(
-      {
-        key: event.target.value,
-      },
-      () => this.props.onChange(this.state, this.props.id),
-    );
-  }
-  render() {
-    const { t } = this.props;
-    return (
-      <div className="co-create-generic-secret__form">
-        <div className="form-group">
-          <label className="control-label co-required" htmlFor={`${this.props.id}-key`}>
-            {t('public~Key')}
-          </label>
-          <div>
-            <input
-              className="pf-v5-c-form-control"
-              id={`${this.props.id}-key`}
-              type="text"
-              name="key"
-              onChange={this.onKeyChange}
-              value={this.state.key}
-              data-test="secret-key"
-              required
-            />
-          </div>
-        </div>
-        <div className="form-group">
-          <div>
-            <DroppableFileInput
-              onChange={this.onValueChange}
-              inputFileData={this.state.value}
-              id={`${this.props.id}-value`}
-              label={t('public~Value')}
-              inputFieldHelpText={t(
-                'public~Drag and drop file with your value here or browse to upload it.',
-              )}
-              inputFileIsBinary={this.state.isBinary}
-            />
-          </div>
+export const KeyValueEntryForm: React.FC<KeyValueEntryFormProps> = ({
+  index,
+  onChange,
+  ...entry
+}) => {
+  const { t } = useTranslation();
+  const onValueChange = (entryValue, isBinary) => {
+    onChange({ ...entry, entryValue, isBinary }, index);
+  };
+
+  const onKeyChange = (event) => {
+    const entryKey = event.target.value;
+    onChange({ ...entry, entryKey }, index);
+  };
+
+  const { entryKey, entryValue, isBinary } = entry;
+  return (
+    <div className="co-create-generic-secret__form">
+      <div className="form-group">
+        <label className="control-label co-required" htmlFor={`${index}-key`}>
+          {t('public~Key')}
+        </label>
+        <div>
+          <input
+            className="pf-v5-c-form-control"
+            id={`${index}-key`}
+            type="text"
+            name="key"
+            onChange={onKeyChange}
+            value={entryKey || ''}
+            data-test="secret-key"
+            required
+          />
         </div>
       </div>
-    );
-  }
-}
+      <div className="form-group">
+        <div>
+          <DroppableFileInput
+            onChange={onValueChange}
+            inputFileData={entryValue || ''}
+            id={`${index}-value`}
+            label={t('public~Value')}
+            inputFieldHelpText={t(
+              'public~Drag and drop file with your value here or browse to upload it.',
+            )}
+            inputFileIsBinary={isBinary}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
 
-export const KeyValueEntryForm = withTranslation()(KeyValueEntryFormWithTranslation);
+type KeyValueEntryFormProps = {
+  entryKey: string; // can't use React reserved prop "key"
+  entryValue: string;
+  index: number;
+  onChange: (entry: KeyValueEntry, index: number) => void;
+  isBinary?: boolean;
+};

--- a/frontend/public/components/secrets/create-secret/types.ts
+++ b/frontend/public/components/secrets/create-secret/types.ts
@@ -1,30 +1,27 @@
 import { SecretType } from '.';
 
+type Base64EncodedString = string;
 export type SecretStringData = { [key: string]: string };
+export type Base64StringData = { [key: string]: Base64EncodedString };
 
-type SecretChangeData = {
-  stringData: SecretStringData;
+export type SecretChangeData = {
+  stringData?: SecretStringData;
   base64StringData?: SecretStringData;
 };
 
-export type KeyValueEntryFormState = {
-  isBase64?: boolean;
+export type KeyValueEntry = {
+  uid?: string;
   isBinary?: boolean;
-  key: string;
-  value: string;
-};
-
-export type KeyValueEntryFormProps = {
-  entry: KeyValueEntryFormState;
-  id: number;
-  onChange: Function;
+  entryKey: string;
+  entryValue: string;
 };
 
 export type SecretSubFormProps = {
-  onChange: (stringData: SecretChangeData) => void;
+  onChange: (data: SecretChangeData) => void;
   onError: (error: any) => void;
   onFormDisable: (disable: boolean) => void;
   stringData: SecretStringData;
+  base64StringData: Base64StringData;
   secretType: SecretType;
   isCreate: boolean;
 };

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1504,6 +1504,7 @@
   "Image registry credentials": "Image registry credentials",
   "Upload configuration file": "Upload configuration file",
   "Authentication type": "Authentication type",
+  "Secret contains binary data which is unsupported on this page.": "Secret contains binary data which is unsupported on this page.",
   "Unique name of the new secret.": "Unique name of the new secret.",
   "Basic authentication": "Basic authentication",
   "SSH key": "SSH key",


### PR DESCRIPTION
Disable secrets form when any field of the Secret data contains binary. Also, fix an issue where the generic secret form did not correctly propagate changes to file input fields.