### PR TITLE
OCPBUGS-38860: Collapse/Expand Feature Added, Removal Option Removed in Version 4.16

### DIFF
--- a/frontend/packages/console-shared/src/components/getting-started/GettingStartedExpandableGrid.scss
+++ b/frontend/packages/console-shared/src/components/getting-started/GettingStartedExpandableGrid.scss
@@ -1,60 +1,77 @@
 .ocs-getting-started-expandable-grid {
-    --min-column-width: 220px;
-  
+  --min-column-width: 220px;
+
+  // Increase css specificity to override a generic [class*="pf-v5-c-"] rule.
+  &__header.pf-v5-c-card__header {
+    // Use padding sm instead of lg to fix alignment of the KebabToggle action button.
+    padding-right: var(--pf-v5-global--spacer--sm);
+  }
+  &__tooltip {
+    white-space: pre-line;
+  }
+  &__tooltip-icon {
+    margin-left: var(--pf-v5-global--spacer--sm);
+  }
+
+  // Increase css specificity to override a generic [class*="pf-v5-c-"] rule.
+  &__content.pf-v5-c-card__body {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(var(--min-column-width), 1fr));
+
+    // Keep only additional spacing at the bottom. Horizontal spacing is added to the child elements.
+    padding: 0 0 calc(var(--pf-v5-c-card--child--PaddingBottom) / 2) 0;
+    // Hide the border on the right side of the content. Works together wie negative margin below.
+    overflow: hidden;
+    padding-top: 0 !important;
+
     // Increase css specificity to override a generic [class*="pf-v5-c-"] rule.
-    &__header.pf-v5-c-card__header {
-      // Use padding sm instead of lg to fix alignment of the KebabToggle action button.
-      padding-right: var(--pf-v5-global--spacer--sm);
-    }
-    &__tooltip {
-      white-space: pre-line;
-    }
-    &__tooltip-icon {
-      margin-left: var(--pf-v5-global--spacer--sm);
-    }
-  
-    // Increase css specificity to override a generic [class*="pf-v5-c-"] rule.
-    &__content.pf-v5-c-card__body {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(var(--min-column-width), 1fr));
-  
-      // Keep only additional spacing at the bottom. Horizontal spacing is added to the child elements.
-      padding: 0 0 calc(var(--pf-v5-c-card--child--PaddingBottom) / 2) 0;
-      // Hide the border on the right side of the content. Works together wie negative margin below.
-      overflow: hidden;
-      padding-top: 0 !important;
-  
-      // Increase css specificity to override a generic [class*="pf-v5-c-"] rule.
-      > .pf-v5-l-flex.pf-m-grow.pf-m-column {
-        // Show a divider on the right side and hide them in the latest column.
-        border-right: var(--pf-v5-global--BorderWidth--sm) solid var(--pf-v5-global--BorderColor--100);
-        margin-right: calc(-1 * var(--pf-v5-global--BorderWidth--sm));
-        // Padding around the card. Vertical spacing is splitted on the card and the grid.
-        padding-top: calc(var(--pf-v5-c-card--first-child--PaddingTop) / 2);
-        padding-bottom: calc(var(--pf-v5-c-card--child--PaddingBottom) / 2);
-        padding-left: var(--pf-v5-c-card--child--PaddingLeft);
-        padding-right: var(--pf-v5-c-card--child--PaddingRight);
-      }
+    > .pf-v5-l-flex.pf-m-grow.pf-m-column {
+      // Show a divider on the right side and hide them in the latest column.
+      border-right: var(--pf-v5-global--BorderWidth--sm) solid var(--pf-v5-global--BorderColor--100);
+      margin-right: calc(-1 * var(--pf-v5-global--BorderWidth--sm));
+      // Padding around the card. Vertical spacing is splitted on the card and the grid.
+      padding-top: calc(var(--pf-v5-c-card--first-child--PaddingTop) / 2);
+      padding-bottom: calc(var(--pf-v5-c-card--child--PaddingBottom) / 2);
+      padding-left: var(--pf-v5-c-card--child--PaddingLeft);
+      padding-right: var(--pf-v5-c-card--child--PaddingRight);
     }
   }
-  
-  .ocs-getting-started-expandable-section {
-    background-color: var(--pf-v5-global--BackgroundColor--100);
-    &__toggle-text {
-      color: var(--pf-v5-global--Color--dark-100);
-      &.is-dark {
-        color: var(--pf-v5-global--Color--light-100);
-      }
-      font-size: var(--pf-v5-global--icon--FontSize--md);
-      font-weight: var(--pf-v5-global--FontWeight--bold);
+}
+
+.ocs-getting-started-expandable-section {
+  width: 100%;
+  background-color: var(--pf-v5-global--BackgroundColor--100);
+  &__toggle-text {
+    color: var(--pf-v5-global--Color--dark-100);
+    &.is-dark {
+      color: var(--pf-v5-global--Color--light-100);
     }
+    font-size: var(--pf-v5-global--icon--FontSize--md);
+    font-weight: var(--pf-v5-global--FontWeight--bold);
   }
-  
-  .pf-v5-c-expandable-section__toggle {
-    align-items: center;
-  }
-  
-  .pf-v5-c-expandable-section__content {
-    padding: 0 !important;
-  }
-  
+}
+
+.pf-v5-c-expandable-section__toggle {
+  align-items: center;
+  width: inherit;
+}
+
+.pf-v5-c-expandable-section__toggle-text {
+  width: inherit;
+}
+
+.pf-v5-c-expandable-section__content {
+  padding: 0 !important;
+}
+
+.ocs-getting-started-expandable-section__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ocs-getting-started-close-icon {
+  cursor: pointer;
+  margin-left: auto;
+  color: var(--pf-v5-global--Color--dark-100);
+}

--- a/frontend/packages/console-shared/src/components/getting-started/GettingStartedExpandableGrid.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/GettingStartedExpandableGrid.tsx
@@ -7,8 +7,10 @@ import {
   Popover,
   ExpandableSection,
 } from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 import { useTranslation } from 'react-i18next';
+import { GettingStartedShowState } from './useGettingStartedShowState';
 
 import './GettingStartedExpandableGrid.scss';
 
@@ -16,12 +18,14 @@ interface GettingStartedExpandableGridProps {
   children?: React.ReactNodeArray;
   isOpen?: boolean;
   setIsOpen?: (isOpen: boolean) => void;
+  setShowState?: (showState: GettingStartedShowState) => void;
 }
 
 export const GettingStartedExpandableGrid: React.FC<GettingStartedExpandableGridProps> = ({
   children,
   isOpen,
   setIsOpen,
+  setShowState,
 }) => {
   const { t } = useTranslation();
 
@@ -34,6 +38,10 @@ export const GettingStartedExpandableGrid: React.FC<GettingStartedExpandableGrid
     </span>
   );
 
+  const handleClose = () => {
+    setShowState(GettingStartedShowState.HIDE);
+  };
+
   return (
     <ExpandableSection
       onToggle={() => setIsOpen(!isOpen)}
@@ -41,19 +49,24 @@ export const GettingStartedExpandableGrid: React.FC<GettingStartedExpandableGrid
       displaySize="lg"
       className="ocs-getting-started-expandable-section"
       toggleContent={
-        <div className="ocs-getting-started-expandable-section__toggle-text">
-          <Title headingLevel="h2" size={TitleSizes.lg} data-test="title">
-            {title}{' '}
-            <Popover bodyContent={titleTooltip} triggerAction="hover">
-              <span
-                role="button"
-                aria-label={t('console-shared~More info')}
-                className="ocs-getting-started-expandable-grid__tooltip-icon"
-              >
-                <OutlinedQuestionCircleIcon />
-              </span>
-            </Popover>
-          </Title>
+        <div className="ocs-getting-started-expandable-section__header">
+          <div className="ocs-getting-started-expandable-section__toggle-text">
+            <Title headingLevel="h2" size={TitleSizes.lg} data-test="title">
+              {title}{' '}
+              <Popover bodyContent={titleTooltip} triggerAction="hover">
+                <span
+                  role="button"
+                  aria-label={t('console-shared~More info')}
+                  className="ocs-getting-started-expandable-grid__tooltip-icon"
+                >
+                  <OutlinedQuestionCircleIcon />
+                </span>
+              </Popover>
+            </Title>
+          </div>
+          {setShowState && (
+            <TimesIcon onClick={handleClose} className="ocs-getting-started-close-icon" />
+          )}
         </div>
       }
     >

--- a/frontend/packages/dev-console/src/components/add/GettingStartedSection.tsx
+++ b/frontend/packages/dev-console/src/components/add/GettingStartedSection.tsx
@@ -7,8 +7,11 @@ import {
 import {
   QuickStartGettingStartedCard,
   GettingStartedExpandableGrid,
+  useGettingStartedShowState,
+  GettingStartedShowState,
 } from '@console/shared/src/components/getting-started';
 import { useFlag } from '@console/shared/src/hooks/flag';
+import { GETTING_STARTED_USER_SETTINGS_KEY } from './constants';
 import { DeveloperFeaturesGettingStartedCard } from './DeveloperFeaturesGettingStartedCard';
 import { SampleGettingStartedCard } from './SampleGettingStartedCard';
 
@@ -16,12 +19,17 @@ import './GettingStartedSection.scss';
 
 export const GettingStartedSection: React.FC = () => {
   const openshiftFlag = useFlag(FLAGS.OPENSHIFT);
+
+  const [showState, setShowState, showStateLoaded] = useGettingStartedShowState(
+    GETTING_STARTED_USER_SETTINGS_KEY,
+  );
+
   const [isGettingStartedSectionOpen, setIsGettingStartedSectionOpen] = useUserSettings<boolean>(
     GETTING_STARTED_USER_SETTINGS_KEY_ADD_PAGE,
     true,
   );
 
-  if (!openshiftFlag) {
+  if (!openshiftFlag || !showStateLoaded || showState !== GettingStartedShowState.SHOW) {
     return null;
   }
 
@@ -30,6 +38,7 @@ export const GettingStartedSection: React.FC = () => {
       <GettingStartedExpandableGrid
         isOpen={isGettingStartedSectionOpen}
         setIsOpen={setIsGettingStartedSectionOpen}
+        setShowState={setShowState}
       >
         <SampleGettingStartedCard featured={['code-with-quarkus', 'java-springboot-basic']} />
         <QuickStartGettingStartedCard

--- a/frontend/packages/dev-console/src/components/add/__tests__/GettingStartedSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/GettingStartedSection.spec.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { useUserSettings } from '@console/shared';
-import { GettingStartedExpandableGrid } from '@console/shared/src/components/getting-started';
+import {
+  GettingStartedExpandableGrid,
+  GettingStartedShowState,
+  useGettingStartedShowState,
+} from '@console/shared/src/components/getting-started';
 import { useFlag } from '@console/shared/src/hooks/flag';
 import { GettingStartedSection } from '../GettingStartedSection';
 
@@ -36,10 +40,12 @@ jest.mock('@console/shared/src/hooks/useUserSettings', () => ({
 const mockUserSettings = useUserSettings as jest.Mock;
 
 const useFlagMock = useFlag as jest.Mock;
+const useGettingStartedShowStateMock = useGettingStartedShowState as jest.Mock;
 
 describe('GettingStartedSection', () => {
   it('should render with three child elements', () => {
     useFlagMock.mockReturnValue(true);
+    useGettingStartedShowStateMock.mockReturnValue([GettingStartedShowState.SHOW, jest.fn(), true]);
     mockUserSettings.mockReturnValue([true, jest.fn()]);
 
     const wrapper = shallow(<GettingStartedSection />);
@@ -50,6 +56,16 @@ describe('GettingStartedSection', () => {
   it('should render nothing when useFlag(FLAGS.OPENSHIFT) return false', () => {
     useFlagMock.mockReturnValue(false);
     mockUserSettings.mockReturnValue([true, jest.fn()]);
+    useGettingStartedShowStateMock.mockReturnValue([GettingStartedShowState.SHOW, jest.fn(), true]);
+
+    const wrapper = shallow(<GettingStartedSection />);
+
+    expect(wrapper.find(GettingStartedExpandableGrid).length).toEqual(0);
+  });
+
+  it('should render nothing if user settings hide them', () => {
+    useFlagMock.mockReturnValue(true);
+    useGettingStartedShowStateMock.mockReturnValue([GettingStartedShowState.HIDE, jest.fn(), true]);
 
     const wrapper = shallow(<GettingStartedSection />);
 

--- a/frontend/packages/dev-console/src/components/add/constants.ts
+++ b/frontend/packages/dev-console/src/components/add/constants.ts
@@ -1,0 +1,1 @@
+export const GETTING_STARTED_USER_SETTINGS_KEY = 'devconsole.addPage.gettingStarted';

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/getting-started-section.spec.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/getting-started-section.spec.tsx
@@ -3,7 +3,11 @@ import { shallow } from 'enzyme';
 
 import { useUserSettings } from '@console/shared';
 import { useFlag } from '@console/shared/src/hooks/flag';
-import { GettingStartedExpandableGrid } from '@console/shared/src/components/getting-started';
+import {
+  GettingStartedExpandableGrid,
+  GettingStartedShowState,
+  useGettingStartedShowState,
+} from '@console/shared/src/components/getting-started';
 
 import { GettingStartedSection } from '../getting-started-section';
 
@@ -38,11 +42,13 @@ jest.mock('@console/shared/src/hooks/useUserSettings', () => ({
 const mockUserSettings = useUserSettings as jest.Mock;
 
 const useFlagMock = useFlag as jest.Mock;
+const useGettingStartedShowStateMock = useGettingStartedShowState as jest.Mock;
 
 describe('GettingStartedSection', () => {
   it('should render with three child elements', () => {
     useFlagMock.mockReturnValue(true);
     mockUserSettings.mockReturnValue([true, jest.fn()]);
+    useGettingStartedShowStateMock.mockReturnValue([GettingStartedShowState.SHOW, jest.fn(), true]);
 
     const wrapper = shallow(<GettingStartedSection />);
 
@@ -53,6 +59,16 @@ describe('GettingStartedSection', () => {
   it('should render nothing when useFlag(FLAGS.OPENSHIFT) return false', () => {
     useFlagMock.mockReturnValue(false);
     mockUserSettings.mockReturnValue([true, jest.fn()]);
+    useGettingStartedShowStateMock.mockReturnValue([GettingStartedShowState.SHOW, jest.fn(), true]);
+
+    const wrapper = shallow(<GettingStartedSection />);
+
+    expect(wrapper.find(GettingStartedExpandableGrid).length).toEqual(0);
+  });
+
+  it('should render nothing if user settings hide them', () => {
+    useFlagMock.mockReturnValue(true);
+    useGettingStartedShowStateMock.mockReturnValue([GettingStartedShowState.HIDE, jest.fn(), true]);
 
     const wrapper = shallow(<GettingStartedSection />);
 

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/constants.ts
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/constants.ts
@@ -1,0 +1,1 @@
+export const USER_SETTINGS_KEY = 'console.clusterDashboard.gettingStarted';

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/getting-started-section.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/getting-started-section.tsx
@@ -8,23 +8,28 @@ import {
 import { useFlag } from '@console/shared/src/hooks/flag';
 import {
   GettingStartedExpandableGrid,
+  GettingStartedShowState,
   QuickStartGettingStartedCard,
+  useGettingStartedShowState,
 } from '@console/shared/src/components/getting-started';
 
 import { ClusterSetupGettingStartedCard } from './cluster-setup-getting-started-card';
 import { ExploreAdminFeaturesGettingStartedCard } from './explore-admin-features-getting-started-card';
+import { USER_SETTINGS_KEY } from './constants';
 
 import './getting-started-section.scss';
 
 export const GettingStartedSection: React.FC = () => {
   const openshiftFlag = useFlag(FLAGS.OPENSHIFT);
 
+  const [showState, setShowState, showStateLoaded] = useGettingStartedShowState(USER_SETTINGS_KEY);
+
   const [isGettingStartedSectionOpen, setIsGettingStartedSectionOpen] = useUserSettings<boolean>(
     GETTING_STARTED_USER_SETTINGS_KEY_CLUSTER_DASHBOARD,
     true,
   );
 
-  if (!openshiftFlag) {
+  if (!openshiftFlag || !showStateLoaded || showState !== GettingStartedShowState.SHOW) {
     return null;
   }
 
@@ -33,6 +38,7 @@ export const GettingStartedSection: React.FC = () => {
       <GettingStartedExpandableGrid
         isOpen={isGettingStartedSectionOpen}
         setIsOpen={setIsGettingStartedSectionOpen}
+        setShowState={setShowState}
       >
         <ClusterSetupGettingStartedCard />
         <QuickStartGettingStartedCard


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-38860

**Analysis / Root cause**: 
From OCP 4.16, getting started section was changed to use expandable section of PatternFly and the removal option was removed.

**Solution Description**: 
Added removal option for getting started section in Add page of developer perspective and in Cluster overview page.

  
**Screen shots / Gifs for design review**: 



https://github.com/user-attachments/assets/0f032e47-ea4c-4183-ac3b-4ef686c76518







**Unit test coverage report**: 
NA

**Test setup:**

    1. Go to Web console. Click on the "Getting started resources." 
    2. Then you can expand and collapse this tab.
    3. But there is no option to directly remove this tab.  
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge




