### PR TITLE
OCPBUGS-56087: Opening Edit Secret modal and saving without changes throws error

### DIFF
--- a/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
+++ b/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
@@ -44,12 +44,13 @@ export const SecretFormWrapper: React.FC<BaseEditSecretProps_> = (props) => {
   const [inProgress, setInProgress] = React.useState(false);
   const [error, setError] = React.useState();
   const [stringData, setStringData] = React.useState(
-    _.mapValues(_.get(props.obj, 'data'), (value) => {
+    Object.entries(props.obj?.data ?? {}).reduce<Record<string, string>>((acc, [key, value]) => {
       if (isBinary(null, Buffer.from(value, 'base64'))) {
         return null;
       }
-      return value ? Base64.decode(value) : '';
-    }),
+      acc[key] = value ? Base64.decode(value) : '';
+      return acc;
+    }, {}),
   );
   const [base64StringData, setBase64StringData] = React.useState(props?.obj?.data ?? {});
   const [disableForm, setDisableForm] = React.useState(false);


### PR DESCRIPTION
restructure initialization of `stringData`

previously when you tried to edit a Secret with binary data, the `stringData` was initialized to be a key pair with null value instead of being an empty object, which resulted in errors when saving the secret without changes. After those changes we omit key pairs that have binary values from the `stringData`.

after:

https://github.com/user-attachments/assets/7137e769-69e9-4c51-8c68-baddaf0744e3

