### PR TITLE
OCPBUGS-49778: Linkify OLM operator uninstall message

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
@@ -16,6 +16,7 @@ import {
 } from '@console/internal/components/factory/modal';
 import {
   history,
+  LinkifyExternal,
   ResourceLink,
   resourceListPathFromModel,
   StatusBox,
@@ -395,7 +396,9 @@ export const UninstallOperatorModal: React.FC<UninstallOperatorModalProps> = ({
                 <Title headingLevel="h2" className="pf-v6-u-mb-sm">
                   {t('olm~Message from Operator developer')}
                 </Title>
-                <p>{uninstallMessage}</p>
+                <p>
+                  <LinkifyExternal>{uninstallMessage}</LinkifyExternal>
+                </p>
               </>
             )}
             {!optedOut && <>{operandsSection}</>}


### PR DESCRIPTION
Make links and email addresses in custom operator uninstall messages clickable.

<img width="626" alt="Screenshot 2025-02-03 at 11 32 02 AM" src="https://github.com/user-attachments/assets/a9029e36-707e-4d61-bd60-cd08c0a91b64" />

Note: This change doesn't support markup in the message. It just highlights URLs or emails addresses in the plain text.