### PR TITLE
OCPBUGS-58050: fix missing form styles in Create PVC page + Clone PVC…

### DIFF
--- a/frontend/packages/console-app/src/components/modals/clone/clone-pvc-modal.tsx
+++ b/frontend/packages/console-app/src/components/modals/clone/clone-pvc-modal.tsx
@@ -132,7 +132,7 @@ const ClonePVCModal = withHandlePromise((props: ClonePVCModalProps) => {
   };
 
   return (
-    <form onSubmit={submit} name="form" className="modal-content">
+    <form onSubmit={submit} name="form" className="modal-content pf-v6-c-form pf-v6-c-form--no-gap">
       <ModalTitle>{t('console-app~Clone')}</ModalTitle>
       <ModalBody>
         <FormGroup

--- a/frontend/public/components/modals/configure-cluster-upstream-modal.tsx
+++ b/frontend/public/components/modals/configure-cluster-upstream-modal.tsx
@@ -67,7 +67,7 @@ export const ConfigureClusterUpstreamModal = withHandlePromise(
     return (
       <>
         <ModalTitle>{t('public~Edit upstream configuration')}</ModalTitle>
-        <Form onSubmit={submit} name="form" className="co-form--within-modal">
+        <Form onSubmit={submit} name="form" className="pf-v6-c-form--no-gap">
           <ModalBody>
             <p>
               {t(

--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -273,7 +273,7 @@ export const CreatePVCPage: React.FC<CreatePVCPageProps> = (props) => {
       />
       <PaneBody>
         <div className="co-m-pane__form">
-          <form onSubmit={save}>
+          <form onSubmit={save} className="pf-v6-c-form pf-v6-c-form--no-gap">
             <CreatePVCForm onChange={setPvcObj} namespace={namespace} />
             <ButtonBar errorMessage={error} inProgress={inProgress}>
               <ActionGroup className="pf-v6-c-form">

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -25,10 +25,6 @@
   vertical-align: top;
 }
 
-.co-form--within-modal {
-  gap: 0;
-}
-
 .co-form-section__label {
   font-size: 14px;
   margin-bottom: $pf-v6-global-gutter-y;

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -173,6 +173,10 @@ $masthead-logo-max-height: 60px;
   position: relative;
 }
 
+.pf-v6-c-form--no-gap {
+  gap: 0;
+}
+
 .pf-v6-c-masthead {
   --pf-v6-c-masthead__logo--MaxHeight: $masthead-logo-max-height; // so that logos with three lines of text fit
 }


### PR DESCRIPTION
… modal

This is a CSS hack to address the bug for ease of backporting.  I stubbed out [a new epic for the removal of the legacy form styles](https://issues.redhat.com/browse/CONSOLE-4637).  

After

<img width="686" alt="Screenshot 2025-06-25 at 9 09 31 AM" src="https://github.com/user-attachments/assets/83fd3a6f-f64a-4070-aeac-5833ca5c6de8" />
<img width="763" alt="Screenshot 2025-06-25 at 9 09 38 AM" src="https://github.com/user-attachments/assets/daf3d45d-09d9-4fc0-8a1b-573a483f0fbe" />

No change

<img width="670" alt="Screenshot 2025-06-25 at 10 12 25 AM" src="https://github.com/user-attachments/assets/1d7a484c-b94a-41a7-9e92-ef56620a776b" />
