### PR TITLE
[release-4.17] OCPBUGS-44169: use TaskRuns results.tekton.dev/record annotation to get the logs

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -915,6 +915,12 @@
     }
   },
   {
+    "type": "console.flag/hookProvider",
+    "properties": {
+      "handler": { "$codeRef": "pipelinesComponent.useIsPipelineOperatorVersion_1_16_or_newer" }
+    }
+  },
+  {
     "type": "dev-console.add/action-group",
     "properties": {
       "id": "pipelines",

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunDetailsPage.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunDetailsPage.spec.tsx
@@ -3,6 +3,7 @@ import { shallow, ShallowWrapper } from 'enzyme';
 import { SemVer } from 'semver';
 import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource';
 import { DetailsPage } from '@console/internal/components/factory';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { PipelineRunModel } from '../../../models';
 import { getPipelineRunKebabActions } from '../../../utils/pipeline-actions';
 import * as hookUtils from '../../pipelines/hooks';
@@ -22,10 +23,17 @@ jest.mock('@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource',
   useK8sWatchResource: jest.fn(),
 }));
 
+jest.mock('@console/shared/src/hooks/flag', () => ({
+  useFlag: jest.fn(),
+}));
+
+const useFlagMock = useFlag as jest.Mock;
+
 describe('PipelineRunDetailsPage:', () => {
   let pipelineRunDetailsPageProps: PipelineRunDetailsPageProps;
   let wrapper: ShallowWrapper<PipelineRunDetailsPageProps>;
   beforeEach(() => {
+    useFlagMock.mockReturnValue(true);
     pipelineRunDetailsPageProps = {
       kind: PipelineRunModel.kind,
       kindObj: PipelineRunModel,

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/TektonTaskRunLog.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/TektonTaskRunLog.tsx
@@ -22,6 +22,7 @@ export const TektonTaskRunLog: React.FC<TektonTaskRunLogProps> = ({
   const [trResults, trLoaded, trError] = useTRTaskRunLog(
     taskRun.metadata.namespace,
     taskRun.metadata.name,
+    taskRun.metadata?.annotations?.['results.tekton.dev/record'],
   );
 
   React.useEffect(() => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/logs-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/logs-utils.ts
@@ -70,6 +70,7 @@ type StepsWatchUrl = {
   [key: string]: {
     name: string;
     steps: { [step: string]: WatchURLStatus };
+    taskRunPath: string;
   };
 };
 
@@ -121,6 +122,7 @@ export const getDownloadAllLogsCallback = (
       acc[currTask] = {
         name: pipelineTaskName,
         steps: { ...allStepUrls },
+        taskRunPath: taskRun.metadata?.annotations?.['results.tekton.dev/record'],
       };
       return acc;
     }, {});
@@ -155,7 +157,7 @@ export const getDownloadAllLogsCallback = (
         }
       } else {
         // eslint-disable-next-line no-await-in-loop
-        allLogs += await getTaskRunLog(namespace, currTask).then(
+        allLogs += await getTaskRunLog(task.taskRunPath).then(
           (log) => `${tasks[currTask].name.toUpperCase()}\n\n${log}\n\n`,
         );
       }

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/utils/tekton-results.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/utils/tekton-results.ts
@@ -108,9 +108,10 @@ export const EQ = (left: string, right: string) => EXP(left, `"${right}"`, '==')
 export const NEQ = (left: string, right: string) => EXP(left, `"${right}"`, '!=');
 
 export enum DataType {
-  PipelineRun = 'tekton.dev/v1beta1.PipelineRun',
-  TaskRun = 'tekton.dev/v1beta1.TaskRun',
-  Log = 'results.tekton.dev/v1alpha2.Log',
+  PipelineRunV1Beta1 = 'tekton.dev/v1beta1.PipelineRun',
+  TaskRunV1Beta1 = 'tekton.dev/v1beta1.TaskRun',
+  PipelineRunV1 = 'tekton.dev/v1.PipelineRun',
+  TaskRunV1 = 'tekton.dev/v1.TaskRun',
 }
 
 export const labelsToFilter = (labels?: MatchLabels): string =>
@@ -317,10 +318,13 @@ const getFilteredPipelineRuns = (
   options?: TektonResultsOptions,
   nextPageToken?: string,
   cacheKey?: string,
+  IS_PIPELINE_OPERATOR_VERSION_1_16_OR_NEWER?: boolean,
 ) =>
   getFilteredRecord<PipelineRunKind>(
     namespace,
-    DataType.PipelineRun,
+    IS_PIPELINE_OPERATOR_VERSION_1_16_OR_NEWER
+      ? DataType.PipelineRunV1
+      : DataType.PipelineRunV1Beta1,
     filter,
     options,
     nextPageToken,
@@ -333,10 +337,11 @@ const getFilteredTaskRuns = (
   options?: TektonResultsOptions,
   nextPageToken?: string,
   cacheKey?: string,
+  IS_PIPELINE_OPERATOR_VERSION_1_16_OR_NEWER?: boolean,
 ) =>
   getFilteredRecord<TaskRunKind>(
     namespace,
-    DataType.TaskRun,
+    IS_PIPELINE_OPERATOR_VERSION_1_16_OR_NEWER ? DataType.TaskRunV1 : DataType.TaskRunV1Beta1,
     filter,
     options,
     nextPageToken,
@@ -349,7 +354,16 @@ export const getPipelineRuns = (
   nextPageToken?: string,
   // supply a cacheKey only if the PipelineRun is complete and response will never change in the future
   cacheKey?: string,
-) => getFilteredPipelineRuns(namespace, '', options, nextPageToken, cacheKey);
+  IS_PIPELINE_OPERATOR_VERSION_1_16_OR_NEWER?: boolean,
+) =>
+  getFilteredPipelineRuns(
+    namespace,
+    '',
+    options,
+    nextPageToken,
+    cacheKey,
+    IS_PIPELINE_OPERATOR_VERSION_1_16_OR_NEWER,
+  );
 
 export const getTaskRuns = (
   namespace: string,
@@ -357,7 +371,16 @@ export const getTaskRuns = (
   nextPageToken?: string,
   // supply a cacheKey only if the TaskRun is complete and response will never change in the future
   cacheKey?: string,
-) => getFilteredTaskRuns(namespace, '', options, nextPageToken, cacheKey);
+  IS_PIPELINE_OPERATOR_VERSION_1_16_OR_NEWER?: boolean,
+) =>
+  getFilteredTaskRuns(
+    namespace,
+    '',
+    options,
+    nextPageToken,
+    cacheKey,
+    IS_PIPELINE_OPERATOR_VERSION_1_16_OR_NEWER,
+  );
 
 const isJSONString = (str: string): boolean => {
   try {
@@ -374,26 +397,14 @@ export const consoleProxyFetchLog = <T>(proxyRequest: ProxyRequest): Promise<T> 
   });
 };
 
-const getLog = async (taskRunPath: string) => {
-  const tektonResultUrl = await getTRURLHost();
-  const url = `https://${tektonResultUrl}/apis/results.tekton.dev/v1alpha2/parents/${taskRunPath.replace(
+export const getTaskRunLog = async (taskRunPath: string): Promise<string> => {
+  if (!taskRunPath) {
+    throw404();
+  }
+  const tektonResultsAPI = await getTRURLHost();
+  const url = `https://${tektonResultsAPI}/apis/results.tekton.dev/v1alpha2/parents/${taskRunPath.replace(
     '/records/',
     '/logs/',
   )}`;
   return consoleProxyFetchLog({ url, method: 'GET', allowInsecure: true });
 };
-
-export const getTaskRunLog = (namespace: string, taskRunName: string): Promise<string> =>
-  getFilteredRecord<any>(
-    namespace,
-    DataType.Log,
-    AND(EQ(`data.spec.resource.kind`, 'TaskRun'), EQ(`data.spec.resource.name`, taskRunName)),
-    { limit: 1 },
-  ).then((x) =>
-    x?.[1]?.records.length > 0
-      ? // eslint-disable-next-line promise/no-nesting
-        getLog(x?.[1]?.records[0].name).then((response: string) => {
-          return response;
-        })
-      : throw404(),
-  );

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/events/__tests__/TaskRunDetailsPage.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/events/__tests__/TaskRunDetailsPage.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource';
 import { DetailsPage } from '@console/internal/components/factory';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { TaskRunModel } from '../../../../models';
 import * as hookUtils from '../../../pipelines/hooks';
 import TaskRunDetailsPage from '../../TaskRunDetailsPage';
@@ -15,9 +16,16 @@ jest.mock('@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource',
   useK8sWatchResource: jest.fn(),
 }));
 
+jest.mock('@console/shared/src/hooks/flag', () => ({
+  useFlag: jest.fn(),
+}));
+
+const useFlagMock = useFlag as jest.Mock;
+
 describe('TaskRunDetailsPage:', () => {
   let taskRunDetailsPageProps: TaskRunDetailsPageProps;
   beforeEach(() => {
+    useFlagMock.mockReturnValue(true);
     taskRunDetailsPageProps = {
       kind: TaskRunModel.kind,
       kindObj: TaskRunModel,


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/openshift/console/pull/14303