### PR TITLE
ODC-7655: Migrate `SelectVariant.Single` `SelectInputField`s to PF5

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/SingleDropdownField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/SingleDropdownField.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Select,
+  SelectList,
+  SelectOption,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
+import { useField, useFormikContext, FormikValues } from 'formik';
+import { useFormikValidationFix } from '../../hooks';
+import { RedExclamationCircleIcon } from '../status';
+import { SingleDropdownFieldProps } from './field-types';
+import { getFieldId } from './field-utils';
+
+const SingleDropdownField: React.FC<SingleDropdownFieldProps> = ({
+  name,
+  label,
+  ariaLabel,
+  options,
+  placeholderText,
+  helpText,
+  required,
+  toggleOnSelection,
+  isDisabled,
+  onChange,
+  getLabelFromValue,
+}) => {
+  const [field, { touched, error }] = useField<string | string[]>(name);
+  const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const fieldId = getFieldId(name, 'select-input');
+  const isValid = !(touched && error);
+  const errorMessage = !isValid ? error : '';
+
+  useFormikValidationFix(field.value);
+
+  const onToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = (_event, selection: string) => {
+    if (onChange) {
+      onChange(selection);
+    } else {
+      setFieldValue(name, selection);
+    }
+    setFieldTouched(name);
+    toggleOnSelection && onToggle();
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      id={fieldId}
+      onClick={onToggle}
+      ref={toggleRef}
+      isExpanded={isOpen}
+      aria-label={ariaLabel}
+      isFullWidth
+      // FIXME(jaclee): uncomment when PF is updated to support this prop
+      // status={isValid ? undefined : 'danger'}
+    >
+      {getLabelFromValue
+        ? getLabelFromValue(field.value as string)
+        : field.value || placeholderText}
+    </MenuToggle>
+  );
+
+  return (
+    <FormGroup fieldId={fieldId} label={label} isRequired={required}>
+      <Select
+        toggle={toggle}
+        aria-describedby={helpText ? `${fieldId}-helper` : undefined}
+        aria-label={ariaLabel}
+        onSelect={onSelect}
+        isOpen={isOpen}
+        isDisabled={isDisabled}
+        onOpenChange={setIsOpen}
+        popperProps={{ maxWidth: 'trigger' }} // prevents dropdown from going off screen
+      >
+        <SelectList>
+          {options.map((op) => (
+            <SelectOption
+              value={op.label ? op.label : op.value}
+              isDisabled={op.disabled}
+              key={op.value}
+              id={`select-option-${name}-${op.value}`}
+              description={op.description ?? ''}
+              hasCheckbox={op.hasCheckbox}
+              isSelected={field.value === op.value}
+            >
+              {op.label}
+            </SelectOption>
+          ))}
+        </SelectList>
+      </Select>
+
+      <FormHelperText>
+        <HelperText>
+          {!isValid ? (
+            <HelperTextItem variant="error" icon={<RedExclamationCircleIcon />}>
+              {errorMessage}
+            </HelperTextItem>
+          ) : (
+            <HelperTextItem>{helpText}</HelperTextItem>
+          )}
+        </HelperText>
+      </FormHelperText>
+    </FormGroup>
+  );
+};
+
+export default SingleDropdownField;

--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -172,6 +172,17 @@ export interface SelectInputOption {
   label?: string;
   description?: string;
   disabled?: boolean;
+  hasCheckbox?: boolean;
+}
+
+export interface SingleDropdownFieldProps extends FieldProps {
+  ariaLabel?: string;
+  options: SelectInputOption[];
+  placeholderText?: React.ReactNode;
+  isDisabled?: boolean;
+  toggleOnSelection?: boolean;
+  onChange?: (selection: string) => void;
+  getLabelFromValue?: (value: string) => string;
 }
 
 export interface SelectInputFieldProps extends FieldProps {

--- a/frontend/packages/console-shared/src/components/formik-fields/index.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/index.ts
@@ -21,6 +21,7 @@ export { default as TextColumnField } from './text-column-field/TextColumnField'
 export { default as DynamicFormField } from './DynamicFormField';
 export { default as SyncedEditorField } from './SyncedEditorField';
 export { default as SelectInputField } from './SelectInputField';
+export { default as SingleDropdownField } from './SingleDropdownField';
 export { default as SelectorInputField } from './SelectorInputField';
 export * from './field-utils';
 export * from './field-types';

--- a/frontend/packages/dev-console/src/components/import/section/ResourceSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/ResourceSection.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { SelectVariant as SelectVariantDeprecated } from '@patternfly/react-core/deprecated';
 import { FormikValues, useField, useFormikContext } from 'formik';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
@@ -12,7 +11,7 @@ import { DeploymentModel, DeploymentConfigModel } from '@console/internal/models
 import { connectToFlags } from '@console/internal/reducers/connectToFlags';
 import { FlagsObject } from '@console/internal/reducers/features';
 import { FLAG_KNATIVE_SERVING_SERVICE, ServiceModel } from '@console/knative-plugin';
-import { SelectInputField, SelectInputOption } from '@console/shared';
+import { SingleDropdownField, SelectInputOption } from '@console/shared';
 import { Resources, ReadableResourcesNames } from '../import-types';
 import FormSection from './FormSection';
 import { useResourceType } from './useResourceType';
@@ -102,11 +101,10 @@ const ResourceSection: React.FC<ResourceSectionProps> = ({ flags }) => {
   ) {
     return (
       <FormSection>
-        <SelectInputField
+        <SingleDropdownField
           name={fieldName}
           label={t('devconsole~Resource type')}
           options={selectInputOptions}
-          variant={SelectVariantDeprecated.single}
           onChange={onChange}
           getLabelFromValue={(value: string) => t(ReadableResourcesNames[value])}
           helpText={
@@ -117,7 +115,6 @@ const ResourceSection: React.FC<ResourceSectionProps> = ({ flags }) => {
               </Trans>
             </p>
           }
-          hideClearButton
           toggleOnSelection
         />
       </FormSection>

--- a/frontend/packages/dev-console/src/components/import/section/build-section/BuildOptions.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/build-section/BuildOptions.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { SelectVariant } from '@patternfly/react-core/deprecated';
 import { FormikValues, useFormikContext } from 'formik';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
@@ -8,7 +7,7 @@ import { getActiveNamespace } from '@console/internal/actions/ui';
 import { LoadingInline, useAccessReview } from '@console/internal/components/utils';
 import { CLUSTER_PIPELINE_NS, FLAG_OPENSHIFT_PIPELINE } from '@console/pipelines-plugin/src/const';
 import { PipelineModel } from '@console/pipelines-plugin/src/models';
-import { SelectInputField, SelectInputOption, useFlag } from '@console/shared';
+import { SingleDropdownField, SelectInputOption, useFlag } from '@console/shared';
 import { FLAG_OPENSHIFT_BUILDCONFIG } from '../../../../const';
 import {
   isPreferredStrategyAvailable,
@@ -104,11 +103,10 @@ export const BuildOption: React.FC<BuildOptionProps> = ({ isDisabled, importStra
   );
 
   return strategyLoaded ? (
-    <SelectInputField
+    <SingleDropdownField
       name={fieldName}
       label={t('devconsole~Build option')}
       options={selectInputOptions}
-      variant={SelectVariant.single}
       onChange={onChange}
       isDisabled={isDisabled}
       getLabelFromValue={(value: string) => t(ReadableBuildOptions[value])}
@@ -119,7 +117,6 @@ export const BuildOption: React.FC<BuildOptionProps> = ({ isDisabled, importStra
           </Trans>
         </p>
       }
-      hideClearButton
       toggleOnSelection
     />
   ) : (

--- a/frontend/packages/dev-console/src/components/import/section/build-section/BuildStrategySelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/build-section/BuildStrategySelector.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import { SelectVariant as SelectVariantDeprecated } from '@patternfly/react-core/deprecated';
 import { FormikValues, useFormikContext } from 'formik';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useClusterBuildStrategy } from '@console/dev-console/src/utils/shipwright-build-hook';
 import { ImportStrategy } from '@console/git-service/src';
 import { LoadingInline } from '@console/internal/components/utils';
-import { SelectInputField, SelectInputOption } from '@console/shared/src';
+import { SingleDropdownField, SelectInputOption } from '@console/shared/src';
 import {
   ClusterBuildStrategy,
   ReadableClusterBuildStrategies,
@@ -61,7 +60,7 @@ export const BuildStrategySelector: React.FC<BuildStrategySelectorProps> = ({
   );
 
   return strategyLoaded ? (
-    <SelectInputField
+    <SingleDropdownField
       data-test-id="cluster-build-strategy-field"
       name="build.clusterBuildStrategy"
       label={t('devconsole~Cluster Build Strategy')}
@@ -74,8 +73,6 @@ export const BuildStrategySelector: React.FC<BuildStrategySelectorProps> = ({
       )}
       getLabelFromValue={(value: string) => t(ReadableClusterBuildStrategies[value])}
       options={clusterBuildStrategyOptions}
-      variant={SelectVariantDeprecated.single}
-      hideClearButton
       toggleOnSelection
     />
   ) : (

--- a/frontend/packages/dev-console/src/components/import/section/build-section/__tests__/BuildOptions.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/build-section/__tests__/BuildOptions.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import * as shipwrightHooks from '@console/dev-console/src/utils/shipwright-build-hook';
 import * as flagsModule from '@console/dynamic-plugin-sdk/src/utils/flags';
-import { SelectInputField } from '@console/shared';
+import { SingleDropdownField, SingleDropdownFieldProps } from '@console/shared';
 import { BuildOption as NamedBuildOption } from '../BuildOptions';
 import * as BuildOption from '../BuildOptions';
 
@@ -32,9 +32,13 @@ describe('BuildOptions', () => {
     spySWClusterBuildStrategy.mockReturnValue([{ s2i: true }, true]);
     spyUsePipelineAccessReview.mockReturnValue(true);
     const component = shallow(<NamedBuildOption isDisabled={false} importStrategy={0} />);
-    expect(component.find(SelectInputField).exists()).toBe(true);
-    expect(component.find(SelectInputField).props().options).toHaveLength(3);
-    expect(component.find(SelectInputField).props().options).toEqual([
+    expect(component.find(SingleDropdownField).exists()).toBe(true);
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).toHaveLength(3);
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).toEqual([
       {
         description:
           'Shipwright is an extensible framework for building container images on OpenShift Container Platform cluster.',
@@ -67,15 +71,21 @@ describe('BuildOptions', () => {
     spySWClusterBuildStrategy.mockReturnValue([{ s2i: true }, true]);
     spyUsePipelineAccessReview.mockReturnValue(true);
     const component = shallow(<NamedBuildOption isDisabled={false} importStrategy={0} />);
-    expect(component.find(SelectInputField).exists()).toBe(true);
-    expect(component.find(SelectInputField).props().options).toHaveLength(2);
-    expect(component.find(SelectInputField).props().options).not.toContainEqual({
+    expect(component.find(SingleDropdownField).exists()).toBe(true);
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).toHaveLength(2);
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).not.toContainEqual({
       description:
         'Build configuration describes build definitions used for transforming source code into a runnable container image.',
       label: 'BuildConfig',
       value: 'BUILDS',
     });
-    expect(component.find(SelectInputField).props().options).toEqual([
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).toEqual([
       {
         description:
           'Shipwright is an extensible framework for building container images on OpenShift Container Platform cluster.',
@@ -105,15 +115,21 @@ describe('BuildOptions', () => {
     spySWClusterBuildStrategy.mockReturnValue([{ s2i: false }, true]);
     spyUsePipelineAccessReview.mockReturnValue(false);
     const component = shallow(<NamedBuildOption isDisabled={false} importStrategy={0} />);
-    expect(component.find(SelectInputField).exists()).toBe(true);
-    expect(component.find(SelectInputField).props().options).toHaveLength(1);
-    expect(component.find(SelectInputField).props().options).not.toContainEqual({
+    expect(component.find(SingleDropdownField).exists()).toBe(true);
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).toHaveLength(1);
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).not.toContainEqual({
       description:
         'Shipwright is an extensible framework for building container images on OpenShift Container Platform cluster.',
       label: 'Builds for OpenShift (Shipwright)',
       value: 'SHIPWRIGHT_BUILD',
     });
-    expect(component.find(SelectInputField).props().options).toEqual([
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).toEqual([
       {
         description:
           'Build configuration describes build definitions used for transforming source code into a runnable container image.',

--- a/frontend/packages/dev-console/src/components/import/section/build-section/__tests__/BuildStrategySelector.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/build-section/__tests__/BuildStrategySelector.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import * as shipwrightHooks from '@console/dev-console/src/utils/shipwright-build-hook';
-import { SelectInputField } from '@console/shared';
+import { SingleDropdownField, SingleDropdownFieldProps } from '@console/shared';
 import { BuildStrategySelector } from '../BuildStrategySelector';
 
 const spySWClusterBuildStrategy = jest.spyOn(shipwrightHooks, 'useClusterBuildStrategy');
@@ -13,45 +13,57 @@ jest.mock('formik', () => ({
 }));
 
 describe('BuildStrategySelector', () => {
-  it('should not render SelectInputField if clusterBuildStrategy is not loaded', () => {
+  it('should not render SingleDropdownField if clusterBuildStrategy is not loaded', () => {
     spySWClusterBuildStrategy.mockReturnValue([{}, false]);
     const component = shallow(<BuildStrategySelector formType="create" importStrategy={0} />);
-    expect(component.find(SelectInputField).exists()).toBe(false);
+    expect(component.find(SingleDropdownField).exists()).toBe(false);
   });
 
   it('should list source-to-image if BuildImage Import Strategy is selected, s2i clusterBuildStrategy is found', () => {
     spySWClusterBuildStrategy.mockReturnValue([{ s2i: true }, true]);
     const component = shallow(<BuildStrategySelector formType="create" importStrategy={0} />);
-    expect(component.find(SelectInputField).exists()).toBe(true);
-    expect(component.find(SelectInputField).props().options).toHaveLength(1);
-    expect(component.find(SelectInputField).props().options).toEqual([
-      { label: 'Source-to-Image', value: 'source-to-image' },
-    ]);
+    expect(component.find(SingleDropdownField).exists()).toBe(true);
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).toHaveLength(1);
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).toEqual([{ label: 'Source-to-Image', value: 'source-to-image' }]);
   });
 
   it('should list buildah if Dockerfile Import Strategy is selected, buildah clusterBuildStrategy is found', () => {
     spySWClusterBuildStrategy.mockReturnValue([{ buildah: true }, true]);
     const component = shallow(<BuildStrategySelector formType="create" importStrategy={1} />);
-    expect(component.find(SelectInputField).exists()).toBe(true);
-    expect(component.find(SelectInputField).props().options).toHaveLength(1);
-    expect(component.find(SelectInputField).props().options).toEqual([
-      { label: 'Buildah', value: 'buildah' },
-    ]);
+    expect(component.find(SingleDropdownField).exists()).toBe(true);
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).toHaveLength(1);
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).toEqual([{ label: 'Buildah', value: 'buildah' }]);
   });
 
   it('should not list buildah if buildah clusterBuildStrategy is not found', () => {
     spySWClusterBuildStrategy.mockReturnValue([{ buildah: false }, true]);
     const component = shallow(<BuildStrategySelector formType="create" importStrategy={1} />);
-    expect(component.find(SelectInputField).exists()).toBe(true);
-    expect(component.find(SelectInputField).props().options).toHaveLength(0);
-    expect(component.find(SelectInputField).props().options).toEqual([]);
+    expect(component.find(SingleDropdownField).exists()).toBe(true);
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).toHaveLength(0);
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).toEqual([]);
   });
 
   it('should not list s2i if s2i clusterBuildStrategy is not found', () => {
     spySWClusterBuildStrategy.mockReturnValue([{ s2i: false }, true]);
     const component = shallow(<BuildStrategySelector formType="create" importStrategy={0} />);
-    expect(component.find(SelectInputField).exists()).toBe(true);
-    expect(component.find(SelectInputField).props().options).toHaveLength(0);
-    expect(component.find(SelectInputField).props().options).toEqual([]);
+    expect(component.find(SingleDropdownField).exists()).toBe(true);
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).toHaveLength(0);
+    expect(
+      (component.find(SingleDropdownField).props() as SingleDropdownFieldProps).options,
+    ).toEqual([]);
   });
 });

--- a/frontend/packages/shipwright-plugin/src/components/build-form/BuildStrategySelector.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/build-form/BuildStrategySelector.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { Alert } from '@patternfly/react-core';
-import { SelectVariant as SelectVariantDeprecated } from '@patternfly/react-core/deprecated';
 import { FormikValues, useFormikContext } from 'formik';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 import { getGroupVersionKindForModel } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
-import { SelectInputField, SelectInputOption } from '@console/shared/src';
+import { SingleDropdownField, SelectInputOption } from '@console/shared/src';
 import { BuildStrategyModel, ClusterBuildStrategyModel } from '../../models';
 import { BuildStrategyKind, ClusterBuildStrategyKind } from '../../types';
 
@@ -103,7 +102,7 @@ const BuildStrategySelector: React.FC<BuildStrategySelectorProps> = ({ namespace
 
   return (
     <FormSection>
-      <SelectInputField
+      <SingleDropdownField
         data-test-id="build-strategy-field"
         name="formData.build.strategy"
         label={t('shipwright-plugin~Build Strategy')}
@@ -115,8 +114,6 @@ const BuildStrategySelector: React.FC<BuildStrategySelectorProps> = ({ namespace
           'shipwright-plugin~Cluster Build Strategies define a shared group of steps, needed to fullfil the application build process.',
         )}
         options={clusterBuildStrategyOptions}
-        variant={SelectVariantDeprecated.single}
-        hideClearButton
         toggleOnSelection
         required
       />


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-7655

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Migrate all SelectInputFields that use the single variant to PF5. Other variants will get other PRs as I am splitting up this component

I commented out the input validation UI because it is not supported in our currently installed version of PatternFly

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

Demo:

https://github.com/user-attachments/assets/ff5c73e1-89c9-453f-8db1-13d10859c773


**Unit test coverage report**: 
<!-- Attach test coverage report -->
unchanged

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
n/a

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari

This pr is 4/? of [ODC-7655](https://issues.redhat.com//browse/ODC-7655) story as each file is being split into a separate PR.