### PR TITLE
OCPBUGS-46088: [Hypershift] Filter by Node type list is empty

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/utilization-card.tsx
@@ -317,13 +317,15 @@ export const UtilizationCard = () => {
             actions: (
               <>
                 <Split>
-                  <SplitItem>
-                    <UtilizationCardNodeFilter
-                      machineConfigPools={machineConfigPools}
-                      onNodeSelect={onNodeSelect}
-                      selectedNodes={selectedNodes}
-                    />
-                  </SplitItem>
+                  {machineConfigPools.length > 0 && (
+                    <SplitItem>
+                      <UtilizationCardNodeFilter
+                        machineConfigPools={machineConfigPools}
+                        onNodeSelect={onNodeSelect}
+                        selectedNodes={selectedNodes}
+                      />
+                    </SplitItem>
+                  )}
                   <SplitItem>
                     <UtilizationDurationDropdown />
                   </SplitItem>


### PR DESCRIPTION
### Before: 

<img width="1674" alt="Screenshot 2025-01-28 at 2 52 50 PM" src="https://github.com/user-attachments/assets/c09175e6-c42c-4c85-b499-e77b81f6a9a5" />

### After:

<img width="1767" alt="Screenshot 2025-01-28 at 2 53 05 PM" src="https://github.com/user-attachments/assets/cabb6d0e-ed3d-4036-892b-de23d9180b1c" />
