### PR TITLE
OCPBUGS-55806: fix bug where AlertItem is missing info icon

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
@@ -9,7 +9,11 @@ import { alertURL } from '@console/internal/components/monitoring/utils';
 import { getAlertActions } from '@console/internal/components/notification-drawer';
 import { ExternalLink } from '@console/internal/components/utils';
 import { Timestamp } from '@console/internal/components/utils/timestamp';
-import { RedExclamationCircleIcon, YellowExclamationTriangleIcon } from '../../status/icons';
+import {
+  RedExclamationCircleIcon,
+  BlueInfoCircleIcon,
+  YellowExclamationTriangleIcon,
+} from '../../status/icons';
 import {
   getAlertSeverity,
   getAlertMessage,
@@ -19,12 +23,24 @@ import {
   getAlertName,
 } from './alert-utils';
 
-const CriticalIcon = () => <RedExclamationCircleIcon title="Critical" />;
-const WarningIcon = () => <YellowExclamationTriangleIcon title="Warning" />;
+const CriticalIcon = () => {
+  const { t } = useTranslation();
+  return <RedExclamationCircleIcon title={t('public~Critical')} />;
+};
+const InfoIcon = () => {
+  const { t } = useTranslation();
+  return <BlueInfoCircleIcon title={t('public~Info')} />;
+};
+const WarningIcon = () => {
+  const { t } = useTranslation();
+  return <YellowExclamationTriangleIcon title={t('public~Warning')} />;
+};
 const getSeverityIcon = (severity: string) => {
   switch (severity) {
     case 'critical':
       return CriticalIcon;
+    case 'info':
+      return InfoIcon;
     case 'warning':
     default:
       return WarningIcon;

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1799,6 +1799,8 @@
   "{{pluginName}} might have violated the Console Content Security Policy. Refer to the browser's console logs for details.": "{{pluginName}} might have violated the Console Content Security Policy. Refer to the browser's console logs for details.",
   "prometheusBaseURL not set": "prometheusBaseURL not set",
   "alertManagerBaseURL not set": "alertManagerBaseURL not set",
+  "Critical": "Critical",
+  "Info": "Info",
   "Loading {{title}} status": "Loading {{title}} status",
   "Waiting for the build": "Waiting for the build",
   "graph timespan": "graph timespan",


### PR DESCRIPTION
After

<img width="1092" alt="Screenshot 2025-05-14 at 9 22 06 AM" src="https://github.com/user-attachments/assets/a845a6b4-f79e-447d-9a4d-3a2498a82dcc" />
