### PR TITLE
OCPBUGS-49870: Can't edit deployment (from the private git repository) in RHOCP 4.15 via console

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/EditApplicationForm.tsx
+++ b/frontend/packages/dev-console/src/components/edit-application/EditApplicationForm.tsx
@@ -49,7 +49,7 @@ const EditApplicationForm: React.FC<
         <FormBody flexLayout>
           {flowType === ApplicationFlowType.Git && <GitSection builderImages={builderImages} />}
           {flowType === ApplicationFlowType.Dockerfile && (
-            <GitSection builderImages={builderImages} />
+            <GitSection builderImages={builderImages} flowType={flowType} />
           )}
           {flowType === ApplicationFlowType.Git && (
             <BuilderSection

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -25,6 +25,7 @@ import {
   NormalizedBuilderImages,
 } from '../../../utils/imagestream-utils';
 import { getSample, getGitImportSample } from '../../../utils/samples';
+import { ApplicationFlowType } from '../../edit-application/edit-application-utils';
 import { GitData, DetectedStrategyFormData } from '../import-types';
 import { detectGitRepoName, detectGitType } from '../import-validation-utils';
 import FormSection from '../section/FormSection';
@@ -78,6 +79,7 @@ export interface GitSectionProps {
   importType?: string;
   imageStreamName?: string;
   autoFocus?: boolean;
+  flowType?: ApplicationFlowType;
 }
 
 const GitSection: React.FC<GitSectionProps> = ({
@@ -90,6 +92,7 @@ const GitSection: React.FC<GitSectionProps> = ({
   importType,
   imageStreamName,
   autoFocus = true,
+  flowType,
 }) => {
   const { t } = useTranslation();
   const inputRef = React.useRef<HTMLInputElement>();
@@ -311,7 +314,11 @@ const GitSection: React.FC<GitSectionProps> = ({
           recommendedStrategy: null,
           showEditImportStrategy: true,
         });
-        setFieldValue('build.strategy', BuildStrategyType.Source);
+        if (flowType === ApplicationFlowType.Dockerfile) {
+          setFieldValue('build.strategy', BuildStrategyType.Docker);
+        } else {
+          setFieldValue('build.strategy', BuildStrategyType.Source);
+        }
         return;
       }
 
@@ -417,6 +424,7 @@ const GitSection: React.FC<GitSectionProps> = ({
       handleBuilderImageRecommendation,
       builderImages,
       handleDevfileStrategyDetection,
+      flowType,
     ],
   );
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-49870

**Analysis / Root cause**: 
If repo is not reachable, by default build strategy was updated to Source

**Solution Description**: 
If it is from dockerfile, updated the build strategy to Docker
  
**Screen shots / Gifs for design review**: 

**---AFTER----**



https://github.com/user-attachments/assets/c67d7336-a01b-45c9-aa10-4fa77e9776e3



-----

**Unit test coverage report**: 
NA

**Test setup:**

   1.importing from a Git repository and a Docker image.
  2. selected "Edit api-assessment" on the Deployment
  3.the content on this page was set to "Import from Dockerfile",  then unable to edit anything. 
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

