### PR TITLE
OCPBUGS-52938: 'Helm Chart Repository' name is used in breadcrumb link, details page heading and action names

### DIFF
--- a/frontend/packages/helm-plugin/console-extensions.json
+++ b/frontend/packages/helm-plugin/console-extensions.json
@@ -7,8 +7,8 @@
         "version": "v1beta1",
         "kind": "HelmChartRepository"
       },
-      "label": "%helm-plugin~Helm Chart Repository%",
-      "labelPlural": "%helm-plugin~Helm Chart Repositories%",
+      "label": "%helm-plugin~HelmChartRepository%",
+      "labelPlural": "%helm-plugin~HelmChartRepositories%",
       "abbr": "HCR"
     }
   },
@@ -20,8 +20,8 @@
         "version": "v1beta1",
         "kind": "ProjectHelmChartRepository"
       },
-      "label": "%helm-plugin~Project Helm Chart Repository%",
-      "labelPlural": "%helm-plugin~Project Helm Chart Repositories%",
+      "label": "%helm-plugin~ProjectHelmChartRepository%",
+      "labelPlural": "%helm-plugin~ProjectHelmChartRepositories%",
       "abbr": "PHCR"
     }
   },
@@ -396,7 +396,9 @@
     "properties": {
       "id": "helm-release-panel-tab-section-details",
       "tab": "topology-side-bar-tab-details",
-      "provider": { "$codeRef": "helmTopologySidebarTabSections.useHelmReleasePanelDetailsTabSection" }
+      "provider": {
+        "$codeRef": "helmTopologySidebarTabSections.useHelmReleasePanelDetailsTabSection"
+      }
     },
     "flags": {
       "required": ["OPENSHIFT_HELM"]
@@ -407,7 +409,9 @@
     "properties": {
       "id": "helm-release-panel-tab-section-resource",
       "tab": "topology-side-bar-tab-resource",
-      "provider": { "$codeRef": "helmTopologySidebarTabSections.useHelmReleasePanelResourceTabSection" }
+      "provider": {
+        "$codeRef": "helmTopologySidebarTabSections.useHelmReleasePanelResourceTabSection"
+      }
     },
     "flags": {
       "required": ["OPENSHIFT_HELM"]
@@ -418,7 +422,9 @@
     "properties": {
       "id": "helm-release-panel-tab-section-releaseNotes",
       "tab": "helm-release-panel-tab-releaseNotes",
-      "provider": { "$codeRef": "helmTopologySidebarTabSections.useHelmReleasePanelReleaseNotesTabSection" }
+      "provider": {
+        "$codeRef": "helmTopologySidebarTabSections.useHelmReleasePanelReleaseNotesTabSection"
+      }
     },
     "flags": {
       "required": ["OPENSHIFT_HELM"]
@@ -449,8 +455,12 @@
   {
     "type": "dev-console.detailsPage/breadcrumbs",
     "properties": {
-      "getModels": { "$codeRef": "useHelmChartRepositoriesBreadcrumbs.getHelmChartRepositoriesModel" },
-      "breadcrumbsProvider": { "$codeRef": "useHelmChartRepositoriesBreadcrumbs.useHelmChartRepositoriesBreadcrumbs" }
+      "getModels": {
+        "$codeRef": "useHelmChartRepositoriesBreadcrumbs.getHelmChartRepositoriesModel"
+      },
+      "breadcrumbsProvider": {
+        "$codeRef": "useHelmChartRepositoriesBreadcrumbs.useHelmChartRepositoriesBreadcrumbs"
+      }
     },
     "flags": {
       "required": ["OPENSHIFT_HELM"]

--- a/frontend/packages/helm-plugin/locales/en/helm-plugin.json
+++ b/frontend/packages/helm-plugin/locales/en/helm-plugin.json
@@ -1,8 +1,8 @@
 {
-  "Helm Chart Repository": "Helm Chart Repository",
-  "Helm Chart Repositories": "Helm Chart Repositories",
-  "Project Helm Chart Repository": "Project Helm Chart Repository",
-  "Project Helm Chart Repositories": "Project Helm Chart Repositories",
+  "HelmChartRepository": "HelmChartRepository",
+  "HelmChartRepositories": "HelmChartRepositories",
+  "ProjectHelmChartRepository": "ProjectHelmChartRepository",
+  "ProjectHelmChartRepositories": "ProjectHelmChartRepositories",
   "Helm Chart repositories": "Helm Chart repositories",
   "Helm Chart": "Helm Chart",
   "Browse the catalog to discover and install Helm Charts": "Browse the catalog to discover and install Helm Charts",

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmChartRepositoryList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmChartRepositoryList.tsx
@@ -9,7 +9,7 @@ const HelmChartRepositoryList: React.FC<TableProps> = (props) => {
   return (
     <Table
       {...props}
-      aria-label={t('helm-plugin~Helm Chart Repositories')}
+      aria-label={t('helm-plugin~HelmChartRepositories')}
       Header={RepositoriesHeader(t)}
       Row={HelmChartRepositoryRow}
       virtualize

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmChartRepositoryListPage.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmChartRepositoryListPage.tsx
@@ -15,7 +15,7 @@ const HelmChartRepositoryListPage: React.FC<React.ComponentProps<typeof ListPage
   return (
     <ListPage
       {...props}
-      aria-label={t('helm-plugin~Helm Chart Repositories')}
+      aria-label={t('helm-plugin~HelmChartRepositories')}
       canCreate
       createProps={createProps}
       kind={referenceForModel(HelmChartRepositoryModel)}

--- a/frontend/packages/helm-plugin/src/components/list-page/ProjectHelmChartRepositoryListPage.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/ProjectHelmChartRepositoryListPage.tsx
@@ -19,7 +19,7 @@ const ProjectHelmChartRepositoryListPage: React.FC<React.ComponentProps<typeof L
       {...props}
       canCreate
       createProps={createProps}
-      aria-label={t('helm-plugin~Project Helm Chart Repositories')}
+      aria-label={t('helm-plugin~ProjectHelmChartRepositories')}
       kind={referenceForModel(ProjectHelmChartRepositoryModel)}
       ListComponent={ProjectHelmChartRepositoryList}
     />

--- a/frontend/packages/helm-plugin/src/components/list-page/RepositoriesList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/RepositoriesList.tsx
@@ -19,7 +19,7 @@ const RepositoriesList: React.FC<TableProps> = (props) => {
     <Table
       {...props}
       EmptyMsg={EmptyMsg}
-      aria-label={t('helm-plugin~Helm Chart Repositories')}
+      aria-label={t('helm-plugin~HelmChartRepositories')}
       Header={RepositoriesHeader(t)}
       Row={RepositoriesRow}
       virtualize


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-52938

**Solution Description**: 
Updated details pages of HCR and PHCR to show `HelmChartRepository` and `ProjectHelmChartRepository` instead of `Helm Chart Repository` and `Project Helm Chart Repository` respectively
  
**Screen shots / Gifs for design review**: 

**---BEFORE----**

https://drive.google.com/file/d/1FROAjVlIa3bumsCXUa__5jeSTS1Sbq9i/view?usp=drive_link

**---AFTER----**

<img width="1415" alt="Screenshot 2025-03-20 at 12 50 37 PM" src="https://github.com/user-attachments/assets/de9ef13a-396a-4129-95b3-82339120fb87" />
<img width="1411" alt="Screenshot 2025-03-20 at 12 50 56 PM" src="https://github.com/user-attachments/assets/dc495f62-fbb1-4cd3-b31c-fa2575c096f5" />



-----

**Unit test coverage report**: 
NA

**Test setup:**

    1. navigate to Helm -> Repositories page, click on on HelmChartRepository
    2. Check the details page heading name, breadcrumb link name and action items name
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

