### PR TITLE
OCPBUGS-57174: Percent sign on creating HPA page doesn't align in the center of outer box.

### DIFF
--- a/frontend/packages/dev-console/src/components/hpa/HPAUtilizationField.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAUtilizationField.tsx
@@ -51,13 +51,12 @@ const HPAUtilizationField: React.FC<HPAUtilizationFieldProps> = ({
             isDisabled={disabled}
             onChange={onUpdate}
             value={Number.isNaN(value) ? '' : value}
+            aria-describedby={`${type}-utilization-unit`}
           />
         </InputGroupItem>
-        <InputGroupItem isBox>
-          <InputGroupText id="percent" aria-label="%">
-            <PercentIcon />
-          </InputGroupText>
-        </InputGroupItem>
+        <InputGroupText id={`${type}-utilization-unit`}>
+          <PercentIcon />
+        </InputGroupText>
       </InputGroup>
 
       <FormHelperText>


### PR DESCRIPTION
before:
<img width="833" alt="Screenshot 2025-06-09 at 17 08 50" src="https://github.com/user-attachments/assets/df93a880-664a-4226-b3a5-36d2cd796bf4" />


after:
<img width="812" alt="Screenshot 2025-06-09 at 17 08 34" src="https://github.com/user-attachments/assets/44c7f51a-3ab9-4822-8a29-7e87ddc1dfb5" />
