### PR TITLE
CONSOLE-4538: Add error reporting link to `ErrorBoundary` modal

### DIFF
--- a/frontend/packages/console-shared/src/components/modals/ErrorDetailsModal.tsx
+++ b/frontend/packages/console-shared/src/components/modals/ErrorDetailsModal.tsx
@@ -7,28 +7,32 @@ import {
   ModalFooter,
   ModalVariant,
 } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { ErrorBoundaryFallbackProps } from '@console/dynamic-plugin-sdk';
 import { CopyToClipboard } from '@console/internal/components/utils/copy-to-clipboard';
+import { getReportBugLink } from '@console/internal/module/k8s/cluster-settings';
+import { ClusterVersionKind } from '@console/internal/module/k8s/types';
+import { useClusterVersion } from '@console/shared/src/hooks/version';
 
 export const ErrorDetailsBlock: React.FC<ErrorBoundaryFallbackProps> = (props) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation('console-shared');
   return (
     <>
       <ModalHeader title={props.title} />
       <ModalBody>
         <div className="form-group">
-          <label htmlFor="description">{t('console-shared~Description:')}</label>
+          <label htmlFor="description">{t('Description:')}</label>
           <p>{props.errorMessage}</p>
         </div>
         <div className="form-group">
-          <label htmlFor="componentTrace">{t('console-shared~Component trace:')}</label>
+          <label htmlFor="componentTrace">{t('Component trace:')}</label>
           <div className="co-copy-to-clipboard__stacktrace-width-height">
             <CopyToClipboard value={props.componentStack.trim()} />
           </div>
         </div>
         <div className="form-group">
-          <label htmlFor="stackTrace">{t('console-shared~Stack trace:')}</label>
+          <label htmlFor="stackTrace">{t('Stack trace:')}</label>
           <div className="co-copy-to-clipboard__stacktrace-width-height">
             <CopyToClipboard value={props.stack.trim()} />
           </div>
@@ -43,25 +47,37 @@ type ErrorDetailsModalProps = ErrorBoundaryFallbackProps & {
 };
 
 export const ErrorDetailsModal: React.FC<ErrorDetailsModalProps> = ({ buttonProps, ...props }) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation('console-shared');
   const [isOpen, setOpen] = React.useState(false);
+  const clusterVersion: ClusterVersionKind = useClusterVersion();
+
+  // destructure to undefined if we're not in a redux context
+  const { label, href } = { ...getReportBugLink(clusterVersion) };
 
   return (
     <>
       <Button onClick={() => setOpen(true)} {...buttonProps}>
-        {t('console-shared~Show details')}
+        {t('Show details')}
       </Button>
-      <Modal
-        variant={ModalVariant.large}
-        title={t('console-shared~Something wrong happened')}
-        isOpen={isOpen}
-        onClose={() => setOpen(false)}
-      >
+      <Modal variant={ModalVariant.large} isOpen={isOpen} onClose={() => setOpen(false)}>
         <ErrorDetailsBlock {...props} />
         <ModalFooter>
           <Button variant="primary" onClick={() => setOpen(false)}>
-            {t('console-shared~Close')}
+            {t('Close')}
           </Button>
+          {label && href && (
+            <Button
+              variant="link"
+              component="a"
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              icon={<ExternalLinkAltIcon />}
+              iconPosition="end"
+            >
+              {label}
+            </Button>
+          )}
         </ModalFooter>
       </Modal>
     </>

--- a/frontend/packages/helm-plugin/src/components/details-page/__tests__/HelmReleaseDetails.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/__tests__/HelmReleaseDetails.spec.tsx
@@ -20,6 +20,11 @@ jest.mock('react-router-dom-v5-compat', () => ({
   useNavigate: jest.fn(),
 }));
 
+// jest mock useClusterVersion
+jest.mock('@console/shared/src/hooks/version', () => ({
+  useClusterVersion: jest.fn(),
+}));
+
 describe('HelmReleaseDetails', () => {
   beforeEach(() => {
     helmReleaseDetailsProps = {

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -78,7 +78,7 @@ export const ExternalLink: React.FC<ExternalLinkProps> = ({
 }) => (
   <a
     {...props}
-    className={classNames('co-external-link', additionalClassName)}
+    className={classNames('co-external-link', additionalClassName, props?.className)}
     href={href}
     target="_blank"
     rel="noopener noreferrer"


### PR DESCRIPTION
after:

https://github.com/user-attachments/assets/8835415f-1c71-4444-88a2-1b6547b9c15e

code review:

/assign @spadgett

adding labels for already approved ticket

/label qe-approved
/label docs-approved
/label px-approved