### PR TITLE
OCPBUGS-54601: fix bug where operator appears twice

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -812,6 +812,15 @@ export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProp
                   kind: referenceForModel(ClusterServiceVersionModel),
                   namespace: GLOBAL_COPIED_CSV_NAMESPACE,
                   prop: 'globalClusterServiceVersions',
+                  selector: {
+                    matchExpressions: [
+                      {
+                        key: 'olm.copiedFrom',
+                        operator: 'NotEquals',
+                        values: [props.namespace],
+                      },
+                    ],
+                  },
                 },
               ]
             : []),


### PR DESCRIPTION
when disableCopiedCSVs is true and the selected project matches the operator's default namespace

Credit to @TheRealJon for this fix.  Thank you!

/assign @cajieh 

After

<img width="1240" alt="Screenshot 2025-04-21 at 2 36 59 PM" src="https://github.com/user-attachments/assets/101dcb88-9804-40dd-ab9b-4fde5cb60054" />
