### PR TITLE
OCPBUGS-49709: Add the ability to launch multiple modals with useModal hook

### DIFF
--- a/dynamic-demo-plugin/locales/en/plugin__console-demo-plugin.json
+++ b/dynamic-demo-plugin/locales/en/plugin__console-demo-plugin.json
@@ -50,6 +50,8 @@
   "Modal Launchers": "Modal Launchers",
   "Launch Modal": "Launch Modal",
   "Launch Modal Asynchronously": "Launch Modal Asynchronously",
+  "Launch Modal with ID 1": "Launch Modal with ID 1",
+  "Launch Modal with ID 2": "Launch Modal with ID 2",
   "Launch overlay": "Launch overlay",
   "Launch overlay with props": "Launch overlay with props",
   "Launch overlay modal": "Launch overlay modal",

--- a/dynamic-demo-plugin/src/components/Modals/ModalPage.tsx
+++ b/dynamic-demo-plugin/src/components/Modals/ModalPage.tsx
@@ -44,6 +44,33 @@ export const TestModal: ModalComponent = (props) => {
   );
 };
 
+const testComponentWithIDStyle: React.CSSProperties = {
+  backgroundColor: 'gray',
+  padding: '1rem 4rem',
+  position: 'absolute',
+  right: '5rem',
+  textAlign: 'center',
+  zIndex: 9999,
+};
+
+const TEST_ID_1 = 'TEST_ID_1';
+const TestComponentWithID1 = ({ closeModal }) => (
+  <div style={{ ...testComponentWithIDStyle, top: '5rem' }}>
+    <p>Test Modal with ID "{TEST_ID_1}"</p>
+    <Button onClick={closeModal}>Close</Button>
+  </div>
+);
+
+const TEST_ID_2 = 'TEST_ID_2';
+const TestComponentWithID2 = ({ closeModal, ...rest }) => (
+  <div style={{ ...testComponentWithIDStyle, bottom: '5rem' }}>
+    <p>
+      Test Modal with ID "{TEST_ID_2}" and testProp "{rest.testProp}"
+    </p>
+    <Button onClick={closeModal}>Close</Button>
+  </div>
+);
+
 const LoadingComponent: React.FC = () => {
   const { t } = useTranslation('plugin__console-demo-plugin');
 
@@ -127,6 +154,16 @@ export const TestModalPage: React.FC<{ closeComponent: any }> = () => {
     launchModal(AsyncTestComponent, {});
   }, [launchModal]);
 
+  const onClickWithID1 = React.useCallback(
+    () => launchModal(TestComponentWithID1, {}, TEST_ID_1),
+    [launchModal],
+  );
+
+  const onClickWithID2 = React.useCallback(
+    () => launchModal(TestComponentWithID2, { testProp: 'abc' }, TEST_ID_2),
+    [launchModal],
+  );
+
   const onClickOverlayBasic = React.useCallback(() => {
     launchOverlay(TestOverlayComponent, {});
   }, [launchOverlay]);
@@ -153,6 +190,12 @@ export const TestModalPage: React.FC<{ closeComponent: any }> = () => {
       <DocumentTitle>{t('Modal Launchers')}</DocumentTitle>
       <Button onClick={onClick}>{t('Launch Modal')}</Button>
       <Button onClick={onAsyncClick}>{t('Launch Modal Asynchronously')}</Button>
+      <Button onClick={onClickWithID1}>
+        {t('plugin__console-demo-plugin~Launch Modal with ID 1')}
+      </Button>
+      <Button onClick={onClickWithID2}>
+        {t('plugin__console-demo-plugin~Launch Modal with ID 2')}
+      </Button>
       <Button onClick={onClickOverlayBasic}>
         {t('plugin__console-demo-plugin~Launch overlay')}
       </Button>

--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -2670,7 +2670,7 @@ A tuple containing the data filtered by all static filteres, the data filtered b
 
 ### Summary [DEPRECATED]
 
-@deprecated - Use useOverlay from \@console/dynamic-plugin-sdk instead.<br/>A hook to launch Modals.
+@deprecated - Use useOverlay from \@console/dynamic-plugin-sdk instead.<br/>A hook to launch Modals.<br/><br/>Additional props can be passed to `useModal` and they will be passed through to the modal component.<br/>An optional ID can also be passed to `useModal`. If provided, this distinguishes the modal from<br/>other modals to allow multiple modals to be displayed at the same time.
 
 
 
@@ -2680,9 +2680,13 @@ A tuple containing the data filtered by all static filteres, the data filtered b
 ```tsx
 const AppPage: React.FC = () => {
  const launchModal = useModal();
- const onClick = () => launchModal(ModalComponent);
+ const onClick1 = () => launchModal(ModalComponent);
+ const onClick2 = () => launchModal(ModalComponent, { title: 'Test modal' }, 'TEST_MODAL_ID');
  return (
-   <Button onClick={onClick}>Launch a Modal</Button>
+   <>
+     <Button onClick={onClick1}>Launch basic modal</Button>
+     <Button onClick={onClick2}>Launch modal with props and an ID</Button>
+   </>
  )
 }
 ```

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/modal-support/ModalProvider.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/modal-support/ModalProvider.tsx
@@ -1,12 +1,17 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { UnknownProps } from '../common-types';
 
 type CloseModal = () => void;
-type CloseModalContextValue = () => void;
+type CloseModalContextValue = (id?: string) => void;
 
 export type ModalComponent<P = UnknownProps> = React.FC<P & { closeModal: CloseModal }>;
 
-export type LaunchModal = <P = UnknownProps>(component: ModalComponent<P>, extraProps: P) => void;
+export type LaunchModal = <P = UnknownProps>(
+  component: ModalComponent<P>,
+  extraProps: P,
+  id?: string,
+) => void;
 
 type ModalContextValue = {
   launchModal: LaunchModal;
@@ -18,25 +23,53 @@ export const ModalContext = React.createContext<ModalContextValue>({
   closeModal: () => {},
 });
 
+type ComponentMap = {
+  [key: string]: {
+    Component: ModalComponent;
+    props: { [key: string]: any };
+  };
+};
+
 export const ModalProvider: React.FC = ({ children }) => {
   const [isOpen, setOpen] = React.useState(false);
   const [Component, setComponent] = React.useState<ModalComponent>();
   const [componentProps, setComponentProps] = React.useState({});
+  const [componentsMap, setComponentsMap] = React.useState<ComponentMap>({});
 
   const launchModal = React.useCallback<LaunchModal>(
-    (component, compProps) => {
-      setComponent(() => component);
+    (component, compProps, id = null) => {
+      if (id) {
+        setComponentsMap((components) => ({
+          ...components,
+          [id]: { Component: component, props: compProps },
+        }));
+      } else {
+        setComponent(() => component);
+      }
       setComponentProps(compProps);
       setOpen(true);
     },
     [setOpen, setComponent, setComponentProps],
   );
 
-  const closeModal = React.useCallback<CloseModalContextValue>(() => setOpen(false), [setOpen]);
+  const closeModal = React.useCallback<CloseModalContextValue>(
+    (id = null) => {
+      if (id) {
+        setComponentsMap((components) => _.omit(components, id));
+      } else {
+        setOpen(false);
+        setComponent(undefined);
+      }
+    },
+    [setOpen],
+  );
 
   return (
     <ModalContext.Provider value={{ launchModal, closeModal }}>
-      {isOpen && !!Component && <Component {...componentProps} closeModal={closeModal} />}
+      {isOpen && !!Component && <Component {...componentProps} closeModal={() => closeModal()} />}
+      {_.map(componentsMap, (c, id) => (
+        <c.Component {...c.props} key={id} closeModal={() => closeModal(id)} />
+      ))}
       {children}
     </ModalContext.Provider>
   );

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/modal-support/useModal.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/modal-support/useModal.ts
@@ -6,13 +6,21 @@ type UseModalLauncher = () => LaunchModal;
 /**
  * @deprecated - Use useOverlay from \@console/dynamic-plugin-sdk instead.
  * A hook to launch Modals.
+ *
+ * Additional props can be passed to `useModal` and they will be passed through to the modal component.
+ * An optional ID can also be passed to `useModal`. If provided, this distinguishes the modal from
+ * other modals to allow multiple modals to be displayed at the same time.
  * @example
  *```tsx
  * const AppPage: React.FC = () => {
  *  const launchModal = useModal();
- *  const onClick = () => launchModal(ModalComponent);
+ *  const onClick1 = () => launchModal(ModalComponent);
+ *  const onClick2 = () => launchModal(ModalComponent, { title: 'Test modal' }, 'TEST_MODAL_ID');
  *  return (
- *    <Button onClick={onClick}>Launch a Modal</Button>
+ *    <>
+ *      <Button onClick={onClick1}>Launch basic modal</Button>
+ *      <Button onClick={onClick2}>Launch modal with props and an ID</Button>
+ *    </>
  *  )
  * }
  * ```


### PR DESCRIPTION
launchModal() now accepts an optional ID. If provided, this ID keeps the modal separate from other modals so that it won't be overwritten when launchModal() is next called (unless it is called with the same ID).