### PR TITLE
OCPBUGS-49996: add missing contextId to be able to inject tabs from plugins

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -291,6 +291,7 @@ export type HorizontalNavProps = {
   resource?: K8sResourceCommon;
   pages: NavPage[];
   customData?: object;
+  contextId?: string;
 };
 
 export type TableColumn<D> = ICell & {

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -377,10 +377,19 @@ export const HorizontalNavFacade: React.FC<HorizontalNavFacadeProps> = ({
   resource,
   pages,
   customData,
+  contextId,
 }) => {
   const obj = { data: resource, loaded: true };
 
-  return <HorizontalNav obj={obj} pages={pages} customData={customData} noStatusBox />;
+  return (
+    <HorizontalNav
+      obj={obj}
+      pages={pages}
+      customData={customData}
+      contextId={contextId}
+      noStatusBox
+    />
+  );
 };
 
 export type PodsComponentProps = {


### PR DESCRIPTION
This PR adds the missing contextId to the `HorizontalNav` so plugins can inject tabs targeted to specific nav sections.