### PR TITLE
OCPBUGS-52948: Multiple favorite icon on same page

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -669,6 +669,7 @@ const exampleList: React.FC = () => {
 | `title` | heading title |
 | `helpText` | (optional) help section as react node |
 | `badge` | (optional) badge icon as react node |
+| `hideFavoriteButton` | (Optional) If true, hides the Favorite button. By default, the Favorite button is displayed, allowing users to add a page as a favorite. Generally, you should use `hideFavoriteButton` when `ListPageHeader` is not the primary page header to avoid duplicate favorite buttons on the page. |
 
 
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/dynamic-core-api.ts
@@ -171,6 +171,7 @@ export const useActiveColumns: UseActiveColumns = require('@console/internal/com
  * @param {string} title - heading title
  * @param {ReactNode} [helpText] -  (optional) help section as react node
  * @param {ReactNode} [badge] -  (optional) badge icon as react node
+ * @param {boolean} [hideFavoriteButton] - (Optional) If true, hides the Favorite button. By default, the Favorite button is displayed, allowing users to add a page as a favorite. Generally, you should use `hideFavoriteButton` when `ListPageHeader` is not the primary page header to avoid duplicate favorite buttons on the page.
  * @example
  * ```ts
  * const exampleList: React.FC = () => {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -350,6 +350,7 @@ export type ListPageHeaderProps = {
   title: string;
   helpText?: React.ReactNode;
   badge?: React.ReactNode;
+  hideFavoriteButton?: boolean;
 };
 
 export type CreateWithPermissionsProps = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -445,7 +445,7 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
 
   return inFlight ? null : (
     <>
-      <ListPageHeader title={showTitle ? t('olm~All Instances') : undefined}>
+      <ListPageHeader title={showTitle ? t('olm~All Instances') : undefined} hideFavoriteButton>
         {managesAllNamespaces && (
           <div className="co-operator-details__toggle-value pf-v6-u-ml-xl-on-md">
             <ShowOperandsInAllNamespacesRadioGroup />
@@ -513,7 +513,7 @@ const DefaultProvidedAPIPage: React.FC<DefaultProvidedAPIPageProps> = (props) =>
 
   return (
     <>
-      <ListPageHeader title={showTitle ? `${labelPlural}` : undefined}>
+      <ListPageHeader title={showTitle ? `${labelPlural}` : undefined} hideFavoriteButton>
         {managesAllNamespaces && (
           <div className="co-operator-details__toggle-value pf-v6-u-ml-xl-on-md">
             <ShowOperandsInAllNamespacesRadioGroup />

--- a/frontend/public/components/error.tsx
+++ b/frontend/public/components/error.tsx
@@ -22,9 +22,9 @@ const ErrorComponent: React.FC<ErrorComponentProps> = ({ title, message }) => {
   const { t } = useTranslation();
   return (
     <>
-      <PageHeading title={t('public~Error')} detail />
+      <PageHeading title={t('public~Error')} detail hideFavoriteButton />
       <div className="co-m-pane__body" data-test-id="error-page">
-        <PageHeading title={title} centerText />
+        <PageHeading title={title} centerText hideFavoriteButton />
         {message && <div className="pf-v6-u-text-align-center">{message}</div>}
       </div>
     </>

--- a/frontend/public/components/factory/ListPage/ListPageHeader.tsx
+++ b/frontend/public/components/factory/ListPage/ListPageHeader.tsx
@@ -3,10 +3,21 @@ import * as classNames from 'classnames';
 import { ListPageHeaderProps } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { PageHeading } from '../../utils';
 
-const ListPageHeader: React.FC<ListPageHeaderProps> = ({ helpText, title, children, badge }) => (
+const ListPageHeader: React.FC<ListPageHeaderProps> = ({
+  helpText,
+  title,
+  children,
+  badge,
+  hideFavoriteButton,
+}) => (
   <>
     {/* Badge rendered from PageHeading only when title is present */}
-    <PageHeading title={title} badge={title ? badge : null} className="co-m-nav-title--row">
+    <PageHeading
+      title={title}
+      badge={title ? badge : null}
+      className="co-m-nav-title--row"
+      hideFavoriteButton={hideFavoriteButton}
+    >
       <div
         className={classNames('co-operator-details__actions', {
           'co-m-pane__createLink--no-title': !title,

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -121,6 +121,7 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
     centerText,
     helpText,
     'data-test': dataTestId,
+    hideFavoriteButton,
   } = props;
   const [perspective] = useActivePerspective();
   const extraResources = _.reduce(
@@ -200,7 +201,7 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
             {link && <div className="co-m-pane__heading-link">{link}</div>}
             {(isAdminPrespective || showActions) && (
               <div className="co-actions" data-test-id="details-actions">
-                {isAdminPrespective && <FavoriteButton />}
+                {isAdminPrespective && !hideFavoriteButton && <FavoriteButton />}
                 {showActions && (
                   <>
                     {hasButtonActions && (
@@ -354,6 +355,7 @@ export type PageHeadingProps = {
   className?: string;
   centerText?: boolean;
   helpText?: React.ReactNode;
+  hideFavoriteButton?: boolean;
 };
 
 export type ResourceOverviewHeadingProps = {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-52948

**Analysis / Root cause**: 
ListPageHeader component was present inside operator details page tab, so multiple Favorite button displayed.

**Solution Description**: 
Favorite button is removed in operator details page tab.
  
**Screen shots / Gifs for design review**: 

**----BEFORE---**

![image (3)](https://github.com/user-attachments/assets/c0e88ea9-9313-423b-a643-980531a6aa9b)

-----

**---AFTER----**


<img width="1706" alt="image" src="https://github.com/user-attachments/assets/dedcdfbe-4ddb-4de3-b3dd-1fa95927b40a" />

-----

**Unit test coverage report**: 
NA

**Test setup:**

    1. install Red Hat Serverless operator
    2. navigate to Operator details > knative serving page
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

