### PR TITLE
OCPBUGS-52870: Links into OpenShift Console plugin ACM sometimes redirect user to the OpenShift dashboard.

### DIFF
--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -152,7 +152,7 @@ const AppContents: React.FC<{}> = () => {
   const location = useLocation();
   const [pluginPageRoutes, inactivePluginPageRoutes] = usePluginRoutes();
 
-  const contentRouter = (
+  const contentRouter = allPluginsProcessed ? (
     <Routes>
       {pluginPageRoutes}
 
@@ -795,21 +795,19 @@ const AppContents: React.FC<{}> = () => {
       {inactivePluginPageRoutes}
       <Route path="/" element={<DefaultPage />} />
 
-      {allPluginsProcessed ? (
-        <Route
-          path="*"
-          element={
-            <AsyncComponent
-              loader={() =>
-                import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage404)
-              }
-            />
-          }
-        />
-      ) : (
-        <Route element={<LoadingBox />} />
-      )}
+      <Route
+        path="*"
+        element={
+          <AsyncComponent
+            loader={() =>
+              import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage404)
+            }
+          />
+        }
+      />
     </Routes>
+  ) : (
+    <LoadingBox />
   );
 
   const matches = matchRoutes(namespacedRoutes, location);


### PR DESCRIPTION
Wait to render the main router until all the plugins are loaded