### PR TITLE
CONSOLE-4484: Reintroduce styling for tabs within a sidebar

### DIFF
--- a/frontend/packages/topology/src/components/side-bar/TopologyEdgePanel.tsx
+++ b/frontend/packages/topology/src/components/side-bar/TopologyEdgePanel.tsx
@@ -44,6 +44,7 @@ const TopologyEdgePanel: React.FC<TopologyEdgePanelProps> = ({ edge }) => {
         </PrimaryHeading>
       </div>
       <SimpleTabNav
+        withinSidebar
         tabs={[
           {
             name: t('topology~Resources'),

--- a/frontend/packages/topology/src/components/side-bar/components/SideBarBody.tsx
+++ b/frontend/packages/topology/src/components/side-bar/components/SideBarBody.tsx
@@ -23,6 +23,7 @@ const SimpleTabNavWrapper: React.FC<{ tabs: Tab[] }> = ({ tabs }) => {
   );
   return (
     <SimpleTabNav
+      withinSidebar
       selectedTab={selectTabParam || selectedTab || t('topology~Details')}
       tabs={tabs}
       onClickTab={handleClickTab}

--- a/frontend/public/components/overview/resource-overview-details.tsx
+++ b/frontend/public/components/overview/resource-overview-details.tsx
@@ -88,6 +88,7 @@ export const ResourceOverviewDetails = connect<PropsFromState, PropsFromDispatch
         <ResourceOverviewHeading actions={menuActions} kindObj={kindObj} resources={item} />
         <SimpleTabNav
           withinSidebar
+          noInset
           onClickTab={onClickTab}
           selectedTab={selectedDetailsTab}
           tabProps={{ item }}

--- a/frontend/public/components/overview/resource-overview-details.tsx
+++ b/frontend/public/components/overview/resource-overview-details.tsx
@@ -87,6 +87,7 @@ export const ResourceOverviewDetails = connect<PropsFromState, PropsFromDispatch
       <div className="overview__sidebar-pane resource-overview">
         <ResourceOverviewHeading actions={menuActions} kindObj={kindObj} resources={item} />
         <SimpleTabNav
+          withinSidebar
           onClickTab={onClickTab}
           selectedTab={selectedDetailsTab}
           tabProps={{ item }}

--- a/frontend/public/components/sidebars/resource-sidebar.tsx
+++ b/frontend/public/components/sidebars/resource-sidebar.tsx
@@ -134,6 +134,7 @@ export const ResourceSidebar: React.FC<{
     <ResourceSidebarWrapper label={label} toggleSidebar={toggleSidebar}>
       {tabs.length > 0 ? (
         <SimpleTabNav
+          withinSidebar
           tabs={tabs}
           tabProps={{
             downloadSampleYaml,

--- a/frontend/public/components/sidebars/resource-sidebar.tsx
+++ b/frontend/public/components/sidebars/resource-sidebar.tsx
@@ -135,6 +135,7 @@ export const ResourceSidebar: React.FC<{
       {tabs.length > 0 ? (
         <SimpleTabNav
           withinSidebar
+          noInset
           tabs={tabs}
           tabProps={{
             downloadSampleYaml,

--- a/frontend/public/components/utils/simple-tab-nav.tsx
+++ b/frontend/public/components/utils/simple-tab-nav.tsx
@@ -14,7 +14,7 @@ type SimpleTabNavProps = {
   tabProps?: any;
   tabs: Tab[];
   additionalClassNames?: string;
-  /** Cancels out padding within a sidebar and adds extra margin to the bottom of the tab list */
+  /** Removes inset and adds extra margin to the bottom of the tab list */
   withinSidebar?: boolean;
 };
 
@@ -35,12 +35,9 @@ export const SimpleTabNav: React.FC<SimpleTabNavProps> = ({
     <div>
       <Tabs
         onSelect={handleTabClick}
-        className={classnames(
-          { 'pf-v6-u-mb-lg co-m-pane__body--offset-padding': withinSidebar },
-          additionalClassNames,
-        )}
+        className={classnames({ 'pf-v6-u-mb-lg': withinSidebar }, additionalClassNames)}
         defaultActiveKey={selectedTab || tabs[0]?.name}
-        inset={{ default: 'insetNone', xl: 'insetSm' }}
+        inset={!withinSidebar && { default: 'insetNone', xl: 'insetSm' }}
         unmountOnExit
       >
         {tabs.map((tab) => {

--- a/frontend/public/components/utils/simple-tab-nav.tsx
+++ b/frontend/public/components/utils/simple-tab-nav.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import classnames from 'classnames';
 import { Tabs, Tab as PfTab, TabTitleText } from '@patternfly/react-core';
 
 export type Tab = {
@@ -13,6 +14,8 @@ type SimpleTabNavProps = {
   tabProps?: any;
   tabs: Tab[];
   additionalClassNames?: string;
+  /** Cancels out padding within a sidebar and adds extra margin to the bottom of the tab list */
+  withinSidebar?: boolean;
 };
 
 export const SimpleTabNav: React.FC<SimpleTabNavProps> = ({
@@ -21,6 +24,7 @@ export const SimpleTabNav: React.FC<SimpleTabNavProps> = ({
   tabProps = null,
   tabs,
   additionalClassNames,
+  withinSidebar,
 }) => {
   const handleTabClick = (_e, tabIndex: string) => {
     onClickTab && onClickTab(tabIndex);
@@ -31,7 +35,10 @@ export const SimpleTabNav: React.FC<SimpleTabNavProps> = ({
     <div>
       <Tabs
         onSelect={handleTabClick}
-        className={additionalClassNames}
+        className={classnames(
+          { 'pf-v6-u-mb-lg co-m-pane__body--offset-padding': withinSidebar },
+          additionalClassNames,
+        )}
         defaultActiveKey={selectedTab || tabs[0]?.name}
         inset={{ default: 'insetNone', xl: 'insetSm' }}
         unmountOnExit

--- a/frontend/public/components/utils/simple-tab-nav.tsx
+++ b/frontend/public/components/utils/simple-tab-nav.tsx
@@ -16,6 +16,7 @@ type SimpleTabNavProps = {
   additionalClassNames?: string;
   /** Removes inset and adds extra margin to the bottom of the tab list */
   withinSidebar?: boolean;
+  noInset?: boolean;
 };
 
 export const SimpleTabNav: React.FC<SimpleTabNavProps> = ({
@@ -25,6 +26,7 @@ export const SimpleTabNav: React.FC<SimpleTabNavProps> = ({
   tabs,
   additionalClassNames,
   withinSidebar,
+  noInset,
 }) => {
   const handleTabClick = (_e, tabIndex: string) => {
     onClickTab && onClickTab(tabIndex);
@@ -35,9 +37,9 @@ export const SimpleTabNav: React.FC<SimpleTabNavProps> = ({
     <div>
       <Tabs
         onSelect={handleTabClick}
-        className={classnames({ 'pf-v6-u-mb-lg': withinSidebar }, additionalClassNames)}
+        className={classnames({ 'pf-v6-u-mb-md': withinSidebar }, additionalClassNames)}
         defaultActiveKey={selectedTab || tabs[0]?.name}
-        inset={!withinSidebar && { default: 'insetNone', xl: 'insetSm' }}
+        inset={!noInset && { default: 'insetSm' }}
         unmountOnExit
       >
         {tabs.map((tab) => {

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -44,7 +44,6 @@ dl.co-inline {
 .co-m-pane__body {
   margin: $pf-v6-global-gutter--md 0 0;
   padding: 0 $pf-v6-global-gutter $pf-v6-global-gutter--md;
-
   @media (min-width: $pf-v6-global--breakpoint--xl) {
     padding-left: $pf-v6-global-gutter--md;
     padding-right: $pf-v6-global-gutter--md;

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -44,9 +44,20 @@ dl.co-inline {
 .co-m-pane__body {
   margin: $pf-v6-global-gutter--md 0 0;
   padding: 0 $pf-v6-global-gutter $pf-v6-global-gutter--md;
+
+  &--offset-padding {
+    margin-left: -$pf-v6-global-gutter;
+    margin-right: -$pf-v6-global-gutter;
+  }
+
   @media (min-width: $pf-v6-global--breakpoint--xl) {
     padding-left: $pf-v6-global-gutter--md;
     padding-right: $pf-v6-global-gutter--md;
+
+    &--offset-padding {
+      margin-left: -$pf-v6-global-gutter--md;
+      margin-right: -$pf-v6-global-gutter--md;
+    }
   }
   &--full-height {
     height: 100%;

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -45,19 +45,9 @@ dl.co-inline {
   margin: $pf-v6-global-gutter--md 0 0;
   padding: 0 $pf-v6-global-gutter $pf-v6-global-gutter--md;
 
-  &--offset-padding {
-    margin-left: -$pf-v6-global-gutter;
-    margin-right: -$pf-v6-global-gutter;
-  }
-
   @media (min-width: $pf-v6-global--breakpoint--xl) {
     padding-left: $pf-v6-global-gutter--md;
     padding-right: $pf-v6-global-gutter--md;
-
-    &--offset-padding {
-      margin-left: -$pf-v6-global-gutter--md;
-      margin-right: -$pf-v6-global-gutter--md;
-    }
   }
   &--full-height {
     height: 100%;


### PR DESCRIPTION
fixes visual regression when SimpleTabNav is used within a sidebar

/cc @rhamilto 

before:
![image](https://github.com/user-attachments/assets/c66548ee-dd6f-438a-b0d4-694c666ac3f8)

after:
![image](https://github.com/user-attachments/assets/7a279401-79ca-48f6-a2a1-e4eca7846d3c)


follow-up for approved ticket #14760, adding labels
/label px-approved
/label docs-approved
/label qe-approved