### PR TITLE
OCPBUGS-43640: Show danger status if invalid

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/SingleTypeaheadField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/SingleTypeaheadField.tsx
@@ -81,8 +81,7 @@ const SingleTypeaheadField: React.FC<SingleTypeaheadFieldProps> = ({
         menuToggleProps={{
           isDisabled,
           isFullWidth: true,
-          // TODO(jaclee): uncomment when PF5 is updated
-          // status: isValid ? 'default' : 'danger',
+          status: isValid ? undefined : 'danger',
         }}
         selectProps={{
           'aria-label': ariaLabel,

--- a/frontend/public/components/utils/single-typeahead-dropdown.tsx
+++ b/frontend/public/components/utils/single-typeahead-dropdown.tsx
@@ -293,13 +293,13 @@ export const SingleTypeaheadDropdown: React.FC<SingleTypeaheadDropdownProps> = (
   };
 
   const selectedItemWidth = React.useMemo(() => {
-    // hardcoded as canvas can't access CSS variables scoped to the component
+    // font is hardcoded because canvas can't read the non-global CSS variables
     return (
       resizeToFit &&
       selectedValue &&
       getTextWidth(String(selectedValue.children), '14px RedHatText')
     );
-  }, [resizeToFit, selectedValue, items]);
+  }, [resizeToFit, selectedValue]);
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGS-43640

**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari