### PR TITLE
ODC-7779: Tests to enable the developer  perspective through UI

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/e2e/enable-dev-perspective-ci.feature
+++ b/frontend/packages/dev-console/integration-tests/features/e2e/enable-dev-perspective-ci.feature
@@ -1,0 +1,20 @@
+@add-flow @smoke
+Feature: Enable dev perspective
+              As a user, I should be able to enable dev perspective from UI
+
+        Background:
+            Given user has only admin perspective enabled
+              And user has logged in as admin user
+
+ 
+        Scenario: Enable dev perspective: P-01-TC04
+            Given user is at admin perspective
+              And user is at Search page in Home section
+              And user searches "console"
+              And user clicks on cluster
+              And user selects "Customize" from actions menu
+              And user selects "Enabled" in the Developer under perspective section of general customisation
+             Then user will see Saved alert
+              And user refreshes the page to see developer option
+              And user will see developer perspective in the perspective switcher
+

--- a/frontend/packages/dev-console/integration-tests/features/perspectives/configure-perspectives.feature
+++ b/frontend/packages/dev-console/integration-tests/features/perspectives/configure-perspectives.feature
@@ -4,7 +4,7 @@ Feature: Configure perspectives
 
 
         Background:
-            Given user has created or selected namespace "aut-perspective"
+            Given user has logged in as admin user
  
         @regression @manual
         Scenario: Configuring available perspectives: P-01-TC01
@@ -21,10 +21,11 @@ Feature: Configure perspectives
             Given user is at cluster YAML of "operator.openshift.io/v1" console
              When user adds the "Add user perspectives" code snippet under spec.customization.perspectives
               And user changes the visibility state of "admin" to "AccessReview"
-              And user adds "accessReview: {missing: [{resource: "namespaces", verb: "list"}]}" under visibility and removes the remaining perspectives
+              And user adds 'accessReview: {missing: [{resource: "namespaces", verb: "list"}]}' under visibility and removes the remaining perspectives
               And user clicks on Save button
               And user clicks on Perspective dropdown
              Then user will not see "Administrator" perspective in the Perspective switcher
+
 
         @regression @manual
         Scenario: Configuring available perspectives - Add empty Perspectives: P-01-TC03
@@ -33,3 +34,20 @@ Feature: Configure perspectives
               And user clicks on Save button
               And user clicks on Perspective dropdown
              Then user will see all the available perspectives in the dropdown
+
+
+        @regression
+        Scenario: Enable dev perspective: P-01-TC04
+            Given user is at admin perspective
+            #   And user is at Cluster Settings page in administration section
+            #  When user goes to configuration tab
+              And user is at Search page in Home section
+              And user searches "console"
+              And user clicks on cluster
+            #   And user selects "operator.openshift.io" console
+              And user selects "Customize" from actions menu
+              And user selects "Enabled" in the Developer under perspective section of general customisation
+             Then user will see Saved alert
+              And user refreshes the page to see developer option
+              And user will see developer perspective in the perspective switcher
+

--- a/frontend/packages/dev-console/integration-tests/package.json
+++ b/frontend/packages/dev-console/integration-tests/package.json
@@ -11,7 +11,7 @@
     "clean-reports": "rm -rf ../../../gui_test_screenshots",
     "cypress-merge": "../../../node_modules/.bin/mochawesome-merge ../../../gui_test_screenshots/cypress_report*.json > ../../../gui_test_screenshots/cypress.json",
     "cypress-generate": "../../../node_modules/.bin/marge -o ../../../gui_test_screenshots/ -f cypress-report -t 'OpenShift DevConsole Cypress Test Results' -p 'OpenShift Cypress Test Results' --showPassed false --assetsDir ../../../gui_test_screenshots/cypress/assets ../../../gui_test_screenshots/cypress.json",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=electron} --headless --spec \"features/e2e/add-flow-ci.feature\"",
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=electron} --headless --spec \"features/e2e/enable-dev-perspective-ci.feature\" \"features/e2e/add-flow-ci.feature\"",
     "test-headless-all": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=electron} --headless",
     "test-cypress-nightly": "yarn run test-headless-all && yarn run cypress-merge && yarn run cypress-generate",
     "posttest-cypress-headless": "yarn run cypress-merge && yarn run cypress-generate"

--- a/frontend/packages/dev-console/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/dev-console/integration-tests/support/commands/hooks.ts
@@ -1,5 +1,4 @@
 import { quickStartSidebarPO } from '../pageObjects/quickStarts-po';
-import { checkDeveloperPerspective } from '../pages/functions/checkDeveloperPerspective';
 
 //  To ignore the resizeObserverLoopErrors on CI, adding below code
 const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
@@ -19,7 +18,7 @@ before(() => {
   const bridgePasswordPassword: string = Cypress.env('BRIDGE_HTPASSWD_PASSWORD') || 'test';
   cy.login(bridgePasswordIDP, bridgePasswordUsername, bridgePasswordPassword);
   cy.document().its('readyState').should('eq', 'complete');
-  checkDeveloperPerspective();
+  // checkDeveloperPerspective();
 });
 
 after(() => {
@@ -28,7 +27,7 @@ after(() => {
 });
 
 beforeEach(() => {
-  cy.initDeveloper();
+  cy.initAdmin();
 });
 
 afterEach(() => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/common/common.ts
@@ -28,6 +28,21 @@ Given('user is at developer perspective', () => {
   // cy.testA11y('Developer perspective');
 });
 
+Given('user has only admin perspective enabled', () => {
+  cy.exec(
+    `oc patch console.operator.openshift.io/cluster --type='merge' -p '{"spec":{"customization":{"perspectives":[{"id":"dev","visibility":{"state":"Disabled"}}]}}}'`,
+    { failOnNonZeroExit: true },
+  ).then((result) => {
+    cy.log(result.stdout);
+    cy.log(result.stderr);
+  });
+  cy.exec(`  oc rollout status -w deploy/console -n openshift-console`, {
+    failOnNonZeroExit: true,
+  }).then((result) => {
+    cy.log(result.stderr);
+  });
+});
+
 Given('user has created namespace starts with {string}', (projectName: string) => {
   const d = new Date();
   const timestamp = d.getTime();

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/customization/configure-perspectives.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/customization/configure-perspectives.ts
@@ -1,0 +1,114 @@
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
+import { nav } from '@console/cypress-integration-tests/views/nav';
+import { switchPerspective } from '../../constants';
+import { app, perspective } from '../../pages';
+
+Given('user has logged in as admin user', () => {
+  cy.login();
+  perspective.switchTo(switchPerspective.Administrator);
+  guidedTour.close();
+  nav.sidenav.switcher.shouldHaveText(switchPerspective.Administrator);
+});
+
+Given('user is at Search page in Home section', () => {
+  cy.get('[data-quickstart-id="qs-nav-home"]')
+    .scrollIntoView()
+    .then(($body) => {
+      if ($body.attr('aria-expanded') === 'false') {
+        cy.wrap($body).click();
+        cy.get('[data-test="nav"][href*="/search"]').click({ force: true });
+      } else {
+        cy.get('[data-test="nav"][href*="/search"]').click({ force: true });
+      }
+    });
+});
+
+Given('user is at Cluster Settings page in administration section', () => {
+  //   cy.get('[data-quickstart-id="qs-nav-home"]').click();
+  //   cy.get('[role="combobox"]').click();
+  //   cy.get('[aria-label="Type to filter"]').should('be.visible').type('console');
+  //   cy.get('[class="co-resource-item"]').then(($el) => {
+  //     if ($el.text().includes('operator.openshift.io')) {
+  //       cy.wrap($el).contains('operator.openshift.io').click();
+  //     }
+  //   });
+
+  cy.get('[data-quickstart-id="qs-nav-administration"]')
+    .scrollIntoView()
+    .then(($body) => {
+      if ($body.attr('aria-expanded') === 'false') {
+        cy.wrap($body).click();
+        cy.get('[data-test="nav"][href="/settings/cluster"]').click({ force: true });
+      } else {
+        cy.get('[data-test="nav"][href="/settings/cluster"]').click({ force: true });
+      }
+    });
+});
+
+When('user goes to configuration tab', () => {
+  cy.byLegacyTestID('horizontal-link-Configuration').should('be.visible').click();
+  cy.wait(100000);
+  app.waitForLoad();
+  cy.get('table[role="grid"]').should('be.visible');
+});
+
+When('user searches {string}', (value: string) => {
+  cy.get('[role="combobox"]').click();
+  cy.get('[aria-label="Type to filter"]').should('be.visible').type(value);
+  cy.get('[class="co-resource-item"]').then(($el) => {
+    if ($el.text().includes('operator.openshift.io')) {
+      cy.wrap($el).contains('operator.openshift.io').click();
+      cy.get('button[aria-label="Clear input value"]').should('be.visible').click();
+    }
+  });
+});
+
+When('user clicks on cluster', () => {
+  cy.byTestID('cluster').should('be.visible').click({ force: true });
+});
+
+When('user selects {string} from actions menu', (item: string) => {
+  cy.byLegacyTestID('actions-menu-button').should('be.visible').click();
+  cy.get(`[data-test-action="${item}"] button`).should('be.visible').click();
+  cy.get('[data-test="page-heading"] h1').should('have.text', 'Cluster configuration');
+});
+
+When(
+  'user selects {string} in the Developer under perspective section of general customisation',
+  (key: string) => {
+    cy.get('[data-test="perspectives form-group"]')
+      .eq(1)
+      .find('button')
+      .contains('Disabled')
+      .click();
+    cy.log('Perspective enabling menu to be opened');
+    cy.get('[role="listbox"]').should('be.visible');
+    cy.get('button[role="option"]').contains(key).click();
+    cy.get('[data-test="perspectives form-group"]')
+      .eq(1)
+      .find('button[class*="menu-toggle"]')
+      .should('contain.text', key);
+  },
+);
+
+When('user will see Saved alert', () => {
+  cy.byTestID('success-alert').should('be.visible');
+});
+
+Then('user refreshes the page to see developer option', () => {
+  cy.exec(`  oc rollout status -w deploy/console -n openshift-console`, {
+    failOnNonZeroExit: true,
+  }).then((result) => {
+    cy.log(result.stderr);
+  });
+  cy.reload(true);
+  app.waitForDocumentLoad();
+});
+
+Then('user will see developer perspective in the perspective switcher', () => {
+  cy.byLegacyTestID('perspective-switcher-toggle')
+    .click({ force: true })
+    .byLegacyTestID('perspective-switcher-menu-option')
+    .contains('Developer');
+});


### PR DESCRIPTION
Issue: 
Bug:[ODC-7779](https://issues.redhat.com//browse/ODC-7779)

Description:
Tests to enable the developer perspective through UI
Command to execute:

export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.13-042801.devcluster.openshift.com/
export BRIDGE_KUBEADMIN_PASSWORD
export BRIDGE_BASE_ADDRESS
oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
In the frontend folder:
Run ./integration-tests/test-cypress.sh -p dev-console
Browser
Electron
Screenshot:
