### PR TITLE
OCPBUGS-54733: fix bug where co-resource-icon--fixed-width can clip

### DIFF
--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -24,7 +24,7 @@
   display: flex;
   justify-content: center;
   text-align: center;
-  width: 50px;
+  width: 54px;
 }
 
 .co-m-resource-application {


### PR DESCRIPTION
After

<img width="503" alt="Screenshot 2025-04-08 at 1 10 16 PM" src="https://github.com/user-attachments/assets/a6c5371e-6dd7-4c27-a9fb-8277cefde39f" />
