### PR TITLE
OCPBUGS-36705: Plugins that use very old PF4 dropdown or menu components with grouped items have bullets and padding that needs to be removed.

### DIFF
--- a/frontend/public/style/ancillary/_patternfly4.scss
+++ b/frontend/public/style/ancillary/_patternfly4.scss
@@ -78,6 +78,15 @@
   }
 }
 
+// Patternfly 4 dropdown and menu groups nest a ul without a class so we have to explicitly remove list-style and padding that the console applies to all ul's by default. https://github.com/openshift/console/blob/master/frontend/public/style/_overrides.scss#L381-L390
+.pf-c-dropdown__group,
+.pf-c-select__menu-group { 
+  ul {
+    list-style: none;
+    padding-left: 0;
+  }
+}
+
 // Reuse PF5 form-control styling that is modified to match our legacy components using PF4 markup
 
 .pf-v5-c-form-control {


### PR DESCRIPTION
**before** 
![image](https://github.com/user-attachments/assets/55cce056-8869-4935-9439-892502973525)


**after**
![Screenshot 2024-09-24 at 12 11 30 PM](https://github.com/user-attachments/assets/9b5c4939-214c-4fe9-9f40-27dcc3cf72eb)
