### PR TITLE
OCPBUGS-48548: The secret created with Basic authentication has an incorrect type

### DIFF
--- a/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
+++ b/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
@@ -21,13 +21,13 @@ import {
 import { SecretSubForm } from './SecretSubForm';
 
 export const SecretFormWrapper: React.FC<BaseEditSecretProps_> = (props) => {
-  const { isCreate, modal, onCancel } = props;
+  const { isCreate, modal, onCancel, secretTypeAbstraction } = props;
   const { t } = useTranslation();
   const navigate = useNavigate();
   const params = useParams();
 
   const existingSecret = _.pick(props.obj, ['metadata', 'type']);
-  const defaultSecretType = toDefaultSecretType(props.secretTypeAbstraction);
+  const defaultSecretType = toDefaultSecretType(secretTypeAbstraction);
   const initialSecret = _.defaultsDeep({}, props.fixed, existingSecret, {
     apiVersion: 'v1',
     data: {},
@@ -38,7 +38,6 @@ export const SecretFormWrapper: React.FC<BaseEditSecretProps_> = (props) => {
     type: defaultSecretType,
   });
 
-  const { secretTypeAbstraction } = props;
   const [secret, setSecret] = React.useState(initialSecret);
   const [inProgress, setInProgress] = React.useState(false);
   const [error, setError] = React.useState();

--- a/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
+++ b/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
@@ -38,7 +38,7 @@ export const SecretFormWrapper: React.FC<BaseEditSecretProps_> = (props) => {
     type: defaultSecretType,
   });
 
-  const [secretTypeAbstraction] = React.useState(props.secretTypeAbstraction);
+  const { secretTypeAbstraction } = props;
   const [secret, setSecret] = React.useState(initialSecret);
   const [inProgress, setInProgress] = React.useState(false);
   const [error, setError] = React.useState();

--- a/frontend/public/components/secrets/create-secret/utils.ts
+++ b/frontend/public/components/secrets/create-secret/utils.ts
@@ -42,7 +42,7 @@ export const determineSecretType = (stringData): SecretType => {
     return SecretType.dockercfg;
   } else if (_.isEqual(dataKeys, ['.dockerconfigjson'])) {
     return SecretType.dockerconfigjson;
-  } else if (_.some(dataKeys, (key) => ['username', 'password'].includes(key))) {
+  } else if (dataKeys.includes('password')) {
     return SecretType.basicAuth;
   } else if (_.isEqual(dataKeys, ['ssh-privatekey'])) {
     return SecretType.sshAuth;

--- a/frontend/public/components/secrets/create-secret/utils.ts
+++ b/frontend/public/components/secrets/create-secret/utils.ts
@@ -42,7 +42,7 @@ export const determineSecretType = (stringData): SecretType => {
     return SecretType.dockercfg;
   } else if (_.isEqual(dataKeys, ['.dockerconfigjson'])) {
     return SecretType.dockerconfigjson;
-  } else if (_.isEqual(dataKeys, ['password', 'username'])) {
+  } else if (_.some(dataKeys, (key) => ['username', 'password'].includes(key))) {
     return SecretType.basicAuth;
   } else if (_.isEqual(dataKeys, ['ssh-privatekey'])) {
     return SecretType.sshAuth;


### PR DESCRIPTION
Source secret form could be of Opaque type when non-mandatory username field was not specified.

When determining the basic auth type for source secrets our logic should expect that the non-mandatory fields wont be specified. I adjusted to logic in the `determineSecretType` function to evaluate a secret as basic auth secret when the secret form includes mandatory field `password`.  This doesn't collide with other secret forms as only the image-pull-secret has a `password` field, but the pull secrets are [being stored](https://github.com/openshift/console/blob/5ebebcbb400bb06180c7f31456b82273445172bc/frontend/public/components/secrets/create-secret/PullSecretUploadForm.tsx#L25) under `.dockerconfigjson` or `.dockercfg` keys, which are [used](https://github.com/openshift/console/blob/5ebebcbb400bb06180c7f31456b82273445172bc/frontend/public/components/secrets/create-secret/utils.ts#L43) to determine their type.

before:

https://github.com/user-attachments/assets/d747e2d5-a308-4c37-bbc6-49dece98494c




after:

https://github.com/user-attachments/assets/691bc43a-882e-42b7-8c44-c4d0fc36bbe6




