### PR TITLE
OCPBUGS-41924, OCPBUGS-43540: Update and enable shipwright e2e test on CI

### DIFF
--- a/frontend/integration-tests/test-cypress.sh
+++ b/frontend/integration-tests/test-cypress.sh
@@ -97,7 +97,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
   yarn run test-cypress-pipelines-headless
-  # yarn run test-cypress-shipwright-headless
+  yarn run test-cypress-shipwright-headless
   # yarn run test-cypress-webterminal-headless
   exit;
 fi

--- a/frontend/packages/shipwright-plugin/integration-tests/features/e2e/shipwright-ci.feature
+++ b/frontend/packages/shipwright-plugin/integration-tests/features/e2e/shipwright-ci.feature
@@ -24,8 +24,8 @@ Feature: Shipwright build details page
               And user will see "BuildStrategies" horizontal link tab
               And user will see "ClusterBuildStrategies" horizontal link tab
 
-
-        @regression
+        # Disabling the test due to the BUG : https://issues.redhat.com/browse/OCPBUGS-41945
+        @regression @broken-test
         Scenario: Shipwright build details page: SWB-01-TC03
             Given user is on Builds navigation in Developer perspective
               And user clicks on "buildpack-nodejs-build-heroku" build

--- a/frontend/packages/shipwright-plugin/integration-tests/features/e2e/shipwright-ci.feature
+++ b/frontend/packages/shipwright-plugin/integration-tests/features/e2e/shipwright-ci.feature
@@ -47,8 +47,8 @@ Feature: Shipwright build details page
               And user clicks on Filter
              Then user will see "Pending", "Running", "Succeeded", "Failed" and "Unknown" options
 
-
-        @regression
+        # Disabling the test due to the BUG : https://issues.redhat.com/browse/OCPBUGS-41944
+        @regression @broken-test
         Scenario: Shipwright build runs details page: SWB-01-TC06
             Given user is at Shipwright Builds details page for build "buildpack-nodejs-build-heroku"
              When user clicks on "BuildRuns" tab in the Developer perspective
@@ -66,8 +66,8 @@ Feature: Shipwright build details page
               And user clicks on Event tab
              Then user will see events steaming
 
-
-        @regression
+        # Disabling the test due to the BUG : https://issues.redhat.com/browse/OCPBUGS-41945
+        @regression @broken-test
         Scenario: Checking error for failed build runs : SWB-01-TC08
             Given user is at Shipwright Builds run page "buildpack-nodejs-build-heroku"
               And user has a failed build run

--- a/frontend/packages/shipwright-plugin/integration-tests/testData/builds/shipwrightBuild.yaml
+++ b/frontend/packages/shipwright-plugin/integration-tests/testData/builds/shipwrightBuild.yaml
@@ -1,29 +1,45 @@
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: buildpack-nodejs-build-heroku
+  labels:
+    app.kubernetes.io/instance: buildpack-nodejs-build-heroku
+    build.shipwright.io/name: buildpack-nodejs-build-heroku
 spec:
   source:
-    url: https://github.com/shipwright-io/sample-nodejs
-    contextDir: source-build
+    type: Git
+    git:
+      url: https://github.com/nodeshift-blog-examples/react-web-app
+    contextDir: /
   strategy:
-    name: buildpacks-v3-heroku
-    kind: BuildStrategy
+    name: source-to-image
+    kind: ClusterBuildStrategy
+  paramValues:
+    - name: builder-image
+      value: image-registry.openshift-image-registry.svc:5000/openshift/nodejs:20-ubi8
   output:
-    image: image-registry.openshift-image-registry.svc:5000/build-examples/buildpack-nodejs-build-heroku
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/s2i-cbs-example:latest
 ---
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: BuildRun
 metadata:
   name: buildpack-nodejs-build-heroku-1
+  labels:
+    app.kubernetes.io/instance: buildpack-nodejs-build-heroku
+    build.shipwright.io/name: buildpack-nodejs-build-heroku
 spec:
-  buildRef:
+  build:
     name: buildpack-nodejs-build-heroku
 ---
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: BuildRun
 metadata:
   name: buildpack-nodejs-build-heroku-2
+  labels:
+    app.kubernetes.io/instance: buildpack-nodejs-build-heroku
+    build.shipwright.io/name: buildpack-nodejs-build-heroku
 spec:
-  buildRef:
+  build:
     name: buildpack-nodejs-build-heroku
+---
+

--- a/frontend/packages/shipwright-plugin/integration-tests/testData/builds/shipwrightBuildStrategies.yaml
+++ b/frontend/packages/shipwright-plugin/integration-tests/testData/builds/shipwrightBuildStrategies.yaml
@@ -11,7 +11,7 @@
 #
 
 ---
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: BuildStrategy
 metadata:
   name: buildah
@@ -192,7 +192,7 @@ spec:
         - quay.io
 
 ---
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: BuildStrategy
 metadata:
   name: buildkit
@@ -340,7 +340,7 @@ spec:
         - $(params.secrets[*])
 
 ---
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: BuildStrategy
 metadata:
   name: buildpacks-v3-heroku
@@ -376,7 +376,7 @@ spec:
           memory: 65Mi
 
 ---
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: BuildStrategy
 metadata:
   name: buildpacks-v3
@@ -416,7 +416,7 @@ spec:
 # This Build Strategy will intentionally fail if the image has any
 # critical CVEs. It will not be pushed into the destination registry
 # if any critical vulnerabilities are found.
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: BuildStrategy
 metadata:
   name: kaniko-trivy
@@ -517,7 +517,7 @@ spec:
           mountPath: /kaniko/oci-image-layout
 
 ---
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: BuildStrategy
 metadata:
   name: kaniko
@@ -579,7 +579,7 @@ spec:
           mountPath: /kaniko/oci-image-layout
 
 ---
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: BuildStrategy
 metadata:
   name: ko
@@ -694,7 +694,7 @@ spec:
           memory: 65Mi
 
 ---
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: BuildStrategy
 metadata:
   name: source-to-image-redhat
@@ -826,7 +826,7 @@ spec:
         - quay.io
 
 ---
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: BuildStrategy
 metadata:
   name: source-to-image

--- a/frontend/packages/shipwright-plugin/integration-tests/testData/shipwrightOperatorSubscription.yaml
+++ b/frontend/packages/shipwright-plugin/integration-tests/testData/shipwrightOperatorSubscription.yaml
@@ -1,12 +1,12 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
- name: shipwright-operator
- namespace: openshift-operators
+  name: shipwright-operator
+  namespace: openshift-operators
 spec:
- channel: alpha
- installPlanApproval: Automatic
- name: shipwright-operator
- source: community-operators
- sourceNamespace: openshift-marketplace
- startingCSV: shipwright-operator.v0.9.0
+  channel: alpha
+  installPlanApproval: Automatic
+  name: shipwright-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: shipwright-operator.v0.13.0


### PR DESCRIPTION
**Fix**:
[OCPBUGS-41924](https://issues.redhat.com/browse/OCPBUGS-41924)
[OCPBUGS-39573](https://issues.redhat.com/browse/OCPBUGS-39573)
**Description**

1. Enable Shipwright e2e tests.
2. Updates Shipwright Operator subscription to latest release
3. Disable `SWB-01-TC06 & SWB-01-TC08` tests