### PR TITLE
OCPBUGS-32033: Fix Function Import: An error occurred Cannot read properties of undefined (reading 'filter')

### DIFF
--- a/frontend/packages/dev-console/src/components/import/serverless-function/AddServerlessFunctionForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless-function/AddServerlessFunctionForm.tsx
@@ -92,8 +92,8 @@ const AddServerlessFunctionForm: React.FC<
           .then((res) => {
             if (res) {
               setStatus({});
-              setFieldValue('build.env', res?.values?.builderEnvs);
-              setFieldValue('deployment.env', res?.values?.runtimeEnvs);
+              setFieldValue('build.env', res?.values?.builderEnvs || []);
+              setFieldValue('deployment.env', res?.values?.runtimeEnvs || []);
               setFieldValue(
                 'image.selected',
                 notSupportedRuntime.indexOf(res?.values?.runtime) === -1

--- a/frontend/packages/dev-console/src/components/import/serverless-function/FuncSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless-function/FuncSection.tsx
@@ -50,8 +50,8 @@ const FuncSection = ({ builderImages }) => {
             );
           }
           setFieldValue('resources', Resources.KnativeService);
-          setFieldValue('build.env', res.values.builderEnvs);
-          setFieldValue('deployment.env', res.values.runtimeEnvs);
+          setFieldValue('build.env', res?.values?.builderEnvs || []);
+          setFieldValue('deployment.env', res?.values?.runtimeEnvs || []);
         })
         .catch((err) => {
           // eslint-disable-next-line no-console

--- a/frontend/packages/dev-console/src/components/import/serverless-function/ServerlessFunctionSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless-function/ServerlessFunctionSection.tsx
@@ -50,8 +50,8 @@ const ServerlessFunctionSection = ({ builderImages }) => {
             );
           }
           setFieldValue('resources', Resources.KnativeService);
-          setFieldValue('build.env', res.values.builderEnvs);
-          setFieldValue('deployment.env', res.values.runtimeEnvs);
+          setFieldValue('build.env', res?.values?.builderEnvs || []);
+          setFieldValue('deployment.env', res?.values?.runtimeEnvs || []);
         })
         .catch((err) => {
           // eslint-disable-next-line no-console


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-32033

Descriptions: When users import a Serverless func repo and `build.buildEnvs` or `run.envs` is not defined in the `func.yaml` then UI throw an error on creation. This PR adds `[]` if envs is not defined.