### PR TITLE
OCPBUGS-37560: Console user settings resources misses ownerRef, removing a user results in remaining data

### DIFF
--- a/pkg/usersettings/helpers_test.go
+++ b/pkg/usersettings/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNewUserSettingsMeta(t *testing.T) {
@@ -25,6 +26,7 @@ func TestNewUserSettingsMeta(t *testing.T) {
 				Username:           "kube:admin",
 				UID:                "",
 				ResourceIdentifier: "kubeadmin",
+				OwnerReferences:    []meta.OwnerReference{},
 			},
 		},
 		{
@@ -38,6 +40,14 @@ func TestNewUserSettingsMeta(t *testing.T) {
 				Username:           "kube:admin",
 				UID:                "1234",
 				ResourceIdentifier: "1234",
+				OwnerReferences: []meta.OwnerReference{
+					{
+						APIVersion: "user.openshift.io/v1",
+						Kind:       "User",
+						Name:       "kube:admin",
+						UID:        "1234",
+					},
+				},
 			},
 		},
 		{
@@ -51,6 +61,14 @@ func TestNewUserSettingsMeta(t *testing.T) {
 				Username:           "developer",
 				UID:                "1234",
 				ResourceIdentifier: "1234",
+				OwnerReferences: []meta.OwnerReference{
+					{
+						APIVersion: "user.openshift.io/v1",
+						Kind:       "User",
+						Name:       "developer",
+						UID:        "1234",
+					},
+				},
 			},
 		},
 	}

--- a/pkg/usersettings/types.go
+++ b/pkg/usersettings/types.go
@@ -1,10 +1,15 @@
 package usersettings
 
+import (
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 type UserSettingMeta struct {
 	Username string
 	UID      string
 	// The resource identifier contains "kubeadmin" for the kubeadmin and the user uid otherwise.
 	ResourceIdentifier string
+	OwnerReferences    []meta.OwnerReference
 }
 
 func (r *UserSettingMeta) getConfigMapName() string {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OCPBUGS-37560

Solution Description:

This reverts the code changes per PR #13321, which removed ownerReferences from ConfigMaps, Roles and RoleBindings.