### PR TITLE
OCPBUGS-46050: Determine if disabled a11y rules can be re-enabled

### DIFF
--- a/frontend/packages/integration-tests-cypress/support/a11y.ts
+++ b/frontend/packages/integration-tests-cypress/support/a11y.ts
@@ -64,9 +64,6 @@ Cypress.Commands.add('testA11y', (target: string, selector?: string) => {
   cy.configureAxe({
     rules: [
       { id: 'color-contrast', enabled: false }, // seem to be somewhat inaccurate and has difficulty always picking up the correct colors, tons of open issues for it on axe-core
-      { id: 'focusable-content', enabled: false }, // recently updated and need to give the PF team time to fix issues before enabling
-      { id: 'scrollable-region-focusable', enabled: false }, // recently updated and need to give the PF team time to fix issues before enabling
-      { id: 'aria-roles', enabled: false }, // rule is outdated and current installation of axe-core is no longer complaint with newest ariaRoles spec, causing false test failures (specifically with the role='code'). reenable when axe core is updated to at least 4.1.0
     ],
   });
   a11yTestResults.numberChecks += 1;


### PR DESCRIPTION
<h2 id="feature-fix">CONSOLE Features and Fixes:</h2>
<!--The pull request title must be prefixed with a Jira issue or Bugzilla bug in order to be merged. For example:
    For e.g Features: https://issues.redhat.com/browse/CONSOLE-XXXX
    - CONSOLE-XXXX: <title>
    For e.g Jira Bug Fixes: https://issues.redhat.com/browse/OCPBUGS-XXXX
    - OCPBUGS-XXXX: <title>
    For e.g Bugzilla Bug Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=XXXXXXX"
    - Bug XXXXXXX: <title>
    Combos:
    - CONSOLE-XXXX, Bug XXXXXXX: <title>-->

<h2 id="solution-description">Solution description</h2> 
<!-- Describe your code changes in detail and explain the solution or functionality -->
<h2 id="reviewers-and-assignees">Reviewers and assignees:</h2>
<!-- 
- Tag an OCP console engineer to review the changes.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign QE, docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  QE approver:
  /assign <gh-user>
  
  Docs approver:
  /assign <gh-user>
  
  PX approver:
  /assign <gh-user>
-->

<h2 id="test-cases">Test cases:</h2>
<!-- Outline any test cases here -->

<h2 id="additional-info">Additional info:</h2>
<!-- Add any additional info here -->
<h2 id="screenshots">Screen shots / gifs / design review:</h2>
<!-- Add screenshots or gifs for visual changes. Be sure to include before and after where relevant -->