### PR TITLE
OCPBUGS-42235: Disable resource row check for when auth is disabled

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -281,7 +281,7 @@ export const projectNameSpace = {
         }).then(($ele) => {
           if ($ele.text().includes('kube:admin')) {
             cy.get('tr[data-test-rows="resource-row"]').should('have.length.at.least', 1);
-          } else {
+          } else if ($ele.text() !== 'Auth disabled') {
             cy.get('[data-test="empty-message"]').should('have.text', 'No Projects found');
           }
         });


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGS-42235

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
When OpenShift Console is run with auth disabled, a developer could be logged in as kube:admin without it showing on the masthead

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Do not expect there to be no projects found if auth is disabled

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
n/a

**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
n/a

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari