### PR TITLE
ODC-7781: Running knative e2e tests from admin view

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective.ts
@@ -1,6 +1,7 @@
 import { guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
 
 export const checkDeveloperPerspective = () => {
+  guidedTour.close();
   cy.get('body').then(($body) => {
     cy.byLegacyTestID('perspective-switcher-toggle').then(($switcher) => {
       // switcher is present
@@ -19,15 +20,16 @@ export const checkDeveloperPerspective = () => {
         `oc patch console.operator.openshift.io/cluster --type='merge' -p '{"spec":{"customization":{"perspectives":[{"id":"dev","visibility":{"state":"Enabled"}}]}}}'`,
         { failOnNonZeroExit: true },
       ).then((result) => {
+        cy.log(result.stdout);
         cy.log(result.stderr);
       });
-      cy.reload(true);
-      cy.document().its('readyState').should('eq', 'complete');
       cy.exec(`  oc rollout status -w deploy/console -n openshift-console`, {
         failOnNonZeroExit: true,
       }).then((result) => {
         cy.log(result.stderr);
       });
+      cy.reload(true);
+      cy.document().its('readyState').should('eq', 'complete');
       cy.log('perspective switcher menu refreshed');
     });
 

--- a/frontend/packages/knative-plugin/integration-tests/features/e2e/knative-ci.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/e2e/knative-ci.feature
@@ -3,13 +3,12 @@ Feature: Perform actions on knative service and revision
               As a user, I want to perform edit or delete operations on knative revision in topology page
 
         Background:
-              And user is at Topology page
+              And user is at Topology page in the admin view
 
         @pre-condition
         Scenario Outline: Create knative workload from From Git card on Add page: KN-05-TC04
             Given user has created or selected namespace "knative-ci"
-              And user is at Add page
-              And user is at Import from Git page
+              And user selects Import from Git from quick create
              When user enters Git Repo url as "<git_url>"
               And user enters Name as "<workload_name>"
               And user selects resource type as "Serverless Deployment"

--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/actions-on-knative-revision.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/actions-on-knative-revision.feature
@@ -10,7 +10,8 @@ Feature: Perform actions on knative revision
         @pre-condition
         Scenario Outline: Create knative workload from From Git card on Add page: KN-05-TC04
             Given user is at Add page
-              And user is at Import from Git page
+          #     And user is at Import from Git page
+              And user selects Import from Git from quick create
              When user enters Git Repo url as "<git_url>"
               And user enters Name as "<workload_name>"
               And user selects resource type as "Serverless Deployment"

--- a/frontend/packages/knative-plugin/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/commands/hooks.ts
@@ -1,7 +1,6 @@
 import { checkErrors } from '@console/cypress-integration-tests/support';
 import { guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
 import { installKnativeOperatorUsingCLI } from '@console/dev-console/integration-tests/support/pages';
-import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 
 before(() => {
   cy.exec('../../../../contrib/create-user.sh');
@@ -10,7 +9,6 @@ before(() => {
   const bridgePasswordPassword: string = Cypress.env('BRIDGE_HTPASSWD_PASSWORD') || 'test';
   cy.login(bridgePasswordIDP, bridgePasswordUsername, bridgePasswordPassword);
   cy.document().its('readyState').should('eq', 'complete');
-  checkDeveloperPerspective();
   installKnativeOperatorUsingCLI();
   //  To ignore the resizeObserverLoopErrors on CI, adding below code
   const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
@@ -26,9 +24,8 @@ before(() => {
 });
 
 beforeEach(() => {
-  cy.initDeveloper();
-  // cy.initAdmin();
-  // cy.byLegacyTestID('topology-header').should('exist').click({force: true});
+  cy.initAdmin();
+  cy.byLegacyTestID('topology-header').should('exist').click({ force: true });
 });
 
 after(() => {

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/addFlow.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/addFlow.ts
@@ -13,10 +13,12 @@ import {
   createGitWorkload,
   catalogPage,
 } from '@console/dev-console/integration-tests/support/pages';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import { topologyPO } from '@console/topology/integration-tests/support/page-objects/topology-po';
 import { topologyPage } from '@console/topology/integration-tests/support/pages/topology/topology-page';
 
 Given('user is at Add page', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Add);
 });
 

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/common.ts
@@ -25,6 +25,7 @@ import {
   installKnativeOperatorUsingCLI,
   installRedHatIntegrationCamelKOperatorUsingCLI,
 } from '@console/dev-console/integration-tests/support/pages';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import { eventingPO } from '@console/knative-plugin/integration-tests/support/pageObjects/global-po';
 import { userLoginPage } from '../../pages/dev-perspective/common';
 
@@ -34,6 +35,7 @@ Given('user has logged in as a basic user', () => {
 });
 
 Given('user is at developer perspective', () => {
+  checkDeveloperPerspective();
   perspective.switchTo(switchPerspective.Developer);
 });
 
@@ -53,6 +55,12 @@ Given('user is at pipelines page', () => {
 
 Given('user is at Topology page', () => {
   navigateTo(devNavigationMenu.Topology);
+});
+
+Given('user is at Topology page in the admin view', () => {
+  cy.get('[data-quickstart-id="qs-nav-workloads"]').should('be.visible').click({ force: true });
+  cy.byLegacyTestID('topology-header').should('be.visible').click({ force: true });
+  topologyPage.verifyTopologyPage();
 });
 
 Given('user is at Monitoring page', () => {

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/actions-on-knative-revision.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/actions-on-knative-revision.ts
@@ -1,10 +1,12 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
-import { guidedTour, guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
+import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
+import { guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
 import { modal } from '@console/cypress-integration-tests/views/modal';
 import {
   addOptions,
   devNavigationMenu,
   nodeActions,
+  pageTitle,
 } from '@console/dev-console/integration-tests/support/constants';
 import { formPO, topologyPO } from '@console/dev-console/integration-tests/support/pageObjects';
 import {
@@ -26,6 +28,14 @@ let numOfAnnotationsBeforeAdd: number;
 
 Given('user is at Import from Git page', () => {
   addPage.selectCardFromOptions(addOptions.ImportFromGit);
+});
+
+When('user selects Import from Git from quick create', () => {
+  cy.get('[data-test="quick-create-dropdown"]').click();
+  cy.get('[data-test="qc-import-from-git"] [role="menuitem"]')
+    .should('be.visible')
+    .click({ force: true });
+  detailsPage.titleShouldContain(pageTitle.Git);
 });
 
 Given(


### PR DESCRIPTION
Story:[ODC-7781](https://issues.redhat.com/browse/ODC-7781)

Description:
Running knative e2e tests from admin view

Command to execute:

export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.13-042801.devcluster.openshift.com/
export BRIDGE_KUBEADMIN_PASSWORD
export BRIDGE_BASE_ADDRESS
oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
oc apply -f ./frontend/packages/console-shared/src/test-data/htpasswd-secret.yaml
oc patch oauths cluster --patch "$(cat ./frontend/packages/console-shared/src/test-data/patch-htpasswd.yaml)" --type=merge
In frontend folder run 
./integration-tests/test-cypress.sh -p knative
Run knative-ci file
Browser
Chrome 125

