### PR TITLE
add data-test attribute for Pod and Node logs toggle button

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
@@ -108,6 +108,7 @@ const LogControls: React.FC<LogControlsProps> = ({
                   ref={toggleRef}
                   onClick={onTogglePath}
                   aria-label={t('public~Select a path')}
+                  data-test="select-path"
                 >
                   {path}
                 </MenuToggle>
@@ -129,7 +130,11 @@ const LogControls: React.FC<LogControlsProps> = ({
                     isOpen={isFilenameOpen}
                     className="co-node-logs__log-select"
                     toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                      <MenuToggle ref={toggleRef} onClick={onToggleFilename}>
+                      <MenuToggle
+                        ref={toggleRef}
+                        onClick={onToggleFilename}
+                        data-test="select-file"
+                      >
                         {logFilename || t('public~Select a log file')}
                       </MenuToggle>
                     )}

--- a/frontend/public/components/utils/container-select.tsx
+++ b/frontend/public/components/utils/container-select.tsx
@@ -61,7 +61,12 @@ export const ContainerSelect: React.FC<ContainerSelectProps> = ({
       onSelect={onSelect}
       onOpenChange={(open) => setIsOpen(open)}
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-        <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+        <MenuToggle
+          ref={toggleRef}
+          onClick={onToggleClick}
+          isExpanded={isOpen}
+          data-test="container-select"
+        >
           <ContainerLabel name={selected} />
         </MenuToggle>
       )}


### PR DESCRIPTION
after the changes

container selector toggle button on pod logs page will have:
```
<button class="pf-v5-c-menu-toggle" type="button" aria-expanded="false" data-test="container-select">......</button>
```


toggle buttons on node logs page will have:
```
<button class="pf-v5-c-menu-toggle" type="button" aria-label="Select a path" aria-expanded="false" data-test="select-path"> .....</button>
```
```
<button class="pf-v5-c-menu-toggle" type="button" aria-expanded="false" data-test="select-file">...</button>
```