### PR TITLE
OCPBUGS-54726: Layout of Welcome to the new OpenShift experience! buttons is wonky on mobile

### DIFF
--- a/frontend/packages/console-app/src/components/tour/steps/StepFooter.tsx
+++ b/frontend/packages/console-app/src/components/tour/steps/StepFooter.tsx
@@ -20,7 +20,7 @@ const StepFooter: React.FC<StepFooterProps> = ({
 }) => (
   <Flex>
     {children && <FlexItem>{children}</FlexItem>}
-    <FlexItem align={{ default: 'alignRight' }}>
+    <FlexItem>
       <Button
         variant="secondary"
         id="tour-step-footer-secondary"


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-54656

**Analysis / Root cause**: 
By default the button was aligned right

**Solution Description**: 
Removed the syling
  
**Screen shots / Gifs for design review**: 

**---BEFORE----**

<img width="523" alt="Screenshot 2025-04-09 at 1 39 08 PM" src="https://github.com/user-attachments/assets/07c0cf08-48b1-4255-b4b3-1a1018adb6ee" />

**---AFTER----**

<img width="539" alt="Screenshot 2025-04-09 at 1 36 50 PM" src="https://github.com/user-attachments/assets/5adb1ad4-1756-4d4d-866d-fe1fd8d610bf" />

-----
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

