### PR TITLE
OCPBUGS-56803: Deleted objects remain in favorites and cause 404 errors

### DIFF
--- a/frontend/__tests__/components/container.spec.tsx
+++ b/frontend/__tests__/components/container.spec.tsx
@@ -7,6 +7,7 @@ import { mount, ReactWrapper, shallow } from 'enzyme';
 import store from '@console/internal/redux';
 import { Provider } from 'react-redux';
 import * as ReactRouter from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router';
 import {
   Firehose,
   HorizontalNav,
@@ -14,16 +15,27 @@ import {
   ConnectedPageHeading,
   ConnectedPageHeadingProps,
 } from '@console/internal/components/utils';
+import { useFavoritesOptions } from '@console/internal/components/useFavoritesOptions';
 import { testPodInstance } from '../../__mocks__/k8sResourcesMocks';
 import { Status } from '@console/shared';
 import { ErrorPage404 } from '@console/internal/components/error';
 import { StatusProps } from '@console/metal3-plugin/src/components/types';
 import { act } from 'react-dom/test-utils';
 
+jest.mock('react-router', () => ({
+  useLocation: jest.fn(),
+}));
+
+const useFavoritesOptionsMock = useFavoritesOptions as jest.Mock;
+const useLocationMock = useLocation as jest.Mock;
+
 jest.mock('react-router-dom-v5-compat', () => ({
   ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: jest.fn(),
   useLocation: jest.fn(),
+}));
+jest.mock('@console/internal/components/useFavoritesOptions', () => ({
+  useFavoritesOptions: jest.fn(),
 }));
 
 describe(ContainersDetailsPage.displayName, () => {
@@ -32,6 +44,8 @@ describe(ContainersDetailsPage.displayName, () => {
   beforeEach(() => {
     jest.spyOn(ReactRouter, 'useParams').mockReturnValue({ podName: 'test-name', ns: 'default' });
     jest.spyOn(ReactRouter, 'useLocation').mockReturnValue({ pathname: '' });
+    useLocationMock.mockReturnValue({ pathname: '' });
+    useFavoritesOptionsMock.mockReturnValue([[], jest.fn(), true]);
 
     containerDetailsPage = mount(<ContainersDetailsPage />, {
       wrappingComponent: ({ children }) => <Provider store={store}>{children}</Provider>,

--- a/frontend/packages/console-app/src/components/favorite/FavoriteButton.tsx
+++ b/frontend/packages/console-app/src/components/favorite/FavoriteButton.tsx
@@ -13,15 +13,9 @@ import { ModalVariant } from '@patternfly/react-core/deprecated';
 import { StarIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { Modal, RedExclamationCircleIcon, useUserSettingsCompatibility } from '@console/shared';
-import { STORAGE_PREFIX } from '@console/shared/src/constants/common';
+import { FAVORITES_CONFIG_MAP_KEY, FAVORITES_LOCAL_STORAGE_KEY } from '../../consts';
+import { FavoritesType } from '../../types';
 
-export type FavoritesType = {
-  name: string;
-  url: string;
-}[];
-
-export const FAVORITES_CONFIG_MAP_KEY = 'console.favorites';
-export const FAVORITES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/favorites`;
 const MAX_FAVORITE_COUNT = 10;
 
 type FavoriteButtonProps = {

--- a/frontend/packages/console-app/src/components/favorite/FavoriteNavItems.tsx
+++ b/frontend/packages/console-app/src/components/favorite/FavoriteNavItems.tsx
@@ -4,11 +4,8 @@ import { StarIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { useTranslation } from 'react-i18next';
 import { useUserSettingsCompatibility } from '@console/shared';
-import {
-  FAVORITES_CONFIG_MAP_KEY,
-  FAVORITES_LOCAL_STORAGE_KEY,
-  FavoritesType,
-} from './FavoriteButton';
+import { FAVORITES_CONFIG_MAP_KEY, FAVORITES_LOCAL_STORAGE_KEY } from '../../consts';
+import { FavoritesType } from '../../types';
 import { FavoriteNavItem } from './FavoriteNavItem';
 
 import './FavoriteNavItems.scss';
@@ -62,7 +59,7 @@ export const FavoriteNavItems: React.FC = () => {
           'data-test': 'favorite-resource-item',
         }}
         className={css('co-favorite-resource')}
-        to={favorite.url}
+        to={`${favorite.url}?from=favorites`}
         isActive={activeItem === `favorites-item-${favorite.url}`}
       >
         <Flex

--- a/frontend/packages/console-app/src/consts.ts
+++ b/frontend/packages/console-app/src/consts.ts
@@ -1,3 +1,5 @@
+import { STORAGE_PREFIX } from '@console/shared/src/constants/common';
+
 export const LAST_PERSPECTIVE_USER_SETTINGS_KEY = 'console.lastPerspective';
 export const LAST_PERSPECTIVE_LOCAL_STORAGE_KEY = `bridge/last-perspective`;
 export const HIDE_USER_WORKLOAD_NOTIFICATIONS_USER_SETTINGS_KEY =
@@ -6,3 +8,6 @@ export const FLAG_DEVELOPER_PERSPECTIVE = 'DEVELOPER_PERSPECTIVE';
 export const ACM_PERSPECTIVE_ID = 'acm';
 export const ADMIN_PERSPECTIVE_ID = 'admin';
 export const FLAG_CAN_GET_CONSOLE_OPERATOR_CONFIG = 'CAN_GET_CONSOLE_OPERATOR_CONFIG';
+
+export const FAVORITES_CONFIG_MAP_KEY = 'console.favorites';
+export const FAVORITES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/favorites`;

--- a/frontend/packages/console-app/src/types.ts
+++ b/frontend/packages/console-app/src/types.ts
@@ -1,0 +1,4 @@
+export type FavoritesType = {
+  name: string;
+  url: string;
+}[];

--- a/frontend/packages/console-shared/src/components/status/__tests__/status-box.spec.tsx
+++ b/frontend/packages/console-shared/src/components/status/__tests__/status-box.spec.tsx
@@ -1,8 +1,10 @@
 import { configure, render } from '@testing-library/react';
+import { useLocation } from 'react-router';
 import {
   IncompleteDataError,
   TimeoutError,
 } from '@console/dynamic-plugin-sdk/src/utils/error/http-error';
+import { useFavoritesOptions } from '@console/internal/components/useFavoritesOptions';
 import { StatusBox } from '..';
 
 configure({ testIdAttribute: 'data-test' });
@@ -11,8 +13,19 @@ jest.mock('react-router-dom-v5-compat', () => ({
   useNavigate: jest.fn(),
 }));
 
+jest.mock('react-router', () => ({
+  useLocation: jest.fn(),
+}));
+const useFavoritesOptionsMock = useFavoritesOptions as jest.Mock;
+jest.mock('@console/internal/components/useFavoritesOptions', () => ({
+  useFavoritesOptions: jest.fn(),
+}));
+const useLocationMock = useLocation as jest.Mock;
+
 describe('StatusBox', () => {
   it('should render 404: Page Not Found if the loadError status is 404', () => {
+    useLocationMock.mockReturnValue({ pathname: '' });
+    useFavoritesOptionsMock.mockReturnValue([[], jest.fn(), true]);
     const { getByText } = render(<StatusBox loadError={{ response: { status: 404 } }} />);
     getByText('404: Page Not Found');
   });

--- a/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
@@ -1,5 +1,6 @@
 import { act } from 'react-dom/test-utils';
 import { useSelector } from 'react-redux';
+import { useFavoritesOptions } from '@console/internal/components/useFavoritesOptions';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ConfigMapKind } from '@console/internal/module/k8s';
 import { testHook } from '../../../../../__tests__/utils/hooks-utils';
@@ -14,6 +15,11 @@ const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
 const createConfigMapMock = createConfigMap as jest.Mock;
 const updateConfigMapMock = updateConfigMap as jest.Mock;
 const useSelectorMock = useSelector as jest.Mock;
+const useFavoritesOptionsMock = useFavoritesOptions as jest.Mock;
+
+jest.mock('@console/internal/components/useFavoritesOptions', () => ({
+  useFavoritesOptions: jest.fn(),
+}));
 
 // need to mock StorageEvent because it doesn't exist
 (global as any).StorageEvent = Event;
@@ -62,6 +68,7 @@ const savedDataConfigMap: ConfigMapKind = {
 beforeEach(() => {
   jest.resetAllMocks();
   useSelectorMock.mockImplementation((selector) => selector({ sdkCore: { user: { uid: 'foo' } } }));
+  useFavoritesOptionsMock.mockReturnValue([[], jest.fn(), true]);
 
   // eslint-disable-next-line no-console
   ['log', 'info', 'warn', 'error'].forEach((key) => (console[key] = consoleMock));

--- a/frontend/public/components/error.tsx
+++ b/frontend/public/components/error.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useLocation } from 'react-router';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
 import { ButtonLink } from '@console/shared/src/components/links/ButtonLink';
 import {
@@ -8,11 +9,20 @@ import {
 } from '@patternfly/react-component-groups';
 import { Trans, useTranslation } from 'react-i18next';
 import { CodeBlock, CodeBlockCode, Stack, StackItem } from '@patternfly/react-core';
-
-import { useLocation } from 'react-router';
+import { useFavoritesOptions } from './useFavoritesOptions';
 
 export const ErrorPage404: React.FC<PfErrorStateProps> = (props) => {
   const { t } = useTranslation();
+  const location = useLocation();
+
+  const [favorites, , loaded] = useFavoritesOptions();
+
+  const currentPath = location.pathname;
+  const queryParams = new URLSearchParams(location.search);
+  const fromFavorites = queryParams.get('from') === 'favorites';
+
+  const isDeletedFavorite =
+    fromFavorites && loaded && favorites?.some((fav) => fav.url === currentPath);
 
   return (
     <>
@@ -22,7 +32,18 @@ export const ErrorPage404: React.FC<PfErrorStateProps> = (props) => {
         icon={NotFoundIcon}
         headingLevel="h1"
         titleText={t('public~404: Page Not Found')}
-        defaultBodyText={t("public~We couldn't find that page.")}
+        defaultBodyText={
+          <>
+            {t("public~We couldn't find that page.")}
+            {isDeletedFavorite && (
+              <p>
+                {t(
+                  'public~If you would like to remove it from your favorites list, unfavorite it.',
+                )}
+              </p>
+            )}
+          </>
+        }
         customFooter={
           <ButtonLink variant="link" href="/">
             {t('public~Return to homepage')}

--- a/frontend/public/components/useFavoritesOptions.ts
+++ b/frontend/public/components/useFavoritesOptions.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { useUserSettingsCompatibility } from '@console/shared/src/hooks/useUserSettingsCompatibility';
+import { FavoritesType } from '@console/app/src/types';
+import { FAVORITES_CONFIG_MAP_KEY, FAVORITES_LOCAL_STORAGE_KEY } from '@console/app/src/consts';
+
+export const useFavoritesOptions = (): [
+  FavoritesType,
+  React.Dispatch<React.SetStateAction<FavoritesType>>,
+  boolean,
+] =>
+  useUserSettingsCompatibility<FavoritesType>(
+    FAVORITES_CONFIG_MAP_KEY,
+    FAVORITES_LOCAL_STORAGE_KEY,
+    null,
+    true,
+  );

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -520,6 +520,7 @@
   "Page Not Found (404)": "Page Not Found (404)",
   "404: Page Not Found": "404: Page Not Found",
   "We couldn't find that page.": "We couldn't find that page.",
+  "If you would like to remove it from your favorites list, unfavorite it.": "If you would like to remove it from your favorites list, unfavorite it.",
   "Return to homepage": "Return to homepage",
   "If the problem persists, contact a cluster administrator, <2>Red Hat Support</2> or check our <5>status page</5> for known outages.": "If the problem persists, contact a cluster administrator, <2>Red Hat Support</2> or check our <5>status page</5> for known outages.",
   "An error occured": "An error occured",


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-56803

**Solution Description**: 
If any resource is deleted but it is added as Favorites, then when user navigated, we added a message as "If you would like to remove it from your favorites list, unfavorite it." 

If the user navigate to the URL directly, then we are not adding the alert message. Only if user navigates from Favorites, alert message will be added.
  
**Screen shots / Gifs for design review**: 

**---BEFORE----**

<img width="1720" alt="Screenshot 2025-06-20 at 2 47 32 PM" src="https://github.com/user-attachments/assets/8d51ebf6-1ce2-495f-9a4c-38fb043d68a0" />



**---AFTER----**
<img width="1710" alt="Screenshot 2025-06-20 at 2 45 35 PM" src="https://github.com/user-attachments/assets/4fb11898-fff3-44be-ad85-8247338dae58" />



-----

**Steps to reproduce**:

1.Mark an object as a favorite
2.Delete the object.
3.Go to the favorites section
4.Click on the deleted item and it will show 404

    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

