### PR TITLE
NO-JIRA: Update plugin SDK docs

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
@@ -12,6 +12,7 @@ in [Console dynamic plugins README](./README.md).
 
 ## 4.19.0-prerelease.2 - 2025-05-20
 
+> [!IMPORTANT]
 > This release includes a change in generated JS code to use new JSX transform `react-jsx` introduced
 > in React 17. Plugins should update their TSConfig files accordingly (i.e. set `jsx` to `react-jsx`)
 > and run the `update-react-imports` [codemod](https://github.com/reactjs/react-codemod) if needed.

--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
@@ -10,19 +10,20 @@ For current development version of Console, use `4.x.0-prerelease.n` packages.
 For 1.x plugin SDK packages, refer to "OpenShift Console Versions vs SDK Versions" compatibility table
 in [Console dynamic plugins README](./README.md).
 
-## 4.19.0-prerelease.2 - TBD
+## 4.19.0-prerelease.2 - 2025-05-20
 
-- The base `tsconfig` file now sets the `jsx` option to `react-jsx` to use the new JSX transform introduced
-  in React 17+. Plugins should update their `tsconfig` files accordingly and run the `update-react-imports`
-  [react-codemod](https://github.com/reactjs/react-codemod) if needed. ([OCPBUGS-52589], [#14864])
-- A new component `DocumentTitle` has been added which allows plugins to modify the document title
-  of the Console. ([CONSOLE-3960], [#14876])
-- Upgraded the `monaco-editor` version used by the `CodeEditor`, `YAMLEditor`, and `ResourceYAMLEditor`
-  components to version `0.51.0`. This affects the `ref` which these components expose. ([CONSOLE-4407], [#14663])
+> This release includes a change in generated JS code to use new JSX transform `react-jsx` introduced
+> in React 17. Plugins should update their TSConfig files accordingly (i.e. set `jsx` to `react-jsx`)
+> and run the `update-react-imports` [codemod](https://github.com/reactjs/react-codemod) if needed.
+
+- Add `DocumentTitle` component that allows plugins to modify Console page title ([CONSOLE-3960], [#14876])
+- Add `hideFavoriteButton` prop to `ListPageHeader` component ([OCPBUGS-52948], [#14863])
+- Upgrade `monaco-editor` version used by `CodeEditor`, `YAMLEditor` and `ResourceYAMLEditor` components
+  to version `0.51.0`. This affects the `ref` which these components expose. ([CONSOLE-4407], [#14663])
+- Generated JS code now uses new JSX transform `react-jsx` ([OCPBUGS-52589], [#14864])
 
 ## 4.19.0-prerelease.1 - 2025-02-17
 
-- Remove Console provided PatternFly 4 shared modules ([CONSOLE-4379], [#14615])
 - Add `customData` prop to `HorizontalNav` component ([OCPBUGS-45319], [#14575])
 - Allow custom popover description in extension type `console.resource/details-item` ([CONSOLE-4269], [#14487])
 - Change generated JS build target from `es2016` to `es2021` ([CONSOLE-4400], [#14620])
@@ -89,7 +90,6 @@ in [Console dynamic plugins README](./README.md).
 [CONSOLE-4185]: https://issues.redhat.com/browse/CONSOLE-4185
 [CONSOLE-4263]: https://issues.redhat.com/browse/CONSOLE-4263
 [CONSOLE-4269]: https://issues.redhat.com/browse/CONSOLE-4269
-[CONSOLE-4379]: https://issues.redhat.com/browse/CONSOLE-4379
 [CONSOLE-4400]: https://issues.redhat.com/browse/CONSOLE-4400
 [CONSOLE-4407]: https://issues.redhat.com/browse/CONSOLE-4407
 [OCPBUGS-19048]: https://issues.redhat.com/browse/OCPBUGS-19048
@@ -105,6 +105,7 @@ in [Console dynamic plugins README](./README.md).
 [OCPBUGS-43998]: https://issues.redhat.com/browse/OCPBUGS-43998
 [OCPBUGS-45319]: https://issues.redhat.com/browse/OCPBUGS-45319
 [OCPBUGS-52589]: https://issues.redhat.com/browse/OCPBUGS-52589
+[OCPBUGS-52948]: https://issues.redhat.com/browse/OCPBUGS-52948
 [ODC-7425]: https://issues.redhat.com/browse/ODC-7425
 [#12983]: https://github.com/openshift/console/pull/12983
 [#13233]: https://github.com/openshift/console/pull/13233
@@ -129,8 +130,8 @@ in [Console dynamic plugins README](./README.md).
 [#14447]: https://github.com/openshift/console/pull/14447
 [#14487]: https://github.com/openshift/console/pull/14487
 [#14575]: https://github.com/openshift/console/pull/14575
-[#14615]: https://github.com/openshift/console/pull/14615
 [#14620]: https://github.com/openshift/console/pull/14620
 [#14663]: https://github.com/openshift/console/pull/14663
+[#14863]: https://github.com/openshift/console/pull/14863
 [#14864]: https://github.com/openshift/console/pull/14864
 [#14876]: https://github.com/openshift/console/pull/14876

--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-webpack.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-webpack.md
@@ -10,11 +10,16 @@ For current development version of Console, use `4.x.0-prerelease.n` packages.
 For 1.x plugin SDK packages, refer to "OpenShift Console Versions vs SDK Versions" compatibility table
 in [Console dynamic plugins README](./README.md).
 
-## 4.19.0-prerelease.2 - TBD
+## 4.19.0-prerelease.2 - 2025-05-20
 
-- The base `tsconfig` file now sets the `jsx` option to `react-jsx` to use the new JSX transform introduced
-  in React 17+. Plugins should update their `tsconfig` files accordingly and run the `update-react-imports`
-  [react-codemod](https://github.com/reactjs/react-codemod) if needed. ([OCPBUGS-52589], [#14864])
+> This release includes a change in generated JS code to use new JSX transform `react-jsx` introduced
+> in React 17. Plugins should update their TSConfig files accordingly (i.e. set `jsx` to `react-jsx`)
+> and run the `update-react-imports` [codemod](https://github.com/reactjs/react-codemod) if needed.
+
+- Add `@patternfly/react-topology` to Console provided shared modules ([OCPBUGS-55323], [#14993])
+- Skip processing type-only dynamic module imports ([OCPBUGS-53030], [#14861])
+- Update `typescript` peer dependency to match Console TS build version ([#14861])
+- Generated JS code now uses new JSX transform `react-jsx` ([OCPBUGS-52589], [#14864])
 
 ## 4.19.0-prerelease.1 - 2025-02-17
 
@@ -68,6 +73,8 @@ in [Console dynamic plugins README](./README.md).
 [OCPBUGS-38734]: https://issues.redhat.com/browse/OCPBUGS-38734
 [OCPBUGS-42985]: https://issues.redhat.com/browse/OCPBUGS-42985
 [OCPBUGS-52589]: https://issues.redhat.com/browse/OCPBUGS-52589
+[OCPBUGS-53030]: https://issues.redhat.com/browse/OCPBUGS-53030
+[OCPBUGS-55323]: https://issues.redhat.com/browse/OCPBUGS-55323
 [#13188]: https://github.com/openshift/console/pull/13188
 [#13388]: https://github.com/openshift/console/pull/13388
 [#13521]: https://github.com/openshift/console/pull/13521
@@ -81,4 +88,6 @@ in [Console dynamic plugins README](./README.md).
 [#14300]: https://github.com/openshift/console/pull/14300
 [#14615]: https://github.com/openshift/console/pull/14615
 [#14620]: https://github.com/openshift/console/pull/14620
+[#14861]: https://github.com/openshift/console/pull/14861
 [#14864]: https://github.com/openshift/console/pull/14864
+[#14993]: https://github.com/openshift/console/pull/14993

--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-webpack.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-webpack.md
@@ -12,6 +12,7 @@ in [Console dynamic plugins README](./README.md).
 
 ## 4.19.0-prerelease.2 - 2025-05-20
 
+> [!IMPORTANT]
 > This release includes a change in generated JS code to use new JSX transform `react-jsx` introduced
 > in React 17. Plugins should update their TSConfig files accordingly (i.e. set `jsx` to `react-jsx`)
 > and run the `update-react-imports` [codemod](https://github.com/reactjs/react-codemod) if needed.

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -169,7 +169,7 @@ This section documents notable changes in Console provided shared modules and ot
 
 - Removed PatternFly 4.x shared modules. Console now uses PatternFly 6.x and provides PatternFly 5.x
   styles for compatibility with existing plugins.
-- Added `@patternfly/react-topology` shared module. This allows plugins to use PatternFly 6 topology
+- Added `@patternfly/react-topology` shared module. This allows plugins to use PatternFly's topology
   components with consistent React context and styling.
 - `react-router-dom-v5-compat` shared module is deprecated and will be removed in the future. Plugins
   should continue using `react-router-dom-v5-compat` module in order to consume React Router v6 APIs.

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -142,14 +142,14 @@ The following shared modules are provided by Console, without plugins providing 
 Any shared modules provided by Console without plugin provided fallback are listed as `dependencies`
 in the `package.json` manifest of `@openshift-console/dynamic-plugin-sdk` package.
 
-### Changes in shared modules
+### Changes in shared modules and APIs
 
-This section documents notable changes in the Console provided shared modules across Console versions.
+This section documents notable changes in Console provided shared modules and other plugin APIs.
 
 #### Console 4.14.x
 
-- Added `react-router-dom-v5-compat` module to allow plugins to migrate to React Router v6. Check the
-  [Official v5 to v6 Migration Guide](https://github.com/remix-run/react-router/discussions/8753)
+- Added `react-router-dom-v5-compat` shared module to allow plugins to migrate to React Router v6.
+  Check the [Official v5 to v6 Migration Guide](https://github.com/remix-run/react-router/discussions/8753)
   (section "Migration Strategy" and beyond) for details.
 
 #### Console 4.15.x
@@ -159,7 +159,7 @@ This section documents notable changes in the Console provided shared modules ac
 
 #### Console 4.16.x
 
-- Removed `react-helmet` module.
+- Removed `react-helmet` shared module.
 - All Console provided PatternFly 4.x shared modules are deprecated and will be removed in the future.
   See [PatternFly Upgrade Notes][console-pf-upgrade-notes] for details on upgrading to PatternFly 5.
 - All Console provided React Router v5 shared modules are deprecated and will be removed in the future.
@@ -169,15 +169,13 @@ This section documents notable changes in the Console provided shared modules ac
 
 - Removed PatternFly 4.x shared modules. Console now uses PatternFly 6.x and provides PatternFly 5.x
   styles for compatibility with existing plugins.
-- VirtualizedTable, ListPageFilter, and useListPageFilter are deprecated and will be removed in the future.
-  PatternFly's [Data view](https://www.patternfly.org/extensions/data-view/overview) extension should be used
+- Added `@patternfly/react-topology` shared module. This allows plugins to use PatternFly 6 topology
+  components with consistent React context and styling.
+- `react-router-dom-v5-compat` shared module is deprecated and will be removed in the future. Plugins
+  should continue using `react-router-dom-v5-compat` module in order to consume React Router v6 APIs.
+- `VirtualizedTable`, `ListPageFilter` and `useListPageFilter` are deprecated and will be removed in
+  the future. Use PatternFly's [Data view](https://www.patternfly.org/extensions/data-view/overview)
   instead. See this [proof of concept](https://github.com/openshift/console/pull/14897) for an example.
-- `react-router-dom-v5-compat` module is deprecated and will aliased to `react-router-dom` v6 and
-  `react-router-dom-v5-compat` will be removed in the future. Plugins should continue migration to the
-  `react-router-dom-v5-compat` module until `react-router-dom` v6 is aliased to `react-router-dom` v6. See the
-  [Official v5 to v6 Migration Guide](https://reactrouter.com/6.30.0/upgrading/v5) for details.
-- Added `@patternfly/react-topology` to shared modules. This supports dynamic plugins using PatternFly 6
-  topology components with consistent context and styling.
 
 ##### CSS styling
 

--- a/frontend/packages/console-dynamic-plugin-sdk/upgrade-PatternFly.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/upgrade-PatternFly.md
@@ -33,8 +33,8 @@ import { Button } from '@patternfly/react-core';
 
 ## Console 4.15 to 4.18
 
-Plugins that only target OpenShift Console 4.15 and newer should upgrade to PatternFly 5.x or newer to take
-advantage of [PatternFly dynamic modules][console-pf-dynamic-modules].
+Plugins that only target OpenShift Console 4.15 and newer should upgrade to PatternFly 5.x or newer
+to take advantage of [PatternFly dynamic modules][console-pf-dynamic-modules].
 
 Any PatternFly related code should be imported via the corresponding package index:
 
@@ -47,9 +47,9 @@ import { MonitoringIcon } from '@patternfly/react-icons';
 
 ## Console 4.19 and newer
 
-OpenShift Console 4.19 and newer no longer provides PatternFly 4.x shared modules.
-Plugins that only target OpenShift Console 4.19 and newer should upgrade to
-PatternFly 6.x or newer due to the design changes made in PatternFly 6.
+OpenShift Console 4.19 and newer no longer provides PatternFly 4.x shared modules. Plugins that only
+target OpenShift Console 4.19 and newer should upgrade to PatternFly 6.x or newer due to the design
+changes made in PatternFly 6.
 
 ## PatternFly resources
 


### PR DESCRIPTION
Ensure that docs are up-to-date before we publish latest 4.19 plugin SDK packages.