### PR TITLE
OCPBUGS-45213: Fix BuildSpec details section heading font size

### DIFF
--- a/frontend/packages/shipwright-plugin/src/components/buildrun-details/BuildRunDetailsTab.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/buildrun-details/BuildRunDetailsTab.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Flex, FlexItem, Text, TextVariants } from '@patternfly/react-core';
+import { Flex, FlexItem } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { Conditions } from '@console/internal/components/conditions';
 import { SectionHeading, ResourceSummary } from '@console/internal/components/utils';
@@ -30,23 +30,31 @@ const BuildRunDetailsTab: React.FC<BuildRunDetailsTabProps> = ({ obj: buildRun }
                 <BuildRunSection buildRun={buildRun} />
               </FlexItem>
               <FlexItem>
-                <Text component={TextVariants.h3}>{t('shipwright-plugin~BuildSpec details')}</Text>
-                <BuildSpecSection
-                  obj={buildRun}
-                  buildSpec={
-                    buildRun.status?.buildSpec ||
-                    (isV1Alpha1Resource(buildRun)
-                      ? buildRun.spec?.buildSpec
-                      : buildRun.spec?.build?.spec)
-                  }
-                  path={
-                    buildRun.status?.buildSpec
-                      ? 'status.buildSpec'
-                      : isV1Alpha1Resource(buildRun)
-                      ? 'spec.buildSpec'
-                      : 'spec.build.spec'
-                  }
-                />
+                <dl>
+                  <dt>{t('shipwright-plugin~BuildSpec details')}</dt>
+                  <dd>
+                    {buildRun.status?.buildSpec || isV1Alpha1Resource(buildRun) ? (
+                      <BuildSpecSection
+                        obj={buildRun}
+                        buildSpec={
+                          buildRun.status?.buildSpec ||
+                          (isV1Alpha1Resource(buildRun)
+                            ? buildRun.spec?.buildSpec
+                            : buildRun.spec?.build?.spec)
+                        }
+                        path={
+                          buildRun.status?.buildSpec
+                            ? 'status.buildSpec'
+                            : isV1Alpha1Resource(buildRun)
+                            ? 'spec.buildSpec'
+                            : 'spec.build.spec'
+                        }
+                      />
+                    ) : (
+                      '-'
+                    )}
+                  </dd>
+                </dl>
               </FlexItem>
             </Flex>
           </div>


### PR DESCRIPTION
Fixes: [OCPBUGS-45213](https://issues.redhat.com/browse/OCPBUGS-45213)

Before
<img width="945" alt="Screenshot 2024-11-29 at 6 11 40 PM" src="https://github.com/user-attachments/assets/74853838-1fff-46d5-9ed6-5b605caebbf0">

After
<img width="1129" alt="image" src="https://github.com/user-attachments/assets/b0de9dea-7e54-4627-b8f4-d19864477ff6">

