### PR TITLE
ODC-7672: Migrate TelemetryUserPreferenceDropdown to PF5

### DIFF
--- a/frontend/packages/console-telemetry-plugin/src/components/TelemetryUserPreferenceDropdown.tsx
+++ b/frontend/packages/console-telemetry-plugin/src/components/TelemetryUserPreferenceDropdown.tsx
@@ -1,10 +1,15 @@
 import * as React from 'react';
-import { FormGroup, FormHelperText, HelperText, HelperTextItem } from '@patternfly/react-core';
 import {
-  Select as SelectDeprecated,
-  SelectOption as SelectOptionDeprecated,
-  SelectVariant as SelectVariantDeprecated,
-} from '@patternfly/react-core/deprecated';
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Select,
+  SelectList,
+  SelectOption,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import {
   CLUSTER_TELEMETRY_ANALYTICS,
@@ -43,33 +48,49 @@ const TelemetryAnalyticsSelect: React.FC<{
   ];
   const [isOpen, setIsOpen] = React.useState(false);
   const selection = options.find((option) => option.isSelected)?.value;
+
+  const toggle = (toggleRef: React.RefObject<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setIsOpen(!isOpen)}
+      isDisabled={disabled}
+      isFullWidth
+      id="telemetry"
+    >
+      {selection
+        ? options.find((option) => option.value === selection)?.title
+        : t('console-telemetry-plugin~Select option')}
+    </MenuToggle>
+  );
+
   return (
-    <>
-      <SelectDeprecated
-        id="telemetry"
-        variant={SelectVariantDeprecated.single}
-        isOpen={isOpen}
-        selections={selection}
-        toggleId="telemetry"
-        onToggle={(_event, isExpanded) => setIsOpen(isExpanded)}
-        onSelect={() => setIsOpen(false)}
-        placeholderText={t('console-telemetry-plugin~Select option')}
-        isDisabled={disabled}
-        aria-label={t('console-telemetry-plugin~Select option')}
-        maxHeight={300}
-      >
+    <Select
+      toggle={toggle}
+      isOpen={isOpen}
+      toggleId="telemetry"
+      onSelect={(_, selectedValue?: TelemetryAnalyticsSelectOptions) => {
+        if (selectedValue) {
+          onChange(selectedValue);
+        }
+        setIsOpen(false);
+      }}
+      aria-label={t('console-telemetry-plugin~Select option')}
+      maxHeight={300}
+      onOpenChange={(open) => setIsOpen(open)}
+    >
+      <SelectList>
         {options.map((option) => (
-          <SelectOptionDeprecated
+          <SelectOption
             key={option.value}
-            value={option.value}
+            value={option}
             description={option.description}
-            onClick={() => onChange(option)}
+            isSelected={option.isSelected}
           >
             {option.title}
-          </SelectOptionDeprecated>
+          </SelectOption>
         ))}
-      </SelectDeprecated>
-    </>
+      </SelectList>
+    </Select>
   );
 };
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-7672

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
before:

https://github.com/user-attachments/assets/95d942a7-91d4-4563-8426-6b12cf4b92fd

after:

https://github.com/user-attachments/assets/0bbff5b9-14df-4a9b-b13f-ac23ecb09ab5


**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
run the bridge with `./bin/bridge --telemetry 'STATE=OPT-IN'` to enable telemetry, then remove the required flags `TELEMETRY_CLUSTER_CONFIGURATION` and `TELEMETRY_ENABLED` in [console-extensions.json](https://github.com/openshift/console/tree/master/frontend/packages/console-telemetry-plugin/console-extensions.json)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari


This pr is 2/2 of [ODC-7672](https://issues.redhat.com//browse/ODC-7672) story as each file is being split into a separate PR.