### PR TITLE
OCPBUGS-56999: Cannot read properties of undefined (reading 'node-role.kubernetes.io/master') error while accessing node logs from console

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
@@ -176,7 +176,7 @@ const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
   const pathItems = ['journal'];
   isWindows
     ? pathItems.push('containers', 'hybrid-overlay', 'kube-proxy', 'kubelet', 'containerd', 'wicd')
-    : labels['node-role.kubernetes.io/master'] === '' &&
+    : labels?.['node-role.kubernetes.io/master'] === '' &&
       pathItems.push('openshift-apiserver', 'kube-apiserver', 'oauth-apiserver');
   const pathQueryArgument = 'path';
   const unitQueryArgument = 'unit';


### PR DESCRIPTION
Reading from undefined labels caused errors when visiting NodeLogs, adding conditional unwrap fixes this problem.

after:
![Screenshot 2025-06-03 at 11 41 05](https://github.com/user-attachments/assets/fa7116e7-3a5e-407c-bfa6-84398ccf4fba)
