### PR TITLE
CONSOLE-4480: fix background color of Command Line Terminal tab

### DIFF
--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/MultiTabbedTerminal.scss
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/MultiTabbedTerminal.scss
@@ -4,5 +4,9 @@
     position: relative;
     height: 100%;
     overflow: auto;
+
+    &.pf-v6-c-tab-content {
+      background-color: var(--pf-t--global--background--color--primary--default) !important;
+    }
   }
 }


### PR DESCRIPTION
This is a CSS hack to fix the presentation.  Long term, we ought to consider a more proper fix.

Before
<img width="1013" alt="Screenshot 2025-02-11 at 4 05 20 PM" src="https://github.com/user-attachments/assets/7f3dbc92-521f-4af6-b3be-5dc4ac2728f6" />
<img width="1007" alt="Screenshot 2025-02-11 at 4 05 48 PM" src="https://github.com/user-attachments/assets/597f3dfe-21ec-42f4-bb03-4d1d8c6dbea4" />

After
<img width="534" alt="Screenshot 2025-02-12 at 8 50 48 AM" src="https://github.com/user-attachments/assets/0cb0eda7-e46c-4646-816a-83044601fffa" />
<img width="532" alt="Screenshot 2025-02-12 at 8 50 58 AM" src="https://github.com/user-attachments/assets/875600cf-8714-4d1b-bde0-a7289ddd277b" />

https://github.com/user-attachments/assets/b0accd26-db50-411f-b905-f3766edeccea


