### PR TITLE
OCPBUGS-44305: Unable to remove finally tasks in pipeline builder mode

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/utils.ts
@@ -363,7 +363,7 @@ export const convertBuilderFormToPipeline = (
           ? tasks
           : existingPipeline?.spec?.tasks ??
             [].map((task) => task && removeEmptyFormFields(removeListRunAfters(task, listIds))),
-      finally: finallyTasks.length > 0 ? finallyTasks : existingPipeline?.spec?.finally ?? [],
+      finally: finallyTasks,
     },
   };
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-44305

**Analysis / Root cause**: 
If all Finally tasks are removed, existing Pipeline Finally task was considered, so user was not able to remove all the Finally tasks

**Solution Description**: 
Used finallyTasks from formData
  
**Screen shots / Gifs for design review**: 

----BEFORE---


https://github.com/user-attachments/assets/2fb44ca2-1be6-44a9-9bad-b5337c151fed








---AFTER----





https://github.com/user-attachments/assets/07f9fda8-dfff-4942-be3a-b91dd1f474da









**Unit test coverage report**: 
NA

**Test setup:**

1. Create a finally task in a pipeline in pipeline builder
2. Save pipeline
3. Edit pipeline and remove finally task in pipeline builder
4. Save pipeline
5. Observe that the finally task has not been removed
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge




