### PR TITLE
OCPBUGS-54657: Expose OdcBaseNode through the dynamic plugin SDK

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-topology-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-topology-api.ts
@@ -23,6 +23,7 @@ import {
   BaseNodeProps,
   WithContextMenu,
   WithCreateConnector,
+  OdcBaseNodeConstructor,
 } from '../extensions/topology-types';
 
 export const CpuCellComponent: React.FC<CpuCellComponentProps> = require('@console/topology/src/components/list-view/cells/CpuCell')
@@ -93,3 +94,6 @@ export const withContextMenu: WithContextMenu = require('@console/topology/src/c
 
 export const withCreateConnector: WithCreateConnector = require('@console/topology/src/behavior')
   .withCreateConnector;
+
+export const OdcBaseNode: OdcBaseNodeConstructor = require('@console/topology/src/elements')
+  .OdcBaseNode;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/topology-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/topology-types.ts
@@ -428,3 +428,18 @@ export type WithCreateConnector = <P extends WithCreateConnectorProps & ElementP
 ) => (
   WrappedComponent: React.ComponentType<Partial<P>>,
 ) => React.FC<Omit<P, keyof WithCreateConnectorProps>>;
+
+export interface OdcBaseNodeInterface extends Node<OdcNodeModel> {
+  resource?: K8sResourceKind;
+  resourceKind?: K8sResourceKindReference;
+
+  getResource(): K8sResourceKind | undefined;
+  setResource(resource: K8sResourceKind | undefined): void;
+
+  getResourceKind(): K8sResourceKindReference | undefined;
+  setResourceKind(kind: K8sResourceKindReference | undefined): void;
+
+  setModel(model: OdcNodeModel): void;
+}
+
+export type OdcBaseNodeConstructor = new () => OdcBaseNodeInterface;

--- a/frontend/packages/topology/src/elements/OdcBaseNode.ts
+++ b/frontend/packages/topology/src/elements/OdcBaseNode.ts
@@ -1,5 +1,6 @@
-import { BaseNode } from '@patternfly/react-topology';
+import { BaseNode, Node } from '@patternfly/react-topology';
 import { observable, makeObservable } from 'mobx';
+import { OdcBaseNodeInterface } from '@console/dynamic-plugin-sdk/src/extensions/topology-types';
 import {
   K8sResourceKind,
   K8sResourceKindReference,
@@ -7,7 +8,7 @@ import {
 } from '@console/internal/module/k8s';
 import { OdcNodeModel } from '../topology-types';
 
-class OdcBaseNode extends BaseNode {
+class OdcBaseNode extends BaseNode implements OdcBaseNodeInterface {
   public resource?: K8sResourceKind | undefined = undefined;
 
   public resourceKind?: K8sResourceKindReference | undefined = undefined;
@@ -19,6 +20,10 @@ class OdcBaseNode extends BaseNode {
       resource: observable.ref,
       resourceKind: observable,
     });
+  }
+
+  getPositionableChildren(): Node[] {
+    return [];
   }
 
   getResource(): K8sResourceKind | undefined {


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/OCPBUGS-54657

**Description:**

I have to export the type manually if I use require since I am only able to import the value not the type.

I tried below approach also

```
import type { OdcBaseNode as OdcBaseNodeType } from '@console/topology/src/elements';

export const OdcBaseNode: OdcBaseNodeType = require('@console/topology/src/elements').OdcBaseNode;
```

but there are errors in yarn install and yarn run dev for this solution and still I was able to import just the value not the type.