### PR TITLE
OCPBUGS-55808: fix cy.createProject command

### DIFF
--- a/frontend/packages/integration-tests-cypress/support/project.ts
+++ b/frontend/packages/integration-tests-cypress/support/project.ts
@@ -27,9 +27,8 @@ Cypress.Commands.add('createProject', (name: string, devConsole: boolean = false
   cy.testA11y('Create Project modal');
   modal.submit();
   modal.shouldBeClosed();
-  // TODO, switch to 'listPage.titleShouldHaveText(name)', when we switch to new test id
   if (devConsole === false) {
-    cy.get('[data-test="page-heading"] h1').should('have.text', name);
+    listPage.titleShouldHaveText(name);
   }
 });
 


### PR DESCRIPTION
QE [e2e tests](https://github.com/openshift/openshift-tests-private/blob/master/frontend/tests/projects/project-lists.cy.ts#L18C1-L18C45) are using `cy.createProject` command, we observed the following error in latest runs

```
{Timed out retrying after 30000ms: expected '<h1.pf-v6-c-content--h1>' to have text 'testuserone-project', but the text was 'ProjectPR testuserone-projectActive'
```
