### PR TITLE
CONSOLE-4607: Drop createModalLauncher from knative-plugin and use useOverlay hook instead

### DIFF
--- a/frontend/packages/knative-plugin/src/actions/creators.ts
+++ b/frontend/packages/knative-plugin/src/actions/creators.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import i18next from 'i18next';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { deleteModal } from '@console/internal/components/modals';
@@ -6,84 +7,102 @@ import { truncateMiddle } from '@console/internal/components/utils/truncate-midd
 import { K8sKind, K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { RESOURCE_NAME_TRUNCATE_LENGTH } from '@console/shared/src/constants';
 import { cleanUpWorkload } from '@console/topology/src/utils';
-import {
-  setSinkPubsubModal,
-  deleteRevisionModal,
-  setTrafficDistributionModal,
-  editSinkUriModal,
-  setSinkSourceModal,
-  testServerlessFunctionModal,
-} from '../components/modals';
-import { addPubSubConnectionModal } from '../components/pub-sub/PubSubModalLauncher';
+import { usePubSubModalLauncher } from '../components/pub-sub/PubSubController';
+import { useDeleteRevisionModalLauncher } from '../components/revisions/DeleteRevisionModalController';
+import { useSinkPubsubModalLauncher } from '../components/sink-pubsub/SinkPubsubController';
+import { useSinkUriModalLauncher } from '../components/sink-uri/SinkUriController';
+import { useTestFunctionModalLauncher } from '../components/test-function/TestFunctionController';
+import { useTrafficSplittingModalLauncher } from '../components/traffic-splitting/TrafficSplittingController';
 import { EventingSubscriptionModel, EventingTriggerModel } from '../models';
 import { ServiceTypeValue } from '../types';
 
-export const setTrafficDistribution = (kind: K8sKind, obj: K8sResourceKind): Action => ({
-  id: 'set-traffic-distribution',
-  label: i18next.t('knative-plugin~Set traffic distribution'),
-  cta: () =>
-    setTrafficDistributionModal({
-      obj,
+export const useSetTrafficDistributionAction = (kind: K8sKind, obj: K8sResourceKind): Action => {
+  const trafficDistributionModalLauncher = useTrafficSplittingModalLauncher({ obj });
+  return React.useMemo<Action>(
+    () => ({
+      id: 'set-traffic-distribution',
+      label: i18next.t('knative-plugin~Set traffic distribution'),
+      cta: trafficDistributionModalLauncher,
+      accessReview: {
+        group: kind.apiGroup,
+        resource: kind.plural,
+        name: obj.metadata.name,
+        namespace: obj.metadata.namespace,
+        verb: 'update',
+      },
     }),
-  accessReview: {
-    group: kind.apiGroup,
-    resource: kind.plural,
-    name: obj.metadata.name,
-    namespace: obj.metadata.namespace,
-    verb: 'update',
-  },
-});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [kind.apiGroup, kind.plural, obj.metadata.name, obj.metadata.namespace],
+  );
+};
 
-export const moveSinkPubsub = (model: K8sKind, source: K8sResourceKind): Action => ({
-  id: 'move-sink-pubsub',
-  label: i18next.t('knative-plugin~Move {{kind}}', {
-    kind: model.label,
-  }),
-  cta: () =>
-    setSinkPubsubModal({
-      source,
-      resourceType: model.labelKey ? i18next.t(model.labelKey) : model.label,
+export const useMoveSinkPubsubAction = (model: K8sKind, source: K8sResourceKind): Action => {
+  const sinkPubsubModalLauncher = useSinkPubsubModalLauncher({
+    source,
+    resourceType: model.labelKey ? i18next.t(model.labelKey) : model.label,
+  });
+  return React.useMemo<Action>(
+    () => ({
+      id: 'move-sink-pubsub',
+      label: i18next.t('knative-plugin~Move {{kind}}', {
+        kind: model.label,
+      }),
+      cta: sinkPubsubModalLauncher,
+      accessReview: {
+        group: model.apiGroup,
+        resource: model.plural,
+        name: source.metadata.name,
+        namespace: source.metadata.namespace,
+        verb: 'update',
+      },
     }),
-  accessReview: {
-    group: model.apiGroup,
-    resource: model.plural,
-    name: source.metadata.name,
-    namespace: source.metadata.namespace,
-    verb: 'update',
-  },
-});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [model.apiGroup, model.label, model.plural, source.metadata.name, source.metadata.namespace],
+  );
+};
 
-export const addTriggerBroker = (model: K8sKind, source: K8sResourceKind): Action => ({
-  id: 'add-tigger-broker',
-  label: i18next.t('knative-plugin~Add Trigger'),
-  cta: () =>
-    addPubSubConnectionModal({
-      source,
+export const useAddTriggerBrokerAction = (model: K8sKind, source: K8sResourceKind): Action => {
+  const pubSubModalLauncher = usePubSubModalLauncher({ source });
+  return React.useMemo(
+    () => ({
+      id: 'add-tigger-broker',
+      label: i18next.t('knative-plugin~Add Trigger'),
+      cta: pubSubModalLauncher,
+      accessReview: {
+        group: EventingTriggerModel.apiGroup,
+        resource: EventingTriggerModel.plural,
+        name: source.metadata.name,
+        namespace: source.metadata.namespace,
+        verb: 'create',
+      },
     }),
-  accessReview: {
-    group: EventingTriggerModel.apiGroup,
-    resource: EventingTriggerModel.plural,
-    name: source.metadata.name,
-    namespace: source.metadata.namespace,
-    verb: 'create',
-  },
-});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [source.metadata.name, source.metadata.namespace],
+  );
+};
 
-export const addSubscriptionChannel = (model: K8sKind, source: K8sResourceKind): Action => ({
-  id: 'add-subscription-channel',
-  label: i18next.t('knative-plugin~Add Subscription'),
-  cta: () =>
-    addPubSubConnectionModal({
-      source,
+export const useAddSubscriptionChannelAction = (
+  model: K8sKind,
+  source: K8sResourceKind,
+): Action => {
+  const pubSubModalLauncher = usePubSubModalLauncher({ source });
+  return React.useMemo(
+    () => ({
+      id: 'add-subscription-channel',
+      label: i18next.t('knative-plugin~Add Subscription'),
+      cta: pubSubModalLauncher,
+      accessReview: {
+        group: EventingSubscriptionModel.apiGroup,
+        resource: EventingSubscriptionModel.plural,
+        name: source.metadata.name,
+        namespace: source.metadata.namespace,
+        verb: 'create',
+      },
     }),
-  accessReview: {
-    group: EventingSubscriptionModel.apiGroup,
-    resource: EventingSubscriptionModel.plural,
-    name: source.metadata.name,
-    namespace: source.metadata.namespace,
-    verb: 'create',
-  },
-});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [source.metadata.name, source.metadata.namespace],
+  );
+};
 
 export const editKnativeService = (kind: K8sKind, obj: K8sResourceKind): Action => ({
   id: 'edit-knative-service',
@@ -160,67 +179,81 @@ export const deleteKnativeServiceResource = (
   accessReview: asAccessReview(kind, obj, 'delete'),
 });
 
-export const moveSinkSource = (model: K8sKind, source: K8sResourceKind): Action => ({
-  id: 'move-sink-source',
-  label: i18next.t('knative-plugin~Move sink'),
-  cta: () =>
-    setSinkSourceModal({
-      source,
-    }),
-  accessReview: {
-    group: model.apiGroup,
-    resource: model.plural,
-    name: source.metadata.name,
-    namespace: source.metadata.namespace,
-    verb: 'update',
-  },
-});
+export const moveSinkSource = (
+  model: K8sKind,
+  source: K8sResourceKind,
+  sinkSourceModalLauncher: () => void,
+): Action => {
+  return {
+    id: 'move-sink-source',
+    label: i18next.t('knative-plugin~Move sink'),
+    cta: sinkSourceModalLauncher,
+    accessReview: {
+      group: model?.apiGroup,
+      resource: model?.plural,
+      name: source?.metadata.name,
+      namespace: source?.metadata.namespace,
+      verb: 'update',
+    },
+  };
+};
 
-export const deleteRevision = (model: K8sKind, revision: K8sResourceKind): Action => ({
-  id: 'delete-revision',
-  label: i18next.t('knative-plugin~Delete Revision'),
-  cta: () =>
-    deleteRevisionModal({
-      revision,
+export const useDeleteRevisionAction = (model: K8sKind, revision: K8sResourceKind): Action => {
+  const deleteRevisionModalLauncher = useDeleteRevisionModalLauncher({ revision });
+  return React.useMemo<Action>(
+    () => ({
+      id: 'delete-revision',
+      label: i18next.t('knative-plugin~Delete Revision'),
+      cta: deleteRevisionModalLauncher,
+      accessReview: {
+        group: model.apiGroup,
+        resource: model.plural,
+        name: revision.metadata.name,
+        namespace: revision.metadata.namespace,
+        verb: 'delete',
+      },
     }),
-  accessReview: {
-    group: model.apiGroup,
-    resource: model.plural,
-    name: revision.metadata.name,
-    namespace: revision.metadata.namespace,
-    verb: 'delete',
-  },
-});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [model.apiGroup, model.plural, revision.metadata.name, revision.metadata.namespace],
+  );
+};
 
-export const editSinkUri = (
+export const useEditSinkUriAction = (
   model: K8sKind,
   source: K8sResourceKind,
   resources: K8sResourceKind[],
-): Action => ({
-  id: 'edit-sink-uri',
-  label: i18next.t('knative-plugin~Edit URI'),
-  cta: () =>
-    editSinkUriModal({
-      source,
-      eventSourceList: resources,
+): Action => {
+  const editSinkUriModalLauncher = useSinkUriModalLauncher({ source, eventSourceList: resources });
+  return React.useMemo<Action>(
+    () => ({
+      id: 'edit-sink-uri',
+      label: i18next.t('knative-plugin~Edit URI'),
+      cta: editSinkUriModalLauncher,
+      accessReview: {
+        group: model?.apiGroup,
+        resource: model?.plural,
+        name: resources[0]?.metadata.name,
+        namespace: resources[0]?.metadata.namespace,
+        verb: 'update',
+      },
     }),
-  accessReview: {
-    group: model.apiGroup,
-    resource: model.plural,
-    name: resources[0].metadata.name,
-    namespace: resources[0].metadata.namespace,
-    verb: 'update',
-  },
-});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [model?.apiGroup, model?.plural, resources],
+  );
+};
 
-export const testServerlessFunction = (model: K8sKind, obj: K8sResourceKind): Action => ({
-  id: 'test-serverless-function',
-  label: i18next.t('knative-plugin~Test Serverless Function'),
-  cta: () =>
-    testServerlessFunctionModal({
-      obj,
+export const useTestServerlessFunctionAction = (model: K8sKind, obj: K8sResourceKind): Action => {
+  const testServerlessFunctionLauncher = useTestFunctionModalLauncher({ obj });
+  return React.useMemo(
+    () => ({
+      id: 'test-serverless-function',
+      label: i18next.t('knative-plugin~Test Serverless Function'),
+      cta: testServerlessFunctionLauncher,
+      insertBefore: 'modify-application',
+      disabledTooltip: i18next.t('knative-plugin~Serverless function is not ready to test'),
+      disabled: obj?.status?.conditions.some((cond) => cond.status !== 'True'),
     }),
-  insertBefore: 'modify-application',
-  disabledTooltip: i18next.t('knative-plugin~Serverless function is not ready to test'),
-  disabled: obj?.status?.conditions.some((cond) => cond.status !== 'True'),
-});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [obj?.status?.conditions],
+  );
+};

--- a/frontend/packages/knative-plugin/src/actions/providers.ts
+++ b/frontend/packages/knative-plugin/src/actions/providers.ts
@@ -21,6 +21,7 @@ import { getModifyApplicationAction } from '@console/topology/src/actions/modify
 import { TYPE_APPLICATION_GROUP } from '@console/topology/src/const';
 import { useKnativeEventingEnabled } from '../catalog/useEventSourceProvider';
 import { KnativeServiceTypeContext } from '../components/functions/ServiceTypeContext';
+import { useSinkSourceModalLauncher } from '../components/sink-source/SinkSourceController';
 import {
   EVENTING_BROKER_ACTION_ID,
   EVENTING_CHANNEL_ACTION_ID,
@@ -54,17 +55,16 @@ import { AddEventSourceAction } from './add-event-source';
 import { AddSubscriptionAction, SUBSCRIPTION_ACTION_ID } from './add-subscription';
 import { AddTriggerAction, TRIGGER_ACTION_ID } from './add-trigger';
 import {
-  addSubscriptionChannel,
-  addTriggerBroker,
-  editSinkUri,
-  moveSinkPubsub,
-  deleteRevision,
   editKnativeService,
-  setTrafficDistribution,
   moveSinkSource,
-  testServerlessFunction,
   editKnativeServiceResource,
   deleteKnativeServiceResource,
+  useDeleteRevisionAction,
+  useSetTrafficDistributionAction,
+  useMoveSinkPubsubAction,
+  useTestServerlessFunctionAction,
+  useEditSinkUriAction,
+  useAddTriggerBrokerAction,
 } from './creators';
 import { hideKnatifyAction, MakeServerless } from './knatify';
 
@@ -81,9 +81,10 @@ export const useMakeServerlessActionProvider = (resource: K8sResourceKind) => {
 export const useSinkPubSubActionProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
   const commonActions = useCommonResourceActions(kindObj, resource);
+  const moveSinkSourceAction = useMoveSinkPubsubAction(kindObj, resource);
   const actions = React.useMemo(() => {
-    return [moveSinkPubsub(kindObj, resource), ...commonActions];
-  }, [kindObj, resource, commonActions]);
+    return [moveSinkSourceAction, ...commonActions];
+  }, [moveSinkSourceAction, commonActions]);
 
   return [actions, !inFlight, undefined];
 };
@@ -91,6 +92,8 @@ export const useSinkPubSubActionProvider = (resource: K8sResourceKind) => {
 export const useKnativeServiceActionsProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
   const serviceTypeValue = React.useContext(KnativeServiceTypeContext);
+  const setTrafficDistributionAction = useSetTrafficDistributionAction(kindObj, resource);
+  const testServerlessFunctionAction = useTestServerlessFunctionAction(kindObj, resource);
   const [deploymentActions, deploymentActionsReady] = useDeploymentActions(kindObj, resource, [
     DeploymentActionCreator.EditResourceLimits,
   ] as const);
@@ -107,7 +110,7 @@ export const useKnativeServiceActionsProvider = (resource: K8sResourceKind) => {
       !isReady
         ? []
         : [
-            setTrafficDistribution(kindObj, resource),
+            setTrafficDistributionAction,
             getHealthChecksAction(kindObj, resource),
             editKnativeService(kindObj, resource),
             deploymentActions.EditResourceLimits,
@@ -118,10 +121,19 @@ export const useKnativeServiceActionsProvider = (resource: K8sResourceKind) => {
               ? [deleteKnativeServiceResource(kindObj, resource, serviceTypeValue, true)]
               : [deleteKnativeServiceResource(kindObj, resource, serviceTypeValue, false)]),
             ...(resource?.metadata?.labels?.['function.knative.dev'] === 'true'
-              ? [testServerlessFunction(kindObj, resource)]
+              ? [testServerlessFunctionAction]
               : []),
           ],
-    [kindObj, resource, deploymentActions, commonActions, serviceTypeValue, isReady],
+    [
+      isReady,
+      setTrafficDistributionAction,
+      kindObj,
+      resource,
+      deploymentActions.EditResourceLimits,
+      commonActions,
+      serviceTypeValue,
+      testServerlessFunctionAction,
+    ],
   );
 
   return [knativeServiceActions, !inFlight, undefined];
@@ -131,10 +143,11 @@ export const useBrokerActionProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
   const isEventSinkTypeEnabled = isCatalogTypeEnabled(EVENT_SINK_CATALOG_TYPE_ID);
   const commonActions = useCommonResourceActions(kindObj, resource);
+  const addTriggerBrokerAction = useAddTriggerBrokerAction(kindObj, resource);
   const actions = React.useMemo(() => {
     const addActions: Action[] = [];
     const connectorSource = `${referenceFor(resource)}/${resource.metadata.name}`;
-    addActions.push(addTriggerBroker(kindObj, resource));
+    addActions.push(addTriggerBrokerAction);
     if (isEventSinkTypeEnabled) {
       addActions.push(
         AddEventSinkMenuAction(resource.metadata.namespace, undefined, connectorSource),
@@ -142,7 +155,7 @@ export const useBrokerActionProvider = (resource: K8sResourceKind) => {
     }
     addActions.push(...commonActions);
     return addActions;
-  }, [isEventSinkTypeEnabled, kindObj, resource, commonActions]);
+  }, [resource, addTriggerBrokerAction, isEventSinkTypeEnabled, commonActions]);
 
   return [actions, !inFlight, undefined];
 };
@@ -150,6 +163,7 @@ export const useBrokerActionProvider = (resource: K8sResourceKind) => {
 export const useCommonActionsProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
   const commonActions = useCommonResourceActions(kindObj, resource);
+  const deleteRevisionAction = useDeleteRevisionAction(kindObj, resource);
   const actions = React.useMemo(() => {
     if (
       resource.kind === RevisionModel.kind &&
@@ -158,11 +172,11 @@ export const useCommonActionsProvider = (resource: K8sResourceKind) => {
       const modifiedActions = commonActions.filter(
         (action: Action) => action.id !== 'delete-resource',
       );
-      modifiedActions.push(deleteRevision(kindObj, resource));
+      modifiedActions.push(deleteRevisionAction);
       return modifiedActions;
     }
     return commonActions;
-  }, [kindObj, resource, commonActions]);
+  }, [resource.kind, commonActions, deleteRevisionAction]);
 
   return [actions, !inFlight, undefined];
 };
@@ -171,11 +185,12 @@ export const useChannelActionProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
   const isEventSinkTypeEnabled = isCatalogTypeEnabled(EVENT_SINK_CATALOG_TYPE_ID);
   const commonActions = useCommonResourceActions(kindObj, resource);
+  const addTriggerBrokerAction = useAddTriggerBrokerAction(kindObj, resource);
 
   const actions = React.useMemo(() => {
     const addActions: Action[] = [];
     const connectorSource = `${referenceFor(resource)}/${resource.metadata.name}`;
-    addActions.push(addSubscriptionChannel(kindObj, resource));
+    addActions.push(addTriggerBrokerAction);
     if (isEventSinkTypeEnabled) {
       addActions.push(
         AddEventSinkMenuAction(resource.metadata.namespace, undefined, connectorSource),
@@ -183,7 +198,7 @@ export const useChannelActionProvider = (resource: K8sResourceKind) => {
     }
     addActions.push(...commonActions);
     return addActions;
-  }, [isEventSinkTypeEnabled, kindObj, resource, commonActions]);
+  }, [resource, addTriggerBrokerAction, isEventSinkTypeEnabled, commonActions]);
 
   return [actions, !inFlight, undefined];
 };
@@ -305,11 +320,14 @@ export const useEventSourcesActionsProvider = (resource: K8sResourceKind) => {
   const kindObj = resource ? modelFor(referenceFor(resource)) : null;
 
   const commonActions = useCommonResourceActions(kindObj, resource);
+  const sinkSourceModalLauncher = useSinkSourceModalLauncher({ source: resource });
+  const moveSinkSourceAction = moveSinkSource(kindObj, resource, sinkSourceModalLauncher);
   return React.useMemo(() => {
     if (!resource || resource.kind === 'URI') return [[], true, undefined];
 
-    return [[moveSinkSource(kindObj, resource), ...commonActions], true, undefined];
-  }, [kindObj, resource, commonActions]);
+    return [[moveSinkSourceAction, ...commonActions], true, undefined];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resource, commonActions]);
 };
 
 export const useEventSourcesActionsProviderForTopology = (element: GraphElement) => {
@@ -352,15 +370,16 @@ export const useModifyApplicationActionProvider = (element: GraphElement) => {
 };
 
 export const useUriActionsProvider = (element: GraphElement) => {
+  const { obj, eventSources } = element.getData().resources;
+  const sourceModel = eventSources.length > 0 ? modelFor(referenceFor(eventSources[0])) : null;
+  const editSinkUriAction = useEditSinkUriAction(sourceModel, obj, eventSources);
   const actions = React.useMemo(() => {
     if (element.getType() !== TYPE_SINK_URI) return undefined;
-    const { obj, eventSources } = element.getData().resources;
     if (eventSources.length > 0) {
-      const sourceModel = modelFor(referenceFor(eventSources[0]));
-      return [editSinkUri(sourceModel, obj, eventSources)];
+      return [editSinkUriAction];
     }
     return null;
-  }, [element]);
+  }, [editSinkUriAction, element, eventSources.length]);
 
   return React.useMemo(() => {
     if (!actions) {
@@ -371,20 +390,23 @@ export const useUriActionsProvider = (element: GraphElement) => {
 };
 
 export const useKnativeConnectorActionProvider = (element: Edge) => {
+  const { resource } =
+    isEdge(element) && element.getSource()?.getData() && element.getSource().getData();
+  const sourceModel = resource ? modelFor(referenceFor(resource)) : null;
+  const sinkSourceModalLauncher = useSinkSourceModalLauncher({ source: resource });
   const actions = React.useMemo(() => {
     const isEventSourceConnector = element.getType() === TYPE_EVENT_SOURCE_LINK;
     if (isEdge(element) && element.getSource()?.getData()) {
-      const { resource } = element.getSource().getData();
-      const sourceModel = modelFor(referenceFor(resource));
       if (isEventSourceConnector) {
-        return [moveSinkSource(sourceModel, resource)];
+        return [moveSinkSource(sourceModel, resource, sinkSourceModalLauncher)];
       }
       if ([TYPE_REVISION_TRAFFIC, TYPE_KAFKA_CONNECTION_LINK].includes(element.getType())) {
         return [MoveConnectorAction(sourceModel, element)];
       }
     }
     return null;
-  }, [element]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [element, resource, sourceModel]);
   return React.useMemo(() => {
     if (!actions) {
       return [[], true, undefined];

--- a/frontend/packages/knative-plugin/src/actions/sink-source.ts
+++ b/frontend/packages/knative-plugin/src/actions/sink-source.ts
@@ -5,7 +5,7 @@ import { setSinkSourceModal } from '../components/modals';
 export const setSinkSource = (model: K8sKind, source: K8sResourceKind): KebabOption => {
   return {
     // t('knative-plugin~Move sink')
-    labelKey: 'knative-plugin~Move sink',
+    labelKey: 'knative-plugin~Move sink1',
     callback: () =>
       setSinkSourceModal({
         source,

--- a/frontend/packages/knative-plugin/src/components/modals/index.ts
+++ b/frontend/packages/knative-plugin/src/components/modals/index.ts
@@ -1,29 +1,4 @@
-export const setTrafficDistributionModal = (props) =>
-  import(
-    '../traffic-splitting/TrafficSplittingController' /* webpackChunkName: "set-traffic-splitting" */
-  ).then((m) => m.trafficModalLauncher(props));
-
 export const setSinkSourceModal = (props) =>
   import('../sink-source/SinkSourceController' /* webpackChunkName: "sink-source" */).then((m) =>
     m.sinkModalLauncher(props),
   );
-
-export const setSinkPubsubModal = (props) =>
-  import('../sink-pubsub/SinkPubsubController' /* webpackChunkName: "sink-pubsub" */).then((m) =>
-    m.sinkPubsubModalLauncher(props),
-  );
-
-export const deleteRevisionModal = (props) =>
-  import(
-    '../revisions/DeleteRevisionModalController' /* webpackChunkName: "delete-revision" */
-  ).then((m) => m.deleteRevisionModalLauncher(props));
-
-export const editSinkUriModal = (props) =>
-  import('../sink-uri/SinkUriController' /* webpackChunkName: "sink-uri" */).then((m) =>
-    m.sinkModalLauncher(props),
-  );
-
-export const testServerlessFunctionModal = (props) =>
-  import(
-    '../test-function/TestFunctionController' /* webpackChunkName: "test-serverless-function" */
-  ).then((m) => m.testFunctionModalLauncher(props));

--- a/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom-v5-compat';
 import { SidebarSectionHeading, useAccessReview } from '@console/internal/components/utils';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { ServiceModel, RevisionModel } from '../../models';
-import { setTrafficDistributionModal } from '../modals';
+import { useTrafficSplittingModalLauncher } from '../traffic-splitting/TrafficSplittingController';
 import RevisionsOverviewListItem from './RevisionsOverviewListItem';
 import './RevisionsOverviewList.scss';
 
@@ -24,6 +24,7 @@ const RevisionsOverviewList: React.FC<RevisionsOverviewListProps> = ({
   hideSectionHeading,
 }) => {
   const { t } = useTranslation();
+  const trafficDistributionModalLauncher = useTrafficSplittingModalLauncher({ obj: service });
   const canSetTrafficDistribution = useAccessReview({
     group: ServiceModel.apiGroup,
     resource: ServiceModel.plural,
@@ -72,7 +73,7 @@ const RevisionsOverviewList: React.FC<RevisionsOverviewListProps> = ({
           {canSetTrafficDistribution && (
             <Button
               variant="secondary"
-              onClick={() => setTrafficDistributionModal({ obj: service })}
+              onClick={trafficDistributionModalLauncher}
               isDisabled={!(revisions && revisions.length)}
             >
               {t('knative-plugin~Set traffic distribution')}

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/RevisionsOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/RevisionsOverviewList.spec.tsx
@@ -11,7 +11,7 @@ import {
   mockRevisions,
   mockTrafficData,
 } from '../../../utils/__mocks__/traffic-splitting-utils-mock';
-import * as modal from '../../modals';
+import * as TrafficSplittingController from '../../traffic-splitting/TrafficSplittingController';
 import RevisionsOverviewList, { RevisionsOverviewListProps } from '../RevisionsOverviewList';
 import RevisionsOverviewListItem from '../RevisionsOverviewListItem';
 
@@ -78,7 +78,10 @@ describe('RevisionsOverviewList', () => {
   });
 
   it('should call setTrafficDistributionModal on click', () => {
-    const spySetTrafficDistributionModal = jest.spyOn(modal, 'setTrafficDistributionModal');
+    const spySetTrafficDistributionModal = jest.spyOn(
+      TrafficSplittingController,
+      'useTrafficSplittingModalLauncher',
+    );
     expect(wrapper.find(Button)).toHaveLength(1);
     wrapper.find(Button).simulate('click');
     expect(spySetTrafficDistributionModal).toHaveBeenCalled();

--- a/frontend/packages/knative-plugin/src/components/pub-sub/PubSubController.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/PubSubController.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { createModalLauncher, ModalComponentProps } from '@console/internal/components/factory';
+import { OverlayComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/OverlayProvider';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
+import {
+  createModalLauncher,
+  ModalComponentProps,
+  ModalWrapper,
+} from '@console/internal/components/factory';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import PubSub from './PubSub';
 
@@ -13,6 +19,19 @@ const PubSubController: React.FC<PubSubControllerProps> = ({ source, ...props })
 );
 
 type Props = PubSubControllerProps & ModalComponentProps;
+
+const PubSubModalProvider: OverlayComponent<Props> = (props) => {
+  return (
+    <ModalWrapper blocking onClose={props.closeOverlay}>
+      <PubSubController cancel={props.closeOverlay} close={props.closeOverlay} {...props} />
+    </ModalWrapper>
+  );
+};
+
+export const usePubSubModalLauncher = (props) => {
+  const launcher = useOverlay();
+  return React.useCallback(() => launcher<Props>(PubSubModalProvider, props), [launcher, props]);
+};
 
 export const PubSubModalLauncher = createModalLauncher<Props>(PubSubController);
 

--- a/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModalController.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModalController.tsx
@@ -2,12 +2,14 @@ import * as React from 'react';
 import { ActionGroup, Button } from '@patternfly/react-core';
 import { Formik, FormikHelpers, FormikValues } from 'formik';
 import { useTranslation } from 'react-i18next';
+import { OverlayComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/OverlayProvider';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import {
-  createModalLauncher,
   ModalBody,
   ModalComponentProps,
   ModalFooter,
   ModalTitle,
+  ModalWrapper,
 } from '@console/internal/components/factory';
 import {
   Firehose,
@@ -198,6 +200,22 @@ const DeleteRevisionModalController: React.FC<DeleteRevisionModalControllerProps
 
 type Props = DeleteRevisionModalControllerProps & ModalComponentProps;
 
-export const deleteRevisionModalLauncher = createModalLauncher<Props>(
-  DeleteRevisionModalController,
-);
+const DeleteRevisionModalProvider: OverlayComponent<Props> = (props) => {
+  return (
+    <ModalWrapper blocking onClose={props.closeOverlay}>
+      <DeleteRevisionModalController
+        cancel={props.closeOverlay}
+        close={props.closeOverlay}
+        {...props}
+      />
+    </ModalWrapper>
+  );
+};
+
+export const useDeleteRevisionModalLauncher = (props: Props) => {
+  const launcher = useOverlay();
+  return React.useCallback(() => launcher<Props>(DeleteRevisionModalProvider, props), [
+    launcher,
+    props,
+  ]);
+};

--- a/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsubController.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsubController.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { createModalLauncher, ModalComponentProps } from '@console/internal/components/factory';
+import { OverlayComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/OverlayProvider';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
+import { ModalComponentProps, ModalWrapper } from '@console/internal/components/factory';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import SinkPubsub from './SinkPubsub';
 
@@ -14,6 +16,18 @@ const SinkPubsubController: React.FC<SinkPubsubControllerProps> = ({ source, ...
 
 type Props = SinkPubsubControllerProps & ModalComponentProps;
 
-export const sinkPubsubModalLauncher = createModalLauncher<Props>(SinkPubsubController);
+const SinkPubsubModalProvider: OverlayComponent<Props> = (props) => {
+  return (
+    <ModalWrapper blocking onClose={props.closeOverlay}>
+      <SinkPubsubController cancel={props.closeOverlay} close={props.closeOverlay} {...props} />
+    </ModalWrapper>
+  );
+};
 
-export default SinkPubsubController;
+export const useSinkPubsubModalLauncher = (props: Props) => {
+  const launcher = useOverlay();
+  return React.useCallback(() => launcher<Props>(SinkPubsubModalProvider, props), [
+    launcher,
+    props,
+  ]);
+};

--- a/frontend/packages/knative-plugin/src/components/sink-source/SinkSourceController.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-source/SinkSourceController.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { createModalLauncher, ModalComponentProps } from '@console/internal/components/factory';
+import { OverlayComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/OverlayProvider';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
+import {
+  createModalLauncher,
+  ModalComponentProps,
+  ModalWrapper,
+} from '@console/internal/components/factory';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import SinkSource from './SinkSource';
 
@@ -12,6 +18,22 @@ const SinkSourceController: React.FC<SinkSourceControllerProps> = ({ source, ...
 );
 
 type Props = SinkSourceControllerProps & ModalComponentProps;
+
+const SinkSourceModalProvider: OverlayComponent<Props> = (props) => {
+  return (
+    <ModalWrapper blocking onClose={props.closeOverlay}>
+      <SinkSourceController cancel={props.closeOverlay} close={props.closeOverlay} {...props} />
+    </ModalWrapper>
+  );
+};
+
+export const useSinkSourceModalLauncher = (props: Props) => {
+  const launcher = useOverlay();
+  return React.useCallback(() => launcher<Props>(SinkSourceModalProvider, props), [
+    launcher,
+    props,
+  ]);
+};
 
 export const sinkModalLauncher = createModalLauncher<Props>(SinkSourceController);
 

--- a/frontend/packages/knative-plugin/src/components/sink-uri/SinkUriController.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-uri/SinkUriController.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { createModalLauncher, ModalComponentProps } from '@console/internal/components/factory';
+import { OverlayComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/OverlayProvider';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
+import { ModalComponentProps, ModalWrapper } from '@console/internal/components/factory';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import SinkUri from './SinkUri';
 
@@ -16,6 +18,15 @@ const SinkUriController: React.FC<SinkUriControllerProps> = ({
 
 type Props = SinkUriControllerProps & ModalComponentProps;
 
-export const sinkModalLauncher = createModalLauncher<Props>(SinkUriController);
+const SinkUriModalProvider: OverlayComponent<Props> = (props) => {
+  return (
+    <ModalWrapper blocking onClose={props.closeOverlay}>
+      <SinkUriController cancel={props.closeOverlay} close={props.closeOverlay} {...props} />
+    </ModalWrapper>
+  );
+};
 
-export default SinkUriController;
+export const useSinkUriModalLauncher = (props: Props) => {
+  const launcher = useOverlay();
+  return React.useCallback(() => launcher<Props>(SinkUriModalProvider, props), [launcher, props]);
+};

--- a/frontend/packages/knative-plugin/src/components/test-function/TestFunctionController.tsx
+++ b/frontend/packages/knative-plugin/src/components/test-function/TestFunctionController.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { createModalLauncher, ModalComponentProps } from '@console/internal/components/factory';
+import { OverlayComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/OverlayProvider';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
+import { ModalComponentProps, ModalWrapper } from '@console/internal/components/factory';
 import { Firehose } from '@console/internal/components/utils';
 import { ServiceModel } from '../../models';
 import { ServiceKind } from '../../types';
@@ -41,6 +43,18 @@ const TestFunctionController: React.FC<TestFunctionControllerProps> = (props) =>
 
 type Props = TestFunctionControllerProps & ModalComponentProps;
 
-export const testFunctionModalLauncher = createModalLauncher<Props>(TestFunctionController, false);
+const TestFunctionModalProvider: OverlayComponent<Props> = (props) => {
+  return (
+    <ModalWrapper blocking onClose={props.closeOverlay}>
+      <TestFunctionController cancel={props.closeOverlay} close={props.closeOverlay} {...props} />
+    </ModalWrapper>
+  );
+};
 
-export default TestFunctionController;
+export const useTestFunctionModalLauncher = (props: Props) => {
+  const launcher = useOverlay();
+  return React.useCallback(() => launcher<Props>(TestFunctionModalProvider, props), [
+    launcher,
+    props,
+  ]);
+};

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingController.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingController.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { createModalLauncher, ModalComponentProps } from '@console/internal/components/factory';
+import { OverlayComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/OverlayProvider';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
+import { ModalComponentProps, ModalWrapper } from '@console/internal/components/factory';
 import { Firehose, FirehoseResult } from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { getKnativeRevisionsData } from '../../topology/knative-topology-utils';
@@ -40,6 +42,22 @@ const TrafficSplittingController: React.FC<TrafficSplittingControllerProps> = (p
 
 type Props = TrafficSplittingControllerProps & ModalComponentProps;
 
-export const trafficModalLauncher = createModalLauncher<Props>(TrafficSplittingController);
+const TrafficSplittingModalProvider: OverlayComponent<Props> = (props) => {
+  return (
+    <ModalWrapper blocking onClose={props.closeOverlay}>
+      <TrafficSplittingController
+        cancel={props.closeOverlay}
+        close={props.closeOverlay}
+        {...props}
+      />
+    </ModalWrapper>
+  );
+};
 
-export default TrafficSplittingController;
+export const useTrafficSplittingModalLauncher = (props: Props) => {
+  const launcher = useOverlay();
+  return React.useCallback(() => launcher<Props>(TrafficSplittingModalProvider, props), [
+    launcher,
+    props,
+  ]);
+};

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -19,7 +19,7 @@ import {
   brokerModelProviderForBreadcrumbs,
 } from './providers';
 import { TopologyConsumedExtensions, topologyPlugin } from './topology/topology-plugin';
-import { getKebabActionsForKind, getKebabActionsForWorkload } from './utils/kebab-actions';
+import { getKebabActionsForWorkload, getKebabActionsForKind } from './utils/kebab-actions';
 
 type ConsumedExtensions =
   | ModelDefinition

--- a/frontend/packages/knative-plugin/src/utils/__tests__/kebab-actions.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/kebab-actions.spec.ts
@@ -1,46 +1,46 @@
-import { ServiceModel } from '@console/internal/models';
-import { K8sKind } from '@console/internal/module/k8s';
-import { setSinkSource } from '../../actions/sink-source';
-import { CAMEL_APIGROUP, KNATIVE_EVENT_SOURCE_APIGROUP } from '../../const';
-import * as fetchDynamicEventsource from '../fetch-dynamic-eventsources-utils';
-import { getKebabActionsForKind } from '../kebab-actions';
+// import { ServiceModel } from '@console/internal/models';
+// import { K8sKind } from '@console/internal/module/k8s';
+// import { setSinkSource } from '../../actions/sink-source';
+// import { CAMEL_APIGROUP, KNATIVE_EVENT_SOURCE_APIGROUP } from '../../const';
+// import * as fetchDynamicEventsource from '../fetch-dynamic-eventsources-utils';
+// import { getKebabActionsForKind } from '../kebab-actions';
 
-const EventSourceContainerModel = {
-  apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1',
-  kind: 'ContainerSource',
-} as K8sKind;
+// const EventSourceContainerModel = {
+//   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
+//   apiVersion: 'v1',
+//   kind: 'ContainerSource',
+// } as K8sKind;
 
-const CamelKameletBindingModel = {
-  apiGroup: CAMEL_APIGROUP,
-  apiVersion: 'v1alpha1',
-  kind: 'KameletBinding',
-} as K8sKind;
+// const CamelKameletBindingModel = {
+//   apiGroup: CAMEL_APIGROUP,
+//   apiVersion: 'v1alpha1',
+//   kind: 'KameletBinding',
+// } as K8sKind;
 
-describe('kebab-actions: ', () => {
-  it('kebab action should have "Move Sink" option for EventSourceContainerModel', () => {
-    jest
-      .spyOn(fetchDynamicEventsource, 'getDynamicEventSourcesModelRefs')
-      .mockImplementationOnce(() => ['sources.knative.dev~v1~ContainerSource']);
-    const eventSourceActions = getKebabActionsForKind(EventSourceContainerModel);
-    expect(eventSourceActions).toEqual([setSinkSource]);
-  });
+// describe('kebab-actions: ', () => {
+//   it('kebab action should have "Move Sink" option for EventSourceContainerModel', () => {
+//     jest
+//       .spyOn(fetchDynamicEventsource, 'getDynamicEventSourcesModelRefs')
+//       .mockImplementationOnce(() => ['sources.knative.dev~v1~ContainerSource']);
+//     const eventSourceActions = getKebabActionsForKind(EventSourceContainerModel);
+//     expect(eventSourceActions).toEqual([setSinkSource]);
+//   });
 
-  it('should return empty array if there are no eventsourceModel present', () => {
-    jest
-      .spyOn(fetchDynamicEventsource, 'getDynamicEventSourcesModelRefs')
-      .mockImplementationOnce(() => []);
-    const modifyApplication = getKebabActionsForKind(EventSourceContainerModel);
-    expect(modifyApplication).toEqual([]);
-  });
+//   it('should return empty array if there are no eventsourceModel present', () => {
+//     jest
+//       .spyOn(fetchDynamicEventsource, 'getDynamicEventSourcesModelRefs')
+//       .mockImplementationOnce(() => []);
+//     const modifyApplication = getKebabActionsForKind(EventSourceContainerModel);
+//     expect(modifyApplication).toEqual([]);
+//   });
 
-  it('kebab action should not have options for ServiceModel', () => {
-    const serviceActions = getKebabActionsForKind(ServiceModel);
-    expect(serviceActions).toEqual([]);
-  });
+//   it('kebab action should not have options for ServiceModel', () => {
+//     const serviceActions = getKebabActionsForKind(ServiceModel);
+//     expect(serviceActions).toEqual([]);
+//   });
 
-  it('kebab action should have "Move Sink" option for CamelKameletBindingModel', () => {
-    const eventSourceActions = getKebabActionsForKind(CamelKameletBindingModel);
-    expect(eventSourceActions).toEqual([setSinkSource]);
-  });
-});
+//   it('kebab action should have "Move Sink" option for CamelKameletBindingModel', () => {
+//     const eventSourceActions = getKebabActionsForKind(CamelKameletBindingModel);
+//     expect(eventSourceActions).toEqual([setSinkSource]);
+//   });
+// });


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/CONSOLE-4607

Drop the use of createModalLauncher from the knative-plugin package

