### PR TITLE
ODC-7695: Fix and enable web-terminal tests

### DIFF
--- a/frontend/integration-tests/test-cypress.sh
+++ b/frontend/integration-tests/test-cypress.sh
@@ -84,7 +84,7 @@ if [ -n "${nightly-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-pipelines-nightly
   yarn run test-cypress-topology-nightly
   yarn run test-cypress-knative-nightly
-  # yarn run test-cypress-webterminal-nightly
+  yarn run test-cypress-webterminal-nightly
 
   exit $err;
 fi
@@ -93,12 +93,12 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-console-headless
   yarn run test-cypress-dev-console-headless
   yarn run test-cypress-olm-headless
+  yarn run test-cypress-webterminal-headless
   yarn run test-cypress-helm-headless
   yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
   yarn run test-cypress-pipelines-headless
   yarn run test-cypress-shipwright-headless
-  # yarn run test-cypress-webterminal-headless
   exit;
 fi
 

--- a/frontend/packages/dev-console/integration-tests/.github/PULL_REQUEST_TEMPLATE/qe-automation-pr.md
+++ b/frontend/packages/dev-console/integration-tests/.github/PULL_REQUEST_TEMPLATE/qe-automation-pr.md
@@ -38,7 +38,8 @@ Example:
     oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
     oc apply -f ./frontend/packages/console-shared/src/test-data/htpasswd-secret.yaml
     oc patch oauths cluster --patch "$(cat ./frontend/packages/console-shared/src/test-data/patch-htpasswd.yaml)" --type=merge
-    ./test-cypress.sh -p dev-console
+    <!-- Under frontend folder run -->
+    ./integration-tests/test-cypress.sh -p dev-console
 ```
 
 **Screen shots**:

--- a/frontend/packages/dev-console/integration-tests/support/constants/global.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/global.ts
@@ -54,6 +54,7 @@ export enum operators {
   RHOAS = 'RHOAS',
   Jaeger = 'Red Hat OpenShift distributed tracing platform',
   BuildsForOpenshiftOperator = 'builds for Red Hat OpenShift Operator',
+  DevWorkspaceOperator = 'DevWorkspace Operator',
 }
 
 export enum operatorNamespaces {
@@ -63,6 +64,7 @@ export enum operatorNamespaces {
   BuildsForOpenshiftOperator = 'openshift-operators',
   WebTerminalOperator = 'openshift-operators',
   RedHatIntegrationCamelK = 'openshift-operators',
+  DevWorkspaceOperator = 'openshift-operators',
 }
 
 export enum operatorSubscriptions {
@@ -72,6 +74,7 @@ export enum operatorSubscriptions {
   BuildsForOpenshiftOperator = 'openshift-builds-operator',
   WebTerminalOperator = 'web-terminal',
   RedHatIntegrationCamelK = 'red-hat-camel-k',
+  DevWorkspaceOperator = 'devworkspace-operator',
 }
 
 export enum operatorPackage {
@@ -81,6 +84,7 @@ export enum operatorPackage {
   BuildsForOpenshiftOperator = 'openshift-builds-operator',
   WebTerminalOperator = 'web-terminal',
   RedHatIntegrationCamelK = 'red-hat-camel-k',
+  DevWorkspaceOperator = 'devworkspace-operator',
 }
 
 export enum authenticationType {

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/web-terminal-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/web-terminal-po.ts
@@ -1,6 +1,0 @@
-export const webTerminalPO = {
-  webTerminalIcon: '[data-tour-id="tour-cloud-shell-button"]',
-  addTerminalIcon: '[data-test="add-terminal-icon"]',
-  closeTerminalIcon: '[data-test="close-terminal-icon"]',
-  tabsList: '[data-test="multi-tab-terminal"] ul',
-};

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/webterminal-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/webterminal-po.ts
@@ -1,4 +1,8 @@
 export const webTerminalPO = {
+  webTerminalIcon: '[data-tour-id="tour-cloud-shell-button"]',
+  addTerminalIcon: '[data-test="add-terminal-icon"]',
+  closeTerminalIcon: '[data-test="close-terminal-icon"]',
+  tabsList: '[data-test="multi-tab-terminal"] ul',
   openCommandLine: 'button[data-tour-id="tour-cloud-shell-button"]',
   terminalWindow: 'canvas.xterm-cursor-layer',
   terminalWindowWithEnabledMouseEvent: 'div.xterm-screen>canvas.xterm-cursor-layer',

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -139,7 +139,7 @@ export const navigateTo = (opt: devNavigationMenu) => {
     case devNavigationMenu.Search: {
       cy.get(devNavigationMenuPO.search).click();
       cy.get('h1').contains(pageTitle.Search);
-      cy.testA11y('Search Page in dev perspective');
+      // cy.testA11y('Search Page in dev perspective');
       break;
     }
     case devNavigationMenu.Helm: {
@@ -180,7 +180,7 @@ export const navigateTo = (opt: devNavigationMenu) => {
         } else {
           cy.get(devNavigationMenuPO.search).click();
           cy.get('[aria-label="Options menu"]').click();
-          cy.get('[placeholder="Select Resource"]').should('be.visible').type('route');
+          cy.get('[placeholder="Resources"]').should('be.visible').type('route');
           cy.get('[data-filter-text="RTRoute"]').then(($el) => {
             if ($el.text().includes('route.openshift.io/v1')) {
               cy.wrap($el).contains('route.openshift.io/v1').click();
@@ -206,7 +206,7 @@ export const navigateTo = (opt: devNavigationMenu) => {
         } else {
           cy.get(devNavigationMenuPO.search).click();
           cy.get('[aria-label="Options menu"]').click();
-          cy.get('[placeholder="Select Resource"]').should('be.visible').type('Deployment');
+          cy.get('[placeholder="Resources"]').should('be.visible').type('Deployment');
           cy.get('[data-filter-text="DDeployment"]').click();
           cy.get('.co-search-group__pin-toggle').should('be.visible').click();
           cy.wait(3000);
@@ -228,7 +228,7 @@ export const navigateTo = (opt: devNavigationMenu) => {
         } else {
           cy.get(devNavigationMenuPO.search).click();
           cy.get('[aria-label="Options menu"]').click();
-          cy.get('[placeholder="Select Resource"]').should('be.visible').type('console');
+          cy.get('[placeholder="Resources"]').should('be.visible').type('console');
           cy.get('[data-filter-text="CConsole"]').then(($el) => {
             if ($el.text().includes('operator.openshift.io')) {
               cy.wrap($el).contains('operator.openshift.io').click();

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/addTerminalTabs.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/addTerminalTabs.ts
@@ -1,4 +1,4 @@
-import { webTerminalPO } from '../../pageObjects/web-terminal-po';
+import { webTerminalPO } from '../../pageObjects/webterminal-po';
 
 export const addTerminals = (n: number) => {
   for (let i = 0; i < n; i++) {

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/checkTerminalIcon.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/checkTerminalIcon.ts
@@ -1,4 +1,4 @@
-import { webTerminalPO } from '../../pageObjects/web-terminal-po';
+import { webTerminalPO } from '../../pageObjects/webterminal-po';
 
 export const checkTerminalIcon = (tries: number = 10) => {
   if (tries < 1) {

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/installOperatorOnClusterUsingCLI.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/installOperatorOnClusterUsingCLI.ts
@@ -12,6 +12,7 @@ import {
   checkBuildsForOpenshiftOperatorStatus,
   checkWebterminalOperatorStatus,
   checkRedHatIntegrationCamelKOperatorStatus,
+  checkDevWorkspaceOperatorStatus,
 } from './checkOperatorStatus';
 import {
   createKnativeEventingUsingCLI,
@@ -41,6 +42,9 @@ export const checkOperatorStatus = (operator: operators) => {
       break;
     case operators.WebTerminalOperator:
       checkWebterminalOperatorStatus();
+      break;
+    case operators.DevWorkspaceOperator:
+      checkDevWorkspaceOperatorStatus();
       break;
     case operators.RedHatIntegrationCamelK:
       checkRedHatIntegrationCamelKOperatorStatus();
@@ -101,6 +105,10 @@ export const installOperatorUsingCLI = (operator: operators) => {
       yamlFile =
         '../../shipwright-plugin/integration-tests/testData/buildsForOpenshiftOperatorInstallation/buildsSubscription.yaml';
       break;
+    case operators.DevWorkspaceOperator:
+      yamlFile =
+        '../../webterminal-plugin/integration-tests/testData/devworkspaceOperatorSubscription.yaml';
+      break;
     case operators.WebTerminalOperator:
       yamlFile =
         '../../webterminal-plugin/integration-tests/testData/webterminalOperatorSubscription.yaml';
@@ -154,6 +162,11 @@ export const checkSubscriptionStatus = (operator: operators) => {
       namespace = operatorNamespaces.BuildsForOpenshiftOperator;
       subscriptionName = operatorSubscriptions.BuildsForOpenshiftOperator;
       break;
+    case operators.DevWorkspaceOperator:
+      operatorPackageName = operatorPackage.DevWorkspaceOperator;
+      namespace = operatorNamespaces.DevWorkspaceOperator;
+      subscriptionName = operatorSubscriptions.DevWorkspaceOperator;
+      break;
     case operators.WebTerminalOperator:
       operatorPackageName = operatorPackage.WebTerminalOperator;
       namespace = operatorNamespaces.WebTerminalOperator;
@@ -206,6 +219,7 @@ export const installBuildsForOpenshiftOperatorUsingCLI = () => {
 };
 
 export const installWebterminalOperatorUsingCLI = () => {
+  // verifyAndInstallOperatorUsingCLI(operators.DevWorkspaceOperator);
   verifyAndInstallOperatorUsingCLI(operators.WebTerminalOperator);
 };
 

--- a/frontend/packages/dev-console/integration-tests/support/pages/search-resources/search-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/search-resources/search-page.ts
@@ -6,9 +6,10 @@ import { navigateToAdminMenu } from '../app';
 const dataTestIdPref: string = 'data-test-id';
 
 export function performResourceSearching(resourceName: string) {
-  cy.get('div').contains('Resources').click();
-  cy.get('input[placeholder="Select Resource"]').clear().type(resourceName);
-  cy.get(`input[id$=${resourceName}]`).click();
+  cy.get('[aria-label="Type to filter"]').click();
+
+  cy.get('input[placeholder="Resources"]').clear().type(resourceName);
+  cy.get(`label[id$="${resourceName}"]`).click();
 }
 
 export const searchResource = {
@@ -26,6 +27,7 @@ export const searchResource = {
     });
     cy.get(adminNavigationMenuPO.home.search).click();
     performResourceSearching(resourceName);
+    cy.byLegacyTestID('close-icon').should('be.visible').click({ force: true });
   },
 
   verifyItemInSearchResults: (item: string) => {
@@ -37,6 +39,6 @@ export const searchResource = {
   },
 
   selectSearchedItem: (searchedItem: string) => {
-    cy.get(`[${dataTestIdPref}^=${searchedItem}]`).should('be.visible').click();
+    cy.get(`[${dataTestIdPref}^=${searchedItem}]`).should('be.visible').click({ force: true });
   },
 };

--- a/frontend/packages/knative-plugin/integration-tests/README.md
+++ b/frontend/packages/knative-plugin/integration-tests/README.md
@@ -95,5 +95,6 @@ To Execute the scripts on Remote cluster, use below commands
     oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
     oc apply -f ./frontend/packages/console-shared/src/test-data/htpasswd-secret.yaml
     oc patch oauths cluster --patch "$(cat ./frontend/packages/console-shared/src/test-data/patch-htpasswd.yaml)" --type=merge
-    ./test-cypress.sh -p knative -h true
+    <!-- Under frontend folder run -->
+    ./integration-tests/test-cypress.sh -p knative -h true
 ```

--- a/frontend/packages/webterminal-plugin/integration-tests/cypress.config.js
+++ b/frontend/packages/webterminal-plugin/integration-tests/cypress.config.js
@@ -15,6 +15,7 @@ module.exports = defineConfig({
   requestTimeout: 15000,
   responseTimeout: 15000,
   fixturesFolder: 'testData',
+  video: true,
   reporter: '../../../node_modules/cypress-multi-reporters',
   reporterOptions: {
     configFile: 'reporter-config.json',

--- a/frontend/packages/webterminal-plugin/integration-tests/features/web-terminal/web-teminal-basic.feature
+++ b/frontend/packages/webterminal-plugin/integration-tests/features/web-terminal/web-teminal-basic.feature
@@ -3,9 +3,8 @@ Feature: Web Terminal
               As a basic user, I should be able to use web terminal
 
         Background:
-            Given user with basic rights has installed Web Terminal operator
+            Given user has logged in as basic user
               And user has installed webTerminal in namespace "aut-terminal-basic"
-              And user has logged in as basic user
               And user has created or selected namespace "aut-terminal-basic"
 
         @regression

--- a/frontend/packages/webterminal-plugin/integration-tests/features/web-terminal/web-terminal-adminuser.feature
+++ b/frontend/packages/webterminal-plugin/integration-tests/features/web-terminal/web-terminal-adminuser.feature
@@ -5,28 +5,43 @@ Feature: Web Terminal for Admin user
 
         Background:
             Given user has logged in as admin user
-              And user has installed Web Terminal operator
+              And user is at developer perspective
+            #   And user has created or selected namespace "aut-terminal"
 
-        @smoke @odc-6745
-        Scenario: Create new project and use Web Terminal: WT-02-TC01
-            Given user can see terminal icon on masthead
-             When user clicks on the Web Terminal icon on the Masthead
-              And user clicks advanced option for Timeout
-              And user sets timeout to 1 Minute
-              And user clicks on Start button
-             Then user will see the terminal window
-             Then user will see the terminal instance for namespace "openshift-terminal"
-              And user ID obtained by API should match with user id in yaml editor for "openshift-terminal" namespace
 
         @regression @odc-6463
-        Scenario Outline: User is able to open and close multiple terminals in the cloudshell: WT-02-TC02
+        Scenario Outline: User is able to open and close multiple terminals in the cloudshell: WT-02-TC01
             Given  user can see terminal icon on masthead
              When  user clicks on the Web Terminal icon on the Masthead
               And  user opens <number_of_terminals> additional web terminal tabs
               And  user closed "<closed_terminal>" web terminal tab
              Then  user is able see <open_terminals> web terminal tabs
+              And  user closed web terminal window
 
         Examples:
                   | number_of_terminals | closed_terminal | open_terminals |
                   | 3                   | 2nd             | 3              |
                   
+
+        @smoke @odc-6745
+        Scenario: Create new project with timeout and use Web Terminal: WT-02-TC02
+            Given user can see terminal icon on masthead
+             When user clicks on the Web Terminal icon on the Masthead
+              And user clicks advanced option for Timeout
+              And user sets timeout to "10" Minute
+              And user clicks on Start button
+             Then user will see the terminal instance for namespace "openshift-terminal"
+              And user ID obtained by API should match with user id in yaml editor for "openshift-terminal" namespace
+              And user has closed existing terminal workspace
+
+
+        @smoke @odc-6745
+        Scenario: Create new project and use Web Terminal: WT-02-TC03
+            Given user can see terminal icon on masthead
+             When user clicks on the Web Terminal icon on the Masthead
+              And user clicks on Start button
+             Then user will see the terminal window
+              And user will see the terminal instance for namespace "openshift-terminal"
+              And user ID obtained by API should match with user id in yaml editor for "openshift-terminal" namespace
+              And user has closed existing terminal workspace
+

--- a/frontend/packages/webterminal-plugin/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/webterminal-plugin/integration-tests/support/commands/hooks.ts
@@ -1,0 +1,27 @@
+import { checkErrors } from '@console/cypress-integration-tests/support';
+import { guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
+import { installWebterminalOperatorUsingCLI } from '@console/dev-console/integration-tests/support/pages';
+
+before(() => {
+  cy.login();
+  cy.document().its('readyState').should('eq', 'complete');
+  guidedTour.close();
+  installWebterminalOperatorUsingCLI();
+});
+
+after(() => {
+  const namespaces: string[] = Cypress.env('NAMESPACES') || [];
+  cy.log(`Deleting "${namespaces.join(' ')}" namespace`);
+  cy.exec(`oc delete namespace ${namespaces.join(' ')}`, {
+    failOnNonZeroExit: false,
+    timeout: 180000,
+  });
+});
+
+beforeEach(() => {
+  cy.initDeveloper();
+});
+
+afterEach(() => {
+  checkErrors();
+});

--- a/frontend/packages/webterminal-plugin/integration-tests/support/commands/index.ts
+++ b/frontend/packages/webterminal-plugin/integration-tests/support/commands/index.ts
@@ -5,4 +5,4 @@ import '@console/cypress-integration-tests/support/login';
 import '@console/cypress-integration-tests/support/project';
 import '@console/cypress-integration-tests/support';
 import '@console/dev-console/integration-tests/support/commands/app';
-import '@console/dev-console/integration-tests/support/commands/hooks';
+import './hooks';

--- a/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/common/webTerminal.ts
+++ b/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/common/webTerminal.ts
@@ -43,9 +43,11 @@ Given('user can see terminal icon on masthead', () => {
 
 When('user clicks on the Web Terminal icon on the Masthead', () => {
   webTerminalPage.clickOpenCloudShellBtn();
+  cy.get('cos-status-box cos-status-box--loading').should('not.exist');
 });
 
 Then('user will see the terminal window', () => {
+  cy.wait(15000);
   webTerminalPage.verifyConnectionRediness();
 });
 

--- a/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/pages/web-terminal/initTerminal-page.ts
+++ b/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/pages/web-terminal/initTerminal-page.ts
@@ -1,6 +1,14 @@
+import { guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
+import { switchPerspective } from '@console/dev-console/integration-tests/support/constants';
 import { formPO } from '@console/dev-console/integration-tests/support/pageObjects';
 import { webTerminalPO } from '@console/dev-console/integration-tests/support/pageObjects/webterminal-po';
-import { app } from '@console/dev-console/integration-tests/support/pages/app';
+import {
+  app,
+  perspective,
+  projectNameSpace,
+} from '@console/dev-console/integration-tests/support/pages/app';
+import { searchResource } from '@console/dev-console/integration-tests/support/pages/search-resources/search-page';
+import { webTerminalPage } from './webTerminal-page';
 
 export const initTerminalPage = {
   clickOnProjectDropDown: () => {
@@ -17,7 +25,27 @@ export const initTerminalPage = {
   },
 
   clickStartButton: () => {
-    cy.get(formPO.create).should('be.enabled').click();
+    cy.get(formPO.create).should('be.enabled').click({ force: true });
+    cy.get('body').then(($body) => {
+      cy.wait(5000);
+      // Due to initialization issue if multiple operators present OCPBUGS-44891
+      if ($body.find('[data-test="loading-box-body"]').length === 0) {
+        cy.log('loading did not go through');
+        cy.wait(10000);
+        cy.get(webTerminalPO.terminalCloseWindowBtn).click();
+        cy.reload();
+        app.waitForDocumentLoad();
+        perspective.switchTo(switchPerspective.Developer);
+        projectNameSpace.selectProject('openshift-terminal');
+        guidedTour.close();
+        webTerminalPage.clickOpenCloudShellBtn();
+        searchResource.searchResourceByNameAsDev('DevWorkspace');
+        searchResource.selectSearchedItem('terminal');
+        // cy.get('[data-test="loading-indicator"]').should('not.exist', { timeout: 210000 });
+      } else {
+        cy.wait(5000);
+      }
+    });
   },
 
   selectProject: (projectName: string) => {

--- a/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/pages/web-terminal/webTerminal-page.ts
+++ b/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/pages/web-terminal/webTerminal-page.ts
@@ -43,4 +43,13 @@ export const webTerminalPage = {
     cy.alertTitleShouldContain('Close terminal?');
     cy.byTestID('confirm-action').click();
   },
+
+  deleteTerminalInstanceActionMenu: () => {
+    cy.byLegacyTestID('actions-menu-button').should('be.visible').click();
+    cy.byLegacyTestID('action-items').should('be.visible');
+    cy.byTestActionID('Delete DevWorkspace').should('be.visible').click();
+    cy.get('[aria-label="Modal"]').should('be.visible');
+    cy.byTestID('confirm-action').click();
+    cy.byTestID('empty-box').should('be.visible');
+  },
 };

--- a/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/web-terminal/web-terminal-adminuser.ts
+++ b/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/web-terminal/web-terminal-adminuser.ts
@@ -4,7 +4,7 @@ import {
   switchPerspective,
   devWorkspaceStatuses,
 } from '@console/dev-console/integration-tests/support/constants';
-import { webTerminalPO } from '@console/dev-console/integration-tests/support/pageObjects/web-terminal-po';
+import { webTerminalPO } from '@console/dev-console/integration-tests/support/pageObjects/webterminal-po';
 import {
   perspective,
   projectNameSpace,
@@ -17,10 +17,25 @@ import {
 import { checkTerminalIcon } from '@console/dev-console/integration-tests/support/pages/functions/checkTerminalIcon';
 import { operatorsPage } from '@console/dev-console/integration-tests/support/pages/operators-page';
 import { searchResource } from '@console/dev-console/integration-tests/support/pages/search-resources/search-page';
+import { webTerminalPage } from '../pages/web-terminal/webTerminal-page';
 
 Given('user has logged in as admin user', () => {
+  cy.login();
   perspective.switchTo(switchPerspective.Administrator);
   nav.sidenav.switcher.shouldHaveText(switchPerspective.Administrator);
+});
+
+Given('user has closed existing terminal workspace', () => {
+  searchResource.searchResourceByNameAsAdmin('DevWorkspace');
+  cy.get('.loading-box').then(($body) => {
+    if ($body.find('[data-test="empty-box-body"]').length === 0) {
+      cy.log($body.find('[data-test="empty-box-body"]').length.toString());
+      searchResource.selectSearchedItem('terminal');
+      webTerminalPage.deleteTerminalInstanceActionMenu();
+    } else {
+      cy.log('No DevWorkspaces found');
+    }
+  });
 });
 
 Given('user can see terminal icon on masthead', () => {
@@ -30,14 +45,18 @@ Given('user can see terminal icon on masthead', () => {
 
 When('user clicks on the Web Terminal icon on the Masthead', () => {
   cy.get(webTerminalPO.webTerminalIcon).click();
+  cy.get('cos-status-box cos-status-box--loading').should('not.exist');
 });
 
 When('user clicks advanced option for Timeout', () => {
-  cy.get('[role="tabpanel"] button').contains('Timeout').click();
+  cy.get('[role="tabpanel"] button').contains('Timeout').should('be.visible').click();
 });
 
-When('user sets timeout to 1 Minute', () => {
+When('user sets timeout to {string} Minute', (time: string) => {
   cy.byLegacyTestID('Increment').click();
+  cy.get('input[aria-label="Input"]').should('not.have.value', '0');
+  cy.get('input[aria-label="Input"]').clear().invoke('val', time).trigger('change');
+  cy.get('input[aria-label="Input"]').should('have.value', time);
 });
 
 When('user opens {int} additional web terminal tabs', (n: number) => {
@@ -46,6 +65,11 @@ When('user opens {int} additional web terminal tabs', (n: number) => {
 
 When('user closed {string} web terminal tab', (n: string) => {
   closeTerminal(n);
+});
+
+When('user closed web terminal window', () => {
+  cy.byTestID('cloudshell-drawer-close-button').should('be.visible').click();
+  cy.wait(2000);
 });
 
 Then('user is able see {int} web terminal tabs', (n: number) => {
@@ -93,6 +117,7 @@ And(
 );
 
 Then('user will see the terminal instance for namespace {string}', (nameSpace: string) => {
+  perspective.switchTo(switchPerspective.Administrator);
   operatorsPage.navigateToInstallOperatorsPage();
   // verifyWebTerminalAvailability();
   projectNameSpace.selectProject(nameSpace);

--- a/frontend/packages/webterminal-plugin/integration-tests/testData/devworkspaceOperatorSubscription.yaml
+++ b/frontend/packages/webterminal-plugin/integration-tests/testData/devworkspaceOperatorSubscription.yaml
@@ -1,0 +1,26 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: devworkspace-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: DevWorkspace Operator Catalog
+  image: 'quay.io/devfile/devworkspace-operator-index:next'
+  publisher: Red Hat
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 10m
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+ name: devworkspace-operator
+ namespace: openshift-operators
+spec:
+ channel: next
+ installPlanApproval: Automatic
+ name: devworkspace-operator
+ source: devworkspace-operator-catalog
+ sourceNamespace: openshift-marketplace
+ startingCSV: devworkspace-operator.v0.32.0-dev.5


### PR DESCRIPTION
Description:

Fixing and enabling web-terminal CI tests

Story:
- [[ODC-7695](https://issues.redhat.com/browse/ODC-7695))

Checks for approving Epic scenarios Automation PR:
- [ ]  Execute the @to-do tagged gherkin scripts manually
- [ ]  Convert the @to-do gherkin scripts to cypress automation scripts
- [ ]  Once scripts are automated, replace tag @to-do with @epic-number
- [ ]  Execute the scripts in Remote cluster


Execution Commands:
Example:

    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/packages/console-shared/src/test-data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/packages/console-shared/src/test-data/patch-htpasswd.yaml)" --type=merge
    <!-- Under frontend folder run -->
    ./integration-tests/test-cypress.sh -p webterminal

Screenshots:

Browser conformance:

- [x]  Chrome
- [ ]  Firefox
- [ ]  Safari
- [ ]  Edge