### PR TITLE
CONSOLE-4489: fix bug where dropdown menu can overflow

### DIFF
--- a/frontend/packages/console-shared/src/components/multi-tab-list/MultiTabListPage.tsx
+++ b/frontend/packages/console-shared/src/components/multi-tab-list/MultiTabListPage.tsx
@@ -88,7 +88,7 @@ const MultiTabListPage: React.FC<MultiTabListPageProps> = ({
             {items && (
               <Dropdown
                 buttonClassName="pf-m-primary"
-                menuClassName="pf-m-align-right-on-md"
+                menuClassName="prevent-overflow"
                 title={t('console-shared~Create')}
                 noSelection
                 items={items}

--- a/frontend/packages/knative-plugin/src/components/functions/CreateActionDropdown.tsx
+++ b/frontend/packages/knative-plugin/src/components/functions/CreateActionDropdown.tsx
@@ -48,7 +48,7 @@ export const CreateActionDropdown: React.FC<CreateActionDropdownProps> = ({ name
   return (
     <Dropdown
       buttonClassName="pf-m-primary"
-      menuClassName="pf-m-align-right-on-md"
+      menuClassName="prevent-overflow"
       title={t('knative-plugin~Create function')}
       noSelection
       items={items}

--- a/frontend/packages/pipelines-plugin/src/components/ListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/ListPage.tsx
@@ -285,7 +285,7 @@ export const FireMan: React.FC<FireManProps & { filterList?: typeof filterList }
             buttonClassName="pf-m-primary"
             id="item-create"
             dataTest="item-create"
-            menuClassName={classNames({ 'pf-m-align-right-on-md': title })}
+            menuClassName={classNames({ 'prevent-overflow': title })}
             title={createButtonText}
             noSelection
             items={createProps.items}

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -139,11 +139,6 @@
 .pf-v6-c-dropdown__menu {
   list-style: none;
   -webkit-overflow-scrolling: touch;
-  @media (min-width: $pf-v6-global--breakpoint--md) {
-    &.pf-m-align-right-on-md {
-      right: 0;
-    }
-  }
 }
 
 .pf-v6-c-menu-toggle {

--- a/frontend/public/components/factory/list-page.tsx
+++ b/frontend/public/components/factory/list-page.tsx
@@ -287,7 +287,7 @@ export const FireMan: React.FC<FireManProps & { filterList?: typeof filterList }
             buttonClassName="pf-m-primary"
             id="item-create"
             dataTest="item-create"
-            menuClassName={classNames({ 'pf-m-align-right-on-md': title })}
+            menuClassName={classNames({ 'prevent-overflow': title })}
             title={createButtonText}
             noSelection
             items={createProps.items}

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -565,10 +565,12 @@ class Dropdown_ extends DropdownMixin {
     );
 
     const menu = (
-      <div className="pf-v6-c-menu dropdown-menu" ref={this.dropdownMenuRef}>
-        <ul ref={this.dropdownList} className={classNames('pf-v6-c-menu-list', menuClassName)}>
-          {rows}
-        </ul>
+      <div className="pf-v6-c-menu" ref={this.dropdownMenuRef}>
+        <div className="pf-v6-c-menu__content">
+          <ul ref={this.dropdownList} className={classNames('pf-v6-c-menu-list', menuClassName)}>
+            {rows}
+          </ul>
+        </div>
       </div>
     );
 
@@ -586,6 +588,7 @@ class Dropdown_ extends DropdownMixin {
             triggerRef={this.dropdownToggleRef}
             popper={menu}
             popperRef={this.dropdownMenuRef}
+            preventOverflow={menuClassName === 'prevent-overflow' ? true : false}
             isVisible={active}
             zIndex={9999}
             appendTo="inline"


### PR DESCRIPTION
PatternFly 6 `<Dropdown>` menus can only be positioned using [popperProps](https://www.patternfly.org/components/menus/dropdown#dropdownpopperprops).  As a result, `.pf-m-align-right-on-md` no longer works to change the positioning of menu. Given this limitation and the need to preserve `menuClassName` for other use cases, I renamed  `pf-m-align-right-on-md` to `prevent-overflow` and use it to conditionally enable `preventOverflow` on the `<Dropdown>` `<Popper>`.  Note this doesn't fully restore the functionality we previously had where the menu was positioned on the right side of the toggle at medium and larger viewports, but it does resolve the issue where the menu was overflowing while preserving the alignment for smaller than medium viewports.

https://github.com/user-attachments/assets/421258d2-0128-46ed-87f0-7cdc97f4f353


