### PR TITLE
OCPBUGS-59382: OpenShift Console's "Start Job" action overrides configured "backoffLimit" to "6"

### DIFF
--- a/frontend/packages/console-app/src/actions/creators/cronjob-factory.ts
+++ b/frontend/packages/console-app/src/actions/creators/cronjob-factory.ts
@@ -29,7 +29,7 @@ const startJob = (obj: CronJobKind): Promise<JobKind> => {
       ],
     },
     spec: {
-      template: obj.spec.jobTemplate.spec.template,
+      ...obj.spec.jobTemplate.spec,
     },
   };
 


### PR DESCRIPTION
Previous payload for job creation from cronjob only preserved the pod-level configuration via `jobTemplate.spec.template`, the job level configuration like backoffLimit, parallelism was ignored. If a cronjob specified a `backoffLimit: 0`, a started job from this cronjob would have a default value `backoffLimit: 6`.
before:

https://github.com/user-attachments/assets/157ed4e4-9a51-44bd-91d5-482db7236422


after:

https://github.com/user-attachments/assets/fa135c51-fe22-4f62-8653-cdeeddf8bbd2

