### PR TITLE
OCPBUGS-41610: restore Spotlight removal on next click

### DIFF
--- a/frontend/packages/console-shared/src/components/spotlight/InteractiveSpotlight.tsx
+++ b/frontend/packages/console-shared/src/components/spotlight/InteractiveSpotlight.tsx
@@ -35,9 +35,23 @@ const InteractiveSpotlight: React.FC<InteractiveSpotlightProps> = ({ element }) 
     width,
   };
 
-  if (!isInViewport(element)) {
-    element.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
-  }
+  const [clicked, setClicked] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!clicked) {
+      if (!isInViewport(element)) {
+        element.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+      }
+      const handleClick = () => setClicked(true);
+      document.addEventListener('click', handleClick);
+      return () => {
+        document.removeEventListener('click', handleClick);
+      };
+    }
+    return () => {};
+  }, [element, clicked]);
+
+  if (clicked) return null;
 
   return (
     <Popper reference={element} placement="top-start" popperOptions={popperOptions}>


### PR DESCRIPTION
Note Spotlight will not reappear on subsequent "Don't show again" clicks until the browser is refreshed as a result of this change.  Per https://issues.redhat.com/browse/OCPBUGS-41610?focusedId=25609208&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-25609208

cc: @yanpzhan 

After:

https://github.com/user-attachments/assets/4e4d6854-b3a8-4640-a300-bf16d4fe18c4

