### PR TITLE
OCPBUGS-56700: UI for search by label is distorted in topology

### DIFF
--- a/frontend/packages/topology/src/filters/NameLabelFilterDropdown.scss
+++ b/frontend/packages/topology/src/filters/NameLabelFilterDropdown.scss
@@ -1,0 +1,3 @@
+.odc-topology-name-label-filter {
+  min-width: fit-content;
+}

--- a/frontend/packages/topology/src/filters/NameLabelFilterDropdown.tsx
+++ b/frontend/packages/topology/src/filters/NameLabelFilterDropdown.tsx
@@ -13,6 +13,8 @@ import { TextFilter } from '@console/internal/components/factory';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { NameLabelFilterValues } from './filter-utils';
 
+import './NameLabelFilterDropdown.scss';
+
 type NameLabelFilterDropdownProps = {
   isDisabled: boolean;
   data: K8sResourceKind[];
@@ -44,6 +46,7 @@ const NameLabelFilterDropdown: React.FC<NameLabelFilterDropdownProps> = (props) 
         onToggle(_event, !isOpen);
       }}
       isDisabled={isDisabled}
+      className="odc-topology-name-label-filter"
     >
       <>
         <FilterIcon className="span--icon__right-margin" /> {t(selected)}

--- a/frontend/public/components/_autocomplete.scss
+++ b/frontend/public/components/_autocomplete.scss
@@ -1,6 +1,6 @@
 .co-suggestion-box {
   background-color: var(--pf-t--global--background--color--primary--default);
-  z-index: 5;
+  z-index: var(--pf-t--global--z-index--sm);
   width: 100%;
   @media (max-width: $screen-xs-min) {
     max-width: calc(100% - 95px);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-56700

**Analysis / Root cause**: 
ZIndex value was lesser than Drawer content's ZIndex

**Solution Description**: 
Increased the z-index value 
  
**Screen shots / Gifs for design review**: 

**---BEFORE----**

<img width="1163" alt="Screenshot 2025-05-27 at 12 18 09 PM" src="https://github.com/user-attachments/assets/6e381200-1f60-44b0-94f3-5677ec585bd4" />


**---AFTER----**

<img width="1201" alt="Screenshot 2025-05-27 at 12 18 50 PM" src="https://github.com/user-attachments/assets/e0e616b5-fc22-4b5b-9696-d2b8109efdd2" />


-----
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

