### PR TITLE
OCPBUGS-38480: Add white background to IconDropdown

### DIFF
--- a/frontend/packages/dev-console/src/components/import/icon/IconDropdown.scss
+++ b/frontend/packages/dev-console/src/components/import/icon/IconDropdown.scss
@@ -2,10 +2,10 @@
   img.icon {
     background-color: var(--pf-v5-global--palette--white);
     border-radius: var(--pf-v5-global--BorderRadius--sm);
-    height: var(--pf-v5-global--FontSize--4xl);
+    height: var(--pf-v5-global--FontSize--3xl);
     margin-right: var(--pf-v5-global--spacer--sm);
     padding: var(--pf-v5-global--spacer--xs);
-    width: var(--pf-v5-global--FontSize--4xl);
+    width: var(--pf-v5-global--FontSize--3xl);
   }
 
   &__item {

--- a/frontend/packages/dev-console/src/components/import/icon/IconDropdown.scss
+++ b/frontend/packages/dev-console/src/components/import/icon/IconDropdown.scss
@@ -1,6 +1,16 @@
 .odc-icon-dropdown {
   img.icon {
+    background-color: var(--pf-v5-global--palette--white);
+    border-radius: var(--pf-v5-global--BorderRadius--sm);
+    height: var(--pf-v5-global--FontSize--4xl);
     margin-right: var(--pf-v5-global--spacer--sm);
+    padding: var(--pf-v5-global--spacer--xs);
+    width: var(--pf-v5-global--FontSize--4xl);
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
   }
 
   .pf-v5-c-dropdown__toggle-text {

--- a/frontend/packages/dev-console/src/components/import/icon/IconDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/icon/IconDropdown.tsx
@@ -17,10 +17,10 @@ type IconProps = {
 };
 
 const Icon: React.FC<IconProps> = ({ label, url }) => (
-  <>
+  <div className="odc-icon-dropdown__item">
     <img src={url} width="24" height="24" alt="" className="icon" />
     {label}
-  </>
+  </div>
 );
 
 const iconLabelAutocompleteFilter = (text: string, item: React.ReactElement<IconProps>) =>


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

https://issues.redhat.com/browse/OCPBUGS-38480

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

No white background in the dropdown in dark mode makes it hard to read

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Added white background in the dropdown and added some padding

**Screen shots / Gifs for design review**: 

https://github.com/user-attachments/assets/9b8eda94-b644-462a-90e5-f2ac3197aa15


**Unit test coverage report**: 
<!-- Attach test coverage report -->

n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

n/a

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari