### PR TITLE
OCPBUGS-43652: Filter dropdown doesn't collapse on second click

### DIFF
--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -398,7 +398,7 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
                       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
                         <MenuToggle
                           ref={toggleRef}
-                          onClick={(open) => setIsOpen(open)}
+                          onClick={() => setIsOpen((prevIsOpen) => !prevIsOpen)}
                           isExpanded={isOpen}
                         >
                           <span>


### PR DESCRIPTION
The select dropdown didnt close on the second click.

The MenuToggle used only the previous value to set the state variable isOpen that determines if the dropdown is opened or not. Using and negating the previous value fixes this problem.

After:

https://github.com/user-attachments/assets/19d829df-f127-4780-b7e1-d15ac887019e

