### PR TITLE
OCPBUGS-47722: always show associated plugin name on CSV details page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -293,7 +293,7 @@ const ConsolePlugins: React.FC<ConsolePluginsProps> = ({ csvPlugins, trusted }) 
           <dt>{t('olm~Console plugin', { count: csvPluginsCount })}</dt>
           {csvPlugins.map((pluginName) => (
             <dd key={pluginName} className="co-clusterserviceversion-details__field-description">
-              {csvPluginsCount > 1 && <strong className="text-muted">{pluginName}: </strong>}
+              <strong className="text-muted">{pluginName}: </strong>
               <Button
                 data-test="edit-console-plugin"
                 type="button"
@@ -301,7 +301,6 @@ const ConsolePlugins: React.FC<ConsolePluginsProps> = ({ csvPlugins, trusted }) 
                 onClick={() =>
                   consolePluginModal({
                     consoleOperatorConfig,
-                    csvPluginsCount,
                     pluginName,
                     trusted,
                   })


### PR DESCRIPTION
- Since we are showing `Console plugin` section only when `csvPlugins.length > 0` and we are aiming to always present console plugin name on CSV details page, so removed `csvPluginsCount` from `ConsolePlugins` 
```
              {csvPlugins.length > 0 && subscription && (
                <ConsolePlugins
                  csvPlugins={csvPlugins}
                  trusted={isCatalogSourceTrusted(subscription?.spec?.source)}
                />
              )}
```
- Since we are trying to always show console plugin name in Console Plugin Modal, so also removed `csvPluginsCount` from `ConsolePluginModal` 

- Always show plugin name on CSV details page regardless of plugin count
![Screenshot 2025-01-03 at 4 14 28 PM](https://github.com/user-attachments/assets/a3a277e6-8a60-4191-be58-ed306cb9de1f)
![Screenshot 2025-01-03 at 4 15 08 PM](https://github.com/user-attachments/assets/012a7e30-835a-4d2b-a57d-27381cff5e5d)

- Always show plugin name in plugin modal regardless of plugin count
![Screenshot 2025-01-03 at 4 27 56 PM](https://github.com/user-attachments/assets/33b02664-1c95-4b6d-ae68-3947e32d0bb0)
![Screenshot 2025-01-03 at 4 29 08 PM](https://github.com/user-attachments/assets/d57c8f92-f6a9-405a-a342-eeb551d10937)
