### PR TITLE
fix(PF quickstarts): pull in updated quickstarts to use marked instead of showdown

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -134,7 +134,7 @@
   "dependencies": {
     "@patternfly-5/patternfly": "npm:@patternfly/patternfly@5.4.2",
     "@patternfly/patternfly": "^6.2.0-prerelease.3",
-    "@patternfly/quickstarts": "^6.2.0-prerelease.4",
+    "@patternfly/quickstarts": "^6.2.0-prerelease.6",
     "@patternfly/react-catalog-view-extension": "^6.1.0-prerelease.3",
     "@patternfly/react-charts": "^8.2.0-prerelease.13",
     "@patternfly/react-component-groups": "^6.2.0-prerelease.4",
@@ -213,7 +213,7 @@
     "sanitize-html": "^2.3.2",
     "screenfull": "4.x",
     "semver": "6.x",
-    "showdown": "1.8.6",
+    "marked": "^15.0.6",
     "subscriptions-transport-ws": "^0.9.16",
     "text-encoding": "0.x",
     "typesafe-actions": "^4.2.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1839,10 +1839,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.2.0-prerelease.5.tgz#beb568a269b2f30ab591e9cee671a2409349d5f2"
   integrity sha512-El+oVuK8IA7EtoFDoKNsMHARW2Z1P1XhbcTCuBCKODurIVuBXv1+UkEbA0GN4768qg18Hl6FwCLLiReYGsCwfw==
 
-"@patternfly/quickstarts@^6.2.0-prerelease.4":
-  version "6.2.0-prerelease.4"
-  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-6.2.0-prerelease.4.tgz#61fa953e7f97c94c8686c94f4c3cc468710b9062"
-  integrity sha512-FSLPkhn5R6iViRowj45oXv10tONMCYO7FF2kuYRDAl+owuN6pO/HEcR1Hx/4xCZXt3KmE2pcrfAfOTpuqdxHHw==
+"@patternfly/quickstarts@^6.2.0-prerelease.6":
+  version "6.2.0-prerelease.6"
+  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-6.2.0-prerelease.6.tgz#c1d904a07be3fc4ebade049e75f29eff598b2170"
+  integrity sha512-YTFW3MLt5la0erulTvpeQro5k7GeNxLEO+NsEWCba5Ixb3Po2dKzwsbz8dfBW8y6+GQoNNbq0Tl8rSAKqgMaaA==
   dependencies:
     dompurify "^3.1.3"
     history "^5.0.0"
@@ -11985,6 +11985,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+marked@^15.0.6:
+  version "15.0.7"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-15.0.7.tgz#f67d7e34d202ce087e6b879107b5efb04e743314"
+  integrity sha512-dgLIeKGLx5FwziAnsk4ONoGwHwGPJzselimvlVskE9XLN4Orv9u2VA3GWw/lYUqjfA0rUT/6fqKwfZJapP9BEg==
 
 matcher-collection@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
PF quickstarts has been updated to use marked rather than showdown for markdown parsing.

I am noticing one issue with this version bump I might need some help diagnosing or addressing. 

The only components not being rendered correctly due to markdown parsing having some sort of issue is the multiline copy feature.

example of multiline copy as defined in markdown:
```
    ```
    Code goes here
    ```{{copy}
```

I see two quickstarts in the console-shared repo using this pattern: https://github.com/search?q=repo%3Aopenshift%2Fconsole-operator%20%7B%7Bcopy%7D%7D&type=code

I believe the formatting is off in the rendered multiline copy quickstarts because the indentation is off in the yaml defining the multiline copy in the console-shared repo. I'd love help verifying that.
I'm also not sure how or if the [multiline-clipboard-extension](https://github.com/openshift/console/blob/main/frontend/packages/console-shared/src/components/markdown-extensions/multiline-clipboard-extension.ts) is being used or interfering with the quickstarts parsing.