### PR TITLE
OCPBUGS-44574: Address circular references in `packages/console-shared`

### DIFF
--- a/frontend/packages/console-shared/src/components/custom-resource-list/CustomResourceList.tsx
+++ b/frontend/packages/console-shared/src/components/custom-resource-list/CustomResourceList.tsx
@@ -3,7 +3,7 @@ import { EmptyState, EmptyStateVariant } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { Table, RowFunctionArgs, TableProps } from '@console/internal/components/factory';
+import { Table, RowFunctionArgs, TableProps } from '@console/internal/components/factory/table';
 import { FilterToolbar, RowFilter } from '@console/internal/components/filter-toolbar';
 import { getQueryArgument, LoadingBox } from '@console/internal/components/utils';
 

--- a/frontend/packages/console-shared/src/components/modals/CreateNamespaceModal.tsx
+++ b/frontend/packages/console-shared/src/components/modals/CreateNamespaceModal.tsx
@@ -16,12 +16,9 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { CreateProjectModalProps } from '@console/dynamic-plugin-sdk/src';
 import { ModalComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/ModalProvider';
-import {
-  SelectorInput,
-  resourceObjPath,
-  LoadingInline,
-  // Dropdown,
-} from '@console/internal/components/utils';
+import { resourceObjPath } from '@console/internal/components/utils/resource-link';
+import { SelectorInput } from '@console/internal/components/utils/selector-input';
+import { LoadingInline } from '@console/internal/components/utils/status-box';
 import { NamespaceModel, NetworkPolicyModel } from '@console/internal/models';
 import { k8sCreate, referenceFor } from '@console/internal/module/k8s';
 

--- a/frontend/public/components/ThemeProvider.tsx
+++ b/frontend/public/components/ThemeProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useUserSettings } from '@console/shared';
+import { useUserSettings } from '@console/shared/src/hooks/useUserSettings';
 
 export const THEME_USER_SETTING_KEY = 'console.theme';
 export const THEME_LOCAL_STORAGE_KEY = 'bridge/theme';

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -19,16 +19,13 @@ import {
 } from '@patternfly/react-virtualized-extension';
 import { Scroll } from '@patternfly/react-virtualized-extension/dist/js/components/Virtualized/types';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import {
-  getMachinePhase,
-  getMachineSetInstanceType,
-  pvcUsed,
-  snapshotSize,
-  snapshotSource,
-  ALL_NAMESPACES_KEY,
-  getName,
-  useDeepCompareMemoize,
-} from '@console/shared';
+import { getMachinePhase } from '@console/shared/src/selectors/machine';
+import { getMachineSetInstanceType } from '@console/shared/src/selectors/machineSet';
+import { pvcUsed } from '@console/shared/src/sorts/pvc';
+import { snapshotSize, snapshotSource } from '@console/shared/src/sorts/snapshot';
+import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants/common';
+import { getName } from '@console/shared/src/selectors/common';
+import { useDeepCompareMemoize } from '@console/shared/src/hooks/deep-compare-memoize';
 import { PackageManifestKind } from '@console/operator-lifecycle-manager/src/types';
 import { defaultChannelFor } from '@console/operator-lifecycle-manager/src/components';
 import { RowFilter as RowFilterExt } from '@console/dynamic-plugin-sdk';


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
Fixes: https://issues.redhat.com/browse/OCPBUGS-44574

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Barrel imports caused circular references 

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Replace `index.ts`/barrel imports with their direct counterparts

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
n/a

**Unit test coverage report**: 
<!-- Attach test coverage report -->
n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Run `yarn check-cycles` and observe that there are no more cycles involving the `packages/webterminal-plugin` and `packages/console-app` folder, excluding cycles with module paths that match the regex `/node_modules|public\/dist|@console\/active-plugins/` (those will be addressed in separate PRs)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

This is 1 of many PRs to inch towards closing [OCPBUGS-44017](https://issues.redhat.com/browse/OCPBUGS-44017)