### PR TITLE
ODC-7669: Migrate PipelineQuickSearchVersionDropdown to PF5

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
@@ -13,7 +13,7 @@ export const pipelineBuilderPO = {
     name: '#form-input-formData-name-field',
     taskDropdown: '[data-id="initial-node"]',
     quickSearch: '[data-test="quick-search-bar"]',
-    versionTask: '[data-test="task-version-toggle"]',
+    versionTask: '[data-test="task-version"]',
     addInstallTask: '[data-test="task-cta"]',
     task: '[data-type="builder"] .odc-pipeline-vis-task',
     plusTaskIcon: 'g.odc-plus-node-decorator',

--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/PipelineQuickSearchVersionDropdown.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/PipelineQuickSearchVersionDropdown.tsx
@@ -49,7 +49,7 @@ const PipelineQuickSearchVersionDropdown: React.FC<PipelineQuickSearchVersionDro
       isExpanded={isOpen}
       ref={toggleRef}
       isDisabled={versions.length === 1}
-      data-test="task-version-toggle"
+      data-test="task-version"
     >
       {versionItems[selectedVersion]}
     </MenuToggle>
@@ -57,7 +57,6 @@ const PipelineQuickSearchVersionDropdown: React.FC<PipelineQuickSearchVersionDro
 
   return (
     <Select
-      data-test="task-version"
       className="opp-quick-search-details__version-dropdown"
       isOpen={isOpen}
       onSelect={(_, value: string) => {

--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/PipelineQuickSearchVersionDropdown.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/PipelineQuickSearchVersionDropdown.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import {
-  Dropdown as DropdownDeprecated,
-  DropdownItem as DropdownItemDeprecated,
-  DropdownToggle as DropdownToggleDeprecated,
-} from '@patternfly/react-core/deprecated';
+  Select,
+  SelectList,
+  SelectOption,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import { global_palette_green_500 as greenColor } from '@patternfly/react-tokens';
 import i18n from 'i18next';
@@ -39,38 +41,47 @@ const PipelineQuickSearchVersionDropdown: React.FC<PipelineQuickSearchVersionDro
     }
     return acc;
   }, {});
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      className="opp-quick-search-details__version-dropdown"
+      onClick={toggleIsOpen}
+      isExpanded={isOpen}
+      ref={toggleRef}
+      isDisabled={versions.length === 1}
+      data-test="task-version-toggle"
+    >
+      {versionItems[selectedVersion]}
+    </MenuToggle>
+  );
+
   return (
-    <DropdownDeprecated
+    <Select
       data-test="task-version"
       className="opp-quick-search-details__version-dropdown"
-      dropdownItems={Object.keys(versionItems).map((key) => (
-        <DropdownItemDeprecated
-          component="button"
-          key={key}
-          label={versionItems[key]}
-          onClick={(e) => {
-            e.stopPropagation();
-            onChange(key);
-            setOpen(false);
-          }}
-        >
-          <div className="opp-quick-search-details__version-dropdown-item">
-            {versionItems[key]}
-            {isSelectedVersionInstalled(item, key) && <CheckCircleIcon color={greenColor.value} />}
-          </div>
-        </DropdownItemDeprecated>
-      ))}
       isOpen={isOpen}
-      toggle={
-        <DropdownToggleDeprecated
-          isDisabled={versions.length === 1}
-          data-test="task-version-toggle"
-          onToggle={toggleIsOpen}
-        >
-          {versionItems[selectedVersion]}
-        </DropdownToggleDeprecated>
-      }
-    />
+      onSelect={(_, value: string) => {
+        if (value) {
+          onChange(value);
+        }
+        setOpen(false);
+      }}
+      toggle={toggle}
+      onOpenChange={(open) => setOpen(open)}
+    >
+      <SelectList>
+        {Object.keys(versionItems).map((key) => (
+          <SelectOption key={key} label={versionItems[key]} value={key}>
+            <div className="opp-quick-search-details__version-dropdown-item">
+              {versionItems[key]}
+              {isSelectedVersionInstalled(item, key) && (
+                <CheckCircleIcon color={greenColor.value} />
+              )}
+            </div>
+          </SelectOption>
+        ))}
+      </SelectList>
+    </Select>
   );
 };
 

--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/__tests__/PipelineQuickSearchVersionDropdown.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/__tests__/PipelineQuickSearchVersionDropdown.spec.tsx
@@ -14,6 +14,19 @@ import PipelineQuickSearchVersionDropdown from '../PipelineQuickSearchVersionDro
 
 configure({ testIdAttribute: 'data-test' });
 
+// FIXME Remove this code when jest is updated to at least 25.1.0 -- see https://github.com/jsdom/jsdom/issues/1555
+if (!Element.prototype.closest) {
+  Element.prototype.closest = function (this: Element, selector: string) {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let el: Element | null = this;
+    while (el) {
+      if (el.matches(selector)) return el;
+      el = el.parentElement;
+    }
+    return null;
+  };
+}
+
 describe('pipelineQuickSearchVersionDropdown', () => {
   const onChange = jest.fn();
   const versionDropdownProps = {
@@ -65,7 +78,7 @@ describe('pipelineQuickSearchVersionDropdown', () => {
         versions={[...sampleClusterTaskCatalogItem.attributes.versions, { version: '0.2' }]}
       />,
     );
-    const taskDropdown = queryByTestId('task-version-toggle');
+    const taskDropdown = queryByTestId('task-version');
     fireEvent.click(taskDropdown);
     const latest = screen.getByText('0.2');
     fireEvent.click(latest);

--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/__tests__/PipelineQuicksearchDetails.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/__tests__/PipelineQuicksearchDetails.spec.tsx
@@ -29,6 +29,19 @@ jest.mock('@console/shared/src/hooks/useTelemetry', () => ({
   useTelemetry: () => {},
 }));
 
+// FIXME Remove this code when jest is updated to at least 25.1.0 -- see https://github.com/jsdom/jsdom/issues/1555
+if (!Element.prototype.closest) {
+  Element.prototype.closest = function (this: Element, selector: string) {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let el: Element | null = this;
+    while (el) {
+      if (el.matches(selector)) return el;
+      el = el.parentElement;
+    }
+    return null;
+  };
+}
+
 beforeEach(() => {
   coFetchMock.mockClear();
   coFetchMock.mockReturnValue(
@@ -147,7 +160,7 @@ describe('pipelineQuickSearchDetails', () => {
         <PipelineQuickSearchDetails {...tektonHubProps} selectedItem={installedTektonHubTask} />,
       );
       await waitFor(async () => {
-        fireEvent.click(queryByTestId('task-version-toggle'));
+        fireEvent.click(queryByTestId('task-version'));
         fireEvent.click(screen.getByText('0.2'));
         expect(getByRole('button', { name: 'Update and add' })).not.toBeNull();
       });


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-7669

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
demo:

https://github.com/user-attachments/assets/c202ba5d-a68a-4f30-b492-38e87b30c368


**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
install pipelines operator

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari


This pr is 2/2 of [ODC-7669](https://issues.redhat.com//browse/ODC-7669) story as each file is being split into a separate PR.