### PR TITLE
CONSOLE-4688: Use PF instead of `noSelection` `Dropdown`

### DIFF
--- a/frontend/packages/console-shared/src/components/multi-tab-list/MultiTabListPage.tsx
+++ b/frontend/packages/console-shared/src/components/multi-tab-list/MultiTabListPage.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { ActionListItem, Button } from '@patternfly/react-core';
+import { SimpleDropdown } from '@patternfly/react-templates';
 import { useTranslation } from 'react-i18next';
 import { useParams, Link } from 'react-router-dom-v5-compat';
-import { history, HorizontalNav, Page, Dropdown } from '@console/internal/components/utils';
+import { history, HorizontalNav, Page } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PageHeading } from '@console/shared/src/components/heading/PageHeading';
 import { PageTitleContext } from '../pagetitle/PageTitleContext';
@@ -84,13 +85,21 @@ const MultiTabListPage: React.FC<MultiTabListPageProps> = ({
             )}
             {items && (
               <ActionListItem>
-                <Dropdown
-                  buttonClassName="pf-m-primary"
-                  menuClassName="prevent-overflow"
-                  title={t('console-shared~Create')}
-                  noSelection
-                  items={items}
-                  onChange={onSelectCreateAction}
+                <SimpleDropdown
+                  toggleProps={{
+                    variant: 'primary',
+                    // @ts-expect-error non-prop attribute is used for cypress
+                    'data-test': 'tab-list-page-create',
+                  }}
+                  toggleContent={t('console-shared~Create')}
+                  initialItems={Object.keys(items).map((item) => ({
+                    value: item,
+                    content: items[item],
+                    'data-test-dropdown-menu': item,
+                  }))}
+                  onSelect={(_e, value: string) => {
+                    onSelectCreateAction(value);
+                  }}
                 />
               </ActionListItem>
             )}

--- a/frontend/packages/knative-plugin/integration-tests/support/pageObjects/global-po.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/pageObjects/global-po.ts
@@ -1,5 +1,5 @@
 export const eventingPO = {
-  createEventDropDownMenu: '[data-test-id="dropdown-button"]',
+  createEventDropDownMenu: '[data-test="tab-list-page-create"]',
   createEventSource: '[data-test-dropdown-menu="eventSource"]',
   createKnativeEvent: '[data-test="item knative-event-source"]',
   yamlEditor: 'div.monaco-scrollable-element.editor-scrollable.vs-dark',

--- a/frontend/packages/knative-plugin/integration-tests/support/pages/functions/functions-page.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/pages/functions/functions-page.ts
@@ -21,11 +21,11 @@ export const functionsPage = {
   verifyPodsTab: () => cy.get(functionsPO.podsTab).should('be.visible'),
   verifyGettingStarted: () => cy.get(functionsPO.gettingStarted).should('be.visible'),
   verifyFunctionsActionsDropdown: () =>
-    cy.byLegacyTestID('dropdown-button').eq(0).should('be.visible'),
-  clickFunctionsActionButton: () => cy.byLegacyTestID('dropdown-button').eq(0).click(),
+    cy.byTestID('create-action-dropdown').eq(0).should('be.visible'),
+  clickFunctionsActionButton: () => cy.byTestID('create-action-dropdown').eq(0).click(),
   verifyActionsInCreateMenu: () => {
-    cy.byLegacyTestID('dropdown-menu').contains('Import from Git').should('exist');
-    cy.byLegacyTestID('dropdown-menu').contains('Samples').should('exist');
+    cy.byTestDropDownMenu('importFromGit').should('exist');
+    cy.byTestDropDownMenu('functionsUsingSamples').should('exist');
   },
   clickonEmptyAreaTopology: () => {
     topologyPage.waitForLoad();

--- a/frontend/packages/knative-plugin/src/components/functions/CreateActionDropdown.tsx
+++ b/frontend/packages/knative-plugin/src/components/functions/CreateActionDropdown.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
+import { SimpleDropdown, SimpleDropdownItem } from '@patternfly/react-templates';
 import { useTranslation } from 'react-i18next';
-import { history, Dropdown } from '@console/internal/components/utils';
-import { MenuAction, MenuActions } from '@console/shared/src';
+import { LinkTo } from '@console/shared/src/components/links/LinkTo';
 
 type CreateActionDropdownProps = {
   namespace: string;
@@ -10,50 +10,32 @@ type CreateActionDropdownProps = {
 export const CreateActionDropdown: React.FC<CreateActionDropdownProps> = ({ namespace }) => {
   const { t } = useTranslation();
 
-  const menuActions: MenuActions = {
-    importfromGit: {
-      label: t('knative-plugin~Import from Git'),
-      onSelection: () => `/serverless-function/ns/${namespace || 'default'}`,
+  const menuActions: SimpleDropdownItem[] = [
+    {
+      value: 'importFromGit',
+      content: t('knative-plugin~Import from Git'),
+      component: LinkTo(`/serverless-function/ns/${namespace || 'default'}`),
+      // @ts-expect-error non-prop attribute is used for cypress
+      'data-test-dropdown-menu': 'importFromGit',
     },
-    functionsUsingSamples: {
-      label: t('knative-plugin~Samples'),
-      onSelection: () => `/samples/ns/${namespace || 'default'}?sampleType=Serverless function`,
+    {
+      value: 'functionsUsingSamples',
+      content: t('knative-plugin~Samples'),
+      component: LinkTo(`/samples/ns/${namespace || 'default'}?sampleType=Serverless function`),
+      // @ts-expect-error non-prop attribute is used for cypress
+      'data-test-dropdown-menu': 'functionsUsingSamples',
     },
-  };
-
-  const items = menuActions
-    ? Object.keys(menuActions).reduce<Record<string, string>>((acc, key) => {
-        const menuAction: MenuAction = menuActions[key];
-        const { label } = menuAction;
-        if (!label) return acc;
-
-        return {
-          ...acc,
-          [key]: label,
-        };
-      }, {})
-    : undefined;
-
-  const onSelectCreateAction = (actionName: string): void => {
-    const selectedMenuItem: MenuAction = menuActions[actionName];
-    let url: string;
-    if (selectedMenuItem.onSelection) {
-      url = selectedMenuItem.onSelection(actionName, selectedMenuItem, url);
-    }
-    if (url) {
-      history.push(url);
-    }
-  };
+  ];
 
   return (
-    <Dropdown
-      buttonClassName="pf-m-primary"
-      menuClassName="prevent-overflow"
-      title={t('knative-plugin~Create function')}
-      noSelection
-      items={items}
-      onChange={onSelectCreateAction}
-      className=""
+    <SimpleDropdown
+      toggleProps={{
+        variant: 'primary',
+        // @ts-expect-error non-prop attribute is used for cypress
+        'data-test': 'create-action-dropdown',
+      }}
+      toggleContent={t('knative-plugin~Create function')}
+      initialItems={menuActions}
     />
   );
 };

--- a/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
@@ -2,8 +2,8 @@ export const pipelineBuilderPO = {
   title: '[data-test="page-heading"] h1',
   create: '[data-test-id="submit-button"]',
   cancel: '[data-test-id="reset-button"]',
-  pipeline: '#pipeline-link',
-  repository: '#repository-link',
+  pipeline: '[data-test-dropdown-menu="pipeline"]',
+  repository: '[data-test-dropdown-menu="repository"]',
   configureVia: {
     pipelineBuilder: '#form-radiobutton-editorType-form-field',
     yamlView: '#form-radiobutton-editorType-yaml-field',

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelines-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelines-page.ts
@@ -15,7 +15,7 @@ export const pipelinesPage = {
       if ($body.find(pipelinesPO.createPipeline).length > 0) {
         cy.get(pipelinesPO.createPipeline).click();
       } else {
-        cy.contains(`[data-test-id="dropdown-button"]`, 'Create').click();
+        cy.byTestID('tab-list-page-create').contains('Create').click();
         cy.get(pipelineBuilderPO.pipeline).click();
       }
     });
@@ -25,8 +25,8 @@ export const pipelinesPage = {
     detailsPage.titleShouldContain(pageTitle.Pipelines);
     app.waitForLoad();
     cy.get('body').then(($body) => {
-      if ($body.find('[data-test-id="dropdown-button"]').length !== 0) {
-        cy.contains('[data-test-id="dropdown-button"]', 'Create').click();
+      if ($body.find('[data-test="tab-list-page-create"]').length !== 0) {
+        cy.byTestID('tab-list-page-create').contains('Create').click();
         cy.get(pipelineBuilderPO.repository).click();
       } else {
         cy.get(pipelinesPO.createPipeline).click();

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/task-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/task-page.ts
@@ -29,7 +29,7 @@ export const tasksPage = {
     cy.get('[data-quickstart-id="qs-nav-pipelines"]').eq(1).click({ force: true });
   },
   clickOnCreatePipeline: () => {
-    cy.get('[data-test-id="dropdown-button"]').contains('Create').click({ force: true });
+    cy.byTestID('tab-list-page-create').contains('Create').click({ force: true });
     cy.byTestDropDownMenu('pipeline').click();
   },
 };

--- a/frontend/packages/pipelines-plugin/src/components/ListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/ListPage.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
 import { Button, Grid, GridItem, TextInput, TextInputProps } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
+import { SimpleDropdown } from '@patternfly/react-templates';
 // eslint-disable-next-line no-restricted-imports
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
@@ -14,7 +14,6 @@ import { ErrorPage404 } from '@console/internal/components/error';
 import { FilterToolbar, RowFilter } from '@console/internal/components/filter-toolbar';
 import { storagePrefix } from '@console/internal/components/row-filter';
 import {
-  Dropdown,
   FirehoseResource,
   FirehoseResourcesResult,
   FirehoseResultObject,
@@ -272,15 +271,20 @@ export const FireMan: React.FC<FireManProps & { filterList?: typeof filterList }
     } else if (createProps.items) {
       createLink = (
         <div>
-          <Dropdown
-            buttonClassName="pf-m-primary"
-            id="item-create"
-            dataTest="item-create"
-            menuClassName={css({ 'prevent-overflow': title })}
-            title={createButtonText}
-            noSelection
-            items={createProps.items}
-            onChange={runOrNavigate}
+          <SimpleDropdown
+            toggleProps={{
+              variant: 'primary',
+              id: 'item-create',
+              // @ts-expect-error non-prop attribute is used for cypress
+              'data-test': 'item-create',
+            }}
+            toggleContent={createButtonText}
+            initialItems={Object.keys(createProps.items).map((item) => ({
+              value: item,
+              content: createProps.items[item],
+              'data-test-dropdown-menu': item,
+            }))}
+            onSelect={(_e, value: string) => runOrNavigate(value)}
           />
         </div>
       );

--- a/frontend/public/components/factory/list-page.tsx
+++ b/frontend/public/components/factory/list-page.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as _ from 'lodash-es';
-import { css } from '@patternfly/react-styles';
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import { useParams, useNavigate } from 'react-router-dom-v5-compat';
@@ -23,7 +22,6 @@ import { ErrorPage404 } from '../error';
 import { K8sKind } from '../../module/k8s/types';
 import { getReferenceForModel as referenceForModel } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';
 import { Selector } from '@console/dynamic-plugin-sdk/src/api/common-types';
-import { Dropdown } from '../utils/dropdown';
 import { Firehose } from '../utils/firehose';
 import {
   FirehoseResource,
@@ -39,6 +37,7 @@ import {
 import { RequireCreatePermission } from '../utils/rbac';
 import { FilterToolbar, RowFilter } from '../filter-toolbar';
 import ListPageHeader from './ListPage/ListPageHeader';
+import { SimpleDropdown } from '@patternfly/react-templates';
 
 type CreateProps = {
   action?: string;
@@ -279,15 +278,20 @@ export const FireMan: React.FC<FireManProps & { filterList?: typeof filterList }
       );
     } else if (createProps.items) {
       createLink = (
-        <Dropdown
-          buttonClassName="pf-m-primary"
-          id="item-create"
-          dataTest="item-create"
-          menuClassName={css({ 'prevent-overflow': title })}
-          title={createButtonText}
-          noSelection
-          items={createProps.items}
-          onChange={runOrNavigate}
+        <SimpleDropdown
+          toggleProps={{
+            variant: 'primary',
+            id: 'item-create',
+            // @ts-expect-error non-prop attribute is used for cypress
+            'data-test': 'item-create',
+          }}
+          toggleContent={createButtonText}
+          initialItems={Object.keys(createProps.items).map((item) => ({
+            value: item,
+            content: createProps.items[item],
+            'data-test-dropdown-menu': item,
+          }))}
+          onSelect={(_e, value: string) => runOrNavigate(value)}
         />
       );
     } else {


### PR DESCRIPTION
Broken off from https://github.com/openshift/console/pull/15284 as I realize that PR is getting kind of big

Removes all usage of the `noSelection` prop from the old `Dropdown` and replaces them with `@patternfly/react-templates`. 

This way, `ConsoleSelect` will not also double as `ConsoleDropdown` :p 

qe review:
/assign @yapei 

/label px-approved
/label docs-approved

code review:
/assign @rhamilto 
