### PR TITLE
OCPBUGS-43925: BuildConfig form breaks on manually enter the Git URL

### DIFF
--- a/frontend/packages/dev-console/src/components/import/git/GitTypeSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitTypeSelector.tsx
@@ -7,6 +7,7 @@ import {
   GitAltIcon,
 } from '@patternfly/react-icons/dist/esm/icons';
 import { FormikValues, useFormikContext } from 'formik';
+import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { GitProvider } from '@console/git-service/src';
 import GiteaIcon from '../GiteaIcon';
@@ -26,6 +27,7 @@ const GitTypeSelector: React.FC<GitTypeSelectorProps> = ({ fieldPrefix }) => {
     setFieldValue(`${fieldPrefix}git.type`, gitType, false);
     setFieldTouched(`${fieldPrefix}git.type`, true, false);
   };
+  const typeValue = _.get(values, `${fieldPrefix}git.type`);
 
   return (
     <>
@@ -37,7 +39,7 @@ const GitTypeSelector: React.FC<GitTypeSelectorProps> = ({ fieldPrefix }) => {
               title={GitReadableTypes[GitProvider.GITHUB]}
               icon={<GithubIcon />}
               onClick={() => handleGitTypeChange(GitProvider.GITHUB)}
-              isSelected={values.git.type === GitProvider.GITHUB}
+              isSelected={typeValue === GitProvider.GITHUB}
               id="git-type-github"
             />
           </FlexItem>
@@ -47,7 +49,7 @@ const GitTypeSelector: React.FC<GitTypeSelectorProps> = ({ fieldPrefix }) => {
               title={GitReadableTypes[GitProvider.GITLAB]}
               icon={<GitlabIcon />}
               onClick={() => handleGitTypeChange(GitProvider.GITLAB)}
-              isSelected={values.git.type === GitProvider.GITLAB}
+              isSelected={typeValue === GitProvider.GITLAB}
               id="git-type-gitlab"
             />
           </FlexItem>
@@ -57,7 +59,7 @@ const GitTypeSelector: React.FC<GitTypeSelectorProps> = ({ fieldPrefix }) => {
               title={GitReadableTypes[GitProvider.BITBUCKET]}
               icon={<BitbucketIcon />}
               onClick={() => handleGitTypeChange(GitProvider.BITBUCKET)}
-              isSelected={values.git.type === GitProvider.BITBUCKET}
+              isSelected={typeValue === GitProvider.BITBUCKET}
               id="git-type-bitbucket"
             />
           </FlexItem>
@@ -67,7 +69,7 @@ const GitTypeSelector: React.FC<GitTypeSelectorProps> = ({ fieldPrefix }) => {
               title={GitReadableTypes[GitProvider.GITEA]}
               icon={<GiteaIcon />}
               onClick={() => handleGitTypeChange(GitProvider.GITEA)}
-              isSelected={values.git.type === GitProvider.GITEA}
+              isSelected={typeValue === GitProvider.GITEA}
               id="git-type-gitea"
             />
           </FlexItem>
@@ -77,7 +79,7 @@ const GitTypeSelector: React.FC<GitTypeSelectorProps> = ({ fieldPrefix }) => {
               title={GitReadableTypes[GitProvider.UNSURE]}
               icon={<GitAltIcon />}
               onClick={() => handleGitTypeChange(GitProvider.UNSURE)}
-              isSelected={values.git.type === GitProvider.UNSURE}
+              isSelected={typeValue === GitProvider.UNSURE}
               id="git-type-other"
             />
           </FlexItem>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-43925

**Analysis / Root cause**: 
While getting git type value from fromik value fieldPrefix was not considered 

**Solution Description**: 
Updated GitTypeSelector component to consider fieldPrefix while fetching git type 
  
**Screen shots / Gifs for design review**: 

-------- BuildConfig form-----

https://github.com/user-attachments/assets/f8bce8eb-cf72-40b3-a8df-ad95cbf8b29c

-----

-------- Import from git form-----

https://github.com/user-attachments/assets/b4e05bbf-4074-442f-9698-b7d58da63b97

-----

-------- Create serverless form-----

https://github.com/user-attachments/assets/0f3c70cc-d48a-423e-88b3-5ba67347c057














**Unit test coverage report**: 
NA

**Test setup:**

    1. Navigate to Create BuildConfig form page
    2. Select source type as Git
    3. Enter the git url by typing manually do not paste or select from the suggestion
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge




