### PR TITLE
ODC-7655: Migrate `SelectVariant.typeaheadMulti` `SelectInputField`s to PF5

### DIFF
--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -146,6 +146,7 @@
   "Add key/value": "Add key/value",
   "Add values": "Add values",
   "Remove": "Remove",
+  "Create new option \"{{option}}\"": "Create new option \"{{option}}\"",
   "Current selections": "Current selections",
   "Configure via:": "Configure via:",
   "Form view": "Form view",

--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -146,6 +146,7 @@
   "Add key/value": "Add key/value",
   "Add values": "Add values",
   "Remove": "Remove",
+  "Current selections": "Current selections",
   "Configure via:": "Configure via:",
   "Form view": "Form view",
   "YAML view": "YAML view",

--- a/frontend/packages/console-shared/src/components/formik-fields/MultiTypeaheadField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/MultiTypeaheadField.tsx
@@ -91,7 +91,10 @@ const MultiTypeaheadField: React.FC<MultiTypeaheadFieldProps> = ({
       if (isCreatable && !initialSelectOptions.some((option) => option.value === inputValue)) {
         newSelectOptions = [
           ...newSelectOptions,
-          { children: `Create new option "${inputValue}"`, value: CREATE_NEW },
+          {
+            children: t('console-shared~Create new option "{{option}}"', { option: inputValue }),
+            value: CREATE_NEW,
+          },
         ];
       }
 

--- a/frontend/packages/console-shared/src/components/formik-fields/MultiTypeaheadField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/MultiTypeaheadField.tsx
@@ -266,7 +266,6 @@ const MultiTypeaheadField: React.FC<MultiTypeaheadFieldProps> = ({
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
       variant="typeahead"
-      aria-label={ariaLabel}
       onClick={onToggleClick}
       innerRef={toggleRef}
       isExpanded={isOpen}
@@ -291,6 +290,7 @@ const MultiTypeaheadField: React.FC<MultiTypeaheadFieldProps> = ({
           {...(activeItemId && { 'aria-activedescendant': activeItemId })}
           role="combobox"
           isExpanded={isOpen}
+          aria-label={ariaLabel}
           aria-controls={`${ID_PREFIX}-listbox`}
         >
           <ChipGroup aria-label={t('console-shared~Current selections')}>
@@ -301,6 +301,9 @@ const MultiTypeaheadField: React.FC<MultiTypeaheadFieldProps> = ({
                   ev.stopPropagation();
                   onSelect(selection);
                 }}
+                closeBtnAriaLabel={t('console-shared~Remove {{singularLabel}}', {
+                  singularLabel: getChildren(selection),
+                })}
               >
                 {getChildren(selection)}
               </Chip>

--- a/frontend/packages/console-shared/src/components/formik-fields/MultiTypeaheadField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/MultiTypeaheadField.tsx
@@ -1,0 +1,376 @@
+import * as React from 'react';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Select,
+  SelectOption,
+  SelectList,
+  SelectOptionProps,
+  MenuToggle,
+  MenuToggleElement,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+  ChipGroup,
+  Chip,
+  Button,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import { useField, useFormikContext, FormikValues } from 'formik';
+import * as _ from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { useFormikValidationFix } from '../../hooks';
+import { RedExclamationCircleIcon } from '../status';
+import { MultiTypeaheadFieldProps } from './field-types';
+import { getFieldId } from './field-utils';
+
+const MultiTypeaheadField: React.FC<MultiTypeaheadFieldProps> = ({
+  name,
+  label,
+  ariaLabel,
+  options,
+  placeholderText,
+  isCreatable,
+  helpText,
+  required,
+  isInputValuePersisted,
+  noResultsFoundText,
+  toggleOnSelection,
+  hideClearButton,
+  isDisabled,
+  onChange,
+  getLabelFromValue,
+}) => {
+  const [initialSelectOptions, setInitialSelectOptions] = React.useState<SelectOptionProps[]>(
+    _.map(options, (option) => ({
+      value: option.value,
+      description: option.description,
+      children: option.label || option.value,
+      isDisabled: option.disabled,
+    })),
+  );
+
+  const { t } = useTranslation();
+
+  const [field, { touched, error }] = useField<string[]>(name);
+  const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const fieldId = getFieldId(name, 'select-input');
+  const isValid = !(touched && error);
+  const errorMessage = !isValid ? error : '';
+
+  const [inputValue, setInputValue] = React.useState<string>('');
+  const [filteredSelectOptions, setFilteredSelectOptions] = React.useState<SelectOptionProps[]>(
+    initialSelectOptions,
+  );
+  const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
+  const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
+  const [onCreation, setOnCreation] = React.useState<boolean>(false); // Boolean to refresh filter state after new option is created
+  const textInputRef = React.useRef<HTMLInputElement>();
+
+  useFormikValidationFix(field.value);
+
+  const ID_PREFIX = _.uniqueId('select-multi-typeahead-'); // for aria to work, ids have to be unique
+  const NO_RESULTS = 'multi_typeahead-dropdown__no-results';
+  const CREATE_NEW = 'multi_typeahead-dropdown__create-new';
+
+  const createItemId = (value: any) => `${ID_PREFIX}-value-${value.replace(' ', '-')}`;
+
+  React.useEffect(() => {
+    let newSelectOptions: SelectOptionProps[] = initialSelectOptions;
+
+    // Filter menu items based on the text input value when one exists
+    if (inputValue) {
+      newSelectOptions = initialSelectOptions.filter((menuItem) =>
+        String(menuItem.children).toLowerCase().includes(inputValue.toLowerCase()),
+      );
+
+      // If no option matches the filter exactly, display creation option
+      if (isCreatable && !initialSelectOptions.some((option) => option.value === inputValue)) {
+        newSelectOptions = [
+          ...newSelectOptions,
+          { children: `Create new option "${inputValue}"`, value: CREATE_NEW },
+        ];
+      }
+
+      // Open the menu when the input value changes and the new value is not empty
+      if (!isOpen) {
+        setIsOpen(true);
+      }
+    }
+
+    setFilteredSelectOptions(newSelectOptions);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inputValue, onCreation]);
+
+  const setActiveAndFocusedItem = (itemIndex: number) => {
+    setFocusedItemIndex(itemIndex);
+    const focusedItem = filteredSelectOptions[itemIndex];
+    setActiveItemId(createItemId(focusedItem.value));
+  };
+
+  const resetActiveAndFocusedItem = () => {
+    setFocusedItemIndex(null);
+    setActiveItemId(null);
+  };
+
+  const closeMenu = () => {
+    setIsOpen(false);
+    resetActiveAndFocusedItem();
+    !isInputValuePersisted && setInputValue('');
+  };
+
+  const onInputClick = () => {
+    if (!isOpen) {
+      setIsOpen(true);
+    } else if (!inputValue) {
+      closeMenu();
+    }
+  };
+
+  const onToggleClick = () => {
+    setIsOpen(!isOpen);
+    textInputRef?.current?.focus();
+  };
+
+  const onSelect = (value: string) => {
+    if (onChange) {
+      onChange(value);
+    } else if (isCreatable && value === CREATE_NEW) {
+      const hasDuplicateOption = [...filteredSelectOptions, ...options].find(
+        (option) => option.value === inputValue,
+      );
+
+      if (!hasDuplicateOption) {
+        setInitialSelectOptions([
+          ...initialSelectOptions,
+          { value: inputValue, children: inputValue },
+        ]);
+        setFieldValue(name, [...field.value, inputValue]);
+        setInputValue('');
+      }
+
+      setOnCreation(!onCreation);
+      resetActiveAndFocusedItem();
+    } else if (value) {
+      const selections = field.value;
+      if (_.includes(selections, value)) {
+        setFieldValue(name, _.pull(selections, value));
+      } else {
+        setFieldValue(name, [...selections, value]);
+      }
+    }
+
+    setFieldTouched(name);
+    toggleOnSelection && onToggleClick();
+
+    textInputRef.current?.focus();
+  };
+
+  const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
+    setInputValue(value);
+    resetActiveAndFocusedItem();
+  };
+
+  const handleMenuArrowKeys = (key: string) => {
+    let indexToFocus = 0;
+
+    if (!isOpen) {
+      setIsOpen(true);
+    }
+
+    if (filteredSelectOptions.every((option) => option.isDisabled)) {
+      return;
+    }
+
+    if (key === 'ArrowUp') {
+      // When no index is set or at the first index, focus to the last, otherwise decrement focus index
+      if (focusedItemIndex === null || focusedItemIndex === 0) {
+        indexToFocus = filteredSelectOptions.length - 1;
+      } else {
+        indexToFocus = focusedItemIndex - 1;
+      }
+
+      // Skip disabled options
+      while (filteredSelectOptions[indexToFocus].isDisabled) {
+        indexToFocus--;
+        if (indexToFocus === -1) {
+          indexToFocus = filteredSelectOptions.length - 1;
+        }
+      }
+    }
+
+    if (key === 'ArrowDown') {
+      // When no index is set or at the last index, focus to the first, otherwise increment focus index
+      if (focusedItemIndex === null || focusedItemIndex === filteredSelectOptions.length - 1) {
+        indexToFocus = 0;
+      } else {
+        indexToFocus = focusedItemIndex + 1;
+      }
+
+      // Skip disabled options
+      while (filteredSelectOptions[indexToFocus].isDisabled) {
+        indexToFocus++;
+        if (indexToFocus === filteredSelectOptions.length) {
+          indexToFocus = 0;
+        }
+      }
+    }
+
+    setActiveAndFocusedItem(indexToFocus);
+  };
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const focusedItem = focusedItemIndex !== null ? filteredSelectOptions[focusedItemIndex] : null;
+
+    switch (event.key) {
+      case 'Enter':
+        if (isOpen && focusedItem && !focusedItem.isAriaDisabled) {
+          onSelect(focusedItem.value as string);
+        }
+
+        if (!isOpen) {
+          setIsOpen(true);
+        }
+
+        break;
+      case 'ArrowUp':
+      case 'ArrowDown':
+        event.preventDefault();
+        handleMenuArrowKeys(event.key);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const onClearButtonClick = () => {
+    setFieldValue(name, []);
+    setFieldTouched(name);
+
+    setInputValue('');
+    resetActiveAndFocusedItem();
+    textInputRef?.current?.focus();
+  };
+
+  const getChildren = (value: string) =>
+    initialSelectOptions.find((option) => option.value === value)?.children ||
+    (getLabelFromValue && getLabelFromValue(value)) ||
+    value;
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      variant="typeahead"
+      aria-label={ariaLabel}
+      onClick={onToggleClick}
+      innerRef={toggleRef}
+      isExpanded={isOpen}
+      isFullWidth
+      isDisabled={isDisabled}
+      // TODO(jaclee): uncomment when PF is updated
+      // status={isValid ? 'default' : 'danger'}
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={inputValue}
+          onClick={onInputClick}
+          onChange={onTextInputChange}
+          onKeyDown={(ev: React.KeyboardEvent<HTMLInputElement>) => {
+            ev.key === 'Enter' && ev.preventDefault(); // prevent accidental form submission
+            onInputKeyDown(ev);
+          }}
+          id={ID_PREFIX}
+          autoComplete="off"
+          innerRef={textInputRef}
+          placeholder={placeholderText}
+          {...(activeItemId && { 'aria-activedescendant': activeItemId })}
+          role="combobox"
+          isExpanded={isOpen}
+          aria-controls={`${ID_PREFIX}-listbox`}
+        >
+          <ChipGroup aria-label={t('console-shared~Current selections')}>
+            {field.value.map((selection) => (
+              <Chip
+                key={selection}
+                onClick={(ev) => {
+                  ev.stopPropagation();
+                  onSelect(selection);
+                }}
+              >
+                {getChildren(selection)}
+              </Chip>
+            ))}
+          </ChipGroup>
+        </TextInputGroupMain>
+        {!hideClearButton && (
+          <TextInputGroupUtilities
+            {...(field.value.length === 0 ? { style: { display: 'none' } } : {})}
+          >
+            <Button
+              variant="plain"
+              onClick={onClearButtonClick}
+              aria-label={t('console-shared~Clear filter')}
+            >
+              <TimesIcon aria-hidden />
+            </Button>
+          </TextInputGroupUtilities>
+        )}
+      </TextInputGroup>
+    </MenuToggle>
+  );
+
+  return (
+    <FormGroup fieldId={fieldId} label={label} isRequired={required}>
+      <Select
+        id={ID_PREFIX}
+        isOpen={isOpen}
+        selected={field.value}
+        onSelect={(_event, selection) => onSelect(selection as string)}
+        onOpenChange={(open) => {
+          !open && closeMenu();
+        }}
+        toggle={toggle}
+        shouldFocusFirstItemOnOpen={false}
+        popperProps={{
+          maxWidth: 'trigger',
+        }}
+      >
+        <SelectList isAriaMultiselectable id={`${ID_PREFIX}-listbox`}>
+          {filteredSelectOptions.map((option, index) => (
+            <SelectOption
+              key={option.value}
+              isFocused={focusedItemIndex === index}
+              className={option.className}
+              id={createItemId(option.value)}
+              {...option}
+              ref={null}
+            >
+              {option.children || getChildren(option.value)}
+            </SelectOption>
+          ))}
+          {(!isCreatable || !inputValue) && filteredSelectOptions.length === 0 && (
+            <SelectOption isDisabled id={NO_RESULTS}>
+              {noResultsFoundText || t('console-shared~No results found')}
+            </SelectOption>
+          )}
+        </SelectList>
+      </Select>
+
+      <FormHelperText>
+        <HelperText>
+          {!isValid ? (
+            <HelperTextItem variant="error" icon={<RedExclamationCircleIcon />}>
+              {errorMessage}
+            </HelperTextItem>
+          ) : (
+            <HelperTextItem>{helpText}</HelperTextItem>
+          )}
+        </HelperText>
+      </FormHelperText>
+    </FormGroup>
+  );
+};
+
+export default MultiTypeaheadField;

--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -200,3 +200,17 @@ export interface SelectInputFieldProps extends FieldProps {
   onChange?: (selection: string) => void;
   getLabelFromValue?: (value: string) => string;
 }
+
+export interface MultiTypeaheadFieldProps extends FieldProps {
+  ariaLabel?: string;
+  options: SelectInputOption[];
+  placeholderText?: string;
+  isCreatable?: boolean;
+  isDisabled?: boolean;
+  isInputValuePersisted?: boolean;
+  noResultsFoundText?: string;
+  toggleOnSelection?: boolean;
+  hideClearButton?: boolean;
+  onChange?: (selection: string) => void;
+  getLabelFromValue?: (value: string) => string;
+}

--- a/frontend/packages/console-shared/src/components/formik-fields/index.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/index.ts
@@ -22,6 +22,7 @@ export { default as DynamicFormField } from './DynamicFormField';
 export { default as SyncedEditorField } from './SyncedEditorField';
 export { default as SelectInputField } from './SelectInputField';
 export { default as SingleDropdownField } from './SingleDropdownField';
+export { default as MultiTypeaheadField } from './MultiTypeaheadField';
 export { default as SelectorInputField } from './SelectorInputField';
 export * from './field-utils';
 export * from './field-types';

--- a/frontend/packages/dev-console/src/components/import/serverless/ServerlessRouteSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless/ServerlessRouteSection.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Alert } from '@patternfly/react-core';
-import { SelectVariant as SelectVariantDeprecated } from '@patternfly/react-core/deprecated';
 import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { WatchK8sResource } from '@console/dynamic-plugin-sdk';
@@ -8,7 +7,7 @@ import { LoadingInline } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { DomainMappingModel } from '@console/knative-plugin/src';
-import { SelectInputField } from '@console/shared';
+import { MultiTypeaheadField } from '@console/shared';
 import { GitImportFormData, DeployImageFormData, UploadJarFormData } from '../import-types';
 import {
   getAllOtherDomainMappingInUse,
@@ -73,17 +72,15 @@ const ServerlessRouteSection: React.FC = () => {
     <>
       {domainMappingLoaded || domainMappingLoadErr ? (
         <>
-          <SelectInputField
+          <MultiTypeaheadField
             data-test-id="domain-mapping-field"
             name="serverless.domainMapping"
             label={t('devconsole~Domain mapping')}
             ariaLabel={t('devconsole~Domain mapping')}
-            variant={SelectVariantDeprecated.typeaheadMulti}
             options={domainMappingResources}
             placeholderText={t('devconsole~Add domain')}
             helpText={t('devconsole~Enter custom domain to map to the Knative service')}
             isCreatable
-            hasOnCreateOption
           />
           {hasOtherKsvcDomainMappings(serverless.domainMapping) && (
             <Alert

--- a/frontend/packages/dev-console/src/components/import/serverless/__tests__/ServerlessRouteSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless/__tests__/ServerlessRouteSection.spec.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import { useFormikContext } from 'formik';
 import { LoadingInline } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
-import { SelectInputField } from '@console/shared';
+import { MultiTypeaheadField } from '@console/shared';
 import ServerlessRouteSection from '../ServerlessRouteSection';
 import { domainMappings } from './serverless-utils.data';
 
@@ -59,36 +59,36 @@ describe(' ServerlessRouteSection', () => {
     expect(component.isEmptyRender()).toBe(false);
   });
 
-  it('Should render SelectInputField if domainMappingLoaded is true', () => {
+  it('Should render MultiTypeaheadField if domainMappingLoaded is true', () => {
     (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
     const component = shallow(<ServerlessRouteSection />);
-    expect(component.find(SelectInputField).exists()).toBe(true);
-    expect(component.find(SelectInputField).props().options).toEqual([]);
+    expect(component.find(MultiTypeaheadField).exists()).toBe(true);
+    expect(component.find(MultiTypeaheadField).props().options).toEqual([]);
   });
 
-  it('Should render SelectInputField if domainMapping could not load', () => {
+  it('Should render MultiTypeaheadField if domainMapping could not load', () => {
     (useK8sWatchResource as jest.Mock).mockReturnValueOnce([null, null, 'err']);
     const component = shallow(<ServerlessRouteSection />);
-    expect(component.find(SelectInputField).exists()).toBe(true);
-    expect(component.find(SelectInputField).props().options).toEqual([]);
+    expect(component.find(MultiTypeaheadField).exists()).toBe(true);
+    expect(component.find(MultiTypeaheadField).props().options).toEqual([]);
   });
 
-  it('Should render SelectInputField if domainMappingLoaded is true and has data with valid options', () => {
+  it('Should render MultiTypeaheadField if domainMappingLoaded is true and has data with valid options', () => {
     (useK8sWatchResource as jest.Mock).mockReturnValueOnce([domainMappings, true]);
     const component = shallow(<ServerlessRouteSection />);
-    expect(component.find(SelectInputField).exists()).toBe(true);
-    expect(component.find(SelectInputField).props().options).toEqual([
+    expect(component.find(MultiTypeaheadField).exists()).toBe(true);
+    expect(component.find(MultiTypeaheadField).props().options).toEqual([
       { value: 'example.domain1.org (service-one)', disabled: false },
       { value: 'example.domain2.org (service-two)', disabled: false },
     ]);
   });
 
-  it('Should render SelectInputField with the domain mapping options without other ksvc info', () => {
+  it('Should render MultiTypeaheadField with the domain mapping options without other ksvc info', () => {
     const connectedDomainMapping = { ...domainMappings[0] };
     connectedDomainMapping.spec.ref.name = 'hello-openshift';
     (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[connectedDomainMapping], true]);
     const component = shallow(<ServerlessRouteSection />);
-    expect(component.find(SelectInputField).props().options).toEqual([
+    expect(component.find(MultiTypeaheadField).props().options).toEqual([
       { value: 'example.domain1.org', disabled: false },
     ]);
   });
@@ -136,10 +136,10 @@ describe(' ServerlessRouteSection', () => {
     expect(component.find('[data-test="domain-mapping-warning"]').exists()).toBe(true);
   });
 
-  it('Should render LoadingInline not SelectInputField if domainMapping is inflight', () => {
+  it('Should render LoadingInline not MultiTypeaheadField if domainMapping is inflight', () => {
     (useK8sWatchResource as jest.Mock).mockReturnValueOnce([null, false]);
     const component = shallow(<ServerlessRouteSection />);
-    expect(component.find(SelectInputField).exists()).toBe(false);
+    expect(component.find(MultiTypeaheadField).exists()).toBe(false);
     expect(component.find(LoadingInline).exists()).toBe(true);
   });
 });

--- a/frontend/packages/knative-plugin/integration-tests/support/pageObjects/global-po.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/pageObjects/global-po.ts
@@ -272,9 +272,8 @@ export const hpaPO = {
 
 export const domainPO = {
   domainMapping: '[aria-label="Domain mapping"]',
-  chipGroup: '[aria-label="Chip group category"]',
+  chipGroup: '.pf-m-typeahead [id*="select-multi-typeahead-"]',
   contentScroll: '[id="content-scrollable"]',
   removeLabel: '[aria-label="Remove"]',
-  chipArea: '#form-select-input-serverless-domainMapping-field',
-  chipDescribe: '[aria-describedby="form-select-input-serverless-domainMapping-field-helper"]',
+  menuToggle: '.pf-m-typeahead [aria-label="Menu toggle"]',
 };

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/domain-mapping.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/domain-mapping.ts
@@ -44,7 +44,11 @@ When('user clicks Save button', () => {
 });
 
 When('user clicks on Show advanced Routing options', () => {
-  cy.get(domainPO.contentScroll).contains('Show advanced Routing options').click();
+  cy.get(domainPO.contentScroll).contains('Show advanced Routing options').scrollIntoView();
+  cy.get(domainPO.contentScroll)
+    .contains('Show advanced Routing options')
+    .closest('button')
+    .click();
 });
 
 When('user clicks create button', () => {
@@ -90,10 +94,11 @@ When(
 );
 
 When('user removes already added custom domain mapping {string} and {string}', (d1, d2) => {
-  cy.get(domainPO.chipArea).should('be.visible').click();
-  cy.get(`[id="select-option-serverless.domainMapping-${d1}"] button`).should('be.visible').click();
-  cy.get(`[id="select-option-serverless.domainMapping-${d2}"] button`).should('be.visible').click();
-  cy.get(domainPO.chipDescribe).should('not.contain', d1).and('not.contain', d2);
+  cy.get(domainPO.menuToggle).scrollIntoView();
+  cy.get(domainPO.menuToggle).should('be.visible').click();
+  cy.get(`button[aria-label="Remove ${d1}"]`).should('be.visible').click();
+  cy.get(`button[aria-label="Remove ${d2}"]`).should('be.visible').click();
+  cy.get(domainPO.chipGroup).should('not.contain', d1).and('not.contain', d2);
 });
 
 Then(
@@ -110,7 +115,8 @@ Given('user can see knative service {string} exist in topology page', (workloadN
 });
 
 When('user removes already added custom domain mapping {string}', (d1) => {
-  cy.get(domainPO.chipArea).should('be.visible').click();
-  cy.get(`[id="select-option-serverless.domainMapping-${d1}"] button`).should('be.visible').click();
-  cy.get(domainPO.chipDescribe).should('not.contain', d1);
+  cy.get(domainPO.menuToggle).scrollIntoView();
+  cy.get(domainPO.menuToggle).should('be.visible').click();
+  cy.get(`button[id*="value-${d1}"]`).should('be.visible').click();
+  cy.get(domainPO.chipGroup).should('not.contain', d1);
 });

--- a/frontend/packages/knative-plugin/src/components/add/event-sinks/KafkaSinkSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sinks/KafkaSinkSection.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { TextInputTypes } from '@patternfly/react-core';
-import { SelectVariant as SelectVariantDeprecated } from '@patternfly/react-core/deprecated';
 import * as fuzzy from 'fuzzysearch';
 import { useTranslation } from 'react-i18next';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 import { FirehoseResource } from '@console/internal/components/utils';
 import { SecretModel } from '@console/internal/models';
-import { InputField, ResourceDropdownField, SelectInputField } from '@console/shared';
+import { InputField, ResourceDropdownField, MultiTypeaheadField } from '@console/shared';
 import { EVENT_SINK_KAFKA_KIND } from '../../../const';
 import { useBootstrapServers } from '../../../hooks';
 
@@ -33,17 +32,15 @@ const KafkaSinkSection: React.FC<KafkaSinkSectionProps> = ({ title, namespace, f
 
   return (
     <FormSection title={title} extraMargin fullWidth={fullWidth}>
-      <SelectInputField
+      <MultiTypeaheadField
         data-test="kafkasink-bootstrapservers-field"
         name={`formData.data.${EVENT_SINK_KAFKA_KIND}.bootstrapServers`}
         label={t('knative-plugin~Bootstrap servers')}
         ariaLabel={t('knative-plugin~Bootstrap servers')}
-        variant={SelectVariantDeprecated.typeaheadMulti}
         options={bootstrapServers}
         placeholderText={bsPlaceholder}
         helpText={t('knative-plugin~The address of the Kafka broker')}
         isCreatable
-        hasOnCreateOption
         required
       />
       <InputField

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { TextInputTypes } from '@patternfly/react-core';
-import { SelectVariant as SelectVariantDeprecated } from '@patternfly/react-core/deprecated';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { InputField, SelectInputField, SelectInputOption } from '@console/shared';
+import { InputField, MultiTypeaheadField, SelectInputOption } from '@console/shared';
 import { useBootstrapServers } from '../../../hooks';
 import { kafkaTopicsResourcesWatcher } from '../../../utils/get-knative-resources';
 import { EventSources } from '../import-types';
@@ -27,7 +26,7 @@ const KafkaSourceSection: React.FC<KafkaSourceSectionProps> = ({ title, namespac
 
   const [kafkaTopics, ktPlaceholder] = React.useMemo(() => {
     let topicsOptions: SelectInputOption[] = [];
-    let placeholder: React.ReactNode = '';
+    let placeholder: string = '';
     if (kafkatopics.loaded && !kafkatopics.loadError) {
       topicsOptions = !_.isEmpty(kafkatopics.data)
         ? _.map(kafkatopics.data, (kt) => ({
@@ -54,30 +53,26 @@ const KafkaSourceSection: React.FC<KafkaSourceSectionProps> = ({ title, namespac
 
   return (
     <FormSection title={title} extraMargin fullWidth={fullWidth}>
-      <SelectInputField
+      <MultiTypeaheadField
         data-test-id="kafkasource-bootstrapservers-field"
         name={`formData.data.${EventSources.KafkaSource}.bootstrapServers`}
         label={t('knative-plugin~Bootstrap servers')}
         ariaLabel={t('knative-plugin~Bootstrap servers')}
-        variant={SelectVariantDeprecated.typeaheadMulti}
         options={bootstrapServers}
         placeholderText={bsPlaceholder}
         helpText={t('knative-plugin~The address of the Kafka broker')}
         isCreatable
-        hasOnCreateOption
         required
       />
-      <SelectInputField
+      <MultiTypeaheadField
         data-test-id="kafkasource-topics-field"
         name={`formData.data.${EventSources.KafkaSource}.topics`}
         label={t('knative-plugin~Topics')}
         ariaLabel={t('knative-plugin~Topics')}
-        variant={SelectVariantDeprecated.typeaheadMulti}
         options={kafkaTopics}
         placeholderText={ktPlaceholder}
         helpText={t('knative-plugin~Virtual groups across Kafka brokers')}
         isCreatable
-        hasOnCreateOption
         required
       />
       <InputField

--- a/frontend/packages/knative-plugin/src/hooks/useBootstrapServers.ts
+++ b/frontend/packages/knative-plugin/src/hooks/useBootstrapServers.ts
@@ -7,7 +7,7 @@ import { SelectInputOption } from '@console/shared';
 import { getBootstrapServers } from '../utils/create-eventsources-utils';
 import { kafkaBootStrapServerResourcesWatcher } from '../utils/get-knative-resources';
 
-export const useBootstrapServers = (namespace: string): [SelectInputOption[], React.ReactNode] => {
+export const useBootstrapServers = (namespace: string): [SelectInputOption[], string] => {
   const { t } = useTranslation();
   const memoResources = React.useMemo(() => kafkaBootStrapServerResourcesWatcher(namespace), [
     namespace,
@@ -18,7 +18,7 @@ export const useBootstrapServers = (namespace: string): [SelectInputOption[], Re
 
   return React.useMemo(() => {
     let bootstrapServersOptions: SelectInputOption[] = [];
-    let placeholder: React.ReactNode = '';
+    let placeholder: string = '';
     const isKafkasLoaded =
       (kafkas.loaded && !kafkas.loadError) ||
       (kafkaconnections.loaded && !kafkaconnections.loadError);


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-7655

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Migrate all SelectInputFields that use the typeaheadMulti variant to PF5. Other variants will get other PRs as I am splitting up this component

I commented out the input validation UI because it is not supported in our currently installed version of PatternFly

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

Demo:

https://github.com/user-attachments/assets/ed4ee913-116c-4e5e-999b-54b2aaa60108


**Unit test coverage report**: 
<!-- Attach test coverage report -->
unchanged

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
n/a

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari

This pr is 6/6 of [ODC-7655](https://issues.redhat.com//browse/ODC-7655) story as each file is being split into a separate PR.