### PR TITLE
NO-JIRA: Fix typos in Console dynamic plugin SDK README

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -443,16 +443,11 @@ The list of shared modules planned for deprecation:
   - `react-router`
   - `react-router-dom`
 
-[console-doc-extensions]: ./docs/console-extensions.md
-[console-doc-api]: ./docs/api.md
-[console-doc-feature-page]: https://github.com/openshift/enhancements/blob/master/enhancements/console/dynamic-plugins.md
-[console-pf-upgrade-notes]: ./upgrade-PatternFly.md
-
-## i18n traslations for messages
+## i18n translations for messages
 
 The following demonstrates how to translate messages in the console plugin using the [i18next](https://www.i18next.com/) and [react-i18next](https://react.i18next.com/) libraries. Also included are the instructions for uploading/downloading strings to/from the Phrase Translation Memory System (TMS).
 
-### Step 1: Mark strings with `t` function for traslation
+### Step 1: Mark strings with `t` function for translation
 
 You can use the `useTranslation` hook within the component, or the `i18next` function outside the component, along with the namespace. The i18n namespace must match the name of the `ConsolePlugin` resource with the `plugin__` prefix to avoid naming conflicts. For example, a console plugin named console-crontab-plugin use the `plugin__console-crontab-plugin` namespace. See the following for examples:
 
@@ -501,13 +496,13 @@ Then, run `yarn i18n` to update the JSON files in the `locales` folder of the pl
 i. Request an account from the localization team for the console plugin project.
 ii. Create a Project Template to include the supported language in the Phrase TMS portal. Refer to the [Phrase Project Templates ](https://support.phrase.com/hc/en-us/articles/5709647439772-Project-Templates-TMS) on how to create/update the Project Template. You must have Phrase project owner permissions to perform this task. The localization team can help with creating the Project Template and setup.
 
-### Step 3: Create utility scripts to automate i18n-related tasks 
+### Step 3: Create utility scripts to automate i18n-related tasks
 
 Create scripts for uploading and downloading the i18n JSON files to/from the Phrase portal. See the [console](https://github.com/openshift/console/tree/master/frontend/i18n-scripts) repository or [Advanced Cluster Management (ACM) console plugin](https://github.com/stolostron/console/tree/main/frontend/i18n-scripts) repository for similar scripts.
 
 ### Step 4: Upload to Phrase portal
 
-i. Install the unofficial Memsource CLI client. This client is a command-line tool designed for interacting with the Phrase portal. See the following link for details: [The unofficial Memsource CLI client](https://github.com/unofficial-memsource/memsource-cli-client#pip-install) 
+i. Install the unofficial Memsource CLI client. This client is a command-line tool designed for interacting with the Phrase portal. See the following link for details: [The unofficial Memsource CLI client](https://github.com/unofficial-memsource/memsource-cli-client#pip-install)
 
 ii. Configure the Memsource client using the account credentials. Create a file named ~/.memsourcerc in any location, for example, /Users/.../, and paste the following content into the file:
 
@@ -522,17 +517,22 @@ See the following link for details:[The RHEL instructions for MacOS](https://git
 
 iii. Change directory to the root of the console plugin, and then run the upload script created earlier in step 3, for example: `yarn memsource-upload -v PLUGIN_VERSION_NUMBER`. Take note of the generated `PROJECT_ID`.
 
-iv. Notify the localization team of the upload and wait for a reply from them on when the translated strings are ready for download. 
+iv. Notify the localization team of the upload and wait for a reply from them on when the translated strings are ready for download.
 
 ### Step 5: Download from Phrase portal
 
 i. Use the `PROJECT_ID` generated during the upload task, or visit the [Phrase TMS](https://cloud.memsource.com) portal. Find the URL of the previously uploaded project, then copy the `PROJECT_ID` from the URL path following `../show/<PROJECT_ID>`
 
-ii.  Use the download script created earlier in step 3 with `PROJECT_ID` to download the translated strings. Change the directory to the root of the console plugin, and then run the download script. 
+ii.  Use the download script created earlier in step 3 with `PROJECT_ID` to download the translated strings. Change the directory to the root of the console plugin, and then run the download script.
 For example: `yarn memsource-download -v PLUGIN_VERSION_NUMBER`.  This should download the updated locale files, which contain the translated strings in the languages that were configured earlier in the Project Template and upload utility script.
 
 iii. Commit, review and merge the changes accordingly.
 
 iv. Reach out to the localization team if you have any questions or concerns regarding the translated strings.
 
-For more information on OpenShift Internationalization, see the console [Internationalization README page](https://github.com/openshift/console/blob/master/INTERNATIONALIZATION.md). 
+For more information on OpenShift Internationalization, see the console [Internationalization README page](https://github.com/openshift/console/blob/master/INTERNATIONALIZATION.md).
+
+[console-doc-extensions]: ./docs/console-extensions.md
+[console-doc-api]: ./docs/api.md
+[console-doc-feature-page]: https://github.com/openshift/enhancements/blob/master/enhancements/console/dynamic-plugins.md
+[console-pf-upgrade-notes]: ./upgrade-PatternFly.md


### PR DESCRIPTION
Improve README
- fix typos
- remove trailing whitespace
- Markdown [Reference-style Link](https://www.markdownguide.org/basic-syntax/#reference-style-links) definitions should appear at the end of the document