### PR TITLE
NO-JIRA: Deprecate `react-router-dom-v5-compat`

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -168,7 +168,13 @@ This section documents notable changes in the Console provided shared modules ac
 
 - Removed PatternFly 4.x shared modules. Console now uses PatternFly 6.x and provides PatternFly 5.x
   styles for compatibility with existing plugins.
-- VirtualizedTable, ListPageFilter, and useListPageFilter are deprecated and will be removed in the future. PatternFly's [Data view](https://www.patternfly.org/extensions/data-view/overview) extension should be used instead. See this [proof of concept](https://github.com/openshift/console/pull/14897) for an example.
+- VirtualizedTable, ListPageFilter, and useListPageFilter are deprecated and will be removed in the future.
+  PatternFly's [Data view](https://www.patternfly.org/extensions/data-view/overview) extension should be used
+  instead. See this [proof of concept](https://github.com/openshift/console/pull/14897) for an example.
+- `react-router-dom-v5-compat` module is deprecated and will aliased to `react-router-dom` v6 and
+  `react-router-dom-v5-compat` will be removed in the future. Plugins should continue migration to the
+  `react-router-dom-v5-compat` module until `react-router-dom` v6 is aliased to `react-router-dom` v6. See the
+  [Official v5 to v6 Migration Guide](https://reactrouter.com/6.30.0/upgrading/v5) for details.
 
 ##### CSS styling
 
@@ -566,6 +572,8 @@ The list of shared modules planned for deprecation:
 - Console provided React Router v5 shared modules
   - `react-router`
   - `react-router-dom`
+- Console provided React Router v6 compatibility module
+  - `react-router-dom-v5-compat`
 
 ## i18n translations for messages
 


### PR DESCRIPTION
We should probably deprecate this now in case #14957 doesn't make it on time

/label px-approved
/label qe-approved

docs approval:

/assign @opayne1 