### PR TITLE
OCPBUGS-45987: Fix alert rule link to alert in dev perspective

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/alerts/useRuleAlertsPoller.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/useRuleAlertsPoller.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Dispatch } from 'redux';
-import { PrometheusRulesResponse } from '@console/dynamic-plugin-sdk';
+import { PrometheusRulesResponse, useActivePerspective } from '@console/dynamic-plugin-sdk';
 import {
   alertingErrored,
   alertingLoaded,
@@ -26,6 +26,8 @@ export const useRulesAlertsPoller = (
     getAlertingRules: (namespace?: string) => Promise<PrometheusRulesResponse>;
   }[],
 ) => {
+  const [perspective] = useActivePerspective();
+
   React.useEffect(() => {
     const url = getPrometheusURL({
       endpoint: PrometheusEndpoint.RULES,
@@ -36,7 +38,10 @@ export const useRulesAlertsPoller = (
     const poller = (): void => {
       fetchAlerts(url, alertsSource, namespace)
         .then(({ data }) => {
-          const { alerts: fetchedAlerts, rules: fetchedRules } = getAlertsAndRules(data);
+          const { alerts: fetchedAlerts, rules: fetchedRules } = getAlertsAndRules(
+            data,
+            perspective,
+          );
           const sortThanosRules = _.sortBy(fetchedRules, alertingRuleStateOrder);
           dispatch(alertingSetRules('devRules', sortThanosRules, 'dev'));
           dispatch(alertingLoaded('devAlerts', fetchedAlerts, 'dev'));
@@ -57,5 +62,5 @@ export const useRulesAlertsPoller = (
         clearTimeout(pollerTimeout);
       }
     };
-  }, [namespace, alertsSource, dispatch]);
+  }, [namespace, alertsSource, dispatch, perspective]);
 };


### PR DESCRIPTION
This PR looks to solve an issue which caused alert rules links in the developer perspective to create an invalid link back the individual alerts. 

In order to fix an issue with showing silenced alerts in the notification bell, we added the external labels to alerts which aren't in the developer perspective in #14464. 

The location which poll for the alert rule page didn't check the perspective, so the extra labels were added to each alert. When the labels were then converted to query parameters for the link to the alert page, the external labels were also included leading to an invalid link.

This PR passes in the perspective information to the `getAlertsAndRules` function so that the external labels aren't added. 