### PR TITLE
CONSOLE-4405 expose useCreateNamespaceOrProjectModal

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -67,12 +67,13 @@
 65.  [useDeleteModal](#usedeletemodal)
 66.  [useLabelsModal](#uselabelsmodal)
 67.  [useActiveNamespace](#useactivenamespace)
-68.  [useUserSettings](#useusersettings)
-69.  [useQuickStartContext](#usequickstartcontext)
-70. [DEPRECATED] [PerspectiveContext](#perspectivecontext)
-71. [DEPRECATED] [useAccessReviewAllowed](#useaccessreviewallowed)
-72. [DEPRECATED] [useSafetyFirst](#usesafetyfirst)
-73. [DEPRECATED] [YAMLEditor](#yamleditor)
+68.  [useCreateNamespaceOrProjectModal](#usecreatenamespaceorprojectmodal)
+69.  [useUserSettings](#useusersettings)
+70.  [useQuickStartContext](#usequickstartcontext)
+71. [DEPRECATED] [PerspectiveContext](#perspectivecontext)
+72. [DEPRECATED] [useAccessReviewAllowed](#useaccessreviewallowed)
+73. [DEPRECATED] [useSafetyFirst](#usesafetyfirst)
+74. [DEPRECATED] [YAMLEditor](#yamleditor)
 
 ---
 
@@ -2404,6 +2405,43 @@ const Component: React.FC = (props) => {
 ### Returns
 
 A tuple containing the current active namespace and setter callback.
+
+
+---
+
+## `useCreateNamespaceOrProjectModal`
+
+### Summary 
+
+A hook that provides a callback to launch a modal for open the CreateProjectModal or CreateNamespaceModal<br/>depending on the flag OPENSHIFT.
+
+
+
+### Example
+
+
+```tsx
+const CreateProjectModalButton = () => {
+  const { t } = useTranslation();
+  const createNamespaceOrProjectModal = useCreateNamespaceOrProjectModal()
+  const createProject = createNamespaceOrProjectModal({
+    onSubmit: (project: K8sResourceKind) => {
+      doSomethingWithIt(project);
+    },
+  });
+  return <button onClick={createProject}>{t('Create Project')}</button>
+}
+```
+
+
+
+
+
+
+
+### Returns
+
+A function which will launch a modal for creating a project.
 
 
 ---

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -38,6 +38,7 @@ import {
   UseQuickStartContext,
 } from '../extensions/console-types';
 import { StatusPopupSectionProps, StatusPopupItemProps } from '../extensions/dashboard-types';
+import { UseCreateProjectModal } from '../extensions';
 
 export * from '../app/components';
 export * from './common-types';
@@ -882,6 +883,28 @@ export const useLabelsModal: UseLabelsModal = require('@console/shared/src/hooks
  */
 export const useActiveNamespace: UseActiveNamespace = require('@console/shared/src/hooks/useActiveNamespace')
   .useActiveNamespace;
+
+/**
+ * A hook that provides a callback to launch a modal for open the CreateProjectModal or CreateNamespaceModal
+ * depending on the flag OPENSHIFT.
+ *
+ * @returns A function which will launch a modal for creating a project.
+ * @example
+ * ```tsx
+ * const CreateProjectModalButton = () => {
+ *   const { t } = useTranslation();
+ *   const createNamespaceOrProjectModal = useCreateNamespaceOrProjectModal()
+ *   const createProject = createNamespaceOrProjectModal({
+ *     onSubmit: (project: K8sResourceKind) => {
+ *       doSomethingWithIt(project);
+ *     },
+ *   });
+ *   return <button onClick={createProject}>{t('Create Project')}</button>
+ * }
+ * ```
+ */
+export const useCreateNamespaceOrProjectModal: UseCreateProjectModal = require('@console/shared/src/hooks/useCreateNamespaceOrProjectModal')
+  .useCreateNamespaceOrProjectModal;
 
 /**
  * Hook that provides a user setting value and a callback for setting the user setting value.

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/create-project-modal.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/create-project-modal.ts
@@ -6,6 +6,8 @@ export type CreateProjectModalProps = {
   onSubmit?: (project: K8sResourceCommon) => void;
 };
 
+export type UseCreateProjectModal = () => (props?: CreateProjectModalProps) => void;
+
 /** This extension can be used to pass a component that will be rendered in place of the standard create project modal. */
 export type CreateProjectModal = ExtensionDeclaration<
   'console.create-project-modal',


### PR DESCRIPTION
The `useCreateNamespaceOrProjectModal` is useful for those plugins that want to launch the project modal.


<img width="1913" alt="Screenshot 2024-12-13 at 12 13 25" src="https://github.com/user-attachments/assets/d88cb370-cf32-44c1-80c3-4cb7b3ebdb92" />
