### PR TITLE
OCPBUGS-41175: Operator Hub does not show correct description when installing new operator

### DIFF
--- a/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
+++ b/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
@@ -267,7 +267,7 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
     <>
       <iframe
         title={_.uniqueId('markdown-view')}
-        sandbox="allow-popups-to-escape-sandbox allow-same-origin"
+        sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin"
         style={{ border: '0px', display: 'block', width: '100%', height: frameHeight }}
         ref={frameRef}
         onLoad={onLoad}

--- a/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
+++ b/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
@@ -251,7 +251,6 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
   React.useEffect(() => {
     if (frameRef.current && frameRef.current.contentDocument) {
       const doc = frameRef.current.contentDocument;
-
       doc.open();
       doc.write(contents);
       doc.close();

--- a/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
+++ b/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
@@ -191,15 +191,15 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const updateDimensions = React.useCallback(
     _.debounce(() => {
-      if (!frameRef?.current?.contentWindow) {
+      if (!frameRef.current?.contentWindow) {
         return;
       }
       setFrameHeight(
-        frameRef?.current.contentWindow.document.body.firstElementChild.scrollHeight +
+        frameRef.current.contentWindow.document.body.firstElementChild.scrollHeight +
           (exactHeight ? 0 : 15),
       );
     }, 100),
-    [frameRef, exactHeight],
+    [exactHeight],
   );
 
   const onLoad = React.useCallback(() => {
@@ -207,7 +207,7 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
     setLoaded(true);
   }, [updateDimensions]);
 
-  useResizeObserver(updateDimensions, frameRef?.current);
+  useResizeObserver(updateDimensions, frameRef.current);
 
   // Find the app's stylesheets and inject them into the frame to ensure consistent styling.
   const filteredLinks = Array.from(document.getElementsByTagName('link')).filter((l) =>
@@ -249,7 +249,7 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
 
   // update the iframe's content
   React.useEffect(() => {
-    if (frameRef.current && frameRef.current.contentDocument) {
+    if (frameRef.current.contentDocument) {
       const doc = frameRef.current.contentDocument;
       doc.open();
       doc.write(contents);
@@ -258,7 +258,7 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
       // adjust height for current content
       const contentHeight = doc.body.scrollHeight;
       setFrameHeight(contentHeight);
-      updateThemeClass(frameRef?.current.contentDocument?.documentElement, theme);
+      updateThemeClass(doc.documentElement, theme);
     }
   }, [contents, theme, updateThemeClass]);
 
@@ -271,12 +271,12 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
         ref={frameRef}
         onLoad={onLoad}
       />
-      {loaded && frameRef && (
+      {loaded && (
         <RenderExtension
           markup={markup}
           selector={''}
           renderExtension={renderExtension}
-          docContext={frameRef?.current.contentDocument}
+          docContext={frameRef.current.contentDocument}
         />
       )}
     </>

--- a/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
+++ b/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
@@ -191,7 +191,7 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const updateDimensions = React.useCallback(
     _.debounce(() => {
-      if (!frameRef?.current || !frameRef.current.contentWindow) {
+      if (!frameRef?.current?.contentWindow) {
         return;
       }
       setFrameHeight(

--- a/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
+++ b/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
@@ -191,7 +191,7 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const updateDimensions = React.useCallback(
     _.debounce(() => {
-      if (!frameRef?.current.contentWindow?.document?.body?.firstElementChild) {
+      if (!frameRef?.current || !frameRef.current.contentWindow) {
         return;
       }
       setFrameHeight(

--- a/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
+++ b/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
@@ -248,7 +248,7 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
 
   // update the iframe's content
   React.useEffect(() => {
-    if (frameRef.current.contentDocument) {
+    if (frameRef.current?.contentDocument) {
       const doc = frameRef.current.contentDocument;
       doc.open();
       doc.write(contents);
@@ -275,7 +275,7 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
           markup={markup}
           selector={''}
           renderExtension={renderExtension}
-          docContext={frameRef.current.contentDocument}
+          docContext={frameRef.current?.contentDocument}
         />
       )}
     </>

--- a/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
+++ b/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
@@ -191,13 +191,12 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const updateDimensions = React.useCallback(
     _.debounce(() => {
-      if (!frameRef.current?.contentWindow) {
-        return;
+      if (frameRef.current?.contentWindow) {
+        setFrameHeight(
+          frameRef.current.contentWindow.document.body.firstElementChild.scrollHeight +
+            (exactHeight ? 0 : 15),
+        );
       }
-      setFrameHeight(
-        frameRef.current.contentWindow.document.body.firstElementChild.scrollHeight +
-          (exactHeight ? 0 : 15),
-      );
     }, 100),
     [exactHeight],
   );

--- a/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
+++ b/frontend/packages/console-plugin-shared/src/components/Markdown/MarkdownView.tsx
@@ -113,6 +113,7 @@ export const MarkdownView: React.FC<MarkdownProps> = ({
       : content;
     return markdownConvert(truncatedContent || emptyMsg, extensions, options);
   }, [content, emptyMsg, extensions, options, truncateContent]);
+
   const innerProps: InnerSyncMarkdownProps = {
     renderExtension: extensions?.length > 0 ? renderExtension : undefined,
     exactHeight,
@@ -183,39 +184,30 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
   theme,
   updateThemeClass,
 }) => {
-  const [frame, setFrame] = React.useState<HTMLIFrameElement>();
+  const frameRef = React.useRef<HTMLIFrameElement>(null);
   const [frameHeight, setFrameHeight] = React.useState(0);
   const [loaded, setLoaded] = React.useState(false);
-  const htmlTagElement = frame?.contentDocument?.documentElement;
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const updateDimensions = React.useCallback(
     _.debounce(() => {
-      if (!frame?.contentWindow?.document?.body?.firstElementChild) {
+      if (!frameRef?.current.contentWindow?.document?.body?.firstElementChild) {
         return;
       }
       setFrameHeight(
-        frame.contentWindow.document.body.firstElementChild.scrollHeight + (exactHeight ? 0 : 15),
+        frameRef?.current.contentWindow.document.body.firstElementChild.scrollHeight +
+          (exactHeight ? 0 : 15),
       );
     }, 100),
-    [frame, exactHeight],
+    [frameRef, exactHeight],
   );
 
   const onLoad = React.useCallback(() => {
-    if (htmlTagElement && updateThemeClass) {
-      updateThemeClass(htmlTagElement, theme);
-    }
     updateDimensions();
     setLoaded(true);
-  }, [htmlTagElement, theme, updateDimensions, updateThemeClass]);
+  }, [updateDimensions]);
 
-  React.useEffect(() => {
-    if (htmlTagElement && updateThemeClass) {
-      updateThemeClass(htmlTagElement, theme);
-    }
-  }, [frame, htmlTagElement, theme, updateThemeClass]);
-
-  useResizeObserver(updateDimensions, frame);
+  useResizeObserver(updateDimensions, frameRef?.current);
 
   // Find the app's stylesheets and inject them into the frame to ensure consistent styling.
   const filteredLinks = Array.from(document.getElementsByTagName('link')).filter((l) =>
@@ -254,22 +246,38 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
   }
   </style>
   <body class="pf-m-redhat-font pf-v5-c-content co-iframe"><div style="overflow-y: auto;">${markup}</div></body>`;
+
+  // update the iframe's content
+  React.useEffect(() => {
+    if (frameRef.current && frameRef.current.contentDocument) {
+      const doc = frameRef.current.contentDocument;
+
+      doc.open();
+      doc.write(contents);
+      doc.close();
+
+      // adjust height for current content
+      const contentHeight = doc.body.scrollHeight;
+      setFrameHeight(contentHeight);
+      updateThemeClass(frameRef?.current.contentDocument?.documentElement, theme);
+    }
+  }, [contents, theme, updateThemeClass]);
+
   return (
     <>
       <iframe
         title={_.uniqueId('markdown-view')}
-        sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin"
-        srcDoc={contents}
+        sandbox="allow-popups-to-escape-sandbox allow-same-origin"
         style={{ border: '0px', display: 'block', width: '100%', height: frameHeight }}
-        ref={setFrame}
+        ref={frameRef}
         onLoad={onLoad}
       />
-      {loaded && frame && (
+      {loaded && frameRef && (
         <RenderExtension
           markup={markup}
           selector={''}
           renderExtension={renderExtension}
-          docContext={frame.contentDocument}
+          docContext={frameRef?.current.contentDocument}
         />
       )}
     </>

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -219,11 +219,11 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
   const {
     catalogSource,
     source,
-    longDescription,
     description,
     infraFeatures,
     installed,
     isInstalling,
+    longDescription,
     marketplaceSupportWorkflow,
     obj,
     provider,
@@ -254,7 +254,7 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
   }, [item?.obj?.status, setDeprecatedPackage]);
   const currentChannel = obj?.status.channels.find((ch) => ch.name === installChannel);
   const selectedChannelContainerImage = currentChannel?.currentCSVDesc.annotations.containerImage;
-  const selectedChannelDescription = currentChannel?.currentCSVDesc.description ?? longDescription;
+  const selectedChannelDescription = currentChannel?.currentCSVDesc.description || longDescription;
   const selectedChannelCreatedAt = currentChannel?.currentCSVDesc.annotations.createdAt;
   const selectedChannelCapabilityLevel =
     currentChannel?.currentCSVDesc.annotations.capabilities ?? item.capabilityLevel;

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -223,7 +223,6 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
     infraFeatures,
     installed,
     isInstalling,
-    longDescription,
     marketplaceSupportWorkflow,
     obj,
     provider,
@@ -254,6 +253,7 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
   }, [item?.obj?.status, setDeprecatedPackage]);
   const currentChannel = obj?.status.channels.find((ch) => ch.name === installChannel);
   const selectedChannelContainerImage = currentChannel?.currentCSVDesc.annotations.containerImage;
+  const selectedChannelDescription = currentChannel?.currentCSVDesc.description;
   const selectedChannelCreatedAt = currentChannel?.currentCSVDesc.annotations.createdAt;
   const selectedChannelCapabilityLevel =
     currentChannel?.currentCSVDesc.annotations.capabilities ?? item.capabilityLevel;
@@ -426,7 +426,11 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
                 authentication={authentication}
                 infrastructure={infrastructure}
               />
-              {longDescription ? <MarkdownView content={longDescription} /> : description}
+              {selectedChannelDescription ? (
+                <MarkdownView content={selectedChannelDescription} />
+              ) : (
+                description
+              )}
             </div>
           </div>
         </div>

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -219,6 +219,7 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
   const {
     catalogSource,
     source,
+    longDescription,
     description,
     infraFeatures,
     installed,
@@ -253,7 +254,7 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
   }, [item?.obj?.status, setDeprecatedPackage]);
   const currentChannel = obj?.status.channels.find((ch) => ch.name === installChannel);
   const selectedChannelContainerImage = currentChannel?.currentCSVDesc.annotations.containerImage;
-  const selectedChannelDescription = currentChannel?.currentCSVDesc.description;
+  const selectedChannelDescription = currentChannel?.currentCSVDesc.description ?? longDescription;
   const selectedChannelCreatedAt = currentChannel?.currentCSVDesc.annotations.createdAt;
   const selectedChannelCapabilityLevel =
     currentChannel?.currentCSVDesc.annotations.capabilities ?? item.capabilityLevel;


### PR DESCRIPTION
Links to: https://issues.redhat.com/browse/OCPBUGS-41175 

Problem: The description of the operator hub item didnt show accordingly to the selected channel.

Fix: 
Pass the description from the `currentCSVDesc` to the `MarkdownView` instead of the longDescription, that is derived from the default channel.

Before:
<img width="1091" alt="Screenshot 2024-09-30 at 12 40 40" src="https://github.com/user-attachments/assets/e86d4be3-43e7-46a2-a4f9-9a98be44d7a8">

After 
<img width="1360" alt="Screenshot 2024-09-30 at 12 05 43" src="https://github.com/user-attachments/assets/bb054e64-45ab-42ca-b303-b27bed1b413e">



