### PR TITLE
OCPBUGS-37988: fix bug where cluster version text appears black in da…

### DIFF
--- a/frontend/public/components/cluster-settings/_cluster-settings.scss
+++ b/frontend/public/components/cluster-settings/_cluster-settings.scss
@@ -142,7 +142,6 @@ $co-channel-height: 60px;
 }
 
 .co-channel-version {
-  color: initial;
   display: flex;
   flex-direction: column;
   height: 35px;


### PR DESCRIPTION
…rk mode

After

<img width="879" alt="Screenshot 2024-08-07 at 2 16 20 PM" src="https://github.com/user-attachments/assets/b92d8f01-125d-46af-89ae-f961344ff3ea">
