### PR TITLE
OCPBUGS-58166: only show the correlation masthead in admin

### DIFF
--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -34,7 +34,7 @@ import { formatNamespacedRouteForResource } from '@console/shared/src/utils';
 import { LinkTo } from '@console/shared/src/components/links/LinkTo';
 import CloudShellMastheadButton from '@console/webterminal-plugin/src/components/cloud-shell/CloudShellMastheadButton';
 import CloudShellMastheadAction from '@console/webterminal-plugin/src/components/cloud-shell/CloudShellMastheadAction';
-import { getUser } from '@console/dynamic-plugin-sdk';
+import { getUser, useActivePerspective } from '@console/dynamic-plugin-sdk';
 import * as UIActions from '../actions/ui';
 import { flagPending, featureReducerName } from '../reducers/features';
 import { authSvc } from '../module/auth';
@@ -126,6 +126,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
   const quickstartFlag = useFlag(FLAGS.CONSOLE_QUICKSTART);
   const dispatch = useDispatch();
   const [activeNamespace] = useActiveNamespace();
+  const [activePerspective] = useActivePerspective();
   const [requestTokenURL, externalLoginCommand] = useCopyLoginCommands();
   const launchCopyLoginCommandModal = useCopyCodeModal(
     t('public~Login with this command'),
@@ -245,7 +246,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
     }
 
     // This should be removed when the extension to add items to the masthead is implemented: https://issues.redhat.com/browse/OU-488
-    if (isTroubleshootingPanelEnabled) {
+    if (isTroubleshootingPanelEnabled && activePerspective === 'admin') {
       sections.push({
         name: t('public~Troubleshooting'),
         isSection: true,


### PR DESCRIPTION
This PR looks to hide the troubleshooting panel "signal correlation" button whenever the user isn't in the admin perspective since the troubleshooting panel is only supported for the admin perspective. 