### PR TITLE
(chore) Update tectonic builder image to use golang-1.23

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: tectonic-console-builder
   namespace: ci
-  tag: v28
+  tag: v29

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -8,7 +8,7 @@
 # You can test the image using `./builder-run.sh`. For instance:
 #   $ ./builder-run.sh ./build-backend.sh
 
-FROM golang:1.22-bullseye
+FROM golang:1.23-bullseye
 
 ### For golang testing stuff
 RUN go install github.com/jstemmer/go-junit-report@latest

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 # Dockerfile to build console image from pre-built front end.
 
-FROM quay.io/coreos/tectonic-console-builder:v28 AS build
+FROM quay.io/coreos/tectonic-console-builder:v29 AS build
 RUN mkdir -p /go/src/github.com/openshift/console/
 ADD . /go/src/github.com/openshift/console/
 WORKDIR /go/src/github.com/openshift/console/

--- a/Dockerfile.plugins.demo
+++ b/Dockerfile.plugins.demo
@@ -3,7 +3,7 @@
 # See dynamic-demo-plugin/README.md for details.
 
 # Stage 0: build the demo plugin
-FROM quay.io/coreos/tectonic-console-builder:v28 AS build
+FROM quay.io/coreos/tectonic-console-builder:v29 AS build
 
 RUN mkdir -p /src/console
 COPY . /src/console

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The console is a more friendly `kubectl` in the form of a single page webapp. It
 ### Dependencies:
 
 1. [node.js](https://nodejs.org/) >= 18 & [yarn](https://yarnpkg.com/en/docs/install) >= 1.20
-2. [go](https://golang.org/) >= 1.22+
+2. [go](https://golang.org/) >= 1.23+
 3. [oc](https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/) or [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and an OpenShift or Kubernetes cluster
 4. [jq](https://stedolan.github.io/jq/download/) (for `contrib/environment.sh`)
 

--- a/builder-run.sh
+++ b/builder-run.sh
@@ -11,7 +11,7 @@ set -e
 # Without env vars:
 #   ./builder-run.sh ./my-script --my-script-arg1 --my-script-arg2
 
-BUILDER_IMAGE="quay.io/coreos/tectonic-console-builder:v28"
+BUILDER_IMAGE="quay.io/coreos/tectonic-console-builder:v29"
 
 # forward whitelisted env variables to docker
 ENV_STR=()


### PR DESCRIPTION
/assign @spadgett 

Tied to https://github.com/openshift/release/pull/61664