### PR TITLE
OCPBUGS-52864: Edit form for key/value secrets should be showing decoded base64 values.

### DIFF
--- a/frontend/public/components/secrets/create-secret/OpaqueSecretFormEntry.tsx
+++ b/frontend/public/components/secrets/create-secret/OpaqueSecretFormEntry.tsx
@@ -53,7 +53,7 @@ export const OpaqueSecretFormEntry: React.FC<OpaqueSecretFormEntryProps> = ({
       <div className="form-group">
         <DroppableFileInput
           onChange={handleValueChange}
-          inputFileData={entry.value}
+          inputFileData={Base64.decode(entry.value)}
           id={`${index}-value`}
           label={t('public~Value')}
           inputFieldHelpText={t(


### PR DESCRIPTION
before:
![Screenshot 2025-03-10 at 17 54 33](https://github.com/user-attachments/assets/952acf9c-af77-470e-b6e4-6254aa7cabaf)

after:
![Screenshot 2025-03-10 at 17 54 54](https://github.com/user-attachments/assets/01139ac2-6aa7-4778-be62-b7cf909a9482)
