### PR TITLE
Fix Timestamp relative display

### DIFF
--- a/frontend/public/components/utils/timestamp.tsx
+++ b/frontend/public/components/utils/timestamp.tsx
@@ -32,7 +32,7 @@ const timestampFor = (mdate: Date, now: Date, omitSuffix: boolean, lang: string)
 const nowStateToProps = ({ UI }) => ({ now: UI.get('lastTick') });
 
 export const Timestamp = (props: TimestampProps) => {
-  const now = useSelector(nowStateToProps);
+  const { now } = useSelector(nowStateToProps);
 
   // Workaround for Date&Time values are not showing in supported languages onchange of language selector.
   const lang = getLastLanguage();


### PR DESCRIPTION
If a timestamp is within about 10 minutes ago, it is supposed to display a relative string like "10 minutes ago" but this functionality currently only works if you use the `omitSuffix` prop, which always uses a relative string. Otherwise, the current time is checked, but there was a destructuring mistake so the current time was never a valid Date object.