### PR TITLE
CONSOLE-4467: replace html heading elements with PatternFly components

### DIFF
--- a/frontend/__tests__/components/command-line-tools.spec.tsx
+++ b/frontend/__tests__/components/command-line-tools.spec.tsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import store from '@console/internal/redux';
 import { CommandLineTools } from '@console/internal/components/command-line-tools';
+import SecondaryHeading from '@console/shared/src/components/heading/SecondaryHeading';
 
 const obj = {
   data: [
@@ -52,7 +53,7 @@ describe('CommandLineTools', () => {
         wrappingComponent: Provider,
         wrappingComponentProps: { store },
       });
-      expect(wrapper.find('.co-section-heading').first().text()).toEqual(
+      expect(wrapper.find(SecondaryHeading).first().text()).toEqual(
         'oc - OpenShift Command Line Interface (CLI)',
       );
     });

--- a/frontend/__tests__/components/graphs/prometheus-graph.spec.tsx
+++ b/frontend/__tests__/components/graphs/prometheus-graph.spec.tsx
@@ -12,6 +12,7 @@ import {
   PrometheusGraphLink,
 } from '@console/internal/components/graphs/prometheus-graph';
 import store from '@console/internal/redux';
+import { Title } from '@patternfly/react-core';
 
 jest.mock('@console/dynamic-plugin-sdk/src/perspective/useActivePerspective', () => ({
   default: jest.fn(),
@@ -22,7 +23,13 @@ const useActivePerspectiveMock = useActivePerspective as jest.Mock;
 describe('<PrometheusGraph />', () => {
   it('should render a title', () => {
     const wrapper = shallow(<PrometheusGraph title="Test" />);
-    expect(wrapper.contains(<h5 className="graph-title">Test</h5>)).toBe(true);
+    expect(
+      wrapper.contains(
+        <Title headingLevel="h5" className="graph-title">
+          Test
+        </Title>,
+      ),
+    ).toBe(true);
   });
 
   it('should not render a title', () => {

--- a/frontend/__tests__/components/utils/page-heading.spec.tsx
+++ b/frontend/__tests__/components/utils/page-heading.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { shallow, ShallowWrapper } from 'enzyme';
 
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 import {
   PageHeading,
   PageHeadingProps,
@@ -62,7 +63,7 @@ describe(PageHeading.displayName, () => {
     const title = <span>My Custom Title</span>;
     wrapper.setProps({ title });
 
-    expect(wrapper.find('.co-m-pane__heading').contains(title)).toBe(true);
+    expect(wrapper.find(PrimaryHeading).contains(title)).toBe(true);
   });
 
   it('renders breadcrumbs if given `breadcrumbsFor` function', () => {

--- a/frontend/packages/console-app/src/components/cluster-configuration/ClusterConfigurationPage.tsx
+++ b/frontend/packages/console-app/src/components/cluster-configuration/ClusterConfigurationPage.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom-v5-compat';
 import { LoadingBox, history } from '@console/internal/components/utils';
 import { PageLayout, isModifiedEvent } from '@console/shared';
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 import ClusterConfigurationForm from './ClusterConfigurationForm';
 import { getClusterConfigurationGroups } from './getClusterConfigurationGroups';
 import { ClusterConfigurationTabGroup } from './types';
@@ -139,7 +140,9 @@ const ClusterConfigurationPage: React.FC = () => {
             {groupNotFound ? (
               /* Similar to a TabContent */
               <section className="co-cluster-configuration-page pf-v6-c-tab-content">
-                <h1>{t('console-app~{{section}} not found', { section: activeTabId })}</h1>
+                <PrimaryHeading>
+                  {t('console-app~{{section}} not found', { section: activeTabId })}
+                </PrimaryHeading>
               </section>
             ) : null}
           </>

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -161,6 +161,7 @@ This section documents notable changes in the Console provided shared modules ac
   removed in the future. Plugins should provide their own CSS to spin icons if needed.
 - Removed PatternFly 4.x shared modules.
 - Upgraded PatternFly to v6.
+- Removed styling for generic HTML heading elements (e.g., `<h1>`). Use PatternFly components to achieve correct styling.
 
 ### PatternFly dynamic modules
 

--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Flex, FlexItem } from '@patternfly/react-core';
+import { Flex, FlexItem, Title } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Humanize, TopConsumerPopoverProps, LIMIT_STATE } from '@console/dynamic-plugin-sdk';
@@ -120,9 +120,9 @@ export const MultilineUtilizationItem: React.FC<MultilineUtilizationItemProps> =
       <div className="co-utilization-card__item" data-test-id="utilization-item">
         <div className="co-utilization-card__item-description">
           <div className="co-utilization-card__item-section-multiline">
-            <h4 className="pf-v6-c-title pf-m-md" data-test="utilization-item-title">
+            <Title headingLevel="h4" data-test="utilization-item-title">
               {title}
-            </h4>
+            </Title>
             {error || (!isLoading && !(data.length && data.every((datum) => datum.length))) ? (
               <div className="text-secondary">{t('console-shared~Not available')}</div>
             ) : (
@@ -255,9 +255,9 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
             className="co-utilization-card__item-section"
           >
             <FlexItem>
-              <h4 className="pf-v6-c-title pf-m-md" data-test="utilization-item-title">
+              <Title headingLevel="h4" data-test="utilization-item-title">
                 {title}
-              </h4>
+              </Title>
             </FlexItem>
             <FlexItem>
               {error || (!isLoading && !utilizationData?.length) ? (

--- a/frontend/packages/console-shared/src/components/error/fallbacks/ErrorBoundaryFallbackPage.tsx
+++ b/frontend/packages/console-shared/src/components/error/fallbacks/ErrorBoundaryFallbackPage.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { Content, ContentVariants } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { ErrorBoundaryFallbackProps } from '@console/dynamic-plugin-sdk';
 import { ExpandCollapse } from '@console/internal/components/utils/expand-collapse';
+import PrimaryHeading from '../../heading/PrimaryHeading';
 import ErrorDetailsBlock from './ErrorDetailsBlock';
 
 /**
@@ -12,12 +12,7 @@ const ErrorBoundaryFallbackPage: React.FC<ErrorBoundaryFallbackProps> = (props) 
   const { t } = useTranslation();
   return (
     <div className="co-m-pane__body">
-      <Content
-        component={ContentVariants.h1}
-        className="co-m-pane__heading co-m-pane__heading--center"
-      >
-        {t('console-shared~Oh no! Something went wrong.')}
-      </Content>
+      <PrimaryHeading centerText>{t('console-shared~Oh no! Something went wrong.')}</PrimaryHeading>
       <ExpandCollapse
         textCollapsed={t('console-shared~Show details')}
         textExpanded={t('console-shared~Hide details')}

--- a/frontend/packages/console-shared/src/components/error/fallbacks/ErrorDetailsBlock.tsx
+++ b/frontend/packages/console-shared/src/components/error/fallbacks/ErrorDetailsBlock.tsx
@@ -2,12 +2,13 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ErrorBoundaryFallbackProps } from '@console/dynamic-plugin-sdk';
 import { CopyToClipboard } from '@console/internal/components/utils/copy-to-clipboard';
+import TertiaryHeading from '../../heading/TertiaryHeading';
 
 const ErrorDetailsBlock: React.FC<ErrorBoundaryFallbackProps> = (props) => {
   const { t } = useTranslation();
   return (
     <>
-      <h3 className="co-section-heading-tertiary">{props.title}</h3>
+      <TertiaryHeading>{props.title}</TertiaryHeading>
       <div className="form-group">
         <label htmlFor="description">{t('console-shared~Description:')}</label>
         <p>{props.errorMessage}</p>

--- a/frontend/packages/console-shared/src/components/heading/PrimaryHeading.tsx
+++ b/frontend/packages/console-shared/src/components/heading/PrimaryHeading.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { Title } from '@patternfly/react-core';
+import * as classNames from 'classnames';
+
+const PrimaryHeading: React.FC<PrimaryHeadingProps> = ({
+  children,
+  className,
+  alignItemsBaseline,
+  centerText,
+  ...props
+}) => (
+  <Title
+    headingLevel="h1"
+    className={classNames(
+      'co-m-pane__heading',
+      { 'co-m-pane__heading--baseline': alignItemsBaseline },
+      { 'co-m-pane__heading--center': centerText },
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </Title>
+);
+
+export type PrimaryHeadingProps = {
+  alignItemsBaseline?: boolean;
+  centerText?: boolean;
+  children: React.ReactNode;
+  className?: string;
+};
+
+export default PrimaryHeading;

--- a/frontend/packages/console-shared/src/components/heading/SecondaryHeading.tsx
+++ b/frontend/packages/console-shared/src/components/heading/SecondaryHeading.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { Title } from '@patternfly/react-core';
+import * as classNames from 'classnames';
+
+const SecondaryHeading: React.FC<SecondaryHeadingProps> = ({ children, className, ...props }) => (
+  <Title headingLevel="h2" className={classNames('co-section-heading', className)} {...props}>
+    {children}
+  </Title>
+);
+
+export type SecondaryHeadingProps = {
+  children: React.ReactNode;
+  className?: string;
+  id?: string;
+  style?: React.CSSProperties;
+};
+
+export default SecondaryHeading;

--- a/frontend/packages/console-shared/src/components/heading/TertiaryHeading.tsx
+++ b/frontend/packages/console-shared/src/components/heading/TertiaryHeading.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Title } from '@patternfly/react-core';
+import * as classNames from 'classnames';
+
+const TertiaryHeading: React.FC<TertiaryHeadingProps> = ({
+  children,
+  className,
+  increasedMargins,
+  ...props
+}) => (
+  <Title
+    headingLevel="h3"
+    className={classNames(increasedMargins ? 'pf-v6-u-my-xl' : 'pf-v6-u-my-md', className)}
+    {...props}
+  >
+    {children}
+  </Title>
+);
+
+export type TertiaryHeadingProps = {
+  children: React.ReactNode;
+  className?: string;
+  increasedMargins?: boolean;
+};
+
+export default TertiaryHeading;

--- a/frontend/packages/console-shared/src/components/status/StatusBox.tsx
+++ b/frontend/packages/console-shared/src/components/status/StatusBox.tsx
@@ -7,6 +7,7 @@ import {
   IncompleteDataError,
   TimeoutError,
 } from '@console/dynamic-plugin-sdk/src/utils/error/http-error';
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 import { AccessDenied, EmptyBox } from '../empty-state';
 import { LoadError, LoadingBox } from '../loading';
 
@@ -46,7 +47,7 @@ export const StatusBox: React.FC<StatusBoxProps> = (props) => {
     if (status === 404) {
       return (
         <div className="co-m-pane__body">
-          <h1 className="co-m-pane__heading co-m-pane__heading--center">{t('404: Not Found')}</h1>
+          <PrimaryHeading centerText>{t('404: Not Found')}</PrimaryHeading>
         </div>
       );
     }

--- a/frontend/packages/container-security/src/components/ImageVulnerabilityToggleGroup.tsx
+++ b/frontend/packages/container-security/src/components/ImageVulnerabilityToggleGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ChartDonut, ChartLabel } from '@patternfly/react-charts/victory';
-import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
+import { Title, ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -98,18 +98,21 @@ const ImageVulnerabilityToggleGroup: React.FC<ImageVulnerabilityToggleGroupProps
             />
           </div>
           <div className="cs-imagevulnerability-details__summary">
-            <h3>
+            <Title headingLevel="h3" className="pf-v6-u-mb-sm">
               {t(
                 'container-security~Quay Security Scanner has detected {{totalSelectedVulnCount, number}} vulnerabilities.',
                 { totalSelectedVulnCount },
               )}
-            </h3>
-            <h4 className="cs-imagevulnerability-details__details__summary--h4">
+            </Title>
+            <Title
+              headingLevel="h4"
+              className="pf-v6-u-mb-sm cs-imagevulnerability-details__details__summary--h4"
+            >
               {t(
                 'container-security~Patches are available for {{fixableVulnCount, number}} vulnerabilities.',
                 { fixableVulnCount: getFixableVulnerabilitiesCount(totalSelectedVuln) },
               )}
-            </h4>
+            </Title>
             <div className="cs-imagevulnerability-details__summary-list">
               {vulnPriority
                 .map((v, k) =>

--- a/frontend/packages/dev-console/src/components/deployments/deployment-strategy/advanced-options/LifecycleHookField.tsx
+++ b/frontend/packages/dev-console/src/components/deployments/deployment-strategy/advanced-options/LifecycleHookField.tsx
@@ -6,6 +6,7 @@ import { FormikValues, useField, useFormikContext } from 'formik';
 import { cloneDeep } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { K8sResourceKind } from '@console/internal/module/k8s';
+import TertiaryHeading from '@console/shared/src/components/heading/TertiaryHeading';
 import { getResourcesType } from '../../../edit-application/edit-application-utils';
 import { getStrategyData } from '../../utils/deployment-utils';
 import LifecycleHookForm from './LifecycleHookForm';
@@ -124,7 +125,7 @@ const LifecycleHookField: React.FC<LifecycleHookFieldProps> = ({
 
   return (
     <div>
-      <div className="co-section-heading-tertiary odc-lifecycle-hook-field__title">{title}</div>
+      <TertiaryHeading className="odc-lifecycle-hook-field__title">{title}</TertiaryHeading>
       <div className="pf-v6-c-form__helper-text">{subTitle}</div>
       {!showForm && (
         <Button

--- a/frontend/packages/dev-console/src/components/health-checks/HealthCheckProbe.scss
+++ b/frontend/packages/dev-console/src/components/health-checks/HealthCheckProbe.scss
@@ -1,6 +1,6 @@
 .odc-heath-check-probe {
   &__formTitle {
-    margin: 0;
+    margin: 0 !important;
     font-weight: var(--pf-t--global--font--weight--body--bold);
   }
   &__successText {

--- a/frontend/packages/dev-console/src/components/health-checks/HealthCheckProbe.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/HealthCheckProbe.tsx
@@ -5,6 +5,7 @@ import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circ
 import { useFormikContext, FormikValues } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { GreenCheckCircleIcon } from '@console/shared';
+import TertiaryHeading from '@console/shared/src/components/heading/TertiaryHeading';
 import { getHealthChecksProbeConfig, healthChecksDefaultValues } from './health-checks-probe-utils';
 import { HealthCheckProbeData } from './health-checks-types';
 import { HealthCheckContext } from './health-checks-utils';
@@ -111,7 +112,7 @@ const HealthCheckProbe: React.FC<HealthCheckProbeProps> = ({ probeType }) => {
 
   return (
     <>
-      <div className="co-section-heading-tertiary odc-heath-check-probe__formTitle">
+      <TertiaryHeading className="odc-heath-check-probe__formTitle">
         {getHealthChecksProbeConfig(probeType, t).formTitle}
         {healthChecks?.[probeType]?.enabled && (
           <Button
@@ -123,7 +124,7 @@ const HealthCheckProbe: React.FC<HealthCheckProbeProps> = ({ probeType }) => {
             {`${viewOnly ? t('devconsole~View') : t('devconsole~Edit')} ${t('devconsole~Probe')}`}
           </Button>
         )}
-      </div>
+      </TertiaryHeading>
       <div className="pf-v6-c-form__helper-text">
         {getHealthChecksProbeConfig(probeType, t).formSubtitle}
       </div>

--- a/frontend/packages/dev-console/src/components/hpa/HPAPageHeader.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAPageHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, Flex } from '@patternfly/react-core';
+import { Alert, Flex, Title } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { PageHeading, ResourceLink } from '@console/internal/components/utils';
 
@@ -24,7 +24,7 @@ const HPAPageHeader: React.FC<HPAPageHeaderProps> = ({
   return (
     <PageHeading>
       <Flex direction={{ default: 'column' }}>
-        <h1 className="pf-v6-c-title pf-m-2xl">{title}</h1>
+        <Title headingLevel="h1">{title}</Title>
         {validSupportedType ? (
           <>
             <div>

--- a/frontend/packages/dev-console/src/components/import/advanced/ResourceLimitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/ResourceLimitSection.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { ResourceIcon } from '@console/internal/components/utils';
 import { ContainerModel } from '@console/internal/models';
 import { ResourceLimitField } from '@console/shared';
+import TertiaryHeading from '@console/shared/src/components/heading/TertiaryHeading';
 import { MemoryUnits, CPUUnits } from '../import-types';
 import FormSection from '../section/FormSection';
 
@@ -30,7 +31,7 @@ const ResourceLimitSection: React.FC<ResourceLimitSectionProps> = ({ hideTitle }
           <ResourceIcon kind={ContainerModel.kind} /> {container}
         </span>
       )}
-      <div className="co-section-heading-tertiary">{t('devconsole~CPU')}</div>
+      <TertiaryHeading>{t('devconsole~CPU')}</TertiaryHeading>
       <ResourceLimitField
         name="limits.cpu.request"
         label={t('devconsole~Request')}
@@ -49,7 +50,7 @@ const ResourceLimitSection: React.FC<ResourceLimitSectionProps> = ({ hideTitle }
         )}
       />
 
-      <div className="co-section-heading-tertiary">{t('devconsole~Memory')}</div>
+      <TertiaryHeading>{t('devconsole~Memory')}</TertiaryHeading>
       <ResourceLimitField
         name="limits.memory.request"
         label={t('devconsole~Request')}

--- a/frontend/packages/dev-console/src/components/import/builder/ImageStreamInfo.tsx
+++ b/frontend/packages/dev-console/src/components/import/builder/ImageStreamInfo.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { ImageStreamIcon } from '@console/internal/components/catalog/catalog-item-icon';
 import { getAnnotationTags } from '@console/internal/components/image-stream';
 import { ExternalLink } from '@console/internal/components/utils';
+import SecondaryHeading from '@console/shared/src/components/heading/SecondaryHeading';
 import { getSampleRepo } from '../../../utils/imagestream-utils';
 
 export type ImageStreamInfoProps = {
@@ -22,7 +23,9 @@ const ImageStreamInfo: React.FC<ImageStreamInfoProps> = ({ displayName, tag }) =
       <div className="co-catalog-item-details">
         <ImageStreamIcon tag={tag} iconSize="large" />
         <div>
-          <h2 className="co-section-heading co-catalog-item-details__name">{displayName}</h2>
+          <SecondaryHeading className="co-catalog-item-details__name">
+            {displayName}
+          </SecondaryHeading>
           {annotationTags && (
             <p className="co-catalog-item-details__tags">
               {_.map(annotationTags, (annotationTag, i) => (

--- a/frontend/packages/dev-console/src/components/import/devfile/DevfileInfo.tsx
+++ b/frontend/packages/dev-console/src/components/import/devfile/DevfileInfo.tsx
@@ -4,6 +4,7 @@ import { LayerGroupIcon } from '@patternfly/react-icons/dist/esm/icons/layer-gro
 import { useTranslation } from 'react-i18next';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import { ExternalLink } from '@console/internal/components/utils';
+import SecondaryHeading from '@console/shared/src/components/heading/SecondaryHeading';
 import { DevfileSample } from './devfile-types';
 
 export type DevfileInfoProps = {
@@ -37,7 +38,9 @@ const DevfileInfo: React.FC<DevfileInfoProps> = ({ devfileSample }) => {
         )}
         &nbsp;
         <div>
-          <h2 className="co-section-heading co-catalog-item-details__name">{displayName}</h2>
+          <SecondaryHeading className="co-catalog-item-details__name">
+            {displayName}
+          </SecondaryHeading>
           {tags && (
             <p className="co-catalog-item-details__tags">
               {tags.map((tag) => (

--- a/frontend/packages/dev-console/src/components/import/git/DockerSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/DockerSection.tsx
@@ -5,6 +5,7 @@ import { FormikValues, useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { DockerFileParser, getGitService, ImportStrategy } from '@console/git-service/src';
 import { InputField } from '@console/shared';
+import SecondaryHeading from '@console/shared/src/components/heading/SecondaryHeading';
 import { GitImportFormData } from '../import-types';
 import FormSection from '../section/FormSection';
 
@@ -112,9 +113,9 @@ const DockerSection: React.FC = () => {
           </Icon>
           &nbsp;
           <div>
-            <h2 className="co-section-heading co-catalog-item-details__name">
+            <SecondaryHeading className="co-catalog-item-details__name">
               {t('devconsole~Dockerfile')}
-            </h2>
+            </SecondaryHeading>
           </div>
         </div>
       )}

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearchSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearchSection.tsx
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { ResourceLink } from '@console/internal/components/utils';
 import { RadioGroupField } from '@console/shared';
+import TertiaryHeading from '@console/shared/src/components/heading/TertiaryHeading';
 import { imageRegistryType } from '../../../utils/imagestream-utils';
 import { hasSampleQueryParameter } from '../../../utils/samples';
 import FormSection from '../section/FormSection';
@@ -39,10 +40,10 @@ const ImageSearchSection: React.FC<{ disabled?: boolean }> = ({ disabled = false
       subTitle={t('devconsole~Deploy an existing Image from an Image Stream or Image registry.')}
     >
       {!_.isEmpty(values.containers) && (
-        <div className="co-section-heading-tertiary">
+        <TertiaryHeading>
           {t('devconsole~Container')}
           <ResourceLink kind="Container" name={values.containers[0].name} linkTo={false} />
-        </div>
+        </TertiaryHeading>
       )}
       {showSample ? (
         <ImageSearch />

--- a/frontend/packages/dev-console/src/components/import/route/SecureRoute.tsx
+++ b/frontend/packages/dev-console/src/components/import/route/SecureRoute.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormHelperText } from '@patternfly/react-core';
+import { FormHelperText, Title } from '@patternfly/react-core';
 import { useFormikContext, FormikValues } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { DropdownField, DroppableFileInputField, CheckboxField } from '@console/shared';
@@ -83,7 +83,9 @@ const SecureRoute: React.FC = () => {
           />
           {tls.termination && tls.termination !== 'passthrough' && (
             <>
-              <h3>{t('devconsole~Certificates')}</h3>
+              <Title headingLevel="h3" className="pf-v6-u-mb-sm">
+                {t('devconsole~Certificates')}
+              </Title>
               <FormHelperText>
                 {t(
                   "devconsole~TLS certificates for edge and re-encrypt termination. If not specified, the router's default certificate is used.",

--- a/frontend/packages/dev-console/src/components/import/section/FormSection.scss
+++ b/frontend/packages/dev-console/src/components/import/section/FormSection.scss
@@ -1,8 +1,3 @@
-.odc-form-section {
-  &__heading {
-    margin: 0;
-  }
-  &--extra-margin {
-    margin: var(--pf-t--global--spacer--md) 0;
-  }
+.odc-form-section--extra-margin {
+  margin: var(--pf-t--global--spacer--md) 0;
 }

--- a/frontend/packages/dev-console/src/components/import/section/FormSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/FormSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormHelperText } from '@patternfly/react-core';
+import { FormHelperText, Title } from '@patternfly/react-core';
 import cx from 'classnames';
 import './FormSection.scss';
 
@@ -39,7 +39,11 @@ const FormSection: React.FC<FormSectionProps> = ({
     style={{ ...(flexLayout ? flexStyle : {}), ...(style || {}) }}
     data-test={dataTest}
   >
-    {title && <h2 className="odc-form-section__heading">{title}</h2>}
+    {title && (
+      <Title headingLevel="h2" className="odc-form-section__heading">
+        {title}
+      </Title>
+    )}
     {subTitle && <FormHelperText>{subTitle}</FormHelperText>}
     {children}
   </div>

--- a/frontend/packages/gitops-plugin/src/components/details/GitOpsDetails.tsx
+++ b/frontend/packages/gitops-plugin/src/components/details/GitOpsDetails.tsx
@@ -19,6 +19,7 @@ import { ExternalLink, Timestamp } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ConsoleLinkModel } from '@console/internal/models';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
+import SecondaryHeading from '@console/shared/src/components/heading/SecondaryHeading';
 import { GitOpsEnvironment } from '../utils/gitops-types';
 import ArgoCdLink from './ArgoCdLink';
 import GitOpsRenderStatusLabel from './GitOpsRenderStatusLabel';
@@ -83,11 +84,11 @@ const GitOpsDetails: React.FC<GitOpsDetailsProps> = ({ envs, appName, manifestUR
                   <CardTitle className="gop-gitops-details__env-section__header">
                     <Stack>
                       <StackItem>
-                        <h2 className="co-section-heading co-truncate co-nowrap gop-gitops-details__env-section__app-name">
+                        <SecondaryHeading className="pf-v6-c-truncate pf-v6-u-text-nowrap gop-gitops-details__env-section__app-name">
                           <Tooltip content={env.environment}>
                             <span>{env.environment}</span>
                           </Tooltip>
-                        </h2>
+                        </SecondaryHeading>
                       </StackItem>
                       <StackItem className="co-truncate co-nowrap">
                         {env.cluster ? (

--- a/frontend/packages/gitops-plugin/src/components/details/GitOpsDetailsPageHeading.tsx
+++ b/frontend/packages/gitops-plugin/src/components/details/GitOpsDetailsPageHeading.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { routeDecoratorIcon } from '@console/dev-console/src/components/import/render-utils';
 import { BreadCrumbs, ExternalLink } from '@console/internal/components/utils';
 import './GitOpsDetailsPageHeading.scss';
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 
 interface GitOpsDetailsPageHeadingProps {
   url: string;
@@ -35,15 +36,12 @@ const GitOpsDetailsPageHeading: React.FC<GitOpsDetailsPageHeadingProps> = ({
         <BreadCrumbs breadcrumbs={breadcrumbs} />
       </div>
       <div className="gop-gitops-details-page-heading co-m-nav-title co-m-nav-title--breadcrumbs">
-        <h1
-          className="co-m-pane__heading"
-          style={{ marginRight: 'var(--pf-t--global--spacer--sm)' }}
-        >
+        <PrimaryHeading className="pf-v6-u-mr-sm">
           <div className="co-m-pane__name co-resource-item">
             <span className="co-resource-item__resource-name">{appName}</span>
           </div>
           {badge && <span className="co-m-pane__heading-badge">{badge}</span>}
-        </h1>
+        </PrimaryHeading>
         <ExternalLink
           href={manifestURL}
           additionalClassName={'co-break-all gop-gitops-details-page-title'}

--- a/frontend/packages/gitops-plugin/src/components/details/GitOpsResourcesSection.tsx
+++ b/frontend/packages/gitops-plugin/src/components/details/GitOpsResourcesSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Stack, StackItem, Split, SplitItem, Card, CardBody } from '@patternfly/react-core';
+import { Stack, StackItem, Split, SplitItem, Card, CardBody, Title } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { ResourceIcon } from '@console/internal/components/utils';
 import { GitOpsEnvironmentService, GitOpsHealthResources } from '../utils/gitops-types';
@@ -73,7 +73,12 @@ const GitOpsResourcesSection: React.FC<GitOpsResourcesSectionProps> = ({
     <>
       <StackItem className="gop-gitops-resources">
         <Card>
-          <h3 className="gop-gitops-resources__title co-nowrap">{t('gitops-plugin~Resources')}</h3>
+          <Title
+            headingLevel="h3"
+            className="pf-v6-u-mb-sm gop-gitops-resources__title pf-v6-u-text-nowrap"
+          >
+            {t('gitops-plugin~Resources')}
+          </Title>
           <CardBody>
             <Split hasGutter>
               <span className="gop-gitops-resources__list">

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartMetaDescription.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartMetaDescription.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Title } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
@@ -28,9 +29,12 @@ const HelmChartMetaDescription: React.FC<HelmChartMetaDescriptionProps> = ({ cha
           </span>
         </div>
         <div className="co-clusterserviceversion-logo__name">
-          <h1 className="co-clusterserviceversion-logo__name__clusterserviceversion">
+          <Title
+            headingLevel="h1"
+            className="co-clusterserviceversion-logo__name__clusterserviceversion"
+          >
             {displayName}
-          </h1>
+          </Title>
           {provider && (
             <span className="co-clusterserviceversion-logo__name__provider text-muted">
               {t('helm-plugin~{{chartVersion}} provided by {{provider}}', {

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ChartDonut, ChartLegend, ChartLabel } from '@patternfly/react-charts/victory';
-import { Stack, StackItem } from '@patternfly/react-core';
+import { Stack, StackItem, Title } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { ErrorState } from '@console/internal/components/error';
@@ -157,7 +157,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
           </div>
           {clusterID ? (
             <>
-              <h6 className="pf-v6-c-title pf-m-md">{t('insights-plugin~Fixable issues')}</h6>
+              <Title headingLevel="h6">{t('insights-plugin~Fixable issues')}</Title>
               <div>
                 <ExternalLink
                   href={`https://console.redhat.com/openshift/insights/advisor/clusters/${clusterID}`}

--- a/frontend/packages/knative-plugin/src/components/add/KnEventMetaDescription.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/KnEventMetaDescription.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Title } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { KnEventCatalogMetaData } from './import-types';
@@ -29,7 +30,12 @@ const KnEventMetaDescription: React.FC<KnEventMetaDescriptionProps> = ({ normali
           </span>
         </div>
         <div className="co-clusterserviceversion-logo__name">
-          <h1 className="co-clusterserviceversion-logo__name__clusterserviceversion">{name}</h1>
+          <Title
+            headingLevel="h1"
+            className="co-clusterserviceversion-logo__name__clusterserviceversion"
+          >
+            {name}
+          </Title>
           {provider && (
             <span className="co-clusterserviceversion-logo__name__provider text-muted">
               {t('knative-plugin~Provided by {{provider}}', {

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/ContainerSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/ContainerSourceSection.tsx
@@ -13,6 +13,7 @@ import FormSection from '@console/dev-console/src/components/import/section/Form
 import { getSuggestedName } from '@console/dev-console/src/utils/imagestream-utils';
 import { AsyncComponent } from '@console/internal/components/utils';
 import { InputField, TextColumnField } from '@console/shared';
+import TertiaryHeading from '@console/shared/src/components/heading/TertiaryHeading';
 import { EventSources } from '../import-types';
 
 const templateSpec = `formData.data.${EventSources.ContainerSource}.template.spec.containers[0]`;
@@ -58,7 +59,7 @@ const ContainerSourceSection: React.FC<ContainerSourceSectionProps> = ({ title, 
   );
   return (
     <FormSection title={title} extraMargin fullWidth={fullWidth} dataTest={`${title} section`}>
-      <h3 className="co-section-heading-tertiary">{t('knative-plugin~Container')}</h3>
+      <TertiaryHeading>{t('knative-plugin~Container')}</TertiaryHeading>
       <InputField
         data-test-id="container-image-field"
         type={TextInputTypes.text}

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceNetSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceNetSection.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useFormikContext, FormikValues } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { CheckboxField } from '@console/shared';
+import TertiaryHeading from '@console/shared/src/components/heading/TertiaryHeading';
 import { EventSources } from '../import-types';
 import SecretKeySelector from '../SecretKeySelector';
 
@@ -18,7 +19,7 @@ const KafkaSourceNetSection: React.FC = () => {
 
   return (
     <>
-      <h3 className="co-section-heading-tertiary">Net</h3>
+      <TertiaryHeading>Net</TertiaryHeading>
       <CheckboxField
         data-test-id="kafkasource-sasl-field"
         name={`formData.data.${kafkaSource}.net.sasl.enable`}

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/SinkBindingSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/SinkBindingSection.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 import { AsyncComponent } from '@console/internal/components/utils/async';
 import { DropdownField, InputField, getFieldId } from '@console/shared';
+import TertiaryHeading from '@console/shared/src/components/heading/TertiaryHeading';
 import { EventSources } from '../import-types';
 
 interface SinkBindingSectionProps {
@@ -62,7 +63,7 @@ const SinkBindingSection: React.FC<SinkBindingSectionProps> = ({ title, fullWidt
 
   return (
     <FormSection title={title} extraMargin fullWidth={fullWidth} dataTest={`${title} section`}>
-      <h3 className="co-section-heading-tertiary">{t('knative-plugin~Subject')}</h3>
+      <TertiaryHeading>{t('knative-plugin~Subject')}</TertiaryHeading>
       <InputField
         data-test-id="sinkbinding-apiversion-field"
         type={TextInputTypes.text}

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/add-baremetal-host/AddBareMetalHostPage.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/add-baremetal-host/AddBareMetalHostPage.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { useParams, useLocation } from 'react-router-dom-v5-compat';
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 import AddBareMetalHost from './AddBareMetalHost';
 
 const AddBareMetalHostPage: React.FunctionComponent = () => {
@@ -22,9 +23,9 @@ const AddBareMetalHostPage: React.FunctionComponent = () => {
       <div className="co-m-pane__body co-m-pane__form">
         {/* TODO(jtomasek): Turn this to PageHeading alternative for create forms (e.g.
         CreateResourceFormPageHeading) */}
-        <h1 className="co-m-pane__heading co-m-pane__heading--baseline">
+        <PrimaryHeading alignItemsBaseline>
           <div className="co-m-pane__name">{title}</div>
-        </h1>
+        </PrimaryHeading>
         {!isEditing && (
           <p className="co-m-pane__explanation">
             {t('metal3-plugin~Expand the hardware inventory by registering a new Bare Metal Host.')}

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
@@ -39,6 +39,7 @@ import {
   validateDNS1123SubdomainValue,
   ValidationErrorType,
 } from '@console/shared';
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 import { NetworkAttachmentDefinitionModel, SriovNetworkNodePolicyModel } from '../..';
 import {
   NET_ATTACH_DEF_HEADER_LABEL,
@@ -303,7 +304,7 @@ const NetworkAttachmentDefinitionFormBase = (props) => {
 
   return (
     <div className="co-m-pane__body co-m-pane__form">
-      <h1 className="co-m-pane__heading co-m-pane__heading--baseline">
+      <PrimaryHeading alignItemsBaseline>
         <div className="co-m-pane__name">{NET_ATTACH_DEF_HEADER_LABEL}</div>
         <div className="co-m-pane__heading-link">
           <Link
@@ -316,7 +317,7 @@ const NetworkAttachmentDefinitionFormBase = (props) => {
             {t('network-attachment-definition-plugin~Edit YAML')}
           </Link>
         </div>
-      </h1>
+      </PrimaryHeading>
       <Form>
         <FormGroup
           fieldId="basic-settings-name"

--- a/frontend/packages/operator-lifecycle-manager/src/components/cluster-service-version-logo.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/cluster-service-version-logo.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Title } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { DeprecatedOperatorWarning } from '@console/operator-lifecycle-manager/src/types';
@@ -29,12 +30,15 @@ export const ClusterServiceVersionLogo: React.FC<ClusterServiceVersionLogoProps>
         </span>
       </div>
       <div className="co-clusterserviceversion-logo__name">
-        <h1 className="co-clusterserviceversion-logo__name__clusterserviceversion">
+        <Title
+          headingLevel="h1"
+          className="co-clusterserviceversion-logo__name__clusterserviceversion"
+        >
           {displayName}{' '}
           {deprecation && (
             <DeprecatedOperatorWarningBadge className="pf-v6-u-ml-sm" deprecation={deprecation} />
           )}
-        </h1>
+        </Title>
         {provider && (
           <span className="co-clusterserviceversion-logo__name__provider text-muted">
             {t('olm~{{version}} provided by {{provider}}', {

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import { Alert, Progress, ProgressSize } from '@patternfly/react-core';
+import { Alert, Progress, ProgressSize, Title } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
 import { k8sGetResource } from '@console/dynamic-plugin-sdk/src/utils/k8s';
@@ -324,7 +324,9 @@ export const UninstallOperatorModal: React.FC<UninstallOperatorModalProps> = ({
     showOperandsContent && (
       <>
         <span className="co-operator-uninstall__operands-section">
-          <h2>{t('olm~Operand instances')}</h2>
+          <Title headingLevel="h2" className="pf-v6-u-mb-sm">
+            {t('olm~Operand instances')}
+          </Title>
           <OperandsTable
             operands={operands}
             loaded={operandsLoaded}
@@ -390,7 +392,9 @@ export const UninstallOperatorModal: React.FC<UninstallOperatorModalProps> = ({
             {!optedOut && <>{instructions}</>}
             {uninstallMessage && (
               <>
-                <h2>{t('olm~Message from Operator developer')}</h2>
+                <Title headingLevel="h2" className="pf-v6-u-mb-sm">
+                  {t('olm~Message from Operator developer')}
+                </Title>
                 <p>{uninstallMessage}</p>
               </>
             )}

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   Checkbox,
   TextInput,
+  Title,
 } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { Helmet } from 'react-helmet';
@@ -1168,7 +1169,9 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
               provider={provider}
               deprecation={packageManifest?.status?.deprecation}
             />
-            <h4>{t('olm~Provided APIs')}</h4>
+            <Title headingLevel="h4" className="pf-v6-u-mb-sm">
+              {t('olm~Provided APIs')}
+            </Title>
             <div className="co-crd-card-row">
               {!providedAPIs.length ? (
                 <span className="text-muted">

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
@@ -8,6 +8,7 @@ import {
   CardBody,
   Icon,
   Spinner,
+  Title,
 } from '@patternfly/react-core';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
@@ -78,9 +79,9 @@ const InstallFailedMessage: React.FC<InstallFailedMessageProps> = ({ namespace, 
     obj?.metadata?.annotations?.[OLMAnnotation.InitializationResource];
   return (
     <>
-      <h2 className="co-clusterserviceversion-install__heading">
+      <Title headingLevel="h2" className="co-clusterserviceversion-install__heading">
         {t('olm~Operator installation failed')}
-      </h2>
+      </Title>
       <p>
         {t('olm~The operator did not install successfully.')}
         {hasInitializationResource && (
@@ -119,9 +120,9 @@ const InstallNeedsApprovalMessage: React.FC<InstallNeedsApprovalMessageProps> = 
 
   return (
     <>
-      <h2 className="co-clusterserviceversion-install__heading">
+      <Title headingLevel="h2" className="co-clusterserviceversion-install__heading">
         {t('olm~Manual approval required')}
-      </h2>
+      </Title>
       <ActionGroup className="pf-v6-c-form pf-v6-c-form__group--no-top-margin">
         <InstallPlanReview installPlan={installObj} />
         {((installObjIsInstallPlan && canPatchInstallPlans) || !installObjIsInstallPlan) && (
@@ -216,10 +217,10 @@ const InstallSucceededMessage: React.FC<InstallSuccededMessageProps> = ({
   });
   return (
     <>
-      <h2 className="co-clusterserviceversion-install__heading">
+      <Title headingLevel="h2" className="co-clusterserviceversion-install__heading">
         {t('olm~Installed operator')}: &nbsp;
         {initializationResource ? t('olm~custom resource required') : t('olm~ready for use')}
-      </h2>
+      </Title>
       {initializationResource && (
         <>
           <span>
@@ -259,7 +260,9 @@ const InstallingMessage: React.FC<InstallingMessageProps> = ({ namespace, obj })
   });
   return (
     <>
-      <h2 className="co-clusterserviceversion-install__heading">{t('olm~Installing Operator')}</h2>
+      <Title headingLevel="h2" className="co-clusterserviceversion-install__heading">
+        {t('olm~Installing Operator')}
+      </Title>
       {reason && (
         <p className="text-muted">
           {reason}: {message}

--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -91,7 +91,8 @@ $co-affinity-row-margin: 15px;
 }
 
 .co-catalog-install-modal .modal-header .co-clusterserviceversion-logo__icon {
-  border: var(--pf-t--global--border--width--regular) solid var(--pf-t--global--border--color--default);
+  border: var(--pf-t--global--border--width--regular) solid
+    var(--pf-t--global--border--color--default);
 }
 
 .co-catalog-details {
@@ -117,7 +118,8 @@ $co-affinity-row-margin: 15px;
 }
 
 .co-spec-descriptor--resource-requirements {
-  border: var(--pf-t--global--border--width--regular) solid var(--pf-t--global--border--color--default);
+  border: var(--pf-t--global--border--width--regular) solid
+    var(--pf-t--global--border--color--default);
   padding: 20px 0 20px 20px;
   margin-top: 5px;
 }
@@ -145,7 +147,8 @@ $co-affinity-row-margin: 15px;
 }
 
 .co-affinity-term {
-  border: var(--pf-t--global--border--width--regular) solid var(--pf-t--global--border--color--default);
+  border: var(--pf-t--global--border--width--regular) solid
+    var(--pf-t--global--border--color--default);
   display: flex;
   flex-direction: column;
   margin-bottom: 15px;
@@ -180,7 +183,8 @@ $co-affinity-row-margin: 15px;
 }
 
 .co-operand-field-group {
-  border: var(--pf-t--global--border--width--regular) solid var(--pf-t--global--border--color--default);
+  border: var(--pf-t--global--border--width--regular) solid
+    var(--pf-t--global--border--color--default);
   display: flex;
   flex-direction: column;
   margin-bottom: 15px;
@@ -261,7 +265,7 @@ $co-affinity-row-margin: 15px;
 }
 
 .co-clusterserviceversion-install__heading {
-  margin-top: 0;
+  margin-bottom: var(--pf-v6-c-content--h2--MarginBlockEnd);
 }
 
 .co-clusterserviceversion__box {

--- a/frontend/packages/patternfly/src/components/notification-drawer/notification-drawer-heading.tsx
+++ b/frontend/packages/patternfly/src/components/notification-drawer/notification-drawer-heading.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TimesIcon } from '@patternfly/react-icons';
+import { Title } from '@patternfly/react-core';
 
 const NotificationDrawerHeading: React.FC<NotificationDrawerHeadingProps> = ({
   count,
@@ -11,9 +12,9 @@ const NotificationDrawerHeading: React.FC<NotificationDrawerHeadingProps> = ({
   return (
     <div className="pf-v6-c-notification-drawer">
       <div className="pf-v6-c-notification-drawer__header">
-        <h1 className="pf-v6-c-notification-drawer__header-title">
+        <Title headingLevel="h1" className="pf-v6-c-notification-drawer__header-title">
           {t('notification-drawer~Notifications')}
-        </h1>
+        </Title>
         {count && (
           <span className="pf-v6-c-notification-drawer__header-status">
             {t('notification-drawer~{{count}} unread', { count })}

--- a/frontend/packages/patternfly/src/components/notification-drawer/notification-entry.tsx
+++ b/frontend/packages/patternfly/src/components/notification-drawer/notification-entry.tsx
@@ -9,7 +9,7 @@ import {
   YellowExclamationTriangleIcon,
 } from '@console/shared';
 import { history, Timestamp, ExternalLink } from '@console/internal/components/utils';
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Button, ButtonVariant, Title } from '@patternfly/react-core';
 
 // eslint-disable-next-line no-shadow
 export enum NotificationTypes {
@@ -116,10 +116,10 @@ const NotificationEntry: React.FC<NotificationEntryProps> = ({
         <span className="pf-v6-c-notification-drawer__list-item-header-icon">
           <NotificationIcon type={type} />
         </span>
-        <h4 className="pf-v6-c-notification-drawer__list-item-header-title">
+        <Title headingLevel="h4" className="pf-v6-c-notification-drawer__list-item-header-title">
           <span className="pf-v6-screen-reader">{notificationTypeString(type)}</span>
           {title}
-        </h4>
+        </Title>
         {actionText && (actionPath || alertAction || actionExternalLinkURL) && (
           <NotificationAction
             text={actionText}

--- a/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
@@ -302,7 +302,7 @@ export const pipelinesPO = {
     },
     secretForm: '.odc-secret-form',
     advancedOptions: {
-      secretFormTitle: 'h1.odc-secret-form__title',
+      secretFormTitle: 'h3.odc-secret-form__title',
       secretName: '#form-input-secretName-field',
       accessTo: '#form-dropdown-annotations-key-field',
       serverUrl: '#form-input-annotations-value-field',

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/SecretForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/SecretForm.tsx
@@ -13,6 +13,7 @@ import {
 } from '@console/internal/components/secrets/create-secret';
 import { ButtonBar } from '@console/internal/components/utils';
 import { DropdownField, InputField, ActionGroupWithIcons } from '@console/shared';
+import TertiaryHeading from '@console/shared/src/components/heading/TertiaryHeading';
 import { SecretAnnotationId } from '../../const';
 import './SecretForm.scss';
 
@@ -143,9 +144,9 @@ const SecretForm: React.FC<FormikProps<SecretFormValues>> = ({
 
   return (
     <div className="odc-secret-form">
-      <h1 className="co-section-heading-tertiary odc-secret-form__title">
+      <TertiaryHeading className="odc-secret-form__title">
         {t('pipelines-plugin~Create Secret')}
-      </h1>
+      </TertiaryHeading>
       <div className="form-group">
         <InputField
           type={TextInputTypes.text}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderFormEditor.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderFormEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { TextInputTypes } from '@patternfly/react-core';
+import { TextInputTypes, Title } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { InputField } from '@console/shared';
 import { PipelineWorkspaces } from '../detail-page-tabs';
@@ -48,10 +48,10 @@ const PipelineBuilderFormEditor: React.FC<PipelineBuilderFormEditorProps> = (pro
       </div>
 
       <div>
-        <h2>
+        <Title headingLevel="h2" className="pf-v6-u-mb-sm">
           {t('pipelines-plugin~Tasks')}
           <span className="pf-v6-c-form__label-required">*</span>
-        </h2>
+        </Title>
         <PipelineBuilderVisualization
           onTaskSelection={onTaskSelection}
           onUpdateTasks={onUpdateTasks}
@@ -62,7 +62,9 @@ const PipelineBuilderFormEditor: React.FC<PipelineBuilderFormEditorProps> = (pro
       </div>
 
       <div>
-        <h2>{t('pipelines-plugin~Parameters')}</h2>
+        <Title headingLevel="h2" className="pf-v6-u-mb-sm">
+          {t('pipelines-plugin~Parameters')}
+        </Title>
         <PipelineParameters
           fieldName="formData.params"
           addLabel={t('pipelines-plugin~Add parameter')}
@@ -78,7 +80,9 @@ const PipelineBuilderFormEditor: React.FC<PipelineBuilderFormEditorProps> = (pro
       </div>
 
       <div>
-        <h2>{t('pipelines-plugin~Workspaces')}</h2>
+        <Title headingLevel="h2" className="pf-v6-u-mb-sm">
+          {t('pipelines-plugin~Workspaces')}
+        </Title>
         <PipelineWorkspaces
           addLabel={t('pipelines-plugin~Add workspace')}
           fieldName="formData.workspaces"

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { TechPreviewBadge } from '@console/shared';
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 import { usePipelineTechPreviewBadge } from '../../../utils/hooks';
 
 import './PipelineBuilderHeader.scss';
@@ -15,9 +16,9 @@ const PipelineBuilderHeader: React.FC<{ namespace: string }> = ({ namespace }) =
       <Flex className="odc-pipeline-builder-header__content">
         <FlexItem grow={{ default: 'grow' }}>
           <div className="co-m-nav-title">
-            <h1 className="co-m-pane__heading odc-pipeline-builder-header__title">
+            <PrimaryHeading className="odc-pipeline-builder-header__title">
               {t('pipelines-plugin~Pipeline builder')}
-            </h1>
+            </PrimaryHeading>
           </div>
         </FlexItem>
         {badge && (

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/modals/ModalContent.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/modals/ModalContent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Split, SplitItem } from '@patternfly/react-core';
+import { Split, SplitItem, Title } from '@patternfly/react-core';
 
 import './ModalContent.scss';
 
@@ -14,7 +14,9 @@ const ModalContent: React.FC<ModalContentProps> = ({ icon, message, title }) => 
     <Split className="odc-modal-content" hasGutter>
       {icon && <SplitItem>{icon}</SplitItem>}
       <SplitItem isFilled>
-        <h2 className="co-break-word odc-modal-content__confirm-title">{title}</h2>
+        <Title headingLevel="h2" className="odc-modal-content__confirm-title">
+          {title}
+        </Title>
         <p className="co-break-word">{message}</p>
       </SplitItem>
     </Split>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Stack, StackItem } from '@patternfly/react-core';
+import { Stack, StackItem, Title } from '@patternfly/react-core';
 import { FormikErrors, useField } from 'formik';
 import { Trans, useTranslation } from 'react-i18next';
 import CloseButton from '@console/shared/src/components/close-button';
@@ -95,7 +95,9 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
 
         {params.length > 0 && (
           <div>
-            <h2>{t('pipelines-plugin~Parameters')}</h2>
+            <Title headingLevel="h2" className="pf-v6-u-mb-sm">
+              {t('pipelines-plugin~Parameters')}
+            </Title>
             <p className="co-help-text opp-task-sidebar__paragraph">
               <Trans ns="pipelines-plugin">
                 Use this format when you reference variables in this form:{' '}
@@ -120,7 +122,9 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
         )}
         {workspaces.length > 0 && (
           <div>
-            <h2>{t('pipelines-plugin~Workspaces')}</h2>
+            <Title headingLevel="h2" className="pf-v6-u-mb-sm">
+              {t('pipelines-plugin~Workspaces')}
+            </Title>
             {workspaces.map((workspace) => {
               const taskWorkspaces: TektonWorkspace[] = thisTask.workspaces || [];
               const workspaceIdx = safeIndex(
@@ -143,13 +147,17 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
 
         {inputResources.length > 0 && (
           <div>
-            <h2>{t('pipelines-plugin~Input resources')}</h2>
+            <Title headingLevel="h2" className="pf-v6-u-mb-sm">
+              {t('pipelines-plugin~Input resources')}
+            </Title>
             {inputResources.map(renderResource('inputs'))}
           </div>
         )}
         {outputResources.length > 0 && (
           <div>
-            <h2>{t('pipelines-plugin~Output resources')}</h2>
+            <Title headingLevel="h2" className="pf-v6-u-mb-sm">
+              {t('pipelines-plugin~Output resources')}
+            </Title>
             {outputResources.map(renderResource('outputs'))}
           </div>
         )}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarHeader.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarHeader.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Divider } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { ActionsMenu } from '@console/internal/components/utils';
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 import { TaskKind } from '../../../../types';
 import PipelineResourceRef from '../../../shared/common/PipelineResourceRef';
 import TaskSidebarShortcuts from './TaskSidebarShortcuts';
@@ -19,7 +20,7 @@ const TaskSidebarHeader: React.FC<TaskSidebarHeaderProps> = ({ removeThisTask, t
   return (
     <div className="opp-task-sidebar-header">
       <div className="opp-task-sidebar-header__title">
-        <h1 className="co-m-pane__heading">
+        <PrimaryHeading>
           <div className="co-m-pane__name co-resource-item">
             <PipelineResourceRef
               resourceKind={taskResource.kind}
@@ -38,7 +39,7 @@ const TaskSidebarHeader: React.FC<TaskSidebarHeaderProps> = ({ removeThisTask, t
               ]}
             />
           </div>
-        </h1>
+        </PrimaryHeading>
       </div>
       <div className="opp-task-sidebar-header__shortcuts clearfix">
         <TaskSidebarShortcuts />

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarWhenExpression.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarWhenExpression.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, ButtonType, ButtonVariant, Tooltip } from '@patternfly/react-core';
+import { Button, ButtonType, ButtonVariant, Title, Tooltip } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';
 import { useField } from 'formik';
 import { Trans, useTranslation } from 'react-i18next';
@@ -26,7 +26,9 @@ const TaskSidebarWhenExpression: React.FC<TaskSidebarWhenExpressionProps> = (pro
 
   return (
     <div className="opp-task-sidebar-when-expression">
-      <h2>{t('pipelines-plugin~When expressions')}</h2>
+      <Title headingLevel="h2" className="pf-v6-u-mb-sm">
+        {t('pipelines-plugin~When expressions')}
+      </Title>
       <p className="co-help-text opp-task-sidebar__paragraph">
         {field.value?.length > 0 ? (
           <Trans ns="pipelines-plugin">

--- a/frontend/packages/topology/src/actions/contextMenuActions.tsx
+++ b/frontend/packages/topology/src/actions/contextMenuActions.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Title } from '@patternfly/react-core';
 import { Node, ContextSubMenuItem, ContextMenuItem, Graph } from '@patternfly/react-topology';
 import {
   Action,
@@ -26,7 +27,11 @@ export const createContextMenuItems = (actions: MenuOption[]) => {
       case MenuOptionType.GROUP_MENU:
         return (
           <React.Fragment key={option.id}>
-            {option.label && <h1 className="pf-v6-c-dropdown__group-title">{option.label}</h1>}
+            {option.label && (
+              <Title headingLevel="h1" className="pf-v6-c-dropdown__group-title">
+                {option.label}
+              </Title>
+            )}
             {createContextMenuItems((option as GroupedMenuOption).children)}
           </React.Fragment>
         );

--- a/frontend/packages/topology/src/components/quick-search/topology-quick-search-utils.tsx
+++ b/frontend/packages/topology/src/components/quick-search/topology-quick-search-utils.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { QuickStart } from '@patternfly/quickstarts';
-import { Content } from '@patternfly/react-core';
+import { Content, Title } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { CatalogItem } from '@console/dynamic-plugin-sdk';
 import { useQuickStartContext } from '@console/shared/src/hooks/useQuickStartContext';
@@ -17,7 +17,9 @@ export const useTransformedQuickStarts = (quickStarts: QuickStart[]): CatalogIte
             <p>{qs.spec.description}</p>
             {prerequisites?.length > 0 && (
               <>
-                <h5>{t('topology~Prerequisites')}</h5>
+                <Title headingLevel="h5" className="pf-v6-u-mb-sm">
+                  {t('topology~Prerequisites')}
+                </Title>
                 <Content component="ul">
                   {prerequisites.map((prerequisite, index) => (
                     // eslint-disable-next-line react/no-array-index-key

--- a/frontend/packages/topology/src/components/side-bar/TopologyEdgePanel.tsx
+++ b/frontend/packages/topology/src/components/side-bar/TopologyEdgePanel.tsx
@@ -6,6 +6,7 @@ import { Edge, isNode, Node } from '@patternfly/react-topology';
 import * as classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { ActionsMenu } from '@console/internal/components/utils';
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 import { edgeActions } from '../../actions/edgeActions';
 import { TYPE_TRAFFIC_CONNECTOR } from '../../const';
 import TopologyEdgeResourcesPanel from './TopologyEdgeResourcesPanel';
@@ -34,14 +35,14 @@ const TopologyEdgePanel: React.FC<TopologyEdgePanelProps> = ({ edge }) => {
   return (
     <div className="overview__sidebar-pane resource-overview">
       <div className="overview__sidebar-pane-head resource-overview__heading">
-        <h1 className="co-m-pane__heading">
+        <PrimaryHeading>
           <div className="co-m-pane__name co-resource-item">
             {t(connectorTypeToTitleKey(edge.getType()))}
           </div>
           <div className="co-actions">
             <ActionsMenu actions={edgeActions(edge, nodes)} />
           </div>
-        </h1>
+        </PrimaryHeading>
       </div>
       <ul
         className={classNames(

--- a/frontend/packages/topology/src/components/side-bar/components/SideBarHeading.tsx
+++ b/frontend/packages/topology/src/components/side-bar/components/SideBarHeading.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import { DeploymentConfigDeprecationAlert } from '@console/internal/components/deployment-config';
 import { DeploymentConfigModel } from '@console/internal/models';
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 import TopologyActions from '../../../actions/TopologyActions';
 import { useDetailsResourceLink } from '../providers/useDetailsResourceLink';
 import SideBarAlerts from './SideBarAlerts';
@@ -13,12 +14,12 @@ const SideBarHeading: React.FC<{ element: GraphElement }> = ({ element }) => {
   const resourceKind = element.getData()?.resource?.kind;
   return (
     <div className="overview__sidebar-pane-head resource-overview__heading">
-      <h1 className="co-m-pane__heading">
+      <PrimaryHeading>
         <div className="co-m-pane__name co-resource-item">{resourceLink ?? resourceLabel}</div>
         <div className="co-actions">
           <TopologyActions element={element} />
         </div>
-      </h1>
+      </PrimaryHeading>
       {resourceKind === DeploymentConfigModel.kind && (
         <div className="dc-deprecation-sidebar-alert">
           <DeploymentConfigDeprecationAlert />

--- a/frontend/public/components/cluster-settings/github-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/github-idp-form.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation, Trans } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { ActionGroup, Button } from '@patternfly/react-core';
+import { ActionGroup, Button, Title } from '@patternfly/react-core';
 
 import { SecretModel, ConfigMapModel } from '../../models';
 import { IdentityProvider, k8sCreate, OAuthKind } from '../../module/k8s';
@@ -210,7 +210,9 @@ export const AddGitHubPage = () => {
           </div>
           <IDPCAFileInput value={caFileContent} onChange={(c: string) => setCaFileContent(c)} />
           <div className="co-form-section__separator" />
-          <h3>{t('public~Organizations')}</h3>
+          <Title headingLevel="h3" className="pf-v6-u-mb-sm">
+            {t('public~Organizations')}
+          </Title>
           <p className="co-help-text">
             <Trans
               t={t}
@@ -228,7 +230,9 @@ export const AddGitHubPage = () => {
             helpText={t('public~Restricts which organizations are allowed to log in.')}
           />
           <div className="co-form-section__separator" />
-          <h3>{t('public~Teams')}</h3>
+          <Title headingLevel="h3" className="pf-v6-u-mb-sm">
+            {t('public~Teams')}
+          </Title>
           <p className="co-help-text">
             <Trans
               t={t}

--- a/frontend/public/components/cluster-settings/ldap-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/ldap-idp-form.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { ActionGroup, Button } from '@patternfly/react-core';
+import { ActionGroup, Button, Title } from '@patternfly/react-core';
 
 import { ConfigMapModel, SecretModel } from '../../models';
 import { IdentityProvider, k8sCreate, OAuthKind } from '../../module/k8s';
@@ -226,7 +226,9 @@ export const AddLDAPPage = () => {
             </div>
           </div>
           <div className="co-form-section__separator" />
-          <h3>{t('public~Attributes')}</h3>
+          <Title headingLevel="h3" className="pf-v6-u-mb-sm">
+            {t('public~Attributes')}
+          </Title>
           <p className="co-help-text">
             {t('public~Attributes map LDAP attributes to identities.')}
           </p>
@@ -263,7 +265,9 @@ export const AddLDAPPage = () => {
             )}
           />
           <div className="co-form-section__separator" />
-          <h3>{t('public~More options')}</h3>
+          <Title headingLevel="h3" className="pf-v6-u-mb-sm">
+            {t('public~More options')}
+          </Title>
           <IDPCAFileInput value={caFileContent} onChange={(c: string) => setCaFileContent(c)} />
           <ButtonBar errorMessage={errorMessage} inProgress={inProgress}>
             <ActionGroup className="pf-v6-c-form">

--- a/frontend/public/components/cluster-settings/openid-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/openid-idp-form.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { ActionGroup, Button } from '@patternfly/react-core';
+import { ActionGroup, Button, Title } from '@patternfly/react-core';
 
 import { SecretModel, ConfigMapModel } from '../../models';
 import { IdentityProvider, k8sCreate, OAuthKind } from '../../module/k8s';
@@ -216,7 +216,9 @@ export const AddOpenIDIDPPage = () => {
             </div>
           </div>
           <div className="co-form-section__separator" />
-          <h3>{t('public~Claims')}</h3>
+          <Title headingLevel="h3" className="pf-v6-u-mb-sm">
+            {t('public~Claims')}
+          </Title>
           <p className="co-help-text">
             {t(
               'public~Claims map metadata from the OpenID provider to an OpenShift user. The first non-empty claim is used.',
@@ -245,7 +247,9 @@ export const AddOpenIDIDPPage = () => {
             )}
           />
           <div className="co-form-section__separator" />
-          <h3>{t('public~More options')}</h3>
+          <Title headingLevel="h3" className="pf-v6-u-mb-sm">
+            {t('public~More options')}
+          </Title>
           <IDPCAFileInput value={caFileContent} onChange={(c: string) => setCaFileContent(c)} />
           <ListInput
             label={t('public~Extra scopes')}

--- a/frontend/public/components/cluster-settings/request-header-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/request-header-idp-form.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { ActionGroup, Button } from '@patternfly/react-core';
+import { ActionGroup, Button, Title } from '@patternfly/react-core';
 
 import { ConfigMapModel } from '../../models';
 import { IdentityProvider, k8sCreate, OAuthKind, K8sResourceKind } from '../../module/k8s';
@@ -138,7 +138,9 @@ export const AddRequestHeaderPage = () => {
         <form onSubmit={submit} name="form" className="co-m-pane__body-group">
           <IDPNameInput value={name} onChange={(e) => setName(e.currentTarget.value)} />
           <div className="co-form-section__separator" />
-          <h3 className="co-required">{t('public~URLs')}</h3>
+          <Title headingLevel="h3" className="pf-v6-u-mb-sm co-required">
+            {t('public~URLs')}
+          </Title>
           <p className="co-m-pane__explanation">{t('public~At least one URL must be provided.')}</p>
           <div className="form-group">
             <label className="control-label" htmlFor="challenge-url">
@@ -179,7 +181,9 @@ export const AddRequestHeaderPage = () => {
             </div>
           </div>
           <div className="co-form-section__separator" />
-          <h3>{t('public~More options')}</h3>
+          <Title headingLevel="h3" className="pf-v6-u-mb-sm">
+            {t('public~More options')}
+          </Title>
           <IDPCAFileInput
             value={caFileContent}
             onChange={(c: string) => setCaFileContent(c)}

--- a/frontend/public/components/command-line-tools.tsx
+++ b/frontend/public/components/command-line-tools.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next';
 import { Button, Divider } from '@patternfly/react-core';
 
 import { FLAGS, useCopyLoginCommands } from '@console/shared';
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
+import SecondaryHeading from '@console/shared/src/components/heading/SecondaryHeading';
 import { ExternalLink, Firehose, FirehoseResult } from './utils';
 import { connectToFlags } from '../reducers/connectToFlags';
 import { ConsoleCLIDownloadModel } from '../models';
@@ -29,9 +31,7 @@ export const CommandLineTools: React.FC<CommandLineToolsProps> = ({ obj }) => {
     return (
       <React.Fragment key={tool.metadata.uid}>
         <Divider className="co-divider" />
-        <h2 className="co-section-heading" data-test-id={displayName}>
-          {displayName}
-        </h2>
+        <SecondaryHeading data-test-id={displayName}>{displayName}</SecondaryHeading>
         <SyncMarkdownView content={tool.spec.description} exactHeight />
         {tool.spec.links.length === 1 && (
           <p>
@@ -60,9 +60,9 @@ export const CommandLineTools: React.FC<CommandLineToolsProps> = ({ obj }) => {
         <title>{t('public~Command Line Tools')}</title>
       </Helmet>
       <div className="co-m-pane__body">
-        <h1 className="co-m-pane__heading">
+        <PrimaryHeading>
           <div className="co-m-pane__name">{t('public~Command Line Tools')}</div>
-        </h1>
+        </PrimaryHeading>
         {showCopyLoginCommand && (
           <>
             <Divider className="co-divider" />

--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -8,6 +8,7 @@ import * as classNames from 'classnames';
 import { Trans, withTranslation } from 'react-i18next';
 import { getImpersonate } from '@console/dynamic-plugin-sdk';
 
+import TertiaryHeading from '@console/shared/src/components/heading/TertiaryHeading';
 import { k8sPatch, k8sGet, referenceFor, referenceForOwnerRef } from '../module/k8s';
 import {
   AsyncComponent,
@@ -555,7 +556,7 @@ export class UnconnectedEnvironmentPage extends PromiseComponent {
         )}
         <div className={classNames({ 'co-m-pane__body-group': !currentEnvVars.isCreate })}>
           {!currentEnvVars.isCreate && (
-            <h3 className="co-section-heading-tertiary">
+            <TertiaryHeading>
               {t('public~Single values (env)')}
               {!readOnly && (
                 <FieldLevelHelp>
@@ -568,7 +569,7 @@ export class UnconnectedEnvironmentPage extends PromiseComponent {
                   </Trans>
                 </FieldLevelHelp>
               )}
-            </h3>
+            </TertiaryHeading>
           )}
           <NameValueEditorComponent
             nameValueId={containerIndex}
@@ -584,7 +585,7 @@ export class UnconnectedEnvironmentPage extends PromiseComponent {
         </div>
         {currentEnvVars.isContainerArray && (
           <div className="co-m-pane__body-group environment-buttons">
-            <h3 className="co-section-heading-tertiary">
+            <TertiaryHeading>
               {t('public~All values from existing ConfigMaps or Secrets (envFrom)')}
               {!readOnly && (
                 <FieldLevelHelp>
@@ -600,7 +601,7 @@ export class UnconnectedEnvironmentPage extends PromiseComponent {
                   </>
                 </FieldLevelHelp>
               )}
-            </h3>
+            </TertiaryHeading>
             <EnvFromEditorComponent
               nameValueId={containerIndex}
               nameValuePairs={envVar[EnvType.ENV_FROM]}

--- a/frontend/public/components/graphs/prometheus-graph.tsx
+++ b/frontend/public/components/graphs/prometheus-graph.tsx
@@ -3,6 +3,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom-v5-compat';
+import { Title } from '@patternfly/react-core';
 
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { FLAGS } from '@console/shared';
@@ -52,7 +53,11 @@ export const PrometheusGraphLink = connect(mapStateToProps)(PrometheusGraphLink_
 export const PrometheusGraph: React.FC<PrometheusGraphProps> = React.forwardRef(
   ({ children, className, title }, ref: React.RefObject<HTMLDivElement>) => (
     <div ref={ref} className={classNames('graph-wrapper graph-wrapper__horizontal-bar', className)}>
-      {title && <h5 className="graph-title">{title}</h5>}
+      {title && (
+        <Title headingLevel="h5" className="graph-title">
+          {title}
+        </Title>
+      )}
       {children}
     </div>
   ),

--- a/frontend/public/components/graphs/status.jsx
+++ b/frontend/public/components/graphs/status.jsx
@@ -3,6 +3,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classnames from 'classnames';
 import { Link } from 'react-router-dom-v5-compat';
+import { Title } from '@patternfly/react-core';
 
 import { coFetchJSON } from '../../co-fetch';
 import { PROMETHEUS_BASE_PATH, PROMETHEUS_TENANCY_BASE_PATH } from './consts';
@@ -110,9 +111,15 @@ export class Status extends React.Component {
 
     const statusElem = (
       <div className="graph-wrapper graph-wrapper--title-center graph-wrapper--status">
-        {title && <h5 className="graph-title">{title}</h5>}
+        {title && (
+          <Title headingLevel="h5" className="graph-title">
+            {title}
+          </Title>
+        )}
         <div className="graph-status">
-          <h1 className={shortStatusClassName}>{short}</h1>
+          <Title headingLevel="h1" className={shortStatusClassName}>
+            {short}
+          </Title>
           <div className="graph-status--long">{long}</div>
         </div>
       </div>

--- a/frontend/public/components/import-yaml-results.tsx
+++ b/frontend/public/components/import-yaml-results.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
-import { Bullseye, Button, Icon, Spinner } from '@patternfly/react-core';
+import { Bullseye, Button, Icon, Spinner, Title } from '@patternfly/react-core';
 import {
   GreenCheckCircleIcon,
   RedExclamationCircleIcon,
@@ -31,7 +31,9 @@ export const ImportYAMLPageStatus: React.FC<ImportYAMLPageStatusProps> = ({ erro
     StatusBlock = (
       <>
         <Spinner size="lg" />
-        <h2>{t('public~Creating resources...')}</h2>
+        <Title headingLevel="h2" className="pf-v6-u-mb-sm">
+          {t('public~Creating resources...')}
+        </Title>
       </>
     );
   } else if (!inFlight && !errors) {
@@ -41,9 +43,13 @@ export const ImportYAMLPageStatus: React.FC<ImportYAMLPageStatusProps> = ({ erro
           <GreenCheckCircleIcon />
         </Icon>
 
-        <h2 data-test="resources-successfully-created">
+        <Title
+          headingLevel="h2"
+          className="pf-v6-u-mb-sm"
+          data-test="resources-successfully-created"
+        >
           {t('public~Resources successfully created')}
-        </h2>
+        </Title>
       </>
     );
   } else {
@@ -53,7 +59,9 @@ export const ImportYAMLPageStatus: React.FC<ImportYAMLPageStatusProps> = ({ erro
           <YellowExclamationTriangleIcon />
         </Icon>
 
-        <h2>{t('public~One or more resources failed to be created')}</h2>
+        <Title headingLevel="h2" className="pf-v6-u-mb-sm">
+          {t('public~One or more resources failed to be created')}
+        </Title>
       </>
     );
   }

--- a/frontend/public/components/instantiate-template.tsx
+++ b/frontend/public/components/instantiate-template.tsx
@@ -25,6 +25,7 @@ import { ANNOTATIONS, withActivePerspective } from '@console/shared';
 
 import { Perspective, isPerspective } from '@console/dynamic-plugin-sdk';
 import { withExtensions } from '@console/plugin-sdk';
+import SecondaryHeading from '@console/shared/src/components/heading/SecondaryHeading';
 import catalogImg from '../imgs/logos/catalog-icon.svg';
 import {
   getImageForIconClass,
@@ -105,7 +106,9 @@ const TemplateInfo: React.FC<TemplateInfoProps> = ({ template }) => {
           </span>
         </div>
         <div>
-          <h2 className="co-section-heading co-catalog-item-details__name">{displayName}</h2>
+          <SecondaryHeading className="co-catalog-item-details__name">
+            {displayName}
+          </SecondaryHeading>
           {!_.isEmpty(tags) && (
             <p className="co-catalog-item-details__tags">
               {_.map(tags, (tag, i) => (

--- a/frontend/public/components/monitoring/alertmanager/alertmanager-config.tsx
+++ b/frontend/public/components/monitoring/alertmanager/alertmanager-config.tsx
@@ -20,6 +20,7 @@ import { PencilAltIcon } from '@patternfly/react-icons/dist/esm/icons/pencil-alt
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 import { breadcrumbsForGlobalConfig } from '../../cluster-settings/global-config';
 
 import { K8sResourceKind } from '../../../module/k8s';
@@ -541,13 +542,13 @@ export const AlertmanagerConfig: React.FC = () => {
         </Breadcrumb>
       </div>
       <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
-        <h1 className="co-m-pane__heading">
+        <PrimaryHeading>
           <div className="co-m-pane__name co-resource-item">
             <span className="co-resource-item__resource-name" data-test-id="resource-title">
               {t('public~Alertmanager')}
             </span>
           </div>
-        </h1>
+        </PrimaryHeading>
       </div>
       <ul className="co-m-horizontal-nav__menu">
         <li

--- a/frontend/public/components/monitoring/alertmanager/alertmanager-page.tsx
+++ b/frontend/public/components/monitoring/alertmanager/alertmanager-page.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, Routes, Route } from 'react-router-dom-v5-compat';
 
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 import { breadcrumbsForGlobalConfig } from '../../cluster-settings/global-config';
 import { AlertmanagerConfig } from './alertmanager-config';
 import AlertmanagerYAML from './alertmanager-yaml-editor';
@@ -31,13 +32,13 @@ const AlertmanagerPage: React.FC<{ match: { url: string } }> = ({ match }) => {
         </Breadcrumb>
       </div>
       <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
-        <h1 className="co-m-pane__heading">
+        <PrimaryHeading>
           <div className="co-m-pane__name co-resource-item">
             <span className="co-resource-item__resource-name" data-test-id="resource-title">
               {t('public~Alertmanager')}
             </span>
           </div>
-        </h1>
+        </PrimaryHeading>
       </div>
       <ul className="co-m-horizontal-nav__menu">
         <li

--- a/frontend/public/components/monitoring/alertmanager/alertmanager-yaml-editor.tsx
+++ b/frontend/public/components/monitoring/alertmanager/alertmanager-yaml-editor.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, Link } from 'react-router-dom-v5-compat';
 import { breadcrumbsForGlobalConfig } from '../../cluster-settings/global-config';
 
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 import { K8sResourceKind } from '../../../module/k8s';
 import { AsyncComponent, Firehose, StatusBox } from '../../utils';
 import { patchAlertmanagerConfig, getAlertmanagerYAML } from './alertmanager-utils';
@@ -140,13 +141,13 @@ const AlertmanagerYAML: React.FC<{}> = () => {
         </Breadcrumb>
       </div>
       <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
-        <h1 className="co-m-pane__heading">
+        <PrimaryHeading>
           <div className="co-m-pane__name co-resource-item">
             <span className="co-resource-item__resource-name" data-test-id="resource-title">
               {t('public~Alertmanager')}
             </span>
           </div>
-        </h1>
+        </PrimaryHeading>
       </div>
       <ul className="co-m-horizontal-nav__menu">
         <li

--- a/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
@@ -9,6 +9,7 @@ import { safeLoad } from 'js-yaml';
 import * as classNames from 'classnames';
 
 import { APIError } from '@console/shared';
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 import { ButtonBar } from '../../utils/button-bar';
 import { Dropdown } from '../../utils/dropdown';
 import { Firehose } from '../../utils/firehose';
@@ -367,13 +368,13 @@ const ReceiverBaseForm: React.FC<ReceiverBaseFormProps> = ({
         <title>{t('public~{{titleVerb}} Receiver', { titleVerb })}</title>
       </Helmet>
       <form className="co-m-pane__body-group" onSubmit={save}>
-        <h1 className="co-m-pane__heading">
+        <PrimaryHeading>
           {t('public~{{titleVerb}} {{receiverTypeLabel}} {{defaultString}} Receiver', {
             titleVerb,
             receiverTypeLabel,
             defaultString,
           })}
-        </h1>
+        </PrimaryHeading>
         {isDefaultReceiver && <ReceiverInfoTip type={InitialReceivers.Default} />}
         {formValues.receiverName === 'Critical' && !formValues.receiverType && (
           <ReceiverInfoTip type={InitialReceivers.Critical} />

--- a/frontend/public/components/monitoring/receiver-forms/pagerduty-receiver-form.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/pagerduty-receiver-form.tsx
@@ -2,6 +2,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Title } from '@patternfly/react-core';
 
 import { RadioInput } from '../../radio';
 import { SendResolvedAlertsCheckbox } from './send-resolved-alerts-checkbox';
@@ -142,7 +143,9 @@ export const Form: React.FC<FormProps> = ({ globals, formValues, dispatchFormCha
               formValues={formValues}
               dispatchFormChange={dispatchFormChange}
             />
-            <h3>{t('public~Client details')}</h3>
+            <Title headingLevel="h3" className="pf-v6-u-mb-sm">
+              {t('public~Client details')}
+            </Title>
             <div className="form-group">
               <label className="control-label" htmlFor="pagerduty-client">
                 {t('public~Client')}
@@ -189,7 +192,9 @@ export const Form: React.FC<FormProps> = ({ globals, formValues, dispatchFormCha
                 {t('public~A backlink to the sender of the notification.')}
               </div>
             </div>
-            <h3>{t('public~Incident details')}</h3>
+            <Title headingLevel="h3" className="pf-v6-u-mb-sm">
+              {t('public~Incident details')}
+            </Title>
             <div className="form-group">
               <label className="control-label" htmlFor="pagerduty-description">
                 {t('public~Description')}

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -11,6 +11,7 @@ import i18next from 'i18next';
 
 import { Status } from '@console/shared';
 import { FLAGS } from '@console/shared/src/constants';
+import TertiaryHeading from '@console/shared/src/components/heading/TertiaryHeading';
 import { DetailsPage, ListPage, RowFunctionArgs, Table, TableData } from './factory';
 import {
   CopyToClipboard,
@@ -392,7 +393,7 @@ const RouteIngressStatus: React.FC<RouteIngressStatusProps> = ({ route }) => {
               )}
             </DetailsItem>
           </dl>
-          <h3 className="co-section-heading-secondary">{t('public~Conditions')}</h3>
+          <TertiaryHeading increasedMargins>{t('public~Conditions')}</TertiaryHeading>
           <Conditions conditions={ingress.conditions} />
         </div>
       ))}

--- a/frontend/public/components/routes/create-route.tsx
+++ b/frontend/public/components/routes/create-route.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as fuzzy from 'fuzzysearch';
 import classnames from 'classnames';
-import { Alert, Button } from '@patternfly/react-core';
+import { Alert, Button, Title } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import { MinusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';
 import { connect, FormikContextType, FormikValues } from 'formik';
@@ -508,7 +508,9 @@ class CreateRouteWithTranslation extends React.Component<
               </div>
               {termination && termination !== 'passthrough' && (
                 <>
-                  <h2 className="h3">{t('public~Certificates')}</h2>
+                  <Title headingLevel="h2" className="pf-v6-u-mb-sm">
+                    {t('public~Certificates')}
+                  </Title>
                   <div className="help-block">
                     <p>
                       {t(

--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import { Breadcrumb, BreadcrumbItem, Button, Content } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem, Button, Content, Title } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { CamelCaseWrap } from '@console/dynamic-plugin-sdk';
 import {
@@ -155,14 +155,17 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
 
               return (
                 <li key={name} className="co-resource-sidebar-item">
-                  <h5 className="co-resource-sidebar-item__header co-break-word">
+                  <Title
+                    headingLevel="h5"
+                    className="pf-v6-u-mb-sm co-resource-sidebar-item__header co-break-word"
+                  >
                     <CamelCaseWrap value={name} />
                     &nbsp;
                     <small>
                       <span className="co-break-word">{definitionTypeStr}</span>
                       {required.has(name) && <> &ndash; required</>}
                     </small>
-                  </h5>
+                  </Title>
                   {definition.description && (
                     <p className="co-break-word co-pre-wrap">
                       <LinkifyExternal>{definition.description}</LinkifyExternal>

--- a/frontend/public/components/sidebars/resource-sidebar-samples.tsx
+++ b/frontend/public/components/sidebars/resource-sidebar-samples.tsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import { Button, Level, LevelItem } from '@patternfly/react-core';
+import { Button, Level, LevelItem, Title } from '@patternfly/react-core';
 import MonacoEditor from 'react-monaco-editor';
 import { ThemeContext } from '@console/internal/components/ThemeProvider';
 import { ChevronDownIcon } from '@patternfly/react-icons/dist/esm/icons/chevron-down-icon';
@@ -23,9 +23,9 @@ const ResourceSidebarSample: React.FC<ResourceSidebarSampleProps> = ({
   const { t } = useTranslation();
   return (
     <li className="co-resource-sidebar-item">
-      <h3 className="h4">
+      <Title headingLevel="h3" className="pf-v6-u-mb-sm">
         <span className="text-uppercase">{highlightText}</span> {title}
-      </h3>
+      </Title>
       {img && <img src={img} className="co-resource-sidebar-item__img img-responsive" />}
       <p>{description}</p>
       <Level>
@@ -124,9 +124,9 @@ const ResourceSidebarSnippet: React.FC<ResourceSidebarSnippetProps> = ({
 
   return (
     <li className="co-resource-sidebar-item">
-      <h3 className="h4">
+      <Title headingLevel="h3" className="pf-v6-u-mb-sm">
         <span className="text-uppercase">{highlightText}</span> {title}
-      </h3>
+      </Title>
       <p>{description}</p>
       <Level>
         <LevelItem>

--- a/frontend/public/components/sidebars/resource-sidebar.tsx
+++ b/frontend/public/components/sidebars/resource-sidebar.tsx
@@ -13,6 +13,7 @@ import {
 import { ExploreType } from './explore-type-sidebar';
 import { SimpleTabNav, Tab } from '../utils';
 import { Sample } from '@console/shared';
+import { Title } from '@patternfly/react-core';
 
 const sidebarScrollTop = () => {
   document.getElementsByClassName('co-p-has-sidebar__sidebar')[0].scrollTop = 0;
@@ -36,7 +37,9 @@ const ResourceSidebarWrapper: React.FC<{
           ariaLabel={t('public~Close')}
           onClick={toggleSidebar}
         />
-        <h2 className="co-p-has-sidebar__sidebar-heading text-capitalize">{label}</h2>
+        <Title headingLevel="h2" className="co-p-has-sidebar__sidebar-heading text-capitalize">
+          {label}
+        </Title>
         {children}
       </div>
     </div>

--- a/frontend/public/components/storage/attach-storage.tsx
+++ b/frontend/public/components/storage/attach-storage.tsx
@@ -7,6 +7,7 @@ import { useExtensions } from '@console/plugin-sdk';
 import { isStorageProvider, StorageProvider } from '@console/dynamic-plugin-sdk';
 import { useDeepCompareMemoize } from '@console/shared';
 import { ErrorBoundaryPage } from '@console/shared/src/components/error';
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
 import { K8sKind } from '../../module/k8s';
 import { AsyncComponent, ResourceLink, LoadingBox } from '../utils';
 import { connectToPlural } from '../../kinds';
@@ -64,7 +65,7 @@ const AttachStorageInner: React.FC<AttachStorageFormProps> = (props) => {
       </Helmet>
       <div className="co-storage-heading__wrapper">
         <Trans t={t} ns="public">
-          <h1 className="co-m-pane__heading">Add Storage</h1>
+          <PrimaryHeading>Add Storage</PrimaryHeading>
           <div className="co-m-pane__explanation co-storage-heading__subtitle">
             {' '}
             to{' '}

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -5,7 +5,7 @@ import * as PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { useTranslation, withTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { Divider, Popper } from '@patternfly/react-core';
+import { Divider, Popper, Title } from '@patternfly/react-core';
 import { impersonateStateToProps, useSafetyFirst } from '@console/dynamic-plugin-sdk';
 import { useUserSettingsCompatibility } from '@console/shared';
 import { CaretDownIcon } from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
@@ -499,7 +499,11 @@ class Dropdown_ extends DropdownMixin {
                 <Divider />
               </>
             )}
-            {_.size(bookMarkRows) ? <h1 className="pf-v6-c-menu__group-title">Favorites</h1> : null}
+            {_.size(bookMarkRows) ? (
+              <Title headingLevel="h1" className="pf-v6-c-menu__group-title">
+                Favorites
+              </Title>
+            ) : null}
             <ul
               role="listbox"
               ref={this.dropdownList}

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -14,6 +14,7 @@ import {
   SplitItem,
   Content,
   ContentVariants,
+  Title,
 } from '@patternfly/react-core';
 import { ResourceStatus } from '@console/dynamic-plugin-sdk';
 import { RootState } from '@console/internal/redux';
@@ -25,6 +26,9 @@ import {
   useCsvWatchResource,
 } from '@console/shared';
 import { getActiveNamespace } from '@console/internal/reducers/ui';
+import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';
+import SecondaryHeading from '@console/shared/src/components/heading/SecondaryHeading';
+
 import {
   ActionsMenu,
   FirehoseResult,
@@ -162,14 +166,13 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
         style={style}
       >
         {showHeading && (
-          <Content
-            component={ContentVariants.h1}
-            className={classNames('co-m-pane__heading', {
-              'co-m-pane__heading--baseline': link,
-              'co-m-pane__heading--center': centerText,
+          <PrimaryHeading
+            className={classNames({
               'co-m-pane__heading--logo': props.icon,
               'co-m-pane__heading--with-help-text': helpText,
             })}
+            alignItemsBaseline={!!link}
+            centerText={centerText}
           >
             {props.icon ? (
               <props.icon obj={data} />
@@ -212,7 +215,7 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
                   : customActionMenu}
               </div>
             )}
-          </Content>
+          </PrimaryHeading>
         )}
         {helpText && (
           <Content>
@@ -237,7 +240,7 @@ export const SectionHeading: React.SFC<SectionHeadingProps> = ({
   required,
   id,
 }) => (
-  <h2 className="co-section-heading" style={style} data-test-section-heading={text} id={id}>
+  <SecondaryHeading style={style} data-test-section-heading={text} id={id}>
     <span
       className={classNames({
         'co-required': required,
@@ -246,7 +249,7 @@ export const SectionHeading: React.SFC<SectionHeadingProps> = ({
       {text}
     </span>
     {children}
-  </h2>
+  </SecondaryHeading>
 );
 
 export const SidebarSectionHeading: React.SFC<SidebarSectionHeadingProps> = ({
@@ -255,10 +258,10 @@ export const SidebarSectionHeading: React.SFC<SidebarSectionHeadingProps> = ({
   style,
   className,
 }) => (
-  <h2 className={`sidebar__section-heading ${className}`} style={style}>
+  <Title headingLevel="h2" className={`sidebar__section-heading ${className}`} style={style}>
     {text}
     {children}
-  </h2>
+  </Title>
 );
 
 export const ResourceOverviewHeading: React.SFC<ResourceOverviewHeadingProps> = ({
@@ -272,7 +275,7 @@ export const ResourceOverviewHeading: React.SFC<ResourceOverviewHeadingProps> = 
   const isDeleting = !!resource.metadata.deletionTimestamp;
   return (
     <div className="overview__sidebar-pane-head resource-overview__heading">
-      <h1 className="co-m-pane__heading">
+      <PrimaryHeading>
         <div className="co-m-pane__name co-resource-item">
           <ResourceIcon
             className="co-m-resource-icon--lg"
@@ -297,7 +300,7 @@ export const ResourceOverviewHeading: React.SFC<ResourceOverviewHeadingProps> = 
             />
           </div>
         )}
-      </h1>
+      </PrimaryHeading>
       <HealthChecksAlert resource={resource} />
     </div>
   );

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -20,6 +20,9 @@
 // Ancillary Styles to achieve likeness with PatternFly 5
 @import 'style/ancillary/patternfly5';
 
+// :root variables
+@import 'style/root';
+
 // Overrides
 @import 'style/overrides';
 

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -178,16 +178,6 @@ dl.co-inline {
   margin: 0 0 20px 0;
 }
 
-.co-section-heading-secondary {
-  font-size: 16px;
-  margin: 30px 0;
-}
-
-.co-section-heading-tertiary {
-  font-size: 16px;
-  margin: 15px 0;
-}
-
 .co-switch-label {
   margin-bottom: 0;
 

--- a/frontend/public/style/_root.scss
+++ b/frontend/public/style/_root.scss
@@ -1,0 +1,6 @@
+// Assigning PF component specific variables globally so we can use
+:root {
+  --pf-v6-c-code-block__pre--FontFamily: var(--pf-v6-c-code-block__pre--FontFamily);
+  --pf-v6-c-code-block__pre--FontSize: var(--pf-t--global--font--size--sm);
+  --pf-v6-c-content--MarginBottom: var(--pf-t--global--spacer--md);
+}

--- a/frontend/public/style/ancillary/_patternfly5.scss
+++ b/frontend/public/style/ancillary/_patternfly5.scss
@@ -9,68 +9,7 @@
   --pf-v5-global--FontSize--sm: 13px;
 }
 
-// Assigning PF component specific variables globally so we can use
-:root {
-  --pf-v6-c-code-block--BackgroundColor: var(--pf-v6-c-code-block--BackgroundColor);
-  --pf-v6-c-code-block__pre--FontFamily: var(--pf-v6-c-code-block__pre--FontFamily);
-  --pf-v6-c-code-block__pre--FontSize: var(--pf-t--global--font--size--sm);
-  --pf-v6-c-content--MarginBottom: var(--pf-t--global--spacer--md);
-}
-:where(:not([class*='pf-v6-c-'])) {
-  @at-root h1#{&} {
-    font-size: var(--pf-v6-c-content--h1--FontSize);
-    font-family: var(--pf-v6-c-content--heading--FontFamily);
-    font-weight: var(--pf-v6-c-content--h1--FontWeight);
-    line-height: var(--pf-v6-c-content--h1--LineHeight);
-    margin-bottom: var(--pf-v6-c-content--h1--MarginBlockEnd);
-    word-break: break-word;
-  }
-
-  @at-root h2#{&} {
-    font-size: var(--pf-v6-c-content--h2--FontSize);
-    font-family: var(--pf-v6-c-content--heading--FontFamily);
-    font-weight: var(--pf-v6-c-content--h2--FontWeight);
-    line-height: var(--pf-v6-c-content--h2--LineHeight);
-    margin-bottom: var(--pf-v6-c-content--h2--MarginBlockEnd);
-    word-break: break-word;
-  }
-
-  @at-root h3#{&} {
-    font-size: var(--pf-v6-c-content--h3--FontSize);
-    font-family: var(--pf-v6-c-content--heading--FontFamily);
-    font-weight: var(--pf-v6-c-content--h3--FontWeight);
-    line-height: var(--pf-v6-c-content--h3--LineHeight);
-    margin-bottom: var(--pf-v6-c-content--h3--MarginBlockEnd);
-    word-break: break-word;
-  }
-
-  @at-root h4#{&} {
-    font-size: var(--pf-v6-c-content--h4--FontSize);
-    font-family: var(--pf-v6-c-content--heading--FontFamily);
-    font-weight: var(--pf-v6-c-content--h4--FontWeight);
-    line-height: var(--pf-v6-c-content--h4--LineHeight);
-    margin-bottom: var(--pf-v6-c-content--h4--MarginBlockEnd);
-    word-break: break-word;
-  }
-
-  @at-root h5#{&} {
-    font-size: var(--pf-v6-c-content--h5--FontSize);
-    font-family: var(--pf-v6-c-content--heading--FontFamily);
-    font-weight: var(--pf-v6-c-content--h5--FontWeight);
-    line-height: var(--pf-v6-c-content--h5--LineHeight);
-    margin-bottom: var(--pf-v6-c-content--h5--MarginBlockEnd);
-    word-break: break-word;
-  }
-
-  @at-root h6#{&} {
-    font-size: var(--pf-v6-c-content--h6--FontSize);
-    font-family: var(--pf-v6-c-content--heading--FontFamily);
-    font-weight: var(--pf-v6-c-content--h6--FontWeight);
-    line-height: var(--pf-v6-c-content--h6--LineHeight);
-    margin-bottom: var(--pf-v6-c-content--h6--MarginBlockEnd);
-    word-break: break-word;
-  }
-
+:where(:not([class*='pf-v5-c-'])) {
   @at-root button#{&} {
     font-family: var(--pf-t--global--font--family--body);
   }


### PR DESCRIPTION
* replaces any existing HTML heading elements with PatternFly components
* introduces `<PrimaryHeading>`, `<SecondaryHeading>`, and `<TertiaryHeading>` components to DRY up the code
* removes duplicated heading styles so that styling must come from PatternFly via a `<Title>` or `<Content>` component
* limits the contents of `_patternfly5.scss` to only PatternFly 5 so it is easier to remove in the future
