### PR TITLE
OCPBUGS-41620: Fix access mode selection menu issue

### DIFF
--- a/frontend/packages/console-app/src/components/access-modes/access-mode.tsx
+++ b/frontend/packages/console-app/src/components/access-modes/access-mode.tsx
@@ -59,7 +59,9 @@ export const AccessModeSelector: React.FC<AccessModeSelectorProps> = (props) => 
   );
 
   const [isOpen, setIsOpen] = React.useState(false);
-  const [selected, setSelected] = React.useState<string>(getAccessModeOptions()[0].title);
+  const [selected, setSelected] = React.useState<string>(
+    getAccessModeOptions().find((mode) => mode.value === pvcInitialAccessMode[0]).title,
+  );
 
   const onToggleClick = () => {
     setIsOpen(!isOpen);


### PR DESCRIPTION
The clone and restore modal shows two different options as selected on toggle, and dropdown options. For more: https://bugzilla.redhat.com/show_bug.cgi?id=2310369
