### PR TITLE
OCPBUGS-51372: Filter 'Name' on resource list page doesn't align well when language is set to Chinese/Japanese/Korean

### DIFF
--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -464,7 +464,7 @@ class Dropdown_ extends DropdownMixin {
           ref={this.dropdownToggleRef}
         >
           <div className="pf-v6-c-dropdown__content-wrap">
-            <span className="pf-v6-c-dropdown__toggle-text">
+            <span className="pf-v6-c-dropdown__toggle-text co-nowrap">
               {titlePrefix && `${titlePrefix}: `}
               {title}
             </span>
@@ -556,7 +556,7 @@ class Dropdown_ extends DropdownMixin {
         disabled={disabled}
         ref={this.dropdownToggleRef}
       >
-        <span className="pf-v6-c-dropdown__toggle-text">
+        <span className="pf-v6-c-dropdown__toggle-text co-nowrap">
           {titlePrefix && `${titlePrefix}: `}
           {title}
         </span>


### PR DESCRIPTION
Configuring the text of a dropdown (`pf-v6-c-dropdown-togle__text` rule) to not wrap on whitespaces (`whitespace: nowrap`) selectively by adding the `co-nowrap` class to the Dropdown text content fixes the problem where chinese/japanese/korean overflowed to second line causing the dropdown to have bigger height than surrounding toolbar buttons. 

before:
![Screenshot 2025-03-04 at 12 36 25](https://github.com/user-attachments/assets/f4947ebb-74d8-4aa1-a04b-114d754e518e)

after:
![Screenshot 2025-03-04 at 12 36 55](https://github.com/user-attachments/assets/43b8709d-1491-4215-9ebd-b759cdfb8968)

