### PR TITLE
OCPBUGS-43996: Add flag to disallowed Pipeline edit URL in the pipelines-plugin

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -770,6 +770,9 @@
       "component": {
         "$codeRef": "pipelinesComponent.PipelineBuilderEditPage"
       }
+    },
+    "flags": {
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_BUILDER"]
     }
   },
   {
@@ -780,6 +783,9 @@
       "component": {
         "$codeRef": "pipelinesComponent.PipelineBuilderEditPage"
       }
+    },
+    "flags": {
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_BUILDER"]
     }
   },
   {


### PR DESCRIPTION
Add a flag to disallowed the Pipeline edit URL in console pipelines-plugin so that it will not conflict between the console and Pipelines console-plugin    