### PR TITLE
OCPBUGS-55401: PVC shows negative Available space in OpenShift Console on RHOCP 4

### DIFF
--- a/frontend/__tests__/units.spec.js
+++ b/frontend/__tests__/units.spec.js
@@ -42,7 +42,7 @@ describe('units', () => {
     };
 
     test_('banana', 0, '0');
-    test_(-1, -1, '-1');
+    test_(-1, 0, '0');
     test_(-0, -0, '0');
     test_(1 / 0, 0, '0');
     test_(-1 / 0, 0, '0');
@@ -120,7 +120,7 @@ describe('units', () => {
     };
 
     test_('banana', '0 B');
-    test_(-1, '-1 B');
+    test_(-1, '0 B');
     test_(-0, '0 B');
     test_(1 / 0, '0 B');
     test_(-1 / 0, '0 B');
@@ -158,7 +158,7 @@ describe('units', () => {
     };
 
     test_('banana', '0 B');
-    test_(-1, '-1 B');
+    test_(-1, '0 B');
     test_(-0, '0 B');
     test_(1 / 0, '0 B');
     test_(-1 / 0, '0 B');
@@ -196,7 +196,7 @@ describe('units', () => {
     };
 
     test_('banana', '0 i');
-    test_(-1, '-1 i');
+    test_(-1, '0 i');
     test_(-0, '0 i');
     test_(1 / 0, '0 i');
     test_(-1 / 0, '0 i');

--- a/frontend/public/components/utils/units.js
+++ b/frontend/public/components/utils/units.js
@@ -162,7 +162,7 @@ const humanize = (units.humanize = (
 ) => {
   const type = getType(typeName);
 
-  if (!isFinite(value)) {
+  if (!isFinite(value) || value < 0) {
     value = 0;
   }
 


### PR DESCRIPTION
### Problem: 
PVC shows negative Available space in OpenShift Console. This is an edge case that primarily occurs with shared filesystems like NFS or Samba share due to filesystem overhead and metrics synchronization issues.

### Root cause: 
Missing logic for handling when used capacity exceeds total capacity, which results in showing negative available space. 

**Analysis:**
  - Prometheus reports `usedMetrics` from `kubelet_volume_stats_used_bytes`
  - PVC reports `totalCapacity` from `status.capacity.storage`
  - Calculation: `availableMetrics = totalCapacity - usedMetrics`
  - When `usedMetrics > totalCapacity → availableMetrics` becomes negative
  - The `humanizeBinaryBytes(availableMetrics)`  displays negative value (e.g., "-11736 MiB")

### Before:
<img width="1609" height="939" alt="Screenshot 2025-08-01 at 5 34 32 PM" src="https://github.com/user-attachments/assets/60f96ebc-a579-4ddb-8384-05d24df56ba0" />

### After:
**Possible solutions:**
**Option 1:**
If available capacity is negative, fallback to showing the total capacity similar to current UI implementation for zero (0) available capacity. 
Fix: Use `Math.max(0, ...)` to prevent negative available capacity display and show the total capacity.

<img width="1552" height="771" alt="Screenshot 2025-08-01 at 5 26 10 PM" src="https://github.com/user-attachments/assets/556b1f71-a509-45a3-bfb5-9358e2a967c2" />


**Option 2.**
If available capacity is negative,, fallback to showing zero (0) similar to current UI implementation for infinite value available capacity. 
**Fix:**  Enhanced the humanize function with `if (!isFinite(value) || value < 0) { value = 0; }` to ensure negative values display as "0 B available".

<img width="1534" height="768" alt="Screenshot 2025-08-01 at 5 36 57 PM" src="https://github.com/user-attachments/assets/a9f39e67-9308-44b6-8b75-2455073c1384" />


**Current Scenarios**
1. 1GiB PV/PVC with a pod that uses exactly 500 MiB, leaving 500 MiB available.
Expected donut chart: 
Used: 500 MiB (50%) 
Available: 500 MiB (50%) 
Total: 1 GiB

<img width="1563" height="938" alt="Screenshot 2025-08-12 at 12 03 08 PM" src="https://github.com/user-attachments/assets/4bff66e3-0f23-472c-a2e6-efd725ac7441" />

