### PR TITLE
OCPBUGS-39494: Unit Tests for the new Ask Lightspeed Button

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/__tests__/CodeEditorToolbar.spec.tsx
+++ b/frontend/packages/console-shared/src/components/editor/__tests__/CodeEditorToolbar.spec.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { useTranslation } from 'react-i18next';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useDispatch } from 'react-redux';
+import { useOLSConfig } from '../../../hooks/ols-hook';
+import CodeEditorToolbar, { ActionType } from '../CodeEditorToolbar';
+import ShortcutsLink from '../ShortcutsLink';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('../../../hooks/ols-hook', () => ({
+  useOLSConfig: jest.fn(),
+}));
+
+describe('CodeEditorToolbar', () => {
+  let wrapper: ShallowWrapper;
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useTranslation as jest.Mock).mockReturnValue({ t: (key: string) => key });
+    (useDispatch as jest.Mock).mockReturnValue(mockDispatch);
+  });
+
+  it('should render null when showShortcuts is false and toolbarLinks is empty', () => {
+    wrapper = shallow(<CodeEditorToolbar />);
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+
+  it('should render toolbar with shortcuts when showShortcuts is true', () => {
+    wrapper = shallow(<CodeEditorToolbar showShortcuts />);
+    expect(wrapper.find(ShortcutsLink).exists()).toBe(true);
+  });
+
+  it('should render toolbar with custom links when toolbarLinks are provided', () => {
+    const toolbarLinks = [<div key="custom">Custom Link</div>];
+    wrapper = shallow(<CodeEditorToolbar toolbarLinks={toolbarLinks} />);
+    expect(wrapper.contains(<div>Custom Link</div>)).toBe(true);
+  });
+
+  it('should render "Ask OpenShift Lightspeed" button when showLightspeedButton is true', () => {
+    (useOLSConfig as jest.Mock).mockReturnValue(true);
+    wrapper = shallow(<CodeEditorToolbar showShortcuts />);
+    expect(wrapper.find(Button).prop('children')).toBe('console-shared~Ask OpenShift Lightspeed');
+  });
+
+  it('should not render "Ask OpenShift Lightspeed" button when showLightspeedButton is false', () => {
+    (useOLSConfig as jest.Mock).mockReturnValue(false);
+    wrapper = shallow(<CodeEditorToolbar showShortcuts />);
+    expect(wrapper.find(Button).exists()).toBe(false);
+  });
+
+  it('should dispatch OpenOLS action when "Ask OpenShift Lightspeed" button is clicked', () => {
+    (useOLSConfig as jest.Mock).mockReturnValue(true);
+    wrapper = shallow(<CodeEditorToolbar showShortcuts />);
+    wrapper.find(Button).simulate('click');
+    expect(mockDispatch).toHaveBeenCalledWith({ type: ActionType.OpenOLS });
+  });
+});


### PR DESCRIPTION
**Type**: 

- [x] Tests

**Jira Link**: 

1. https://issues.redhat.com/browse/ODC-7685

**Solution Description**: 

As a developer, I need to set up unit tests to test the Lightspeed button's proper functioning when the Lightspeed operator is installed in the cluster.

**Screenshots / Videos for review**: 
![image](https://github.com/user-attachments/assets/6572e849-523d-482a-9f0f-d9d8abb85168)


**Test coverage**: 

- [x] Unit Tests Updated
- [ ] E2E Tests Updated


**Test setup:**
[ Not Needed- CI Frontend Tests will cover this ]

**Browser conformance**: 

- [x] Chrome
- [ ] Firefox
- [ ] Safari