### PR TITLE
OCPBUGS-42985: Update Console dynamic plugin SDK webpack dependency

### DIFF
--- a/dynamic-demo-plugin/package.json
+++ b/dynamic-demo-plugin/package.json
@@ -40,7 +40,7 @@
     "ts-loader": "9.x",
     "ts-node": "10.9.2",
     "typescript": "4.5.5",
-    "webpack": "5.75.0",
+    "webpack": "^5.75.0",
     "webpack-cli": "5.0.x"
   },
   "consolePlugin": {

--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -128,7 +128,7 @@
     lodash "^4.17.21"
     read-pkg "5.x"
     semver "6.x"
-    webpack "5.75.0"
+    webpack "^5.75.0"
 
 "@openshift-console/dynamic-plugin-sdk@file:../frontend/packages/console-dynamic-plugin-sdk/dist/core":
   version "0.0.0-fixed"
@@ -3983,7 +3983,7 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@5.75.0:
+webpack@^5.75.0:
   version "5.75.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.75.0.tgz#1e440468647b2505860e94c9ff3e44d5b582c152"
   integrity sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==

--- a/frontend/packages/console-dynamic-plugin-sdk/package.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/package.json
@@ -24,6 +24,6 @@
     "fs-extra": "9.x",
     "ts-json-schema-generator": "0.98.0",
     "tsutils": "3.21.0",
-    "webpack": "5.75.0"
+    "webpack": "^5.75.0"
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -18183,7 +18183,7 @@ webpack-virtual-modules@^0.6.2:
   resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz#057faa9065c8acf48f24cb57ac0e77739ab9a7e8"
   integrity sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==
 
-webpack@5.75.0:
+webpack@^5.75.0:
   version "5.75.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.75.0.tgz#1e440468647b2505860e94c9ff3e44d5b582c152"
   integrity sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==


### PR DESCRIPTION
This PR fixes a webpack dependency issue in `@openshift-console/dynamic-plugin-sdk-webpack` package.

Console plugins are currently supposed to use webpack version `5.75.0` (exactly this version).

If a plugin project updates its webpack dependency to a newer version, it may cause the package manager to not hoist `node_modules/@openshift/dynamic-plugin-sdk-webpack` (which is a dependency of the :point_up: package) which then causes problems during the webpack build, for example in [Kubevirt plugin](https://github.com/kubevirt-ui/kubevirt-plugin):

![](https://github.com/user-attachments/assets/ae197ef7-a41a-446c-ac01-3b7c8f3d584e)

With this PR, the webpack dependency in `@openshift-console/dynamic-plugin-sdk-webpack` package will be `"^5.75.0"` version range instead of `"5.75.0"` exact version.

This PR also de-dupes two webpack 5 resolutions into a single resolution.

cc @metalice 