### PR TITLE
OCPBUGS-59550: add data-test attrs to console plugins table

### DIFF
--- a/frontend/packages/console-app/src/components/console-operator/ConsoleOperatorConfig.tsx
+++ b/frontend/packages/console-app/src/components/console-operator/ConsoleOperatorConfig.tsx
@@ -248,7 +248,11 @@ const ConsolePluginsTable: React.FC<ConsolePluginsTableProps> = ({ obj, rows, lo
         </div>
       </RequireCreatePermission>
       {rows.length ? (
-        <Table aria-label="console plugins table" ouiaId="ConsolePluginsTable">
+        <Table
+          aria-label="console plugins table"
+          ouiaId="ConsolePluginsTable"
+          data-test="console-plugins-table"
+        >
           <Thead>
             <Tr>
               {columns.map(({ id, name, sortable }, columnIndex) => (
@@ -262,22 +266,26 @@ const ConsolePluginsTable: React.FC<ConsolePluginsTableProps> = ({ obj, rows, lo
             {sortedRows.map(
               ({ name, version, description, status, enabled, errorMessage, hasCSPViolations }) => (
                 <Tr key={name}>
-                  <Td dataLabel={columns[0].id}>
+                  <Td dataLabel={columns[0].id} data-test={`${name}-name`}>
                     {!developmentMode ? (
                       <ResourceLink groupVersionKind={consolePluginGVK} name={name} hideIcon />
                     ) : (
                       name
                     )}
                   </Td>
-                  <Td dataLabel={columns[1].id}>{version || DASH}</Td>
-                  <Td dataLabel={columns[2].id}>{description || DASH}</Td>
-                  <Td dataLabel={columns[3].id}>
+                  <Td dataLabel={columns[1].id} data-test={`${name}-version`}>
+                    {version || DASH}
+                  </Td>
+                  <Td dataLabel={columns[2].id} data-test={`${name}-description`}>
+                    {description || DASH}
+                  </Td>
+                  <Td dataLabel={columns[3].id} data-test={`${name}-status`}>
                     <ConsolePluginStatus status={status} errorMessage={errorMessage} />
                   </Td>
-                  <Td dataLabel={columns[4].id}>
+                  <Td dataLabel={columns[4].id} data-test={`${name}-enabled`}>
                     <ConsolePluginEnabledStatus pluginName={name} enabled={enabled} />
                   </Td>
-                  <Td dataLabel={columns[5].id}>
+                  <Td dataLabel={columns[5].id} data-test={`${name}-csp-violations`}>
                     <ConsolePluginCSPStatus hasViolations={hasCSPViolations ?? false} />
                   </Td>
                 </Tr>


### PR DESCRIPTION
For use in https://github.com/openshift/console-crontab-plugin/pull/36

I don't have a current need for a `data-test` attribute on every `<td>`, but figure it's good future proofing.