### PR TITLE
CONSOLE-4403: Add renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "commitMessagePrefix": "NO-JIRA: (deps) ",
+  "addLabels": [
+    "ok-to-test",
+    "px-approved",
+    "docs-approved"
+  ],
+  "ignoreDeps": [
+    "@patternfly/patternfly",
+    "@patternfly/quickstarts",
+    "@patternfly/react-catalog-view-extension",
+    "@patternfly/react-charts",
+    "@patternfly/react-component-groups",
+    "@patternfly/react-console",
+    "@patternfly/react-core",
+    "@patternfly/react-icons",
+    "@patternfly/react-log-viewer",
+    "@patternfly/react-styles",
+    "@patternfly/react-table",
+    "@patternfly/react-templates",
+    "@patternfly/react-tokens",
+    "@patternfly/react-topology",
+    "@patternfly/react-user-feedback",
+    "@patternfly/react-virtualized-extension"
+  ]
+}


### PR DESCRIPTION
https://issues.redhat.com//browse/CONSOLE-4403

The idea is that the config will hopefully be picked up by the Konflux bot since it's powered by Renovate and start pumping out PRs

- Add renovate config to `.github/renovate.json`
- Ignore all PatternFly packages because they need to be deduped manually
 