### PR TITLE
OCPBUGS-59563: Resolving API Version Conflicts in Tekton Pipeline Runs

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/utils.ts
@@ -1,5 +1,6 @@
 import i18next from 'i18next';
 import * as _ from 'lodash';
+import { groupVersionFor } from '@console/internal/module/k8s';
 import { PipelineModel, PipelineResourceModel } from '../../../models';
 import {
   PipelineKind,
@@ -44,6 +45,7 @@ type PipelineTaskLinks = {
 export const getPipelineTaskLinks = (pipeline: PipelineKind): PipelineTaskLinks => {
   const toResourceLinkData = (tasks: PipelineTask[]): ResourceModelLink[] => {
     if (!tasks) return [];
+    const { version } = groupVersionFor(pipeline.apiVersion);
     return tasks?.map((task) =>
       task.taskRef
         ? task.taskRef.kind === 'ClusterTask' || task.taskRef.kind === 'Task'
@@ -51,6 +53,7 @@ export const getPipelineTaskLinks = (pipeline: PipelineKind): PipelineTaskLinks 
               resourceKind: getSafeTaskResourceKind(task.taskRef.kind),
               name: task.taskRef.name,
               qualifier: task.name,
+              resourceApiVersion: version,
             }
           : {
               resourceKind: task.taskRef?.kind,
@@ -105,10 +108,12 @@ export const convertBackingPipelineToPipelineResourceRefProps = (
   pipelineRun: PipelineRunKind,
 ): React.ComponentProps<typeof PipelineResourceRef> => {
   if (pipelineRun.spec.pipelineRef) {
+    const { version } = groupVersionFor(pipelineRun.apiVersion);
     return {
       resourceKind: PipelineModel.kind,
       resourceName: pipelineRun.spec.pipelineRef.name,
       namespace: pipelineRun.metadata.namespace,
+      resourceApiVersion: version,
     };
   }
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/DynamicResourceLinkList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/DynamicResourceLinkList.tsx
@@ -14,6 +14,7 @@ export type ResourceModelLink = {
   name: string;
   qualifier?: string;
   disableLink?: boolean;
+  resourceApiVersion?: string;
 };
 
 type DynamicResourceLinkListProps = {
@@ -42,23 +43,26 @@ const DynamicResourceLinkList: React.FC<DynamicResourceLinkListProps> = ({
         <DescriptionListGroup>
           {title && <DescriptionListTerm>{title}</DescriptionListTerm>}
           <DescriptionListDescription>
-            {links.map(({ name, resourceKind, qualifier = '', disableLink = false }) => {
-              let linkName = qualifier;
-              if (qualifier?.length > 0 && name !== qualifier) {
-                linkName += ` (${name})`;
-              }
-              return (
-                <div key={`${resourceKind}/${linkName}`}>
-                  <PipelineResourceRef
-                    resourceKind={resourceKind}
-                    resourceName={name}
-                    displayName={linkName}
-                    namespace={namespace}
-                    disableLink={disableLink}
-                  />
-                </div>
-              );
-            })}
+            {links.map(
+              ({ name, resourceKind, qualifier = '', disableLink = false, resourceApiVersion }) => {
+                let linkName = qualifier;
+                if (qualifier?.length > 0 && name !== qualifier) {
+                  linkName += ` (${name})`;
+                }
+                return (
+                  <div key={`${resourceKind}/${linkName}`}>
+                    <PipelineResourceRef
+                      resourceKind={resourceKind}
+                      resourceName={name}
+                      displayName={linkName}
+                      namespace={namespace}
+                      disableLink={disableLink}
+                      resourceApiVersion={resourceApiVersion}
+                    />
+                  </div>
+                );
+              },
+            )}
           </DescriptionListDescription>
         </DescriptionListGroup>
       </DescriptionList>

--- a/frontend/packages/pipelines-plugin/src/components/shared/common/PipelineResourceRef.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/common/PipelineResourceRef.tsx
@@ -7,7 +7,11 @@ import * as models from '../../../models';
 import './PipelineResourceRef.scss';
 
 const MODEL_KINDS = Object.values(models).reduce(
-  (acc, model: K8sKind) => ({ ...acc, [model.kind]: model }),
+  (acc, model: K8sKind) => ({
+    ...acc,
+    [`${model.kind}-${model.apiVersion}`]: model,
+    [model.kind]: model,
+  }),
   {},
 );
 
@@ -18,6 +22,7 @@ type PipelineResourceRefProps = {
   displayName?: string;
   largeIcon?: boolean;
   namespace?: string;
+  resourceApiVersion?: string;
 };
 
 const PipelineResourceRef: React.FC<PipelineResourceRefProps> = ({
@@ -27,8 +32,10 @@ const PipelineResourceRef: React.FC<PipelineResourceRefProps> = ({
   namespace,
   resourceKind,
   resourceName,
+  resourceApiVersion,
 }) => {
-  const model: K8sKind | undefined = MODEL_KINDS[resourceKind];
+  const modelKey = resourceApiVersion ? `${resourceKind}-${resourceApiVersion}` : resourceKind;
+  const model: K8sKind | undefined = MODEL_KINDS[modelKey] || MODEL_KINDS[resourceKind];
   let kind = resourceKind;
   if (model) {
     kind = referenceForModel(model);


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/OCPBUGS-59563

**Description:** 

API version was not considered while selecting the model and creating the resource link. With this fix, api version is also considered. 

**Screenshot:**

<img width="1215" height="1038" alt="Screenshot 2025-07-21 at 2 35 35 PM" src="https://github.com/user-attachments/assets/f94d758b-c282-4c8a-8714-1ff76af4e220" />
