### PR TITLE
OCPBUGS-60373: QuickStarts Link buttons to other quickstarts are duplicate

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -136,7 +136,7 @@
   "dependencies": {
     "@patternfly-5/patternfly": "npm:@patternfly/patternfly@5.4.2",
     "@patternfly/patternfly": "^6.2.3",
-    "@patternfly/quickstarts": "^6.2.2",
+    "@patternfly/quickstarts": "^6.3.1",
     "@patternfly/react-catalog-view-extension": "^6.1.0",
     "@patternfly/react-charts": "^8.2.2",
     "@patternfly/react-code-editor": "^6.2.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1758,12 +1758,12 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.2.3.tgz#cf7678e442aa31101befe389651bca4256fd1c7f"
   integrity sha512-FR027W7JygcQpvlRU/Iom936Vm0apzfi2o5lvtlcWW6IaeZCCTtTaDxehoYuELHlemzkLziQAgu6LuCJEVayjw==
 
-"@patternfly/quickstarts@^6.2.2":
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-6.2.2.tgz#fc37ab03102408709f6d7eb5e238d51e0c93dfc5"
-  integrity sha512-YVO/QglCK3HpuS3TV4fcwXoklpoLCSh/kil2zYTFjcJ14OY8LDlp7vrbWDw799PyldVr+1eo2zp8Aon6MpVQSw==
+"@patternfly/quickstarts@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-6.3.1.tgz#6475dec57521851a99a7d389d1a183e50ef20597"
+  integrity sha512-cuQ+m0K90vbGyNo4oR8UToXo1Jw24QDfCaIoAW0pbUkEcYuSPGqVvrOSf7w5hUMJ8jrXqE7g0T7JkcQXElMbHg==
   dependencies:
-    dompurify "^3.1.3"
+    dompurify "^3.2.4"
     history "^5.0.0"
 
 "@patternfly/react-catalog-view-extension@^6.1.0":
@@ -7276,10 +7276,10 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^3.1.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.3.tgz#05dd2175225324daabfca6603055a09b2382a4cd"
-  integrity sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==
+dompurify@^3.2.4:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.6.tgz#ca040a6ad2b88e2a92dc45f38c79f84a714a1cad"
+  integrity sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
## Problem
If a Quickstart uses nextQuickStart spec to link to other Quickstarts, the link buttons are duplicate (i.e. appear twice). This only occurs when a user visit `/quickstart`. If you have the Quickstart panel open while on other path (e.g. `/k8s/ns/hypershift/events`), the link shows correctly.

## Steps to test out
**Prerequisite**: you should have a cluster spin up and build the console locally.

    1. Go the `<ocp-console-url>/quickstart` to open Quickstart catalog.
    2. Search for any Quickstart that links others. For example, `Get started with a sample application`or `Add health checks to your sample application`
    3. Go to the last step to see the link buttons.


## Before Fix
<img width="1462" height="978" alt="image" src="https://github.com/user-attachments/assets/6b48e2f3-401c-40b4-b6a4-9c0edf5e7c7c" />


## After fix
<img width="431" height="642" alt="Screenshot 2025-08-11 at 2 32 14 PM" src="https://github.com/user-attachments/assets/787b0594-a4a9-42a0-bd06-176baf3f351f" />


As you can see from the screenshots, `Start Monitor your sample application quick start` button only appears once now.

## Root Cause
This issue has been fixed in https://github.com/patternfly/patternfly-quickstarts/pull/402/files, but it is not being backported until version v6.3.1. Therefore, we need to upgrade patternfly/quickstarts to 6.3.1 to have this fix.

In 6.2.2, the code that fix the issue is not applied, as you can see [here](https://github.com/patternfly/patternfly-quickstarts/blob/v6.2.2/packages/module/src/QuickStartDrawerContent.tsx#L27).

In 6.3.1, the code fix has been applied as you can see [here](https://github.com/patternfly/patternfly-quickstarts/blob/v6.3.1/packages/module/src/QuickStartDrawerContent.tsx#L27).

    