### PR TITLE
OCPBUGS-46415: Revert "OCPBUGS-44920: save all `window.windowError`s for easier debugging"

### DIFF
--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -57,7 +57,7 @@ declare interface Window {
     k8sMode: string;
     capabilities: Record<string, string>[];
   };
-  windowError?: string[];
+  windowError?: string;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;
   i18n?: {}; // i18next instance, only available in development builds for debugging
   store?: {}; // Redux store, only available in development builds for debugging

--- a/frontend/packages/console-dynamic-plugin-sdk/@types/sdk/index.d.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/@types/sdk/index.d.ts
@@ -2,6 +2,6 @@ declare interface Window {
   SERVER_FLAGS: {
     basePath: string;
   };
-  windowError?: string[];
+  windowError?: string;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;
 }

--- a/frontend/packages/integration-tests-cypress/support/index.ts
+++ b/frontend/packages/integration-tests-cypress/support/index.ts
@@ -8,10 +8,6 @@ import { a11yTestResults } from './a11y';
 import './admin';
 
 declare global {
-  interface Window {
-    windowError?: string[];
-  }
-
   namespace Cypress {
     interface Chainable {
       visitAndWait(
@@ -86,8 +82,8 @@ after(() => {
 });
 
 export const checkErrors = () =>
-  cy.window().then(({ windowError }) => {
-    assert.isTrue(!windowError || windowError.length === 0, String(windowError));
+  cy.window().then((win) => {
+    assert.isTrue(!win.windowError, win.windowError);
   });
 
 export const testName = `test-${Math.random()

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -591,18 +591,18 @@ graphQLReady.onReady(() => {
   setInterval(() => store.dispatch(UIActions.updateTimestamps(Date.now())), 10000);
 
   // Used by GUI tests to check for unhandled exceptions
-  window.windowError = [];
+  window.windowError = null;
   window.onerror = (message, source, lineno, colno, error) => {
     const formattedStack = error?.stack?.replace(/\\n/g, '\n');
     const formattedMessage = `unhandled error: ${message} ${formattedStack || ''}`;
-    window.windowError.push(formattedMessage);
+    window.windowError = formattedMessage;
     // eslint-disable-next-line no-console
     console.error(formattedMessage, error || message);
   };
   window.onunhandledrejection = (promiseRejectionEvent) => {
     const { reason } = promiseRejectionEvent;
     const formattedMessage = `unhandled promise rejection: ${reason}`;
-    window.windowError.push(formattedMessage);
+    window.windowError = formattedMessage;
     // eslint-disable-next-line no-console
     console.error(formattedMessage, reason);
   };

--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -108,10 +108,9 @@ export const init = () => {
       },
       saveMissing: true,
       missingKeyHandler: function (lng, ns, key) {
-        const error = `Missing i18n key "${key}" in namespace "${ns}" and language "${lng}".`;
-        window.windowError = [...(window.windowError || []), error]; // OCPBUGS-45139: store all i18n errors for easy debugging
+        window.windowError = `Missing i18n key "${key}" in namespace "${ns}" and language "${lng}".`;
         // eslint-disable-next-line no-console
-        console.error(error);
+        console.error(window.windowError);
       },
     })
     // Update loading promise and pass values and errors to the caller


### PR DESCRIPTION
Reverts openshift/console#14547

See https://github.com/openshift/console-plugin-template/pull/73#issuecomment-2541684682. This original change causes plugins that use the Cypress utilities from the openshift/console-plugin-template repo to fail.