### PR TITLE
OCPBUGS-41904: fix annotation for ovn localnet

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
@@ -100,6 +100,12 @@ const buildConfig = (
 const getResourceName = (networkType, typeParamsData): string => {
   if (_.isEmpty(typeParamsData)) return null;
 
+  if (
+    _.isEmpty(_.get(typeParamsData, 'resourceName.value', '')) &&
+    _.isEmpty(_.get(typeParamsData, 'bridge.value', ''))
+  )
+    return null;
+
   return networkType === bridgeNetworkType
     ? `bridge.network.kubevirt.io/${_.get(typeParamsData, 'bridge.value', '')}`
     : `openshift.io/${_.get(typeParamsData, 'resourceName.value', '')}`;


### PR DESCRIPTION
Do not add annotations for ovn localnet. 
So make sure `typeParamsData` has `resourceName.value` or `bridge.value` . In case of ovn localnet does not have those fields.