### PR TITLE
NO-JIRA: Apply plugin-api-changed label on changes to the api package

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/OWNERS
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - plugin-api-changed

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/OWNERS
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - plugin-api-changed


### PR DESCRIPTION
Changes to this package will require API reviewers to apply the plugin-api-approved label to approve PRs for merge.

See https://github.com/openshift/release/pull/62098 which adds the labels and updates the tide queries.

/cc @jhadvig @vojtechszocs 