### PR TITLE
OCPBUGS-48413: Sorted Links according to OS in CLI

### DIFF
--- a/frontend/packages/console-app/src/components/user-preferences/lightspeed/HideLightspeedUserPreferences.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/lightspeed/HideLightspeedUserPreferences.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Checkbox } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { useUserSettings } from '@console/shared';
+
+const PREFERRED_LIGHTSPEED_USER_SETTING_KEY = 'console.hideLightspeedButton';
+
+const HideLightspeedUserPreferences: React.FC = () => {
+  const { t } = useTranslation();
+  const [hideLightspeed, setHideLightspeed, hideLightspeedLoaded] = useUserSettings<boolean>(
+    PREFERRED_LIGHTSPEED_USER_SETTING_KEY,
+    false,
+    true,
+  );
+
+  if (!hideLightspeedLoaded) {
+    return null;
+  }
+
+  return (
+    <Checkbox
+      id="hide-lightspeed"
+      name="hide-lightspeed"
+      label={t('console-app~Hide Lightspeed')}
+      description={t('console-app~Do not display the Lightspeed button.')}
+      isChecked={hideLightspeed}
+      onChange={(_event, checked) => setHideLightspeed(checked)}
+    />
+  );
+};
+
+export default HideLightspeedUserPreferences;

--- a/frontend/public/components/command-line-tools.tsx
+++ b/frontend/public/components/command-line-tools.tsx
@@ -28,22 +28,23 @@ export const CommandLineTools: React.FC<CommandLineToolsProps> = ({ obj }) => {
   const additionalCommandLineTools = _.map(cliData.concat(data), (tool) => {
     const displayName = tool.spec.displayName;
     const defaultLinkText = t('Download {{displayName}}', { displayName });
+    const sortedLinks = _.sortBy(tool.spec.links, 'text');
     return (
       <React.Fragment key={tool.metadata.uid}>
         <Divider className="co-divider" />
         <SecondaryHeading data-test-id={displayName}>{displayName}</SecondaryHeading>
         <SyncMarkdownView content={tool.spec.description} exactHeight />
-        {tool.spec.links.length === 1 && (
+        {sortedLinks.length === 1 && (
           <p>
             <ExternalLink
-              href={tool.spec.links[0].href}
-              text={tool.spec.links[0].text || defaultLinkText}
+              href={sortedLinks[0].href}
+              text={sortedLinks[0].text || defaultLinkText}
             />
           </p>
         )}
-        {tool.spec.links.length > 1 && (
+        {sortedLinks.length > 1 && (
           <ul>
-            {_.map(tool.spec.links, (link, i) => (
+            {_.map(sortedLinks, (link, i) => (
               <li key={i}>
                 <ExternalLink href={link.href} text={link.text || defaultLinkText} />
               </li>


### PR DESCRIPTION
On the page/command-line-tools, the oc and virtctl sorted the links differently. It's now sorted based on OS
