### PR TITLE
CONSOLE-4125,CONSOLE-4294: Replace SelectDeprecated component in user preferences PerspectiveDropdown

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -524,7 +524,7 @@
       "description": "%console-app~If a perspective is not selected, the console defaults to the last viewed.%",
       "field": {
         "type": "custom",
-        "component": { "$codeRef": "userPreferences.PerspectiveDropdown" }
+        "component": { "$codeRef": "userPreferences.PreferredPerspectiveSelect" }
       },
       "insertAfter": "console.theme"
     }

--- a/frontend/packages/console-app/src/components/user-preferences/perspective/PreferredPerspectiveSelect.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/perspective/PreferredPerspectiveSelect.tsx
@@ -13,7 +13,7 @@ import {
   usePreferredPerspective,
 } from './usePreferredPerspective';
 
-const PerspectiveDropdown: React.FC = () => {
+const PreferrredPerspectiveSelect: React.FC = () => {
   // resources and calls to hooks
   const { t } = useTranslation();
   const fireTelemetryEvent = useTelemetry();
@@ -89,4 +89,4 @@ const PerspectiveDropdown: React.FC = () => {
   );
 };
 
-export default PerspectiveDropdown;
+export default PreferrredPerspectiveSelect;

--- a/frontend/packages/console-app/src/components/user-preferences/perspective/__tests__/PreferredPerspectiveSelect.spec.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/perspective/__tests__/PreferredPerspectiveSelect.spec.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Select as SelectDeprecated } from '@patternfly/react-core/deprecated';
-import { shallow, ShallowWrapper } from 'enzyme';
+import { render, screen, configure } from '@testing-library/react';
 import { useExtensions } from '@console/plugin-sdk/src';
 import PreferredPerspectiveSelect from '../PreferredPerspectiveSelect';
 import { usePreferredPerspective } from '../usePreferredPerspective';
@@ -21,8 +20,11 @@ jest.mock('@console/shared/src/hooks/useTelemetry', () => ({
 const useExtensionsMock = useExtensions as jest.Mock;
 const usePreferredPerspectiveMock = usePreferredPerspective as jest.Mock;
 
-describe('PerspectiveDropdown', () => {
-  let wrapper: ShallowWrapper;
+describe('PreferredPerspectiveSelect', () => {
+  configure({
+    testIdAttribute: 'data-test',
+  });
+
   const {
     id: preferredPerspectiveValue,
     name: preferredPerspectiveLabel,
@@ -35,29 +37,23 @@ describe('PerspectiveDropdown', () => {
   it('should render skeleton if user preferences have not loaded', () => {
     useExtensionsMock.mockReturnValue(mockPerspectiveExtensions);
     usePreferredPerspectiveMock.mockReturnValue(['', jest.fn(), false]);
-    wrapper = shallow(<PreferredPerspectiveSelect />);
-    expect(
-      wrapper.find('[data-test="dropdown skeleton console.preferredPerspective"]').exists(),
-    ).toBeTruthy();
+    render(<PreferredPerspectiveSelect />);
+    expect(screen.findByTestId('select skeleton console.preferredPerspective')).toBeTruthy();
   });
 
   it('should render select with value corresponding to preferred perspective if user preferences have loaded and preferred perspective is defined', () => {
     useExtensionsMock.mockReturnValue(mockPerspectiveExtensions);
     usePreferredPerspectiveMock.mockReturnValue([preferredPerspectiveValue, jest.fn(), true]);
-    wrapper = shallow(<PreferredPerspectiveSelect />);
-    expect(
-      wrapper.find('[data-test="dropdown console.preferredPerspective"]').exists(),
-    ).toBeTruthy();
-    expect(wrapper.find(SelectDeprecated).props().selections).toBe(preferredPerspectiveLabel);
+    render(<PreferredPerspectiveSelect />);
+    expect(screen.findByTestId('select console.preferredPerspective')).toBeTruthy();
+    expect(screen.findByText(preferredPerspectiveLabel)).toBeTruthy();
   });
 
   it('should render select with value "Last viewed" if user preferences have loaded but preferred perspective is not defined', () => {
     useExtensionsMock.mockReturnValue(mockPerspectiveExtensions);
     usePreferredPerspectiveMock.mockReturnValue([undefined, jest.fn(), true]);
-    wrapper = shallow(<PreferredPerspectiveSelect />);
-    expect(
-      wrapper.find('[data-test="dropdown console.preferredPerspective"]').exists(),
-    ).toBeTruthy();
-    expect(wrapper.find(SelectDeprecated).props().selections).toEqual('Last viewed');
+    render(<PreferredPerspectiveSelect />);
+    expect(screen.findByTestId('select console.preferredPerspective"]')).toBeTruthy();
+    expect(screen.findByText('Last viewed')).toBeTruthy();
   });
 });

--- a/frontend/packages/console-app/src/components/user-preferences/perspective/__tests__/PreferredPerspectiveSelect.spec.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/perspective/__tests__/PreferredPerspectiveSelect.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Select as SelectDeprecated } from '@patternfly/react-core/deprecated';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { useExtensions } from '@console/plugin-sdk/src';
-import PerspectiveDropdown from '../PerspectiveDropdown';
+import PreferredPerspectiveSelect from '../PreferredPerspectiveSelect';
 import { usePreferredPerspective } from '../usePreferredPerspective';
 import { mockPerspectiveExtensions } from './perspective.data';
 
@@ -35,7 +35,7 @@ describe('PerspectiveDropdown', () => {
   it('should render skeleton if user preferences have not loaded', () => {
     useExtensionsMock.mockReturnValue(mockPerspectiveExtensions);
     usePreferredPerspectiveMock.mockReturnValue(['', jest.fn(), false]);
-    wrapper = shallow(<PerspectiveDropdown />);
+    wrapper = shallow(<PreferredPerspectiveSelect />);
     expect(
       wrapper.find('[data-test="dropdown skeleton console.preferredPerspective"]').exists(),
     ).toBeTruthy();
@@ -44,7 +44,7 @@ describe('PerspectiveDropdown', () => {
   it('should render select with value corresponding to preferred perspective if user preferences have loaded and preferred perspective is defined', () => {
     useExtensionsMock.mockReturnValue(mockPerspectiveExtensions);
     usePreferredPerspectiveMock.mockReturnValue([preferredPerspectiveValue, jest.fn(), true]);
-    wrapper = shallow(<PerspectiveDropdown />);
+    wrapper = shallow(<PreferredPerspectiveSelect />);
     expect(
       wrapper.find('[data-test="dropdown console.preferredPerspective"]').exists(),
     ).toBeTruthy();
@@ -54,7 +54,7 @@ describe('PerspectiveDropdown', () => {
   it('should render select with value "Last viewed" if user preferences have loaded but preferred perspective is not defined', () => {
     useExtensionsMock.mockReturnValue(mockPerspectiveExtensions);
     usePreferredPerspectiveMock.mockReturnValue([undefined, jest.fn(), true]);
-    wrapper = shallow(<PerspectiveDropdown />);
+    wrapper = shallow(<PreferredPerspectiveSelect />);
     expect(
       wrapper.find('[data-test="dropdown console.preferredPerspective"]').exists(),
     ).toBeTruthy();

--- a/frontend/packages/console-app/src/components/user-preferences/perspective/index.ts
+++ b/frontend/packages/console-app/src/components/user-preferences/perspective/index.ts
@@ -1,2 +1,2 @@
-export { default as PerspectiveDropdown } from './PerspectiveDropdown';
+export { default as PreferredPerspectiveSelect } from './PreferredPerspectiveSelect';
 export * from './usePreferredPerspective';


### PR DESCRIPTION
- Rename PerspectiveDropdown to PreferredPerspectiveSelect
- Refactor PreferredPerspectiveSelect to use supported PF Select component
- Update unit tests to use RTL