### PR TITLE
OCPBUGS-52316: enable clicking outside NodeLogs Selects to close them

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
@@ -43,6 +43,7 @@ type LogControlsProps = {
   onChangePath: (event: React.ChangeEvent<HTMLInputElement>, newAPI: string) => void;
   path: string;
   isPathOpen: boolean;
+  setPathOpen: (value: boolean) => void;
   pathItems: string[];
   isJournal: boolean;
   onChangeUnit: (value: string) => void;
@@ -51,6 +52,7 @@ type LogControlsProps = {
   logFilenamesExist: boolean;
   onToggleFilename: () => void;
   onChangeFilename: (event: React.ChangeEvent<HTMLInputElement>, newFilename: string) => void;
+  setFilenameOpen: (value: boolean) => void;
   logFilename: string;
   isFilenameOpen: boolean;
   logFilenames: string[];
@@ -64,6 +66,7 @@ const LogControls: React.FC<LogControlsProps> = ({
   onChangePath,
   path,
   isPathOpen,
+  setPathOpen,
   pathItems,
   isJournal,
   onChangeUnit,
@@ -74,6 +77,7 @@ const LogControls: React.FC<LogControlsProps> = ({
   onChangeFilename,
   logFilename,
   isFilenameOpen,
+  setFilenameOpen,
   logFilenames,
   isWrapLines,
   setWrapLines,
@@ -112,6 +116,7 @@ const LogControls: React.FC<LogControlsProps> = ({
                   {path}
                 </MenuToggle>
               )}
+              onOpenChange={(open) => setPathOpen(open)}
             >
               <SelectList>{options(pathItems)}</SelectList>
             </Select>
@@ -137,6 +142,7 @@ const LogControls: React.FC<LogControlsProps> = ({
                         {logFilename || t('public~Select a log file')}
                       </MenuToggle>
                     )}
+                    onOpenChange={(open) => setFilenameOpen(open)}
                   >
                     <SelectList>{options(logFilenames)}</SelectList>
                   </Select>
@@ -329,6 +335,7 @@ const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
       path={path}
       isPathOpen={isPathOpen}
       pathItems={pathItems}
+      setPathOpen={setPathOpen}
       isJournal={isJournal}
       onChangeUnit={onChangeUnit}
       unit={unit}
@@ -338,6 +345,7 @@ const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
       onChangeFilename={onChangeFilename}
       logFilename={logFilename}
       isFilenameOpen={isFilenameOpen}
+      setFilenameOpen={setFilenameOpen}
       logFilenames={logFilenames}
       isWrapLines={isWrapLines}
       setWrapLines={setWrapLines}


### PR DESCRIPTION
After


https://github.com/user-attachments/assets/6122d42d-9eb3-4f7d-86d8-87af5e0dc786

