### PR TITLE
CONSOLE-4188: Add the signals correlation to the app launcher

### DIFF
--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -51,6 +51,7 @@ import ClusterMenu from '@console/app/src/components/nav/ClusterMenu';
 import { ACM_PERSPECTIVE_ID } from '@console/app/src/consts';
 import { FeedbackModal } from '@patternfly/react-user-feedback';
 import { useFeedbackLocal } from './feedback-local';
+import { action as reduxAction } from 'typesafe-actions';
 import feedbackImage from '@patternfly/react-user-feedback/dist/esm/images/rh_feedback.svg';
 
 const LAST_CONSOLE_ACTIVITY_TIMESTAMP_LOCAL_STORAGE_KEY = 'last-console-activity-timestamp';
@@ -190,6 +191,8 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
         return 1;
       case 'Customer Applications':
         return 2;
+      case 'Troubleshooting':
+        return 3;
       case '':
         return 9; // Items w/o sections go last
       default:
@@ -198,6 +201,9 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
   };
 
   const getLaunchActions = () => {
+    const isTroubleshootingPanelEnabled = Array.isArray(window.SERVER_FLAGS.consolePlugins)
+      ? window.SERVER_FLAGS.consolePlugins.includes('troubleshooting-panel-console-plugin')
+      : false;
     const launcherItems = getAdditionalLinks(consoleLinks?.data, 'ApplicationMenu');
 
     const sections = [];
@@ -231,6 +237,28 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
               fireTelemetryEvent('Launcher Menu Accessed', {
                 id: 'Red Hat Hybrid Cloud Console',
                 name: 'Red Hat Hybrid Cloud Console',
+              });
+            },
+          },
+        ],
+      });
+    }
+
+    // This should be removed when the extension to add items to the masthead is implemented: https://issues.redhat.com/browse/OU-488
+    if (isTroubleshootingPanelEnabled) {
+      sections.push({
+        name: t('public~Troubleshooting'),
+        isSection: true,
+        actions: [
+          {
+            label: t('public~Signal Correlation'),
+            component: 'button',
+            callback: (e) => {
+              e.preventDefault();
+              dispatch(reduxAction('openTroubleshootingPanel'));
+              fireTelemetryEvent('Launcher Menu Accessed', {
+                id: 'Signal Correlation',
+                name: 'Signal Correlation',
               });
             },
           },

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -786,6 +786,8 @@
   "System status": "System status",
   "Red Hat Applications": "Red Hat Applications",
   "Red Hat Hybrid Cloud Console": "Red Hat Hybrid Cloud Console",
+  "Troubleshooting": "Troubleshooting",
+  "Signal Correlation": "Signal Correlation",
   "Quick Starts": "Quick Starts",
   "Documentation": "Documentation",
   "Share Feedback": "Share Feedback",


### PR DESCRIPTION
This PR adds the signal correlation under the application launcher under a new Troubleshooting section. It detects the installed plugin `troubleshooting-panel-console-plugin`, this requires https://github.com/openshift/troubleshooting-panel-console-plugin/pull/43 from the plugin side

[OU-484](https://issues.redhat.com/browse/OU-484)
[CONSOLE-4188](https://issues.redhat.com/browse/CONSOLE-4188)

![Screenshot 2024-07-31 at 13 02 49](https://github.com/user-attachments/assets/d9d01f55-b55e-46cb-84bc-872c7bb271d5)

(Mobile)

![Screenshot 2024-07-31 at 13 03 17](https://github.com/user-attachments/assets/7b5ba65d-64ae-49e6-8762-14c55e90737e)

