### PR TITLE
CONSOLE-4662: remove `screenfull`

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -210,7 +210,6 @@
     "redux-thunk": "2.4.0",
     "reselect": "4.x",
     "sanitize-html": "^2.3.2",
-    "screenfull": "4.x",
     "semver": "6.x",
     "showdown": "1.8.6",
     "subscriptions-transport-ws": "^0.9.16",

--- a/frontend/packages/console-shared/src/hooks/useFullscreen.ts
+++ b/frontend/packages/console-shared/src/hooks/useFullscreen.ts
@@ -1,0 +1,45 @@
+import { useRef, useState, useEffect, useCallback, RefObject } from 'react';
+
+/**
+ * Returns a tuple containing a ref to the element that will be toggled to fullscreen,
+ * a function to toggle fullscreen mode, a boolean indicating if the element is currently in fullscreen,
+ * and a boolean indicating if the browser supports fullscreen mode.
+ *
+ * Adapted from https://www.timsanteford.com/posts/creating-a-reusable-fullscreen-hook-in-react/
+ */
+export const useFullscreen = () => {
+  /** The element that will be toggled to fullscreen */
+  const fullscreenRef = useRef<HTMLDivElement>(null);
+  /** Whether the browser supports fullscreen mode */
+  const canUseFullScreen = document.fullscreenEnabled;
+
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  /** Toggle currently displayed content to/from fullscreen */
+  const toggleFullscreen = useCallback(() => {
+    if (fullscreenRef.current) {
+      if (!document.fullscreenElement) {
+        fullscreenRef.current.requestFullscreen();
+      } else {
+        document.exitFullscreen();
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(Boolean(document.fullscreenElement));
+    };
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () => {
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+    };
+  }, []);
+
+  return [fullscreenRef, toggleFullscreen, isFullscreen, canUseFullScreen] as [
+    RefObject<HTMLDivElement>,
+    () => void,
+    boolean,
+    boolean,
+  ];
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -15336,10 +15336,6 @@ schemes@^1.4.0:
   dependencies:
     extend "^3.0.0"
 
-screenfull@4.x:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-4.0.0.tgz#86f3c26a2e516c8143884d8af16d07f0cb653394"
-
 scuid@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/scuid/-/scuid-1.1.0.tgz#d3f9f920956e737a60f72d0e4ad280bf324d5dab"


### PR DESCRIPTION
https://issues.redhat.com/browse/CONSOLE-4662

We no longer need it as the non-vendor-prefixed `fullscreen` API now works on the latest versions of dekstop WebKit, Blink, and Firefox (tested google-chrome-stable 137.0.7151.103-1, epiphany 1:48.3-1.fc42, and firefox 139.0.4-1.fc42)

qe review:
/assign @yapei 

code review:
/assign @rhamilto 

tech debt, adding labels
/label docs-approved
/label px-approved