### PR TITLE
OCPBUGS-6589: Workloads - Jobs: Completions column i18n misses

### DIFF
--- a/frontend/public/components/job.tsx
+++ b/frontend/public/components/job.tsx
@@ -75,6 +75,7 @@ const JobTableRow: React.FC<RowFunctionArgs<JobKind>> = ({ obj: job }) => {
   const { type, completions } = getJobTypeAndCompletions(job);
   const resourceKind = referenceFor(job);
   const context = { [resourceKind]: job };
+  const { t } = useTranslation();
   return (
     <>
       <TableData className={tableColumnClasses[0]}>
@@ -91,7 +92,10 @@ const JobTableRow: React.FC<RowFunctionArgs<JobKind>> = ({ obj: job }) => {
       </TableData>
       <TableData className={tableColumnClasses[3]}>
         <Link to={`/k8s/ns/${job.metadata.namespace}/jobs/${job.metadata.name}/pods`} title="pods">
-          {job.status.succeeded || 0} of {completions}
+          {t('public~{{jobsSucceeded}} of {{completions}}', {
+            jobsSucceeded: job.status.succeeded || 0,
+            completions,
+          })}
         </Link>
       </TableData>
       <TableData className={tableColumnClasses[4]}>{type}</TableData>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -702,6 +702,7 @@
   "Template": "Template",
   "(generated if empty)": "(generated if empty)",
   "Edit parallelism": "Edit parallelism",
+  "{{jobsSucceeded}} of {{completions}}": "{{jobsSucceeded}} of {{completions}}",
   "Job status": "Job status",
   "Succeeded pods": "Succeeded pods",
   "Active pods": "Active pods",

--- a/frontend/public/locales/es/public.json
+++ b/frontend/public/locales/es/public.json
@@ -1500,6 +1500,7 @@
   "Unknown error submitting": "Error desconocido al enviar",
   "Select all filters": "Seleccionar todos los filtros",
   "{{selectedCount}} of {{itemCount}}": "{{selectedCount}} de {{itemCount}}",
+  "{{jobsSucceeded}} of {{completions}}": "{{jobsSucceeded}} de {{completions}}",
   "Item_one": "Artículo",
   "Item_other": "Artículos",
   "Search": "Buscar",

--- a/frontend/public/locales/fr/public.json
+++ b/frontend/public/locales/fr/public.json
@@ -1497,6 +1497,7 @@
   "Unknown error submitting": "Erreur inconnue lors de l’envoi",
   "Select all filters": "Sélectionner tous les filtres",
   "{{selectedCount}} of {{itemCount}}": "{{selectedCount}} sur {{itemCount}}",
+  "{{jobsSucceeded}} of {{completions}}": "{{jobsSucceeded}} sur {{completions}}",
   "Item_one": "élément",
   "Item_other": "éléments",
   "Search": "Recherche",

--- a/frontend/public/locales/ja/public.json
+++ b/frontend/public/locales/ja/public.json
@@ -1496,6 +1496,7 @@
   "Unknown error submitting": "不明な送信エラー",
   "Select all filters": "すべてのフィルターを選択",
   "{{selectedCount}} of {{itemCount}}": "{{selectedCount}}/{{itemCount}}",
+  "{{jobsSucceeded}} of {{completions}}": "{{jobsSucceeded}}/{{completions}}",
   "Item_one": "アイテム",
   "Item_other": "アイテム",
   "Search": "検索",

--- a/frontend/public/locales/ko/public.json
+++ b/frontend/public/locales/ko/public.json
@@ -1496,6 +1496,7 @@
   "Unknown error submitting": "알 수 없는 오류 제출",
   "Select all filters": "모든 필터 선택",
   "{{selectedCount}} of {{itemCount}}": "{{selectedCount}} / {{itemCount}}",
+  "{{jobsSucceeded}} of {{completions}}": "{{jobsSucceeded}} / {{completions}}",
   "Item_one": "항목",
   "Item_other": "항목",
   "Search": "검색",

--- a/frontend/public/locales/zh/public.json
+++ b/frontend/public/locales/zh/public.json
@@ -1496,6 +1496,7 @@
   "Unknown error submitting": "提交未知错误",
   "Select all filters": "清除所有过滤器",
   "{{selectedCount}} of {{itemCount}}": "{{selectedCount}}（共 {{itemCount}}）",
+  "{{jobsSucceeded}} of {{completions}}": "{{jobsSucceeded}}（共 {{completions}}) ",
   "Item_one": "项",
   "Item_other": "项",
   "Search": "搜索",


### PR DESCRIPTION
fixes:
[https://issues.redhat.com/browse/OCPBUGS-6589](https://issues.redhat.com/browse/OCPBUGS-6589 )

Cause: the column for rendering the completions status missed i18n.

Result: After inserting the missing translations the column is translated as expected.

<img width="1361" alt="Screenshot 2024-09-09 at 12 28 58" src="https://github.com/user-attachments/assets/a1ffd136-1144-4cbe-8505-cb3b7644a494">

<img width="1342" alt="Screenshot 2024-09-09 at 12 28 44" src="https://github.com/user-attachments/assets/37284bbf-bc0d-485e-83f2-0f58921643cf">
