### PR TITLE
OCPBUGS-43998: add allRowsSelected and canSelectAll in the virtualizedtable

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -318,6 +318,8 @@ export type VirtualizedTableProps<D, R extends any = {}> = {
   EmptyMsg?: React.ComponentType<{}>;
   scrollNode?: () => HTMLElement;
   onSelect?: OnSelect;
+  allRowsSelected?: boolean;
+  canSelectAll?: boolean;
   label?: string;
   'aria-label'?: string;
   gridBreakPoint?: TableGridBreakpoint;

--- a/frontend/public/components/factory/Table/VirtualizedTable.tsx
+++ b/frontend/public/components/factory/Table/VirtualizedTable.tsx
@@ -73,6 +73,8 @@ const VirtualizedTable: VirtualizedTableFC = ({
   'aria-label': ariaLabel,
   gridBreakPoint = TableGridBreakpoint.none,
   onSelect,
+  allRowsSelected,
+  canSelectAll = true,
   Row,
   rowData,
   unfilteredData,
@@ -224,7 +226,8 @@ const VirtualizedTable: VirtualizedTableFC = ({
             )}
             <PfTable
               cells={columns}
-              rows={[]}
+              rows={[{ selected: allRowsSelected }]}
+              canSelectAll={canSelectAll}
               gridBreakPoint={gridBreakPoint}
               onSort={onSort}
               onSelect={onSelect}


### PR DESCRIPTION
Lets just use a patternfly feature in the virtualized table. We already have the onSelect method for doing that but it's pretty much useless if we don't add those two props for controlling the header select.



**Demo**

**List state when we use the `onSelect` prop**
(You can't check the header checkbox)

<img width="1920" alt="Screenshot 2024-10-30 at 10 56 25" src="https://github.com/user-attachments/assets/3f8e3dda-0f5d-4a77-b802-4b517c094df4">


**Have selection in the table but not in the header**
<img width="1920" alt="Screenshot 2024-10-29 at 16 22 27" src="https://github.com/user-attachments/assets/f320e0a5-1626-4a52-ad48-391dd39362ed">


**Select the header selection in case all rows are selected**

<img width="1920" alt="Screenshot 2024-10-29 at 16 21 44" src="https://github.com/user-attachments/assets/def9e426-ba13-4346-9b5a-cbc302972c78">
