### PR TITLE
OCPBUGS-56137: Added developer getting started card in Admin project overview page

### DIFF
--- a/frontend/public/components/dashboard/project-dashboard/project-dashboard.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/project-dashboard.tsx
@@ -18,7 +18,6 @@ import { ProjectDashboardContext } from './project-dashboard-context';
 import { LauncherCard } from './launcher-card';
 import { ResourceQuotaCard } from './resource-quota-card';
 import { GettingStartedSection as DevGettingStartedSection } from './getting-started/GettingStartedSection';
-import { GettingStartedSection } from '../dashboards-page/cluster-dashboard/getting-started/getting-started-section';
 import { PROJECT_OVERVIEW_USER_SETTINGS_KEY } from '../dashboards-page/cluster-dashboard/getting-started/constants';
 
 const mainCards = [{ Card: StatusCard }, { Card: UtilizationCard }, { Card: ResourceQuotaCard }];
@@ -84,7 +83,7 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = ({ obj }) => {
             <DevGettingStartedSection userSettingKey="devconsole.projectOverview.gettingStarted" />
           ) : (
             consoleCapabilityGettingStartedBannerIsEnabled && (
-              <GettingStartedSection userSettingKey={PROJECT_OVERVIEW_USER_SETTINGS_KEY} />
+              <DevGettingStartedSection userSettingKey={PROJECT_OVERVIEW_USER_SETTINGS_KEY} />
             )
           )}
           <DashboardGrid mainCards={mainCards} leftCards={leftCards} rightCards={rc} />


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-56137

**Solution Description**: 
Added Developer getting started section in Project overview page of Admin perspective
  
**Screen shots / Gifs for design review**: 

**---BEFORE----**

<img width="1728" alt="Screenshot 2025-05-21 at 3 05 44 PM" src="https://github.com/user-attachments/assets/2c38a9b5-df02-4992-8d3c-66f335a1ca4b" />


**---AFTER----**

<img width="1728" alt="Screenshot 2025-05-22 at 3 41 50 PM" src="https://github.com/user-attachments/assets/9dc3b300-a20e-4477-8b83-fc2523153a1f" />


-----
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

