### PR TITLE
CONSOLE-4266: Fix CSP inline script tag error in Console HTML template

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,34 +1,34 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
   <head>
-    <base href="[[ .BasePath ]]" />
+    <base href="[[ .ServerFlags.BasePath ]]" />
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    [[ if .CustomProductName ]]
-    <title>[[ .CustomProductName ]]</title>
-    <meta name="application-name" content="[[ .CustomProductName ]]" />
-    [[ else ]] [[ if eq .Branding "okd" ]]
+    [[ if .ServerFlags.CustomProductName ]]
+    <title>[[ .ServerFlags.CustomProductName ]]</title>
+    <meta name="application-name" content="[[ .ServerFlags.CustomProductName ]]" />
+    [[ else ]] [[ if eq .ServerFlags.Branding "okd" ]]
     <title>OKD</title>
     <meta name="application-name" content="OKD" />
-    [[ end ]] [[ if eq .Branding "openshift" ]]
+    [[ end ]] [[ if eq .ServerFlags.Branding "openshift" ]]
     <title>Red Hat OpenShift</title>
     <meta name="application-name" content="Red Hat OpenShift" />
-    [[ end ]] [[ if eq .Branding "ocp" ]]
+    [[ end ]] [[ if eq .ServerFlags.Branding "ocp" ]]
     <title>Red Hat OpenShift</title>
     <meta name="application-name" content="Red Hat OpenShift" />
-    [[ end ]] [[ if eq .Branding "online" ]]
+    [[ end ]] [[ if eq .ServerFlags.Branding "online" ]]
     <title>Red Hat OpenShift Online</title>
     <meta name="application-name" content="Red Hat OpenShift Online" />
-    [[ end ]] [[ if eq .Branding "dedicated" ]]
+    [[ end ]] [[ if eq .ServerFlags.Branding "dedicated" ]]
     <title>Red Hat OpenShift Dedicated</title>
     <meta name="application-name" content="Red Hat OpenShift Dedicated" />
-    [[ end ]] [[ if eq .Branding "azure" ]]
+    [[ end ]] [[ if eq .ServerFlags.Branding "azure" ]]
     <title>Azure Red Hat OpenShift</title>
     <meta name="application-name" content="Azure Red Hat OpenShift" />
-    [[ end ]] [[ if eq .Branding "rosa" ]]
+    [[ end ]] [[ if eq .ServerFlags.Branding "rosa" ]]
     <title>Red Hat OpenShift Service on AWS</title>
     <meta name="application-name" content="Red Hat OpenShift Service on AWS" />
-    [[ end ]] [[ if eq .Branding "okd" ]]
+    [[ end ]] [[ if eq .ServerFlags.Branding "okd" ]]
     <link rel="shortcut icon" href="<%= require('./imgs/okd-favicon.png') %>" />
     <link
       rel="apple-touch-icon-precomposed"
@@ -58,8 +58,8 @@
 
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script type="text/javascript">
-      window.SERVER_FLAGS = [[.]];
+    <script type="text/javascript" nonce="[[ .ScriptNonce ]]">
+      window.SERVER_FLAGS = [[ .ServerFlags ]];
       let theme = localStorage.getItem('bridge/theme') || 'systemDefault';
       if (theme === 'systemDefault' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
         theme = 'dark';

--- a/pkg/auth/oauth2/auth_oidc_test.go
+++ b/pkg/auth/oauth2/auth_oidc_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openshift/console/pkg/auth"
 	"github.com/openshift/console/pkg/auth/sessions"
 	"github.com/openshift/console/pkg/metrics"
+	consoleUtils "github.com/openshift/console/pkg/utils"
 )
 
 const (
@@ -657,20 +658,12 @@ func BenchmarkRefreshSession(b *testing.B) {
 	}
 }
 
-func randomBytes(size int) []byte {
-	b := make([]byte, size)
-	if _, err := rand.Read(b); err != nil {
-		panic(err) // rand should never fail
-	}
-	return b
-}
-
 func randomString(size int) string {
-	// each byte (8 bits) gives us 4/3 base64 (6 bits) characters
-	// we account for that conversion and add one to handle truncation
-	b64size := base64.RawURLEncoding.DecodedLen(size) + 1
-	// trim down to the original requested size since we added one above
-	return base64.RawURLEncoding.EncodeToString(randomBytes(b64size))[:size]
+	str, err := consoleUtils.RandomString(size)
+	if err != nil {
+		panic(err) // should never fail
+	}
+	return str
 }
 
 func addIDToken(t *oauth2.Token, idtoken string) *oauth2.Token {

--- a/pkg/auth/sessions/combined_sessions_test.go
+++ b/pkg/auth/sessions/combined_sessions_test.go
@@ -1,8 +1,6 @@
 package sessions
 
 import (
-	"crypto/rand"
-	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -11,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/securecookie"
+	consoleUtils "github.com/openshift/console/pkg/utils"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 	utilptr "k8s.io/utils/ptr"
@@ -274,20 +273,12 @@ func addIDToken(t *oauth2.Token, idtoken string) *oauth2.Token {
 	return t
 }
 
-func randomBytes(size int) []byte {
-	b := make([]byte, size)
-	if _, err := rand.Read(b); err != nil {
-		panic(err) // rand should never fail
-	}
-	return b
-}
-
 func randomString(size int) string {
-	// each byte (8 bits) gives us 4/3 base64 (6 bits) characters
-	// we account for that conversion and add one to handle truncation
-	b64size := base64.RawURLEncoding.DecodedLen(size) + 1
-	// trim down to the original requested size since we added one above
-	return base64.RawURLEncoding.EncodeToString(randomBytes(b64size))[:size]
+	str, err := consoleUtils.RandomString(size)
+	if err != nil {
+		panic(err) // should never fail
+	}
+	return str
 }
 
 func TestCombinedSessionStore_UpdateTokens(t *testing.T) {

--- a/pkg/auth/sessions/server_session.go
+++ b/pkg/auth/sessions/server_session.go
@@ -1,18 +1,16 @@
 package sessions
 
 import (
-	"crypto/rand"
-	"encoding/base64"
 	"fmt"
 	"slices"
 	"sort"
 	"sync"
 	"time"
 
+	consoleUtils "github.com/openshift/console/pkg/utils"
 	"golang.org/x/oauth2"
-	"k8s.io/klog/v2"
-
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -175,12 +173,11 @@ func (ss *SessionStore) pruneSessions() {
 func loginStateSorter(a, b *LoginState) int { return a.CompareExpiry(b) }
 
 func RandomString(length int) string {
-	bytes := make([]byte, length)
-	_, err := rand.Read(bytes)
+	str, err := consoleUtils.RandomString(length)
 	if err != nil {
 		panic(fmt.Sprintf("FATAL ERROR: Unable to get random bytes for session token: %v", err))
 	}
-	return base64.StdEncoding.EncodeToString(bytes)
+	return str
 }
 
 func spliceOut(slice []*LoginState, toRemove *LoginState) []*LoginState {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+)
+
+// Generate a cryptographically secure random array of bytes.
+func RandomBytes(length int) ([]byte, error) {
+	bytes := make([]byte, length)
+	_, err := rand.Read(bytes)
+	return bytes, err
+}
+
+// Generate a cryptographically secure random string.
+// Returned string is encoded using [encoding.RawURLEncoding]
+// which makes it safe to use in URLs and file names.
+func RandomString(length int) (string, error) {
+	encoding := base64.RawURLEncoding
+	// each byte (8 bits) gives us 4/3 base64 (6 bits) characters,
+	// we account for that conversion and add one to handle truncation
+	b64size := encoding.DecodedLen(length) + 1
+	randomBytes, err := RandomBytes(b64size)
+	// trim down to the original requested size since we added one above
+	return encoding.EncodeToString(randomBytes)[:length], err
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -21,6 +21,9 @@ func RandomString(length int) (string, error) {
 	// we account for that conversion and add one to handle truncation
 	b64size := encoding.DecodedLen(length) + 1
 	randomBytes, err := RandomBytes(b64size)
+	if err != nil {
+		return "", err
+	}
 	// trim down to the original requested size since we added one above
-	return encoding.EncodeToString(randomBytes)[:length], err
+	return encoding.EncodeToString(randomBytes)[:length], nil
 }


### PR DESCRIPTION
This PR addresses a [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) violation due to [Console HTML index template](https://github.com/openshift/console/blob/master/frontend/public/index.html) containing an inline `<script>` tag.

![](https://github.com/user-attachments/assets/135b90f9-2214-4a52-943d-56cc06dbfb79)

By default, CSP standard treats inline `<script>` tags as [unsafe](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script).

This particular `<script>` tag is part of the Console application, so we allow it within our policy via the [nonce](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#nonce) attribute.

> A cryptographic nonce (number used once) to allow scripts in a [script-src Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src). The server must generate a unique nonce value each time it transmits a policy. It is critical to provide a nonce that cannot be guessed as bypassing a resource's policy is otherwise trivial.

This PR also does a bit of refactoring around `crypto/rand` related functions, removing code duplication.

### 1. Basic verification steps

1. `git clone` Console repo, switch to latest `master` branch, build Console backend and frontend, `oc login` to cluster and run the Bridge server (enabling [dynamic demo plugin](https://github.com/openshift/console/tree/master/dynamic-demo-plugin) is **_not_** necessary). Visit `http://localhost:9000/` in your browser, the above CSP error :point_up:  should appear in browser dev tools "Console" tab.
1. Apply changes from this PR, rebuild Console backend (rebuilding frontend is **_not_** necessary) and rerun the Bridge server. Open Console in your web browser, the CSP error as mentioned above should not appear.

### 2. CSP standard compliance verification steps

1. Inspect HTML and check the presence of `nonce` attribute on the inline `<script>` tag.

![](https://github.com/user-attachments/assets/7c4de387-d502-4b7d-8163-de75a8168b29)

2. Inspect network activity and check the presence of `'nonce-{value}'` within the CSP response header.

![](https://github.com/user-attachments/assets/e9ab97f1-fdcc-43c3-8129-aab10d17a28b)

3. Reload the page and repeat steps 1. and 2. above. **The `nonce` value should be different upon each reload.**

cc @jhadvig @spadgett 