### PR TITLE
OCPBUGS-46438: Pipeline visualisation shows all tasks as Failed and after that goes to Running state

### DIFF
--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
@@ -147,10 +147,7 @@ export const appendPipelineRunStatus = (
       if (pipelineRun.spec.status === SucceedConditionReason.PipelineRunCancelled) {
         return _.merge(task, { status: { reason: ComputedStatus.Cancelled } });
       }
-      if (pipelineRun.spec.status === SucceedConditionReason.PipelineRunPending) {
-        return _.merge(task, { status: { reason: ComputedStatus.Idle } });
-      }
-      return _.merge(task, { status: { reason: ComputedStatus.Failed } });
+      return _.merge(task, { status: { reason: ComputedStatus.Idle } });
     }
 
     const taskRun = _.find(


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-46438

**Analysis / Root cause**: 
By default user was shown Failed state if there is no TaskRun details available. 

**Solution Description**: 
Since we already have a alert to show if there is no task available for the resource, we can remove the the default failed state added and if the PipelineRun is failed also, we don't have `pipelineRun.spec.status` attribute in the resource. 
  
**Screen shots / Gifs for design review**: 

**----BEFORE---**


https://github.com/user-attachments/assets/e904d64e-a4e6-4f0e-97a4-ae5b56999789

----Shared by Pipelines team---



https://github.com/user-attachments/assets/e1d60ce1-4dbf-4d97-a43b-66de810c2896



-----



**---AFTER----**




https://github.com/user-attachments/assets/dc5ac823-bdec-473f-b80e-a0cc77df625f

---If no task---


https://github.com/user-attachments/assets/40987490-9fbb-40ed-8f83-f2bf7bb80902

-----



**Unit test coverage report**: 
NA

**Test setup:**

1. Create below PLR and ReRun (I am only able to reproduce this issue while using resolver)
```

kind: PipelineRun
apiVersion: tekton.dev/v1
metadata:
  name: run-basic-pipeline-from-git
spec:
  pipelineRef:
    resolver: git
    params:
    - name: url
      value: https://github.com/lokanandaprabhu/pipelines-testing
    - name: revision
      value: main
    - name: pathInRepo
      value: pipeline.yaml
  params:
  - name: username
    value: admin
```


    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge






