### PR TITLE
OCPBUGS-44567: Address circular references in `packages/pipelines-plugin`

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/utils.ts
@@ -11,7 +11,7 @@ import {
   TaskKind,
   TektonParam,
 } from '../../../types';
-import { sanitizePipelineParams } from '../detail-page-tabs';
+import { sanitizePipelineParams } from '../detail-page-tabs/utils';
 import { getTaskParameters } from '../resource-utils';
 import {
   getTaskErrorString,


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
Fixes: https://issues.redhat.com/browse/OCPBUGS-44566

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Barrel imports caused circular references 

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Replace `index.ts`/barrel imports with their direct counterparts

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
n/a

**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Run `yarn check-cycles` and observe that there are no more cycles involving the `packages/pipelines-plugin` folder, excluding cycles with module paths that match the regex `/node_modules|public\/dist|@console\/active-plugins/` (those will be addressed in separate PRs)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

This is 1 of many PRs to inch towards closing [OCPBUGS-44017](https://issues.redhat.com/browse/OCPBUGS-44017)