### PR TITLE
OCPBUGS-53030: Fix type-only dynamic module import build warnings for plugins

### DIFF
--- a/dynamic-demo-plugin/package.json
+++ b/dynamic-demo-plugin/package.json
@@ -40,7 +40,7 @@
     "style-loader": "0.23.1",
     "ts-loader": "9.x",
     "ts-node": "10.9.2",
-    "typescript": "4.5.5",
+    "typescript": "5.7.2",
     "webpack": "^5.75.0",
     "webpack-cli": "5.0.x"
   },

--- a/dynamic-demo-plugin/src/components/ProjectOverview/Inventory.tsx
+++ b/dynamic-demo-plugin/src/components/ProjectOverview/Inventory.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import {
   K8sResourceCommon,
   useK8sWatchResource,

--- a/dynamic-demo-plugin/tsconfig.json
+++ b/dynamic-demo-plugin/tsconfig.json
@@ -1,15 +1,15 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "target": "es2021",
     "module": "esnext",
     "moduleResolution": "node",
-    "target": "es2021",
     "jsx": "react-jsx",
     "allowJs": true,
     "experimentalDecorators": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
-    "lib": ["dom", "es7", "es2017.string"]
+    "lib": ["es2021", "dom"]
   },
   "include": ["src"],
   "ts-node": {

--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -3775,10 +3775,10 @@ typesafe-actions@^4.2.1:
   resolved "https://registry.yarnpkg.com/typesafe-actions/-/typesafe-actions-4.4.2.tgz#8f817c479d12130b5ebb442032968b2a18929e1a"
   integrity sha512-QW61P4cOX8dCNmrfpcUMjvU/MF/sFTC8/PlG9215W1gKDzZUBjRGdyYSO6ZcEUNsn491S2VpryJOHSIVSDqJrg==
 
-typescript@4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
+  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
 
 typescript@^4.2.4:
   version "4.3.5"

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs-extra';
 import * as glob from 'glob';
 import * as _ from 'lodash';
 import * as readPkg from 'read-pkg';
+import * as semver from 'semver';
 import {
   sharedPluginModules,
   getSharedModuleMetadata,
@@ -98,6 +99,15 @@ const parseSharedModuleDeps = (
     missingDepCallback,
   );
 
+const getMinDepVersion = (
+  pkg: readPkg.PackageJson,
+  depName: string,
+  missingDepCallback: MissingDependencyCallback,
+) => {
+  const versionOrRange = parseDeps(pkg, [depName], missingDepCallback)[depName];
+  return semver.minVersion(versionOrRange).version;
+};
+
 export const getCorePackage: GetPackageDefinition = (
   sdkPackage,
   rootPackage,
@@ -172,7 +182,7 @@ export const getWebpackPackage: GetPackageDefinition = (
       ...parseDepsAs(rootPackage, { 'lodash-es': 'lodash' }, missingDepCallback),
     },
     peerDependencies: {
-      typescript: '>=4.5.5',
+      typescript: `>=${getMinDepVersion(rootPackage, 'typescript', missingDepCallback)}`,
     },
   },
   filesToCopy: {

--- a/frontend/packages/console-dynamic-plugin-sdk/tsconfig-base.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/tsconfig-base.json
@@ -10,7 +10,7 @@
     "experimentalDecorators": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
-    "lib": ["es2016", "es2017.object", "es2020.promise", "es2020.string", "dom"],
+    "lib": ["es2021", "dom"],
     "typeRoots": ["node_modules/@types", "@types", "../../node_modules/@types"],
     "types": ["node", "sdk"]
   }

--- a/frontend/packages/console-plugin-shared/tsconfig.json
+++ b/frontend/packages/console-plugin-shared/tsconfig.json
@@ -12,7 +12,7 @@
     "experimentalDecorators": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
-    "lib": ["es2016", "es2017.object", "es2020.promise", "dom"],
+    "lib": ["es2021", "dom"],
     "typeRoots": ["node_modules/@types", "@types", "../../node_modules/@types"],
     "types": ["node"]
   },

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -626,7 +626,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
     userInactivityTimeout.current = setTimeout(() => {
       authSvc.logout('', isKubeAdmin);
     }, window.SERVER_FLAGS.inactivityTimeout * 1000);
-  }, [openshiftFlag, isKubeAdmin]);
+  }, [isKubeAdmin]);
 
   React.useEffect(() => {
     const onStorageChange = (e) => {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -245,12 +245,7 @@
   dependencies:
     "@babel/types" "^7.11.0"
 
-"@babel/helper-validator-identifier@^7.10.4":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
-  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
-
-"@babel/helper-validator-identifier@^7.25.9":
+"@babel/helper-validator-identifier@^7.10.4", "@babel/helper-validator-identifier@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
   integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
@@ -788,31 +783,10 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.17.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
-  version "7.23.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.2.tgz#062b0ac103261d68a966c4c7baf2ae3e62ec3885"
-  integrity sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
-"@babel/runtime@^7.23.2":
-  version "7.23.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.5.tgz#11edb98f8aeec529b82b211028177679144242db"
-  integrity sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
-"@babel/runtime@^7.26.0":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.17.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.26.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
   integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
-"@babel/runtime@^7.3.1", "@babel/runtime@^7.8.3":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
-  integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
   dependencies:
     regenerator-runtime "^0.14.0"
 


### PR DESCRIPTION
This PR fixes the following kind of warnings :warning: that may occur when building Console dynamic plugins:
```
LOG from @openshift-console/dynamic-plugin-sdk-webpack/lib/webpack/loaders/dynamic-module-import-loader ../node_modules/ts-loader/index.js??ruleSet[1].rules[0].use[0]!./components/Nav.tsx
<w> Non-index and non-dynamic module import @patternfly/react-table/dist/esm/components/Table/base/types
```
In the snippet above, `@patternfly/react-table` package does not provide a corresponding dynamic module for e.g. `ThSortType` which causes Console webpack `dynamic-module-import-loader` to skip import transformation with a warning.

For actual JS code, this would indicate a problem with e.g. `@patternfly/react-table` package. However, for TypeScript types like `ThSortType` it's not really an issue due to TS to JS transpilation.

Therefore, Console webpack `dynamic-module-import-loader` will skip processing type-only imports since these have no impact on generated module federation code.

This PR also bumps `typescript` version in dynamic demo plugin to match Console frontend and aligns `compilerOptions.lib` setting with respect to `compilerOptions.target` (ES 2021) across `tsconfig.json` files.

### How to reproduce the build warning
Open `dynamic-demo-plugin/src/components/Nav.tsx` and add the following code after existing import statements:
```ts
import type { ThSortType } from '@patternfly/react-table/dist/esm/components/Table/base/types';

console.log({} as ThSortType);
```
then update plugin SDK dependencies and build demo plugin:
```
(cd dynamic-demo-plugin ; yarn install-plugin-sdk && yarn build-dev)
```