### PR TITLE
OCPBUGS-43752: Add flag to hide the pipelines-plugin pipeline builder extensions

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -733,6 +733,9 @@
       "component": {
         "$codeRef": "pipelinesComponent.PipelineBuilderPage"
       }
+    },
+    "flags": {
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_BUILDER"]
     }
   },
   {
@@ -754,6 +757,9 @@
       "component": {
         "$codeRef": "pipelinesComponent.PipelineBuilderPage"
       }
+    },
+    "flags": {
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_BUILDER"]
     }
   },
   {
@@ -855,7 +861,7 @@
     "type": "dev-console.add/action",
     "flags": {
       "required": ["OPENSHIFT_PIPELINE_V1BETA1"],
-      "disallowed": ["FLAG_TEKTON_V1_ENABLED"]
+      "disallowed": ["FLAG_TEKTON_V1_ENABLED", "HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_BUILDER"]
     },
     "properties": {
       "id": "pipeline",
@@ -876,7 +882,8 @@
   {
     "type": "dev-console.add/action",
     "flags": {
-      "required": ["OPENSHIFT_PIPELINE", "FLAG_TEKTON_V1_ENABLED"]
+      "required": ["OPENSHIFT_PIPELINE", "FLAG_TEKTON_V1_ENABLED"],
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_BUILDER"]
     },
     "properties": {
       "id": "pipeline",
@@ -1098,7 +1105,8 @@
       "catalogDescription": "%pipelines-plugin~Browse for openshift pipeline tasks available in the cluster.%"
     },
     "flags": {
-      "required": ["OPENSHIFT_PIPELINE"]
+      "required": ["OPENSHIFT_PIPELINE"],
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_BUILDER"]
     }
   },
   {
@@ -1109,7 +1117,8 @@
       "catalogDescription": "%pipelines-plugin~Browse tekton hub tasks.%"
     },
     "flags": {
-      "required": ["OPENSHIFT_PIPELINE"]
+      "required": ["OPENSHIFT_PIPELINE"],
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_BUILDER"]
     }
   },
   {
@@ -1121,7 +1130,8 @@
       "provider": { "$codeRef": "catalog.TektonTaskProvider" }
     },
     "flags": {
-      "required": ["OPENSHIFT_PIPELINE"]
+      "required": ["OPENSHIFT_PIPELINE"],
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_BUILDER"]
     }
   },
   {
@@ -1133,7 +1143,8 @@
       "provider": { "$codeRef": "catalog.TektonHubTaskProvider" }
     },
     "flags": {
-      "required": ["OPENSHIFT_PIPELINE"]
+      "required": ["OPENSHIFT_PIPELINE"],
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_BUILDER"]
     }
   },
   {
@@ -1145,7 +1156,8 @@
       "provider": { "$codeRef": "catalog.ArtifactHubTaskProvider" }
     },
     "flags": {
-      "required": ["OPENSHIFT_PIPELINE"]
+      "required": ["OPENSHIFT_PIPELINE"],
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_BUILDER"]
     }
   },
   {


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/OCPBUGS-43752

Descriptions: Add disallowed flag to hide the pipelines-plugin pipeline builder route, add action and to catalog provider extension as it is migrated to Pipelines console-plugin. So, that no duplicate action in console