### PR TITLE
OCPBUGS-55828: Edit paralelism modal has unresponsive decrease button in the number spinner

### DIFF
--- a/frontend/public/components/modals/configure-count-modal.tsx
+++ b/frontend/public/components/modals/configure-count-modal.tsx
@@ -52,6 +52,14 @@ export const ConfigureCountModal = withHandlePromise((props: ConfigureCountModal
     messageVariablesSafe.resourceKinds = t(labelKey, titleVariables);
   }
 
+  const onValueChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const eventValue = (event.target as HTMLInputElement).value;
+    const numericValue = Number(eventValue);
+    if (!isNaN(numericValue)) {
+      setValue(numericValue);
+    }
+  };
+
   return (
     <form onSubmit={submit} name="form" className="modal-content ">
       <ModalTitle>{titleKey ? t(titleKey, titleVariables) : title}</ModalTitle>
@@ -61,7 +69,7 @@ export const ConfigureCountModal = withHandlePromise((props: ConfigureCountModal
         </p>
         <NumberSpinner
           value={value}
-          onChange={(e: any) => setValue(e.target.value)}
+          onChange={onValueChange}
           changeValueBy={(operation) => setValue(_.toInteger(value) + operation)}
           autoFocus
           required


### PR DESCRIPTION
Setting the NumberSpinner value directly via e.target.value caused the decrease button to be disabled on initial render, most likely due to string to number conversion issue. Handling the conversion in a separate handler fixed this issue.

before:

https://github.com/user-attachments/assets/1eb81df3-77c2-4c2b-bccc-739a7829f24b

after:



https://github.com/user-attachments/assets/563f3f3c-b4d5-41bb-b58d-0cdedb9646db


