### PR TITLE
OCPBUGS-53200: Fix highlighting nav items with nested routes

### DIFF
--- a/frontend/__tests__/components/nav/utils.spec.ts
+++ b/frontend/__tests__/components/nav/utils.spec.ts
@@ -1,4 +1,8 @@
-import { getSortedNavExtensions, sortExtensionItems } from '@console/app/src/components/nav/utils';
+import {
+  getSortedNavExtensions,
+  navItemHrefIsActive,
+  sortExtensionItems,
+} from '@console/app/src/components/nav/utils';
 import { LoadedExtension } from '@console/dynamic-plugin-sdk/src/types';
 import { NavExtension } from '@console/dynamic-plugin-sdk/src';
 
@@ -159,5 +163,14 @@ describe('perspective-nav insertPositionedItems', () => {
     expect(indexOfId('test3', sortedItems)).toBeGreaterThan(indexOfId('test5', sortedItems));
     // test7 depends on test1
     expect(indexOfId('test7', sortedItems)).toBeGreaterThan(indexOfId('test1', sortedItems));
+  });
+
+  describe('navItemHrefIsActive', () => {
+    it('should be true for exact matches', () => {
+      expect(navItemHrefIsActive('/example/foobar', '/example/foobar')).toBeTruthy();
+    });
+    it('should not match nested paths', () => {
+      expect(navItemHrefIsActive('/example/foobar', '/example')).toBeFalsy();
+    });
   });
 });

--- a/frontend/packages/console-app/src/components/nav/utils.ts
+++ b/frontend/packages/console-app/src/components/nav/utils.ts
@@ -172,9 +172,7 @@ export const navItemHrefIsActive = (
 ): boolean => {
   const scopelessLocation = stripScopeFromPath(location);
   const scopelessHref = stripScopeFromPath(href);
-  const locationSegments = scopelessLocation.split('/');
-  const hrefSegments = scopelessHref.split('/');
-  const hrefMatch = hrefSegments.every((segment, i) => segment === locationSegments?.[i]);
+  const hrefMatch = scopelessLocation === scopelessHref;
   return hrefMatch || startsWithSome(scopelessLocation, ...(startsWith ?? []));
 };
 


### PR DESCRIPTION
Hi! I've been working on porting over an application to be a dynamic plugin, and ran into a nav highlighting issue where if a nested route existed for another nav item then both of them would be highlighted. At the moment I have some code in our plugin that corrects the highlighting, but it would be nicer if this solution was baked into the console.

For example, our application (cryostat) has a landing page which displays dashboards. In our original web app we want this to be the entry point, so it uses the route "/cryostat". In our nav we have a "Dashboard" item, that routes to "/cryostat", alongside all the other nav items that route to other pages.

When working on the console plugin we found that if we visited any other page, lets say "/cryostat/about" for example, then both nav items for "Dashboard" and "About" would be highlighted. This is because the current logic tries to match the href and location fragments, and returns true for both nav items because of our nested route.

I posted a question about this on Slack and was pointed at the code here, so here's a change that will make the highlighting logic match the scopeless href to scopeless location in order to avoid nested routes from being highlighted.

## Before
![before](https://github.com/user-attachments/assets/10db1b5d-85cd-44ad-b866-13d9cc3638a4)

## After
![after](https://github.com/user-attachments/assets/3182a325-c704-4120-96d2-45df1bdd9529)
