### PR TITLE
[release-4.14] OCPBUGS-38972: Redirects to new PipelineRun logs URL from old PipelineRun logs URL

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -739,6 +739,17 @@
     "type": "console.page/route",
     "properties": {
       "exact": true,
+      "path": [
+        "/k8s/ns/:ns/tekton.dev~v1~PipelineRun/:plrName/logs/:taskName",
+        "/k8s/ns/:ns/tekton.dev~v1beta1~PipelineRun/:plrName/logs/:taskName"
+      ],
+      "component": { "$codeRef": "pipelinesComponent.LogURLRedirect" }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
       "path": "/k8s/ns/:ns/tekton.dev~v1~Pipeline/~new/builder",
       "component": {
         "$codeRef": "pipelinesComponent.PipelineBuilderPage"

--- a/frontend/packages/pipelines-plugin/src/components/LogURLRedirect.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/LogURLRedirect.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { Redirect, RouteComponentProps } from 'react-router-dom';
+
+type LogURLRedirectProps = RouteComponentProps<{ ns: string; taskName: string; plrName: string }>;
+
+const createLogURL = (pathname: string, taskName: string): string => {
+  const basePath = pathname.replace(/\/$/, '');
+  const detailsURL = basePath.split('/logs/');
+  return `${detailsURL[0]}/logs?taskName=${taskName}`;
+};
+
+export const LogURLRedirect: React.FC<LogURLRedirectProps> = ({ match }) => {
+  const { taskName } = match.params;
+  return <Redirect to={createLogURL(window.location.pathname, taskName)} />;
+};

--- a/frontend/packages/pipelines-plugin/src/components/pipelines-index.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines-index.ts
@@ -4,3 +4,4 @@ export * from './conditions';
 export * from './pipelines-lists';
 export * from './repository';
 export { useIsTektonV1VersionPresent } from './pipelines/utils/pipeline-operator';
+export { LogURLRedirect } from './LogURLRedirect';


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/console/pull/14083