### PR TITLE
OCPBUGS-54878: Align left/right margins of add card items

### DIFF
--- a/frontend/packages/dev-console/src/components/add/AddCard.scss
+++ b/frontend/packages/dev-console/src/components/add/AddCard.scss
@@ -1,6 +1,8 @@
 .odc-add-card {
+  --odc-add-card-item-margin-horizontal: calc(var(--pf-t--global--spacer--lg) - var(--pf-t--global--spacer--sm));
+
   margin-bottom: var(--pf-t--global--spacer--lg);
-  padding: 0px var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--lg) 0px;
+  padding: 0px var(--odc-add-card-item-margin-horizontal) var(--pf-t--global--spacer--lg) 0px;
   max-width: 100%;
 
   &__title {

--- a/frontend/packages/dev-console/src/components/add/AddCardItem.scss
+++ b/frontend/packages/dev-console/src/components/add/AddCardItem.scss
@@ -6,7 +6,7 @@
   }
 
   margin-top: var(--pf-t--global--spacer--lg);
-  margin-left: calc(var(--pf-t--global--spacer--lg) - var(--pf-t--global--spacer--sm));
+  margin-left: var(--odc-add-card-item-margin-horizontal);
 
   &__icon {
     height: var(--pf-t--global--font--size--lg);


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/OCPBUGS-54878

![image](https://github.com/user-attachments/assets/8818b8f0-3d89-4c53-8129-4d40ac990c2e)

code review:

/assign @rhamilto