### PR TITLE
OCPBUGS-56628: Fix regression with drawers and modals

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -176,6 +176,8 @@ $masthead-logo-max-height: 60px;
 // Drawer
 .pf-v6-c-drawer__body {
   height: 100%;
+  // (OCPBUGS-56628): A PF6 regression caused modals to not move when a drawer is open
+  position: relative;
 }
 
 .pf-v6-c-masthead {


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/OCPBUGS-56628

before:

![before](https://i.imgur.com/xIgeiqE.png)

after:

![after](https://github.com/user-attachments/assets/4b4479ad-3d4f-4e42-bd18-de4fa4444346)