### PR TITLE
CONSOLE-4263: Add initial Content Security Policy for Console web application

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -177,11 +177,11 @@ import { MonitoringIcon } from '@patternfly/react-icons';
 ## Content Security Policy
 
 Console application uses [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
-(CSP) in order to detect and mitigate certain types of attacks. By default, the list of allowed
+(CSP) to detect and mitigate certain types of attacks. By default, the list of allowed
 [CSP sources](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources)
-includes the document origin `'self'` as well as Console webpack dev server when running off-cluster.
+includes the document origin `'self'` and Console webpack dev server when running off-cluster.
 
-All dynamic plugin assets _should_ be loaded via `/api/plugins/<plugin-name>` Bridge endpoint which
+All dynamic plugin assets _should_ be loaded using `/api/plugins/<plugin-name>` Bridge endpoint which
 matches the `'self'` CSP source of Console application.
 
 See `cspSources` and `cspDirectives` in

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -174,6 +174,29 @@ import { MonitoringIcon } from '@patternfly/react-icons/dist/esm/icons/monitorin
 import { MonitoringIcon } from '@patternfly/react-icons';
 ```
 
+## Content Security Policy
+
+Console application uses [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+(CSP) in order to detect and mitigate certain types of attacks. By default, the list of allowed
+[CSP sources](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources)
+includes the document origin `'self'` as well as Console webpack dev server when running off-cluster.
+
+All dynamic plugin assets _should_ be loaded via `/api/plugins/<plugin-name>` Bridge endpoint which
+matches the `'self'` CSP source of Console application.
+
+See `cspSources` and `cspDirectives` in
+[`pkg/server/server.go`](https://github.com/openshift/console/blob/master/pkg/server/server.go)
+for details on the current Console CSP implementation.
+
+### Changes in Console CSP
+
+This section documents notable changes in the Console Content Security Policy.
+
+#### Console 4.18.x
+
+Console CSP is deployed in report-only mode. CSP violations will be logged in the browser console
+but the associated CSP directives will not be enforced.
+
 ## Plugin metadata
 
 Older versions of webpack `ConsoleRemotePlugin` assumed that the plugin metadata is specified via

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -673,6 +673,27 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// This Content Security Policy (CSP) applies to Console web application resources.
+	// Console CSP is deployed in report-only mode via "Content-Security-Policy-Report-Only" header.
+	// See https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for details on CSP specification.
+	cspSources := "'self'"
+	if s.K8sMode == "off-cluster" {
+		// Console local development involves a webpack server running on port 8080
+		cspSources = cspSources + " http://localhost:8080 ws://localhost:8080"
+	}
+	cspDirectives := []string{
+		fmt.Sprintf("default-src %s", cspSources),
+		fmt.Sprintf("base-uri %s", cspSources),
+		fmt.Sprintf("img-src %s data:", cspSources),
+		fmt.Sprintf("font-src %s data:", cspSources),
+		fmt.Sprintf("script-src %s 'unsafe-eval'", cspSources),
+		fmt.Sprintf("style-src %s 'unsafe-inline'", cspSources),
+		"frame-src 'none'",
+		"frame-ancestors 'none'",
+		"object-src 'none'",
+	}
+	w.Header().Set("Content-Security-Policy-Report-Only", strings.Join(cspDirectives, "; "))
+
 	plugins := make([]string, 0, len(s.EnabledConsolePlugins))
 	for plugin := range s.EnabledConsolePlugins {
 		plugins = append(plugins, plugin)


### PR DESCRIPTION
## Summary

This PR adds initial [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) implementation for Console web application.

> Content Security Policy ([CSP](https://developer.mozilla.org/en-US/docs/Glossary/CSP)) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross-Site Scripting ([XSS](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting)) and data injection attacks. These attacks are used for everything from data theft, to site defacement, to malware distribution.

Initially, we will deploy CSP in **report-only mode** via [`Content-Security-Policy-Report-Only`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only) HTTP header.

CSP violations are handled explicitly via Console [`SecurityPolicyViolationEvent`](https://developer.mozilla.org/en-US/docs/Web/API/SecurityPolicyViolationEvent) handler, which does the following:
- log the CSP event to browser console
- send the relevant CSP report data to Telemetry service

With this PR, running Console and Bridge locally with [dynamic demo plugin](https://github.com/openshift/console/tree/master/dynamic-demo-plugin) enabled should not trigger any CSP violations.

```sh
./bin/bridge -plugins console-demo-plugin=http://localhost:9001/ -i18n-namespaces=plugin__console-demo-plugin
```

**Note** :memo: since we use `Content-Security-Policy-Report-Only` instead of `Content-Security-Policy` header, the browser may warn about Console CSP not containing [`report-to`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to) (standard) or [`report-uri`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri) (deprecated) directives as shown in the following screenshot:

![](https://github.com/user-attachments/assets/01417108-7db0-4810-a1b8-ecb90a7ae821)

This warning is not an issue, since we use a custom CSP violation event handler. The "cannot report violations" part of this warning means the browser itself will not make any CSP related HTTP requests.

The error below the warning in the screenshot is due to [Console HTML index template](https://github.com/openshift/console/blob/master/frontend/public/index.html) containing an inline script tag used to set up `SERVER_FLAGS` and visual theme config. The proper way to address this error is to allow this script tag - either [generate a SHA hash representing its contents](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#integrity) or [generate a cryptographically secure random token](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#nonce) for the script.

## Follow-up work

1. Address the above mentioned CSP inline script tag error.

2. Testing this PR has revealed that webpack generated Console assets require the following CSP exceptions, these should be removed in the future:

- [`script-src 'unsafe-eval'`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_eval_expressions) triggered by unsafe JS code like `eval()`
- [`style-src 'unsafe-inline'`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles) triggered by inline `<style>` elements

cc @spadgett @jhadvig 