### PR TITLE
CONSOLE-4486: decrease TertiaryHeading margins in Edit resource limit…

### DIFF
--- a/frontend/packages/console-shared/src/components/heading/TertiaryHeading.tsx
+++ b/frontend/packages/console-shared/src/components/heading/TertiaryHeading.tsx
@@ -3,14 +3,14 @@ import { Title } from '@patternfly/react-core';
 import * as classNames from 'classnames';
 
 const TertiaryHeading: React.FC<TertiaryHeadingProps> = ({
+  altSpacing,
   children,
   className,
-  increasedMargins,
   ...props
 }) => (
   <Title
     headingLevel="h3"
-    className={classNames(increasedMargins ? 'pf-v6-u-my-xl' : 'pf-v6-u-my-md', className)}
+    className={classNames({ 'pf-v6-u-my-md': !altSpacing }, altSpacing, className)}
     {...props}
   >
     {children}
@@ -20,7 +20,7 @@ const TertiaryHeading: React.FC<TertiaryHeadingProps> = ({
 export type TertiaryHeadingProps = {
   children: React.ReactNode;
   className?: string;
-  increasedMargins?: boolean;
+  altSpacing?: string;
 };
 
 export default TertiaryHeading;

--- a/frontend/packages/dev-console/src/components/import/advanced/ResourceLimitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/ResourceLimitSection.tsx
@@ -31,7 +31,7 @@ const ResourceLimitSection: React.FC<ResourceLimitSectionProps> = ({ hideTitle }
           <ResourceIcon kind={ContainerModel.kind} /> {container}
         </span>
       )}
-      <TertiaryHeading>{t('devconsole~CPU')}</TertiaryHeading>
+      <TertiaryHeading altSpacing="pf-v6-u-my-0">{t('devconsole~CPU')}</TertiaryHeading>
       <ResourceLimitField
         name="limits.cpu.request"
         label={t('devconsole~Request')}
@@ -50,7 +50,7 @@ const ResourceLimitSection: React.FC<ResourceLimitSectionProps> = ({ hideTitle }
         )}
       />
 
-      <TertiaryHeading>{t('devconsole~Memory')}</TertiaryHeading>
+      <TertiaryHeading altSpacing="pf-v6-u-my-0">{t('devconsole~Memory')}</TertiaryHeading>
       <ResourceLimitField
         name="limits.memory.request"
         label={t('devconsole~Request')}

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -393,7 +393,7 @@ const RouteIngressStatus: React.FC<RouteIngressStatusProps> = ({ route }) => {
               )}
             </DetailsItem>
           </dl>
-          <TertiaryHeading increasedMargins>{t('public~Conditions')}</TertiaryHeading>
+          <TertiaryHeading altSpacing="pf-v6-u-my-xl">{t('public~Conditions')}</TertiaryHeading>
           <Conditions conditions={ingress.conditions} />
         </div>
       ))}


### PR DESCRIPTION
…s modal

After

<img width="661" alt="Screenshot 2025-02-19 at 9 51 21 AM" src="https://github.com/user-attachments/assets/da1ef395-7ca8-4303-88c7-782e7c1c00c4" />
<img width="644" alt="Screenshot 2025-02-19 at 9 56 10 AM" src="https://github.com/user-attachments/assets/52f63bfd-843f-4fec-a091-cda1bba27fa9" />
