### PR TITLE
NO-JIRA: Update README with instructions for running monitoring-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ In order to enable the monitoring UI and see the "Observe" navigation item while
 2. `cd` to the monitoring-plugin root dir
 3. Run
   ```
-  yarn && yarn start
+  make install && make start-frontend
   ```
 4. Run Bridge in another terminal following the steps above, but set the following environment variable before starting Bridge:
   ```


### PR DESCRIPTION
NO-JIRA: Update README.md with instructions for running monitoring-plugin (which now uses make commands).