### PR TITLE
OCPBUGS-52843: Make `loginMethod` implementations responsible for token reviews

### DIFF
--- a/pkg/auth/oauth2/auth_oidc.go
+++ b/pkg/auth/oauth2/auth_oidc.go
@@ -2,6 +2,7 @@ package oauth2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -9,11 +10,14 @@ import (
 
 	oidc "github.com/coreos/go-oidc"
 	"golang.org/x/oauth2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/openshift/console/pkg/auth"
 	"github.com/openshift/console/pkg/auth/sessions"
 	"github.com/openshift/console/pkg/serverutils/asynccache"
+	authv1 "k8s.io/api/authentication/v1"
+	authenticationv1 "k8s.io/client-go/kubernetes/typed/authentication/v1"
 )
 
 type oauth2ConfigConstructor func(oauth2.Endpoint) *oauth2.Config
@@ -180,4 +184,38 @@ func (o *oidcAuth) LogoutRedirectURL() string {
 
 func (o *oidcAuth) oauth2Config() *oauth2.Config {
 	return o.oidcConfig.constructOAuth2Config(o.providerCache.GetItem().Endpoint())
+}
+
+func (o *oidcAuth) ReviewToken(r *http.Request, tokenReviewClient authenticationv1.TokenReviewInterface) error {
+	loginState, err := o.sessions.GetSession(nil, r)
+	if err != nil {
+		return fmt.Errorf("getting session state: %w", err)
+	}
+	if loginState == nil {
+		return errors.New("no login state found for session")
+	}
+
+	tokenReview := &authv1.TokenReview{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "authentication.k8s.io/v1",
+			Kind:       "TokenReview",
+		},
+		Spec: authv1.TokenReviewSpec{
+			Token: loginState.AccessToken(),
+		},
+	}
+
+	completedTokenReview, err := tokenReviewClient.Create(r.Context(), tokenReview, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create TokenReview, %v", err)
+	}
+
+	// Check if the token is authenticated
+	if !completedTokenReview.Status.Authenticated {
+		if completedTokenReview.Status.Error != "" {
+			return errors.New(completedTokenReview.Status.Error)
+		}
+		return errors.New("failed to authenticate the token, unknown error")
+	}
+	return nil
 }

--- a/pkg/auth/oauth2/auth_openshift.go
+++ b/pkg/auth/oauth2/auth_openshift.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -13,7 +14,9 @@ import (
 
 	"golang.org/x/oauth2"
 
+	authv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	authenticationv1 "k8s.io/client-go/kubernetes/typed/authentication/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
@@ -220,6 +223,7 @@ func (o *openShiftAuth) logout(w http.ResponseWriter, r *http.Request) {
 func (o *openShiftAuth) LogoutRedirectURL() string {
 	return o.logoutRedirectOverride
 }
+
 func (o *openShiftAuth) Authenticate(_ http.ResponseWriter, r *http.Request) (*auth.User, error) {
 	token, err := sessions.GetSessionTokenFromCookie(r)
 	if err != nil {
@@ -260,4 +264,37 @@ func tokenToObjectName(token string) string {
 	name := strings.TrimPrefix(token, sha256Prefix)
 	h := sha256.Sum256([]byte(name))
 	return sha256Prefix + base64.RawURLEncoding.EncodeToString(h[0:])
+}
+
+func (o *openShiftAuth) ReviewToken(r *http.Request, tokenReviewClient authenticationv1.TokenReviewInterface) error {
+	// This is only sufficient because this token handler stores the actual
+	// access token in the session token cookie
+	token, err := sessions.GetSessionTokenFromCookie(r)
+	if err != nil {
+		return fmt.Errorf("failed to get session token: %v", err)
+	}
+
+	tokenReview := &authv1.TokenReview{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "authentication.k8s.io/v1",
+			Kind:       "TokenReview",
+		},
+		Spec: authv1.TokenReviewSpec{
+			Token: token,
+		},
+	}
+
+	completedTokenReview, err := tokenReviewClient.Create(r.Context(), tokenReview, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create TokenReview, %v", err)
+	}
+
+	// Check if the token is authenticated
+	if !completedTokenReview.Status.Authenticated {
+		if completedTokenReview.Status.Error != "" {
+			return errors.New(completedTokenReview.Status.Error)
+		}
+		return errors.New("failed to authenticate the token, unknown error")
+	}
+	return nil
 }


### PR DESCRIPTION
In OCPBUGS-52843 it was discovered that the monitoring plugin for console was not present when the `ExternalOIDC` feature is enabled and an external OIDC provider is configured.

Upon further investigation, it looked like token reviews were failing based on the console log messages of:
```sh
E0310 10:02:30.125150 1 middleware.go:51] TOKEN_REVIEW: 'GET monitoring-plugin/plugin-manifest.json' unauthorized, invalid user token, invalid bearer token
```

Digging into the console code showed that the `OAuth2Authenticator.ReviewToken()` method was pulling the token from the session token cookie. It seems that when using the OpenShift OAuth server this cookie is the actual access token, but when an external OIDC provider is configured this is a random string that is used as a session identifier for console's backend to map to an access token.

This PR fixes this bug by moving the responsibility of reviewing the token to the configured `loginMethod`.