### PR TITLE
CONSOLE-4125: Convert language dropdown deprecated select

### DIFF
--- a/frontend/packages/console-app/src/components/user-preferences/language/LanguageDropdown.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/language/LanguageDropdown.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
-import { Skeleton, Checkbox } from '@patternfly/react-core';
 import {
-  SelectOption as SelectOptionDeprecated,
-  Select as SelectDeprecated,
-  SelectVariant as SelectVariantDeprecated,
-} from '@patternfly/react-core/deprecated';
+  Skeleton,
+  Checkbox,
+  Select,
+  SelectList,
+  SelectOption,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 import { supportedLocales } from './const';
@@ -17,13 +20,13 @@ const LanguageDropdown: React.FC = () => {
   const { t } = useTranslation();
   const fireTelemetryEvent = useTelemetry();
   const [preferredLanguage, setPreferredLanguage, preferredLanguageLoaded] = usePreferredLanguage();
-  const [dropdownOpen, setDropdownOpen] = React.useState(false);
-  const selectOptions: JSX.Element[] = React.useMemo(
+  const [isOpen, setIsOpen] = React.useState(false);
+  const options: JSX.Element[] = React.useMemo(
     () =>
-      Object.keys(supportedLocales).map((lang) => (
-        <SelectOptionDeprecated key={lang} value={lang}>
-          {supportedLocales[lang]}
-        </SelectOptionDeprecated>
+      Object.keys(supportedLocales).map((language) => (
+        <SelectOption key={language} value={language}>
+          {supportedLocales[language]}
+        </SelectOption>
       )),
     [],
   );
@@ -31,7 +34,6 @@ const LanguageDropdown: React.FC = () => {
   const [isUsingDefault, setIsUsingDefault] = React.useState<boolean>(!preferredLanguage);
   const checkboxLabel: string = t('console-app~Use the default browser language setting.');
 
-  const onToggle = (_event, isOpen: boolean) => setDropdownOpen(isOpen);
   const onSelect = (_, selection: string) => {
     if (selection !== preferredLanguage) {
       setPreferredLanguage(selection);
@@ -40,7 +42,7 @@ const LanguageDropdown: React.FC = () => {
         value: 'custom',
       });
     }
-    setDropdownOpen(false);
+    setIsOpen(false);
   };
 
   const onUsingDefault = (_event, checked: boolean) => {
@@ -77,21 +79,27 @@ const LanguageDropdown: React.FC = () => {
         data-test="checkbox console.preferredLanguage"
         className="co-language-dropdown__system-default-checkbox"
       />
-      <SelectDeprecated
-        variant={SelectVariantDeprecated.single}
-        isOpen={dropdownOpen}
-        selections={preferredLanguage}
-        toggleId={'console.preferredLanguage'}
-        onToggle={onToggle}
+      <Select
+        isOpen={isOpen}
+        onOpenChange={(open) => setIsOpen(open)}
+        selected={preferredLanguage}
         onSelect={onSelect}
-        placeholderText={t('console-app~Select a language')}
-        aria-label={t('console-app~Select a language')}
         data-test="dropdown console.preferredLanguage"
-        maxHeight={300}
-        isDisabled={isUsingDefault}
+        id={'console.preferredLanguage'}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            aria-label={t('console-app~Select a language')}
+            isFullWidth
+            isDisabled={isUsingDefault}
+            ref={toggleRef}
+            onClick={(open) => setIsOpen(open)}
+          >
+            {supportedLocales[preferredLanguage] || t('console-app~Select a language')}
+          </MenuToggle>
+        )}
       >
-        {selectOptions}
-      </SelectDeprecated>
+        <SelectList>{options}</SelectList>
+      </Select>
     </>
   ) : (
     <>

--- a/frontend/packages/console-app/src/components/user-preferences/language/__tests__/LanguageDropdown.spec.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/language/__tests__/LanguageDropdown.spec.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Checkbox } from '@patternfly/react-core';
-import { Select as SelectDeprecated } from '@patternfly/react-core/deprecated';
-import { shallow, ShallowWrapper } from 'enzyme';
+import { Checkbox, MenuToggle, Select } from '@patternfly/react-core';
+import { mount, shallow, ShallowWrapper } from 'enzyme';
 import { getLastLanguage } from '../getLastLanguage';
 import LanguageDropdown from '../LanguageDropdown';
 import { usePreferredLanguage } from '../usePreferredLanguage';
@@ -68,10 +67,14 @@ describe('LanguageDropdown', () => {
     getLastLanguageMock.mockReturnValue(['']);
     spyOn(React, 'useContext').and.returnValue({ getProcessedResourceBundle: jest.fn() });
     wrapper = shallow(<LanguageDropdown />);
+    const mountlanguagedropdown = mount(<LanguageDropdown />);
     expect(wrapper.find('[data-test="checkbox console.preferredLanguage"]').exists()).toBeTruthy();
     expect(wrapper.find(Checkbox).props().isChecked).toBe(true);
     expect(wrapper.find('[data-test="dropdown console.preferredLanguage"]').exists()).toBeTruthy();
-    expect(wrapper.find(SelectDeprecated).props().isDisabled).toBe(true);
+
+    expect(
+      (mountlanguagedropdown.find(MenuToggle).props() as { isDisabled: boolean }).isDisabled,
+    ).toBe(true); // This Fails :( test errror => "TypeError: localStorage.removeItem is not a function"
   });
 
   it('should render checkbox in unchecked state and select in enabled state if user preferences have loaded and preferred language is defined', () => {
@@ -79,19 +82,24 @@ describe('LanguageDropdown', () => {
     getLastLanguageMock.mockReturnValue(['']);
     spyOn(React, 'useContext').and.returnValue({ getProcessedResourceBundle: jest.fn() });
     wrapper = shallow(<LanguageDropdown />);
+    const mountlanguagedropdown = mount(<LanguageDropdown />);
     expect(wrapper.find('[data-test="checkbox console.preferredLanguage"]').exists()).toBeTruthy();
     expect(wrapper.find(Checkbox).props().isChecked).toBe(false);
     expect(wrapper.find('[data-test="dropdown console.preferredLanguage"]').exists()).toBeTruthy();
-    expect(wrapper.find(SelectDeprecated).props().isDisabled).toBe(false);
+
+    expect(
+      (mountlanguagedropdown.find(MenuToggle).props() as { isDisabled: boolean }).isDisabled,
+    ).toBe(false); // This passes :)
   });
 
   it('should render select with value corresponding to preferred language if user preferences have loaded and preferred language is defined', () => {
     usePreferredLanguageMock.mockReturnValue([preferredLanguageValue, jest.fn(), true]);
     getLastLanguageMock.mockReturnValue(['']);
     spyOn(React, 'useContext').and.returnValue({ getProcessedResourceBundle: jest.fn() });
-    wrapper = shallow(<LanguageDropdown />);
     expect(wrapper.find('[data-test="checkbox console.preferredLanguage"]').exists()).toBeTruthy();
     expect(wrapper.find('[data-test="dropdown console.preferredLanguage"]').exists()).toBeTruthy();
-    expect(wrapper.find(SelectDeprecated).props().selections).toEqual(preferredLanguageValue);
+    expect((wrapper.find(Select).props() as { selected: string }).selected).toEqual(
+      preferredLanguageValue,
+    );
   });
 });


### PR DESCRIPTION
1 of several for https://issues.redhat.com/browse/CONSOLE-4125
![LanguageDropdown](https://github.com/user-attachments/assets/862637bc-c2f0-43d6-974d-e2a902696bd1)
