### PR TITLE
OCPBUGS-51037: Update the monitoring topic used by the console team

### DIFF
--- a/frontend/public/components/utils/documentation.tsx
+++ b/frontend/public/components/utils/documentation.tsx
@@ -30,10 +30,9 @@ export const documentationURLs: documentationURLsType = {
     upstream: 'applications/application-health.html',
   },
   configuringMonitoring: {
-    downstream:
-      'html/monitoring/configuring-the-monitoring-stack#maintenance-and-support_configuring-the-monitoring-stack',
+    downstream: 'html/monitoring/getting-started#maintenance-and-support-for-monitoring',
     upstream:
-      'observability/monitoring/configuring-the-monitoring-stack.html#maintenance-and-support_configuring-monitoring',
+      'observability/monitoring/getting-started/maintenance-and-support-for-monitoring.html#maintenance-and-support-for-monitoring',
   },
   networkPolicy: {
     downstream: 'html/networking/network-policy#about-network-policy',


### PR DESCRIPTION
The monitoring documentation is going through the restructuring. For this reason, the console links need to be updated to reflect that change.

For versions 4.14+ 

* Link (docs.openshift): https://docs.openshift.com/container-platform/4.17/observability/monitoring/getting-started/maintenance-and-support-for-monitoring.html#maintenance-and-support-for-monitoring

* Link (docs.redhat): https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/monitoring/getting-started#maintenance-and-support-for-monitoring