### PR TITLE
OCPBUGS-55323: Add patternfly/react-topology to shared modules list of dynamic plugin sdk

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -129,6 +129,7 @@ The following shared modules are provided by Console, without plugins providing 
 
 - `@openshift-console/dynamic-plugin-sdk`
 - `@openshift-console/dynamic-plugin-sdk-internal`
+- `@patternfly/react-topology`
 - `react`
 - `react-i18next`
 - `react-redux`
@@ -175,6 +176,8 @@ This section documents notable changes in the Console provided shared modules ac
   `react-router-dom-v5-compat` will be removed in the future. Plugins should continue migration to the
   `react-router-dom-v5-compat` module until `react-router-dom` v6 is aliased to `react-router-dom` v6. See the
   [Official v5 to v6 Migration Guide](https://reactrouter.com/6.30.0/upgrading/v5) for details.
+- Added `@patternfly/react-topology` to shared modules. This supports dynamic plugins using PatternFly 6
+  topology components with consistent context and styling.
 
 ##### CSS styling
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules/shared-modules-init.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules/shared-modules-init.ts
@@ -35,6 +35,7 @@ const initSharedScope = () => {
   addModule('@openshift-console/dynamic-plugin-sdk-internal', async () => () =>
     require('@console/dynamic-plugin-sdk/src/lib-internal'),
   );
+  addModule('@patternfly/react-topology', async () => () => require('@patternfly/react-topology'));
   addModule('react', async () => () => require('react'));
   addModule('react-i18next', async () => () => require('react-i18next'));
   addModule('react-redux', async () => () => require('react-redux'));

--- a/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules/shared-modules-meta.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules/shared-modules-meta.ts
@@ -24,6 +24,7 @@ type SharedModuleMetadata = Partial<{
 export const sharedPluginModules = [
   '@openshift-console/dynamic-plugin-sdk',
   '@openshift-console/dynamic-plugin-sdk-internal',
+  '@patternfly/react-topology',
   'react',
   'react-i18next',
   'react-redux',
@@ -42,6 +43,7 @@ export type SharedModuleNames = typeof sharedPluginModules[number];
 const sharedPluginModulesMetadata: Record<SharedModuleNames, SharedModuleMetadata> = {
   '@openshift-console/dynamic-plugin-sdk': { singleton: true, allowFallback: false },
   '@openshift-console/dynamic-plugin-sdk-internal': { singleton: true, allowFallback: false },
+  '@patternfly/react-topology': { singleton: true, allowFallback: false },
   react: { singleton: true, allowFallback: false },
   'react-i18next': { singleton: true, allowFallback: false },
   'react-redux': { singleton: true, allowFallback: false },


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/OCPBUGS-55323

**Description:**

Added patternfly/react-topology to shared modules list based on discussion https://redhat-internal.slack.com/archives/C011BL0FEKZ/p1745429881530709?thread_ts=1744645281.276009&cid=C011BL0FEKZ