### PR TITLE
OCPBUGS-41358: While upgrading the cluster from UI observed `Warning alert:Admission Webhook Warning`

### DIFF
--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -70,8 +70,8 @@ import {
   getSimilarClusterVersionChannels,
   getSortedAvailableUpdates,
   referenceForModel,
-  Release,
   splitClusterVersionChannel,
+  VersionUpdate,
 } from '../module/k8s';
 import { pluginStore } from '../plugins';
 import { LinkifyExternal } from './utils';
@@ -147,7 +147,7 @@ const getUpdateNotificationEntries = (
   if (!cv || !canUpgrade) {
     return [];
   }
-  const updateData: Release[] = getSortedAvailableUpdates(cv);
+  const updateData: VersionUpdate[] = getSortedAvailableUpdates(cv);
   const currentChannel = cv?.spec?.channel;
   const currentPrefix = splitClusterVersionChannel(currentChannel)?.prefix;
   const similarChannels = getSimilarClusterVersionChannels(cv, currentPrefix);

--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -12,8 +12,8 @@ import {
   k8sPatch,
   K8sResourceCondition,
   K8sResourceConditionStatus,
-  Release,
   UpdateHistory,
+  VersionUpdate,
 } from '.';
 import { MachineConfigPoolKind } from './types';
 
@@ -30,11 +30,10 @@ export enum ClusterUpdateStatus {
 
 export const clusterVersionReference = referenceForModel(ClusterVersionModel);
 
-const getAvailableClusterUpdates = (cv: ClusterVersionKind): Release[] => {
-  return cv?.status?.availableUpdates || [];
-};
+const getAvailableClusterUpdates = (cv: ClusterVersionKind): VersionUpdate[] =>
+  cv?.status?.availableUpdates?.map((update) => _.pick(update, ['version', 'image'])) || [];
 
-export const getSortedAvailableUpdates = (cv: ClusterVersionKind): Release[] => {
+export const getSortedAvailableUpdates = (cv: ClusterVersionKind): VersionUpdate[] => {
   const available = getAvailableClusterUpdates(cv);
   try {
     return available.sort(({ version: left }, { version: right }) => semver.rcompare(left, right));

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -807,6 +807,8 @@ export type Release = {
   channels?: string[];
 };
 
+export type VersionUpdate = { version?: string; image?: string };
+
 export type ConditionalUpdate = {
   release: Release;
   conditions: K8sResourceCondition[];
@@ -841,7 +843,7 @@ type ClusterVersionStatus = {
   observedGeneration: number;
   versionHash: string;
   conditions?: ClusterVersionCondition[];
-  availableUpdates: Release[];
+  availableUpdates?: VersionUpdate[];
   conditionalUpdates?: ConditionalUpdate[];
 };
 


### PR DESCRIPTION
### Comparing ClusterVersion responses

**Cluster version 4.16** 
<img width="958" alt="Screenshot 2024-10-15 at 11 18 34 AM" src="https://github.com/user-attachments/assets/d531f769-9738-4667-9c28-c56635db510e">

**Root cause:**
The 4.16 cluster version response includes `cv?.status?.availableUpdates.channels` and `cv?.status?.availableUpdates.url` which is causing the issue.

**Fix**
The incorrect properties in the cluster cluster version request payload are removed before invoking the update cluster action. 


**Cluster version 4.18** 
This issue is not happening in 4.18. It seems the change in the API was not backported to 4.16
<img width="963" alt="Screenshot 2024-10-15 at 11 17 14 AM" src="https://github.com/user-attachments/assets/c1897755-4105-42cd-a43d-ae92dd97f229">