### PR TITLE
OCPBUGS-38350: Improve hpa validation schema messaging for extreme values

### DIFF
--- a/frontend/packages/dev-console/src/components/hpa/validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/hpa/validation-utils.ts
@@ -2,6 +2,7 @@ import { TFunction } from 'i18next';
 import * as yup from 'yup';
 import { nameRegex } from '@console/shared';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+import { isInteger } from '../../utils/yup-validation-util';
 
 export const hpaValidationSchema = (t: TFunction) =>
   yup.object({
@@ -24,7 +25,7 @@ export const hpaValidationSchema = (t: TFunction) =>
         spec: yup.object({
           minReplicas: yup
             .number()
-            .integer(t('devconsole~Minimum Pods must be an integer.'))
+            .test(isInteger(t('devconsole~Minimum Pods must be an integer.')))
             .min(1, t('devconsole~Minimum Pods must greater than or equal to 1.'))
             .test(
               'test-less-than-max',
@@ -36,7 +37,11 @@ export const hpaValidationSchema = (t: TFunction) =>
             ),
           maxReplicas: yup
             .number()
-            .integer(t('devconsole~Maximum Pods must be an integer.'))
+            .test(isInteger(t('devconsole~Maximum Pods must be an integer.')))
+            .max(
+              Number.MAX_SAFE_INTEGER,
+              t('devconsole~Value is larger than maximum value allowed.'),
+            )
             .test(
               'test-greater-than-min',
               t('devconsole~Maximum Pods should be greater than or equal to Minimum Pods.'),


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGS-38350

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
The faulty `.integer()` feature was used (which was fixed in yup 0.28.0, we are on 0.27.0) incorrectly determined that the maximum value of an integer to be 2147483647, there was also no messaging for when users reached values above that maximum

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Use our custom `isInteger` helper and added a message for max int

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://github.com/user-attachments/assets/fbd7f152-3c62-4147-920f-d26a6d2b6ca3


**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
n/a

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
