### PR TITLE
OCPBUGS-54328: Incorrect English for remaining days of trial in OpenShift Console 

### DIFF
--- a/frontend/public/components/utils/service-level.tsx
+++ b/frontend/public/components/utils/service-level.tsx
@@ -48,7 +48,7 @@ const TrialDaysLeft: React.FC<{
 
   let variant: 'warning' | 'danger' = 'warning';
 
-  let alertText = t('public~{{count}} days remaining', { count: trialDaysLeft });
+  let alertText = t('public~{{count}} day remaining', { count: trialDaysLeft });
   if (trialDaysLeft === 0) {
     alertText = t('public~< 1 day remaining');
   }

--- a/frontend/public/components/utils/service-level.tsx
+++ b/frontend/public/components/utils/service-level.tsx
@@ -48,7 +48,7 @@ const TrialDaysLeft: React.FC<{
 
   let variant: 'warning' | 'danger' = 'warning';
 
-  let alertText = t('public~{{count}} day remaining', { count: trialDaysLeft });
+  let alertText = t('public~{{count}} days remaining', { count: trialDaysLeft });
   if (trialDaysLeft === 0) {
     alertText = t('public~< 1 day remaining');
   }

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1640,7 +1640,7 @@
   "Self-support": "Self-support",
   "Self-support, 60 day trial": "Self-support, 60 day trial",
   "{{count}} day remaining_one": "{{count}} day remaining",
-  "{{count}} day remaining_other": "{{count}} day remainings",
+  "{{count}} day remaining_other": "{{count}} days remaining",
   "< 1 day remaining": "< 1 day remaining",
   "Trial expired": "Trial expired",
   "API failed to return the Service Level Agreement setting for this cluster. Check again later.": "API failed to return the Service Level Agreement setting for this cluster. Check again later.",


### PR DESCRIPTION
fixed typo