### PR TITLE
OCPBUGS-44573: Address circular references in `webterminal-plugin` and `console-app`

### DIFF
--- a/frontend/packages/console-app/src/components/user-preferences/synced-editor/usePreferredCreateEditMethod.ts
+++ b/frontend/packages/console-app/src/components/user-preferences/synced-editor/usePreferredCreateEditMethod.ts
@@ -1,4 +1,4 @@
-import { useUserSettings } from '@console/shared';
+import { useUserSettings } from '@console/shared/src/hooks/useUserSettings';
 
 export const PREFERRED_CREATE_EDIT_METHOD_USER_SETTING_VALUE_LATEST = 'latest';
 const PREFERRED_CREATE_EDIT_METHOD_USER_SETTING_KEY = 'console.preferredCreateEditMethod';

--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/__tests__/useCloudShellAvailable.spec.ts
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/__tests__/useCloudShellAvailable.spec.ts
@@ -4,7 +4,7 @@ import { checkTerminalAvailable } from '../cloud-shell-utils';
 import useCloudShellAvailable from '../useCloudShellAvailable';
 // Need to import useFlag after useCloudShellAvailable for the mock to work correctly. FInd out why?
 // eslint-disable-next-line import/order
-import { useFlag } from '@console/shared';
+import { useFlag } from '@console/shared/src/hooks/flag';
 
 const useFlagMock = useFlag as jest.Mock;
 const checkTerminalAvailableMock = checkTerminalAvailable as jest.Mock;
@@ -15,8 +15,8 @@ jest.mock('../cloud-shell-utils', () => {
   };
 });
 
-jest.mock('@console/shared', () => {
-  const originalModule = (jest as any).requireActual('@console/shared');
+jest.mock('@console/shared/src/hooks/flag', () => {
+  const originalModule = (jest as any).requireActual('@console/shared/src/hooks/flag');
   return {
     ...originalModule,
     useFlag: jest.fn<boolean>(),

--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/useCloudShellAvailable.ts
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/useCloudShellAvailable.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useFlag } from '@console/shared';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { FLAG_DEVWORKSPACE } from '../../const';
 import { checkTerminalAvailable } from './cloud-shell-utils';
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
Fixes: https://issues.redhat.com/browse/OCPBUGS-44573

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Barrel imports caused circular references 

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Replace `index.ts`/barrel imports with their direct counterparts

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
n/a

**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Run `yarn check-cycles` and observe that there are no more cycles involving the `packages/webterminal-plugin` and `packages/console-app` folder, excluding cycles with module paths that match the regex `/node_modules|public\/dist|@console\/active-plugins/` (those will be addressed in separate PRs)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

This is 1 of many PRs to inch towards closing [OCPBUGS-44017](https://issues.redhat.com/browse/OCPBUGS-44017)