### PR TITLE
OCPBUGS-42574: Project is "Undefined" on "VolumeSnapshot" create page

### DIFF
--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
@@ -214,13 +214,13 @@ const VolumeSnapshotTable: React.FC<VolumeSnapshotTableProps> = (props) => {
 const VolumeSnapshotPage: React.FC<VolumeSnapshotPageProps> = ({
   canCreate = true,
   showTitle = true,
-  namespace,
+  namespace = 'default',
 }) => {
   const { t } = useTranslation();
   const canListVSC = useFlag(FLAGS.CAN_LIST_VSC);
-  const createPath = `/k8s/${namespace === 'all-namespaces' ? namespace : `ns/${namespace}`}/${
-    VolumeSnapshotModel.plural
-  }/~new/form`;
+
+  const createPath = `/k8s/ns/${namespace}/${VolumeSnapshotModel.plural}/~new/form`;
+
   const [resources, loaded, loadError] = useK8sWatchResource<VolumeSnapshotKind[]>({
     groupVersionKind: {
       group: VolumeSnapshotModel.apiGroup,


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/OCPBUGS-42574

Problem: The VolumeSnapshot creation form was attempting to create new snapshots for 'All projects'/all-namespaces namespace. 

Resolution:
Use ‘default’ namespace as default instead of ‘All projects’ namespace in the VolumeSnapshot creation form.

https://github.com/user-attachments/assets/7c589c0b-fdeb-4692-8bb8-deccdeda4609

