### PR TITLE
OCPBUGS-38036: Properly chain trap commands

### DIFF
--- a/frontend/integration-tests/test-cypress.sh
+++ b/frontend/integration-tests/test-cypress.sh
@@ -28,7 +28,6 @@ function copyArtifacts {
     cp -r "$SCREENSHOTS_DIR" "${ARTIFACT_DIR}/gui_test_screenshots"
   fi
 }
-trap copyArtifacts EXIT
 
 function generateReport {
   yarn run cypress-postreport
@@ -36,7 +35,7 @@ function generateReport {
     yarn cypress-a11y-report
   fi
 }
-trap generateReport EXIT
+trap "copyArtifacts; generateReport" EXIT
 
 while getopts p:s:h:l:n: flag
 do


### PR DESCRIPTION
Looks like that by default, if you set multiple trap commands for the same signal, the last one will override the previous ones. 

/assign @rhamilto

@jerolimov FYI