### PR TITLE
CONSOLE-4617: add additionalPrinterColumns to CustomResource details page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -179,6 +179,7 @@
     "js-base64": "^3.7.7",
     "js-yaml": "^3.13.1",
     "json-schema": "^0.3.0",
+    "jsonpath-plus": "^10.3.0",
     "lodash-es": "^4.17.21",
     "marked": "^15.0.6",
     "monaco-yaml": "^5.3.1",

--- a/frontend/packages/console-shared/src/components/additional-printer-column/AdditionalPrinterColumnValue.tsx
+++ b/frontend/packages/console-shared/src/components/additional-printer-column/AdditionalPrinterColumnValue.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { JSONPath } from 'jsonpath-plus';
+import { CRDAdditionalPrinterColumn, K8sResourceKind } from '@console/internal/module/k8s';
+import { Timestamp } from '@console/shared/src/components/datetime/Timestamp';
+import { DASH } from '../../constants';
+
+export const AdditionalPrinterColumnValue: React.FCC<AdditionalPrinterColumnValueProps> = ({
+  col,
+  obj,
+}) => {
+  const value = JSONPath({
+    path: col.jsonPath.replace(/^\./, ''),
+    json: obj,
+    wrap: false,
+  });
+
+  if (col.type === 'date') {
+    return <Timestamp timestamp={value} />;
+  }
+
+  switch (typeof value) {
+    case 'boolean':
+    case 'number':
+      return value.toString();
+    case 'object':
+      if (value === null) {
+        return DASH;
+      }
+      if (col.jsonPath.includes('status.conditions') || col.jsonPath.includes('status.history')) {
+        return value;
+      }
+      return JSON.stringify(value);
+    case 'string':
+    default:
+      return value || DASH;
+  }
+};
+
+type AdditionalPrinterColumnValueProps = {
+  col: CRDAdditionalPrinterColumn;
+  obj: K8sResourceKind;
+};

--- a/frontend/packages/console-shared/src/hooks/useCRDAdditionalPrinterColumns.ts
+++ b/frontend/packages/console-shared/src/hooks/useCRDAdditionalPrinterColumns.ts
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { consoleFetchJSON as coFetchJSON } from '@console/dynamic-plugin-sdk/src/utils/fetch';
+import {
+  CRDAdditionalPrinterColumn,
+  CRDAdditionalPrinterColumns,
+  K8sModel,
+} from '@console/internal/module/k8s';
+
+export const useCRDAdditionalPrinterColumns = (model: K8sModel): CRDAdditionalPrinterColumn[] => {
+  const [CRDAPC, setCRDAPC] = React.useState<CRDAdditionalPrinterColumns>({});
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    coFetchJSON(`/api/console/crd-columns/${model.plural}.${model.apiGroup}`)
+      .then((response) => {
+        setCRDAPC(response);
+        setLoading(false);
+      })
+      .catch((e) => {
+        setLoading(false);
+        // eslint-disable-next-line no-console
+        console.log(e.message);
+      });
+  }, [model.plural, model.apiGroup]);
+
+  return !loading ? CRDAPC?.[model.apiVersion] ?? [] : [];
+};

--- a/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-notification.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-notification.cy.ts
@@ -50,7 +50,16 @@ describe(`${crd} CRD`, () => {
     });
 
     cy.visit(`/k8s/cluster/console.openshift.io~v1~${crd}/${name}`);
+    detailsPage.isLoaded();
     detailsPage.titleShouldContain(name);
+    cy.log('Additional printer columns should exist.');
+    cy.byTestID('additional-printer-columns').should('exist');
+    cy.byTestSelector('details-item-label__Text').should('have.text', 'Text');
+    cy.byTestSelector('details-item-value__Text').should('have.text', text);
+    cy.byTestSelector('details-item-label__Location').should('have.text', 'Location');
+    cy.byTestSelector('details-item-value__Location').should('have.text', location);
+    cy.byTestSelector('details-item-label__Age').should('have.text', 'Age');
+    cy.byTestSelector('details-item-value__Age').should('exist');
 
     cy.get(notification).contains(text).should('exist').and('be.visible');
 

--- a/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-yaml-sample.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-yaml-sample.cy.ts
@@ -77,7 +77,10 @@ metadata:
 
     // Check if ConsoleYAMLSample CR was created
     cy.visit(`/k8s/cluster/console.openshift.io~v1~${crd}/${name}`);
+    detailsPage.isLoaded();
     detailsPage.titleShouldContain(name);
+    cy.log('Additional printer columns should not exist.');
+    cy.byTestID('additional-printer-columns').should('not.exist');
 
     // Create Job from sample
     cy.visit(`k8s/ns/${testName}/batch~v1~Job`);

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -541,6 +541,17 @@ export type CronJobKind = {
   };
 };
 
+export type CRDAdditionalPrinterColumn = {
+  name: string;
+  type: string;
+  jsonPath: string;
+  description?: string;
+};
+
+export type CRDAdditionalPrinterColumns = {
+  [key: string]: CRDAdditionalPrinterColumn[];
+};
+
 export type CRDVersion = {
   name: string;
   served: boolean;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1559,6 +1559,16 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jsep-plugin/assignment@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/assignment/-/assignment-1.3.0.tgz#fcfc5417a04933f7ceee786e8ab498aa3ce2b242"
+  integrity sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==
+
+"@jsep-plugin/regex@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/regex/-/regex-1.0.4.tgz#cb2fc423220fa71c609323b9ba7f7d344a755fcc"
+  integrity sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==
+
 "@jsonjoy.com/base64@^1.1.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jsonjoy.com/base64/-/base64-1.1.2.tgz#cf8ea9dcb849b81c95f14fc0aaa151c6b54d2578"
@@ -11676,6 +11686,11 @@ jsdom@^11.5.1:
     ws "^5.2.0"
     xml-name-validator "^3.0.0"
 
+jsep@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsep/-/jsep-1.4.0.tgz#19feccbfa51d8a79f72480b4b8e40ce2e17152f0"
+  integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
+
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
@@ -11824,6 +11839,15 @@ jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
+
+jsonpath-plus@^10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz#59e22e4fa2298c68dfcd70659bb47f0cad525238"
+  integrity sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==
+  dependencies:
+    "@jsep-plugin/assignment" "^1.3.0"
+    "@jsep-plugin/regex" "^1.0.4"
+    jsep "^1.4.0"
 
 jsonpointer@^4.0.1:
   version "4.1.0"


### PR DESCRIPTION
A few examples:
* k8s/cluster/olm.operatorframework.io~v1~ClusterCatalog/openshift-certified-operators
* k8s/cluster/security.openshift.io~v1~SecurityContextConstraints/anyuid
* k8s/cluster/security.openshift.io~v1~SecurityContextConstraints/hostnetwork-v2
* k8s/ns/openshift-cluster-node-tuning-operator/tuned.openshift.io~v1~Tuned/default
* k8s/ns/openshift-cluster-node-tuning-operator/tuned.openshift.io~v1~Profile/*

https://github.com/user-attachments/assets/cc7c6323-507f-46b2-bfb2-ccfb3c168678

If a resource has `additionalPrinterColumns` and `console.resource/details-item`(s) in the `right` `column`, the `console.resource/details-item`(s) appear below the `additionalPrinterColumns`.

`Priority` is added via `console.resource/details-item`
<img width="3012" height="2426" alt="localhost_9000_k8s_cluster_olm operatorframework io~v1~ClusterCatalog_openshift-certified-operators_ (1)" src="https://github.com/user-attachments/assets/3e69e8fb-0389-4037-9b9b-c8bba314e5d7" />


