### PR TITLE
OCPBUGS-43266: remove Architecture from workloads Metrics tab

### DIFF
--- a/frontend/packages/console-shared/src/promql/resource-metrics.ts
+++ b/frontend/packages/console-shared/src/promql/resource-metrics.ts
@@ -5,7 +5,6 @@ import { useK8sModel } from '../hooks/useK8sModel';
 export enum ResourceUtilizationQuery {
   MEMORY = 'MEMORY',
   CPU = 'CPU',
-  CPU_ARCH = 'CPU_ARCH',
   FILESYSTEM = 'FILESYSTEM',
   NETWORK_IN = 'NETWORK_IN',
   NETWORK_OUT = 'NETWORK_OUT',
@@ -41,9 +40,6 @@ const podControllerMetricsQueries = {
   ),
   [ResourceUtilizationQuery.CPU]: _.template(
     "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{} * on(pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
-  ),
-  [ResourceUtilizationQuery.CPU_ARCH]: _.template(
-    "sum by(node) (kube_node_info{node='<%= name %>'})",
   ),
   [ResourceUtilizationQuery.FILESYSTEM]: _.template(
     "sum(pod:container_fs_usage_bytes:sum * on(pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",

--- a/frontend/public/components/utils/resource-metrics.tsx
+++ b/frontend/public/components/utils/resource-metrics.tsx
@@ -62,13 +62,6 @@ export const ResourceMetricsDashboard: React.FC<ResourceMetricsDashboardProps> =
             title={t('public~Network out')}
           />
         </GridItem>
-        <GridItem xl={6} lg={12}>
-          <ResourceMetricsDashboardCard
-            namespace={obj.metadata.namespace}
-            queries={queries[ResourceUtilizationQuery.CPU_ARCH]}
-            title={t('public~Architecture')}
-          />
-        </GridItem>
       </Grid>
     </Dashboard>
   ) : null;


### PR DESCRIPTION
`Architecture` metrics seems not needed regarding [comments](https://github.com/openshift/console/pull/13718/files#r1550952714) 
Also `Architecture` metrics only returns `No datapoints found`

<img width="1440" alt="Screenshot 2024-11-04 at 4 43 28 PM" src="https://github.com/user-attachments/assets/64273379-df3c-45a0-81be-5ba0c9ec2dfe">
