### PR TITLE
ODC-7775: Update content in Getting started resources on cluster and project overview page

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/cluster-dashboard.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/cluster-dashboard.tsx
@@ -14,6 +14,7 @@ import { K8sResourceKind } from '../../../../module/k8s';
 import { ClusterDashboardContext } from './context';
 
 import { GettingStartedSection } from './getting-started/getting-started-section';
+import { CLUSTER_DASHBOARD_USER_SETTINGS_KEY } from './getting-started/constants';
 
 const mainCards = [{ Card: StatusCard }, { Card: UtilizationCard }];
 const leftCards = [{ Card: DetailsCard }, { Card: InventoryCard }];
@@ -38,7 +39,9 @@ export const ClusterDashboard: React.FC<{}> = () => {
   return (
     <ClusterDashboardContext.Provider value={context}>
       <Dashboard>
-        {consoleCapabilityGettingStartedBannerIsEnabled && <GettingStartedSection />}
+        {consoleCapabilityGettingStartedBannerIsEnabled && (
+          <GettingStartedSection userSettingKey={CLUSTER_DASHBOARD_USER_SETTINGS_KEY} />
+        )}
         <DashboardGrid mainCards={mainCards} leftCards={leftCards} rightCards={rightCards} />
       </Dashboard>
     </ClusterDashboardContext.Provider>

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/getting-started-section.spec.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/getting-started-section.spec.tsx
@@ -10,6 +10,7 @@ import {
 } from '@console/shared/src/components/getting-started';
 
 import { GettingStartedSection } from '../getting-started-section';
+import { CLUSTER_DASHBOARD_USER_SETTINGS_KEY } from '../constants';
 
 jest.mock('@console/shared/src/hooks/flag', () => ({
   ...require.requireActual('@console/shared/src/hooks/flag'),
@@ -50,7 +51,9 @@ describe('GettingStartedSection', () => {
     mockUserSettings.mockReturnValue([true, jest.fn()]);
     useGettingStartedShowStateMock.mockReturnValue([GettingStartedShowState.SHOW, jest.fn(), true]);
 
-    const wrapper = shallow(<GettingStartedSection />);
+    const wrapper = shallow(
+      <GettingStartedSection userSettingKey={CLUSTER_DASHBOARD_USER_SETTINGS_KEY} />,
+    );
 
     expect(wrapper.find(GettingStartedExpandableGrid).length).toEqual(1);
     expect(wrapper.find(GettingStartedExpandableGrid).props().children.length).toEqual(3);
@@ -61,7 +64,9 @@ describe('GettingStartedSection', () => {
     mockUserSettings.mockReturnValue([true, jest.fn()]);
     useGettingStartedShowStateMock.mockReturnValue([GettingStartedShowState.SHOW, jest.fn(), true]);
 
-    const wrapper = shallow(<GettingStartedSection />);
+    const wrapper = shallow(
+      <GettingStartedSection userSettingKey={CLUSTER_DASHBOARD_USER_SETTINGS_KEY} />,
+    );
 
     expect(wrapper.find(GettingStartedExpandableGrid).length).toEqual(0);
   });
@@ -70,7 +75,9 @@ describe('GettingStartedSection', () => {
     useFlagMock.mockReturnValue(true);
     useGettingStartedShowStateMock.mockReturnValue([GettingStartedShowState.HIDE, jest.fn(), true]);
 
-    const wrapper = shallow(<GettingStartedSection />);
+    const wrapper = shallow(
+      <GettingStartedSection userSettingKey={CLUSTER_DASHBOARD_USER_SETTINGS_KEY} />,
+    );
 
     expect(wrapper.find(GettingStartedExpandableGrid).length).toEqual(0);
   });

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
@@ -12,16 +12,28 @@ import {
 import { useIdentityProviderLink } from './cluster-setup-identity-provider-link';
 import { useAlertReceiverLink } from './cluster-setup-alert-receiver-link';
 import { documentationURLs, getDocumentationURL, isManaged } from '../../../../utils';
+import { TourActions, TourContext } from '@console/app/src/components/tour';
 
 export const ClusterSetupGettingStartedCard: React.FC = () => {
   const { t } = useTranslation();
 
   const canUpgrade = useCanClusterUpgrade();
 
+  const { tourDispatch, tour } = React.useContext(TourContext);
+
   const identityProviderLink = useIdentityProviderLink();
   const alertReceiverLink = useAlertReceiverLink();
+  const takeConsoleTourAction: GettingStartedLink = {
+    id: 'console-tour',
+    title: t('public~Take console tour'),
+    onClick: () => tourDispatch({ type: TourActions.start }),
+  };
 
-  const links = [canUpgrade && identityProviderLink, alertReceiverLink].filter(Boolean);
+  const links = [
+    tour && takeConsoleTourAction,
+    canUpgrade && identityProviderLink,
+    alertReceiverLink,
+  ].filter(Boolean);
 
   if (links.length === 0) {
     return null;

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/constants.ts
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/constants.ts
@@ -1,1 +1,2 @@
-export const USER_SETTINGS_KEY = 'console.clusterDashboard.gettingStarted';
+export const CLUSTER_DASHBOARD_USER_SETTINGS_KEY = 'console.clusterDashboard.gettingStarted';
+export const PROJECT_OVERVIEW_USER_SETTINGS_KEY = 'console.projectOverview.gettingStarted';

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/getting-started-section.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/getting-started-section.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
 
-import {
-  FLAGS,
-  GETTING_STARTED_USER_SETTINGS_KEY_CLUSTER_DASHBOARD,
-  useUserSettings,
-} from '@console/shared';
+import { FLAGS, useUserSettings } from '@console/shared';
 import { useFlag } from '@console/shared/src/hooks/flag';
 import {
   GettingStartedExpandableGrid,
@@ -15,17 +11,20 @@ import {
 
 import { ClusterSetupGettingStartedCard } from './cluster-setup-getting-started-card';
 import { ExploreAdminFeaturesGettingStartedCard } from './explore-admin-features-getting-started-card';
-import { USER_SETTINGS_KEY } from './constants';
 
 import './getting-started-section.scss';
 
-export const GettingStartedSection: React.FC = () => {
+type GettingStartedSectionProps = {
+  userSettingKey: string;
+};
+
+export const GettingStartedSection: React.FC<GettingStartedSectionProps> = ({ userSettingKey }) => {
   const openshiftFlag = useFlag(FLAGS.OPENSHIFT);
 
-  const [showState, setShowState, showStateLoaded] = useGettingStartedShowState(USER_SETTINGS_KEY);
+  const [showState, setShowState, showStateLoaded] = useGettingStartedShowState(userSettingKey);
 
   const [isGettingStartedSectionOpen, setIsGettingStartedSectionOpen] = useUserSettings<boolean>(
-    GETTING_STARTED_USER_SETTINGS_KEY_CLUSTER_DASHBOARD,
+    `${userSettingKey}.expanded`,
     true,
   );
 
@@ -44,6 +43,8 @@ export const GettingStartedSection: React.FC = () => {
         <QuickStartGettingStartedCard
           featured={[
             // All part of the console-operator:
+            // - Enable the Developer perspective
+            'enable-developer-perspective',
             // - Impersonate a user
             'user-impersonation',
             // - Monitor your sample application

--- a/frontend/public/components/dashboard/project-dashboard/project-dashboard.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/project-dashboard.tsx
@@ -3,6 +3,7 @@ import Helmet from 'react-helmet';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';
+import { FLAGS, useFlag } from '@console/shared';
 import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
 import DashboardGrid from '@console/shared/src/components/dashboard/DashboardGrid';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
@@ -16,7 +17,9 @@ import { ActivityCard } from './activity-card';
 import { ProjectDashboardContext } from './project-dashboard-context';
 import { LauncherCard } from './launcher-card';
 import { ResourceQuotaCard } from './resource-quota-card';
-import { GettingStartedSection } from './getting-started/GettingStartedSection';
+import { GettingStartedSection as DevGettingStartedSection } from './getting-started/GettingStartedSection';
+import { GettingStartedSection } from '../dashboards-page/cluster-dashboard/getting-started/getting-started-section';
+import { PROJECT_OVERVIEW_USER_SETTINGS_KEY } from '../dashboards-page/cluster-dashboard/getting-started/constants';
 
 const mainCards = [{ Card: StatusCard }, { Card: UtilizationCard }, { Card: ResourceQuotaCard }];
 const leftCards = [{ Card: DetailsCard }, { Card: InventoryCard }];
@@ -51,6 +54,9 @@ export const getNamespaceDashboardConsoleLinks = (
 export const ProjectDashboard: React.FC<ProjectDashboardProps> = ({ obj }) => {
   const { t } = useTranslation();
   const [perspective] = useActivePerspective();
+  const consoleCapabilityGettingStartedBannerIsEnabled = useFlag(
+    FLAGS.CONSOLE_CAPABILITY_GETTINGSTARTEDBANNER_IS_ENABLED,
+  );
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     kind: referenceForModel(ConsoleLinkModel),
@@ -78,7 +84,13 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = ({ obj }) => {
       )}
       <ProjectDashboardContext.Provider value={context}>
         <Dashboard>
-          <GettingStartedSection userSettingKey="console.projectOverview.gettingStarted" />
+          {perspective === 'dev' ? (
+            <DevGettingStartedSection userSettingKey="devconsole.projectOverview.gettingStarted" />
+          ) : (
+            consoleCapabilityGettingStartedBannerIsEnabled && (
+              <GettingStartedSection userSettingKey={PROJECT_OVERVIEW_USER_SETTINGS_KEY} />
+            )
+          )}
           <DashboardGrid mainCards={mainCards} leftCards={leftCards} rightCards={rc} />
         </Dashboard>
       </ProjectDashboardContext.Provider>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -398,6 +398,7 @@
   "Control plane high availability": "Control plane high availability",
   "No (single control plane node)": "No (single control plane node)",
   "Configure alert receivers": "Configure alert receivers",
+  "Take console tour": "Take console tour",
   "View all steps in documentation": "View all steps in documentation",
   "Set up your cluster": "Set up your cluster",
   "Finish setting up your cluster with recommended configurations.": "Finish setting up your cluster with recommended configurations.",


### PR DESCRIPTION
Adds start admin perspective guided tour action and Enable the developer perspective quick start link in cluster and project overview getting started resources section.

https://github.com/user-attachments/assets/337e5a0e-97bb-4fd9-bf30-30a53f4a2b39


Step to test
- Create a sample quick start with name `enable-developer-perspective` and displayName `Enable the developer perspective`