### PR TITLE
OCPBUGS-20230: Prevent yaml editor crash 

### DIFF
--- a/frontend/packages/dev-console/src/components/deployments/utils/deployment-utils.ts
+++ b/frontend/packages/dev-console/src/components/deployments/utils/deployment-utils.ts
@@ -351,9 +351,13 @@ export const getTriggersAndImageStreamValues = (
     };
   }
 
-  imageTrigger = JSON.parse(
-    deployment?.metadata?.annotations?.['image.openshift.io/triggers'] ?? '[]',
-  )?.[0];
+  try {
+    const triggersAnnotation =
+      deployment?.metadata?.annotations?.['image.openshift.io/triggers'] ?? '[]';
+    imageTrigger = JSON.parse(triggersAnnotation)?.[0];
+  } catch (error) {
+    imageTrigger = undefined;
+  }
   imageName = imageTrigger?.from?.name?.split(':') ?? [];
   return {
     ...data,


### PR DESCRIPTION
Prevent yaml editor crash when editing a deployment with annotation `image.openshift.io/triggers: ''` 

fixes: https://issues.redhat.com/browse/OCPBUGS-20230
