### PR TITLE
OCPBUGS-54436: Warning: React.useMemo has a missing dependency

### DIFF
--- a/frontend/public/components/configmap-and-secret-data.tsx
+++ b/frontend/public/components/configmap-and-secret-data.tsx
@@ -154,7 +154,7 @@ export const SecretData: React.FC<SecretDataProps> = ({ data }) => {
             );
           })
       : [];
-  }, [data, reveal]);
+  }, [data, reveal, hasRevealableContent]);
 
   return (
     <>


### PR DESCRIPTION
### Before:
<img width="1016" alt="Screenshot 2025-03-29 at 1 05 09 AM" src="https://github.com/user-attachments/assets/f7d464d3-f12b-4097-beaf-541b5333e567" />

### After:
<img width="1418" alt="Screenshot 2025-03-29 at 1 08 05 AM" src="https://github.com/user-attachments/assets/685cc398-7c5e-414c-bb23-51d4b3f94266" />
