### PR TITLE
CONSOLE-4268: add CSP violations to cluster dashboard

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -257,6 +257,7 @@
   "Pending plugins": "Pending plugins",
   "Loaded plugins": "Loaded plugins",
   "{{enabledCount}}/{{totalCount}} enabled": "{{enabledCount}}/{{totalCount}} enabled",
+  "One or more plugins might have Content Security Policy violations.": "One or more plugins might have Content Security Policy violations.",
   "View all": "View all",
   "Single control plane node": "Single control plane node",
   "Perspectives are enabled by default.": "Perspectives are enabled by default.",

--- a/frontend/packages/console-app/src/components/dashboards-page/dynamic-plugins-health-resource/DynamicPluginsPopover.tsx
+++ b/frontend/packages/console-app/src/components/dashboards-page/dynamic-plugins-health-resource/DynamicPluginsPopover.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Stack, StackItem } from '@patternfly/react-core';
+import { Alert, Stack, StackItem } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
 import { WatchK8sResults, WatchK8sResources } from '@console/dynamic-plugin-sdk';
@@ -17,6 +17,9 @@ const DynamicPluginsPopover: React.FC<DynamicPluginsPopoverProps> = ({ consolePl
   const failedPlugins = notLoadedDynamicPluginInfo.filter((plugin) => plugin.status === 'Failed');
   const pendingPlugins = notLoadedDynamicPluginInfo.filter((plugin) => plugin.status === 'Pending');
   const loadedPlugins = pluginInfoEntries.filter(isLoadedDynamicPluginInfo);
+  const loadedPluginsWithCSPViolations = loadedPlugins.filter(
+    (plugin) => plugin.hasCSPViolations === true,
+  );
   const enabledPlugins = loadedPlugins.filter((plugin) => plugin.enabled === true);
   const developmentMode = window.SERVER_FLAGS.k8sMode === 'off-cluster';
 
@@ -48,6 +51,16 @@ const DynamicPluginsPopover: React.FC<DynamicPluginsPopoverProps> = ({ consolePl
             </>
           }
         >
+          {loadedPluginsWithCSPViolations.length > 0 && (
+            <Alert
+              variant="warning"
+              isInline
+              isPlain
+              title={t(
+                'console-app~One or more plugins might have Content Security Policy violations.',
+              )}
+            />
+          )}
           <Link
             to={`/k8s/cluster/${referenceForModel(
               ConsoleOperatorConfigModel,

--- a/frontend/packages/integration-tests-cypress/tests/app/demo-dynamic-plugin.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/demo-dynamic-plugin.cy.ts
@@ -129,9 +129,7 @@ if (!Cypress.env('OPENSHIFT_CI') || Cypress.env('PLUGIN_PULL_SPEC')) {
               listPage.rows.shouldBeLoaded();
               listPage.filter.byName(PLUGIN_NAME);
               listPage.rows.shouldExist(PLUGIN_NAME);
-              if (!isLocalDevEnvironment && PLUGIN_PULL_SPEC) {
-                enableDemoPlugin(true);
-              }
+              enableDemoPlugin(true);
             });
         } else {
           console.log('this IS A local env, not setting the pull spec for the deployment');


### PR DESCRIPTION
Includes changes from https://github.com/openshift/console/pull/14374, which should merge first.  **Note** https://github.com/openshift/console/pull/14374 includes a bug that needs to be addressed where not Loaded plugins do not appear in the `Console plugins` list.

### Testing setup

To force a CSP violation in `console-demo-plugin`, add  `fetch('https://catfact.ninja/fact')` to line 4 of https://github.com/openshift/console/blob/master/dynamic-demo-plugin/src/utils/example-navs.tsx, rebuild and restart the plugin, and visit http://localhost:9000/dynamic-route-1.

### Demo
The alert in the Dynamic Plugins popover is the addition.
(Disregard the tooltip clipping at the end; that's the result of the recording being made with the browser's dev tools open.)

https://github.com/user-attachments/assets/3a80069e-039c-4400-8d51-612026b18cf9



