### PR TITLE
OCPBUGS-50665: fix bug where Demo Plugin tab url is always appended

### DIFF
--- a/dynamic-demo-plugin/console-extensions.json
+++ b/dynamic-demo-plugin/console-extensions.json
@@ -196,7 +196,7 @@
       },
       "page": {
         "name": "Demo Plugin",
-        "href": "/demo-plugin"
+        "href": "demo-plugin"
       },
       "component": { "$codeRef": "projectTabContent" }
     }


### PR DESCRIPTION
After

https://github.com/user-attachments/assets/83c9e90d-64a1-4115-a419-1b0635f4df04

