### PR TITLE
OCPBUGS-49919: Catalog card label should be right aligned

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -53,8 +53,6 @@ form.pf-v6-c-form {
 .odc-catalog-tile {
   // Get rid of weird stretching of catalog grid items
   .pf-v6-c-card__header-main {
-    flex: unset;
-
     // When images are too wide, scale them instead of squishing
     img {
       object-fit: contain;


### PR DESCRIPTION
**Before:**
<img width="1212" alt="image" src="https://github.com/user-attachments/assets/9bd7f36d-0c00-4518-99b3-9a50e42640ce" />


**After:**
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/817fa79f-5d69-4c73-85c8-c7181e8436f2" />
