### PR TITLE
OCPBUGS-46555: fix bug where two external link icons can appear in Op…

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -9,7 +9,6 @@ import {
   EmptyStateFooter,
   Truncate,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import * as classNames from 'classnames';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -628,15 +627,12 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
               <div className="co-catalog-page__overlay-actions">
                 {remoteWorkflowUrl && (
                   <ExternalLink
-                    additionalClassName="pf-v5-c-button pf-m-primary co-catalog-page__overlay-action"
+                    additionalClassName="pf-v5-c-button pf-m-primary co-catalog-page__overlay-action co-catalog-page__overlay-action--external"
                     href={remoteWorkflowUrl}
                     text={
-                      <>
-                        <div className="co-catalog-page__overlay-action-label">
-                          {detailsItem.marketplaceActionText || t('olm~Purchase')}
-                        </div>
-                        <ExternalLinkAltIcon className="co-catalog-page__overlay-action-icon" />
-                      </>
+                      <div className="co-catalog-page__overlay-action-label">
+                        {detailsItem.marketplaceActionText || t('olm~Purchase')}
+                      </div>
                     }
                   />
                 )}

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -249,12 +249,6 @@ $catalog-tile-width: $co-m-catalog-tile-width;
     overflow-x: hidden;
   }
 
-  &__overlay-action-icon {
-    flex-shrink: 0;
-    font-size: $font-size-base;
-    margin-left: 6px;
-  }
-
   &__overlay-action-label {
     overflow-x: hidden;
     text-overflow: ellipsis;

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -299,6 +299,10 @@ dl.co-inline {
 .co-external-link {
   display: inline-block;
   padding-right: $co-external-link-padding-right;
+
+  &.co-catalog-page__overlay-action--external {
+    padding-right: $co-external-link-padding-right * 2; // extra padding for external link icon
+  }
 }
 // Enable break word within co-m-table-grid
 .co-external-link--block {


### PR DESCRIPTION
…eratorHub modal

After

<img width="481" alt="Screenshot 2024-12-23 at 1 10 31 PM" src="https://github.com/user-attachments/assets/62373511-bc48-418f-9b54-1adc127c99c9" />

