### PR TITLE
CONSOLE-4462: update dark theme specific styles

### DIFF
--- a/frontend/packages/console-app/src/components/lightspeed/Lightspeed.scss
+++ b/frontend/packages/console-app/src/components/lightspeed/Lightspeed.scss
@@ -104,5 +104,6 @@
 
   .pf-v6-theme-dark & {
     background-image: url('logo-dark.svg');
+    background-color: var(--pf-t--global--background--color--primary--default) !important;
   }
 }

--- a/frontend/packages/console-app/src/components/lightspeed/Lightspeed.scss
+++ b/frontend/packages/console-app/src/components/lightspeed/Lightspeed.scss
@@ -91,6 +91,7 @@
 
   .pf-v6-theme-dark & {
     background-image: url('logo-dark.svg');
+    background-color: var(--pf-t--global--background--color--primary--default) !important;
   }
 }
 
@@ -104,6 +105,5 @@
 
   .pf-v6-theme-dark & {
     background-image: url('logo-dark.svg');
-    background-color: var(--pf-t--global--background--color--primary--default) !important;
   }
 }

--- a/frontend/packages/console-app/src/components/lightspeed/Lightspeed.scss
+++ b/frontend/packages/console-app/src/components/lightspeed/Lightspeed.scss
@@ -91,7 +91,6 @@
 
   .pf-v6-theme-dark & {
     background-image: url('logo-dark.svg');
-    background-color: var(--pf-t--global--background--color--primary--default) !important;
   }
 }
 

--- a/frontend/packages/console-shared/src/components/getting-started/QuickStartGettingStartedCard.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/QuickStartGettingStartedCard.tsx
@@ -116,7 +116,7 @@ export const QuickStartGettingStartedCard: React.FC<QuickStartGettingStartedCard
             id="quick-start"
             icon={<RouteIcon color="var(--co-global--palette--purple-600)" aria-hidden="true" />}
             title={title || t('console-shared~Build with guided documentation')}
-            titleColor={'var(--co-global--palette--purple-700)'}
+            titleColor={'var(--co-global--palette--purple-600)'}
             description={
               description ||
               t(

--- a/frontend/packages/dev-console/src/components/add/AddCardItem.scss
+++ b/frontend/packages/dev-console/src/components/add/AddCardItem.scss
@@ -42,9 +42,3 @@
     text-decoration: none;
   }
 }
-
-:root:where(.pf-v6-theme-dark) .odc-add-card-item {
-  &__img-icon {
-    filter: brightness(1.5) invert(1) hue-rotate(180deg) saturate(4);
-  }
-}

--- a/frontend/packages/knative-plugin/src/components/functions/QuickStartGettingStartedCard.tsx
+++ b/frontend/packages/knative-plugin/src/components/functions/QuickStartGettingStartedCard.tsx
@@ -110,7 +110,7 @@ export const QuickStartGettingStartedCard: React.FC<QuickStartGettingStartedCard
             id="quick-start"
             icon={<RouteIcon color="var(--co-global--palette--purple-600)" aria-hidden="true" />}
             title={title || t('knative-plugin~Build with guided documentation')}
-            titleColor={'var(--co-global--palette--purple-700)'}
+            titleColor={'var(--co-global--palette--purple-600)'}
             description={
               description ||
               t(

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/create-local-volume-set.scss
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/create-local-volume-set.scss
@@ -54,8 +54,4 @@
   &.pf-v6-c-alert {
     --pf-v6-c-alert--BoxShadow: 0;
   }
-
-  :where(.pf-v6-theme-dark) & {
-    background-color: var(--pf-v6-c-alert--m-inline--m-plain--BackgroundColor);
-  }
 }

--- a/frontend/packages/service-binding-plugin/src/components/service-binding-utils/ServiceBindingAlerts.scss
+++ b/frontend/packages/service-binding-plugin/src/components/service-binding-utils/ServiceBindingAlerts.scss
@@ -1,5 +1,0 @@
-.service-binding-alert-modal {
-  :where(.pf-v6-theme-dark) & {
-    background-color: var(--pf-v6-global--BackgroundColor--400) !important;
-  }
-}

--- a/frontend/packages/service-binding-plugin/src/components/service-binding-utils/ServiceBindingAlerts.tsx
+++ b/frontend/packages/service-binding-plugin/src/components/service-binding-utils/ServiceBindingAlerts.tsx
@@ -5,7 +5,6 @@ import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/api/core-ap
 import { K8sResourceCommon } from '@console/internal/module/k8s';
 import { ServiceBindingModel } from '../../models';
 import { getBrandingDetails } from '../../utils';
-import './ServiceBindingAlerts.scss';
 
 export interface ServiceBindingWarningProps {
   namespace: string;

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -32,7 +32,7 @@ form.pf-v6-c-form {
     max-width: 100%;
     min-width: 50px; // prevent collapsed state before img loads
     width: fit-content;
-    :where(.pf-v6-theme-dark) & {
+    :where(.pf-v6-theme-dark) & { // custom styling needed to provide extra padding on dark mode due to white background imgs
       margin-left: 0;
       margin-top: 0;
     }
@@ -219,10 +219,6 @@ form.pf-v6-c-form {
   }
 }
 
-:where(:root:not(.pf-v6-theme-dark)) .pf-v6-c-page {
-  --pf-v6-c-page__sidebar--BoxShadow: none;
-}
-
 .pf-v6-c-page__main-breadcrumb {
   // so breadcrumb padding matches .co-m-nav-title
   @media (min-width: $pf-v6-global--breakpoint--xl) {
@@ -235,11 +231,6 @@ form.pf-v6-c-form {
   @media print {
     display: none !important;
   }
-}
-
-// Remove when upstream issue is addressed. https://github.com/patternfly/patternfly/issues/4889
-.pf-v6-theme-dark .pf-v6-c-card {
-  --pf-v6-c-card--BoxShadow: var(--pf-t--global--box-shadow--md);
 }
 
 .pf-v6-c-wizard__nav-list > ul {
@@ -321,6 +312,7 @@ ul {
   }
 }
 
+// should be unnecessary, but this looks like custom styling instead of PF styling
 :where(.pf-theme-dark) .pfext-quick-start-task__content .pfext-markdown-view pre code {
   color: var(--pf-t--global--text--color--regular);
   background-color: var(--pf-v6-global--palette--black-600);

--- a/frontend/public/style/_theme-dark.scss
+++ b/frontend/public/style/_theme-dark.scss
@@ -1,17 +1,10 @@
 :root {
   // Co Palette
-  --co-global--palette--blue-400: var(--pf-t--color--blue--50);
-  --co-global--palette--purple-600: var(--pf-t--color--purple--60);
-  --co-global--palette--orange-400: var(--pf-t--color--orange--50);
-  --co-global--palette--purple-700: var(--pf-t--color--purple--70);
+  --co-global--palette--blue-400: var(--pf-t--global--icon--color--brand--default);
+  --co-global--palette--purple-600: var(--pf-t--global--icon--color--status--info--default); // minor difference
+  --co-global--palette--orange-400: var(--pf-t--global--icon--color--severity--important--default); // minor difference
 
-  // Co Palette Dark
-  --co-global--dark--palette--blue-400: var(--pf-t--color--blue--20);
-  --co-global--dark--palette--purple-600: var(--pf-t--color--purple--20);
-  --co-global--dark--palette--orange-400: var(--pf-t--color--orange--20);
-  --co-global--dark--palette--purple-700: var(--pf-t--color--purple--20);
-
-  // Skeleton
+  // Skeleton colors are fully custom, PF skeleton's are darker in dark theme
   --co-skeleton--Color: var(--pf-t--color--gray--20);
   --co-skeleton--Color--300: var(--pf-t--color--gray--30);
 
@@ -21,12 +14,6 @@
 }
 
 :root:where(.pf-v6-theme-dark) {
-  // Co palette updates
-  --co-global--palette--blue-400: var(--co-global--dark--palette--blue-400);
-  --co-global--palette--purple-600: var(--co-global--dark--palette--purple-600);
-  --co-global--palette--orange-400: var(--co-global--dark--palette--orange-400);
-  --co-global--palette--purple-700: var(--co-global--dark--palette--purple-600);
-
   // Skeleton
   --co-skeleton--Color: var(--co-skeleton--dark--Color);
   --co-skeleton--Color--300: var(--co-skeleton--dark--Color--300);


### PR DESCRIPTION
By file:
- `AddCardItem.scss` token should be unneeded, but wasn't able to find a natural occurrence of the __img-icon. After locally overriding an icon with this variant, it appears unnecessary.  
- `create-local-volume-set.scss`, `_monitoring.scss`, and `ServiceBindingAlerts.scss` use invalid tokens in V6, meaning the styles aren't being applied currently, so I opted to remove them. Still need to verify, but having trouble finding these in the UI.
- `_overrides.scss` - removed some styling that wasn't necessary anymore with V6, but some overrides are still necessary (noted inline in comments)
- `_theme-dark.scss` / QuickGettingStartedCard - I've updated the palette tokens (images below as the new colors are slightly different). The skeleton tokens are still necessary in its current state, as PF skeleton styles do not include a secondary skeleton color, and other gray semantic color tokens do not match the lighter styling in dark theme.

Getting started card before (blue/purple/orange colored card headers):
<img width="1097" alt="old tokens-dark" src="https://github.com/user-attachments/assets/a31512fc-6dec-4e97-ac6f-dd4168a16731" />
<img width="1097" alt="old tokens-light" src="https://github.com/user-attachments/assets/7e9b7691-e53a-462e-84ad-235fe2405ba1" />

Getting started card after:
The purple is slightly lighter in light theme and orange is slightly darker in dark theme
<img width="1097" alt="new tokens-dark" src="https://github.com/user-attachments/assets/b95e0dd3-e0c9-4fa8-81cf-8dfb0a246be7" />
<img width="1097" alt="new tokens-light" src="https://github.com/user-attachments/assets/d185a0ec-a60f-4942-b7bf-f137e5c83081" />
