### PR TITLE
OCPBUGS-38543: OCP web console show pod status as Init:0/1 after using Native sidecars

### DIFF
--- a/frontend/public/module/k8s/pods.ts
+++ b/frontend/public/module/k8s/pods.ts
@@ -235,7 +235,13 @@ export const podPhase = (pod: PodKind): PodPhase => {
 
   _.each(pod.status.initContainerStatuses, (container: ContainerStatus, i: number) => {
     const { terminated, waiting } = container.state;
+    const initContainerSpec = pod.spec.initContainers.find((c) => c.name === container.name);
+
     if (terminated && terminated.exitCode === 0) {
+      return true;
+    }
+
+    if (initContainerSpec?.restartPolicy === 'Always' && container.started) {
       return true;
     }
 

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -245,6 +245,7 @@ export type ContainerStatus = {
   image: string;
   imageID: string;
   containerID?: string;
+  started?: boolean;
 };
 
 export type PodCondition = {


### PR DESCRIPTION
### Before:

<img width="954" alt="Screenshot 2024-09-19 at 10 23 47 AM" src="https://github.com/user-attachments/assets/3b651bc2-7f52-441d-a5e7-aff95ab782c8">


### After:
<img width="1879" alt="Screenshot 2024-09-19 at 10 24 22 AM" src="https://github.com/user-attachments/assets/fdeac393-b5b7-4d32-960a-3f34c1ffde27">


