### PR TITLE
OCPBUGS-45104: update release note link

### DIFF
--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -329,7 +329,7 @@ export const getReleaseNotesLink = (version: string): string => {
     return null;
   }
 
-  return `https://access.redhat.com/documentation/en-us/openshift_container_platform/${major}.${minor}/html/release_notes/ocp-${major}-${minor}-release-notes#ocp-${major}-${minor}-${patch}`;
+  return `https://access.redhat.com/documentation/en-us/openshift_container_platform/${major}.${minor}/html/release_notes/ocp-${major}-${minor}-release-notes#ocp-${major}-${minor}-${patch}_release-notes`;
 };
 
 export const getClusterName = (): string => window.SERVER_FLAGS.kubeAPIServerURL || null;


### PR DESCRIPTION
`/release_notes/ocp-${major}-${minor}-release-notes#ocp-${major}-${minor}-${patch}` is an invalid doc link, it's not a specific link to `${patch}` 

Check available links for `ocp-${major}-${minor}-${patch}` on access.redhat.com 
![Screenshot 2024-11-27 at 3 43 05 PM](https://github.com/user-attachments/assets/989ad9e0-f6f9-4d1c-935d-90a1c9f744de)

We can see the most suitable link should be `/release_notes/ocp-${major}-${minor}-release-notes#ocp-${major}-${minor}-${patch}_release-notes` 