### PR TITLE
CONSOLE-4616: add additionalPrinterColumns to CustomResource list page

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-notification.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-notification.cy.ts
@@ -49,6 +49,20 @@ describe(`${crd} CRD`, () => {
       });
     });
 
+    cy.visit(`/k8s/cluster/console.openshift.io~v1~${crd}`);
+    listPage.rows.shouldBeLoaded();
+    cy.log('Additional printer columns should exist.');
+    cy.byTestID('has-additional-printer-columns').should('exist');
+    cy.byTestID('additional-printer-column-header-Text').should('have.text', 'Text');
+    cy.byTestID('additional-printer-column-data-Text').should('have.text', text);
+    cy.byTestID('additional-printer-column-header-Location').should('have.text', 'Location');
+    cy.byTestID('additional-printer-column-data-Location').should('have.text', location);
+    cy.byTestID('additional-printer-column-header-Age').should('have.text', 'Age');
+    cy.byTestID('additional-printer-column-data-Age').should('exist');
+    cy.log('Created date should not exist since Age does.');
+    cy.byTestID('column-header-Created').should('not.exist');
+    cy.byTestID('column-data-Created').should('not.exist');
+
     cy.visit(`/k8s/cluster/console.openshift.io~v1~${crd}/${name}`);
     detailsPage.isLoaded();
     detailsPage.titleShouldContain(name);

--- a/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-yaml-sample.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crd-extensions/console-yaml-sample.cy.ts
@@ -75,6 +75,14 @@ metadata:
       });
     });
 
+    cy.visit(`/k8s/cluster/console.openshift.io~v1~${crd}`);
+    listPage.rows.shouldBeLoaded();
+    cy.log('Additional printer columns should not exist.');
+    cy.byTestID('has-additional-printer-columns').should('not.exist');
+    cy.log('Created date should exist since Age does not.');
+    cy.byTestID('column-header-Created').should('exist');
+    cy.byTestID('column-data-Created').should('exist');
+
     // Check if ConsoleYAMLSample CR was created
     cy.visit(`/k8s/cluster/console.openshift.io~v1~${crd}/${name}`);
     detailsPage.isLoaded();

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -175,11 +175,12 @@ export const TableData: React.FC<TableDataProps> = ({
   className,
   columnID,
   columns,
+  dataTest,
   showNamespaceOverride,
   children,
 }) => {
   return isColumnVisible(window.innerWidth, columnID, columns, showNamespaceOverride) ? (
-    <Td data-label={columnID} className={className} role="gridcell">
+    <Td data-label={columnID} className={className} role="gridcell" data-test={dataTest}>
       {children}
     </Td>
   ) : null;
@@ -189,6 +190,7 @@ export type TableDataProps = {
   className?: string;
   columnID?: string;
   columns?: Set<string>;
+  dataTest?: string;
   id?: string;
   showNamespaceOverride?: boolean;
 };


### PR DESCRIPTION
In the interest of ensuring we deliver this functionality prior to feature freeze, I am opting to update the existing CustomResource list knowing that we can refactor once the [Data View work](https://issues.redhat.com/browse/CONSOLE-4667) is complete.

Notes:
* To avoid an overly wide table, only the first three additional printer columns get added to the table at screen sizes medium and larger.
* If one of the three additional printer columns is to display `metadata.creationTimestamp`, the `Created` column is removed from the table.
* Column sorting is limited to columns with simple `jsonPath` values (those without special characters).


https://github.com/user-attachments/assets/b3f966f5-77b3-4bad-b023-8ada7fdf1993


