### PR TITLE
[release-4.18] OCPBUGS-36173: Secret key with binary file changes when edited via Console.

### DIFF
--- a/frontend/public/components/secrets/create-secret/KeyValueEntryForm.tsx
+++ b/frontend/public/components/secrets/create-secret/KeyValueEntryForm.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { withTranslation } from 'react-i18next';
 import { WithT } from 'i18next';
+import { Base64 } from 'js-base64';
 import { DroppableFileInput } from './DropableFileInput';
 import { KeyValueEntryFormState, KeyValueEntryFormProps } from './types';
 
@@ -13,7 +14,7 @@ export class KeyValueEntryFormWithTranslation extends React.Component<
     this.state = {
       key: props.entry.key,
       value: props.entry.value,
-      isBinary: props.entry.isBinary,
+      isBinary_: props.entry.isBinary_,
     };
     this.onValueChange = this.onValueChange.bind(this);
     this.onKeyChange = this.onKeyChange.bind(this);
@@ -21,8 +22,8 @@ export class KeyValueEntryFormWithTranslation extends React.Component<
   onValueChange(fileData, isBinary) {
     this.setState(
       {
-        value: fileData,
-        isBase64: isBinary,
+        value: isBinary ? fileData : Base64.encode(fileData),
+        isBinary_: isBinary,
       },
       () => this.props.onChange(this.state, this.props.id),
     );
@@ -60,13 +61,13 @@ export class KeyValueEntryFormWithTranslation extends React.Component<
           <div>
             <DroppableFileInput
               onChange={this.onValueChange}
-              inputFileData={this.state.value}
+              inputFileData={Base64.decode(this.state.value)}
               id={`${this.props.id}-value`}
               label={t('public~Value')}
               inputFieldHelpText={t(
                 'public~Drag and drop file with your value here or browse to upload it.',
               )}
-              inputFileIsBinary={this.state.isBinary}
+              inputFileIsBinary={this.state.isBinary_}
             />
           </div>
         </div>

--- a/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
+++ b/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
@@ -1,6 +1,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
+import { isBinary } from 'istextorbinary/edition-es2017/index';
 import { useTranslation } from 'react-i18next';
 import { Base64 } from 'js-base64';
 import { ActionGroup, Button } from '@patternfly/react-core';
@@ -41,11 +42,15 @@ export const SecretFormWrapper: React.FC<BaseEditSecretProps_> = (props) => {
   const [inProgress, setInProgress] = React.useState(false);
   const [error, setError] = React.useState();
   const [stringData, setStringData] = React.useState(
-    _.mapValues(_.get(props.obj, 'data'), (value) => {
-      return value ? Base64.decode(value) : '';
-    }),
+    Object.entries(props.obj?.data ?? {}).reduce<Record<string, string>>((acc, [key, value]) => {
+      if (isBinary(null, Buffer.from(value, 'base64'))) {
+        return {};
+      }
+      acc[key] = value ? Base64.decode(value) ?? '' : '';
+      return acc;
+    }, {}),
   );
-  const [base64StringData, setBase64StringData] = React.useState({});
+  const [base64StringData, setBase64StringData] = React.useState(props?.obj?.data ?? {});
   const [disableForm, setDisableForm] = React.useState(false);
   const title = useSecretTitle(isCreate, secretTypeAbstraction);
   const helptext = useSecretDescription(secretTypeAbstraction);
@@ -141,6 +146,7 @@ export const SecretFormWrapper: React.FC<BaseEditSecretProps_> = (props) => {
           onError={onError}
           onFormDisable={(disable) => setDisableForm(disable)}
           stringData={stringData}
+          base64StringData={base64StringData}
           secretType={secret.type}
           isCreate={isCreate}
         />

--- a/frontend/public/components/secrets/create-secret/types.ts
+++ b/frontend/public/components/secrets/create-secret/types.ts
@@ -1,6 +1,7 @@
 import { SecretType } from '.';
 
-export type SecretStringData = { [key: string]: string };
+export type SecretStringData = Record<string, string>;
+export type Base64StringData = Record<string, string>;
 
 type SecretChangeData = {
   stringData: SecretStringData;
@@ -8,8 +9,7 @@ type SecretChangeData = {
 };
 
 export type KeyValueEntryFormState = {
-  isBase64?: boolean;
-  isBinary?: boolean;
+  isBinary_?: boolean;
   key: string;
   value: string;
 };
@@ -25,6 +25,7 @@ export type SecretSubFormProps = {
   onError: (error: any) => void;
   onFormDisable: (disable: boolean) => void;
   stringData: SecretStringData;
+  base64StringData: Base64StringData;
   secretType: SecretType;
   isCreate: boolean;
 };


### PR DESCRIPTION
manual novel fix for 4.18 combining core changes done within https://github.com/openshift/console/pull/14520 , https://github.com/openshift/console/pull/14852 and https://github.com/openshift/console/pull/15058. 

store all data within key/value form in `Base64` encoded form. Removed the part where we encoded binary data twice, as the secret binary data created through oc API is already `Base64` encoded and also  through UI, as the underlying `FileInput` component handles the `Base64` encoding. The non-binary data remains to be the only case where its needed to `Base64` encode/decode the data within `GenericSecretForm`/`GenericEntrySecretForm`.
