### PR TITLE
CONSOLE-4462: Remove two more overrides

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeDetailsOverview.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeDetailsOverview.tsx
@@ -151,7 +151,7 @@ const NodeDetailsOverview: React.FC<NodeDetailsOverviewProps> = ({ node }) => {
             <dt>{t('console-app~OS image')}</dt>
             <dd>{_.get(node, 'status.nodeInfo.osImage', '-')}</dd>
             <dt>{t('console-app~Architecture')}</dt>
-            <dd className="text-uppercase">{_.get(node, 'status.nodeInfo.architecture', '-')}</dd>
+            <dd>{_.get(node, 'status.nodeInfo.architecture', '-')}</dd>
             <dt>{t('console-app~Kernel version')}</dt>
             <dd>{_.get(node, 'status.nodeInfo.kernelVersion', '-')}</dd>
             <dt>{t('console-app~Boot ID')}</dt>

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/match-expressions.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/match-expressions.tsx
@@ -29,7 +29,7 @@ const MatchExpression: React.FC<MatchExpressionProps> = ({
   return (
     <div className="row key-operator-value__row">
       <div className="col-md-4 col-xs-5 key-operator-value__name-field">
-        <div className="key-operator-value__heading hidden-md hidden-lg text-secondary text-uppercase">
+        <div className="key-operator-value__heading hidden-md hidden-lg text-secondary">
           {t('olm~Key')}
         </div>
         <span className="pf-v6-c-form-control">
@@ -41,7 +41,7 @@ const MatchExpression: React.FC<MatchExpressionProps> = ({
         </span>
       </div>
       <div className="col-md-3 col-xs-5 key-operator-value__operator-field">
-        <div className="key-operator-value__heading hidden-md hidden-lg text-secondary text-uppercase">
+        <div className="key-operator-value__heading hidden-md hidden-lg text-secondary">
           {t('olm~Operator')}
         </div>
         <Dropdown
@@ -53,7 +53,7 @@ const MatchExpression: React.FC<MatchExpressionProps> = ({
         />
       </div>
       <div className="col-md-3 col-xs-5 key-operator-value__value-field key-operator-value__value-field--stacked">
-        <div className="key-operator-value__heading hidden-md hidden-lg text-secondary text-uppercase">
+        <div className="key-operator-value__heading hidden-md hidden-lg text-secondary">
           {t('olm~Values')}
         </div>
         <span
@@ -110,9 +110,9 @@ export const MatchExpressions: React.FC<MatchExpressionsProps> = ({
   return (
     <>
       <div className="row key-operator-value__heading hidden-sm hidden-xs">
-        <div className="col-md-4 text-secondary text-uppercase">{t('olm~Key')}</div>
-        <div className="col-md-3 text-secondary text-uppercase">{t('olm~Operator')}</div>
-        <div className="col-md-3 text-secondary text-uppercase">{t('olm~Values')}</div>
+        <div className="col-md-4 text-secondary">{t('olm~Key')}</div>
+        <div className="col-md-3 text-secondary">{t('olm~Operator')}</div>
+        <div className="col-md-3 text-secondary">{t('olm~Values')}</div>
       </div>
       {matchExpressions.map((expression, index) => (
         // Have to use array index in the key bc any other unique id whould have to use editable fields.

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/resource-requirements.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/resource-requirements.tsx
@@ -21,11 +21,7 @@ export const ResourceRequirements: React.FC<ResourceRequirementsProps> = (props)
   return (
     <div className="row co-m-form-row">
       <div className="col-xs-4">
-        <label
-          style={{ fontWeight: 300 }}
-          className="text-muted text-uppercase"
-          htmlFor={`${path}.cpu`}
-        >
+        <label style={{ fontWeight: 300 }} className="text-muted" htmlFor={`${path}.cpu`}>
           {t('olm~CPU cores')}
         </label>
         <span className="pf-v6-c-form-control">
@@ -40,11 +36,7 @@ export const ResourceRequirements: React.FC<ResourceRequirementsProps> = (props)
         </span>
       </div>
       <div className="col-xs-4">
-        <label
-          style={{ fontWeight: 300 }}
-          className="text-muted text-uppercase"
-          htmlFor={`${path}.memory`}
-        >
+        <label style={{ fontWeight: 300 }} className="text-muted" htmlFor={`${path}.memory`}>
           {t('olm~Memory')}
         </label>
         <span className="pf-v6-c-form-control">
@@ -61,7 +53,7 @@ export const ResourceRequirements: React.FC<ResourceRequirementsProps> = (props)
       <div className="col-xs-4">
         <label
           style={{ fontWeight: 300 }}
-          className="text-muted text-uppercase"
+          className="text-muted"
           htmlFor={`${path}.ephemeral-storage`}
         >
           {t('olm~Storage')}

--- a/frontend/public/components/modals/taints-modal.tsx
+++ b/frontend/public/components/modals/taints-modal.tsx
@@ -74,15 +74,15 @@ const TaintsModal = withHandlePromise((props: TaintsModalProps) => {
         ) : (
           <>
             <div className="row taint-modal__heading hidden-sm hidden-xs">
-              <div className="col-sm-4 text-secondary text-uppercase">{t('public~Key')}</div>
-              <div className="col-sm-3 text-secondary text-uppercase">{t('public~Value')}</div>
-              <div className="col-sm-4 text-secondary text-uppercase">{t('public~Effect')}</div>
+              <div className="col-sm-4 text-secondary">{t('public~Key')}</div>
+              <div className="col-sm-3 text-secondary">{t('public~Value')}</div>
+              <div className="col-sm-4 text-secondary">{t('public~Effect')}</div>
               <div className="col-sm-1 co-empty__header" />
             </div>
             {_.map(taints, (c, i) => (
               <div className="row taint-modal__row" key={i}>
                 <div className="col-md-4 col-xs-5 taint-modal__field">
-                  <div className="taint-modal__heading hidden-md hidden-lg text-secondary text-uppercase">
+                  <div className="taint-modal__heading hidden-md hidden-lg text-secondary">
                     {t('public~Key')}
                   </div>
                   <span className="pf-v6-c-form-control">
@@ -96,7 +96,7 @@ const TaintsModal = withHandlePromise((props: TaintsModalProps) => {
                   </span>
                 </div>
                 <div className="col-md-3 col-xs-5 taint-modal__field">
-                  <div className="taint-modal__heading hidden-md hidden-lg text-secondary text-uppercase">
+                  <div className="taint-modal__heading hidden-md hidden-lg text-secondary">
                     {t('public~Value')}
                   </div>
                   <span className="pf-v6-c-form-control">
@@ -105,7 +105,7 @@ const TaintsModal = withHandlePromise((props: TaintsModalProps) => {
                 </div>
                 <div className="clearfix visible-sm visible-xs" />
                 <div className="col-md-4 col-xs-5 taint-modal__field">
-                  <div className="taint-modal__heading hidden-md hidden-lg text-secondary text-uppercase">
+                  <div className="taint-modal__heading hidden-md hidden-lg text-secondary">
                     {t('public~Effect')}
                   </div>
                   <Dropdown

--- a/frontend/public/components/modals/tolerations-modal.tsx
+++ b/frontend/public/components/modals/tolerations-modal.tsx
@@ -113,10 +113,10 @@ const TolerationsModal = withHandlePromise((props: TolerationsModalProps) => {
         ) : (
           <>
             <div className="row toleration-modal__heading hidden-sm hidden-xs">
-              <div className="col-md-4 text-secondary text-uppercase">{t('public~Key')}</div>
-              <div className="col-md-2 text-secondary text-uppercase">{t('public~Operator')}</div>
-              <div className="col-md-3 text-secondary text-uppercase">{t('public~Value')}</div>
-              <div className="col-md-2 text-secondary text-uppercase">{t('public~Effect')}</div>
+              <div className="col-md-4 text-secondary">{t('public~Key')}</div>
+              <div className="col-md-2 text-secondary">{t('public~Operator')}</div>
+              <div className="col-md-3 text-secondary">{t('public~Value')}</div>
+              <div className="col-md-2 text-secondary">{t('public~Effect')}</div>
               <div className="col-md-1" />
             </div>
             {_.map(tolerations, (toleration, i) => {
@@ -126,7 +126,7 @@ const TolerationsModal = withHandlePromise((props: TolerationsModalProps) => {
               return (
                 <div className="row toleration-modal__row" key={i}>
                   <div className="col-md-4 col-sm-5 col-xs-5 toleration-modal__field">
-                    <div className="toleration-modal__heading hidden-md hidden-lg text-secondary text-uppercase">
+                    <div className="toleration-modal__heading hidden-md hidden-lg text-secondary">
                       {t('public~Key')}
                     </div>
                     <span
@@ -143,7 +143,7 @@ const TolerationsModal = withHandlePromise((props: TolerationsModalProps) => {
                     </span>
                   </div>
                   <div className="col-md-2 col-sm-5 col-xs-5 toleration-modal__field">
-                    <div className="toleration-modal__heading hidden-md hidden-lg text-secondary text-uppercase">
+                    <div className="toleration-modal__heading hidden-md hidden-lg text-secondary">
                       {t('public~Operator')}
                     </div>
                     {isEditable(toleration) ? (
@@ -163,7 +163,7 @@ const TolerationsModal = withHandlePromise((props: TolerationsModalProps) => {
                   </div>
                   <div className="clearfix visible-sm visible-xs" />
                   <div className="col-md-3 col-sm-5 col-xs-5 toleration-modal__field">
-                    <div className="toleration-modal__heading hidden-md hidden-lg text-secondary text-uppercase">
+                    <div className="toleration-modal__heading hidden-md hidden-lg text-secondary">
                       {t('public~Value')}
                     </div>
                     <span
@@ -180,7 +180,7 @@ const TolerationsModal = withHandlePromise((props: TolerationsModalProps) => {
                     </span>
                   </div>
                   <div className="col-md-2 col-sm-5 col-xs-5 toleration-modal__field">
-                    <div className="toleration-modal__heading hidden-md hidden-lg text-secondary text-uppercase">
+                    <div className="toleration-modal__heading hidden-md hidden-lg text-secondary">
                       {t('public~Effect')}
                     </div>
                     {isEditable(toleration) ? (

--- a/frontend/public/components/sidebars/resource-sidebar-samples.tsx
+++ b/frontend/public/components/sidebars/resource-sidebar-samples.tsx
@@ -24,7 +24,7 @@ const ResourceSidebarSample: React.FC<ResourceSidebarSampleProps> = ({
   return (
     <li className="co-resource-sidebar-item">
       <Title headingLevel="h3" className="pf-v6-u-mb-sm">
-        <span className="text-uppercase">{highlightText}</span> {title}
+        <span>{highlightText}</span> {title}
       </Title>
       {img && <img src={img} className="co-resource-sidebar-item__img img-responsive" />}
       <p>{description}</p>
@@ -122,7 +122,7 @@ const ResourceSidebarSnippet: React.FC<ResourceSidebarSnippetProps> = ({
   return (
     <li className="co-resource-sidebar-item">
       <Title headingLevel="h3" className="pf-v6-u-mb-sm">
-        <span className="text-uppercase">{highlightText}</span> {title}
+        <span>{highlightText}</span> {title}
       </Title>
       <p>{description}</p>
       <Level>

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -311,10 +311,10 @@ const EnvFromEditor_ = withDragDropContext(
         <>
           <div className="row pairs-list__heading">
             {!readOnly && <div className="col-xs-1 co-empty__header" />}
-            <div className="col-xs-5 text-secondary text-uppercase">
+            <div className="col-xs-5 text-secondary">
               {firstTitle || t('public~ConfigMap/Secret')}
             </div>
-            <div className="col-xs-5 text-secondary text-uppercase">
+            <div className="col-xs-5 text-secondary">
               {secondTitle || t('public~Prefix (optional)')}
             </div>
             <div className="col-xs-1 co-empty__header" />

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -307,22 +307,11 @@ ul {
   font-size: $font-size-base !important;
 }
 
-// TODO Remove this override when skip to content CSS is figured out.
-.pf-v6-c-skip-to-content {
-  position: absolute !important;
-}
-
 .properties-side-panel-pf-property-value {
   .pf-v6-c-alert__title,
   .pf-v6-c-menu__item-text,
   .pf-v6-c-menu-toggle {
     font-size: $font-size-base;
-  }
-}
-
-.odc-topology {
-  .pf-topology-content {
-    background-color: var(--pf-v6-c-page__main-section--BackgroundColor);
   }
 }
 


### PR DESCRIPTION
the `skip-to-content` override is not required as it's already the PF default: https://github.com/patternfly/patternfly/blob/main/src/patternfly/components/SkipToContent/skip-to-content.scss

the second one is my opinion that we should align with PatternFly and use their preferred background color.

removed `text-uppercase` class as that no longer does anything.

I have talked to @nicolethoen regarding the intended the PF topology background color before, and she confirmed with designers that the intended color is "secondary grey"

before:
![](https://i.imgur.com/PHQNRZN.png)

after:
![](https://i.imgur.com/yPNgYQC.png)

follow up ticket, adding labels
/label px-approved
/label docs-approved
/label qe-approved