### PR TITLE
OCPBUGS-43792: Load extensions in same order as plugins listed in SERVER_FLAGS global

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
@@ -432,6 +432,14 @@ describe('PluginStore', () => {
 
       expect(store.getExtensionsInUse()).toEqual([
         {
+          type: 'Baz',
+          properties: {},
+          flags: { required: [], disallowed: ['foo', 'bar'] },
+          pluginID: 'TestA@3.4.5',
+          pluginName: 'TestA',
+          uid: 'TestA@3.4.5[0]',
+        },
+        {
           type: 'Qux',
           properties: { value: 'test' },
           flags: { required: ['foo', 'bar'], disallowed: [] },
@@ -446,14 +454,6 @@ describe('PluginStore', () => {
           pluginID: 'TestC@2.3.4',
           pluginName: 'TestC',
           uid: 'TestC@2.3.4[0]',
-        },
-        {
-          type: 'Baz',
-          properties: {},
-          flags: { required: [], disallowed: ['foo', 'bar'] },
-          pluginID: 'TestA@3.4.5',
-          pluginName: 'TestA',
-          uid: 'TestA@3.4.5[0]',
         },
       ]);
 

--- a/frontend/packages/console-plugin-sdk/src/store.ts
+++ b/frontend/packages/console-plugin-sdk/src/store.ts
@@ -186,7 +186,6 @@ export class PluginStore {
       (acc, plugin) => (plugin.enabled ? [...acc, ...plugin.processedExtensions] : acc),
       [] as LoadedExtension[],
     );
-    console.dir(this.dynamicPluginExtensions);
   }
 
   setDynamicPluginEnabled(pluginID: string, enabled: boolean) {

--- a/frontend/packages/console-plugin-sdk/src/store.ts
+++ b/frontend/packages/console-plugin-sdk/src/store.ts
@@ -172,7 +172,6 @@ export class PluginStore {
 
   private updateExtensions() {
     const allowedDynamicPluginNames = Array.from(this.allowedDynamicPluginNames.values());
-    console.dir(allowedDynamicPluginNames);
     const dynamicPlugins = Array.from(this.loadedDynamicPlugins.values()).sort((a, b) => {
       const indexA = allowedDynamicPluginNames.indexOf(a.manifest.name);
       const indexB = allowedDynamicPluginNames.indexOf(b.manifest.name);

--- a/frontend/packages/console-plugin-sdk/src/store.ts
+++ b/frontend/packages/console-plugin-sdk/src/store.ts
@@ -171,7 +171,13 @@ export class PluginStore {
   }
 
   private updateExtensions() {
-    const dynamicPlugins = Array.from(this.loadedDynamicPlugins.values());
+    const allowedDynamicPluginNames = Array.from(this.allowedDynamicPluginNames.values());
+    console.dir(allowedDynamicPluginNames);
+    const dynamicPlugins = Array.from(this.loadedDynamicPlugins.values()).sort((a, b) => {
+      const indexA = allowedDynamicPluginNames.indexOf(a.manifest.name);
+      const indexB = allowedDynamicPluginNames.indexOf(b.manifest.name);
+      return indexA - indexB;
+    });
 
     this.staticPluginExtensions = this.staticPlugins
       .filter((plugin) => !this.disabledStaticPluginNames.has(plugin.name))
@@ -181,6 +187,7 @@ export class PluginStore {
       (acc, plugin) => (plugin.enabled ? [...acc, ...plugin.processedExtensions] : acc),
       [] as LoadedExtension[],
     );
+    console.dir(this.dynamicPluginExtensions);
   }
 
   setDynamicPluginEnabled(pluginID: string, enabled: boolean) {


### PR DESCRIPTION
Adjust how console dynamic plugin extensions are resolved so that the order can be controlled using the console operator config. The extensions will resolve in the same order as the list of enabled plugins in the console operator config. This means that cluster admins can choose which plugin takes priority when there are extension collisions for extension points like the Project modal where only one extension can be resolved and rendered.