### PR TITLE
OCPBUGS-57481: fix: Fix negative CPU util graphs

### DIFF
--- a/frontend/packages/console-shared/src/promql/cluster-dashboard.ts
+++ b/frontend/packages/console-shared/src/promql/cluster-dashboard.ts
@@ -309,7 +309,10 @@ const overviewQueries = {
   [OverviewQuery.CPU_UTILIZATION]: _.template(
     `
       sum(
-        1 - sum without (mode) (rate(node_cpu_seconds_total{mode=~"idle|iowait|steal"}[2m]))
+          (
+            sum without (mode) (rate(node_cpu_seconds_total{}[2m]))
+            - sum without (mode) (rate(node_cpu_seconds_total{mode=~"idle|iowait|steal"}[2m]))
+          )
         *
         on(instance) group_left() (
           label_replace(max by (node) (kube_node_role{role=~"<%= nodeType %>"}), "instance", "$1", "node","(.*)")


### PR DESCRIPTION
Sometimes `rate(node_cpu_seconds_total{}[2m]` returns values >1. The old query assumes that the total rate is always <= 1. We want to display the time spend in CPU modes other then `idle|iowait|steal` so lets deduct those from the total across all modes instead of 1. This can be considered a work around since rate(counter_of_seconds) should never be over one.