### PR TITLE
OCPBUGS-41492: show Samples tab when one or more exists

### DIFF
--- a/frontend/public/components/configmaps/ConfigMapFormEditor.tsx
+++ b/frontend/public/components/configmaps/ConfigMapFormEditor.tsx
@@ -60,7 +60,7 @@ export const ConfigMapFormEditor: React.FC<FormikProps<any> & ConfigMapFormEdito
     <CodeEditorField
       name="yamlData"
       model={ConfigMapModel}
-      showSamples={false}
+      showSamples={!configMap?.metadata?.name}
       onSave={() => handleSubmit()}
     />
   );


### PR DESCRIPTION
After

If creating new and sample and snippet exist, both tabs appear; if neither sample not snippet exist, no tabs show:

https://github.com/user-attachments/assets/52d9ab48-8e76-4ce4-9e9f-f6722908dada

If editing existing and sample and snippet exist, only snippet tab appears:

https://github.com/user-attachments/assets/24104507-43a0-446e-b694-bdd024cf8243

