### PR TITLE
OCPBUGS-38923: remove nav psuedolocalization test

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/i18n/pseudolocalization.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/i18n/pseudolocalization.cy.ts
@@ -24,13 +24,6 @@ describe('Localization', () => {
     });
   });
 
-  // temporarily disable until https://github.com/openshift/networking-console-plugin/issues/46 is resolved
-  xit('pseudolocalizes navigation', () => {
-    cy.log('test navigation');
-    cy.visitWithDefaultLang(url);
-    cy.byTestID('nav').isPseudoLocalized();
-  });
-
   it('pseudolocalizes activity card', () => {
     cy.log('test activity card components');
     cy.visitWithDefaultLang(url);


### PR DESCRIPTION
Follow on to https://github.com/openshift/console/pull/14191

We discussed this as a team and believe the best option is to remove this test so that future plugin changes do not block CI.