### PR TITLE
OCPBUGS-57466: Default name is comprised of '-' on 'Add to favorites' page when language is Korean/Japanese/Chinese.

### DIFF
--- a/frontend/packages/console-app/src/components/favorite/FavoriteButton.tsx
+++ b/frontend/packages/console-app/src/components/favorite/FavoriteButton.tsx
@@ -35,7 +35,7 @@ export const FavoriteButton = ({ defaultName }: FavoriteButtonProps) => {
     null,
     true,
   );
-  const alphanumericRegex = /^[a-zA-Z0-9- ]*$/;
+  const alphanumericRegex = /^[\p{L}\p{N}\s-]*$/u;
 
   const currentUrlPath = window.location.pathname;
 
@@ -60,7 +60,7 @@ export const FavoriteButton = ({ defaultName }: FavoriteButtonProps) => {
         : currentUrlPath.split('/');
       const sanitizedDefaultName = (
         defaultName ?? currentUrlSplit.slice(-1)[0].split('?')[0]
-      ).replace(/[^a-zA-Z0-9- ]/g, '-');
+      ).replace(/[^\p{L}\p{N}\s-]/gu, '-');
       setName(sanitizedDefaultName);
       setIsModalOpen(true);
     }


### PR DESCRIPTION
### Before:
<img width="1860" height="922" alt="Screenshot 2025-07-21 at 3 33 25 PM" src="https://github.com/user-attachments/assets/6d08263f-ff48-47c8-b611-ee88473d8911" />

### After:
<img width="1524" height="772" alt="Screenshot 2025-07-21 at 3 33 56 PM" src="https://github.com/user-attachments/assets/a4afca39-143d-4c1c-a02d-c2f85d350f08" />
