### PR TITLE
OCPBUGS-46511: fix navigation from non-General User Preference tab to…

### DIFF
--- a/frontend/packages/console-app/src/components/user-preferences/UserPreferencePage.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/UserPreferencePage.tsx
@@ -105,9 +105,10 @@ const UserPreferencePage: React.FC = () => {
   const [spotlightElement, setSpotlightElement] = React.useState<Element>(null);
 
   React.useEffect(() => {
+    setActiveTabId(groupIdFromUrl ?? 'general');
     const element = document.querySelector(spotlight);
     setSpotlightElement(element);
-  }, [spotlight, userPreferenceItemResolved, userPreferenceTabContents]);
+  }, [groupIdFromUrl, spotlight, userPreferenceItemResolved, userPreferenceTabContents]);
 
   // utils and callbacks
   const handleTabClick = (event: React.MouseEvent<HTMLElement>, eventKey: string) => {


### PR DESCRIPTION
… Lightspeed setting

After

https://github.com/user-attachments/assets/1a21e3c7-df37-4bd1-aa74-190afe2baf53

Note:  because the navigation occurs from the same page in this case (the User Preferences page), the spotlight feature is not rendered when switching tabs, which is expected behavior.
