### PR TITLE
[release-4.16] OCPBUGS-38093: correct link for Lightspeed operator

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
@@ -61,7 +61,7 @@ export const ExploreAdminFeaturesGettingStartedCard: React.FC = () => {
           title: t('public~OpenShift LightSpeed'),
           description: t('public~Your personal AI helper.'),
           href:
-            '/operatorhub/all-namespaces?keyword=lightspeed&details-item=lightspeed-operator-lightspeed-operator-catalog-openshift-marketplace',
+            '/operatorhub/all-namespaces?keyword=lightspeed&details-item=lightspeed-operator-redhat-operators-openshift-marketplace',
         });
       }
     };


### PR DESCRIPTION
After

https://github.com/user-attachments/assets/f28cb6e0-4039-45f3-82ac-1b877b1ea134

