### PR TITLE
OCPBUGS-36658: Fetching taskRuns in PLR details page using PLR UID also

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/TaskRuns.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/TaskRuns.tsx
@@ -15,7 +15,12 @@ const TaskRuns: React.FC<TaskRunsProps> = ({ obj }) => {
       <DocumentTitle>{t('pipelines-plugin~TaskRuns')}</DocumentTitle>
       <TaskRunsListPage
         showTitle={false}
-        selector={{ matchLabels: { 'tekton.dev/pipelineRun': obj.metadata.name } }}
+        selector={{
+          matchLabels: {
+            'tekton.dev/pipelineRun': obj.metadata.name,
+            'tekton.dev/pipelineRunUID': obj.metadata?.uid,
+          },
+        }}
         showPipelineColumn={false}
         namespace={obj.metadata.namespace}
         hideBadge

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTaskRuns.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTaskRuns.ts
@@ -10,8 +10,17 @@ export const useTaskRuns = (
   pipelineRunName?: string,
   taskName?: string,
   cacheKey?: string,
+  pipelineRunUid?: string,
 ): [TaskRunKind[], boolean, unknown, GetNextPage] => {
   const selector: Selector = React.useMemo(() => {
+    if (pipelineRunName && pipelineRunUid) {
+      return {
+        matchLabels: {
+          [TektonResourceLabel.pipelinerun]: pipelineRunName,
+          [TektonResourceLabel.pipelineRunUid]: pipelineRunUid,
+        },
+      };
+    }
     if (pipelineRunName) {
       return { matchLabels: { [TektonResourceLabel.pipelinerun]: pipelineRunName } };
     }
@@ -19,7 +28,7 @@ export const useTaskRuns = (
       return { matchLabels: { [TektonResourceLabel.pipelineTask]: taskName } };
     }
     return undefined;
-  }, [taskName, pipelineRunName]);
+  }, [taskName, pipelineRunName, pipelineRunUid]);
   const [taskRuns, loaded, error, getNextPage] = useTaskRuns2(
     namespace,
     selector && {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
@@ -24,6 +24,7 @@ export enum TektonTaskLabel {
 export enum TektonResourceLabel {
   pipeline = 'tekton.dev/pipeline',
   pipelinerun = 'tekton.dev/pipelineRun',
+  pipelineRunUid = 'tekton.dev/pipelineRunUID',
   taskrun = 'tekton.dev/taskRun',
   pipelineTask = 'tekton.dev/pipelineTask',
 }

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsListPage.tsx
@@ -38,7 +38,14 @@ const TaskRunsListPage: React.FC<
   const ns = namespace || params?.ns;
   const badge = usePipelineTechPreviewBadge(ns);
   const trForPlr = props.selector && props.selector?.matchLabels?.['tekton.dev/pipelineRun'];
-  const [taskRuns, taskRunsLoaded, taskRunsLoadError, getNextPage] = useTaskRuns(ns, trForPlr);
+  const trForPlrUid = props.selector && props.selector?.matchLabels?.['tekton.dev/pipelineRunUID'];
+  const [taskRuns, taskRunsLoaded, taskRunsLoadError, getNextPage] = useTaskRuns(
+    ns,
+    trForPlr,
+    undefined,
+    undefined,
+    trForPlrUid,
+  );
 
   const taskRunsResource = {
     [referenceForModel(TaskRunModel)]: {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-36658

**Analysis / Root cause**: 
In TaskRun list page under PLR details page, TaskRuns were fetching based on name

**Solution Description**: 
Added a condition to fetch based on UID also
  
**Screen shots / Gifs for design review**: 

**---BEFORE----**


https://github.com/user-attachments/assets/65937093-25c3-4451-a9d0-6d84445b267c



**---AFTER----**


https://github.com/user-attachments/assets/a1a5e4a9-e1e9-4d3d-890b-707d3cc99f86




-----

**Unit test coverage report**: 
NA

**Test setup:**

1. Create Pipeline foo with Task bar
2. Create PipelineRun with name myplr using Pipeline foo
3. Wait until completion (spawns TaskRun myplr-bar)
4. In OpenShift web UI for PipelineRun myplr can see TaskRun myplr-bar
5. Delete PipelineRun myplr
6. Repeat step 2 & 3
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

