### PR TITLE
OCPBUGS-44369: Event modal persists after Add option is selected if knative service is not present

### DIFF
--- a/frontend/packages/knative-plugin/src/components/pub-sub/PubSubModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/PubSubModal.tsx
@@ -44,7 +44,7 @@ const PubSubModal: React.FC<Props> = ({
             label={t('knative-plugin~Name')}
             required
           />
-          <PubSubSubscriber />
+          <PubSubSubscriber cancel={cancel} />
           {filterEnabled && <PubSubFilter />}
         </FormSection>
       </ModalBody>

--- a/frontend/packages/knative-plugin/src/components/pub-sub/form-fields/PubSubSubscriber.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/form-fields/PubSubSubscriber.tsx
@@ -12,9 +12,10 @@ import { craftResourceKey } from '../pub-sub-utils';
 
 type PubSubSubscriberProps = {
   autoSelect?: boolean;
+  cancel?: () => void;
 };
 
-const PubSubSubscriber: React.FC<PubSubSubscriberProps> = ({ autoSelect = true }) => {
+const PubSubSubscriber: React.FC<PubSubSubscriberProps> = ({ autoSelect = true, cancel }) => {
   const { t } = useTranslation();
   const { values, setFieldValue, setFieldTouched, validateForm, setStatus } = useFormikContext<
     FormikValues
@@ -65,7 +66,15 @@ const PubSubSubscriber: React.FC<PubSubSubscriberProps> = ({ autoSelect = true }
           <Alert variant="custom" title={t('knative-plugin~No Subscriber available')} isInline>
             <Trans t={t} ns="knative-plugin">
               {'To create a Subscriber, first create a Knative Service from the '}
-              <Link to={`/add/ns/${namespace}`}>{'Add page'}</Link>.
+              <Link
+                to={`/add/ns/${namespace}`}
+                onClick={() => {
+                  cancel && cancel();
+                }}
+              >
+                {'Add page'}
+              </Link>
+              .
             </Trans>
           </Alert>
           &nbsp;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-44369

**Analysis / Root cause**: 
OnClick event was not added for Add page link

**Solution Description**: 
Added onClick event to close the modal on click of the link
  
**Screen shots / Gifs for design review**: 

----BEFORE---


https://drive.google.com/file/d/16hMbtBj0GeqUOLnUdCTMeYR3exY84oEn/view?usp=sharing







---AFTER----

https://github.com/user-attachments/assets/685e5753-82d3-408e-9756-b07a2ff889bd










**Unit test coverage report**: 
NA

**Test setup:**

    1. Enable event option in config map of knative-eventing namespace
    2. Create a broker and associate an event to it
    3. In topology select add trigger for the broker
    4. Since no service is created it will ask to go to Add page to create a service so select Add from the modal 
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge




