### PR TITLE
OCPBUGS-43799: Debounce tile view searches

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogToolbar.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogToolbar.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { SearchInput } from '@patternfly/react-core';
 import * as _ from 'lodash';
-import * as ReactDOM from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Dropdown } from '@console/internal/components/utils';
 import { useDebounceCallback } from '@console/shared';
@@ -20,7 +19,6 @@ type CatalogToolbarProps = {
   onSortOrderChange: (sortOrder: CatalogSortOrder) => void;
 };
 
-// TODO: update to use inputRef on SearchInput once https://github.com/patternfly/patternfly-react/issues/5168 is fixed.
 const CatalogToolbar = React.forwardRef<HTMLInputElement, CatalogToolbarProps>(
   (
     {
@@ -34,10 +32,9 @@ const CatalogToolbar = React.forwardRef<HTMLInputElement, CatalogToolbarProps>(
       onSearchKeywordChange,
       onSortOrderChange,
     },
-    toolbarRef,
+    inputRef,
   ) => {
     const { t } = useTranslation();
-    const inputRef = React.useRef<HTMLDivElement>();
 
     const catalogSortItems = {
       [CatalogSortOrder.ASC]: t('console-shared~A-Z'),
@@ -53,19 +50,13 @@ const CatalogToolbar = React.forwardRef<HTMLInputElement, CatalogToolbarProps>(
 
     const debouncedOnSearchKeywordChange = useDebounceCallback(onSearchKeywordChange);
 
-    React.useImperativeHandle(toolbarRef, () => {
-      // TODO: Remove this hack once https://github.com/patternfly/patternfly-react/issues/5168 is fixed.
-      // eslint-disable-next-line react/no-find-dom-node
-      const toolbarDOMNode = ReactDOM.findDOMNode(inputRef.current) as HTMLDivElement;
-      return toolbarDOMNode.querySelector('.pf-v5-c-search-input__text-input') as HTMLInputElement;
-    });
-
     return (
       <div className="co-catalog-page__header">
         <div className="co-catalog-page__heading text-capitalize">{title}</div>
         <div className="co-catalog-page__filter">
-          <div ref={inputRef} className="co-catalog-page__searchfilter">
+          <div className="co-catalog-page__searchfilter">
             <SearchInput
+              ref={inputRef}
               className="co-catalog-page__input"
               data-test="search-catalog"
               type="text"

--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogToolbar.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogToolbar.tsx
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 import * as ReactDOM from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Dropdown } from '@console/internal/components/utils';
+import { useDebounceCallback } from '@console/shared';
 import { NO_GROUPING } from '../utils/category-utils';
 import { CatalogSortOrder, CatalogStringMap } from '../utils/types';
 
@@ -50,6 +51,8 @@ const CatalogToolbar = React.forwardRef<HTMLInputElement, CatalogToolbarProps>(
       [NO_GROUPING]: t('console-shared~None'),
     };
 
+    const debouncedOnSearchKeywordChange = useDebounceCallback(onSearchKeywordChange);
+
     React.useImperativeHandle(toolbarRef, () => {
       // TODO: Remove this hack once https://github.com/patternfly/patternfly-react/issues/5168 is fixed.
       // eslint-disable-next-line react/no-find-dom-node
@@ -68,7 +71,7 @@ const CatalogToolbar = React.forwardRef<HTMLInputElement, CatalogToolbarProps>(
               type="text"
               placeholder={t('console-shared~Filter by keyword...')}
               value={searchKeyword}
-              onChange={(event, text) => onSearchKeywordChange(text)}
+              onChange={(_event, text) => debouncedOnSearchKeywordChange(text)}
               onClear={() => onSearchKeywordChange('')}
               aria-label={t('console-shared~Filter by keyword...')}
             />

--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogView.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogView.tsx
@@ -107,7 +107,6 @@ const CatalogView: React.FC<CatalogViewProps> = ({
 
     // Don't take focus if a modal was opened while the page was loading.
     if (!isModalOpen()) {
-      // this doesn't work right now because of issue with PF SearchInput
       catalogToolbarRef.current && catalogToolbarRef.current.focus({ preventScroll: true });
     }
   }, [catalogType, items.length]);

--- a/frontend/public/components/utils/tile-view-page.jsx
+++ b/frontend/public/components/utils/tile-view-page.jsx
@@ -21,7 +21,7 @@ import {
   EmptyStateHeader,
   EmptyStateFooter,
 } from '@patternfly/react-core';
-import { getURLWithParams, VirtualizedGrid } from '@console/shared';
+import { useDebounceCallback, getURLWithParams, VirtualizedGrid } from '@console/shared';
 import { Link, useSearchParams } from 'react-router-dom-v5-compat';
 import { isModifiedEvent } from '@console/shared/src/utils';
 
@@ -670,9 +670,9 @@ export const TileViewPage = (props) => {
     setFilterCounts(updatedState.filterCounts);
   };
 
-  const onKeywordChange = (value) => {
+  const onKeywordChange = useDebounceCallback((value) => {
     onFilterChange('keyword', null, value);
-  };
+  });
 
   const onShowAllToggle = (groupName) => {
     const updatedShow = _.clone(filterGroupsShowAll);


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
Fixes: https://issues.redhat.com/browse/OCPBUGS-43799

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
when searching in tile catalogs such as OperatorHub or the Samples catalog, the input is not debounced so all the filtering logic happens on each keystroke

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
debounce for 300ms

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
n/a

**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
n/a

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
