### PR TITLE
OCPBUGS-56155: Click 'View operator details' in Plugin available popover will close the modal

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -380,6 +380,7 @@ const ConsolePluginStatus: React.FC<ConsolePluginStatusProps> = ({ csv, csvPlugi
             </Link>
           </div>
         }
+        appendTo="inline"
       >
         <Button variant="link" isInline>
           {t('olm~Plugin available')}


### PR DESCRIPTION
WIP: Fixed the View operator details to close the modal. Need to figure out the jumping popper

https://github.com/user-attachments/assets/c63cf94b-54a9-4a6a-8dcb-5fab0a95df6f

