### PR TITLE
ODC-7672: Migrate TelemetryConfiguration to PF5

### DIFF
--- a/frontend/packages/console-telemetry-plugin/src/components/TelemetryConfiguration.tsx
+++ b/frontend/packages/console-telemetry-plugin/src/components/TelemetryConfiguration.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
-import { FormHelperText, FormSection } from '@patternfly/react-core';
 import {
-  Select as SelectDeprecated,
-  SelectOption as SelectOptionDeprecated,
-} from '@patternfly/react-core/deprecated';
+  FormHelperText,
+  FormSection,
+  Select,
+  SelectList,
+  SelectOption,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { CLUSTER_TELEMETRY_ANALYTICS, useTelemetry } from '@console/shared/src';
@@ -67,28 +71,47 @@ const TelemetryAnalyticsSelect: React.FC<{
 
   const [isOpen, setIsOpen] = React.useState(false);
   const selection = options.find((option) => option.isSelected)?.value;
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setIsOpen(!isOpen)}
+      isExpanded={isOpen}
+      isDisabled={disabled}
+      isFullWidth
+    >
+      {options.find((option) => option.value === selection)?.title ||
+        t('console-telemetry-plugin~Select option')}
+    </MenuToggle>
+  );
+
   return (
     <div data-test="telemetry-dropdown">
-      <SelectDeprecated
-        disabled={disabled}
+      <Select
+        toggle={toggle}
         isOpen={isOpen}
-        selections={selection}
-        onToggle={(_event, isExpanded) => setIsOpen(isExpanded)}
-        onSelect={() => setIsOpen(false)}
-        placeholderText={t('console-telemetry-plugin~Select option')}
+        onSelect={(_, selectedValue: TelemetryAnalyticsSelectOptions) => {
+          if (selectedValue && !disabled) {
+            onChange(selectedValue);
+          }
+          setIsOpen(false);
+        }}
+        onOpenChange={(open) => setIsOpen(open)}
       >
-        {options.map((option) => (
-          <SelectOptionDeprecated
-            key={option.value}
-            value={option.value}
-            description={option.description}
-            onClick={() => onChange(option)}
-            data-test={`telemetry-dropdown-option-${option.title}`}
-          >
-            {option.title}
-          </SelectOptionDeprecated>
-        ))}
-      </SelectDeprecated>
+        <SelectList>
+          {options.map((option) => (
+            <SelectOption
+              key={option.value}
+              value={option}
+              description={option.description}
+              data-test={`telemetry-dropdown-option-${option.title}`}
+              isSelected={option.isSelected}
+            >
+              {option.title}
+            </SelectOption>
+          ))}
+        </SelectList>
+      </Select>
     </div>
   );
 };


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-7672

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
before:

https://github.com/user-attachments/assets/915c1720-1e84-40d4-8941-6bb00584867b

after:

https://github.com/user-attachments/assets/d0502520-e174-43ab-b36d-6cb8baeaa83d

**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
run the bridge with `./bin/bridge --telemetry 'STATE=OPT-IN'` to enable telemetry, then remove the required flags `TELEMETRY_CLUSTER_CONFIGURATION` and `TELEMETRY_ENABLED` in [console-extensions.json](https://github.com/openshift/console/tree/master/frontend/packages/console-telemetry-plugin/console-extensions.json)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari


This pr is 1/2 of [ODC-7672](https://issues.redhat.com//browse/ODC-7672) story as each file is being split into a separate PR.