### PR TITLE
OCPBUGS-41613: Various tests are failing due to missing content in <li.pf-v5-c-menu__list-item> element

### DIFF
--- a/frontend/packages/integration-tests-cypress/views/common.ts
+++ b/frontend/packages/integration-tests-cypress/views/common.ts
@@ -13,6 +13,7 @@ export const projectDropdown = {
     // TODO - remove and fix properly
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(3000);
+    cy.reload();
     cy.byLegacyTestID('namespace-bar-dropdown').contains('Project:').click();
     cy.byTestID('showSystemSwitch').check();
     cy.byTestID('dropdown-menu-item-link').contains(projectName).click();


### PR DESCRIPTION
Adding reload after the project creation and before the project selection.

The wait on its own didn't fix the issue, reloading the page might help as whenever the dropdown got rerendered the issue seemed to go away.