### PR TITLE
OCPBUGS-52842: Fix TypeError Cannot read properties of null (reading 'metadata')

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useServicesWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/useServicesWatcher.ts
@@ -6,7 +6,7 @@ import { getServicesForResource } from '../utils';
 export const useServicesWatcher = (
   resource: K8sResourceKind,
 ): { loaded: boolean; loadError: string; services: K8sResourceKind[] } => {
-  const { namespace } = resource.metadata;
+  const namespace = resource?.metadata?.namespace || '';
   const [allServices, loaded, loadError] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     kind: 'Service',


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-52842

Description: Prevent a TypeError if the resource is null while retrieving the namespace.