### PR TITLE
OCPBUGS-43983: update ConditionalUpdates release type

### DIFF
--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -45,7 +45,15 @@ export const getSortedAvailableUpdates = (cv: ClusterVersionKind): VersionUpdate
 };
 
 const getConditionalClusterUpdates = (cv: ClusterVersionKind): ConditionalUpdate[] => {
-  return cv?.status?.conditionalUpdates || [];
+  return (
+    cv?.status?.conditionalUpdates?.map((update) => ({
+      conditions: update.conditions,
+      release: {
+        image: update.release.image,
+        version: update.release.version,
+      },
+    })) ?? []
+  );
 };
 
 export const getNotRecommendedUpdateCondition = (

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -810,7 +810,7 @@ export type Release = {
 export type VersionUpdate = { version?: string; image?: string };
 
 export type ConditionalUpdate = {
-  release: Release;
+  release: VersionUpdate;
   conditions: K8sResourceCondition[];
 };
 


### PR DESCRIPTION
After: ConditonalUpdate patch will look like following, which will not trigger Admission Webhook Warning
```
[{"op":"add","path":"/spec/desiredUpdate","value":{"image":"registry.ci.openshift.org/ocp/release@sha256:20abbd29314c68c67cd6822952f5688bc5955d526b5663e561780d2cffa4277a","version":"4.18.0-0.nightly-2024-10-31-064113"}}]
```
https://github.com/user-attachments/assets/f19e5cc6-c03e-4513-b217-256ec1e98eb7