### PR TITLE
OCPBUGS-49366: fix bug where Search filter dropdown label isn't i18n

### DIFF
--- a/frontend/public/components/search-filter-dropdown.tsx
+++ b/frontend/public/components/search-filter-dropdown.tsx
@@ -70,7 +70,7 @@ export const SearchFilterDropdown: React.FC<SearchFilterDropdownProps> = ({
                 icon={<FilterIcon />}
                 id="search-filter-toggle"
               >
-                {selected}
+                {t(selected)}
               </MenuToggle>
             );
           }}


### PR DESCRIPTION
After

https://github.com/user-attachments/assets/cda42b44-cb22-4075-81af-ebf442504f43

