### PR TITLE
OCPBUGS-44265: ReRun of Resolver based PipelineRuns fails from UI

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/utils.ts
@@ -148,9 +148,14 @@ export const getPipelineRunData = (
     spec: {
       ...(latestRun?.spec || {}),
       ...((latestRun?.spec.pipelineRef || pipeline) && {
-        pipelineRef: {
-          name: pipelineName,
-        },
+        pipelineRef: latestRun?.spec.pipelineRef?.resolver
+          ? {
+              resolver: latestRun.spec.pipelineRef?.resolver,
+              params: latestRun.spec.pipelineRef?.params,
+            }
+          : {
+              name: pipelineName,
+            },
       }),
       ...(params && { params }),
       workspaces,

--- a/frontend/packages/pipelines-plugin/src/types/pipelineRun.ts
+++ b/frontend/packages/pipelines-plugin/src/types/pipelineRun.ts
@@ -4,7 +4,7 @@ import {
   ObjectMetadata,
 } from '@console/internal/module/k8s';
 import { TektonResultsRun, TektonTaskSpec } from './coreTekton';
-import { PipelineKind, PipelineSpec } from './pipeline';
+import { PipelineKind, PipelineSpec, PipelineTaskParam } from './pipeline';
 
 export type PLRTaskRunStep = {
   container: string;
@@ -155,7 +155,7 @@ export type PipelineRunStatus = {
 
 export type PipelineRunKind = K8sResourceCommon & {
   spec: {
-    pipelineRef?: { name: string };
+    pipelineRef?: { name?: string; resolver?: string; params?: PipelineTaskParam[] };
     pipelineSpec?: PipelineSpec;
     params?: PipelineRunParam[];
     workspaces?: PipelineRunWorkspace[];

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
@@ -56,7 +56,7 @@ export const reRunPipelineRun: KebabAction = (kind: K8sKind, pipelineRun: Pipeli
   callback: () => {
     const namespace = _.get(pipelineRun, 'metadata.namespace');
     const { pipelineRef, pipelineSpec } = pipelineRun.spec;
-    if (namespace && (pipelineRef?.name || pipelineSpec)) {
+    if (namespace && (pipelineRef?.name || pipelineSpec || pipelineRef?.resolver)) {
       k8sCreate(returnValidPipelineRunModel(pipelineRun), getPipelineRunData(null, pipelineRun));
     } else {
       errorModal({


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-44265

**Analysis / Root cause**: 
PipelineRun with Resolver case was not handled. Only Pipeline name was sent at the time of rerun under pipelineRef.

**Solution Description**: 
If PLR is using resolver, instead of sending pipeline name in pipelineRef, resolver and params values are used.
  
**Screen shots / Gifs for design review**: 

**----BEFORE---**

----PLR list page kebab menu----


https://github.com/user-attachments/assets/60a7b2db-039b-4cf2-9d52-5d6ee0f9d5bd

-----

----PLR details page action menu----

https://github.com/user-attachments/assets/d6b68bdc-fd52-4a21-b770-38089eee3556


-----



**---AFTER----**




https://github.com/user-attachments/assets/ddc69380-3714-4b42-ae88-910148739e58








**Unit test coverage report**: 
NA

**Test setup:**

1. Create a resolver based pipelinerun using https://tekton.dev/docs/pipelines/resolution-getting-started/ or use the below provided yaml directly.
2. Attempt to "ReRun" the same from Console  

```
kind: PipelineRun
apiVersion: tekton.dev/v1
metadata:
  name: run-basic-pipeline-from-git
spec:
  pipelineRef:
    resolver: git
    params:
    - name: url
      value: https://github.com/lokanandaprabhu/pipelines-testing
    - name: revision
      value: main
    - name: pathInRepo
      value: pipeline.yaml
  params:
  - name: username
    value: admin
```
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge






