### PR TITLE
OCPBUGS-54461: Add missing `href` props to masthead items

### DIFF
--- a/frontend/packages/console-shared/src/components/links/LinkTo.tsx
+++ b/frontend/packages/console-shared/src/components/links/LinkTo.tsx
@@ -1,0 +1,17 @@
+import { Link, LinkProps } from 'react-router-dom-v5-compat';
+
+/**
+ * A helper which creates a `Link` component that **only**
+ * links to a specific location in the console.
+ *
+ * This is needed to bypass PatternFly `DropdownItem`
+ * forcing the `to` prop to pass as `href`, which breaks
+ * `react-router-dom` routing and causes a hard reload.
+ *
+ * @param href - The location to link to.
+ * @param extraLinkProps - Any additional props to pass to the `Link` component.
+ * @returns A component that links to the specified location.
+ */
+export const LinkTo = (href: string, extraLinkProps?: Partial<LinkProps>) => (props: LinkProps) => (
+  <Link {...props} to={href} {...extraLinkProps} />
+);

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/quck-starts/quick-start-devperspective.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/quck-starts/quick-start-devperspective.ts
@@ -25,7 +25,7 @@ Then('user can see the "View all quick starts" on the card', () => {
 
 When('user selects QuickStarts from the help menu icon on the masthead', () => {
   cy.get(helpDropdownMenu).should('be.visible').click();
-  cy.get('button[role="menuitem"]').contains('Quick Starts').click();
+  cy.get('[data-test="masthead-quick-starts"]').contains('Quick Starts').click();
 });
 
 Then(

--- a/frontend/public/components/QuickCreate.tsx
+++ b/frontend/public/components/QuickCreate.tsx
@@ -85,18 +85,17 @@ const QuickCreate: React.FC<QuickCreateProps> = ({ namespace }) => {
       onSelect={onSelect}
       onOpenChange={(open: boolean) => setIsOpen(open)}
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-        <MenuToggle
-          ref={toggleRef}
-          aria-label="kebab dropdown toggle"
-          variant="plain"
-          onClick={onToggleClick}
-          isExpanded={isOpen}
-          data-test="quick-create-dropdown"
-        >
-          <Tooltip content={t('public~Quick create')}>
-            <PlusCircleIcon alt="" />
-          </Tooltip>
-        </MenuToggle>
+        <Tooltip content={t('public~Quick create')} position="bottom">
+          <MenuToggle
+            ref={toggleRef}
+            aria-label={t('public~Quick create')}
+            variant="plain"
+            onClick={onToggleClick}
+            isExpanded={isOpen}
+            data-test="quick-create-dropdown"
+            icon={<PlusCircleIcon alt="" />}
+          />
+        </Tooltip>
       )}
       popperProps={{
         position: 'center',

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -31,10 +31,10 @@ import {
   YellowExclamationTriangleIcon,
 } from '@console/shared';
 import { formatNamespacedRouteForResource } from '@console/shared/src/utils';
+import { LinkTo } from '@console/shared/src/components/links/LinkTo';
 import CloudShellMastheadButton from '@console/webterminal-plugin/src/components/cloud-shell/CloudShellMastheadButton';
 import CloudShellMastheadAction from '@console/webterminal-plugin/src/components/cloud-shell/CloudShellMastheadAction';
 import { getUser } from '@console/dynamic-plugin-sdk';
-import { history } from '@console/internal/components/utils';
 import * as UIActions from '../actions/ui';
 import { flagPending, featureReducerName } from '../reducers/features';
 import { authSvc } from '../module/auth';
@@ -303,10 +303,8 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
           ? [
               {
                 label: t('public~Quick Starts'),
-                callback: (e) => {
-                  e.preventDefault();
-                  history.push('/quickstart');
-                },
+                component: LinkTo('/quickstart'),
+                dataTest: 'masthead-quick-starts',
               },
             ]
           : []),
@@ -322,11 +320,10 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
           ? [
               {
                 label: t('public~Command Line Tools'),
-                callback: (e) => {
-                  e.preventDefault();
-                  history.push('/command-line-tools');
+                callback: () => {
                   fireTelemetryEvent('CLI Clicked');
                 },
+                component: LinkTo('/command-line-tools'),
               },
             ]
           : []),
@@ -400,9 +397,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
                   {...externalProps(sectionAction.externalLink)}
                   onClick={sectionAction.callback}
                   component={sectionAction.component}
-                  data-test={
-                    sectionAction.dataTest ? sectionAction.dataTest : 'application-launcher-item'
-                  }
+                  data-test={sectionAction.dataTest ?? 'application-launcher-item'}
                   value={sectionAction.label}
                 >
                   {sectionAction.label}
@@ -463,10 +458,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
     const userActions = [
       {
         label: t('public~User Preferences'),
-        callback: (e) => {
-          e.preventDefault();
-          history.push('/user-preferences');
-        },
+        component: LinkTo('/user-preferences'),
       },
     ];
 
@@ -514,10 +506,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
         actions: [
           {
             label: t('public~Import YAML'),
-            callback: (e) => {
-              e.preventDefault();
-              history.push(getImportYAMLPath());
-            },
+            component: LinkTo(getImportYAMLPath()),
           },
           {
             component: () => (


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/OCPBUGS-54461

adds `href` prop so that users can now middle-click these masthead dropdown items. left-clicking still works and does not reload the page