### PR TITLE
OCPBUGS-39361: Add help text for output image field in Create Shipwright build form

### DIFF
--- a/frontend/packages/shipwright-plugin/locales/en/shipwright-plugin.json
+++ b/frontend/packages/shipwright-plugin/locales/en/shipwright-plugin.json
@@ -37,6 +37,7 @@
   "Select a ConfigMap": "Select a ConfigMap",
   "Invalid YAML - {{err}}": "Invalid YAML - {{err}}",
   "Image": "Image",
+  "Example for OpenShift internal registry: image-registry.openshift-image-registry.svc:5000/<image-namespace>/<image-name>:latest": "Example for OpenShift internal registry: image-registry.openshift-image-registry.svc:5000/<image-namespace>/<image-name>:latest",
   "Parameters": "Parameters",
   "Select a Secret": "Select a Secret",
   "Push Secret": "Push Secret",

--- a/frontend/packages/shipwright-plugin/src/components/build-form/ImageSection.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/build-form/ImageSection.tsx
@@ -15,6 +15,9 @@ const ImageSection: React.FC<{ namespace: string }> = ({ namespace }) => {
         label={t('shipwright-plugin~Output image')}
         required
         autoComplete="off"
+        helpText={t(
+          'shipwright-plugin~Example for OpenShift internal registry: image-registry.openshift-image-registry.svc:5000/<image-namespace>/<image-name>:latest',
+        )}
       />
       <PushSecretSelector formContextField="formData.outputImage.secret" namespace={namespace} />
     </FormSection>


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-39361

Descriptions: Add help text for output image form.

Screenshots:
<img width="1146" alt="image" src="https://github.com/user-attachments/assets/db1b2a8d-b19f-4485-a43c-6a9891e4983e">
