### PR TITLE
ODC-7794: Add event-source, channel, and broker form page automation in CI

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/topology.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/topology.ts
@@ -26,6 +26,7 @@ export enum nodeActions {
   MoveSink = 'Move sink',
   EditSinkBinding = 'Edit SinkBinding',
   DeleteSinkBinding = 'Delete SinkBinding',
+  DeletePingSource = 'Delete PingSource',
   DeleteService = 'Delete Service',
   EditService = 'Edit Service',
   EditHealthChecks = 'Edit Health Checks',

--- a/frontend/packages/dev-console/integration-tests/support/pages/modal.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/modal.ts
@@ -13,10 +13,10 @@ export const editLabels = {
 
 export const addSubscription = {
   enterSubscriberName: (name: string) =>
-    cy.get('#form-input-metadata-name-field').clear().type(name),
+    cy.get('[id="form-input-formData-metadata-name-field"]').clear().type(name),
   selectKnativeService: (knativeService: string = 'nodejs-ex-git') => {
     cy.get('[id$="subscriber-ref-name-field"]').click();
-    cy.get('li').contains(knativeService).click();
+    cy.get('[data-test="dropdown-menu-item-link"]').contains(knativeService).click();
   },
 };
 

--- a/frontend/packages/knative-plugin/integration-tests/features/e2e/knative-ci.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/e2e/knative-ci.feature
@@ -39,12 +39,16 @@ Feature: Perform actions on knative service and revision
                   | quay.io/openshift-knative/showcase | kn-service    |
 
 
+        # Marking the following test as manual to reduce load on ci from new tests based on relavance
+        @manual
         Scenario: knative service menu options: KN-02-TC01
             Given user has created or selected namespace "knative-ci"
              When user right clicks on the knative service "kn-service" to open the context menu
              Then user is able to see the options like Edit Application Grouping, Set Traffic Distribution, Edit Health Checks, Edit Labels, Edit Annotations, Edit Service, Delete Service, Edit "kn-service"
 
 
+        # Marking the following test as manual to reduce load on ci from new tests based on relavance
+        @manual
         Scenario: side bar details of knative Service: KN-06-TC01
             Given user has created or selected namespace "knative-ci"
              When user clicks on the knative service "kn-service"
@@ -71,6 +75,59 @@ Feature: Perform actions on knative service and revision
               And save, cancel buttons are displayed
 
 
+
+        @regression
+        Scenario: Create new Event Source: KA-01-TC01
+            Given user has created knative service "kn-service" in admin
+              And user is at administrator perspective
+              And user is at eventing page
+             When user clicks on Create dropdown button
+              And user selects Event Source
+              And user clicks on Ping Source
+              And user enters "Message" in Data field
+              And user enters "* * * * *" in Schedule field
+              And user selects resource "kn-service"
+              And user clicks on Create button to submit
+             Then user will be redirected to Topology page
+              And ApiServerSource event source "ping-source" is created and linked to selected knative service "kn-service"
+
+
+        @regression
+        Scenario: Create new Channel: KA-01-TC02
+            Given user is at eventing page
+             When user clicks on Create dropdown button
+              And user selects Channel
+              And user selects Default channels
+              And user clicks on Create button to create channel
+             Then user will be redirected to Topology page
+              And user will see the channel "channel" created
+
+
+        @smoke
+        Scenario: Create Broker using Form view: KE-05-TC01
+            Given user is at eventing page
+             When user clicks on Create dropdown button
+              And user selects Broker
+              And user selects Form view
+              And user enters broker name as "default-broker"
+              And user clicks on Create button to create broker
+             Then user will be redirected to Topology page
+              And user will see the "default-broker" broker created
+
+
+        @smoke
+        Scenario: Add Subscription to channel: KE-05-TC01
+            # Given user has created knative service "knative-ci-2" in admin
+            #   And user has created channel "channel"
+            #   And user is at Topology page
+             When user right clicks on the Channel "channel" to open the context menu
+              And user selects "Add Subscription" from Context Menu
+              And user enters Name as "channel-subscrip" on Add Subscription modal
+              And user selects Subscriber "kn-service" on Add Subscription modal
+              And user clicks on Add button
+             Then user will see connection between Channel "channel" and Subscriber "kn-service"
+
+
         Scenario: Update the service to new application group: KN-02-TC08
             Given user has created or selected namespace "knative-ci"
              When user right clicks on the knative service "kn-service" to open the context menu
@@ -83,6 +140,8 @@ Feature: Perform actions on knative service and revision
              Then updated service "kn-service" is present in side bar of application "openshift-app"
 
 
+        # Marking the following test as manual to reduce load on ci from new tests based on relavance
+        @manual
         Scenario: Context menu for knative Revision: KN-01-TC01
             Given user has created or selected namespace "knative-ci"
               And Knative Revision is available in topology page
@@ -146,6 +205,34 @@ Feature: Perform actions on knative service and revision
               And user clicks save button on the "Set traffic distribution" modal
               And user clicks on the knative service name "kn-service"
              Then number of revisions should get increased in side bar - resources tab - routes section
+
+
+        @regression
+        Scenario: Delete Broker action on Broker: KE-05-TC11
+             When user clicks on the "default-broker" broker to open the sidebar
+              And user selects "Delete Broker" from Actions drop down
+              And user clicks on the Delete button on the modal
+             Then user will not see "default-broker" broker in admin view topology
+
+
+        @regression
+        Scenario: Delete Channel action on Channel: KE-06-TC16
+            Given user has already created the channel "channel"
+             When user right clicks on the channel "channel"
+              And user clicks on the "Delete Channel"
+              And user clicks on the Delete button on the modal
+             Then user will not see channel "channel"
+
+
+        @regression
+        Scenario: Delete event source: KE-01-TC03
+            # Given user has created knative service "kn-service"
+            #   And user has created Sink Binding event source "ping-source" with knative resource "kn-service"
+             When user clicks on event source "ping-source" to open side bar
+              And user selects "Delete PingSource" from side bar Action menu
+              And user selects the Delete option on "Delete PingSource" modal
+             Then event source "ping-source" will not be displayed in topology page
+
 
         @broken-test
         Scenario: Delete revision modal details for service with multiple revisions: KN-01-TC10

--- a/frontend/packages/knative-plugin/integration-tests/support/pageObjects/global-po.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/pageObjects/global-po.ts
@@ -133,6 +133,7 @@ export const eventingPO = {
   broker: {
     actionDropDown: '.pf-v6-c-menu__list-item',
     actionMenu: '[data-test-id="actions-menu-button"]',
+    createBroker: '[data-test-dropdown-menu="brokers"]',
     formView: '[id="form-radiobutton-editorType-form-field"]',
     eventingCard: '[data-test="card eventing"]',
     createEvent: '[data-test="item knative-eventing-broker"]',

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/admin-perspective/eventing-page-admin.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/admin-perspective/eventing-page-admin.ts
@@ -43,6 +43,10 @@ When('user selects Channel', () => {
   cy.get(eventingPO.channel.createChannel).click();
 });
 
+When('user selects Broker', () => {
+  cy.get(eventingPO.broker.createBroker).click();
+});
+
 When('user selects Default channels', () => {
   cy.get(eventingPO.channel.typeField).click();
   cy.get(eventingPO.channel.typeFieldMenu).contains('Default Channel').click();

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/common.ts
@@ -28,6 +28,7 @@ import {
 import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import { eventingPO } from '@console/knative-plugin/integration-tests/support/pageObjects/global-po';
 import { userLoginPage } from '../../pages/dev-perspective/common';
+import { topologyAdminPerspective } from './functions/topology-admin-perspective';
 
 Given('user has logged in as a basic user', () => {
   app.waitForDocumentLoad();
@@ -59,9 +60,7 @@ Given('user is at Topology page', () => {
 });
 
 Given('user is at Topology page in the admin view', () => {
-  cy.get('[data-quickstart-id="qs-nav-workloads"]').should('be.visible').click({ force: true });
-  cy.byLegacyTestID('topology-header').should('be.visible').click({ force: true });
-  topologyPage.verifyTopologyPage();
+  topologyAdminPerspective();
 });
 
 Given('user is at Monitoring page', () => {

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/functions/topology-admin-perspective.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/functions/topology-admin-perspective.ts
@@ -1,0 +1,9 @@
+import { switchPerspective } from '@console/dev-console/integration-tests/support/constants';
+import { perspective, topologyPage } from '@console/dev-console/integration-tests/support/pages';
+
+export const topologyAdminPerspective = () => {
+  perspective.switchTo(switchPerspective.Administrator);
+  cy.get('[data-quickstart-id="qs-nav-workloads"]').should('be.visible').click({ force: true });
+  cy.byLegacyTestID('topology-header').should('be.visible').click({ force: true });
+  topologyPage.verifyTopologyPage();
+};

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/eventing/eventing-broker-actions.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/eventing/eventing-broker-actions.ts
@@ -13,6 +13,7 @@ import {
 } from '@console/dev-console/integration-tests/support/pages';
 import { topologyPO } from '@console/topology/integration-tests/support/page-objects/topology-po';
 import { eventingPO } from '../../pageObjects';
+import { topologyAdminPerspective } from '../common/functions/topology-admin-perspective';
 
 When('user selects on {string} from {string} card', (eventName: string, addFlowCard: string) => {
   cy.get(eventingPO.broker.eventingCard).contains(addFlowCard);
@@ -21,7 +22,8 @@ When('user selects on {string} from {string} card', (eventName: string, addFlowC
 
 When('user selects {string} from Actions drop down', (actionName: string) => {
   cy.get(eventingPO.broker.actionMenu).click();
-  cy.byTestActionID(actionName).click();
+  cy.byTestActionID(actionName).should('be.visible');
+  cy.get(`[data-test-action="${actionName}"] button`).click();
 });
 
 When('user selects Form view', () => {
@@ -36,6 +38,10 @@ When(
     cy.get(eventingPO.broker.applicationGrouping.nameField).clear().type(brokerName);
   },
 );
+
+When('user enters broker name as {string}', (brokerName: string) => {
+  cy.get(eventingPO.broker.applicationGrouping.nameField).clear().type(brokerName);
+});
 
 When('user clicks on Create button to create broker', () => {
   cy.get(eventingPO.broker.create).click();
@@ -143,7 +149,7 @@ When('user selects {string} from Subscriber drop down', (subscriberName: string)
 
 When('user clicks on Add button', () => {
   cy.get(eventingPO.broker.confirm).click();
-  cy.get('[aria-label="Modal"]').should('not.exist');
+  cy.get('[class*="modal-dialog"]').should('not.exist');
 });
 
 Then('user will see {string} created', (triggerName) => {
@@ -199,6 +205,13 @@ Then('user will not see {string} broker', (brokerName: string) => {
   app.waitForLoad();
   perspective.switchTo(switchPerspective.Developer);
   navigateTo(devNavigationMenu.Topology);
+  topologyHelper.verifyWorkloadDeleted(brokerName);
+});
+
+Then('user will not see {string} broker in admin view topology', (brokerName: string) => {
+  cy.reload();
+  app.waitForLoad();
+  topologyAdminPerspective();
   topologyHelper.verifyWorkloadDeleted(brokerName);
 });
 

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/eventing/eventing-channel.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/eventing/eventing-channel.ts
@@ -106,7 +106,8 @@ Then('user will see option {string}', (optionName: string) => {
 });
 
 When('user clicks on the {string}', (optionName: string) => {
-  cy.byTestActionID(optionName).should('be.visible').click();
+  cy.byTestActionID(optionName).should('be.visible');
+  cy.get(`[data-test-action="${optionName}"] button`).click();
 });
 
 When('user will click on the Application dropdown on the modal', () => {

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-actions-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-actions-page.ts
@@ -63,6 +63,11 @@ export const topologyActions = {
         cy.byTestActionID(action).should('be.visible').click();
         break;
       }
+      case 'Delete PingSource':
+      case nodeActions.DeletePingSource: {
+        cy.byTestActionID(action).should('be.visible').click();
+        break;
+      }
       case 'Delete SinkBinding':
       case nodeActions.DeleteSinkBinding: {
         cy.byTestActionID(action).should('be.visible').click();

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -284,7 +284,8 @@ export const topologyPage = {
   verifyDecorators: (nodeName: string, numOfDecorators: number) =>
     topologyPage.componentNode(nodeName).siblings('a').should('have.length', numOfDecorators),
   selectContextMenuAction: (action: nodeActions | string) => {
-    cy.byTestActionID(action).should('be.visible').click();
+    cy.byTestActionID(action).should('be.visible');
+    cy.get(`[data-test-action="${action}"] button`).click();
   },
   getNode: (nodeName: string) => {
     return cy.get(topologyPO.graph.nodeLabel).should('be.visible').contains(nodeName);
@@ -352,8 +353,10 @@ export const topologyPage = {
     cy.log(id);
     cy.get('[data-test-id="base-node-handler"] image').should('be.visible');
     cy.get('body').then(($el) => {
-      if ($el.find(topologyPO.sidePane.applicationGroupingsTitle).length === 0) {
+      if (!$el.find(topologyPO.sidePane.applicationGroupingsTitle).text().includes(appName)) {
         cy.get(id).next('text').click({ force: true });
+      } else {
+        cy.log('sidebar is already open');
       }
     });
     // cy.get(id).next('text').click({ force: true });


### PR DESCRIPTION
Issue: 
Bug:[ODC-7794](https://issues.redhat.com//browse/ODC-7794)

Description:
Add event source creation through form view in CI

Command to execute:

export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.13-042801.devcluster.openshift.com/
export BRIDGE_KUBEADMIN_PASSWORD
export BRIDGE_BASE_ADDRESS
oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
oc apply -f ./frontend/packages/console-shared/src/test-data/htpasswd-secret.yaml
oc patch oauths cluster --patch "$(cat ./frontend/packages/console-shared/src/test-data/patch-htpasswd.yaml)" --type=merge
In the frontend folder:
Run ./integration-tests/test-cypress.sh -p knative
Browser
Electron
Screenshot:
![Screenshot From 2025-06-30 20-51-33](https://github.com/user-attachments/assets/3ef92a35-f047-4918-9d0f-f6c8d081d50f)
