### PR TITLE
CONSOLE-4619: Fix `ExternalLinkWithCopy` visual regression

### DIFF
--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -119,27 +119,17 @@ export const getRouteLabel = (route: RouteKind): string => {
   return label;
 };
 
-export const RouteLinkAndCopy: React.FC<RouteLinkAndCopyProps> = ({
-  route,
-  className,
-  isInline,
-}) => {
+export const RouteLinkAndCopy: React.FC<RouteLinkAndCopyProps> = ({ route, className }) => {
   const link = getRouteWebURL(route);
   return (
-    <ExternalLinkWithCopy
-      className={className}
-      href={link}
-      text={link}
-      dataTestID="route-link"
-      isInline={isInline}
-    />
+    <ExternalLinkWithCopy className={className} href={link} text={link} dataTestID="route-link" />
   );
 };
 
 // Renders LinkAndCopy for non subdomains
 export const RouteLocation: React.FC<RouteHostnameProps> = ({ obj }) => (
   <div className="co-break-word">
-    {isWebRoute(obj) ? <RouteLinkAndCopy route={obj} isInline={false} /> : getRouteLabel(obj)}
+    {isWebRoute(obj) ? <RouteLinkAndCopy route={obj} /> : getRouteLabel(obj)}
   </div>
 );
 RouteLocation.displayName = 'RouteLocation';
@@ -651,7 +641,6 @@ export type RouteIngressStatusProps = {
 export type RouteLinkAndCopyProps = {
   route: RouteKind;
   className?: React.ComponentProps<typeof ExternalLinkWithCopy>['className'];
-  isInline?: React.ComponentProps<typeof ExternalLinkWithCopy>['isInline'];
 };
 
 export type CustomRouteHelpProps = {

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -107,7 +107,7 @@ export const ExternalLinkWithCopy = ({
       )}
     >
       <span className="pf-v6-c-clipboard-copy__text">
-        <ExternalLink href={href} {...props}>
+        <ExternalLink href={href} isInline {...props}>
           {displayText}
         </ExternalLink>
       </span>


### PR DESCRIPTION
Previously, when viewing a deployment in the topology page, the links in the route details list looked broken. This PR fixes that by forcing all the links in all `ExternalLinkWithCopy` instances to inherit PF `isInline` styles

before:
![image](https://github.com/user-attachments/assets/9829d0bd-f288-45d4-a439-bf4a5ec4b67f)

after:
![image](https://github.com/user-attachments/assets/35d2dabe-148d-409f-9cfa-54c6b8dd6da9)

adding labels for bugfix
/label px-approved
/label docs-approved
/label qe-approved

code review:
/assign @rhamilto 