### PR TITLE
CONSOLE-4484: Fix `Skip to content` regression

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -242,8 +242,8 @@ const App = (props) => {
               />
             }
             skipToContent={
-              <SkipToContent href={`${location.pathname}${location.search}#content`}>
-                Skip to Content
+              <SkipToContent href={`${location.pathname}${location.search}#content-scrollable`}>
+                {t('public~Skip to content')}
               </SkipToContent>
             }
             notificationDrawer={

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -59,6 +59,7 @@
   "Details": "Details",
   "Schema": "Schema",
   "Instances": "Instances",
+  "Skip to content": "Skip to content",
   "Modal": "Modal",
   "Web console update is available": "Web console update is available",
   "There has been an update to the web console. Ensure any changes have been saved and refresh your browser to access the latest version.": "There has been an update to the web console. Ensure any changes have been saved and refresh your browser to access the latest version.",


### PR DESCRIPTION
follow up to fix an a11y regression I caused in https://issues.redhat.com/browse/CONSOLE-4484

The button now links to `content-scrollable`which is the div that contains the main content

follow up PR for approved ticket, adding labels
/label px-approved
/label docs-approved
/label qe-approved

code review:
/assign @rhamilto