### PR TITLE
OCPBUGS-55368: [knative] Self-provisioner user can not access or create event sources via ODC

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/utils/rbac.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/utils/rbac.tsx
@@ -107,6 +107,7 @@ export const checkAccess = (
 export const useAccessReview = (
   resourceAttributes: AccessReviewResourceAttributes,
   impersonate?: ImpersonateKind,
+  noCheckForEmptyGroupAndResource?: boolean,
 ): [boolean, boolean] => {
   const [loading, setLoading] = useSafetyFirst(true);
   const [isAllowed, setAllowed] = useSafetyFirst(false);
@@ -121,7 +122,13 @@ export const useAccessReview = (
     namespace = '',
   } = resourceAttributes;
   const impersonateKey = getImpersonateKey(impersonate);
+  const skipCheck = noCheckForEmptyGroupAndResource && !group && !resource;
   React.useEffect(() => {
+    if (skipCheck) {
+      setAllowed(false);
+      setLoading(false);
+      return;
+    }
     checkAccessInternal(group, resource, subresource, verb, name, namespace, impersonateKey)
       .then((result: SelfSubjectAccessReviewKind) => {
         setAllowed(result.status.allowed);
@@ -136,7 +143,18 @@ export const useAccessReview = (
         setAllowed(true);
         setLoading(false);
       });
-  }, [setLoading, setAllowed, group, resource, subresource, verb, name, namespace, impersonateKey]);
+  }, [
+    setLoading,
+    setAllowed,
+    group,
+    resource,
+    subresource,
+    verb,
+    name,
+    namespace,
+    impersonateKey,
+    skipCheck,
+  ]);
 
   return [isAllowed, loading];
 };

--- a/frontend/packages/knative-plugin/src/hooks/useEventSourceStatus.ts
+++ b/frontend/packages/knative-plugin/src/hooks/useEventSourceStatus.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAccessReview2 } from '@console/internal/components/utils';
+import { useAccessReview } from '@console/dynamic-plugin-sdk/src';
 import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
 import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { KnEventCatalogMetaData } from '../components/add/import-types';
@@ -50,13 +50,16 @@ export const useEventSourceStatus = (
     !isKameletSource &&
     eventSourceModels?.find((model: K8sKind) => model.kind === sourceKindProp);
   const sourceModel = isKameletSource ? CamelKameletBindingModel : eventSourceModel;
-
-  const [createSourceAccess, createSourceAccessLoading] = useAccessReview2({
-    group: sourceModel?.apiGroup,
-    resource: sourceModel?.plural,
-    verb: 'create',
-    namespace,
-  });
+  const [createSourceAccess, createSourceAccessLoading] = useAccessReview(
+    {
+      group: sourceModel?.apiGroup,
+      resource: sourceModel?.plural,
+      verb: 'create',
+      namespace,
+    },
+    undefined,
+    true,
+  );
 
   const sourceStatus = React.useMemo(() => {
     if (!isSourceKindPresent) {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-55368

**Analysis / Root cause**: 
When user went to create event source page for 1st time, SelfSubjectAccessReview call is made with empty group and empty resource and allowed value is returned as false but when the group and resource value is sent, due to cache, true value is returned back before first call response and when first call response came back, user was not allowed to create event source

**Solution Description**: 
Added a flag in useAccessReview whether to check for empty group and resource, so now the first call is returned false before second.
  
**Screen shots / Gifs for design review**: 

**---BEFORE----**


https://github.com/user-attachments/assets/5c340c07-c58e-40d7-af51-1adc22739987



**---AFTER----**

https://github.com/user-attachments/assets/d45ac1d4-77a4-4a1b-903e-cb8049ed1554



-----
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

