### PR TITLE
ODC-7655: Migrate IntervalDropdown to PF5

### DIFF
--- a/frontend/public/components/monitoring/poll-interval-dropdown.tsx
+++ b/frontend/public/components/monitoring/poll-interval-dropdown.tsx
@@ -6,10 +6,12 @@ import {
   parsePrometheusDuration,
 } from '@openshift-console/plugin-shared/src/datetime/prometheus';
 import {
-  Dropdown as DropdownDeprecated,
-  DropdownToggle as DropdownToggleDeprecated,
-  DropdownItem as DropdownItemDeprecated,
-} from '@patternfly/react-core/deprecated';
+  Select,
+  SelectList,
+  SelectOption,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 
 import { useBoolean } from './hooks/useBoolean';
 
@@ -22,10 +24,10 @@ type Props = {
 };
 
 const IntervalDropdown: React.FC<Props> = ({ id, interval, setInterval }) => {
-  const [isOpen, toggleIsOpen, , setClosed] = useBoolean(false);
+  const [isOpen, toggleIsOpen, setOpen, setClosed] = useBoolean(false);
   const { t } = useTranslation();
 
-  const onChange = React.useCallback(
+  const onSelect = React.useCallback(
     (v: string) => setInterval(v === OFF_KEY ? null : parsePrometheusDuration(v)),
     [setInterval],
   );
@@ -45,26 +47,39 @@ const IntervalDropdown: React.FC<Props> = ({ id, interval, setInterval }) => {
 
   const selectedKey = interval === null ? OFF_KEY : formatPrometheusDuration(interval);
 
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      id={`${id}-dropdown`}
+      onClick={toggleIsOpen}
+      isExpanded={isOpen}
+      ref={toggleRef}
+      className="monitoring-dashboards__dropdown-button"
+    >
+      {intervalOptions[selectedKey]}
+    </MenuToggle>
+  );
+
   return (
-    <DropdownDeprecated
-      dropdownItems={_.map(intervalOptions, (name, key) => (
-        <DropdownItemDeprecated component="button" key={key} onClick={() => onChange(key)}>
-          {name}
-        </DropdownItemDeprecated>
-      ))}
+    <Select
       isOpen={isOpen}
-      onSelect={setClosed}
-      toggle={
-        <DropdownToggleDeprecated
-          className="monitoring-dashboards__dropdown-button"
-          id={`${id}-dropdown`}
-          onToggle={toggleIsOpen}
-        >
-          {intervalOptions[selectedKey]}
-        </DropdownToggleDeprecated>
-      }
+      onSelect={(_event, value: string) => {
+        if (value) {
+          onSelect(value);
+        }
+        setClosed();
+      }}
+      toggle={toggle}
       className="monitoring-dashboards__variable-dropdown"
-    />
+      onOpenChange={(open) => (open ? setOpen() : setClosed())}
+    >
+      <SelectList>
+        {_.map(intervalOptions, (name, key) => (
+          <SelectOption key={key} value={key} isSelected={key === selectedKey}>
+            {name}
+          </SelectOption>
+        ))}
+      </SelectList>
+    </Select>
   );
 };
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-7655

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Migrate file to PF5

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

Demo:


https://github.com/user-attachments/assets/114c340c-850f-44c0-8e6c-9bee34be9823


**Unit test coverage report**: 
<!-- Attach test coverage report -->
unchanged

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
to see the observe dashboard in local development, use the mock data linked here https://github.com/openshift/monitoring-plugin/compare/main...zhuje:monitoring-plugin:mock_monitoring_dashboard_config

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari

This pr is 1/4 of [ODC-7655](https://issues.redhat.com//browse/ODC-7655) story as each file is being split into a separate PR.