### PR TITLE
OCPBUGS-44049: conditionally display MachineConfig details page Confi…

### DIFF
--- a/frontend/public/components/machine-config.tsx
+++ b/frontend/public/components/machine-config.tsx
@@ -69,33 +69,45 @@ const MachineConfigDetails: React.SFC<MachineConfigDetailsProps> = ({ obj }) => 
                 <TextContent>
                   <Text data-test={`config-file-path-${i}`}>{file.path}</Text>
                 </TextContent>
-                <Popover
-                  headerContent={t('public~Properties')}
-                  bodyContent={
-                    <DescriptionList isHorizontal isFluid>
-                      <DescriptionListGroup>
-                        <DescriptionListTerm>{t('public~Mode')}</DescriptionListTerm>
-                        <DescriptionListDescription>{file.mode}</DescriptionListDescription>
-                        <DescriptionListTerm>{t('public~Overwrite')}</DescriptionListTerm>
-                        <DescriptionListDescription>
-                          {file.overwrite.toString()}
-                        </DescriptionListDescription>
-                      </DescriptionListGroup>
-                    </DescriptionList>
-                  }
-                >
-                  <Button
-                    variant={ButtonVariant.plain}
-                    aria-label={'public~Info'}
-                    className="pf-v5-u-ml-sm pf-v5-u-p-0"
+                {(file.mode || file.overwrite) && (
+                  <Popover
+                    headerContent={t('public~Properties')}
+                    bodyContent={
+                      <DescriptionList isHorizontal isFluid>
+                        <DescriptionListGroup>
+                          {file.mode && (
+                            <>
+                              <DescriptionListTerm>{t('public~Mode')}</DescriptionListTerm>
+                              <DescriptionListDescription>{file.mode}</DescriptionListDescription>
+                            </>
+                          )}
+                          {file.overwrite && (
+                            <>
+                              <DescriptionListTerm>{t('public~Overwrite')}</DescriptionListTerm>
+                              <DescriptionListDescription>
+                                {file.overwrite.toString()}
+                              </DescriptionListDescription>
+                            </>
+                          )}
+                        </DescriptionListGroup>
+                      </DescriptionList>
+                    }
                   >
-                    <BlueInfoCircleIcon />
-                  </Button>
-                </Popover>
+                    <Button
+                      variant={ButtonVariant.plain}
+                      aria-label={'public~Info'}
+                      className="pf-v5-u-ml-sm pf-v5-u-p-0"
+                    >
+                      <BlueInfoCircleIcon />
+                    </Button>
+                  </Popover>
+                )}
               </Flex>
-              <CopyToClipboard
-                value={decodeURIComponent(file.contents.source).replace(/^(data:,)/, '')}
-              />
+              {file.contents?.source && (
+                <CopyToClipboard
+                  value={decodeURIComponent(file.contents.source).replace(/^(data:,)/, '')}
+                />
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
…guration files details

Based on my reading of [the Ignition Config Spec](https://coreos.github.io/ignition/configuration-v3_5/), only `path` is required, so make the display of the other properties optional.

After

https://github.com/user-attachments/assets/f64cf269-2578-4f68-a02d-0c05116ad932