### PR TITLE
OCPBUGS-54237: click resource dropdown button on Operand form page will always put use to page top when scrolling

### DIFF
--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -533,7 +533,7 @@ class Dropdown_ extends DropdownMixin {
               popperRef={this.dropdownMenuRef}
               isVisible={active}
               zIndex={9999}
-              appendTo="inline"
+              appendTo={() => document.body}
             />
           </div>
         </div>
@@ -591,7 +591,7 @@ class Dropdown_ extends DropdownMixin {
             preventOverflow={menuClassName === 'prevent-overflow' ? true : false}
             isVisible={active}
             zIndex={9999}
-            appendTo="inline"
+            appendTo={() => document.body}
           />
         </div>
       </div>


### PR DESCRIPTION
Append the Popper to the body of the page fixes the problem of the page scrolling to top when clicking dropdowns. (e.g. in dynamic forms).

before:

https://github.com/user-attachments/assets/f74a7a8f-1b6f-4a11-8dce-0dc95b66ff50


after:

https://github.com/user-attachments/assets/8c394457-7a08-48a0-84c5-00741c3ba3b4

