### PR TITLE
OCPBUGS-37802: Build option is selected as Shipwright on edit if created the deployment using BuildConfig

### DIFF
--- a/frontend/packages/dev-console/src/components/import/section/build-section/BuildSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/build-section/BuildSection.tsx
@@ -107,6 +107,12 @@ export const BuildSection: React.FC<BuildSectionProps> = ({ values, appResources
     if (values?.formType === 'edit' && values?.pipeline?.enabled) {
       setFieldValue('build.option', BuildOptions.PIPELINES);
     }
+    if (values?.formType === 'edit' && values.build.option === BuildOptions.BUILDS) {
+      setFieldValue('build.option', BuildOptions.BUILDS);
+    }
+    if (values?.formType === 'edit' && values.build.option === BuildOptions.SHIPWRIGHT_BUILD) {
+      setFieldValue('build.option', BuildOptions.SHIPWRIGHT_BUILD);
+    }
   }, [values, setFieldValue]);
 
   React.useEffect(() => {
@@ -122,15 +128,17 @@ export const BuildSection: React.FC<BuildSectionProps> = ({ values, appResources
 
   /** NOTE: Shipwright Builds are not supported with Devfile Import Strategy currently and if required ClusterBuildStrategy for the ImportType is not available */
   React.useEffect(() => {
-    if (
-      values?.import?.selectedStrategy?.type === ImportStrategy.DEVFILE ||
-      !isPreferredStrategyAvailable(values?.import?.selectedStrategy?.type, strategy)
-    ) {
-      setFieldValue('build.option', BuildOptions.BUILDS);
-    } else {
-      setFieldValue('build.option', BuildOptions.SHIPWRIGHT_BUILD);
+    if (values?.formType !== 'edit') {
+      if (
+        values?.import?.selectedStrategy?.type === ImportStrategy.DEVFILE ||
+        !isPreferredStrategyAvailable(values?.import?.selectedStrategy?.type, strategy)
+      ) {
+        setFieldValue('build.option', BuildOptions.BUILDS);
+      } else {
+        setFieldValue('build.option', BuildOptions.SHIPWRIGHT_BUILD);
+      }
     }
-  }, [setFieldValue, values?.import?.selectedStrategy?.type, strategy]);
+  }, [setFieldValue, values?.import?.selectedStrategy?.type, strategy, values?.formType]);
 
   return (
     <FormSection title={t('devconsole~Build')}>

--- a/frontend/packages/shipwright-plugin/src/components/build-list/BuildTable.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/build-list/BuildTable.tsx
@@ -181,7 +181,7 @@ export const BuildTable: React.FC<BuildTableProps> = (props) => {
     }),
     [buildRuns, buildRunsLoaded, buildRunsLoadError],
   );
-  const buildResource = props.data.map((sBuild) => {
+  const buildResource = props.data?.map((sBuild) => {
     sBuild.latestBuild =
       data.buildRuns.latestByBuildName[`${sBuild.metadata.name}-${sBuild.metadata.namespace}`];
     return sBuild;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-37802

**Analysis / Root cause**: 
Created build option was not considered when editing the deployment

**Solution Description**: 
Create build option is used to select build option value

**Screen shots / Gifs for design review**: 


---BEFORE---




https://github.com/user-attachments/assets/f6ba31a1-dd7c-476d-b644-31884c246164





---AFTER---


https://github.com/user-attachments/assets/e193106e-ff36-49c8-b3fd-62339f66978c





**Unit test coverage report**: 
NA

**Test setup:**

    1. Install Shipwright
    2. Create a deployment using BuildConfig as build option
    3. Edit it and see build option dropdown
    4. Click on Save

    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge




