### PR TITLE
CONSOLE-4542: Remove base `dl` `dd` `dt` CSS

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -182,6 +182,8 @@ This section documents notable changes in the Console provided shared modules ac
   removed in the future. Plugins should provide their own CSS to spin icons if needed.
 - Removed styling for generic HTML heading elements (e.g., `<h1>`). Use PatternFly components to achieve
   correct styling.
+  Removed styling for generic HTML description list elements (e.g., `<dl>`, `<dt>`, `<dd>`). Use PatternFly
+  components to achieve correct styling.
 - Removed `co-m-horizontal-nav` styling. Use [PatternFly Tabs](https://www.patternfly.org/components/tabs/)
   instead.
 - Removed `co-m-page__body` styling. Use [PatternFly Flex](https://www.patternfly.org/layouts/flex) instead.

--- a/frontend/packages/console-shared/src/components/editor/BasicCodeEditor.scss
+++ b/frontend/packages/console-shared/src/components/editor/BasicCodeEditor.scss
@@ -1,3 +1,11 @@
+.co-code-editor {
+  .monaco-editor {
+    // revert custom overrides
+    a.label-name { text-decoration-line: none; } // PF normalize.scss
+    label { font-weight: unset; } // our _bootstrap-residual.scss
+  }
+}
+
 // match the token in theme.ts. it already matches for light theme
 .pf-v6-theme-dark {
   .co-code-editor:not(.pf-m-read-only) {

--- a/frontend/packages/console-shared/src/components/editor/CodeEditor.scss
+++ b/frontend/packages/console-shared/src/components/editor/CodeEditor.scss
@@ -13,10 +13,6 @@
   .monaco-editor {
     position: absolute; // part of the fix for ResizeObserver issue
 
-    // revert custom overrides
-    .label-name { text-decoration: none; }
-    label { font-weight: unset; }
-
     .monaco-hover-content .markdown-hover {
       // matches tooltip styling seen back in OpenShift 4.18
       max-width: 500px;

--- a/frontend/public/style/_base.scss
+++ b/frontend/public/style/_base.scss
@@ -7,23 +7,6 @@
 // @at-root .foo#{&}
 
 :where(:not([class*='pf-v5-c-'], [class*='pf-v6-c-'])) {
-  @at-root dd#{&} {
-    margin-bottom: var(--pf-t--global--spacer--lg);
-  }
-
-  @at-root dd:last-child#{&} {
-    margin-bottom: 0;
-  }
-
-  @at-root dl#{&} {
-    margin: 0;
-  }
-
-  // match pf4 styling / table col head styling
-  @at-root dt#{&} {
-    font-weight: var(--pf-t--global--font--weight--heading--default);
-  }
-
   @at-root fieldset#{&} {
     border: 0;
   }


### PR DESCRIPTION
follow up on https://github.com/openshift/console/pull/14947 to remove unused `dl` `dd` `dt` CSS styles.

adding labels for follow up PR:

/label px-approved
/label docs-approved
/label qe-approved

code review:

/assign @rhamilto 