### PR TITLE
CONSOLE-4500: Segment Analytics integration code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,5 +497,32 @@ Currently this feature is behind feature gate.
 - [knative-plugin](./frontend/packages/knative-plugin/README.md)
 
 - operator-lifecycle-manager
+
+## Telemetry
+
+Console uses Segment Analytics for telemetry purposes. To test Console telemetry on local
+development environment, set up `BRIDGE_TELEMETRY` environment variable before running the
+Console Bridge server.
+
+```sh
+# https://github.com/openshift/console-operator/blob/main/manifests/05-telemetry-config.yaml
+API_HOST="console.redhat.com/connections/api/v1"
+JS_HOST="console.redhat.com/connections/cdn"
+PUBLIC_API_KEY="..." # Use API key from the link above
+
+# The BRIDGE_TELEMETRY variable contains a comma separated list of Console telemetry options
+export BRIDGE_TELEMETRY=\
+SEGMENT_API_HOST="${API_HOST}",\
+SEGMENT_JS_HOST="${JS_HOST}",\
+SEGMENT_API_KEY="${PUBLIC_API_KEY}",\
+DISABLED="false"
+
+# Run Bridge server, telemetry options should get passed to frontend as SERVER_FLAGS.telemetry
+./bin/bridge
+
+# If you no longer need the custom telemetry options, unset the BRIDGE_TELEMETRY variable
+unset BRIDGE_TELEMETRY
+```
+
 [[Descriptors README]](./frontend/packages/operator-lifecycle-manager/src/components/descriptors/README.md)
 [[Descriptors API Reference]](./frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md)

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -288,6 +289,19 @@ func main() {
 		err = json.Unmarshal([]byte(*fCapabilities), &capabilities)
 		if err != nil {
 			klog.Fatalf("Error unmarshaling capabilities JSON: %v", err)
+		}
+	}
+
+	if len(telemetryFlags) > 0 {
+		keys := make([]string, 0, len(telemetryFlags))
+		for name := range telemetryFlags {
+			keys = append(keys, name)
+		}
+		sort.Strings(keys)
+
+		klog.Infoln("Console telemetry options:")
+		for _, k := range keys {
+			klog.Infof(" - %s %s", k, telemetryFlags[k])
 		}
 	}
 

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -52,7 +52,21 @@ declare interface Window {
     quickStarts: string;
     projectAccessClusterRoles: string;
     controlPlaneTopology: string;
-    telemetry: Record<string, string>;
+    telemetry?: Partial<{
+      // All of the following should be always available on prod env.
+      SEGMENT_API_HOST: string;
+      SEGMENT_JS_HOST: string;
+      // One of the following should be always available on prod env.
+      SEGMENT_API_KEY: string;
+      SEGMENT_PUBLIC_API_KEY: string;
+      DEVSANDBOX_SEGMENT_API_KEY: string;
+      // Optional override for analytics.min.js script URL
+      SEGMENT_JS_URL: string;
+      // Additional telemetry options passed to Console frontend
+      DEBUG: 'true' | 'false';
+      DISABLED: 'true' | 'false';
+      [name: string]: string;
+    }>;
     nodeArchitectures: string[];
     nodeOperatingSystems: string[];
     hubConsoleURL: string;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-api.ts
@@ -22,47 +22,68 @@ import {
 } from './internal-types';
 import { UseUserSettings } from '../extensions/console-types';
 
+export * from './internal-console-api';
 export * from './internal-topology-api';
 
 export const ActivityItem: React.FC<ActivityItemProps> = require('@console/shared/src/components/dashboard/activity-card/ActivityItem')
   .default;
+
 export const ActivityBody: React.FC<ActivityBodyProps> = require('@console/shared/src/components/dashboard/activity-card/ActivityBody')
   .default;
+
 export const RecentEventsBody: React.FC<RecentEventsBodyProps> = require('@console/shared/src/components/dashboard/activity-card/ActivityBody')
   .RecentEventsBody;
+
 export const OngoingActivityBody: React.FC<OngoingActivityBodyProps> = require('@console/shared/src/components/dashboard/activity-card/ActivityBody')
   .OngoingActivityBody;
+
 export const AlertsBody: React.FC<AlertsBodyProps> = require('@console/shared/src/components/dashboard/status-card/AlertsBody')
   .default;
+
 export const AlertItem: React.FC<AlertItemProps> = require('@console/shared/src/components/dashboard/status-card/AlertItem')
   .default;
+
 export const HealthItem: React.FC<HealthItemProps> = require('@console/shared/src/components/dashboard/status-card/HealthItem')
   .default;
+
 export const HealthBody: React.FC = require('@console/shared/src/components/dashboard/status-card/HealthBody')
   .default;
+
 export const ResourceInventoryItem: React.FC<ResourceInventoryItemProps> = require('@console/shared/src/components/dashboard/inventory-card/InventoryItem')
   .ResourceInventoryItem;
+
 export const UtilizationItem: React.FC<UtilizationItemProps> = require('@console/shared/src/components/dashboard/utilization-card/UtilizationItem')
   .default;
+
 export const UtilizationBody: React.FC<UtilizationBodyProps> = require('@console/shared/src/components/dashboard/utilization-card/UtilizationBody')
   .default;
+
 export const UtilizationDurationDropdown: React.FC<UtilizationDurationDropdownProps> = require('@console/shared/src/components/dashboard/utilization-card/UtilizationDurationDropdown')
   .UtilizationDurationDropdown;
+
 export const VirtualizedGrid: React.FC<VirtualizedGridProps> = require('@console/shared/src/components/virtualized-grid/VirtualizedGrid')
   .default;
+
 export const LazyActionMenu: React.FC<LazyActionMenuProps> = require('@console/shared/src/components/actions/LazyActionMenu')
   .default;
+
 export const QuickStartsLoader: React.FC<QuickStartsLoaderProps> = require('@console/app/src/components/quick-starts/loader/QuickStartsLoader')
   .default;
 
 export const useUtilizationDuration: UseUtilizationDuration = require('@console/shared/src/hooks/useUtilizationDuration')
   .useUtilizationDuration;
+
 export const useDashboardResources: UseDashboardResources = require('@console/shared/src/hooks/useDashboardResources')
   .useDashboardResources;
-// useUserSettings is deprecated and is now exposed in dynamic plugin SDK.
+
+/**
+ * @deprecated This hook is now exposed by core plugin SDK package.
+ */
 export const useUserSettings: UseUserSettings = require('@console/shared/src/hooks/useUserSettings')
   .useUserSettings;
+
 export const useURLPoll: UseURLPoll = require('@console/internal/components/utils/url-poll-hook')
   .useURLPoll;
+
 export const useLastNamespace: UseLastNamespace = require('@console/app/src/components/detect-namespace/useLastNamespace')
   .useLastNamespace;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-console-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-console-api.ts
@@ -1,0 +1,23 @@
+/* eslint-disable */
+import { GetSegmentAnalytics } from '../extensions/console-types';
+
+/**
+ * Allows integration with Console specific Segment Analytics instance.
+ *
+ * This API is meant to be used by Red Hat plugins only.
+ *
+ * Console application takes care of loading the analytics.min.js script.
+ *
+ * @example
+ * ```ts
+ * const { analytics, analyticsEnabled } = getSegmentAnalytics();
+ *
+ * if (analyticsEnabled) {
+ *   // invoke methods on analytics object as needed
+ * }
+ * ```
+ *
+ * @see https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/
+ */
+export const getSegmentAnalytics: GetSegmentAnalytics = require('@console/dynamic-plugin-sdk/src/api/segment-analytics')
+  .getSegmentAnalytics;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/segment-analytics.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/segment-analytics.ts
@@ -1,0 +1,130 @@
+import { GetSegmentAnalytics } from '../extensions/console-types';
+
+// Segment API key. Must be present for telemetry to be enabled.
+const TELEMETRY_API_KEY =
+  window.SERVER_FLAGS.telemetry?.SEGMENT_API_KEY ||
+  window.SERVER_FLAGS.telemetry?.SEGMENT_PUBLIC_API_KEY ||
+  window.SERVER_FLAGS.telemetry?.DEVSANDBOX_SEGMENT_API_KEY ||
+  '';
+
+// Segment "apiHost" parameter, should be like "api.segment.io/v1"
+const TELEMETRY_API_HOST = window.SERVER_FLAGS.telemetry?.SEGMENT_API_HOST || '';
+
+// Segment JS host, defaults to "cdn.segment.com" if not defined
+const TELEMETRY_JS_HOST = window.SERVER_FLAGS.telemetry?.SEGMENT_JS_HOST || 'cdn.segment.com';
+
+// Segment analytics.min.js script URL
+const TELEMETRY_JS_URL =
+  window.SERVER_FLAGS.telemetry?.SEGMENT_JS_URL ||
+  `https://${TELEMETRY_JS_HOST}/analytics.js/v1/${encodeURIComponent(
+    TELEMETRY_API_KEY,
+  )}/analytics.min.js`;
+
+export const TELEMETRY_DISABLED =
+  !TELEMETRY_API_KEY ||
+  window.SERVER_FLAGS.telemetry?.DISABLED === 'true' ||
+  window.SERVER_FLAGS.telemetry?.DEVSANDBOX_DISABLED === 'true' ||
+  window.SERVER_FLAGS.telemetry?.TELEMETER_CLIENT_DISABLED === 'true';
+
+export const TELEMETRY_DEBUG = window.SERVER_FLAGS.telemetry?.DEBUG === 'true';
+
+// Sample 20% of sessions
+const SAMPLE_SESSION = Math.random() < 0.2;
+
+// TODO: replace this copy-pasted Segment init snippet with proper use of Segment package
+// https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/#step-2-install-segment-to-your-site
+const initSegmentAnalytics = () => {
+  if (TELEMETRY_DEBUG) {
+    // eslint-disable-next-line no-console
+    console.info('Initialize Segment Analytics', {
+      TELEMETRY_API_HOST,
+      TELEMETRY_API_KEY,
+      TELEMETRY_JS_HOST,
+      TELEMETRY_JS_URL,
+    });
+  }
+  // eslint-disable-next-line no-multi-assign
+  const analytics = ((window as any).analytics = (window as any).analytics || []);
+  if (analytics.initialize) {
+    return;
+  }
+  if (analytics.invoked) {
+    // eslint-disable-next-line no-console
+    console.error('Analytics snippet included twice');
+    return;
+  }
+  analytics.invoked = true;
+  analytics.methods = [
+    'trackSubmit',
+    'trackClick',
+    'trackLink',
+    'trackForm',
+    'pageview',
+    'identify',
+    'reset',
+    'group',
+    'track',
+    'ready',
+    'alias',
+    'debug',
+    'page',
+    'once',
+    'off',
+    'on',
+    'addSourceMiddleware',
+    'addIntegrationMiddleware',
+    'setAnonymousId',
+    'addDestinationMiddleware',
+  ];
+  analytics.factory = function (e: string) {
+    return function () {
+      // eslint-disable-next-line prefer-rest-params
+      const t = Array.prototype.slice.call(arguments);
+      t.unshift(e);
+      analytics.push(t);
+      return analytics;
+    };
+  };
+  for (const key of analytics.methods) {
+    analytics[key] = analytics.factory(key);
+  }
+  analytics.load = function (key: string, e: Event) {
+    const t = document.createElement('script');
+    t.type = 'text/javascript';
+    t.async = true;
+    t.src = TELEMETRY_JS_URL;
+    const n = document.getElementsByTagName('script')[0];
+    if (n.parentNode) {
+      n.parentNode.insertBefore(t, n);
+    }
+    // eslint-disable-next-line no-underscore-dangle
+    analytics._loadOptions = e;
+  };
+  analytics.SNIPPET_VERSION = '4.13.1';
+  const options: Record<string, any> = {};
+  if (TELEMETRY_API_HOST) {
+    options.integrations = { 'Segment.io': { apiHost: TELEMETRY_API_HOST } };
+  }
+  analytics.load(TELEMETRY_API_KEY, options);
+  analytics.page(); // Make the first page call to load the integrations
+};
+
+if (!SAMPLE_SESSION) {
+  // eslint-disable-next-line no-console
+  console.debug('Analytics session is not being sampled, telemetry events will be ignored');
+}
+
+const analyticsEnabled = !TELEMETRY_DISABLED && SAMPLE_SESSION;
+
+// Initialize Segment Analytics as soon as possible, outside of React useEffect.
+// This ensures that analytics.load method is invoked before any other methods.
+if (analyticsEnabled) {
+  initSegmentAnalytics();
+}
+
+export const getSegmentAnalytics: GetSegmentAnalytics = () => {
+  return {
+    analytics: (window as any).analytics,
+    analyticsEnabled,
+  };
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -254,6 +254,12 @@ export type UseResolvedExtensions = <E extends Extension>(
   ...typeGuards: ExtensionTypeGuard<E>[]
 ) => [ResolvedExtension<E>[], boolean, any[]];
 
+export type GetSegmentAnalytics = () => {
+  // TODO: use proper Segment Analytics API type
+  analytics: Record<string, (...args: any) => any>;
+  analyticsEnabled: boolean;
+};
+
 export type ConsoleFetch = (
   url: string,
   options?: RequestInit,

--- a/frontend/packages/console-shared/src/hooks/useTelemetry.ts
+++ b/frontend/packages/console-shared/src/hooks/useTelemetry.ts
@@ -39,19 +39,19 @@ let telemetryEvents: TelemetryEvent[] = [];
 
 export const getClusterProperties = () => {
   const clusterProperties: ClusterProperties = {};
-  clusterProperties.clusterId = window.SERVER_FLAGS?.telemetry?.CLUSTER_ID;
-  clusterProperties.clusterType = window.SERVER_FLAGS?.telemetry?.CLUSTER_TYPE;
+  clusterProperties.clusterId = window.SERVER_FLAGS.telemetry?.CLUSTER_ID;
+  clusterProperties.clusterType = window.SERVER_FLAGS.telemetry?.CLUSTER_TYPE;
   if (
-    window.SERVER_FLAGS?.telemetry?.CLUSTER_TYPE === 'OSD' &&
-    window.SERVER_FLAGS?.telemetry?.DEVSANDBOX === 'true'
+    window.SERVER_FLAGS.telemetry?.CLUSTER_TYPE === 'OSD' &&
+    window.SERVER_FLAGS.telemetry?.DEVSANDBOX === 'true'
   ) {
     clusterProperties.clusterType = 'DEVSANDBOX';
   }
   // Prefer to report the OCP version (releaseVersion) if available.
   clusterProperties.consoleVersion =
-    window.SERVER_FLAGS?.releaseVersion || window.SERVER_FLAGS?.consoleVersion;
-  clusterProperties.organizationId = window.SERVER_FLAGS?.telemetry?.ORGANIZATION_ID;
-  clusterProperties.accountMail = window.SERVER_FLAGS?.telemetry?.ACCOUNT_MAIL;
+    window.SERVER_FLAGS.releaseVersion || window.SERVER_FLAGS.consoleVersion;
+  clusterProperties.organizationId = window.SERVER_FLAGS.telemetry?.ORGANIZATION_ID;
+  clusterProperties.accountMail = window.SERVER_FLAGS.telemetry?.ACCOUNT_MAIL;
   return clusterProperties;
 };
 

--- a/frontend/packages/console-telemetry-plugin/src/flags/detect-telemetry.ts
+++ b/frontend/packages/console-telemetry-plugin/src/flags/detect-telemetry.ts
@@ -1,5 +1,8 @@
-import { SetFeatureFlag } from '@console/dynamic-plugin-sdk';
-import { TELEMETRY_DEBUG, TELEMETRY_DISABLED } from '../listeners/const';
+import {
+  TELEMETRY_DEBUG,
+  TELEMETRY_DISABLED,
+} from '@console/dynamic-plugin-sdk/src/api/segment-analytics';
+import { SetFeatureFlag } from '@console/dynamic-plugin-sdk/src/extensions/feature-flags';
 
 export const detectTelemetry = (setFeatureFlag: SetFeatureFlag) => {
   setFeatureFlag('TELEMETRY_DEBUG', TELEMETRY_DEBUG);

--- a/frontend/packages/console-telemetry-plugin/src/listeners/const.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/const.ts
@@ -1,6 +1,0 @@
-export const TELEMETRY_DISABLED =
-  window.SERVER_FLAGS?.telemetry?.DISABLED === 'true' ||
-  window.SERVER_FLAGS?.telemetry?.DEVSANDBOX_DISABLED === 'true' ||
-  window.SERVER_FLAGS?.telemetry?.TELEMETER_CLIENT_DISABLED === 'true';
-
-export const TELEMETRY_DEBUG = window.SERVER_FLAGS?.telemetry?.DEBUG === 'true';

--- a/frontend/packages/console-telemetry-plugin/src/listeners/debug.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/debug.ts
@@ -1,5 +1,5 @@
-import { TelemetryEventListener } from '@console/dynamic-plugin-sdk/src';
-import { TELEMETRY_DEBUG } from './const';
+import { TELEMETRY_DEBUG } from '@console/dynamic-plugin-sdk/src/api/segment-analytics';
+import { TelemetryEventListener } from '@console/dynamic-plugin-sdk/src/extensions/telemetry';
 
 export const eventListener: TelemetryEventListener = (eventType: string, properties?: any) => {
   if (TELEMETRY_DEBUG) {

--- a/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts
@@ -1,112 +1,12 @@
-import { TelemetryEventListener } from '@console/dynamic-plugin-sdk/src';
+import {
+  TELEMETRY_DEBUG,
+  getSegmentAnalytics,
+} from '@console/dynamic-plugin-sdk/src/api/segment-analytics';
+import { TelemetryEventListener } from '@console/dynamic-plugin-sdk/src/extensions/telemetry';
 import {
   getClusterProperties,
   TelemetryEventProperties,
 } from '@console/shared/src/hooks/useTelemetry';
-import { TELEMETRY_DISABLED, TELEMETRY_DEBUG } from './const';
-
-// Sample 20% of sessions
-const SAMPLE_SESSION = Math.random() < 0.2;
-
-/** Segmnet API Key that looks like a hash */
-const apiKey =
-  window.SERVER_FLAGS?.telemetry?.DEVSANDBOX_SEGMENT_API_KEY ||
-  window.SERVER_FLAGS?.telemetry?.SEGMENT_API_KEY ||
-  window.SERVER_FLAGS?.telemetry?.SEGMENT_PUBLIC_API_KEY ||
-  '';
-
-/**
- * Segment `apiHost` parameter that should have the format like `api.segment.io/v1`.
- * Is not defined here so that Segment can change it.
- */
-const apiHost = window.SERVER_FLAGS?.telemetry?.SEGMENT_API_HOST || '';
-
-/** Segment JS host. Default: `cdn.segment.com` */
-const jsHost = window.SERVER_FLAGS?.telemetry?.SEGMENT_JS_HOST || 'cdn.segment.com';
-
-/** Full segment JS URL */
-const jsUrl =
-  window.SERVER_FLAGS?.telemetry?.SEGMENT_JS_URL ||
-  `https://${jsHost}/analytics.js/v1/${encodeURIComponent(apiKey)}/analytics.min.js`;
-
-const initSegment = () => {
-  if (TELEMETRY_DEBUG) {
-    // eslint-disable-next-line no-console
-    console.info('console-telemetry-plugin: initialize segment API with:', {
-      apiKey,
-      apiHost,
-      jsHost,
-      jsUrl,
-    });
-  }
-  // eslint-disable-next-line no-multi-assign
-  const analytics = ((window as any).analytics = (window as any).analytics || []);
-  if (analytics.initialize) {
-    return;
-  }
-  if (analytics.invoked) {
-    // eslint-disable-next-line no-console
-    console.error('console-telemetry-plugin: segment snippet included twice');
-    return;
-  }
-  analytics.invoked = true;
-  analytics.methods = [
-    'trackSubmit',
-    'trackClick',
-    'trackLink',
-    'trackForm',
-    'pageview',
-    'identify',
-    'reset',
-    'group',
-    'track',
-    'ready',
-    'alias',
-    'debug',
-    'page',
-    'once',
-    'off',
-    'on',
-    'addSourceMiddleware',
-    'addIntegrationMiddleware',
-    'setAnonymousId',
-    'addDestinationMiddleware',
-  ];
-  analytics.factory = function (e: string) {
-    return function () {
-      // eslint-disable-next-line prefer-rest-params
-      const t = Array.prototype.slice.call(arguments);
-      t.unshift(e);
-      analytics.push(t);
-      return analytics;
-    };
-  };
-  for (const key of analytics.methods) {
-    analytics[key] = analytics.factory(key);
-  }
-  analytics.load = function (key: string, e: Event) {
-    const t = document.createElement('script');
-    t.type = 'text/javascript';
-    t.async = true;
-    t.src = jsUrl;
-    const n = document.getElementsByTagName('script')[0];
-    if (n.parentNode) {
-      n.parentNode.insertBefore(t, n);
-    }
-    // eslint-disable-next-line no-underscore-dangle
-    analytics._loadOptions = e;
-  };
-  analytics.SNIPPET_VERSION = '4.13.1';
-  const options: Record<string, any> = {};
-  if (apiHost) {
-    options.integrations = { 'Segment.io': { apiHost } };
-  }
-  analytics.load(apiKey, options);
-};
-
-if (!TELEMETRY_DISABLED && apiKey && SAMPLE_SESSION) {
-  initSegment();
-}
 
 const anonymousIP = {
   context: {
@@ -130,28 +30,20 @@ export const eventListener: TelemetryEventListener = async (
   eventType: string,
   properties?: any,
 ) => {
-  if (!apiKey) {
+  const { analytics, analyticsEnabled } = getSegmentAnalytics();
+
+  if (!analyticsEnabled) {
     if (TELEMETRY_DEBUG) {
       // eslint-disable-next-line no-console
       console.debug(
-        'console-telemetry-plugin: missing Segment API key - ignoring telemetry event:',
+        'console-telemetry-plugin: analytics is disabled, ignoring telemetry event',
         eventType,
         properties,
       );
     }
     return;
   }
-  if (!SAMPLE_SESSION) {
-    if (TELEMETRY_DEBUG) {
-      // eslint-disable-next-line no-console
-      console.debug(
-        'console-telemetry-plugin: session is not being sampled - ignoring telemetry event',
-        eventType,
-        properties,
-      );
-    }
-    return;
-  }
+
   switch (eventType) {
     case 'identify':
       {
@@ -184,12 +76,12 @@ export const eventListener: TelemetryEventListener = async (
           if (TELEMETRY_DEBUG) {
             // eslint-disable-next-line no-console
             console.debug(
-              `console-telemetry-plugin: use anonymized user identifier to group events`,
+              'console-telemetry-plugin: use anonymized user identifier to group events',
               { username, clusterId, organizationId, userId, processedUserId },
             );
           }
 
-          (window as any).analytics.identify(processedUserId, otherProperties, anonymousIP);
+          analytics.identify(processedUserId, otherProperties, anonymousIP);
         } else {
           // eslint-disable-next-line no-console
           console.error(
@@ -200,9 +92,9 @@ export const eventListener: TelemetryEventListener = async (
       }
       break;
     case 'page':
-      (window as any).analytics.page(undefined, properties, anonymousIP);
+      analytics.page(undefined, properties, anonymousIP);
       break;
     default:
-      (window as any).analytics.track(eventType, properties, anonymousIP);
+      analytics.track(eventType, properties, anonymousIP);
   }
 };

--- a/frontend/packages/console-telemetry-plugin/src/providers/telemetry-provider.ts
+++ b/frontend/packages/console-telemetry-plugin/src/providers/telemetry-provider.ts
@@ -1,12 +1,7 @@
-import { SetFeatureFlag } from '@console/dynamic-plugin-sdk';
+import { TELEMETRY_DISABLED } from '@console/dynamic-plugin-sdk/src/api/segment-analytics';
+import { SetFeatureFlag } from '@console/dynamic-plugin-sdk/src/extensions/feature-flags';
 import { CLUSTER_TELEMETRY_ANALYTICS } from '@console/shared';
 import { FLAG_TELEMETRY_ENABLED, FLAG_TELEMETRY_USER_PREFERENCE } from '../const';
-import { TELEMETRY_DISABLED } from '../listeners/const';
-
-const apiKey =
-  window.SERVER_FLAGS?.telemetry?.DEVSANDBOX_SEGMENT_API_KEY ||
-  window.SERVER_FLAGS?.telemetry?.SEGMENT_API_KEY ||
-  '';
 
 const isTelemetryUserPreferenceEnabled = () => {
   return (
@@ -16,6 +11,6 @@ const isTelemetryUserPreferenceEnabled = () => {
 };
 
 export const useTelemetryProvider = (setFeatureFlag: SetFeatureFlag) => {
-  setFeatureFlag(FLAG_TELEMETRY_ENABLED, apiKey && !TELEMETRY_DISABLED);
+  setFeatureFlag(FLAG_TELEMETRY_ENABLED, !TELEMETRY_DISABLED);
   setFeatureFlag(FLAG_TELEMETRY_USER_PREFERENCE, isTelemetryUserPreferenceEnabled());
 };

--- a/frontend/public/components/app.tsx
+++ b/frontend/public/components/app.tsx
@@ -154,10 +154,10 @@ const App = (props) => {
   );
 
   useEffect(() => {
-    const lightspeedButtonCapability = window.SERVER_FLAGS?.capabilities?.find(
+    const lightspeedButtonCapability = window.SERVER_FLAGS.capabilities?.find(
       (capability) => capability.name === 'LightspeedButton',
     );
-    const gettingStartedBannerCapability = window.SERVER_FLAGS?.capabilities?.find(
+    const gettingStartedBannerCapability = window.SERVER_FLAGS.capabilities?.find(
       (capability) => capability.name === 'GettingStartedBanner',
     );
     dispatch(


### PR DESCRIPTION
### Summary

This PR cleans up Segment Analytics related code and exposes new `getSegmentAnalytics` function via `@openshift-console/dynamic-plugin-sdk-internal` package.

:exclamation: This API function is meant to be used by Red Hat plugins only.

```ts
const { analytics, analyticsEnabled } = getSegmentAnalytics();

if (analyticsEnabled) {
  // invoke methods on analytics object as needed
}
```

`analyticsEnabled` is `true` if all of the following conditions are met:
- Segment API key is available
- Console telemetry is not disabled via Bridge injected `SERVER_FLAGS`
- Console telemetry is not disabled via [random session sampling](https://github.com/openshift/console/pull/14990)

### Additional notes

Console Bridge server will now print the list of telemetry options if provided.

<img width="1780" height="308" src="https://github.com/user-attachments/assets/dfda3f61-dda7-46ee-bb0a-15ccef982224" />

### Future follow-ups

Copy-pasted Segment init snippet in `segment-analytics.ts` should be replaced with proper use of the relevant [Segment npm package](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/#step-2-install-segment-to-your-site).