### PR TITLE
OCPBUGS-39325: Add ConsolePlugin YAML example to yaml editor templates.

### DIFF
--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -972,6 +972,23 @@ spec:
 `,
   )
   .setIn(
+    [referenceForModel(k8sModels.ConsolePluginModel), 'default'],
+    `
+apiVersion: console.openshift.io/v1
+kind: ConsolePlugin
+metadata:
+  name: example
+spec:
+  backend:
+    service:
+      name: my-backend-service
+      namespace: default
+      port: 443
+    type: Service
+  displayName: myConsolePlugin
+`,
+  )
+  .setIn(
     [referenceForModel(k8sModels.ConsoleLinkModel), 'default'],
     `
 apiVersion: console.openshift.io/v1


### PR DESCRIPTION
Solution description:
The ConsolePlugin K8sKind has missed its own YAML template and thus it resorted to the default YAML template that misses the required fields for [ConsolePlugin](https://docs.openshift.com/container-platform/4.16/rest_api/console_apis/consoleplugin-console-openshift-io-v1.html). As a result of this addition, the yaml editor in the ConsolePlugin creation page shows a correct yaml example/template instead of the default one that does not specify these required fields.
Screen shots / gifs / design review:
before:
![Screenshot 2024-09-04 at 12 14 10](https://github.com/user-attachments/assets/e7236a03-aa40-421e-9a2b-8b922510bc91)
after:
![Screenshot 2024-09-04 at 12 00 13](https://github.com/user-attachments/assets/052eb042-667e-4e43-9d05-b538aa5f2f6c)
