### PR TITLE
[release-4.14] OCPBUGS-51118: redirect to correct alert

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/alerts/useRuleAlertsPoller.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/useRuleAlertsPoller.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Dispatch } from 'redux';
-import { PrometheusRulesResponse } from '@console/dynamic-plugin-sdk';
+import { PrometheusRulesResponse, useActivePerspective } from '@console/dynamic-plugin-sdk';
 import {
   alertingErrored,
   alertingLoaded,
@@ -26,6 +26,7 @@ export const useRulesAlertsPoller = (
     getAlertingRules: (namespace?: string) => Promise<PrometheusRulesResponse>;
   }[],
 ) => {
+  const [perspective] = useActivePerspective();
   React.useEffect(() => {
     const url = getPrometheusURL({
       endpoint: PrometheusEndpoint.RULES,
@@ -36,7 +37,10 @@ export const useRulesAlertsPoller = (
     const poller = (): void => {
       fetchAlerts(url, alertsSource, namespace)
         .then(({ data }) => {
-          const { alerts: fetchedAlerts, rules: fetchedRules } = getAlertsAndRules(data);
+          const { alerts: fetchedAlerts, rules: fetchedRules } = getAlertsAndRules(
+            data,
+            perspective,
+          );
           const sortThanosRules = _.sortBy(fetchedRules, alertingRuleStateOrder);
           dispatch(alertingSetRules('devRules', sortThanosRules, 'dev'));
           dispatch(alertingLoaded('devAlerts', fetchedAlerts, 'dev'));
@@ -57,5 +61,5 @@ export const useRulesAlertsPoller = (
         clearTimeout(pollerTimeout);
       }
     };
-  }, [namespace, alertsSource, dispatch]);
+  }, [namespace, alertsSource, dispatch, perspective]);
 };


### PR DESCRIPTION
This PR looks to ensure the correct linking from the notification bar and the Admin Overview page to the Admin > Observe > Alerts > Alerts Detail page by including the external labels in the alert details URL's in the admin perspective. 

The PR looks to include the two following fixes:
1. https://github.com/openshift/console/pull/14718 - Ensure the external labels are added to the URL
2. https://github.com/openshift/console/pull/14785 - Don't include the external labels in the developer perspective links