### PR TITLE
[WIP] OCPBUGS-60425 `kube:admin` user is immediately logged back in after token expiration

### DIFF
--- a/frontend/public/module/auth.js
+++ b/frontend/public/module/auth.js
@@ -1,11 +1,9 @@
-import * as _ from 'lodash-es';
 import { consoleFetch as coFetch } from '@console/dynamic-plugin-sdk/src/utils/fetch';
 import { stripBasePath } from '../components/utils/link';
 
 const {
   kubeAdminLogoutURL,
   loginErrorURL,
-  loginSuccessURL,
   loginURL,
   logoutRedirect,
   logoutURL,
@@ -81,7 +79,7 @@ export const authSvc = {
     }
   },
 
-  logout: _.once((next, isKubeAdmin = false) => {
+  logout: (next, isKubeAdmin = false) => {
     setNext(next);
     clearLocalStorage(clearLocalStorageKeys);
     coFetch(logoutURL, { method: 'POST' })
@@ -94,7 +92,7 @@ export const authSvc = {
           authSvc.logoutRedirect(next);
         }
       });
-  }),
+  },
 
   // The kube:admin user has a special logout flow. The OAuth server has a
   // session cookie that must be cleared by POSTing to the kube:admin logout
@@ -107,12 +105,12 @@ export const authSvc = {
     form.action = kubeAdminLogoutURL;
     form.method = 'POST';
 
-    // Redirect back to the console when logout is complete by passing a
-    // `then` parameter.
+    // Redirect to the console root when logout is complete by passing a
+    // `then` parameter. Use window.location.origin to avoid cross-origin issues.
     const input = document.createElement('input');
     input.type = 'hidden';
     input.name = 'then';
-    input.value = loginSuccessURL;
+    input.value = window.location.origin;
     form.appendChild(input);
 
     document.body.appendChild(form);


### PR DESCRIPTION
## Description
There is an issue with the session handling for the special kube:admin user. 

When the session's access token expires (as defined by accessTokenMaxAgeSeconds in the OAuth configuration), the console receives a 401 Unauthorized error. This 401 error incorrectly triggers the standard logout flow instead of the specific flow required for kube:admin.

As noted in the console's own source code, the kube:admin user requires a special logout process (logoutKubeAdmin function) to clear a session cookie on the OAuth server. 

Because this special process is not being called upon token expiry, the OAuth server immediately re-issues a token, logging the user back in without any user interaction. This prevents the session from properly terminating.    

## Steps to Reproduce:

1. Log in to the web console as the kube:admin user.

2. Set the accessTokenMaxAgeSeconds. You can do with this command: 

oc patch oauth cluster --type='merge' -p='{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":10}}}'

3. Wait for the session's access token to expire based on the accessTokenMaxAgeSeconds duration.

4. After the token has expired, perform any action in the console that requires an API call (e.g., navigating to a new page or refreshing data).

5. Observe the application's behavior.     