### PR TITLE
OCPBUGS-43859: Getting `Oh no, something went wrong` error when trying to install operator. 

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -253,11 +253,11 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
     setDeprecatedPackage(_.pick(item?.obj?.status, 'deprecation'));
   }, [item?.obj?.status, setDeprecatedPackage]);
   const currentChannel = obj?.status.channels.find((ch) => ch.name === installChannel);
-  const selectedChannelContainerImage = currentChannel?.currentCSVDesc.annotations.containerImage;
+  const selectedChannelContainerImage = currentChannel?.currentCSVDesc.annotations?.containerImage;
   const selectedChannelDescription = currentChannel?.currentCSVDesc.description || longDescription;
-  const selectedChannelCreatedAt = currentChannel?.currentCSVDesc.annotations.createdAt;
+  const selectedChannelCreatedAt = currentChannel?.currentCSVDesc.annotations?.createdAt;
   const selectedChannelCapabilityLevel =
-    currentChannel?.currentCSVDesc.annotations.capabilities ?? item.capabilityLevel;
+    currentChannel?.currentCSVDesc.annotations?.capabilities ?? item.capabilityLevel;
 
   const installedChannel = item?.subscription?.spec?.channel;
   const notAvailable = (


### PR DESCRIPTION
Some PackageManifests did not have a currentCSVDesc.annotations property resulting in console crashing for attempting to read from undefined