### PR TITLE
OCPBUGS-44014: Cancelling the file browser dialog causes TypeError crash

### DIFF
--- a/frontend/public/components/utils/file-input.tsx
+++ b/frontend/public/components/utils/file-input.tsx
@@ -26,6 +26,9 @@ class FileInputWithTranslation extends React.Component<FileInputProps, FileInput
   }
   readFile(file) {
     const { t } = this.props;
+    if (!file) {
+      return;
+    }
     if (file.size > maxFileUploadSize) {
       this.props.onChange({
         errorMessage: t('public~Maximum file size exceeded. File limit is 4MB.'),


### PR DESCRIPTION
When user closed the file browser, we attempted to read size from file that was undefined at that time, adding additional condition fixes this issue