### PR TITLE
OCPBUGS-23924: Render TaskRun results even when failed

### DIFF
--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -430,8 +430,6 @@
   "No options matching your criteria": "No options matching your criteria",
   "No Output found": "No Output found",
   "{{resourceName}} results": "{{resourceName}} results",
-  "{{resourceName}} failed": "{{resourceName}} failed",
-  "Results may be incomplete due to failure. ": "Results may be incomplete due to failure. ",
   "No {{resourceName}} results available due to failure": "No {{resourceName}} results available due to failure",
   "Empty Directories": "Empty Directories",
   "Empty Directory ({{workspaceName}})": "Empty Directory ({{workspaceName}})",

--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -430,6 +430,8 @@
   "No options matching your criteria": "No options matching your criteria",
   "No Output found": "No Output found",
   "{{resourceName}} results": "{{resourceName}} results",
+  "{{resourceName}} failed": "{{resourceName}} failed",
+  "Results may be incomplete due to failure. ": "Results may be incomplete due to failure. ",
   "No {{resourceName}} results available due to failure": "No {{resourceName}} results available due to failure",
   "Empty Directories": "Empty Directories",
   "Empty Directory ({{workspaceName}})": "Empty Directory ({{workspaceName}})",

--- a/frontend/packages/pipelines-plugin/src/components/shared/results/ResultsList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/results/ResultsList.tsx
@@ -19,7 +19,7 @@ const ResultsList: React.FC<ResultsListProps> = ({ results, resourceName, status
   return (
     <>
       <SectionHeading text={t('pipelines-plugin~{{resourceName}} results', { resourceName })} />
-      {status !== ComputedStatus.Failed ? (
+      {results.length ? (
         <Table aria-label={t('pipelines-plugin~{{resourceName}} results', { resourceName })}>
           <Thead>
             <Tr>
@@ -37,15 +37,17 @@ const ResultsList: React.FC<ResultsListProps> = ({ results, resourceName, status
           </Tbody>
         </Table>
       ) : (
-        <Bullseye>
-          <EmptyState variant={EmptyStateVariant.full}>
-            <EmptyStateBody>
-              {t('pipelines-plugin~No {{resourceName}} results available due to failure', {
-                resourceName,
-              })}
-            </EmptyStateBody>
-          </EmptyState>
-        </Bullseye>
+        status !== ComputedStatus.Failed && (
+          <Bullseye>
+            <EmptyState variant={EmptyStateVariant.full}>
+              <EmptyStateBody>
+                {t('pipelines-plugin~No {{resourceName}} results available due to failure', {
+                  resourceName,
+                })}
+              </EmptyStateBody>
+            </EmptyState>
+          </Bullseye>
+        )
       )}
     </>
   );

--- a/frontend/packages/pipelines-plugin/src/components/shared/results/ResultsList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/results/ResultsList.tsx
@@ -1,14 +1,7 @@
 import * as React from 'react';
-import {
-  Alert,
-  Bullseye,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateVariant,
-} from '@patternfly/react-core';
+import { Bullseye, EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
 import { Table, Thead, Tbody, Th, Td, Tr } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
 import { SectionHeading } from '@console/internal/components/utils';
 import { ComputedStatus, TektonResultsRun } from '../../../types';
 import { handleURLs } from '../../../utils/render-utils';
@@ -20,50 +13,35 @@ export interface ResultsListProps {
 }
 
 const ResultsList: React.FC<ResultsListProps> = ({ results, resourceName, status }) => {
-  const { t } = useTranslation('pipelines-plugin');
+  const { t } = useTranslation();
   if (!results.length) return null;
 
   return (
     <>
-      <SectionHeading text={t('{{resourceName}} results', { resourceName })} />
+      <SectionHeading text={t('pipelines-plugin~{{resourceName}} results', { resourceName })} />
       {results.length ? (
-        <>
-          {status === ComputedStatus.Failed && (
-            <Alert
-              variant="danger"
-              title={t('{{resourceName}} failed', {
-                resourceName,
-              })}
-            >
-              <p>
-                {t('Results may be incomplete due to failure. ')}
-                <Link to="./logs">{t('View logs')}</Link>
-              </p>
-            </Alert>
-          )}
-          <Table aria-label={t('{{resourceName}} results', { resourceName })}>
-            <Thead>
-              <Tr>
-                <Th>{t('Name')}</Th>
-                <Th>{t('Value')}</Th>
+        <Table aria-label={t('pipelines-plugin~{{resourceName}} results', { resourceName })}>
+          <Thead>
+            <Tr>
+              <Th>{t('pipelines-plugin~Name')}</Th>
+              <Th>{t('pipelines-plugin~Value')}</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {results.map(({ name, value }) => (
+              <Tr key={`row-${name}`}>
+                <Td>{name}</Td>
+                <Td>{handleURLs(value)}</Td>
               </Tr>
-            </Thead>
-            <Tbody>
-              {results.map(({ name, value }) => (
-                <Tr key={`row-${name}`}>
-                  <Td>{name}</Td>
-                  <Td>{handleURLs(value)}</Td>
-                </Tr>
-              ))}
-            </Tbody>
-          </Table>
-        </>
+            ))}
+          </Tbody>
+        </Table>
       ) : (
         status !== ComputedStatus.Failed && (
           <Bullseye>
             <EmptyState variant={EmptyStateVariant.full}>
               <EmptyStateBody>
-                {t('No {{resourceName}} results available due to failure', {
+                {t('pipelines-plugin~No {{resourceName}} results available due to failure', {
                   resourceName,
                 })}
               </EmptyStateBody>

--- a/frontend/packages/pipelines-plugin/src/components/shared/results/ResultsList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/results/ResultsList.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react';
-import { Bullseye, EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
+import {
+  Alert,
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+} from '@patternfly/react-core';
 import { Table, Thead, Tbody, Th, Td, Tr } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import { SectionHeading } from '@console/internal/components/utils';
 import { ComputedStatus, TektonResultsRun } from '../../../types';
 import { handleURLs } from '../../../utils/render-utils';
@@ -13,35 +20,50 @@ export interface ResultsListProps {
 }
 
 const ResultsList: React.FC<ResultsListProps> = ({ results, resourceName, status }) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation('pipelines-plugin');
   if (!results.length) return null;
 
   return (
     <>
-      <SectionHeading text={t('pipelines-plugin~{{resourceName}} results', { resourceName })} />
+      <SectionHeading text={t('{{resourceName}} results', { resourceName })} />
       {results.length ? (
-        <Table aria-label={t('pipelines-plugin~{{resourceName}} results', { resourceName })}>
-          <Thead>
-            <Tr>
-              <Th>{t('pipelines-plugin~Name')}</Th>
-              <Th>{t('pipelines-plugin~Value')}</Th>
-            </Tr>
-          </Thead>
-          <Tbody>
-            {results.map(({ name, value }) => (
-              <Tr key={`row-${name}`}>
-                <Td>{name}</Td>
-                <Td>{handleURLs(value)}</Td>
+        <>
+          {status === ComputedStatus.Failed && (
+            <Alert
+              variant="danger"
+              title={t('{{resourceName}} failed', {
+                resourceName,
+              })}
+            >
+              <p>
+                {t('Results may be incomplete due to failure. ')}
+                <Link to="./logs">{t('View logs')}</Link>
+              </p>
+            </Alert>
+          )}
+          <Table aria-label={t('{{resourceName}} results', { resourceName })}>
+            <Thead>
+              <Tr>
+                <Th>{t('Name')}</Th>
+                <Th>{t('Value')}</Th>
               </Tr>
-            ))}
-          </Tbody>
-        </Table>
+            </Thead>
+            <Tbody>
+              {results.map(({ name, value }) => (
+                <Tr key={`row-${name}`}>
+                  <Td>{name}</Td>
+                  <Td>{handleURLs(value)}</Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        </>
       ) : (
         status !== ComputedStatus.Failed && (
           <Bullseye>
             <EmptyState variant={EmptyStateVariant.full}>
               <EmptyStateBody>
-                {t('pipelines-plugin~No {{resourceName}} results available due to failure', {
+                {t('No {{resourceName}} results available due to failure', {
                   resourceName,
                 })}
               </EmptyStateBody>

--- a/frontend/packages/pipelines-plugin/src/components/shared/results/__tests__/ResultsList.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/results/__tests__/ResultsList.spec.tsx
@@ -23,14 +23,14 @@ describe('ResultsList', () => {
     expect(resultsListWrapper.find(Table).exists()).toBe(true);
     expect(resultsListWrapper.find(EmptyState).exists()).toBe(false);
   });
-  it('Should render an EmptyState instead', () => {
+  it('Should still render Results Table even if failed', () => {
     resultsListProps = {
       status: ComputedStatus.Failed,
       resourceName: 'TaskRun',
       results: taskRunWithResults.status.taskResults,
     };
     resultsListWrapper = shallow(<ResultsList {...resultsListProps} />);
-    expect(resultsListWrapper.find(Table).exists()).toBe(false);
-    expect(resultsListWrapper.find(EmptyState).exists()).toBe(true);
+    expect(resultsListWrapper.find(Table).exists()).toBe(true);
+    expect(resultsListWrapper.find(EmptyState).exists()).toBe(false);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/shared/results/__tests__/ResultsList.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/results/__tests__/ResultsList.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, EmptyState } from '@patternfly/react-core';
+import { EmptyState } from '@patternfly/react-core';
 import { Table } from '@patternfly/react-table';
 import { ShallowWrapper, shallow } from 'enzyme';
 import { ComputedStatus } from '../../../../types';
@@ -23,14 +23,13 @@ describe('ResultsList', () => {
     expect(resultsListWrapper.find(Table).exists()).toBe(true);
     expect(resultsListWrapper.find(EmptyState).exists()).toBe(false);
   });
-  it('Should render Results Table with an alert if failed', () => {
+  it('Should still render Results Table even if failed', () => {
     resultsListProps = {
       status: ComputedStatus.Failed,
       resourceName: 'TaskRun',
       results: taskRunWithResults.status.taskResults,
     };
     resultsListWrapper = shallow(<ResultsList {...resultsListProps} />);
-    expect(resultsListWrapper.find(Alert).exists()).toBe(true);
     expect(resultsListWrapper.find(Table).exists()).toBe(true);
     expect(resultsListWrapper.find(EmptyState).exists()).toBe(false);
   });

--- a/frontend/packages/pipelines-plugin/src/components/shared/results/__tests__/ResultsList.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/results/__tests__/ResultsList.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { EmptyState } from '@patternfly/react-core';
+import { Alert, EmptyState } from '@patternfly/react-core';
 import { Table } from '@patternfly/react-table';
 import { ShallowWrapper, shallow } from 'enzyme';
 import { ComputedStatus } from '../../../../types';
@@ -23,13 +23,14 @@ describe('ResultsList', () => {
     expect(resultsListWrapper.find(Table).exists()).toBe(true);
     expect(resultsListWrapper.find(EmptyState).exists()).toBe(false);
   });
-  it('Should still render Results Table even if failed', () => {
+  it('Should render Results Table with an alert if failed', () => {
     resultsListProps = {
       status: ComputedStatus.Failed,
       resourceName: 'TaskRun',
       results: taskRunWithResults.status.taskResults,
     };
     resultsListWrapper = shallow(<ResultsList {...resultsListProps} />);
+    expect(resultsListWrapper.find(Alert).exists()).toBe(true);
     expect(resultsListWrapper.find(Table).exists()).toBe(true);
     expect(resultsListWrapper.find(EmptyState).exists()).toBe(false);
   });


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
[OCPBUGS-23924](https://issues.redhat.com/browse/OCPBUGS-23924)

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Render of `TaskRun` results was blocked if failed

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Render results regardless of failure

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

After:

![image](https://github.com/user-attachments/assets/6cee0b26-890d-43b5-8758-a279ced3eb89)


**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
install pipeline operator and use the pipeline provided in the jira

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
