### PR TITLE
CONSOLE-4699: Update dynamic demo plugin e2e tests

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/app/demo-dynamic-plugin.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/demo-dynamic-plugin.cy.ts
@@ -12,7 +12,6 @@ const PLUGIN_PATH = '../../../dynamic-demo-plugin';
 const PLUGIN_PULL_SPEC = Cypress.env('PLUGIN_PULL_SPEC');
 /* The update wait is the value to wait for the poll of /api/check-updates to return with the updated list of plugins
  after the plugin is enabled and loaded. This wait will be longer on ci than when debugging locally. */
-const CHECK_UPDATE_WAIT = 300000;
 /*
   These tests are meant to:
     1. show how to test a dynamic plugin using demo as the plugin instance
@@ -53,8 +52,8 @@ const enableDemoPlugin = (enable: boolean) => {
       cy.byTestID('edit-console-plugin').contains(enable ? 'Enabled' : 'Disabled');
     });
   cy.log(`Running plugin test on ci using PLUGIN_PULL_SPEC: ${PLUGIN_PULL_SPEC}`);
-  cy.byTestID('admin-demo-section', { timeout: CHECK_UPDATE_WAIT })
-    .should(enable ? 'exist' : 'not.exist')
+  cy.byTestID(`${PLUGIN_NAME}-status`)
+    .should('include.text', enable ? 'Loaded' : '-')
     .then(() => {
       if (!enable) {
         cy.byLegacyTestID(PLUGIN_NAME).click();


### PR DESCRIPTION
Update dynamic demo plugin e2e test "enabled" conditions to be consistent with crontab plugin tests.