### PR TITLE
OCPBUGS-38775: add role exclusion to avoid unexpected triggering the namespace menu

### DIFF
--- a/frontend/packages/console-shared/src/components/namespace/NamespaceMenuToggle.tsx
+++ b/frontend/packages/console-shared/src/components/namespace/NamespaceMenuToggle.tsx
@@ -22,7 +22,9 @@ const NamespaceMenuToggle = (props: {
       shortCut &&
       event.key === shortCut &&
       event.target.nodeName !== 'INPUT' &&
-      event.target.nodeName !== 'TEXTAREA'
+      event.target.nodeName !== 'TEXTAREA' &&
+      event.target.role !== 'textbox' &&
+      event.target.role !== 'code'
     ) {
       onToggle(true);
       event.stopPropagation();


### PR DESCRIPTION
This PR adds an exclusion logic, based on the target element role, to avoid triggering the namespace menu when pressing the `n` key. 

This prevents that the namespace menu is opened when using custom input components such as codemirror or monaco.