### PR TITLE
OCPBUGS-55340:  Not able to launch terminal window from OCP web console due to console plugin conflicts

### DIFF
--- a/frontend/packages/webterminal-plugin/console-extensions.json
+++ b/frontend/packages/webterminal-plugin/console-extensions.json
@@ -2,7 +2,7 @@
   {
     "type": "console.redux-reducer",
     "properties": {
-      "scope": "console",
+      "scope": "webterminal",
       "reducer": { "$codeRef": "reduxReducer" }
     }
   },

--- a/frontend/packages/webterminal-plugin/src/redux/actions/__tests__/cloud-shell-actions.spec.ts
+++ b/frontend/packages/webterminal-plugin/src/redux/actions/__tests__/cloud-shell-actions.spec.ts
@@ -62,7 +62,7 @@ describe('Cloud shell actions', () => {
   it('should thunk dispatch toggle expand true action', () => {
     const dispatch = jest.fn<Dispatch>();
     // initial isExpanded state is false
-    const state = { plugins: { console: { cloudShell: { isExpanded: false } } } } as any;
+    const state = { plugins: { webterminal: { cloudShell: { isExpanded: false } } } } as any;
     toggleCloudShellExpanded()(dispatch, () => state);
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -78,7 +78,7 @@ describe('Cloud shell actions', () => {
     const dispatch = jest.fn<Dispatch>();
     // initial isExpanded state is true but isActive is false
     const state = {
-      plugins: { console: { cloudShell: { isExpanded: true, isActive: false } } },
+      plugins: { webterminal: { cloudShell: { isExpanded: true, isActive: false } } },
     } as any;
     toggleCloudShellExpanded()(dispatch, () => state);
     expect(dispatch).toHaveBeenCalledWith(
@@ -97,7 +97,7 @@ describe('Cloud shell actions', () => {
     const dispatch = jest.fn<Dispatch>();
     // initial isExpanded state is true and isActive is true
     const state = {
-      plugins: { console: { cloudShell: { isExpanded: true, isActive: true } } },
+      plugins: { webterminal: { cloudShell: { isExpanded: true, isActive: true } } },
     } as any;
     await toggleCloudShellExpanded()(dispatch, () => state);
     expect(dispatch).toHaveBeenCalledWith(
@@ -115,7 +115,7 @@ describe('Cloud shell actions', () => {
   it('should thunk dispatch toggle expand true action', () => {
     const dispatch = jest.fn<Dispatch>();
     // initial isExpanded state is false
-    const state = { plugins: { console: { cloudShell: { isExpanded: false } } } } as any;
+    const state = { plugins: { webterminal: { cloudShell: { isExpanded: false } } } } as any;
     toggleCloudShellExpanded()(dispatch, () => state);
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/frontend/packages/webterminal-plugin/src/redux/reducers/__tests__/cloud-shell-selectors.spec.ts
+++ b/frontend/packages/webterminal-plugin/src/redux/reducers/__tests__/cloud-shell-selectors.spec.ts
@@ -9,7 +9,7 @@ describe('Cloud shell selectors', () => {
     expect(isCloudShellExpanded({} as any)).toBe(false);
     expect(
       isCloudShellExpanded({
-        plugins: { console: { [cloudShellReducerName]: { isExpanded: true } } },
+        plugins: { webterminal: { [cloudShellReducerName]: { isExpanded: true } } },
       } as any),
     ).toBe(true);
   });
@@ -18,7 +18,7 @@ describe('Cloud shell selectors', () => {
     expect(isCloudShellActive({} as any)).toBe(false);
     expect(
       isCloudShellActive({
-        plugins: { console: { [cloudShellReducerName]: { isActive: true } } },
+        plugins: { webterminal: { [cloudShellReducerName]: { isActive: true } } },
       } as any),
     ).toBe(true);
   });

--- a/frontend/packages/webterminal-plugin/src/redux/reducers/cloud-shell-selectors.ts
+++ b/frontend/packages/webterminal-plugin/src/redux/reducers/cloud-shell-selectors.ts
@@ -3,10 +3,10 @@ import { RootState } from '@console/internal/redux';
 export const cloudShellReducerName = 'cloudShell';
 
 export const isCloudShellExpanded = (state: RootState): boolean =>
-  !!state.plugins?.console?.[cloudShellReducerName]?.isExpanded;
+  !!state.plugins?.webterminal?.[cloudShellReducerName]?.isExpanded;
 
 export const isCloudShellActive = (state: RootState): boolean =>
-  !!state.plugins?.console?.[cloudShellReducerName]?.isActive;
+  !!state.plugins?.webterminal?.[cloudShellReducerName]?.isActive;
 
 export const getCloudShellCommand = (state: RootState): string | null =>
-  state.plugins?.console?.[cloudShellReducerName]?.command ?? null;
+  state.plugins?.webterminal?.[cloudShellReducerName]?.command ?? null;


### PR DESCRIPTION
the `tvk-console-plugin` of `Trilio for Kubernetes` operator had a conflicting `console.redux-reducer` extension `scope` value. Changing the scope name for `webterminal plugin` fixed this issue, which suggests that there were some internal redux conflicts between `webterminal` and `tvk-console-plugin`.