### PR TITLE
OCPBUGS-59277: update guided tour selector for Software catalog

### DIFF
--- a/frontend/packages/console-app/src/components/guided-tour/index.ts
+++ b/frontend/packages/console-app/src/components/guided-tour/index.ts
@@ -29,7 +29,7 @@ export const getGuidedTour = (): TourDataType => ({
       content:
         '%console-app~Add shared applications, services, event sources, or source-to-image builders to your project. Cluster administrators can customize the content made available in the catalog.%',
       selector: getSelector('tour-software-catalog-nav'),
-      expandableSelector: getSelector('tour-home-nav'),
+      expandableSelector: getSelector('tour-ecosystem-nav'),
     },
     {
       placement: 'bottom',

--- a/frontend/packages/console-shared/src/components/spotlight/Spotlight.tsx
+++ b/frontend/packages/console-shared/src/components/spotlight/Spotlight.tsx
@@ -25,10 +25,10 @@ type SpotlightProps = {
 const Spotlight: React.FC<SpotlightProps> = ({ expandableSelector, selector, interactive }) => {
   React.useEffect(() => {
     if (expandableSelector) {
-      const expandableElemet = document.querySelector(expandableSelector);
-      const ariaExpanded = expandableElemet.getAttribute('aria-expanded');
+      const expandableElement = document.querySelector(expandableSelector);
+      const ariaExpanded = expandableElement?.getAttribute('aria-expanded');
       if (ariaExpanded === 'false') {
-        simulateMouseClick(expandableElemet);
+        simulateMouseClick(expandableElement);
       }
     }
   }, [expandableSelector]);


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-59277

The software catalog has moved to the Ecosystem navigation section, and the guided tour selector is not updating in the defined guided tour.


https://github.com/user-attachments/assets/66e4da5c-a45f-4c2e-b918-6a38dff40397

