### PR TITLE
OCPBUGS-42712: Replace usage of `containsNonPrintableCharacters` function with `isBinary` function from 'istextorbinary' lib.

### DIFF
--- a/frontend/public/components/configmap-and-secret-data.tsx
+++ b/frontend/public/components/configmap-and-secret-data.tsx
@@ -6,7 +6,7 @@ import { EyeSlashIcon } from '@patternfly/react-icons/dist/esm/icons/eye-slash-i
 import { Button } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { CopyToClipboard, EmptyBox, SectionHeading } from './utils';
-import { containsNonPrintableCharacters } from './utils/file-input';
+import * as ITOB from 'istextorbinary/edition-es2017';
 
 export const MaskedData: React.FC<{}> = () => {
   const { t } = useTranslation();
@@ -114,7 +114,7 @@ export const SecretData: React.FC<SecretDataProps> = ({ data, title }) => {
       );
       dl.push(
         <dd key={`${k}-v`}>
-          {containsNonPrintableCharacters(Base64.decode(data[k])) ? (
+          {ITOB.isBinary(k, Buffer.from(data[k], 'base64')) ? (
             <DownloadBinaryButton label={k} value={data[k]} />
           ) : (
             <SecretValue value={data[k]} reveal={reveal} />

--- a/frontend/public/components/droppable-edit-yaml.tsx
+++ b/frontend/public/components/droppable-edit-yaml.tsx
@@ -8,7 +8,7 @@ import { ResourceYAMLEditorProps } from '@console/dynamic-plugin-sdk';
 import { EditYAML } from './edit-yaml';
 import withDragDropContext from './utils/drag-drop-context';
 import { DropTargetMonitor } from 'react-dnd/lib/interfaces';
-import { containsNonPrintableCharacters } from './utils/file-input';
+import * as ITOB from 'istextorbinary/edition-es2017';
 
 // Maximal file size, in bytes, that user can upload
 const maxFileUploadSize = 4000000;
@@ -82,19 +82,19 @@ export const DroppableEditYAML = withDragDropContext<DroppableEditYAMLProps>(
       if (file.size <= maxFileUploadSize) {
         const reader = new FileReader();
         reader.onload = () => {
-          const input = reader.result as string;
-          if (containsNonPrintableCharacters(input)) {
+          const buffer = Buffer.from(reader.result);
+          if (ITOB.isBinary(null, buffer)) {
             this.setState((previousState) => ({
               errors: [...previousState.errors, `Ignoring ${file.name}: ${fileTypeErrorMsg}`],
             }));
           } else {
-            this.addDocument(input.trim());
+            this.addDocument(buffer.toString().trim());
             if (lastFile) {
               this.setState({ fileUpload: this.fileUploadContents });
             }
           }
         };
-        reader.readAsText(file, 'UTF-8');
+        reader.readAsArrayBuffer(file);
       } else {
         this.setState((previousState) => ({
           errors: [...previousState.errors, `Ignoring ${file.name}: ${fileSizeErrorMsg}`],

--- a/frontend/public/components/secrets/create-secret/GenericSecretForm.tsx
+++ b/frontend/public/components/secrets/create-secret/GenericSecretForm.tsx
@@ -6,7 +6,7 @@ import { Base64 } from 'js-base64';
 import { Button } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
-import { containsNonPrintableCharacters } from '../../utils/file-input';
+import * as ITOB from 'istextorbinary/edition-es2017';
 import { KeyValueEntryFormState, KeyValueEntryForm } from '.';
 
 class GenericSecretFormWithTranslation extends React.Component<
@@ -34,7 +34,7 @@ class GenericSecretFormWithTranslation extends React.Component<
       return [this.newGenericSecretEntry()];
     }
     return _.map(genericSecretObject, (value, key) => {
-      const isBinary = containsNonPrintableCharacters(value);
+      const isBinary = ITOB.isBinary(null, value);
       return {
         uid: _.uniqueId(),
         entry: {

--- a/frontend/public/components/utils/file-input.tsx
+++ b/frontend/public/components/utils/file-input.tsx
@@ -13,14 +13,6 @@ import withDragDropContext from './drag-drop-context';
 // Maximal file size, in bytes, that user can upload
 const maxFileUploadSize = 4000000;
 
-export const containsNonPrintableCharacters = (value: string) => {
-  if (!value) {
-    return false;
-  }
-  // eslint-disable-next-line no-control-regex
-  return /[\x00-\x09\x0E-\x1F]/.test(value);
-};
-
 class FileInputWithTranslation extends React.Component<FileInputProps, FileInputState> {
   constructor(props) {
     super(props);
@@ -47,7 +39,7 @@ class FileInputWithTranslation extends React.Component<FileInputProps, FileInput
         ? (reader.result as string).split(',')[1]
         : (reader.result as string);
       // OnLoad, if inputFileIsBinary we have read as a binary string, skip next block
-      if (containsNonPrintableCharacters(input) && isBinary(null, input) && !fileIsBinary) {
+      if (isBinary(null, input) && !fileIsBinary) {
         fileIsBinary = true;
         reader.readAsDataURL(file);
       } else {
@@ -177,10 +169,7 @@ const DroppableFileInputWithTranslation = withDragDropContext(
       this.state = {
         inputFileName: '',
         inputFileData: this.props.inputFileData || '',
-        inputFileIsBinary:
-          this.props.inputFileIsBinary ||
-          (containsNonPrintableCharacters(this.props.inputFileData) &&
-            isBinary(null, this.props.inputFileData)),
+        inputFileIsBinary: this.props.inputFileIsBinary || isBinary(null, this.props.inputFileData),
       };
       this.handleFileDrop = this.handleFileDrop.bind(this);
       this.onDataChange = this.onDataChange.bind(this);
@@ -204,7 +193,7 @@ const DroppableFileInputWithTranslation = withDragDropContext(
       reader.onload = () => {
         const input = reader.result as string; // Note(Yaacov): we use reader.readAsText
         // OnLoad, if inputFileIsBinary we have read as a binary string, skip next block
-        if (containsNonPrintableCharacters(input) && isBinary(null, input) && !inputFileIsBinary) {
+        if (isBinary(null, input) && !inputFileIsBinary) {
           inputFileIsBinary = true;
           reader.readAsBinaryString(file);
         } else {


### PR DESCRIPTION
The `containsNonPrintableCharacters` function was improperly detecting strings with tab characters as non-printable. The 'istextorbinary' library has more extensive logic for detecting binary, so this PR removes our util function and updates all references to use the `isBinary` function from the 'istextorbinary' lib.