### PR TITLE
OCPBUGS-55208: Should show default OpenShift Logo for a theme when there is not custom logo set for the theme. 

### DIFF
--- a/frontend/public/components/utils/branding.ts
+++ b/frontend/public/components/utils/branding.ts
@@ -106,6 +106,8 @@ export const useCustomLogoURL = (type: CUSTOM_LOGO): { logoUrl: string; loading:
         setLogoUrl(URL.createObjectURL(blob));
         setLoading(false);
       } else if (response.status === 404) {
+        setLogoUrl('');
+        setLoading(false);
         return;
       } else {
         throw new Error(`Failed to fetch ${fetchURL}: ${response.statusText}`);


### PR DESCRIPTION
Fixed a problem where default logo did not appear when no custom logo has been specified for the given theme

This bug is a regression introduced by the loading logic inside useCustomLogoURL hook which missed correct state handling in case of 404 responses. 

before (only dark logo is configured - should have shown default logo on light theme):

https://github.com/user-attachments/assets/31cca273-504d-4a90-a026-97c824c6bab8


after (shows default logo for light theme):

https://github.com/user-attachments/assets/183daf08-4957-4fd1-ba7e-99b22119d636



