### PR TITLE
CONSOLE-4491: Deanonymize Developer Sandbox users

### DIFF
--- a/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
@@ -24,6 +24,22 @@ jest.mock('@console/shared/src/hooks/useUserSettings', () => ({
   useUserSettings: jest.fn(),
 }));
 
+const mockUserResource = {};
+
+const exampleReturnValue = {
+  accountMail: undefined,
+  clusterId: undefined,
+  clusterType: undefined,
+  consoleVersion: undefined,
+  organizationId: undefined,
+  path: undefined,
+  userResource: mockUserResource,
+};
+
+jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
+  useK8sGet: () => [mockUserResource, true],
+}));
+
 const mockUserSettings = useUserSettings as jest.Mock;
 
 const useResolvedExtensionsMock = useResolvedExtensions as jest.Mock;
@@ -136,8 +152,9 @@ describe('useTelemetry', () => {
     fireTelemetryEvent('test 1');
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toBeCalledWith('test 1', {
-      consoleVersion: undefined,
+      ...exampleReturnValue,
       clusterType: undefined,
+      consoleVersion: undefined,
     });
   });
 
@@ -153,8 +170,9 @@ describe('useTelemetry', () => {
     fireTelemetryEvent('test 2');
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toBeCalledWith('test 2', {
-      consoleVersion: 'x.y.z',
+      ...exampleReturnValue,
       clusterType: 'OSD',
+      consoleVersion: 'x.y.z',
     });
   });
 
@@ -170,10 +188,11 @@ describe('useTelemetry', () => {
     fireTelemetryEvent('test 3', { 'a-string': 'works fine', 'a-boolean': true });
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toBeCalledWith('test 3', {
-      consoleVersion: 'x.y.z',
-      clusterType: 'OSD',
-      'a-string': 'works fine',
+      ...exampleReturnValue,
       'a-boolean': true,
+      'a-string': 'works fine',
+      clusterType: 'OSD',
+      consoleVersion: 'x.y.z',
     });
   });
 
@@ -193,8 +212,9 @@ describe('useTelemetry', () => {
     fireTelemetryEvent('test 4');
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toBeCalledWith('test 4', {
-      consoleVersion: 'x.y.z',
+      ...exampleReturnValue,
       clusterType: 'DEVSANDBOX',
+      consoleVersion: 'x.y.z',
     });
   });
 

--- a/frontend/packages/console-shared/src/hooks/useTelemetry.ts
+++ b/frontend/packages/console-shared/src/hooks/useTelemetry.ts
@@ -4,15 +4,17 @@ import {
   isTelemetryListener,
   TelemetryListener,
   TelemetryEventListener,
+  UserInfo,
 } from '@console/dynamic-plugin-sdk';
+import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
+import { UserModel } from '@console/internal/models';
+import type { UserKind } from '@console/internal/module/k8s/types';
 import {
   CLUSTER_TELEMETRY_ANALYTICS,
   PREFERRED_TELEMETRY_USER_SETTING_KEY,
   USER_TELEMETRY_ANALYTICS,
 } from '../constants';
 import { useUserSettings } from './useUserSettings';
-
-let telemetryEvents: { eventType: string; event: Record<string, any> }[] = [];
 
 export interface ClusterProperties {
   clusterId?: string;
@@ -21,6 +23,19 @@ export interface ClusterProperties {
   organizationId?: string;
   accountMail?: string;
 }
+
+export type TelemetryEventProperties = {
+  user?: UserInfo;
+  userResource?: UserKind;
+} & ClusterProperties &
+  Record<string, any>;
+
+export interface TelemetryEvent {
+  eventType: string;
+  event: TelemetryEventProperties;
+}
+
+let telemetryEvents: TelemetryEvent[] = [];
 
 export const getClusterProperties = () => {
   const clusterProperties: ClusterProperties = {};
@@ -40,6 +55,18 @@ export const getClusterProperties = () => {
   return clusterProperties;
 };
 
+const clusterIsOptedInToTelemetry = () =>
+  window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.OPTIN;
+
+const isOptedOutFromTelemetry = (currentUserPreferenceTelemetryValue: USER_TELEMETRY_ANALYTICS) =>
+  window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.DISABLED ||
+  (currentUserPreferenceTelemetryValue === USER_TELEMETRY_ANALYTICS.DENY &&
+    (clusterIsOptedInToTelemetry() ||
+      window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.OPTOUT));
+
+const userIsOptedInToTelemetry = (currentUserPreferenceTelemetryValue: USER_TELEMETRY_ANALYTICS) =>
+  currentUserPreferenceTelemetryValue === USER_TELEMETRY_ANALYTICS.ALLOW;
+
 let clusterProperties = getClusterProperties();
 
 export const updateClusterPropertiesFromTests = () => (clusterProperties = getClusterProperties());
@@ -54,50 +81,51 @@ export const useTelemetry = () => {
     true,
   );
 
+  const [userResource, userResourceIsLoaded] = useK8sGet<UserKind>(UserModel, '~');
+
   const [extensions] = useResolvedExtensions<TelemetryListener>(isTelemetryListener);
 
   React.useEffect(() => {
     if (
-      currentUserPreferenceTelemetryValue === USER_TELEMETRY_ANALYTICS.ALLOW &&
-      window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.OPTIN &&
-      telemetryEvents.length > 0
+      userIsOptedInToTelemetry(currentUserPreferenceTelemetryValue) &&
+      clusterIsOptedInToTelemetry() &&
+      telemetryEvents.length > 0 &&
+      userResourceIsLoaded
     ) {
       telemetryEvents.forEach(({ eventType, event }) => {
-        extensions.forEach((e) => e.properties.listener(eventType, event));
+        extensions.forEach((e) => e.properties.listener(eventType, { ...event, userResource }));
       });
       telemetryEvents = [];
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentUserPreferenceTelemetryValue]);
+  }, [currentUserPreferenceTelemetryValue, userResourceIsLoaded]);
 
   return React.useCallback<TelemetryEventListener>(
     (eventType, properties: Record<string, any>) => {
+      if (isOptedOutFromTelemetry(currentUserPreferenceTelemetryValue)) return;
+
       const event = {
         ...clusterProperties,
         ...properties,
         // This is required to ensure that the replayed events uses the right path.
         path: properties?.pathname,
       };
+
       if (
-        window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.DISABLED ||
-        (currentUserPreferenceTelemetryValue === USER_TELEMETRY_ANALYTICS.DENY &&
-          (window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.OPTIN ||
-            window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.OPTOUT))
-      ) {
-        return;
-      }
-      if (
-        !currentUserPreferenceTelemetryValue &&
-        window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.OPTIN
+        (clusterIsOptedInToTelemetry() && !currentUserPreferenceTelemetryValue) ||
+        !userResourceIsLoaded
       ) {
         telemetryEvents.push({ eventType, event });
+
         if (telemetryEvents.length > 10) {
           telemetryEvents.shift(); // Remove the first element
         }
+
         return;
       }
-      extensions.forEach((e) => e.properties.listener(eventType, event));
+
+      extensions.forEach((e) => e.properties.listener(eventType, { ...event, userResource }));
     },
-    [extensions, currentUserPreferenceTelemetryValue],
+    [extensions, currentUserPreferenceTelemetryValue, userResource, userResourceIsLoaded],
   );
 };


### PR DESCRIPTION
addresses https://issues.redhat.com/browse/CONSOLE-4491

Users in a developer sandbox cluster (https://sandbox.redhat.com/) will now be identified by their user id (defined by the `toolchain.dev.openshift.com/sso-user-id` annotation) instead of being anonymized
