### PR TITLE
OCPBUGS-32526: Disable Pipeline if using Devfiles

### DIFF
--- a/frontend/packages/dev-console/src/components/import/section/build-section/BuildOptions.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/build-section/BuildOptions.tsx
@@ -74,7 +74,8 @@ export const BuildOption: React.FC<BuildOptionProps> = ({ isDisabled, importStra
       });
     }
 
-    if (isPipelineEnabled && hasCreatePipelineAccess) {
+    // OCPBUGS-32526: Pipeline builds and Devfile import are mutually exclusive
+    if (isPipelineEnabled && hasCreatePipelineAccess && importStrategy !== ImportStrategy.DEVFILE) {
       options.push({
         label: t(ReadableBuildOptions[BuildOptions.PIPELINES]),
         value: BuildOptions.PIPELINES,


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGS-32526

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of  -->
there is an import error when trying to select the pipeline strategy, which is `pipeline.templateSelected` that is not filled in. however the error isn't displayed to the user

I tried to set a template by force by manually showing the pipeline section in the import form to try and set a template and got this

![image](https://github.com/user-attachments/assets/e1fb8763-f695-4316-9012-aa7645caa41c)

but it seems like the pipeline import section is supposed to be [hidden if using devfile import](https://github.com/openshift/console/blob/ef9c3fca7888b584fbc87511d441a9edad2c192b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx#L50), which makes me think that not being able to build with pipelines is intentional, but its lack of support is poorly communicated

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

remove the option

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://github.com/user-attachments/assets/55d56736-f1fc-4035-975b-8c7410fd8c35

**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
n/a


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari