### PR TITLE
OCPBUGS-34595: Clicking Size control in PVC form throws a warning error

### DIFF
--- a/frontend/public/components/utils/request-size-input.tsx
+++ b/frontend/public/components/utils/request-size-input.tsx
@@ -18,7 +18,7 @@ export const RequestSizeInput: React.FC<RequestSizeInputProps> = ({
   required,
   testID,
 }) => {
-  const parsedRequestSizeValue = parseInt(defaultRequestSizeValue, 10);
+  const parsedRequestSizeValue = parseInt(defaultRequestSizeValue, 10) || 1;
   const defaultValue = Number.isFinite(parsedRequestSizeValue) ? parsedRequestSizeValue : null;
   const [unit, setUnit] = React.useState<string>(defaultRequestSizeUnit);
   const [value, setValue] = React.useState<number>(defaultValue);


### PR DESCRIPTION
### Before:

<img width="945" alt="Screenshot 2024-09-25 at 10 13 25 AM" src="https://github.com/user-attachments/assets/e6602c9f-8bc3-4854-b350-333e28a65d09">

### After:

<img width="942" alt="Screenshot 2024-09-25 at 10 43 21 AM" src="https://github.com/user-attachments/assets/2a4d3f09-bf0b-4571-bf8a-fe996476be20">
