### PR TITLE
OCPBUGS-43409: 'control plane' option is missing on 'filter node type' list

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/utilization-card.tsx
@@ -236,16 +236,19 @@ const UtilizationCardNodeFilter: React.FC<UtilizationCardNodeFilterProps> = ({
     return indexA - indexB;
   });
 
-  const selectOptions = sortedMCPs.map((mcp) => (
-    <SelectOption
-      hasCheckbox
-      key={mcp.metadata.name}
-      value={mcp.metadata.name === 'master' ? 'control plane' : mcp.metadata.name}
-      isSelected={selectedNodes.includes(mcp.metadata.name)}
-    >
-      {mcp.metadata.name}
-    </SelectOption>
-  ));
+  const selectOptions = sortedMCPs.map((mcp) => {
+    const mcpName = mcp.metadata.name === 'master' ? 'control plane' : mcp.metadata.name;
+    return (
+      <SelectOption
+        hasCheckbox
+        key={mcp.metadata.name}
+        value={mcpName}
+        isSelected={selectedNodes.includes(mcp.metadata.name)}
+      >
+        {mcpName}
+      </SelectOption>
+    );
+  });
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle ref={toggleRef} onClick={(open) => setIsOpen(open)} variant="plainText">


### PR DESCRIPTION
Analysis: The name metadata adjusted to not use the word 'master' for the MachineConfigPool was not passed as a children to the SelectOption

Resolution: Pass the adjusted value
Before:
![Screenshot 2024-10-17 at 14 17 08](https://github.com/user-attachments/assets/ae45ce01-55b3-4318-af73-453b12812ff2)

After:
![Screenshot 2024-10-17 at 14 16 23](https://github.com/user-attachments/assets/1972ee94-6680-4785-b421-0d78fc5c80ae)
![Screenshot 2024-10-17 at 14 16 27](https://github.com/user-attachments/assets/92cdc3fa-22d1-4d49-adc0-3734fb63b323)
