### PR TITLE
CONSOLE-4409: Update monaco theming and sidebar logic

### DIFF
--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -141,7 +141,6 @@
   "Click {{submit}} to save changes or {{reset}} to cancel changes.": "Click {{submit}} to save changes or {{reset}} to cancel changes.",
   "Reload": "Reload",
   "Download": "Download",
-  "View sidebar": "View sidebar",
   "Name": "Name",
   "Add value": "Add value",
   "Filter by type...": "Filter by type...",

--- a/frontend/packages/console-shared/src/components/editor/BasicCodeEditor.tsx
+++ b/frontend/packages/console-shared/src/components/editor/BasicCodeEditor.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
-import { loader, Monaco } from '@monaco-editor/react';
+import { loader } from '@monaco-editor/react';
 import { CodeEditor } from '@patternfly/react-code-editor';
 import classNames from 'classnames';
 import * as monaco from 'monaco-editor';
 import { useTranslation } from 'react-i18next';
 import { BasicCodeEditorProps } from '@console/dynamic-plugin-sdk';
+import { ThemeContext } from '@console/internal/components/ThemeProvider';
 import { ErrorBoundaryInline } from '@console/shared/src/components/error';
-import { useConsoleMonacoTheme } from './theme';
+import { defineThemes } from './theme';
 import './BasicCodeEditor.scss';
 
 // Avoid using monaco from CDN
@@ -21,8 +22,7 @@ loader.config({ monaco });
  */
 export const BasicCodeEditor: React.FC<BasicCodeEditorProps> = (props) => {
   const { t } = useTranslation('console-shared');
-  const [monacoRef, setMonacoRef] = React.useState<Monaco | null>(null);
-  useConsoleMonacoTheme(monacoRef?.editor);
+  const theme = React.useContext(ThemeContext);
 
   return (
     <ErrorBoundaryInline>
@@ -44,10 +44,14 @@ export const BasicCodeEditor: React.FC<BasicCodeEditorProps> = (props) => {
         editorProps={{
           ...props?.editorProps,
           beforeMount: (monacoInstance) => {
-            setMonacoRef(monacoInstance);
+            defineThemes(monacoInstance?.editor);
             window.monaco = monacoInstance; // for e2e tests
             props?.editorProps?.beforeMount?.(monacoInstance);
           },
+        }}
+        options={{
+          ...props?.options,
+          theme: `console-${theme}`,
         }}
       />
     </ErrorBoundaryInline>

--- a/frontend/packages/console-shared/src/components/editor/CodeEditor.scss
+++ b/frontend/packages/console-shared/src/components/editor/CodeEditor.scss
@@ -40,10 +40,14 @@
     }
   }
 
-  /* Needed to get the CodeEditorToolbar to place buttons on the right side */
-  .pf-v6-c-code-editor__controls, .ocs-yaml-editor-toolbar {
+  .pf-v6-c-code-editor__controls {
     width: 100%;
-    height: 100% !important;
     align-items: center;
+    // the height+padding of a PatternFly standard button.
+    // makes sure all toolbars are of the same height regardless of content
+    min-height: calc(
+      1em * var(--pf-t--global--font--line-height--body) +
+      2 * var(--pf-t--global--spacer--control--vertical--default)
+    );
   }
 }

--- a/frontend/packages/console-shared/src/components/editor/theme.ts
+++ b/frontend/packages/console-shared/src/components/editor/theme.ts
@@ -1,4 +1,3 @@
-import { useContext, useEffect, useState } from 'react';
 import {
   t_color_green_70,
   t_color_yellow_70,
@@ -15,12 +14,11 @@ import {
   t_color_black,
 } from '@patternfly/react-tokens';
 import type { editor as monacoEditor } from 'monaco-editor/esm/vs/editor/editor.api';
-import { ThemeContext } from '@console/internal/components/ThemeProvider';
 
 /**
  * Define the themes `console-light` and `console-dark` for an instance of Monaco editor.
  */
-const defineThemes = (editor: typeof monacoEditor) => {
+export const defineThemes = (editor: typeof monacoEditor) => {
   editor.defineTheme('console-light', {
     base: 'vs',
     inherit: true,
@@ -52,46 +50,4 @@ const defineThemes = (editor: typeof monacoEditor) => {
       { token: 'keyword', foreground: t_color_purple_30.value },
     ],
   });
-};
-
-const useSystemTheme = () => {
-  const [theme, setTheme] = useState('light');
-
-  useEffect(() => {
-    const query = window.matchMedia('(prefers-color-scheme: dark)');
-    const updateTheme = () => setTheme(query.matches ? 'dark' : 'light');
-
-    query.addEventListener('change', updateTheme);
-    updateTheme();
-
-    return () => query.removeEventListener('change', updateTheme);
-  }, []);
-
-  return theme;
-};
-
-/**
- * Sets the theme of a provided Monaco editor instance based on the current theme.
- */
-export const useConsoleMonacoTheme = (editor: typeof monacoEditor | null) => {
-  const systemTheme = useSystemTheme();
-  const theme = useContext(ThemeContext);
-  const [themeLoaded, setThemeLoaded] = useState(false);
-
-  useEffect(() => {
-    if (editor) {
-      if (!themeLoaded) {
-        defineThemes(editor);
-        setThemeLoaded(true);
-      }
-
-      if (theme === 'light') {
-        editor.setTheme('console-light');
-      } else if (theme === 'dark') {
-        editor.setTheme('console-dark');
-      } else if (theme === 'systemDefault') {
-        editor.setTheme(`console-${systemTheme}`);
-      }
-    }
-  }, [theme, editor, themeLoaded, systemTheme]);
 };

--- a/frontend/packages/console-shared/src/components/formik-fields/CodeEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/CodeEditorField.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Button } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
+import { Switch } from '@patternfly/react-core';
 import classNames from 'classnames';
 import { FormikValues, useField, useFormikContext } from 'formik';
 import { isEmpty } from 'lodash';
@@ -98,20 +97,18 @@ const CodeEditorField: React.FC<CodeEditorFieldProps> = ({
             showShortcuts={showShortcuts}
             isMinimapVisible={isMinimapVisible}
             language={language}
-            toolbarLinks={
-              !sidebarOpen &&
-              hasSidebarContent && [
-                <Button
-                  icon={
-                    <InfoCircleIcon className="co-icon-space-r co-p-has-sidebar__sidebar-link-icon" />
-                  }
-                  variant="link"
-                  onClick={() => setSidebarOpen(true)}
-                >
-                  {t('console-shared~View sidebar')}
-                </Button>,
-              ]
-            }
+            toolbarLinks={[
+              hasSidebarContent && (
+                <Switch
+                  label={t('public~Sidebar')}
+                  id="showSidebar"
+                  isChecked={sidebarOpen}
+                  data-checked-state={sidebarOpen}
+                  onChange={() => setSidebarOpen(!sidebarOpen)}
+                  hasCheckIcon
+                />
+              ),
+            ]}
           />
         </div>
       </div>

--- a/frontend/public/components/ThemeProvider.tsx
+++ b/frontend/public/components/ThemeProvider.tsx
@@ -11,7 +11,7 @@ const THEME_LIGHT = 'light';
 
 type PROCESSED_THEME = typeof THEME_DARK | typeof THEME_LIGHT;
 
-export const updateThemeClass = (htmlTagElement: HTMLElement, theme: string) => {
+export const updateThemeClass = (htmlTagElement: HTMLElement, theme: string): PROCESSED_THEME => {
   let systemTheme: string;
   if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
     systemTheme = THEME_DARK;
@@ -19,10 +19,12 @@ export const updateThemeClass = (htmlTagElement: HTMLElement, theme: string) => 
   if (theme === THEME_DARK || (theme === THEME_SYSTEM_DEFAULT && systemTheme === THEME_DARK)) {
     htmlTagElement.classList.add(THEME_DARK_CLASS);
     htmlTagElement.classList.add(THEME_DARK_CLASS_LEGACY);
-  } else {
-    htmlTagElement.classList.remove(THEME_DARK_CLASS);
-    htmlTagElement.classList.remove(THEME_DARK_CLASS_LEGACY);
+    return THEME_DARK;
   }
+
+  htmlTagElement.classList.remove(THEME_DARK_CLASS);
+  htmlTagElement.classList.remove(THEME_DARK_CLASS_LEGACY);
+  return THEME_LIGHT;
 };
 
 export const ThemeContext = React.createContext<string>('');
@@ -60,14 +62,13 @@ export const ThemeProvider: React.FC<{}> = ({ children }) => {
       darkThemeMq.addEventListener('change', mqListener);
     }
     if (themeLoaded) {
-      updateThemeClass(htmlTagElement, theme);
+      setProcessedTheme(updateThemeClass(htmlTagElement, theme));
     }
     return () => darkThemeMq.removeEventListener('change', mqListener);
   }, [htmlTagElement, mqListener, theme, themeLoaded]);
 
   React.useEffect(() => {
     themeLoaded && localStorage.setItem(THEME_LOCAL_STORAGE_KEY, theme);
-    themeLoaded && setProcessedTheme(theme as PROCESSED_THEME);
   }, [theme, themeLoaded]);
 
   return <ThemeContext.Provider value={processedTheme}>{children}</ThemeContext.Provider>;


### PR DESCRIPTION
follow up PR on [issues.redhat.com/browse/CONSOLE-4409](https://issues.redhat.com/browse/CONSOLE-4409), adding labels

/label qe-approved
/label px-approved
/label docs-approved

- Fixes bug where PROCESSED_THEME is sometimes `systemDefault` when it shouldn't be
- Uses a `Switch` for `CodeEditorField` sidebar toggle

after:
![image](https://github.com/user-attachments/assets/f9d854a1-6833-46ba-831f-f2775593666d)

code review:

/cc @rhamilto 