### PR TITLE
OCPBUGS-35744: Fix JSON annotation parsing issue and harden related code

### DIFF
--- a/frontend/packages/operator-lifecycle-manager-v1/src/database/metadata.ts
+++ b/frontend/packages/operator-lifecycle-manager-v1/src/database/metadata.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
-import { OperatorHubCSVAnnotationKey } from '@console/operator-lifecycle-manager/src/components/operator-hub';
-import { normalizedInfrastructureFeatures } from '@console/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils';
+import { OLMAnnotation } from '@console/operator-lifecycle-manager/src/components/operator-hub';
+import { normalizeInfrastructureFeature } from '@console/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils';
 import {
   CommaSeparatedList,
   ExtensionCatalogItemMetadata,
@@ -69,7 +69,7 @@ const aggregateLegacyInfrastructureFeatures = (acc, key, value) => {
   if (!infrastructureFeatures) return acc;
   return {
     ...acc,
-    infrastructureFeatures: infrastructureFeatures.map((i) => normalizedInfrastructureFeatures[i]),
+    infrastructureFeatures: infrastructureFeatures.map((i) => normalizeInfrastructureFeature[i]),
   };
 };
 
@@ -97,19 +97,19 @@ const aggregateAnnotations = (
         );
       case CSVMetadataKey.categories:
         return aggregateCommaSeparatedList(acc, key, value);
-      case OperatorHubCSVAnnotationKey.disconnected:
-      case OperatorHubCSVAnnotationKey.fipsCompliant:
-      case OperatorHubCSVAnnotationKey.proxyAware:
-      case OperatorHubCSVAnnotationKey.cnf:
-      case OperatorHubCSVAnnotationKey.cni:
-      case OperatorHubCSVAnnotationKey.csi:
-      case OperatorHubCSVAnnotationKey.tlsProfiles:
-      case OperatorHubCSVAnnotationKey.tokenAuthAWS:
-      case OperatorHubCSVAnnotationKey.tokenAuthAzure:
-      case OperatorHubCSVAnnotationKey.tokenAuthGCP:
+      case OLMAnnotation.Disconnected:
+      case OLMAnnotation.FIPSCompliant:
+      case OLMAnnotation.ProxyAware:
+      case OLMAnnotation.CNF:
+      case OLMAnnotation.CNI:
+      case OLMAnnotation.CSI:
+      case OLMAnnotation.TLSProfiles:
+      case OLMAnnotation.TokenAuthAWS:
+      case OLMAnnotation.TokenAuthAzure:
+      case OLMAnnotation.TokenAuthGCP:
         return value === 'true'
           ? aggregateArray(acc, NormalizedCSVMetadataKey.infrastructureFeatures, [
-              normalizedInfrastructureFeatures[key],
+              normalizeInfrastructureFeature[key],
             ])
           : acc;
       default:

--- a/frontend/packages/operator-lifecycle-manager-v1/src/database/types.ts
+++ b/frontend/packages/operator-lifecycle-manager-v1/src/database/types.ts
@@ -1,4 +1,4 @@
-import { InfraFeatures } from '@console/operator-lifecycle-manager/src/components/operator-hub';
+import { InfrastructureFeature } from '@console/operator-lifecycle-manager/src/components/operator-hub';
 
 export enum FileBasedCatalogSchema {
   package = 'olm.package',
@@ -84,7 +84,7 @@ export type ExtensionCatalogItemMetadata = {
   categories?: string[];
   description?: string;
   displayName?: string;
-  infrastructureFeatures?: InfraFeatures[];
+  infrastructureFeatures?: InfrastructureFeature[];
   keywords?: string[];
   longDescription?: string;
   provider?: string;

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -98,11 +98,7 @@ import {
   CSVConditionReason,
   SubscriptionKind,
 } from '../types';
-import {
-  getClusterServiceVersionPlugins,
-  isCatalogSourceTrusted,
-  upgradeRequiresApproval,
-} from '../utils';
+import { isCatalogSourceTrusted, upgradeRequiresApproval } from '../utils';
 import { isCopiedCSV, isStandaloneCSV } from '../utils/clusterserviceversions';
 import { useClusterServiceVersion } from '../utils/useClusterServiceVersion';
 import { useClusterServiceVersionPath } from '../utils/useClusterServiceVersionPath';
@@ -115,6 +111,7 @@ import {
 import { createUninstallOperatorModal } from './modals/uninstall-operator-modal';
 import { ProvidedAPIsPage, ProvidedAPIPage, ProvidedAPIPageProps } from './operand';
 import { operatorGroupFor, operatorNamespaceFor, targetNamespacesFor } from './operator-group';
+import { getClusterServiceVersionPlugins } from './operator-hub/operator-hub-utils';
 import { CreateInitializationResourceButton } from './operator-install-page';
 import {
   SourceMissingStatus,
@@ -785,7 +782,7 @@ export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProp
           _.isNil(_.get(sub, 'status.installedCSV')),
       ),
     ].filter(
-      (obj, i, all) =>
+      (obj, _i, all) =>
         isCSV(obj) ||
         _.isUndefined(
           all.find(({ metadata }) =>

--- a/frontend/packages/operator-lifecycle-manager/src/components/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/index.tsx
@@ -24,7 +24,7 @@ import {
   StepResource,
   SubscriptionKind,
 } from '../types';
-import { getInternalObjects } from '../utils';
+import { getInternalObjects } from './operator-hub/operator-hub-utils';
 
 export const visibilityLabel = 'olm-visibility';
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
@@ -37,14 +37,12 @@ import { CONSOLE_OPERATOR_CONFIG_NAME } from '@console/shared/src/constants';
 import { usePromiseHandler } from '@console/shared/src/hooks/promise-handler';
 import { useOperands } from '@console/shared/src/hooks/useOperands';
 import { getPatchForRemovingPlugins, isPluginEnabled } from '@console/shared/src/utils';
-import {
-  DEFAULT_GLOBAL_OPERATOR_INSTALLATION_NAMESPACE,
-  OPERATOR_UNINSTALL_MESSAGE_ANNOTATION,
-} from '../../const';
+import { DEFAULT_GLOBAL_OPERATOR_INSTALLATION_NAMESPACE } from '../../const';
 import { ClusterServiceVersionModel, SubscriptionModel } from '../../models';
 import { ClusterServiceVersionKind, SubscriptionKind } from '../../types';
-import { getClusterServiceVersionPlugins } from '../../utils';
 import { OperandLink } from '../operand/operand-link';
+import { OLMAnnotation } from '../operator-hub';
+import { getClusterServiceVersionPlugins } from '../operator-hub/operator-hub-utils';
 import Timeout = NodeJS.Timeout;
 
 const deleteOptions = {
@@ -292,7 +290,7 @@ export const UninstallOperatorModal: React.FC<UninstallOperatorModalProps> = ({
     subscription.metadata.namespace === DEFAULT_GLOBAL_OPERATOR_INSTALLATION_NAMESPACE
       ? 'all-namespaces'
       : subscription.metadata.namespace;
-  const uninstallMessage = csv?.metadata?.annotations?.[OPERATOR_UNINSTALL_MESSAGE_ANNOTATION];
+  const uninstallMessage = csv?.metadata?.annotations?.[OLMAnnotation.UninstallMessage];
   const showOperandsContent = !operandsLoaded || operands.length > 0;
 
   const instructions = (

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
@@ -19,17 +19,17 @@ export enum CapabilityLevel {
   DeepInsights = 'Deep Insights',
 }
 
-export enum InfraFeatures {
-  disconnected = 'Disconnected',
-  proxyAware = 'Proxy-aware',
-  fipsMode = 'Designed for FIPS',
-  tlsProfiles = 'Configurable TLS ciphers',
-  cnf = 'Cloud-Native Network Function',
-  cni = 'Container Network Interface',
-  csi = 'Container Storage Interface',
-  sno = 'Single Node Clusters',
-  tokenAuth = 'Short-lived token authentication',
-  tokenAuthGCP = 'Auth Token GCP',
+export enum InfrastructureFeature {
+  Disconnected = 'Disconnected',
+  ProxyAware = 'Proxy-aware',
+  FIPSMode = 'Designed for FIPS',
+  TLSProfiles = 'Configurable TLS ciphers',
+  CNF = 'Cloud-Native Network Function',
+  CNI = 'Container Network Interface',
+  CSI = 'Container Storage Interface',
+  SNO = 'Single Node Clusters',
+  TokenAuth = 'Short-lived token authentication',
+  TokenAuthGCP = 'Auth Token GCP',
 }
 
 export enum ValidSubscriptionValue {
@@ -47,7 +47,7 @@ export type OperatorHubItem = {
   cloudCredentials: CloudCredentialKind;
   createdAt?: string;
   description: string;
-  infraFeatures: InfraFeatures[];
+  infraFeatures: InfrastructureFeature[];
   infrastructure: InfrastructureKind;
   installed: boolean;
   installState?: InstalledState;
@@ -64,61 +64,67 @@ export type OperatorHubItem = {
   [key: string]: any;
 };
 
-export enum OperatorHubCSVAnnotationKey {
-  certifiedLevel = 'certifiedLevel',
-  healthIndex = 'healthIndex',
-  repository = 'repository',
-  containerImage = 'containerImage',
-  createdAt = 'createdAt',
-  support = 'support',
-  description = 'description',
-  categories = 'categories',
-  capabilities = 'capabilities',
-  actionText = 'marketplace.openshift.io/action-text',
-  remoteWorkflow = 'marketplace.openshift.io/remote-workflow',
-  supportWorkflow = 'marketplace.openshift.io/support-workflow',
-  infrastructureFeatures = 'operators.openshift.io/infrastructure-features',
-  validSubscription = 'operators.openshift.io/valid-subscription',
-  tags = 'tags',
-  disconnected = 'features.operators.openshift.io/disconnected',
-  fipsCompliant = 'features.operators.openshift.io/fips-compliant',
-  proxyAware = 'features.operators.openshift.io/proxy-aware',
-  cnf = 'features.operators.openshift.io/cnf',
-  cni = 'features.operators.openshift.io/cni',
-  csi = 'features.operators.openshift.io/csi',
-  tlsProfiles = 'features.operators.openshift.io/tls-profiles',
-  tokenAuthAWS = 'features.operators.openshift.io/token-auth-aws',
-  tokenAuthAzure = 'features.operators.openshift.io/token-auth-azure',
-  tokenAuthGCP = 'features.operators.openshift.io/token-auth-gcp',
+export enum OLMAnnotation {
+  CertifiedLevel = 'certifiedLevel',
+  HealthIndex = 'healthIndex',
+  Repository = 'repository',
+  ContainerImage = 'containerImage',
+  CreatedAt = 'createdAt',
+  Support = 'support',
+  Description = 'description',
+  Categories = 'categories',
+  Capabilitiecs = 'capabilities',
+  ActionText = 'marketplace.openshift.io/action-text',
+  RemoteWorkflow = 'marketplace.openshift.io/remote-workflow',
+  SupportWorkflow = 'marketplace.openshift.io/support-workflow',
+  InfrastructureFeatures = 'operators.openshift.io/infrastructure-features',
+  ValidSubscription = 'operators.openshift.io/valid-subscription',
+  Tags = 'tags',
+  Disconnected = 'features.operators.openshift.io/disconnected',
+  FIPSCompliant = 'features.operators.openshift.io/fips-compliant',
+  ProxyAware = 'features.operators.openshift.io/proxy-aware',
+  CNF = 'features.operators.openshift.io/cnf',
+  CNI = 'features.operators.openshift.io/cni',
+  CSI = 'features.operators.openshift.io/csi',
+  TLSProfiles = 'features.operators.openshift.io/tls-profiles',
+  TokenAuthAWS = 'features.operators.openshift.io/token-auth-aws',
+  TokenAuthAzure = 'features.operators.openshift.io/token-auth-azure',
+  TokenAuthGCP = 'features.operators.openshift.io/token-auth-gcp',
+  SuggestedNamespaceTemplate = 'operatorframework.io/suggested-namespace-template',
+  InitializationResource = 'operatorframework.io/initialization-resource',
+  InternalObjects = 'operators.operatorframework.io/internal-objects',
+  OperatorPlugins = 'console.openshift.io/plugins',
+  OperatorType = 'operators.operatorframework.io/operator-type',
+  UninstallMessage = 'operator.openshift.io/uninstall-message',
 }
 
-export type OperatorHubCSVAnnotations = {
-  [OperatorHubCSVAnnotationKey.certifiedLevel]?: string;
-  [OperatorHubCSVAnnotationKey.healthIndex]?: string;
-  [OperatorHubCSVAnnotationKey.repository]?: string;
-  [OperatorHubCSVAnnotationKey.containerImage]?: string;
-  [OperatorHubCSVAnnotationKey.createdAt]?: string;
-  [OperatorHubCSVAnnotationKey.support]?: string;
-  [OperatorHubCSVAnnotationKey.description]?: string;
-  [OperatorHubCSVAnnotationKey.categories]?: string;
-  [OperatorHubCSVAnnotationKey.capabilities]?: CapabilityLevel;
-  [OperatorHubCSVAnnotationKey.actionText]?: string;
-  [OperatorHubCSVAnnotationKey.remoteWorkflow]?: string;
-  [OperatorHubCSVAnnotationKey.supportWorkflow]?: string;
-  [OperatorHubCSVAnnotationKey.infrastructureFeatures]?: string;
-  [OperatorHubCSVAnnotationKey.validSubscription]?: string;
-  [OperatorHubCSVAnnotationKey.tags]?: string[];
-  [OperatorHubCSVAnnotationKey.disconnected]?: string;
-  [OperatorHubCSVAnnotationKey.fipsCompliant]?: string;
-  [OperatorHubCSVAnnotationKey.proxyAware]?: string;
-  [OperatorHubCSVAnnotationKey.tlsProfiles]?: string;
-  [OperatorHubCSVAnnotationKey.cnf]?: string;
-  [OperatorHubCSVAnnotationKey.cni]?: string;
-  [OperatorHubCSVAnnotationKey.csi]?: string;
-  [OperatorHubCSVAnnotationKey.tlsProfiles]?: string;
-  [OperatorHubCSVAnnotationKey.tokenAuthAWS]?: string;
-  [OperatorHubCSVAnnotationKey.tokenAuthAzure]?: string;
-  [OperatorHubCSVAnnotationKey.tokenAuthGCP]?: string;
+export type CSVAnnotations = {
+  [OLMAnnotation.CertifiedLevel]?: string;
+  [OLMAnnotation.HealthIndex]?: string;
+  [OLMAnnotation.Repository]?: string;
+  [OLMAnnotation.ContainerImage]?: string;
+  [OLMAnnotation.CreatedAt]?: string;
+  [OLMAnnotation.Support]?: string;
+  [OLMAnnotation.Description]?: string;
+  [OLMAnnotation.Categories]?: string;
+  [OLMAnnotation.Capabilitiecs]?: CapabilityLevel;
+  [OLMAnnotation.ActionText]?: string;
+  [OLMAnnotation.RemoteWorkflow]?: string;
+  [OLMAnnotation.SupportWorkflow]?: string;
+  [OLMAnnotation.InfrastructureFeatures]?: string;
+  [OLMAnnotation.ValidSubscription]?: string;
+  [OLMAnnotation.Tags]?: string[];
+  [OLMAnnotation.Disconnected]?: string;
+  [OLMAnnotation.FIPSCompliant]?: string;
+  [OLMAnnotation.ProxyAware]?: string;
+  [OLMAnnotation.TLSProfiles]?: string;
+  [OLMAnnotation.CNF]?: string;
+  [OLMAnnotation.CNI]?: string;
+  [OLMAnnotation.CSI]?: string;
+  [OLMAnnotation.TLSProfiles]?: string;
+  [OLMAnnotation.TokenAuthAWS]?: string;
+  [OLMAnnotation.TokenAuthAzure]?: string;
+  [OLMAnnotation.TokenAuthGCP]?: string;
 } & ObjectMetadata['annotations'];
 
 type OperatorHubSpec = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -35,7 +35,7 @@ import { defaultChannelNameFor } from '../index';
 import { OperatorChannelSelect, OperatorVersionSelect } from './operator-channel-version-select';
 import { CloudServiceTokenWarningAlert } from './operator-hub-subscribe';
 import { isAWSSTSCluster, isAzureWIFCluster, isGCPWIFCluster } from './operator-hub-utils';
-import { InfraFeatures, OperatorHubItem } from './index';
+import { InfrastructureFeature, OperatorHubItem } from './index';
 
 // t('olm~Basic Install'),
 // t('olm~Seamless Upgrades'),
@@ -377,7 +377,7 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
             <div className="co-catalog-page__overlay-description">
               {isAWSSTSCluster(cloudCredentials, infrastructure, authentication) &&
                 showCSTokenWarn &&
-                infraFeatures?.find((i) => i === InfraFeatures.tokenAuth) && (
+                infraFeatures?.find((i) => i === InfrastructureFeature.TokenAuth) && (
                   <CloudServiceTokenWarningAlert
                     title={t('olm~Cluster in STS Mode')}
                     message={t(
@@ -388,7 +388,7 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
                 )}
               {isAzureWIFCluster(cloudCredentials, infrastructure, authentication) &&
                 showCSTokenWarn &&
-                infraFeatures?.find((i) => i === InfraFeatures.tokenAuth) && (
+                infraFeatures?.find((i) => i === InfrastructureFeature.TokenAuth) && (
                   <CloudServiceTokenWarningAlert
                     title={t('olm~Cluster in Azure Workload Identity / Federated Identity Mode')}
                     message={t(
@@ -399,7 +399,7 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
                 )}
               {isGCPWIFCluster(cloudCredentials, infrastructure, authentication) &&
                 showCSTokenWarn &&
-                infraFeatures?.find((i) => i === InfraFeatures.tokenAuthGCP) && (
+                infraFeatures?.find((i) => i === InfrastructureFeature.TokenAuthGCP) && (
                   <CloudServiceTokenWarningAlert
                     title={t('olm~Cluster in GCP Workload Identity / Federated Identity Mode')}
                     message={t(

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -37,8 +37,8 @@ import {
   OperatorHubItem,
   InstalledState,
   CapabilityLevel,
-  InfraFeatures,
   ValidSubscriptionValue,
+  InfrastructureFeature,
 } from './index';
 
 const osBaseLabel = 'operatorframework.io/os.';
@@ -212,15 +212,15 @@ const capabilityLevelSort = (provider) => {
 
 const infraFeaturesSort = (infrastructure) => {
   switch (infrastructure.value) {
-    case InfraFeatures.disconnected:
+    case InfrastructureFeature.Disconnected:
       return 0;
-    case InfraFeatures.proxyAware:
+    case InfrastructureFeature.ProxyAware:
       return 1;
-    case InfraFeatures.fipsMode:
+    case InfrastructureFeature.FIPSMode:
       return 2;
-    case InfraFeatures.tokenAuth:
+    case InfrastructureFeature.TokenAuth:
       return 3;
-    case InfraFeatures.tlsProfiles:
+    case InfrastructureFeature.TLSProfiles:
       return 4;
     default:
       return 5;
@@ -439,7 +439,7 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
         currentItem.infrastructure,
         currentItem.authentication,
       ) &&
-      currentItem.infraFeatures?.find((i) => i === InfraFeatures.tokenAuth)
+      currentItem.infraFeatures?.find((i) => i === InfrastructureFeature.TokenAuth)
     ) {
       setTokenizedAuth('AWS');
     }
@@ -450,7 +450,7 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
         currentItem.infrastructure,
         currentItem.authentication,
       ) &&
-      currentItem.infraFeatures?.find((i) => i === InfraFeatures.tokenAuth)
+      currentItem.infraFeatures?.find((i) => i === InfrastructureFeature.TokenAuth)
     ) {
       setTokenizedAuth('Azure');
     }
@@ -461,7 +461,7 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
         currentItem.infrastructure,
         currentItem.authentication,
       ) &&
-      currentItem.infraFeatures?.find((i) => i === InfraFeatures.tokenAuthGCP)
+      currentItem.infraFeatures?.find((i) => i === InfrastructureFeature.TokenAuth)
     ) {
       setTokenizedAuth('GCP');
     }

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -51,7 +51,6 @@ import {
 } from '@console/internal/module/k8s';
 import { fromRequirements } from '@console/internal/module/k8s/selector';
 import { CONSOLE_OPERATOR_CONFIG_NAME } from '@console/shared/src/constants';
-import { parseJSONAnnotation } from '@console/shared/src/utils/annotations';
 import { SubscriptionModel, OperatorGroupModel, PackageManifestModel } from '../../models';
 import {
   OperatorGroupKind,
@@ -60,7 +59,7 @@ import {
   InstallPlanApproval,
   InstallModeType,
 } from '../../types';
-import { getClusterServiceVersionPlugins, isCatalogSourceTrusted } from '../../utils';
+import { isCatalogSourceTrusted } from '../../utils';
 import { ConsolePluginFormGroup } from '../../utils/console-plugin-form-group';
 import { ClusterServiceVersionLogo } from '../cluster-service-version-logo';
 import { CRDCard } from '../clusterserviceversion';
@@ -77,6 +76,11 @@ import {
 } from '../index';
 import { installedFor, supports, providedAPIsForOperatorGroup, isGlobal } from '../operator-group';
 import { OperatorChannelSelect, OperatorVersionSelect } from './operator-channel-version-select';
+import {
+  getSuggestedNamespaceTemplate,
+  getInitializationResource,
+  getClusterServiceVersionPlugins,
+} from './operator-hub-utils';
 
 export const CloudServiceTokenWarningAlert = ({
   title,
@@ -220,22 +224,18 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
 
   const suggestedNamespace =
     currentCSVDesc.annotations?.['operatorframework.io/suggested-namespace'];
-  const suggestedNamespaceTemplate = parseJSONAnnotation(
-    currentCSVDesc.annotations,
-    'operatorframework.io/suggested-namespace-template',
-    // eslint-disable-next-line no-console
-    () => console.error('Could not parse JSON annotation.'),
-    {},
-  );
+  const suggestedNamespaceTemplate =
+    getSuggestedNamespaceTemplate(currentCSVDesc.annotations, {
+      // eslint-disable-next-line no-console
+      onError: () => console.error('Could not parse JSON annotation.'),
+    }) ?? {};
   const suggestedNamespaceTemplateName = suggestedNamespaceTemplate?.metadata?.name;
   const operatorRequestsMonitoring =
     currentCSVDesc.annotations?.['operatorframework.io/cluster-monitoring'] === 'true';
-  const initializationResource = parseJSONAnnotation(
-    currentCSVDesc.annotations,
-    'operatorframework.io/initialization-resource',
+  const initializationResource = getInitializationResource(currentCSVDesc.annotations, {
     // eslint-disable-next-line no-console
-    () => console.error('Operator Hub Subscribe: Could not get initialization resource.'),
-  );
+    onError: () => console.error('Operator Hub Subscribe: Could not get initialization resource.'),
+  });
   const canPatchConsoleOperatorConfig = useAccessReview({
     group: ConsoleOperatorConfigModel.apiGroup,
     resource: ConsoleOperatorConfigModel.plural,

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.spec.ts
@@ -1,0 +1,653 @@
+import {
+  AuthenticationKind,
+  CloudCredentialKind,
+  InfrastructureKind,
+} from '@console/internal/module/k8s';
+import { PackageManifestKind } from '../../types';
+import {
+  defaultPackageSourceMap,
+  getPackageSource,
+  infrastructureFeatureMap,
+  isAWSSTSCluster,
+  isAzureWIFCluster,
+  isGCPWIFCluster,
+  normalizeInfrastructureFeature,
+  isArrayOfStrings,
+  getClusterServiceVersionPlugins,
+  isK8sResource,
+  getInternalObjects,
+  getSuggestedNamespaceTemplate,
+  getInitializationResource,
+  getValidSubscription,
+  getInfrastructureFeatures,
+} from './operator-hub-utils';
+import { InfrastructureFeature, OLMAnnotation, ValidSubscriptionValue } from '.';
+
+describe('getPackageSource', () => {
+  it('should handle undefined argument', () => {
+    const source = getPackageSource(undefined);
+    expect(source).toBeUndefined();
+  });
+  it('should return correct default Red Hat operator sources', () => {
+    Object.entries(defaultPackageSourceMap).forEach(([key, value]) => {
+      const pm = {
+        status: { catalogSource: key },
+      } as PackageManifestKind;
+      expect(getPackageSource(pm)).toEqual(value);
+    });
+  });
+  it('should fall back to PackageManifest.status.catalogSourceDisplayName first', () => {
+    const pm = {
+      status: {
+        catalogSource: 'foo',
+        catalogSourceDisplayName: 'Foo Source',
+      },
+    } as PackageManifestKind;
+    const source = getPackageSource(pm);
+    expect(source).toEqual('Foo Source');
+  });
+  it('should fall back to PackageManifest.status.catalogSource second', () => {
+    const pm = { status: { catalogSource: 'foo' } } as PackageManifestKind;
+    const source = getPackageSource(pm);
+    expect(source).toEqual('foo');
+  });
+});
+
+describe('isAWSSTSCluster', () => {
+  it('should handle undefined arguments', () => {
+    const result = isAWSSTSCluster(undefined, undefined, undefined);
+    expect(result).toEqual(false);
+  });
+  it('should return true', () => {
+    const cloudcreds = { spec: { credentialsMode: 'Manual' } } as CloudCredentialKind;
+    const infra = { status: { platform: 'AWS' } } as InfrastructureKind;
+    const auth = { spec: { serviceAccountIssuer: 'foo' } } as AuthenticationKind;
+    const result = isAWSSTSCluster(cloudcreds, infra, auth);
+    expect(result).toEqual(true);
+  });
+  it('should return false if cloud credential mode is not Manual', () => {
+    const cloudcreds = { spec: { credentialsMode: 'Automatic' } } as CloudCredentialKind;
+    const infra = { status: { platform: 'AWS' } } as InfrastructureKind;
+    const auth = { spec: { serviceAccountIssuer: '' } } as AuthenticationKind;
+    const result = isAWSSTSCluster(cloudcreds, infra, auth);
+    expect(result).toEqual(false);
+  });
+  it('should return false if infrastructure platform is not AWS', () => {
+    const cloudcreds = { spec: { credentialsMode: 'Manual' } } as CloudCredentialKind;
+    const infra = { status: { platform: 'GCP' } } as InfrastructureKind;
+    const auth = { spec: { serviceAccountIssuer: '' } } as AuthenticationKind;
+    const result = isAWSSTSCluster(cloudcreds, infra, auth);
+    expect(result).toEqual(false);
+  });
+  it('should return false if auth service account issuer is empty', () => {
+    const cloudcreds = { spec: { credentialsMode: 'Manual' } } as CloudCredentialKind;
+    const infra = { status: { platform: 'AWS' } } as InfrastructureKind;
+    const auth = { spec: { serviceAccountIssuer: '' } } as AuthenticationKind;
+    const result = isAWSSTSCluster(cloudcreds, infra, auth);
+    expect(result).toEqual(false);
+  });
+});
+
+describe('isAzureWIFCluster', () => {
+  it('should handle undefined arguments', () => {
+    const result = isAzureWIFCluster(undefined, undefined, undefined);
+    expect(result).toEqual(false);
+  });
+  it('should return true', () => {
+    const cloudcreds = { spec: { credentialsMode: 'Manual' } } as CloudCredentialKind;
+    const infra = { status: { platform: 'Azure' } } as InfrastructureKind;
+    const auth = { spec: { serviceAccountIssuer: 'foo' } } as AuthenticationKind;
+    const result = isAzureWIFCluster(cloudcreds, infra, auth);
+    expect(result).toEqual(true);
+  });
+  it('should return false if cloud credential mode is not Manual', () => {
+    const cloudcreds = { spec: { credentialsMode: 'Automatic' } } as CloudCredentialKind;
+    const infra = { status: { platform: 'Azure' } } as InfrastructureKind;
+    const auth = { spec: { serviceAccountIssuer: '' } } as AuthenticationKind;
+    const result = isAzureWIFCluster(cloudcreds, infra, auth);
+    expect(result).toEqual(false);
+  });
+  it('should return false if infrastructure platform is not Azure', () => {
+    const cloudcreds = { spec: { credentialsMode: 'Manual' } } as CloudCredentialKind;
+    const infra = { status: { platform: 'GCP' } } as InfrastructureKind;
+    const auth = { spec: { serviceAccountIssuer: '' } } as AuthenticationKind;
+    const result = isAzureWIFCluster(cloudcreds, infra, auth);
+    expect(result).toEqual(false);
+  });
+  it('should return false if auth service account issuer is empty', () => {
+    const cloudcreds = { spec: { credentialsMode: 'Manual' } } as CloudCredentialKind;
+    const infra = { status: { platform: 'Azure' } } as InfrastructureKind;
+    const auth = { spec: { serviceAccountIssuer: '' } } as AuthenticationKind;
+    const result = isAzureWIFCluster(cloudcreds, infra, auth);
+    expect(result).toEqual(false);
+  });
+});
+
+describe('isGCPWIFCluster', () => {
+  it('should handle undefined arguments', () => {
+    const result = isGCPWIFCluster(undefined, undefined, undefined);
+    expect(result).toEqual(false);
+  });
+  it('should return true', () => {
+    const cloudcreds = { spec: { credentialsMode: 'Manual' } } as CloudCredentialKind;
+    const infra = { status: { platform: 'GCP' } } as InfrastructureKind;
+    const auth = { spec: { serviceAccountIssuer: 'foo' } } as AuthenticationKind;
+    const result = isGCPWIFCluster(cloudcreds, infra, auth);
+    expect(result).toEqual(true);
+  });
+  it('should return false if cloud credential mode is not Manual', () => {
+    const cloudcreds = { spec: { credentialsMode: 'Automatic' } } as CloudCredentialKind;
+    const infra = { status: { platform: 'GCP' } } as InfrastructureKind;
+    const auth = { spec: { serviceAccountIssuer: '' } } as AuthenticationKind;
+    const result = isGCPWIFCluster(cloudcreds, infra, auth);
+    expect(result).toEqual(false);
+  });
+  it('should return false if infrastructure platform is not GCP', () => {
+    const cloudcreds = { spec: { credentialsMode: 'Manual' } } as CloudCredentialKind;
+    const infra = { status: { platform: 'AWS' } } as InfrastructureKind;
+    const auth = { spec: { serviceAccountIssuer: '' } } as AuthenticationKind;
+    const result = isGCPWIFCluster(cloudcreds, infra, auth);
+    expect(result).toEqual(false);
+  });
+  it('should return false if auth service account issuer is empty', () => {
+    const cloudcreds = { spec: { credentialsMode: 'Manual' } } as CloudCredentialKind;
+    const infra = { status: { platform: 'GCP' } } as InfrastructureKind;
+    const auth = { spec: { serviceAccountIssuer: '' } } as AuthenticationKind;
+    const result = isGCPWIFCluster(cloudcreds, infra, auth);
+    expect(result).toEqual(false);
+  });
+});
+
+describe('normalizeInfrastructureFeature', () => {
+  Object.entries(infrastructureFeatureMap).forEach(([key, value]) => {
+    it(`should map ${key} to ${value}`, () => {
+      expect(normalizeInfrastructureFeature(key)).toEqual(value);
+    });
+  });
+  it('should fall back to the argument if not known', () => {
+    expect(normalizeInfrastructureFeature('foo')).toEqual('foo');
+  });
+});
+
+describe('isArrayOfStrings', () => {
+  it('should return true for empty array', () => {
+    const result = isArrayOfStrings([]);
+    expect(result).toEqual(true);
+  });
+  it('should return true for an array containing only strings', () => {
+    const result = isArrayOfStrings(['foo', 'bar']);
+    expect(result).toEqual(true);
+  });
+  it('should return false for an array containing non-string elements', () => {
+    const result = isArrayOfStrings(['foo', false]);
+    expect(result).toEqual(false);
+  });
+  it('should return false for null', () => {
+    const result = isArrayOfStrings(null);
+    expect(result).toEqual(false);
+  });
+  it('should return false for undefined', () => {
+    const result = isArrayOfStrings(undefined);
+    expect(result).toEqual(false);
+  });
+});
+
+describe('isK8sResource', () => {
+  it('should return false for empty object', () => {
+    const result = isK8sResource({});
+    expect(result).toEqual(false);
+  });
+  it('should return false for null', () => {
+    const result = isK8sResource(null);
+    expect(result).toEqual(false);
+  });
+  it('should return false for undefined', () => {
+    const result = isK8sResource(undefined);
+    expect(result).toEqual(false);
+  });
+  it('should return true for object with metadata.name property', () => {
+    const result = isK8sResource({ metadata: { name: 'foo' } });
+    expect(result).toEqual(true);
+  });
+  it('should return false for non-empty object without metadata.name', () => {
+    const result = isK8sResource({ foo: 'bar' });
+    expect(result).toEqual(false);
+  });
+});
+
+describe('getClusterServiceVersionPlugins', () => {
+  it(`returns correctly parsed value  when ${OLMAnnotation.OperatorPlugins} is set correctly`, () => {
+    const result = getClusterServiceVersionPlugins({
+      [OLMAnnotation.OperatorPlugins]: '["foo", "bar"]',
+    });
+    expect(result).toEqual(['foo', 'bar']);
+  });
+  it(`returns empty array when ${OLMAnnotation.OperatorPlugins} is an empty array`, () => {
+    const result = getClusterServiceVersionPlugins({
+      [OLMAnnotation.OperatorPlugins]: '[]',
+    });
+    expect(result).toEqual([]);
+  });
+  it(`returns empty array when ${OLMAnnotation.OperatorPlugins} is not JSON`, () => {
+    const result = getClusterServiceVersionPlugins({
+      [OLMAnnotation.OperatorPlugins]: 'foo',
+    });
+    expect(result).toEqual([]);
+  });
+  it(`returns empty array when ${OLMAnnotation.OperatorPlugins} is incorrect JSON`, () => {
+    const result = getClusterServiceVersionPlugins({
+      [OLMAnnotation.OperatorPlugins]: 'false',
+    });
+    expect(result).toEqual([]);
+  });
+  it(`returns an empty array when ${OLMAnnotation.OperatorPlugins} annotation is not set`, () => {
+    const result = getClusterServiceVersionPlugins({ foo: '["foo", "bar"]' });
+    expect(result).toEqual([]);
+  });
+  it('returns an empty array when annotations are null', () => {
+    const result = getClusterServiceVersionPlugins(null);
+    expect(result).toEqual([]);
+  });
+  it('returns an empty array when annotations are undefined', () => {
+    const result = getClusterServiceVersionPlugins(undefined);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('getInternalObjects', () => {
+  it(`returns correctly parsed value when ${OLMAnnotation.InternalObjects} is set correctly`, () => {
+    const result = getInternalObjects({
+      [OLMAnnotation.InternalObjects]: '["foo", "bar"]',
+    });
+    expect(result).toEqual(['foo', 'bar']);
+  });
+  it(`returns empty array when ${OLMAnnotation.InternalObjects} is not JSON`, () => {
+    const result = getInternalObjects({
+      [OLMAnnotation.InternalObjects]: 'foo',
+    });
+    expect(result).toEqual([]);
+  });
+  it(`returns empty array when ${OLMAnnotation.InternalObjects} is an empty array`, () => {
+    const result = getInternalObjects({
+      [OLMAnnotation.InternalObjects]: '[]',
+    });
+    expect(result).toEqual([]);
+  });
+  it(`returns empty array when ${OLMAnnotation.InternalObjects} is incorrect JSON`, () => {
+    const result = getInternalObjects({
+      [OLMAnnotation.InternalObjects]: 'false',
+    });
+    expect(result).toEqual([]);
+  });
+  it(`returns an empty array when ${OLMAnnotation.InternalObjects} annotation is not set`, () => {
+    const result = getInternalObjects({ foo: '["foo", "bar"]' });
+    expect(result).toEqual([]);
+  });
+  it('returns an empty array when annotations are null', () => {
+    const result = getInternalObjects(null);
+    expect(result).toEqual([]);
+  });
+  it('returns an empty array when annotations are undefined', () => {
+    const result = getInternalObjects(undefined);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('getSuggestedNamespaceTemplate', () => {
+  it(`returns correctly parsed value when ${OLMAnnotation.SuggestedNamespaceTemplate} is set correctly`, () => {
+    const result = getSuggestedNamespaceTemplate({
+      [OLMAnnotation.SuggestedNamespaceTemplate]: '{"metadata":{ "name": "foo" }}',
+    });
+    expect(result).toEqual({ metadata: { name: 'foo' } });
+  });
+  it(`returns null when ${OLMAnnotation.SuggestedNamespaceTemplate} is an empty object`, () => {
+    const result = getSuggestedNamespaceTemplate({
+      [OLMAnnotation.SuggestedNamespaceTemplate]: '{}',
+    });
+    expect(result).toBeNull();
+  });
+  it(`returns null when ${OLMAnnotation.SuggestedNamespaceTemplate} is not JSON`, () => {
+    const result = getSuggestedNamespaceTemplate({
+      [OLMAnnotation.SuggestedNamespaceTemplate]: 'foo',
+    });
+    expect(result).toBeNull();
+  });
+  it(`returns null when ${OLMAnnotation.SuggestedNamespaceTemplate} is incorrect JSON`, () => {
+    const result = getSuggestedNamespaceTemplate({
+      [OLMAnnotation.SuggestedNamespaceTemplate]: 'false',
+    });
+    expect(result).toBeNull();
+  });
+  it(`returns null when ${OLMAnnotation.SuggestedNamespaceTemplate} annotation is not set`, () => {
+    const result = getSuggestedNamespaceTemplate({ foo: '["foo", "bar"]' });
+    expect(result).toBeNull();
+  });
+  it('returns null when annotations are null', () => {
+    const result = getSuggestedNamespaceTemplate(null);
+    expect(result).toBeNull();
+  });
+  it('returns null when annotations are undefined', () => {
+    const result = getSuggestedNamespaceTemplate(undefined);
+    expect(result).toBeNull();
+  });
+});
+
+describe('getInitializationResource', () => {
+  it(`returns correctly parsed value when ${OLMAnnotation.InitializationResource} is set correctly`, () => {
+    const result = getInitializationResource({
+      [OLMAnnotation.InitializationResource]: '{"metadata":{ "name": "foo" }}',
+    });
+    expect(result).toEqual({ metadata: { name: 'foo' } });
+  });
+  it(`returns null when ${OLMAnnotation.InitializationResource} is an empty object`, () => {
+    const result = getInitializationResource({
+      [OLMAnnotation.InitializationResource]: '{}',
+    });
+    expect(result).toBeNull();
+  });
+  it(`returns null when ${OLMAnnotation.InitializationResource} is not JSON`, () => {
+    const result = getInitializationResource({
+      [OLMAnnotation.InitializationResource]: 'foo',
+    });
+    expect(result).toBeNull();
+  });
+  it(`returns null when ${OLMAnnotation.InitializationResource} is incorrect JSON`, () => {
+    const result = getInitializationResource({
+      [OLMAnnotation.InitializationResource]: 'false',
+    });
+    expect(result).toBeNull();
+  });
+  it(`returns null when ${OLMAnnotation.InitializationResource} annotation is not set`, () => {
+    const result = getInitializationResource({ foo: '["foo", "bar"]' });
+    expect(result).toBeNull();
+  });
+  it('returns null when annotations are null', () => {
+    const result = getInitializationResource(null);
+    expect(result).toBeNull();
+  });
+  it('returns null when annotations are undefined', () => {
+    const result = getInitializationResource(undefined);
+    expect(result).toBeNull();
+  });
+});
+
+describe('getValidSubscription', () => {
+  it(`collapses non-Red Hat subscriptions into "${ValidSubscriptionValue.RequiresSeparateSubscription}" filter`, () => {
+    const [subscriptions, filters] = getValidSubscription({
+      [OLMAnnotation.ValidSubscription]: '["foo", "bar"]',
+    });
+    expect(subscriptions).toEqual(['foo', 'bar']);
+    expect(filters).toEqual([ValidSubscriptionValue.RequiresSeparateSubscription]);
+  });
+  it(`parses ${ValidSubscriptionValue.OpenShiftContainerPlatform}`, () => {
+    const [subscriptions, filters] = getValidSubscription({
+      [OLMAnnotation.ValidSubscription]: `["${ValidSubscriptionValue.OpenShiftContainerPlatform}"]`,
+    });
+    expect(subscriptions).toEqual([ValidSubscriptionValue.OpenShiftContainerPlatform]);
+    expect(filters).toEqual([ValidSubscriptionValue.OpenShiftContainerPlatform]);
+  });
+  it(`parses ${ValidSubscriptionValue.OpenShiftKubernetesEngine}`, () => {
+    const [subscriptions, filters] = getValidSubscription({
+      [OLMAnnotation.ValidSubscription]: `["${ValidSubscriptionValue.OpenShiftKubernetesEngine}"]`,
+    });
+    expect(subscriptions).toEqual([ValidSubscriptionValue.OpenShiftKubernetesEngine]);
+    expect(filters).toEqual([ValidSubscriptionValue.OpenShiftKubernetesEngine]);
+  });
+  it(`parses ${ValidSubscriptionValue.OpenShiftPlatformPlus}`, () => {
+    const [subscriptions, filters] = getValidSubscription({
+      [OLMAnnotation.ValidSubscription]: `["${ValidSubscriptionValue.OpenShiftPlatformPlus}"]`,
+    });
+    expect(subscriptions).toEqual([ValidSubscriptionValue.OpenShiftPlatformPlus]);
+    expect(filters).toEqual([ValidSubscriptionValue.OpenShiftPlatformPlus]);
+  });
+  it(`parses all valid subscription values`, () => {
+    const [subscriptions, filters] = getValidSubscription({
+      [OLMAnnotation.ValidSubscription]: `["${ValidSubscriptionValue.OpenShiftContainerPlatform}", "${ValidSubscriptionValue.OpenShiftKubernetesEngine}", "${ValidSubscriptionValue.OpenShiftPlatformPlus}", "foo", "bar"]`,
+    });
+    expect(subscriptions).toEqual([
+      ValidSubscriptionValue.OpenShiftContainerPlatform,
+      ValidSubscriptionValue.OpenShiftKubernetesEngine,
+      ValidSubscriptionValue.OpenShiftPlatformPlus,
+      'foo',
+      'bar',
+    ]);
+    expect(filters).toEqual([
+      ValidSubscriptionValue.OpenShiftContainerPlatform,
+      ValidSubscriptionValue.OpenShiftKubernetesEngine,
+      ValidSubscriptionValue.OpenShiftPlatformPlus,
+      ValidSubscriptionValue.RequiresSeparateSubscription,
+    ]);
+  });
+  it(`returns empty when ${OLMAnnotation.ValidSubscription} is an empty array`, () => {
+    const [subscriptions, filters] = getValidSubscription({
+      [OLMAnnotation.ValidSubscription]: '[]',
+    });
+    expect(subscriptions).toEqual([]);
+    expect(filters).toEqual([]);
+  });
+  it(`returns empty when ${OLMAnnotation.ValidSubscription} is not JSON`, () => {
+    const [subscriptions, filters] = getValidSubscription({
+      [OLMAnnotation.ValidSubscription]: 'foo',
+    });
+    expect(subscriptions).toEqual([]);
+    expect(filters).toEqual([]);
+  });
+  it(`returns empty when ${OLMAnnotation.ValidSubscription} is incorrect JSON`, () => {
+    const [subscriptions, filters] = getValidSubscription({
+      [OLMAnnotation.ValidSubscription]: 'false',
+    });
+    expect(subscriptions).toEqual([]);
+    expect(filters).toEqual([]);
+  });
+  it(`returns an empty when ${OLMAnnotation.ValidSubscription} annotation is not set`, () => {
+    const [subscriptions, filters] = getValidSubscription({ foo: '["foo", "bar"]' });
+    expect(subscriptions).toEqual([]);
+    expect(filters).toEqual([]);
+  });
+  it('returns an empty when annotations are null', () => {
+    const [subscriptions, filters] = getValidSubscription(null);
+    expect(subscriptions).toEqual([]);
+    expect(filters).toEqual([]);
+  });
+  it('returns an empty when annotations are undefined', () => {
+    const [subscriptions, filters] = getValidSubscription(undefined);
+    expect(subscriptions).toEqual([]);
+    expect(filters).toEqual([]);
+  });
+});
+
+describe('getInfrastructureFeatures', () => {
+  it(`correctly normalizes mutations of legacy annotation values`, () => {
+    const clusterIsAWSSTS = false;
+    const clusterIsAzureWIF = false;
+    const clusterIsGCPWIF = false;
+    const result = getInfrastructureFeatures(
+      {
+        [OLMAnnotation.InfrastructureFeatures]:
+          '["disconnected","Disconnected","Proxy","ProxyAware","proxy-aware","FipsMode","fips","FIPS","tlsProfiles","TLSProfiles","tls","TLS","cnf","CNF","cni","CNI","csi","CSI","sno","SNO", "tokenAuth", "TokenAuth", "tokenAuthGCP", "TokenAuthGCP"]',
+      },
+      { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
+    );
+    expect(result).toEqual([
+      InfrastructureFeature.Disconnected,
+      InfrastructureFeature.ProxyAware,
+      InfrastructureFeature.FIPSMode,
+      InfrastructureFeature.TLSProfiles,
+      InfrastructureFeature.CNF,
+      InfrastructureFeature.CNI,
+      InfrastructureFeature.CSI,
+      InfrastructureFeature.SNO,
+    ]);
+  });
+  it(`includes normalized legacy "tokenAuth" feature on AWS STS cluster`, () => {
+    const clusterIsAWSSTS = true;
+    const clusterIsAzureWIF = false;
+    const clusterIsGCPWIF = false;
+    const result = getInfrastructureFeatures(
+      {
+        [OLMAnnotation.InfrastructureFeatures]: '["tokenAuth"]',
+      },
+      { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
+    );
+    expect(result).toEqual([InfrastructureFeature.TokenAuth]);
+  });
+  it(`includes normalized legacy "TokenAuth" feature on AWS STS cluster`, () => {
+    const clusterIsAWSSTS = true;
+    const clusterIsAzureWIF = false;
+    const clusterIsGCPWIF = false;
+    const result = getInfrastructureFeatures(
+      {
+        [OLMAnnotation.InfrastructureFeatures]: '["TokenAuth"]',
+      },
+      { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
+    );
+    expect(result).toEqual([InfrastructureFeature.TokenAuth]);
+  });
+  it(`includes normalized legacy "tokenAuth" feature on Azure WIF cluster`, () => {
+    const clusterIsAWSSTS = false;
+    const clusterIsAzureWIF = true;
+    const clusterIsGCPWIF = false;
+    const result = getInfrastructureFeatures(
+      {
+        [OLMAnnotation.InfrastructureFeatures]: '["tokenAuth"]',
+      },
+      { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
+    );
+    expect(result).toEqual([InfrastructureFeature.TokenAuth]);
+  });
+  it(`includes normalized legacy "TokenAuth" feature on Azure WIF cluster`, () => {
+    const clusterIsAWSSTS = false;
+    const clusterIsAzureWIF = true;
+    const clusterIsGCPWIF = false;
+    const result = getInfrastructureFeatures(
+      {
+        [OLMAnnotation.InfrastructureFeatures]: '["TokenAuth"]',
+      },
+      { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
+    );
+    expect(result).toEqual([InfrastructureFeature.TokenAuth]);
+  });
+  it(`excludes legacy token auth feature when not AWS STS or Azure WIF cluster`, () => {
+    const clusterIsAWSSTS = false;
+    const clusterIsAzureWIF = false;
+    const clusterIsGCPWIF = false;
+    const result = getInfrastructureFeatures(
+      {
+        [OLMAnnotation.InfrastructureFeatures]: '["tokenAuth","TokenAuth"]',
+      },
+      { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
+    );
+    expect(result).toEqual([]);
+  });
+  it(`includes normalized legacy "tokenAuthGCP" feature when on GCP WIF cluster`, () => {
+    const clusterIsAWSSTS = false;
+    const clusterIsAzureWIF = false;
+    const clusterIsGCPWIF = true;
+    const result = getInfrastructureFeatures(
+      {
+        [OLMAnnotation.InfrastructureFeatures]: '["tokenAuthGCP"]',
+      },
+      { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
+    );
+    expect(result).toEqual([InfrastructureFeature.TokenAuthGCP]);
+  });
+  it(`includes normalized legacy "TokenAuthGCP" feature when on GCP WIF cluster`, () => {
+    const clusterIsAWSSTS = false;
+    const clusterIsAzureWIF = false;
+    const clusterIsGCPWIF = true;
+    const result = getInfrastructureFeatures(
+      {
+        [OLMAnnotation.InfrastructureFeatures]: '["TokenAuthGCP"]',
+      },
+      { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
+    );
+    expect(result).toEqual([InfrastructureFeature.TokenAuthGCP]);
+  });
+  it(`excludes legacy token auth GCP feature when not GCP WIF cluster`, () => {
+    const clusterIsAWSSTS = false;
+    const clusterIsAzureWIF = false;
+    const clusterIsGCPWIF = false;
+    const result = getInfrastructureFeatures(
+      {
+        [OLMAnnotation.InfrastructureFeatures]: '["TokenAuthGCP"]',
+      },
+      { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
+    );
+    expect(result).toEqual([]);
+  });
+  it(`includes features defined by latest annotation format`, () => {
+    const clusterIsAWSSTS = true;
+    const clusterIsAzureWIF = true;
+    const clusterIsGCPWIF = true;
+    const result = getInfrastructureFeatures(
+      {
+        [OLMAnnotation.Disconnected]: 'true',
+        [OLMAnnotation.FIPSCompliant]: 'true',
+        [OLMAnnotation.ProxyAware]: 'true',
+        [OLMAnnotation.CNF]: 'true',
+        [OLMAnnotation.CNI]: 'true',
+        [OLMAnnotation.CSI]: 'true',
+        [OLMAnnotation.TLSProfiles]: 'true',
+        [OLMAnnotation.TokenAuthAWS]: 'true',
+        [OLMAnnotation.TokenAuthAzure]: 'true',
+        [OLMAnnotation.TokenAuthGCP]: 'true',
+      },
+      { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
+    );
+    expect(result).toEqual([
+      InfrastructureFeature.Disconnected,
+      InfrastructureFeature.FIPSMode,
+      InfrastructureFeature.ProxyAware,
+      InfrastructureFeature.CNF,
+      InfrastructureFeature.CNI,
+      InfrastructureFeature.CSI,
+      InfrastructureFeature.TLSProfiles,
+      InfrastructureFeature.TokenAuth,
+      InfrastructureFeature.TokenAuthGCP,
+    ]);
+  });
+  it(`only includes one feature when repeated by legacy and latest annotation format`, () => {
+    const result = getInfrastructureFeatures({
+      [OLMAnnotation.InfrastructureFeatures]: '["Disconnected", "fips"]',
+      [OLMAnnotation.Disconnected]: 'true',
+    });
+    expect(result).toEqual([InfrastructureFeature.Disconnected, InfrastructureFeature.FIPSMode]);
+  });
+  it(`excludes legacy feature when negated by latest annotation format`, () => {
+    const result = getInfrastructureFeatures({
+      [OLMAnnotation.InfrastructureFeatures]: '["Disconnected", "fips"]',
+      [OLMAnnotation.Disconnected]: 'false',
+    });
+    expect(result).toEqual([InfrastructureFeature.FIPSMode]);
+  });
+  it(`returns empty array when ${OLMAnnotation.InfrastructureFeatures} is empty`, () => {
+    const result = getInfrastructureFeatures({
+      [OLMAnnotation.InfrastructureFeatures]: '[]',
+    });
+    expect(result).toEqual([]);
+  });
+  it(`returns empty array when ${OLMAnnotation.InfrastructureFeatures} is not JSON`, () => {
+    const result = getInfrastructureFeatures({
+      [OLMAnnotation.InfrastructureFeatures]: 'foo',
+    });
+    expect(result).toEqual([]);
+  });
+  it(`returns empty array when ${OLMAnnotation.InfrastructureFeatures} is incorrect JSON`, () => {
+    const result = getInfrastructureFeatures({
+      [OLMAnnotation.InfrastructureFeatures]: 'false',
+    });
+    expect(result).toEqual([]);
+  });
+  it(`returns an empty array when ${OLMAnnotation.InfrastructureFeatures} annotation is not set`, () => {
+    const result = getInfrastructureFeatures({ foo: '["foo", "bar"]' });
+    expect(result).toEqual([]);
+  });
+  it('returns an empty array when annotations are null', () => {
+    const result = getInfrastructureFeatures(null);
+    expect(result).toEqual([]);
+  });
+  it('returns an empty array when annotations are undefined', () => {
+    const result = getInfrastructureFeatures(undefined);
+    expect(result).toEqual([]);
+  });
+});

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.ts
@@ -2,10 +2,13 @@ import {
   CloudCredentialKind,
   InfrastructureKind,
   AuthenticationKind,
+  K8sResourceKind,
+  ObjectMetadata,
 } from '@console/internal/module/k8s';
+import { parseJSONAnnotation } from '@console/shared/src/utils/annotations';
 import { DefaultCatalogSource, PackageSource } from '../../const';
 import { PackageManifestKind } from '../../types';
-import { InfraFeatures, OperatorHubCSVAnnotationKey } from '.';
+import { InfrastructureFeature, OLMAnnotation, ValidSubscriptionValue } from './index';
 
 export const defaultPackageSourceMap = {
   [DefaultCatalogSource.RedHatOperators]: PackageSource.RedHatOperators,
@@ -14,7 +17,7 @@ export const defaultPackageSourceMap = {
   [DefaultCatalogSource.CommunityOperators]: PackageSource.CommunityOperators,
 };
 
-export const getPackageSource = (packageManifest: PackageManifestKind): string => {
+export const getPackageSource = (packageManifest: PackageManifestKind): PackageSource => {
   const { catalogSource, catalogSourceDisplayName } = packageManifest?.status ?? {};
   return defaultPackageSourceMap?.[catalogSource] || catalogSourceDisplayName || catalogSource;
 };
@@ -23,7 +26,7 @@ export const isAWSSTSCluster = (
   cloudcreds: CloudCredentialKind,
   infra: InfrastructureKind,
   auth: AuthenticationKind,
-) => {
+): boolean => {
   return (
     cloudcreds?.spec?.credentialsMode === 'Manual' &&
     infra?.status?.platform === 'AWS' &&
@@ -35,7 +38,7 @@ export const isAzureWIFCluster = (
   cloudcreds: CloudCredentialKind,
   infra: InfrastructureKind,
   auth: AuthenticationKind,
-) => {
+): boolean => {
   return (
     cloudcreds?.spec?.credentialsMode === 'Manual' &&
     infra?.status?.platform === 'Azure' &&
@@ -47,7 +50,7 @@ export const isGCPWIFCluster = (
   cloudcreds: CloudCredentialKind,
   infra: InfrastructureKind,
   auth: AuthenticationKind,
-) => {
+): boolean => {
   return (
     cloudcreds?.spec?.credentialsMode === 'Manual' &&
     infra?.status?.platform === 'GCP' &&
@@ -55,28 +58,193 @@ export const isGCPWIFCluster = (
   );
 };
 
-export const normalizedInfrastructureFeatures = {
-  disconnected: InfraFeatures.disconnected,
-  Disconnected: InfraFeatures.disconnected,
-  Proxy: InfraFeatures['proxy-aware'],
-  'proxy-aware': InfraFeatures.proxyAware,
-  FipsMode: InfraFeatures.fipsMode,
-  fips: InfraFeatures.fipsMode,
-  tlsProfiles: InfraFeatures.tlsProfiles,
-  cnf: InfraFeatures.cnf,
-  cni: InfraFeatures.cni,
-  csi: InfraFeatures.csi,
-  sno: InfraFeatures.sno,
-  TokenAuth: InfraFeatures.tokenAuth,
-  tokenAuthGCP: InfraFeatures.tokenAuthGCP,
-  [OperatorHubCSVAnnotationKey.disconnected]: InfraFeatures.disconnected,
-  [OperatorHubCSVAnnotationKey.fipsCompliant]: InfraFeatures.fipsMode,
-  [OperatorHubCSVAnnotationKey.proxyAware]: InfraFeatures.proxyAware,
-  [OperatorHubCSVAnnotationKey.cnf]: InfraFeatures.cnf,
-  [OperatorHubCSVAnnotationKey.cni]: InfraFeatures.cni,
-  [OperatorHubCSVAnnotationKey.csi]: InfraFeatures.csi,
-  [OperatorHubCSVAnnotationKey.tlsProfiles]: InfraFeatures.tlsProfiles,
-  [OperatorHubCSVAnnotationKey.tokenAuthAWS]: InfraFeatures.tokenAuth,
-  [OperatorHubCSVAnnotationKey.tokenAuthAzure]: InfraFeatures.tokenAuth,
-  [OperatorHubCSVAnnotationKey.tokenAuthGCP]: InfraFeatures.tokenAuthGCP,
+export const infrastructureFeatureMap = {
+  disconnected: InfrastructureFeature.Disconnected,
+  Disconnected: InfrastructureFeature.Disconnected,
+  Proxy: InfrastructureFeature.ProxyAware,
+  ProxyAware: InfrastructureFeature.ProxyAware,
+  'proxy-aware': InfrastructureFeature.ProxyAware,
+  FipsMode: InfrastructureFeature.FIPSMode,
+  fips: InfrastructureFeature.FIPSMode,
+  FIPS: InfrastructureFeature.FIPSMode,
+  tlsProfiles: InfrastructureFeature.TLSProfiles,
+  TLSProfiles: InfrastructureFeature.TLSProfiles,
+  tls: InfrastructureFeature.TLSProfiles,
+  TLS: InfrastructureFeature.TLSProfiles,
+  cnf: InfrastructureFeature.CNF,
+  CNF: InfrastructureFeature.CNF,
+  cni: InfrastructureFeature.CNI,
+  CNI: InfrastructureFeature.CNI,
+  csi: InfrastructureFeature.CSI,
+  CSI: InfrastructureFeature.CSI,
+  sno: InfrastructureFeature.SNO,
+  SNO: InfrastructureFeature.SNO,
+  tokenAuth: InfrastructureFeature.TokenAuth,
+  TokenAuth: InfrastructureFeature.TokenAuth,
+  tokenAuthGCP: InfrastructureFeature.TokenAuthGCP,
+  TokenAuthGCP: InfrastructureFeature.TokenAuthGCP,
+  [OLMAnnotation.Disconnected]: InfrastructureFeature.Disconnected,
+  [OLMAnnotation.FIPSCompliant]: InfrastructureFeature.FIPSMode,
+  [OLMAnnotation.ProxyAware]: InfrastructureFeature.ProxyAware,
+  [OLMAnnotation.CNF]: InfrastructureFeature.CNF,
+  [OLMAnnotation.CNI]: InfrastructureFeature.CNI,
+  [OLMAnnotation.CSI]: InfrastructureFeature.CSI,
+  [OLMAnnotation.TLSProfiles]: InfrastructureFeature.TLSProfiles,
+  [OLMAnnotation.TokenAuthAWS]: InfrastructureFeature.TokenAuth,
+  [OLMAnnotation.TokenAuthAzure]: InfrastructureFeature.TokenAuth,
+  [OLMAnnotation.TokenAuthGCP]: InfrastructureFeature.TokenAuthGCP,
 };
+export const normalizeInfrastructureFeature = (feature: string): InfrastructureFeature =>
+  infrastructureFeatureMap[feature] ?? feature;
+
+// TODO Replace with JSONSchema validation
+export const isArrayOfStrings = (value: any): value is string[] =>
+  Array.isArray(value) && !value.some((element) => typeof element !== 'string');
+
+// TODO Replace with JSONSchema validation
+export const isK8sResource = (value: any): value is K8sResourceKind =>
+  Boolean(value?.metadata?.name);
+
+export const getClusterServiceVersionPlugins: AnnotationParser<string[]> = (
+  annotations,
+  options,
+): string[] =>
+  parseJSONAnnotation<string[]>(annotations, OLMAnnotation.OperatorPlugins, {
+    validate: isArrayOfStrings,
+    ...options,
+  }) ?? [];
+
+export const getInternalObjects: AnnotationParser<string[]> = (annotations, options) =>
+  parseJSONAnnotation<string[]>(annotations, OLMAnnotation.InternalObjects, {
+    validate: isArrayOfStrings,
+    ...options,
+  }) ?? [];
+
+export const getSuggestedNamespaceTemplate: AnnotationParser<K8sResourceKind> = (
+  annotations,
+  options,
+) =>
+  parseJSONAnnotation<K8sResourceKind>(annotations, OLMAnnotation.SuggestedNamespaceTemplate, {
+    validate: isK8sResource,
+    ...options,
+  });
+
+export const getInitializationResource: AnnotationParser<K8sResourceKind> = (
+  annotations,
+  options,
+) =>
+  parseJSONAnnotation<K8sResourceKind>(annotations, OLMAnnotation.InitializationResource, {
+    validate: isK8sResource,
+    ...options,
+  });
+
+const parseValidSubscriptionAnnotation: AnnotationParser<string[]> = (annotations, options) =>
+  parseJSONAnnotation<string[]>(annotations, OLMAnnotation.ValidSubscription, {
+    validate: isArrayOfStrings,
+    ...options,
+  }) ?? [];
+
+export const getValidSubscription: AnnotationParser<[string[], ValidSubscriptionValue[]]> = (
+  annotations,
+  options,
+) => {
+  const validSubscription = parseValidSubscriptionAnnotation(annotations, options);
+  const validSubscriptionFilters = validSubscription.reduce<ValidSubscriptionValue[]>(
+    (acc, value) => {
+      const filterValue =
+        {
+          [ValidSubscriptionValue.OpenShiftContainerPlatform]:
+            ValidSubscriptionValue.OpenShiftContainerPlatform,
+          [ValidSubscriptionValue.OpenShiftKubernetesEngine]:
+            ValidSubscriptionValue.OpenShiftKubernetesEngine,
+          [ValidSubscriptionValue.OpenShiftPlatformPlus]:
+            ValidSubscriptionValue.OpenShiftPlatformPlus,
+        }[value] ?? ValidSubscriptionValue.RequiresSeparateSubscription;
+      return acc.includes(filterValue) ? acc : [...acc, filterValue];
+    },
+    [],
+  );
+  return [validSubscription, validSubscriptionFilters];
+};
+
+const parseInfrastructureFeaturesAnnotation: AnnotationParser<string[]> = (annotations, options) =>
+  parseJSONAnnotation<InfrastructureFeature[]>(annotations, OLMAnnotation.InfrastructureFeatures, {
+    validate: isArrayOfStrings,
+    ...options,
+  }) ?? [];
+
+export const getInfrastructureFeatures: AnnotationParser<
+  InfrastructureFeature[],
+  GetInfrastructureFeatureOptions
+> = (annotations, options) => {
+  const { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF, onError } = options ?? {};
+  const parsedInfrastructureFeatures = parseInfrastructureFeaturesAnnotation(annotations, {
+    onError,
+  });
+  const azureTokenAuthIsSupported =
+    clusterIsAzureWIF && annotations[OLMAnnotation.TokenAuthAzure] !== 'false';
+  const awsTokenAuthIsSupported =
+    clusterIsAWSSTS && annotations[OLMAnnotation.TokenAuthAWS] !== 'false';
+  return [...parsedInfrastructureFeatures, ...Object.keys(annotations ?? {})].reduce(
+    (supportedFeatures, key) => {
+      const feature = normalizeInfrastructureFeature(key);
+
+      if (!feature) {
+        return supportedFeatures;
+      }
+
+      const featureIsSupported = annotations?.[key] !== 'false';
+      const featureIsIncluded = supportedFeatures.includes(feature);
+      const includeFeature = () =>
+        featureIsIncluded ? supportedFeatures : [...supportedFeatures, feature];
+      const excludeFeature = () =>
+        featureIsIncluded ? supportedFeatures.filter((v) => v !== feature) : supportedFeatures;
+
+      if (!featureIsSupported) {
+        return excludeFeature();
+      }
+
+      const resolveTokenAuthFeature = () => {
+        const tokenAuthIsSupported = azureTokenAuthIsSupported || awsTokenAuthIsSupported;
+        return tokenAuthIsSupported ? includeFeature() : excludeFeature();
+      };
+      const resolveTokenAuthGCPFeature = () => {
+        return clusterIsGCPWIF ? includeFeature() : excludeFeature();
+      };
+
+      switch (feature) {
+        case InfrastructureFeature.Disconnected:
+        case InfrastructureFeature.FIPSMode:
+        case InfrastructureFeature.ProxyAware:
+        case InfrastructureFeature.CNF:
+        case InfrastructureFeature.CNI:
+        case InfrastructureFeature.CSI:
+        case InfrastructureFeature.TLSProfiles:
+        case InfrastructureFeature.SNO:
+          return includeFeature();
+        case InfrastructureFeature.TokenAuth:
+          return resolveTokenAuthFeature();
+        case InfrastructureFeature.TokenAuthGCP:
+          return resolveTokenAuthGCPFeature();
+        default:
+          return supportedFeatures;
+      }
+    },
+    [],
+  );
+};
+
+type AnnotationParserOptions = {
+  onError?: (e: any) => void;
+};
+
+type GetInfrastructureFeatureOptions = AnnotationParserOptions & {
+  clusterIsAWSSTS: boolean;
+  clusterIsAzureWIF: boolean;
+  clusterIsGCPWIF: boolean;
+};
+
+type AnnotationParser<
+  Result = any,
+  Options extends AnnotationParserOptions = AnnotationParserOptions
+> = (annotations: ObjectMetadata['annotations'], options?: Options) => Result;

--- a/frontend/packages/operator-lifecycle-manager/src/const.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/const.ts
@@ -1,4 +1,4 @@
-import { ALL_NAMESPACES_KEY } from '@console/shared/src';
+import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants/common';
 
 export enum Flags {
   OPERATOR_LIFECYCLE_MANAGER = 'OPERATOR_LIFECYCLE_MANAGER',
@@ -22,12 +22,8 @@ export enum PackageSource {
 export const DEFAULT_GLOBAL_OPERATOR_INSTALLATION_NAMESPACE = 'openshift-operators';
 export const DEFAULT_SOURCE_NAMESPACE = 'openshift-marketplace';
 export const GLOBAL_COPIED_CSV_NAMESPACE = 'openshift';
-export const INTERNAL_OBJECTS_ANNOTATION = 'operators.operatorframework.io/internal-objects';
 export const NON_STANDALONE_ANNOTATION_VALUE = 'non-standalone';
 export const OPERATOR_NAMESPACE_ANNOTATION = 'olm.operatorNamespace';
-export const OPERATOR_PLUGINS_ANNOTATION = 'console.openshift.io/plugins';
-export const OPERATOR_TYPE_ANNOTATION = 'operators.operatorframework.io/operator-type';
-export const OPERATOR_UNINSTALL_MESSAGE_ANNOTATION = 'operator.openshift.io/uninstall-message';
 
 export const GLOBAL_OPERATOR_NAMESPACES = [
   DEFAULT_GLOBAL_OPERATOR_INSTALLATION_NAMESPACE,

--- a/frontend/packages/operator-lifecycle-manager/src/utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/utils.ts
@@ -1,14 +1,4 @@
-import { ObjectMetadata } from '@console/internal/module/k8s';
-import { parseJSONAnnotation } from '@console/shared/src/utils/annotations';
-import { INTERNAL_OBJECTS_ANNOTATION, OPERATOR_PLUGINS_ANNOTATION } from './const';
 import { SubscriptionKind, SubscriptionState } from './types';
-
-export const getClusterServiceVersionPlugins = (
-  annotations: ObjectMetadata['annotations'],
-): string[] => parseJSONAnnotation(annotations, OPERATOR_PLUGINS_ANNOTATION) ?? [];
-
-export const getInternalObjects = (annotations: ObjectMetadata['annotations']): string[] =>
-  parseJSONAnnotation(annotations, INTERNAL_OBJECTS_ANNOTATION) ?? [];
 
 export const isCatalogSourceTrusted = (catalogSource: string): boolean =>
   catalogSource === 'redhat-operators';

--- a/frontend/packages/operator-lifecycle-manager/src/utils/clusterserviceversions.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/utils/clusterserviceversions.ts
@@ -1,5 +1,6 @@
 import { K8sResourceKind, referenceFor, referenceForModel } from '@console/internal/module/k8s';
-import { NON_STANDALONE_ANNOTATION_VALUE, OPERATOR_TYPE_ANNOTATION } from '../const';
+import { OLMAnnotation } from '../components/operator-hub';
+import { NON_STANDALONE_ANNOTATION_VALUE } from '../const';
 import { ClusterServiceVersionModel } from '../models';
 import { ClusterServiceVersionPhase } from '../types';
 
@@ -12,5 +13,5 @@ export const isCopiedCSV = (obj: K8sResourceKind): boolean =>
 
 export const isStandaloneCSV = (obj: K8sResourceKind): boolean =>
   isCSV(obj) &&
-  (obj.metadata.annotations?.[OPERATOR_TYPE_ANNOTATION] !== NON_STANDALONE_ANNOTATION_VALUE ||
+  (obj.metadata.annotations?.[OLMAnnotation.OperatorType] !== NON_STANDALONE_ANNOTATION_VALUE ||
     obj.status?.phase === ClusterServiceVersionPhase.CSVPhaseFailed);


### PR DESCRIPTION
Add validation to PackageManifest/CSV annotations that are expected to contain JSON of a certain type (e.g. array of strings, k8s resource, etc.)
Clean up and dedupe code around csv annotations so that all parsing happens in one place and all references to these annotations look alike in the code.