### PR TITLE
OCPBUGS-42000: use TaskRuns `results.tekton.dev/record` annotation to get the logs

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -843,6 +843,12 @@
     }
   },
   {
+    "type": "console.flag/hookProvider",
+    "properties": {
+      "handler": { "$codeRef": "pipelinesComponent.useIsPipelineOperatorVersion_1_16" }
+    }
+  },
+  {
     "type": "dev-console.add/action-group",
     "properties": {
       "id": "pipelines",

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunDetailsPage.tsx
@@ -4,6 +4,7 @@ import { ArchiveIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
 import { KebabAction, navFactory, viewYamlComponent } from '@console/internal/components/utils';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import {
   DELETED_RESOURCE_IN_K8S_ANNOTATION,
   RESOURCE_LOADED_FROM_RESULTS_ANNOTATION,
@@ -13,7 +14,7 @@ import { PipelineRunKind } from '../../types';
 import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 import { getPipelineRunKebabActions } from '../../utils/pipeline-actions';
 import { pipelineRunStatus } from '../../utils/pipeline-filter-reducer';
-import { chainsSignedAnnotation } from '../pipelines/const';
+import { chainsSignedAnnotation, FLAG_PIPELINES_OPERATOR_VERSION_1_16 } from '../pipelines/const';
 import { useDevPipelinesBreadcrumbsFor } from '../pipelines/hooks';
 import { usePipelineOperatorVersion } from '../pipelines/utils/pipeline-operator';
 import { PipelineRunDetails } from './detail-page-tabs/PipelineRunDetails';
@@ -30,7 +31,14 @@ const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { kindObj, namespace, name } = props;
   const { t } = useTranslation();
   const operatorVersion = usePipelineOperatorVersion(namespace);
-  const [taskRuns] = useTaskRuns(namespace, name);
+  const IS_PIPELINE_OPERATOR_VERSION_1_16 = useFlag(FLAG_PIPELINES_OPERATOR_VERSION_1_16);
+  const [taskRuns] = useTaskRuns(
+    namespace,
+    name,
+    undefined,
+    undefined,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
+  );
   const menuActions: KebabAction[] = useMenuActionsWithUserAnnotation(
     getPipelineRunKebabActions(operatorVersion, taskRuns, true),
   );
@@ -55,7 +63,11 @@ const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
     );
   };
 
-  const [pipelineRun, loaded, error] = usePipelineRun(namespace, name);
+  const [pipelineRun, loaded, error] = usePipelineRun(
+    namespace,
+    name,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
+  );
 
   return (
     <DetailsPage

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsResourceList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsResourceList.tsx
@@ -2,9 +2,11 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom-v5-compat';
 import { referenceForModel } from '@console/internal/module/k8s';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { PipelineRunModel } from '../../models';
 import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 import { ListPage } from '../ListPage';
+import { FLAG_PIPELINES_OPERATOR_VERSION_1_16 } from '../pipelines/const';
 import { runFilters } from '../pipelines/detail-page-tabs/PipelineRuns';
 import { useGetPipelineRuns } from './hooks/useTektonResults';
 import PipelineRunsList from './list-page/PipelineRunList';
@@ -21,9 +23,12 @@ const PipelineRunsResourceList: React.FC<
   const { t } = useTranslation();
   const params = useParams();
   const ns = props.namespace || params?.ns;
+  const IS_PIPELINE_OPERATOR_VERSION_1_16 = useFlag(FLAG_PIPELINES_OPERATOR_VERSION_1_16);
   const badge = usePipelineTechPreviewBadge(ns);
   const [pipelineRuns, pipelineRunsLoaded, pipelineRunsLoadError, getNextPage] = useGetPipelineRuns(
     ns,
+    undefined,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
   );
   const resources = {
     [referenceForModel(PipelineRunModel)]: {

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunDetailsPage.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunDetailsPage.spec.tsx
@@ -3,6 +3,7 @@ import { shallow, ShallowWrapper } from 'enzyme';
 import { SemVer } from 'semver';
 import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource';
 import { DetailsPage } from '@console/internal/components/factory';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { PipelineRunModel } from '../../../models';
 import { getPipelineRunKebabActions } from '../../../utils/pipeline-actions';
 import * as hookUtils from '../../pipelines/hooks';
@@ -22,10 +23,17 @@ jest.mock('@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource',
   useK8sWatchResource: jest.fn(),
 }));
 
+jest.mock('@console/shared/src/hooks/flag', () => ({
+  useFlag: jest.fn(),
+}));
+
+const useFlagMock = useFlag as jest.Mock;
+
 describe('PipelineRunDetailsPage:', () => {
   let pipelineRunDetailsPageProps: PipelineRunDetailsPageProps;
   let wrapper: ShallowWrapper<PipelineRunDetailsPageProps>;
   beforeEach(() => {
+    useFlagMock.mockReturnValue(true);
     pipelineRunDetailsPageProps = {
       kind: PipelineRunModel.kind,
       kindObj: PipelineRunModel,

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunsResourceList.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunsResourceList.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import { shallow, ShallowWrapper } from 'enzyme';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { ListPage } from '../../ListPage';
 import { PIPELINE_GA_VERSION } from '../../pipelines/const';
 import * as operatorUtils from '../../pipelines/utils/pipeline-operator';
@@ -9,12 +10,19 @@ import PipelineRunsResourceList from '../PipelineRunsResourceList';
 
 type PipelineRunsResourceListProps = React.ComponentProps<typeof PipelineRunsResourceList>;
 
+jest.mock('@console/shared/src/hooks/flag', () => ({
+  useFlag: jest.fn(),
+}));
+
+const useFlagMock = useFlag as jest.Mock;
+
 describe('PipelineRunsResourceList:', () => {
   let pipelineRunsResourceListProps: PipelineRunsResourceListProps;
   let wrapper: ShallowWrapper<PipelineRunsResourceListProps>;
   jest.spyOn(tektonResultsHooks, 'useGetPipelineRuns').mockReturnValue([[], true, '']);
 
   beforeEach(() => {
+    useFlagMock.mockReturnValue(true);
     pipelineRunsResourceListProps = {
       hideBadge: false,
       canCreate: false,

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.tsx
@@ -6,11 +6,12 @@ import { withTranslation } from 'react-i18next';
 import { Link, useLocation } from 'react-router-dom-v5-compat';
 import { WatchK8sResource } from '@console/dynamic-plugin-sdk';
 import { resourcePathFromModel } from '@console/internal/components/utils';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { PipelineRunModel } from '../../../models';
 import { ComputedStatus, PipelineRunKind, PipelineTask, TaskRunKind } from '../../../types';
 import { pipelineRunStatus } from '../../../utils/pipeline-filter-reducer';
 import { taskRunStatus } from '../../../utils/pipeline-utils';
-import { TektonResourceLabel } from '../../pipelines/const';
+import { FLAG_PIPELINES_OPERATOR_VERSION_1_16, TektonResourceLabel } from '../../pipelines/const';
 import { ColoredStatusIcon } from '../../pipelines/detail-page-tabs/pipeline-details/StatusIcon';
 import { useTaskRuns } from '../hooks/useTaskRuns';
 import { ErrorDetailsWithStaticLog } from '../logs/log-snippet-types';
@@ -227,9 +228,16 @@ export const PipelineRunLogsWithActiveTask: React.FC<PipelineRunLogsWithActiveTa
   obj,
 }) => {
   const location = useLocation();
+  const IS_PIPELINE_OPERATOR_VERSION_1_16 = useFlag(FLAG_PIPELINES_OPERATOR_VERSION_1_16);
   const params = new URLSearchParams(location.search);
   const activeTask = params?.get('taskName');
-  const [taskRuns, taskRunsLoaded] = useTaskRuns(obj?.metadata?.namespace, obj?.metadata?.name);
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(
+    obj?.metadata?.namespace,
+    obj?.metadata?.name,
+    undefined,
+    undefined,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
+  );
 
   return (
     taskRunsLoaded && <PipelineRunLogs obj={obj} activeTask={activeTask} taskRuns={taskRuns} />

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunVisualization.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunVisualization.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { LoadingInline } from '@console/internal/components/utils';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { PipelineKind, PipelineRunKind } from '../../../types';
+import { FLAG_PIPELINES_OPERATOR_VERSION_1_16 } from '../../pipelines/const';
 import PipelineVisualization from '../../pipelines/detail-page-tabs/pipeline-details/PipelineVisualization';
 import { usePipelineFromPipelineRun } from '../hooks/usePipelineFromPipelineRun';
 import { useTaskRuns } from '../hooks/useTaskRuns';
@@ -11,9 +13,13 @@ type PipelineRunVisualizationProps = {
 };
 
 const PipelineRunVisualization: React.FC<PipelineRunVisualizationProps> = ({ pipelineRun }) => {
+  const IS_PIPELINE_OPERATOR_VERSION_1_16 = useFlag(FLAG_PIPELINES_OPERATOR_VERSION_1_16);
   const [taskRuns, taskRunsLoaded] = useTaskRuns(
     pipelineRun?.metadata?.namespace,
     pipelineRun?.metadata?.name,
+    undefined,
+    undefined,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
   );
   const pipeline: PipelineKind = usePipelineFromPipelineRun(pipelineRun);
   if (!pipeline) {

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/__tests__/PipelineRunVisualization.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/__tests__/PipelineRunVisualization.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { LoadingInline } from '@console/internal/components/utils';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import {
   DataState,
   PipelineExampleNames,
@@ -16,6 +17,12 @@ const pipelineRun = pipelineData.pipelineRuns[DataState.SUCCESS];
 
 const spyUseTaskRuns = jest.spyOn(utils, 'useTaskRuns');
 
+jest.mock('@console/shared/src/hooks/flag', () => ({
+  useFlag: jest.fn(),
+}));
+
+const useFlagMock = useFlag as jest.Mock;
+
 describe('PipelineRunVisualization', () => {
   type PipelineRunVisualizationProps = React.ComponentProps<typeof PipelineRunVisualization>;
   let wrapper: ShallowWrapper<PipelineRunVisualizationProps>;
@@ -28,6 +35,7 @@ describe('PipelineRunVisualization', () => {
   it('Should render the loading component if pipeline from pipeline run is not defined or null', () => {
     usePipelineFromPipelineRunSpy.mockReturnValueOnce(null);
     spyUseTaskRuns.mockReturnValue([[], true]);
+    useFlagMock.mockReturnValue(true);
     wrapper = shallow(<PipelineRunVisualization pipelineRun={pipelineRun} />);
     const LoadingInlineComponent = wrapper.find(LoadingInline);
     expect(LoadingInlineComponent.exists()).toBe(true);
@@ -36,6 +44,7 @@ describe('PipelineRunVisualization', () => {
   it('Should render the visualization component if the pipelinerun has the graphable data', () => {
     usePipelineFromPipelineRunSpy.mockReturnValueOnce(pipelineData.pipeline);
     spyUseTaskRuns.mockReturnValue([[], true]);
+    useFlagMock.mockReturnValue(true);
     wrapper = shallow(<PipelineRunVisualization pipelineRun={pipelineRun} />);
     const PipelineVisualizationComponent = wrapper.find(PipelineVisualization);
     expect(PipelineVisualizationComponent.exists()).toBe(true);

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
@@ -26,6 +26,7 @@ const useRuns = <Kind extends K8sResourceCommon>(
     name?: string;
   },
   cacheKey?: string,
+  IS_PIPELINE_OPERATOR_VERSION_1_16?: boolean,
 ): [Kind[], boolean, unknown, GetNextPage] => {
   const etcdRunsRef = React.useRef<Kind[]>([]);
   const optionsMemo = useDeepCompareMemoize(options);
@@ -97,12 +98,12 @@ const useRuns = <Kind extends K8sResourceCommon>(
   const [trResources, trLoaded, trError, trGetNextPage] = (groupVersionKind ===
     PipelineRunGroupVersionKind
     ? useTRPipelineRuns
-    : useTRTaskRuns)(queryTr ? namespace : null, trOptions, cacheKey) as [
-    [],
-    boolean,
-    unknown,
-    GetNextPage,
-  ];
+    : useTRTaskRuns)(
+    queryTr ? namespace : null,
+    trOptions,
+    cacheKey,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
+  ) as [[], boolean, unknown, GetNextPage];
 
   return React.useMemo(() => {
     const rResources =
@@ -142,8 +143,15 @@ export const usePipelineRuns = (
     selector?: Selector;
     limit?: number;
   },
+  IS_PIPELINE_OPERATOR_VERSION_1_16?: boolean,
 ): [PipelineRunKind[], boolean, unknown, GetNextPage] =>
-  useRuns<PipelineRunKind>(PipelineRunGroupVersionKind, namespace, options);
+  useRuns<PipelineRunKind>(
+    PipelineRunGroupVersionKind,
+    namespace,
+    options,
+    undefined,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
+  );
 
 export const useTaskRuns = (
   namespace: string,
@@ -152,12 +160,20 @@ export const useTaskRuns = (
     limit?: number;
   },
   cacheKey?: string,
+  IS_PIPELINE_OPERATOR_VERSION_1_16?: boolean,
 ): [TaskRunKind[], boolean, unknown, GetNextPage] =>
-  useRuns<TaskRunKind>(TaskRunGroupVersionKind, namespace, options, cacheKey);
+  useRuns<TaskRunKind>(
+    TaskRunGroupVersionKind,
+    namespace,
+    options,
+    cacheKey,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
+  );
 
 export const usePipelineRun = (
   namespace: string,
   pipelineRunName: string,
+  IS_PIPELINE_OPERATOR_VERSION_1_16?: boolean,
 ): [PipelineRunKind, boolean, string] => {
   const result = (usePipelineRuns(
     namespace,
@@ -168,6 +184,7 @@ export const usePipelineRun = (
       }),
       [pipelineRunName],
     ),
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
   ) as unknown) as [PipelineRunKind[], boolean, string];
 
   return React.useMemo(() => [result[0]?.[0], result[1], result[0]?.[0] ? undefined : result[2]], [
@@ -178,6 +195,7 @@ export const usePipelineRun = (
 export const useTaskRun = (
   namespace: string,
   taskRunName: string,
+  IS_PIPELINE_OPERATOR_VERSION_1_16?: boolean,
 ): [TaskRunKind, boolean, string] => {
   const result = (useTaskRuns(
     namespace,
@@ -188,6 +206,8 @@ export const useTaskRun = (
       }),
       [taskRunName],
     ),
+    undefined,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
   ) as unknown) as [TaskRunKind[], boolean, string];
 
   return React.useMemo(() => [result[0]?.[0], result[1], result[0]?.[0] ? undefined : result[2]], [

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTaskRuns.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTaskRuns.ts
@@ -10,6 +10,7 @@ export const useTaskRuns = (
   pipelineRunName?: string,
   taskName?: string,
   cacheKey?: string,
+  IS_PIPELINE_OPERATOR_VERSION_1_16?: boolean,
 ): [TaskRunKind[], boolean, unknown, GetNextPage] => {
   const selector: Selector = React.useMemo(() => {
     if (pipelineRunName) {
@@ -26,6 +27,7 @@ export const useTaskRuns = (
       selector,
     },
     cacheKey,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
   );
 
   const sortedTaskRuns = React.useMemo(

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
@@ -5,9 +5,7 @@ import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/h
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../../models';
 import { PipelineRunKind, TaskRunKind } from '../../../types';
-import { TektonResourceLabel } from '../../pipelines/const';
 import { RepositoryLabels, RepositoryFields } from '../../repository/consts';
-import { useTaskRuns } from '../../taskruns/useTaskRuns';
 import {
   getPipelineRuns,
   TektonResultsOptions,
@@ -24,10 +22,12 @@ const useTRRuns = <Kind extends K8sResourceCommon>(
     options?: TektonResultsOptions,
     nextPageToken?: string,
     cacheKey?: string,
+    IS_PIPELINE_OPERATOR_VERSION_1_16?: boolean,
   ) => Promise<[Kind[], RecordsList, boolean?]>,
   namespace: string,
   options?: TektonResultsOptions,
   cacheKey?: string,
+  IS_PIPELINE_OPERATOR_VERSION_1_16?: boolean,
 ): [Kind[], boolean, unknown, GetNextPage] => {
   const [nextPageToken, setNextPageToken] = React.useState<string>(null);
   const [localCacheKey, setLocalCacheKey] = React.useState(cacheKey);
@@ -54,7 +54,13 @@ const useTRRuns = <Kind extends K8sResourceCommon>(
     let disposed = false;
     (async () => {
       try {
-        const tkPipelineRuns = await getRuns(namespace, options, nextPageToken, localCacheKey);
+        const tkPipelineRuns = await getRuns(
+          namespace,
+          options,
+          nextPageToken,
+          localCacheKey,
+          IS_PIPELINE_OPERATOR_VERSION_1_16,
+        );
         if (!disposed) {
           const token = tkPipelineRuns[1].nextPageToken;
           const callInflight = !!tkPipelineRuns?.[2];
@@ -95,7 +101,14 @@ const useTRRuns = <Kind extends K8sResourceCommon>(
     return () => {
       disposed = true;
     };
-  }, [namespace, options, nextPageToken, localCacheKey, getRuns]);
+  }, [
+    namespace,
+    options,
+    nextPageToken,
+    localCacheKey,
+    getRuns,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
+  ]);
   return result;
 };
 
@@ -103,17 +116,35 @@ export const useTRPipelineRuns = (
   namespace: string,
   options?: TektonResultsOptions,
   cacheKey?: string,
+  IS_PIPELINE_OPERATOR_VERSION_1_16?: boolean,
 ): [PipelineRunKind[], boolean, unknown, GetNextPage] =>
-  useTRRuns<PipelineRunKind>(getPipelineRuns, namespace, options, cacheKey);
+  useTRRuns<PipelineRunKind>(
+    getPipelineRuns,
+    namespace,
+    options,
+    cacheKey,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
+  );
 
 export const useTRTaskRuns = (
   namespace: string,
   options?: TektonResultsOptions,
   cacheKey?: string,
+  IS_PIPELINE_OPERATOR_VERSION_1_16?: boolean,
 ): [TaskRunKind[], boolean, unknown, GetNextPage] =>
-  useTRRuns<TaskRunKind>(getTaskRuns, namespace, options, cacheKey);
+  useTRRuns<TaskRunKind>(
+    getTaskRuns,
+    namespace,
+    options,
+    cacheKey,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
+  );
 
-export const useGetPipelineRuns = (ns: string, options?: { name: string; kind: string }) => {
+export const useGetPipelineRuns = (
+  ns: string,
+  options?: { name: string; kind: string },
+  IS_PIPELINE_OPERATOR_VERSION_1_16?: boolean,
+) => {
   let selector: Selector;
 
   if (options?.kind === 'Pipeline') {
@@ -129,6 +160,8 @@ export const useGetPipelineRuns = (ns: string, options?: { name: string; kind: s
     options && {
       selector,
     },
+    undefined,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
   );
   const [k8sPlrs, k8sPlrsLoaded, k8sPlrsLoadError] = useK8sWatchResource<PipelineRunKind[]>({
     isList: true,
@@ -148,45 +181,10 @@ export const useGetPipelineRuns = (ns: string, options?: { name: string; kind: s
   ];
 };
 
-export const useGetTaskRuns = (
-  ns: string,
-  pipelineRunName?: string,
-): [TaskRunKind[], boolean, unknown, GetNextPage] => {
-  let selector: Selector;
-  if (pipelineRunName) {
-    selector = {
-      matchLabels: {
-        [TektonResourceLabel.pipelinerun]: pipelineRunName,
-      },
-    };
-  }
-  const [k8sTaskRuns, k8sTaskRunsLoaded, k8sTaskRunsLoadError] = useTaskRuns(ns, pipelineRunName);
-  const [
-    resultTaskRuns,
-    resultTaskRunsLoaded,
-    resultTaskRunsLoadError,
-    getNextPage,
-  ] = useTRTaskRuns(
-    ns,
-    pipelineRunName && {
-      selector,
-    },
-  );
-  const mergedTaskRuns =
-    resultTaskRunsLoaded || k8sTaskRunsLoaded
-      ? uniqBy([...k8sTaskRuns, ...resultTaskRuns], (r) => r.metadata.name)
-      : [];
-  return [
-    mergedTaskRuns,
-    resultTaskRunsLoaded || k8sTaskRunsLoaded,
-    k8sTaskRunsLoadError || resultTaskRunsLoadError,
-    getNextPage,
-  ];
-};
-
 export const useTRTaskRunLog = (
   namespace: string,
   taskRunName: string,
+  taskRunPath: string,
 ): [string, boolean, unknown] => {
   const [result, setResult] = React.useState<[string, boolean, unknown]>([null, false, undefined]);
   React.useEffect(() => {
@@ -194,7 +192,7 @@ export const useTRTaskRunLog = (
     if (namespace && taskRunName) {
       (async () => {
         try {
-          const log = await getTaskRunLog(namespace, taskRunName);
+          const log = await getTaskRunLog(taskRunPath);
           if (!disposed) {
             setResult([log, true, undefined]);
           }
@@ -208,6 +206,6 @@ export const useTRTaskRunLog = (
     return () => {
       disposed = true;
     };
-  }, [namespace, taskRunName]);
+  }, [namespace, taskRunName, taskRunPath]);
   return result;
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
@@ -6,6 +6,7 @@ import { SemVer } from 'semver';
 import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
 import { Timestamp, ResourceLink } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import {
   DELETED_RESOURCE_IN_K8S_ANNOTATION,
   RESOURCE_LOADED_FROM_RESULTS_ANNOTATION,
@@ -21,7 +22,10 @@ import {
   pipelineRunTitleFilterReducer,
 } from '../../../utils/pipeline-filter-reducer';
 import { getPipelineRunStatus, pipelineRunDuration } from '../../../utils/pipeline-utils';
-import { chainsSignedAnnotation } from '../../pipelines/const';
+import {
+  chainsSignedAnnotation,
+  FLAG_PIPELINES_OPERATOR_VERSION_1_16,
+} from '../../pipelines/const';
 import { useTaskRuns } from '../hooks/useTaskRuns';
 import LinkedPipelineRunTaskStatus from '../status/LinkedPipelineRunTaskStatus';
 import PipelineRunStatusContent from '../status/PipelineRunStatusContent';
@@ -150,12 +154,14 @@ const PipelineRunRowWithoutTaskRuns: React.FC<PipelineRunRowWithoutTaskRunsProps
 
 const PipelineRunRowWithTaskRunsFetch: React.FC<PipelineRunRowWithTaskRunsProps> = React.memo(
   ({ obj, operatorVersion }) => {
+    const IS_PIPELINE_OPERATOR_VERSION_1_16 = useFlag(FLAG_PIPELINES_OPERATOR_VERSION_1_16);
     const cacheKey = `${obj.metadata.namespace}-${obj.metadata.name}`;
     const [PLRTaskRuns, taskRunsLoaded] = useTaskRuns(
       obj.metadata.namespace,
       obj.metadata.name,
       undefined,
       `${obj.metadata.namespace}-${obj.metadata.name}`,
+      IS_PIPELINE_OPERATOR_VERSION_1_16,
     );
     InFlightStoreForTaskRunsForPLR[cacheKey] = false;
     if (taskRunsLoaded) {

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/TektonTaskRunLog.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/TektonTaskRunLog.tsx
@@ -22,6 +22,7 @@ export const TektonTaskRunLog: React.FC<TektonTaskRunLogProps> = ({
   const [trResults, trLoaded, trError] = useTRTaskRunLog(
     taskRun.metadata.namespace,
     taskRun.metadata.name,
+    taskRun.metadata?.annotations?.['results.tekton.dev/record'],
   );
 
   React.useEffect(() => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/logs-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/logs-utils.ts
@@ -70,6 +70,7 @@ type StepsWatchUrl = {
   [key: string]: {
     name: string;
     steps: { [step: string]: WatchURLStatus };
+    taskRunPath: string;
   };
 };
 
@@ -121,6 +122,7 @@ export const getDownloadAllLogsCallback = (
       acc[currTask] = {
         name: pipelineTaskName,
         steps: { ...allStepUrls },
+        taskRunPath: taskRun.metadata?.annotations?.['results.tekton.dev/record'],
       };
       return acc;
     }, {});
@@ -155,7 +157,7 @@ export const getDownloadAllLogsCallback = (
         }
       } else {
         // eslint-disable-next-line no-await-in-loop
-        allLogs += await getTaskRunLog(namespace, currTask).then(
+        allLogs += await getTaskRunLog(task.taskRunPath).then(
           (log) => `${tasks[currTask].name.toUpperCase()}\n\n${log}\n\n`,
         );
       }

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatusPopoverContent.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatusPopoverContent.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
 import { LoadingInline, resourcePathFromModel } from '@console/internal/components/utils';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { PipelineRunModel } from '../../../models';
 import { PipelineRunKind } from '../../../types';
+import { FLAG_PIPELINES_OPERATOR_VERSION_1_16 } from '../../pipelines/const';
 import { useTaskRuns } from '../hooks/useTaskRuns';
 import LogSnippetBlock from '../logs/LogSnippetBlock';
 import { getPLRLogSnippet } from '../logs/pipelineRunLogSnippet';
@@ -14,9 +16,13 @@ type StatusPopoverContentProps = {
 };
 const PipelineRunStatusPopoverContent: React.FC<StatusPopoverContentProps> = ({ pipelineRun }) => {
   const { t } = useTranslation();
+  const IS_PIPELINE_OPERATOR_VERSION_1_16 = useFlag(FLAG_PIPELINES_OPERATOR_VERSION_1_16);
   const [PLRTaskRuns, taskRunsLoaded] = useTaskRuns(
     pipelineRun.metadata.namespace,
     pipelineRun.metadata.name,
+    undefined,
+    undefined,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
   );
 
   if (!taskRunsLoaded) {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines-index.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines-index.ts
@@ -4,4 +4,5 @@ export * from './conditions';
 export * from './pipelines-lists';
 export * from './repository';
 export { useIsTektonV1VersionPresent } from './pipelines/utils/pipeline-operator';
+export { useIsPipelineOperatorVersion_1_16 } from './pipelines/utils/pipeline-operator';
 export { LogURLRedirect } from './LogURLRedirect';

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
@@ -82,3 +82,4 @@ export enum PipelineMetricsLevel {
 }
 
 export const FLAG_TEKTON_V1_ENABLED = 'FLAG_TEKTON_V1_ENABLED';
+export const FLAG_PIPELINES_OPERATOR_VERSION_1_16 = 'PIPELINES_OPERATOR_VERSION_1_16';

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineRuns.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineRuns.tsx
@@ -3,6 +3,7 @@ import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { RowFilter } from '@console/internal/components/filter-toolbar';
 import { referenceForModel } from '@console/internal/module/k8s';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { PipelineRunModel } from '../../../models';
 import {
   pipelineRunFilterReducer,
@@ -12,6 +13,7 @@ import { ListFilterId, ListFilterLabels } from '../../../utils/pipeline-utils';
 import { ListPage } from '../../ListPage';
 import { usePipelineRuns } from '../../pipelineruns/hooks/usePipelineRuns';
 import PipelineRunsList from '../../pipelineruns/list-page/PipelineRunList';
+import { FLAG_PIPELINES_OPERATOR_VERSION_1_16 } from '../const';
 import { PipelineDetailsTabProps } from './types';
 
 export const runFilters = (t: TFunction): RowFilter[] => {
@@ -34,6 +36,7 @@ export const runFilters = (t: TFunction): RowFilter[] => {
 const PipelineRuns: React.FC<PipelineDetailsTabProps> = (props) => {
   const { t } = useTranslation();
   const { obj } = props;
+  const IS_PIPELINE_OPERATOR_VERSION_1_16 = useFlag(FLAG_PIPELINES_OPERATOR_VERSION_1_16);
   const selector = React.useMemo(() => {
     return {
       matchLabels: { 'tekton.dev/pipeline': obj.metadata.name },
@@ -44,6 +47,7 @@ const PipelineRuns: React.FC<PipelineDetailsTabProps> = (props) => {
     {
       selector,
     },
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
   );
   const resources = React.useMemo(
     () => ({

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/PipelineRuns.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/PipelineRuns.spec.tsx
@@ -1,8 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { ListPage } from '../../../ListPage';
 import * as pipelineRunssHooks from '../../../pipelineruns/hooks/usePipelineRuns';
 import PipelineRuns from '../PipelineRuns';
+
+jest.mock('@console/shared/src/hooks/flag', () => ({
+  useFlag: jest.fn(),
+}));
+
+const useFlagMock = useFlag as jest.Mock;
 
 const pipelineRunProps: React.ComponentProps<typeof PipelineRuns> = {
   obj: {
@@ -22,6 +29,7 @@ const pipelineRunProps: React.ComponentProps<typeof PipelineRuns> = {
 };
 
 jest.spyOn(pipelineRunssHooks, 'usePipelineRuns').mockReturnValue([[], true, '']);
+useFlagMock.mockReturnValue(true);
 const pipelineRunWrapper = shallow(<PipelineRuns {...pipelineRunProps} />);
 
 describe('Pipeline Run List', () => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRunsWrapper.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRunsWrapper.tsx
@@ -6,9 +6,11 @@ import { ListPageWrapper } from '@console/internal/components/factory';
 import { EmptyBox, LoadingBox } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { useUserSettings } from '@console/shared/src';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY } from '../../../const';
 import { PipelineRunModel } from '../../../models';
 import { useGetPipelineRuns } from '../../pipelineruns/hooks/useTektonResults';
+import { FLAG_PIPELINES_OPERATOR_VERSION_1_16 } from '../const';
 import PipelineAugmentRuns, { filters } from './PipelineAugmentRuns';
 import PipelineList from './PipelineList';
 
@@ -21,6 +23,7 @@ interface PipelineAugmentRunsWrapperProps {
 
 const PipelineAugmentRunsWrapper: React.FC<PipelineAugmentRunsWrapperProps> = (props) => {
   const { t } = useTranslation();
+  const IS_PIPELINE_OPERATOR_VERSION_1_16 = useFlag(FLAG_PIPELINES_OPERATOR_VERSION_1_16);
   const activePerspective = useActivePerspective()[0];
   const [, setPreferredTab, preferredTabLoaded] = useUserSettings<string>(
     PREFERRED_DEV_PIPELINE_PAGE_TAB_USER_SETTING_KEY,
@@ -28,6 +31,8 @@ const PipelineAugmentRunsWrapper: React.FC<PipelineAugmentRunsWrapperProps> = (p
   );
   const [pipelineRuns, pipelineRunsLoaded, pipelineRunsLoadError] = useGetPipelineRuns(
     props.namespace,
+    undefined,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
   );
   const resources = {
     data: pipelineRuns,

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/__tests__/PipelineAugmentRunsWrapper.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/__tests__/PipelineAugmentRunsWrapper.spec.tsx
@@ -3,6 +3,7 @@ import { shallow, ShallowWrapper } from 'enzyme';
 import { ListPageWrapper } from '@console/internal/components/factory';
 import { EmptyBox, LoadingBox } from '@console/internal/components/utils';
 import { useUserSettings } from '@console/shared';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
 import * as tektonResultsHooks from '../../../pipelineruns/hooks/useTektonResults';
 import PipelineAugmentRunsWrapper from '../PipelineAugmentRunsWrapper';
@@ -16,6 +17,11 @@ jest.mock('@console/shared/src/hooks/useUserSettings', () => ({
   useUserSettings: jest.fn(),
 }));
 
+jest.mock('@console/shared/src/hooks/flag', () => ({
+  useFlag: jest.fn(),
+}));
+
+const useFlagMock = useFlag as jest.Mock;
 const mockUserSettings = useUserSettings as jest.Mock;
 
 describe('Pipeline Augment Run Wrapper', () => {
@@ -24,6 +30,7 @@ describe('Pipeline Augment Run Wrapper', () => {
   jest.spyOn(tektonResultsHooks, 'useGetPipelineRuns').mockReturnValue([[], true, '']);
 
   beforeEach(() => {
+    useFlagMock.mockReturnValue(true);
     mockUserSettings.mockReturnValue(['pipelines', jest.fn(), true]);
     pipelineAugmentRunsWrapperProps = {
       pipeline: {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/utils/pipeline-operator.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/utils/pipeline-operator.ts
@@ -16,6 +16,7 @@ import {
   PipelineMetricsLevel,
   PIPELINE_NAMESPACE,
   FLAG_TEKTON_V1_ENABLED,
+  FLAG_PIPELINES_OPERATOR_VERSION_1_16,
 } from '../const';
 import { MetricsQueryPrefix } from '../pipeline-metrics/pipeline-metrics-utils';
 import { getPipelineMetricsLevel, usePipelineConfig } from './pipeline-config';
@@ -100,4 +101,12 @@ export const useIsTektonV1VersionPresent = (setFeatureFlag: SetFeatureFlag) => {
   const operatorVersion = usePipelineOperatorVersion(activeNamespace);
   const isTektonV1VersionPresent = operatorVersion?.major === 1 && operatorVersion?.minor >= 11;
   setFeatureFlag(FLAG_TEKTON_V1_ENABLED, isTektonV1VersionPresent);
+};
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const useIsPipelineOperatorVersion_1_16 = (setFeatureFlag: SetFeatureFlag) => {
+  const [activeNamespace] = useActiveNamespace();
+  const operatorVersion = usePipelineOperatorVersion(activeNamespace);
+  const IS_PIPELINE_OPERATOR_VERSION_1_16 =
+    operatorVersion?.major === 1 && operatorVersion?.minor >= 16;
+  setFeatureFlag(FLAG_PIPELINES_OPERATOR_VERSION_1_16, IS_PIPELINE_OPERATOR_VERSION_1_16);
 };

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunList.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import { SortByDirection } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 import { Table } from '@console/internal/components/factory';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { PipelineRunModel } from '../../models';
 import { useTaskRuns } from '../pipelineruns/hooks/useTaskRuns';
+import { FLAG_PIPELINES_OPERATOR_VERSION_1_16 } from '../pipelines/const';
 import { usePipelineOperatorVersion } from '../pipelines/utils/pipeline-operator';
 import RepositoryPipelineRunHeader from './RepositoryPipelineRunHeader';
 import RepositoryPipelineRunRow from './RepositoryPipelineRunRow';
@@ -15,7 +17,14 @@ type RepositoryPipelineRunListProps = {
 export const RepositoryPipelineRunList: React.FC<RepositoryPipelineRunListProps> = (props) => {
   const { t } = useTranslation();
   const operatorVersion = usePipelineOperatorVersion(props.namespace);
-  const [taskRuns, taskRunsLoaded] = useTaskRuns(props.namespace);
+  const IS_PIPELINE_OPERATOR_VERSION_1_16 = useFlag(FLAG_PIPELINES_OPERATOR_VERSION_1_16);
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(
+    props.namespace,
+    undefined,
+    undefined,
+    undefined,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
+  );
   return (
     <Table
       {...props}

--- a/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/RepositoryPipelineRunListPage.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { referenceForModel } from '@console/internal/module/k8s';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { PipelineRunModel } from '../../models';
 import { ListPage } from '../ListPage';
 import { usePipelineRuns } from '../pipelineruns/hooks/usePipelineRuns';
+import { FLAG_PIPELINES_OPERATOR_VERSION_1_16 } from '../pipelines/const';
 import { runFilters } from '../pipelines/detail-page-tabs/PipelineRuns';
 import { RepositoryFields, RepositoryLabels } from './consts';
 import RunList from './RepositoryPipelineRunList';
@@ -16,6 +18,7 @@ export interface RepositoryPipelineRunListPageProps {
 const RepositoryPipelineRunListPage: React.FC<RepositoryPipelineRunListPageProps> = (props) => {
   const { t } = useTranslation();
   const { obj } = props;
+  const IS_PIPELINE_OPERATOR_VERSION_1_16 = useFlag(FLAG_PIPELINES_OPERATOR_VERSION_1_16);
   const selector = React.useMemo(() => {
     return {
       matchLabels: { [RepositoryLabels[RepositoryFields.REPOSITORY]]: obj.metadata.name },
@@ -26,6 +29,7 @@ const RepositoryPipelineRunListPage: React.FC<RepositoryPipelineRunListPageProps
     {
       selector,
     },
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
   );
   const resources = {
     [referenceForModel(PipelineRunModel)]: {

--- a/frontend/packages/pipelines-plugin/src/components/repository/list-page/ReppositoryList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/list-page/ReppositoryList.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { Table } from '@console/internal/components/factory';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { RepositoryModel } from '../../../models';
 import { usePipelineRuns } from '../../pipelineruns/hooks/usePipelineRuns';
 import { useTaskRuns } from '../../pipelineruns/hooks/useTaskRuns';
+import { FLAG_PIPELINES_OPERATOR_VERSION_1_16 } from '../../pipelines/const';
 import { RepositoryKind } from '../types';
 import RepositoryHeader from './RepositoryHeader';
 import RepositoryRow from './RepositoryRow';
@@ -13,8 +15,19 @@ export interface RepositoryListProps {
 }
 
 const RepositoryList: React.FC<RepositoryListProps> = (props) => {
-  const [taskRuns, taskRunsLoaded] = useTaskRuns(props.namespace);
-  const [pipelineRuns, pipelineRunsLoaded] = usePipelineRuns(props.namespace);
+  const IS_PIPELINE_OPERATOR_VERSION_1_16 = useFlag(FLAG_PIPELINES_OPERATOR_VERSION_1_16);
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(
+    props.namespace,
+    undefined,
+    undefined,
+    undefined,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
+  );
+  const [pipelineRuns, pipelineRunsLoaded] = usePipelineRuns(
+    props.namespace,
+    undefined,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
+  );
   return (
     <Table
       {...props}

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/TaskRunDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/TaskRunDetailsPage.tsx
@@ -4,6 +4,7 @@ import { ArchiveIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
 import { navFactory, viewYamlComponent } from '@console/internal/components/utils';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import {
   DELETED_RESOURCE_IN_K8S_ANNOTATION,
   RESOURCE_LOADED_FROM_RESULTS_ANNOTATION,
@@ -12,6 +13,7 @@ import { TaskRunKind } from '../../types';
 import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 import { taskRunFilterReducer } from '../../utils/pipeline-filter-reducer';
 import { useTaskRun } from '../pipelineruns/hooks/usePipelineRuns';
+import { FLAG_PIPELINES_OPERATOR_VERSION_1_16 } from '../pipelines/const';
 import { useTasksBreadcrumbsFor } from '../pipelines/hooks';
 import TaskRunEvents from './events/TaskRunEvents';
 import TaskRunDetails from './TaskRunDetails';
@@ -22,9 +24,10 @@ import './TaskRunDetailsPage.scss';
 const TaskRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { kindObj, namespace, name } = props;
   const { t } = useTranslation();
+  const IS_PIPELINE_OPERATOR_VERSION_1_16 = useFlag(FLAG_PIPELINES_OPERATOR_VERSION_1_16);
   const breadcrumbsFor = useTasksBreadcrumbsFor(kindObj);
   const badge = usePipelineTechPreviewBadge(props.namespace);
-  const [taskRun, loaded, error] = useTaskRun(namespace, name);
+  const [taskRun, loaded, error] = useTaskRun(namespace, name, IS_PIPELINE_OPERATOR_VERSION_1_16);
   const resourceTitleFunc = (obj: TaskRunKind): string | JSX.Element => {
     return (
       <div className="taskrun-details-page">

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/events/__tests__/TaskRunDetailsPage.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/events/__tests__/TaskRunDetailsPage.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource';
 import { DetailsPage } from '@console/internal/components/factory';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { TaskRunModel } from '../../../../models';
 import * as hookUtils from '../../../pipelines/hooks';
 import TaskRunDetailsPage from '../../TaskRunDetailsPage';
@@ -15,9 +16,16 @@ jest.mock('@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource',
   useK8sWatchResource: jest.fn(),
 }));
 
+jest.mock('@console/shared/src/hooks/flag', () => ({
+  useFlag: jest.fn(),
+}));
+
+const useFlagMock = useFlag as jest.Mock;
+
 describe('TaskRunDetailsPage:', () => {
   let taskRunDetailsPageProps: TaskRunDetailsPageProps;
   beforeEach(() => {
+    useFlagMock.mockReturnValue(true);
     taskRunDetailsPageProps = {
       kind: TaskRunModel.kind,
       kindObj: TaskRunModel,

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsListPage.tsx
@@ -11,10 +11,12 @@ import {
   TableColumnsType,
   useUserSettingsCompatibility,
 } from '@console/shared';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { TaskRunModel } from '../../../models';
 import { usePipelineTechPreviewBadge } from '../../../utils/hooks';
 import { ListPage } from '../../ListPage';
 import { useTaskRuns } from '../../pipelineruns/hooks/useTaskRuns';
+import { FLAG_PIPELINES_OPERATOR_VERSION_1_16 } from '../../pipelines/const';
 import { runFilters as taskRunFilters } from '../../pipelines/detail-page-tabs/PipelineRuns';
 import TaskRunsHeader from './TaskRunsHeader';
 import TaskRunsList from './TaskRunsList';
@@ -36,9 +38,16 @@ const TaskRunsListPage: React.FC<
   const searchParams = getURLSearchParams();
   const kind = searchParams?.kind;
   const ns = namespace || params?.ns;
+  const IS_PIPELINE_OPERATOR_VERSION_1_16 = useFlag(FLAG_PIPELINES_OPERATOR_VERSION_1_16);
   const badge = usePipelineTechPreviewBadge(ns);
   const trForPlr = props.selector && props.selector?.matchLabels?.['tekton.dev/pipelineRun'];
-  const [taskRuns, taskRunsLoaded, taskRunsLoadError, getNextPage] = useTaskRuns(ns, trForPlr);
+  const [taskRuns, taskRunsLoaded, taskRunsLoadError, getNextPage] = useTaskRuns(
+    ns,
+    trForPlr,
+    undefined,
+    undefined,
+    IS_PIPELINE_OPERATOR_VERSION_1_16,
+  );
 
   const taskRunsResource = {
     [referenceForModel(TaskRunModel)]: {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-42000

**Solution Description**: 
We were making 2 API calls to get the logs for the PipelineRuns. Now used `results.tekton.dev/record` annotation and replaced the `records` in the value of the annotation with `logs` to get the logs of the PipelineRuns.
  
**Screen shots / Gifs for design review**: 

----Pipelines 1.15.x---

https://drive.google.com/file/d/11t96sxdHTlE2lvLYRRcJMEBWLdz2Fnnn/view?usp=drive_link


----Pipelines 1.16---

https://drive.google.com/file/d/1YowjpGQ6q-2lpMLE1mCSQXH7V770ajZa/view?usp=drive_link






**Unit test coverage report**: 
NA

**Test setup:**

    1. Install Pipelines operator and install Tekton results
    2. Verify all the pages by deleting some PipelineRuns and TaskRuns
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge




