### PR TITLE
OCPBUGS-55815: Breadcrumb Link fixed in Explore-type-sidebar.tsx

### DIFF
--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -110,7 +110,6 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
   // Get the type to display for a property reference.
   const getTypeForRef = (ref: string): string =>
     _.get(allDefinitions, [ref, 'format']) || _.get(allDefinitions, [ref, 'type']);
-
   return (
     <>
       {!_.isEmpty(breadcrumbs) && (
@@ -118,7 +117,12 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
           {breadcrumbs.map((crumb, i) => {
             const isLast = i === breadcrumbs.length - 1;
             return (
-              <BreadcrumbItem key={i} isActive={isLast} onClick={(e) => breadcrumbClicked(e, i)}>
+              <BreadcrumbItem
+                key={i}
+                isActive={isLast}
+                onClick={!isLast ? (e) => breadcrumbClicked(e, i) : undefined}
+                to={!isLast ? `/explore/${kindObj?.kind || 'schema'}/${i}` : undefined}
+              >
                 {crumb}
               </BreadcrumbItem>
             );


### PR DESCRIPTION
**Before:**

![Screenshot 2025-06-27 at 7 45 13 PM](https://github.com/user-attachments/assets/df23461e-fc5f-4f0a-b47f-4e065ad7ddb3)

**After:** 
![image](https://github.com/user-attachments/assets/027724d0-2b7a-4a1a-9ab3-12f0ac3fd67f)
