### PR TITLE
OCPBUGS-56985: Getting "Oh no something went wrong" error message in web console.

### DIFF
--- a/frontend/public/components/monitoring/alertmanager/alertmanager-config.tsx
+++ b/frontend/public/components/monitoring/alertmanager/alertmanager-config.tsx
@@ -194,7 +194,7 @@ const hasSimpleReceiver = (
     return true;
   } else if (receiverIntegrationTypes.length === 1) {
     const receiverConfig = receiverIntegrationTypes[0]; // ex: 'pagerduty_configs'
-    const numConfigs = _.get(receiver, receiverConfig).length; // 'pagerduty_configs' is array and may have multiple sets of properties
+    const numConfigs = _.get(receiver, receiverConfig)?.length; // 'pagerduty_configs' is array and may have multiple sets of properties
     return _.hasIn(receiverTypes, receiverConfig) && numConfigs <= 1; // known receiver type and a single set of props
   }
   return false;


### PR DESCRIPTION
`AlertmanagerConfig` receiver with missing values for <something>_configs attribute causes the page to crash. Conditionally unwrapping these attribute fixes this problem.

Even though this is not something that can happen by default, such miss configuration within the yaml editor is possible. Other references to `.length` usage within [alertmanager-config.tsx](https://github.com/openshift/console/blob/main/frontend/public/components/monitoring/alertmanager/alertmanager-config.tsx) are in the worst case operating on top of empty arrays, so those are out of suspicion.

