### PR TITLE
OCPBUGS-62281: InsecureSkipVerify to true for results proxy endpoint in off-cluster

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -141,6 +141,7 @@ type jsGlobals struct {
 	Telemetry                       serverconfig.MultiKeyValue `json:"telemetry"`
 	ThanosPublicURL                 string                     `json:"thanosPublicURL"`
 	UserSettingsLocation            string                     `json:"userSettingsLocation"`
+	DevConsoleProxyAvailable        bool                       `json:"devConsoleProxyAvailable"`
 }
 
 type Server struct {
@@ -181,6 +182,7 @@ type Server struct {
 	InactivityTimeout                   int
 	InternalProxiedK8SClientConfig      *rest.Config
 	K8sMode                             string
+	K8sModeOffClusterSkipVerifyTLS      bool
 	K8sProxyConfig                      *proxy.Config
 	ProxyHeaderDenyList                 []string
 	KnativeChannelCRDLister             ResourceLister
@@ -212,6 +214,7 @@ type Server struct {
 	UserSettingsLocation                string
 	EnabledPlugins                      serverconfig.MultiKeyValue
 	EnabledPluginsOrder                 []string
+	DevConsoleProxyAvailable            bool
 }
 
 func disableDirectoryListing(handler http.Handler) http.Handler {
@@ -764,6 +767,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		Telemetry:                 s.Telemetry,
 		ThanosPublicURL:           s.ThanosPublicURL.String(),
 		UserSettingsLocation:      s.UserSettingsLocation,
+		DevConsoleProxyAvailable:  true,
 	}
 
 	if s.prometheusProxyEnabled() {


### PR DESCRIPTION
**Descriptions** Results proxy end-point fails with error `{error: "failed to read CA certificate: open /var/serving-cert/tls.crt: no such file or directory"}` in localhost. So, pass the `InsecureSkipVerify: true` for these endpoints if it is an off-cluster.