### PR TITLE
CONSOLE-4619: `_blank` removal followup

### DIFF
--- a/frontend/packages/console-shared/src/components/getting-started/GettingStartedCard.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/GettingStartedCard.tsx
@@ -15,8 +15,8 @@ import {
 import { ArrowRightIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom-v5-compat';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';
+import { ExternalLink } from '@console/shared/src/components/links/ExternalLink';
 import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
-import { ExternalLink } from '../links/ExternalLink';
 import './GettingStartedCard.scss';
 
 export interface GettingStartedLink {

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -1120,16 +1120,15 @@ export const ClusterServiceVersionDetails: React.FC<ClusterServiceVersionDetails
                 <DescriptionListTerm>{t('olm~Links')}</DescriptionListTerm>
                 {spec.links && spec.links.length > 0 ? (
                   spec.links.map((link) => (
-                    <DescriptionListDescription
-                      key={link.url}
-                      style={{ display: 'flex', flexDirection: 'column' }}
-                    >
-                      {link.name}{' '}
-                      <ExternalLink
-                        href={link.url}
-                        text={link.url || '-'}
-                        className="co-break-all"
-                      />
+                    <DescriptionListDescription key={link.url}>
+                      <div className="pf-v6-u-display-flex pf-v6-u-flex-direction-column">
+                        {link.name}
+                        <ExternalLink
+                          href={link.url}
+                          text={link.url || '-'}
+                          className="co-break-all"
+                        />
+                      </div>
                     </DescriptionListDescription>
                   ))
                 ) : (

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -31,6 +31,7 @@ import {
   YellowExclamationTriangleIcon,
 } from '@console/shared';
 import { formatNamespacedRouteForResource } from '@console/shared/src/utils';
+import { ExternalLinkButton } from '@console/shared/src/components/links/ExternalLinkButton';
 import { LinkTo } from '@console/shared/src/components/links/LinkTo';
 import CloudShellMastheadButton from '@console/webterminal-plugin/src/components/cloud-shell/CloudShellMastheadButton';
 import CloudShellMastheadAction from '@console/webterminal-plugin/src/components/cloud-shell/CloudShellMastheadAction';
@@ -104,15 +105,13 @@ const FeedbackModalLocalized = ({ isOpen, onClose, reportBugLink }) => {
 const SystemStatusButton = ({ statuspageData }) => {
   const { t } = useTranslation();
   return !_.isEmpty(_.get(statuspageData, 'incidents')) ? (
-    <a
-      className="pf-v6-c-button pf-m-plain co-masthead-button"
+    <ExternalLinkButton
+      variant="plain"
+      className="co-masthead-button"
       aria-label={t('public~System status')}
+      icon={<YellowExclamationTriangleIcon />}
       href={statuspageData.page.url}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      <YellowExclamationTriangleIcon />
-    </a>
+    />
   ) : null;
 };
 

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -133,8 +133,8 @@ export const ExternalLinkWithCopy = ({
 };
 
 // Open links in a new window and set noopener/noreferrer.
-export const LinkifyExternal: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <Linkify properties={{ target: '_blank', rel: 'noopener noreferrer' }}>{children}</Linkify>
+export const LinkifyExternal = ({ children }: { children: React.ReactNode }) => (
+  <Linkify component={ExternalLink}>{children}</Linkify>
 );
 LinkifyExternal.displayName = 'LinkifyExternal';
 


### PR DESCRIPTION
This PR removes some additional `_blank`s that I did not address in the previous PR #15177.

after:

updated `SystemStatusButton` to use `ExternalLinkButton`
![image](https://github.com/user-attachments/assets/c83988a9-5dfa-47d5-b4e3-6ae7f29c6f3a)

fixed visual regression in CSV sidebar:
![image](https://github.com/user-attachments/assets/48ba6ab4-37d9-41a5-b934-00365c80fa06)

addition of "opens in new tab" icon in `LinkifyExternal`:
![image](https://github.com/user-attachments/assets/99153efa-a098-4807-9de8-448cca25fdc6)

code review:
/assign @rhamilto 

follow up pr, adding labels
/label px-approved 
/label docs-approved
/label qe-approved