### PR TITLE
OCPBUGS-56050: Cannot read properties of undefined (reading 'filter') error while accessing nodes from console.

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeStatus.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeStatus.tsx
@@ -28,7 +28,7 @@ const isMonitoredCondition = (condition: Condition): boolean =>
   [Condition.DISK_PRESSURE, Condition.MEM_PRESSURE, Condition.PID_PRESSURE].includes(condition);
 
 const getDegradedStates = (node: NodeKind): Condition[] => {
-  return node.status.conditions
+  return (node.status?.conditions ?? [])
     .filter(({ status, type }) => status === 'True' && isMonitoredCondition(type as Condition))
     .map(({ type }) => type as Condition);
 };

--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -744,7 +744,7 @@ const NodesPage: React.FC<NodesPageProps> = ({ selector }) => {
   const { t } = useTranslation();
 
   const data = React.useMemo(() => {
-    const csrBundle = getNodeClientCSRs(csrs)?.filter(
+    const csrBundle = getNodeClientCSRs(csrs).filter(
       (csr) => !nodes.some((n) => n.metadata.name === csr.metadata.name),
     );
     return [...csrBundle, ...nodes];


### PR DESCRIPTION
Follow up on https://github.com/openshift/console/pull/15121 , which did not fix this issue.

Remove unnecessary optional unwrap on `getNodeClientCSRs` result in `NodesPage` as [this function](https://github.com/openshift/console/blob/b686015e805ca099d282ac64b243013269ca38ac/frontend/packages/metal3-plugin/src/selectors/csr.ts#L25) results in worst scenario to empty array (this was added in prior PR attempting to fix this issue, but it has not). Add optional unwrap to `getDegradedStates` within `NodeStatus`, which was the actual reason for the `reading .filter from undefined` errors.

before:
<img width="1051" alt="Screenshot 2025-06-12 at 17 39 48" src="https://github.com/user-attachments/assets/7119fa83-b66b-4faa-8fcf-e38b3e8e89a8" />

after:
<img width="1208" alt="Screenshot 2025-06-12 at 17 40 08" src="https://github.com/user-attachments/assets/037c7150-935c-4efe-872e-2570f216db51" />

