### PR TITLE
OCPEDGE-1614: fix: soften topology validations from preventing console deployment

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -142,7 +142,7 @@ func main() {
 	fProjectAccessClusterRoles := fs.String("project-access-cluster-roles", "", "The list of Cluster Roles assignable for the project access page. (JSON as string)")
 	fPerspectives := fs.String("perspectives", "", "Allow enabling/disabling of perspectives in the console. (JSON as string)")
 	fCapabilities := fs.String("capabilities", "", "Allow enabling/disabling of capabilities in the console. (JSON as string)")
-	fControlPlaneTopology := fs.String("control-plane-topology-mode", "", "Defines the topology mode of the control/infra nodes (External | HighlyAvailable | SingleReplica)")
+	fControlPlaneTopology := fs.String("control-plane-topology-mode", "", "Defines the topology mode of the control plane nodes")
 	fReleaseVersion := fs.String("release-version", "", "Defines the release version of the cluster")
 	fNodeArchitectures := fs.String("node-architectures", "", "List of node architectures. Example --node-architecture=amd64,arm64")
 	fNodeOperatingSystems := fs.String("node-operating-systems", "", "List of node operating systems. Example --node-operating-system=linux,windows")

--- a/pkg/serverconfig/validate.go
+++ b/pkg/serverconfig/validate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
 	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -38,7 +39,9 @@ func Validate(fs *flag.FlagSet) error {
 	}
 
 	if _, err := validateControlPlaneTopology(fs.Lookup("control-plane-topology-mode").Value.String()); err != nil {
-		return err
+		// We log control plane topology errors but don't block deployments on them
+		// We can revert this back to `return err` once https://github.com/openshift/console/pull/14846 lands
+		fmt.Fprintln(os.Stderr, err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
Currently, the server config validations re-verify all of the API-driven values for the infrastructure configuration values for controlPlaneTopology. This requires this values to be updated each time an API change is introduced, or else the console replicas don't deploy because they fail the validation step. This patch is intended as a holdover until the API can be bumped so that we can deploy the console for the DualReplica controlPlane topology, while still providing an err message in stderr in case a user provides a bogus value via the config via CLI or an env var.