### PR TITLE
OCPBUGS-42782: Add missing pipelines plugin name to known plugins

### DIFF
--- a/pkg/serverconfig/metrics.go
+++ b/pkg/serverconfig/metrics.go
@@ -77,6 +77,7 @@ var knownPluginNames = map[string]MappedPluginName{
 	"odf-console":                     "odf",
 	"odf-multicluster-console":        "odf-multicluster",
 	"pipeline-console-plugin":         "pipelines",
+	"pipelines-console-plugin":        "pipelines",
 
 	// Unchanged template name from https://github.com/openshift/console-plugin-template
 	"console-plugin-template": "demo",


### PR DESCRIPTION
Solves an issue that the pipelines plugin (installed with the OpenShift Pipelines operator) was reported as "unknown" instead of "pipelines" after the plugin was renamed.

![image](https://github.com/user-attachments/assets/33108a0c-b7c2-4dfe-a6c2-9ef1313af1fe)


/cc @spadgett @jhadvig @vikram-raj 
/king bug