### PR TITLE
CONSOLE-4608: Drop createModalLauncher from helm-plugin and use useOverlay hook instead

### DIFF
--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
@@ -21,7 +21,7 @@ import { EditorType } from '@console/shared/src/components/synced-editor/editor-
 import { HelmActionType, HelmChart, HelmActionConfigType } from '../../../types/helm-types';
 import { helmActionString } from '../../../utils/helm-utils';
 import HelmChartVersionDropdown from './HelmChartVersionDropdown';
-import { helmReadmeModalLauncher } from './HelmReadmeModal';
+import { useHelmReadmeModalLauncher } from './HelmReadmeModal';
 
 export type HelmInstallUpgradeFormData = {
   releaseName: string;
@@ -74,7 +74,10 @@ const HelmInstallUpgradeForm: React.FC<
   const theme = React.useContext(ThemeContext);
   const { chartName, chartVersion, chartReadme, formData, formSchema, editorType } = values;
   const { type: helmAction, title, subTitle } = helmActionConfig;
-
+  const helmReadmeModalLauncher = useHelmReadmeModalLauncher({
+    readme: chartReadme,
+    theme,
+  });
   const isSubmitDisabled =
     (helmAction === HelmActionType.Upgrade && !dirty) ||
     isSubmitting ||
@@ -113,13 +116,7 @@ const HelmInstallUpgradeForm: React.FC<
         type="button"
         variant="link"
         data-test-id="helm-readme-modal"
-        onClick={() =>
-          helmReadmeModalLauncher({
-            readme: chartReadme,
-            modalClassName: 'modal-lg',
-            theme,
-          })
-        }
+        onClick={helmReadmeModalLauncher}
         isInline
       >
         README

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmReadmeModal.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmReadmeModal.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { OverlayComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/OverlayProvider';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import {
   ModalTitle,
   ModalBody,
-  createModalLauncher,
   ModalComponentProps,
+  ModalWrapper,
 } from '@console/internal/components/factory';
 import { SyncMarkdownView } from '@console/internal/components/markdown-view';
 
@@ -26,5 +28,18 @@ const HelmReadmeModal: React.FunctionComponent<Props> = ({ readme, theme, close 
   );
 };
 
-export const helmReadmeModalLauncher = createModalLauncher<Props>(HelmReadmeModal);
-export default HelmReadmeModal;
+const HelmReadmeModalProvider: OverlayComponent<Props> = (props) => {
+  return (
+    <ModalWrapper blocking onClose={props.closeOverlay} className="modal-lg">
+      <HelmReadmeModal close={props.closeOverlay} cancel={props.closeOverlay} {...props} />
+    </ModalWrapper>
+  );
+};
+
+export const useHelmReadmeModalLauncher = (props: Props) => {
+  const launcher = useOverlay();
+  return React.useCallback(() => launcher<Props>(HelmReadmeModalProvider, props), [
+    launcher,
+    props,
+  ]);
+};


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/CONSOLE-4608


https://github.com/user-attachments/assets/9884d7af-4718-4775-b701-40a7ce76ad9a

