### PR TITLE
OCPBUGS-56707: fix bug where Roles list was displaying invalid data f…

### DIFF
--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -403,6 +403,7 @@ export const RolesPage = ({ namespace, mock, showTitle }) => {
         },
       ]}
       title={t('public~Roles')}
+      mock={mock}
     />
   );
 };


### PR DESCRIPTION
…or normal users

This is an odd one due to the combination of `<WithStartGuide>` and `<MultiListPage>`!

The `Roles` page differed from the `ServiceAccounts` and `RoleBindings` pages in that the `mock` prop was not being passed through to the list page component.  Passing the `mock` prop makes the `Roles` page consistent with the `ServiceAccounts` and `RoleBindings` pages.

### After 

#### If a regular user without a project 

##### The `Roles` page now displays the empty state (rather than the mock list)
![localhost_9000_k8s_all-namespaces_rbac authorization k8s io~v1~Role](https://github.com/user-attachments/assets/5211a400-3fe6-4153-98d3-de010d2e9575)

##### Which is the same existing behavior for the `ServiceAccounts` and `RoleBindings` pages
![localhost_9000_k8s_all-namespaces_rbac authorization k8s io~v1~Role (4)](https://github.com/user-attachments/assets/61c34c56-b7d1-429e-aa93-6d65eaae3b23)
![localhost_9000_k8s_all-namespaces_rbac authorization k8s io~v1~Role (5)](https://github.com/user-attachments/assets/508972b4-9ce0-4cd9-bc50-85402be35d12)



