### PR TITLE
OCPBUGS-44595: only enable Save button in Console plugin enablement m…

### DIFF
--- a/frontend/packages/console-shared/src/components/modals/ConsolePluginModal.tsx
+++ b/frontend/packages/console-shared/src/components/modals/ConsolePluginModal.tsx
@@ -71,6 +71,7 @@ export const ConsolePluginModal = withHandlePromise((props: ConsolePluginModalPr
         inProgress={inProgress}
         submitText={t('public~Save')}
         cancel={cancel}
+        submitDisabled={(previouslyEnabled && enabled) || (!previouslyEnabled && !enabled)}
       />
     </form>
   );


### PR DESCRIPTION
…odal if value changes

### Demo 
Note the demo was recorded with the console in development mode, so the `Enable` link is hacked to appear (it normally wouldn't in dev mode) and its label doesn't change because the plugin was enabled manually.

https://github.com/user-attachments/assets/7d87b3ab-2dcb-4bcc-92d7-ee49ef0a0646

