### PR TITLE
[release-4.18] OCPBUGS-54660: Expose OdcBaseNode through the dynamic plugin SDK

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-topology-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-topology-api.ts
@@ -18,6 +18,7 @@ import {
   GetWorkloadResources,
   ContextMenuActions,
   CreateConnectorProps,
+  OdcBaseNodeConstructor,
 } from '../extensions/topology-types';
 
 export const CpuCellComponent: React.FC<CpuCellComponentProps> = require('@console/topology/src/components/list-view/cells/CpuCell')
@@ -73,3 +74,6 @@ export const CreateConnector: CreateConnectorProps = require('@console/topology/
 
 export const createConnectorCallback = require('@console/topology/src/components/graph-view')
   .createConnectorCallback;
+
+export const OdcBaseNode: OdcBaseNodeConstructor = require('@console/topology/src/elements')
+  .OdcBaseNode;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/topology-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/topology-types.ts
@@ -305,3 +305,18 @@ export type CreateConnectorProps = {
   dragging?: boolean;
   hover?: boolean;
 };
+
+export interface OdcBaseNodeInterface extends Node<OdcNodeModel> {
+  resource?: K8sResourceKind;
+  resourceKind?: K8sResourceKindReference;
+
+  getResource(): K8sResourceKind | undefined;
+  setResource(resource: K8sResourceKind | undefined): void;
+
+  getResourceKind(): K8sResourceKindReference | undefined;
+  setResourceKind(kind: K8sResourceKindReference | undefined): void;
+
+  setModel(model: OdcNodeModel): void;
+}
+
+export type OdcBaseNodeConstructor = new () => OdcBaseNodeInterface;

--- a/frontend/packages/topology/src/elements/OdcBaseNode.ts
+++ b/frontend/packages/topology/src/elements/OdcBaseNode.ts
@@ -1,16 +1,14 @@
+import { BaseNode, Node } from '@patternfly/react-topology';
 import { observable, makeObservable } from 'mobx';
+import { OdcBaseNodeInterface } from '@console/dynamic-plugin-sdk/src/extensions/topology-types';
 import {
   K8sResourceKind,
   K8sResourceKindReference,
   referenceFor,
 } from '@console/internal/module/k8s';
 import { OdcNodeModel } from '../topology-types';
-//
-// Import from @patternfly/react-topology when updated to a branch containing https://github.com/patternfly/patternfly-react/pull/7573
-//
-import BaseNode from './BaseNode';
 
-class OdcBaseNode extends BaseNode {
+class OdcBaseNode extends BaseNode implements OdcBaseNodeInterface {
   public resource?: K8sResourceKind | undefined = undefined;
 
   public resourceKind?: K8sResourceKindReference | undefined = undefined;
@@ -22,6 +20,10 @@ class OdcBaseNode extends BaseNode {
       resource: observable.ref,
       resourceKind: observable,
     });
+  }
+
+  getPositionableChildren(): Node[] {
+    return [];
   }
 
   getResource(): K8sResourceKind | undefined {


### PR DESCRIPTION
This is a backport of https://github.com/openshift/console/pull/14955 to the 4.18 release branch.