### PR TITLE
OCPBUGS-34956: increase namespace deletion timeout for k-native e2e tests

### DIFF
--- a/frontend/packages/knative-plugin/integration-tests/cypress.config.js
+++ b/frontend/packages/knative-plugin/integration-tests/cypress.config.js
@@ -10,7 +10,7 @@ module.exports = defineConfig({
   viewportWidth: 1920,
   viewportHeight: 1080,
   animationDistanceThreshold: 40,
-  execTimeout: 100000,
+  execTimeout: 120000,
   pageLoadTimeout: 100000,
   requestTimeout: 15000,
   responseTimeout: 15000,


### PR DESCRIPTION
Fix : 
[OCPBUGS-34956](https://issues.redhat.com/browse/OCPBUGS-34956)