### PR TITLE
Dockerfile yarn line update

### DIFF
--- a/Dockerfile.product
+++ b/Dockerfile.product
@@ -17,8 +17,15 @@ ADD . .
 
 USER 0
 
+ARG YARN_VERSION=v1.22.19
+
 # bootstrap yarn so we can install and run the other tools.
-RUN container-entrypoint npm install ./artifacts/yarn-v1.22.19.tar.gz
+RUN CACHED_YARN=./artifacts/yarn-${YARN_VERSION}.tar.gz; \
+    if [ -f ${CACHED_YARN} ]; then \
+      npm install ${CACHED_YARN}; \
+    else \
+      npm install https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz; \
+    fi
 
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 


### PR DESCRIPTION
Copying from `release-4.13` branch: https://github.com/openshift/console/blob/release-4.13/Dockerfile#L20-L28

Konflux build is failing due to the missing tar file. Until cachi2 support is setup by ART, builds will be running non-hermetically, hence this change is needed.