### PR TITLE
OCPBUGS-47723: always show 'Plugin available' button on CSV list no matter plugin enabled or not

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -337,14 +337,11 @@ const ConsolePluginStatus: React.FC<ConsolePluginStatusProps> = ({ csv, csvPlugi
     verb: 'patch',
     name: CONSOLE_OPERATOR_CONFIG_NAME,
   });
-  const aPluginIsDisabled =
-    !consoleOperatorConfig?.spec?.plugins?.length ||
-    csvPlugins.some((plugin) => !isPluginEnabled(consoleOperatorConfig, plugin));
 
   return (
     consoleOperatorConfig &&
     canPatchConsoleOperatorConfig &&
-    aPluginIsDisabled && (
+    csvPlugins.length > 0 && (
       <Popover
         headerContent={<div>{t('olm~Console plugin available')}</div>}
         bodyContent={


### PR DESCRIPTION
- Show `Plugin available` button when associated plugin is `Disabled`

https://github.com/user-attachments/assets/85289d2d-0f20-4fe1-9690-fbc5b93d2563



- Show `Plugin available` button when associated plugin is `Enabled`

https://github.com/user-attachments/assets/f1950e9f-faa0-40e5-b164-685e92973cc8




- Also updated popover text