### PR TITLE
OCPBUGS-60010: Fix i18n string for event stream

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -481,7 +481,7 @@ const EventStream = ({
     statusBtnTxt = (
       <span className="co-sysevent-stream__connection-error">
         {_.isString(error)
-          ? t('public~Error connecting to event stream: { error }', {
+          ? t('public~Error connecting to event stream: {{ error }}', {
               error,
             })
           : t('public~Error connecting to event stream')}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -581,7 +581,7 @@
   "An error occurred during event retrieval. Attempting to reconnect...": "An error occurred during event retrieval. Attempting to reconnect...",
   "Events": "Events",
   "Connection did not close cleanly.": "Connection did not close cleanly.",
-  "Error connecting to event stream: { error }": "Error connecting to event stream: { error }",
+  "Error connecting to event stream: {{ error }}": "Error connecting to event stream: {{ error }}",
   "Error connecting to event stream": "Error connecting to event stream",
   "Loading events...": "Loading events...",
   "Streaming events...": "Streaming events...",

--- a/frontend/public/locales/es/public.json
+++ b/frontend/public/locales/es/public.json
@@ -556,7 +556,7 @@
   "An error occurred during event retrieval. Attempting to reconnect...": "Se produjo un error durante la recuperación del evento. Intentando reconectar...",
   "Events": "Eventos",
   "Connection did not close cleanly.": "La conexión no se cerró correctamente.",
-  "Error connecting to event stream: { error }": "Error al conectarse al flujo de eventos: { error }",
+  "Error connecting to event stream: {{ error }}": "Error al conectarse al flujo de eventos: {{ error }}",
   "Error connecting to event stream": "Error al conectarse al flujo de eventos",
   "Loading events...": "Cargando eventos...",
   "Streaming events...": "Transmisión de eventos...",

--- a/frontend/public/locales/fr/public.json
+++ b/frontend/public/locales/fr/public.json
@@ -556,7 +556,7 @@
   "An error occurred during event retrieval. Attempting to reconnect...": "Une erreur s’est produite lors de la récupération de l’événement. Tentative de reconnexion...",
   "Events": "Événements",
   "Connection did not close cleanly.": "La connexion ne s’est pas fermée proprement.",
-  "Error connecting to event stream: { error }": "Erreur de connexion au flux d’événements : { error }",
+  "Error connecting to event stream: {{ error }}": "Erreur de connexion au flux d’événements : {{ error }}",
   "Error connecting to event stream": "Erreur de connexion au flux d’événements",
   "Loading events...": "Chargement des événements...",
   "Streaming events...": "Streaming des événements...",

--- a/frontend/public/locales/ja/public.json
+++ b/frontend/public/locales/ja/public.json
@@ -556,7 +556,7 @@
   "An error occurred during event retrieval. Attempting to reconnect...": "イベントの取得中にエラーが発生しました。再接続の試行中...",
   "Events": "イベント",
   "Connection did not close cleanly.": "接続が正常に閉じられませんでした。",
-  "Error connecting to event stream: { error }": "イベントストリームへの接続エラー: { error }",
+  "Error connecting to event stream: {{ error }}": "イベントストリームへの接続エラー: {{ error }}",
   "Error connecting to event stream": "イベントストリームへの接続エラー",
   "Loading events...": "イベントを読み込み中...",
   "Streaming events...": "イベントをストリーミング中...",

--- a/frontend/public/locales/ko/public.json
+++ b/frontend/public/locales/ko/public.json
@@ -556,7 +556,7 @@
   "An error occurred during event retrieval. Attempting to reconnect...": "이벤트 검색 중에 오류가 발생했습니다. 다시 연결하는 중 ...",
   "Events": "이벤트",
   "Connection did not close cleanly.": "연결이 제대로 닫히지 않았습니다.",
-  "Error connecting to event stream: { error }": "이벤트 스트림에 연결 오류: { error }",
+  "Error connecting to event stream: {{ error }}": "이벤트 스트림에 연결 오류: {{ error }}",
   "Error connecting to event stream": "이벤트 스트림에 연결하는 동안 오류가 발생했습니다.",
   "Loading events...": "이벤트 로드 중...",
   "Streaming events...": "이벤트 스트리밍 중...",

--- a/frontend/public/locales/zh/public.json
+++ b/frontend/public/locales/zh/public.json
@@ -556,7 +556,7 @@
   "An error occurred during event retrieval. Attempting to reconnect...": "在检索事件的过程中发生错误。尝试重新连接......",
   "Events": "事件",
   "Connection did not close cleanly.": "连接没有“干净”地关闭。",
-  "Error connecting to event stream: { error }": "连接到事件流时出错： { error }",
+  "Error connecting to event stream: {{ error }}": "连接到事件流时出错： { error }",
   "Error connecting to event stream": "连接到事件流时出错",
   "Loading events...": "加载事件......",
   "Streaming events...": "流事件......",


### PR DESCRIPTION
note: i manually updated the other locales so we can backport without breaking i18n

code review:

/assign @rhamilto 

/cherry-pick release-4.19 release-4.18