### PR TITLE
CNV-64586: show default storageclass for VMs info

### DIFF
--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -40,12 +40,19 @@ export const StorageClassReference: K8sResourceKindReference = 'StorageClass';
 
 export const defaultClassAnnotation = 'storageclass.kubernetes.io/is-default-class';
 const betaDefaultStorageClassAnnotation = 'storageclass.beta.kubernetes.io/is-default-class';
+const defaultVirtClassAnnotation = 'storageclass.kubevirt.io/is-default-virt-class';
+
 export const isDefaultClass = (storageClass: K8sResourceKind) => {
   const annotations = _.get(storageClass, 'metadata.annotations') || {};
   return (
     annotations[defaultClassAnnotation] === 'true' ||
     annotations[betaDefaultStorageClassAnnotation] === 'true'
   );
+};
+
+const isDefaultVirtClass = (storageClass: K8sResourceKind) => {
+  const annotations = _.get(storageClass, 'metadata.annotations') || {};
+  return annotations[defaultVirtClassAnnotation] === 'true';
 };
 
 const tableColumnClasses = [
@@ -89,6 +96,10 @@ const StorageClassDetails: React.FC<StorageClassDetailsProps> = ({ obj }) => {
 
 const StorageClassTableRow: React.FC<RowFunctionArgs<StorageClassResourceKind>> = ({ obj }) => {
   const { t } = useTranslation();
+  const isKubevirtPluginActive =
+    Array.isArray(window.SERVER_FLAGS.consolePlugins) &&
+    window.SERVER_FLAGS.consolePlugins.includes('kubevirt-plugin');
+
   const resourceKind = referenceFor(obj);
   const context = { [resourceKind]: obj };
   return (
@@ -98,6 +109,11 @@ const StorageClassTableRow: React.FC<RowFunctionArgs<StorageClassResourceKind>> 
           {isDefaultClass(obj) && (
             <span className="pf-v6-u-font-size-xs pf-v6-u-text-color-subtle co-resource-item__help-text">
               &ndash; {t('public~Default')}
+            </span>
+          )}
+          {isDefaultVirtClass(obj) && isKubevirtPluginActive && (
+            <span className="pf-v6-u-font-size-xs pf-v6-u-text-color-subtle co-resource-item__help-text">
+              &ndash; {t('public~Default for VirtualMachines')}
             </span>
           )}
         </ResourceLink>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1363,6 +1363,7 @@
   "Allow PersistentVolumeClaims to be expanded": "Allow PersistentVolumeClaims to be expanded",
   "StorageClass details": "StorageClass details",
   "Default class": "Default class",
+  "Default for VirtualMachines": "Default for VirtualMachines",
   "Create StorageClass": "Create StorageClass",
   "Device path is already in use.": "Device path is already in use.",
   "Use existing claim": "Use existing claim",


### PR DESCRIPTION
When `kubevirt-plugin` is installed, this will be added:
- "Default for VirtualMachines" indicator to a StorageClass in a list

After:

https://github.com/user-attachments/assets/045e3a80-3adc-4a56-85bb-53bc9c024c8e


