### PR TITLE
OCPBUGS-42796: Do not pass CSV name to operand list page when an exen…

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -574,6 +574,7 @@ export const ProvidedAPIPage = (props: ProvidedAPIPageProps) => {
   return resourceListPage ? (
     <AsyncComponent
       {...props}
+      name={null}
       model={{ group, version, kind }}
       kind={props.kind}
       namespace={namespace}


### PR DESCRIPTION
…sion is provided.

This was causing some operand list page extensions to fail where props were spread into a ListPage component. The 'name' prop causes the list to be filtered by the CSV name, which will almost always make it empty.