### PR TITLE
OCPBUGS-43039: Broker form view by default throws error in Application name if an application exists

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/brokers/add-broker-utils.ts
+++ b/frontend/packages/knative-plugin/src/components/add/brokers/add-broker-utils.ts
@@ -47,7 +47,7 @@ export const addBrokerInitialValues = (
     application: {
       initial: sanitizeApplicationValue(selectedApplication),
       name: sanitizeApplicationValue(selectedApplication) || EVENT_BROKER_APP,
-      selectedKey: selectedApplication,
+      selectedKey: selectedApplication || '',
     },
   };
   const initialYamlData: string = safeJSToYAML(


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-43039

**Analysis / Root cause**: 
`application.selectedKey` can be null also if user specify no application grouping, but the schema always expecting string

**Solution Description**: 
Updated the initial value for broker form to accept null as well along with string for `application.selectedKey`
  
**Screen shots / Gifs for design review**: 

----BEFORE---

https://github.com/user-attachments/assets/7bafd1bd-aaa5-4fcd-9c73-0f5e57fe1ec0





---AFTER----

https://github.com/user-attachments/assets/07045e0a-d0b3-4796-91fa-2ac9674580ee










**Unit test coverage report**: 
NA

**Test setup:**

    1. Install serverless operator
    2. Create any application in a namespace 
    3. Now open broker in form view
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge




