### PR TITLE
OCPBUGS-43061: update the Deployment pod on change in imageStream

### DIFF
--- a/frontend/packages/dev-console/src/components/deployments/utils/deployment-utils.ts
+++ b/frontend/packages/dev-console/src/components/deployments/utils/deployment-utils.ts
@@ -358,7 +358,7 @@ export const getTriggersAndImageStreamValues = (
   return {
     ...data,
     triggers: {
-      image: imageTrigger?.paused === 'false',
+      image: imageTrigger?.paused === false,
     },
     fromImageStreamTag: !!imageTrigger,
     imageStream: {

--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -410,7 +410,7 @@ export const getDeploymentData = (resource: K8sResourceKind) => {
       return {
         env,
         triggers: {
-          image: imageTrigger?.paused === 'false',
+          image: imageTrigger?.paused === false,
         },
         replicas: resource.spec?.replicas ?? 1,
       };

--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
@@ -58,7 +58,7 @@ describe('Import Submit Utils', () => {
             namespace: 'gijohn',
           },
           fieldPath: 'spec.template.spec.containers[?(@.name=="nodejs-ex-git")].image',
-          paused: 'false',
+          paused: false,
         },
       ]);
       done();
@@ -431,7 +431,7 @@ describe('Import Submit Utils', () => {
             'app.openshift.io/vcs-ref': 'master',
             'app.openshift.io/vcs-uri': 'https://github.com/redhat-developer/devfile-sample',
             'image.openshift.io/triggers':
-              '[{"from":{"kind":"ImageStreamTag","name":"devfile-sample:latest","namespace":"gijohn"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"devfile-sample\\")].image","paused":"false"}]',
+              '[{"from":{"kind":"ImageStreamTag","name":"devfile-sample:latest","namespace":"gijohn"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"devfile-sample\\")].image","paused":false}]',
             isFromDevfile: 'true',
             'openshift.io/generated-by': 'OpenShiftWebConsole',
             'app.openshift.io/route-disabled': 'false',

--- a/frontend/packages/dev-console/src/components/import/__tests__/upload-jar-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/upload-jar-submit-utils.spec.ts
@@ -44,7 +44,7 @@ describe('Upload Jar Submit Utils', () => {
             namespace: 'my-app',
           },
           fieldPath: 'spec.template.spec.containers[?(@.name=="java-ex-git")].image',
-          paused: 'false',
+          paused: false,
         },
       ]);
       done();

--- a/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils-data.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils-data.ts
@@ -7,7 +7,7 @@ export const originalDeployment = {
       'app.openshift.io/vcs-ref': 'master',
       'app.openshift.io/vcs-uri': 'https://github.com/divyanshiGupta/nationalparks-py',
       'image.openshift.io/triggers':
-        '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","paused":"false"}]',
+        '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","paused":false}]',
       'openshift.io/generated-by': 'OpenShiftWebConsole',
       'app.openshift.io/connects-to': 'database',
       'deployment.kubernetes.io/revision': '4',
@@ -104,7 +104,7 @@ export const newDeployment = {
       'app.openshift.io/vcs-ref': 'master',
       'app.openshift.io/vcs-uri': 'https://github.com/divyanshiGupta/nationalparks-py',
       'image.openshift.io/triggers':
-        '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","paused":"true"}]',
+        '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","paused":true}]',
       'openshift.io/generated-by': 'OpenShiftWebConsole',
     },
     name: 'nationalparks-py',
@@ -169,7 +169,7 @@ export const devfileDeployment = {
       'app.openshift.io/vcs-ref': 'master',
       'app.openshift.io/vcs-uri': 'https://github.com/divyanshiGupta/nationalparks-py',
       'image.openshift.io/triggers':
-        '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","paused":"true"}]',
+        '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","paused":true}]',
       'openshift.io/generated-by': 'OpenShiftWebConsole',
       isFromDevfile: 'true',
     },

--- a/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils.spec.tsx
+++ b/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils.spec.tsx
@@ -36,7 +36,7 @@ describe('resource-label-utils', () => {
         'app.openshift.io/vcs-ref': 'master',
         'app.openshift.io/vcs-uri': 'https://github.com/divyanshiGupta/nationalparks-py',
         'image.openshift.io/triggers':
-          '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","paused":"true"}]',
+          '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","paused":true}]',
         'openshift.io/generated-by': 'OpenShiftWebConsole',
         'app.openshift.io/connects-to': 'database',
         'deployment.kubernetes.io/revision': '4',
@@ -125,12 +125,12 @@ describe('resource-label-utils', () => {
       let annotation = getTriggerAnnotation('test', 'python', 'div', true);
       expect(annotation).toEqual({
         'image.openshift.io/triggers':
-          '[{"from":{"kind":"ImageStreamTag","name":"python:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"test\\")].image","paused":"false"}]',
+          '[{"from":{"kind":"ImageStreamTag","name":"python:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"test\\")].image","paused":false}]',
       });
       annotation = getTriggerAnnotation('test', 'test', 'div', false);
       expect(annotation).toEqual({
         'image.openshift.io/triggers':
-          '[{"from":{"kind":"ImageStreamTag","name":"test:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"test\\")].image","paused":"true"}]',
+          '[{"from":{"kind":"ImageStreamTag","name":"test:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"test\\")].image","paused":true}]',
       });
     });
   });

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -75,7 +75,7 @@ export const getTriggerAnnotation = (
     {
       from: { kind: 'ImageStreamTag', name: `${imageName}:${imageTag}`, namespace: imageNamespace },
       fieldPath: `spec.template.spec.containers[?(@.name=="${containerName}")].image`,
-      paused: `${!imageTrigger}`,
+      paused: !imageTrigger,
     },
   ]),
 });


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-43061

Descriptions: 
- When the ImageStreamTag is updated, the pod does not automatically reflect the new image for Deployments created via the OpenShift Console. As in trigger annotation boolean value for paused is set as a string.


https://github.com/user-attachments/assets/eae9c096-7229-4c4a-8d8c-d3e17e66897d

