### PR TITLE
ODC-7640: Remove Alerting Details Page from Console

### DIFF
--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -1292,14 +1292,6 @@
     "type": "console.page/route",
     "properties": {
       "exact": false,
-      "path": ["/dev-monitoring/ns/:ns/alerts/:ruleID"],
-      "component": { "$codeRef": "monitoring.MonitoringAlertsRulesDetailsPage" }
-    }
-  },
-  {
-    "type": "console.page/route",
-    "properties": {
-      "exact": false,
       "path": ["/dev-monitoring/ns/:ns/rules/:id"],
       "component": { "$codeRef": "monitoring.MonitoringAlertsRulesDetailsPage" }
     }

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlertsRulesDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlertsRulesDetailsPage.tsx
@@ -9,10 +9,7 @@ import {
   AlertingRulesSourceExtension,
   isAlertingRulesSource,
 } from '@console/dynamic-plugin-sdk';
-import {
-  AlertsDetailsPage,
-  AlertRulesDetailsPage,
-} from '@console/internal/components/monitoring/alerting';
+import { AlertRulesDetailsPage } from '@console/internal/components/monitoring/alerting';
 import { history, StatusBox, LoadingBox } from '@console/internal/components/utils';
 import { RootState } from '@console/internal/redux';
 import { ALL_NAMESPACES_KEY } from '@console/shared';
@@ -62,7 +59,6 @@ const MonitoringAlertsDetailsPage: React.FC = () => {
       hideApplications
       onNamespaceChange={handleNamespaceChange}
     >
-      {location.pathname.includes('alerts') && <AlertsDetailsPage />}
       {location.pathname.includes('rules') && <AlertRulesDetailsPage />}
     </NamespacedPage>
   );

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -1001,7 +1001,7 @@ const AlertsDetailsPage_: React.FC<{}> = () => {
     </>
   );
 };
-export const AlertsDetailsPage = withFallback(AlertsDetailsPage_);
+const AlertsDetailsPage = withFallback(AlertsDetailsPage_);
 
 // Renders Prometheus template text and highlights any {{ ... }} tags that it contains
 const PrometheusTemplate = ({ text }) => (


### PR DESCRIPTION
[ODC-7640](https://issues.redhat.com/browse/ODC-7640)
[OU-248](https://issues.redhat.com/browse/OU-248)

This PR is the counterpart of one in the monitoring-plugin ([PR](https://github.com/openshift/monitoring-plugin/pull/131)) which looks to transfer the dev perspective alerts detail page out of the console codebase and into the monitoring-plugin. This PR should not merge until the one in the monitoring-plugin has.

![image](https://github.com/user-attachments/assets/f8870349-460e-434c-ac80-6738644c3a9b)


The only change to the dev perspective alerts detail page is that it will no longer have a namespace selector. Since the selected alert is already namespaced, it didn't make sense to swap namespaces while focused on a specific alert.