### PR TITLE
ODC-7691: Operator availability check through CLI

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/global.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/global.ts
@@ -74,6 +74,15 @@ export enum operatorSubscriptions {
   RedHatIntegrationCamelK = 'red-hat-camel-k',
 }
 
+export enum operatorPackage {
+  PipelinesOperator = 'openshift-pipelines-operator-rh',
+  ServerlessOperator = 'serverless-operator',
+  ShipwrightOperator = 'shipwright-operator',
+  BuildsForOpenshiftOperator = 'openshift-builds-operator',
+  WebTerminalOperator = 'web-terminal',
+  RedHatIntegrationCamelK = 'red-hat-camel-k',
+}
+
 export enum authenticationType {
   BasicAuthentication = 'Basic Authentication',
   SSHKey = 'SSHKey',

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/checkOperatorHub.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/checkOperatorHub.ts
@@ -1,0 +1,11 @@
+export const checkOperatorvailabilityStatus = (operatorName: string) => {
+  cy.exec(`source ../../dev-console/integration-tests/testData/krew-install.sh ${operatorName}`, {
+    failOnNonZeroExit: false,
+  }).then(function (result) {
+    cy.log(`Operator availability check :`);
+    cy.log(result.stdout || result.stderr);
+    if (result.stdout.includes(`"${operatorName}" not found`)) {
+      throw new Error(`Failed to install ${operatorName} Operator - Operator not available.`);
+    }
+  });
+};

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/installOperatorOnClusterUsingCLI.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/installOperatorOnClusterUsingCLI.ts
@@ -1,4 +1,10 @@
-import { operatorNamespaces, operatorSubscriptions, operators } from '../../constants/global';
+import {
+  operatorNamespaces,
+  operatorSubscriptions,
+  operatorPackage,
+  operators,
+} from '../../constants/global';
+import { checkOperatorvailabilityStatus } from './checkOperatorHub';
 import {
   checkPipelineOperatorStatus,
   checkKnativeOperatorStatus,
@@ -123,31 +129,38 @@ export const installOperatorUsingCLI = (operator: operators) => {
 export const checkSubscriptionStatus = (operator: operators) => {
   let namespace;
   let subscriptionName;
+  let operatorPackageName;
   const resourceName = 'subscriptions.operators.coreos.com';
   const condition = 'CatalogSourcesUnhealthy=false';
 
   switch (operator) {
     case operators.PipelinesOperator:
+      operatorPackageName = operatorPackage.PipelinesOperator;
       namespace = operatorNamespaces.PipelinesOperator;
       subscriptionName = operatorSubscriptions.PipelinesOperator;
       break;
     case operators.ServerlessOperator:
+      operatorPackageName = operatorPackage.ServerlessOperator;
       namespace = operatorNamespaces.ServerlessOperator;
       subscriptionName = operatorSubscriptions.ServerlessOperator;
       break;
     case operators.ShipwrightOperator:
+      operatorPackageName = operatorPackage.ShipwrightOperator;
       namespace = operatorNamespaces.ShipwrightOperator;
       subscriptionName = operatorSubscriptions.ShipwrightOperator;
       break;
     case operators.BuildsForOpenshiftOperator:
+      operatorPackageName = operatorPackage.BuildsForOpenshiftOperator;
       namespace = operatorNamespaces.BuildsForOpenshiftOperator;
       subscriptionName = operatorSubscriptions.BuildsForOpenshiftOperator;
       break;
     case operators.WebTerminalOperator:
+      operatorPackageName = operatorPackage.WebTerminalOperator;
       namespace = operatorNamespaces.WebTerminalOperator;
       subscriptionName = operatorSubscriptions.WebTerminalOperator;
       break;
     case operators.RedHatIntegrationCamelK:
+      operatorPackageName = operatorPackage.RedHatIntegrationCamelK;
       namespace = operatorNamespaces.RedHatIntegrationCamelK;
       subscriptionName = operatorSubscriptions.RedHatIntegrationCamelK;
       break;
@@ -166,6 +179,7 @@ export const checkSubscriptionStatus = (operator: operators) => {
       checkOperatorStatus(operator);
     } else {
       cy.log(`${operator} not installed, installing...`);
+      checkOperatorvailabilityStatus(operatorPackageName);
       installOperatorUsingCLI(operator);
     }
   });

--- a/frontend/packages/dev-console/integration-tests/testData/krew-install.sh
+++ b/frontend/packages/dev-console/integration-tests/testData/krew-install.sh
@@ -1,0 +1,22 @@
+# Refer : https://krew.sigs.k8s.io/docs/user-guide/setup/install/
+echo -e "\n Installing Krew plugin :"
+
+(
+  set -x; cd "$(mktemp -d)" &&
+  OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+  ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+  KREW="krew-${OS}_${ARCH}" &&
+  curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+  tar zxvf "${KREW}.tar.gz" &&
+  ./"${KREW}" install krew
+)
+
+export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
+
+echo -e "\n Installing Operator plugin :"
+
+oc krew install operator
+
+echo -e "\n Checking availability of $1 :"
+
+oc operator list-available $1


### PR DESCRIPTION
Story:
[ODC-7691](https://issues.redhat.com/browse/ODC-7691)

**Description**
- Improve CI test observability by adding operator availability check through CLI.
- Discontinue test execution if operator is not available on operator hub.