### PR TITLE
OCPBUGS-44059: Run `check-resolution` in parallel

### DIFF
--- a/frontend/scripts/check-patternfly-modules.sh
+++ b/frontend/scripts/check-patternfly-modules.sh
@@ -71,7 +71,7 @@ PKGS_TO_CHECK=(
 
 echo -e "Checking ${COL_YELLOW}yarn.lock${COL_RESET} file for PatternFly module resolutions"
 
-if [ "$OPENSHIFT_CI" = true ]; then
+if [[ "$OPENSHIFT_CI" == "true" ]]; then
   # disable parallel execution in CI to reduce CPU usage
   for pkg in "${PKGS_TO_CHECK[@]}"; do
     check-resolution "${pkg%%:*}" "${pkg#*:}"

--- a/frontend/scripts/check-patternfly-modules.sh
+++ b/frontend/scripts/check-patternfly-modules.sh
@@ -8,6 +8,9 @@ COL_YELLOW='\033[33m'
 
 resolution_errors=false
 
+# https://docs.ci.openshift.org/docs/architecture/step-registry/#step-execution-environment
+OPENSHIFT_CI=${OPENSHIFT_CI:=false}
+
 # Ensure that only one major version resolution exists for the given package in yarn.lock file.
 # Having multiple version resolutions may lead to bugs and webpack build or performance issues.
 check-resolution() {
@@ -68,9 +71,18 @@ PKGS_TO_CHECK=(
 
 echo -e "Checking ${COL_YELLOW}yarn.lock${COL_RESET} file for PatternFly module resolutions"
 
-for pkg in "${PKGS_TO_CHECK[@]}"; do
-  check-resolution "${pkg%%:*}" "${pkg#*:}"
-done
+if [ "$OPENSHIFT_CI" = true ]; then
+  # disable parallel execution in CI to reduce CPU usage
+  for pkg in "${PKGS_TO_CHECK[@]}"; do
+    check-resolution "${pkg%%:*}" "${pkg#*:}"
+  done
+else
+  for pkg in "${PKGS_TO_CHECK[@]}"; do
+    check-resolution "${pkg%%:*}" "${pkg#*:}" &
+  done
+
+  wait
+fi
 
 if [[ "$resolution_errors" == "false" ]]; then
   echo -e "${COL_GREEN}No issues detected${COL_RESET}"


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGS-44059

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of -->
Currently check-patternfly-modules.sh checks dependencies serially, which could be made faster by checking them in parallel. 

Since `yarn why` does not write to anything, this should be easily parallelizable as there is no race condition with writing back to the yarn.lock

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
The `check-resolution` function is now run in parallel

Hardware used:
```
Fedora Linux 41 (Workstation Edition)
Dell Inc. XPS 13 9310
11th Gen Intel® Core™ i7-1185G7 × 8
32.0 GiB Memory
```

Results after running `time ./check-patternfly-modules.sh`:
```
before (trial 1):
real	3m43.195s
user	4m12.756s
sys	1m23.471s

before (trial 2):
real	3m28.193s
user	4m6.334s
sys	1m17.644s

before (trial 3):
real	3m16.052s
user	3m59.488s
sys	1m16.666s



after (trial 1):
real	2m9.005s
user	5m47.988s
sys	1m38.153s

after (trial 2):
real	1m35.808s
user	5m51.834s
sys	1m46.357s

after (trial 3):
real	1m32.960s
user	5m49.147s
sys	1m42.260s
```

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
n/a

**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
`./check-patternfly-modules.sh` should run the same as before

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
n/a