### PR TITLE
CONSOLE-3414: Fix flaky `Loading` tests

### DIFF
--- a/frontend/packages/console-shared/src/components/loading/Loading.scss
+++ b/frontend/packages/console-shared/src/components/loading/Loading.scss
@@ -1,0 +1,3 @@
+.co-m-loader {
+  display: contents;
+}

--- a/frontend/packages/console-shared/src/components/loading/Loading.tsx
+++ b/frontend/packages/console-shared/src/components/loading/Loading.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
 import { Spinner } from '@patternfly/react-core';
 import classNames from 'classnames';
+import './Loading.scss';
 
-export const Loading: React.FC<LoadingProps> = ({ className, isInline }) => (
-  <Spinner
-    aria-live="polite"
-    aria-busy="true"
+export const Loading: React.FCC<LoadingProps> = ({ className, isInline }) => (
+  // the extra div wrapper is needed as `Spinner`'s `className` property
+  // is a `SVGAnimatedString`, and not `string`, which breaks tests
+  <div
     className={classNames('co-m-loader', { 'co-m-loader--inline': isInline }, className)}
     data-test="loading-indicator"
-    isInline={isInline}
-    size="lg"
-  />
+  >
+    <Spinner aria-live="polite" aria-busy="true" isInline={isInline} size="lg" />
+  </div>
 );
 
 Loading.displayName = 'Loading';


### PR DESCRIPTION
fixes this flake:

```
{this.className.includes is not a function TypeError TypeError: this.className.includes is not a function
    at SVGSVGElement.eval (webpack://@knative-plugin/integration-tests/../../dev-console/integration-tests/support/pages/app.ts:28:32)
    at Context.eval (webpack://@knative-plugin/integration-tests/../../dev-console/integration-tests/support/pages/app.ts:27:36)}
```

adding labels for follow on ticket:

/label px-approved
/label docs-approved
/label qe-approved

code review:
/assign @rhamilto