### PR TITLE
OCPBUGS-59195: Clicking on container dropdown button has no response when pod log is in fullscreen.

### DIFF
--- a/frontend/public/components/utils/container-select.tsx
+++ b/frontend/public/components/utils/container-select.tsx
@@ -71,6 +71,7 @@ export const ContainerSelect: React.FC<ContainerSelectProps> = ({
         </MenuToggle>
       )}
       shouldFocusToggleOnSelect
+      popperProps={{ appendTo: 'inline' }}
     >
       {!_.isEmpty(initContainers) ? (
         <>


### PR DESCRIPTION
Adjusting the ContainerSelect's Select component to render inline within its parent container fixes this problem.
after:

https://github.com/user-attachments/assets/8318a4c7-c1a7-44e5-9d11-aea70913cfdf

