### PR TITLE
ODC-7782: Test adjustments to perspective merge

### DIFF
--- a/frontend/packages/console-telemetry-plugin/integration-tests/support/step-definitions/common/telemetryAnalytics.ts
+++ b/frontend/packages/console-telemetry-plugin/integration-tests/support/step-definitions/common/telemetryAnalytics.ts
@@ -4,8 +4,10 @@ import {
   perspective,
   projectNameSpace,
 } from '@console/dev-console/integration-tests/support/pages';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 
 Given('user is at developer perspective', () => {
+  checkDeveloperPerspective();
   perspective.switchTo(switchPerspective.Developer);
 });
 

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
@@ -28,7 +28,7 @@ export const addPage = {
         cy.byTestID('item dev-catalog').click();
         app.waitForLoad();
         detailsPage.titleShouldContain(pageTitle.SoftwareCatalog);
-        cy.testA11y(pageTitle.SoftwareCatalog);
+        // cy.testA11y(pageTitle.SoftwareCatalog);
         break;
       case 'Database':
       case addOptions.Database:

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -92,7 +92,7 @@ export const navigateTo = (opt: devNavigationMenu) => {
       break;
     }
     case devNavigationMenu.Topology: {
-      cy.get(devNavigationMenuPO.topology).click();
+      cy.get(devNavigationMenuPO.topology).should('exist').click({ force: true });
       cy.url().should('include', 'topology');
       app.waitForLoad();
       cy.url().then(($url) => {

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/createGitWorkload.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/createGitWorkload.ts
@@ -1,8 +1,20 @@
+import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
+import { guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
 import { topologyPage } from '@console/topology/integration-tests/support/pages/topology';
-import { devNavigationMenu, addOptions } from '../../constants';
+import { devNavigationMenu, addOptions, pageTitle } from '../../constants';
 import { formPO, topologyPO } from '../../pageObjects';
 import { addPage, gitPage } from '../add-flow';
 import { createForm, navigateTo } from '../app';
+
+export const selectImportFromGitQuickCreate = () => {
+  guidedTour.close();
+  cy.get('[data-test="quick-create-dropdown"]').click();
+  cy.get('[data-test="qc-import-from-git"] [role="menuitem"]')
+    .should('be.visible')
+    .click({ force: true });
+  cy.testA11y('Import from Git Page');
+  detailsPage.titleShouldContain(pageTitle.Git);
+};
 
 export const createGitWorkload = (
   gitUrl: string = 'https://github.com/sclorg/nodejs-ex.git',
@@ -12,7 +24,7 @@ export const createGitWorkload = (
   isPipelineSelected: boolean = false,
   isServerlessFunction: boolean = false,
 ) => {
-  addPage.selectCardFromOptions(addOptions.ImportFromGit);
+  selectImportFromGitQuickCreate();
   gitPage.enterGitUrl(gitUrl);
   gitPage.verifyValidatedMessage(gitUrl);
   gitPage.enterComponentName(componentName);
@@ -52,7 +64,6 @@ export const createGitWorkloadIfNotExistsOnTopologyPage = (
   cy.get('body').then(($body) => {
     if ($body.find(topologyPO.emptyStateIcon).length) {
       cy.log(`Topology doesn't have workload "${componentName}", lets create it`);
-      navigateTo(devNavigationMenu.Add);
       createGitWorkload(
         gitUrl,
         componentName,
@@ -68,7 +79,6 @@ export const createGitWorkloadIfNotExistsOnTopologyPage = (
         if ($node.find(topologyPO.highlightNode).length) {
           cy.log(`knative service: ${componentName} is already created`);
         } else {
-          navigateTo(devNavigationMenu.Add);
           createGitWorkload(
             gitUrl,
             componentName,

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/export-application.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/export-application.ts
@@ -8,6 +8,7 @@ import {
   closeExportNotification,
 } from '../../pages';
 import { navigateTo } from '../../pages/app';
+import { checkDeveloperPerspective } from '../../pages/functions/checkDeveloperPerspective';
 
 Given(
   'user has created {string} workload in {string} application',
@@ -23,6 +24,7 @@ Given(
 );
 
 Given('user is at Add page', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Add);
 });
 

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/helm-chart-repositories.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/helm-chart-repositories.ts
@@ -3,8 +3,10 @@ import { addOptions, devNavigationMenu } from '../../constants';
 import { addPagePO, helmChartRepositoriesPO } from '../../pageObjects';
 import { addPage, createForm, navigateTo } from '../../pages';
 import { helmChartRepository } from '../../pages/add-flow/helm-chart-repository';
+import { checkDeveloperPerspective } from '../../pages/functions/checkDeveloperPerspective';
 
 Given('user is at Add page', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Add);
 });
 

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/sharing.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/sharing.ts
@@ -2,8 +2,10 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
 import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
 import { addOptions, devNavigationMenu } from '../../constants';
 import { addPage, navigateTo } from '../../pages';
+import { checkDeveloperPerspective } from '../../pages/functions/checkDeveloperPerspective';
 
 Given('user is at Add page', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Add);
 });
 

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/common/addFlow.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/common/addFlow.ts
@@ -22,8 +22,10 @@ import {
   createGitWorkloadIfNotExistsOnTopologyPage,
   verifyAndInstallGitopsPrimerOperator,
 } from '../../pages';
+import { checkDeveloperPerspective } from '../../pages/functions/checkDeveloperPerspective';
 
 Given('user is at Add page', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Add);
 });
 

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/common/common.ts
@@ -5,6 +5,7 @@ import { modal } from '@console/cypress-integration-tests/views/modal';
 import { nav } from '@console/cypress-integration-tests/views/nav';
 import { switchPerspective, devNavigationMenu, adminNavigationMenu } from '../../constants';
 import { perspective, projectNameSpace, navigateTo, app } from '../../pages';
+import { checkDeveloperPerspective } from '../../pages/functions/checkDeveloperPerspective';
 
 Given('user has logged in as a basic user', () => {
   cy.logout();
@@ -17,6 +18,7 @@ Given('user has logged in as a basic user', () => {
 });
 
 Given('user is at developer perspective', () => {
+  checkDeveloperPerspective();
   perspective.switchTo(switchPerspective.Developer);
   // Due to bug ODC-6231
   // cy.testA11y('Developer perspective with guide tour modal');

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/getting-started/sample-card-add-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/getting-started/sample-card-add-page.ts
@@ -12,8 +12,10 @@ import {
   topologyPage,
   verifyAddPage,
 } from '../../pages';
+import { checkDeveloperPerspective } from '../../pages/functions/checkDeveloperPerspective';
 
 Given('user is at developer perspective', () => {
+  checkDeveloperPerspective();
   perspective.switchTo(switchPerspective.Developer);
 });
 
@@ -22,6 +24,7 @@ Given('user has created or selected namespace {string}', (projectName: string) =
 });
 
 Given('user is at Add page', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Add);
 });
 

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/common/common.ts
@@ -18,8 +18,10 @@ import {
   catalogPage,
   addPage,
 } from '@console/dev-console/integration-tests/support/pages';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 
 Given('user is at developer perspective', () => {
+  checkDeveloperPerspective();
   perspective.switchTo(switchPerspective.Developer);
   // cy.testA11y('Developer perspective with guider tour modal');
 });
@@ -111,6 +113,7 @@ When('user clicks on the link for the {string} of helm release', (resource: stri
 });
 
 Given('user is at Add page', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Add);
 });
 

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-navigation.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-navigation.ts
@@ -18,6 +18,7 @@ import {
   perspective,
   createForm,
 } from '@console/dev-console/integration-tests/support/pages';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import { topologyPage } from '@console/topology/integration-tests/support/pages/topology/topology-page';
 import { helmPage, helmDetailsPage } from '../../pages';
 
@@ -30,6 +31,7 @@ const deleteChartRepositoryFromDetailsPage = (name: string, type: string) => {
 };
 
 Given('user is at developer perspective', () => {
+  checkDeveloperPerspective();
   perspective.switchTo(switchPerspective.Developer);
 });
 

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm.ts
@@ -19,6 +19,7 @@ import {
   projectNameSpace,
   app,
 } from '@console/dev-console/integration-tests/support/pages';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 
 When('user selects YAML view', () => {
   cy.document().its('readyState').should('eq', 'complete');
@@ -80,6 +81,7 @@ Then('user will see A-Z, Z-A sort by dropdown', () => {
 });
 
 Given('user is at Add page', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Add);
 });
 

--- a/frontend/packages/knative-plugin/integration-tests/features/admin-perspective/eventing-page-admin.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/admin-perspective/eventing-page-admin.feature
@@ -1,4 +1,5 @@
-@knative-admin @knative
+@knative-admin @knative @broken-test
+# Broken due to https://issues.redhat.com/browse/OCPBUGS-55368
 Feature: Eventing page at Administrator perspective
               As a user, I should be able to access event sources, channels, brokers at Administrator perspective
 
@@ -10,7 +11,7 @@ Feature: Eventing page at Administrator perspective
 
         @regression
         Scenario: Create new Event Source: KA-01-TC01
-            Given user has created knative service "hello-openshift"
+            Given user has created knative service "hello-openshift" in admin
               And user is at administrator perspective
               And user is at eventing page
              When user clicks on Create dropdown button
@@ -20,8 +21,8 @@ Feature: Eventing page at Administrator perspective
               And user enters "* * * * *" in Schedule field
               And user selects resource "hello-openshift"
               And user clicks on Create button to submit
-             Then user will be redirected to Project Details page
-              And user will see ping-source created
+             Then user will be redirected to Topology page
+              And ApiServerSource event source "ping-source" is created and linked to selected knative service "hello-openshift"
 
 
         @regression
@@ -31,8 +32,8 @@ Feature: Eventing page at Administrator perspective
               And user selects Channel
               And user selects Default channels
               And user clicks on Create button to create channel
-             Then user will be redirected to Project Details page
-              And user will see channel created
+             Then user will be redirected to Topology page
+              And user will see the channel "channel" created
 
 
         @manual

--- a/frontend/packages/knative-plugin/integration-tests/features/admin-perspective/filters-serving-eventing-admin.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/admin-perspective/filters-serving-eventing-admin.feature
@@ -5,7 +5,7 @@ Feature: Filters on Serving and Eventing page
 
         Background:
             Given user has created or selected namespace "aut-serving-eventing"
-              And user has created knative service "hello-openshift"
+              And user has created knative service "hello-openshift" in admin
               And user is at administrator perspective
 
         @regression
@@ -41,7 +41,8 @@ Feature: Filters on Serving and Eventing page
               And user will see Clear all filters
 
 
-        @regression
+        @regression @broken-test
+        # Broken due to https://issues.redhat.com/browse/OCPBUGS-55368
         Scenario: Filter the Event Sources: KA-02-TC04
             Given user has created ApiServer Source
               And user has created Ping Source

--- a/frontend/packages/knative-plugin/integration-tests/features/admin-perspective/serving-page-admin.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/admin-perspective/serving-page-admin.feature
@@ -5,7 +5,7 @@ Feature: Serving page at Administrator perspective
 
         Background:
             Given user has created or selected namespace "aut-serving-page"
-              And user has created knative service "hello-openshift"
+              And user has created knative service "hello-openshift" in admin
               And user is at administrator perspective
 
 

--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/create-knative-workload.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/create-knative-workload.feature
@@ -4,6 +4,7 @@ Feature: Create a workload of 'knative Service' type resource
 
         Background:
             Given user has created or selected namespace "aut-knative-workload"
+              And user is at Add page
 
 
         @regression

--- a/frontend/packages/knative-plugin/integration-tests/support/pageObjects/global-po.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/pageObjects/global-po.ts
@@ -190,7 +190,7 @@ export const eventingPO = {
     containersource: '[data-test-row-filter="containersource"]',
     pingsource: '[data-test-row-filter="pingsource"]',
     sinkbinding: '[data-test-row-filter="sinkbinding"]',
-    labelSuggestion: '.co-suggestion-line',
+    labelSuggestion: '[data-test="suggestion-line"]',
     checkbox: '.pf-v6-c-check__input',
   },
   resourceIcon: '.co-m-resource-icon',

--- a/frontend/packages/knative-plugin/integration-tests/support/pages/admin-perspective/eventing-page.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/pages/admin-perspective/eventing-page.ts
@@ -1,4 +1,4 @@
-import { operatorsPage } from '@console/dev-console/integration-tests/support/pages';
+import { operatorsPage, topologyPage } from '@console/dev-console/integration-tests/support/pages';
 import { eventingPO } from '@console/knative-plugin/integration-tests/support/pageObjects/global-po';
 
 export const eventingSources = {
@@ -15,7 +15,8 @@ export const eventingSources = {
     cy.get(eventingPO.pingSource.resource).click();
     cy.get(eventingPO.pingSource.resourceItem).eq(0).click({ force: true });
     cy.get(eventingPO.pingSource.submit).click();
-    cy.get(eventingPO.pageDetails).should('include.text', 'Project details');
+    // cy.get(eventingPO.pageDetails).should('include.text', 'Project details');
+    topologyPage.verifyTopologyPage();
   },
   createApiServerSource: () => {
     operatorsPage.navigateToEventingPage();
@@ -30,7 +31,8 @@ export const eventingSources = {
     cy.get(eventingPO.apiServerSource.resource).click();
     cy.get(eventingPO.apiServerSource.resourceItem).eq(0).click({ force: true });
     cy.get(eventingPO.apiServerSource.submit).click();
-    cy.get(eventingPO.pageDetails).should('include.text', 'Project details');
+    // cy.get(eventingPO.pageDetails).should('include.text', 'Project details');
+    topologyPage.verifyTopologyPage();
   },
   createSinkBinding: () => {
     operatorsPage.navigateToEventingPage();
@@ -45,7 +47,8 @@ export const eventingSources = {
     cy.get(eventingPO.sinkBinding.resource).click();
     cy.get(eventingPO.sinkBinding.resourceItem).contains('openshift').click({ force: true });
     cy.get(eventingPO.sinkBinding.submit).click();
-    cy.get(eventingPO.pageDetails).should('include.text', 'Project details');
+    // cy.get(eventingPO.pageDetails).should('include.text', 'Project details');
+    topologyPage.verifyTopologyPage();
   },
   createContainerSource: () => {
     operatorsPage.navigateToEventingPage();
@@ -59,7 +62,8 @@ export const eventingSources = {
     cy.get(eventingPO.containerSource.resource).click();
     cy.get(eventingPO.containerSource.resourceItem).contains('openshift').click({ force: true });
     cy.get(eventingPO.containerSource.submit).click();
-    cy.get(eventingPO.pageDetails).should('include.text', 'Project details');
+    // cy.get(eventingPO.pageDetails).should('include.text', 'Project details');
+    topologyPage.verifyTopologyPage();
   },
 };
 
@@ -71,7 +75,8 @@ export const eventingChannel = {
     cy.get(eventingPO.channel.typeField).click();
     cy.get(eventingPO.channel.createDropDownDefaultChannel).click();
     cy.get(eventingPO.channel.submit).click();
-    cy.get(eventingPO.pageDetails).should('include.text', 'Project details');
+    // cy.get(eventingPO.pageDetails).should('include.text', 'Project details');
+    topologyPage.verifyTopologyPage();
   },
   createInMemoryChannel: () => {
     operatorsPage.navigateToEventingPage();
@@ -80,7 +85,8 @@ export const eventingChannel = {
     cy.get(eventingPO.channel.typeField).click();
     cy.get(eventingPO.channel.createDropDownInMemoryChannel).click();
     cy.get(eventingPO.channel.submit).click();
-    cy.get(eventingPO.pageDetails).should('include.text', 'Project details');
+    // cy.get(eventingPO.pageDetails).should('include.text', 'Project details');
+    topologyPage.verifyTopologyPage();
   },
 };
 

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/admin-perspective/serving-page-admin.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/admin-perspective/serving-page-admin.ts
@@ -49,7 +49,8 @@ When('user clicks on Service button', () => {
 });
 
 Then('user can see titles URL, Revision, Created, Conditions, Ready, Reason', () => {
-  cy.get('[role="rowgroup"]')
+  cy.get('[aria-label="Services"]')
+    // cy.get('[role="rowgroup"]')
     .should('contain', 'URL')
     .and('contain', 'Revision')
     .and('contain', 'Created')
@@ -59,7 +60,8 @@ Then('user can see titles URL, Revision, Created, Conditions, Ready, Reason', ()
 });
 
 Then('user can see titles Namespace, Service, Created, Conditions, Ready, Reason', () => {
-  cy.get('[role="rowgroup"]')
+  cy.get('[aria-label="Revisions"]')
+    // cy.get('[role="rowgroup"]')
     .should('contain', 'Name')
     .and('contain', 'Service')
     .and('contain', 'Created')
@@ -69,7 +71,8 @@ Then('user can see titles Namespace, Service, Created, Conditions, Ready, Reason
 });
 
 Then('user can see titles URL, Created, Conditions, Traffic', () => {
-  cy.get('[role="rowgroup"]')
+  cy.get('[aria-label="Routes"]')
+    // cy.get('[role="rowgroup"]')
     .should('contain', 'URL')
     .and('contain', 'Created')
     .and('contain', 'Conditions')

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/common.ts
@@ -41,7 +41,7 @@ Given('user is at developer perspective', () => {
 
 Given('user is at administrator perspective', () => {
   perspective.switchTo(switchPerspective.Administrator);
-  cy.testA11y('Administrator perspective');
+  // cy.testA11y('Administrator perspective');
 });
 
 Given('user has created or selected namespace {string}', (projectName: string) => {
@@ -50,6 +50,7 @@ Given('user has created or selected namespace {string}', (projectName: string) =
 });
 
 Given('user is at pipelines page', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Pipelines);
 });
 
@@ -133,6 +134,15 @@ Given(
 
 Given('user has created knative service {string}', (knativeServiceName: string) => {
   perspective.switchTo(switchPerspective.Developer);
+  createGitWorkloadIfNotExistsOnTopologyPage(
+    'https://github.com/sclorg/nodejs-ex.git',
+    knativeServiceName,
+    resourceTypes.knativeService,
+  );
+});
+
+Given('user has created knative service {string} in admin', (knativeServiceName: string) => {
+  perspective.switchTo(switchPerspective.Administrator);
   createGitWorkloadIfNotExistsOnTopologyPage(
     'https://github.com/sclorg/nodejs-ex.git',
     knativeServiceName,

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/functions/functions-navigation.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/functions/functions-navigation.ts
@@ -9,9 +9,11 @@ import {
   navigateTo,
   perspective,
 } from '@console/dev-console/integration-tests/support/pages';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import { functionsPage } from '../../pages/functions/functions-page';
 
 Given('user is at developer perspective', () => {
+  checkDeveloperPerspective();
   perspective.switchTo(switchPerspective.Developer);
 });
 

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-add-options.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-add-options.feature
@@ -64,7 +64,7 @@ Feature: Create Pipeline from Add Options
         @smoke
         Scenario Outline: Search the created pipeline from Add options in pipelines page: P-01-TC05
             Given user created workload "<name>" from add page with pipeline
-              And user is at pipelines page
+              And user is at pipelines page in developer view
              When user searches for pipeline "<name>" in pipelines page
              Then pipeline "<name>" is displayed in pipelines page
 

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
@@ -4,6 +4,7 @@ Feature: Create the pipeline from builder page
 
         Background:
             Given user has created or selected namespace "aut-pipelines"
+              And user is at Add page
 
 
         @smoke
@@ -36,7 +37,7 @@ Feature: Create the pipeline from builder page
 
         @regression
         Scenario: Pipeline Builder page: P-02-TC02
-            Given user is at pipelines page
+            Given user is at pipelines page in admin view
              When user clicks Create Pipeline button on Pipelines page
              Then user will be redirected to Pipeline Builder page
               And user is able to see pipeline name with default value "new-pipeline"
@@ -311,7 +312,7 @@ Feature: Create the pipeline from builder page
 
         @regression
         Scenario: Code assistance for referencing Context-based values in the Pipeline Builder: P-02-TC20
-            Given user is at pipelines page
+            Given user is at pipelines page in admin view
              When user clicks on import YAML button
               And user enters yaml content from yaml file "pipelineRun-using_context_variables.yaml" in the editor
         # user uses yaml content "pipelineRun-using_context_variables.yaml"

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/event-tab-in-pipeline-run-page.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/event-tab-in-pipeline-run-page.feature
@@ -34,9 +34,9 @@ Feature: Events tab in Pipeline run and Task run details pages
         @smoke
         Scenario: Events tab in pipeline run details page of developer perspective: P-03-TC03
             Given user is at developer perspective
-              And user is at pipelines page
+              And user is at pipelines page in developer view
               And pipeline run is displayed for "ex-pipeline-two" with resource
-              And user is at pipelines page
+              And user is at pipelines page in developer view
              When user navigates to Pipeline Runs tab
               # And user clicks on pipeline "ex-pipeline-two"
               And user clicks on pipeline run for pipeline "ex-pipeline-two"
@@ -48,7 +48,7 @@ Feature: Events tab in Pipeline run and Task run details pages
         Scenario: Events tab in task run details page of developer perspective: P-03-TC04
             Given user is at developer perspective
               And task named "ex-task-one" is available with task run for pipeline
-              And user is at pipelines page
+              And user is at pipelines page in developer view
              When user clicks on available pipeline "new-pipeline-one"
               And user goes to Pipeline Runs tab
               And user opens pipeline run "new-pipeline-one"

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipeline-metrics.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipeline-metrics.feature
@@ -5,7 +5,7 @@ Feature: Pipeline metrics
 
         Background:
             Given user has created or selected namespace "aut-pipelines"
-              And user is at pipelines page
+              And user is at pipelines page in developer view
 
 
         @regression

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipeline-navigation.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipeline-navigation.feature
@@ -4,7 +4,7 @@ Feature: Perform the actions on Pipelines page
 
         Background:
             Given user has created or selected namespace "aut-pipelines-nav"
-              And user is at pipelines page
+              And user is at pipelines page in developer view
 
         @regression @odc-7131
         Scenario: Remember last visited tab for the Pipeline page: P-12-TC01

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipeline-task-runs-display.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipeline-task-runs-display.feature
@@ -4,7 +4,7 @@ Feature: Display task runs page
 
         Background:
             Given user has created or selected namespace "aut-pipelines"
-              And user is at pipelines page
+              And user is at pipelines page in developer view
 
 
         @smoke

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-actions.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-actions.feature
@@ -4,7 +4,7 @@ Feature: Perform the actions on Pipelines page
 
         Background:
             Given user has created or selected namespace "aut-pipelines"
-              And user is at pipelines page
+              And user is at pipelines page in developer view
 
 
         @smoke

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-as-code.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-as-code.feature
@@ -4,7 +4,7 @@ Feature: Perform Actions on repository
 
         Background:
             Given user has created or selected namespace "aut-pipelines"
-              And user is at pipelines page
+              And user is at pipelines page in developer view
 
 
         @pre-condition

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-runs.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-runs.feature
@@ -4,13 +4,13 @@ Feature: Pipeline Runs
 
         Background:
             Given user has created or selected namespace "aut-pipelines"
-              And user is at pipelines page
+              And user is at pipelines page in developer view
 
 
         @regression
         Scenario Outline: Start pipeline popup details for pipeline with one resource: P-07-TC01
             Given pipeline "<pipeline_name>" consists of task "<task_name>" with one git resource
-              And user is at pipelines page
+              And user is at pipelines page in developer view
              When user selects "Start" option from kebab menu for pipeline "<pipeline_name>"
              Then Start Pipeline modal displays with Workspaces, Advanced Options sections
               And start button is enabled
@@ -23,7 +23,7 @@ Feature: Pipeline Runs
         @smoke
         Scenario Outline: Start the pipeline with one resource: P-07-TC02
             Given pipeline "<pipeline_name>" consists of task "<task_name>" with one git resource
-              And user is at pipelines page
+              And user is at pipelines page in developer view
              When user selects "Start" option from kebab menu for pipeline "<pipeline_name>"
               And user enters git url as "https://github.com/sclorg/nodejs-ex.git" in start pipeline modal
               And user clicks Start button in start pipeline modal
@@ -40,7 +40,7 @@ Feature: Pipeline Runs
         @smoke
         Scenario Outline: Pipeline Run Details page for pipeline without resource: P-07-TC04
             Given pipeline run is displayed for "<pipeline_name>" without resource
-              And user is at pipelines page
+              And user is at pipelines page in developer view
              When user clicks Last Run value of "<pipeline_name>"
              Then user will be redirected to Pipeline Run Details page
               And user is able to see Details, YAML, TaskRuns, Parameters, Logs, Events and Output tabs
@@ -75,7 +75,7 @@ Feature: Pipeline Runs
         @smoke
         Scenario Outline: Rerun the Pipeline Run from pipeline runs page: P-07-TC07
             Given pipeline run is displayed for "<pipeline_name>" without resource
-              And user is at pipelines page
+              And user is at pipelines page in developer view
              When user selects the Pipeline Run for "<pipeline_name>"
               And user navigates to Pipeline runs page
               And user selects Rerun option from kebab menu of "<pipeline_name>"
@@ -89,7 +89,7 @@ Feature: Pipeline Runs
         @smoke
         Scenario Outline: Pipeline Run Details page for a pipeline with resource: P-07-TC08
             Given pipeline run is displayed for "<pipeline_name>" with resource
-              And user is at pipelines page
+              And user is at pipelines page in developer view
              When user clicks Last Run value of the pipeline "<pipeline_name>"
              Then user will be redirected to Pipeline Run Details page
               And Pipeline Resources field will be displayed
@@ -103,7 +103,7 @@ Feature: Pipeline Runs
   # Marking it as to-do due to flakiness
         Scenario Outline: Filter the pipeline runs based on status: P-07-TC09
             Given pipeline "<pipeline_name>" is executed for 3 times
-              And user is at pipelines page
+              And user is at pipelines page in developer view
              When user filters the pipeline runs of pipeline "<pipeline_name>" based on the "<status>"
              Then user is able to see the filtered results with pipelineRuns status "<status>"
 
@@ -168,7 +168,7 @@ Feature: Pipeline Runs
         @manual
         Scenario: Maximum pipeline runs display in topology page: P-07-TC16
             Given user created workload "nodejs-last-run-1" from add page with pipeline
-              And user is at pipelines page
+              And user is at pipelines page in developer view
               And pipeline "nodejs-last-run-1" is executed for 5 times
              When user clicks node "nodejs-last-run-1" to open the side bar
              Then side bar is displayed with the pipelines section
@@ -342,7 +342,7 @@ Feature: Pipeline Runs
         @regression @odc-4793
         Scenario: Pipeline Run details page with Parameters tab and no parameters: P-07-TC34
             Given pipeline run is displayed for "pipeline-run-no-parameters" without resource
-              And user is at pipelines page
+              And user is at pipelines page in developer view
              When user clicks Last Run value of "pipeline-run-no-parameters"
              Then user will be redirected to Pipeline Run Details page
               And user is able to see Details, YAML, TaskRuns, Parameters, Logs, Events and Output tabs
@@ -352,7 +352,7 @@ Feature: Pipeline Runs
         @regression @odc-4793
         Scenario: Pipeline Run with parameters: P-07-TC35
             Given pipeline run is displayed for "pipeline-run-parameters" with parameters
-              And user is at pipelines page
+              And user is at pipelines page in developer view
              When user clicks Last Run value of "pipeline-run-parameters"
              Then user will be redirected to Pipeline Run Details page
               And user navigates to pipelineRun parameters tab

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-secrets.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-secrets.feature
@@ -5,7 +5,7 @@ Feature: Secrets
 
         Background:
             Given user has created or selected namespace "aut-pipelines"
-              And user is at pipelines page
+              And user is at pipelines page in developer view
 
 
         @smoke

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-triggers.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-triggers.feature
@@ -4,7 +4,7 @@ Feature: Triggers
 
         Background:
             Given user has created or selected namespace "aut-pipelines"
-              And user is at pipelines page
+              And user is at pipelines page in developer view
 
 
         @regression

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-workspaces.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-workspaces.feature
@@ -4,7 +4,7 @@ Feature: Workspaces
 
         Background:
             Given user has created or selected namespace "aut-pipelines"
-              And user is at pipelines page
+              And user is at pipelines page in developer view
 
 
         @smoke @broken-test
@@ -19,7 +19,7 @@ Feature: Workspaces
         @regression
         Scenario: Types of volume present in shared workspace: P-10-TC02
             Given user created pipeline with workspace using yaml "testData/pipelines-workspaces/s2i-build-and-deploy-pipeline-using-workspace.yaml"
-              And user is at pipelines page
+              And user is at pipelines page in developer view
              When user selects "Start" option from kebab menu for pipeline "s2i-build-and-deploy-workspace"
               And user selects shared workspaces dropdown
              Then user is able to see different shared workspaces like Empty Directory, Config Map, Secret, PVC, VolumeClaimTemplate
@@ -48,7 +48,7 @@ Feature: Workspaces
         Scenario: Start the pipeline with Secret: P-10-TC05
             Given user created pipeline "test-secret-pipeline" with workspace
               And user created Secret using yaml "pipeline-secret.yaml"
-              And user is at pipelines page
+              And user is at pipelines page in developer view
              When user selects "Start" option from kebab menu for pipeline "test-secret-pipeline"
               And user selects volume type "Secret" from workspaces dropdown
               And user selects "secret-password" from Secret dropdown
@@ -61,7 +61,7 @@ Feature: Workspaces
         Scenario: Start the pipeline with PVC: P-10-TC06
             Given user created pipeline "test-pvc-pipeline" with workspace
               And user created PVC using yaml "pipeline-persistentVolumeClaim.yaml"
-              And user is at pipelines page
+              And user is at pipelines page in developer view
              When user selects "Start" option from kebab menu for pipeline "test-pvc-pipeline"
               And user selects volume type "PersistentVolumeClaim" from workspaces dropdown
               And user selects "shared-task-storage" from PVC dropdown

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/common.ts
@@ -19,6 +19,7 @@ import {
   app,
   installKnativeOperatorUsingCLI,
 } from '@console/dev-console/integration-tests/support/pages';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import { userLoginPage } from '../../pages/functions/common';
 
 Given('user has installed OpenShift Serverless Operator', () => {
@@ -31,6 +32,7 @@ Given('user has logged in as a basic user', () => {
 });
 
 Given('user is at developer perspective', () => {
+  checkDeveloperPerspective();
   perspective.switchTo(switchPerspective.Developer);
   cy.testA11y('Developer perspective with guide tour modal');
   guidedTour.close();

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/pipelines.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/pipelines.ts
@@ -6,6 +6,7 @@ import {
   pageTitle,
 } from '@console/dev-console/integration-tests/support/constants';
 import { app, navigateTo } from '@console/dev-console/integration-tests/support/pages';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import { pipelineActions } from '../../constants';
 import { pipelinesPO } from '../../page-objects';
 import {
@@ -82,7 +83,8 @@ When('user adds another task {string} in parallel', (taskName: string) => {
   pipelineBuilderPage.selectParallelTask(taskName);
 });
 
-Given('user is at pipelines page', () => {
+Given('user is at pipelines page in developer view', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Pipelines);
   cy.get(pipelinesPO.pipelinesTab).click();
 });

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-add-options.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-add-options.ts
@@ -16,11 +16,13 @@ import {
   createGitWorkload,
   dockerfilePage,
 } from '@console/dev-console/integration-tests/support/pages';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import { pipelineActions } from '../../constants';
 import { pipelineRunDetailsPO } from '../../page-objects/pipelines-po';
 import { pipelinesPage, pipelineRunDetailsPage } from '../../pages';
 
 Given('user is at Add page', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Add);
 });
 

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
@@ -3,6 +3,7 @@ import * as yamlEditor from '@console/cypress-integration-tests/views/yaml-edito
 import { devNavigationMenu } from '@console/dev-console/integration-tests/support/constants/global';
 import { quickSearchAddPO } from '@console/dev-console/integration-tests/support/pageObjects';
 import { navigateTo, sidePane } from '@console/dev-console/integration-tests/support/pages/app';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import { safeYAMLToJS } from '@console/shared/src/utils/yaml';
 import {
   pipelineBuilderPO,
@@ -453,7 +454,8 @@ Then('user will be able to see the output in print-motd task', () => {
   cy.get(pipelineRunDetailsPO.logs.logPage).should('be.visible');
 });
 
-Given('user is at pipelines page', () => {
+Given('user is at pipelines page in developer view', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Pipelines);
   cy.get(pipelinesPO.pipelinesTab).click();
 });
@@ -506,7 +508,9 @@ Given('user has imported YAML {string} and {string}', (task1: string, task2: str
 });
 
 And('user is at YAML view of Pipeline Builder page', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Pipelines);
+  // cy.get('[data-quickstart-id="qs-nav-pipelines"]').should('exist').click();
   pipelinesPage.clickOnCreatePipeline();
   cy.get(pipelineBuilderPO.yamlView.switchToYAMLView).click();
 });

--- a/frontend/packages/shipwright-plugin/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/shipwright-plugin/integration-tests/support/step-definitions/common/common.ts
@@ -15,6 +15,7 @@ import {
   navigateTo,
   app,
 } from '@console/dev-console/integration-tests/support/pages';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import { devNavigationMenuPO } from '../../pageObjects';
 
 Given('user has logged in as a basic user', () => {
@@ -28,6 +29,7 @@ Given('user has logged in as a basic user', () => {
 });
 
 Given('user is at developer perspective', () => {
+  checkDeveloperPerspective();
   perspective.switchTo(switchPerspective.Developer);
   // Due to bug ODC-6231
   // cy.testA11y('Developer perspective with guide tour modal');
@@ -38,6 +40,7 @@ Given('user is at developer perspective', () => {
 });
 
 Given('user is at Add page', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Add);
 });
 

--- a/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
@@ -17,6 +17,7 @@ import {
   navigateTo,
   createForm,
 } from '@console/dev-console/integration-tests/support/pages/app';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import {
   verifyAndInstallGitopsPrimerOperator,
   verifyAndInstallPipelinesOperator,
@@ -116,6 +117,7 @@ Then('user is able to see health check notification', () => {
 });
 
 Given('user is at developer perspective', () => {
+  checkDeveloperPerspective();
   perspective.switchTo(switchPerspective.Developer);
   guidedTour.close();
   nav.sidenav.switcher.shouldHaveText(switchPerspective.Developer);
@@ -159,6 +161,7 @@ Given(
 );
 
 Given('user is at Add page', () => {
+  checkDeveloperPerspective();
   navigateTo(devNavigationMenu.Add);
 });
 

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/chart-view.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/chart-view.ts
@@ -21,6 +21,7 @@ import {
   projectNameSpace,
   yamlEditor,
 } from '@console/dev-console/integration-tests/support/pages/app';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import { chartAreaPO } from '../../page-objects/chart-area-po';
 import { topologyPO, typeOfWorkload } from '../../page-objects/topology-po';
 import {
@@ -195,6 +196,7 @@ Given('user has installed Service Binding operator', () => {
 });
 
 Given('user is at developer perspective', () => {
+  checkDeveloperPerspective();
   perspective.switchTo(switchPerspective.Developer);
   guidedTour.close();
   nav.sidenav.switcher.shouldHaveText(switchPerspective.Developer);

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/horizontal-pod-autoscaler/action-on-hpa.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/horizontal-pod-autoscaler/action-on-hpa.ts
@@ -11,6 +11,7 @@ import {
   topologyPage,
   topologySidePane,
 } from '@console/dev-console/integration-tests/support/pages';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import { hpaPO } from '../../../page-objects/hpa-po';
 import { checkPodsCount } from '../../../pages/functions/add-secret';
 
@@ -34,6 +35,7 @@ Given('user is at administrator perspective', () => {
 });
 
 Given('user is at developer perspective', () => {
+  checkDeveloperPerspective();
   perspective.switchTo(switchPerspective.Developer);
   cy.testA11y('Developer perspective with guider tour modal');
 });

--- a/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/common/webTerminal.ts
+++ b/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/common/webTerminal.ts
@@ -6,6 +6,7 @@ import {
   perspective,
   projectNameSpace,
 } from '@console/dev-console/integration-tests/support/pages';
+import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import { checkTerminalIcon } from '@console/dev-console/integration-tests/support/pages/functions/checkTerminalIcon';
 import { webTerminalPage } from '@console/webterminal-plugin/integration-tests/support/step-definitions/pages/web-terminal/webTerminal-page';
 
@@ -81,6 +82,7 @@ And('user has logged in as basic user', () => {
 });
 
 Given('user is at developer perspective', () => {
+  checkDeveloperPerspective();
   perspective.switchTo(switchPerspective.Developer);
 });
 


### PR DESCRIPTION
Story:[ODC-7782](https://issues.redhat.com/browse/ODC-7782)

Description:
Test adjustments to perspective merge

Command to execute:

export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.13-042801.devcluster.openshift.com/
export BRIDGE_KUBEADMIN_PASSWORD
export BRIDGE_BASE_ADDRESS
oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
oc apply -f ./frontend/packages/console-shared/src/test-data/htpasswd-secret.yaml
oc patch oauths cluster --patch "$(cat ./frontend/packages/console-shared/src/test-data/patch-htpasswd.yaml)" --type=merge
In frontend folder run 
./integration-tests/test-cypress.sh -p knative
Run eventing-page-admin, filters-serving-eventing-admin, serverless-admin-empty-state, serving-page-admin files
Browser
Chrome 125

