### PR TITLE
CONSOLE-4617: follow-on fix for DetailsItem popover

### DIFF
--- a/frontend/public/components/default-resource.tsx
+++ b/frontend/public/components/default-resource.tsx
@@ -114,7 +114,7 @@ export const DetailsForKind: React.FC<PageComponentProps<K8sResourceKind>> = ({ 
                   {hasAdditionalPrinterColumns && (
                     <>
                       {additionalPrinterColumns.map((col) => {
-                        const path = col.jsonPath;
+                        const path = col.jsonPath.replace(/^\./, '');
                         const pathArray = getPathArray(path);
                         const pathHasSpecialCharacter = checkPathHasSpecialCharacter(path);
 


### PR DESCRIPTION
Before

The swagger definition wasn't loading as the `.` at the start of the `path` was being interpreted as separate segment.

After

https://github.com/user-attachments/assets/1c249293-8691-4c0e-b70b-dce3f1c55d2d

