### PR TITLE
OCPBUGS-52486: Notification drawer should have keyboard navigation focus when expanded.

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -216,6 +216,16 @@ const App = (props) => {
     (state) => !!state.UI.getIn(['notifications', 'isExpanded']),
   );
 
+  const drawerRef = React.useRef();
+
+  const focusDrawer = () => {
+    if (drawerRef.current === null) {
+      return;
+    }
+    const firstTabbableItem = drawerRef.current.querySelector('a, button');
+    firstTabbableItem?.focus();
+  };
+
   const content = (
     <>
       <Helmet titleTemplate={`%s · ${productName}`} defaultTitle={productName} />
@@ -250,8 +260,10 @@ const App = (props) => {
               <NotificationDrawer
                 onDrawerChange={onNotificationDrawerToggle}
                 isDrawerExpanded={isNotificationDrawerExpanded}
+                drawerRef={drawerRef}
               />
             }
+            onNotificationDrawerExpand={() => focusDrawer()}
             isNotificationDrawerExpanded={isNotificationDrawerExpanded}
           >
             <AppContents />

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -204,6 +204,7 @@ const getUpdateNotificationEntries = (
 export const NotificationDrawer: React.FC<NotificationDrawerProps> = ({
   isDrawerExpanded,
   onDrawerChange,
+  drawerRef,
 }) => {
   const { t } = useTranslation();
   const clusterID = getClusterID(useClusterVersion());
@@ -361,7 +362,7 @@ export const NotificationDrawer: React.FC<NotificationDrawerProps> = ({
   ) : null;
 
   return (
-    <PfNotificationDrawer>
+    <PfNotificationDrawer ref={drawerRef}>
       <NotificationDrawerHeader onClose={toggleNotificationDrawer} />
       <NotificationDrawerBody>
         {[criticalAlertCategory, nonCriticalAlertCategory, recommendationsCategory]}
@@ -374,6 +375,7 @@ export type NotificationDrawerProps = {
   toggleNotificationDrawer: () => any;
   isDrawerExpanded: boolean;
   onDrawerChange: () => void;
+  drawerRef: React.Ref<typeof PfNotificationDrawer>;
 };
 
 type AlertErrorProps = {


### PR DESCRIPTION
Opened notification drawer should be prioritized for the tab/keyboard navigation.

before:

https://github.com/user-attachments/assets/d4ceef54-4cd9-4bc6-bac0-f58b8ae04493


after:

https://github.com/user-attachments/assets/3062989b-bfd0-4078-b58c-632933808e33


QE test scenario:

1. Navigate via keyboard (pressing TAB)
2. Open the notification drawer.
3. Try to navigate further via keyboard.

Expected results: The navigation should continue on the opened drawer instead of the underlying page.