### PR TITLE
OCPBUGS-37401, CNV-35124: OVN Kubernetes multi-homing

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/locales/en/network-attachment-definition-plugin.json
+++ b/frontend/packages/network-attachment-definition-plugin/locales/en/network-attachment-definition-plugin.json
@@ -20,6 +20,8 @@
   "<0>OpenShift Virtualization Operator</0> or <3>SR-IOV Network Operator </3>needs to be installed on the cluster, in order to pick the Network Type.": "<0>OpenShift Virtualization Operator</0> or <3>SR-IOV Network Operator </3>needs to be installed on the cluster, in order to pick the Network Type.",
   "Create": "Create",
   "Cancel": "Cancel",
+  "Assigns IP addresses from this subnet to Pods and VirtualMachines.": "Assigns IP addresses from this subnet to Pods and VirtualMachines.",
+  "Tech preview": "Tech preview",
   "Resource name": "Resource name",
   "VLAN tag number": "VLAN tag number",
   "IP address management": "IP address management",
@@ -28,5 +30,7 @@
   "Bridge mapping": "Bridge mapping",
   "Physical network name. Bridge mapping must be configured on cluster nodes to map between physical network names and Open vSwitch bridges.": "Physical network name. Bridge mapping must be configured on cluster nodes to map between physical network names and Open vSwitch bridges.",
   "MTU": "MTU",
-  "VLAN": "VLAN"
+  "VLAN": "VLAN",
+  "Invalid subnet format": "Invalid subnet format",
+  "Invalid IP address or subnet format": "Invalid IP address or subnet format"
 }

--- a/frontend/packages/network-attachment-definition-plugin/src/components/SubnetHelperText/SubnetHelperText.scss
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/SubnetHelperText/SubnetHelperText.scss
@@ -1,0 +1,11 @@
+.kv-subnets-container {
+  &__info-icon {
+    color: var(--pf-v5-global--info-color--100);
+    margin-right: var(--pf-v5-global--spacer--sm);
+  }
+
+  &__helper-text {
+    font-weight: bolder;
+    color: var(--pf-v5-global--link--Color);
+  }
+}

--- a/frontend/packages/network-attachment-definition-plugin/src/components/SubnetHelperText/SubnetHelperText.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/SubnetHelperText/SubnetHelperText.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import { useTranslation } from 'react-i18next';
+
+import './SubnetHelperText.scss';
+
+const SubnetsHelperText: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="kv-subnets-container">
+      <InfoCircleIcon className="kv-subnets-container__info-icon" />
+      <span className="kv-subnets-container__helper-text">
+        {t(
+          'network-attachment-definition-plugin~Assigns IP addresses from this subnet to Pods and VirtualMachines.',
+        )}
+      </span>
+    </div>
+  );
+};
+
+export default SubnetsHelperText;

--- a/frontend/packages/network-attachment-definition-plugin/src/components/TechPreview/TechPreview.scss
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/TechPreview/TechPreview.scss
@@ -1,0 +1,6 @@
+.kv-tech-preview-label {
+  color: var(--pf-v5-c-button--m-danger--Color);
+  background-color: var(--pf-v5-c-button--m-danger--BackgroundColor);
+  margin-left: var(--pf-v5-global--spacer--md);
+  padding: 0 var(--pf-v5-global--spacer--sm);
+}

--- a/frontend/packages/network-attachment-definition-plugin/src/components/TechPreview/TechPreview.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/TechPreview/TechPreview.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import './TechPreview.scss';
+import { useTranslation } from 'react-i18next';
+
+const TechPreview: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <div className={classNames('pf-v5-c-button', 'kv-tech-preview-label')}>
+      {t('network-attachment-definition-plugin~Tech preview')}
+    </div>
+  );
+};
+
+export default TechPreview;

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
@@ -11,7 +11,7 @@ import {
 import { connectToPlural } from '@console/internal/kinds';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { getNamespace, getName } from '@console/shared';
-import { NET_ATTACH_DEF_HEADER_LABEL } from '../../constants';
+import { NET_ATTACH_DEF_HEADER_LABEL } from '../../constants/constants';
 import { NetworkAttachmentDefinitionModel } from '../../models';
 import { NetworkAttachmentDefinitionsYAMLTemplates } from '../../models/templates';
 

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetails.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetails.tsx
@@ -9,7 +9,7 @@ import {
 } from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { getName, getNamespace } from '@console/shared/src';
-import { networkTypes } from '../../constants';
+import { networkTypes } from '../../constants/constants';
 import { getConfigAsJSON, getType } from '../../selectors';
 import { NetworkAttachmentDefinitionKind } from '../../types';
 

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
@@ -47,7 +47,7 @@ import {
   networkTypes,
   ovnKubernetesNetworkType,
   ovnKubernetesSecondaryLocalnet,
-} from '../../constants';
+} from '../../constants/constants';
 import {
   NetworkAttachmentDefinitionAnnotations,
   NetworkAttachmentDefinitionConfig,
@@ -85,6 +85,7 @@ const buildConfig = (
   } else if (networkType === ovnKubernetesNetworkType) {
     config.topology = 'layer2';
     config.netAttachDefName = `${namespace}/${name}`;
+    config.subnets = _.get(typeParamsData, 'subnets.value');
   } else if (networkType === ovnKubernetesSecondaryLocalnet) {
     config.cniVersion = '0.4.0';
     config.name = _.get(typeParamsData, 'bridgeMapping.value', '');
@@ -93,6 +94,8 @@ const buildConfig = (
     config.vlanID = parseInt(typeParamsData?.vlanID?.value, 10) || undefined;
     config.mtu = parseInt(typeParamsData?.mtu?.value, 10) || undefined;
     config.netAttachDefName = `${namespace}/${name}`;
+    config.subnets = _.get(typeParamsData, 'subnets.value');
+    config.excludeSubnets = _.get(typeParamsData, 'excludeSubnets.value');
   }
   return config;
 };

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkTypeOptions.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkTypeOptions.tsx
@@ -14,7 +14,8 @@ import * as classNames from 'classnames';
 import { isEmpty } from 'lodash';
 import { RedExclamationCircleIcon } from '@console/dynamic-plugin-sdk';
 import { Dropdown } from '@console/internal/components/utils';
-import { ELEMENT_TYPES, networkTypeParams, NetworkTypeParams } from '../../constants';
+import { ELEMENT_TYPES, networkTypeParams, NetworkTypeParams } from '../../constants/constants';
+import TechPreview from '../TechPreview/TechPreview';
 
 const handleTypeParamChange = (
   paramKey,
@@ -69,6 +70,7 @@ const NetworkTypeOptions = (props) => {
     const typeParamsDataValidationMsg = typeParamsData?.[key]?.validationMsg;
     const { type, name } = parameter;
     const value = typeParamsDataValue ?? parameter?.initValue;
+    const isHintText = typeof parameter?.hintText === 'string';
 
     let children;
     switch (type) {
@@ -176,12 +178,13 @@ const NetworkTypeOptions = (props) => {
               id={`network-type-params-${key}-label`}
             >
               {name}{' '}
-              {parameter?.hintText && (
+              {isHintText && (
                 <Popover bodyContent={parameter.hintText} position={PopoverPosition.right}>
                   <HelpIcon className="network-type-options--help-icon" />
                 </Popover>
               )}
             </label>
+            {parameter?.techPreview && <TechPreview />}
             <TextInput
               type="text"
               value={value}
@@ -197,8 +200,12 @@ const NetworkTypeOptions = (props) => {
               }
               id={`network-type-params-${key}-text`}
             />
-            {typeParamsDataValidationMsg && (
-              <div className="text-secondary">{typeParamsDataValidationMsg}</div>
+            {!isHintText && (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem variant="default">{parameter?.hintText}</HelperTextItem>
+                </HelperText>
+              </FormHelperText>
             )}
           </div>
         );

--- a/frontend/packages/network-attachment-definition-plugin/src/constants/constants.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/constants/constants.tsx
@@ -1,3 +1,7 @@
+import * as React from 'react';
+import SubnetsHelperText from '../components/SubnetHelperText/SubnetHelperText';
+import { validateIPOrSubnets, validateSubnets } from '../utils/utils';
+
 // t('network-attachment-definition-plugin~Create network attachment definition')
 export const NET_ATTACH_DEF_HEADER_LABEL = 'Create network attachment definition';
 
@@ -86,6 +90,27 @@ export const networkTypeParams: NetworkTypeParamsList = {
       name: 'VLAN',
       type: ELEMENT_TYPES.TEXT,
     },
+    subnets: {
+      name: 'Subnets',
+      type: ELEMENT_TYPES.TEXT,
+      validation: (params) => validateSubnets(params?.subnets?.value),
+      techPreview: true,
+      hintText: <SubnetsHelperText />,
+    },
+    excludeSubnets: {
+      name: 'Exclude subnets',
+      type: ELEMENT_TYPES.TEXT,
+      validation: (params) => validateIPOrSubnets(params?.excludeSubnets?.value),
+    },
+  },
+  [ovnKubernetesNetworkType]: {
+    subnets: {
+      name: 'Subnets',
+      type: ELEMENT_TYPES.TEXT,
+      validation: (params) => validateSubnets(params?.subnets?.value),
+      techPreview: true,
+      hintText: <SubnetsHelperText />,
+    },
   },
 };
 
@@ -101,7 +126,8 @@ export type NetworkTypeParameter = {
   name: string;
   required?: boolean;
   type: string;
-  hintText?: string;
+  hintText?: React.ReactNode;
+  techPreview?: boolean;
   initValue?: any;
   values?: { [key: string]: string };
   validation?: (params: {

--- a/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
@@ -30,6 +30,8 @@ export type NetworkAttachmentDefinitionConfig = {
   preserveDefaultVlan?: boolean;
   vlanID?: number;
   mtu?: number;
+  subnets?: string;
+  excludeSubnets?: string;
 };
 
 // The config is a JSON object with the NetworkAttachmentDefinitionConfig type stored as a string

--- a/frontend/packages/network-attachment-definition-plugin/src/utils/utils.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/utils/utils.ts
@@ -1,0 +1,33 @@
+const subnetRegex = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/(?:[0-9]|[1-2][0-9]|3[0-2])$/;
+const ipRegex = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/;
+// t('network-attachment-definition-plugin~Invalid subnet format')
+// t('network-attachment-definition-plugin~Invalid IP address or subnet format')
+export const validateSubnets = (value: string): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const subnets = value.split(',').map((subnet) => subnet.trim());
+
+  for (const subnet of subnets) {
+    if (!subnetRegex.test(subnet)) {
+      return 'Invalid subnet format';
+    }
+  }
+  return null;
+};
+
+export const validateIPOrSubnets = (value: string): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const parts = value.split(',').map((part) => part.trim());
+
+  for (const part of parts) {
+    if (!subnetRegex.test(part) && !ipRegex.test(part)) {
+      return 'Invalid IP address or subnet format';
+    }
+  }
+  return null;
+};


### PR DESCRIPTION
[UX doc](https://docs.google.com/document/d/1dhYGVd_V6u_MmvHp1ZBWcKobHh0UgTS4r3r89pVpc8c/edit)

I am adding subnet input for both L2 and localnet types - which allows entering subnet or list of subnets separated with commas.
I am adding excluded subnet input for localnet - which allows entering subnet/ IP address or list of subnets/IP addresses separated with commas.

After:
![nad-subnets-console4](https://github.com/openshift/console/assets/67270715/ba876965-c851-4e42-93dc-ab5f19efa6af)
![nad-subnets-console3](https://github.com/openshift/console/assets/67270715/8c05c7ef-a86c-4881-9c73-8473f8b46406)
![nad-subnets-console2](https://github.com/openshift/console/assets/67270715/f124d05f-8fc8-426a-8657-a22fd22bb15c)
![nad-subnets-console](https://github.com/openshift/console/assets/67270715/b37cb64b-f962-4d25-9171-0591713ba6db)
