### PR TITLE
CONSOLE-4191: update ContainerDropdown to use PatternFly Select

### DIFF
--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
@@ -6,7 +6,7 @@ import * as _ from 'lodash';
 import Helmet from 'react-helmet';
 import { useTranslation, Trans } from 'react-i18next';
 import {
-  ContainerDropdown,
+  ContainerSelect,
   documentationURLs,
   getDocumentationURL,
   history,
@@ -110,7 +110,7 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
           <p className="odc-add-health-checks__paragraph">
             {t('devconsole~Container')} &nbsp;
             {_.size(containers) > 1 ? (
-              <ContainerDropdown
+              <ContainerSelect
                 currentKey={currentKey}
                 containers={containersByKey}
                 onChange={handleSelectContainer}

--- a/frontend/packages/dev-console/src/components/health-checks/__tests__/AddHealthChecks.spec.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/__tests__/AddHealthChecks.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { ContainerDropdown, ResourceLink } from '@console/internal/components/utils';
+import { ContainerSelect, ResourceLink } from '@console/internal/components/utils';
 import * as utils from '@console/internal/components/utils/rbac';
 import { FormFooter } from '@console/shared';
 import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
@@ -42,7 +42,7 @@ describe('AddHealthCheck', () => {
 
   it('should load AddHealthCheck', () => {
     const wrapper = shallow(<AddHealthChecks {...addHealthCheckProbs} />);
-    expect(wrapper.find(ContainerDropdown).exists()).toBe(false);
+    expect(wrapper.find(ContainerSelect).exists()).toBe(false);
     expect(wrapper.find(ResourceLink).exists()).toBe(true);
     expect(wrapper.find(HealthChecks).exists()).toBe(true);
     expect(wrapper.find(FormFooter).exists()).toBe(true);

--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -12,7 +12,7 @@ import { k8sPatch, k8sGet, referenceFor, referenceForOwnerRef } from '../module/
 import {
   AsyncComponent,
   checkAccess,
-  ContainerDropdown,
+  ContainerSelect,
   EnvFromPair,
   EnvType,
   FieldLevelHelp,
@@ -510,7 +510,7 @@ export class UnconnectedEnvironmentPage extends PromiseComponent {
     const envVar = currentEnvVars.getEnvVarByTypeAndIndex(containerType, containerIndex);
 
     const containerDropdown = currentEnvVars.isContainerArray ? (
-      <ContainerDropdown
+      <ContainerSelect
         currentKey={rawEnvData[containerType][containerIndex].name}
         containers={getContainersObjectForDropdown(rawEnvData.containers)}
         initContainers={getContainersObjectForDropdown(rawEnvData.initContainers)}

--- a/frontend/public/components/pod-logs.jsx
+++ b/frontend/public/components/pod-logs.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 
 import {
-  ContainerDropdown,
+  ContainerSelect,
   getQueryArgument,
   LOG_SOURCE_RESTARTING,
   LOG_SOURCE_RUNNING,
@@ -91,7 +91,7 @@ export class PodLogs extends React.Component {
     const currentContainer = _.get(containers, currentKey) || _.get(initContainers, currentKey);
     const currentContainerStatus = containerToLogSourceStatus(currentContainer);
     const containerDropdown = (
-      <ContainerDropdown
+      <ContainerSelect
         currentKey={currentKey}
         containers={containers}
         initContainers={initContainers}

--- a/frontend/public/components/utils/container-select.tsx
+++ b/frontend/public/components/utils/container-select.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+import {
+  Divider,
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectGroup,
+  SelectList,
+  SelectOption,
+} from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+
+import { ContainerModel } from '@console/internal/models';
+import { ContainerSpec } from '@console/internal/module/k8s';
+import { ResourceName } from './resource-icon';
+
+export const ContainerLabel: React.FC<ContainerLabelProps> = ({ name }) => (
+  <ResourceName name={name} kind={ContainerModel.kind} />
+);
+
+const ContainerSelectOptions: React.FC<ContainerSelectOptionsProps> = ({ containers }) => (
+  <>
+    {Object.values(containers ?? {}).map(({ name }) => (
+      <SelectOption key={name} value={name}>
+        <ContainerLabel name={name} />
+      </SelectOption>
+    ))}
+  </>
+);
+
+export const ContainerSelect: React.FC<ContainerSelectProps> = ({
+  containers,
+  currentKey,
+  initContainers,
+  onChange,
+}) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [selected, setSelected] = React.useState<string>(
+    currentKey || Object.values(containers ?? {})?.[0]?.name,
+  );
+  const { t } = useTranslation();
+
+  if (_.isEmpty(containers)) {
+    return null;
+  }
+
+  const onToggleClick = () => {
+    setIsOpen(!isOpen);
+  };
+  const onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string) => {
+    onChange(value);
+    setSelected(value);
+    setIsOpen(false);
+  };
+
+  return (
+    <Select
+      isOpen={isOpen}
+      selected={selected}
+      onSelect={onSelect}
+      onOpenChange={(open) => setIsOpen(open)}
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+          <ContainerLabel name={selected} />
+        </MenuToggle>
+      )}
+      shouldFocusToggleOnSelect
+    >
+      {!_.isEmpty(initContainers) ? (
+        <>
+          <SelectGroup label={t('public~Containers')}>
+            <SelectList>
+              <ContainerSelectOptions containers={containers} />
+            </SelectList>
+          </SelectGroup>
+          <Divider />
+          <SelectGroup label={t('public~Init containers')}>
+            <SelectList>
+              <ContainerSelectOptions containers={initContainers} />
+            </SelectList>
+          </SelectGroup>
+        </>
+      ) : (
+        <SelectList>
+          <ContainerSelectOptions containers={containers} />
+        </SelectList>
+      )}
+    </Select>
+  );
+};
+
+type Containers = { [key: string]: ContainerSpec };
+
+type ContainerLabelProps = {
+  name: string;
+};
+
+type ContainerSelectOptionsProps = {
+  containers: Containers;
+};
+
+type ContainerSelectProps = {
+  containers: Containers;
+  currentKey?: string;
+  initContainers?: Containers;
+  onChange: (value: string) => void;
+};

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -14,7 +14,6 @@ import { StarIcon } from '@patternfly/react-icons/dist/esm/icons/star-icon';
 
 import { checkAccess } from './rbac';
 import { KebabItems } from './kebab';
-import { ResourceName } from './resource-icon';
 
 class DropdownMixin extends React.PureComponent {
   constructor(props) {
@@ -785,59 +784,4 @@ ActionsMenu.propTypes = {
     }),
   ).isRequired,
   title: PropTypes.node,
-};
-
-const containerLabel = (container) => (
-  <ResourceName name={container ? container.name : ''} kind="Container" />
-);
-
-export const ContainerDropdown = (props) => {
-  const { t } = useTranslation();
-
-  const getSpacer = (container) => {
-    const spacerBefore = new Set();
-    return container ? spacerBefore.add(container.name) : spacerBefore;
-  };
-
-  const getHeaders = (container, initContainer) => {
-    return initContainer
-      ? {
-          [container.name]: t('public~Containers'),
-          [initContainer.name]: t('public~Init containers'),
-        }
-      : {};
-  };
-
-  const { currentKey, containers, initContainers, onChange } = props;
-  if (_.isEmpty(containers) && _.isEmpty(initContainers)) {
-    return null;
-  }
-  const firstInitContainer = _.find(initContainers, { order: 0 });
-  const firstContainer = _.find(containers, { order: 0 });
-  const spacerBefore = getSpacer(firstInitContainer);
-  const headerBefore = getHeaders(firstContainer, firstInitContainer);
-  const dropdownItems = _.mapValues(_.merge(containers, initContainers), containerLabel);
-  const title = _.get(dropdownItems, currentKey) || containerLabel(firstContainer);
-  return (
-    <Dropdown
-      headerBefore={headerBefore}
-      items={dropdownItems}
-      spacerBefore={spacerBefore}
-      title={title}
-      onChange={onChange}
-      selectedKey={currentKey}
-    />
-  );
-};
-
-ContainerDropdown.propTypes = {
-  containers: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
-  currentKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  initContainers: PropTypes.object,
-  onChange: PropTypes.func.isRequired,
-};
-
-ContainerDropdown.defaultProps = {
-  currentKey: '',
-  initContainers: {},
 };

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -59,3 +59,4 @@ export * from './details-item';
 export * from './types';
 export * from './release-notes-link';
 export * from './service-level';
+export * from './container-select';


### PR DESCRIPTION
This PR:
* Replaces the usage of `Dropdown` with PatternFly's `Select` in `ContainerDropdown`
* Moves the component out of `dropdown.jsx` so we can eventually eliminate that file
* Renames the component and converts it to TypeScript
* Fixes prop type errors

### After

If there are `containers` and `initContainers` on the pod:

https://github.com/user-attachments/assets/292094f6-c5eb-4f9c-bd0a-332a2dfca958

If there are only `containers` on the pod:

https://github.com/user-attachments/assets/31fab2b9-64b0-4636-a4ee-bba641f4e909

If there are only `containers` and there is only one (existing difference in display between `Logs` and `Terminal`):

https://github.com/user-attachments/assets/63a0883d-9577-4af6-84dd-2e5a27a98dd4

<img width="724" alt="Screenshot 2024-10-02 at 5 15 17 PM" src="https://github.com/user-attachments/assets/1712c43d-206c-440c-a40e-5e9f22c84720">





