### PR TITLE
OCPBUGS-59215: switch to dev perspective for `/dev-monitoring`

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/TopConsumerPopover.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/TopConsumerPopover.tsx
@@ -131,7 +131,7 @@ export const PopoverBody = withDashboardResources<DashboardItemProps & PopoverBo
     }) => {
       const { t } = useTranslation();
       const [currentConsumer, setCurrentConsumer] = React.useState(consumers[0]);
-      const activePerspective = useActivePerspective()[0];
+      const [activePerspective, setActivePerspective] = useActivePerspective();
       const canAccessMonitoring =
         useFlag(FLAGS.CAN_GET_NS) && !!window.SERVER_FLAGS.prometheusBaseURL;
       const { query, model, metric, fieldSelector } = currentConsumer;
@@ -235,7 +235,16 @@ export const PopoverBody = withDashboardResources<DashboardItemProps & PopoverBo
                   );
                 })}
             </ul>
-            <Link to={monitoringURL}>{t('console-shared~View more')}</Link>
+            <Link
+              to={monitoringURL}
+              onClick={() => {
+                if (monitoringURL.startsWith('/dev-monitoring') && activePerspective !== 'dev') {
+                  setActivePerspective('dev');
+                }
+              }}
+            >
+              {t('console-shared~View more')}
+            </Link>
           </>
         );
       }

--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverviewAlerts.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverviewAlerts.tsx
@@ -14,7 +14,7 @@ interface MonitoringOverviewAlertsProps {
 }
 
 const MonitoringOverviewAlerts: React.FC<MonitoringOverviewAlertsProps> = ({ alerts }) => {
-  const [activePerspective] = useActivePerspective();
+  const [activePerspective, setActivePerspective] = useActivePerspective();
   const sortedAlerts = sortMonitoringAlerts(alerts);
 
   return (
@@ -35,6 +35,14 @@ const MonitoringOverviewAlerts: React.FC<MonitoringOverviewAlertsProps> = ({ ale
             variant={getAlertType(severity)}
             isInline
             title={<Link to={alertDetailsPageLink}>{name}</Link>}
+            onClick={() => {
+              if (
+                alertDetailsPageLink.startsWith('/dev-monitoring') &&
+                activePerspective !== 'dev'
+              ) {
+                setActivePerspective('dev');
+              }
+            }}
             key={`${alertname}-${id}`}
           >
             {message}

--- a/frontend/public/components/graphs/prometheus-graph.tsx
+++ b/frontend/public/components/graphs/prometheus-graph.tsx
@@ -24,7 +24,7 @@ const PrometheusGraphLink_: React.FC<PrometheusGraphLinkProps> = ({
   namespace,
   ariaChartLinkLabel,
 }) => {
-  const [perspective] = useActivePerspective();
+  const [activePerspective, setActivePerspective] = useActivePerspective();
   const queries = _.compact(_.castArray(query));
   if (!queries.length) {
     return <>{children}</>;
@@ -34,7 +34,7 @@ const PrometheusGraphLink_: React.FC<PrometheusGraphLinkProps> = ({
   queries.forEach((q, index) => params.set(`query${index}`, q));
 
   const url =
-    canAccessMonitoring && perspective === 'admin'
+    canAccessMonitoring && activePerspective === 'admin'
       ? `/monitoring/query-browser?${params.toString()}`
       : `/dev-monitoring/ns/${namespace}/metrics?${params.toString()}`;
 
@@ -43,6 +43,11 @@ const PrometheusGraphLink_: React.FC<PrometheusGraphLinkProps> = ({
       to={url}
       aria-label={ariaChartLinkLabel}
       style={{ color: 'inherit', textDecoration: 'none' }}
+      onClick={() => {
+        if (url.startsWith('/dev-monitoring/') && activePerspective !== 'dev') {
+          setActivePerspective('dev');
+        }
+      }}
     >
       {children}
     </Link>


### PR DESCRIPTION
This PR looks to add an onclick action to the `/dev-montitoring` links to ensure that when clicking on a page located in the dev perspective the perspective is switched.