### PR TITLE
OCPBUGS-13685: use default StorageClass for ServerlessFunction pipelineVolumeClaimTemplate

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils.ts
@@ -136,14 +136,15 @@ export const createPipelineRunForImportFlow = async (
 ): Promise<PipelineRunKind> => {
   const isServerlessFunctionPipeline =
     pipeline?.metadata?.labels?.['function.knative.dev'] === 'true';
+  const defaultPVC = isServerlessFunctionPipeline
+    ? await getServerlessFunctionDefaultPersistentVolumeClaim(pipeline?.metadata?.name)
+    : getDefaultVolumeClaimTemplate(pipeline?.metadata?.name);
   const pipelineInitialValues: StartPipelineFormValues = {
     ...convertPipelineToModalData(pipeline),
     workspaces: (pipeline.spec.workspaces || []).map((workspace: TektonWorkspace) => ({
       ...workspace,
       type: VolumeTypes.VolumeClaimTemplate,
-      data: isServerlessFunctionPipeline
-        ? getServerlessFunctionDefaultPersistentVolumeClaim(pipeline?.metadata?.name)
-        : getDefaultVolumeClaimTemplate(pipeline?.metadata?.name),
+      data: defaultPVC,
     })),
     secretOpen: false,
   };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/utils.ts
@@ -1,5 +1,8 @@
 import * as _ from 'lodash';
+import { K8sResourceCommon } from '@console/dynamic-plugin-sdk/src';
+import { k8sListResourceItems } from '@console/dynamic-plugin-sdk/src/utils/k8s';
 import { getActiveUserName } from '@console/internal/actions/ui';
+import { StorageClassModel } from '@console/internal/models';
 import { getRandomChars } from '@console/shared';
 import {
   DELETED_RESOURCE_IN_K8S_ANNOTATION,
@@ -178,9 +181,19 @@ export const getDefaultVolumeClaimTemplate = (pipelineName: string): VolumeClaim
   };
 };
 
-export const getServerlessFunctionDefaultPersistentVolumeClaim = (
+export const getServerlessFunctionDefaultPersistentVolumeClaim = async (
   pipelineName: string,
-): VolumeClaimTemplateType => {
+): Promise<VolumeClaimTemplateType> => {
+  const storageClasses: K8sResourceCommon[] = await k8sListResourceItems<K8sResourceCommon>({
+    model: StorageClassModel,
+    queryParams: {},
+  });
+  const defaultStorageClass = storageClasses?.find((storageClass) => {
+    return (
+      storageClass.metadata?.annotations?.['storageclass.kubernetes.io/is-default-class'] === 'true'
+    );
+  });
+  const defaultStorageClassName = defaultStorageClass?.metadata?.name;
   return {
     volumeClaimTemplate: {
       metadata: {
@@ -199,7 +212,7 @@ export const getServerlessFunctionDefaultPersistentVolumeClaim = (
             storage: '1Gi',
           },
         },
-        storageClassName: 'gp3-csi',
+        storageClassName: defaultStorageClassName,
         volumeMode: 'Filesystem',
       },
     },


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/OCPBUGS-13685

Descriptions: 
The "Create Serverless Function" is not working for OCP installation in Openstack. It fails to create the PersistentVolume used by the pipeline with the error `storageclass.storage.k8s.io "gp3-csi" not found`. So, this PR fetch the default Storage class and use that in VolumeClaimTemplate.

Test setup:
- Install Pipeline and Serverless Operator and create CRs
- Add all ClusterTasks and Pipeline from this gist https://gist.github.com/vikram-raj/386b4eca5193036b0ca29471f6e513a5
- Navigate to `Create Serverless function` form and create a Serverless function by entering Git URL https://github.com/pierDipi/node-func-logger and enable Pipeline in the form