### PR TITLE
CONSOLE-4234,CONSOLE-4298,CONSOLE-4299: Remove PF deprecated table from public/components/factory/table.tsx and public/components/factory/Table/VirtualizedTable.tsx

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -303,6 +303,8 @@ export type RowProps<D, R extends any = {}> = {
   obj: D;
   rowData: R;
   activeColumnIDs: Set<string>;
+  index: number;
+  onSelect?: OnSelect;
 };
 
 export type OnRowsRendered = (params: any) => void;

--- a/frontend/packages/console-shared/src/components/custom-resource-list/CustomResourceList.tsx
+++ b/frontend/packages/console-shared/src/components/custom-resource-list/CustomResourceList.tsx
@@ -8,9 +8,10 @@ import {
   RowFunctionArgs,
   TableProps,
   TableColumn,
-} from '@console/internal/components/factory';
+} from '@console/internal/components/factory/table';
 import { FilterToolbar, RowFilter } from '@console/internal/components/filter-toolbar';
-import { getQueryArgument, LoadingBox } from '@console/internal/components/utils';
+import { getQueryArgument } from '@console/internal/components/utils/router';
+import { LoadingBox } from '@console/shared/src/components/loading/LoadingBox';
 
 interface CustomResourceListProps {
   queryArg?: string;

--- a/frontend/packages/console-shared/src/components/custom-resource-list/CustomResourceList.tsx
+++ b/frontend/packages/console-shared/src/components/custom-resource-list/CustomResourceList.tsx
@@ -3,7 +3,12 @@ import { EmptyState, EmptyStateVariant } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { Table, RowFunctionArgs, TableProps } from '@console/internal/components/factory/table';
+import {
+  Table,
+  RowFunctionArgs,
+  TableProps,
+  TableColumn,
+} from '@console/internal/components/factory';
 import { FilterToolbar, RowFilter } from '@console/internal/components/filter-toolbar';
 import { getQueryArgument, LoadingBox } from '@console/internal/components/utils';
 
@@ -14,7 +19,7 @@ interface CustomResourceListProps {
   sortOrder: SortByDirection;
   ResourceRow: React.FC<RowFunctionArgs>;
   resources?: { [key: string]: any }[];
-  resourceHeader: () => { [key: string]: any }[];
+  resourceHeader: () => TableColumn[];
   EmptyMsg?: React.ComponentType;
   loaded?: boolean;
   rowFilterReducer?: (

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/catalog-source-details.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/catalog-source-details.cy.ts
@@ -86,7 +86,7 @@ describe(`Interacting with CatalogSource page`, () => {
     detailsPage.sectionHeaderShouldExist('CatalogSource details');
 
     cy.byLegacyTestID('horizontal-link-Operators').click();
-    cy.get('[data-label=Name]').should('exist');
+    cy.byTestID('PackageManifestTable').should('exist');
   });
 
   it(`allows modifying registry poll interval on test catalog source`, () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/package-manifest.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/package-manifest.tsx
@@ -127,6 +127,7 @@ export const PackageManifestList = (props: PackageManifestListProps) => {
     <Table
       {...props}
       aria-label="PackageManifests"
+      data-test="PackageManifestTable"
       loaded={props.loaded}
       data={props.data || []}
       filters={props.filters}

--- a/frontend/public/components/factory/ListPage/ListPageCreate.tsx
+++ b/frontend/public/components/factory/ListPage/ListPageCreate.tsx
@@ -18,10 +18,9 @@ import {
   ListPageCreateLinkProps,
   ListPageCreateButtonProps,
   ListPageCreateDropdownProps,
-} from '@console/dynamic-plugin-sdk';
-
-import { RequireCreatePermission } from '../../utils';
-import { transformGroupVersionKindToReference } from '@console/dynamic-plugin-sdk/src/utils/k8s';
+} from '@console/dynamic-plugin-sdk/src/extensions/console-types';
+import { RequireCreatePermission } from '../../utils/rbac';
+import { transformGroupVersionKindToReference } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';
 
 const CreateWithPermissions: React.FC<CreateWithPermissionsProps> = ({
   createAccessReview,

--- a/frontend/public/components/factory/ListPage/ListPageFilter.tsx
+++ b/frontend/public/components/factory/ListPage/ListPageFilter.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { ListPageFilterProps } from '@console/dynamic-plugin-sdk';
-
+import { ListPageFilterProps } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { FilterToolbar } from '../../filter-toolbar';
 
 const ListPageFilter: React.FC<ListPageFilterProps> = ({

--- a/frontend/public/components/factory/ListPage/ListPageHeader.tsx
+++ b/frontend/public/components/factory/ListPage/ListPageHeader.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
-import { ListPageHeaderProps } from '@console/dynamic-plugin-sdk';
-
+import { ListPageHeaderProps } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { PageHeading } from '../../utils';
 
 const ListPageHeader: React.FC<ListPageHeaderProps> = ({ helpText, title, children, badge }) => (

--- a/frontend/public/components/factory/ListPage/filter-hook.ts
+++ b/frontend/public/components/factory/ListPage/filter-hook.ts
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { useLocation } from 'react-router-dom-v5-compat';
-import { UseListPageFilter, FilterValue } from '@console/dynamic-plugin-sdk';
-
-import { useExactSearch } from '@console/app/src/components/user-preferences/search';
+import {
+  UseListPageFilter,
+  FilterValue,
+} from '@console/dynamic-plugin-sdk/src/extensions/console-types';
+import { useExactSearch } from '@console/app/src/components/user-preferences/search/useExactSearch';
 import { getAllTableFilters, FilterMap } from '../table-filters';
 
 const filterData = <D>(

--- a/frontend/public/components/factory/Table/TableHeader.tsx
+++ b/frontend/public/components/factory/Table/TableHeader.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ISortBy, OnSelect, OnSort, Th, Thead, Tr } from '@patternfly/react-table';
+import { TableColumn as InternalTableColumn } from '..';
+import { TableColumn as SDKTableColumn } from '@console/dynamic-plugin-sdk';
+
+export const TableHeader: React.FCC<TableHeaderProps> = ({
+  allRowsSelected,
+  canSelectAll,
+  columns,
+  sortBy,
+  onSelect,
+  onSort,
+}) => {
+  const { t } = useTranslation();
+  const select = canSelectAll ? { select: { onSelect, isSelected: allRowsSelected } } : {};
+  return (
+    <Thead>
+      <Tr>
+        {onSelect && <Th aria-label={t('public~Row select')} {...select} />}
+        {columns.map(({ id, title, sort, sortField, sortFunc, props }, columnIndex) => {
+          const sortable = sortField || sortFunc || sort;
+          return (
+            <Th
+              key={id}
+              sort={sortable ? { sortBy, onSort, columnIndex } : null}
+              data-label={title}
+              {...(props ?? {})}
+            >
+              {title}
+            </Th>
+          );
+        })}
+      </Tr>
+    </Thead>
+  );
+};
+
+TableHeader.displayName = 'TableHeader';
+
+type TableHeaderProps = {
+  allRowsSelected?: boolean;
+  canSelectAll?: boolean;
+  columns: InternalTableColumn[] | SDKTableColumn<any>[];
+  onSelect?: OnSelect;
+  onSort?: OnSort;
+  sortBy?: ISortBy;
+};
+
+export default TableHeader;

--- a/frontend/public/components/factory/Table/TableHeader.tsx
+++ b/frontend/public/components/factory/Table/TableHeader.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ISortBy, OnSelect, OnSort, Th, Thead, Tr } from '@patternfly/react-table';
-import { TableColumn as InternalTableColumn } from '..';
-import { TableColumn as SDKTableColumn } from '@console/dynamic-plugin-sdk';
+import { TableColumn as InternalTableColumn } from '../table';
+import { TableColumn as SDKTableColumn } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 
 export const TableHeader: React.FCC<TableHeaderProps> = ({
   allRowsSelected,

--- a/frontend/public/components/factory/Table/VirtualizedTable.tsx
+++ b/frontend/public/components/factory/Table/VirtualizedTable.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { TableGridBreakpoint, SortByDirection } from '@patternfly/react-table';
 import {
+  TableGridBreakpoint,
+  SortByDirection,
   Table as PfTable,
-  TableHeader as TableHeaderDeprecated,
-} from '@patternfly/react-table/deprecated';
-import * as classNames from 'classnames';
+  Td,
+} from '@patternfly/react-table';
 import { AutoSizer, WindowScroller } from '@patternfly/react-virtualized-extension';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { VirtualizedTableFC, TableColumn, TableDataProps } from '@console/dynamic-plugin-sdk';
+import { TableColumn, TableDataProps, VirtualizedTableFC } from '@console/dynamic-plugin-sdk';
 
 import VirtualizedTableBody from './VirtualizedTableBody';
+import TableHeader from './TableHeader';
 import { StatusBox, WithScrollContainer, EmptyBox } from '../../utils';
 import { sortResourceByValue } from './sort';
 import { Button } from '@patternfly/react-core';
@@ -55,9 +56,9 @@ const isColumnVisible = <D extends any>(
 
 export const TableData: React.FC<TableDataProps> = ({ className, id, activeColumnIDs, children }) =>
   (activeColumnIDs.has(id) || id === '') && (
-    <td id={id} className={classNames('pf-v5-c-table__td', className)} role="gridcell">
+    <Td data-label={id} className={className} role="gridcell">
       {children}
-    </td>
+    </Td>
   );
 TableData.displayName = 'TableData';
 
@@ -117,7 +118,7 @@ const VirtualizedTable: VirtualizedTableFC = ({
     [columnShift, columns, navigate],
   );
 
-  data = React.useMemo(() => {
+  const sortedData = React.useMemo(() => {
     const sortColumn = columns[sortBy.index - columnShift];
     if (!sortColumn.sort) {
       return data;
@@ -162,31 +163,6 @@ const VirtualizedTable: VirtualizedTableFC = ({
     [applySort],
   );
 
-  const renderVirtualizedTable = (scrollContainer) => (
-    <WindowScroller scrollElement={scrollContainer}>
-      {({ height, isScrolling, registerChild, onChildScroll, scrollTop }) => (
-        <AutoSizer disableHeight>
-          {({ width }) => (
-            <div ref={registerChild}>
-              <VirtualizedTableBody
-                Row={Row}
-                height={height}
-                isScrolling={isScrolling}
-                onChildScroll={onChildScroll}
-                data={data}
-                columns={columns}
-                scrollTop={scrollTop}
-                width={width}
-                rowData={rowData}
-                onRowsRendered={onRowsRendered}
-              />
-            </div>
-          )}
-        </AutoSizer>
-      )}
-    </WindowScroller>
-  );
-
   const downloadCsv = () => {
     // csvData should be formatted as comma-seperated values
     // (e.g. `"a","b","c", \n"d","e","f", \n"h","i","j"`)
@@ -213,35 +189,49 @@ const VirtualizedTable: VirtualizedTableFC = ({
           NoDataEmptyMsg={NoDataEmptyMsg}
           EmptyMsg={EmptyMsg}
         >
-          <div
-            className="co-virtualized-table"
-            role="grid"
-            aria-label={ariaLabel}
-            aria-rowcount={data?.length}
-          >
+          <div className="co-virtualized-table" aria-label={ariaLabel}>
             {csvData && (
               <Button className="co-virtualized-table--export-csv-button" onClick={downloadCsv}>
                 Export as CSV
               </Button>
             )}
-            <PfTable
-              cells={columns}
-              rows={[{ selected: allRowsSelected }]}
-              canSelectAll={canSelectAll}
-              gridBreakPoint={gridBreakPoint}
-              onSort={onSort}
-              onSelect={onSelect}
-              sortBy={sortBy}
-              className="pf-m-compact pf-m-border-rows"
-              role="presentation"
-            >
-              <TableHeaderDeprecated />
+            <PfTable gridBreakPoint={gridBreakPoint} className="pf-m-compact pf-m-border-rows">
+              <TableHeader
+                allRowsSelected={allRowsSelected}
+                canSelectAll={canSelectAll}
+                columns={columns}
+                onSelect={onSelect}
+                onSort={onSort}
+                sortBy={sortBy}
+              />
             </PfTable>
-            {scrollNode ? (
-              renderVirtualizedTable(scrollNode)
-            ) : (
-              <WithScrollContainer>{renderVirtualizedTable}</WithScrollContainer>
-            )}
+            <WithScrollContainer>
+              {(scrollContainer) => (
+                <WindowScroller scrollElement={scrollNode?.() ?? scrollContainer}>
+                  {({ height, isScrolling, registerChild, onChildScroll, scrollTop }) => (
+                    <AutoSizer disableHeight>
+                      {({ width }) => (
+                        <div ref={registerChild}>
+                          <VirtualizedTableBody
+                            columns={columns}
+                            data={sortedData}
+                            height={height}
+                            isScrolling={isScrolling}
+                            onChildScroll={onChildScroll}
+                            onRowsRendered={onRowsRendered}
+                            Row={Row}
+                            rowData={rowData}
+                            scrollTop={scrollTop}
+                            width={width}
+                            onSelect={onSelect}
+                          />
+                        </div>
+                      )}
+                    </AutoSizer>
+                  )}
+                </WindowScroller>
+              )}
+            </WithScrollContainer>
           </div>
         </StatusBox>
       )}

--- a/frontend/public/components/factory/Table/VirtualizedTable.tsx
+++ b/frontend/public/components/factory/Table/VirtualizedTable.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
+import { useNavigate } from 'react-router-dom-v5-compat';
+import { Button } from '@patternfly/react-core';
 import {
   TableGridBreakpoint,
   SortByDirection,
@@ -7,14 +9,17 @@ import {
   Td,
 } from '@patternfly/react-table';
 import { AutoSizer, WindowScroller } from '@patternfly/react-virtualized-extension';
-import { useNavigate } from 'react-router-dom-v5-compat';
-import { TableColumn, TableDataProps, VirtualizedTableFC } from '@console/dynamic-plugin-sdk';
-
+import {
+  TableColumn,
+  TableDataProps,
+  VirtualizedTableFC,
+} from '@console/dynamic-plugin-sdk/src/extensions/console-types';
+import { StatusBox } from '@console/shared/src/components/status/StatusBox';
+import { EmptyBox } from '@console/shared/src/components/empty-state/EmptyBox';
 import VirtualizedTableBody from './VirtualizedTableBody';
 import TableHeader from './TableHeader';
-import { StatusBox, WithScrollContainer, EmptyBox } from '../../utils';
+import { WithScrollContainer } from '../../utils/dom-utils';
 import { sortResourceByValue } from './sort';
-import { Button } from '@patternfly/react-core';
 
 const BREAKPOINT_SM = 576;
 const BREAKPOINT_MD = 768;

--- a/frontend/public/components/factory/Table/VirtualizedTableBody.tsx
+++ b/frontend/public/components/factory/Table/VirtualizedTableBody.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
-import { VirtualTableBody } from '@patternfly/react-virtualized-extension';
 import { CellMeasurerCache, CellMeasurer } from 'react-virtualized';
+import { VirtualTableBody } from '@patternfly/react-virtualized-extension';
 import { Scroll } from '@patternfly/react-virtualized-extension/dist/js/components/Virtualized/types';
+import { OnSelect } from '@patternfly/react-table';
 import {
   K8sResourceCommon,
   TableColumn,
   RowProps,
   OnRowsRendered,
-} from '@console/dynamic-plugin-sdk';
+} from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { TableRow } from '../table';
-import { OnSelect } from '@patternfly/react-table';
 
 type VirtualizedTableBodyProps<D, R = {}> = {
   Row: React.ComponentType<RowProps<D, R>>;

--- a/frontend/public/components/factory/Table/VirtualizedTableBody.tsx
+++ b/frontend/public/components/factory/Table/VirtualizedTableBody.tsx
@@ -9,6 +9,7 @@ import {
   OnRowsRendered,
 } from '@console/dynamic-plugin-sdk';
 import { TableRow } from '../table';
+import { OnSelect } from '@patternfly/react-table';
 
 type VirtualizedTableBodyProps<D, R = {}> = {
   Row: React.ComponentType<RowProps<D, R>>;
@@ -24,6 +25,7 @@ type VirtualizedTableBodyProps<D, R = {}> = {
   getRowTitle?: (obj: D) => string;
   getRowClassName?: (obj: D) => string;
   onRowsRendered?: OnRowsRendered;
+  onSelect?: OnSelect;
 };
 
 const RowMemo = React.memo<
@@ -56,6 +58,7 @@ const VirtualizedTableBody = <D extends any, R extends any = {}>({
   getRowTitle,
   getRowClassName,
   onRowsRendered,
+  onSelect,
 }: VirtualizedTableBodyProps<D, R>) => {
   const cellMeasurementCache = new CellMeasurerCache({
     fixedWidth: true,
@@ -70,6 +73,8 @@ const VirtualizedTableBody = <D extends any, R extends any = {}>({
       obj: data[index],
       activeColumnIDs,
       rowData,
+      index,
+      onSelect,
     };
 
     // do not render non visible elements (this excludes overscan)

--- a/frontend/public/components/factory/Table/active-columns-hook.ts
+++ b/frontend/public/components/factory/Table/active-columns-hook.ts
@@ -3,10 +3,10 @@ import {
   ALL_NAMESPACES_KEY,
   COLUMN_MANAGEMENT_CONFIGMAP_KEY,
   COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY,
-  useActiveNamespace,
-  useUserSettingsCompatibility,
-} from '@console/shared';
-import { TableColumn } from '@console/dynamic-plugin-sdk';
+} from '@console/shared/src/constants/common';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
+import { useUserSettingsCompatibility } from '@console/shared/src/hooks/useUserSettingsCompatibility';
+import { TableColumn } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 
 export const useActiveColumns = <D = any>({
   columns,

--- a/frontend/public/components/factory/details-breadcrumb-resolver.tsx
+++ b/frontend/public/components/factory/details-breadcrumb-resolver.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Location } from 'react-router-dom-v5-compat';
-import { DetailsPageBreadCrumbsHook } from '@console/plugin-sdk';
-import { K8sKind } from '@console/internal/module/k8s';
+import { DetailsPageBreadCrumbsHook } from '@console/plugin-sdk/src/typings/detail-page-bread-crumbs';
+import { K8sKind } from '../../module/k8s';
 
 type DetailsBreadcrumbResolverType = {
   useBreadcrumbs: DetailsPageBreadCrumbsHook;

--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -1,45 +1,41 @@
 import * as React from 'react';
 import { useLocation, useParams, Location } from 'react-router-dom-v5-compat';
 import * as _ from 'lodash-es';
-
 import { getBadgeFromType, getTitleForNodeKind } from '@console/shared';
 import { PageTitleContext } from '@console/shared/src/components/pagetitle/PageTitleContext';
-import { ErrorBoundaryFallbackPage, withFallback } from '@console/shared/src/components/error';
+import withFallback from '@console/shared/src/components/error/fallbacks/withFallback';
+import ErrorBoundaryFallbackPage from '@console/shared/src/components/error/fallbacks/ErrorBoundaryFallbackPage';
+import { useExtensions } from '@console/plugin-sdk/src/api/useExtensions';
+import { ResourceTabPage, isResourceTabPage } from '@console/plugin-sdk/src/typings/pages';
 import {
-  useExtensions,
-  ResourceTabPage,
-  isResourceTabPage,
   isDetailPageBreadCrumbs,
   DetailPageBreadCrumbs,
-} from '@console/plugin-sdk';
+} from '@console/plugin-sdk/src/typings/detail-page-bread-crumbs';
+import { ResolvedExtension } from '@console/dynamic-plugin-sdk/src/types';
+import { useResolvedExtensions } from '@console/dynamic-plugin-sdk/src/api/useResolvedExtensions';
 import {
-  ResolvedExtension,
-  useResolvedExtensions,
   ResourceTabPage as DynamicResourceTabPage,
   isResourceTabPage as isDynamicResourceTabPage,
-  K8sModel,
+} from '@console/dynamic-plugin-sdk/src/extensions/pages';
+import { K8sModel } from '@console/dynamic-plugin-sdk/src/api/common-types';
+import {
   isDetailPageBreadCrumbs as isDynamicDetailPageBreadCrumbs,
   DetailPageBreadCrumbs as DynamicDetailPageBreadCrumbs,
+} from '@console/dynamic-plugin-sdk/src/extensions/breadcrumbs';
+import {
   FirehoseResult,
-} from '@console/dynamic-plugin-sdk';
-import {
-  Firehose,
-  HorizontalNav,
-  PageHeading,
-  FirehoseResource,
-  KebabOptionsCreator,
-  Page,
-  AsyncComponent,
-  PageComponentProps,
-  KebabAction,
-} from '../utils';
-import {
   K8sResourceKindReference,
   K8sResourceKind,
-  K8sKind,
-  referenceForModel,
-  referenceForExtensionModel,
-} from '../../module/k8s';
+} from '@console/dynamic-plugin-sdk/src/extensions/console-types';
+import { Firehose } from '../utils/firehose';
+import { HorizontalNav, Page, PageComponentProps } from '../utils/horizontal-nav';
+import { PageHeading, KebabOptionsCreator } from '../utils/headings';
+import { FirehoseResource } from '../utils/types';
+import { AsyncComponent } from '../utils/async';
+import { KebabAction } from '../utils/kebab';
+import { K8sKind } from '../../module/k8s/types';
+import { getReferenceForModel as referenceForModel } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';
+import { referenceForExtensionModel } from '../../module/k8s/k8s';
 import { breadcrumbsForDetailsPage } from '../utils/breadcrumbs';
 import DetailsBreadcrumbResolver from './details-breadcrumb-resolver';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';

--- a/frontend/public/components/factory/list-page.tsx
+++ b/frontend/public/components/factory/list-page.tsx
@@ -6,32 +6,38 @@ import * as React from 'react';
 // @ts-ignore
 import { useDispatch } from 'react-redux';
 import { Link, useParams, useNavigate } from 'react-router-dom-v5-compat';
-
 import { Button, TextInput, TextInputProps } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-
-import { useDocumentListener, KEYBOARD_SHORTCUTS, useDeepCompareMemoize } from '@console/shared';
-import { withFallback, ErrorBoundaryFallbackPage } from '@console/shared/src/components/error';
-import { ColumnLayout } from '@console/dynamic-plugin-sdk';
-
+import { useDocumentListener } from '@console/shared/src/hooks/document-listener';
+import { KEYBOARD_SHORTCUTS } from '@console/shared/src/constants/common';
+import { useDeepCompareMemoize } from '@console/shared/src/hooks/deep-compare-memoize';
+import withFallback from '@console/shared/src/components/error/fallbacks/withFallback';
+import ErrorBoundaryFallbackPage from '@console/shared/src/components/error/fallbacks/ErrorBoundaryFallbackPage';
+import {
+  ColumnLayout,
+  K8sResourceCommon,
+} from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { filterList } from '@console/dynamic-plugin-sdk/src/app/k8s/actions/k8s';
 import { storagePrefix } from '../row-filter';
 import { ErrorPage404 } from '../error';
-import { K8sKind, K8sResourceCommon, referenceForModel, Selector } from '../../module/k8s';
+import { K8sKind } from '../../module/k8s/types';
+import { getReferenceForModel as referenceForModel } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';
+import { Selector } from '@console/dynamic-plugin-sdk/src/api/common-types';
+import { Dropdown } from '../utils/dropdown';
+import { Firehose } from '../utils/firehose';
 import {
-  Dropdown,
-  Firehose,
   FirehoseResource,
   FirehoseResourcesResult,
   FirehoseResultObject,
   FirehoseResult,
-  inject,
-  kindObj,
+} from '../utils/types';
+import { inject, kindObj } from '../utils/inject';
+import {
   makeQuery,
   makeReduxID,
-  PageHeading,
-  RequireCreatePermission,
-} from '../utils';
+} from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/k8s-watcher';
+import { PageHeading } from '../utils/headings';
+import { RequireCreatePermission } from '../utils/rbac';
 import { FilterToolbar, RowFilter } from '../filter-toolbar';
 
 type CreateProps = {

--- a/frontend/public/components/factory/table-data-hook.ts
+++ b/frontend/public/components/factory/table-data-hook.ts
@@ -5,10 +5,9 @@ import * as _ from 'lodash';
 import { useSelector } from 'react-redux';
 import { createSelectorCreator, defaultMemoize } from 'reselect';
 import { SortByDirection } from '@patternfly/react-table';
-import { useDeepCompareMemoize } from '@console/shared';
-import { RowFilter } from '@console/dynamic-plugin-sdk';
+import { useDeepCompareMemoize } from '@console/shared/src/hooks/deep-compare-memoize';
+import { RowFilter } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { useExactSearch } from '@console/app/src/components/user-preferences/search';
-
 import { RootState } from '../../redux';
 import { tableFilters } from './table-filters';
 import { Filter } from './table';

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -1,23 +1,28 @@
 import * as _ from 'lodash-es';
 import * as fuzzy from 'fuzzysearch';
-import { nodeStatus, volumeSnapshotStatus } from '@console/app/src/status';
-import { getNodeRoles, getLabelsAsString } from '@console/shared';
-import { Alert, AnyRowFilter, FilterValue, Rule } from '@console/dynamic-plugin-sdk';
+import { nodeStatus } from '@console/app/src/status/node';
+import { volumeSnapshotStatus } from '@console/app/src/status/snapshot';
+import { getNodeRoles } from '@console/shared/src/selectors/node';
+import { getLabelsAsString } from '@console/shared/src/utils/label-filter';
+import { Alert, Rule } from '@console/dynamic-plugin-sdk/src/api/common-types';
+import {
+  AnyRowFilter,
+  FilterValue,
+} from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { routeStatus } from '../routes';
 import { secretTypeFilterReducer } from '../secret';
-import { roleType } from '../RBAC';
+import { roleType } from '../RBAC/role';
 import {
   K8sResourceKind,
   MachineKind,
-  getClusterOperatorStatus,
-  getTemplateInstanceStatus,
   VolumeSnapshotKind,
   CustomResourceDefinitionKind,
-} from '../../module/k8s';
+} from '../../module/k8s/types';
+import { getClusterOperatorStatus } from '../../module/k8s/cluster-operator';
+import { getTemplateInstanceStatus } from '../../module/k8s/template';
 import { alertDescription } from '../monitoring/utils';
-
 import { Target } from '../monitoring/types';
-import { requesterFilter } from '@console/shared/src/components/namespace';
+import { requesterFilter } from '@console/shared/src/components/namespace/filters';
 
 export const fuzzyCaseInsensitive = (a: string, b: string): boolean =>
   fuzzy(_.toLower(a), _.toLower(b));

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -3,13 +3,18 @@ import * as React from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
-import { TableGridBreakpoint, SortByDirection, OnSelect } from '@patternfly/react-table';
 import {
+  TableGridBreakpoint,
+  SortByDirection,
+  OnSelect,
   Table as PfTable,
-  TableHeader as TableHeaderDeprecated,
-  TableBody as TableBodyDeprecated,
-  TableProps as PfTableProps,
-} from '@patternfly/react-table/deprecated';
+  Tr,
+  Tbody,
+  Td,
+  IRow,
+  ISortBy,
+  OnSort,
+} from '@patternfly/react-table';
 import * as classNames from 'classnames';
 import { CellMeasurerCache, CellMeasurer } from 'react-virtualized';
 import {
@@ -52,6 +57,7 @@ import {
   ClusterOperator,
 } from '../../module/k8s';
 import { useTableData } from './table-data-hook';
+import TableHeader from './Table/TableHeader';
 
 const sorts = {
   alertingRuleStateOrder,
@@ -101,7 +107,7 @@ export const TableRow: React.FC<TableRowProps> = ({
   ...props
 }) => {
   return (
-    <tr
+    <Tr
       {...props}
       data-id={id}
       data-index={index}
@@ -175,10 +181,12 @@ export const TableData: React.FC<TableDataProps> = ({
   columnID,
   columns,
   showNamespaceOverride,
-  ...props
+  children,
 }) => {
   return isColumnVisible(window.innerWidth, columnID, columns, showNamespaceOverride) ? (
-    <td {...props} className={classNames('pf-v5-c-table__td', className)} role="gridcell" />
+    <Td data-label={columnID} className={className} role="gridcell">
+      {children}
+    </Td>
   ) : null;
 };
 TableData.displayName = 'TableData';
@@ -190,23 +198,6 @@ export type TableDataProps = {
   showNamespaceOverride?: boolean;
 };
 
-const TableWrapper: React.FC<TableWrapperProps> = ({
-  virtualize,
-  ariaLabel,
-  ariaRowCount,
-  ...props
-}) => {
-  return virtualize ? (
-    <div {...props} role="grid" aria-label={ariaLabel} aria-rowcount={ariaRowCount} />
-  ) : (
-    <React.Fragment {...props} />
-  );
-};
-export type TableWrapperProps = {
-  virtualize: boolean;
-  ariaLabel: string;
-  ariaRowCount: number;
-};
 const RowMemo = React.memo<RowFunctionArgs & { Row: React.FC<RowFunctionArgs> }>(
   ({ Row, ...props }) => <Row {...props} />,
 );
@@ -288,18 +279,18 @@ export type RowFunctionArgs<T = any, C = any> = {
   customData?: C;
 };
 
-export type VirtualBodyProps<D = any, C = any> = {
-  customData?: C;
+export type VirtualBodyProps = {
+  customData?: any;
   Row: React.FC<RowFunctionArgs>;
   height: number;
   isScrolling: boolean;
   onChildScroll: (params: Scroll) => void;
-  data: D[];
+  data: any[];
   columns: any[];
   scrollTop: number;
   width: number;
   expand: boolean;
-  getRowProps?: (obj: D) => Partial<Pick<TableRowProps, 'id' | 'className' | 'title'>>;
+  getRowProps?: (obj: any) => Partial<Pick<TableRowProps, 'id' | 'className' | 'title'>>;
   onRowsRendered?: (params: {
     overscanStartIndex: number;
     overscanStopIndex: number;
@@ -308,7 +299,7 @@ export type VirtualBodyProps<D = any, C = any> = {
   }) => void;
 };
 
-type HeaderFunc = (componentProps: ComponentProps) => any[];
+type HeaderFunc = (componentProps: ComponentProps) => TableColumn[];
 
 const getActiveColumns = (
   windowWidth: number,
@@ -317,7 +308,7 @@ const getActiveColumns = (
   activeColumns: Set<string>,
   columnManagementID: string,
   showNamespaceOverride: boolean,
-) => {
+): TableColumn[] => {
   let columns = Header(componentProps);
   if (_.isEmpty(activeColumns)) {
     activeColumns = new Set(
@@ -346,17 +337,115 @@ const getActiveColumns = (
   return columns;
 };
 
-const getComponentProps = (
-  data: any[],
-  filters: Filter[],
-  selected: boolean,
-  kindObj: K8sResourceKindReference,
-): ComponentProps => ({
+// TODO Replace with ./Table/VirtualizedTable
+const VirtualizedTable: React.FCC<VirtualizedTableProps> = ({
+  ariaLabel,
+  columns,
+  customData,
+  data,
+  expand,
+  getRowProps,
+  gridBreakPoint,
+  onRowsRendered,
+  onSelect,
+  onSort,
+  Row,
+  scrollElement,
+  sortBy,
+}) => {
+  const ariaRowCount = data && data.length;
+  const scrollNode = typeof scrollElement === 'function' ? scrollElement() : scrollElement;
+  return (
+    <div className="co-virtualized-table">
+      <div role="grid" aria-label={ariaLabel} aria-rowcount={ariaRowCount}>
+        <PfTable gridBreakPoint={gridBreakPoint} aria-label={ariaLabel}>
+          <TableHeader onSort={onSort} sortBy={sortBy} columns={columns} onSelect={onSelect} />
+        </PfTable>
+        <WithScrollContainer>
+          {(scrollContainer) => (
+            <WindowScroller scrollElement={scrollNode ?? scrollContainer}>
+              {({ height, isScrolling, registerChild, onChildScroll, scrollTop }) => (
+                <AutoSizer disableHeight>
+                  {({ width }) => (
+                    <div ref={registerChild}>
+                      <VirtualBody
+                        Row={Row}
+                        customData={customData}
+                        height={height}
+                        isScrolling={isScrolling}
+                        onChildScroll={onChildScroll}
+                        data={data}
+                        columns={columns}
+                        scrollTop={scrollTop}
+                        width={width}
+                        expand={expand}
+                        getRowProps={getRowProps}
+                        onRowsRendered={onRowsRendered}
+                      />
+                    </div>
+                  )}
+                </AutoSizer>
+              )}
+            </WindowScroller>
+          )}
+        </WithScrollContainer>
+      </div>
+    </div>
+  );
+};
+
+const StandardTable: React.FCC<StandardTableProps> = ({
+  columns,
+  customData,
   data,
   filters,
-  selected,
+  gridBreakPoint,
   kindObj,
-});
+  onSelect,
+  onSort,
+  Rows,
+  selected,
+  selectedResourcesForKind,
+  sortBy,
+}) => {
+  const rows = React.useMemo<IRow[]>(
+    () =>
+      Rows({
+        componentProps: { data, filters, selected, kindObj },
+        customData,
+        selectedResourcesForKind,
+      }),
+    [Rows, data, filters, selected, kindObj, customData, selectedResourcesForKind],
+  );
+  return (
+    <PfTable gridBreakPoint={gridBreakPoint}>
+      <TableHeader onSort={onSort} sortBy={sortBy} columns={columns} onSelect={onSelect} />
+      <Tbody>
+        {rows.map((row, rowIndex) => {
+          return (
+            <Tr key={`row-${rowIndex}`}>
+              {onSelect && (
+                <Td
+                  select={{
+                    rowIndex,
+                    onSelect,
+                    isSelected: row.selected ?? false,
+                    isDisabled: row.disableSelection ?? false,
+                  }}
+                />
+              )}
+              {(Array.isArray(row) ? row : row.cells).map(({ props, title }, colIndex) => (
+                <Td key={`col-${colIndex}`} {...(props ?? {})}>
+                  {title}
+                </Td>
+              ))}
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </PfTable>
+  );
+};
 
 export const Table: React.FC<TableProps> = ({
   onSelect,
@@ -368,8 +457,8 @@ export const Table: React.FC<TableProps> = ({
   columnManagementID,
   showNamespaceOverride,
   scrollElement,
-  Rows,
   Row,
+  Rows,
   expand,
   label,
   mock,
@@ -384,7 +473,7 @@ export const Table: React.FC<TableProps> = ({
   EmptyMsg,
   defaultSortOrder,
   customSorts,
-  data: propData,
+  data: unfilteredData,
   defaultSortFunc,
   reduxID,
   reduxIDs,
@@ -394,9 +483,16 @@ export const Table: React.FC<TableProps> = ({
   defaultSortField,
   getRowProps,
   onRowsRendered,
+  'data-test': dataTest,
 }) => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
   const filters = useDeepCompareMemoize(initFilters);
   const Header = useDeepCompareMemoize(initHeader);
+  const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
+  const [sortBy, setSortBy] = React.useState({});
+  const columnShift = onSelect ? 1 : 0; //shift indexes by 1 if select provided
+
   const { currentSortField, currentSortFunc, currentSortOrder, data, listId } = useTableData({
     reduxID,
     reduxIDs,
@@ -406,7 +502,7 @@ export const Table: React.FC<TableProps> = ({
     staticFilters,
     filters,
     rowFilters: rowFilters as RowFilterExt[],
-    propData,
+    propData: unfilteredData,
     loaded,
     isPinned,
     customData,
@@ -414,55 +510,28 @@ export const Table: React.FC<TableProps> = ({
     sorts,
   });
 
-  const dispatch = useDispatch();
-  const navigate = useNavigate();
-  const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
-  const [sortBy, setSortBy] = React.useState({});
-
-  const [columns, componentProps] = React.useMemo(() => {
-    const cProps = getComponentProps(data, filters, selected, kindObj);
-    return [
+  const columns = React.useMemo(
+    () =>
       getActiveColumns(
         windowWidth,
         Header,
-        cProps,
+        { data, filters, selected, kindObj },
         activeColumns,
         columnManagementID,
         showNamespaceOverride,
       ),
-      cProps,
-    ];
-  }, [
-    windowWidth,
-    Header,
-    data,
-    filters,
-    selected,
-    kindObj,
-    activeColumns,
-    columnManagementID,
-    showNamespaceOverride,
-  ]);
-
-  const columnShift = onSelect ? 1 : 0; //shift indexes by 1 if select provided
-
-  React.useEffect(() => {
-    if (!sortBy) {
-      let newSortBy = {};
-      if (currentSortField && currentSortOrder) {
-        const columnIndex = _.findIndex(columns, { sortField: currentSortField });
-        if (columnIndex > -1) {
-          newSortBy = { index: columnIndex + columnShift, direction: currentSortOrder };
-        }
-      } else if (currentSortFunc && currentSortOrder) {
-        const columnIndex = _.findIndex(columns, { sortFunc: currentSortFunc });
-        if (columnIndex > -1) {
-          newSortBy = { index: columnIndex + columnShift, direction: currentSortOrder };
-        }
-      }
-      setSortBy(newSortBy);
-    }
-  }, [columnShift, columns, currentSortField, currentSortFunc, currentSortOrder, sortBy]);
+    [
+      windowWidth,
+      Header,
+      data,
+      filters,
+      selected,
+      kindObj,
+      activeColumns,
+      columnManagementID,
+      showNamespaceOverride,
+    ],
+  );
 
   const applySort = React.useCallback(
     (sortField, sortFunc, direction, columnTitle) => {
@@ -490,6 +559,26 @@ export const Table: React.FC<TableProps> = ({
   );
 
   React.useEffect(() => {
+    setSortBy((currentSortBy) => {
+      if (!currentSortBy) {
+        if (currentSortField && currentSortOrder) {
+          const columnIndex = _.findIndex(columns, { sortField: currentSortField });
+          if (columnIndex > -1) {
+            return { index: columnIndex + columnShift, direction: currentSortOrder };
+          }
+        }
+        if (currentSortFunc && currentSortOrder) {
+          const columnIndex = _.findIndex(columns, { sortFunc: currentSortFunc });
+          if (columnIndex > -1) {
+            return { index: columnIndex + columnShift, direction: currentSortOrder };
+          }
+        }
+      }
+      return currentSortBy;
+    });
+  }, [columnShift, columns, currentSortField, currentSortFunc, currentSortOrder, sortBy]);
+
+  React.useEffect(() => {
     const handleResize = _.debounce(() => setWindowWidth(window.innerWidth), 100);
     const sp = new URLSearchParams(window.location.search);
     const columnIndex = _.findIndex(columns, { title: sp.get('sortBy') });
@@ -512,86 +601,53 @@ export const Table: React.FC<TableProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const ariaRowCount = data && data.length;
-  const scrollNode = typeof scrollElement === 'function' ? scrollElement() : scrollElement;
-  const renderVirtualizedTable = (scrollContainer) => (
-    <WindowScroller scrollElement={scrollContainer}>
-      {({ height, isScrolling, registerChild, onChildScroll, scrollTop }) => (
-        <AutoSizer disableHeight>
-          {({ width }) => (
-            <div ref={registerChild}>
-              <VirtualBody
-                Row={Row}
-                customData={customData}
-                height={height}
-                isScrolling={isScrolling}
-                onChildScroll={onChildScroll}
-                data={data}
-                columns={columns}
-                scrollTop={scrollTop}
-                width={width}
-                expand={expand}
-                getRowProps={getRowProps}
-                onRowsRendered={onRowsRendered}
-              />
-            </div>
-          )}
-        </AutoSizer>
-      )}
-    </WindowScroller>
-  );
-  const children = mock ? (
-    <EmptyBox label={label} />
-  ) : (
-    <div className={classNames({ 'co-virtualized-table': virtualize })}>
-      <TableWrapper virtualize={virtualize} ariaLabel={ariaLabel} ariaRowCount={ariaRowCount}>
-        <PfTable
-          cells={columns}
-          rows={
-            virtualize
-              ? []
-              : Rows({
-                  componentProps,
-                  selectedResourcesForKind,
-                  customData,
-                })
-          }
-          gridBreakPoint={gridBreakPoint}
-          onSort={onSort}
-          onSelect={onSelect}
-          sortBy={sortBy}
-          className="pf-m-compact pf-m-border-rows"
-          role={virtualize ? 'presentation' : 'grid'}
-          aria-label={virtualize ? null : ariaLabel}
-        >
-          <TableHeaderDeprecated role="rowgroup" />
-          {!virtualize && <TableBodyDeprecated />}
-        </PfTable>
-        {virtualize &&
-          (scrollNode ? (
-            renderVirtualizedTable(scrollNode)
-          ) : (
-            <WithScrollContainer>{renderVirtualizedTable}</WithScrollContainer>
-          ))}
-      </TableWrapper>
-    </div>
-  );
   return (
-    <div className="co-m-table-grid co-m-table-grid--bordered">
+    <div data-test={dataTest} className="co-m-table-grid co-m-table-grid--bordered">
       {mock ? (
-        children
+        <EmptyBox label={label} />
       ) : (
         <StatusBox
           skeleton={<div className="loading-skeleton--table" />}
           data={data}
           loaded={loaded}
           loadError={loadError}
-          unfilteredData={propData}
+          unfilteredData={unfilteredData}
           label={label}
           NoDataEmptyMsg={NoDataEmptyMsg}
           EmptyMsg={EmptyMsg}
         >
-          {children}
+          {virtualize ? (
+            <VirtualizedTable
+              Row={Row}
+              ariaLabel={ariaLabel}
+              columns={columns}
+              customData={customData}
+              data={data}
+              expand={expand}
+              getRowProps={getRowProps}
+              gridBreakPoint={gridBreakPoint}
+              onRowsRendered={onRowsRendered}
+              onSelect={onSelect}
+              onSort={onSort}
+              scrollElement={scrollElement}
+              sortBy={sortBy}
+            />
+          ) : (
+            <StandardTable
+              Rows={Rows}
+              columns={columns}
+              data={data}
+              filters={filters}
+              selected={selected}
+              kindObj={kindObj}
+              customData={customData}
+              gridBreakPoint={gridBreakPoint}
+              onSelect={onSelect}
+              onSort={onSort}
+              selectedResourcesForKind={selectedResourcesForKind}
+              sortBy={sortBy}
+            />
+          )}
         </StatusBox>
       )}
     </div>
@@ -600,23 +656,32 @@ export const Table: React.FC<TableProps> = ({
 
 export type Filter = { key: string; value: string };
 
-type RowsArgs<C = any> = {
+type RowsArgs = {
   componentProps: ComponentProps;
   selectedResourcesForKind: string[];
-  customData: C;
+  customData: any;
 };
 
-export type TableProps<D = any, C = any> = Partial<ComponentProps<D>> & {
-  customData?: C;
-  customSorts?: { [key: string]: (obj: D) => number | string };
+export type TableColumn = {
+  title: string;
+  id?: string;
+  additional?: boolean;
+  sortFunc?: string;
+  sortField?: string;
+  props?: any;
+};
+
+export type TableProps = Partial<ComponentProps> & {
+  customData?: any;
+  customSorts?: { [key: string]: (obj: any) => number | string };
   defaultSortFunc?: string;
   defaultSortField?: string;
   defaultSortOrder?: SortByDirection;
   showNamespaceOverride?: boolean;
   Header: HeaderFunc;
   loadError?: string | Object;
-  Row?: React.FC<RowFunctionArgs<D, C>>;
-  Rows?: (args: RowsArgs<C>) => PfTableProps['rows'];
+  Row?: React.FC<RowFunctionArgs>;
+  Rows?: (args: RowsArgs) => IRow[];
   'aria-label': string;
   onSelect?: OnSelect;
   virtualize?: boolean;
@@ -628,20 +693,48 @@ export type TableProps<D = any, C = any> = Partial<ComponentProps<D>> & {
   rowFilters?: RowFilter[];
   label?: string;
   columnManagementID?: string;
-  isPinned?: (val: D) => boolean;
+  isPinned?: (val: any) => boolean;
   staticFilters?: Filter[];
+  filters?: Filter[];
   activeColumns?: Set<string>;
   gridBreakPoint?: TableGridBreakpoint;
   selectedResourcesForKind?: string[];
   mock?: boolean;
   expand?: boolean;
   scrollElement?: HTMLElement | (() => HTMLElement);
-  getRowProps?: VirtualBodyProps<D>['getRowProps'];
-  onRowsRendered?: VirtualBodyProps<D>['onRowsRendered'];
+  getRowProps?: VirtualBodyProps['getRowProps'];
+  onRowsRendered?: VirtualBodyProps['onRowsRendered'];
+  'data-test'?: string;
 };
 
-export type ComponentProps<D = any> = {
-  data: D[];
+type VirtualizedTableProps = Partial<ComponentProps> & {
+  ariaLabel?: TableProps['aria-label'];
+  columns: TableColumn[];
+  customData?: TableProps['customData'];
+  expand?: boolean;
+  getRowProps?: TableProps['getRowProps'];
+  gridBreakPoint?: TableProps['gridBreakPoint'];
+  onRowsRendered?: VirtualBodyProps['onRowsRendered'];
+  onSelect?: TableProps['onSelect'];
+  onSort?: OnSort;
+  Row: TableProps['Row'];
+  scrollElement?: TableProps['scrollElement'];
+  sortBy: ISortBy;
+};
+
+type StandardTableProps = Partial<ComponentProps> & {
+  columns: TableColumn[];
+  customData?: TableProps['customData'];
+  gridBreakPoint?: TableProps['gridBreakPoint'];
+  onSelect: TableProps['onSelect'];
+  onSort: OnSort;
+  Rows?: TableProps['Rows'];
+  selectedResourcesForKind?: TableProps['selectedResourcesForKind'];
+  sortBy?: ISortBy;
+};
+
+export type ComponentProps = {
+  data: any[];
   filters: Filter[];
   selected: boolean;
   kindObj: K8sResourceKindReference;

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -33,7 +33,10 @@ import { getName } from '@console/shared/src/selectors/common';
 import { useDeepCompareMemoize } from '@console/shared/src/hooks/deep-compare-memoize';
 import { PackageManifestKind } from '@console/operator-lifecycle-manager/src/types';
 import { defaultChannelFor } from '@console/operator-lifecycle-manager/src/components';
-import { RowFilter as RowFilterExt } from '@console/dynamic-plugin-sdk';
+import {
+  RowFilter as RowFilterExt,
+  K8sResourceKindReference,
+} from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { RowFilter } from '../filter-toolbar';
 import * as UIActions from '../../actions/ui';
 import { alertingRuleStateOrder, alertSeverityOrder } from '../monitoring/utils';
@@ -41,21 +44,17 @@ import { ingressValidHosts } from '../ingress';
 import { convertToBaseValue, EmptyBox, StatusBox, WithScrollContainer } from '../utils';
 import {
   CustomResourceDefinitionKind,
-  getClusterOperatorStatus,
-  getClusterOperatorVersion,
-  getJobTypeAndCompletions,
-  getLatestVersionForCRD,
-  getTemplateInstanceStatus,
   K8sResourceKind,
-  K8sResourceKindReference,
   PodKind,
-  podPhase,
-  podReadiness,
-  podRestarts,
   MachineKind,
   VolumeSnapshotKind,
   ClusterOperator,
-} from '../../module/k8s';
+} from '../../module/k8s/types';
+import { getClusterOperatorStatus } from '../../module/k8s/cluster-operator';
+import { getClusterOperatorVersion, getJobTypeAndCompletions } from '../../module/k8s';
+import { getLatestVersionForCRD } from '../../module/k8s/k8s';
+import { getTemplateInstanceStatus } from '../../module/k8s/template';
+import { podPhase, podReadiness, podRestarts } from '../../module/k8s/pods';
 import { useTableData } from './table-data-hook';
 import TableHeader from './Table/TableHeader';
 

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -562,6 +562,7 @@
   "Modal": "Modal",
   "Submit": "Submit",
   "Reset": "Reset",
+  "Row select": "Row select",
   "Back": "Back",
   "Bug Reported": "Bug Reported",
   "Close": "Close",


### PR DESCRIPTION
public/components/factory/table.tsx
- Refactor Table component to remove PatternFly deprecated Table component 
- Separate virtualized/non-virtualized tables into local sub-components
- Remove unused generic types
- Address some nits and tech debt

public/components/factory/Table/VirtualizedTable.tsx
- Refactor VirtualizedTable component to remove PatternFly deprecated Table component
- Address a few nits and tech debt