### PR TITLE
OCPBUGS-41228: Console crashes when ssh is selected in add secret for starting a pipeline run

### DIFF
--- a/frontend/public/components/utils/drag-drop-context.tsx
+++ b/frontend/public/components/utils/drag-drop-context.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
-import { DndProvider, createDndContext } from 'react-dnd';
+import { DndProvider } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
-
-const dndContext = createDndContext(HTML5Backend);
 
 const withDragDropContext = <TProps extends {}>(
   Component: React.ComponentClass<TProps> | React.FC<TProps>,
 ) => (props: TProps) => {
-  const manager = React.useRef(dndContext);
   return (
-    <DndProvider manager={manager.current.dragDropManager}>
+    <DndProvider backend={HTML5Backend} context={window}>
       <Component {...props} />
     </DndProvider>
   );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-41228

**Analysis / Root cause**: 
`withDragDropContext` is not exposed to dynamic plugins. In start pipeline form, user can create secret, there again, another HTML5Backend was getting created and this lead to "Cannot have two HTML5 backends at the same time." error.

Ideally `DroppableFileInput` and `TextColumnField` should be exposed to dynamic plugins which internally uses DND but since these components are not exposed, this change is required to set the context to window.

**Solution Description**: 
`HTML5Backend` is passed directly as `backend` prop to `DndProvider` instead of `manager` prop and the `context` is set to `window`
  
**Screen shots / Gifs for design review**: 

----BEFORE---


https://github.com/user-attachments/assets/7b9a2efd-9c97-48d2-835a-7d222e605018



---AFTER----



https://github.com/user-attachments/assets/8ba8f87d-3ac4-40b0-abb0-c8fb251077b9





**Unit test coverage report**: 
NA

**Test setup:**

    1. Install pipelines operator and enable dynamic plugin
    2. Create a pipeline through add flow and open start pipeline page in developer perspective
    3. Under show credentials select add secret
    4. In the secret form select `Access to ` as Git server and `Authentication type` as SSH key
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge




