### PR TITLE
NO-JIRA: Remove yarn-generate from post-install script

### DIFF
--- a/Dockerfile.plugins.demo
+++ b/Dockerfile.plugins.demo
@@ -9,11 +9,10 @@ RUN mkdir -p /src/console
 COPY . /src/console
 
 WORKDIR /src/console/frontend
-RUN yarn install
+RUN yarn install && yarn generate
 
 WORKDIR /src/console/dynamic-demo-plugin
-RUN yarn install && \
-    yarn build
+RUN yarn install && yarn build
 
 # Stage 1: build the target image
 FROM node:22

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "integration-tests"
   ],
   "scripts": {
-    "postinstall": "./scripts/check-patternfly-modules.sh && yarn prepare-husky && yarn generate",
+    "postinstall": "./scripts/check-patternfly-modules.sh && yarn prepare-husky",
     "clean": "rm -rf ./public/dist",
     "dev": "yarn clean && yarn generate && REACT_REFRESH=true NODE_OPTIONS=--max-old-space-size=4096 yarn ts-node ./node_modules/.bin/webpack serve --mode=development --progress",
     "dev-once": "yarn clean && yarn generate && NODE_OPTIONS=--max-old-space-size=4096 yarn ts-node ./node_modules/.bin/webpack --mode=development",


### PR DESCRIPTION
This is a build task and is repetitive when installing then immediately building, which is a very common use case.

- remove yarn generate from post-install script
- add yarn generate step to Dockerfile.plugins.demo