### PR TITLE
OCPBUGS-41974: ImagePullSecret getting duplicated when editing DeploymentConfig in Form View

### DIFF
--- a/frontend/packages/dev-console/src/components/deployments/utils/deployment-utils.ts
+++ b/frontend/packages/dev-console/src/components/deployments/utils/deployment-utils.ts
@@ -595,7 +595,12 @@ export const convertEditFormToDeployment = (
           containers: getUpdatedContainers(containers, fromImageStreamTag, isi, imageName, envs),
           imagePullSecrets: [
             ...(deployment.spec.template.spec.imagePullSecrets ?? []),
-            ...(imagePullSecret ? [{ name: imagePullSecret }] : []),
+            ...(imagePullSecret &&
+            !(deployment.spec.template.spec.imagePullSecrets ?? []).some(
+              (secret) => secret.name === imagePullSecret,
+            )
+              ? [{ name: imagePullSecret }]
+              : []),
           ],
         },
       },


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-41974

**Analysis / Root cause**: 
Duplicate check was not considered for image pull secrets

**Solution Description**: 
Added a check to skip if the secret is already added
  
**Screen shots / Gifs for design review**: 

**----BEFORE---**


https://github.com/user-attachments/assets/d84daab3-82b2-43cb-854e-18dc1bf52b10


-----



**---AFTER----**



https://github.com/user-attachments/assets/6fe725ac-9727-4960-a20c-826932d4592c











**Unit test coverage report**: 
NA

**Test setup:**

1. Create a Deployment or Deployment config
2. Add image pull secret
3. Edit D/DC and check imagePullSecrets


    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge






