### PR TITLE
CONSOLE-4474: Unbold pf-v6 labels by default

### DIFF
--- a/frontend/public/style/ancillary/_bootstrap-residual.scss
+++ b/frontend/public/style/ancillary/_bootstrap-residual.scss
@@ -16,11 +16,13 @@
   ); // matches --pf-v6-c-helper-text__item-text--Color and picks up dark theme variable
 }
 
-label {
-  display: inline-block;
-  max-width: 100%;
-  margin-bottom: 5px;
-  font-weight: bold;
+:where(:not([class*='pf-v6-c-'])) {
+  @at-root label#{&} {
+    display: inline-block;
+    max-width: 100%;
+    margin-bottom: 5px;
+    font-weight: bold;
+  }
 }
 
 //


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/CONSOLE-4474

before:

![before](https://i.imgur.com/4DHKh0m.png)

after:

![after](https://i.imgur.com/3IAGVGz.png)

adding labels for PF6 bugfix:
/label docs-approved
/label px-approved
/label acknowledge-critical-fixes-only

/assign @rhamilto