### PR TITLE
OCPBUGS-56462: Clicking '-' button has not response unless clicking '+' button first on 'Edit Pod count' modal.

### DIFF
--- a/frontend/public/components/modals/configure-count-modal.tsx
+++ b/frontend/public/components/modals/configure-count-modal.tsx
@@ -61,7 +61,7 @@ export const ConfigureCountModal = withHandlePromise((props: ConfigureCountModal
         </p>
         <NumberSpinner
           value={value}
-          onChange={(e: any) => setValue(e.target.value)}
+          onChange={(e: any) => setValue(_.toInteger(e.target.value))}
           changeValueBy={(operation) => setValue(_.toInteger(value) + operation)}
           autoFocus
           required


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-56462

**Analysis / Root cause**: 
Due to data type mismatch, decrement button was disabled

**Solution Description**: 
Updated onChange event function to set value as number 
  
**Screen shots / Gifs for design review**: 

**---BEFORE----**


https://github.com/user-attachments/assets/c564ac15-f322-472c-b6bb-8b8643d2a410




**---AFTER----**


https://github.com/user-attachments/assets/09012cea-9a7d-42cc-8162-64b134fef9e8




-----

**Steps to reproduce**:

    1.Open 'Edit Pod count' modal from deployment/deploymentconfig/daemonset/statefulset/replicatset/replicationctrolleraction list.
    2.Click '-' button.
    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

