### PR TITLE
CONSOLE-4098: Show deprecated operators in OperatorHub (Post-installation screens)

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/cluster-service-version-logo.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/cluster-service-version-logo.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { DeprecatedOperatorWarning } from '@console/operator-lifecycle-manager/src/types';
 import * as operatorLogo from '../operator.svg';
 import { ClusterServiceVersionIcon } from '../types';
 import { DeprecatedOperatorWarningBadge } from './deprecated-operator-warnings/deprecated-operator-warnings';
@@ -51,5 +52,4 @@ export type ClusterServiceVersionLogoProps = {
   icon: ClusterServiceVersionIcon | string;
   provider: { name: string } | string;
   version?: string;
-  deprecation?: { message: string };
-};
+} & DeprecatedOperatorWarning;

--- a/frontend/packages/operator-lifecycle-manager/src/components/deprecated-operator-warnings/deprecated-operator-warnings.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/deprecated-operator-warnings/deprecated-operator-warnings.tsx
@@ -1,8 +1,32 @@
 import * as React from 'react';
-import { Label, FormAlert, Alert, Tooltip } from '@patternfly/react-core';
+import { Label, FormAlert, Alert, Tooltip, AlertActionCloseButton } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { YellowExclamationTriangleIcon } from '@console/dynamic-plugin-sdk/src/api/core-api';
 import { DeprecatedOperatorWarning } from '@console/operator-lifecycle-manager/src/types';
+import { SubscriptionKind } from '../../types';
+
+export enum DeprecatedOperatorType {
+  PackageDeprecated = 'PackageDeprecated',
+  ChannelDeprecated = 'ChannelDeprecated',
+  VersionDeprecated = 'BundleDeprecated',
+}
+const findDeprecation = (obj: SubscriptionKind, type: string): DeprecatedOperatorWarning => {
+  return { deprecation: obj?.status?.conditions?.find((f) => f.type === type) };
+};
+
+export const findDeprecatedOperator = (
+  obj: SubscriptionKind,
+): {
+  deprecatedPackage: DeprecatedOperatorWarning;
+  deprecatedChannel: DeprecatedOperatorWarning;
+  deprecatedVersion: DeprecatedOperatorWarning;
+} => {
+  return {
+    deprecatedPackage: findDeprecation(obj, DeprecatedOperatorType.PackageDeprecated),
+    deprecatedChannel: findDeprecation(obj, DeprecatedOperatorType.ChannelDeprecated),
+    deprecatedVersion: findDeprecation(obj, DeprecatedOperatorType.VersionDeprecated),
+  };
+};
 
 export const DeprecatedOperatorWarningBadge: React.FC<DeprecatedOperatorWarningBadge> = ({
   deprecation,
@@ -35,17 +59,29 @@ export const DeprecatedOperatorWarningAlert: React.FC<DeprecatedOperatorWarningP
   deprecatedPackage,
   deprecatedChannel,
   deprecatedVersion,
+  dismissible,
 }) => {
   const { t } = useTranslation();
+  const [alertVisible, setAlertVisible] = React.useState<boolean>(true);
 
   return (
-    <FormAlert className="pf-v5-u-my-md">
-      <Alert variant="warning" title={t('olm~Deprecated warnings')} aria-live="polite" isInline>
-        <div>{deprecatedPackage?.deprecation?.message}</div>
-        <div>{deprecatedChannel?.deprecation?.message}</div>
-        <div>{deprecatedVersion?.deprecation?.message}</div>
-      </Alert>
-    </FormAlert>
+    alertVisible && (
+      <FormAlert className="pf-v5-u-my-md">
+        <Alert
+          variant="warning"
+          title={t('olm~Deprecated warnings')}
+          aria-live="polite"
+          isInline
+          actionClose={
+            dismissible && <AlertActionCloseButton onClose={() => setAlertVisible(false)} />
+          }
+        >
+          <div>{deprecatedPackage?.deprecation?.message}</div>
+          <div>{deprecatedChannel?.deprecation?.message}</div>
+          <div>{deprecatedVersion?.deprecation?.message}</div>
+        </Alert>
+      </FormAlert>
+    )
   );
 };
 
@@ -57,4 +93,5 @@ type DeprecatedOperatorWarningProps = {
   deprecatedPackage: DeprecatedOperatorWarning;
   deprecatedChannel: DeprecatedOperatorWarning;
   deprecatedVersion: DeprecatedOperatorWarning;
+  dismissible?: boolean;
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/subscription-channel-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/subscription-channel-modal.tsx
@@ -12,6 +12,7 @@ import { K8sKind, K8sResourceKind, referenceForModel } from '@console/internal/m
 import { usePromiseHandler } from '@console/shared/src/hooks/promise-handler';
 import { SubscriptionModel, ClusterServiceVersionModel } from '../../models';
 import { SubscriptionKind, PackageManifestKind } from '../../types';
+import { DeprecatedOperatorWarningIcon } from '../deprecated-operator-warnings/deprecated-operator-warnings';
 
 export const SubscriptionChannelModal: React.FC<SubscriptionChannelModalProps> = ({
   cancel,
@@ -66,7 +67,11 @@ export const SubscriptionChannelModal: React.FC<SubscriptionChannelModalProps> =
                     name={channel.currentCSV}
                     title={channel.currentCSV}
                     kind={referenceForModel(ClusterServiceVersionModel)}
-                  />
+                  >
+                    {channel?.deprecation ? (
+                      <DeprecatedOperatorWarningIcon deprecation={channel?.deprecation} />
+                    ) : null}
+                  </ResourceLink>
                 }
               />
             </div>

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -379,7 +379,7 @@ const OperatorHubTile: React.FC<OperatorHubTileProps> = ({ item, onClick }) => {
         <div>
           <DeprecatedOperatorWarningBadge
             className="pf-v5-u-mt-xs"
-            deprecation={item?.obj?.status?.deprecation}
+            deprecation={item.obj.status.deprecation}
           />
         </div>
       )}
@@ -573,7 +573,7 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
       {detailsItem?.obj?.status?.deprecation && (
         <DeprecatedOperatorWarningBadge
           className="pf-v5-u-ml-sm"
-          deprecation={detailsItem?.obj?.status?.deprecation}
+          deprecation={detailsItem.obj.status.deprecation}
         />
       )}
     </>

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -71,6 +71,11 @@ import {
   CatalogSourceKind,
 } from '../types';
 import { upgradeRequiresApproval } from '../utils';
+import {
+  DeprecatedOperatorWarningAlert,
+  DeprecatedOperatorWarningIcon,
+  findDeprecatedOperator,
+} from './deprecated-operator-warnings/deprecated-operator-warnings';
 import { createInstallPlanApprovalModal } from './modals/installplan-approval-modal';
 import { createSubscriptionChannelModal } from './modals/subscription-channel-modal';
 import { createUninstallOperatorModal } from './modals/uninstall-operator-modal';
@@ -436,6 +441,7 @@ export const SubscriptionDetails: React.FC<SubscriptionDetailsProps> = ({
       .result.then(() => removeQueryArgument('showDelete'))
       .catch(_.noop);
   }
+  const { deprecatedPackage, deprecatedChannel, deprecatedVersion } = findDeprecatedOperator(obj);
 
   return (
     <>
@@ -446,6 +452,16 @@ export const SubscriptionDetails: React.FC<SubscriptionDetailsProps> = ({
           sourceNamespace={sourceNamespace}
         />
         <InstallFailedAlert installPlan={installPlan} />
+        {(deprecatedPackage.deprecation ||
+          deprecatedChannel.deprecation ||
+          deprecatedVersion.deprecation) && (
+          <DeprecatedOperatorWarningAlert
+            deprecatedPackage={deprecatedPackage}
+            deprecatedChannel={deprecatedChannel}
+            deprecatedVersion={deprecatedVersion}
+            dismissible
+          />
+        )}
         <SectionHeading text={t('olm~Subscription details')} />
         <div className="co-m-pane__body-group">
           <SubscriptionUpdates
@@ -581,6 +597,7 @@ export const SubscriptionUpdates: React.FC<SubscriptionUpdatesProps> = ({
     subscriptions,
     obj.metadata.namespace,
   );
+  const { deprecatedChannel } = findDeprecatedOperator(obj);
 
   return (
     <div className="co-detail-table">
@@ -597,16 +614,23 @@ export const SubscriptionUpdates: React.FC<SubscriptionUpdatesProps> = ({
               {waitingForUpdate ? (
                 <LoadingInline />
               ) : (
-                <Button
-                  type="button"
-                  isInline
-                  onClick={channelModal}
-                  variant="link"
-                  isDisabled={!pkg}
-                >
-                  {obj.spec.channel || 'default'}
-                  {pkg && <PencilAltIcon className="co-icon-space-l pf-v5-c-button-icon--plain" />}
-                </Button>
+                <>
+                  <Button
+                    type="button"
+                    isInline
+                    onClick={channelModal}
+                    variant="link"
+                    isDisabled={!pkg}
+                  >
+                    {obj.spec.channel || 'default'}
+                    {pkg && (
+                      <PencilAltIcon className="co-icon-space-l pf-v5-c-button-icon--plain" />
+                    )}
+                  </Button>
+                  {deprecatedChannel.deprecation && (
+                    <DeprecatedOperatorWarningIcon deprecation={deprecatedChannel.deprecation} />
+                  )}
+                </>
               )}
             </dd>
           </dl>

--- a/frontend/packages/operator-lifecycle-manager/src/types.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/types.ts
@@ -294,6 +294,6 @@ export type OperatorGroupKind = {
 
 export type DeprecatedOperatorWarning = {
   deprecation?: {
-    message: string;
+    message?: string;
   };
 };


### PR DESCRIPTION
### After:

<img width="1796" alt="Screenshot 2024-07-17 at 2 17 54 PM" src="https://github.com/user-attachments/assets/5f3367c1-1ef0-4ec0-ba08-24da1efc8bbf">

<img width="940" alt="Screenshot 2024-07-17 at 2 18 13 PM" src="https://github.com/user-attachments/assets/85edbffc-6e31-4eb7-bc79-f7649215cc89">

<img width="950" alt="Screenshot 2024-07-17 at 2 18 22 PM" src="https://github.com/user-attachments/assets/5ec96bef-20c7-495e-b493-3dc136244b7d">

<img width="1877" alt="Screenshot 2024-07-17 at 2 18 30 PM" src="https://github.com/user-attachments/assets/db0522a5-1048-4db1-9675-22ca8d3bbc4c">
