### PR TITLE
CONSOLE-4465: add workaround for menu scroll

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -163,6 +163,14 @@ form.pf-v6-c-form {
   --pf-v6-c-masthead__logo--Width: auto; // Do not set a width to maintain backwards compatibility
 }
 
+// TODO: remove the following two menu overrides when upstream fix is merged (see https://github.com/patternfly/patternfly/issues/7256)
+.pf-v6-c-menu.pf-m-scrollable .pf-v6-c-menu__content {
+  overflow: auto;
+}
+.pf-v6-c-menu.pf-m-drilldown:not(.pf-m-scrollable) {
+  overflow: hidden;
+}
+
 // PF components that calculate their correct height based on --pf-t--global--font--size--md: 1rem
 .pf-v6-c-modal-box,
 .pf-v6-c-switch {


### PR DESCRIPTION
Added two css blocks to `_overrides.scss` to account for the scrollable menu bug, which can be removed once the upstream fix is live and brought in.