### PR TITLE
OCPBUGS-51076: Console UI Displays Incorrect Subscription Values

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -407,6 +407,7 @@
   "1 requires approval": "1 requires approval",
   "1 failed": "1 failed",
   "1 installing": "1 installing",
+  "No channel": "No channel",
   "Functioning as manual approval strategy": "Functioning as manual approval strategy",
   "Functioning as manual": "Functioning as manual",
   "Upgrade status": "Upgrade status",

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/subscription-channel-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/subscription-channel-modal.tsx
@@ -22,7 +22,7 @@ export const SubscriptionChannelModal: React.FC<SubscriptionChannelModalProps> =
   subscription,
 }) => {
   const { t } = useTranslation();
-  const currentChannel = subscription?.spec?.channel ?? pkg?.status?.channels?.[0]?.name;
+  const currentChannel = subscription?.spec?.channel;
   const [handlePromise, inProgress, errorMessage] = usePromiseHandler();
   const [selectedChannel, setSelectedChannel] = React.useState(currentChannel);
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -628,7 +628,7 @@ export const SubscriptionUpdates: React.FC<SubscriptionUpdatesProps> = ({
                     icon={<PencilAltIcon />}
                     iconPosition="end"
                   >
-                    {obj.spec.channel || 'No channel'}
+                    {obj.spec.channel || t('olm~No channel')}
                   </Button>
                   {deprecatedChannel.deprecation && (
                     <DeprecatedOperatorWarningIcon

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -628,7 +628,7 @@ export const SubscriptionUpdates: React.FC<SubscriptionUpdatesProps> = ({
                     icon={<PencilAltIcon />}
                     iconPosition="end"
                   >
-                    {obj.spec.channel || 'default'}
+                    {obj.spec.channel || 'No channel'}
                   </Button>
                   {deprecatedChannel.deprecation && (
                     <DeprecatedOperatorWarningIcon


### PR DESCRIPTION
When subscription has no channel configured, we should not be showing 'default' channel as a fallback. We should instead show that there is 'No channel' or channel 'Not found'. In addition we should not show any channels as selected in the radio input of subscription channel modal, when no channels are configured.

before:

https://github.com/user-attachments/assets/f09bd8e1-0a40-4cf5-af32-d3845f096878



after:

https://github.com/user-attachments/assets/d92b5ddd-f3c8-4368-91d8-1c35ab0aaa8b

