### PR TITLE
OCPBUGS-53065: Debug pod logs are not accessible when debugging a node via OpenShift Console

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeTerminal.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeTerminal.tsx
@@ -33,9 +33,15 @@ const getDebugImage = async (): Promise<string> => {
   }
 };
 
-const getDebugPod = async (name: string, namespace: string, nodeName: string): Promise<PodKind> => {
+const getDebugPod = async (
+  name: string,
+  namespace: string,
+  nodeName: string,
+  isWindows: boolean,
+): Promise<PodKind> => {
   const image = await getDebugImage();
-  return {
+  // configuration as specified in https://github.com/openshift/oc/blob/master/pkg/cli/debug/debug.go#L1024-L1114
+  const template: PodKind = {
     kind: 'Pod',
     apiVersion: 'v1',
     metadata: {
@@ -48,7 +54,44 @@ const getDebugPod = async (name: string, namespace: string, nodeName: string): P
       },
     },
     spec: {
-      activeDeadlineSeconds: 21600,
+      containers: [
+        {
+          command: ['/bin/sh'],
+          env: [
+            {
+              // Set the Shell variable to auto-logout after 15m idle timeout
+              name: 'TMOUT',
+              value: '900',
+            },
+            {
+              // this env requires to be set in order to collect more sos reports
+              name: 'HOST',
+              value: '/host',
+            },
+          ],
+          image,
+          name: 'container-00',
+          resources: {},
+          securityContext: {
+            privileged: true,
+            runAsUser: 0,
+          },
+          stdin: true,
+          stdinOnce: true,
+          tty: true,
+          volumeMounts: [
+            {
+              name: 'host',
+              mountPath: '/host',
+            },
+          ],
+        },
+      ],
+      hostIPC: true,
+      hostPID: true,
+      hostNetwork: true,
+      nodeName,
+      restartPolicy: 'Never',
       volumes: [
         {
           name: 'host',
@@ -58,33 +101,21 @@ const getDebugPod = async (name: string, namespace: string, nodeName: string): P
           },
         },
       ],
-      containers: [
-        {
-          name: 'container-00',
-          image,
-          command: ['/bin/sh'],
-          resources: {},
-          volumeMounts: [
-            {
-              name: 'host',
-              mountPath: '/host',
-            },
-          ],
-          securityContext: {
-            privileged: true,
-            runAsUser: 0,
-          },
-          stdin: true,
-          stdinOnce: true,
-          tty: true,
-        },
-      ],
-      restartPolicy: 'Never',
-      nodeName,
-      hostNetwork: true,
-      hostPID: true,
     },
   };
+
+  if (isWindows) {
+    template.spec.OS = 'windows';
+    template.spec.hostPID = false;
+    template.spec.hostIPC = false;
+    const containerUser = 'ContainerUser';
+    template.spec.containers[0].securityContext = {
+      windowsOptions: {
+        runAsUserName: containerUser,
+      },
+    };
+  }
+  return template;
 };
 
 const NodeTerminalError: React.FC<NodeTerminalErrorProps> = ({ error }) => {
@@ -128,6 +159,8 @@ const NodeTerminal: React.FC<NodeTerminalProps> = ({ obj: node }) => {
   const [resources, setResources] = React.useState<FirehoseResource[]>([]);
   const [errorMessage, setErrorMessage] = React.useState('');
   const nodeName = node.metadata.name;
+  const isWindows = node.status?.nodeInfo?.operatingSystem === 'windows';
+
   React.useEffect(() => {
     let namespace;
     const name = `${nodeName?.replace(/\./g, '-')}-debug`;
@@ -160,7 +193,7 @@ const NodeTerminal: React.FC<NodeTerminalProps> = ({ obj: node }) => {
             },
           },
         });
-        const podToCreate = await getDebugPod(name, namespace.metadata.name, nodeName);
+        const podToCreate = await getDebugPod(name, namespace.metadata.name, nodeName, isWindows);
         // wait for the namespace to be ready
         await new Promise((resolve) => setTimeout(resolve, 1000));
         const debugPod = await k8sCreate(PodModel, podToCreate);
@@ -188,7 +221,7 @@ const NodeTerminal: React.FC<NodeTerminalProps> = ({ obj: node }) => {
       deleteNamespace(namespace.metadata.name);
       window.removeEventListener('beforeunload', closeTab);
     };
-  }, [nodeName]);
+  }, [nodeName, isWindows]);
 
   return errorMessage ? (
     <NodeTerminalError error={errorMessage} />

--- a/frontend/public/components/pod-attach.jsx
+++ b/frontend/public/components/pod-attach.jsx
@@ -14,19 +14,15 @@ import { Terminal } from './terminal';
 import { WSFactory } from '../module/ws-factory';
 import { resourceURL } from '../module/k8s';
 import { PodModel } from '../models';
-import { isWindowsPod } from '../module/k8s/pods';
 
-// pod exec WS protocol is FD prefixed, base64 encoded data (sometimes json stringified)
+// pod attach WS protocol is FD prefixed, base64 encoded data (sometimes json stringified)
 
 // Channel 0 is STDIN, 1 is STDOUT, 2 is STDERR (if TTY is not requested), and 3 is a special error channel - 4 is C&C
 // The server only reads from STDIN, writes to the other three.
 // see also: https://github.com/kubernetes/kubernetes/pull/13885
 
-const NO_SH =
-  'starting container process caused "exec: \\"sh\\": executable file not found in $PATH"';
-
-const PodExec_ = connectToFlags(FLAGS.OPENSHIFT)(
-  class PodExec extends React.PureComponent {
+const PodAttach_ = connectToFlags(FLAGS.OPENSHIFT)(
+  class PodAttach extends React.PureComponent {
     constructor(props) {
       super(props);
       this.state = {
@@ -47,19 +43,16 @@ const PodExec_ = connectToFlags(FLAGS.OPENSHIFT)(
         metadata: { name, namespace },
       } = this.props.obj;
       const { activeContainer } = this.state;
-      const usedClient = this.props.flags[FLAGS.OPENSHIFT] ? 'oc' : 'kubectl';
-      const command = isWindowsPod(this.props.obj) ? ['cmd'] : ['sh', '-i', '-c', 'TERM=xterm sh'];
       const params = {
         ns: namespace,
         name,
-        path: 'exec',
+        path: 'attach',
         queryParams: {
           stdout: 1,
           stdin: 1,
           stderr: 1,
           tty: 1,
           container: activeContainer,
-          command: command.map((c) => encodeURIComponent(c)).join('&command='),
         },
       };
 
@@ -72,7 +65,6 @@ const PodExec_ = connectToFlags(FLAGS.OPENSHIFT)(
       const impersonate = getImpersonate(store.getState()) || {};
       const subprotocols = (impersonate.subprotocols || []).concat('base64.channel.k8s.io');
 
-      let previous;
       this.ws = new WSFactory(`${name}-terminal`, {
         host: 'auto',
         reconnect: true,
@@ -82,26 +74,12 @@ const PodExec_ = connectToFlags(FLAGS.OPENSHIFT)(
       })
         .onmessage((raw) => {
           const { current } = this.terminal;
-          // error channel
-          if (raw[0] === '3') {
-            if (previous.includes(NO_SH)) {
-              current.reset();
-              current.onConnectionClosed(
-                `This container doesn't have a /bin/sh shell. Try specifying your command in a terminal with:\r\n\r\n ${usedClient} -n ${namespace} exec ${name} -ti <command>`,
-              );
-              this.ws.destroy();
-              previous = '';
-              return;
-            }
-          }
           const data = Base64.decode(raw.slice(1));
           current && current.onDataReceived(data);
-          previous = data;
         })
         .onopen(() => {
           const { current } = this.terminal;
           current && current.reset();
-          previous = '';
           this.setState({ open: true, error: null });
         })
         .onclose((evt) => {
@@ -227,4 +205,4 @@ const PodExec_ = connectToFlags(FLAGS.OPENSHIFT)(
   },
 );
 
-export const PodExec = withTranslation()(PodExec_);
+export const PodAttach = withTranslation()(PodAttach_);

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -971,7 +971,7 @@ export const PodExecLoader: React.FC<PodExecLoaderProps> = ({
       <div className="col-xs-12">
         <div className="panel-body">
           <AsyncComponent
-            loader={() => import('./pod-exec').then((c) => c.PodExec)}
+            loader={() => import('./pod-attach').then((c) => c.PodAttach)}
             obj={obj}
             message={message}
             infoMessage={infoMessage}


### PR DESCRIPTION
Explanations behind changes:
kubectl/oc [exec](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_exec/) runs a command inside a new separate terminal outside of the main terminal process within the container. In contrast, [attach](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_attach/) connects directly to the standard output and error streams of an already running main process. This is crucial towards the fix of the logs not showing the executed commands within the debug pod, because both UI and CLI logs are retrieving history from the main terminal process. Attaching the debug terminal to the main process allows for continuous log updates and ensures that the logs reflect the active state. Using attach instead of exec also [corresponds](https://github.com/openshift/oc/blob/33cbfe154012e938b00420aa6c4a62e38184da99/pkg/cli/debug/debug.go#L674) to the way node debug is implemented within oc CLI debug command.


