### PR TITLE
OCPBUGS-54656: Add space between quick start action list items

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.scss
@@ -1,0 +1,5 @@
+.co-quick-start-drawer {
+  .pf-v6-c-action-list {
+    justify-content: space-between;
+  }
+}

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.tsx
@@ -2,12 +2,13 @@ import * as React from 'react';
 import { QuickStartDrawer as PfQuickStartDrawer } from '@patternfly/quickstarts';
 import { LoadingBox } from '@console/internal/components/utils';
 import QuickStartsLoader from './loader/QuickStartsLoader';
+import './QuickStartDrawer.scss';
 
 const QuickStartDrawer: React.FC = ({ children, ...props }) => (
   <QuickStartsLoader>
     {(quickStarts, loaded) =>
       loaded ? (
-        <PfQuickStartDrawer quickStarts={quickStarts} {...props}>
+        <PfQuickStartDrawer quickStarts={quickStarts} {...props} className="co-quick-start-drawer">
           {children}
         </PfQuickStartDrawer>
       ) : (


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-54656

**Analysis / Root cause**: 
Styling was missing

**Solution Description**: 
Added the styling to align the Restart button to the end
  
**Screen shots / Gifs for design review**: 

**---BEFORE----**


<img width="443" alt="Screenshot 2025-04-07 at 2 19 49 PM" src="https://github.com/user-attachments/assets/3957afcd-cbc0-4ba8-b6ed-ec59d3aa8713" />



**---AFTER----**


<img width="435" alt="Screenshot 2025-04-07 at 3 04 31 PM" src="https://github.com/user-attachments/assets/43feda33-8d6a-4a74-afee-b6e8122beb5a" />




-----

**Unit test coverage report**: 
NA

**Test setup:**

    1. Open any Quick Start
    2. Click on start
    3. See Restart button is aligned in middle
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

