### PR TITLE
OCPBUGS-49839: fix run time error when no completed version exists

### DIFF
--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -85,6 +85,9 @@ export const getSortedNotRecommendedUpdates = (cv: ClusterVersionKind): Conditio
 
 export const getNewerMinorVersionUpdate = (currentVersion, availableUpdates) => {
   const currentVersionParsed = semver.parse(currentVersion);
+  if (!currentVersionParsed) {
+    return;
+  }
   return availableUpdates?.find(
     // find the next minor version update, which there should never be more than one
     (update) => {


### PR DESCRIPTION
After
<img width="922" alt="Screenshot 2025-02-04 at 3 08 18 PM" src="https://github.com/user-attachments/assets/132d2630-12a1-4acc-9782-4d5223afee6f" />
