### PR TITLE
OCPBUGS-55414: fix runtime error on MachineConfigPools page

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -845,10 +845,10 @@ export const MachineConfigPoolsArePausedAlert: React.FC<MachineConfigPoolsArePau
     name: NodeTypes.worker,
   });
   const pausedMCPs = machineConfigPools
-    .filter((mcp) => !isMCPMaster(mcp))
-    .filter((mcp) => isMCPPaused(mcp));
+    ?.filter((mcp) => !isMCPMaster(mcp))
+    ?.filter((mcp) => isMCPPaused(mcp));
   return clusterIsUpToDateOrUpdateAvailable(getClusterUpdateStatus(clusterVersion)) &&
-    pausedMCPs.length > 0 ? (
+    pausedMCPs?.length > 0 ? (
     <Alert
       isInline
       title={t('public~{{resource}} updates are paused.', {


### PR DESCRIPTION
After

Note the existing behavior of the page is different depending upon whether or not a project exists for the user.

<img width="1441" alt="Screenshot 2025-04-28 at 9 36 38 AM" src="https://github.com/user-attachments/assets/297daf40-7ff6-49a4-b93d-fd83903cb3be" />
<img width="1376" alt="Screenshot 2025-04-28 at 9 42 21 AM" src="https://github.com/user-attachments/assets/669d1143-f50d-4803-b3dc-7de6f07f5ad6" />
