### PR TITLE
OCPBUGS-51355:  VolumeSnapshots are not displayed in OpenShift Web Console

### DIFF
--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
@@ -215,13 +215,13 @@ const VolumeSnapshotTable: React.FC<VolumeSnapshotTableProps> = (props) => {
 const VolumeSnapshotPage: React.FC<VolumeSnapshotPageProps> = ({
   canCreate = true,
   showTitle = true,
-  namespace = 'default',
+  namespace,
   selector,
 }) => {
   const { t } = useTranslation();
   const canListVSC = useFlag(FLAGS.CAN_LIST_VSC);
 
-  const createPath = `/k8s/ns/${namespace}/${VolumeSnapshotModel.plural}/~new/form`;
+  const createPath = `/k8s/ns/${namespace || 'default'}/${VolumeSnapshotModel.plural}/~new/form`;
   const [resources, loaded, loadError] = useK8sWatchResource<VolumeSnapshotKind[]>({
     groupVersionKind: {
       group: VolumeSnapshotModel.apiGroup,


### PR DESCRIPTION
VolumeSnapshotPage used default initializes for namespace prop which caused problem when retrieving All projects list page. Removing the initialized and only providing the fallback default value in the createLink fixed this problem.

before:

https://github.com/user-attachments/assets/f4201520-fc50-485c-9587-26e143ed589d



after:

https://github.com/user-attachments/assets/8a92ba05-ac02-4eb3-a8aa-8db2a3416d15

