### PR TITLE
[release-4.15] OCPBUGS-37458: one OAuth.config.openshift.io item on Global Configuration page links to non-existing resource

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -99,22 +99,6 @@
     }
   },
   {
-    "type": "console.global-config",
-    "properties": {
-      "id": "oauth-config",
-      "name": "oauth-config",
-      "model": {
-        "group": "config.openshift.io",
-        "version": "v1",
-        "kind": "OAuth"
-      },
-      "namespace": ""
-    },
-    "flags": {
-      "required": ["OPENSHIFT_OAUTH_API"]
-    }
-  },
-  {
     "type": "console.page/resource/details",
     "properties": {
       "model": {


### PR DESCRIPTION
Manual backport of https://issues.redhat.com/browse/OCPBUGS-35565

/assign @rhamilto @TheRealJon 