### PR TITLE
NO-JIRA: Console PR Template: Fix position of colon

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/console_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/console_pr.md
@@ -1,4 +1,4 @@
-<h2 id="feature-fix">CONSOLE Features and Fixes: </h2>
+<h2 id="feature-fix">CONSOLE Features and Fixes:</h2>
 <!--The pull request title must be prefixed with a Jira issue or Bugzilla bug in order to be merged. For example:
     For e.g Features: https://issues.redhat.com/browse/CONSOLE-XXXX
     - CONSOLE-XXXX: <title>
@@ -12,7 +12,7 @@
 <h2 id="solution-description">Solution description</h2> 
 <!-- Describe your code changes in detail and explain the solution or functionality -->
 
-<h2 id="reviewers-and-assignees">Reviewers and assignees</h2>: 
+<h2 id="reviewers-and-assignees">Reviewers and assignees:</h2>
 <!-- 
 - Tag an OCP console engineer to review the changes.
 - If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"


### PR DESCRIPTION
I was trying to use the Console PR template but noticed a random colon in the `Reviewers and assignees` section. Turns out that it was placed outside the `h2` element, so I moved it back in