### PR TITLE
OCPBUGS-53065: Fix regression where normal Pod terminals are unresponsive.

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeTerminal.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeTerminal.tsx
@@ -1,17 +1,16 @@
 import * as React from 'react';
 import { Alert } from '@patternfly/react-core';
 import { useTranslation, Trans } from 'react-i18next';
+import { PodConnectLoader } from '@console/internal/components/pod';
 import {
   Firehose,
   FirehoseResource,
   FirehoseResult,
   LoadingBox,
 } from '@console/internal/components/utils';
-import { NodeKind, PodKind } from '@console/internal/module/k8s';
+import { ImageStreamTagModel, NamespaceModel, PodModel } from '@console/internal/models';
+import { NodeKind, PodKind, k8sCreate, k8sGet, k8sKillByName } from '@console/internal/module/k8s';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';
-import { PodExecLoader } from '../../../../../public/components/pod';
-import { ImageStreamTagModel, NamespaceModel, PodModel } from '../../../../../public/models';
-import { k8sCreate, k8sGet, k8sKillByName } from '../../../../../public/module/k8s';
 
 type NodeTerminalErrorProps = {
   error: React.ReactNode;
@@ -150,7 +149,7 @@ const NodeTerminalInner: React.FC<NodeTerminalInnerProps> = ({ obj }) => {
         />
       );
     case 'Running':
-      return <PodExecLoader obj={obj.data} message={message} />;
+      return <PodConnectLoader obj={obj.data} message={message} attach />;
     default:
       return <LoadingBox />;
   }

--- a/frontend/public/components/debug-terminal.tsx
+++ b/frontend/public/components/debug-terminal.tsx
@@ -6,7 +6,7 @@ import { Alert } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { LoadingBox, PageHeading } from '@console/internal/components/utils';
 import { ObjectMetadata, PodKind, k8sCreate, k8sKillByName } from '@console/internal/module/k8s';
-import { PodExecLoader } from '@console/internal/components/pod';
+import { PodConnectLoader } from '@console/internal/components/pod';
 import { PodModel } from '@console/internal/models';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';
@@ -93,7 +93,7 @@ const DebugTerminalInner: React.FC<DebugTerminalInnerProps> = ({ debugPod, initi
       );
     case 'Running':
       return (
-        <PodExecLoader
+        <PodConnectLoader
           obj={debugPod}
           initialContainer={initialContainer}
           infoMessage={infoMessage}

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -961,22 +961,24 @@ const PodEnvironmentComponent = (props) => (
   <EnvironmentPage obj={props.obj} rawEnvData={props.obj.spec} envPath={envPath} readOnly={true} />
 );
 
-export const PodExecLoader: React.FC<PodExecLoaderProps> = ({
+export const PodConnectLoader: React.FC<PodConnectLoaderProps> = ({
   obj,
   message,
   initialContainer,
   infoMessage,
+  attach = false,
 }) => (
   <PaneBody>
     <div className="row">
       <div className="col-xs-12">
         <div className="panel-body">
           <AsyncComponent
-            loader={() => import('./pod-attach').then((c) => c.PodAttach)}
+            loader={() => import('./pod-connect').then((c) => c.PodConnect)}
             obj={obj}
             message={message}
             infoMessage={infoMessage}
             initialContainer={initialContainer}
+            attach={attach}
           />
         </div>
       </div>
@@ -1010,7 +1012,7 @@ export const PodsDetailsPage: React.FC<PodDetailsPageProps> = (props) => {
         navFactory.envEditor(PodEnvironmentComponent),
         navFactory.logs(PodLogs),
         navFactory.events(ResourceEventStream),
-        navFactory.terminal(PodExecLoader),
+        navFactory.terminal(PodConnectLoader),
       ]}
     />
   );
@@ -1242,11 +1244,12 @@ export type PodDetailsListProps = {
   pod: PodKind;
 };
 
-type PodExecLoaderProps = {
+type PodConnectLoaderProps = {
   obj: PodKind;
   message?: React.ReactElement;
   infoMessage?: React.ReactElement;
   initialContainer?: string;
+  attach?: boolean;
 };
 
 type PodDetailsProps = {


### PR DESCRIPTION
Followup for https://github.com/openshift/console/pull/14898. The node debugging fix caused a regression where standard Pod terminals were unresponsive, when using attach command. Before this PR merged we were solely using exec command, which was working fine for pod terminals. 

Added a logic for passing a prop that specifies if the websocket will attach (for node debug pods) or exec (for standard pods) to the given pod, besides that the changes are bringing back the old code from `pod-exec.jsx` before https://github.com/openshift/console/pull/14898 merged. Renamed the `pod-attach.jsx` component to reflect the functional duality of the component.

before:
![Screenshot 2025-04-02 at 11 00 09](https://github.com/user-attachments/assets/17a0938d-d49e-4b8f-90a3-735c1c92ca0f)

after:
![Screenshot 2025-04-02 at 10 44 50](https://github.com/user-attachments/assets/11f31cd1-3168-4aee-9583-acc590ad350e)

Possible test scenario:

1. Visit any Pod details page
2. Click on Terminal tab
3. Use the terminal
