### PR TITLE
ODC-7681: fix flaking k-native e2e test cases

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -96,7 +96,8 @@ export const navigateTo = (opt: devNavigationMenu) => {
       cy.url().should('include', 'topology');
       app.waitForLoad();
       cy.url().then(($url) => {
-        if ($url.includes('view=list')) {
+        if ($url.includes('view=list') && !$url.includes('all-namespace')) {
+          cy.log('Topology view is in list');
           cy.get(topologyPO.switcher).click({ force: true });
         }
       });

--- a/frontend/packages/integration-tests-cypress/support/admin.ts
+++ b/frontend/packages/integration-tests-cypress/support/admin.ts
@@ -1,4 +1,3 @@
-import { guidedTour } from '../views/guided-tour';
 import { nav } from '../views/nav';
 
 declare global {
@@ -27,6 +26,7 @@ Cypress.Commands.add('initDeveloper', () => {
   cy.byTestID('loading-indicator').should('not.exist');
   cy.log('ensure perspective switcher is set to Developer');
   nav.sidenav.switcher.changePerspectiveTo('Developer');
+  cy.log('switched perspective to Developer');
   nav.sidenav.switcher.shouldHaveText('Developer');
-  guidedTour.close();
+  cy.log('Developer perspective confirmed ');
 });

--- a/frontend/packages/knative-plugin/integration-tests/features/e2e/knative-ci.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/e2e/knative-ci.feature
@@ -5,8 +5,24 @@ Feature: Perform actions on knative service and revision
         Background:
               And user is at Topology page
 
-
         @pre-condition
+        Scenario Outline: Create knative workload from From Git card on Add page: KN-05-TC04
+            Given user has created or selected namespace "knative-ci"
+              And user is at Add page
+              And user is at Import from Git page
+             When user enters Git Repo url as "<git_url>"
+              And user enters Name as "<workload_name>"
+              And user selects resource type as "Serverless Deployment"
+              And user clicks Create button on Add page
+             Then user will be redirected to Topology page
+              And user is able to see workload "<workload_name>" in topology page
+              And user is able to see Knative Revision
+
+        Examples:
+                  | git_url                                 | workload_name |
+                  | https://github.com/sclorg/nodejs-ex.git | kn-service    |
+
+        @manual
         Scenario Outline: Create knative workload using Container image with extrenal registry on Add page: KN-05-TC05
             Given user has logged in as a basic user
               And user is at developer perspective
@@ -75,7 +91,7 @@ Feature: Perform actions on knative service and revision
              When user right clicks on the revision of knative service "kn-service" to open the context menu
              Then user is able to see Edit Labels, Edit Annotations, Edit Revision, Delete Revision options in context menu
 
-
+        @broken-test
         Scenario: side bar details of knative Revision: KN-06-TC02
             Given user has created or selected namespace "knative-ci"
              When user clicks on the revision of knative service "kn-service"
@@ -121,7 +137,7 @@ Feature: Perform actions on knative service and revision
               And user clicks save button on the "Set traffic distribution" modal
              Then error message displays as "validation failed: Traffic targets sum to 75, want 100: spec.traffic"
 
-
+        @broken-test
         Scenario: Set traffic distribution equal to 100% for the Revisions of the knative Service: KN-02-TC12
             Given user has created or selected namespace "knative-ci"
              When user selects "Set traffic distribution" context menu option of knative service "kn-service"
@@ -133,7 +149,7 @@ Feature: Perform actions on knative service and revision
               And user clicks on the knative service name "kn-service"
              Then number of revisions should get increased in side bar - resources tab - routes section
 
-
+        @broken-test
         Scenario: Delete revision modal details for service with multiple revisions: KN-01-TC10
             Given user has created or selected namespace "knative-ci"
              When user right clicks on the revision of knative service "kn-service" to open the context menu

--- a/frontend/packages/knative-plugin/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/commands/hooks.ts
@@ -1,8 +1,13 @@
 import { checkErrors } from '@console/cypress-integration-tests/support';
+import { guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
 import { installKnativeOperatorUsingCLI } from '@console/dev-console/integration-tests/support/pages';
 
 before(() => {
-  cy.login();
+  cy.exec('../../../../contrib/create-user.sh');
+  const bridgePasswordIDP: string = Cypress.env('BRIDGE_HTPASSWD_IDP') || 'test';
+  const bridgePasswordUsername: string = Cypress.env('BRIDGE_HTPASSWD_USERNAME') || 'test';
+  const bridgePasswordPassword: string = Cypress.env('BRIDGE_HTPASSWD_PASSWORD') || 'test';
+  cy.login(bridgePasswordIDP, bridgePasswordUsername, bridgePasswordPassword);
   cy.document().its('readyState').should('eq', 'complete');
   installKnativeOperatorUsingCLI();
   //  To ignore the resizeObserverLoopErrors on CI, adding below code
@@ -15,6 +20,7 @@ before(() => {
     }
     cy.log('uncaught:exception', err, runnable, promise);
   });
+  guidedTour.close();
 });
 
 beforeEach(() => {
@@ -26,30 +32,6 @@ after(() => {
   let start = 0;
   cy.then(() => {
     start = performance.now();
-  });
-
-  cy.exec(`oc adm top pod -n ${namespaces.join(' ')}`, {
-    failOnNonZeroExit: false,
-  }).then((result) => {
-    cy.log(result.stdout);
-  });
-
-  cy.exec(`oc get events -n ${namespaces.join(' ')}`, {
-    failOnNonZeroExit: false,
-  }).then((result) => {
-    cy.log(result.stdout);
-  });
-
-  cy.exec(`oc adm top pod -n ${namespaces.join(' ')}`, {
-    failOnNonZeroExit: false,
-  }).then((result) => {
-    cy.log(result.stdout);
-  });
-
-  cy.exec(`oc get all -n ${namespaces.join(' ')}`, {
-    failOnNonZeroExit: false,
-  }).then((result) => {
-    cy.log(result.stdout);
   });
 
   cy.exec(`oc delete namespace ${namespaces.join(' ')}`, {

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-helper-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-helper-page.ts
@@ -1,9 +1,10 @@
-import { app } from '@console/dev-console/integration-tests/support/pages';
+import { app, topologyPage } from '@console/dev-console/integration-tests/support/pages';
 import { topologyPO } from '@console/topology/integration-tests/support/page-objects/topology-po';
 
 export const topologyHelper = {
   search: (name: string) => cy.get(topologyPO.search).clear().type(name),
   verifyWorkloadInTopologyPage: (appName: string, options?: { timeout: number }) => {
+    topologyPage.verifyToplogyPageNotEmpty();
     topologyHelper.search(appName);
     // eslint-disable-next-line promise/catch-or-return
     cy.get('body').then(($body) => {

--- a/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
@@ -44,11 +44,13 @@ Then('user is able to see workload {string} in topology page list view', (worklo
 });
 
 Then('user is able to see workload {string} in topology page', (workloadName: string) => {
+  topologyPage.waitForLoad();
+  topologyPage.verifyToplogyPageNotEmpty();
   topologyPage.verifyWorkloadInTopologyPage(workloadName);
 });
 
 Then('user will be redirected to Topology page', () => {
-  topologyPage.verifyTopologyPage();
+  topologyPage.verifyTopologyPage(5);
 });
 
 When('user clicks on workload {string}', (workloadName: string) => {


### PR DESCRIPTION
**Story**:
[ODC-7681](https://issues.redhat.com/browse/ODC-7681)


**Description**

- Replace `KN-05-TC05` knative test to use Git flow to create knative workload 
- [OCPBUGS-42104](https://issues.redhat.com/browse/OCPBUGS-42104) Disabling `KN-01-TC10` `KN-02-TC12` `KN-06-TC02` due to flaking nature 