### PR TITLE
OCPBUGS-21755: Add catalog to operator installation route parameters and PackageManifest list request label selector

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/console-extensions.json
+++ b/frontend/packages/operator-lifecycle-manager/console-extensions.json
@@ -99,7 +99,7 @@
   {
     "type": "console.page/route",
     "properties": {
-      "path": "/operatorhub/install/:catalogNamespace/:pkg/:currentCSV/to/:targetNamespace/",
+      "path": "/operatorhub/install/:catalogNamespace/:catalog/:pkg/:currentCSV/to/:targetNamespace/",
       "component": {
         "$codeRef": "install.OperatorInstallStatusPage"
       }

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -147,7 +147,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
   const [gcpServiceAcctEmail, setGcpServiceAcctEmail] = React.useState('');
   const [targetNamespace, setTargetNamespace] = React.useState(null);
   const [installMode, setInstallMode] = React.useState(null);
-  const { catalogNamespace, channel, pkg, tokenizedAuth, version } = getURLSearchParams();
+  const { catalog, catalogNamespace, channel, pkg, tokenizedAuth, version } = getURLSearchParams();
 
   const defaultChannel = defaultChannelNameFor(packageManifest);
   const [updateChannelName, setUpdateChannelName] = React.useState(channel || defaultChannel);
@@ -351,10 +351,10 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
   const navigateToInstallPage = React.useCallback(
     (csvName: string) => {
       history.push(
-        `/operatorhub/install/${catalogNamespace}/${pkg}/${csvName}/to/${selectedTargetNamespace}`,
+        `/operatorhub/install/${catalogNamespace}/${catalog}/${pkg}/${csvName}/to/${selectedTargetNamespace}`,
       );
     },
-    [catalogNamespace, pkg, selectedTargetNamespace],
+    [catalog, catalogNamespace, pkg, selectedTargetNamespace],
   );
 
   if (!supportsSingle && !supportsGlobal) {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
@@ -297,13 +297,15 @@ const InstallingMessage: React.FC<InstallingMessageProps> = ({ namespace, obj })
 };
 
 type OperatorInstallStatusPageRouteParams = RouteParams<
-  'pkg' | 'catalogNamespace' | 'currentCSV' | 'targetNamespace'
+  'pkg' | 'catalogNamespace' | 'currentCSV' | 'targetNamespace' | 'catalog'
 >;
 
 const OperatorInstallLogo = ({ subscription }) => {
   const { t } = useTranslation();
   const notFound = t('olm~Not found');
-  const { currentCSV, catalogNamespace, pkg } = useParams<OperatorInstallStatusPageRouteParams>();
+  const { currentCSV, catalogNamespace, catalog, pkg } = useParams<
+    OperatorInstallStatusPageRouteParams
+  >();
   const [packageManifests, loaded, loadError] = useK8sWatchResource<PackageManifestKind[]>({
     groupVersionKind: {
       group: PackageManifestModel.apiGroup,
@@ -313,6 +315,7 @@ const OperatorInstallLogo = ({ subscription }) => {
     selector: {
       matchLabels: {
         'catalog-namespace': catalogNamespace,
+        catalog,
       },
     },
     fieldSelector: `metadata.name=${pkg}`,


### PR DESCRIPTION
In order to predictably fetch the singular PackageManifest that is being used during an install, the providing catalog needs to be included as a label selector. Otherwise, it's possible to recieve two or more PackageManifests in the list response.