### PR TITLE
OCPBUGS-55047: align spacing after breadrcumb with PatternFly

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -85,10 +85,6 @@
   }
 }
 
-.monitoring-breadcrumbs {
-  padding-bottom: var(--pf-t--global--spacer--sm);
-}
-
 .monitoring-dashboards__card {
   height: calc(100% - 20px);
   margin: 0 0 20px 0;
@@ -582,7 +578,8 @@ $monitoring-line-height: 18px;
 }
 
 .query-browser__wrapper {
-  border: var(--pf-t--global--border--width--regular) solid var(--pf-t--global--border--color--default);
+  border: var(--pf-t--global--border--width--regular) solid
+    var(--pf-t--global--border--color--default);
   margin: 0 0 20px 0;
   overflow: visible;
   padding: 10px;

--- a/frontend/public/components/monitoring/alertmanager/alertmanager-config.tsx
+++ b/frontend/public/components/monitoring/alertmanager/alertmanager-config.tsx
@@ -552,7 +552,7 @@ export const AlertmanagerConfig: React.FC = () => {
   return (
     <>
       <PageBreadcrumb>
-        <Breadcrumb className="monitoring-breadcrumbs">
+        <Breadcrumb>
           <BreadcrumbItem>
             <Link className="pf-v6-c-breadcrumb__link" to={breadcrumbs[0].path}>
               {breadcrumbs[0].name}
@@ -561,7 +561,7 @@ export const AlertmanagerConfig: React.FC = () => {
           <BreadcrumbItem isActive>{breadcrumbs[1].name}</BreadcrumbItem>
         </Breadcrumb>
       </PageBreadcrumb>
-      <NavTitle className="co-m-nav-title--detail co-m-nav-title--breadcrumbs">
+      <NavTitle className="co-m-nav-title--detail">
         <PrimaryHeading>
           <div className="co-m-pane__name co-resource-item">
             <span className="co-resource-item__resource-name" data-test-id="resource-title">

--- a/frontend/public/components/monitoring/alertmanager/alertmanager-yaml-editor.tsx
+++ b/frontend/public/components/monitoring/alertmanager/alertmanager-yaml-editor.tsx
@@ -129,7 +129,7 @@ const AlertmanagerYAML: React.FC<{}> = () => {
   return (
     <>
       <PageBreadcrumb>
-        <Breadcrumb className="monitoring-breadcrumbs">
+        <Breadcrumb>
           <BreadcrumbItem>
             <Link className="pf-v6-c-breadcrumb__link" to={breadcrumbs[0].path}>
               {breadcrumbs[0].name}
@@ -138,7 +138,7 @@ const AlertmanagerYAML: React.FC<{}> = () => {
           <BreadcrumbItem isActive>{breadcrumbs[1].name}</BreadcrumbItem>
         </Breadcrumb>
       </PageBreadcrumb>
-      <NavTitle className="co-m-nav-title--detail co-m-nav-title--breadcrumbs">
+      <NavTitle className="co-m-nav-title--detail">
         <PrimaryHeading>
           <div className="co-m-pane__name co-resource-item">
             <span className="co-resource-item__resource-name" data-test-id="resource-title">

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -152,11 +152,7 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
       )}
       <NavTitle
         data-test-id={dataTestId}
-        className={classNames(
-          { 'co-m-nav-title--breadcrumbs': showBreadcrumbs },
-          { 'co-m-nav-title--row': navTitleAsRow },
-          className,
-        )}
+        className={classNames({ 'co-m-nav-title--row': navTitleAsRow }, className)}
         style={style}
       >
         {showHeading && (


### PR DESCRIPTION
After

<img width="527" alt="Screenshot 2025-04-15 at 5 17 46 PM" src="https://github.com/user-attachments/assets/e73f28ec-722c-45ce-9d6d-a4918d873c94" />
<img width="531" alt="Screenshot 2025-04-15 at 5 17 50 PM" src="https://github.com/user-attachments/assets/f7f35959-4cbd-425f-95fe-1791d595ab4b" />
<img width="551" alt="Screenshot 2025-04-15 at 5 17 53 PM" src="https://github.com/user-attachments/assets/0438bef4-22bf-4bd7-bfe3-5d1ca63b0c6e" />

@PeterYurkovich, you're going to need to account for the removal of `.monitoring-breadcrumbs`.  `.pf-v6-u-pb-md` is an easy subtitute.