### PR TITLE
OCPBUGS-45103: update variable name for plugin name parsing

### DIFF
--- a/frontend/packages/console-shared/src/components/modals/ConsolePluginModal.tsx
+++ b/frontend/packages/console-shared/src/components/modals/ConsolePluginModal.tsx
@@ -41,7 +41,7 @@ export const ConsolePluginModal = withHandlePromise((props: ConsolePluginModalPr
     <form onSubmit={submit} name="form" className="modal-content">
       <ModalTitle>
         {csvPluginsCount > 1
-          ? t('console-shared~Console plugin enablement - {{plugin}}', { pluginName })
+          ? t('console-shared~Console plugin enablement - {{plugin}}', { plugin: pluginName })
           : t('console-shared~Console plugin enablement')}
       </ModalTitle>
       <ModalBody>

--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -37,7 +37,6 @@
   "{{count}} Namespaces_other": "{{count}} Namespaces",
   "Console plugin_one": "Console plugin",
   "Console plugin_other": "Console plugins",
-  "{{plugin}}:": "{{plugin}}:",
   "Enabled": "Enabled",
   "Console plugin available": "Console plugin available",
   "To let this operator provide a custom interface and run its own code in your console, enable its console plugin in the operator details.": "To let this operator provide a custom interface and run its own code in your console, enable its console plugin in the operator details.",

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -293,9 +293,7 @@ const ConsolePlugins: React.FC<ConsolePluginsProps> = ({ csvPlugins, trusted }) 
           <dt>{t('olm~Console plugin', { count: csvPluginsCount })}</dt>
           {csvPlugins.map((pluginName) => (
             <dd key={pluginName} className="co-clusterserviceversion-details__field-description">
-              {csvPluginsCount > 1 && (
-                <strong className="text-muted">{t('olm~{{plugin}}:', { pluginName })} </strong>
-              )}
+              {csvPluginsCount > 1 && <strong className="text-muted">{pluginName}: </strong>}
               <Button
                 data-test="edit-console-plugin"
                 type="button"


### PR DESCRIPTION
Before - on CSV details page
![Screenshot 2024-12-26 at 4 29 56 PM](https://github.com/user-attachments/assets/0791e282-9162-439d-a1b9-8e8fbe3dc455)
- within modal
![Screenshot 2024-12-26 at 4 29 29 PM](https://github.com/user-attachments/assets/23ab8072-7618-49c1-8cc4-27ae70b2bcc8)

After - on CSV details page
![Screenshot 2024-12-26 at 4 30 30 PM](https://github.com/user-attachments/assets/2715d6f1-d044-4069-91a2-ea76809b9428)
- within modal
![Screenshot 2024-12-26 at 4 30 37 PM](https://github.com/user-attachments/assets/e5f2e089-34b4-42e0-bf20-34f7188eb3b8)
- pseudo translation
![Screenshot 2024-12-26 at 4 31 30 PM](https://github.com/user-attachments/assets/9bfde4e0-59c7-415e-83df-25bb0ba54a4e)

