### PR TITLE
[release-4.17] OCPBUGS-47497: Getting `Oh no, something went wrong` error when trying to install operator. 

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -253,10 +253,10 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
     setDeprecatedPackage(_.pick(item?.obj?.status, 'deprecation'));
   }, [item?.obj?.status, setDeprecatedPackage]);
   const currentChannel = obj?.status.channels.find((ch) => ch.name === installChannel);
-  const selectedChannelContainerImage = currentChannel?.currentCSVDesc.annotations.containerImage;
-  const selectedChannelCreatedAt = currentChannel?.currentCSVDesc.annotations.createdAt;
+  const selectedChannelContainerImage = currentChannel?.currentCSVDesc.annotations?.containerImage;
+  const selectedChannelCreatedAt = currentChannel?.currentCSVDesc.annotations?.createdAt;
   const selectedChannelCapabilityLevel =
-    currentChannel?.currentCSVDesc.annotations.capabilities ?? item.capabilityLevel;
+    currentChannel?.currentCSVDesc.annotations?.capabilities ?? item.capabilityLevel;
 
   const installedChannel = item?.subscription?.spec?.channel;
   const notAvailable = (


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/console/pull/14568.
Annotations are not defined in all of the Package Manifests, conditional unwrap prevents the issue of console crashing.