### PR TITLE
OCPBUGS-38734: Expose EncodedExtension type via Console webpack SDK package

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/lib-webpack.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/lib-webpack.ts
@@ -4,5 +4,6 @@
  * Provides webpack plugin `ConsoleRemotePlugin` used to build all Console dynamic plugin assets.
  */
 
+export { EncodedExtension } from '@openshift/dynamic-plugin-sdk-webpack';
 export { ConsoleRemotePlugin, ConsoleRemotePluginOptions } from './webpack/ConsoleRemotePlugin';
 export { ConsolePluginBuildMetadata } from './build-types';


### PR DESCRIPTION
Console plugin SDK should directly expose any code & types related to building Console dynamic plugins.

Before - not recommended:
```ts
import { EncodedExtension } from '@openshift/dynamic-plugin-sdk';
// or
import { EncodedExtension } from '@openshift/dynamic-plugin-sdk-webpack';
```

After - this is recommended:
```ts
import { EncodedExtension } from '@openshift-console/dynamic-plugin-sdk-webpack';
```

Known plugins that should be updated:
- https://github.com/kubevirt-ui/kubevirt-plugin
- https://github.com/kubev2v/forklift-console-plugin