### PR TITLE
OCPBUGS-48491: Namespace is not persisting when switching to developer view from the topology page of admin page

### DIFF
--- a/frontend/packages/console-app/src/components/detect-namespace/__tests__/getValueForNamespace.spec.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/__tests__/getValueForNamespace.spec.ts
@@ -8,6 +8,7 @@ jest.mock('../checkNamespaceExists', () => ({
 
 const checkNamespaceExistsMock = checkNamespaceExists as jest.Mock;
 
+const activeNamespace: string = 'active-ns';
 const preferredNamespace: string = 'preferred-ns';
 const lastNamespace: string = 'last-ns';
 
@@ -16,16 +17,31 @@ describe('getValueForNamespace', () => {
     jest.resetAllMocks();
   });
 
-  it(`should return preferredNamespace if it is defined and exists`, async () => {
+  it(`should return activeNamespace if it is defined and exists`, async () => {
     checkNamespaceExistsMock.mockReturnValueOnce(Promise.resolve(true));
 
+    const namespace = await getValueForNamespace(
+      preferredNamespace,
+      lastNamespace,
+      true,
+      activeNamespace,
+    );
+
+    expect(namespace).toEqual(activeNamespace);
+  });
+
+  it(`should return preferredNamespace if activeNamespace does not exist and preferredNamespace is defined and exists`, async () => {
+    checkNamespaceExistsMock
+      .mockReturnValueOnce(Promise.resolve(false))
+      .mockReturnValueOnce(Promise.resolve(true));
     const namespace = await getValueForNamespace(preferredNamespace, lastNamespace, true);
 
     expect(namespace).toEqual(preferredNamespace);
   });
 
-  it('should return lastNamespace if preferred namespace does not exist and last namespace is defined and exists', async () => {
+  it('should return lastNamespace if activeNamespace and preferred namespace does not exist and last namespace is defined and exists', async () => {
     checkNamespaceExistsMock
+      .mockReturnValueOnce(Promise.resolve(false))
       .mockReturnValueOnce(Promise.resolve(false))
       .mockReturnValueOnce(Promise.resolve(true));
 
@@ -34,8 +50,9 @@ describe('getValueForNamespace', () => {
     expect(namespace).toEqual(lastNamespace);
   });
 
-  it(`should return ${ALL_NAMESPACES_KEY} if preferred and last namespace does not exists`, async () => {
+  it(`should return ${ALL_NAMESPACES_KEY} if activeNamespace, preferred and last namespace does not exists`, async () => {
     checkNamespaceExistsMock
+      .mockReturnValueOnce(Promise.resolve(false))
       .mockReturnValueOnce(Promise.resolve(false))
       .mockReturnValueOnce(Promise.resolve(false));
 

--- a/frontend/packages/console-app/src/components/detect-namespace/getValueForNamespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/getValueForNamespace.ts
@@ -5,7 +5,11 @@ export const getValueForNamespace = async (
   preferredNamespace: string,
   lastNamespace: string,
   useProjects: boolean,
+  activeNamespace?: string,
 ): Promise<string> => {
+  if (await checkNamespaceExists(activeNamespace, useProjects)) {
+    return activeNamespace;
+  }
   if (await checkNamespaceExists(preferredNamespace, useProjects)) {
     return preferredNamespace;
   }

--- a/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
@@ -55,7 +55,7 @@ export const useValuesForNamespaceContext: UseValuesForNamespaceContext = () => 
     !flagPending(useProjects) && preferredNamespaceLoaded && lastNamespaceLoaded;
   React.useEffect(() => {
     if (!urlNamespace && resourcesLoaded) {
-      getValueForNamespace(preferredNamespace, lastNamespace, useProjects)
+      getValueForNamespace(preferredNamespace, lastNamespace, useProjects, activeNamespace)
         .then((ns: string) => {
           updateNamespace(ns);
         })


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-48491

**Analysis / Root cause**: 
Active namespace value was not considered in namespace context

**Solution Description**: 
Considered Active namespace value  in namespace context

  
**Screen shots / Gifs for design review**: 

**----BEFORE---**


https://drive.google.com/file/d/1VYg-pWt4ZCYKtmPx4bIK6L2Lkt3WpOPv/view?usp=sharing


-----



**---AFTER----**


https://github.com/user-attachments/assets/5dc0a0d7-5949-49bb-bd27-97c56bfd7ba6




-----



**Unit test coverage report**: 
NA

**Test setup:**

    1. Go to topology page on ain view after login
    2. Select/Create a namespace 
    3. Switch to developer perspective
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

