### PR TITLE
CONSOLE-4117: replace deprecated components in MastheadToolbar

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/quck-starts/quick-start-devperspective.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/quck-starts/quick-start-devperspective.ts
@@ -25,7 +25,7 @@ Then('user can see the "View all quick starts" on the card', () => {
 
 When('user selects QuickStarts from the help menu icon on the masthead', () => {
   cy.get(helpDropdownMenu).should('be.visible').click();
-  cy.get('a[role="menuitem"]').contains('Quick Starts').click();
+  cy.get('button[role="menuitem"]').contains('Quick Starts').click();
 });
 
 Then(

--- a/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-link.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-link.cy.ts
@@ -14,14 +14,14 @@ describe(`${crd} CRD`, () => {
     {
       name,
       dropdownMenuName: 'help menu',
-      dropdownToggle: '[data-test=help-dropdown-toggle] [aria-label="Help menu"]',
+      dropdownToggle: '[data-test=help-dropdown-toggle]',
       menuLinkLocation: 'HelpMenu',
       menuLinkText: `${name} help menu link`,
     },
     {
       name,
       dropdownMenuName: 'user menu',
-      dropdownToggle: '[data-test=user-dropdown] [aria-label="User menu"]',
+      dropdownToggle: '[data-test=user-dropdown]',
       menuLinkLocation: 'UserMenu',
       menuLinkText: `${name} user menu link`,
     },

--- a/frontend/packages/integration-tests-cypress/tests/i18n/pseudolocalization.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/i18n/pseudolocalization.cy.ts
@@ -16,11 +16,11 @@ describe('Localization', () => {
     cy.log('test masthead');
     cy.visitWithDefaultLang(url);
     masthead.clickMastheadLink('help-dropdown-toggle');
-    cy.byTestID('help-dropdown-toggle').within(() => {
+    cy.byTestID('help-dropdown').within(() => {
       // wait for both console help menu items and additionalHelpActions items to load
-      cy.get('section').should('have.length', 2);
+      cy.get('ul[role="menu"]').should('have.length', 2);
       // Test that all links are translated
-      cy.get('section [role="menuitem"]').isPseudoLocalized();
+      cy.get('ul[role="menu"] [role="menuitem"]').isPseudoLocalized();
     });
   });
 

--- a/frontend/packages/integration-tests-cypress/views/masthead.ts
+++ b/frontend/packages/integration-tests-cypress/views/masthead.ts
@@ -10,7 +10,7 @@ export const masthead = {
         .should('have.text', text),
   },
   userDropdown: () => cy.byTestID('user-dropdown'),
-  copyLoginCommand: () => cy.byTestID('copy-login-command'),
+  copyLoginCommand: () => cy.byTestID('copy-login-command').find('a'),
   clickMastheadLink: (path: string) => {
     return cy.byTestID(path).click();
   },

--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/CloudShellMastheadAction.tsx
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/CloudShellMastheadAction.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Split, SplitItem } from '@patternfly/react-core';
 import { CheckIcon } from '@patternfly/react-icons/dist/esm/icons/check-icon';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -31,19 +32,22 @@ const ClouldShellMastheadAction: React.FC<Props> = ({ onClick, className, open }
       data-tour-id="tour-cloud-shell-button"
       data-quickstart-id="qs-masthead-cloudshell"
     >
-      {t('webterminal-plugin~OpenShift command line')}
-      {open ? (
-        <span
-          style={{
-            marginLeft: 'auto',
-            color: 'var(--pf-v5-global--active-color--100)',
-            fontSize: 'var(--pf-v5-global--FontSize--xs)',
-            paddingLeft: 'var(--pf-v5-global--spacer--md)',
-          }}
-        >
-          <CheckIcon />
-        </span>
-      ) : null}
+      <Split className="pf-v5-u-w-100">
+        <SplitItem isFilled>{t('webterminal-plugin~OpenShift command line')}</SplitItem>
+        {open ? (
+          <SplitItem>
+            <span
+              style={{
+                color: 'var(--pf-v5-global--active-color--100)',
+                fontSize: 'var(--pf-v5-global--FontSize--xs)',
+                paddingLeft: 'var(--pf-v5-global--spacer--md)',
+              }}
+            >
+              <CheckIcon />
+            </span>
+          </SplitItem>
+        ) : null}
+      </Split>
     </button>
   );
 };

--- a/frontend/public/components/_masthead.scss
+++ b/frontend/public/components/_masthead.scss
@@ -1,14 +1,13 @@
 .co-app-launcher {
-  ul {
-    list-style: none;
-    margin-bottom: 0;
-    padding-left: 0;
-  }
-
-  .pf-v5-c-app-launcher__menu-item-external-icon {
-    --pf-v5-c-app-launcher__menu-item-external-icon--Color: var(--pf-v5-c-menu__item-action--Color);
+  .pf-v5-c-menu__item-external-icon {
+    --pf-v5-c-menu__item-external-icon--Color: var(--pf-v5-c-menu__item-action--Color);
 
     opacity: 1;
+  }
+
+  .pf-v5-c-menu__item-icon {
+    height: var(--pf-v5-global--icon--FontSize--lg);
+    width: var(--pf-v5-global--icon--FontSize--lg);
   }
 }
 


### PR DESCRIPTION
After

https://github.com/user-attachments/assets/cab25a62-8517-4b85-9de1-cbb9744a0957


https://github.com/user-attachments/assets/764279bd-4adf-46e3-b1ae-95bbba444e04


https://github.com/user-attachments/assets/61f8efd9-e1ca-4128-b8d5-b6a7e6746548

