### PR TITLE
OCPBUGS-50693: Show Observe section without PROMETHEUS and MONITORING flags

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -736,9 +736,6 @@
       "dataAttributes": {
         "data-quickstart-id": "qs-nav-monitoring"
       }
-    },
-    "flags": {
-      "required": ["PROMETHEUS", "MONITORING", "CAN_GET_NS"]
     }
   },
   {


### PR DESCRIPTION
Currently, the Observe section is only shown to users which have the `PROMETHEUS`, `MONITORING` and `CAN_GET_NS` flags.

Some dynamic plugins, for example distributed tracing and logging, add a new link to the Observe section, which should be visible to all users, even without the `PROMETHEUS`, `MONITORING` and `CAN_GET_NS` flags. Therefore this
PR removes the requirement on this flags.

I checked the links in the section, and the monitoring-related links (Alerting, Metrics, Dashboards, Targets) set the required permissions (`PROMETHEUS`, `MONITORING` and `CAN_GET_NS`) on the `console.navigation/href` already:
https://github.com/openshift/monitoring-plugin/blob/6b92084514ea9007d7d797f7699eab19e0c2f2fc/web/console-extensions.json

In case the Observe section is empty, it is hidden:
https://github.com/openshift/console/blob/855f949121cefb3ea63b17ebf91e6bdcdc60d9c8/frontend/packages/console-app/src/components/nav/NavSection.tsx#L57-L60