### PR TITLE
CONSOLE-4379: remove PatternFly 4 shared modules

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -223,10 +223,6 @@ const config: Configuration = {
             return 'vendors~[name]-chunk-[contenthash].min.js';
           },
         },
-        'vendor-patternfly-5': {
-          // modules with @patternfly/ that don't also have @patternfly-4/ in the string
-          test: /^(?!.*@patternfly-4\/).*@patternfly\/.*/,
-        },
         'vendor-plugins-shared': {
           test(module: { resource?: string }) {
             return (


### PR DESCRIPTION
Follow on to https://github.com/openshift/console/pull/14615 as this deletion was overlooked.