### PR TITLE
OCPBUGS-38011: Need to allow blank for Project/namespace when setting SA Subject in 'Project access tab'

### DIFF
--- a/frontend/packages/dev-console/src/components/project-access/project-access-form-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/project-access/project-access-form-submit-utils.ts
@@ -147,7 +147,9 @@ export const sendRoleBindingRequest = (
         ? [
             {
               ...(user.subject.kind === 'ServiceAccount'
-                ? { namespace: user.subject.namespace }
+                ? user.subject.namespace
+                  ? { namespace: user.subject.namespace }
+                  : {}
                 : { apiGroup: 'rbac.authorization.k8s.io' }),
               kind: user.subject.kind,
               name: user.subject.name,

--- a/frontend/packages/dev-console/src/components/project-access/project-access-form-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/project-access/project-access-form-validation-utils.ts
@@ -7,10 +7,6 @@ export const validationSchema = yup.object().shape({
       subject: yup.object().shape({
         name: yup.string().required(i18n.t('devconsole~Required')),
         kind: yup.string().required(i18n.t('devconsole~Required')),
-        namespace: yup.string().when('kind', {
-          is: 'ServiceAccount',
-          then: yup.string().required(i18n.t('devconsole~Required')),
-        }),
       }),
       role: yup.string().required(i18n.t('devconsole~Required')),
     }),


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-38011

**Analysis / Root cause**: 
If subject kind is ServiceAccount, namespace was mandatory

**Solution Description**: 
RoleBinding can be created without the namespace also for ServiceAccount kind, only for ClusterRoleBinding it is mandatory. So made namespace as optional for ServiceAccount kind in Project Access tab

```
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: test-view-1191ae83298eec3f
  namespace: prabhu
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: view
subjects:
- kind: ServiceAccount
  name: test
```
  
**Screen shots / Gifs for design review**: 


---BEFORE---

https://github.com/user-attachments/assets/b18b43af-0819-490a-89d2-d8f4750afd67






---AFTER---



https://github.com/user-attachments/assets/316f9ef7-7838-4b65-85b0-ccc2c6699e73





**Unit test coverage report**: 
NA

**Test setup:**

    1. Login to the web console for Developer.
    2. Select Project on the left.
    3. Select 'Project Access' tab.
    4. Add  access -> Select Sevice Account on the dropdown
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge




