### PR TITLE
OCPBUGS-56050: Cannot read properties of undefined (reading 'filter') error while accessing nodes from console

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -744,7 +744,7 @@ const NodesPage: React.FC<NodesPageProps> = ({ selector }) => {
   const { t } = useTranslation();
 
   const data = React.useMemo(() => {
-    const csrBundle = getNodeClientCSRs(csrs).filter(
+    const csrBundle = getNodeClientCSRs(csrs)?.filter(
       (csr) => !nodes.some((n) => n.metadata.name === csr.metadata.name),
     );
     return [...csrBundle, ...nodes];


### PR DESCRIPTION
Calling filter on potentionally undefined getNodeClientCSRs result caused error, added conditional unwrap to prevent these errors.

after:
![Screenshot 2025-06-03 at 11 23 43](https://github.com/user-attachments/assets/88d1993f-28d8-4974-bb38-23f579174631)
