### PR TITLE
OCPBUGS-2956: 'create a Project' button on Getting started page doesn't work

### DIFF
--- a/frontend/packages/dev-console/src/components/projects/CreateProjectListPage.tsx
+++ b/frontend/packages/dev-console/src/components/projects/CreateProjectListPage.tsx
@@ -21,6 +21,10 @@ export const CreateAProjectButton: React.FC<CreateAProjectButtonProps> = ({ open
   const { t } = useTranslation();
   const canCreateNs = useFlag(FLAGS.CAN_CREATE_NS);
   const canCreateProject = useFlag(FLAGS.CAN_CREATE_PROJECT);
+  const isStartGuideEnabled = useFlag(FLAGS.SHOW_OPENSHIFT_START_GUIDE);
+  if (isStartGuideEnabled) {
+    return null;
+  }
   if (canCreateProject) {
     return (
       <Trans t={t} ns="devconsole">


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-2956

**Analysis / Root cause**: 
By default the pages will be disabled if user don't have any projects created. 

**Solution Description**: 
If user don't have any project and Getting Started section is disabled then `Create a Project` button will not be shown to user.
  
**Screen shots / Gifs for design review**: 

**----BEFORE---**


https://github.com/user-attachments/assets/5b84b795-a583-4fc4-b722-8a4846f19859



-----



**---AFTER----**

https://github.com/user-attachments/assets/1e564909-892e-4573-b650-5a4cfbdf5247



-----



**Unit test coverage report**: 
NA

**Test setup:**

1. A new normal user login to OCP web console, user will be redirected to Getting Started page
2. try to create a project via 'create a Project' button in message "Select a Project to start adding to it or create a Project."
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

