### PR TITLE
[release-4.13] OCPBUGS-41594: Redirects to new PipelineRun logs URL from old PipelineRun logs URL

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -498,6 +498,14 @@
     "type": "console.page/route",
     "properties": {
       "exact": true,
+      "path": ["/k8s/ns/:ns/tekton.dev~v1beta1~PipelineRun/:plrName/logs/:taskName"],
+      "component": { "$codeRef": "pipelinesComponent.LogURLRedirect" }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
       "path": "/k8s/ns/:ns/tekton.dev~v1beta1~Pipeline/:pipelineName/builder",
       "component": {
         "$codeRef": "pipelinesComponent.PipelineBuilderEditPage"

--- a/frontend/packages/pipelines-plugin/src/components/LogURLRedirect.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/LogURLRedirect.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { Redirect, RouteComponentProps } from 'react-router-dom';
+
+type LogURLRedirectProps = RouteComponentProps<{ ns: string; taskName: string; plrName: string }>;
+
+const createLogURL = (pathname: string, taskName: string): string => {
+  const basePath = pathname.replace(/\/$/, '');
+  const detailsURL = basePath.split('/logs/');
+  return `${detailsURL[0]}/logs?taskName=${taskName}`;
+};
+
+export const LogURLRedirect: React.FC<LogURLRedirectProps> = ({ match }) => {
+  const { taskName } = match.params;
+  return <Redirect to={createLogURL(window.location.pathname, taskName)} />;
+};

--- a/frontend/packages/pipelines-plugin/src/components/pipelines-index.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines-index.ts
@@ -3,3 +3,4 @@ export * from './pipelineruns';
 export * from './conditions';
 export * from './pipelines-lists';
 export * from './repository';
+export { LogURLRedirect } from './LogURLRedirect';


### PR DESCRIPTION
Manually cherry-pick of PR https://github.com/openshift/console/pull/14234