### PR TITLE
OCPBUGS-36212: Missing translation for ""Read write once pod (RWOP)" ja and zh

### DIFF
--- a/frontend/i18n-scripts/languages.sh
+++ b/frontend/i18n-scripts/languages.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-export LANGUAGES=( 'ja' 'zh-cn' 'ko' 'fr')
+export LANGUAGES=( 'ja' 'zh-cn' 'ko' 'fr' 'es')

--- a/frontend/public/locales/zh/public.json
+++ b/frontend/public/locales/zh/public.json
@@ -1612,7 +1612,7 @@
   "Single user (RWO)": "单一用户（RWO）",
   "Shared access (RWX)": "共享的访问（RWX）",
   "Read only (ROX)": "只读（ROX）",
-  "Read write once pod (RWOP)": "Read write once pod (RWOP)",
+  "Read write once pod (RWOP)": "读写一次 pod (RWOP)",
   "Block": "块",
   "TemplateInstances": "模板实例",
   "TemplateInstance details": "模块实例详情",


### PR DESCRIPTION
FYI: The Japanese translation for "Read write once pod (RWOP)" is the same as the EN. 