### PR TITLE
OCPBUGS-54472: fix position of OpenShift Lightspeed button

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -257,12 +257,12 @@ const App = (props) => {
           >
             <AppContents />
           </Page>
-          {consoleCapabilityLightspeedButtonIsEnabled && lightspeedIsAvailableToInstall && (
-            <Lightspeed />
-          )}
           <CloudShell />
           <GuidedTour />
         </Flex>
+        {consoleCapabilityLightspeedButtonIsEnabled && lightspeedIsAvailableToInstall && (
+          <Lightspeed />
+        )}
         <div id="modal-container" role="dialog" aria-modal="true" aria-label={t('public~Modal')} />
       </QuickStartDrawer>
       <ConsoleNotifier location="BannerBottom" />


### PR DESCRIPTION
Before
<img width="95" alt="Screenshot 2025-04-01 at 9 59 59 AM" src="https://github.com/user-attachments/assets/1d431404-2a9c-4915-bb9f-5cbb86c595f5" />

After
<img width="158" alt="Screenshot 2025-04-01 at 10 16 01 AM" src="https://github.com/user-attachments/assets/2c0960eb-2fe0-426e-81aa-42970ef0829d" />
