### PR TITLE
OCPBUGS-34365: Unrelated readme opened when opening CodeReady workspaces from Quarkus using s2i quickstart

### DIFF
--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -33,6 +33,7 @@ import {
   getTopologyNodeItem,
   mergeGroup,
   WorkloadModelProps,
+  getContextDirByName,
 } from '@console/topology/src/data-transforms/transform-utils';
 import { TopologyDataResources, TopologyDataObject } from '@console/topology/src/topology-types';
 import {
@@ -1016,11 +1017,14 @@ export const createTopologyServiceNodeData = (
   resource: K8sResourceKind,
   svcRes: OverviewItem,
   type: string,
+  resources: TopologyDataResources,
 ): TopologyDataObject => {
   const { obj: knativeSvc } = svcRes;
   const uid = _.get(knativeSvc, 'metadata.uid');
   const labels = _.get(knativeSvc, 'metadata.labels', {});
   const annotations = _.get(knativeSvc, 'metadata.annotations', {});
+  const serviceName = _.get(knativeSvc, 'metadata.name');
+  const contextDir = getContextDirByName(resources, serviceName);
   return {
     id: uid,
     name: _.get(knativeSvc, 'metadata.name') || labels['app.kubernetes.io/instance'],
@@ -1032,7 +1036,9 @@ export const createTopologyServiceNodeData = (
       kind: referenceFor(knativeSvc),
       editURL: annotations['app.openshift.io/edit-url'],
       vcsURI: annotations['app.openshift.io/vcs-uri'],
+      vcsRef: annotations['app.openshift.io/vcs-ref'],
       isKnativeResource: true,
+      contextDir,
     },
   };
 };
@@ -1231,7 +1237,7 @@ export const transformKnNodeData = (
         break;
       }
       case NodeType.KnService: {
-        const data = createTopologyServiceNodeData(res, item, type);
+        const data = createTopologyServiceNodeData(res, item, type, resources);
         knDataModel.nodes.push(...getKnativeTopologyNodeItems(res, type, data, resources));
         knDataModel.edges.push(...getTrafficTopologyEdgeItems(res, resources.revisions));
         const newGroup = getTopologyGroupItems(res);

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/EditDecorator.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/EditDecorator.tsx
@@ -26,9 +26,9 @@ const EditDecorator: React.FC<DefaultDecoratorProps> = ({ element, radius, x, y 
   });
   const { cheURL, cheIconURL } = getCheDecoratorData(consoleLinks);
   const workloadData = element.getData().data;
-  const { editURL, vcsURI, vcsRef } = workloadData;
+  const { editURL, vcsURI, vcsRef, contextDir } = workloadData;
   const cheEnabled = !!cheURL;
-  const editUrl = editURL || getEditURL(vcsURI, vcsRef, cheURL);
+  const editUrl = editURL || getEditURL(vcsURI, vcsRef, cheURL, contextDir);
   const repoIcon = routeDecoratorIcon(editUrl, radius, t, cheEnabled, cheIconURL);
 
   if (!repoIcon) {

--- a/frontend/packages/topology/src/data-transforms/__tests__/__snapshots__/data-transformer.spec.ts.snap
+++ b/frontend/packages/topology/src/data-transforms/__tests__/__snapshots__/data-transformer.spec.ts.snap
@@ -16,6 +16,7 @@ Object {
       "data": Object {
         "data": Object {
           "builderImage": "test-file-stub",
+          "contextDir": null,
           "editURL": undefined,
           "isKnativeResource": false,
           "kind": "apps~v1~Deployment",
@@ -230,6 +231,7 @@ Object {
       "data": Object {
         "data": Object {
           "builderImage": "test-file-stub",
+          "contextDir": null,
           "editURL": undefined,
           "isKnativeResource": false,
           "kind": "apps~v1~Deployment",
@@ -531,6 +533,7 @@ Object {
       "data": Object {
         "data": Object {
           "builderImage": "test-file-stub",
+          "contextDir": null,
           "editURL": undefined,
           "isKnativeResource": false,
           "kind": "apps~v1~Deployment",
@@ -922,6 +925,7 @@ Object {
       "data": Object {
         "data": Object {
           "builderImage": "test-file-stub",
+          "contextDir": null,
           "editURL": undefined,
           "isKnativeResource": false,
           "kind": "apps~v1~DeploymentConfig",
@@ -1148,6 +1152,7 @@ Object {
       "data": Object {
         "data": Object {
           "builderImage": "test-file-stub",
+          "contextDir": null,
           "editURL": undefined,
           "isKnativeResource": false,
           "kind": "apps~v1~DeploymentConfig",
@@ -1377,6 +1382,7 @@ Object {
       "data": Object {
         "data": Object {
           "builderImage": "test-file-stub",
+          "contextDir": null,
           "editURL": undefined,
           "isKnativeResource": false,
           "kind": "apps~v1~DeploymentConfig",
@@ -1554,6 +1560,7 @@ Object {
             "data": Object {
               "data": Object {
                 "builderImage": "test-file-stub",
+                "contextDir": null,
                 "editURL": undefined,
                 "isKnativeResource": false,
                 "kind": "apps~v1~Deployment",
@@ -1768,6 +1775,7 @@ Object {
             "data": Object {
               "data": Object {
                 "builderImage": "test-file-stub",
+                "contextDir": null,
                 "editURL": undefined,
                 "isKnativeResource": false,
                 "kind": "apps~v1~Deployment",
@@ -2094,6 +2102,7 @@ Object {
             "data": Object {
               "data": Object {
                 "builderImage": "test-file-stub",
+                "contextDir": null,
                 "editURL": undefined,
                 "isKnativeResource": false,
                 "kind": "apps~v1~Deployment",

--- a/frontend/packages/topology/src/data-transforms/__tests__/data-transformer.spec.ts
+++ b/frontend/packages/topology/src/data-transforms/__tests__/data-transformer.spec.ts
@@ -176,6 +176,46 @@ describe('data transformer ', () => {
     expect(editUrl).toBe('https://bitbucket.org/username/examplerepo/src/branch1');
   });
 
+  it('should return full git url for GitHub URI with context directory', () => {
+    const mockGitURI = 'https://github.com/openshift/console';
+    const editUrl = getEditURL(mockGitURI, 'branch1', '', 'context-directory');
+    expect(editUrl).toBe('https://github.com/openshift/console/tree/branch1/context-directory');
+  });
+
+  it('should return full git url for GitLab URI with context directory', () => {
+    const mockGitURI = 'https://gitlab.com/example/reponame';
+    const editUrl = getEditURL(mockGitURI, 'branch1', '', 'context-directory');
+    expect(editUrl).toBe('https://gitlab.com/example/reponame/-/tree/branch1/context-directory');
+  });
+
+  it('should return full git url for Bitbucket URI with context directory', () => {
+    const mockGitURI = 'https://bitbucket.org/username/examplerepo';
+    const editUrl = getEditURL(mockGitURI, 'branch1', '', 'context-directory');
+    expect(editUrl).toBe(
+      'https://bitbucket.org/username/examplerepo/src/branch1/context-directory',
+    );
+  });
+
+  it('should return full git url for GitHub URI with context directory with forward slash', () => {
+    const mockGitURI = 'https://github.com/openshift/console';
+    const editUrl = getEditURL(mockGitURI, 'branch1', '', '/context-directory');
+    expect(editUrl).toBe('https://github.com/openshift/console/tree/branch1/context-directory');
+  });
+
+  it('should return full git url for GitLab URI with context directory with forward slash', () => {
+    const mockGitURI = 'https://gitlab.com/example/reponame';
+    const editUrl = getEditURL(mockGitURI, 'branch1', '', '/context-directory');
+    expect(editUrl).toBe('https://gitlab.com/example/reponame/-/tree/branch1/context-directory');
+  });
+
+  it('should return full git url for Bitbucket URI with context directory with forward slash', () => {
+    const mockGitURI = 'https://bitbucket.org/username/examplerepo';
+    const editUrl = getEditURL(mockGitURI, 'branch1', '', '/context-directory');
+    expect(editUrl).toBe(
+      'https://bitbucket.org/username/examplerepo/src/branch1/context-directory',
+    );
+  });
+
   it('should return only git url for repo from non-supported git provider', () => {
     const mockGitURI = 'https://example.com/username/examplerepo';
     const editUrl = getEditURL(mockGitURI, 'branch1');

--- a/frontend/packages/topology/src/data-transforms/data-transformer.ts
+++ b/frontend/packages/topology/src/data-transforms/data-transformer.ts
@@ -80,6 +80,8 @@ const getBaseTopologyDataModel = (
             item,
             TYPE_WORKLOAD,
             getImageForIconClass(`icon-openshift`),
+            undefined,
+            resources,
           );
           typedDataModel.nodes.push(
             getTopologyNodeItem(resource, TYPE_WORKLOAD, data, WorkloadModelProps),

--- a/frontend/packages/topology/src/utils/topology-utils.ts
+++ b/frontend/packages/topology/src/utils/topology-utils.ts
@@ -44,33 +44,39 @@ export const getCheDecoratorData = (consoleLinks: K8sResourceKind[]): CheDecorat
   };
 };
 
-const getFullGitURL = (gitUrl: GitUrlParse.GitUrl, branch?: string) => {
+const getFullGitURL = (gitUrl: GitUrlParse.GitUrl, branch?: string, contextDir?: string) => {
   const baseUrl = `https://${gitUrl.resource}/${gitUrl.owner}/${gitUrl.name}`;
   if (!branch) {
     return baseUrl;
   }
+  const contextPart = contextDir ? `/${contextDir.replace(/^\//, '')}` : '';
   if (gitUrl.resource.includes('github')) {
-    return `${baseUrl}/tree/${branch}`;
+    return `${baseUrl}/tree/${branch}${contextPart}`;
   }
   if (gitUrl.resource.includes('gitlab')) {
-    return `${baseUrl}/-/tree/${branch}`;
+    return `${baseUrl}/-/tree/${branch}${contextPart}`;
   }
   if (gitUrl.resource.includes('gitea')) {
-    return `${baseUrl}/src/branch/${branch}`;
+    return `${baseUrl}/src/branch/${branch}${contextPart}`;
   }
   // Branch names containing '/' do not work with bitbucket src URLs
   // https://jira.atlassian.com/browse/BCLOUD-9969
   if (gitUrl.resource.includes('bitbucket') && !branch.includes('/')) {
-    return `${baseUrl}/src/${branch}`;
+    return `${baseUrl}/src/${branch}${contextPart}`;
   }
   return baseUrl;
 };
 
-export const getEditURL = (vcsURI?: string, gitBranch?: string, cheURL?: string) => {
+export const getEditURL = (
+  vcsURI?: string,
+  gitBranch?: string,
+  cheURL?: string,
+  contextDir?: string,
+) => {
   if (!vcsURI) {
     return null;
   }
-  const fullGitURL = getFullGitURL(GitUrlParse(vcsURI), gitBranch);
+  const fullGitURL = getFullGitURL(GitUrlParse(vcsURI), gitBranch, contextDir);
   return cheURL ? `${cheURL}/f?url=${fullGitURL}&policies.create=peruser` : fullGitURL;
 };
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-34365

**Analysis / Root cause**: 
Edit source code button of topology decorator always redirected to URL used for import. Context directory is not considered. 

**Solution Description**: 
There are 2 option in Advanced section, one is to enter branch/tag/commit-id and other is to enter context directory. With this change, if user enters conext directory of particular branch/tag/commit-id, then user will be redirected to that directory on click of "Edit source code" decorator. If branch/tag/commit-id is not entered, the user will be redirected to base url as before. 

It will not be a good idea to call the provider API to get the default branch every time, so only if branch/tag/commit-id is entered and context directory value is entered then user will be redirected to the specific directory.

**Screen shots / Gifs for design review**: 



https://github.com/user-attachments/assets/0d634e88-7388-4f89-b905-5e3f659edaf3







**Unit test coverage report**: 
NA

**Test setup:**

    1. Add git url and in show advanced Git option, enter branch/tag/commit-id and context directory and create.
    2. In topology page, click on Edit source code icon of the decorator. 

    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge




