### PR TITLE
OCPBUGS-60130: Remove ancient `X-XSS-Protection` header

### DIFF
--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -130,8 +130,6 @@ func securityHeadersMiddleware(hdlr http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Prevent MIME sniffing (https://en.wikipedia.org/wiki/Content_sniffing)
 		w.Header().Set("X-Content-Type-Options", "nosniff")
-		// Ancient weak protection against reflected XSS (equivalent to CSP no unsafe-inline)
-		w.Header().Set("X-XSS-Protection", "1; mode=block")
 		// Prevent clickjacking attacks involving iframes
 		w.Header().Set("X-Frame-Options", "DENY")
 		// Less information leakage about what domains we link to


### PR DESCRIPTION
Removes `X-XSS-Protection` and thus addresses  #15344 

This header should really not be set anywhere anymore and it should be phased out.