### PR TITLE
OCPBUGS-56379:  Custom masthead logo doesn't work with a specific kiwi graphic 

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -2,8 +2,6 @@
 
 // Use this file to override styles from 3rd party dependencies
 
-$masthead-logo-max-height: 60px;
-
 // TODO: Remove when upgrading to PF 6.3.0: https://github.com/patternfly/patternfly/pull/7420
 .catalog-tile-pf-title {
   @include co-break-word;
@@ -176,15 +174,6 @@ $masthead-logo-max-height: 60px;
 // Drawer
 .pf-v6-c-drawer__body {
   height: 100%;
-}
-
-.pf-v6-c-masthead {
-  --pf-v6-c-masthead__logo--MaxHeight: $masthead-logo-max-height; // so that logos with three lines of text fit
-}
-
-.pf-v6-c-masthead__logo {
-  --pf-v6-c-masthead__logo--MaxHeight: #{$masthead-logo-max-height}; // Restore the max-height from PageHeader to maintain backwards compatibility
-  --pf-v6-c-masthead__logo--Width: auto; // Do not set a width to maintain backwards compatibility
 }
 
 // PF components that calculate their correct height based on --pf-t--global--font--size--md: 1rem


### PR DESCRIPTION
Using PF defaults for masthead logo max width CSS styling fixes a problem, where certain logos were not displaying at all (this [kiwi](https://publicdomainvectors.org/en/free-clipart/Kiwi-halfs/45171.html) logo for example). The custom logo images rendered within the Brand component scale well even without these overrides (even though the logos appear to be a bit smaller), the static logos appearance within ReactSVG component remained the same as well.

before (custom logo - kiwi):
![Screenshot 2025-05-26 at 17 32 15](https://github.com/user-attachments/assets/fa2e8832-6506-495a-adcd-e3382b6182cb)


after(kiwi):
![Screenshot 2025-05-26 at 17 21 37](https://github.com/user-attachments/assets/1f0af47f-95c9-4a71-a898-4209e70b0324)

before (custom logo - banana):
![Screenshot 2025-05-26 at 17 32 36](https://github.com/user-attachments/assets/c0558aea-b34a-4951-b291-a9a875eaad30)


after (custom logo - banana):

![Screenshot 2025-05-26 at 17 21 48](https://github.com/user-attachments/assets/7290da4d-42a7-425e-ad44-4248efe3762e)
