### PR TITLE
OCPBUGS-57088: Update dynamic-plugin-demo/oc-manifest.yaml to use fresh image

### DIFF
--- a/dynamic-demo-plugin/oc-manifest.yaml
+++ b/dynamic-demo-plugin/oc-manifest.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: console-demo-plugin
-          image: quay.io/jcaianirh/console-demo-plugin
+          image: quay.io/rh-ee-jonjacks/console-demo-plugin
           ports:
             - containerPort: 9001
               protocol: TCP


### PR DESCRIPTION
The current image is broken and causes runtime errors in latest 4.20 console. Update to a fresh build.