### PR TITLE
[release-4.17] OCPBUGS-58365: change '/metrics/usage' endpoint to '/api/metrics/usage'

### DIFF
--- a/frontend/packages/console-telemetry-plugin/src/listeners/usage.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/usage.ts
@@ -6,7 +6,7 @@ import { consoleFetch } from '@console/dynamic-plugin-sdk/src/lib-core';
  * See pkg/usage/ for more information.
  */
 const trackUsage = (data: { event: string; perspective: string }) => {
-  return consoleFetch('/metrics/usage', {
+  return consoleFetch('/api/metrics/usage', {
     method: 'POST',
     body: JSON.stringify(data),
   })

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -602,7 +602,7 @@ func (s *Server) HTTPHandler() (http.Handler, error) {
 	handle("/metrics", bearerTokenReviewHandler(func(w http.ResponseWriter, r *http.Request) {
 		promhttp.Handler().ServeHTTP(w, r)
 	}))
-	handleFunc("/metrics/usage", authHandler(func(w http.ResponseWriter, r *http.Request) {
+	handleFunc("/api/metrics/usage", authHandler(func(w http.ResponseWriter, r *http.Request) {
 		usage.Handle(usageMetrics, w, r)
 	}))
 


### PR DESCRIPTION
Manual backport of https://github.com/openshift/console/pull/15252