### PR TITLE
OCPBUGS-39203: Set default build option as BUILDS for Builder Image sample

### DIFF
--- a/frontend/packages/dev-console/src/components/import/ImportSamplePage.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportSamplePage.tsx
@@ -25,7 +25,7 @@ import {
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import { getBaseInitialValues } from './form-initial-values';
 import { createOrUpdateResources } from './import-submit-utils';
-import { BaseFormData, GitImportFormData } from './import-types';
+import { BaseFormData, BuildOptions, GitImportFormData } from './import-types';
 import { detectGitType, validationSchema } from './import-validation-utils';
 import ImportSampleForm from './ImportSampleForm';
 
@@ -103,6 +103,7 @@ const ImportSamplePage: React.FC = () => {
         image: true,
         config: true,
       },
+      option: BuildOptions.BUILDS,
     },
     import: {
       showEditImportStrategy: true,


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-39203

Descriptions: No build option is set in the Sample form, so BuildConfig is not created. This PR set the build option as BUILDS for the BuilderImage sample form.

Screen recording:

https://github.com/user-attachments/assets/0f8de741-4247-4d96-ae48-dc18ca3e64d3



