### PR TITLE
CONSOLE-4484: follow on fix to ensure Bottom ConsoleNotification are …

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-notification.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-notification.cy.ts
@@ -52,7 +52,7 @@ describe(`${crd} CRD`, () => {
     cy.visit(`/k8s/cluster/console.openshift.io~v1~${crd}/${name}`);
     detailsPage.titleShouldContain(name);
 
-    cy.get(notification).contains(text).should('exist');
+    cy.get(notification).contains(text).should('exist').and('be.visible');
 
     cy.visit(`/k8s/cluster/console.openshift.io~v1~${crd}/${name}/yaml`);
     yamlEditor.isLoaded();
@@ -74,7 +74,7 @@ describe(`${crd} CRD`, () => {
       });
     });
 
-    cy.get(altNotification).contains(altText).should('exist');
+    cy.get(altNotification).contains(altText).should('exist').and('be.visible');
 
     cy.visit(`/k8s/cluster/console.openshift.io~v1~${crd}`);
     listPage.rows.shouldBeLoaded();

--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -1078,7 +1078,7 @@ spec:
     href: 'https://www.example.com'
     text: Optional link text
   color: '#fff'
-  backgroundColor: '#0088ce'
+  backgroundColor: '#0066cc'
 `,
   )
   .setIn(

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -2,6 +2,9 @@ html,
 body,
 #app,
 .pf-v6-c-drawer {
+  display: flex;
+  flex-basis: 100%;
+  flex-direction: column;
   height: 100%;
 }
 


### PR DESCRIPTION
…visible

After
![localhost_9000_k8s_cluster_console openshift io~v1~ConsoleNotification_example](https://github.com/user-attachments/assets/41ef24a1-35e6-49ef-8bfb-e18d678ac083)

