### PR TITLE
Wrong translation correction

### DIFF
--- a/frontend/public/locales/es/public.json
+++ b/frontend/public/locales/es/public.json
@@ -1616,7 +1616,7 @@
   "Shared access (RWX)": "Acceso compartido (RWX)",
   "Read only (ROX)": "Solo lectura (ROX)",
   "Read write once pod (RWOP)": "Pod de lectura y escritura único (RWOP)",
-  "Block": "Bloquear",
+  "Block": "Bloques",
   "TemplateInstances": "Instancias de plantilla",
   "TemplateInstance details": "Detalles de TemplateInstance",
   "Parameters": "Parámetros",


### PR DESCRIPTION
"Bloquear" means block or lock in the context of denying access
"Bloques" means block in the context of block devices. In this case, plural is correct.