### PR TITLE
ODC-7680: Migrate `ResultsList` to PF5

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/shared/results/ResultsList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/results/ResultsList.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Bullseye, EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
-import { Thead, Tbody, Th, Td, Tr } from '@patternfly/react-table';
-import { Table as TableDeprecated } from '@patternfly/react-table/deprecated';
+import { Table, Thead, Tbody, Th, Td, Tr } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 import { SectionHeading } from '@console/internal/components/utils';
 import { ComputedStatus, TektonResultsRun } from '../../../types';
@@ -13,17 +12,6 @@ export interface ResultsListProps {
   status: string;
 }
 
-/**
- * Without this prop our current TS types fail to match and require a `translate` prop to be added. PF suggests we
- * update our types, but that causes other issues. This will have to do as a workaround for now.
- *
- * This is the best that I can find relates to this value:
- * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3423b4fc3e3da09f8acc386bc2fee6fb8f5e0880/types/react/index.d.ts#L1763
- */
-const reactPropFix = {
-  translate: 'no',
-};
-
 const ResultsList: React.FC<ResultsListProps> = ({ results, resourceName, status }) => {
   const { t } = useTranslation();
   if (!results.length) return null;
@@ -32,26 +20,22 @@ const ResultsList: React.FC<ResultsListProps> = ({ results, resourceName, status
     <>
       <SectionHeading text={t('pipelines-plugin~{{resourceName}} results', { resourceName })} />
       {status !== ComputedStatus.Failed ? (
-        <TableDeprecated
-          aria-label={t('pipelines-plugin~{{resourceName}} results', { resourceName })}
-          {...reactPropFix}
-          data-codemods="true"
-        >
-          <Thead {...reactPropFix}>
-            <Tr {...reactPropFix}>
-              <Th {...reactPropFix}>{t('pipelines-plugin~Name')}</Th>
-              <Th {...reactPropFix}>{t('pipelines-plugin~Value')}</Th>
+        <Table aria-label={t('pipelines-plugin~{{resourceName}} results', { resourceName })}>
+          <Thead>
+            <Tr>
+              <Th>{t('pipelines-plugin~Name')}</Th>
+              <Th>{t('pipelines-plugin~Value')}</Th>
             </Tr>
           </Thead>
-          <Tbody {...reactPropFix}>
+          <Tbody>
             {results.map(({ name, value }) => (
-              <Tr key={`row-${name}`} {...reactPropFix}>
-                <Td {...reactPropFix}>{name}</Td>
-                <Td {...reactPropFix}>{handleURLs(value)}</Td>
+              <Tr key={`row-${name}`}>
+                <Td>{name}</Td>
+                <Td>{handleURLs(value)}</Td>
               </Tr>
             ))}
           </Tbody>
-        </TableDeprecated>
+        </Table>
       ) : (
         <Bullseye>
           <EmptyState variant={EmptyStateVariant.full}>

--- a/frontend/packages/pipelines-plugin/src/components/shared/results/__tests__/ResultsList.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/results/__tests__/ResultsList.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { EmptyState } from '@patternfly/react-core';
-import { Table as TableDeprecated } from '@patternfly/react-table/deprecated';
+import { Table } from '@patternfly/react-table';
 import { ShallowWrapper, shallow } from 'enzyme';
 import { ComputedStatus } from '../../../../types';
 import { taskRunWithResults } from '../../../taskruns/__tests__/taskrun-test-data';
@@ -20,7 +20,7 @@ describe('ResultsList', () => {
   });
 
   it('Should render Results Table', () => {
-    expect(resultsListWrapper.find(TableDeprecated).exists()).toBe(true);
+    expect(resultsListWrapper.find(Table).exists()).toBe(true);
     expect(resultsListWrapper.find(EmptyState).exists()).toBe(false);
   });
   it('Should render an EmptyState instead', () => {
@@ -30,7 +30,7 @@ describe('ResultsList', () => {
       results: taskRunWithResults.status.taskResults,
     };
     resultsListWrapper = shallow(<ResultsList {...resultsListProps} />);
-    expect(resultsListWrapper.find(TableDeprecated).exists()).toBe(false);
+    expect(resultsListWrapper.find(Table).exists()).toBe(false);
     expect(resultsListWrapper.find(EmptyState).exists()).toBe(true);
   });
 });


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-7680

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Migrate ResultsList to PF5

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://github.com/user-attachments/assets/f1b937d7-9cd6-4e7e-96f9-a39ce82cd4a1

**Unit test coverage report**: 
<!-- Attach test coverage report -->
unchanged

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
n/a

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari

This pr is 2/? of [ODC-7680](https://issues.redhat.com//browse/ODC-7680) story as each file is being split into a separate PR.