### PR TITLE
OCPBUGS-41496: incorrect access mode for provisioner: file.csi.azure.com

### DIFF
--- a/frontend/public/components/storage/shared.ts
+++ b/frontend/public/components/storage/shared.ts
@@ -117,6 +117,10 @@ export const provisionerAccessModeMapping: ProvisionerAccessModeMapping = Object
     Block: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany', 'ReadWriteOncePod'],
     partialMatch: true,
   },
+  'file.csi.azure.com': {
+    Filesystem: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany', 'ReadWriteOncePod'],
+    Block: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany', 'ReadWriteOncePod'],
+  },
 });
 
 export const getAccessModeOptions = () => [


### PR DESCRIPTION
Fix incorrect access mode for provisioner: file.csi.azure.com: https://issues.redhat.com/browse/OCPBUGS-41496?filter=-1

Resolution:
added a missing file.csi.azure.com key in a dictionary of access modes for provisioners