### PR TITLE
CONSOLE-4642: replace Bootstrap radio with PatternFly equivalent

### DIFF
--- a/frontend/packages/console-app/src/components/volume-modes/volume-mode.tsx
+++ b/frontend/packages/console-app/src/components/volume-modes/volume-mode.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { FormGroup } from '@patternfly/react-core';
+import { FormGroup, Radio } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
 import { useTranslation, Trans } from 'react-i18next';
-import { RadioInput } from '@console/internal/components/radio';
 import {
   getVolumeModeRadios,
   getVolumeModeForProvisioner,
@@ -57,10 +57,12 @@ export const VolumeModeSelector: React.FC<VolumeModeSelectorProps> = (props) => 
 
   return (
     <FormGroup
+      role="radiogroup"
+      isInline
       fieldId="volume-mode"
-      className={className}
       label={t('console-app~Volume mode')}
       isRequired
+      className={css(className, 'pf-v6-c-form__group-control--no-row-gap')}
     >
       {allowedVolumeModes.length === 1 ? (
         <>
@@ -73,17 +75,21 @@ export const VolumeModeSelector: React.FC<VolumeModeSelectorProps> = (props) => 
           </FieldLevelHelp>
         </>
       ) : (
-        getVolumeModeRadios().map((radio) => (
-          <RadioInput
-            {...radio}
-            key={radio.value}
-            onChange={(event) => changeVolumeMode(event.currentTarget.value)}
-            inline
-            checked={radio.value === volumeMode}
-            name="volumeMode"
-            disabled={!allowedVolumeModes.includes(radio.value)}
-          />
-        ))
+        getVolumeModeRadios().map((radio) => {
+          const checked = radio.value === volumeMode;
+          return (
+            <Radio
+              key={radio.value}
+              id={`volumeMode-${radio.value}`}
+              name="volumeMode"
+              {...radio}
+              onChange={(event) => changeVolumeMode(event.currentTarget.value)}
+              isChecked={checked}
+              data-checked-state={checked}
+              isDisabled={!allowedVolumeModes.includes(radio.value)}
+            />
+          );
+        })
       )}
     </FormGroup>
   );

--- a/frontend/packages/console-shared/src/components/dynamic-form/widgets.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/widgets.tsx
@@ -178,8 +178,9 @@ export const ImagePullPolicyWidget: React.FC<WidgetProps> = ({ id, value, onChan
       id={id}
       currentValue={value}
       items={_.values(ImagePullPolicy).map((policy) => ({
+        name: id,
         value: policy,
-        title: policy,
+        label: policy,
       }))}
       onChange={({ currentTarget }) => onChange(currentTarget.value)}
     />

--- a/frontend/packages/console-shared/src/components/modals/ConsolePluginModal.tsx
+++ b/frontend/packages/console-shared/src/components/modals/ConsolePluginModal.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Form } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import {
   createModalLauncher,
@@ -54,17 +55,19 @@ export const ConsolePluginModal = withHandlePromise((props: ConsolePluginModalPr
                 'console-shared~This console plugin provides a custom interface that can be included in the console. Updating the enablement of this console plugin will prompt for the console to be refreshed once it has been updated. Make sure you trust this console plugin before enabling.',
               )}
         </p>
-        <ConsolePluginRadioInputs
-          autofocus
-          name={pluginName}
-          enabled={enabled}
-          onChange={setEnabled}
-        />
-        <ConsolePluginWarning
-          previouslyEnabled={previouslyEnabled}
-          enabled={enabled}
-          trusted={trusted}
-        />
+        <Form>
+          <ConsolePluginRadioInputs
+            autofocus
+            name={pluginName}
+            enabled={enabled}
+            onChange={setEnabled}
+          />
+          <ConsolePluginWarning
+            previouslyEnabled={previouslyEnabled}
+            enabled={enabled}
+            trusted={trusted}
+          />
+        </Form>
       </ModalBody>
       <ModalSubmitFooter
         errorMessage={errorMessage}

--- a/frontend/packages/console-shared/src/components/utils/ConsolePluginRadioInputs.tsx
+++ b/frontend/packages/console-shared/src/components/utils/ConsolePluginRadioInputs.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { FormGroup, Radio } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { RadioInput } from '@console/internal/components/radio';
 
 const ConsolePluginRadioInputs: React.FC<ConsolePluginRadioInputsProps> = ({
   autofocus,
@@ -12,24 +12,30 @@ const ConsolePluginRadioInputs: React.FC<ConsolePluginRadioInputsProps> = ({
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     setEnabled(e.currentTarget.value === 'enabled');
   return (
-    <>
-      <RadioInput
+    <FormGroup isStack>
+      <Radio
+        id={`${name}-enabled`}
         name={name}
-        onChange={onChange}
         value="enabled"
-        checked={enabled}
-        title={t('console-shared~Enable')}
-        autoFocus={autofocus && enabled}
-      />
-      <RadioInput
-        name={name}
+        label={t('console-shared~Enable')}
         onChange={onChange}
-        value="disabled"
-        checked={!enabled}
-        title={t('console-shared~Disable')}
-        autoFocus={autofocus && !enabled}
+        isChecked={enabled}
+        data-checked-state={enabled}
+        autoFocus={autofocus && enabled}
+        data-test="Enable-radio-input"
       />
-    </>
+      <Radio
+        id={`${name}-disabled`}
+        name={name}
+        value="disabled"
+        label={t('console-shared~Disable')}
+        onChange={onChange}
+        isChecked={!enabled}
+        data-checked-state={!enabled}
+        autoFocus={autofocus && !enabled}
+        data-test="Disable-radio-input"
+      />
+    </FormGroup>
   );
 };
 

--- a/frontend/packages/integration-tests-cypress/tests/cluster-settings/alertmanager/receivers/slack.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/cluster-settings/alertmanager/receivers/slack.cy.ts
@@ -36,7 +36,7 @@ describe('Alertmanager: Slack Receiver Form', () => {
       .invoke('val')
       .should('eq', '{{ template "slack.default.iconurl" .}}');
     cy.byLegacyTestID('slack-icon-emoji').should('not.exist');
-    cy.byLegacyTestID('slack-icon-type-emoji').click();
+    cy.byTestID('Emoji-radio-input').click();
     cy.byLegacyTestID('slack-icon-url').should('not.exist');
     cy.byLegacyTestID('slack-icon-emoji')
       .invoke('val')

--- a/frontend/packages/operator-lifecycle-manager/src/components/create-catalog-source.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/create-catalog-source.tsx
@@ -10,7 +10,7 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { RadioGroup } from '@console/internal/components/radio';
+import { RadioGroup, RadioGroupItems } from '@console/internal/components/radio';
 import {
   ButtonBar,
   history,
@@ -72,16 +72,18 @@ export const CreateCatalogSource: React.FC = withHandlePromise(
     };
 
     const { t } = useTranslation();
-    const availabilityKinds = [
+    const availabilityKinds: RadioGroupItems = [
       {
+        name: 'catalog-source-availability',
         value: AvailabilityValue.ALL_NAMESPACES,
-        title: t('olm~Cluster-wide CatalogSource'),
-        desc: t('olm~Catalog will be available in all namespaces'),
+        label: t('olm~Cluster-wide CatalogSource'),
+        description: t('olm~Catalog will be available in all namespaces'),
       },
       {
+        name: 'catalog-source-availability',
         value: AvailabilityValue.SINGLE_NAMESPACE,
-        title: t('olm~Namespaced CatalogSource'),
-        desc: t('olm~Catalog will only be available in a single namespace'),
+        label: t('olm~Namespaced CatalogSource'),
+        description: t('olm~Catalog will only be available in a single namespace'),
       },
     ];
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/installplan-approval-modal.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/installplan-approval-modal.spec.tsx
@@ -1,3 +1,4 @@
+import { Radio } from '@patternfly/react-core';
 import { ShallowWrapper, shallow } from 'enzyme';
 import * as _ from 'lodash';
 import {
@@ -5,7 +6,6 @@ import {
   ModalSubmitFooter,
   ModalBody,
 } from '@console/internal/components/factory/modal';
-import { RadioInput } from '@console/internal/components/radio';
 import * as k8sModelsModule from '@console/internal/module/k8s/k8s-models';
 import { testSubscription, testInstallPlan } from '../../../mocks';
 import { SubscriptionModel, InstallPlanModel } from '../../models';
@@ -46,16 +46,16 @@ describe(InstallPlanApprovalModal.name, () => {
   });
 
   it('renders a radio button for each available approval strategy', () => {
-    expect(wrapper.find(ModalBody).find(RadioInput).length).toEqual(2);
+    expect(wrapper.find(ModalBody).find(Radio).length).toEqual(2);
   });
 
   it('pre-selects the approval strategy option that is currently being used by a subscription', () => {
-    expect(wrapper.find(ModalBody).find(RadioInput).at(0).props().checked).toBe(true);
+    expect(wrapper.find(ModalBody).find(Radio).at(0).props().isChecked).toBe(true);
   });
 
   it('pre-selects the approval strategy option that is currently being used by an install plan', () => {
     wrapper = wrapper.setProps({ obj: _.cloneDeep(testInstallPlan) });
-    expect(wrapper.find(ModalBody).find(RadioInput).at(0).props().checked).toBe(true);
+    expect(wrapper.find(ModalBody).find(Radio).at(0).props().isChecked).toBe(true);
   });
 
   it('calls `props.k8sUpdate` to update the subscription when form is submitted', () => {
@@ -67,10 +67,10 @@ describe(InstallPlanApprovalModal.name, () => {
     });
     wrapper
       .find(ModalBody)
-      .find(RadioInput)
+      .find(Radio)
       .at(1)
       .props()
-      .onChange({ target: { value: InstallPlanApproval.Manual } });
+      .onChange({ target: { value: InstallPlanApproval.Manual } } as any, true);
     wrapper.find('form').simulate('submit', new Event('submit'));
   });
 
@@ -84,10 +84,10 @@ describe(InstallPlanApprovalModal.name, () => {
     });
     wrapper
       .find(ModalBody)
-      .find(RadioInput)
+      .find(Radio)
       .at(1)
       .props()
-      .onChange({ target: { value: InstallPlanApproval.Manual } });
+      .onChange({ target: { value: InstallPlanApproval.Manual } } as any, true);
     wrapper.find('form').simulate('submit', new Event('submit'));
   });
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/installplan-approval-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/installplan-approval-modal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Grid, GridItem } from '@patternfly/react-core';
+import { Grid, GridItem, Radio } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import {
@@ -8,7 +8,6 @@ import {
   ModalBody,
   ModalSubmitFooter,
 } from '@console/internal/components/factory/modal';
-import { RadioInput } from '@console/internal/components/radio';
 import {
   K8sKind,
   K8sResourceKind,
@@ -62,33 +61,38 @@ export const InstallPlanApprovalModal: React.FC<InstallPlanApprovalModalProps> =
           </GridItem>
 
           <GridItem>
-            <RadioInput
-              onChange={(e) => setSelectedApprovalStrategy(e.target.value)}
+            <Radio
+              id="approval-strategy-automatic"
+              name="approval-strategy"
               value={InstallPlanApproval.Automatic}
-              checked={selectedApprovalStrategy === InstallPlanApproval.Automatic}
-              title={t(`olm~Automatic`)}
-              subTitle={`(${t('public~default')})`}
-            >
-              <div className="co-m-radio-desc">
-                <p className="pf-v6-u-text-color-subtle">
-                  {t('olm~New updates will be installed as soon as they become available.')}
-                </p>
-              </div>
-            </RadioInput>
+              label={`${t(`olm~Automatic`)} (${t('public~default')})`}
+              description={t('olm~New updates will be installed as soon as they become available.')}
+              onChange={(e) =>
+                setSelectedApprovalStrategy(
+                  (e.target as HTMLInputElement).value as InstallPlanApproval,
+                )
+              }
+              isChecked={selectedApprovalStrategy === InstallPlanApproval.Automatic}
+              data-checked-state={selectedApprovalStrategy === InstallPlanApproval.Automatic}
+            />
           </GridItem>
           <GridItem>
-            <RadioInput
-              onChange={(e) => setSelectedApprovalStrategy(e.target.value)}
+            <Radio
+              id="approval-strategy-manual"
+              name="approval-strategy"
               value={InstallPlanApproval.Manual}
-              checked={selectedApprovalStrategy === InstallPlanApproval.Manual}
-              title={t(`olm~Manual`)}
-            >
-              <div className="co-m-radio-desc">
-                <p className="pf-v6-u-text-color-subtle">
-                  {t('olm~New updates need to be manually approved before installation begins.')}
-                </p>
-              </div>
-            </RadioInput>
+              label={`${t(`olm~Manual`)} (${t('public~default')})`}
+              description={t(
+                'olm~New updates need to be manually approved before installation begins.',
+              )}
+              onChange={(e) =>
+                setSelectedApprovalStrategy(
+                  (e.target as HTMLInputElement).value as InstallPlanApproval,
+                )
+              }
+              isChecked={selectedApprovalStrategy === InstallPlanApproval.Manual}
+              data-checked-state={selectedApprovalStrategy === InstallPlanApproval.Manual}
+            />
           </GridItem>
         </Grid>
       </ModalBody>

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/subscription-channel-modal.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/subscription-channel-modal.spec.tsx
@@ -1,3 +1,4 @@
+import { Radio } from '@patternfly/react-core';
 import { ShallowWrapper, shallow } from 'enzyme';
 import * as _ from 'lodash';
 import {
@@ -5,7 +6,6 @@ import {
   ModalSubmitFooter,
   ModalBody,
 } from '@console/internal/components/factory/modal';
-import { RadioInput } from '@console/internal/components/radio';
 import { testSubscription, testPackageManifest } from '../../../mocks';
 import { SubscriptionModel } from '../../models';
 import { SubscriptionKind, PackageManifestKind } from '../../types';
@@ -77,7 +77,7 @@ describe('SubscriptionChannelModal', () => {
   });
 
   it('renders a radio button for each available channel in the package', () => {
-    expect(wrapper.find(ModalBody).find(RadioInput).length).toEqual(pkg.status.channels.length);
+    expect(wrapper.find(ModalBody).find(Radio).length).toEqual(pkg.status.channels.length);
   });
 
   it('calls `props.k8sUpdate` to update the subscription when form is submitted', (done) => {
@@ -88,10 +88,10 @@ describe('SubscriptionChannelModal', () => {
       return Promise.resolve();
     });
     wrapper
-      .find(RadioInput)
+      .find(Radio)
       .at(1)
       .props()
-      .onChange({ target: { value: 'nightly' } });
+      .onChange({ target: { value: 'nightly' } } as any, true);
     wrapper.find('form').simulate('submit', new Event('submit'));
   });
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/subscription-channel-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/subscription-channel-modal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Grid, GridItem } from '@patternfly/react-core';
+import { Radio, Form, FormGroup } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import {
   createModalLauncher,
@@ -7,7 +7,6 @@ import {
   ModalBody,
   ModalSubmitFooter,
 } from '@console/internal/components/factory/modal';
-import { RadioInput } from '@console/internal/components/radio';
 import { ResourceLink } from '@console/internal/components/utils';
 import { K8sKind, K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { usePromiseHandler } from '@console/shared/src/hooks/promise-handler';
@@ -51,34 +50,39 @@ export const SubscriptionChannelModal: React.FC<SubscriptionChannelModalProps> =
         {t('olm~Change Subscription update channel')}
       </ModalTitle>
       <ModalBody>
-        <Grid>
-          <GridItem>
-            <p>{t('olm~Which channel is used to receive updates?')}</p>
-          </GridItem>
-
-          {pkg?.status?.channels?.map?.((channel) => (
-            <GridItem key={channel.name}>
-              <RadioInput
-                onChange={(e) => setSelectedChannel(e.target.value)}
-                value={channel.name}
-                checked={selectedChannel === channel.name}
-                title={channel.name}
-                subTitle={
-                  <ResourceLink
-                    linkTo={false}
-                    name={channel.currentCSV}
-                    title={channel.currentCSV}
-                    kind={referenceForModel(ClusterServiceVersionModel)}
-                  >
-                    {channel?.deprecation ? (
-                      <DeprecatedOperatorWarningIcon deprecation={channel?.deprecation} />
-                    ) : null}
-                  </ResourceLink>
-                }
-              />
-            </GridItem>
-          ))}
-        </Grid>
+        <Form>
+          <FormGroup label={t('olm~Which channel is used to receive updates?')} isStack>
+            {pkg?.status?.channels?.map?.((channel) => {
+              const checked = selectedChannel === channel.name;
+              return (
+                <Radio
+                  key={channel.name}
+                  id={`channel-${channel.name}`}
+                  name="channel"
+                  value={channel.name}
+                  label={
+                    <>
+                      {channel.name}
+                      <ResourceLink
+                        linkTo={false}
+                        name={channel.currentCSV}
+                        title={channel.currentCSV}
+                        kind={referenceForModel(ClusterServiceVersionModel)}
+                      >
+                        {channel?.deprecation ? (
+                          <DeprecatedOperatorWarningIcon deprecation={channel?.deprecation} />
+                        ) : null}
+                      </ResourceLink>
+                    </>
+                  }
+                  onChange={(e) => setSelectedChannel((e.target as HTMLInputElement).value)}
+                  isChecked={checked}
+                  data-checked-state={checked}
+                />
+              );
+            })}
+          </FormGroup>
+        </Form>
       </ModalBody>
       <ModalSubmitFooter
         inProgress={inProgress}

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/DEPRECATED_operand-form.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/DEPRECATED_operand-form.tsx
@@ -845,8 +845,9 @@ export const DEPRECATED_CreateOperandForm: React.FC<OperandFormProps> = ({
           id={id}
           currentValue={currentValue}
           items={_.values(ImagePullPolicy).map((policy) => ({
+            name: id,
             value: policy,
-            title: policy,
+            label: policy,
           }))}
           onChange={({ currentTarget: { value } }) => handleFormDataUpdate(path, value)}
         />

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/ShowOperandsInAllNamespacesRadioGroup.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/ShowOperandsInAllNamespacesRadioGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { Form, FormGroup, Radio } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { RadioGroup } from '@console/internal/components/radio';
 import { useShowOperandsInAllNamespaces } from './useShowOperandsInAllNamespaces';
 
 export const ShowOperandsInAllNamespacesRadioGroup: React.FC = () => {
@@ -10,23 +10,33 @@ export const ShowOperandsInAllNamespacesRadioGroup: React.FC = () => {
     setShowOperandsInAllNamespaces,
   ] = useShowOperandsInAllNamespaces();
   return (
-    <RadioGroup
-      label={t('olm~Show operands in:')}
-      currentValue={showOperandsInAllNamespaces ? 'true' : 'false'}
-      inline
-      items={[
-        {
-          value: 'true',
-          title: t('olm~All namespaces'),
-        },
-        {
-          value: 'false',
-          title: t('olm~Current namespace only'),
-        },
-      ]}
-      onChange={({ currentTarget }) =>
-        setShowOperandsInAllNamespaces(currentTarget.value === 'true')
-      }
-    />
+    <Form isHorizontal>
+      <FormGroup
+        role="radiogroup"
+        fieldId="show-operands"
+        label={t('olm~Show operands in:')}
+        isInline
+        hasNoPaddingTop
+      >
+        <Radio
+          id="all-namespaces"
+          name="show-operands"
+          value="true"
+          label={t('olm~All namespaces')}
+          onChange={() => setShowOperandsInAllNamespaces(true)}
+          isChecked={showOperandsInAllNamespaces}
+          data-checked-state={showOperandsInAllNamespaces}
+        />
+        <Radio
+          id="current-namespace-only"
+          name="show-operands"
+          value="false"
+          label={t('olm~Current namespace only')}
+          onChange={() => setShowOperandsInAllNamespaces(false)}
+          isChecked={!showOperandsInAllNamespaces}
+          data-checked-state={!showOperandsInAllNamespaces}
+        />
+      </FormGroup>
+    </Form>
   );
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -447,12 +447,11 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
 
   return inFlight ? null : (
     <>
-      <ListPageHeader title={showTitle ? t('olm~All Instances') : undefined} hideFavoriteButton>
-        {managesAllNamespaces && (
-          <div className="co-operator-details__toggle-value pf-v6-u-ml-xl-on-md">
-            <ShowOperandsInAllNamespacesRadioGroup />
-          </div>
-        )}
+      <ListPageHeader
+        title={showTitle ? t('olm~All Instances') : undefined}
+        hideFavoriteButton
+        helpText={managesAllNamespaces && <ShowOperandsInAllNamespacesRadioGroup />}
+      >
         <ListPageCreateDropdown onClick={createNavigate} items={createItems}>
           {t('olm~Create new')}
         </ListPageCreateDropdown>
@@ -515,12 +514,11 @@ const DefaultProvidedAPIPage: React.FC<DefaultProvidedAPIPageProps> = (props) =>
 
   return (
     <>
-      <ListPageHeader title={showTitle ? `${labelPlural}` : undefined} hideFavoriteButton>
-        {managesAllNamespaces && (
-          <div className="co-operator-details__toggle-value pf-v6-u-ml-xl-on-md">
-            <ShowOperandsInAllNamespacesRadioGroup />
-          </div>
-        )}
+      <ListPageHeader
+        title={showTitle ? `${labelPlural}` : undefined}
+        hideFavoriteButton
+        helpText={managesAllNamespaces && <ShowOperandsInAllNamespacesRadioGroup />}
+      >
         <ListPageCreateLink to={createPath}>
           {t('public~Create {{label}}', { label })}
         </ListPageCreateLink>

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -5,15 +5,17 @@ import {
   AlertActionCloseButton,
   Button,
   Checkbox,
+  FormGroup,
   Grid,
   GridItem,
+  Radio,
   TextInput,
   Title,
 } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
 import { useLocation, Link } from 'react-router-dom-v5-compat';
-import { RadioGroup, RadioInput } from '@console/internal/components/radio';
+import { RadioGroup } from '@console/internal/components/radio';
 import {
   documentationURLs,
   FieldLevelHelp,
@@ -775,47 +777,55 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
   );
 
   const installedNamespaceOptions = (
-    <div className="form-group">
-      <RadioInput
-        onChange={() => {
-          setUseSuggestedNSForSingleInstallMode(true);
-          setTargetNamespace(operatorSuggestedNamespace);
-        }}
-        value={operatorSuggestedNamespace}
-        checked={useSuggestedNSForSingleInstallMode}
-        title={t('olm~Operator recommended Namespace:')}
-      >
-        {' '}
-        <ResourceIcon kind="Project" />
-        <b>{operatorSuggestedNamespace}</b>
-      </RadioInput>
-      <RadioInput
-        onChange={() => {
-          setUseSuggestedNSForSingleInstallMode(false);
-          setTargetNamespace(null);
-        }}
-        value={operatorSuggestedNamespace}
-        checked={!useSuggestedNSForSingleInstallMode}
-        title={t('olm~Select a Namespace')}
-      />
-      {!useSuggestedNSForSingleInstallMode && (
-        <>
-          <NsDropdown
-            id="dropdown-selectbox"
-            selectedKey={selectedTargetNamespace}
-            onChange={(ns) => setTargetNamespace(ns)}
-            dataTest="dropdown-selectbox"
-          />
-          <Alert
-            isInline
-            className="co-alert pf-v6-c-alert--top-margin"
-            variant="warning"
-            title={t(
-              'olm~Not installing the Operator into the recommended namespace can cause unexpected behavior.',
-            )}
-          />
-        </>
-      )}
+    <div className="pf-v6-c-form">
+      <FormGroup role="radiogroup" fieldId="operator-namespace" isStack className="form-group">
+        <Radio
+          id="operator-namespace-recommended"
+          name="operator-namespace"
+          value={operatorSuggestedNamespace}
+          label={
+            <>
+              {t('olm~Operator recommended Namespace:')} <ResourceIcon kind="Project" />
+              <b>{operatorSuggestedNamespace}</b>
+            </>
+          }
+          onChange={() => {
+            setUseSuggestedNSForSingleInstallMode(true);
+            setTargetNamespace(operatorSuggestedNamespace);
+          }}
+          isChecked={useSuggestedNSForSingleInstallMode}
+          data-checked-state={useSuggestedNSForSingleInstallMode}
+        />
+        <Radio
+          id="operator-namespace-select"
+          name="operator-namespace"
+          value={operatorSuggestedNamespace}
+          label={t('olm~Select a Namespace')}
+          onChange={() => {
+            setUseSuggestedNSForSingleInstallMode(false);
+            setTargetNamespace(null);
+          }}
+          isChecked={!useSuggestedNSForSingleInstallMode}
+          data-checked-state={!useSuggestedNSForSingleInstallMode}
+        />
+        {!useSuggestedNSForSingleInstallMode && (
+          <>
+            <NsDropdown
+              id="dropdown-selectbox"
+              selectedKey={selectedTargetNamespace}
+              onChange={(ns) => setTargetNamespace(ns)}
+              dataTest="dropdown-selectbox"
+            />
+            <Alert
+              isInline
+              variant="warning"
+              title={t(
+                'olm~Not installing the Operator into the recommended namespace can cause unexpected behavior.',
+              )}
+            />
+          </>
+        )}
+      </FormGroup>
     </div>
   );
 
@@ -1006,7 +1016,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
                   />
                 </fieldset>
               </div>
-              <div className="form-group pf-v6-u-mb-xl">
+              <div className="form-group">
                 <fieldset>
                   <label className="co-required">{t('olm~Version')}</label>
                   <OperatorVersionSelect
@@ -1018,49 +1028,61 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
                   />
                 </fieldset>
               </div>
-              <div className="form-group">
+              <div className="pf-v6-c-form">
                 <fieldset>
                   <label className="co-required">{t('olm~Installation mode')}</label>
-                  <RadioInput
-                    onChange={(e) => {
-                      setInstallMode(e.target.value);
-                      setTargetNamespace(null);
-                      setCannotResolve(false);
-                    }}
-                    value={InstallModeType.InstallModeTypeAllNamespaces}
-                    checked={selectedInstallMode === InstallModeType.InstallModeTypeAllNamespaces}
-                    disabled={!supportsGlobal}
-                    title={t('olm~All namespaces on the cluster')}
-                    subTitle={t('olm~(default)')}
+                  <FormGroup
+                    role="radiogroup"
+                    fieldId="operator-install-mode"
+                    isStack
+                    className="form-group"
                   >
-                    <div className="co-m-radio-desc">
-                      <p className="pf-v6-u-text-color-subtle">
-                        {descFor(InstallModeType.InstallModeTypeAllNamespaces)}
-                      </p>
-                    </div>
-                  </RadioInput>
-                  <RadioInput
-                    onChange={(e) => {
-                      setInstallMode(e.target.value);
-                      setTargetNamespace(
-                        useSuggestedNSForSingleInstallMode ? operatorSuggestedNamespace : null,
-                      );
-                      setCannotResolve(false);
-                    }}
-                    value={InstallModeType.InstallModeTypeOwnNamespace}
-                    checked={selectedInstallMode === InstallModeType.InstallModeTypeOwnNamespace}
-                    disabled={!supportsSingle}
-                    title={t('olm~A specific namespace on the cluster')}
-                  >
-                    <div className="co-m-radio-desc">
-                      <p className="pf-v6-u-text-color-subtle">
-                        {descFor(InstallModeType.InstallModeTypeOwnNamespace)}
-                      </p>
-                    </div>
-                  </RadioInput>
+                    <Radio
+                      id="operator-install-mode-all-namespaces"
+                      name="operator-install-mode"
+                      value={InstallModeType.InstallModeTypeAllNamespaces}
+                      label={`${t('olm~All namespaces on the cluster')} ${t('olm~(default)')}`}
+                      description={descFor(InstallModeType.InstallModeTypeAllNamespaces)}
+                      onChange={(e) => {
+                        setInstallMode((e.target as HTMLInputElement).value);
+                        setTargetNamespace(null);
+                        setCannotResolve(false);
+                      }}
+                      isChecked={
+                        selectedInstallMode === InstallModeType.InstallModeTypeAllNamespaces
+                      }
+                      data-checked-state={
+                        selectedInstallMode === InstallModeType.InstallModeTypeAllNamespaces
+                      }
+                      isDisabled={!supportsGlobal}
+                      data-test="All namespaces on the cluster-radio-input"
+                    />
+                    <Radio
+                      id="operator-install-mode-own-namespace"
+                      name="operator-install-mode"
+                      value={InstallModeType.InstallModeTypeOwnNamespace}
+                      label={t('olm~A specific namespace on the cluster')}
+                      description={descFor(InstallModeType.InstallModeTypeOwnNamespace)}
+                      onChange={(e) => {
+                        setInstallMode((e.target as HTMLInputElement).value);
+                        setTargetNamespace(
+                          useSuggestedNSForSingleInstallMode ? operatorSuggestedNamespace : null,
+                        );
+                        setCannotResolve(false);
+                      }}
+                      isChecked={
+                        selectedInstallMode === InstallModeType.InstallModeTypeOwnNamespace
+                      }
+                      data-checked-state={
+                        selectedInstallMode === InstallModeType.InstallModeTypeOwnNamespace
+                      }
+                      isDisabled={!supportsSingle}
+                      data-test="A specific namespace on the cluster-radio-input"
+                    />
+                  </FormGroup>
                 </fieldset>
               </div>
-              <div className="form-group pf-v6-u-mb-xl">
+              <div className="form-group">
                 <label className="co-required" htmlFor="dropdown-selectbox">
                   {t('olm~Installed Namespace')}
                 </label>
@@ -1069,7 +1091,12 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
                 {selectedInstallMode === InstallModeType.InstallModeTypeOwnNamespace &&
                   singleNamespaceInstallMode}
               </div>
-              <div className="form-group">
+              <FormGroup
+                role="radiogroup"
+                fieldId="operator-approval"
+                isStack
+                className="form-group"
+              >
                 <fieldset>
                   <label className="co-required">{t('olm~Update approval')}</label>
                   <FieldLevelHelp>
@@ -1079,13 +1106,15 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
                     currentValue={approval}
                     items={[
                       {
+                        name: 'operator-approval-strategy',
                         value: InstallPlanApproval.Automatic,
-                        title: t('olm~Automatic'),
+                        label: t('olm~Automatic'),
                         disabled: isApprovalItemDisabled,
                       },
                       {
+                        name: 'operator-approval-strategy',
                         value: InstallPlanApproval.Manual,
-                        title: t('olm~Manual'),
+                        label: t('olm~Manual'),
                       },
                     ]}
                     onChange={(e) => {
@@ -1128,14 +1157,16 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
                     </Alert>
                   )}
                 </fieldset>
-              </div>
+              </FormGroup>
               {csvPlugins.length > 0 && consoleOperatorConfig && canPatchConsoleOperatorConfig && (
-                <ConsolePluginFormGroup
-                  catalogSource={catalogSource}
-                  csvPlugins={csvPlugins}
-                  enabledPlugins={enabledPlugins}
-                  setPluginEnabled={setPluginEnabled}
-                />
+                <div className="pf-v6-c-form">
+                  <ConsolePluginFormGroup
+                    catalogSource={catalogSource}
+                    csvPlugins={csvPlugins}
+                    enabledPlugins={enabledPlugins}
+                    setPluginEnabled={setPluginEnabled}
+                  />
+                </div>
               )}
             </>
             {deprecatedWarning && (

--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -31,7 +31,7 @@ $co-affinity-row-margin: 15px;
   text-decoration: none;
 
   .co-clusterserviceversion-logo__name__clusterserviceversion {
-      text-decoration: underline;
+    text-decoration: underline;
   }
 }
 
@@ -277,27 +277,4 @@ $co-affinity-row-margin: 15px;
 
 .co-operator-uninstall__operands-section loading-skeleton--table::after {
   min-height: 160px;
-}
-
-.co-operator-details__actions {
-  align-items: baseline;
-  display: flex;
-  flex-wrap: wrap;
-  @media (min-width: $screen-sm-min) {
-    flex-wrap: nowrap;
-    justify-content: flex-end;
-  }
-}
-
-.co-operator-details__toggle-value {
-  flex-grow: 1;
-  margin-right: var(--pf-t--global--spacer--xl);
-}
-
-.co-operator-details__toggle-value .radio-inline input[type='radio'] {
-  position: relative; //To override bootstrap absolute position
-}
-
-.co-operator-details__toggle-value label {
-  font-weight: var(--pf-t--global--font--weight--body--default);
 }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/VolumeClaimTemplateForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/VolumeClaimTemplateForm.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { FormGroup, Alert } from '@patternfly/react-core';
+import { FormGroup, Alert, Radio } from '@patternfly/react-core';
 import { useField, useFormikContext, FormikValues } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { AccessModeSelector } from '@console/app/src/components/access-modes/access-mode';
-import { RadioInput } from '@console/internal/components//radio';
 import {
   getVolumeModeRadios,
   initialAccessModes,
@@ -166,17 +165,23 @@ const VolumeClaimTemplateForm: React.FC<VolumeClaimTemplateFormProps> = ({
             <p className="help-block">{t('pipelines-plugin~Desired storage capacity')}</p>
           )}
         </div>
-        <div className="odc-VolumeClaimTemplateForm--section">
-          <label htmlFor="volume-mode">{t('pipelines-plugin~Volume Mode')}</label>
-          <FormGroup fieldId="volumeMode" data-test-id="volumeModeRadio">
+        <div className="odc-VolumeClaimTemplateForm--section pf-v6-c-form">
+          <FormGroup
+            role="radiogroup"
+            fieldId="volume-mode"
+            label={t('pipelines-plugin~Volume Mode')}
+            isInline
+            className="pf-v6-c-form__group-control--no-row-gap"
+            data-test-id="volumeModeRadio"
+          >
             {getVolumeModeRadios().map((radio) => (
-              <RadioInput
-                {...radio}
+              <Radio
                 key={radio.value}
+                id={`${name}.volumeMode`}
+                name="volumeMode"
+                {...radio}
                 onChange={handleVolumeMode}
-                inline
-                checked={radio.value === volumeMode}
-                name={`${name}.volumeMode`}
+                isChecked={radio.value === volumeMode}
               />
             ))}
           </FormGroup>

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -609,28 +609,30 @@ const BaseEditRoleBinding = (props) => {
 
   const bindingKinds = [
     {
+      name: 'binding-type',
       value: 'RoleBinding',
-      title: t('public~Namespace role binding (RoleBinding)'),
-      desc: t(
+      label: t('public~Namespace role binding (RoleBinding)'),
+      description: t(
         'public~Grant the permissions to a user or set of users within the selected namespace.',
       ),
     },
     {
+      name: 'binding-type',
       value: 'ClusterRoleBinding',
-      title: t('public~Cluster-wide role binding (ClusterRoleBinding)'),
-      desc: t(
+      label: t('public~Cluster-wide role binding (ClusterRoleBinding)'),
+      description: t(
         'public~Grant the permissions to a user or set of users at the cluster level and in all namespaces.',
       ),
     },
   ];
 
   const subjectKinds = [
-    { value: 'User', title: t('public~User'), disabled: false },
-    { value: 'Group', title: t('public~Group'), disabled: false },
+    { name: 'subject-kind', value: 'User', label: t('public~User') },
+    { name: 'subject-kind', value: 'Group', label: t('public~Group') },
     {
+      name: 'subject-kind',
       value: 'ServiceAccount',
-      title: t('public~ServiceAccount'),
-      disabled: false,
+      label: t('public~ServiceAccount'),
     },
   ];
 

--- a/frontend/public/components/_radio.scss
+++ b/frontend/public/components/_radio.scss
@@ -1,8 +1,0 @@
-.co-radio-group--inline {
-  display: flex;
-  align-items: flex-start;
-}
-
-.co-radio-group .co-radio-group__label {
-  margin-right: 15px;
-}

--- a/frontend/public/components/modals/add-secret-to-workload.tsx
+++ b/frontend/public/components/modals/add-secret-to-workload.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as fuzzy from 'fuzzysearch';
 import { useNavigate } from 'react-router-dom-v5-compat';
+import { FormGroup, Radio } from '@patternfly/react-core';
 
 import { K8sKind, k8sList, k8sPatch, K8sResourceKind } from '../../module/k8s';
 import { DeploymentModel, DeploymentConfigModel, StatefulSetModel } from '../../models';
 import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
 import { Dropdown, ResourceIcon, ResourceName, resourcePathFromModel } from '../utils';
-import { RadioInput } from '../radio';
 /* eslint-disable import/named */
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -191,58 +191,71 @@ export const AddSecretToWorkloadModal: React.FC<AddSecretToWorkloadModalProps> =
         </div>
         <fieldset>
           <legend className="co-legend co-required">{t('public~Add secret as')}</legend>
-          <RadioInput
-            title={t('public~Environment variables')}
-            name="co-add-secret-to-workload__add-as"
-            id="co-add-secret-to-workload__envvars"
-            value="environment"
-            onChange={onAddAsChange}
-            checked={addAsEnvironment}
-          />
-          {addAsEnvironment && (
-            <div className="co-m-radio-desc">
-              <div className="form-group">
-                <label htmlFor="co-add-secret-to-workload__prefix">{t('public~Prefix')}</label>
-                <span className="pf-v6-c-form-control">
-                  <input
-                    name="prefix"
-                    id="co-add-secret-to-workload__prefix"
-                    data-test="add-secret-to-workload-prefix"
-                    placeholder="(optional)"
-                    type="text"
-                    onChange={(e) => setPrefix(e.currentTarget.value)}
-                  />
-                </span>
-              </div>
-            </div>
-          )}
-          <RadioInput
-            title={t('public~Volume')}
-            name="co-add-secret-to-workload__add-as"
-            id="co-add-secret-to-workload__volume"
-            value="volume"
-            onChange={onAddAsChange}
-            checked={addAsVolume}
-          />
-          {addAsVolume && (
-            <div className="co-m-radio-desc">
-              <div className="form-group">
-                <label htmlFor="co-add-secret-to-workload__mountpath" className="co-required">
-                  {t('public~Mount path')}
-                </label>
-                <span className="pf-v6-c-form-control">
-                  <input
-                    name="mountPath"
-                    id="co-add-secret-to-workload__mountpath"
-                    data-test="add-secret-to-workload-mountpath"
-                    type="text"
-                    onChange={(e) => setMountPath(e.currentTarget.value)}
-                    required
-                  />
-                </span>
-              </div>
-            </div>
-          )}
+          <div className="pf-v6-c-form">
+            <FormGroup
+              role="radiogroup"
+              fieldId="co-add-secret-to-workload"
+              isStack
+              className="form-group"
+            >
+              <Radio
+                id="co-add-secret-to-workload__envvars"
+                name="co-add-secret-to-workload__add-as"
+                label={t('public~Environment variables')}
+                value="environment"
+                onChange={onAddAsChange}
+                isChecked={addAsEnvironment}
+                data-test="Environment variables-radio-input"
+                data-checked-state={addAsEnvironment}
+              />
+              {addAsEnvironment && (
+                <div className="co-m-radio-desc">
+                  <div className="form-group">
+                    <label htmlFor="co-add-secret-to-workload__prefix">{t('public~Prefix')}</label>
+                    <span className="pf-v6-c-form-control">
+                      <input
+                        name="prefix"
+                        id="co-add-secret-to-workload__prefix"
+                        data-test="add-secret-to-workload-prefix"
+                        placeholder="(optional)"
+                        type="text"
+                        onChange={(e) => setPrefix(e.currentTarget.value)}
+                      />
+                    </span>
+                  </div>
+                </div>
+              )}
+              <Radio
+                id="co-add-secret-to-workload__volume"
+                name="co-add-secret-to-workload__add-as"
+                label={t('public~Volume')}
+                value="volume"
+                onChange={onAddAsChange}
+                isChecked={addAsVolume}
+                data-test="Volume-radio-input"
+                data-checked-state={addAsVolume}
+              />
+              {addAsVolume && (
+                <div className="co-m-radio-desc">
+                  <div className="form-group">
+                    <label htmlFor="co-add-secret-to-workload__mountpath" className="co-required">
+                      {t('public~Mount path')}
+                    </label>
+                    <span className="pf-v6-c-form-control">
+                      <input
+                        name="mountPath"
+                        id="co-add-secret-to-workload__mountpath"
+                        data-test="add-secret-to-workload-mountpath"
+                        type="text"
+                        onChange={(e) => setMountPath(e.currentTarget.value)}
+                        required
+                      />
+                    </span>
+                  </div>
+                </div>
+              )}
+            </FormGroup>
+          </div>
         </fieldset>
       </ModalBody>
       <ModalSubmitFooter

--- a/frontend/public/components/modals/configure-ns-pull-secret-modal.jsx
+++ b/frontend/public/components/modals/configure-ns-pull-secret-modal.jsx
@@ -1,7 +1,15 @@
 import * as _ from 'lodash-es';
 import * as PropTypes from 'prop-types';
 import { Base64 } from 'js-base64';
-import { Alert, CodeBlock, CodeBlockCode, Grid, GridItem } from '@patternfly/react-core';
+import {
+  Alert,
+  CodeBlock,
+  CodeBlockCode,
+  FormGroup,
+  Grid,
+  GridItem,
+  Radio,
+} from '@patternfly/react-core';
 import { withTranslation } from 'react-i18next';
 
 import { CONST } from '@console/shared';
@@ -172,29 +180,27 @@ class ConfigureNamespacePullSecretWithTranslation extends PromiseComponent {
               <label>{t('public~Method')}</label>
             </GridItem>
             <GridItem span={9}>
-              <div className="radio">
-                <label>
-                  <input
-                    type="radio"
+              <div className="pf-v6-c-form">
+                <FormGroup role="radiogroup" fieldId="namespace-pull-secret-method" isStack>
+                  <Radio
                     id="namespace-pull-secret-method--form"
-                    checked={this.state.method === 'form'}
-                    onChange={this._onMethodChange}
+                    name="namespace-pull-secret-method"
+                    label={t('public~Enter username/password')}
                     value="form"
-                  />
-                  {t('public~Enter username/password')}
-                </label>
-              </div>
-              <div className="radio">
-                <label>
-                  <input
-                    type="radio"
-                    checked={this.state.method === 'upload'}
                     onChange={this._onMethodChange}
-                    id="namespace-pull-secret-method--upload"
-                    value="upload"
+                    isChecked={this.state.method === 'form'}
+                    data-checked-state={this.state.method === 'form'}
                   />
-                  {t('public~Upload Docker config.json')}
-                </label>
+                  <Radio
+                    id="namespace-pull-secret-method--upload"
+                    name="namespace-pull-secret-method"
+                    label={t('public~Upload Docker config.json')}
+                    value="upload"
+                    onChange={this._onMethodChange}
+                    isChecked={this.state.method === 'upload'}
+                    data-checked-state={this.state.method === 'upload'}
+                  />
+                </FormGroup>
               </div>
             </GridItem>
 

--- a/frontend/public/components/monitoring/receiver-forms/pagerduty-receiver-form.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/pagerduty-receiver-form.tsx
@@ -2,9 +2,8 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Grid, GridItem, Title } from '@patternfly/react-core';
+import { FormGroup, Grid, GridItem, Radio, Title } from '@patternfly/react-core';
 
-import { RadioInput } from '../../radio';
 import { SendResolvedAlertsCheckbox } from './send-resolved-alerts-checkbox';
 import { SaveAsDefaultCheckbox } from './save-as-default-checkbox';
 import { FormProps } from './receiver-form-props';
@@ -23,39 +22,45 @@ export const Form: React.FC<FormProps> = ({ globals, formValues, dispatchFormCha
   const { t } = useTranslation();
   return (
     <div data-test-id="pagerduty-receiver-form">
-      <div className="form-group">
-        <label htmlFor="integration-type-events">{t('public~Integration type')}</label>
-        <div>
-          <RadioInput
-            title={t('public~Events API v2')}
+      <div className="form-group pf-v6-c-form">
+        <FormGroup
+          role="radiogroup"
+          fieldId="integration-type"
+          label={t('public~Integration type')}
+          isInline
+          className="pf-v6-c-form__group-control--no-row-gap"
+        >
+          <Radio
             id="integration-type-events"
+            name="pagerdutyIntegrationKeyType"
+            label={t('public~Events API v2')}
             value="events"
             onChange={(e) =>
               dispatchFormChange({
                 type: 'setFormValues',
-                payload: { pagerdutyIntegrationKeyType: e.target.value },
+                payload: { pagerdutyIntegrationKeyType: (e.target as HTMLInputElement).value },
               })
             }
-            checked={formValues.pagerdutyIntegrationKeyType === 'events'}
-            aria-checked={formValues.pagerdutyIntegrationKeyType === 'events'}
-            inline
+            isChecked={formValues.pagerdutyIntegrationKeyType === 'events'}
+            data-checked-state={formValues.pagerdutyIntegrationKeyType === 'events'}
+            data-test-id="integration-type-events"
           />
-          <RadioInput
-            title={t('public~Prometheus')}
+          <Radio
+            id="integration-type-prometheus"
             name="pagerdutyIntegrationKeyType"
-            data-test-id="integration-type-prometheus"
+            label={t('public~Prometheus')}
             value="prometheus"
             onChange={(e) =>
               dispatchFormChange({
                 type: 'setFormValues',
-                payload: { pagerdutyIntegrationKeyType: e.target.value },
+                payload: { pagerdutyIntegrationKeyType: (e.target as HTMLInputElement).value },
               })
             }
-            checked={formValues.pagerdutyIntegrationKeyType === 'prometheus'}
-            aria-checked={formValues.pagerdutyIntegrationKeyType === 'prometheus'}
-            inline
+            isChecked={formValues.pagerdutyIntegrationKeyType === 'prometheus'}
+            data-checked-state={formValues.pagerdutyIntegrationKeyType === 'prometheus'}
+            data-test-id="integration-type-prometheus"
           />
-        </div>
+        </FormGroup>
       </div>
       <div className="form-group">
         <label data-test-id="pagerduty-key-label" className="co-required" htmlFor="integration-key">

--- a/frontend/public/components/monitoring/receiver-forms/slack-receiver-form.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/slack-receiver-form.tsx
@@ -2,9 +2,8 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { Checkbox, Grid, GridItem, TextArea } from '@patternfly/react-core';
+import { Checkbox, FormGroup, Grid, GridItem, Radio, TextArea } from '@patternfly/react-core';
 
-import { RadioInput } from '../../radio';
 import { ExpandCollapse } from '../../utils';
 import { ExternalLink } from '@console/shared/src/components/links/ExternalLink';
 import { SendResolvedAlertsCheckbox } from './send-resolved-alerts-checkbox';
@@ -103,90 +102,97 @@ export const Form: React.FC<FormProps> = ({ globals, formValues, dispatchFormCha
                 dispatchFormChange={dispatchFormChange}
               />
             </div>
-            <div className="form-group">
-              <label htmlFor="slack-icon-type">
-                {t('public~Icon')} &nbsp;
-                <RadioInput
-                  title={t('public~URL')}
-                  name="slackIconType"
+            <div className="form-group pf-v6-c-form">
+              <FormGroup
+                role="radiogroup"
+                fieldId="slack-icon-type-group"
+                label={t('public~Icon')}
+                isInline
+                className="pf-v6-c-form__group-control--no-row-gap"
+              >
+                <Radio
                   id="slack-icon-type"
+                  name="slackIconType"
+                  label={t('public~URL')}
                   value="url"
                   onChange={(e) =>
                     dispatchFormChange({
                       type: 'setFormValues',
-                      payload: { slackIconType: e.target.value },
+                      payload: { slackIconType: (e.target as HTMLInputElement).value },
                     })
                   }
-                  checked={formValues.slackIconType === 'url'}
-                  inline
+                  isChecked={formValues.slackIconType === 'url'}
+                  data-checked-state={formValues.slackIconType === 'url'}
+                  data-test="URL-radio-input"
                 />
-                <RadioInput
-                  title={t('public~Emoji')}
+                <Radio
+                  id="slack-icon-type-emoji"
                   name="slackIconType"
+                  label={t('public~Emoji')}
                   value="emoji"
-                  data-test-id="slack-icon-type-emoji"
                   onChange={(e) =>
                     dispatchFormChange({
                       type: 'setFormValues',
-                      payload: { slackIconType: e.target.value },
+                      payload: { slackIconType: (e.target as HTMLInputElement).value },
                     })
                   }
-                  checked={formValues.slackIconType === 'emoji'}
-                  inline
+                  isChecked={formValues.slackIconType === 'emoji'}
+                  data-checked-state={formValues.slackIconType === 'emoji'}
+                  data-test="Emoji-radio-input"
                 />
-              </label>
-              {formValues.slackIconType === 'url' && (
-                <>
-                  <span className="pf-v6-c-form-control">
-                    <input
-                      type="text"
-                      aria-describedby="slack-icon-url-help"
-                      aria-label={t('public~The URL of the icon.')}
-                      data-test-id="slack-icon-url"
-                      value={formValues.slack_icon_url}
-                      onChange={(e) =>
-                        dispatchFormChange({
-                          type: 'setFormValues',
-                          payload: { slack_icon_url: e.target.value },
-                        })
-                      }
-                    />
-                  </span>
-                  <div className="help-block" id="slack-icon-url-help">
-                    {t('public~The URL of the icon.')}
-                  </div>
-                </>
-              )}
-              {formValues.slackIconType === 'emoji' && (
-                <>
-                  <span className="pf-v6-c-form-control">
-                    <input
-                      type="text"
-                      aria-describedby="slack-icon-emoji-help"
-                      aria-label={t('public~An emoji code to use in place of the default icon.')}
-                      name="slackIconEmoji"
-                      data-test-id="slack-icon-emoji"
-                      value={formValues.slack_icon_emoji}
-                      onChange={(e) =>
-                        dispatchFormChange({
-                          type: 'setFormValues',
-                          payload: { slack_icon_emoji: e.target.value },
-                        })
-                      }
-                    />
-                  </span>
-                  <div className="help-block" id="slack-icon-emoji-help">
-                    <Trans ns="public">
-                      An{' '}
-                      <ExternalLink
-                        href="https://www.webfx.com/tools/emoji-cheat-sheet/"
-                        text={t('public~emoji code')}
-                      />{' '}
-                      to use in place of the default icon.
-                    </Trans>
-                  </div>
-                </>
-              )}
+                {formValues.slackIconType === 'url' && (
+                  <>
+                    <span className="pf-v6-c-form-control">
+                      <input
+                        type="text"
+                        aria-describedby="slack-icon-url-help"
+                        aria-label={t('public~The URL of the icon.')}
+                        data-test-id="slack-icon-url"
+                        value={formValues.slack_icon_url}
+                        onChange={(e) =>
+                          dispatchFormChange({
+                            type: 'setFormValues',
+                            payload: { slack_icon_url: e.target.value },
+                          })
+                        }
+                      />
+                    </span>
+                    <div className="help-block" id="slack-icon-url-help">
+                      {t('public~The URL of the icon.')}
+                    </div>
+                  </>
+                )}
+                {formValues.slackIconType === 'emoji' && (
+                  <>
+                    <span className="pf-v6-c-form-control">
+                      <input
+                        type="text"
+                        aria-describedby="slack-icon-emoji-help"
+                        aria-label={t('public~An emoji code to use in place of the default icon.')}
+                        name="slackIconEmoji"
+                        data-test-id="slack-icon-emoji"
+                        value={formValues.slack_icon_emoji}
+                        onChange={(e) =>
+                          dispatchFormChange({
+                            type: 'setFormValues',
+                            payload: { slack_icon_emoji: e.target.value },
+                          })
+                        }
+                      />
+                    </span>
+                    <div className="help-block" id="slack-icon-emoji-help">
+                      <Trans ns="public">
+                        An{' '}
+                        <ExternalLink
+                          href="https://www.webfx.com/tools/emoji-cheat-sheet/"
+                          text={t('public~emoji code')}
+                        />{' '}
+                        to use in place of the default icon.
+                      </Trans>
+                    </div>
+                  </>
+                )}
+              </FormGroup>
             </div>
             <div className="form-group">
               <label htmlFor="slack-username">{t('public~Username')}</label>

--- a/frontend/public/components/radio.tsx
+++ b/frontend/public/components/radio.tsx
@@ -1,97 +1,47 @@
-import * as _ from 'lodash-es';
 import * as React from 'react';
-import { css } from '@patternfly/react-styles';
+import { FormGroup, Radio } from '@patternfly/react-core';
 
-export const RadioInput: React.SFC<RadioInputProps> = (props) => {
-  const inputProps: React.InputHTMLAttributes<any> = _.omit(props, [
-    'title',
-    'subTitle',
-    'desc',
-    'children',
-    'inline',
-  ]);
-  const inputElement = (
-    <>
-      <label className={css({ 'radio-inline': props.inline, 'co-disabled': props.disabled })}>
-        <input
-          type="radio"
-          {...inputProps}
-          data-test={`${props.title}-radio-input`}
-          data-checked-state={props.checked}
-        />
-        {props.title} {props.subTitle && <span className="co-no-bold">{props.subTitle}</span>}
-      </label>
-      {props.desc && <p className="co-m-radio-desc pf-v6-u-text-color-subtle">{props.desc}</p>}
-      {props.children}
-    </>
-  );
-
-  return props.inline ? inputElement : <div className="radio">{inputElement}</div>;
-};
-
-export const RadioGroup: React.SFC<RadioGroupProps> = ({
-  currentValue,
-  inline = false,
-  items,
-  label,
-  onChange,
-  id = JSON.stringify(items),
-}) => {
-  const radios = items.map(({ desc, title, subTitle, value, disabled }) => (
-    <RadioInput
-      key={value}
-      checked={value === currentValue}
-      desc={desc}
-      onChange={onChange}
-      title={title}
-      subTitle={subTitle}
-      value={value}
-      disabled={disabled}
-      inline={inline}
-    />
-  ));
+export const RadioGroup = ({ currentValue, items, label, onChange }: RadioGroupProps) => {
+  const radios = items.map(({ label: radioLabel, value, disabled, name, description }) => {
+    const checked = value === currentValue;
+    return (
+      <Radio
+        key={value}
+        id={value}
+        name={name}
+        value={value}
+        label={radioLabel}
+        description={description}
+        onChange={onChange}
+        isChecked={checked}
+        data-checked-state={checked}
+        isDisabled={disabled}
+        data-test={`${radioLabel}-radio-input`}
+      />
+    );
+  });
   return (
-    <div className={css('co-radio-group', { 'co-radio-group--inline': inline })}>
-      {label ? (
-        <>
-          <label className="form-label co-radio-group__label" htmlFor={id}>
-            {label}
-          </label>
-          <div className="co-radio-group__controls" id={id}>
-            {radios}
-          </div>
-        </>
-      ) : (
-        radios
-      )}
+    // use div.pf-v6-c-form instead of Form to avoid additional form element
+    <div className="pf-v6-c-form">
+      <FormGroup role="radiogroup" fieldId={label ?? 'pf-radio-group'} label={label} isStack>
+        {radios}
+      </FormGroup>
     </div>
   );
 };
 
-export type RadioInputProps = {
-  checked: boolean;
-  desc?: string | JSX.Element;
-  onChange: (v: any) => void;
-  subTitle?: string | JSX.Element;
-  value: any;
-  disabled?: boolean;
-  inline?: boolean;
-} & React.InputHTMLAttributes<any>;
-
 export type RadioGroupProps = {
-  currentValue: any;
+  currentValue: string;
   id?: string;
-  inline?: boolean;
-  items: ({
-    desc?: string | JSX.Element;
-    title: string | JSX.Element;
-    subTitle?: string | JSX.Element;
-    value: any;
-    disabled?: boolean;
-  } & React.InputHTMLAttributes<any>)[];
+  items: RadioGroupItems;
   label?: string;
   onChange: React.InputHTMLAttributes<any>['onChange'];
 };
 
-RadioInput.displayName = 'RadioInput';
-RadioGroup.displayName = 'RadioGroup';
+export type RadioGroupItems = {
+  name: string;
+  value: string;
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  disabled?: boolean;
+}[];

--- a/frontend/public/components/storage/attach-pvc-storage.tsx
+++ b/frontend/public/components/storage/attach-pvc-storage.tsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import { ActionGroup, Button } from '@patternfly/react-core';
+import { ActionGroup, Button, Radio } from '@patternfly/react-core';
 import { useTranslation, Trans } from 'react-i18next';
 import { useParams, useNavigate } from 'react-router-dom-v5-compat';
 import {
@@ -13,7 +13,6 @@ import {
 } from '../../module/k8s';
 import { ButtonBar, LoadingBox, resourceObjPath } from '../utils';
 import { Checkbox } from '../checkbox';
-import { RadioInput } from '../radio';
 import { CreatePVCForm } from './create-pvc';
 import { PersistentVolumeClaimModel } from '../../models';
 import { ContainerSelector } from '../container-selector';
@@ -271,13 +270,15 @@ export const AttachStorageForm: React.FC<AttachStorageFormProps> = (props) => {
     <form className="co-m-pane__body-group co-m-pane__form" onSubmit={save}>
       <label className="co-required">{t('public~PersistentVolumeClaim')}</label>
       <div className="form-group">
-        <RadioInput
-          title={t('public~Use existing claim')}
-          value="existing"
-          key="existing"
-          onChange={handleShowCreatePVCChange}
-          checked={showCreatePVC === 'existing'}
+        <Radio
+          id="existing"
           name="showCreatePVC"
+          label={t('public~Use existing claim')}
+          value="existing"
+          onChange={handleShowCreatePVCChange}
+          isChecked={showCreatePVC === 'existing'}
+          data-checked-state={showCreatePVC === 'existing'}
+          data-test="existing-claim-radio-input"
         />
       </div>
 
@@ -293,13 +294,15 @@ export const AttachStorageForm: React.FC<AttachStorageFormProps> = (props) => {
         </div>
       )}
       <div className="form-group">
-        <RadioInput
-          title={t('public~Create new claim')}
-          value="new"
-          key="new"
-          onChange={handleShowCreatePVCChange}
-          checked={showCreatePVC === 'new'}
+        <Radio
+          id="new"
           name="showCreatePVC"
+          label={t('public~Create new claim')}
+          value="new"
+          onChange={handleShowCreatePVCChange}
+          isChecked={showCreatePVC === 'new'}
+          data-checked-state={showCreatePVC === 'new'}
+          data-test="Create new claim-radio-input"
         />
       </div>
 

--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -222,7 +222,7 @@ export const CreatePVCForm: React.FC<CreatePVCFormProps> = (props) => {
           )}
         </p>
       </div>
-      <div className="form-group">
+      <div className="form-group pf-v6-c-form">
         <VolumeModeSelector
           onChange={setVolumeMode}
           provisioner={storageProvisioner}

--- a/frontend/public/components/storage/shared.ts
+++ b/frontend/public/components/storage/shared.ts
@@ -145,11 +145,11 @@ export const getAccessModeOptions = () => [
 export const getVolumeModeRadios = () => [
   {
     value: 'Filesystem',
-    title: i18next.t('public~Filesystem'),
+    label: i18next.t('public~Filesystem'),
   },
   {
     value: 'Block',
-    title: i18next.t('public~Block'),
+    label: i18next.t('public~Block'),
   },
 ];
 

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -86,7 +86,6 @@
 @import 'components/storage-class-form';
 @import 'components/quota';
 @import 'components/cluster-settings/cluster-settings';
-@import 'components/radio';
 @import 'components/filter-toolbar';
 @import 'components/autocomplete';
 @import 'components/conditions';

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -177,6 +177,13 @@ $masthead-logo-max-height: 60px;
   gap: 0;
 }
 
+.pf-v6-c-form__group-control--no-row-gap {
+  &,
+  & > .pf-v6-c-form__group-control.pf-m-inline {
+    row-gap: 0;
+  }
+}
+
 .pf-v6-c-masthead {
   --pf-v6-c-masthead__logo--MaxHeight: $masthead-logo-max-height; // so that logos with three lines of text fit
 }

--- a/frontend/public/style/ancillary/_bootstrap-residual.scss
+++ b/frontend/public/style/ancillary/_bootstrap-residual.scss
@@ -49,59 +49,6 @@
   border: 1px solid var(--pf-t--global--border--color--default);
 }
 
-.radio {
-  position: relative;
-  display: block;
-  margin-top: var(--pf-t--global--spacer--sm);
-  margin-bottom: var(--pf-t--global--spacer--sm);
-
-  // These are used on elements with <label> descendants
-  &.disabled,
-  fieldset[disabled] & {
-    label {
-      cursor: not-allowed;
-    }
-  }
-
-  label {
-    min-height: $line-height-computed; // Ensure the input doesn't jump when there is no text
-    padding-left: 20px;
-    margin-bottom: 0;
-    font-weight: var(--pf-t--global--font--weight--body--default);
-    cursor: pointer;
-  }
-}
-.radio input[type='radio'],
-.radio-inline input[type='radio'] {
-  position: absolute;
-  margin-top: var(--pf-t--global--spacer--xs);
-  margin-left: -20px;
-}
-
-.radio + .radio {
-  margin-top: calc(
-    var(--pf-t--global--spacer--xs) * -1
-  ); // Move up sibling radios or checkboxes for tighter spacing
-}
-
-// Radios on same line
-.radio-inline {
-  position: relative;
-  display: inline-block;
-  padding-left: 20px;
-  margin-bottom: 0;
-  margin-right: 20px;
-  font-weight: var(--pf-t--global--font--weight--body--default);
-  vertical-align: middle;
-  cursor: pointer;
-
-  // These are used directly on <label>s
-  &.disabled,
-  fieldset[disabled] & {
-    cursor: not-allowed;
-  }
-}
-
 .small,
 small {
   font-size: var(--pf-t--global--font--size--xs) !important;


### PR DESCRIPTION
Note there are minor cosmetic differences due to the differences between the two libraries (nothing major).

But there is a significant change in the layout of the `Show operands in:` toggle on the top of the operands list page as the existing layout was a bit wonky and the change migration made them worse, so I opted to relocate the toggle which fixes all the wonkiness.

After

<img width="1490" alt="Screenshot 2025-06-27 at 3 36 01 PM" src="https://github.com/user-attachments/assets/e8c0fcb2-945a-4172-b9a3-ed8f4929309c" />
