### PR TITLE
OCPBUGS-37453: A value submitted in From view is wrapped with single quotation after switching to Yaml view.

### DIFF
--- a/frontend/packages/dev-console/src/components/hpa/HPADetailsForm.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPADetailsForm.tsx
@@ -76,10 +76,12 @@ const HPADetailsForm: React.FC = () => {
             <NumberSpinnerField
               label={t('devconsole~Minimum Pods')}
               name={`${name}.spec.minReplicas`}
+              setOutputAsIntegerFlag
             />
             <NumberSpinnerField
               label={t('devconsole~Maximum Pods')}
               name={`${name}.spec.maxReplicas`}
+              setOutputAsIntegerFlag
             />
             <HPAUtilizationField
               disabled={cpuUtilization}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-37453

**Analysis / Root cause**: 
When user type the number, the value is set as string. On click of + and - sign, the value is set as integer.

**Solution Description**: 
Added `setOutputAsIntegerFlag` prop while adding `NumberSpinnerField`

**Screen shots / Gifs for design review**: 


---BEFORE---



https://github.com/user-attachments/assets/de2652c0-e133-44a5-b765-29df1fb7816e




---AFTER---

https://github.com/user-attachments/assets/4e20134e-9bb1-40f0-83b4-11a04af962e2




**Unit test coverage report**: 
NA

**Test setup:**

1. Login to the web console as a developer.
2. Get to 'Edit HorizentalPodAutoscaler'.
3. Input a value on 'minReplicas/maxReplicas' not clicking - / + from the Form view page.
4. Switching to Yaml view.
5. The value is wrapped with single quotation (').

    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge




