### PR TITLE
OCPBUGS-43792: Follow-on fix. Add new "plugins-order" flag to bridge cli args

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -124,6 +124,7 @@ func main() {
 
 	consolePluginsFlags := serverconfig.MultiKeyValue{}
 	fs.Var(&consolePluginsFlags, "plugins", "List of plugin entries that are enabled for the console. Each entry consist of plugin-name as a key and plugin-endpoint as a value.")
+	fPluginsOrder := fs.String("plugins-order", "", "List of plugin names which determines the order in which plugin extensions will be resolved.")
 	fPluginProxy := fs.String("plugin-proxy", "", "Defines various service types to which will console proxy plugins requests. (JSON as string)")
 	fI18NamespacesFlags := fs.String("i18n-namespaces", "", "List of namespaces separated by comma. Example --i18n-namespaces=plugin__acm,plugin__kubevirt")
 	fContentSecurityPolicyEnabled := fs.Bool("content-security-policy-enabled", false, "Flag to indicate if Content Secrity Policy features should be enabled.")
@@ -231,6 +232,20 @@ func main() {
 		}
 	}
 
+	pluginsOrder := []string{}
+	if *fPluginsOrder != "" {
+		for _, str := range strings.Split(*fPluginsOrder, ",") {
+			str = strings.TrimSpace(str)
+			if str == "" {
+				flags.FatalIfFailed(flags.NewInvalidFlagError("plugins-order", "list must contain name of i18n namespaces separated by comma"))
+			}
+			if consolePluginsFlags[str] == "" {
+				flags.FatalIfFailed(flags.NewInvalidFlagError("plugins-order", "list must only contain currently enabled plugins"))
+			}
+			pluginsOrder = append(pluginsOrder, str)
+		}
+	}
+
 	nodeArchitectures := []string{}
 	if *fNodeArchitectures != "" {
 		for _, str := range strings.Split(*fNodeArchitectures, ",") {
@@ -296,6 +311,7 @@ func main() {
 		K8sMode:                      *fK8sMode,
 		CopiedCSVsDisabled:           *fCopiedCSVsDisabled,
 		Capabilities:                 capabilities,
+		PluginsOrder:                 pluginsOrder,
 	}
 
 	completedAuthnOptions, err := authOptions.Complete()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -201,6 +201,7 @@ type Server struct {
 	ThanosTenancyProxyForRulesConfig    *proxy.Config
 	UserSettingsLocation                string
 	AuthMetrics                         *auth.Metrics
+	PluginsOrder                        []string
 }
 
 func disableDirectoryListing(handler http.Handler) http.Handler {
@@ -703,11 +704,6 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Security-Policy-Report-Only", strings.Join(cspDirectives, "; "))
 	}
 
-	plugins := make([]string, 0, len(s.EnabledConsolePlugins))
-	for plugin := range s.EnabledConsolePlugins {
-		plugins = append(plugins, plugin)
-	}
-
 	jsg := &jsGlobals{
 		AuthDisabled:              s.Authenticator.IsStatic(),
 		ConsoleVersion:            version.Version,
@@ -736,7 +732,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		DevCatalogCategories:      s.DevCatalogCategories,
 		DevCatalogTypes:           s.DevCatalogTypes,
 		UserSettingsLocation:      s.UserSettingsLocation,
-		ConsolePlugins:            plugins,
+		ConsolePlugins:            s.PluginsOrder,
 		I18nNamespaces:            s.I18nNamespaces,
 		QuickStarts:               s.QuickStarts,
 		AddPage:                   s.AddPage,

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -119,6 +119,7 @@ func SetFlagsFromConfig(fs *flag.FlagSet, config *Config) (err error) {
 	addMonitoringInfo(fs, &config.MonitoringInfo)
 	addHelmConfig(fs, &config.Helm)
 	addPlugins(fs, config.Plugins)
+	addPluginsOrder(fs, config.PluginsOrder)
 	addI18nNamespaces(fs, config.I18nNamespaces)
 	err = addProxy(fs, &config.Proxy)
 	if err != nil {
@@ -356,6 +357,10 @@ func addPlugins(fs *flag.FlagSet, plugins MultiKeyValue) {
 	for pluginName, pluginEndpoint := range plugins {
 		fs.Set("plugins", fmt.Sprintf("%s=%s", pluginName, pluginEndpoint))
 	}
+}
+
+func addPluginsOrder(fs *flag.FlagSet, pluginsOrder []string) {
+	fs.Set("plugins-order", strings.Join(pluginsOrder, ","))
 }
 
 func addTelemetry(fs *flag.FlagSet, telemetry MultiKeyValue) {

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -24,6 +24,7 @@ type Config struct {
 	Helm                         `yaml:"helm"`
 	MonitoringInfo               `yaml:"monitoringInfo,omitempty"`
 	Plugins                      MultiKeyValue                 `yaml:"plugins,omitempty"`
+	PluginsOrder                 []string                      `yaml:"pluginsOrder,omitempty"`
 	I18nNamespaces               []string                      `yaml:"i18nNamespaces,omitempty"`
 	Proxy                        Proxy                         `yaml:"proxy,omitempty"`
 	ContentSecurityPolicyEnabled bool                          `yaml:"contentSecurityPolicyEnabled,omitempty"`


### PR DESCRIPTION
Since "plugins" is an unordered map, we need a new way to enforce plugin resolution order from console operator config to the frontend.