### PR TITLE
ODC-7671: Migrate FilterDropdown to PF5

### DIFF
--- a/frontend/packages/topology/src/filters/FilterDropdown.scss
+++ b/frontend/packages/topology/src/filters/FilterDropdown.scss
@@ -5,8 +5,10 @@
     display: flex;
     align-items: center;
 
-    .pf-v5-c-select__menu-group-title {
+    .pf-v5-c-menu__group-title {
       flex: 1;
+      padding-block-start: var(--pf-v5-global--spacer--sm);
+      padding-block-end: var(--pf-v5-global--spacer--sm);
     }
 
     .pf-v5-c-switch {
@@ -15,16 +17,6 @@
 
     .pf-m-disabled {
       color: var(--pf-v5-c-check__label--disabled--Color);
-    }
-  }
-
-  &__group {
-    &:not(:first-of-type) {
-      margin-top: var(--pf-v5-global--spacer--sm);
-      border-top: 1px solid var(--pf-v5-global--BorderColor--300);
-    }
-    .pf-v5-c-check__input {
-      --pf-v5-c-check__input--MarginTop: 0;
     }
   }
 

--- a/frontend/packages/topology/src/filters/FilterDropdown.tsx
+++ b/frontend/packages/topology/src/filters/FilterDropdown.tsx
@@ -127,7 +127,12 @@ const FilterDropdown: React.FC<FilterDropdownProps> = ({
   );
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle ref={toggleRef} onClick={() => setIsOpen(!isOpen)} isExpanded={isOpen}>
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setIsOpen(!isOpen)}
+      isExpanded={isOpen}
+      isDisabled={isSelectDisabled}
+    >
       {t('topology~Display options')}
     </MenuToggle>
   );
@@ -136,8 +141,6 @@ const FilterDropdown: React.FC<FilterDropdownProps> = ({
     <Select
       toggle={toggle}
       className="odc-topology-filter-dropdown__select"
-      customContent={selectContent}
-      isDisabled={isSelectDisabled}
       onToggle={onToggle}
       isOpen={isOpen}
       onSelect={onSelect}

--- a/frontend/packages/topology/src/filters/FilterDropdown.tsx
+++ b/frontend/packages/topology/src/filters/FilterDropdown.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
-import { Switch } from '@patternfly/react-core';
 import {
-  Select as SelectDeprecated,
-  SelectGroup as SelectGroupDeprecated,
-  SelectVariant as SelectVariantDeprecated,
-  SelectOption as SelectOptionDeprecated,
-} from '@patternfly/react-core/deprecated';
+  Switch,
+  Divider,
+  Select,
+  SelectGroup,
+  SelectList,
+  SelectOption,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 import { DisplayFilters, TopologyDisplayFilterType, TopologyViewType } from '../topology-types';
@@ -86,54 +89,64 @@ const FilterDropdown: React.FC<FilterDropdownProps> = ({
       {expandFilters.length ? (
         <div className="odc-topology-filter-dropdown__group">
           <span className="odc-topology-filter-dropdown__expand-groups-switcher">
-            <span className="pf-v5-c-select__menu-group-title">{t('topology~Expand')}</span>
+            <span className="pf-v5-c-menu__group-title">{t('topology~Expand')}</span>
             <Switch
               aria-label={t('topology~Collapse groups')}
               isChecked={groupsExpanded}
               onChange={onGroupsExpandedChange}
             />
           </span>
-          <SelectGroupDeprecated className="odc-topology-filter-dropdown__expand-groups-label">
+          <SelectGroup className="odc-topology-filter-dropdown__expand-groups-label" label={<></>}>
             {expandFilters.map((filter) => (
-              <SelectOptionDeprecated
+              <SelectOption
                 key={filter.id}
                 value={filter.id}
                 isDisabled={!groupsExpanded}
-                isChecked={filter.value}
+                isSelected={filter.value}
+                hasCheckbox
               >
                 {filter.labelKey ? t(filter.labelKey) : filter.label}
-              </SelectOptionDeprecated>
+              </SelectOption>
             ))}
-          </SelectGroupDeprecated>
+          </SelectGroup>
         </div>
       ) : null}
       {viewType === TopologyViewType.graph && showFilters.length ? (
-        <div className="odc-topology-filter-dropdown__group">
-          <SelectGroupDeprecated label={t('topology~Show')}>
+        <div>
+          <Divider />
+          <SelectGroup label={t('topology~Show')}>
             {showFilters.map((filter) => (
-              <SelectOptionDeprecated key={filter.id} value={filter.id} isChecked={filter.value}>
+              <SelectOption key={filter.id} value={filter.id} isSelected={filter.value} hasCheckbox>
                 {filter.labelKey ? t(filter.labelKey) : filter.label}
-              </SelectOptionDeprecated>
+              </SelectOption>
             ))}
-          </SelectGroupDeprecated>
+          </SelectGroup>
         </div>
       ) : null}
     </div>
   );
 
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle ref={toggleRef} onClick={() => setIsOpen(!isOpen)} isExpanded={isOpen}>
+      {t('topology~Display options')}
+    </MenuToggle>
+  );
+
   return (
-    <SelectDeprecated
+    <Select
+      toggle={toggle}
       className="odc-topology-filter-dropdown__select"
-      variant={SelectVariantDeprecated.checkbox}
       customContent={selectContent}
       isDisabled={isSelectDisabled}
       onToggle={onToggle}
       isOpen={isOpen}
       onSelect={onSelect}
-      placeholderText={t('topology~Display options')}
       isGrouped
       isCheckboxSelectionBadgeHidden
-    />
+      onOpenChange={(open) => setIsOpen(open)}
+    >
+      <SelectList>{selectContent}</SelectList>
+    </Select>
   );
 };
 

--- a/frontend/packages/topology/src/filters/__tests__/FilterDropdown.spec.tsx
+++ b/frontend/packages/topology/src/filters/__tests__/FilterDropdown.spec.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Switch } from '@patternfly/react-core';
-import { SelectOption as SelectOptionDeprecated } from '@patternfly/react-core/deprecated';
+import { Switch, SelectOption } from '@patternfly/react-core';
 import { mount, shallow } from 'enzyme';
 import { DisplayFilters, TopologyDisplayFilterType, TopologyViewType } from '../../topology-types';
 import {
@@ -14,6 +13,19 @@ import FilterDropdown from '../FilterDropdown';
 jest.mock('@console/shared/src/hooks/useTelemetry', () => ({
   useTelemetry: () => {},
 }));
+
+// FIXME Remove this code when jest is updated to at least 25.1.0 -- see https://github.com/jsdom/jsdom/issues/1555
+if (!Element.prototype.closest) {
+  Element.prototype.closest = function (this: Element, selector: string) {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let el: Element | null = this;
+    while (el) {
+      if (el.matches(selector)) return el;
+      el = el.parentElement;
+    }
+    return null;
+  };
+}
 
 describe(FilterDropdown.displayName, () => {
   let dropdownFilter: DisplayFilters;
@@ -45,7 +57,7 @@ describe(FilterDropdown.displayName, () => {
         opened
       />,
     );
-    expect(wrapper.find(SelectOptionDeprecated)).toHaveLength(DEFAULT_TOPOLOGY_FILTERS.length - 1);
+    expect(wrapper.find(SelectOption)).toHaveLength(DEFAULT_TOPOLOGY_FILTERS.length - 1);
   });
 
   it('should hide the show filters for list view', () => {
@@ -58,7 +70,7 @@ describe(FilterDropdown.displayName, () => {
         opened
       />,
     );
-    expect(wrapper.find(SelectOptionDeprecated)).toHaveLength(
+    expect(wrapper.find(SelectOption)).toHaveLength(
       DEFAULT_TOPOLOGY_FILTERS.filter((f) => f.type !== TopologyDisplayFilterType.show).length - 1,
     );
   });
@@ -73,7 +85,7 @@ describe(FilterDropdown.displayName, () => {
         opened
       />,
     );
-    expect(wrapper.find(SelectOptionDeprecated)).toHaveLength(1);
+    expect(wrapper.find(SelectOption)).toHaveLength(1);
   });
 
   it('should contain the expand groups switch', () => {
@@ -100,6 +112,6 @@ describe(FilterDropdown.displayName, () => {
         opened
       />,
     );
-    expect(wrapper.find(SelectOptionDeprecated).first().props().isDisabled).toBeTruthy();
+    expect(wrapper.find('[disabled].pf-v5-c-menu-toggle')).toBeTruthy();
   });
 });


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-7671

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
demo:

https://github.com/user-attachments/assets/91e155d3-8321-487c-ae8f-c86e01d55204

**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
n/a

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari

This pr is 2/3 of [ODC-7671](https://issues.redhat.com//browse/ODC-7671) story as each file is being split into a separate PR.