### PR TITLE
ODC-7667: Migrate SecureRouteFields to PF5

### DIFF
--- a/frontend/packages/dev-console/src/components/user-preferences/SecureRouteFields.tsx
+++ b/frontend/packages/dev-console/src/components/user-preferences/SecureRouteFields.tsx
@@ -6,6 +6,7 @@ import {
   HelperText,
   HelperTextItem,
   Select,
+  SelectList,
   SelectOption,
   MenuToggle,
   MenuToggleElement,
@@ -131,6 +132,7 @@ const SecureRouteFields: React.FC = () => {
   const tlsTerminationToggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
       isFullWidth
+      id="tls-termination"
       ref={toggleRef}
       onClick={onTLSTerminationToggle}
       isExpanded={isTLSTerminationOpen}
@@ -151,6 +153,7 @@ const SecureRouteFields: React.FC = () => {
     <MenuToggle
       isFullWidth
       ref={toggleRef}
+      id="insecure-traffic"
       onClick={onInsecureTrafficToggle}
       isExpanded={isInsecureTrafficOpen}
       isDisabled={!preferredRoutingOptionsLoaded}
@@ -190,7 +193,7 @@ const SecureRouteFields: React.FC = () => {
 
       <FormGroup fieldId="tls-termination" label={t('devconsole~TLS termination')}>
         <Select
-          id="tls-termination"
+          id="tls-termination-select"
           isOpen={isTLSTerminationOpen}
           onSelect={onTLSTerminationSelect}
           selected={tlsTermination}
@@ -198,12 +201,12 @@ const SecureRouteFields: React.FC = () => {
           toggle={tlsTerminationToggle}
           shouldFocusToggleOnSelect
         >
-          {tlsTerminationSelectOptions}
+          <SelectList>{tlsTerminationSelectOptions}</SelectList>
         </Select>
       </FormGroup>
       <FormGroup fieldId="insecure-traffic" label={t('devconsole~Insecure traffic')}>
         <Select
-          id="insecure-traffic"
+          id="insecure-traffic-select"
           isOpen={isInsecureTrafficOpen}
           selected={insecureTraffic}
           onSelect={onInsecureTrafficSelect}
@@ -211,7 +214,7 @@ const SecureRouteFields: React.FC = () => {
           toggle={insecureTrafficToggle}
           shouldFocusToggleOnSelect
         >
-          {insecureTrafficSelectOptions}
+          <SelectList>{insecureTrafficSelectOptions}</SelectList>
         </Select>
 
         <FormHelperText>

--- a/frontend/packages/dev-console/src/components/user-preferences/__tests__/SecureRouteFields.spec.tsx
+++ b/frontend/packages/dev-console/src/components/user-preferences/__tests__/SecureRouteFields.spec.tsx
@@ -24,7 +24,7 @@ describe('SecureRouteFields', () => {
     expect(screen.queryByTestId('tls-termination')).not.toBeNull();
   });
 
-  it('should render skelton if usePreferredRoutingOptions is not loaded', () => {
+  it('should render skeleton if usePreferredRoutingOptions is not loaded', () => {
     mockUsePreferredRoutingOptions.mockReturnValue([{}, () => {}, false]);
     render(<SecureRouteFields />);
     const secureRouteCheckbox = screen.queryByTestId('secure-route-checkbox');


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-7667

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Migrate file to PF5

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

Before:
![image](https://github.com/user-attachments/assets/9c92d60c-eb1b-427e-a98a-8e9d790eea76)

After:
![image](https://github.com/user-attachments/assets/b5032afe-7a95-4d31-a817-ec5edba34851)

Demo:

https://github.com/user-attachments/assets/6789a3da-93ff-4b67-ae16-76bec020b616


**Unit test coverage report**: 
<!-- Attach test coverage report -->
unchanged

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
n/a

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
