### PR TITLE
OCPBUGS-55454: Disable web terminal and Shipwright e2e

### DIFF
--- a/frontend/integration-tests/test-cypress.sh
+++ b/frontend/integration-tests/test-cypress.sh
@@ -84,7 +84,7 @@ if [ -n "${nightly-}" ] && [ -z "${pkg-}" ]; then
   # yarn run test-cypress-pipelines-nightly
   yarn run test-cypress-topology-nightly
   yarn run test-cypress-knative-nightly
-  yarn run test-cypress-webterminal-nightly
+  # yarn run test-cypress-webterminal-nightly
 
   exit $err;
 fi
@@ -93,7 +93,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-console-headless
   yarn run test-cypress-dev-console-headless
   yarn run test-cypress-olm-headless
-  yarn run test-cypress-webterminal-headless
+  # yarn run test-cypress-webterminal-headless
   yarn run test-cypress-helm-headless
   yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless

--- a/frontend/integration-tests/test-cypress.sh
+++ b/frontend/integration-tests/test-cypress.sh
@@ -80,7 +80,7 @@ if [ -n "${nightly-}" ] && [ -z "${pkg-}" ]; then
 
   yarn run test-cypress-dev-console-nightly
   yarn run test-cypress-helm-nightly
-  yarn run test-cypress-shipwright-nightly
+  # yarn run test-cypress-shipwright-nightly
   # yarn run test-cypress-pipelines-nightly
   yarn run test-cypress-topology-nightly
   yarn run test-cypress-knative-nightly
@@ -98,7 +98,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
   # yarn run test-cypress-pipelines-headless
-  yarn run test-cypress-shipwright-headless
+  # yarn run test-cypress-shipwright-headless
   exit;
 fi
 

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -90,7 +90,7 @@ export const topologyPO = {
     podScaleUP: '[aria-label="Increase the Pod count"]',
     podScaleDown: '[aria-label="Decrease the Pod count"]',
     podText: 'text.pod-ring__center-text',
-    applicationGroupingsTitle: '.overview__sidebar-pane-head data-test-id="resource-title"]',
+    applicationGroupingsTitle: '.overview__sidebar-pane-head [data-test="page-heading"] h1',
     applicationGroupingsSidepane: 'overview__sidebar-pane resource-overview',
     resourcesTabApplicationGroupings: '.pf-v6-c-tabs__item',
     pipelineRunsDetails: '.sidebar__section-heading',


### PR DESCRIPTION
Disabling the Web terminal e2e in CI as it is failing and blocking the other PRs.

https://search.dptools.openshift.org/?search=Create+new+project+with+timeout+and+use+Web+Terminal%3A&maxAge=12h&context=1&type=junit&name=pull-ci-openshift-console-main-e2e-gcp-console&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job
