### PR TITLE
CONSOLE-4467: replace html heading elements with PatternFly components

### DIFF
--- a/dynamic-demo-plugin/src/components/ExampleNamespacedPage.tsx
+++ b/dynamic-demo-plugin/src/components/ExampleNamespacedPage.tsx
@@ -27,8 +27,8 @@ const NamespacePageContent = ({ namespace }: { namespace?: string }) => {
               grow={{ default: 'grow' }}
               direction={{ default: 'column' }}
             >
-              <h1>{t('Currently selected namespace')}</h1>
-              <h2>{namespace}</h2>
+              <Title headingLevel='h1'>{t('Currently selected namespace')}</Title>
+              <Title headingLevel='h2'>{namespace}</Title>
             </Flex>
           </CardBody>
         </Card>

--- a/dynamic-demo-plugin/src/components/Nav.tsx
+++ b/dynamic-demo-plugin/src/components/Nav.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { HorizontalNav } from '@openshift-console/dynamic-plugin-sdk';
 import { useTranslation } from 'react-i18next';
-import { PageSection } from '@patternfly/react-core';
+import { PageSection, Title } from '@patternfly/react-core';
 
 type Hero = {
   customData: {
@@ -13,7 +13,7 @@ const Thor: React.FC<Hero> = ( {customData} ) => {
   const { t } = useTranslation();
 
   return <PageSection>
-    <h1>{t('plugin__console-demo-plugin~Hello {{planet}}! I am Thor!',  { planet: customData.planet })}</h1>
+    <Title headingLevel='h1'>{t('plugin__console-demo-plugin~Hello {{planet}}! I am Thor!',  { planet: customData.planet })}</Title>
   </PageSection>
 };
 
@@ -21,7 +21,7 @@ const Loki: React.FC<Hero> = ( {customData} ) => {
   const { t } = useTranslation();
 
   return <PageSection>
-    <h1>{t('plugin__console-demo-plugin~Hello {{planet}}! I am Loki!', { planet: customData.planet })}</h1>
+    <Title headingLevel='h1'>{t('plugin__console-demo-plugin~Hello {{planet}}! I am Loki!', { planet: customData.planet })}</Title>
     </PageSection>
 };
 


### PR DESCRIPTION
I overlooked these two instances in https://github.com/openshift/console/pull/14726 since they live outside `frontend`.

After
![localhost_9000_example-namespaced-page_all-namespaces (1)](https://github.com/user-attachments/assets/22851ad0-0eb9-472e-9a4b-c022d6b4035d)
![localhost_9000_example-namespaced-page_all-namespaces](https://github.com/user-attachments/assets/d4aed81d-e0c9-42f0-98dc-3940181f2036)
