### PR TITLE
OCPBUGS-45606: 'Channel' and 'Version' dropdowns do not collapse if the user does not select an option.

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-channel-version-select.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-channel-version-select.tsx
@@ -66,7 +66,7 @@ export const OperatorChannelSelect: React.FC<OperatorChannelSelectProps> = ({
         toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
           <MenuToggle
             ref={toggleRef}
-            onClick={(open) => setIsChannelSelectOpen(open)}
+            onClick={() => setIsChannelSelectOpen((prev) => !prev)}
             isExpanded={isChannelSelectOpen}
             isDisabled={!packageManifest}
             isFullWidth
@@ -165,7 +165,7 @@ export const OperatorVersionSelect: React.FC<OperatorVersionSelectProps> = ({
         toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
           <MenuToggle
             ref={toggleRef}
-            onClick={(open) => setIsVersionSelectOpen(open)}
+            onClick={() => setIsVersionSelectOpen((prev) => !prev)}
             isExpanded={isVersionSelectOpen}
             isDisabled={!packageManifest}
             isFullWidth


### PR DESCRIPTION
The onclick event in MenuToggle was always setting the dropdown to be opened, after these changes the toggle behavior functions as expected