### PR TITLE
ODC-6775, CONSOLE-4393: @types/node pre-merge prep

### DIFF
--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference path="./jest.d.ts" />
 /// <reference path="./react.d.ts" />
 /// <reference path="./generated/graphql-queries.d.ts" />
 

--- a/frontend/@types/console/jest.d.ts
+++ b/frontend/@types/console/jest.d.ts
@@ -1,0 +1,13 @@
+import 'jest';
+
+declare global {
+  namespace jest {
+    /**
+     * Returns the actual module instead of a mock, bypassing all checks on
+     * whether the module should receive a mock implementation or not.
+     *
+     * TODO: Remove when jest is updated
+     */
+    function requireActual(moduleName: string): any;
+  }
+}

--- a/frontend/__mocks__/i18next.ts
+++ b/frontend/__mocks__/i18next.ts
@@ -1,7 +1,7 @@
 /* eslint-env node */
 import { TFunction } from 'i18next';
 
-const i18next = require.requireActual('i18next');
+const i18next = jest.requireActual('i18next');
 
 const interpolationPattern = /{{([A-Za-z0-9]+)}}/;
 

--- a/frontend/__mocks__/react-i18next.ts
+++ b/frontend/__mocks__/react-i18next.ts
@@ -1,7 +1,7 @@
 /* eslint-env node */
 const i18next = require('i18next');
-const react = require.requireActual('react');
-const reactI18next = require.requireActual('react-i18next');
+const react = jest.requireActual('react');
+const reactI18next = jest.requireActual('react-i18next');
 
 module.exports = {
   ...reactI18next,

--- a/frontend/__tests__/components/container.spec.tsx
+++ b/frontend/__tests__/components/container.spec.tsx
@@ -21,7 +21,7 @@ import { StatusProps } from '@console/metal3-plugin/src/components/types';
 import { act } from 'react-dom/test-utils';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
 }));

--- a/frontend/__tests__/components/factory/details.spec.tsx
+++ b/frontend/__tests__/components/factory/details.spec.tsx
@@ -9,7 +9,7 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { Firehose } from '@console/internal/components/utils';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
 }));

--- a/frontend/__tests__/components/factory/list-page.spec.tsx
+++ b/frontend/__tests__/components/factory/list-page.spec.tsx
@@ -10,7 +10,7 @@ import {
 import { Firehose, PageHeading } from '../../../public/components/utils';
 
 jest.mock('react-redux', () => {
-  const ActualReactRedux = require.requireActual('react-redux');
+  const ActualReactRedux = jest.requireActual('react-redux');
   return {
     ...ActualReactRedux,
     useDispatch: jest.fn(),
@@ -18,7 +18,7 @@ jest.mock('react-redux', () => {
 });
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useNavigate: jest.fn(),
 }));
 

--- a/frontend/__tests__/components/pod.spec.tsx
+++ b/frontend/__tests__/components/pod.spec.tsx
@@ -23,7 +23,7 @@ import * as ReactRouter from 'react-router-dom-v5-compat';
 import { PodKind } from '@console/internal/module/k8s';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
 }));

--- a/frontend/__tests__/components/storage-class-form.spec.tsx
+++ b/frontend/__tests__/components/storage-class-form.spec.tsx
@@ -9,7 +9,7 @@ import {
 import { PageHeading } from '../../public/components/utils';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useNavigate: jest.fn(),
 }));
 

--- a/frontend/packages/console-app/src/__tests__/network-policies/create-network-policy.spec.tsx
+++ b/frontend/packages/console-app/src/__tests__/network-policies/create-network-policy.spec.tsx
@@ -19,7 +19,7 @@ jest.mock('@console/shared/src/hooks/useUserSettingsCompatibility', () => ({
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(() => ({ ns: 'default' })),
   useLocation: jest.fn(() => ({
     pathname: '/k8s/ns/default/networking.k8s.io~v1~NetworkPolicy/~new/form',

--- a/frontend/packages/console-app/src/__tests__/network-policies/network-policy-form.spec.tsx
+++ b/frontend/packages/console-app/src/__tests__/network-policies/network-policy-form.spec.tsx
@@ -17,7 +17,7 @@ jest.mock('@console/shared/src/hooks/useUserSettingsCompatibility', () => ({
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(() => ({ ns: 'default' })),
   useLocation: jest.fn(() => ({
     pathname: '/k8s/ns/default/networking.k8s.io~v1~NetworkPolicy/~new/form',

--- a/frontend/packages/console-app/src/components/detect-namespace/__tests__/namespace.spec.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/__tests__/namespace.spec.ts
@@ -11,12 +11,12 @@ import { useValuesForNamespaceContext } from '../namespace';
 import { useLastNamespace } from '../useLastNamespace';
 
 jest.mock('react-redux', () => ({
-  ...require.requireActual('react-redux'),
+  ...jest.requireActual('react-redux'),
   useDispatch: jest.fn(),
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useLocation: jest.fn(),
   useNavigate: jest.fn(),
 }));

--- a/frontend/packages/console-app/src/components/detect-perspective/__tests__/PerspectiveDetector.spec.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/__tests__/PerspectiveDetector.spec.tsx
@@ -15,7 +15,7 @@ jest.mock('@console/shared/src', () => ({
 
 jest.mock('react-router', () => {
   return {
-    ...require.requireActual('react-router'),
+    ...jest.requireActual('react-router'),
     useLocation: jest.fn(() => ({ pathname: '' })),
   };
 });

--- a/frontend/packages/console-app/src/components/detect-perspective/__tests__/useValuesForPerspectiveContext.spec.ts
+++ b/frontend/packages/console-app/src/components/detect-perspective/__tests__/useValuesForPerspectiveContext.spec.ts
@@ -24,7 +24,7 @@ jest.mock('../../user-preferences/perspective/usePreferredPerspective', () => ({
 }));
 
 jest.mock('react', () => {
-  const reactModule = require.requireActual('react');
+  const reactModule = jest.requireActual('react');
   return {
     ...reactModule,
     useState: jest.fn(),

--- a/frontend/packages/console-app/src/components/favorite/FavoriteNavItems.tsx
+++ b/frontend/packages/console-app/src/components/favorite/FavoriteNavItems.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { NavExpandable, Button, FlexItem, Flex, Truncate } from '@patternfly/react-core';
 import { StarIcon } from '@patternfly/react-icons';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useUserSettingsCompatibility } from '@console/shared';
 import {

--- a/frontend/packages/console-app/src/components/nav/PerspectiveNav.tsx
+++ b/frontend/packages/console-app/src/components/nav/PerspectiveNav.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { NavGroup, NavList } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import {
   useActivePerspective,

--- a/frontend/packages/console-app/src/components/nav/PinnedResource.tsx
+++ b/frontend/packages/console-app/src/components/nav/PinnedResource.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import { GripVerticalIcon } from '@patternfly/react-icons/dist/esm/icons/grip-vertical-icon';
 import { MinusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { debounce } from 'lodash';
 import { useDrag, useDrop } from 'react-dnd';
 import { useTranslation } from 'react-i18next';

--- a/frontend/packages/console-app/src/components/nav/__tests__/PerspectiveNav.spec.tsx
+++ b/frontend/packages/console-app/src/components/nav/__tests__/PerspectiveNav.spec.tsx
@@ -7,8 +7,8 @@ import { usePinnedResources } from '@console/shared/src/hooks/usePinnedResources
 import PerspectiveNav from '../PerspectiveNav';
 
 jest.mock('react', () => ({
-  ...require.requireActual('react'),
-  useLayoutEffect: require.requireActual('react').useEffect,
+  ...jest.requireActual('react'),
+  useLayoutEffect: jest.requireActual('react').useEffect,
 }));
 jest.mock('@console/dynamic-plugin-sdk/src/perspective/useActivePerspective', () => ({
   default: jest.fn().mockReturnValue(['dev', jest.fn()]),
@@ -20,7 +20,7 @@ jest.mock('@console/shared/src/hooks/perspective-utils', () => ({
   usePerspectives: jest.fn(),
 }));
 jest.mock('react-dnd', () => {
-  const reactDnd = require.requireActual('react-dnd');
+  const reactDnd = jest.requireActual('react-dnd');
   return {
     ...reactDnd,
     useDrag: jest.fn().mockReturnValue([{}, {}, jest.fn()]),

--- a/frontend/packages/console-app/src/components/nav/__tests__/perspective-nav.spec.tsx
+++ b/frontend/packages/console-app/src/components/nav/__tests__/perspective-nav.spec.tsx
@@ -7,8 +7,8 @@ import { usePinnedResources } from '@console/shared/src/hooks/usePinnedResources
 import PerspectiveNav from '../PerspectiveNav';
 
 jest.mock('react', () => ({
-  ...require.requireActual('react'),
-  useLayoutEffect: require.requireActual('react').useEffect,
+  ...jest.requireActual('react'),
+  useLayoutEffect: jest.requireActual('react').useEffect,
 }));
 jest.mock('@console/dynamic-plugin-sdk/src/perspective/useActivePerspective', () => ({
   default: jest.fn().mockReturnValue(['dev', jest.fn()]),
@@ -20,7 +20,7 @@ jest.mock('@console/shared/src/hooks/perspective-utils', () => ({
   usePerspectives: jest.fn(),
 }));
 jest.mock('react-dnd', () => {
-  const reactDnd = require.requireActual('react-dnd');
+  const reactDnd = jest.requireActual('react-dnd');
   return {
     ...reactDnd,
     useDrag: jest.fn().mockReturnValue([{}, {}, jest.fn()]),

--- a/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
@@ -15,7 +15,7 @@ import {
   Switch,
 } from '@patternfly/react-core';
 import { LogViewer, LogViewerSearch } from '@patternfly/react-log-viewer';
-import classnames from 'classnames';
+import classNames from 'classnames';
 import { Trans, useTranslation } from 'react-i18next';
 import { coFetch } from '@console/internal/co-fetch';
 import { ThemeContext } from '@console/internal/components/ThemeProvider';
@@ -89,7 +89,7 @@ const LogControls: React.FC<LogControlsProps> = ({
         <SelectOption
           key={value}
           value={value}
-          className={classnames({ 'co-node-logs__log-select-option': value.length > 50 })}
+          className={classNames({ 'co-node-logs__log-select-option': value.length > 50 })}
         >
           {value}
         </SelectOption>

--- a/frontend/packages/console-app/src/components/pdb/pdb-table-columns.tsx
+++ b/frontend/packages/console-app/src/components/pdb/pdb-table-columns.tsx
@@ -1,5 +1,5 @@
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import i18next from 'i18next';
 import { TableColumn } from '@console/dynamic-plugin-sdk';
 import { Kebab } from '@console/internal/components/utils';

--- a/frontend/packages/console-app/src/components/user-preferences/__tests__/UserPreferencesPage.spec.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/__tests__/UserPreferencesPage.spec.tsx
@@ -13,7 +13,7 @@ import {
 } from './userPreferences.data';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
 }));
 

--- a/frontend/packages/console-app/src/components/user-preferences/language/__tests__/LanguageDropdown.spec.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/language/__tests__/LanguageDropdown.spec.tsx
@@ -6,7 +6,7 @@ import LanguageDropdown from '../LanguageDropdown';
 import { usePreferredLanguage } from '../usePreferredLanguage';
 
 jest.mock('react', () => {
-  const reactActual = require.requireActual('react');
+  const reactActual = jest.requireActual('react');
   return {
     ...reactActual,
     useContext: () => jest.fn(),
@@ -18,7 +18,7 @@ jest.mock('@console/shared/src/hooks/useTelemetry', () => ({
 }));
 
 jest.mock('react-i18next', () => {
-  const reactI18next = require.requireActual('react-i18next');
+  const reactI18next = jest.requireActual('react-i18next');
   return {
     ...reactI18next,
     useTranslation: () => ({

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-class.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-class.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import {
   ListPageBody,

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import {
   ListPageBody,

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import i18next from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom-v5-compat';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/__tests__/AppInitSDK.spec.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/__tests__/AppInitSDK.spec.tsx
@@ -8,7 +8,7 @@ import * as apiDiscovery from '../k8s/api-discovery/api-discovery';
 import * as hooks from '../useReduxStore';
 
 jest.mock('react-redux', () => {
-  const ActualReactRedux = require.requireActual('react-redux');
+  const ActualReactRedux = jest.requireActual('react-redux');
   return {
     ...ActualReactRedux,
     useStore: jest.fn(),

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.tsx
@@ -6,7 +6,7 @@ import {
   ExclamationTriangleIcon,
   InfoCircleIcon,
 } from '@patternfly/react-icons';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 import './icons.scss';
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/utils/resource-status.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/utils/resource-status.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Badge } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import './resource-status.scss';
 
 type ResourceStatusProps = {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResource.spec.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResource.spec.tsx
@@ -17,7 +17,7 @@ jest.mock('../../k8s-resource', () => ({
   k8sGet: jest.fn(),
 }));
 jest.mock('../../k8s-utils', () => ({
-  ...require.requireActual('../../k8s-utils'),
+  ...jest.requireActual('../../k8s-utils'),
   k8sWatch: jest.fn(),
 }));
 const k8sListMock = k8sList as jest.Mock;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResources.spec.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResources.spec.tsx
@@ -17,7 +17,7 @@ jest.mock('../../k8s-resource', () => ({
   k8sGet: jest.fn(),
 }));
 jest.mock('../../k8s-utils', () => ({
-  ...require.requireActual('../../k8s-utils'),
+  ...jest.requireActual('../../k8s-utils'),
   k8sWatch: jest.fn(),
 }));
 const k8sListMock = k8sList as jest.Mock;

--- a/frontend/packages/console-plugin-shared/src/components/OverviewPage/OverviewDetailItem.tsx
+++ b/frontend/packages/console-plugin-shared/src/components/OverviewPage/OverviewDetailItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 import './OverviewDetailItem.scss';
 

--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenuItem.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenuItem.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DropdownItemProps, KeyTypes, MenuItem, Tooltip } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash';
 import { connect } from 'react-redux';
 import { Action, ImpersonateKind, impersonateStateToProps } from '@console/dynamic-plugin-sdk';

--- a/frontend/packages/console-shared/src/components/catalog/__tests__/CatalogController.spec.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/__tests__/CatalogController.spec.tsx
@@ -5,7 +5,7 @@ import * as UseQueryParams from '@console/shared/src/hooks/useQueryParams';
 import CatalogController from '../CatalogController';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useLocation: () => {
     return 'path';
   },

--- a/frontend/packages/console-shared/src/components/dynamic-form/fields.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/fields.tsx
@@ -3,7 +3,7 @@ import { AccordionContent, AccordionItem, AccordionToggle } from '@patternfly/re
 import { FieldProps, UiSchema } from '@rjsf/core';
 import SchemaField, { SchemaFieldProps } from '@rjsf/core/dist/cjs/components/fields/SchemaField';
 import { retrieveSchema, getUiOptions } from '@rjsf/core/dist/cjs/utils';
-import * as classnames from 'classnames';
+import classNames from 'classnames';
 import { JSONSchema7 } from 'json-schema';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -47,7 +47,7 @@ export const FormField: React.FC<FormFieldProps> = ({
   return (
     <div id={`${id}_field`} className="form-group">
       {showLabel && label && (
-        <label className={classnames('form-label', { 'co-required': required })} htmlFor={id}>
+        <label className={classNames('form-label', { 'co-required': required })} htmlFor={id}>
           {label}
         </label>
       )}
@@ -76,7 +76,7 @@ export const FieldSet: React.FC<FieldSetProps> = ({
       <AccordionItem isExpanded={expanded}>
         <AccordionToggle id={`${idSchema.$id}_accordion-toggle`} onClick={onToggle}>
           <label
-            className={classnames({ 'co-required': required })}
+            className={classNames({ 'co-required': required })}
             htmlFor={`${idSchema.$id}_accordion-content`}
           >
             {label}

--- a/frontend/packages/console-shared/src/components/form-utils/FormBody.tsx
+++ b/frontend/packages/console-shared/src/components/form-utils/FormBody.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 type FormBodyProps = {
   children: React.ReactNode;

--- a/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { FormGroup, FormHelperText, HelperText, HelperTextItem } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useField } from 'formik';
 import { RedExclamationCircleIcon } from '../status';
 import { RadioGroupFieldProps } from './field-types';

--- a/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/SelectorCard.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/SelectorCard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Card, CardBody, CardTitle } from '@patternfly/react-core';
 import { StarIcon } from '@patternfly/react-icons/dist/esm/icons/star-icon';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import './SelectorCard.scss';
 
 interface SelectorCardProps {

--- a/frontend/packages/console-shared/src/components/formik-fields/text-column-field/__tests__/TextColumnItem.spec.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/text-column-field/__tests__/TextColumnItem.spec.tsx
@@ -4,7 +4,7 @@ import TextColumnItemContent from '../TextColumnItemContent';
 import TextColumnItemWithDnd from '../TextColumnItemWithDnd';
 
 jest.mock('react-dnd', () => {
-  const reactDnd = require.requireActual('react-dnd');
+  const reactDnd = jest.requireActual('react-dnd');
   return {
     ...reactDnd,
     useDrag: jest.fn(() => [{}, {}]),

--- a/frontend/packages/console-shared/src/components/getting-started/__tests__/RestoreGettingStartedButton.spec.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/__tests__/RestoreGettingStartedButton.spec.tsx
@@ -3,16 +3,16 @@ import { RestoreGettingStartedButton } from '../RestoreGettingStartedButton';
 import { useGettingStartedShowState, GettingStartedShowState } from '../useGettingStartedShowState';
 
 jest.mock('react', () => ({
-  ...require.requireActual('react'),
+  ...jest.requireActual('react'),
   // Set useLayoutEffect to useEffect to solve react warning
   // "useLayoutEffect does nothing on the server, ..." while
   // running this test. useLayoutEffect was used internally by
   // the PatternFly Label for a tooltip.
-  useLayoutEffect: require.requireActual('react').useEffect,
+  useLayoutEffect: jest.requireActual('react').useEffect,
 }));
 
 jest.mock('../useGettingStartedShowState', () => ({
-  ...require.requireActual('../useGettingStartedShowState'),
+  ...jest.requireActual('../useGettingStartedShowState'),
   useGettingStartedShowState: jest.fn(),
 }));
 

--- a/frontend/packages/console-shared/src/components/heading/PrimaryHeading.tsx
+++ b/frontend/packages/console-shared/src/components/heading/PrimaryHeading.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Title } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 const PrimaryHeading: React.FC<PrimaryHeadingProps> = ({
   children,

--- a/frontend/packages/console-shared/src/components/heading/SecondaryHeading.tsx
+++ b/frontend/packages/console-shared/src/components/heading/SecondaryHeading.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Title } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 const SecondaryHeading: React.FC<SecondaryHeadingProps> = ({ children, className, ...props }) => (
   <Title headingLevel="h2" className={classNames('co-section-heading', className)} {...props}>

--- a/frontend/packages/console-shared/src/components/heading/TertiaryHeading.tsx
+++ b/frontend/packages/console-shared/src/components/heading/TertiaryHeading.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Title } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 const TertiaryHeading: React.FC<TertiaryHeadingProps> = ({
   altSpacing,

--- a/frontend/packages/console-shared/src/components/layout/NavTitle.tsx
+++ b/frontend/packages/console-shared/src/components/layout/NavTitle.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PageSection } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 const NavTitle: React.FC<NavTitleProps> = ({
   children,

--- a/frontend/packages/console-shared/src/components/layout/PageBody.tsx
+++ b/frontend/packages/console-shared/src/components/layout/PageBody.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Flex } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 const PageBody: React.FC<PageBodyProps> = ({ children, className, ...props }) => {
   return (

--- a/frontend/packages/console-shared/src/components/layout/PaneBody.tsx
+++ b/frontend/packages/console-shared/src/components/layout/PaneBody.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PageSection } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 const PaneBody: React.FC<PaneBodyProps> = ({
   children,

--- a/frontend/packages/console-shared/src/components/virtualized-grid/Grid.tsx
+++ b/frontend/packages/console-shared/src/components/virtualized-grid/Grid.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { Grid as GridComponent, GridCellProps } from 'react-virtualized';
 import { Item, GridChildrenProps } from './types';
 import { CellMeasurementContext } from './utils';

--- a/frontend/packages/console-shared/src/components/virtualized-grid/GroupByFilterGrid.tsx
+++ b/frontend/packages/console-shared/src/components/virtualized-grid/GroupByFilterGrid.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { Grid as GridComponent, GridCellProps } from 'react-virtualized';
 import { Params, GroupedItems, GridChildrenProps } from './types';
 import { getItemsAndRowCount, CellMeasurementContext } from './utils';

--- a/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
@@ -16,7 +16,7 @@ import {
 } from '../useTelemetry';
 
 jest.mock('@console/dynamic-plugin-sdk', () => ({
-  ...require.requireActual('@console/dynamic-plugin-sdk'),
+  ...jest.requireActual('@console/dynamic-plugin-sdk'),
   useResolvedExtensions: jest.fn(),
 }));
 

--- a/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
@@ -24,7 +24,7 @@ jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
 
 jest.mock('../../utils/user-settings', () => {
   // requireActual exist in used jest 21 and still in latest version, but was not defined well in old TS definition
-  const originalModule = (jest as any).requireActual('../../utils/user-settings');
+  const originalModule = jest.requireActual('../../utils/user-settings');
   return {
     ...originalModule,
     createConfigMap: jest.fn(),
@@ -33,7 +33,7 @@ jest.mock('../../utils/user-settings', () => {
 });
 
 jest.mock('react-redux', () => {
-  const originalModule = (jest as any).requireActual('react-redux');
+  const originalModule = jest.requireActual('react-redux');
   return {
     ...originalModule,
     useSelector: jest.fn(),

--- a/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ChartLabel } from '@patternfly/react-charts/victory';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import i18next, { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import { ImpersonateKind, useSafetyFirst } from '@console/dynamic-plugin-sdk';

--- a/frontend/packages/container-security/src/components/ImageVulnerabilityRow.tsx
+++ b/frontend/packages/container-security/src/components/ImageVulnerabilityRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { RowFunctionArgs, TableData } from '@console/internal/components/factory';
 import { ExternalLink } from '@console/internal/components/utils';
 import { priorityFor } from '../const';

--- a/frontend/packages/container-security/src/components/__tests__/ImageVulnerabilityToggleGroup.spec.tsx
+++ b/frontend/packages/container-security/src/components/__tests__/ImageVulnerabilityToggleGroup.spec.tsx
@@ -9,7 +9,7 @@ import { VulnerabilitiesType } from '../image-vulnerability-utils';
 import ImageVulnerabilityToggleGroup from '../ImageVulnerabilityToggleGroup';
 
 jest.mock('react-i18next', () => {
-  const reactI18next = require.requireActual('react-i18next');
+  const reactI18next = jest.requireActual('react-i18next');
   return {
     ...reactI18next,
     useTranslation: () => ({ t: (key) => key }),

--- a/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
+++ b/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { EmptyState, EmptyStateVariant, Tooltip } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';

--- a/frontend/packages/dev-console/src/components/add/__tests__/AddPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/AddPage.spec.tsx
@@ -5,12 +5,12 @@ import { PageContents as AddPage } from '../AddPage';
 import AddCardsLoader from '../AddPageLayout';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
 }));
 
 jest.mock('@console/shared', () => {
-  const originalModule = (jest as any).requireActual('@console/shared');
+  const originalModule = jest.requireActual('@console/shared');
   return {
     ...originalModule,
     useFlag: jest.fn<boolean>(),

--- a/frontend/packages/dev-console/src/components/add/__tests__/AddPageLayout.spec.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/AddPageLayout.spec.tsx
@@ -9,7 +9,7 @@ import { useShowAddCardItemDetails } from '../hooks/useShowAddCardItemDetails';
 import { addActionExtensions } from './add-page-test-data';
 
 jest.mock('@console/plugin-sdk/src/api/useExtensions', () => {
-  const addActionGroupExtensions = require.requireActual('./add-page-test-data');
+  const addActionGroupExtensions = jest.requireActual('./add-page-test-data');
   return { useExtensions: () => addActionGroupExtensions };
 });
 

--- a/frontend/packages/dev-console/src/components/buildconfig/__tests__/BuildConfigFormPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/buildconfig/__tests__/BuildConfigFormPage.spec.tsx
@@ -27,7 +27,7 @@ jest.mock('@console/shared/src/hooks/useResizeObserver', () => ({
 }));
 
 jest.mock('../sections/EditorField', () =>
-  require.requireActual('@console/shared/src/components/formik-fields/TextAreaField'),
+  jest.requireActual('@console/shared/src/components/formik-fields/TextAreaField'),
 );
 
 jest.mock('@console/shared/src/hooks/useUserSettings', () => ({
@@ -42,7 +42,7 @@ jest.mock(
 );
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
 }));
 

--- a/frontend/packages/dev-console/src/components/buildconfig/sections/__tests__/HooksSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/buildconfig/sections/__tests__/HooksSection.spec.tsx
@@ -7,7 +7,7 @@ import userEvent from '../../__tests__/user-event';
 import HooksSection, { HooksSectionFormData } from '../HooksSection';
 
 jest.mock('../EditorField', () =>
-  require.requireActual('@console/shared/src/components/formik-fields/TextAreaField'),
+  jest.requireActual('@console/shared/src/components/formik-fields/TextAreaField'),
 );
 
 configure({ testIdAttribute: 'data-test' });

--- a/frontend/packages/dev-console/src/components/buildconfig/sections/__tests__/SecretsSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/buildconfig/sections/__tests__/SecretsSection.spec.tsx
@@ -10,7 +10,7 @@ configure({ testIdAttribute: 'data-test' });
 
 // Skip Firehose fetching and render just the children
 jest.mock('@console/internal/components/utils/firehose', () => ({
-  ...require.requireActual('@console/internal/components/utils/firehose'),
+  ...jest.requireActual('@console/internal/components/utils/firehose'),
   Firehose: ({ children }) => children,
 }));
 

--- a/frontend/packages/dev-console/src/components/buildconfig/sections/__tests__/SourceSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/buildconfig/sections/__tests__/SourceSection.spec.tsx
@@ -12,20 +12,20 @@ import SourceSection, { SourceSectionFormData } from '../SourceSection';
 
 // Skip Firehose fetching and render just the children
 jest.mock('@console/internal/components/utils/firehose', () => ({
-  ...require.requireActual('@console/internal/components/utils/firehose'),
+  ...jest.requireActual('@console/internal/components/utils/firehose'),
   Firehose: ({ children }) => children,
 }));
 
 // Skip network calls to any external git service
 jest.mock('@console/git-service', () => ({
-  ...require.requireActual('@console/git-service'),
+  ...jest.requireActual('@console/git-service'),
   getGitService: function mockedGetGitService() {
     return null;
   },
 }));
 
 jest.mock('../EditorField', () =>
-  require.requireActual('@console/shared/src/components/formik-fields/TextAreaField'),
+  jest.requireActual('@console/shared/src/components/formik-fields/TextAreaField'),
 );
 
 const spyUseAccessReview = jest.spyOn(rbacModule, 'useAccessReview');

--- a/frontend/packages/dev-console/src/components/import/__tests__/DeployImage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/__tests__/DeployImage.spec.tsx
@@ -17,7 +17,7 @@ import ImageSearchSection from '../image-search/ImageSearchSection';
 import { DeploySection } from '../section/deploy-section/DeploySection';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
 }));

--- a/frontend/packages/dev-console/src/components/import/devfile/__tests__/devfile-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/devfile/__tests__/devfile-utils.spec.ts
@@ -286,7 +286,7 @@ const git = {
 };
 
 jest.mock('@console/git-service', () => ({
-  ...require.requireActual('@console/git-service'),
+  ...jest.requireActual('@console/git-service'),
   getGitService: function mockedGetGitService() {
     return {
       getFileContent: (path: string) =>
@@ -300,7 +300,7 @@ jest.mock('@console/git-service', () => ({
 }));
 
 jest.mock('@console/internal/co-fetch', () => ({
-  ...require.requireActual('@console/internal/co-fetch'),
+  ...jest.requireActual('@console/internal/co-fetch'),
   coFetch: function mockedCoFetch() {
     return Promise.resolve({
       text: () => mockExternalDeploymentYaml,

--- a/frontend/packages/dev-console/src/components/import/jar/__tests__/UploadJarPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/jar/__tests__/UploadJarPage.spec.tsx
@@ -11,7 +11,7 @@ jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
 }));

--- a/frontend/packages/dev-console/src/components/monitoring/__tests__/MonitoringPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/__tests__/MonitoringPage.spec.tsx
@@ -6,7 +6,7 @@ import CreateProjectListPage from '../../projects/CreateProjectListPage';
 import { PageContents } from '../MonitoringPage';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
 }));
 

--- a/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringTab.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringTab.spec.tsx
@@ -4,7 +4,7 @@ import MonitoringOverview from '../MonitoringOverview';
 import MonitoringTab from '../MonitoringTab';
 
 jest.mock('@console/shared', () => {
-  const ActualShared = require.requireActual('@console/shared');
+  const ActualShared = jest.requireActual('@console/shared');
   return {
     ...ActualShared,
     usePodsWatcher: () => {

--- a/frontend/packages/dev-console/src/components/project-access/__tests__/ProjectAccessPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/__tests__/ProjectAccessPage.spec.tsx
@@ -13,7 +13,7 @@ jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
 }));

--- a/frontend/packages/dev-console/src/components/projects/details/__tests__/ProjectDetailsPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/__tests__/ProjectDetailsPage.spec.tsx
@@ -10,7 +10,7 @@ import { ProjectDetailsPage, PageContents } from '../ProjectDetailsPage';
 let spyUseAccessReview;
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
 }));
 

--- a/frontend/packages/dev-console/src/utils/__tests__/usePerspectiveDetection.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/usePerspectiveDetection.spec.ts
@@ -3,7 +3,7 @@ import { testHook } from '../../../../../__tests__/utils/hooks-utils';
 import { usePerspectiveDetection } from '../perspective';
 
 jest.mock('react-redux', () => ({
-  ...(jest as any).requireActual('react-redux'),
+  ...jest.requireActual('react-redux'),
   useSelector: jest.fn(),
 }));
 

--- a/frontend/packages/gitops-plugin/src/components/history/GitOpsDeploymentHistoryTableColumnClasses.tsx
+++ b/frontend/packages/gitops-plugin/src/components/history/GitOpsDeploymentHistoryTableColumnClasses.tsx
@@ -1,4 +1,4 @@
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 export const GitOpsDeploymentHistoryTableColumnClasses = [
   classNames('pf-m-width-30'),

--- a/frontend/packages/gitops-plugin/src/components/history/GitOpsDeploymentHistoryTableRow.tsx
+++ b/frontend/packages/gitops-plugin/src/components/history/GitOpsDeploymentHistoryTableRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { RowFunctionArgs, TableData } from '@console/internal/components/factory';
 import { Timestamp } from '@console/internal/components/utils';
 import { GitOpsHistoryData } from '../utils/gitops-types';

--- a/frontend/packages/gitops-plugin/src/components/list/GitOpsTableHeader.tsx
+++ b/frontend/packages/gitops-plugin/src/components/list/GitOpsTableHeader.tsx
@@ -1,5 +1,5 @@
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import i18n from '@console/internal/i18n';
 
 const tableColumnClasses = [

--- a/frontend/packages/gitops-plugin/src/components/list/GitOpsTableRow.tsx
+++ b/frontend/packages/gitops-plugin/src/components/list/GitOpsTableRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Flex, FlexItem, Split, SplitItem } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
 import { routeDecoratorIcon } from '@console/dev-console/src/components/import/render-utils';

--- a/frontend/packages/helm-plugin/src/components/details-page/__tests__/HelmReleaseDetails.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/__tests__/HelmReleaseDetails.spec.tsx
@@ -14,7 +14,7 @@ let helmReleaseDetailsProps: React.ComponentProps<typeof HelmReleaseDetails>;
 let loadedHelmReleaseDetailsProps: React.ComponentProps<typeof LoadedHelmReleaseDetails>;
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
 }));

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmChartRepositoryRow.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmChartRepositoryRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { LazyActionMenu } from '@console/dynamic-plugin-sdk/src/lib-internal';
 import { RowFunctionArgs, TableData } from '@console/internal/components/factory';

--- a/frontend/packages/helm-plugin/src/components/list-page/ProjectHelmChartRepositoryRow.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/ProjectHelmChartRepositoryRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { LazyActionMenu } from '@console/dynamic-plugin-sdk/src/lib-internal';
 import { RowFunctionArgs, TableData } from '@console/internal/components/factory';

--- a/frontend/packages/helm-plugin/src/components/list-page/RepositoriesHeader.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/RepositoriesHeader.tsx
@@ -1,5 +1,5 @@
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { TFunction } from 'i18next';
 import { Kebab } from '@console/internal/components/utils';
 

--- a/frontend/packages/helm-plugin/src/components/list-page/RepositoriesRow.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/RepositoriesRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { LazyActionMenu } from '@console/dynamic-plugin-sdk/src/lib-internal';
 import { RowFunctionArgs, TableData } from '@console/internal/components/factory';

--- a/frontend/packages/helm-plugin/src/topology/components/HelmRelease.tsx
+++ b/frontend/packages/helm-plugin/src/topology/components/HelmRelease.tsx
@@ -7,7 +7,7 @@ import {
   WithContextMenuProps,
   WithDragNodeProps,
 } from '@patternfly/react-topology';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useAccessReview } from '@console/internal/components/utils';
 import { modelFor, referenceFor } from '@console/internal/module/k8s';
 import GroupNode from '@console/topology/src/components/graph-view/components/groups/GroupNode';

--- a/frontend/packages/helm-plugin/src/topology/components/HelmReleaseGroup.tsx
+++ b/frontend/packages/helm-plugin/src/topology/components/HelmReleaseGroup.tsx
@@ -13,7 +13,7 @@ import {
   useCombineRefs,
   NodeLabel,
 } from '@patternfly/react-topology';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import {
   NodeShadows,

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSink.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSink.spec.tsx
@@ -12,7 +12,7 @@ import EventSink from '../EventSink';
 const useSelectorMock = useSelector as jest.Mock;
 
 jest.mock('react-redux', () => {
-  const originalModule = require.requireActual('react-redux');
+  const originalModule = jest.requireActual('react-redux');
   return {
     ...originalModule,
     useSelector: jest.fn(),

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSinkPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSinkPage.spec.tsx
@@ -17,7 +17,7 @@ jest.mock('../../../hooks/useEventSinkStatus', () => ({
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
 }));

--- a/frontend/packages/knative-plugin/src/components/eventing/__tests__/EventingListPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/eventing/__tests__/EventingListPage.spec.tsx
@@ -5,7 +5,7 @@ import { MultiTabListPage } from '@console/shared';
 import EventingListPage from '../EventingListPage';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
 }));
 

--- a/frontend/packages/knative-plugin/src/components/knatify/__tests__/CreateKnatifyPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/knatify/__tests__/CreateKnatifyPage.spec.tsx
@@ -19,7 +19,7 @@ jest.mock('@console/shared/src/hooks/hpa-hooks', () => ({
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
 }));

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSourceResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSourceResources.spec.tsx
@@ -14,7 +14,7 @@ import { getEventSourceResponse } from '../../../topology/__tests__/topology-kna
 import { EventSourceTarget } from '../EventSourceResources';
 
 jest.mock('@console/shared', () => {
-  const ActualShared = require.requireActual('@console/shared');
+  const ActualShared = jest.requireActual('@console/shared');
   return {
     ...ActualShared,
     usePodsWatcher: jest.fn(),

--- a/frontend/packages/knative-plugin/src/components/overview/serving-list/__tests__/ServingListPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/serving-list/__tests__/ServingListPage.spec.tsx
@@ -7,7 +7,7 @@ import ServingListPage from '../ServingListsPage';
 let wrapper: ShallowWrapper;
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
 }));
 

--- a/frontend/packages/knative-plugin/src/components/services/service-table.ts
+++ b/frontend/packages/knative-plugin/src/components/services/service-table.ts
@@ -1,4 +1,4 @@
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { Kebab } from '@console/internal/components/utils';
 
 export const tableColumnClasses = [

--- a/frontend/packages/knative-plugin/src/topology/sidebar/__tests__/KnativeOverviewSections.spec.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/__tests__/KnativeOverviewSections.spec.tsx
@@ -16,7 +16,7 @@ import {
 } from '../KnativeOverviewSections';
 
 jest.mock('@console/shared', () => {
-  const ActualShared = require.requireActual('@console/shared');
+  const ActualShared = jest.requireActual('@console/shared');
   return {
     ...ActualShared,
     usePodScalingAccessStatus: jest.fn(),

--- a/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.spec.tsx
@@ -28,7 +28,7 @@ jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
 }));

--- a/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useParams, useLocation } from 'react-router-dom-v5-compat';

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
@@ -66,7 +66,7 @@ jest.mock('@console/shared/src/hooks/redux-selectors', () => {
 });
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
 }));

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -11,7 +11,7 @@ import {
 import { AddCircleOIcon } from '@patternfly/react-icons/dist/esm/icons/add-circle-o-icon';
 import { PencilAltIcon } from '@patternfly/react-icons/dist/esm/icons/pencil-alt-icon';
 import { sortable, wrappable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams, useLocation, Link } from 'react-router-dom-v5-compat';

--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.spec.tsx
@@ -43,7 +43,7 @@ import Spy = jasmine.Spy;
 const i18nNS = 'public';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
 }));
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Alert, Button, Hint, HintTitle, HintBody, HintFooter } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { Map as ImmutableMap, Set as ImmutableSet, fromJS } from 'immutable';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.spec.tsx
@@ -24,7 +24,7 @@ jest.mock('@console/shared/src/hooks/useOperands', () => ({
 }));
 
 jest.mock('react-i18next', () => {
-  const reactI18next = require.requireActual('react-i18next');
+  const reactI18next = jest.requireActual('react-i18next');
   return {
     ...reactI18next,
     Trans: () => null,

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/DEPRECATED_operand-form.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/DEPRECATED_operand-form.tsx
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as Immutable from 'immutable';
 import { JSONSchema6, JSONSchema6TypeName } from 'json-schema';
 import * as _ from 'lodash';

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.spec.tsx
@@ -30,7 +30,7 @@ jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
 }));
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -49,7 +49,7 @@ import {
 } from '.';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
 }));
@@ -110,12 +110,12 @@ jest.mock('@console/shared/src/hooks/useK8sModel', () => {
 });
 
 jest.mock('react-redux', () => ({
-  ...(jest as any).requireActual('react-redux'),
+  ...jest.requireActual('react-redux'),
   useDispatch: () => jest.fn(),
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
 }));

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { JSONSchema7 } from 'json-schema';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-link.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-link.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { Link } from 'react-router-dom-v5-compat';
 import { ResourceIcon } from '@console/internal/components/utils';
 import { referenceForModel, K8sResourceKind, referenceFor } from '@console/internal/module/k8s';

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -11,7 +11,7 @@ import {
   HintFooter,
 } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -8,7 +8,7 @@ import {
   EmptyStateFooter,
   Truncate,
 } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';

--- a/frontend/packages/operator-lifecycle-manager/src/components/package-manifest.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/package-manifest.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams, Link } from 'react-router-dom-v5-compat';

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.spec.tsx
@@ -40,7 +40,7 @@ import {
 } from './subscription';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
 }));
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -4,7 +4,7 @@ import { Alert, Button, Popover } from '@patternfly/react-core';
 import { InProgressIcon } from '@patternfly/react-icons/dist/esm/icons/in-progress-icon';
 import { PencilAltIcon } from '@patternfly/react-icons/dist/esm/icons/pencil-alt-icon';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router-dom-v5-compat';

--- a/frontend/packages/patternfly/src/components/notification-drawer/notification-category.tsx
+++ b/frontend/packages/patternfly/src/components/notification-drawer/notification-category.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { Badge } from '@patternfly/react-core';
 import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
 

--- a/frontend/packages/patternfly/src/components/notification-drawer/notification-entry.tsx
+++ b/frontend/packages/patternfly/src/components/notification-drawer/notification-entry.tsx
@@ -1,4 +1,4 @@
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import {

--- a/frontend/packages/pipelines-plugin/src/components/ListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/ListPage.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
 import { Button, TextInput, TextInputProps } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 // eslint-disable-next-line no-restricted-imports
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';

--- a/frontend/packages/pipelines-plugin/src/components/pac/__tests__/PacPage.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pac/__tests__/PacPage.spec.tsx
@@ -15,7 +15,7 @@ import PacPage from '../PacPage';
 var mockNavigate = jest.fn();
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useLocation: jest.fn(),
   useParams: jest.fn(),
   useNavigate: () => mockNavigate,

--- a/frontend/packages/pipelines-plugin/src/components/pac/hooks/__tests__/usePacGHManifest.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pac/hooks/__tests__/usePacGHManifest.spec.ts
@@ -7,7 +7,7 @@ import { usePacGHManifest } from '../usePacGHManifest';
 const k8sListMock = k8sListResourceItems as jest.Mock;
 
 jest.mock('@console/dynamic-plugin-sdk/src/utils/k8s', () => {
-  const originalModule = (jest as any).requireActual('@console/dynamic-plugin-sdk/src/utils/k8s');
+  const originalModule = jest.requireActual('@console/dynamic-plugin-sdk/src/utils/k8s');
   return {
     ...originalModule,
     k8sListResourceItems: jest.fn(),

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/events/__tests__/PipelineRunEvents.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/events/__tests__/PipelineRunEvents.spec.tsx
@@ -18,7 +18,7 @@ const spyUsePipelineRunRelatedResources = jest.spyOn(utils, 'usePipelineRunRelat
 type PipelineRunEventsProps = React.ComponentProps<typeof PipelineRunEvents>;
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
 }));
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/__tests__/PipelineTabbedPage.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/__tests__/PipelineTabbedPage.spec.tsx
@@ -9,14 +9,14 @@ import PipelinesList from '../list-page/PipelinesList';
 import PipelineTabbedPage, { PageContents } from '../PipelineTabbedPage';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
   useNavigate: jest.fn(),
 }));
 
 jest.mock('@console/shared', () => {
-  const originalModule = (jest as any).requireActual('@console/shared');
+  const originalModule = jest.requireActual('@console/shared');
   return {
     ...originalModule,
     useFlag: jest.fn<boolean>(),

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/__tests__/PipelinesPage.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/__tests__/PipelinesPage.spec.tsx
@@ -5,7 +5,7 @@ import { PipelinesPage } from '../PipelinesPage';
 import PipelinesResourceList from '../PipelinesResourceList';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
 }));

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/__tests__/pipelineDetailsPage.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/__tests__/pipelineDetailsPage.spec.tsx
@@ -45,12 +45,12 @@ jest.mock('@console/dynamic-plugin-sdk/src/perspective/useActivePerspective', ()
 }));
 
 jest.mock('@console/internal/components/utils/firehose', () => ({
-  ...require.requireActual('@console/internal/components/utils/firehose'),
+  ...jest.requireActual('@console/internal/components/utils/firehose'),
   Firehose: ({ children }) => children,
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useLocation: jest.fn(),
   useParams: jest.fn(),
 }));

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/PipelineBuilderPage.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/PipelineBuilderPage.spec.tsx
@@ -9,7 +9,7 @@ type PipelineBuilderPageProps = React.ComponentProps<typeof PipelineBuilderPage>
 type BuilderProps = React.ComponentProps<typeof Formik>;
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
 }));
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineOverview.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineOverview.spec.tsx
@@ -7,7 +7,7 @@ import PipelineStartButton from './PipelineStartButton';
 import TriggerLastRunButton from './TriggerLastRunButton';
 
 jest.mock('@console/internal/module/k8s/k8s-models', () => {
-  const dependency = require.requireActual('@console/internal/module/k8s/k8s-models');
+  const dependency = jest.requireActual('@console/internal/module/k8s/k8s-models');
   return {
     ...dependency,
     modelFor: () => ({}),

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/DynamicResourceLinkList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/DynamicResourceLinkList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import PipelineResourceRef from '../../shared/common/PipelineResourceRef';
 
 import './DynamicResourceLinkList.scss';

--- a/frontend/packages/service-binding-plugin/src/components/service-binding-details/__tests__/ServiceBindingDetailsPage.spec.tsx
+++ b/frontend/packages/service-binding-plugin/src/components/service-binding-details/__tests__/ServiceBindingDetailsPage.spec.tsx
@@ -15,47 +15,47 @@ import { ServiceBindingModel } from '../../../models';
 import ServiceBindingDetailsPage from '../ServiceBindingDetailsPage';
 
 jest.mock('@console/plugin-sdk', () => ({
-  ...require.requireActual('@console/plugin-sdk'),
+  ...jest.requireActual('@console/plugin-sdk'),
   useExtensions: () => [],
   useResolvedExtensions: () => [[]],
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   Link: 'Link',
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
   useRoutes: jest.fn(),
 }));
 
 jest.mock('@console/shared/src/components/error/error-boundary', () => ({
-  ...require.requireActual('@console/shared/src/components/error/error-boundary'),
+  ...jest.requireActual('@console/shared/src/components/error/error-boundary'),
   withFallback: (children) => children,
 }));
 
 jest.mock('@console/shared/src/hooks/useK8sModel', () => ({
-  ...require.requireActual('@console/shared/src/hooks/useK8sModel'),
+  ...jest.requireActual('@console/shared/src/hooks/useK8sModel'),
   useK8sModel: jest.fn(),
 }));
 
 jest.mock('@console/internal/module/k8s/k8s-models', () => ({
-  ...require.requireActual('@console/internal/module/k8s/k8s-models'),
+  ...jest.requireActual('@console/internal/module/k8s/k8s-models'),
   modelFor: jest.fn(),
 }));
 
 jest.mock('@console/internal/module/k8s', () => ({
-  ...require.requireActual('@console/internal/module/k8s'),
+  ...jest.requireActual('@console/internal/module/k8s'),
   useModelFinder: jest.fn(() => ({
     findModel: jest.fn(),
   })),
 }));
 
 jest.mock('@console/internal/components/utils/rbac', () => ({
-  ...require.requireActual('@console/internal/components/utils/rbac'),
+  ...jest.requireActual('@console/internal/components/utils/rbac'),
   useAccessReview: () => true,
 }));
 
@@ -64,12 +64,12 @@ jest.mock('@console/internal/components/utils/timestamp', () => ({
 }));
 
 jest.mock('@console/internal/components/utils/firehose', () => ({
-  ...require.requireActual('@console/internal/components/utils/firehose'),
+  ...jest.requireActual('@console/internal/components/utils/firehose'),
   Firehose: jest.fn(),
 }));
 
 jest.mock('@console/shared/src/components/actions', () => ({
-  ...require.requireActual('@console/shared/src/components/actions'),
+  ...jest.requireActual('@console/shared/src/components/actions'),
   ActionServiceProvider: () => null,
 }));
 

--- a/frontend/packages/service-binding-plugin/src/components/service-binding-details/__tests__/ServiceBindingDetailsTab.spec.tsx
+++ b/frontend/packages/service-binding-plugin/src/components/service-binding-details/__tests__/ServiceBindingDetailsTab.spec.tsx
@@ -13,24 +13,24 @@ import { ServiceBindingModel } from '../../../models';
 import ServiceBindingDetailsTab from '../ServiceBindingDetailsTab';
 
 jest.mock('@console/shared/src/hooks/useK8sModel', () => ({
-  ...require.requireActual('@console/shared/src/hooks/useK8sModel'),
+  ...jest.requireActual('@console/shared/src/hooks/useK8sModel'),
   useK8sModel: () => [],
 }));
 
 jest.mock('@console/internal/module/k8s/k8s-models', () => ({
-  ...require.requireActual('@console/internal/module/k8s/k8s-models'),
+  ...jest.requireActual('@console/internal/module/k8s/k8s-models'),
   modelFor: jest.fn(),
 }));
 
 jest.mock('@console/internal/module/k8s', () => ({
-  ...require.requireActual('@console/internal/module/k8s'),
+  ...jest.requireActual('@console/internal/module/k8s'),
   useModelFinder: jest.fn(() => ({
     findModel: jest.fn(),
   })),
 }));
 
 jest.mock('@console/internal/components/utils/rbac', () => ({
-  ...require.requireActual('@console/internal/components/utils/rbac'),
+  ...jest.requireActual('@console/internal/components/utils/rbac'),
   useAccessReview: () => true,
 }));
 

--- a/frontend/packages/service-binding-plugin/src/components/service-binding-list/__tests__/ServiceBindingListPage.spec.tsx
+++ b/frontend/packages/service-binding-plugin/src/components/service-binding-list/__tests__/ServiceBindingListPage.spec.tsx
@@ -6,7 +6,7 @@ import { connectedServiceBinding, failedServiceBinding } from '../../../__tests_
 import ServiceBindingListPage from '../ServiceBindingListPage';
 
 jest.mock('@console/internal/components/factory', () => ({
-  ...require.requireActual('@console/internal/components/factory'),
+  ...jest.requireActual('@console/internal/components/factory'),
   ListPage: jest.fn(),
 }));
 

--- a/frontend/packages/service-binding-plugin/src/components/service-binding-list/__tests__/ServiceBindingTable.spec.tsx
+++ b/frontend/packages/service-binding-plugin/src/components/service-binding-list/__tests__/ServiceBindingTable.spec.tsx
@@ -10,7 +10,7 @@ import { ServiceBindingModel } from '../../../models';
 import { ServiceBindingHeader, ServiceBindingRow } from '../ServiceBindingTable';
 
 jest.mock('@console/internal/module/k8s/k8s-models', () => ({
-  ...require.requireActual('@console/internal/module/k8s/k8s-models'),
+  ...jest.requireActual('@console/internal/module/k8s/k8s-models'),
   modelFor: jest.fn(),
 }));
 

--- a/frontend/packages/topology/src/__tests__/DataModelProvider.spec.tsx
+++ b/frontend/packages/topology/src/__tests__/DataModelProvider.spec.tsx
@@ -11,7 +11,7 @@ jest.mock('@console/plugin-sdk/src/api/useExtensions', () => ({
   useExtensions: () => [],
 }));
 jest.mock('@console/shared', () => {
-  const ActualShared = require.requireActual('@console/shared');
+  const ActualShared = jest.requireActual('@console/shared');
   return {
     ...ActualShared,
     useQueryParams: () => new Map(),

--- a/frontend/packages/topology/src/__tests__/TopologyPage.spec.tsx
+++ b/frontend/packages/topology/src/__tests__/TopologyPage.spec.tsx
@@ -12,7 +12,7 @@ jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
 }));
 
 jest.mock('react', () => {
-  const ActualReact = require.requireActual('react');
+  const ActualReact = jest.requireActual('react');
   return {
     ...ActualReact,
     useContext: () => jest.fn(),
@@ -20,7 +20,7 @@ jest.mock('react', () => {
 });
 
 jest.mock('react-redux', () => {
-  const ActualReactRedux = require.requireActual('react-redux');
+  const ActualReactRedux = jest.requireActual('react-redux');
   return {
     ...ActualReactRedux,
     useSelector: jest.fn(),
@@ -31,7 +31,7 @@ jest.mock('react-redux', () => {
 let mockViewParam = '';
 
 jest.mock('@console/shared', () => {
-  const ActualShared = require.requireActual('@console/shared');
+  const ActualShared = jest.requireActual('@console/shared');
   return {
     ...ActualShared,
     useQueryParams: jest.fn(),
@@ -44,7 +44,7 @@ jest.mock('../user-preferences/usePreferredTopologyView', () => ({
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...require.requireActual('react-router-dom-v5-compat'),
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
 }));
 

--- a/frontend/packages/topology/src/__tests__/TopologyPageToolbar.spec.tsx
+++ b/frontend/packages/topology/src/__tests__/TopologyPageToolbar.spec.tsx
@@ -6,7 +6,7 @@ import TopologyPageToolbar from '../components/page/TopologyPageToolbar';
 import { TopologyViewType } from '../topology-types';
 
 jest.mock('react', () => {
-  const ActualReact = require.requireActual('react');
+  const ActualReact = jest.requireActual('react');
   return {
     ...ActualReact,
     useContext: () => jest.fn(),
@@ -14,7 +14,7 @@ jest.mock('react', () => {
 });
 
 jest.mock('react-redux', () => {
-  const ActualReactRedux = require.requireActual('react-redux');
+  const ActualReactRedux = jest.requireActual('react-redux');
   return {
     ...ActualReactRedux,
     useSelector: jest.fn(),
@@ -23,7 +23,7 @@ jest.mock('react-redux', () => {
 });
 
 jest.mock('@console/shared', () => {
-  const ActualShared = require.requireActual('@console/shared');
+  const ActualShared = jest.requireActual('@console/shared');
   return {
     ...ActualShared,
     useQueryParams: () => new Map(),

--- a/frontend/packages/topology/src/components/graph-view/components/GraphComponent.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/GraphComponent.tsx
@@ -3,7 +3,7 @@ import {
   GraphComponent as BaseGraphComponent,
   WithContextMenuProps,
 } from '@patternfly/react-topology';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 type GraphComponentProps = React.ComponentProps<typeof BaseGraphComponent> & {
   dragInProgress?: boolean;

--- a/frontend/packages/topology/src/components/graph-view/components/edges/BaseEdge.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/edges/BaseEdge.tsx
@@ -12,7 +12,7 @@ import {
   NodeStatus,
   GraphElement,
 } from '@patternfly/react-topology';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useAccessReviewAllowed } from '@console/dynamic-plugin-sdk';
 import { referenceFor, modelFor } from '@console/internal/module/k8s';
 import { getResource } from '../../../../utils/topology-utils';

--- a/frontend/packages/topology/src/components/graph-view/components/groups/GroupNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/groups/GroupNode.tsx
@@ -13,7 +13,7 @@ import {
   WithContextMenuProps,
   useAnchor,
 } from '@patternfly/react-topology';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import {
   truncateMiddle,
   shouldTruncate,

--- a/frontend/packages/topology/src/components/list-view/TopologyListViewAppGroup.tsx
+++ b/frontend/packages/topology/src/components/list-view/TopologyListViewAppGroup.tsx
@@ -7,7 +7,7 @@ import {
   DataListItemRow,
 } from '@patternfly/react-core';
 import { Node, observer } from '@patternfly/react-topology';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { ResourceIcon } from '@console/internal/components/utils';
 import { showKind, useDisplayFilters, useSearchFilter } from '../../filters';
 import { ApplicationModel } from '../../models';

--- a/frontend/packages/topology/src/components/list-view/TopologyListViewNode.tsx
+++ b/frontend/packages/topology/src/components/list-view/TopologyListViewNode.tsx
@@ -11,7 +11,7 @@ import {
   TooltipPosition,
 } from '@patternfly/react-core';
 import { observer } from '@patternfly/react-topology';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { TopologyListViewNodeProps } from '@console/dynamic-plugin-sdk/src/extensions/topology-types';

--- a/frontend/packages/topology/src/components/page/TopologyView.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyView.tsx
@@ -7,7 +7,7 @@ import {
   TopologyQuadrant,
   Visualization,
 } from '@patternfly/react-topology';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { ConnectDropTarget, DropTargetMonitor } from 'react-dnd';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';

--- a/frontend/packages/topology/src/filters/__tests__/useSearchFilter.spec.ts
+++ b/frontend/packages/topology/src/filters/__tests__/useSearchFilter.spec.ts
@@ -9,7 +9,7 @@ let mockCurrentSearchQuery = '';
 let mockLabelsQuery = '';
 
 jest.mock('@console/shared', () => {
-  const ActualShared = require.requireActual('@console/shared');
+  const ActualShared = jest.requireActual('@console/shared');
   return {
     ...ActualShared,
     useQueryParams: () =>

--- a/frontend/packages/topology/src/operators/components/OperatorBackedService.tsx
+++ b/frontend/packages/topology/src/operators/components/OperatorBackedService.tsx
@@ -12,7 +12,7 @@ import {
   useDndDrop,
   WithContextMenuProps,
 } from '@patternfly/react-topology';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { useAccessReview } from '@console/internal/components/utils';
 import { modelFor, referenceFor } from '@console/internal/module/k8s';

--- a/frontend/packages/topology/src/operators/components/OperatorBackedServiceGroup.tsx
+++ b/frontend/packages/topology/src/operators/components/OperatorBackedServiceGroup.tsx
@@ -16,7 +16,7 @@ import {
   WithContextMenuProps,
   NodeLabel,
 } from '@patternfly/react-topology';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import {
   noRegroupDragSourceSpec,

--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/CloudShellMastheadButton.tsx
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/CloudShellMastheadButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import { TerminalIcon } from '@patternfly/react-icons/dist/esm/icons/terminal-icon';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { RootState } from '@console/internal/redux';

--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/__tests__/CloudShellExec.spec.tsx
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/__tests__/CloudShellExec.spec.tsx
@@ -5,7 +5,7 @@ import { InternalCloudShellExec, CloudShellExecProps } from '../CloudShellExec';
 import TerminalLoadingBox from '../TerminalLoadingBox';
 
 jest.mock('@console/shared', () => {
-  const originalModule = (jest as any).requireActual('@console/shared');
+  const originalModule = jest.requireActual('@console/shared');
   return {
     ...originalModule,
     useTelemetry: () => {},

--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/__tests__/CloudShellTerminal.spec.tsx
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/__tests__/CloudShellTerminal.spec.tsx
@@ -27,7 +27,7 @@ jest.mock('@console/shared/src/hooks/useUserSettingsCompatibility', () => {
 });
 
 jest.mock('@console/shared', () => {
-  const originalModule = (jest as any).requireActual('@console/shared');
+  const originalModule = jest.requireActual('@console/shared');
   return {
     ...originalModule,
     useFlag: jest.fn<boolean>(),

--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/__tests__/useCloudShellAvailable.spec.ts
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/__tests__/useCloudShellAvailable.spec.ts
@@ -16,7 +16,7 @@ jest.mock('../cloud-shell-utils', () => {
 });
 
 jest.mock('@console/shared/src/hooks/flag', () => {
-  const originalModule = (jest as any).requireActual('@console/shared/src/hooks/flag');
+  const originalModule = jest.requireActual('@console/shared/src/hooks/flag');
   return {
     ...originalModule,
     useFlag: jest.fn<boolean>(),

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
 import { connect } from 'react-redux';
 import { useParams, useLocation, useNavigate } from 'react-router-dom-v5-compat';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { ActionGroup, Button } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import { ListPageBody } from '@console/dynamic-plugin-sdk';

--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as fuzzy from 'fuzzysearch';
 import { useLocation, useParams } from 'react-router-dom-v5-compat';
 import { RoleModel, RoleBindingModel, ClusterRoleBindingModel } from '../../models';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation, withTranslation } from 'react-i18next';
 import i18next from 'i18next';
 import { sortable } from '@patternfly/react-table';

--- a/frontend/public/components/autocomplete.tsx
+++ b/frontend/public/components/autocomplete.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useDocumentListener, getLabelsAsString } from '@console/shared';
 import { KeyEventModes } from '@console/shared/src/hooks';
 import { fuzzyCaseInsensitive } from './factory/table-filters';

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, redirect } from 'react-router-dom-v5-compat';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';
 import {

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Link, redirect } from 'react-router-dom-v5-compat';
 import { Trans, useTranslation } from 'react-i18next';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import {
   Alert,

--- a/frontend/public/components/catalog/catalog-item-icon.tsx
+++ b/frontend/public/components/catalog/catalog-item-icon.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 import { TemplateKind, PartialObjectMetadata } from '../../module/k8s';
 import aerogearImg from '../../imgs/logos/aerogear.svg';

--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { sortable } from '@patternfly/react-table';
 import { Alert } from '@patternfly/react-core';

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as semver from 'semver';
 import {
   Alert,

--- a/frontend/public/components/cluster-settings/related-objects.tsx
+++ b/frontend/public/components/cluster-settings/related-objects.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';

--- a/frontend/public/components/configmap.jsx
+++ b/frontend/public/components/configmap.jsx
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';

--- a/frontend/public/components/cron-job.tsx
+++ b/frontend/public/components/cron-job.tsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';

--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import {
   sortable,
   SortByDirection,

--- a/frontend/public/components/daemon-set.tsx
+++ b/frontend/public/components/daemon-set.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-getting-started-card.spec.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-getting-started-card.spec.tsx
@@ -7,8 +7,8 @@ import { useIdentityProviderLink } from '../cluster-setup-identity-provider-link
 import { useAlertReceiverLink } from '../cluster-setup-alert-receiver-link';
 
 jest.mock('react', () => ({
-  ...require.requireActual('react'),
-  useLayoutEffect: require.requireActual('react').useEffect,
+  ...jest.requireActual('react'),
+  useLayoutEffect: jest.requireActual('react').useEffect,
 }));
 
 jest.mock('@console/shared/src/hooks/useCanClusterUpgrade', () => ({

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/explore-admin-features-getting-started-card.spec.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/explore-admin-features-getting-started-card.spec.tsx
@@ -4,12 +4,12 @@ import { GettingStartedCard } from '@console/shared/src/components/getting-start
 import { ExploreAdminFeaturesGettingStartedCard } from '../explore-admin-features-getting-started-card';
 
 jest.mock('react', () => ({
-  ...require.requireActual('react'),
-  useLayoutEffect: require.requireActual('react').useEffect,
+  ...jest.requireActual('react'),
+  useLayoutEffect: jest.requireActual('react').useEffect,
 }));
 
 jest.mock('@console/shared/src', () => ({
-  ...require.requireActual('@console/shared/src'),
+  ...jest.requireActual('@console/shared/src'),
   useOpenShiftVersion: () => '4.16.0',
 }));
 

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/getting-started-section.spec.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/getting-started-section.spec.tsx
@@ -12,12 +12,12 @@ import { GettingStartedSection } from '../getting-started-section';
 import { CLUSTER_DASHBOARD_USER_SETTINGS_KEY } from '../constants';
 
 jest.mock('@console/shared/src/hooks/flag', () => ({
-  ...require.requireActual('@console/shared/src/hooks/flag'),
+  ...jest.requireActual('@console/shared/src/hooks/flag'),
   useFlag: jest.fn(),
 }));
 
 jest.mock('@console/shared/src/components/getting-started', () => ({
-  ...require.requireActual('@console/shared/src/components/getting-started'),
+  ...jest.requireActual('@console/shared/src/components/getting-started'),
   useGettingStartedShowState: jest.fn(),
 }));
 

--- a/frontend/public/components/dashboard/project-dashboard/getting-started/__tests__/DeveloperFeaturesGettingStartedCard.spec.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/getting-started/__tests__/DeveloperFeaturesGettingStartedCard.spec.tsx
@@ -4,7 +4,7 @@ import { GettingStartedCard } from '@console/shared/src/components/getting-start
 import { DeveloperFeaturesGettingStartedCard } from '../DeveloperFeaturesGettingStartedCard';
 
 jest.mock('@console/shared/src', () => ({
-  ...require.requireActual('@console/shared/src'),
+  ...jest.requireActual('@console/shared/src'),
   useActiveNamespace: jest.fn(),
   useOpenShiftVersion: () => '4.8.0',
   useFlag: jest.fn<boolean>(),

--- a/frontend/public/components/dashboard/project-dashboard/getting-started/__tests__/GettingStartedSection.spec.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/getting-started/__tests__/GettingStartedSection.spec.tsx
@@ -9,12 +9,12 @@ import { useFlag } from '@console/shared/src/hooks/flag';
 import { GettingStartedSection } from '../GettingStartedSection';
 
 jest.mock('@console/shared/src/hooks/flag', () => ({
-  ...require.requireActual('@console/shared/src/hooks/flag'),
+  ...jest.requireActual('@console/shared/src/hooks/flag'),
   useFlag: jest.fn(),
 }));
 
 jest.mock('@console/shared/src/components/getting-started', () => ({
-  ...require.requireActual('@console/shared/src/components/getting-started'),
+  ...jest.requireActual('@console/shared/src/components/getting-started'),
   useGettingStartedShowState: jest.fn(),
 }));
 

--- a/frontend/public/components/default-resource.tsx
+++ b/frontend/public/components/default-resource.tsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { sortable } from '@patternfly/react-table';
 import { PageComponentProps } from '@console/dynamic-plugin-sdk/src/extensions/horizontal-nav-tabs';

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable tsdoc/syntax */
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useDispatch, useSelector, connect } from 'react-redux';
 import { action } from 'typesafe-actions';
 import { ActionType, getOLSCodeBlock } from '@console/internal/reducers/ols';

--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import * as PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Alert, Button, ActionGroup, AlertActionCloseButton } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { Trans, withTranslation } from 'react-i18next';
 import { getImpersonate } from '@console/dynamic-plugin-sdk';
 

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define, tsdoc/syntax */
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as PropTypes from 'prop-types';
 import { Link, useParams } from 'react-router-dom-v5-compat';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';

--- a/frontend/public/components/factory/ListPage/ListPageHeader.tsx
+++ b/frontend/public/components/factory/ListPage/ListPageHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { ListPageHeaderProps } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { PageHeading } from '../../utils';
 

--- a/frontend/public/components/factory/list-page.tsx
+++ b/frontend/public/components/factory/list-page.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import { Link, useParams, useNavigate } from 'react-router-dom-v5-compat';

--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -1,4 +1,4 @@
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as Modal from 'react-modal';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -13,7 +13,7 @@ import {
   ISortBy,
   OnSort,
 } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { CellMeasurerCache, CellMeasurer } from 'react-virtualized';
 import {
   AutoSizer,

--- a/frontend/public/components/graphs/prometheus-graph.tsx
+++ b/frontend/public/components/graphs/prometheus-graph.tsx
@@ -1,4 +1,4 @@
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { connect } from 'react-redux';

--- a/frontend/public/components/graphs/status.jsx
+++ b/frontend/public/components/graphs/status.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable tsdoc/syntax */
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as classnames from 'classnames';
+import classNames from 'classnames';
 import { Link } from 'react-router-dom-v5-compat';
 import { Title } from '@patternfly/react-core';
 
@@ -103,7 +103,7 @@ export class Status extends React.Component {
   render() {
     const title = this.props.title;
     const { short, long, status } = this.state;
-    const shortStatusClassName = classnames('graph-status__short', {
+    const shortStatusClassName = classNames('graph-status__short', {
       'graph-status__short--ok': status === 'OK',
       'graph-status__short--warn': status === 'WARN',
       'graph-status__short--error': status === 'ERROR',

--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { Trans, useTranslation } from 'react-i18next';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import * as _ from 'lodash-es';
 import * as semver from 'semver';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { AlertVariant, Button, Popover } from '@patternfly/react-core';
 import { QuestionCircleIcon } from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';

--- a/frontend/public/components/ingress.jsx
+++ b/frontend/public/components/ingress.jsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';
 import { DetailsPage, ListPage, Table, TableData } from './factory';

--- a/frontend/public/components/instantiate-template.tsx
+++ b/frontend/public/components/instantiate-template.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import * as _ from 'lodash-es';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import {
   ActionGroup,
   Button,

--- a/frontend/public/components/job.tsx
+++ b/frontend/public/components/job.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 import {

--- a/frontend/public/components/machine-autoscaler.tsx
+++ b/frontend/public/components/machine-autoscaler.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import PaneBody from '@console/shared/src/components/layout/PaneBody';

--- a/frontend/public/components/machine-config-pool.tsx
+++ b/frontend/public/components/machine-config-pool.tsx
@@ -1,7 +1,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { Tooltip } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { PauseCircleIcon } from '@patternfly/react-icons/dist/esm/icons/pause-circle-icon';

--- a/frontend/public/components/machine-config.tsx
+++ b/frontend/public/components/machine-config.tsx
@@ -1,7 +1,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
 import {

--- a/frontend/public/components/machine-health-check.tsx
+++ b/frontend/public/components/machine-health-check.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import PaneBody from '@console/shared/src/components/layout/PaneBody';

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom-v5-compat';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { getMachineAWSPlacement, getMachineRole, getMachineSetInstanceType } from '@console/shared';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ListPageBody, RowProps, TableColumn } from '@console/dynamic-plugin-sdk';

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import {
   getMachineAddresses,

--- a/frontend/public/components/modals/tolerations-modal.tsx
+++ b/frontend/public/components/modals/tolerations-modal.tsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import classnames from 'classnames';
+import classNames from 'classnames';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
@@ -130,7 +130,7 @@ const TolerationsModal = withHandlePromise((props: TolerationsModalProps) => {
                       {t('public~Key')}
                     </div>
                     <span
-                      className={classnames('pf-v6-c-form-control', {
+                      className={classNames('pf-v6-c-form-control', {
                         'pf-m-readonly': keyReadOnly,
                       })}
                     >
@@ -167,7 +167,7 @@ const TolerationsModal = withHandlePromise((props: TolerationsModalProps) => {
                       {t('public~Value')}
                     </div>
                     <span
-                      className={classnames('pf-v6-c-form-control', {
+                      className={classNames('pf-v6-c-form-control', {
                         'pf-m-readonly': valueReadOnly,
                       })}
                     >

--- a/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate } from 'react-router-dom-v5-compat';
 import { ActionGroup, Alert, Button } from '@patternfly/react-core';
 import { safeLoad } from 'js-yaml';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 import { APIError } from '@console/shared';
 import PrimaryHeading from '@console/shared/src/components/heading/PrimaryHeading';

--- a/frontend/public/components/monitoring/receiver-forms/save-as-default-checkbox.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/save-as-default-checkbox.tsx
@@ -1,4 +1,4 @@
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import { BlueInfoCircleIcon } from '@console/shared';

--- a/frontend/public/components/namespace-bar.tsx
+++ b/frontend/public/components/namespace-bar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -2,7 +2,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { Alert, Button, Tooltip } from '@patternfly/react-core';
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';

--- a/frontend/public/components/network-policy.tsx
+++ b/frontend/public/components/network-policy.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { connectToFlags } from '../reducers/connectToFlags';
 import { FlagsObject } from '../reducers/features';
 import { BlueInfoCircleIcon, FLAGS } from '@console/shared';

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useDispatch, connect } from 'react-redux';
 import { sortable } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom-v5-compat';
 import { sortable } from '@patternfly/react-table';
 import { Trans, useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash-es';
 import {
   Button,

--- a/frontend/public/components/radio.tsx
+++ b/frontend/public/components/radio.tsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 export const RadioInput: React.SFC<RadioInputProps> = (props) => {
   const inputProps: React.InputHTMLAttributes<any> = _.omit(props, [

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -1,7 +1,7 @@
 // TODO file should be renamed replica-set.jsx to match convention
 
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { Link } from 'react-router-dom-v5-compat';
 import { sortable } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
 import { sortable } from '@patternfly/react-table';

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { connect } from 'react-redux';
 import { Map as ImmutableMap, Set as ImmutableSet } from 'immutable';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { ResourceIcon } from './utils';
 import { K8sKind, K8sResourceKindReference, referenceForModel } from '../module/k8s';

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useParams } from 'react-router-dom-v5-compat';
 import { sortable } from '@patternfly/react-table';
 import { OutlinedCircleIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-circle-icon';

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { Trans, useTranslation } from 'react-i18next';
 import { Button, Popover } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';

--- a/frontend/public/components/routes/create-route.tsx
+++ b/frontend/public/components/routes/create-route.tsx
@@ -2,7 +2,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as fuzzy from 'fuzzysearch';
-import classnames from 'classnames';
+import classNames from 'classnames';
 import { Alert, Button, Title } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import { MinusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';
@@ -306,7 +306,7 @@ class CreateRouteWithTranslation extends React.Component<
             {t('public~Name')}
           </label>
           <span
-            className={classnames('pf-v6-c-form-control', { 'pf-m-disabled': !!existingRoute })}
+            className={classNames('pf-v6-c-form-control', { 'pf-m-disabled': !!existingRoute })}
           >
             <input
               type="text"

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -1,4 +1,4 @@
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';

--- a/frontend/public/components/service.jsx
+++ b/frontend/public/components/service.jsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 
 import PaneBody from '@console/shared/src/components/layout/PaneBody';

--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom-v5-compat';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as fuzzy from 'fuzzysearch';
 import * as _ from 'lodash-es';
 import { ActionGroup, Button } from '@patternfly/react-core';

--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -8,7 +8,7 @@ import {
   LazyActionMenu,
 } from '@console/shared';
 import { useTranslation } from 'react-i18next';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';
 import { DetailsPage, ListPage, Table, TableData, RowFunctionArgs } from './factory';
 import {

--- a/frontend/public/components/template-instance.tsx
+++ b/frontend/public/components/template-instance.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 

--- a/frontend/public/components/utils/__tests__/firehose.spec.tsx
+++ b/frontend/public/components/utils/__tests__/firehose.spec.tsx
@@ -19,7 +19,7 @@ jest.mock('@console/dynamic-plugin-sdk/src/utils/k8s/k8s-resource', () => ({
   k8sGet: jest.fn(),
 }));
 jest.mock('@console/dynamic-plugin-sdk/src/utils/k8s', () => ({
-  ...require.requireActual('@console/dynamic-plugin-sdk/src/utils/k8s'),
+  ...jest.requireActual('@console/dynamic-plugin-sdk/src/utils/k8s'),
   k8sWatch: jest.fn(),
 }));
 const k8sListMock = k8sList as jest.Mock;

--- a/frontend/public/components/utils/button-bar.jsx
+++ b/frontend/public/components/utils/button-bar.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable tsdoc/syntax */
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as PropTypes from 'prop-types';
 import { Alert, AlertGroup } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';

--- a/frontend/public/components/utils/details-item.tsx
+++ b/frontend/public/components/utils/details-item.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import * as classnames from 'classnames';
+import classNames from 'classnames';
 import { PencilAltIcon } from '@patternfly/react-icons/dist/esm/icons/pencil-alt-icon';
 import {
   Breadcrumb,
@@ -78,7 +78,7 @@ export const DetailsItem: React.FC<DetailsItemProps> = ({
   return hide ? null : (
     <>
       <dt
-        className={classnames('details-item__label', labelClassName)}
+        className={classNames('details-item__label', labelClassName)}
         data-test-selector={`details-item-label__${label}`}
       >
         <Split>
@@ -121,7 +121,7 @@ export const DetailsItem: React.FC<DetailsItemProps> = ({
         </Split>
       </dt>
       <dd
-        className={classnames('details-item__value', valueClassName, {
+        className={classNames('details-item__value', valueClassName, {
           'details-item__value--group': editable && editAsGroup,
         })}
         data-test-selector={`details-item-value__${label}`}

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { useTranslation, withTranslation } from 'react-i18next';

--- a/frontend/public/components/utils/file-input.tsx
+++ b/frontend/public/components/utils/file-input.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { NativeTypes } from 'react-dnd-html5-backend';
 import { DropTarget } from 'react-dnd';
 import { ConnectDropTarget, DropTargetMonitor } from 'react-dnd/lib/interfaces';

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom-v5-compat';
 import { useTranslation } from 'react-i18next';

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 /* eslint-disable import/named */
 import { useTranslation } from 'react-i18next';

--- a/frontend/public/components/utils/label-list.tsx
+++ b/frontend/public/components/utils/label-list.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { Label as PfLabel, LabelGroup as PfLabelGroup } from '@patternfly/react-core';
 

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import Linkify from 'react-linkify';
 import { useTranslation } from 'react-i18next';
 import { ClipboardCopyButton } from '@patternfly/react-core';

--- a/frontend/public/components/utils/list-input.tsx
+++ b/frontend/public/components/utils/list-input.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { Button } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import { MinusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';

--- a/frontend/public/components/utils/managed-by.tsx
+++ b/frontend/public/components/utils/managed-by.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { Link } from 'react-router-dom-v5-compat';
 import { useTranslation } from 'react-i18next';
 

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import * as _ from 'lodash-es';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { DragSource, DropTarget } from 'react-dnd';
 import { DRAGGABLE_TYPE } from './draggable-item-types';
 import { Button, Tooltip } from '@patternfly/react-core';

--- a/frontend/public/components/utils/resource-icon.tsx
+++ b/frontend/public/components/utils/resource-icon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as _ from 'lodash-es';
 
 import { getReference } from '@console/dynamic-plugin-sdk/src/utils/k8s';

--- a/frontend/public/components/utils/resource-link.tsx
+++ b/frontend/public/components/utils/resource-link.tsx
@@ -1,7 +1,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 import { FLAGS } from '@console/shared/src/constants';
 import { ResourceLinkProps } from '@console/dynamic-plugin-sdk';

--- a/frontend/public/components/utils/resource-log.tsx
+++ b/frontend/public/components/utils/resource-log.tsx
@@ -29,7 +29,7 @@ import {
   OutlinedWindowRestoreIcon,
   OutlinedPlayCircleIcon,
 } from '@patternfly/react-icons';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import {
   FLAGS,
   LOG_WRAP_LINES_USERSETTINGS_KEY,

--- a/frontend/public/components/utils/selector-input.jsx
+++ b/frontend/public/components/utils/selector-input.jsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as TagsInput from 'react-tagsinput';
 import { Label as PfLabel } from '@patternfly/react-core';
 

--- a/frontend/public/components/utils/simple-tab-nav.tsx
+++ b/frontend/public/components/utils/simple-tab-nav.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import classnames from 'classnames';
+import classNames from 'classnames';
 import { Tabs, Tab as PfTab, TabTitleText } from '@patternfly/react-core';
 
 export type Tab = {
@@ -37,7 +37,7 @@ export const SimpleTabNav: React.FC<SimpleTabNavProps> = ({
     <div>
       <Tabs
         onSelect={handleTabClick}
-        className={classnames({ 'pf-v6-u-mb-md': withinSidebar }, additionalClassNames)}
+        className={classNames({ 'pf-v6-u-mb-md': withinSidebar }, additionalClassNames)}
         defaultActiveKey={selectedTab || tabs[0]?.name}
         inset={!noInset && { default: 'insetSm' }}
         unmountOnExit

--- a/frontend/public/components/utils/storage-class-dropdown.tsx
+++ b/frontend/public/components/utils/storage-class-dropdown.tsx
@@ -7,7 +7,7 @@ import { WithTranslation, withTranslation } from 'react-i18next';
 
 import { Firehose, LoadingInline, Dropdown, ResourceName, ResourceIcon } from '.';
 import { isDefaultClass } from '../storage-class';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 
 /* Component StorageClassDropdown - creates a dropdown list of storage classes */
 

--- a/frontend/public/components/utils/timestamp.tsx
+++ b/frontend/public/components/utils/timestamp.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 import { Tooltip } from '@patternfly/react-core';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { GlobeAmericasIcon } from '@patternfly/react-icons/dist/esm/icons/globe-americas-icon';
 import { TimestampProps } from '@console/dynamic-plugin-sdk';
 

--- a/frontend/public/components/utils/toggle-play.jsx
+++ b/frontend/public/components/utils/toggle-play.jsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import * as PropTypes from 'prop-types';
 import { Button } from '@patternfly/react-core';
 import { withTranslation } from 'react-i18next';

--- a/frontend/public/components/workload-table.tsx
+++ b/frontend/public/components/workload-table.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { Link } from 'react-router-dom-v5-compat';
 import { K8sResourceKind } from '../module/k8s';


### PR DESCRIPTION
Pulling out the `jest.requireActual` change into a separate PR to make the changeset of https://github.com/openshift/console/pull/14841 smaller. 

This PR also includes the `classNames` import rewrite from https://github.com/openshift/console/pull/13986 in case that is needed for a future Jest upgrade.

code review:

/assign @jhadvig 

no docs/qe/px approval needed since this doesn't really affect anything:

/label px-approved
/label docs-approved
/label qe-approved
