### PR TITLE
OCPBUGS-44170: clear PVC size doesn't set input value to zero in PVC creation page and Expand PVC modal

### DIFF
--- a/frontend/public/components/utils/request-size-input.tsx
+++ b/frontend/public/components/utils/request-size-input.tsx
@@ -18,7 +18,7 @@ export const RequestSizeInput: React.FC<RequestSizeInputProps> = ({
   required,
   testID,
 }) => {
-  const parsedRequestSizeValue = parseInt(defaultRequestSizeValue, 10) || 1;
+  const parsedRequestSizeValue = parseInt(defaultRequestSizeValue, 10) || 0;
   const defaultValue = Number.isFinite(parsedRequestSizeValue) ? parsedRequestSizeValue : null;
   const [unit, setUnit] = React.useState<string>(defaultRequestSizeUnit);
   const [value, setValue] = React.useState<number>(defaultValue);


### PR DESCRIPTION
setting the fallback value for the requesSize to 0 instead of 1, to conform to expected behaviour when clearing the input field

before:

https://drive.google.com/file/d/1Y-FwiCndGpnR6A8ZR1V9weumBi2xzcp0/view?usp=drive_link

after changes:


https://github.com/user-attachments/assets/a55cb154-fe23-4503-932e-24c4d77bc3dc

