### PR TITLE
ODC-7770: Remove perspective switcher if only one perspective is present

### DIFF
--- a/frontend/packages/console-app/src/components/nav/NavHeader.scss
+++ b/frontend/packages/console-app/src/components/nav/NavHeader.scss
@@ -1,3 +1,0 @@
-.oc-nav-header__menu-toggle--is-empty {
-  cursor: default !important;
-}

--- a/frontend/packages/console-app/src/components/nav/NavHeader.tsx
+++ b/frontend/packages/console-app/src/components/nav/NavHeader.tsx
@@ -166,7 +166,13 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
         <SelectList>{perspectiveDropdownItems}</SelectList>
       </Select>
     </div>
-  ) : null;
+  ) : (
+    <div
+      className="pf-v6-u-display-none"
+      data-test-id="perspective-switcher-toggle"
+      aria-hidden="true"
+    />
+  ); // Empty div for e2e purposes
 };
 
 export default NavHeader;

--- a/frontend/packages/console-app/src/components/nav/NavHeader.tsx
+++ b/frontend/packages/console-app/src/components/nav/NavHeader.tsx
@@ -7,7 +7,6 @@ import {
   SelectOption,
   Title,
 } from '@patternfly/react-core';
-import * as cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Perspective, useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource';
@@ -16,7 +15,6 @@ import { ConsoleLinkModel } from '@console/internal/models';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { ACM_LINK_ID, usePerspectiveExtension, usePerspectives } from '@console/shared';
 import { ACM_PERSPECTIVE_ID } from '../../consts';
-import './NavHeader.scss';
 
 export type NavHeaderProps = {
   onPerspectiveSelected: () => void;
@@ -135,48 +133,40 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
       : []),
   ];
 
-  return (
-    <>
-      {activePerspective !== ACM_PERSPECTIVE_ID && (
-        <div
-          className="oc-nav-header"
-          data-tour-id="tour-perspective-dropdown"
-          data-quickstart-id="qs-perspective-switcher"
-        >
-          <Select
-            isOpen={isPerspectiveDropdownOpen}
-            data-test-id="perspective-switcher-menu"
-            onOpenChange={(open) => setPerspectiveDropdownOpen(open)}
-            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-              <MenuToggle
-                isFullWidth
-                data-test-id="perspective-switcher-toggle"
-                isExpanded={isPerspectiveDropdownOpen}
-                ref={toggleRef}
-                onClick={() => (perspectiveItems.length === 1 ? null : togglePerspectiveOpen())}
-                className={cx({
-                  'oc-nav-header__menu-toggle--is-empty': perspectiveItems.length === 1,
-                })}
-                icon={<LazyIcon />}
-              >
-                {name && (
-                  <Title headingLevel="h2" size="md">
-                    {name}
-                  </Title>
-                )}
-              </MenuToggle>
-            )}
-            popperProps={{
-              appendTo: () =>
-                document.querySelector("[data-test-id='perspective-switcher-toggle']"),
-            }}
+  return activePerspective !== ACM_PERSPECTIVE_ID && perspectiveItems.length > 1 ? (
+    <div
+      className="oc-nav-header"
+      data-tour-id="tour-perspective-dropdown"
+      data-quickstart-id="qs-perspective-switcher"
+    >
+      <Select
+        isOpen={isPerspectiveDropdownOpen}
+        data-test-id="perspective-switcher-menu"
+        onOpenChange={(open) => setPerspectiveDropdownOpen(open)}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            isFullWidth
+            data-test-id="perspective-switcher-toggle"
+            isExpanded={isPerspectiveDropdownOpen}
+            ref={toggleRef}
+            onClick={() => togglePerspectiveOpen()}
+            icon={<LazyIcon />}
           >
-            <SelectList>{perspectiveDropdownItems}</SelectList>
-          </Select>
-        </div>
-      )}
-    </>
-  );
+            {name && (
+              <Title headingLevel="h2" size="md">
+                {name}
+              </Title>
+            )}
+          </MenuToggle>
+        )}
+        popperProps={{
+          appendTo: () => document.querySelector("[data-test-id='perspective-switcher-toggle']"),
+        }}
+      >
+        <SelectList>{perspectiveDropdownItems}</SelectList>
+      </Select>
+    </div>
+  ) : null;
 };
 
 export default NavHeader;

--- a/frontend/packages/integration-tests-cypress/views/nav.ts
+++ b/frontend/packages/integration-tests-cypress/views/nav.ts
@@ -1,11 +1,23 @@
+import { switchPerspective } from '@console/dev-console/integration-tests/support/constants';
 import { app } from '@console/dev-console/integration-tests/support/pages';
 import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 
 export const nav = {
   sidenav: {
     switcher: {
-      shouldHaveText: (text: string) =>
-        cy.byLegacyTestID('perspective-switcher-toggle').scrollIntoView().contains(text),
+      shouldHaveText: (text: string) => {
+        cy.byLegacyTestID('perspective-switcher-toggle').then(($body) => {
+          if (text === switchPerspective.Administrator) {
+            // if the switcher is hidden it means we are in the admin perspective
+            if ($body.attr('aria-hidden') === 'true') {
+              cy.log('Admin is the only perspective available');
+              cy.byLegacyTestID('perspective-switcher-toggle').should('not.be.visible');
+              return;
+            }
+          }
+          cy.byLegacyTestID('perspective-switcher-toggle').scrollIntoView().contains(text);
+        });
+      },
       changePerspectiveTo: (newPerspective: string) => {
         app.waitForDocumentLoad();
         switch (newPerspective) {
@@ -14,6 +26,12 @@ export const nav = {
           case 'Admin':
           case 'admin':
             cy.byLegacyTestID('perspective-switcher-toggle').then(($body) => {
+              if ($body.attr('aria-hidden') === 'true') {
+                cy.log('Admin is the only perspective available');
+                cy.byLegacyTestID('perspective-switcher-toggle').should('not.be.visible');
+                return;
+              }
+
               if ($body.text().includes('Administrator')) {
                 cy.log('Already on admin perspective');
                 cy.byLegacyTestID('perspective-switcher-toggle')


### PR DESCRIPTION
https://issues.redhat.com/browse/ODC-7770

before:

![Screenshot From 2025-02-12 16-39-29](https://github.com/user-attachments/assets/7b165fe4-451b-4add-bbed-5977def85938)


after:

![Screenshot From 2025-02-12 16-47-02](https://github.com/user-attachments/assets/48c253d8-653c-476e-92b2-309180a6cd63)


/assign @vikram-raj @sanketpathak 

/label px-approved docs-approved acknowledge-critical-fixes-only
