### PR TITLE
OLS-944: Allow operators to enable monitoring by default

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -118,7 +118,12 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
     useSuggestedNSForSingleInstallMode,
     setUseSuggestedNSForSingleInstallMode,
   ] = React.useState(true);
-  const [enableMonitoring, setEnableMonitoring] = React.useState(false);
+
+  const defaultEnableMonitoring =
+    packageManifest?.metadata?.labels?.provider?.includes('Red Hat') &&
+    currentCSVDesc.annotations?.['console.openshift.io/operator-monitoring-default'] === 'true';
+  const [enableMonitoring, setEnableMonitoring] = React.useState(defaultEnableMonitoring);
+
   const [error, setError] = React.useState('');
   const [consoleOperatorConfig] = useK8sWatchResource<K8sResourceKind>({
     kind: referenceForModel(ConsoleOperatorConfigModel),


### PR DESCRIPTION
![default-monitoring](https://github.com/user-attachments/assets/5f41a7dd-0831-4280-9f9c-aa15640e3b7d)

Related OpenShfit Lightspeed PR: https://github.com/openshift/lightspeed-operator/pull/366