### PR TITLE
OCPBUGS-44566: Address circular references in `packages/knative-plugin`

### DIFF
--- a/frontend/packages/knative-plugin/src/topology/listView/KnativeRevisionListViewNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/listView/KnativeRevisionListViewNode.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import { DataListCell } from '@patternfly/react-core';
 import { Node, observer } from '@patternfly/react-topology';
-import {
-  CpuCellComponent,
-  MemoryCellComponent,
-  StatusCellResourceStatus,
-  TopologyListViewNode,
-} from '@console/topology/src/components/list-view';
+import { CpuCellComponent } from '@console/topology/src/components/list-view/cells/CpuCell';
+import { MemoryCellComponent } from '@console/topology/src/components/list-view/cells/MemoryCell';
+import { StatusCellResourceStatus } from '@console/topology/src/components/list-view/cells/StatusCell';
+import TopologyListViewNode from '@console/topology/src/components/list-view/TopologyListViewNode';
 import {
   getTopologyResourceObject,
   useOverviewMetrics,

--- a/frontend/packages/knative-plugin/src/topology/listView/KnativeServiceListViewNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/listView/KnativeServiceListViewNode.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { Node, observer } from '@patternfly/react-topology';
-import {
-  TopologyListViewNode,
-  TypedResourceBadgeCell,
-} from '@console/topology/src/components/list-view';
+import TypedResourceBadgeCell from '@console/topology/src/components/list-view/cells/TypedResourceBadgeCell';
+import TopologyListViewNode from '@console/topology/src/components/list-view/TopologyListViewNode';
 import { getResource, getResourceKind } from '@console/topology/src/utils';
 import { isServerlessFunction } from '../knative-topology-utils';
 

--- a/frontend/packages/knative-plugin/src/topology/listView/NoStatusListViewNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/listView/NoStatusListViewNode.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import {
-  TopologyListViewNode,
-  TypedResourceBadgeCell,
-} from '@console/topology/src/components/list-view';
+import TypedResourceBadgeCell from '@console/topology/src/components/list-view/cells/TypedResourceBadgeCell';
+import TopologyListViewNode from '@console/topology/src/components/list-view/TopologyListViewNode';
 import { OdcBaseNode } from '@console/topology/src/elements';
 import { getResourceKind } from '@console/topology/src/utils';
 import { EventSourceIcon, eventIconStyle } from '../../utils/icons';

--- a/frontend/packages/knative-plugin/src/topology/listView/SinkUriListViewNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/listView/SinkUriListViewNode.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { DataListCell } from '@patternfly/react-core';
 import { observer } from '@patternfly/react-topology';
-import {
-  TopologyListViewNode,
-  TypedResourceBadgeCell,
-} from '@console/topology/src/components/list-view';
+import TypedResourceBadgeCell from '@console/topology/src/components/list-view/cells/TypedResourceBadgeCell';
+import TopologyListViewNode from '@console/topology/src/components/list-view/TopologyListViewNode';
 import { OdcBaseNode } from '@console/topology/src/elements';
 
 interface SinkUriListViewNodeProps {


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
Fixes: https://issues.redhat.com/browse/OCPBUGS-44566

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Barrel imports caused circular references 

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Replace `index.ts`/barrel imports with their direct counterparts

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
n/a

**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Run `yarn check-cycles` and observe that there are no more cycles involving the `knative-plugin/src/topology` folder, excluding cycles with module paths that match the regex `/node_modules|public\/dist|@console\/active-plugins/` (those will be addressed in separate PRs)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

This is 1 of many PRs to inch towards closing [OCPBUGS-44017](https://issues.redhat.com/browse/OCPBUGS-44017)