### PR TITLE
CONSOLE-4185: Export CSV option for Virtualized Table

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -322,6 +322,7 @@ export type VirtualizedTableProps<D, R extends any = {}> = {
   mock?: boolean;
   sortColumnIndex?: number;
   sortDirection?: SortByDirection;
+  csvData?: string;
 };
 
 export type VirtualizedTableFC = <D, R extends any = {}>(

--- a/frontend/public/components/factory/Table/VirtualizedTable.tsx
+++ b/frontend/public/components/factory/Table/VirtualizedTable.tsx
@@ -13,6 +13,7 @@ import { VirtualizedTableFC, TableColumn, TableDataProps } from '@console/dynami
 import VirtualizedTableBody from './VirtualizedTableBody';
 import { StatusBox, WithScrollContainer, EmptyBox } from '../../utils';
 import { sortResourceByValue } from './sort';
+import { Button } from '@patternfly/react-core';
 
 const BREAKPOINT_SM = 576;
 const BREAKPOINT_MD = 768;
@@ -78,6 +79,7 @@ const VirtualizedTable: VirtualizedTableFC = ({
   mock = false,
   sortColumnIndex,
   sortDirection,
+  csvData,
 }) => {
   const navigate = useNavigate();
   const columnShift = onSelect ? 1 : 0; //shift indexes by 1 if select provided
@@ -181,6 +183,17 @@ const VirtualizedTable: VirtualizedTableFC = ({
     </WindowScroller>
   );
 
+  const downloadCsv = () => {
+    // csvData should be formatted as comma-seperated values
+    // (e.g. `"a","b","c", \n"d","e","f", \n"h","i","j"`)
+    const blobCsvData = new Blob([csvData], { type: 'text/csv' });
+    const csvURL = URL.createObjectURL(blobCsvData);
+    const link = document.createElement('a');
+    link.href = csvURL;
+    link.download = `openshift.csv`;
+    link.click();
+  };
+
   return (
     <div className="co-m-table-grid co-m-table-grid--bordered">
       {mock ? (
@@ -202,6 +215,11 @@ const VirtualizedTable: VirtualizedTableFC = ({
             aria-label={ariaLabel}
             aria-rowcount={data?.length}
           >
+            {csvData && (
+              <Button className="co-virtualized-table--export-csv-button" onClick={downloadCsv}>
+                Export as CSV
+              </Button>
+            )}
             <PfTable
               cells={columns}
               rows={[]}

--- a/frontend/public/components/factory/Table/_virtualized-table.scss
+++ b/frontend/public/components/factory/Table/_virtualized-table.scss
@@ -37,6 +37,10 @@
   }
 }
 
+.co-virtualized-table--export-csv-button {
+  margin-bottom: 20px 
+}
+
 .pf-v5-c-window-scroller.ReactVirtualized__VirtualGrid,
 .pf-v5-c-window-scroller .ReactVirtualized__VirtualGrid,
 .pf-v5-c-window-scroller .ReactVirtualized__VirtualGrid__innerScrollContainer {


### PR DESCRIPTION
**JIRA Issues:** 
Openshift Observability Board 
[OU-431](https://issues.redhat.com/secure/RapidBoard.jspa?rapidView=17707&view=detail&selectedIssue=[OU-431](https://issues.redhat.com//browse/OU-431)#)
OpenShift Console Board
[CONSOLE-4185](https://issues.redhat.com/browse/CONSOLE-4185)
These are duplicate issues. [OU-431](https://issues.redhat.com//browse/OU-431) was created first, and a duplicate of this issue is [CONSOLE-4185](https://issues.redhat.com//browse/CONSOLE-4185). This was done because the openshift/console CI/CD pipeline needs a valid JIRA issue on the console board. 

**This PR must be tested with the PR below to render the 'Export as CSV' button:** 
https://github.com/openshift/monitoring-plugin/pull/133

**Feature Description:**
Adding an 'Export as CSV' button to the Virtualized Table to allow users to download the table data as a .csv file. 


https://github.com/user-attachments/assets/fc9d1b43-0412-4f83-ada8-97c6b0fa6237



