### PR TITLE
OCPBUGS-44657: Add IBM Block Storage CSI driver support for RWX

### DIFF
--- a/frontend/public/components/storage/shared.ts
+++ b/frontend/public/components/storage/shared.ts
@@ -93,8 +93,8 @@ export const provisionerAccessModeMapping: ProvisionerAccessModeMapping = Object
     Block: ['ReadWriteOnce'],
   },
   'block.csi.ibm.com': {
-    Filesystem: ['ReadWriteOnce'],
-    Block: ['ReadWriteOnce'],
+    Filesystem: ['ReadWriteOnce', 'ReadWriteMany'],
+    Block: ['ReadWriteOnce', 'ReadWriteMany'],
   },
   'csi.ovirt.org': {
     Filesystem: ['ReadWriteOnce'],


### PR DESCRIPTION
the upcoming IBM Block Storage CSI driver support release will add support for RWX
adding now so that we can start Beta testing with customers