### PR TITLE
OCPBUGS-38845: Update vendor imports to include all PatternFly components

### DIFF
--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -13,17 +13,9 @@
 @import '~@patternfly/react-catalog-view-extension/dist/sass/properties-side-panel';
 @import '~@patternfly/react-catalog-view-extension/dist/sass/vertical-tabs';
 @import '~@patternfly/patternfly/sass-utilities/all';
-@import '~@patternfly/patternfly/base/base';
-@import '~@patternfly/patternfly/base/fonts';
-@import '~@patternfly/patternfly/base/svg-icons';
-@import '~@patternfly/patternfly/base/variables';
-@import '~@patternfly/patternfly/components/Drawer/drawer';
-@import '~@patternfly/patternfly/components/Form/form';
-@import '~@patternfly/patternfly/components/FormControl/form-control';
-@import '~@patternfly/patternfly/components/InputGroup/input-group';
-@import '~@patternfly/patternfly/components/NotificationBadge/notification-badge';
-@import '~@patternfly/patternfly/components/NotificationDrawer/notification-drawer';
-@import '~@patternfly/patternfly/components/Toolbar/toolbar';
+@import '~@patternfly/patternfly/patternfly-base';
+@import '~@patternfly/patternfly/components/all';
+@import '~@patternfly/patternfly/layouts/all';
 @import '~@patternfly/patternfly/patternfly-charts';
 @import '~@patternfly/patternfly/patternfly-addons';
 


### PR DESCRIPTION
Explicitly import all PatternFly styles within `vendor.scss`

When the following changes were made to the `console-dynamic-plugin-sdk/webpack` configuration, it removed the ability for plugins to bring in their own PatternFly styles. 
https://github.com/openshift/console/pull/13521
https://github.com/openshift/console/pull/13388

This exposed [a bug](https://issues.redhat.com/browse/OCPBUGS-38845) where certain PF components, that are not being used in Console, do not have their associated component styles available for plugins to utilize.

Tests using `console-plugin-template` to show before and after this change.

**Before**
<img width="1434" alt="Screenshot 2024-09-06 at 8 19 07 AM" src="https://github.com/user-attachments/assets/3bf861ac-d59a-4ba9-8363-0eb2068a144f">


**After**
<img width="1492" alt="Screenshot 2024-09-06 at 8 14 22 AM" src="https://github.com/user-attachments/assets/0e378030-c4f5-4f1e-8c27-38bccc78e876">
