### PR TITLE
CONSOLE-4631: Run 'react' namespace import codemod

### DIFF
--- a/frontend/@types/console/VictoryPortal.d.ts
+++ b/frontend/@types/console/VictoryPortal.d.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { Component } from 'react';
 import { VictoryPortal } from 'victory-core';
 
 /**
@@ -6,5 +6,5 @@ import { VictoryPortal } from 'victory-core';
  * which is not compatible with the `./frontend` tsconfig
  **/
 declare module 'victory-core' {
-  export declare class VictoryPortal extends React.Component<VictoryPortalProps> {}
+  export declare class VictoryPortal extends Component<VictoryPortalProps> {}
 }

--- a/frontend/__tests__/reducers/features.spec.tsx
+++ b/frontend/__tests__/reducers/features.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { Component } from 'react';
 import * as Immutable from 'immutable';
 import * as _ from 'lodash-es';
 
@@ -109,7 +109,7 @@ describe('featureReducer', () => {
 describe('connectToFlags', () => {
   type MyComponentProps = { propA: number; propB: boolean; flags: { [key: string]: boolean } };
 
-  class MyComponent extends React.Component<MyComponentProps> {
+  class MyComponent extends Component<MyComponentProps> {
     render() {
       return <div>{this.props.propA}</div>;
     }

--- a/frontend/packages/console-app/src/actions/creators/hpa-factory.ts
+++ b/frontend/packages/console-app/src/actions/creators/hpa-factory.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import i18next from 'i18next';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
@@ -92,7 +92,7 @@ type DeploymentActionExtraResources = {
 export const useHPAActions = (kindObj: K8sKind, resource: K8sResourceKind) => {
   const namespace = resource?.metadata?.namespace;
 
-  const watchedResources = React.useMemo(
+  const watchedResources = useMemo(
     () => ({
       hpas: {
         isList: true,
@@ -110,18 +110,18 @@ export const useHPAActions = (kindObj: K8sKind, resource: K8sResourceKind) => {
     [namespace],
   );
   const extraResources = useK8sWatchResources<DeploymentActionExtraResources>(watchedResources);
-  const relatedHPAs = React.useMemo(() => extraResources.hpas.data.filter(doesHpaMatch(resource)), [
+  const relatedHPAs = useMemo(() => extraResources.hpas.data.filter(doesHpaMatch(resource)), [
     extraResources.hpas.data,
     resource,
   ]);
 
-  const supportsHPA = React.useMemo(
+  const supportsHPA = useMemo(
     () =>
       !(isHelmResource(resource) || isOperatorBackedService(resource, extraResources.csvs.data)),
     [extraResources.csvs.data, resource],
   );
 
-  const result = React.useMemo<[Action[], HorizontalPodAutoscalerKind[]]>(() => {
+  const result = useMemo<[Action[], HorizontalPodAutoscalerKind[]]>(() => {
     return [supportsHPA ? getHpaActions(kindObj, resource, relatedHPAs) : [], relatedHPAs];
   }, [kindObj, relatedHPAs, resource, supportsHPA]);
 

--- a/frontend/packages/console-app/src/actions/creators/pdb-factory.ts
+++ b/frontend/packages/console-app/src/actions/creators/pdb-factory.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import i18next from 'i18next';
 import * as _ from 'lodash';
 import { Action } from '@console/dynamic-plugin-sdk';
@@ -72,7 +72,7 @@ const getPDBActions = (
 export const usePDBActions = (kindObj: K8sKind, resource: K8sPodControllerKind) => {
   const namespace = resource?.metadata?.namespace;
 
-  const watchedResource = React.useMemo(
+  const watchedResource = useMemo(
     () => ({
       isList: true,
       groupVersionKind: {
@@ -90,7 +90,7 @@ export const usePDBActions = (kindObj: K8sKind, resource: K8sPodControllerKind) 
 
   const matchedPDB = getPDBResource(pdbResources, resource);
 
-  const result = React.useMemo(() => {
+  const result = useMemo(() => {
     return [getPDBActions(kindObj, resource, matchedPDB)];
   }, [kindObj, matchedPDB, resource]);
 

--- a/frontend/packages/console-app/src/actions/hooks/useBindingActions.ts
+++ b/frontend/packages/console-app/src/actions/hooks/useBindingActions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 import { ButtonVariant } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -37,7 +37,7 @@ export const useBindingActions = (
   const { t } = useTranslation();
   const [model] = useK8sModel(referenceFor(obj));
   const dispatch = useDispatch();
-  const startImpersonate = React.useCallback(
+  const startImpersonate = useCallback(
     (kind, name) => dispatch(UIActions.startImpersonate(kind, name)),
     [dispatch],
   );
@@ -74,7 +74,7 @@ export const useBindingActions = (
 
   const memoizedFilterActions = useDeepCompareMemoize(filterActions);
 
-  const factory = React.useMemo(
+  const factory = useMemo(
     () => ({
       [BindingActionCreator.ImpersonateBindingSubject]: () => ({
         id: 'impersonate-binding',
@@ -135,7 +135,7 @@ export const useBindingActions = (
   );
 
   // filter and initialize requested actions or construct list of all BindingActions
-  const actions = React.useMemo<Action[]>(() => {
+  const actions = useMemo<Action[]>(() => {
     if (memoizedFilterActions) {
       return memoizedFilterActions.map((creator) => factory[creator]());
     }

--- a/frontend/packages/console-app/src/actions/hooks/useCommonActions.ts
+++ b/frontend/packages/console-app/src/actions/hooks/useCommonActions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { useDeepCompareMemoize } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useDeepCompareMemoize';
@@ -60,7 +60,7 @@ export const useCommonActions = <T extends readonly CommonActionCreator[]>(
 
   const memoizedFilterActions = useDeepCompareMemoize(filterActions);
 
-  const factory = React.useMemo(
+  const factory = useMemo(
     () => ({
       [CommonActionCreator.Delete]: (): Action => ({
         id: `delete-resource`,
@@ -159,7 +159,7 @@ export const useCommonActions = <T extends readonly CommonActionCreator[]>(
     [kind, resource, t, message],
   );
 
-  const result = React.useMemo((): [ActionObject<T>, boolean] => {
+  const result = useMemo((): [ActionObject<T>, boolean] => {
     const actions = {} as ActionObject<T>;
 
     if (!kind || !resource) {

--- a/frontend/packages/console-app/src/actions/hooks/useCommonResourceActions.ts
+++ b/frontend/packages/console-app/src/actions/hooks/useCommonResourceActions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { K8sModel, K8sResourceKind } from '@console/internal/module/k8s';
 import { CommonActionCreator } from './types';
@@ -40,5 +40,5 @@ export const useCommonResourceActions = (
     ] as const,
     message,
   );
-  return React.useMemo(() => (isReady ? Object.values(actions) : []), [actions, isReady]);
+  return useMemo(() => (isReady ? Object.values(actions) : []), [actions, isReady]);
 };

--- a/frontend/packages/console-app/src/actions/hooks/useDeploymentActions.ts
+++ b/frontend/packages/console-app/src/actions/hooks/useDeploymentActions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { useDeepCompareMemoize } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useDeepCompareMemoize';
@@ -85,7 +85,7 @@ export const useDeploymentActions = <T extends readonly DeploymentActionCreator[
 
   const memoizedFilterActions = useDeepCompareMemoize(filterActions);
 
-  const factory = React.useMemo(
+  const factory = useMemo(
     () => ({
       [DeploymentActionCreator.EditDeployment]: (): Action => ({
         id: `edit-deployment`,
@@ -180,7 +180,7 @@ export const useDeploymentActions = <T extends readonly DeploymentActionCreator[
     [t, resource, kind],
   );
 
-  return React.useMemo((): [ActionObject<T>, boolean] => {
+  return useMemo((): [ActionObject<T>, boolean] => {
     const actions = {} as ActionObject<T>;
 
     if (!kind || !resource) {

--- a/frontend/packages/console-app/src/actions/hooks/useJobActions.ts
+++ b/frontend/packages/console-app/src/actions/hooks/useJobActions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { useDeepCompareMemoize } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useDeepCompareMemoize';
@@ -33,7 +33,7 @@ export const useJobActions = (obj: JobKind, filterActions?: JobActionCreator[]):
 
   const memoizedFilterActions = useDeepCompareMemoize(filterActions);
 
-  const factory = React.useMemo(
+  const factory = useMemo(
     () => ({
       [JobActionCreator.ModifyJobParallelism]: () => ({
         id: 'edit-parallelism',
@@ -50,7 +50,7 @@ export const useJobActions = (obj: JobKind, filterActions?: JobActionCreator[]):
   );
 
   // filter and initialize requested actions or construct list of all PVCActions
-  const actions = React.useMemo<Action[]>(() => {
+  const actions = useMemo<Action[]>(() => {
     if (memoizedFilterActions) {
       return memoizedFilterActions.map((creator) => factory[creator]());
     }

--- a/frontend/packages/console-app/src/actions/hooks/usePVCActions.ts
+++ b/frontend/packages/console-app/src/actions/hooks/usePVCActions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { useDeepCompareMemoize } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useDeepCompareMemoize';
@@ -37,7 +37,7 @@ export const usePVCActions = (
 
   const memoizedFilterActions = useDeepCompareMemoize(filterActions);
 
-  const factory = React.useMemo(
+  const factory = useMemo(
     () => ({
       [PVCActionCreator.ExpandPVC]: () => ({
         id: 'expand-pvc',
@@ -85,7 +85,7 @@ export const usePVCActions = (
   );
 
   // filter and initialize requested actions or construct list of all PVCActions
-  const actions = React.useMemo<Action[]>(() => {
+  const actions = useMemo<Action[]>(() => {
     if (memoizedFilterActions) {
       return memoizedFilterActions.map((creator) => factory[creator]());
     }

--- a/frontend/packages/console-app/src/actions/hooks/useReplicaSetActions.ts
+++ b/frontend/packages/console-app/src/actions/hooks/useReplicaSetActions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { useDeepCompareMemoize } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useDeepCompareMemoize';
@@ -24,7 +24,7 @@ export const useReplicaSetActions = (
   const { t } = useTranslation();
   const memoizedFilterActions = useDeepCompareMemoize(filterActions);
 
-  const factory = React.useMemo(
+  const factory = useMemo(
     () => ({
       [ReplicaSetActionCreator.RollbackDeploymentAction]: (): Action => ({
         id: 'rollback-deployment',
@@ -46,7 +46,7 @@ export const useReplicaSetActions = (
     [t, kind, resource],
   );
 
-  const actions = React.useMemo<Action[]>(() => {
+  const actions = useMemo<Action[]>(() => {
     if (memoizedFilterActions) {
       return memoizedFilterActions.map((creator) => factory[creator]());
     }

--- a/frontend/packages/console-app/src/actions/hooks/useReplicationControllerActions.ts
+++ b/frontend/packages/console-app/src/actions/hooks/useReplicationControllerActions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { useDeepCompareMemoize } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useDeepCompareMemoize';
@@ -45,7 +45,7 @@ export const useReplicationControllerActions = <
 
   const memoizedFilterActions = useDeepCompareMemoize(filterActions);
 
-  const factory = React.useMemo(
+  const factory = useMemo(
     () => ({
       [ReplicationControllerActionCreator.RollbackDeploymentConfig]: (): Action => ({
         id: 'rollback-deployment-config',
@@ -95,7 +95,7 @@ export const useReplicationControllerActions = <
     [t, kind, obj],
   );
 
-  const result = React.useMemo((): [ActionObject<T>, boolean] => {
+  const result = useMemo((): [ActionObject<T>, boolean] => {
     const actions = {} as ActionObject<T>;
 
     if (!kind || !obj) {

--- a/frontend/packages/console-app/src/actions/hooks/useRetryRolloutAction.ts
+++ b/frontend/packages/console-app/src/actions/hooks/useRetryRolloutAction.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Action, K8sResourceCommon } from '@console/dynamic-plugin-sdk';
 import { k8sPatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-resource';
@@ -72,7 +72,7 @@ export const useRetryRolloutAction = (resource: DeploymentConfigKind): Action =>
     rc?.metadata?.annotations?.['openshift.io/deployment.phase'] === 'Failed' &&
     resource.status?.latestVersion !== 0;
 
-  return React.useMemo<Action>(
+  return useMemo<Action>(
     () => ({
       id: 'retry-rollout',
       label: t('console-app~Retry rollout'),

--- a/frontend/packages/console-app/src/actions/hooks/useVolumeSnapshotActions.ts
+++ b/frontend/packages/console-app/src/actions/hooks/useVolumeSnapshotActions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { useDeepCompareMemoize } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useDeepCompareMemoize';
@@ -35,7 +35,7 @@ export const useVolumeSnapshotActions = (
 
   const memoizedFilterActions = useDeepCompareMemoize(filterActions);
 
-  const factory = React.useMemo(
+  const factory = useMemo(
     () => ({
       [VolumeSnapshotActionCreator.RestorePVC]: () => ({
         id: 'clone-pvc',
@@ -53,7 +53,7 @@ export const useVolumeSnapshotActions = (
     [t, resource],
   );
 
-  const actions = React.useMemo<Action[]>(() => {
+  const actions = useMemo<Action[]>(() => {
     if (memoizedFilterActions) {
       return memoizedFilterActions.map((creator) => factory[creator]());
     }

--- a/frontend/packages/console-app/src/actions/providers/binding-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/binding-provider.ts
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { ClusterRoleBindingKind, RoleBindingKind } from '@console/internal/module/k8s';
 import { useBindingActions } from '../hooks/useBindingActions';
 
 export const useBindingActionsProvider = (resource: RoleBindingKind | ClusterRoleBindingKind) => {
   const bindingActions = useBindingActions(resource);
 
-  const actions = React.useMemo(() => [...bindingActions], [bindingActions]);
+  const actions = useMemo(() => [...bindingActions], [bindingActions]);
 
   return [actions, true];
 };

--- a/frontend/packages/console-app/src/actions/providers/cronjob-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/cronjob-provider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { CronJobKind, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { CronJobActionFactory } from '../creators/cronjob-factory';
@@ -9,7 +9,7 @@ export const useCronJobActionsProvider = (resource: CronJobKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
   const [pdbActions] = usePDBActions(kindObj, resource);
   const commonActions = useCommonResourceActions(kindObj, resource);
-  const actions = React.useMemo(
+  const actions = useMemo(
     () => [CronJobActionFactory.StartJob(kindObj, resource), ...pdbActions, ...commonActions],
     [kindObj, pdbActions, resource, commonActions],
   );

--- a/frontend/packages/console-app/src/actions/providers/daemon-set-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/daemon-set-provider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { getHealthChecksAction } from '../creators/health-checks-factory';
@@ -14,7 +14,7 @@ export const useDaemonSetActionsProvider = (resource: K8sResourceKind) => {
     CommonActionCreator.AddStorage,
   ] as const);
   const commonResourceActions = useCommonResourceActions(kindObj, resource);
-  const actions = React.useMemo(
+  const actions = useMemo(
     () => [
       getHealthChecksAction(kindObj, resource),
       ...pdbActions,

--- a/frontend/packages/console-app/src/actions/providers/default-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/default-provider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { Action } from '@console/dynamic-plugin-sdk/';
 import { K8sResourceCommon, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
@@ -10,7 +10,7 @@ export const useDefaultActionsProvider = (
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
   const commonActions = useCommonResourceActions(kindObj, resource);
 
-  const actions = React.useMemo(() => [...commonActions], [commonActions]);
+  const actions = useMemo(() => [...commonActions], [commonActions]);
 
   return [actions, !inFlight, (undefined as unknown) as Error];
 };

--- a/frontend/packages/console-app/src/actions/providers/deployment-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/deployment-provider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { DeleteResourceAction } from '@console/dev-console/src/actions/context-menu';
 import { Action } from '@console/dynamic-plugin-sdk/src';
 import { DeploymentKind, referenceFor } from '@console/internal/module/k8s';
@@ -36,7 +36,7 @@ export const useDeploymentActionsProvider = (resource: DeploymentKind) => {
 
   const isReady = commonActionsReady || deploymentActionsReady;
 
-  const deploymentActions = React.useMemo<Action[]>(() => {
+  const deploymentActions = useMemo<Action[]>(() => {
     return !isReady
       ? []
       : [

--- a/frontend/packages/console-app/src/actions/providers/deploymentconfig-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/deploymentconfig-provider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { DeleteResourceAction } from '@console/dev-console/src/actions/context-menu';
 import { DeploymentConfigKind, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
@@ -32,7 +32,7 @@ export const useDeploymentConfigActionsProvider = (resource: DeploymentConfigKin
 
   const isReady = commonActionsReady || deploymentActionsReady;
 
-  const deploymentConfigActions = React.useMemo(
+  const deploymentConfigActions = useMemo(
     () =>
       isReady
         ? [

--- a/frontend/packages/console-app/src/actions/providers/job-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/job-provider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { JobKind, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { usePDBActions } from '../creators/pdb-factory';
@@ -11,7 +11,7 @@ export const useJobActionsProvider = (resource: JobKind) => {
   const commonActions = useCommonResourceActions(kindObj, resource);
   const jobActions = useJobActions(resource);
 
-  const actions = React.useMemo(() => [...jobActions, ...pdbActions, ...commonActions], [
+  const actions = useMemo(() => [...jobActions, ...pdbActions, ...commonActions], [
     pdbActions,
     commonActions,
     jobActions,

--- a/frontend/packages/console-app/src/actions/providers/persistent-volume-claim-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/persistent-volume-claim-provider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { usePVCActions } from '@console/app/src/actions/hooks/usePVCActions';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { referenceFor, PersistentVolumeClaimKind } from '@console/internal/module/k8s';
@@ -16,7 +16,7 @@ export const usePVCActionsProvider = (
     CommonActionCreator.ModifyAnnotations,
     CommonActionCreator.Edit,
   ]);
-  const actions = React.useMemo(() => [...actionsPVC, ...Object.values(commonActions)], [
+  const actions = useMemo(() => [...actionsPVC, ...Object.values(commonActions)], [
     actionsPVC,
     commonActions,
   ]);

--- a/frontend/packages/console-app/src/actions/providers/pod-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/pod-provider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { useCommonResourceActions } from '../hooks/useCommonResourceActions';
@@ -7,7 +7,7 @@ export const usePodActionsProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
   const commonActions = useCommonResourceActions(kindObj, resource);
 
-  const actions = React.useMemo(() => [...commonActions], [commonActions]);
+  const actions = useMemo(() => [...commonActions], [commonActions]);
 
   return [actions, !inFlight, undefined];
 };

--- a/frontend/packages/console-app/src/actions/providers/replicaset-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/replicaset-provider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { DeploymentModel } from '@console/internal/models';
 import { ReplicaSetKind, referenceFor } from '@console/internal/module/k8s';
 import { getOwnerNameByKind } from '@console/shared/src';
@@ -20,7 +20,7 @@ export const useReplicaSetActionsProvider = (resource: ReplicaSetKind) => {
   const commonResourceActions = useCommonResourceActions(kindObj, resource);
   const replicaSetActions = useReplicaSetActions(kindObj, resource);
 
-  const actions = React.useMemo(
+  const actions = useMemo(
     () =>
       !isReady
         ? []

--- a/frontend/packages/console-app/src/actions/providers/replication-controllers-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/replication-controllers-provider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import * as _ from 'lodash';
 import { DeploymentConfigModel } from '@console/internal/models';
 import { ReplicationControllerKind, referenceFor } from '@console/internal/module/k8s';
@@ -26,7 +26,7 @@ export const useReplicationControllerActionsProvider = (resource: ReplicationCon
   ]);
   const isReady = commonActionsReady && rcActionsReady;
 
-  const actions = React.useMemo(
+  const actions = useMemo(
     () =>
       !isReady
         ? []

--- a/frontend/packages/console-app/src/actions/providers/stateful-set-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/stateful-set-provider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { getHealthChecksAction } from '../creators/health-checks-factory';
@@ -16,7 +16,7 @@ export const useStatefulSetActionsProvider = (resource: K8sResourceKind) => {
   ] as const);
   const commonResourceActions = useCommonResourceActions(kindObj, resource);
 
-  const actions = React.useMemo(
+  const actions = useMemo(
     () =>
       !isReady
         ? []

--- a/frontend/packages/console-app/src/actions/providers/storageclass-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/storageclass-provider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/api/dynamic-core-api';
@@ -24,7 +24,7 @@ export const useStorageClassActions = (
     isList: true,
   });
 
-  const existingDefaultStorageClass = React.useMemo(
+  const existingDefaultStorageClass = useMemo(
     () =>
       storageClasses.find((sc) => sc.metadata?.annotations?.[defaultClassAnnotation] === 'true'),
     [storageClasses],
@@ -33,7 +33,7 @@ export const useStorageClassActions = (
   const isDefaultStorageClass =
     storageClass.metadata?.annotations?.[defaultClassAnnotation] === 'true';
 
-  const storageClassActions: Action[] = React.useMemo(
+  const storageClassActions: Action[] = useMemo(
     () => [
       {
         accessReview: asAccessReview(storageClassModel, storageClass, 'patch'),

--- a/frontend/packages/console-app/src/actions/providers/volume-snaphot-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/volume-snaphot-provider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useVolumeSnapshotActions } from '@console/app/src/actions/hooks/useVolumeSnapshotActions';
 import { VolumeSnapshotKind, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
@@ -8,7 +8,7 @@ export const useVolumeSnapshotActionsProvider = (resource: VolumeSnapshotKind) =
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
   const volumeSnapshotActions = useVolumeSnapshotActions(resource);
   const commonActions = useCommonResourceActions(kindObj, resource);
-  const actions = React.useMemo(() => {
+  const actions = useMemo(() => {
     return [...volumeSnapshotActions, ...commonActions];
   }, [volumeSnapshotActions, commonActions]);
 

--- a/frontend/packages/console-app/src/components/admission-webhook-warnings/AdmissionWebhookWarningNotifications.tsx
+++ b/frontend/packages/console-app/src/components/admission-webhook-warnings/AdmissionWebhookWarningNotifications.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 import { AlertVariant } from '@patternfly/react-core';
 import { Map } from 'immutable';
 import { useTranslation } from 'react-i18next';
@@ -21,7 +21,7 @@ export const AdmissionWebhookWarningNotifications = () => {
   const toastContext = useToast();
   const dispatch = useDispatch();
   const admissionWebhookWarnings = useAdmissionWebhookWarnings();
-  React.useEffect(() => {
+  useEffect(() => {
     const docURL = getDocumentationURL(documentationURLs.admissionWebhookWarning);
     admissionWebhookWarnings.forEach((warning, id) => {
       toastContext.addToast({

--- a/frontend/packages/console-app/src/components/cluster-configuration/useClusterConfigurationGroups.ts
+++ b/frontend/packages/console-app/src/components/cluster-configuration/useClusterConfigurationGroups.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import {
   ClusterConfigurationGroup,
   isClusterConfigurationGroup,
@@ -16,7 +16,7 @@ const useClusterConfigurationGroups = (): [
     isClusterConfigurationGroup,
   );
 
-  const sortedGroups = React.useMemo(() => {
+  const sortedGroups = useMemo(() => {
     return orderExtensionBasedOnInsertBeforeAndAfter(
       resolvedExtensions.map((resolvedExtension) => resolvedExtension.properties),
     );

--- a/frontend/packages/console-app/src/components/cluster-configuration/useClusterConfigurationItems.ts
+++ b/frontend/packages/console-app/src/components/cluster-configuration/useClusterConfigurationItems.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import {
   checkAccess,
   ClusterConfigurationItem,
@@ -14,16 +14,16 @@ const useClusterConfigurationItems = (): [ResolvedClusterConfigurationItem[], bo
   );
 
   // Sort
-  const sortedItems = React.useMemo(() => {
+  const sortedItems = useMemo(() => {
     return orderExtensionBasedOnInsertBeforeAndAfter(
       resolvedExtensions.map((resolvedExtension) => resolvedExtension.properties),
     );
   }, [resolvedExtensions]);
 
   // Filter based on permission checks
-  const [canRead, updateCanRead] = React.useState<Record<string, boolean>>({});
-  const [canWrite, updateCanWrite] = React.useState<Record<string, boolean>>({});
-  React.useEffect(() => {
+  const [canRead, updateCanRead] = useState<Record<string, boolean>>({});
+  const [canWrite, updateCanWrite] = useState<Record<string, boolean>>({});
+  useEffect(() => {
     sortedItems.forEach((item) => {
       if (item.readAccessReview?.length > 0) {
         Promise.all(item.readAccessReview.map((accessReview) => checkAccess(accessReview)))
@@ -51,7 +51,7 @@ const useClusterConfigurationItems = (): [ResolvedClusterConfigurationItem[], bo
     });
   }, [sortedItems]);
 
-  const filteredItems = React.useMemo<ResolvedClusterConfigurationItem[]>(() => {
+  const filteredItems = useMemo<ResolvedClusterConfigurationItem[]>(() => {
     return sortedItems
       .filter((item) => (item.readAccessReview?.length > 0 ? canRead[item.id] : true))
       .map((item) => {

--- a/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { createContext, useState, useEffect, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import {
@@ -18,7 +18,7 @@ type NamespaceContextType = {
   setNamespace?: (ns: string) => void;
 };
 
-export const NamespaceContext = React.createContext<NamespaceContextType>({});
+export const NamespaceContext = createContext<NamespaceContextType>({});
 
 const useUrlNamespace = () => getNamespace(useLocation().pathname);
 
@@ -31,7 +31,7 @@ type UseValuesForNamespaceContext = () => {
 export const useValuesForNamespaceContext: UseValuesForNamespaceContext = () => {
   const urlNamespace = useUrlNamespace();
   const navigate = useNavigate();
-  const [activeNamespace, setActiveNamespace] = React.useState<string>(urlNamespace);
+  const [activeNamespace, setActiveNamespace] = useState<string>(urlNamespace);
   const [preferredNamespace, , preferredNamespaceLoaded] = usePreferredNamespace();
   const [lastNamespace, setLastNamespace, lastNamespaceLoaded] = useLastNamespace();
   const useProjects: boolean = useFlag(FLAGS.OPENSHIFT);
@@ -53,7 +53,7 @@ export const useValuesForNamespaceContext: UseValuesForNamespaceContext = () => 
   // Automatically check if preferred and last namespace still exist.
   const resourcesLoaded: boolean =
     !flagPending(useProjects) && preferredNamespaceLoaded && lastNamespaceLoaded;
-  React.useEffect(() => {
+  useEffect(() => {
     if (!urlNamespace && resourcesLoaded) {
       getValueForNamespace(preferredNamespace, lastNamespace, useProjects, activeNamespace)
         .then((ns: string) => {
@@ -70,7 +70,7 @@ export const useValuesForNamespaceContext: UseValuesForNamespaceContext = () => 
 
   // Updates active namespace (in context and redux state) when the url changes.
   // This updates the redux state also after the initial rendering.
-  React.useEffect(() => {
+  useEffect(() => {
     if (urlNamespace) {
       updateNamespace(urlNamespace);
     }
@@ -79,7 +79,7 @@ export const useValuesForNamespaceContext: UseValuesForNamespaceContext = () => 
 
   // Change active namespace (in context and redux state) as well as last used namespace
   // when a component calls setNamespace, for example via useActiveNamespace()
-  const setNamespace = React.useCallback(
+  const setNamespace = useCallback(
     (ns: string) => {
       ns !== lastNamespace && setLastNamespace(ns);
       updateNamespace(ns);

--- a/frontend/packages/console-app/src/components/detect-perspective/useValuesForPerspectiveContext.ts
+++ b/frontend/packages/console-app/src/components/detect-perspective/useValuesForPerspectiveContext.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { PerspectiveType } from '@console/dynamic-plugin-sdk';
 import { usePerspectiveExtension, usePerspectives, useTelemetry } from '@console/shared';
@@ -16,7 +16,7 @@ export const useValuesForPerspectiveContext = (): [
   const perspectiveExtensions = usePerspectives();
   const [lastPerspective, setLastPerspective, lastPerspectiveLoaded] = useLastPerspective();
   const [preferredPerspective, , preferredPerspectiveLoaded] = usePreferredPerspective();
-  const [activePerspective, setActivePerspective] = React.useState('');
+  const [activePerspective, setActivePerspective] = useState('');
   const loaded = lastPerspectiveLoaded && preferredPerspectiveLoaded;
   const latestPerspective = loaded && (preferredPerspective || lastPerspective);
   const acmPerspectiveExtension = usePerspectiveExtension(ACM_PERSPECTIVE_ID);

--- a/frontend/packages/console-app/src/components/file-upload/file-upload-context.ts
+++ b/frontend/packages/console-app/src/components/file-upload/file-upload-context.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { createContext, useState, useMemo, useCallback } from 'react';
 import { AlertVariant } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -13,7 +13,7 @@ export type FileUploadContextType = {
   setFileUpload: (file: File) => void;
 };
 
-export const FileUploadContext = React.createContext<FileUploadContextType>({
+export const FileUploadContext = createContext<FileUploadContextType>({
   fileUpload: undefined,
   setFileUpload: () => {},
   extensions: [],
@@ -26,8 +26,8 @@ export const useValuesFileUploadContext = (): FileUploadContextType => {
   const [fileUploadExtensions, resolved] = useResolvedExtensions<FileUpload>(isFileUpload);
   const toastContext = useToast();
   const [namespace] = useActiveNamespace();
-  const [file, setFile] = React.useState<File>(undefined);
-  const fileExtensions = React.useMemo(
+  const [file, setFile] = useState<File>(undefined);
+  const fileExtensions = useMemo(
     () =>
       resolved
         ? _.flatten(fileUploadExtensions.map((e) => e.properties.fileExtensions)).map((ext) =>
@@ -37,7 +37,7 @@ export const useValuesFileUploadContext = (): FileUploadContextType => {
     [fileUploadExtensions, resolved],
   );
 
-  const setFileUpload = React.useCallback(
+  const setFileUpload = useCallback(
     (f: File): void => {
       if (!f) {
         setFile(undefined);

--- a/frontend/packages/console-app/src/components/nav/useNavExtensionForPerspective.ts
+++ b/frontend/packages/console-app/src/components/nav/useNavExtensionForPerspective.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo, useCallback } from 'react';
 import { NavExtension, isNavExtension } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { LoadedExtension, useExtensions } from '@console/plugin-sdk';
 import { usePerspectives } from '@console/shared/src';
@@ -8,19 +8,19 @@ export const useNavExtensionsForPerspective = (
 ): LoadedExtension<NavExtension>[] => {
   const allPerspectives = usePerspectives();
   const allNavExtensions = useExtensions<NavExtension>(isNavExtension);
-  const isDefaultPerspective = React.useMemo(
+  const isDefaultPerspective = useMemo(
     () =>
       allPerspectives?.some((p) => p.properties.default && p.properties.id === perspective) ??
       false,
     [allPerspectives, perspective],
   );
-  const isExtensionForCurrentPerspective = React.useCallback(
+  const isExtensionForCurrentPerspective = useCallback(
     (extension) =>
       perspective === extension.properties.perspective ||
       (!extension.properties.perspective && isDefaultPerspective),
     [isDefaultPerspective, perspective],
   );
-  return React.useMemo(() => allNavExtensions.filter(isExtensionForCurrentPerspective), [
+  return useMemo(() => allNavExtensions.filter(isExtensionForCurrentPerspective), [
     allNavExtensions,
     isExtensionForCurrentPerspective,
   ]);

--- a/frontend/packages/console-app/src/components/nav/useNavExtensionsForSection.ts
+++ b/frontend/packages/console-app/src/components/nav/useNavExtensionsForSection.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 import { useActivePerspective, NavExtension } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { LoadedExtension } from '@console/dynamic-plugin-sdk/src/types';
 import { useNavExtensionsForPerspective } from './useNavExtensionForPerspective';
@@ -7,11 +7,11 @@ import { getSortedNavExtensions } from './utils';
 export const useNavExtensionsForSection = (section: string): LoadedExtension<NavExtension>[] => {
   const [activePerspective] = useActivePerspective();
   const extensions = useNavExtensionsForPerspective(activePerspective);
-  const isExtensionForSection = React.useCallback(
+  const isExtensionForSection = useCallback(
     (extension) => section === extension.properties.section,
     [section],
   );
-  return React.useMemo(() => {
+  return useMemo(() => {
     const filtered = extensions.filter(isExtensionForSection);
     return getSortedNavExtensions(filtered);
   }, [extensions, isExtensionForSection]);

--- a/frontend/packages/console-app/src/components/nodes/menu-actions.tsx
+++ b/frontend/packages/console-app/src/components/nodes/menu-actions.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCommonResourceActions } from '@console/app/src/actions//hooks/useCommonResourceActions';
 import { Action } from '@console/dynamic-plugin-sdk';
@@ -47,7 +47,7 @@ export const denyCSR = (csr: CertificateSigningRequestKind) => updateCSR(csr, 'D
 export const useNodeActions: ExtensionHook<Action[], NodeKind> = (obj) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(obj));
   const { t } = useTranslation();
-  const deleteMessage = React.useMemo(
+  const deleteMessage = useMemo(
     () => (
       <p>
         {t(
@@ -58,7 +58,7 @@ export const useNodeActions: ExtensionHook<Action[], NodeKind> = (obj) => {
     [t],
   );
   const commonActions = useCommonResourceActions(kindObj, obj, deleteMessage);
-  const nodeActions = React.useMemo<Action[]>(() => {
+  const nodeActions = useMemo<Action[]>(() => {
     const actions: Action[] = [];
     if (isNodeUnschedulable(obj)) {
       actions.push({

--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/NodeDashboardContext.tsx
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/NodeDashboardContext.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import { createContext } from 'react';
 import { NodeKind } from '@console/internal/module/k8s';
 import { LimitRequested } from '@console/shared/src/components/dashboard/utilization-card/UtilizationItem';
 
-export const NodeDashboardContext = React.createContext<NodeDashboardContext>({
+export const NodeDashboardContext = createContext<NodeDashboardContext>({
   setCPULimit: () => {},
   setMemoryLimit: () => {},
   setHealthCheck: () => {},

--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import {
   QuickStartContextValues,
   getDefaultQuickStartState,
@@ -60,7 +60,7 @@ export const useValuesForQuickStartContext = (): QuickStartContextValues => {
   const inlineExecuteCommandShowdownExtension = useInlineExecuteCommandShowdownExtension();
   const multilineExecuteCommandShowdownExtension = useMultilineExecuteCommandShowdownExtension();
 
-  const startQuickStart = React.useCallback(
+  const startQuickStart = useCallback(
     (quickStartId: string, totalTasks?: number) => {
       setActiveQuickStartID((id) => {
         if (!id || id !== quickStartId) {
@@ -88,7 +88,7 @@ export const useValuesForQuickStartContext = (): QuickStartContextValues => {
     [setActiveQuickStartID, setAllQuickStartStates, fireTelemetryEvent],
   );
 
-  const restartQuickStart = React.useCallback(
+  const restartQuickStart = useCallback(
     (quickStartId: string, totalTasks: number) => {
       setActiveQuickStartID((id) => {
         if (!id || id !== quickStartId) {
@@ -108,7 +108,7 @@ export const useValuesForQuickStartContext = (): QuickStartContextValues => {
     [setActiveQuickStartID, setAllQuickStartStates, fireTelemetryEvent],
   );
 
-  const nextStep = React.useCallback(
+  const nextStep = useCallback(
     (totalTasks: number) => {
       if (!activeQuickStartID) return;
 

--- a/frontend/packages/console-app/src/components/quick-starts/utils/useQuickStarts.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/useQuickStarts.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { QuickStart, getDisabledQuickStarts } from '@patternfly/quickstarts';
 import { useTranslation } from 'react-i18next';
 import {
@@ -101,7 +101,7 @@ export const useQuickStarts = (filterDisabledQuickStarts = true): WatchK8sResult
     isList: true,
   });
 
-  const bestMatchQuickStarts = React.useMemo(() => {
+  const bestMatchQuickStarts = useMemo(() => {
     if (!quickStartsLoaded) {
       return [];
     }

--- a/frontend/packages/console-app/src/components/user-preferences/language/useLanguage.ts
+++ b/frontend/packages/console-app/src/components/user-preferences/language/useLanguage.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuickStartContext } from '@console/shared/src/hooks/useQuickStartContext';
 import { getProcessedResourceBundle } from '../../quick-starts/utils/quick-start-context';
@@ -9,7 +9,7 @@ export const useLanguage = (preferredLanguage: string, preferredLanguageLoaded: 
   const { i18n } = useTranslation();
   const { setResourceBundle } = useQuickStartContext();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const onLanguageChange = (lng: string) => {
       if (setResourceBundle) {
         // Update language resource of quick starts components

--- a/frontend/packages/console-app/src/hooks/useCSPViolationDetector.tsx
+++ b/frontend/packages/console-app/src/hooks/useCSPViolationDetector.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback, useEffect } from 'react';
 import { AlertVariant } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -75,7 +75,7 @@ export const useCSPViolationDetector = () => {
     pluginCSPViolationsAreEqual,
   );
 
-  const reportViolation = React.useCallback(
+  const reportViolation = useCallback(
     (event) => {
       // eslint-disable-next-line no-console
       console.warn('Content Security Policy violation detected', event);
@@ -127,7 +127,7 @@ export const useCSPViolationDetector = () => {
     [cacheEvent, fireTelemetryEvent, pluginStore, toastContext, t],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     document.addEventListener('securitypolicyviolation', reportViolation);
     return () => {
       document.removeEventListener('securitypolicyviolation', reportViolation);

--- a/frontend/packages/console-app/src/hooks/useNotificationPoller.ts
+++ b/frontend/packages/console-app/src/hooks/useNotificationPoller.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -35,11 +35,11 @@ export const useNotificationPoller = () => {
 
   // Update alert count.
   const alertCount = alerts?.length ?? 0;
-  React.useEffect(() => {
+  useEffect(() => {
     dispatch(setAlertCount(alertCount));
   }, [alertCount, dispatch]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const pollerTimeouts = {};
     const pollers = {};
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/useResolvedExtensions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/useResolvedExtensions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { useExtensions } from '@console/plugin-sdk/src/api/useExtensions';
 import { resolveExtension } from '../coderefs/coderef-resolver';
 import { UseResolvedExtensions } from '../extensions/console-types';
@@ -10,11 +10,11 @@ export const useResolvedExtensions: UseResolvedExtensions = <E extends Extension
 ): [ResolvedExtension<E>[], boolean, any[]] => {
   const extensions = useExtensions<E>(...typeGuards);
 
-  const [resolvedExtensions, setResolvedExtensions] = React.useState<ResolvedExtension<E>[]>([]);
-  const [resolved, setResolved] = React.useState<boolean>(false);
-  const [errors, setErrors] = React.useState<any[]>([]);
+  const [resolvedExtensions, setResolvedExtensions] = useState<ResolvedExtension<E>[]>([]);
+  const [resolved, setResolved] = useState<boolean>(false);
+  const [errors, setErrors] = useState<any[]>([]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     let disposed = false;
 
     // eslint-disable-next-line promise/catch-or-return

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/utils/rbac.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/utils/rbac.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as _ from 'lodash';
 import { K8sVerb } from '../../../api/common-types';
 import {
@@ -123,7 +123,7 @@ export const useAccessReview = (
   } = resourceAttributes;
   const impersonateKey = getImpersonateKey(impersonate);
   const skipCheck = noCheckForEmptyGroupAndResource && !group && !resource;
-  React.useEffect(() => {
+  useEffect(() => {
     if (skipCheck) {
       setAllowed(false);
       setLoading(false);

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/modal-support/useModal.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/modal-support/useModal.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useContext } from 'react';
 import { LaunchModal, ModalContext } from './ModalProvider';
 
 type UseModalLauncher = () => LaunchModal;
@@ -26,6 +26,6 @@ type UseModalLauncher = () => LaunchModal;
  * ```
  */
 export const useModal: UseModalLauncher = () => {
-  const { launchModal } = React.useContext(ModalContext);
+  const { launchModal } = useContext(ModalContext);
   return launchModal;
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/modal-support/useOverlay.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/modal-support/useOverlay.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useContext } from 'react';
 import { LaunchOverlay, OverlayContext } from './OverlayProvider';
 
 type UseOverlayLauncher = () => LaunchOverlay;
@@ -45,6 +45,6 @@ type UseOverlayLauncher = () => LaunchOverlay;
  * ```
  */
 export const useOverlay: UseOverlayLauncher = () => {
-  const { launchOverlay } = React.useContext(OverlayContext);
+  const { launchOverlay } = useContext(OverlayContext);
   return launchOverlay;
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/useReduxStore.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/useReduxStore.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useMemo } from 'react';
 import { useStore } from 'react-redux';
 import { applyMiddleware, combineReducers, createStore, compose, Store } from 'redux';
 import thunk from 'redux-thunk';
@@ -22,8 +22,8 @@ const composeEnhancers =
  */
 export const useReduxStore = (): { store: Store<any>; storeContextPresent: boolean } => {
   const storeContext = useStore();
-  const [storeContextPresent, setStoreContextPresent] = React.useState(false);
-  const store = React.useMemo(() => {
+  const [storeContextPresent, setStoreContextPresent] = useState(false);
+  const store = useMemo(() => {
     // check if store exists and if not create it
     if (storeContext) {
       setStoreContextPresent(true);

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useDeepCompareMemoize.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useDeepCompareMemoize.ts
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import { useRef } from 'react';
 import * as _ from 'lodash';
 
 export const useDeepCompareMemoize = <T = any>(value: T, strinfigy?: boolean): T => {
-  const ref = React.useRef<T>();
+  const ref = useRef<T>();
 
   if (
     strinfigy

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo, useEffect } from 'react';
 import { Map as ImmutableMap } from 'immutable';
 import { useSelector, useDispatch } from 'react-redux';
 import * as k8sActions from '../../../app/k8s/actions/k8s';
@@ -31,11 +31,11 @@ export const useK8sWatchResource: UseK8sWatchResource = (initResource) => {
 
   const [k8sModel] = useK8sModel(resource?.groupVersionKind || resource?.kind);
 
-  const reduxID = React.useMemo(() => getIDAndDispatch(resource, k8sModel), [k8sModel, resource]);
+  const reduxID = useMemo(() => getIDAndDispatch(resource, k8sModel), [k8sModel, resource]);
 
   const dispatch = useDispatch();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (reduxID) {
       dispatch(reduxID.dispatch);
     }
@@ -50,7 +50,7 @@ export const useK8sWatchResource: UseK8sWatchResource = (initResource) => {
     reduxID ? getReduxIdPayload(state, reduxID.id) : null,
   );
 
-  return React.useMemo(() => {
+  return useMemo(() => {
     if (!resource) {
       return [undefined, true, undefined];
     }

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useRef, useMemo, useEffect } from 'react';
 import { Map as ImmutableMap, Iterable as ImmutableIterable } from 'immutable';
 import { useSelector, useDispatch } from 'react-redux';
 import { createSelectorCreator, defaultMemoize } from 'reselect';
@@ -45,7 +45,7 @@ export const useK8sWatchResources: UseK8sWatchResources = (initResources) => {
   const prevK8sModels = usePrevious(allK8sModels);
   const prevResources = usePrevious(resources);
 
-  const k8sModelsRef = React.useRef<ImmutableIterable<string, K8sModel>>(ImmutableMap());
+  const k8sModelsRef = useRef<ImmutableIterable<string, K8sModel>>(ImmutableMap());
 
   if (
     prevResources !== resources ||
@@ -68,7 +68,7 @@ export const useK8sWatchResources: UseK8sWatchResources = (initResources) => {
 
   const k8sModels = k8sModelsRef.current;
 
-  const reduxIDs = React.useMemo<{
+  const reduxIDs = useMemo<{
     [key: string]: ReturnType<GetIDAndDispatch<OpenShiftReduxRootState>> & { noModel: boolean };
   }>(
     () =>
@@ -99,7 +99,7 @@ export const useK8sWatchResources: UseK8sWatchResources = (initResources) => {
   );
 
   const dispatch = useDispatch();
-  React.useEffect(() => {
+  useEffect(() => {
     const reduxIDKeys = Object.keys(reduxIDs || {});
     reduxIDKeys.forEach((k) => {
       if (reduxIDs[k].dispatch) {
@@ -115,7 +115,7 @@ export const useK8sWatchResources: UseK8sWatchResources = (initResources) => {
     };
   }, [dispatch, reduxIDs]);
 
-  const resourceK8sSelectorCreator = React.useMemo(
+  const resourceK8sSelectorCreator = useMemo(
     () =>
       createSelectorCreator(
         // specifying createSelectorCreator<ImmutableMap<string, K8sKind>> throws type error
@@ -128,7 +128,7 @@ export const useK8sWatchResources: UseK8sWatchResources = (initResources) => {
     [reduxIDs],
   );
 
-  const resourceK8sSelector = React.useMemo(
+  const resourceK8sSelector = useMemo(
     () =>
       resourceK8sSelectorCreator(
         (state: OpenShiftReduxRootState) => state.k8s,
@@ -139,7 +139,7 @@ export const useK8sWatchResources: UseK8sWatchResources = (initResources) => {
 
   const resourceK8s = useSelector(resourceK8sSelector);
 
-  const results = React.useMemo(
+  const results = useMemo(
     () =>
       Object.keys(resources).reduce((acc, key) => {
         if (reduxIDs?.[key].noModel) {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useModelsLoaded.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useModelsLoaded.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { K8sModel } from '../../../api/common-types';
 import { OpenShiftReduxRootState } from './k8s-watch-types';
@@ -10,7 +10,7 @@ import { OpenShiftReduxRootState } from './k8s-watch-types';
  * that uses this hook is mounted, this hook waits until this is resolved, too.
  */
 export const useModelsLoaded = (): boolean => {
-  const ref = React.useRef(false);
+  const ref = useRef(false);
   const loaded = useSelector<OpenShiftReduxRootState, K8sModel>(({ k8s }) =>
     k8s.getIn(['RESOURCES', 'loaded']),
   );

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/usePrevious.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/usePrevious.ts
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import { useRef, useEffect } from 'react';
 
 export const usePrevious = <P = any>(value: P, deps?: any[]): P => {
-  const ref = React.useRef<P>();
-  React.useEffect(() => {
+  const ref = useRef<P>();
+  useEffect(() => {
     ref.current = value;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps || [value]);

--- a/frontend/packages/console-plugin-sdk/src/api/useDynamicPluginInfo.ts
+++ b/frontend/packages/console-plugin-sdk/src/api/useDynamicPluginInfo.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useRef, useCallback, useEffect } from 'react';
 import { useForceRender } from '@console/shared/src/hooks/useForceRender';
 import { DynamicPluginInfo } from '../store';
 import { subscribeToDynamicPlugins } from './pluginSubscriptionService';
@@ -25,12 +25,12 @@ import { subscribeToDynamicPlugins } from './pluginSubscriptionService';
 export const useDynamicPluginInfo = (): [DynamicPluginInfo[], boolean] => {
   const forceRender = useForceRender();
 
-  const isMountedRef = React.useRef(true);
-  const unsubscribeRef = React.useRef<VoidFunction>(null);
-  const pluginInfoEntriesRef = React.useRef<DynamicPluginInfo[]>([]);
-  const allPluginsProcessedRef = React.useRef<boolean>(false);
+  const isMountedRef = useRef(true);
+  const unsubscribeRef = useRef<VoidFunction>(null);
+  const pluginInfoEntriesRef = useRef<DynamicPluginInfo[]>([]);
+  const allPluginsProcessedRef = useRef<boolean>(false);
 
-  const trySubscribe = React.useCallback(() => {
+  const trySubscribe = useCallback(() => {
     if (unsubscribeRef.current === null) {
       unsubscribeRef.current = subscribeToDynamicPlugins((pluginInfoEntries) => {
         pluginInfoEntriesRef.current = pluginInfoEntries;
@@ -40,7 +40,7 @@ export const useDynamicPluginInfo = (): [DynamicPluginInfo[], boolean] => {
     }
   }, [forceRender]);
 
-  const tryUnsubscribe = React.useCallback(() => {
+  const tryUnsubscribe = useCallback(() => {
     if (unsubscribeRef.current !== null) {
       unsubscribeRef.current();
       unsubscribeRef.current = null;
@@ -49,7 +49,7 @@ export const useDynamicPluginInfo = (): [DynamicPluginInfo[], boolean] => {
 
   trySubscribe();
 
-  React.useEffect(
+  useEffect(
     () => () => {
       isMountedRef.current = false;
       tryUnsubscribe();

--- a/frontend/packages/console-plugin-sdk/src/api/useExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/api/useExtensions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useRef, useCallback, useEffect } from 'react';
 import * as _ from 'lodash';
 import { useForceRender } from '@console/shared/src/hooks/useForceRender';
 import { Extension, ExtensionTypeGuard, LoadedExtension } from '../typings';
@@ -46,12 +46,12 @@ export const useExtensions = <E extends Extension>(
 
   const forceRender = useForceRender();
 
-  const isMountedRef = React.useRef(true);
-  const unsubscribeRef = React.useRef<VoidFunction>(null);
-  const extensionsInUseRef = React.useRef<LoadedExtension<E>[]>([]);
-  const latestTypeGuardsRef = React.useRef<ExtensionTypeGuard<E>[]>(typeGuards);
+  const isMountedRef = useRef(true);
+  const unsubscribeRef = useRef<VoidFunction>(null);
+  const extensionsInUseRef = useRef<LoadedExtension<E>[]>([]);
+  const latestTypeGuardsRef = useRef<ExtensionTypeGuard<E>[]>(typeGuards);
 
-  const trySubscribe = React.useCallback(() => {
+  const trySubscribe = useCallback(() => {
     if (unsubscribeRef.current === null) {
       unsubscribeRef.current = subscribeToExtensions<E>((extensions) => {
         extensionsInUseRef.current = extensions;
@@ -60,7 +60,7 @@ export const useExtensions = <E extends Extension>(
     }
   }, [forceRender]);
 
-  const tryUnsubscribe = React.useCallback(() => {
+  const tryUnsubscribe = useCallback(() => {
     if (unsubscribeRef.current !== null) {
       unsubscribeRef.current();
       unsubscribeRef.current = null;
@@ -74,7 +74,7 @@ export const useExtensions = <E extends Extension>(
 
   trySubscribe();
 
-  React.useEffect(
+  useEffect(
     () => () => {
       isMountedRef.current = false;
       tryUnsubscribe();

--- a/frontend/packages/console-plugin-sdk/src/utils/useTranslatedExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/utils/useTranslatedExtensions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { Extension, LoadedExtension } from '@console/dynamic-plugin-sdk/src/types';
 import { isTranslatableString, translateExtensionDeep } from './extension-i18n';
 import useTranslationExt from './useTranslationExt';
@@ -16,7 +16,7 @@ const useTranslatedExtensions = <E extends Extension>(
 ): typeof extensions => {
   const { t } = useTranslationExt();
 
-  React.useMemo(
+  useMemo(
     // Mutate "extensions" parameter only if changed (i.e. a flag-enabled or translations changed)
     () =>
       extensions.forEach((e) => {

--- a/frontend/packages/console-plugin-sdk/src/utils/useTranslationExt.ts
+++ b/frontend/packages/console-plugin-sdk/src/utils/useTranslationExt.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import { TFunction } from 'i18next';
 import { Namespace, useTranslation, UseTranslationOptions } from 'react-i18next';
 import { isTranslatableString, getTranslationKey } from './extension-i18n';
@@ -11,7 +11,7 @@ import { isTranslatableString, getTranslationKey } from './extension-i18n';
 const useTranslationExt = (ns?: Namespace, options?: UseTranslationOptions) => {
   const result = useTranslation(ns, options);
   const { t } = result;
-  const cb: TFunction = React.useCallback(
+  const cb: TFunction = useCallback(
     (value: string) => (isTranslatableString(value) ? t(getTranslationKey(value)) : value),
     [t],
   );

--- a/frontend/packages/console-plugin-shared/src/hooks/useForceRender.ts
+++ b/frontend/packages/console-plugin-shared/src/hooks/useForceRender.ts
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import { useReducer } from 'react';
 
 /**
  * React hook that forces component render.
  */
-export const useForceRender = () => React.useReducer((s: boolean) => !s, false)[1] as VoidFunction;
+export const useForceRender = () => useReducer((s: boolean) => !s, false)[1] as VoidFunction;

--- a/frontend/packages/console-plugin-shared/src/hooks/useResizeObserver.ts
+++ b/frontend/packages/console-plugin-shared/src/hooks/useResizeObserver.ts
@@ -1,13 +1,11 @@
-import * as React from 'react';
+import { useMemo, useEffect } from 'react';
 
 export const useResizeObserver = (
   callback: ResizeObserverCallback,
   targetElement?: HTMLElement | null,
 ): void => {
-  const element = React.useMemo(() => targetElement ?? document.querySelector('body'), [
-    targetElement,
-  ]);
-  React.useEffect(() => {
+  const element = useMemo(() => targetElement ?? document.querySelector('body'), [targetElement]);
+  useEffect(() => {
     const observer = new ResizeObserver(callback);
     observer.observe(element);
     return () => {

--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogToolbar.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogToolbar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { forwardRef } from 'react';
 import { Flex, FlexItem, SearchInput } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -23,7 +23,7 @@ type CatalogToolbarProps = {
   onSortOrderChange: (sortOrder: CatalogSortOrder) => void;
 };
 
-const CatalogToolbar = React.forwardRef<HTMLInputElement, CatalogToolbarProps>(
+const CatalogToolbar = forwardRef<HTMLInputElement, CatalogToolbarProps>(
   (
     {
       title,

--- a/frontend/packages/console-shared/src/components/catalog/hooks/useCatalogCategories.ts
+++ b/frontend/packages/console-shared/src/components/catalog/hooks/useCatalogCategories.ts
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { defaultCatalogCategories } from '../../../utils/default-categories';
 import { CatalogCategory } from '../utils/types';
 
 const useCatalogCategories = (): CatalogCategory[] => {
-  const categories = React.useMemo<CatalogCategory[]>(() => {
+  const categories = useMemo<CatalogCategory[]>(() => {
     try {
       const categoriesString = window.SERVER_FLAGS.developerCatalogCategories;
       if (!categoriesString) {

--- a/frontend/packages/console-shared/src/components/catalog/hooks/useCatalogExtensions.ts
+++ b/frontend/packages/console-shared/src/components/catalog/hooks/useCatalogExtensions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 import * as _ from 'lodash';
 import { useResolvedExtensions, ResolvedExtension } from '@console/dynamic-plugin-sdk';
 import {
@@ -25,7 +25,7 @@ const useCatalogExtensions = (
   boolean,
 ] => {
   const [itemTypeExtensions, itemTypesResolved] = useResolvedExtensions<CatalogItemType>(
-    React.useCallback(
+    useCallback(
       (e): e is CatalogItemType =>
         isCatalogItemType(e) && (!catalogType || e.properties.type === catalogType),
       [catalogType],
@@ -35,7 +35,7 @@ const useCatalogExtensions = (
   const [typeMetadataExtensions, itemTypeMetadataResolved] = useResolvedExtensions<
     CatalogItemTypeMetadata
   >(
-    React.useCallback(
+    useCallback(
       (e): e is CatalogItemTypeMetadata =>
         isCatalogItemTypeMetadata(e) && (!catalogType || e.properties.type === catalogType),
       [catalogType],
@@ -43,7 +43,7 @@ const useCatalogExtensions = (
   );
 
   const [catalogProviderExtensions, providersResolved] = useResolvedExtensions<CatalogItemProvider>(
-    React.useCallback(
+    useCallback(
       (e): e is CatalogItemProvider =>
         isCatalogItemProvider(e) &&
         _.castArray(e.properties.catalogId).includes(catalogId) &&
@@ -53,7 +53,7 @@ const useCatalogExtensions = (
   );
 
   const [itemFilterExtensions, filtersResolved] = useResolvedExtensions<CatalogItemFilter>(
-    React.useCallback(
+    useCallback(
       (e): e is CatalogItemFilter =>
         isCatalogItemFilter(e) &&
         _.castArray(e.properties.catalogId).includes(catalogId) &&
@@ -65,7 +65,7 @@ const useCatalogExtensions = (
   const [metadataProviderExtensions, metadataProvidersResolved] = useResolvedExtensions<
     CatalogItemMetadataProvider
   >(
-    React.useCallback(
+    useCallback(
       (e): e is CatalogItemMetadataProvider =>
         isCatalogItemMetadataProvider(e) &&
         _.castArray(e.properties.catalogId).includes(catalogId) &&
@@ -74,7 +74,7 @@ const useCatalogExtensions = (
     ),
   );
 
-  const catalogTypeExtensions = React.useMemo<ResolvedExtension<CatalogItemType>[]>(
+  const catalogTypeExtensions = useMemo<ResolvedExtension<CatalogItemType>[]>(
     () =>
       (catalogType
         ? itemTypeExtensions.filter((e) => e.properties.type === catalogType)

--- a/frontend/packages/console-shared/src/components/catalog/service/CatalogExtensionHookResolver.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/service/CatalogExtensionHookResolver.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 import { ExtensionHook } from '@console/dynamic-plugin-sdk/src/api/common-types';
 import { CatalogExtensionHookOptions } from '@console/dynamic-plugin-sdk/src/extensions';
 
@@ -19,13 +19,13 @@ const CatalogExtensionHookResolver = function <T>({
 }: CatalogExtensionHookResolverProps<T>) {
   const [value, loaded, loadError] = useValue(options);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (loaded) onValueResolved(value, id);
     // unnecessary to run effect again if the onValueResolved callback changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, loaded, value]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (loadError && onValueError) onValueError(loadError, id);
     // unnecessary to run effect again if the onValueError callback changes
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/prometheus-hook.ts
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/prometheus-hook.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect, useMemo } from 'react';
 import { Map as ImmutableMap } from 'immutable';
 import { useSelector, useDispatch } from 'react-redux';
 import {
@@ -13,7 +13,7 @@ import { RootState } from '@console/internal/redux';
 /** @deprecated use usePrometheusPoll() instead */
 export const usePrometheusQuery: UsePrometheusQuery = (query, humanize) => {
   const dispatch = useDispatch();
-  React.useEffect(() => {
+  useEffect(() => {
     dispatch(watchPrometheusQuery(query));
     return () => {
       dispatch(stopWatchPrometheusQuery(query));
@@ -23,7 +23,7 @@ export const usePrometheusQuery: UsePrometheusQuery = (query, humanize) => {
   const queryResult = useSelector<RootState, ImmutableMap<string, any>>(({ dashboards }) =>
     dashboards.getIn([RESULTS_TYPE.PROMETHEUS, query]),
   );
-  const results = React.useMemo<[HumanizeResult, any, number]>(() => {
+  const results = useMemo<[HumanizeResult, any, number]>(() => {
     if (!queryResult || !queryResult.get('data')) {
       return [{}, null, null] as [HumanizeResult, any, number];
     }

--- a/frontend/packages/console-shared/src/components/editor/CodeEditor.tsx
+++ b/frontend/packages/console-shared/src/components/editor/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { forwardRef, useState, useCallback, useImperativeHandle, useMemo, useEffect } from 'react';
 import { EditorDidMount, Language } from '@patternfly/react-code-editor';
 import { getResizeObserver } from '@patternfly/react-core';
 import { CodeEditorRef, CodeEditorProps } from '@console/dynamic-plugin-sdk';
@@ -8,16 +8,16 @@ import { useShortcutPopover } from './ShortcutsPopover';
 import { registerYAMLinMonaco, registerAutoFold, defaultEditorOptions } from './yaml-editor-utils';
 import './CodeEditor.scss';
 
-const CodeEditor = React.forwardRef<CodeEditorRef, CodeEditorProps>((props, ref) => {
+const CodeEditor = forwardRef<CodeEditorRef, CodeEditorProps>((props, ref) => {
   const { value, minHeight, showShortcuts, toolbarLinks, onSave, onEditorDidMount } = props;
 
-  const [editorRef, setEditorRef] = React.useState<CodeEditorRef['editor'] | null>(null);
-  const [monacoRef, setMonacoRef] = React.useState<CodeEditorRef['monaco'] | null>(null);
-  const [usesValue] = React.useState<boolean>(value !== undefined);
+  const [editorRef, setEditorRef] = useState<CodeEditorRef['editor'] | null>(null);
+  const [monacoRef, setMonacoRef] = useState<CodeEditorRef['monaco'] | null>(null);
+  const [usesValue] = useState<boolean>(value !== undefined);
 
   const shortcutPopover = useShortcutPopover(props.shortcutsPopoverProps);
 
-  const editorDidMount: EditorDidMount = React.useCallback(
+  const editorDidMount: EditorDidMount = useCallback(
     (editor, monaco) => {
       setEditorRef(editor);
       setMonacoRef(monaco);
@@ -43,7 +43,7 @@ const CodeEditor = React.forwardRef<CodeEditorRef, CodeEditorProps>((props, ref)
   );
 
   // expose the editor instance to the parent component via ref
-  React.useImperativeHandle(
+  useImperativeHandle(
     ref,
     () => ({
       editor: editorRef,
@@ -53,26 +53,26 @@ const CodeEditor = React.forwardRef<CodeEditorRef, CodeEditorProps>((props, ref)
   );
 
   // do not render toolbar if the component is null
-  const ToolbarLinks = React.useMemo(() => {
+  const ToolbarLinks = useMemo(() => {
     return showShortcuts || toolbarLinks?.length ? (
       <CodeEditorToolbar toolbarLinks={toolbarLinks} />
     ) : undefined;
   }, [toolbarLinks, showShortcuts]);
 
   // recalculate bounds when viewport is changed
-  const handleResize = React.useCallback(() => {
+  const handleResize = useCallback(() => {
     monacoRef?.editor?.getEditors()?.forEach((editor) => {
       editor.layout({ width: 0, height: 0 });
       editor.layout();
     });
   }, [monacoRef]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const observer = getResizeObserver(undefined, handleResize, true);
     return () => observer();
   }, [handleResize]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     handleResize();
   }, [handleResize, minHeight, ToolbarLinks]);
 

--- a/frontend/packages/console-shared/src/components/formik-fields/InputField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/InputField.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import { forwardRef } from 'react';
 import { TextInput, TextInputTypes, ValidatedOptions } from '@patternfly/react-core';
 import BaseInputField from './BaseInputField';
 import { BaseInputFieldProps } from './field-types';
 
 import './InputField.scss';
 
-const InputField = React.forwardRef<HTMLInputElement, BaseInputFieldProps>(
+const InputField = forwardRef<HTMLInputElement, BaseInputFieldProps>(
   ({ type = TextInputTypes.text, ...baseProps }, ref) => (
     <BaseInputField type={type} {...baseProps}>
       {(props) => (

--- a/frontend/packages/console-shared/src/components/formik-fields/TextAreaField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/TextAreaField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { forwardRef } from 'react';
 import {
   FormGroup,
   FormHelperText,
@@ -10,7 +10,7 @@ import { useField } from 'formik';
 import { TextAreaProps } from './field-types';
 import { getFieldId } from './field-utils';
 
-const TextAreaField = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
+const TextAreaField = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   ({ label, helpText, required, onChange, ...props }, ref) => {
     const [field, { touched, error }] = useField(props.name);
     const fieldId = getFieldId(props.name, 'input');

--- a/frontend/packages/console-shared/src/components/modals/ConsolePluginModal.tsx
+++ b/frontend/packages/console-shared/src/components/modals/ConsolePluginModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import { Form } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import {
@@ -30,7 +30,7 @@ export const ConsolePluginModal = withHandlePromise((props: ConsolePluginModalPr
   } = props;
   const previouslyEnabled = isPluginEnabled(consoleOperatorConfig, pluginName);
   const { t } = useTranslation();
-  const [enabled, setEnabled] = React.useState(previouslyEnabled);
+  const [enabled, setEnabled] = useState(previouslyEnabled);
   const submit = (event) => {
     event.preventDefault();
     const patch = getPluginPatch(consoleOperatorConfig, pluginName, enabled);

--- a/frontend/packages/console-shared/src/components/modals/CreateProjectModal.tsx
+++ b/frontend/packages/console-shared/src/components/modals/CreateProjectModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useCallback } from 'react';
 import { Button, Alert, ContentVariants, Content } from '@patternfly/react-core';
 import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { useTranslation } from 'react-i18next';
@@ -30,12 +30,12 @@ const DefaultCreateProjectModal: ModalComponent<CreateProjectModalProps> = ({
 }) => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const [inProgress, setInProgress] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState('');
-  const [name, setName] = React.useState('');
-  const [displayName, setDisplayName] = React.useState('');
-  const [description, setDescription] = React.useState('');
-  const hideStartGuide = React.useCallback(
+  const [inProgress, setInProgress] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [name, setName] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [description, setDescription] = useState('');
+  const hideStartGuide = useCallback(
     () => dispatch(setFlag(FLAGS.SHOW_OPENSHIFT_START_GUIDE, false)),
     [dispatch],
   );

--- a/frontend/packages/console-shared/src/components/synced-editor/useEditorType.ts
+++ b/frontend/packages/console-shared/src/components/synced-editor/useEditorType.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import {
   PREFERRED_CREATE_EDIT_METHOD_USER_SETTING_VALUE_LATEST,
   usePreferredCreateEditMethod,
@@ -36,12 +36,12 @@ export const useEditorType = (
     return defaultValue;
   };
 
-  const [activeEditorType, setActiveEditorType] = React.useState<EditorType>(null);
+  const [activeEditorType, setActiveEditorType] = useState<EditorType>(null);
   const setEditorType = (type: EditorType) => {
     setActiveEditorType(type);
     setLastViewedEditorType(type);
   };
-  React.useEffect(() => {
+  useEffect(() => {
     if (resourceLoaded) {
       const editorType: EditorType = getEditorType();
       if (!lastViewedEditorType || lastViewedEditorType !== editorType) {

--- a/frontend/packages/console-shared/src/components/toast/useToast.ts
+++ b/frontend/packages/console-shared/src/components/toast/useToast.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useContext } from 'react';
 import ToastContext from './ToastContext';
 
-export default () => React.useContext(ToastContext);
+export default () => useContext(ToastContext);

--- a/frontend/packages/console-shared/src/hooks/__tests__/usePluginsOverviewTabSection.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/usePluginsOverviewTabSection.spec.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { createElement } from 'react';
 import { Button } from '@patternfly/react-core';
 import { useExtensions, OverviewTabSection, LazyLoader } from '@console/plugin-sdk';
 import { testHook } from '@console/shared/src/test-utils/hooks-utils';
@@ -28,7 +28,7 @@ describe('usePluginsOverviewTabSection', () => {
   it('should not be empty, when there is overview tab section registered', () => {
     const loader: LazyLoader = jasmine
       .createSpy('loader')
-      .and.returnValue(Promise.resolve(React.createElement(Button)));
+      .and.returnValue(Promise.resolve(createElement(Button)));
 
     const tabSection: OverviewTabSection = {
       type: 'Overview/Section',

--- a/frontend/packages/console-shared/src/hooks/create-resource-hook.ts
+++ b/frontend/packages/console-shared/src/hooks/create-resource-hook.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import { isCreateResource, CreateResource, GroupVersionKind } from '@console/dynamic-plugin-sdk';
 import { referenceForExtensionModel } from '@console/internal/module/k8s';
 import { Extension, LoadedExtension, useExtensions } from '@console/plugin-sdk';
@@ -6,7 +6,7 @@ import { Extension, LoadedExtension, useExtensions } from '@console/plugin-sdk';
 export const useCreateResourceExtension = (
   modelReference: GroupVersionKind,
 ): LoadedExtension<CreateResource> => {
-  const createResourceTypeGuard = React.useCallback(
+  const createResourceTypeGuard = useCallback(
     (e: Extension): e is CreateResource =>
       isCreateResource(e) && referenceForExtensionModel(e.properties.model) === modelReference,
     [modelReference],

--- a/frontend/packages/console-shared/src/hooks/csv-watch-hook.ts
+++ b/frontend/packages/console-shared/src/hooks/csv-watch-hook.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { referenceForModel } from '@console/internal/module/k8s';
 import {
@@ -12,7 +12,7 @@ type CsvWatchResource = {
   csvError: {};
 };
 export const useCsvWatchResource = (ns: string): CsvWatchResource => {
-  const csvResource = React.useMemo(
+  const csvResource = useMemo(
     () => ({
       isList: true,
       kind: referenceForModel(ClusterServiceVersionModel),

--- a/frontend/packages/console-shared/src/hooks/debounce.ts
+++ b/frontend/packages/console-shared/src/hooks/debounce.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useRef, useMemo } from 'react';
 import { debounce, DebounceSettings } from 'lodash';
 import { useDeepCompareMemoize } from './deep-compare-memoize';
 
@@ -16,10 +16,10 @@ export const useDebounceCallback = <T extends (...args: any[]) => any>(
   },
 ): ((...args) => any) & Cancelable => {
   const memDebounceParams = useDeepCompareMemoize(debounceParams);
-  const callbackRef = React.useRef<T>();
+  const callbackRef = useRef<T>();
   callbackRef.current = callback;
 
-  return React.useMemo(() => {
+  return useMemo(() => {
     return debounce((...args) => callbackRef.current(...args), timeout, memDebounceParams);
   }, [memDebounceParams, timeout]);
 };

--- a/frontend/packages/console-shared/src/hooks/deep-compare-memoize.ts
+++ b/frontend/packages/console-shared/src/hooks/deep-compare-memoize.ts
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import { useRef } from 'react';
 import * as _ from 'lodash';
 
 export const useDeepCompareMemoize = <T = any>(value: T, stringify?: boolean): T => {
-  const ref = React.useRef<T>();
+  const ref = useRef<T>();
 
   if (
     stringify

--- a/frontend/packages/console-shared/src/hooks/document-listener.ts
+++ b/frontend/packages/console-shared/src/hooks/document-listener.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { isModalOpen } from '@console/internal/components/modals';
 import { KEYBOARD_SHORTCUTS } from '../constants/common';
 
@@ -20,8 +20,8 @@ const textInputKeyHandler = {
 export const useDocumentListener = <T extends HTMLElement>(
   keyEventMap: KeyEventMap = textInputKeyHandler,
 ) => {
-  const [visible, setVisible] = React.useState(true);
-  const ref = React.useRef<T>(null);
+  const [visible, setVisible] = useState(true);
+  const ref = useRef<T>(null);
 
   const handleEvent = (e) => {
     if (!ref?.current?.contains(e.target)) {
@@ -56,7 +56,7 @@ export const useDocumentListener = <T extends HTMLElement>(
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     document.addEventListener('click', handleEvent, true);
     document.addEventListener('keydown', handleKeyEvents, true);
     return () => {

--- a/frontend/packages/console-shared/src/hooks/formik-validation-fix.ts
+++ b/frontend/packages/console-shared/src/hooks/formik-validation-fix.ts
@@ -1,13 +1,13 @@
-import * as React from 'react';
+import { useRef, useEffect } from 'react';
 import { useFormikContext, FormikValues } from 'formik';
 import { useDeepCompareMemoize } from './deep-compare-memoize';
 
 export const useFormikValidationFix = (value: any) => {
   const { validateForm } = useFormikContext<FormikValues>();
   const memoizedValue = useDeepCompareMemoize(value);
-  const mounted = React.useRef(false);
+  const mounted = useRef(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!mounted.current) {
       // skip auto validation when the component just mounted
       mounted.current = true;

--- a/frontend/packages/console-shared/src/hooks/hpa-hooks.ts
+++ b/frontend/packages/console-shared/src/hooks/hpa-hooks.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { HorizontalPodAutoscalerModel } from '@console/internal/models';
 import { HorizontalPodAutoscalerKind } from '@console/internal/module/k8s';
@@ -22,7 +22,7 @@ export const useRelatedHPA = (
     isList: true,
   });
 
-  const matchingHpa = React.useMemo<HorizontalPodAutoscalerKind>(() => {
+  const matchingHpa = useMemo<HorizontalPodAutoscalerKind>(() => {
     if (hpas && loaded && !error) {
       return hpas.find(
         doesHpaMatch({

--- a/frontend/packages/console-shared/src/hooks/perspective-utils.ts
+++ b/frontend/packages/console-shared/src/hooks/perspective-utils.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import {
   isPerspective,
   Perspective as PerspectiveExtension,
@@ -81,7 +81,7 @@ export const hasReviewAccess = async (accessReview: PerspectiveAccessReview) => 
 
 export const usePerspectives = (): LoadedExtension<PerspectiveExtension>[] => {
   const perspectiveExtensions = useExtensions<PerspectiveExtension>(isPerspective);
-  const [results, setResults] = React.useState<Record<string, boolean>>(() => {
+  const [results, setResults] = useState<Record<string, boolean>>(() => {
     let obj: Record<string, boolean> = {};
     if (!window.SERVER_FLAGS.perspectives) {
       obj = perspectiveExtensions.reduce(
@@ -110,7 +110,7 @@ export const usePerspectives = (): LoadedExtension<PerspectiveExtension>[] => {
     return obj;
   });
 
-  const handleResults = React.useCallback(
+  const handleResults = useCallback(
     (id: string, newState: boolean) => {
       setResults((oldResults: Record<string, boolean>) => {
         if (oldResults[id] === newState) {
@@ -124,7 +124,7 @@ export const usePerspectives = (): LoadedExtension<PerspectiveExtension>[] => {
     },
     [setResults],
   );
-  React.useEffect(() => {
+  useEffect(() => {
     if (window.SERVER_FLAGS.perspectives) {
       const perspectives: Perspective[] = JSON.parse(window.SERVER_FLAGS.perspectives);
       perspectiveExtensions.forEach((perspectiveExtension) => {
@@ -156,7 +156,7 @@ export const usePerspectives = (): LoadedExtension<PerspectiveExtension>[] => {
       });
     }
   }, [perspectiveExtensions, handleResults]);
-  const perspectives = React.useMemo(() => {
+  const perspectives = useMemo(() => {
     if (!window.SERVER_FLAGS.perspectives) {
       return perspectiveExtensions;
     }
@@ -173,7 +173,7 @@ export const usePerspectives = (): LoadedExtension<PerspectiveExtension>[] => {
 
 export const usePerspectiveExtension = (id: string): LoadedExtension<PerspectiveExtension> => {
   const perspectiveExtensions = usePerspectives();
-  return React.useMemo(() => perspectiveExtensions.find((e) => e.properties.id === id), [
+  return useMemo(() => perspectiveExtensions.find((e) => e.properties.id === id), [
     id,
     perspectiveExtensions,
   ]);

--- a/frontend/packages/console-shared/src/hooks/promise-handler.ts
+++ b/frontend/packages/console-shared/src/hooks/promise-handler.ts
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import { useState } from 'react';
 
 export const usePromiseHandler: PromiseHandlerHook = <T extends unknown = any>() => {
-  const [inProgress, setInProgress] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState('');
+  const [inProgress, setInProgress] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
   const handlePromise: PromiseHandlerCallback<T> = (promise) => {
     setInProgress(true);
     return promise

--- a/frontend/packages/console-shared/src/hooks/scroll.ts
+++ b/frontend/packages/console-shared/src/hooks/scroll.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useRef, useState, useCallback } from 'react';
 
 export enum ScrollDirection {
   scrollingUp = 'scrolling-up',
@@ -27,9 +27,9 @@ export const getScrollDirection = (
 };
 
 export const useScrollDirection = (): [ScrollDirection, (event) => void] => {
-  const scrollPosition = React.useRef<number>(null);
-  const [scrollDirection, setScrollDirection] = React.useState<ScrollDirection>(null);
-  const handleScroll = React.useCallback(
+  const scrollPosition = useRef<number>(null);
+  const [scrollDirection, setScrollDirection] = useState<ScrollDirection>(null);
+  const handleScroll = useCallback(
     (event) => {
       const { scrollHeight, scrollTop, clientHeight } = event.target;
       if (scrollPosition.current !== null) {

--- a/frontend/packages/console-shared/src/hooks/select-list.ts
+++ b/frontend/packages/console-shared/src/hooks/select-list.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useCallback } from 'react';
 import { OnSelect } from '@patternfly/react-table';
 import { K8sResourceCommon } from '@console/internal/module/k8s';
 
@@ -11,9 +11,9 @@ export const useSelectList = <R extends K8sResourceCommon>(
   selectedRows: Set<string>;
   updateSelectedRows: (rows: R[]) => void;
 } => {
-  const [selectedRows, setSelectedRows] = React.useState<Set<string>>(visibleRows);
+  const [selectedRows, setSelectedRows] = useState<Set<string>>(visibleRows);
 
-  const onSelect = React.useCallback(
+  const onSelect = useCallback(
     (_event, isSelected, rowIndex, rowData) => {
       const uniqueUIDs: Set<string> = selectedRows ? new Set([...selectedRows]) : new Set<string>();
 
@@ -31,7 +31,7 @@ export const useSelectList = <R extends K8sResourceCommon>(
     [data, onRowSelected, selectedRows, visibleRows],
   );
 
-  const updateSelectedRows = React.useCallback(
+  const updateSelectedRows = useCallback(
     (rows: R[]) => {
       onRowSelected(rows);
       setSelectedRows(new Set(rows.map((row) => row.metadata.uid)));

--- a/frontend/packages/console-shared/src/hooks/useAnnotationsModal.tsx
+++ b/frontend/packages/console-shared/src/hooks/useAnnotationsModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import { ModalComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/ModalProvider';
 import { useModal } from '@console/dynamic-plugin-sdk/src/app/modal-support/useModal';
 import { UseAnnotationsModal } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
@@ -23,7 +23,7 @@ export const useAnnotationsModal: UseAnnotationsModal = (resource) => {
   const launcher = useModal();
   const groupVersionKind = getGroupVersionKindForResource(resource);
   const [kind] = useK8sModel(groupVersionKind);
-  return React.useCallback(
+  return useCallback(
     () =>
       resource &&
       kind &&

--- a/frontend/packages/console-shared/src/hooks/useBoundingClientRect.ts
+++ b/frontend/packages/console-shared/src/hooks/useBoundingClientRect.ts
@@ -1,14 +1,14 @@
-import * as React from 'react';
+import { useState, useCallback } from 'react';
 import { useResizeObserver } from './useResizeObserver';
 
 type BoundingClientRect = ClientRect | null;
 
 export const useBoundingClientRect = (targetElement: HTMLElement | null): BoundingClientRect => {
-  const [clientRect, setClientRect] = React.useState<BoundingClientRect>(() =>
+  const [clientRect, setClientRect] = useState<BoundingClientRect>(() =>
     targetElement ? targetElement.getBoundingClientRect() : null,
   );
 
-  const observerCallback = React.useCallback(() => {
+  const observerCallback = useCallback(() => {
     setClientRect(targetElement ? targetElement.getBoundingClientRect() : null);
   }, [targetElement]);
 

--- a/frontend/packages/console-shared/src/hooks/useBuildConfigsWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/useBuildConfigsWatcher.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { BuildConfigOverviewItem } from '../types';
@@ -12,7 +12,7 @@ export type BuildConfigData = {
 
 export const useBuildConfigsWatcher = (resource: K8sResourceKind): BuildConfigData => {
   const { namespace } = resource.metadata;
-  const watchedResources = React.useMemo(
+  const watchedResources = useMemo(
     () => ({
       buildConfigs: {
         isList: true,
@@ -30,7 +30,7 @@ export const useBuildConfigsWatcher = (resource: K8sResourceKind): BuildConfigDa
 
   const resources = useK8sWatchResources(watchedResources);
 
-  const result = React.useMemo(() => {
+  const result = useMemo(() => {
     const resourceWithLoadError = Object.values(resources).find((r) => r.loadError);
     if (resourceWithLoadError) {
       return { loaded: false, loadError: resourceWithLoadError.loadError, buildConfigs: null };

--- a/frontend/packages/console-shared/src/hooks/useCRDAdditionalPrinterColumns.ts
+++ b/frontend/packages/console-shared/src/hooks/useCRDAdditionalPrinterColumns.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { consoleFetchJSON as coFetchJSON } from '@console/dynamic-plugin-sdk/src/utils/fetch';
 import {
   CRDAdditionalPrinterColumn,
@@ -7,10 +7,10 @@ import {
 } from '@console/internal/module/k8s';
 
 export const useCRDAdditionalPrinterColumns = (model: K8sModel): CRDAdditionalPrinterColumn[] => {
-  const [CRDAPC, setCRDAPC] = React.useState<CRDAdditionalPrinterColumns>({});
-  const [loading, setLoading] = React.useState(true);
+  const [CRDAPC, setCRDAPC] = useState<CRDAdditionalPrinterColumns>({});
+  const [loading, setLoading] = useState(true);
 
-  React.useEffect(() => {
+  useEffect(() => {
     coFetchJSON(`/api/console/crd-columns/${model.plural}.${model.apiGroup}`)
       .then((response) => {
         setCRDAPC(response);

--- a/frontend/packages/console-shared/src/hooks/useCopyCodeModal.tsx
+++ b/frontend/packages/console-shared/src/hooks/useCopyCodeModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import { useModal } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { CopyToClipboard } from '@console/internal/components/utils';
 import { Modal } from '@console/shared/src/components/modal';
@@ -12,7 +12,7 @@ const CopyCodeModal: CopyCodeModalComponent = ({ title, snippet, closeModal }) =
 
 export const useCopyCodeModal: UseCopyCodeModal = (title, snippet) => {
   const launcher = useModal();
-  return React.useCallback(() => (snippet ? launcher(CopyCodeModal, { title, snippet }) : null), [
+  return useCallback(() => (snippet ? launcher(CopyCodeModal, { title, snippet }) : null), [
     launcher,
     snippet,
     title,

--- a/frontend/packages/console-shared/src/hooks/useCopyLoginCommands.ts
+++ b/frontend/packages/console-shared/src/hooks/useCopyLoginCommands.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { consoleFetchJSON as coFetchJSON } from '@console/dynamic-plugin-sdk/src/utils/fetch';
 import { FLAGS } from '../constants';
 import { useFlag } from './flag';
@@ -6,10 +6,10 @@ import { useFlag } from './flag';
 const COPY_LOGIN_COMMANDS_ENDPOINT = '/api/copy-login-commands';
 
 export const useCopyLoginCommands = (): [string, string] => {
-  const [requestTokenURL, setRequestTokenURL] = React.useState<string>();
-  const [externalLoginCommand, setExternalLoginCommand] = React.useState<string>();
+  const [requestTokenURL, setRequestTokenURL] = useState<string>();
+  const [externalLoginCommand, setExternalLoginCommand] = useState<string>();
   const authEnabled = useFlag(FLAGS.AUTH_ENABLED);
-  React.useEffect(() => {
+  useEffect(() => {
     if (authEnabled) {
       coFetchJSON(COPY_LOGIN_COMMANDS_ENDPOINT, 'GET', {}, 5000)
         .then((resp) => {

--- a/frontend/packages/console-shared/src/hooks/useCreateNamespaceModal.ts
+++ b/frontend/packages/console-shared/src/hooks/useCreateNamespaceModal.ts
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import { CreateProjectModalProps } from '@console/dynamic-plugin-sdk/src';
 import { useModal } from '@console/dynamic-plugin-sdk/src/app/modal-support/useModal';
 import { CreateNamespaceModal } from '../components/modals/CreateNamespaceModal';
 
 export const useCreateNamespaceModal: UseCreateNamespaceModal = () => {
   const launcher = useModal();
-  return React.useCallback((props) => launcher(CreateNamespaceModal, props), [launcher]);
+  return useCallback((props) => launcher(CreateNamespaceModal, props), [launcher]);
 };
 
 type UseCreateNamespaceModal = () => (props: CreateProjectModalProps) => void;

--- a/frontend/packages/console-shared/src/hooks/useCreateNamespaceOrProjectModal.ts
+++ b/frontend/packages/console-shared/src/hooks/useCreateNamespaceOrProjectModal.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import { CreateProjectModalProps } from '@console/dynamic-plugin-sdk/src';
 import { useModal } from '@console/dynamic-plugin-sdk/src/app/modal-support/useModal';
 import { FLAGS } from '@console/shared/src/constants/common';
@@ -10,7 +10,7 @@ export const useCreateNamespaceOrProjectModal: UseCreateProjectModal = () => {
   const launcher = useModal();
   const isOpenShift = useFlag(FLAGS.OPENSHIFT);
   const ModalComponent = isOpenShift ? CreateProjectModal : CreateNamespaceModal;
-  return React.useCallback((props) => launcher(ModalComponent, props), [launcher, ModalComponent]);
+  return useCallback((props) => launcher(ModalComponent, props), [launcher, ModalComponent]);
 };
 
 type UseCreateProjectModal = () => (props: CreateProjectModalProps) => void;

--- a/frontend/packages/console-shared/src/hooks/useCreateProjectModal.ts
+++ b/frontend/packages/console-shared/src/hooks/useCreateProjectModal.ts
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import { CreateProjectModalProps } from '@console/dynamic-plugin-sdk/src';
 import { useModal } from '@console/dynamic-plugin-sdk/src/app/modal-support/useModal';
 import { CreateProjectModal } from '../components/modals/CreateProjectModal';
 
 export const useCreateProjectModal: UseCreateProjectModal = () => {
   const launcher = useModal();
-  return React.useCallback((props) => launcher(CreateProjectModal, props), [launcher]);
+  return useCallback((props) => launcher(CreateProjectModal, props), [launcher]);
 };
 
 type UseCreateProjectModal = () => (props: CreateProjectModalProps) => void;

--- a/frontend/packages/console-shared/src/hooks/useDashboardResources.ts
+++ b/frontend/packages/console-shared/src/hooks/useDashboardResources.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   RequestMap,
@@ -25,7 +25,7 @@ export const useDashboardResources: UseDashboardResources = ({
   );
 
   const dispatch = useDispatch();
-  React.useEffect(() => {
+  useEffect(() => {
     prometheusQueries?.forEach((query) =>
       dispatch(watchPrometheusQuery(query.query, null, query.timespan)),
     );

--- a/frontend/packages/console-shared/src/hooks/useDeleteModal.tsx
+++ b/frontend/packages/console-shared/src/hooks/useDeleteModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import { UseDeleteModal } from '@console/dynamic-plugin-sdk/src';
 import { ModalComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/ModalProvider';
 import { useModal } from '@console/dynamic-plugin-sdk/src/app/modal-support/useModal';
@@ -42,7 +42,7 @@ export const useDeleteModal: UseDeleteModal = (
   const launcher = useModal();
   const groupVersionKind = getGroupVersionKindForResource(resource);
   const [kind] = useK8sModel(groupVersionKind);
-  return React.useCallback(
+  return useCallback(
     () =>
       resource &&
       kind &&

--- a/frontend/packages/console-shared/src/hooks/useDetailsItemExtensionsForResource.ts
+++ b/frontend/packages/console-shared/src/hooks/useDetailsItemExtensionsForResource.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 import { useResolvedExtensions } from '@console/dynamic-plugin-sdk/src/api/useResolvedExtensions';
 import { K8sResourceCommon } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import {
@@ -20,7 +20,7 @@ export const useDetailsItemExtensionsForResource: UseDetailsItemExtensionsForRes
   obj,
   column,
 ) => {
-  const typeGuard = React.useCallback<ExtensionTypeGuard<DetailsItem>>(
+  const typeGuard = useCallback<ExtensionTypeGuard<DetailsItem>>(
     (e): e is DetailsItem => {
       const columnMatches = e.properties.column === column;
       const modelMatches = referenceFor(obj) === referenceForExtensionModel(e.properties.model);
@@ -31,7 +31,7 @@ export const useDetailsItemExtensionsForResource: UseDetailsItemExtensionsForRes
 
   const [extensions] = useResolvedExtensions<DetailsItem>(typeGuard);
 
-  return React.useMemo(
+  return useMemo(
     () =>
       (extensions ?? []).sort((a, b) => {
         const aWeight = Number(a.properties.sortWeight);

--- a/frontend/packages/console-shared/src/hooks/useForceUpdate.ts
+++ b/frontend/packages/console-shared/src/hooks/useForceUpdate.ts
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import { useState, useCallback } from 'react';
 
 export const useForceUpdate = () => {
-  const [, setTick] = React.useState(0);
-  const update = React.useCallback(() => {
+  const [, setTick] = useState(0);
+  const update = useCallback(() => {
     setTick((tick) => tick + 1);
   }, []);
   return update;

--- a/frontend/packages/console-shared/src/hooks/useGetUserSettingConfigMap.ts
+++ b/frontend/packages/console-shared/src/hooks/useGetUserSettingConfigMap.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getImpersonate, getUser, K8sResourceKind } from '@console/dynamic-plugin-sdk/src';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
@@ -28,7 +28,7 @@ export const useGetUserSettingConfigMap = () => {
     return impersonateName || uid || hashName || '';
   });
 
-  const configMapResource = React.useMemo(
+  const configMapResource = useMemo(
     () =>
       !userUid
         ? null

--- a/frontend/packages/console-shared/src/hooks/useIsMobile.ts
+++ b/frontend/packages/console-shared/src/hooks/useIsMobile.ts
@@ -1,12 +1,12 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 
 const MAX_MOBILE_WIDTH = 767;
 const MOBILE_MEDIA_QUERY = `(max-width: ${MAX_MOBILE_WIDTH}px)`;
 
 export const useIsMobile = () => {
-  const [isMobile, setIsMobile] = React.useState<boolean>(window.innerWidth <= MAX_MOBILE_WIDTH);
+  const [isMobile, setIsMobile] = useState<boolean>(window.innerWidth <= MAX_MOBILE_WIDTH);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const mobileResolutionMatch = window.matchMedia(MOBILE_MEDIA_QUERY);
 
     const updateIsMobile = (e) => {

--- a/frontend/packages/console-shared/src/hooks/useJobsForCronJobWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/useJobsForCronJobWatcher.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind, JobKind } from '@console/internal/module/k8s';
 import { getJobsForCronJob } from '../utils';
@@ -7,10 +7,10 @@ export const useJobsForCronJobWatcher = (
   cronJob: K8sResourceKind,
 ): { loaded: boolean; loadError: string; jobs: JobKind[] } => {
   const { namespace, uid } = cronJob.metadata;
-  const [loaded, setLoaded] = React.useState<boolean>(false);
-  const [loadError, setLoadError] = React.useState<string>('');
-  const [jobs, setJobs] = React.useState<JobKind[]>([]);
-  const watchedResources = React.useMemo(
+  const [loaded, setLoaded] = useState<boolean>(false);
+  const [loadError, setLoadError] = useState<string>('');
+  const [jobs, setJobs] = useState<JobKind[]>([]);
+  const watchedResources = useMemo(
     () => ({
       jobs: {
         isList: true,
@@ -22,7 +22,7 @@ export const useJobsForCronJobWatcher = (
   );
   const resources = useK8sWatchResources(watchedResources);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const errorKey = Object.keys(resources).find((key) => resources[key].loadError);
     if (errorKey) {
       setLoadError(resources[errorKey].loadError);

--- a/frontend/packages/console-shared/src/hooks/useLabelsModal.tsx
+++ b/frontend/packages/console-shared/src/hooks/useLabelsModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import { ModalComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/ModalProvider';
 import { useModal } from '@console/dynamic-plugin-sdk/src/app/modal-support/useModal';
 import { UseLabelsModal } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
@@ -19,7 +19,7 @@ export const useLabelsModal: UseLabelsModal = (resource) => {
   const launcher = useModal();
   const groupVersionKind = getGroupVersionKindForResource(resource);
   const [kind] = useK8sModel(groupVersionKind);
-  return React.useCallback(
+  return useCallback(
     () => resource && kind && launcher<LabelsModalProps>(LabelsModalComponent, { kind, resource }),
     [launcher, kind, resource],
   );

--- a/frontend/packages/console-shared/src/hooks/useLocalStorageCache.ts
+++ b/frontend/packages/console-shared/src/hooks/useLocalStorageCache.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import * as _ from 'lodash';
 
 const isFresh = ({ timestamp }: Timestamped, expiration: number): boolean =>
@@ -9,7 +9,7 @@ export const useLocalStorageCache = <T = any>(
   expiration?: number,
   comparator?: (a: T, b: T) => boolean,
 ): [Getter<T>, Setter<T>] => {
-  const refreshCache = React.useCallback(() => {
+  const refreshCache = useCallback(() => {
     try {
       const serializedCache = window.localStorage.getItem(key);
       const records = serializedCache ? JSON.parse(serializedCache) : [];
@@ -21,7 +21,7 @@ export const useLocalStorageCache = <T = any>(
     }
   }, [expiration, key]);
 
-  const recordExists = React.useCallback(
+  const recordExists = useCallback(
     (newRecord: T, records: T[]): boolean =>
       records.some((existingRecord) =>
         (comparator ?? _.isEqual)(
@@ -32,7 +32,7 @@ export const useLocalStorageCache = <T = any>(
     [comparator],
   );
 
-  const getNewSerializedRecords = React.useCallback(
+  const getNewSerializedRecords = useCallback(
     (newRecord: T): [string, boolean] => {
       const currentRecords = refreshCache();
       if (recordExists(newRecord, currentRecords)) {
@@ -43,7 +43,7 @@ export const useLocalStorageCache = <T = any>(
     [recordExists, refreshCache],
   );
 
-  const addRecord = React.useCallback(
+  const addRecord = useCallback(
     (newRecord: T) => {
       const currentSerializedRecords = window.localStorage.getItem(key);
       const [updatedSerializedRecords, recordAdded] = getNewSerializedRecords({
@@ -64,10 +64,9 @@ export const useLocalStorageCache = <T = any>(
     [getNewSerializedRecords, key],
   );
 
-  const getRecords = React.useCallback(
-    (): T[] => refreshCache().map(({ timestamp, ...rest }) => rest),
-    [refreshCache],
-  );
+  const getRecords = useCallback((): T[] => refreshCache().map(({ timestamp, ...rest }) => rest), [
+    refreshCache,
+  ]);
 
   return [getRecords, addRecord];
 };

--- a/frontend/packages/console-shared/src/hooks/useNotificationAlerts.ts
+++ b/frontend/packages/console-shared/src/hooks/useNotificationAlerts.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import * as _ from 'lodash';
 import { useSelector } from 'react-redux';
 import { HIDE_USER_WORKLOAD_NOTIFICATIONS_USER_SETTINGS_KEY } from '@console/app/src/consts';
@@ -27,9 +27,9 @@ export const useNotificationAlerts = (
     ({ observe }) => observe.get('notificationAlerts') ?? {},
   );
 
-  const [filteredAlerts, setFilteredAlerts] = React.useState<NotificationAlerts['data']>([]);
+  const [filteredAlerts, setFilteredAlerts] = useState<NotificationAlerts['data']>([]);
 
-  const next = React.useMemo(() => {
+  const next = useMemo(() => {
     const alertLabelSelector = new LabelSelector(overrideMatchLabels);
     const alertRuleLabelSelector = new LabelSelector(
       hideUserWorkloadNotifications ? SYSTEM_ALERT_RULE_LABEL : {},
@@ -42,7 +42,7 @@ export const useNotificationAlerts = (
     );
   }, [alerts, overrideMatchLabels, hideUserWorkloadNotifications]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setFilteredAlerts((current) => (_.isEqual(current, next) ? current : next));
   }, [next]);
   return [filteredAlerts, loaded, loadError];

--- a/frontend/packages/console-shared/src/hooks/useOperands.ts
+++ b/frontend/packages/console-shared/src/hooks/useOperands.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { consoleFetchJSON as coFetchJSON } from '@console/dynamic-plugin-sdk/src/utils/fetch';
 import { K8sResourceCommon } from '@console/internal/module/k8s';
 
@@ -6,11 +6,11 @@ export const useOperands = (
   operatorName: string,
   operatorNamespace: string,
 ): [K8sResourceCommon[], boolean, string] => {
-  const [operands, setOperands] = React.useState<K8sResourceCommon[]>([]);
-  const [loaded, setLoaded] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState('');
+  const [operands, setOperands] = useState<K8sResourceCommon[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
 
-  React.useEffect(() => {
+  useEffect(() => {
     const url = `${window.SERVER_FLAGS.basePath}api/list-operands/?name=${operatorName}&namespace=${operatorNamespace}`;
     coFetchJSON(url)
       .then((data) => {

--- a/frontend/packages/console-shared/src/hooks/usePackageManifestCheck.ts
+++ b/frontend/packages/console-shared/src/hooks/usePackageManifestCheck.ts
@@ -1,15 +1,15 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { consoleFetchJSON as coFetchJSON } from '@console/dynamic-plugin-sdk/src/utils/fetch';
 
 export const usePackageManifestCheck = (
   operatorName: string,
   operatorNamespace: string,
 ): [boolean, boolean, string] => {
-  const [pmExists, setPMExists] = React.useState<boolean>(false);
-  const [loaded, setLoaded] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState('');
+  const [pmExists, setPMExists] = useState<boolean>(false);
+  const [loaded, setLoaded] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
 
-  React.useEffect(() => {
+  useEffect(() => {
     const url = `${window.SERVER_FLAGS.basePath}api/check-package-manifest/?name=${operatorName}&namespace=${operatorNamespace}`;
     coFetchJSON(url)
       .then(() => {

--- a/frontend/packages/console-shared/src/hooks/usePodsWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/usePodsWatcher.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo, useCallback, useEffect } from 'react';
 import { useSafetyFirst } from '@console/dynamic-plugin-sdk';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind } from '@console/internal/module/k8s';
@@ -22,14 +22,14 @@ export const usePodsWatcher = (
   const [podData, setPodData] = useSafetyFirst<PodRCData>(undefined);
   const watchKind = kind || resource?.kind;
   const watchNS = namespace || resource?.metadata.namespace;
-  const watchedResources = React.useMemo(
+  const watchedResources = useMemo(
     () => (watchKind ? getResourcesToWatchForPods(watchKind, watchNS) : {}),
     [watchKind, watchNS],
   );
 
   const resources = useK8sWatchResources(watchedResources);
 
-  const updateResults = React.useCallback(
+  const updateResults = useCallback(
     (watchedResource, updatedResources) => {
       const errorKey = Object.keys(updatedResources).find((key) => updatedResources[key].loadError);
       if (errorKey) {
@@ -51,7 +51,7 @@ export const usePodsWatcher = (
 
   const debouncedUpdateResources = useDebounceCallback(updateResults, 250);
 
-  React.useEffect(() => {
+  useEffect(() => {
     debouncedUpdateResources(resource, resources);
   }, [debouncedUpdateResources, resources, resource]);
 

--- a/frontend/packages/console-shared/src/hooks/useQuickStartContext.ts
+++ b/frontend/packages/console-shared/src/hooks/useQuickStartContext.ts
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import { useContext } from 'react';
 import { QuickStartContext, QuickStartContextValues } from '@patternfly/quickstarts';
 
 export const useQuickStartContext = () => {
-  return React.useContext<QuickStartContextValues>(QuickStartContext);
+  return useContext<QuickStartContextValues>(QuickStartContext);
 };

--- a/frontend/packages/console-shared/src/hooks/useReplicationControllersWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/useReplicationControllersWatcher.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { PodControllerOverviewItem } from '../types';
@@ -13,7 +13,7 @@ export const useReplicationControllersWatcher = (
   visibleReplicationControllers: PodControllerOverviewItem[];
 } => {
   const { namespace } = resource.metadata;
-  const watchedResources = React.useMemo(
+  const watchedResources = useMemo(
     () => ({
       replicationControllers: {
         isList: true,
@@ -30,7 +30,7 @@ export const useReplicationControllersWatcher = (
   );
   const resources = useK8sWatchResources(watchedResources);
 
-  const { loaded, loadError, mostRecentRC, visibleReplicationControllers } = React.useMemo(() => {
+  const { loaded, loadError, mostRecentRC, visibleReplicationControllers } = useMemo(() => {
     const resourcesLoaded =
       Object.keys(resources).length > 0 &&
       Object.keys(resources).every((key) => resources[key].loaded);

--- a/frontend/packages/console-shared/src/hooks/useResourceDetailsPage.ts
+++ b/frontend/packages/console-shared/src/hooks/useResourceDetailsPage.ts
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useResourceDetailsPages } from './useResourceDetailsPages';
 
 export const useResourceDetailsPage = (key: string) => {
   const detailsPages = useResourceDetailsPages();
-  return React.useMemo(() => detailsPages.get(key), [detailsPages, key]);
+  return useMemo(() => detailsPages.get(key), [detailsPages, key]);
 };

--- a/frontend/packages/console-shared/src/hooks/useResourceDetailsPages.tsx
+++ b/frontend/packages/console-shared/src/hooks/useResourceDetailsPages.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import {
   ResourceDetailsPage as DynamicResourceDetailsPage,
   isResourceDetailsPage as isDynamicResourceDetailsPage,
@@ -11,7 +11,7 @@ export const useResourceDetailsPages = () => {
   const dynamicResourceDetailsPageExtensions = useExtensions<DynamicResourceDetailsPage>(
     isDynamicResourceDetailsPage,
   );
-  return React.useMemo(
+  return useMemo(
     () =>
       getResourceDetailsPages(resourceDetailsPageExtensions, dynamicResourceDetailsPageExtensions),
     [resourceDetailsPageExtensions, dynamicResourceDetailsPageExtensions],

--- a/frontend/packages/console-shared/src/hooks/useResourceListPages.tsx
+++ b/frontend/packages/console-shared/src/hooks/useResourceListPages.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import {
   ResourceListPage as DynamicResourceListPage,
   isResourceListPage as isDynamicResourceListPage,
@@ -11,7 +11,7 @@ export const useResourceListPages = () => {
   const dynamicResourceListPageExtensions = useExtensions<DynamicResourceListPage>(
     isDynamicResourceListPage,
   );
-  return React.useMemo(
+  return useMemo(
     () => getResourceListPages(resourceListPageExtensions, dynamicResourceListPageExtensions),
     [resourceListPageExtensions, dynamicResourceListPageExtensions],
   );

--- a/frontend/packages/console-shared/src/hooks/useRoutesWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/useRoutesWatcher.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind, RouteKind } from '@console/internal/module/k8s';
 import { getRoutesForServices } from '../utils';
@@ -14,7 +14,7 @@ export const useRoutesWatcher = (
     namespace: resource?.metadata?.namespace,
   });
 
-  const servicesNames = React.useMemo(
+  const servicesNames = useMemo(
     () =>
       !watchedServices.loadError && watchedServices.loaded
         ? watchedServices.services.map((s) => s.metadata?.name)
@@ -22,7 +22,7 @@ export const useRoutesWatcher = (
     [watchedServices.loadError, watchedServices.loaded, watchedServices.services],
   );
 
-  const routes = React.useMemo(() => getRoutesForServices(servicesNames, allRoutes), [
+  const routes = useMemo(() => getRoutesForServices(servicesNames, allRoutes), [
     servicesNames,
     allRoutes,
   ]);

--- a/frontend/packages/console-shared/src/hooks/useScrollContainer.ts
+++ b/frontend/packages/console-shared/src/hooks/useScrollContainer.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useCallback } from 'react';
 
 const isHTMLElement = (n: Node): n is HTMLElement => {
   return n.nodeType === Node.ELEMENT_NODE;
@@ -22,8 +22,8 @@ export const getParentScrollableElement = (node: HTMLElement) => {
 };
 
 export const useScrollContainer = (): [HTMLElement, (node: HTMLElement) => void] => {
-  const [scrollContainer, setScrollContainer] = React.useState<HTMLElement>(null);
-  const elementRef = React.useCallback((node: HTMLElement) => {
+  const [scrollContainer, setScrollContainer] = useState<HTMLElement>(null);
+  const elementRef = useCallback((node: HTMLElement) => {
     if (node === null) {
       setScrollContainer(null);
     }

--- a/frontend/packages/console-shared/src/hooks/useScrollShadows.ts
+++ b/frontend/packages/console-shared/src/hooks/useScrollShadows.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useResizeObserver } from './useResizeObserver';
 
 export enum Shadows {
@@ -9,8 +9,8 @@ export enum Shadows {
 }
 
 export const useScrollShadows = (node: HTMLElement): Shadows => {
-  const [shadows, setShadows] = React.useState(Shadows.none);
-  const computeShadows = React.useCallback(() => {
+  const [shadows, setShadows] = useState(Shadows.none);
+  const computeShadows = useCallback(() => {
     if (node) {
       const { scrollTop, clientHeight, scrollHeight } = node;
       const top = scrollTop !== 0;
@@ -28,7 +28,7 @@ export const useScrollShadows = (node: HTMLElement): Shadows => {
   }, [node]);
   // recompute when the scroll container changes in size
   useResizeObserver(computeShadows, node);
-  React.useEffect(() => {
+  useEffect(() => {
     if (node) {
       // compute initial shadows
       computeShadows();

--- a/frontend/packages/console-shared/src/hooks/useServicesWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/useServicesWatcher.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { getServicesForResource } from '../utils';
@@ -13,7 +13,7 @@ export const useServicesWatcher = (
     namespace,
   });
 
-  const services = React.useMemo(
+  const services = useMemo(
     () => (!loadError && loaded ? getServicesForResource(resource, allServices) : []),
     [allServices, loadError, loaded, resource],
   );

--- a/frontend/packages/console-shared/src/hooks/useTelemetry.ts
+++ b/frontend/packages/console-shared/src/hooks/useTelemetry.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect, useCallback } from 'react';
 import {
   useResolvedExtensions,
   isTelemetryListener,
@@ -85,7 +85,7 @@ export const useTelemetry = () => {
 
   const [extensions] = useResolvedExtensions<TelemetryListener>(isTelemetryListener);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (
       userIsOptedInToTelemetry(currentUserPreferenceTelemetryValue) &&
       clusterIsOptedInToTelemetry() &&
@@ -100,7 +100,7 @@ export const useTelemetry = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentUserPreferenceTelemetryValue, userResourceIsLoaded]);
 
-  return React.useCallback<TelemetryEventListener>(
+  return useCallback<TelemetryEventListener>(
     (eventType, properties: Record<string, any>) => {
       if (isOptedOutFromTelemetry(currentUserPreferenceTelemetryValue)) return;
 

--- a/frontend/packages/console-shared/src/hooks/useUtilizationDuration.ts
+++ b/frontend/packages/console-shared/src/hooks/useUtilizationDuration.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { UseUtilizationDuration } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 import * as UIActions from '@console/internal/actions/ui';
@@ -20,16 +20,16 @@ export const useUtilizationDuration: UseUtilizationDuration = (
     useSelector<RootState, string>(({ UI }) => UI.getIn(['utilizationDuration', 'selectedKey'])) ??
     DEFAULT_DURATION_KEY;
   const startDate = new Date(endDate.getTime() - duration);
-  const updateEndDate = React.useCallback(
+  const updateEndDate = useCallback(
     (date: Date) => date > endDate && dispatch(UIActions.setUtilizationDurationEndTime(date)),
     [dispatch, endDate],
   );
-  const updateDuration = React.useCallback(
+  const updateDuration = useCallback(
     (newDuration: number) =>
       dispatch(UIActions.setUtilizationDuration(adjustDuration?.(newDuration) ?? newDuration)),
     [adjustDuration, dispatch],
   );
-  const updateSelectedKey = React.useCallback(
+  const updateSelectedKey = useCallback(
     (key: string) => dispatch(UIActions.setUtilizationDurationSelectedKey(key)),
     [dispatch],
   );

--- a/frontend/packages/dev-console/src/actions/providers.tsx
+++ b/frontend/packages/dev-console/src/actions/providers.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { GraphElement, Node, isGraph } from '@patternfly/react-topology';
 import { K8sModel, Action, SetFeatureFlag } from '@console/dynamic-plugin-sdk';
 import { TopologyApplicationObject } from '@console/dynamic-plugin-sdk/src/extensions/topology-types';
@@ -47,7 +47,7 @@ type TopologyActionProvider = (data: {
 export const useEditImportActionProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
 
-  const editImportAction = React.useMemo(() => {
+  const editImportAction = useMemo(() => {
     const annotation = resource?.metadata?.annotations?.['openshift.io/generated-by'];
     const isFromDevfile = resource?.metadata?.annotations?.isFromDevfile;
     const hideEditImportAction = annotation !== 'OpenShiftWebConsole' || !!isFromDevfile;
@@ -109,7 +109,7 @@ export const useTopologyGraphActionProvider: TopologyActionProvider = ({
   const isServerlessEnabled = useFlag('KNATIVE_SERVING_SERVICE');
   const isJavaImageStreamEnabled = useFlag('JAVA_IMAGE_STREAM_ENABLED');
 
-  return React.useMemo(() => {
+  return useMemo(() => {
     const sourceObj = connectorSource?.getData()?.resource;
     const sourceReference = sourceObj
       ? `${referenceFor(sourceObj)}/${sourceObj?.metadata?.name}`
@@ -287,7 +287,7 @@ export const useTopologyApplicationActionProvider: TopologyActionProvider = ({
   const isServerlessEnabled = useFlag('KNATIVE_SERVING_SERVICE');
   const isJavaImageStreamEnabled = useFlag('JAVA_IMAGE_STREAM_ENABLED');
   const application = element.getLabel();
-  const appData: TopologyApplicationObject = React.useMemo(
+  const appData: TopologyApplicationObject = useMemo(
     () => ({
       id: element.getId(),
       name: application,
@@ -298,7 +298,7 @@ export const useTopologyApplicationActionProvider: TopologyActionProvider = ({
   const primaryResource = appData.resources?.[0]?.resource || {};
   const [kindObj, inFlight] = useK8sModel(referenceFor(primaryResource));
 
-  return React.useMemo(() => {
+  return useMemo(() => {
     if (element.getType() === TYPE_APPLICATION_GROUP) {
       if (inFlight) return [[], !inFlight, undefined];
       const path = connectorSource ? '' : 'add-to-application';

--- a/frontend/packages/dev-console/src/components/add/hooks/useAccessFilterExtensions.ts
+++ b/frontend/packages/dev-console/src/components/add/hooks/useAccessFilterExtensions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { AddAction, ResolvedExtension } from '@console/dynamic-plugin-sdk';
 import {
   AddAccessReviewResults,
@@ -14,7 +14,7 @@ export const useAccessFilterExtensions = (
     namespace,
     addActionExtensions,
   );
-  const loaded = React.useMemo(
+  const loaded = useMemo(
     () =>
       !Object.values(accessReviewResults).some(
         (reviewStatus) => reviewStatus === AccessReviewStatus.LOADING,
@@ -22,7 +22,7 @@ export const useAccessFilterExtensions = (
     [accessReviewResults],
   );
 
-  return React.useMemo(
+  return useMemo(
     () =>
       loaded
         ? [

--- a/frontend/packages/dev-console/src/components/add/hooks/useAddActionsAccessReviews.ts
+++ b/frontend/packages/dev-console/src/components/add/hooks/useAddActionsAccessReviews.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { AddAction, ResolvedExtension } from '@console/dynamic-plugin-sdk';
 import { checkAccess } from '@console/internal/components/utils';
 import { SelfSubjectAccessReviewKind } from '@console/internal/module/k8s';
@@ -19,10 +19,10 @@ export const useAddActionsAccessReviews = (
   namespace: string,
   addActionExtensions: ResolvedExtension<AddAction>[],
 ): AddAccessReviewResults => {
-  const [namespacedAccessReviewResults, setNamespacedAccessReviewResults] = React.useState<
+  const [namespacedAccessReviewResults, setNamespacedAccessReviewResults] = useState<
     NamespacedAddAccessReviewResults
   >({});
-  const setAccessReviewResults = React.useCallback(
+  const setAccessReviewResults = useCallback(
     (newResults: AddAccessReviewResults) => {
       setNamespacedAccessReviewResults((oldResults) => ({
         ...oldResults,
@@ -34,7 +34,7 @@ export const useAddActionsAccessReviews = (
     },
     [namespace, setNamespacedAccessReviewResults],
   );
-  React.useEffect(() => {
+  useEffect(() => {
     const newAddActions = addActionExtensions.filter(
       ({ properties: { id } }) => !namespacedAccessReviewResults[namespace]?.[id],
     );

--- a/frontend/packages/dev-console/src/components/catalog/providers/useBindableItemMetadataProvider.ts
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useBindableItemMetadataProvider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   CatalogItem,
@@ -18,7 +18,7 @@ const useBindableItemMetadataProvider: ExtensionHook<CatalogItemMetadataProvider
 
   const [t] = useTranslation();
 
-  const bindableMetadata = React.useRef<ReturnType<CatalogItemMetadataProviderFunction>>({
+  const bindableMetadata = useRef<ReturnType<CatalogItemMetadataProviderFunction>>({
     tags: ['bindable'],
     badges: [{ text: t('devconsole~Bindable') }],
     attributes: {
@@ -26,7 +26,7 @@ const useBindableItemMetadataProvider: ExtensionHook<CatalogItemMetadataProvider
     },
   });
 
-  const provider = React.useCallback<CatalogItemMetadataProviderFunction>(
+  const provider = useCallback<CatalogItemMetadataProviderFunction>(
     (item: CatalogItem) => {
       if (!loaded || !Array.isArray(bindableKinds?.status)) {
         return null;

--- a/frontend/packages/dev-console/src/components/catalog/providers/useBuilderImageSamples.ts
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useBuilderImageSamples.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -67,7 +67,7 @@ const useBuilderImageSamples: ExtensionHook<CatalogItem[]> = ({ namespace }) => 
     resourceSelector,
   );
 
-  const normalizedBuilderImages = React.useMemo<CatalogItem[]>(() => {
+  const normalizedBuilderImages = useMemo<CatalogItem[]>(() => {
     const filteredImageStreams = imageStreams.filter((imageStream) => {
       const recentTag = getMostRecentBuilderTag(imageStream);
       const sampleRepo = recentTag?.annotations?.sampleRepo;

--- a/frontend/packages/dev-console/src/components/catalog/providers/useBuilderImages.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useBuilderImages.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
@@ -140,11 +140,9 @@ const useBuilderImages: ExtensionHook<CatalogItem[]> = ({
     resourceSelector,
   );
 
-  const builderImageStreams = React.useMemo(() => _.filter(imageStreams, isBuilder), [
-    imageStreams,
-  ]);
+  const builderImageStreams = useMemo(() => _.filter(imageStreams, isBuilder), [imageStreams]);
 
-  const normalizedBuilderImages = React.useMemo(
+  const normalizedBuilderImages = useMemo(
     () => normalizeBuilderImages(builderImageStreams, namespace, t),
     [builderImageStreams, namespace, t],
   );

--- a/frontend/packages/dev-console/src/components/catalog/providers/useConsoleSamples.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useConsoleSamples.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import * as React from 'react';
+import { useMemo } from 'react';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { CatalogItem } from '@console/dynamic-plugin-sdk';
@@ -55,7 +55,7 @@ export const useConsoleSamplesCatalogProvider = (): [CatalogItem[], boolean, any
   const [activeNamespace] = useActiveNamespace();
   const [allSamples, loaded, loadedError] = useSamples();
 
-  const catalogItems = React.useMemo<CatalogItem[]>(() => {
+  const catalogItems = useMemo<CatalogItem[]>(() => {
     const filteredSamples = allSamples.filter((sample) => !sample.spec.tags?.includes('hidden'));
 
     const groupedSamples = groupConsoleSamplesByName(filteredSamples);

--- a/frontend/packages/dev-console/src/components/catalog/providers/useDevfile.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useDevfile.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import {
@@ -67,11 +67,11 @@ const normalizeDevfile = (devfileSamples: DevfileSample[], t: TFunction): Catalo
 };
 
 const useDevfile: ExtensionHook<CatalogItem[]> = (): [CatalogItem[], boolean, any] => {
-  const [devfileSamples, setDevfileSamples] = React.useState<DevfileSample[]>();
-  const [loadedError, setLoadedError] = React.useState<APIError>();
+  const [devfileSamples, setDevfileSamples] = useState<DevfileSample[]>();
+  const [loadedError, setLoadedError] = useState<APIError>();
   const { t } = useTranslation();
 
-  React.useEffect(() => {
+  useEffect(() => {
     let mounted = true;
     coFetchJSON('/api/devfile/samples/?registry=https://registry.devfile.io')
       .then((resp) => {
@@ -85,7 +85,7 @@ const useDevfile: ExtensionHook<CatalogItem[]> = (): [CatalogItem[], boolean, an
     };
   }, []);
 
-  const normalizedDevfileSamples = React.useMemo(() => normalizeDevfile(devfileSamples || [], t), [
+  const normalizedDevfileSamples = useMemo(() => normalizeDevfile(devfileSamples || [], t), [
     devfileSamples,
     t,
   ]);

--- a/frontend/packages/dev-console/src/components/catalog/providers/useDevfileSamples.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useDevfileSamples.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { CatalogItem, ExtensionHook } from '@console/dynamic-plugin-sdk';
@@ -49,10 +49,10 @@ const normalizeDevfileSamples = (
 const useDevfileSamples: ExtensionHook<CatalogItem[]> = (): [CatalogItem[], boolean, any] => {
   const { t } = useTranslation();
   const [activeNamespace] = useActiveNamespace();
-  const [devfileSamples, setDevfileSamples] = React.useState<DevfileSample[]>();
-  const [loadedError, setLoadedError] = React.useState<APIError>();
+  const [devfileSamples, setDevfileSamples] = useState<DevfileSample[]>();
+  const [loadedError, setLoadedError] = useState<APIError>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     let mounted = true;
     coFetchJSON('/api/devfile/samples/?registry=https://registry.devfile.io')
       .then((res) => {
@@ -67,7 +67,7 @@ const useDevfileSamples: ExtensionHook<CatalogItem[]> = (): [CatalogItem[], bool
     };
   }, []);
 
-  const normalizedDevfileSamples = React.useMemo(
+  const normalizedDevfileSamples = useMemo(
     () => normalizeDevfileSamples(devfileSamples || [], activeNamespace, t),
     [activeNamespace, devfileSamples, t],
   );

--- a/frontend/packages/dev-console/src/components/catalog/providers/useTemplates.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useTemplates.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -69,18 +69,18 @@ const useTemplates: ExtensionHook<CatalogItem<PartialObjectMetadata>[]> = ({
   namespace,
 }): [CatalogItem[], boolean, any] => {
   const { t } = useTranslation();
-  const [templates, setTemplates] = React.useState<PartialObjectMetadata[]>([]);
-  const [templatesLoaded, setTemplatesLoaded] = React.useState<boolean>(false);
-  const [templatesError, setTemplatesError] = React.useState<APIError>();
+  const [templates, setTemplates] = useState<PartialObjectMetadata[]>([]);
+  const [templatesLoaded, setTemplatesLoaded] = useState<boolean>(false);
+  const [templatesError, setTemplatesError] = useState<APIError>();
 
-  const [projectTemplates, setProjectTemplates] = React.useState<PartialObjectMetadata[]>([]);
-  const [projectTemplatesLoaded, setProjectTemplatesLoaded] = React.useState<boolean>(false);
-  const [projectTemplatesError, setProjectTemplatesError] = React.useState<APIError>();
+  const [projectTemplates, setProjectTemplates] = useState<PartialObjectMetadata[]>([]);
+  const [projectTemplatesLoaded, setProjectTemplatesLoaded] = useState<boolean>(false);
+  const [projectTemplatesError, setProjectTemplatesError] = useState<APIError>();
 
   // Load templates from the shared `openshift` namespace. Don't use Firehose
   // for templates so that we can request only metadata. This keeps the request
   // much smaller.
-  React.useEffect(() => {
+  useEffect(() => {
     k8sListPartialMetadata(TemplateModel, { ns: 'openshift' })
       .then((metadata) => {
         setTemplates(metadata ?? []);
@@ -91,7 +91,7 @@ const useTemplates: ExtensionHook<CatalogItem<PartialObjectMetadata>[]> = ({
   }, []);
 
   // Load templates for the current project.
-  React.useEffect(() => {
+  useEffect(() => {
     // Don't load templates from the `openshift` namespace twice if it's the current namespace
     if (!namespace || namespace === 'openshift') {
       setProjectTemplates([]);
@@ -112,7 +112,7 @@ const useTemplates: ExtensionHook<CatalogItem<PartialObjectMetadata>[]> = ({
 
   const error = templatesError || projectTemplatesError;
 
-  const normalizedTemplates = React.useMemo(
+  const normalizedTemplates = useMemo(
     () => normalizeTemplates([...templates, ...projectTemplates], namespace, t),
     [namespace, projectTemplates, t, templates],
   );

--- a/frontend/packages/dev-console/src/components/import/builder/builderImageHooks.ts
+++ b/frontend/packages/dev-console/src/components/import/builder/builderImageHooks.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import {
   ImageEnvironment,
   ImportEnvironment,
@@ -14,7 +14,7 @@ export const useBuilderImageEnvironments = (
     isImportEnvironment,
   );
 
-  const filteredExtensions = React.useMemo(
+  const filteredExtensions = useMemo(
     () =>
       resolved
         ? environmentExtensions

--- a/frontend/packages/dev-console/src/components/import/devfile/devfileHooks.ts
+++ b/frontend/packages/dev-console/src/components/import/devfile/devfileHooks.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { FormikValues, useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { coFetchJSON } from '@console/internal/co-fetch';
@@ -14,8 +14,8 @@ export const useDevfileServer = (
   setFieldValue: (name: string, value: any, shouldValidate?: boolean) => any,
 ): [boolean, string] => {
   const { t } = useTranslation();
-  const [devfileParseError, setDevfileParseError] = React.useState<string>(null);
-  const [parsingDevfile, setParsingDevfile] = React.useState<boolean>(false);
+  const [devfileParseError, setDevfileParseError] = useState<string>(null);
+  const [parsingDevfile, setParsingDevfile] = useState<boolean>(false);
 
   const {
     name,
@@ -26,7 +26,7 @@ export const useDevfileServer = (
 
   const { devfileContent, devfilePath } = devfile || {};
 
-  const devfileDataPromise = React.useMemo(async () => {
+  const devfileDataPromise = useMemo(async () => {
     if (!name || !url || !devfileContent) {
       return null;
     }
@@ -47,7 +47,7 @@ export const useDevfileServer = (
     };
   }, [name, url, devfileContent, ref, dir, type, secretResource, smartSlashDir, devfilePath]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const setError = (msg) => {
       setDevfileParseError(msg);
       setFieldValue('devfile.devfileHasError', true);
@@ -129,7 +129,7 @@ export const useDevfileSource = () => {
     devfile,
   } = values;
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (devfileSourceUrl && !devfile.devfileContent) {
       setFieldValue('devfile.devfileSourceUrl', devfileSourceUrl);
       setFieldValue('devfile.devfilePath', recommendedStrategy?.detectedFiles?.[0]);
@@ -156,9 +156,9 @@ export const useDevfileSource = () => {
 export const useSelectedDevfileSample = () => {
   const searchParams = new URLSearchParams(window.location.search);
   const devfileName = searchParams.get('devfileName');
-  const [devfileSamples, setDevfileSamples] = React.useState<DevfileSample[]>();
+  const [devfileSamples, setDevfileSamples] = useState<DevfileSample[]>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     let mounted = true;
     coFetchJSON('/api/devfile/samples/?registry=https://registry.devfile.io')
       .then((samples: DevfileSample[]) => {
@@ -173,7 +173,7 @@ export const useSelectedDevfileSample = () => {
     };
   }, []);
 
-  return React.useMemo(() => devfileSamples?.find((sample) => sample.name === devfileName), [
+  return useMemo(() => devfileSamples?.find((sample) => sample.name === devfileName), [
     devfileSamples,
     devfileName,
   ]);

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamContext.ts
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamContext.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { createContext } from 'react';
 import { ImageStreamContextProps } from '../import-types';
 
-export const ImageStreamContext = React.createContext<ImageStreamContextProps>(undefined as any);
+export const ImageStreamContext = createContext<ImageStreamContextProps>(undefined as any);

--- a/frontend/packages/dev-console/src/components/import/jar/useUploadJarFormToast.ts
+++ b/frontend/packages/dev-console/src/components/import/jar/useUploadJarFormToast.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo, useCallback } from 'react';
 import { AlertVariant } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { WatchK8sResource } from '@console/dynamic-plugin-sdk';
@@ -12,7 +12,7 @@ export const useUploadJarFormToast = () => {
   const toast = useToast();
   const { t } = useTranslation();
   const [namespace] = useActiveNamespace();
-  const buildsResource: WatchK8sResource = React.useMemo(
+  const buildsResource: WatchK8sResource = useMemo(
     () => ({
       kind: BuildModel.kind,
       namespace,
@@ -22,7 +22,7 @@ export const useUploadJarFormToast = () => {
   );
   const [builds] = useK8sWatchResource<K8sResourceKind[]>(buildsResource);
 
-  return React.useCallback(
+  return useCallback(
     (resp) => {
       const createdBuildConfig = resp.find((d) => d.kind === BuildConfigModel.kind);
       const ownBuilds = getOwnedResources(createdBuildConfig, builds);

--- a/frontend/packages/dev-console/src/components/import/section/useDefaultBuildOption.ts
+++ b/frontend/packages/dev-console/src/components/import/section/useDefaultBuildOption.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useShipwrightBuilds } from '@console/dev-console/src/utils/shipwright-build-hook';
 import { FLAG_OPENSHIFT_PIPELINE } from '@console/pipelines-plugin/src/const';
 import { useFlag } from '@console/shared';
@@ -10,7 +10,7 @@ export const useDefaultBuildOption = (): BuildOptions => {
   const isShipwrightEnabled = useShipwrightBuilds();
   const isPipelineEnabled = useFlag(FLAG_OPENSHIFT_PIPELINE);
 
-  const defaultBuildOption = React.useMemo(() => {
+  const defaultBuildOption = useMemo(() => {
     if (isShipwrightEnabled) {
       return BuildOptions.SHIPWRIGHT_BUILD;
     }

--- a/frontend/packages/dev-console/src/components/import/serverless-function/FuncSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless-function/FuncSection.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { Alert } from '@patternfly/react-core';
 import { FormikValues, useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
@@ -24,12 +24,12 @@ const FuncSection = ({ builderImages }) => {
     git: { url, type, ref, dir, secretResource },
     image,
   } = values;
-  const [runtimeImage, setRuntimeImage] = React.useState<BuilderImage>();
-  const [loaded, setLoaded] = React.useState<boolean>(false);
+  const [runtimeImage, setRuntimeImage] = useState<BuilderImage>();
+  const [loaded, setLoaded] = useState<boolean>(false);
   const [, setResourceType] = useResourceType();
-  const [helpText, setHelpText] = React.useState<string>('');
+  const [helpText, setHelpText] = useState<string>('');
 
-  React.useEffect(() => {
+  useEffect(() => {
     const gitService = url && getGitService(url, type, ref, dir, secretResource);
     gitService &&
       evaluateFunc(gitService)
@@ -73,7 +73,7 @@ const FuncSection = ({ builderImages }) => {
     t,
   ]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (loaded && runtimeImage) {
       setFieldValue('image.tag', runtimeImage?.recentTag?.name);
       setFieldValue('image.selected', runtimeImage?.name);
@@ -81,7 +81,7 @@ const FuncSection = ({ builderImages }) => {
     }
   }, [runtimeImage, setFieldValue, loaded]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (loaded && !runtimeImage) {
       setFieldError('ServerlessFunction', 'Unsupported Runtime detected');
     }

--- a/frontend/packages/dev-console/src/components/import/serverless-function/ServerlessFunctionSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless-function/ServerlessFunctionSection.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { Alert } from '@patternfly/react-core';
 import { FormikValues, useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
@@ -24,12 +24,12 @@ const ServerlessFunctionSection = ({ builderImages }) => {
     git: { url, type, ref, dir, secretResource },
     image,
   } = values;
-  const [runtimeImage, setRuntimeImage] = React.useState<BuilderImage>();
-  const [loaded, setLoaded] = React.useState<boolean>(false);
+  const [runtimeImage, setRuntimeImage] = useState<BuilderImage>();
+  const [loaded, setLoaded] = useState<boolean>(false);
   const [, setResourceType] = useResourceType();
-  const [helpText, setHelpText] = React.useState<string>('');
+  const [helpText, setHelpText] = useState<string>('');
 
-  React.useEffect(() => {
+  useEffect(() => {
     const gitService = url && getGitService(url, type, ref, dir, secretResource);
     gitService &&
       evaluateFunc(gitService)
@@ -76,7 +76,7 @@ const ServerlessFunctionSection = ({ builderImages }) => {
     t,
   ]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (loaded && runtimeImage) {
       setFieldValue('image.tag', runtimeImage?.recentTag?.name);
       setFieldValue('image.selected', runtimeImage?.name);
@@ -84,7 +84,7 @@ const ServerlessFunctionSection = ({ builderImages }) => {
     }
   }, [runtimeImage, setFieldValue, loaded]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (loaded && !runtimeImage) {
       setFieldError('ServerlessFunction', 'Unsupported Runtime detected');
     }

--- a/frontend/packages/dev-console/src/components/import/serverless/useUpdateKnScalingDefaultValues.ts
+++ b/frontend/packages/dev-console/src/components/import/serverless/useUpdateKnScalingDefaultValues.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { getAutoscaleWindow } from './serverless-utils';
 import { useGetAutoscalerConfig } from './useGetAutoscalerConfig';
 
@@ -26,8 +26,8 @@ export const setKnScalingDefaultValue = (initialValues, knScalingConfig) => {
 export const useUpdateKnScalingDefaultValues = (initialValues) => {
   const knScalingConfig = useGetAutoscalerConfig();
   // TODO: We should not expect that overridding the formik initialValues in a hook works fine.
-  const [initialValuesState, setInitialValuesState] = React.useState(initialValues);
-  React.useEffect(() => {
+  const [initialValuesState, setInitialValuesState] = useState(initialValues);
+  useEffect(() => {
     if (knScalingConfig) {
       setInitialValuesState((previousValues) =>
         setKnScalingDefaultValue(previousValues, knScalingConfig),

--- a/frontend/packages/dev-console/src/components/project-access/hooks.ts
+++ b/frontend/packages/dev-console/src/components/project-access/hooks.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { ClusterRoleModel } from '@console/internal/models';
 import { K8sResourceCommon, WatchK8sResource } from '@console/internal/module/k8s';
@@ -11,7 +11,7 @@ export type ClusterRoleKind = K8sResourceCommon & {
 export const useProjectAccessRoles = (): { data: Roles; loaded: boolean } => {
   const availableClusterRoles = getAvailableAccessRoles();
 
-  const watchedClusterRoles = React.useMemo<Record<string, WatchK8sResource>>(() => {
+  const watchedClusterRoles = useMemo<Record<string, WatchK8sResource>>(() => {
     if (!availableClusterRoles || !availableClusterRoles.length) {
       return {};
     }

--- a/frontend/packages/dev-console/src/components/topology/bindable-services/bindable-service-context.ts
+++ b/frontend/packages/dev-console/src/components/topology/bindable-services/bindable-service-context.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { createContext, useState, useEffect } from 'react';
 import { fetchBindableServices } from './fetch-bindable-services-utils';
 import { BindableServiceGVK } from './types';
 
@@ -7,7 +7,7 @@ export type ServiceBindingContextType = {
   loaded: boolean;
 };
 
-export const ServiceBindingContext = React.createContext<ServiceBindingContextType>({
+export const ServiceBindingContext = createContext<ServiceBindingContextType>({
   bindableServices: [],
   loaded: false,
 });
@@ -15,9 +15,9 @@ export const ServiceBindingContext = React.createContext<ServiceBindingContextTy
 export const ServiceBindingContextProvider = ServiceBindingContext.Provider;
 
 export const useValuesServiceBindingContext = (): ServiceBindingContextType => {
-  const [bindableServices, setBindableServices] = React.useState([]);
-  const [loaded, setLoaded] = React.useState(false);
-  React.useEffect(() => {
+  const [bindableServices, setBindableServices] = useState([]);
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
     fetchBindableServices()
       .then((resp) => {
         setBindableServices(resp);

--- a/frontend/packages/dev-console/src/utils/shipwright-build-hook.tsx
+++ b/frontend/packages/dev-console/src/utils/shipwright-build-hook.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { ImportStrategy } from '@console/git-service/src';
 import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
 import { K8sResourceKind } from '@console/internal/module/k8s';
@@ -17,11 +17,11 @@ export interface AvailableBuildStrategies {
 }
 
 export const useClusterBuildStrategy = (): [AvailableBuildStrategies, boolean] => {
-  const [data, setData] = React.useState<AvailableBuildStrategies>({
+  const [data, setData] = useState<AvailableBuildStrategies>({
     s2i: false,
     buildah: false,
   });
-  const [loaded, setLoaded] = React.useState<boolean>(false);
+  const [loaded, setLoaded] = useState<boolean>(false);
   const [, s2iLoaded, s2iErr] = useK8sGet<K8sResourceKind>(
     ClusterBuildStrategyModel,
     ClusterBuildStrategy.S2I,
@@ -31,13 +31,13 @@ export const useClusterBuildStrategy = (): [AvailableBuildStrategies, boolean] =
     ClusterBuildStrategy.BUILDAH,
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (s2iLoaded && buildahLoaded) {
       setLoaded(true);
     }
   }, [s2iLoaded, buildahLoaded]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (loaded) {
       if (!s2iErr) {
         setData((prevData) => ({

--- a/frontend/packages/dev-console/src/utils/useAddToProjectAccess.ts
+++ b/frontend/packages/dev-console/src/utils/useAddToProjectAccess.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useAccessReview } from '@console/internal/components/utils';
 import {
   BuildConfigModel,
@@ -34,7 +34,7 @@ export const useAddToProjectAccess = (activeNamespace: string): string[] => {
   const routeAccess = useAccessReview(resourceAttributes(RouteModel, activeNamespace));
   const serviceAccess = useAccessReview(resourceAttributes(ServiceModel, activeNamespace));
 
-  return React.useMemo(() => {
+  return useMemo(() => {
     const createResourceAccess: string[] = [];
     if (
       buildConfigsAccess &&

--- a/frontend/packages/gitops-plugin/src/components/utils/useEnvDetails.ts
+++ b/frontend/packages/gitops-plugin/src/components/utils/useEnvDetails.ts
@@ -1,13 +1,13 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { fetchAppGroups } from './gitops-utils';
 
 const useEnvDetails = (appName, manifestURL, pipelinesBaseURI) => {
   const { t } = useTranslation();
-  const [envs, setEnvs] = React.useState<string[]>(null);
-  const [emptyStateMsg, setEmptyStateMsg] = React.useState(null);
-  React.useEffect(() => {
+  const [envs, setEnvs] = useState<string[]>(null);
+  const [emptyStateMsg, setEmptyStateMsg] = useState(null);
+  useEffect(() => {
     let ignore = false;
 
     if (pipelinesBaseURI) {

--- a/frontend/packages/helm-plugin/src/actions/providers.ts
+++ b/frontend/packages/helm-plugin/src/actions/providers.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { GraphElement, isGraph, Node } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
 import { useCommonResourceActions } from '@console/app/src/actions//hooks/useCommonResourceActions';
@@ -26,7 +26,7 @@ import { HelmActionsScope } from './types';
 
 export const useHelmActionProvider = (scope: HelmActionsScope) => {
   const { t } = useTranslation();
-  const result = React.useMemo(() => {
+  const result = useMemo(() => {
     if (!scope) return [[], true, undefined];
     switch (scope?.release?.info?.status) {
       case HelmReleaseStatus.PendingInstall:
@@ -51,7 +51,7 @@ export const useHelmActionProvider = (scope: HelmActionsScope) => {
 export const useHelmActionProviderForTopology = (element: GraphElement) => {
   const resource = getResource(element);
   const data = element.getData();
-  const scope = React.useMemo(() => {
+  const scope = useMemo(() => {
     const nodeType = element.getType();
     if (nodeType !== TYPE_HELM_RELEASE) return undefined;
     const releaseName = element.getLabel();
@@ -86,7 +86,7 @@ export const useTopologyActionProvider = ({
   const [namespace] = useActiveNamespace();
   const disabledAddActions = getDisabledAddActions();
   const isHelmDisabled = disabledAddActions?.includes(HELM_CHART_ACTION_ID);
-  return React.useMemo(() => {
+  return useMemo(() => {
     if (isGraph(element) && !connectorSource && !isHelmDisabled) {
       return [[AddHelmChartAction(namespace, 'add-to-project', true)], true, undefined];
     }
@@ -98,7 +98,7 @@ export const useHelmChartRepositoryActions = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
   const { t } = useTranslation();
   const commonActions = useCommonResourceActions(kindObj, resource);
-  const actions = React.useMemo(() => {
+  const actions = useMemo(() => {
     const index = commonActions.findIndex((action: Action) => action.id === 'edit-resource');
     if (index >= 0) {
       const modifiedActions = commonActions.filter(

--- a/frontend/packages/helm-plugin/src/catalog/providers/useHelmCharts.tsx
+++ b/frontend/packages/helm-plugin/src/catalog/providers/useHelmCharts.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { safeLoad } from 'js-yaml';
 import { useTranslation } from 'react-i18next';
 import { ExtensionHook, CatalogItem, WatchK8sResults } from '@console/dynamic-plugin-sdk';
@@ -19,10 +19,10 @@ const useHelmCharts: ExtensionHook<CatalogItem[]> = ({
 }): [CatalogItem[], boolean, any] => {
   const { t } = useTranslation();
   const [activeNamespace] = useActiveNamespace();
-  const [helmCharts, setHelmCharts] = React.useState<HelmChartEntries>();
-  const [loadedError, setLoadedError] = React.useState<APIError>();
+  const [helmCharts, setHelmCharts] = useState<HelmChartEntries>();
+  const [loadedError, setLoadedError] = useState<APIError>();
 
-  const resourceSelector = React.useMemo(
+  const resourceSelector = useMemo(
     () => ({
       hcrs: {
         isList: true,
@@ -45,7 +45,7 @@ const useHelmCharts: ExtensionHook<CatalogItem[]> = ({
     Object.keys(chartRepositories).length > 0 &&
     Object.values(chartRepositories).some((value) => value.loaded || !!value.loadError);
 
-  React.useEffect(() => {
+  useEffect(() => {
     let mounted = true;
     coFetch(`/api/helm/charts/index.yaml?namespace=${activeNamespace}`)
       .then(async (res) => {
@@ -66,7 +66,7 @@ const useHelmCharts: ExtensionHook<CatalogItem[]> = ({
     };
   }, [activeNamespace]);
 
-  const normalizedHelmCharts: CatalogItem[] = React.useMemo(
+  const normalizedHelmCharts: CatalogItem[] = useMemo(
     () =>
       normalizeHelmCharts(
         helmCharts,

--- a/frontend/packages/helm-plugin/src/catalog/utils/catalog-utils.tsx
+++ b/frontend/packages/helm-plugin/src/catalog/utils/catalog-utils.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { Fragment } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import { TFunction } from 'i18next';
 import * as _ from 'lodash';
@@ -74,12 +74,12 @@ export const normalizeHelmCharts = (
           <>
             {chart.maintainers?.map((maintainer, index) => (
               // eslint-disable-next-line react/no-array-index-key
-              <React.Fragment key={index}>
+              <Fragment key={index}>
                 {maintainer.name}
                 <br />
                 <a href={`mailto:${maintainer.email}`}>{maintainer.email}</a>
                 <br />
-              </React.Fragment>
+              </Fragment>
             ))}
           </>
         );

--- a/frontend/packages/helm-plugin/src/providers/helm-detection-provider.ts
+++ b/frontend/packages/helm-plugin/src/providers/helm-detection-provider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useCallback } from 'react';
 import { SetFeatureFlag } from '@console/dynamic-plugin-sdk';
 import { settleAllPromises } from '@console/dynamic-plugin-sdk/src/utils/promise';
 import { usePoll } from '@console/internal/components/utils/poll-hook';
@@ -13,8 +13,8 @@ export const hasEnabledHelmCharts = (helmChartRepositories: K8sResourceKind[]): 
 
 export const useDetectHelmChartRepositories = (setFeatureFlag: SetFeatureFlag) => {
   const [namespace] = useActiveNamespace();
-  const [delay, setDelay] = React.useState<number>(10 * 1000);
-  const fetchHelmChartRepositories = React.useCallback(() => {
+  const [delay, setDelay] = useState<number>(10 * 1000);
+  const fetchHelmChartRepositories = useCallback(() => {
     const helmChartRepos: Promise<ListKind<K8sResourceKind>>[] = [
       fetchK8s<ListKind<K8sResourceKind>>(HelmChartRepositoryModel),
       fetchK8s<ListKind<K8sResourceKind>>(ProjectHelmChartRepositoryModel, null, namespace),

--- a/frontend/packages/integration-tests-cypress/tests/app/resource-log.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/resource-log.cy.ts
@@ -1,7 +1,7 @@
 import { checkErrors } from '../../support';
 import { detailsPage } from '../../views/details-page';
 import { guidedTour } from '../../views/guided-tour';
-import { listPage, listPage } from '../../views/list-page';
+import { listPage } from '../../views/list-page';
 
 describe('Pod log viewer tab', () => {
   before(() => {

--- a/frontend/packages/knative-plugin/src/actions/providers.ts
+++ b/frontend/packages/knative-plugin/src/actions/providers.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo, useContext } from 'react';
 import { GraphElement, Graph, Node, Edge, isEdge, isGraph } from '@patternfly/react-topology';
 import { getHealthChecksAction } from '@console/app/src/actions/creators/health-checks-factory';
 import { DeploymentActionCreator, CommonActionCreator } from '@console/app/src/actions/hooks/types';
@@ -71,7 +71,7 @@ import { hideKnatifyAction, MakeServerless } from './knatify';
 export const useMakeServerlessActionProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
 
-  const deploymentActions = React.useMemo(() => {
+  const deploymentActions = useMemo(() => {
     return hideKnatifyAction(resource) ? [] : MakeServerless(kindObj, resource);
   }, [kindObj, resource]);
 
@@ -81,7 +81,7 @@ export const useMakeServerlessActionProvider = (resource: K8sResourceKind) => {
 export const useSinkPubSubActionProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
   const commonActions = useCommonResourceActions(kindObj, resource);
-  const actions = React.useMemo(() => {
+  const actions = useMemo(() => {
     return [moveSinkPubsub(kindObj, resource), ...commonActions];
   }, [kindObj, resource, commonActions]);
 
@@ -90,7 +90,7 @@ export const useSinkPubSubActionProvider = (resource: K8sResourceKind) => {
 
 export const useKnativeServiceActionsProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
-  const serviceTypeValue = React.useContext(KnativeServiceTypeContext);
+  const serviceTypeValue = useContext(KnativeServiceTypeContext);
   const [deploymentActions, deploymentActionsReady] = useDeploymentActions(kindObj, resource, [
     DeploymentActionCreator.EditResourceLimits,
   ] as const);
@@ -102,7 +102,7 @@ export const useKnativeServiceActionsProvider = (resource: K8sResourceKind) => {
 
   const isReady = commonActionsReady || deploymentActionsReady;
 
-  const knativeServiceActions = React.useMemo(
+  const knativeServiceActions = useMemo(
     () =>
       !isReady
         ? []
@@ -131,7 +131,7 @@ export const useBrokerActionProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
   const isEventSinkTypeEnabled = isCatalogTypeEnabled(EVENT_SINK_CATALOG_TYPE_ID);
   const commonActions = useCommonResourceActions(kindObj, resource);
-  const actions = React.useMemo(() => {
+  const actions = useMemo(() => {
     const addActions: Action[] = [];
     const connectorSource = `${referenceFor(resource)}/${resource.metadata.name}`;
     addActions.push(addTriggerBroker(kindObj, resource));
@@ -150,7 +150,7 @@ export const useBrokerActionProvider = (resource: K8sResourceKind) => {
 export const useCommonActionsProvider = (resource: K8sResourceKind) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(resource));
   const commonActions = useCommonResourceActions(kindObj, resource);
-  const actions = React.useMemo(() => {
+  const actions = useMemo(() => {
     if (
       resource.kind === RevisionModel.kind &&
       commonActions.findIndex((action: Action) => action.id === 'delete-resource')
@@ -172,7 +172,7 @@ export const useChannelActionProvider = (resource: K8sResourceKind) => {
   const isEventSinkTypeEnabled = isCatalogTypeEnabled(EVENT_SINK_CATALOG_TYPE_ID);
   const commonActions = useCommonResourceActions(kindObj, resource);
 
-  const actions = React.useMemo(() => {
+  const actions = useMemo(() => {
     const addActions: Action[] = [];
     const connectorSource = `${referenceFor(resource)}/${resource.metadata.name}`;
     addActions.push(addSubscriptionChannel(kindObj, resource));
@@ -216,7 +216,7 @@ export const useTopologyActionsProvider = ({
   } = getEventingEnabledAddAction();
 
   const [namespace] = useActiveNamespace();
-  const actions = React.useMemo(() => {
+  const actions = useMemo(() => {
     const application = element.getLabel();
     if (!connectorSource) {
       if (!isGraph(element) && element.getType() !== TYPE_APPLICATION_GROUP) {
@@ -305,7 +305,7 @@ export const useEventSourcesActionsProvider = (resource: K8sResourceKind) => {
   const kindObj = resource ? modelFor(referenceFor(resource)) : null;
 
   const commonActions = useCommonResourceActions(kindObj, resource);
-  return React.useMemo(() => {
+  return useMemo(() => {
     if (!resource || resource.kind === 'URI') return [[], true, undefined];
 
     return [[moveSinkSource(kindObj, resource), ...commonActions], true, undefined];
@@ -313,7 +313,7 @@ export const useEventSourcesActionsProvider = (resource: K8sResourceKind) => {
 };
 
 export const useEventSourcesActionsProviderForTopology = (element: GraphElement) => {
-  const resource = React.useMemo(() => {
+  const resource = useMemo(() => {
     if (![TYPE_EVENT_SOURCE, TYPE_EVENT_SOURCE_KAFKA].includes(element.getType())) return undefined;
 
     return element.getData().resources.obj;
@@ -323,7 +323,7 @@ export const useEventSourcesActionsProviderForTopology = (element: GraphElement)
 };
 
 export const useModifyApplicationActionProvider = (element: GraphElement) => {
-  const actions = React.useMemo(() => {
+  const actions = useMemo(() => {
     if (
       ![
         TYPE_KNATIVE_SERVICE,
@@ -345,14 +345,14 @@ export const useModifyApplicationActionProvider = (element: GraphElement) => {
     ];
   }, [element]);
 
-  return React.useMemo(() => {
+  return useMemo(() => {
     if (!actions) return [[], true, undefined];
     return [actions, true, undefined];
   }, [actions]);
 };
 
 export const useUriActionsProvider = (element: GraphElement) => {
-  const actions = React.useMemo(() => {
+  const actions = useMemo(() => {
     if (element.getType() !== TYPE_SINK_URI) return undefined;
     const { obj, eventSources } = element.getData().resources;
     if (eventSources.length > 0) {
@@ -362,7 +362,7 @@ export const useUriActionsProvider = (element: GraphElement) => {
     return null;
   }, [element]);
 
-  return React.useMemo(() => {
+  return useMemo(() => {
     if (!actions) {
       return [[], true, undefined];
     }
@@ -371,7 +371,7 @@ export const useUriActionsProvider = (element: GraphElement) => {
 };
 
 export const useKnativeConnectorActionProvider = (element: Edge) => {
-  const actions = React.useMemo(() => {
+  const actions = useMemo(() => {
     const isEventSourceConnector = element.getType() === TYPE_EVENT_SOURCE_LINK;
     if (isEdge(element) && element.getSource()?.getData()) {
       const { resource } = element.getSource().getData();
@@ -385,7 +385,7 @@ export const useKnativeConnectorActionProvider = (element: Edge) => {
     }
     return null;
   }, [element]);
-  return React.useMemo(() => {
+  return useMemo(() => {
     if (!actions) {
       return [[], true, undefined];
     }
@@ -412,10 +412,10 @@ export const topologyServerlessActionsFilter = (
 };
 
 export const useKnativeEventSinkActionProvider = (element: Node) => {
-  const resource = React.useMemo(() => element.getData()?.resources?.obj || {}, [element]);
+  const resource = useMemo(() => element.getData()?.resources?.obj || {}, [element]);
   const [k8sModel] = useK8sModel(referenceFor(resource));
   const commonActions = useCommonResourceActions(k8sModel, resource);
-  const actions = React.useMemo(() => {
+  const actions = useMemo(() => {
     const type = element.getType();
     if ((type !== TYPE_EVENT_SINK && type !== TYPE_KAFKA_SINK) || !k8sModel) return undefined;
     return k8sModel && resource
@@ -423,7 +423,7 @@ export const useKnativeEventSinkActionProvider = (element: Node) => {
       : undefined;
   }, [element, k8sModel, resource, commonActions]);
 
-  return React.useMemo(() => {
+  return useMemo(() => {
     if (!actions) {
       return [[], true, undefined];
     }

--- a/frontend/packages/knative-plugin/src/catalog/useEventSourceProvider.ts
+++ b/frontend/packages/knative-plugin/src/catalog/useEventSourceProvider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { CatalogItem, ExtensionHook, SetFeatureFlag } from '@console/dynamic-plugin-sdk';
@@ -55,7 +55,7 @@ export const useEventSourceProvider: ExtensionHook<CatalogItem[]> = ({
   const { loaded, eventSourceModelsList: eventSourceModels } = useEventSourceModelsWithAccess(
     namespace,
   );
-  const normalizedSources = React.useMemo(
+  const normalizedSources = useMemo(
     () => (loaded ? normalizeEventSources(eventSourceModels, namespace, t) : []),
 
     [loaded, namespace, t, eventSourceModels],

--- a/frontend/packages/knative-plugin/src/catalog/useEventTypeProvider.tsx
+++ b/frontend/packages/knative-plugin/src/catalog/useEventTypeProvider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { CatalogItem, ExtensionHook, useAccessReview } from '@console/dynamic-plugin-sdk';
@@ -98,7 +98,7 @@ const useEventTypeProvider: ExtensionHook<CatalogItem[]> = ({
 
   const [eventTypes, eventTypesLoaded, eventTypesLoadError] = useEventTypesData(namespace);
 
-  const normalized = React.useMemo(() => {
+  const normalized = useMemo(() => {
     if (!eventTypesLoaded || !canGetEventType || !canListEventType || !canWatchEventType) return [];
 
     return eventTypes.map((et) => normalizeEventType(et, t));

--- a/frontend/packages/knative-plugin/src/catalog/useKafkaSinkProvider.ts
+++ b/frontend/packages/knative-plugin/src/catalog/useKafkaSinkProvider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { CatalogItem, ExtensionHook, useAccessReview } from '@console/dynamic-plugin-sdk';
@@ -45,7 +45,7 @@ const useKafkaSinkProvider: ExtensionHook<CatalogItem[]> = ({
     namespace,
   });
 
-  const normalizedKafkaSink = React.useMemo(() => {
+  const normalizedKafkaSink = useMemo(() => {
     if (!canCreateKameletSink) return [];
     return normalizeKafkaSink(namespace, t);
   }, [canCreateKameletSink, namespace, t]);

--- a/frontend/packages/knative-plugin/src/catalog/useKameletsProvider.ts
+++ b/frontend/packages/knative-plugin/src/catalog/useKameletsProvider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { CatalogItem, ExtensionHook } from '@console/dynamic-plugin-sdk';
@@ -58,7 +58,7 @@ const useKameletsProvider: ExtensionHook<CatalogItem[]> = ({
   });
   const [kamelets, kameletsLoaded, kameletsLoadError] = useKameletsData(namespace);
 
-  const normalizedSource = React.useMemo(() => {
+  const normalizedSource = useMemo(() => {
     if (!kameletsLoaded || !canCreateKameletBinding) return [];
     const kameletSource = kamelets.filter(
       (k) => k.metadata?.labels?.[CAMEL_K_TYPE_LABEL] === 'source',

--- a/frontend/packages/knative-plugin/src/catalog/useKameletsSinkProvider.ts
+++ b/frontend/packages/knative-plugin/src/catalog/useKameletsSinkProvider.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { CatalogItem, ExtensionHook } from '@console/dynamic-plugin-sdk';
@@ -58,7 +58,7 @@ const useKameletsSinkProvider: ExtensionHook<CatalogItem[]> = ({
   });
   const [kamelets, kameletsLoaded, kameletsLoadError] = useKameletsData(namespace);
 
-  const normalizedSource = React.useMemo(() => {
+  const normalizedSource = useMemo(() => {
     if (!kameletsLoaded || !canCreateKameletBinding) return [];
     const kameletSource = kamelets.filter(
       (k) => k.metadata?.labels?.[CAMEL_K_TYPE_LABEL] === 'sink',

--- a/frontend/packages/knative-plugin/src/components/functions/ServiceTypeContext.ts
+++ b/frontend/packages/knative-plugin/src/components/functions/ServiceTypeContext.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { createContext } from 'react';
 import { ServiceTypeValue } from '../../types';
 
-export const KnativeServiceTypeContext = React.createContext(ServiceTypeValue.Service);
+export const KnativeServiceTypeContext = createContext(ServiceTypeValue.Service);

--- a/frontend/packages/knative-plugin/src/hooks/useBootstrapServers.ts
+++ b/frontend/packages/knative-plugin/src/hooks/useBootstrapServers.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
@@ -9,14 +9,12 @@ import { kafkaBootStrapServerResourcesWatcher } from '../utils/get-knative-resou
 
 export const useBootstrapServers = (namespace: string): [SelectInputOption[], string] => {
   const { t } = useTranslation();
-  const memoResources = React.useMemo(() => kafkaBootStrapServerResourcesWatcher(namespace), [
-    namespace,
-  ]);
+  const memoResources = useMemo(() => kafkaBootStrapServerResourcesWatcher(namespace), [namespace]);
   const { kafkas, kafkaconnections } = useK8sWatchResources<{
     [key: string]: K8sResourceKind[];
   }>(memoResources);
 
-  return React.useMemo(() => {
+  return useMemo(() => {
     let bootstrapServersOptions: SelectInputOption[] = [];
     let placeholder: string = '';
     const isKafkasLoaded =

--- a/frontend/packages/knative-plugin/src/hooks/useEventSinkStatus.ts
+++ b/frontend/packages/knative-plugin/src/hooks/useEventSinkStatus.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAccessReview } from '@console/dynamic-plugin-sdk';
 import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
@@ -56,7 +56,7 @@ export const useEventSinkStatus = (
     namespace,
   });
 
-  const sourceStatus = React.useMemo(() => {
+  const sourceStatus = useMemo(() => {
     if (!isSinkKindPresent) {
       return {
         isValidSink: false,

--- a/frontend/packages/knative-plugin/src/hooks/useEventSourceModelsWithAccess.ts
+++ b/frontend/packages/knative-plugin/src/hooks/useEventSourceModelsWithAccess.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { K8sKind } from '@console/internal/module/k8s';
 import { getEventSourceModelsWithAccess } from '../utils/create-eventsources-utils';
 import { useEventSourceModels } from '../utils/fetch-dynamic-eventsources-utils';
@@ -7,12 +7,12 @@ export const useEventSourceModelsWithAccess = (
   namespace: string,
 ): { loaded: boolean; eventSourceModelsList: K8sKind[] } => {
   const { loaded, eventSourceModels } = useEventSourceModels();
-  const [accessModelData, setAccessModelData] = React.useState({
+  const [accessModelData, setAccessModelData] = useState({
     loaded: false,
     eventSourceModelsList: [],
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (loaded) {
       const eventSourceModelsWithAccess = getEventSourceModelsWithAccess(
         namespace,

--- a/frontend/packages/knative-plugin/src/hooks/useEventSourceStatus.ts
+++ b/frontend/packages/knative-plugin/src/hooks/useEventSourceStatus.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAccessReview } from '@console/dynamic-plugin-sdk/src';
 import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
@@ -61,7 +61,7 @@ export const useEventSourceStatus = (
     true,
   );
 
-  const sourceStatus = React.useMemo(() => {
+  const sourceStatus = useMemo(() => {
     if (!isSourceKindPresent) {
       return {
         isValidSource: false,

--- a/frontend/packages/knative-plugin/src/hooks/useEventTypesData.ts
+++ b/frontend/packages/knative-plugin/src/hooks/useEventTypesData.ts
@@ -1,14 +1,14 @@
-import * as React from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { EventingEventTypeModel } from '../models';
 
 export const useEventTypesData = (namespace: string): [K8sResourceKind[], boolean, any] => {
-  const [eventTypes, setEventTypes] = React.useState<K8sResourceKind[]>([]);
-  const [eventTypesLoaded, setEventTypesLoaded] = React.useState(false);
-  const [eventTypesLoadError, setEventTypesLoadError] = React.useState(null);
+  const [eventTypes, setEventTypes] = useState<K8sResourceKind[]>([]);
+  const [eventTypesLoaded, setEventTypesLoaded] = useState(false);
+  const [eventTypesLoadError, setEventTypesLoadError] = useState(null);
 
-  const watchedResources = React.useMemo(
+  const watchedResources = useMemo(
     () => ({
       eventTypes: {
         isList: true,
@@ -24,7 +24,7 @@ export const useEventTypesData = (namespace: string): [K8sResourceKind[], boolea
     [key: string]: K8sResourceKind[];
   }>(watchedResources);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const resDataLoaded = Object.keys(extraResources).some((key) => extraResources[key].loaded);
     const resDataloadError = Object.keys(extraResources).every(
       (key) => extraResources[key].loadError,

--- a/frontend/packages/knative-plugin/src/hooks/useKameletsData.ts
+++ b/frontend/packages/knative-plugin/src/hooks/useKameletsData.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import uniqBy from 'lodash-es/uniqBy';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
@@ -6,11 +6,11 @@ import { CAMEL_K_OPERATOR_NS, GLOBAL_OPERATOR_NS } from '../const';
 import { CamelKameletModel } from '../models';
 
 export const useKameletsData = (namespace: string): [K8sResourceKind[], boolean, any] => {
-  const [kamelets, setKamelets] = React.useState<K8sResourceKind[]>([]);
-  const [kameletsLoaded, setKameletsLoaded] = React.useState(false);
-  const [kameletsLoadError, setKameletsLoadError] = React.useState(null);
+  const [kamelets, setKamelets] = useState<K8sResourceKind[]>([]);
+  const [kameletsLoaded, setKameletsLoaded] = useState(false);
+  const [kameletsLoadError, setKameletsLoadError] = useState(null);
 
-  const watchedResources = React.useMemo(
+  const watchedResources = useMemo(
     () => ({
       kamelets: {
         isList: true,
@@ -38,7 +38,7 @@ export const useKameletsData = (namespace: string): [K8sResourceKind[], boolean,
     [key: string]: K8sResourceKind[];
   }>(watchedResources);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const resDataLoaded = Object.keys(extraResources).some((key) => extraResources[key].loaded);
     const resDataloadError = Object.keys(extraResources).every(
       (key) => extraResources[key].loadError,

--- a/frontend/packages/knative-plugin/src/topology/eventing-context.ts
+++ b/frontend/packages/knative-plugin/src/topology/eventing-context.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { createContext } from 'react';
 import { K8sModel } from '@console/dynamic-plugin-sdk/src/api/common-types';
 import { useEventSourceModels, useChannelModels } from '../utils/fetch-dynamic-eventsources-utils';
 
@@ -17,7 +17,7 @@ export type EventingContextType = {
   channelsData: DynamicChannelDataType;
 };
 
-export const EventingContext = React.createContext<EventingContextType>({
+export const EventingContext = createContext<EventingContextType>({
   eventSourceData: { eventSourceModels: [], loaded: false },
   channelsData: { eventSourceChannels: [], loaded: false },
 });

--- a/frontend/packages/knative-plugin/src/topology/sidebar/knative-common-tab-sections.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/knative-common-tab-sections.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
 import {
@@ -33,7 +33,7 @@ const usePodsAdapterForKnative = (resource: K8sResourceCommon): PodsAdapterDataT
     isList: true,
   });
 
-  const revisionIds = React.useMemo(() => {
+  const revisionIds = useMemo(() => {
     if (resource.kind === RevisionModel.kind) {
       return resource.metadata.uid;
     }
@@ -47,7 +47,7 @@ const usePodsAdapterForKnative = (resource: K8sResourceCommon): PodsAdapterDataT
   }, [revisionLoaded, revisionErrorLoad, rev, resource.kind, resource.metadata]);
 
   const { pods } = usePodsForRevisions(revisionIds, resource.metadata.namespace);
-  const servicePods = React.useMemo(() => {
+  const servicePods = useMemo(() => {
     return pods.reduce((acc, pod) => {
       if (pod.pods) {
         acc.push(...pod.pods.filter((p) => podPhase(p as PodKind) !== AllPodStatus.AutoScaledTo0));
@@ -62,7 +62,7 @@ const usePodsAdapterForKnative = (resource: K8sResourceCommon): PodsAdapterDataT
     `serving.knative.dev/${resource.kind.toLowerCase()}=${resource.metadata.name}`,
   )}`;
 
-  return React.useMemo(
+  return useMemo(
     () => ({
       pods: servicePods,
       loaded: revisionLoaded,

--- a/frontend/packages/knative-plugin/src/utils/create-channel-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-channel-utils.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 import { safeLoad } from 'js-yaml';
 import * as _ from 'lodash';
 import {
@@ -42,7 +42,7 @@ export const getChannelKind = (ref: string): string => {
 export const useChannelList = (namespace: string): ChannelListProps => {
   const [accessData, setAccessData] = useSafetyFirst({ loaded: false, channelList: [] });
   const { channels, loaded: channelsLoaded } = useChannelResourcesList();
-  React.useEffect(() => {
+  useEffect(() => {
     const accessList = [];
     if (channelsLoaded) {
       _.forIn(channels, (channelRef: string) => {

--- a/frontend/packages/knative-plugin/src/utils/usePodsForRevisions.ts
+++ b/frontend/packages/knative-plugin/src/utils/usePodsForRevisions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import * as _ from 'lodash';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { DeploymentModel } from '@console/internal/models';
@@ -18,11 +18,11 @@ export const usePodsForRevisions = (
   revisionIds: string | string[],
   namespace: string,
 ): { loaded: boolean; loadError: string; pods: PodControllerOverviewItem[] } => {
-  const [loaded, setLoaded] = React.useState<boolean>(false);
-  const [loadError, setLoadError] = React.useState<string>('');
-  const [pods, setPods] = React.useState<PodControllerOverviewItem[]>([]);
+  const [loaded, setLoaded] = useState<boolean>(false);
+  const [loadError, setLoadError] = useState<string>('');
+  const [pods, setPods] = useState<PodControllerOverviewItem[]>([]);
   const revisions = useDeepCompareMemoize(Array.isArray(revisionIds) ? revisionIds : [revisionIds]);
-  const watchedResources = React.useMemo(
+  const watchedResources = useMemo(
     () => ({
       deployments: {
         isList: true,
@@ -45,7 +45,7 @@ export const usePodsForRevisions = (
 
   const resources = useK8sWatchResources<{ [key: string]: K8sResourceCommon[] }>(watchedResources);
 
-  const updateResults = React.useCallback(
+  const updateResults = useCallback(
     (updatedResources) => {
       const errorKey = Object.keys(updatedResources).find((key) => updatedResources[key].loadError);
       if (errorKey) {
@@ -85,7 +85,7 @@ export const usePodsForRevisions = (
 
   const debouncedUpdateResources = useDebounceCallback(updateResults, 250);
 
-  React.useEffect(() => {
+  useEffect(() => {
     debouncedUpdateResources(resources);
   }, [debouncedUpdateResources, resources]);
 

--- a/frontend/packages/knative-plugin/src/utils/useRoutesURL.ts
+++ b/frontend/packages/knative-plugin/src/utils/useRoutesURL.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { ROUTE_DISABLED_ANNOTATION, ROUTE_URL_ANNOTATION } from '@console/topology/src/const';
@@ -23,12 +23,12 @@ export const useRoutesURL = (resource: K8sResourceKind): string => {
         },
   );
 
-  const routes = React.useMemo(() => (loaded && !loadError ? allRoutes : []), [
+  const routes = useMemo(() => (loaded && !loadError ? allRoutes : []), [
     loaded,
     loadError,
     allRoutes,
   ]);
-  const watchedURL = React.useMemo(() => getRoutesURL(resource, routes), [resource, routes]);
+  const watchedURL = useMemo(() => getRoutesURL(resource, routes), [resource, routes]);
 
   const url = annotationURL || watchedURL;
   if (disabled || !url || !(url.startsWith('http://') || url.startsWith('https://'))) {

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/BareMetalHostDashboardContext.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/BareMetalHostDashboardContext.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import { createContext } from 'react';
 import { K8sResourceKind, MachineKind, NodeKind } from '@console/internal/module/k8s';
 import { BareMetalHostKind } from '../../../types';
 
-export const BareMetalHostDashboardContext = React.createContext<BareMetalDashboardContext>({});
+export const BareMetalHostDashboardContext = createContext<BareMetalDashboardContext>({});
 
 type BareMetalDashboardContext = {
   obj?: BareMetalHostKind;

--- a/frontend/packages/metal3-plugin/src/components/maintenance/actions.tsx
+++ b/frontend/packages/metal3-plugin/src/components/maintenance/actions.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Action, ExtensionHook, K8sResourceCommon } from '@console/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
@@ -22,7 +22,7 @@ export const useNodeMaintenanceActions: ExtensionHook<Action[], NodeKind> = (res
     namespaced: false,
   });
 
-  const actions = React.useMemo(() => {
+  const actions = useMemo(() => {
     const nodeMaintenance = findNodeMaintenance(maintenances, resource.metadata.name);
 
     let action: Action = {

--- a/frontend/packages/metal3-plugin/src/components/modals/RestartHostModal.tsx
+++ b/frontend/packages/metal3-plugin/src/components/modals/RestartHostModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   createModalLauncher,
@@ -29,7 +29,7 @@ const RestartHostModal = ({
   cancel = undefined,
 }: RestartHostModalProps) => {
   const { t } = useTranslation();
-  const onSubmit = React.useCallback(
+  const onSubmit = useCallback(
     async (event) => {
       event.preventDefault();
       const promise = restartHost(host);

--- a/frontend/packages/metal3-plugin/src/components/modals/StartNodeMaintenanceModal.tsx
+++ b/frontend/packages/metal3-plugin/src/components/modals/StartNodeMaintenanceModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import { Alert, FormGroup, Stack, StackItem, TextInput } from '@patternfly/react-core';
 import { Trans, useTranslation } from 'react-i18next';
 import {
@@ -31,7 +31,7 @@ const StartNodeMaintenanceModal = withHandlePromise<StartNodeMaintenanceModalPro
   const { nodeName, inProgress, errorMessage, handlePromise, close, cancel } = props;
   const [model] = useMaintenanceCapability();
 
-  const [reason, setReason] = React.useState('');
+  const [reason, setReason] = useState('');
 
   const submit = (event) => {
     event.preventDefault();

--- a/frontend/packages/operator-lifecycle-manager-v1/src/contexts/ExtensionCatalogDatabaseContext.ts
+++ b/frontend/packages/operator-lifecycle-manager-v1/src/contexts/ExtensionCatalogDatabaseContext.ts
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import { createContext } from 'react';
 import { ExtensionCatalogDatabaseContextValues } from './types';
 
-export const ExtensionCatalogDatabaseContext = React.createContext<
-  ExtensionCatalogDatabaseContextValues
->({ done: false, error: null });
+export const ExtensionCatalogDatabaseContext = createContext<ExtensionCatalogDatabaseContextValues>(
+  { done: false, error: null },
+);
 
 export default ExtensionCatalogDatabaseContext.Provider;

--- a/frontend/packages/operator-lifecycle-manager-v1/src/contexts/useExtensionCatalogDatabaseContextValues.ts
+++ b/frontend/packages/operator-lifecycle-manager-v1/src/contexts/useExtensionCatalogDatabaseContextValues.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useRef, useEffect } from 'react';
 import * as _ from 'lodash';
 import { K8sResourceCommon } from '@console/dynamic-plugin-sdk/src';
 import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/api/core-api';
@@ -12,9 +12,9 @@ export const useExtensionCatalogDatabaseContextValues: UseExtensionCatalogDataba
     groupVersionKind: CLUSTER_CATALOG_GROUP_VERSION_KIND,
     isList: true,
   });
-  const [done, setDone] = React.useState(false);
-  const [error, setError] = React.useState<Error>();
-  const refresh = React.useRef(
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<Error>();
+  const refresh = useRef(
     _.debounce((newCatalogs: K8sResourceCommon[]) => {
       setDone(false);
       setError(null);
@@ -31,7 +31,7 @@ export const useExtensionCatalogDatabaseContextValues: UseExtensionCatalogDataba
     }, 5000),
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     const currentRefresh = refresh.current;
     currentRefresh(catalogs);
     return () => currentRefresh.cancel();

--- a/frontend/packages/operator-lifecycle-manager-v1/src/hooks/useExtensionCatalogCategories.ts
+++ b/frontend/packages/operator-lifecycle-manager-v1/src/hooks/useExtensionCatalogCategories.ts
@@ -1,23 +1,23 @@
-import * as React from 'react';
+import { useContext, useState, useEffect, useCallback, useMemo } from 'react';
 import { usePoll } from '@console/internal/components/utils';
 import { CatalogCategory } from '@console/shared/src/components/catalog/utils/types';
 import { ExtensionCatalogDatabaseContext } from '../contexts/ExtensionCatalogDatabaseContext';
 import { getUniqueIndexKeys, openDatabase } from '../database/indexeddb';
 
 export const useExtensionCatalogCategories = (): [CatalogCategory[], boolean, Error] => {
-  const { done: initDone, error: initError } = React.useContext(ExtensionCatalogDatabaseContext);
-  const [categories, setCategories] = React.useState([]);
-  const [loading, setLoading] = React.useState(!initDone);
-  const [error, setError] = React.useState<Error>(initError);
+  const { done: initDone, error: initError } = useContext(ExtensionCatalogDatabaseContext);
+  const [categories, setCategories] = useState([]);
+  const [loading, setLoading] = useState(!initDone);
+  const [error, setError] = useState<Error>(initError);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!initDone || initError) {
       setLoading(!initDone);
       setError(initError);
     }
   }, [initDone, initError]);
 
-  const tick = React.useCallback(() => {
+  const tick = useCallback(() => {
     if (initDone && !initError) {
       openDatabase('olm')
         .then((database) => getUniqueIndexKeys(database, 'extension-catalog', 'categories'))
@@ -36,7 +36,7 @@ export const useExtensionCatalogCategories = (): [CatalogCategory[], boolean, Er
 
   // Poll IndexedDB (IDB) every 10 seconds
   usePoll(tick, 10000);
-  const catalogCategories = React.useMemo<CatalogCategory[]>(
+  const catalogCategories = useMemo<CatalogCategory[]>(
     () => categories.map((c) => ({ id: c, label: c, tags: [c] })),
     [categories],
   );

--- a/frontend/packages/operator-lifecycle-manager-v1/src/hooks/useExtensionCatalogItems.ts
+++ b/frontend/packages/operator-lifecycle-manager-v1/src/hooks/useExtensionCatalogItems.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useContext, useState, useEffect, useCallback, useMemo } from 'react';
 import { CatalogItem } from '@console/dynamic-plugin-sdk/src';
 import { usePoll } from '@console/internal/components/utils';
 import { ExtensionCatalogDatabaseContext } from '../contexts/ExtensionCatalogDatabaseContext';
@@ -8,19 +8,19 @@ import { ExtensionCatalogItem } from '../fbc/types';
 
 type UseExtensionCatalogItems = () => [CatalogItem[], boolean, Error];
 export const useExtensionCatalogItems: UseExtensionCatalogItems = () => {
-  const { done: initDone, error: initError } = React.useContext(ExtensionCatalogDatabaseContext);
-  const [items, setItems] = React.useState<ExtensionCatalogItem[]>([]);
-  const [loading, setLoading] = React.useState(true);
-  const [error, setError] = React.useState<Error>();
+  const { done: initDone, error: initError } = useContext(ExtensionCatalogDatabaseContext);
+  const [items, setItems] = useState<ExtensionCatalogItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!initDone || initError) {
       setLoading(!initDone);
       setError(initError);
     }
   }, [initDone, initError]);
 
-  const tick = React.useCallback(() => {
+  const tick = useCallback(() => {
     if (initDone && !initError) {
       openDatabase('olm')
         .then((database) => getItems<ExtensionCatalogItem>(database, 'extension-catalog'))
@@ -40,10 +40,9 @@ export const useExtensionCatalogItems: UseExtensionCatalogItems = () => {
   // Poll IndexedDB (IDB) every 10 seconds
   usePoll(tick, 10000);
 
-  const normalizedItems = React.useMemo<CatalogItem[]>(
-    () => items.map(normalizeExtensionCatalogItem),
-    [items],
-  );
+  const normalizedItems = useMemo<CatalogItem[]>(() => items.map(normalizeExtensionCatalogItem), [
+    items,
+  ]);
 
   return [normalizedItems, loading, error];
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/useShowOperandsInAllNamespaces.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/useShowOperandsInAllNamespaces.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import * as UIActions from '@console/internal/actions/ui';
 import { RootState } from '@console/internal/redux';
@@ -11,7 +11,7 @@ export const useShowOperandsInAllNamespaces: UseShowOperandsInAllNamespaces = ()
   const showOperandsInAllNamespaces = useSelector((state: RootState) =>
     state.UI.get('showOperandsInAllNamespaces'),
   );
-  const setShowOperandsInAllNamespaces = React.useCallback(
+  const setShowOperandsInAllNamespaces = useCallback(
     (value: boolean) => dispatch(UIActions.setShowOperandsInAllNamespaces(value)),
     [dispatch],
   );

--- a/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersion.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { GLOBAL_COPIED_CSV_NAMESPACE } from '../const';
 import { ClusterServiceVersionModel } from '../models';
@@ -38,7 +38,7 @@ export const useClusterServiceVersion = (
       : null,
   );
 
-  return React.useMemo(() => {
+  return useMemo(() => {
     if (copiedCSVsDisabled && Boolean(namespacedCSVLoadError)) {
       return [isCopiedCSV(globalCSV) ? globalCSV : null, globalCSVLoaded, globalCSVLoadError];
     }

--- a/frontend/packages/pipelines-plugin/src/components/catalog/apis/artifactHub.ts
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/apis/artifactHub.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import * as _ from 'lodash';
 import { CatalogItem } from '@console/dynamic-plugin-sdk';
 import { K8sResourceKind, k8sCreate, k8sUpdate } from '@console/internal/module/k8s';
@@ -31,11 +31,11 @@ export const getArtifactHubTaskDetails = async (
 };
 
 export const useGetArtifactHubTasks = (hasPermission: boolean): ApiResult<ArtifactHubTask[]> => {
-  const [resultData, setResult] = React.useState<ArtifactHubTask[]>([]);
-  const [loaded, setLoaded] = React.useState(false);
-  const [loadedError, setLoadedError] = React.useState<string>();
+  const [resultData, setResult] = useState<ArtifactHubTask[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [loadedError, setLoadedError] = useState<string>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     let mounted = true;
     if (hasPermission) {
       searchTasks()

--- a/frontend/packages/pipelines-plugin/src/components/catalog/hooks/useApiResponse.ts
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/hooks/useApiResponse.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { coFetch } from '@console/internal/co-fetch';
 
 export type ApiResult<R extends any[]> = [R, boolean, string];
@@ -8,11 +8,11 @@ export type UseApiResponse = <R extends any = any>(
 ) => ApiResult<R[]>;
 
 const useApiResponse: UseApiResponse = (url: string, hasPermission: boolean) => {
-  const [resultData, setResult] = React.useState([]);
-  const [loaded, setLoaded] = React.useState(false);
-  const [loadedError, setLoadedError] = React.useState<string>();
+  const [resultData, setResult] = useState([]);
+  const [loaded, setLoaded] = useState(false);
+  const [loadedError, setLoadedError] = useState<string>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     let mounted = true;
     if (hasPermission) {
       coFetch(url)

--- a/frontend/packages/pipelines-plugin/src/components/catalog/providers/useArtifactHubTasksProvider.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/providers/useArtifactHubTasksProvider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import i18next from 'i18next';
 import { CatalogItem, ExtensionHook } from '@console/dynamic-plugin-sdk';
 import { ResourceIcon, useAccessReview } from '@console/internal/components/utils';
@@ -66,7 +66,7 @@ const useArtifactHubTasksProvider: ExtensionHook<CatalogItem[]> = ({
   const [artifactHubTasks, tasksLoaded, tasksError] = useGetArtifactHubTasks(
     canCreateTask && canUpdateTask && artifactHubIntegration,
   );
-  const normalizedArtifactHubTasks = React.useMemo<CatalogItem<TektonHubTask>[]>(
+  const normalizedArtifactHubTasks = useMemo<CatalogItem<TektonHubTask>[]>(
     () => normalizeArtifactHubTasks(artifactHubTasks),
     [artifactHubTasks],
   );

--- a/frontend/packages/pipelines-plugin/src/components/catalog/providers/useTasksProvider.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/providers/useTasksProvider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useFormikContext } from 'formik';
 import i18next from 'i18next';
 import * as _ from 'lodash';
@@ -72,14 +72,12 @@ const useTasksProvider: ExtensionHook<CatalogItem[]> = (): [CatalogItem[], boole
     taskResources: { namespacedTasks, clusterTasks, tasksLoaded },
   } = values;
 
-  const tektonTasks = React.useMemo(() => _.filter([...namespacedTasks, ...clusterTasks]), [
+  const tektonTasks = useMemo(() => _.filter([...namespacedTasks, ...clusterTasks]), [
     namespacedTasks,
     clusterTasks,
   ]);
 
-  const normalizedTektonTasks = React.useMemo(() => normalizeTektonTasks(tektonTasks), [
-    tektonTasks,
-  ]);
+  const normalizedTektonTasks = useMemo(() => normalizeTektonTasks(tektonTasks), [tektonTasks]);
   return [normalizedTektonTasks, tasksLoaded, status?.taskLoadingError];
 };
 

--- a/frontend/packages/pipelines-plugin/src/components/catalog/providers/useTekonHubTasksProvider.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/catalog/providers/useTekonHubTasksProvider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useMemo } from 'react';
 import { Label } from '@patternfly/react-core';
 import i18next from 'i18next';
 import { CatalogItem, ExtensionHook } from '@console/dynamic-plugin-sdk';
@@ -55,7 +55,7 @@ const normalizeTektonHubTasks = (
 const useTektonHubTasksProvider: ExtensionHook<CatalogItem[]> = ({
   namespace,
 }): [CatalogItem[], boolean, string] => {
-  const [normalizedTektonHubTasks, setNormalizedTektonHubTasks] = React.useState<
+  const [normalizedTektonHubTasks, setNormalizedTektonHubTasks] = useState<
     CatalogItem<TektonHubTask>[]
   >([]);
 
@@ -81,7 +81,7 @@ const useTektonHubTasksProvider: ExtensionHook<CatalogItem[]> = ({
     canCreateTask && canUpdateTask && integrationEnabled && baseURLLoaded,
   );
 
-  React.useMemo(
+  useMemo(
     () => setNormalizedTektonHubTasks(normalizeTektonHubTasks(tektonHubTasks, apiURL, uiURL)),
     [apiURL, tektonHubTasks, uiURL],
   );

--- a/frontend/packages/pipelines-plugin/src/components/pac/hooks/usePacData.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pac/hooks/usePacData.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { coFetch } from '@console/internal/co-fetch';
 import { removeQueryArgument } from '@console/internal/components/utils';
 import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
@@ -11,18 +11,18 @@ import { createPACSecret, updatePACInfo } from '../pac-utils';
 export const usePacData = (
   code: string,
 ): { loaded: boolean; secretData: SecretKind; loadError: Error; isFirstSetup: boolean } => {
-  const apiCallProgressRef = React.useRef(false);
-  const [loaded, setloaded] = React.useState<boolean>(false);
-  const [secretData, setSecretData] = React.useState<SecretKind>();
-  const [loadError, setLoadError] = React.useState(null);
-  const [isFirstSetup, setIsFirstSetup] = React.useState<boolean>(false);
+  const apiCallProgressRef = useRef(false);
+  const [loaded, setloaded] = useState<boolean>(false);
+  const [secretData, setSecretData] = useState<SecretKind>();
+  const [loadError, setLoadError] = useState(null);
+  const [isFirstSetup, setIsFirstSetup] = useState<boolean>(false);
   const [pacSecretData, pacSecretDataLoaded, pacSecretDataError] = useK8sGet<SecretKind>(
     SecretModel,
     PAC_SECRET_NAME,
     PIPELINE_NAMESPACE,
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     let mounted = true;
     const configureGitHubApp = async () => {
       if (code && !apiCallProgressRef.current) {
@@ -59,7 +59,7 @@ export const usePacData = (
     };
   }, [code]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (pacSecretDataLoaded && pacSecretData && !pacSecretDataError) {
       setSecretData(pacSecretData);
       setloaded(true);

--- a/frontend/packages/pipelines-plugin/src/components/pac/hooks/usePacGHManifest.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pac/hooks/usePacGHManifest.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { PAC_GH_APP_NAME } from '../const';
 import { getControllerUrl } from '../pac-utils';
 
@@ -14,11 +14,11 @@ type GHManifestData = {
 };
 
 export const usePacGHManifest = (): { loaded: boolean; manifestData: GHManifestData } => {
-  const [elRoute, setElRoute] = React.useState<string>();
-  const [loaded, setLoded] = React.useState<boolean>(false);
+  const [elRoute, setElRoute] = useState<string>();
+  const [loaded, setLoded] = useState<boolean>(false);
   const locURL = window.location.href;
 
-  React.useEffect(() => {
+  useEffect(() => {
     const getELRoute = async () => {
       try {
         const controllerUrl = await getControllerUrl();

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/events/event-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/events/event-utils.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { WatchK8sResources, WatchK8sResults } from '@console/dynamic-plugin-sdk';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { PodModel } from '@console/internal/models';
@@ -37,7 +37,7 @@ export const usePipelineRunRelatedResources = (
   namespace: string,
   pipelineRunName: string,
 ): WatchK8sResults<ResourcesType> => {
-  const plrRelatedResources: WatchK8sResources<ResourcesType> = React.useMemo(() => {
+  const plrRelatedResources: WatchK8sResources<ResourcesType> = useMemo(() => {
     return {
       taskruns: {
         kind: referenceForModel(TaskRunModel),
@@ -62,7 +62,7 @@ export const useTaskRunRelatedResources = (
   namespace: string,
   taskRunName: string,
 ): WatchK8sResults<ResourcesType> => {
-  const tsrRelatedResources: WatchK8sResources<ResourcesType> = React.useMemo(() => {
+  const tsrRelatedResources: WatchK8sResources<ResourcesType> = useMemo(() => {
     return {
       pods: getPodsByLabels(namespace, { [TektonResourceLabel.taskrun]: taskRunName }),
     };

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineFromPipelineRun.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineFromPipelineRun.ts
@@ -1,12 +1,12 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { k8sGet } from '@console/internal/module/k8s';
 import { PipelineModel } from '../../../models';
 import { PipelineKind, PipelineRunKind } from '../../../types';
 import { getPipelineFromPipelineRun } from '../../../utils/pipeline-augment';
 
 export const usePipelineFromPipelineRun = (pipelineRun: PipelineRunKind): PipelineKind => {
-  const [pipeline, setPipeline] = React.useState<PipelineKind>(null);
-  React.useEffect(() => {
+  const [pipeline, setPipeline] = useState<PipelineKind>(null);
+  useEffect(() => {
     const emptyPipeline: PipelineKind = { spec: { tasks: [] } };
     const pipelineFromPipelineRun = getPipelineFromPipelineRun(pipelineRun);
     if (pipelineFromPipelineRun) {

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRunVulnerabilities.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRunVulnerabilities.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { PipelineRunKind } from '../../../types';
 
 const SCAN_OUTPUT_SUFFIX = 'SCAN_OUTPUT';
@@ -36,7 +36,7 @@ export const getPipelineRunVulnerabilities = (pipelineRun: PipelineRunKind): Sca
 };
 
 export const usePipelineRunVulnerabilities = (pipelineRun: PipelineRunKind): ScanResults =>
-  React.useMemo(() => {
+  useMemo(() => {
     if (!pipelineRun) {
       return null;
     }

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineRuns.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useRef, useMemo } from 'react';
 import differenceBy from 'lodash-es/differenceBy';
 import uniqBy from 'lodash-es/uniqBy';
 import { Selector } from '@console/dynamic-plugin-sdk/src';
@@ -27,12 +27,12 @@ const useRuns = <Kind extends K8sResourceCommon>(
   },
   cacheKey?: string,
 ): [Kind[], boolean, unknown, GetNextPage] => {
-  const etcdRunsRef = React.useRef<Kind[]>([]);
+  const etcdRunsRef = useRef<Kind[]>([]);
   const optionsMemo = useDeepCompareMemoize(options);
   const isList = !optionsMemo?.name;
   const limit = optionsMemo?.limit;
   // do not include the limit when querying etcd because result order is not sorted
-  const watchOptions = React.useMemo(() => {
+  const watchOptions = useMemo(() => {
     // reset cached runs as the options have changed
     etcdRunsRef.current = [];
     return {
@@ -47,7 +47,7 @@ const useRuns = <Kind extends K8sResourceCommon>(
   const [resources, loaded, error] = useK8sWatchResource(watchOptions);
 
   // if a pipeline run was removed from etcd, we want to still include it in the return value without re-querying tekton-results
-  const etcdRuns = React.useMemo(() => {
+  const etcdRuns = useMemo(() => {
     if (!loaded || error) {
       return [];
     }
@@ -56,7 +56,7 @@ const useRuns = <Kind extends K8sResourceCommon>(
     return resourcesArray;
   }, [isList, resources, loaded, error]);
 
-  const runs = React.useMemo(() => {
+  const runs = useMemo(() => {
     if (!etcdRuns) {
       return etcdRuns;
     }
@@ -81,7 +81,7 @@ const useRuns = <Kind extends K8sResourceCommon>(
   const queryTr =
     !limit || (namespace && ((runs && loaded && optionsMemo.limit > runs.length) || error));
 
-  const trOptions: typeof optionsMemo = React.useMemo(() => {
+  const trOptions: typeof optionsMemo = useMemo(() => {
     if (optionsMemo?.name) {
       const { name, ...rest } = optionsMemo;
       return {
@@ -104,7 +104,7 @@ const useRuns = <Kind extends K8sResourceCommon>(
     GetNextPage,
   ];
 
-  return React.useMemo(() => {
+  return useMemo(() => {
     const rResources =
       runs && trResources
         ? uniqBy([...runs, ...trResources], (r) => r.metadata.uid)
@@ -161,7 +161,7 @@ export const usePipelineRun = (
 ): [PipelineRunKind, boolean, string] => {
   const result = (usePipelineRuns(
     namespace,
-    React.useMemo(
+    useMemo(
       () => ({
         name: pipelineRunName,
         limit: 1,
@@ -170,7 +170,7 @@ export const usePipelineRun = (
     ),
   ) as unknown) as [PipelineRunKind[], boolean, string];
 
-  return React.useMemo(() => [result[0]?.[0], result[1], result[0]?.[0] ? undefined : result[2]], [
+  return useMemo(() => [result[0]?.[0], result[1], result[0]?.[0] ? undefined : result[2]], [
     result,
   ]);
 };
@@ -181,7 +181,7 @@ export const useTaskRun = (
 ): [TaskRunKind, boolean, string] => {
   const result = (useTaskRuns(
     namespace,
-    React.useMemo(
+    useMemo(
       () => ({
         name: taskRunName,
         limit: 1,
@@ -190,7 +190,7 @@ export const useTaskRun = (
     ),
   ) as unknown) as [TaskRunKind[], boolean, string];
 
-  return React.useMemo(() => [result[0]?.[0], result[1], result[0]?.[0] ? undefined : result[2]], [
+  return useMemo(() => [result[0]?.[0], result[1], result[0]?.[0] ? undefined : result[2]], [
     result,
   ]);
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTaskRuns.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTaskRuns.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { Selector } from '@console/dynamic-plugin-sdk/src';
 import { TaskRunKind } from '../../../types';
 import { TektonResourceLabel } from '../../pipelines/const';
@@ -12,7 +12,7 @@ export const useTaskRuns = (
   cacheKey?: string,
   pipelineRunUid?: string,
 ): [TaskRunKind[], boolean, unknown, GetNextPage] => {
-  const selector: Selector = React.useMemo(() => {
+  const selector: Selector = useMemo(() => {
     if (pipelineRunName && pipelineRunUid) {
       return {
         matchLabels: {
@@ -37,7 +37,7 @@ export const useTaskRuns = (
     cacheKey,
   );
 
-  const sortedTaskRuns = React.useMemo(
+  const sortedTaskRuns = useMemo(
     () =>
       taskRuns?.sort((a, b) => {
         if (a?.status?.completionTime) {
@@ -53,7 +53,7 @@ export const useTaskRuns = (
       }),
     [taskRuns],
   );
-  return React.useMemo(() => [sortedTaskRuns, loaded, error, getNextPage], [
+  return useMemo(() => [sortedTaskRuns, loaded, error, getNextPage], [
     sortedTaskRuns,
     loaded,
     error,

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTektonResults.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { uniqBy } from 'lodash';
 import { K8sResourceCommon, Selector } from '@console/dynamic-plugin-sdk/src';
 import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks';
@@ -33,15 +33,15 @@ const useTRRuns = <Kind extends K8sResourceCommon>(
   const IS_PIPELINE_OPERATOR_VERSION_1_16_OR_NEWER = useFlag(
     FLAG_PIPELINES_OPERATOR_VERSION_1_16_OR_NEWER,
   );
-  const [nextPageToken, setNextPageToken] = React.useState<string>(null);
-  const [localCacheKey, setLocalCacheKey] = React.useState(cacheKey);
+  const [nextPageToken, setNextPageToken] = useState<string>(null);
+  const [localCacheKey, setLocalCacheKey] = useState(cacheKey);
 
   if (cacheKey !== localCacheKey) {
     // force update local cache key
     setLocalCacheKey(cacheKey);
   }
 
-  const [result, setResult] = React.useState<[Kind[], boolean, unknown, GetNextPage]>([
+  const [result, setResult] = useState<[Kind[], boolean, unknown, GetNextPage]>([
     [],
     false,
     undefined,
@@ -49,12 +49,12 @@ const useTRRuns = <Kind extends K8sResourceCommon>(
   ]);
 
   // reset token if namespace or options change
-  React.useEffect(() => {
+  useEffect(() => {
     setNextPageToken(null);
   }, [namespace, options, cacheKey]);
 
   // eslint-disable-next-line consistent-return
-  React.useEffect(() => {
+  useEffect(() => {
     let disposed = false;
     (async () => {
       try {
@@ -170,8 +170,8 @@ export const useTRTaskRunLog = (
   taskRunName: string,
   taskRunPath: string,
 ): [string, boolean, unknown] => {
-  const [result, setResult] = React.useState<[string, boolean, unknown]>([null, false, undefined]);
-  React.useEffect(() => {
+  const [result, setResult] = useState<[string, boolean, unknown]>([null, false, undefined]);
+  useEffect(() => {
     let disposed = false;
     if (namespace && taskRunName) {
       (async () => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/hooks.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect, useRef } from 'react';
 import { useFormikContext, FormikTouched } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
@@ -78,7 +78,7 @@ export const useFormikFetchAndSaveTasks = (
     : watchedClusterTasks.loaded
     ? watchedClusterTasks.data
     : null;
-  React.useEffect(() => {
+  useEffect(() => {
     if (namespacedTaskData) {
       setFieldValue('taskResources.namespacedTasks', namespacedTaskData, false);
     }
@@ -103,7 +103,7 @@ export const useFormikFetchAndSaveTasks = (
   const error =
     namespacedTasks.loadError ||
     (!IS_PIPELINE_OPERATOR_VERSION_1_17_OR_NEWER && watchedClusterTasks.loadError);
-  React.useEffect(() => {
+  useEffect(() => {
     if (!error) return;
 
     setStatus({
@@ -123,7 +123,7 @@ const useConnectFinally = (
   tasksInError: TaskErrors,
 ): PipelineMixedNodeModel => {
   const { clusterTasks, namespacedTasks } = taskResources;
-  const taskGroupRef = React.useRef(taskGroup);
+  const taskGroupRef = useRef(taskGroup);
   taskGroupRef.current = taskGroup;
   const addNewFinallyListNode = () => {
     const data: UpdateOperationConvertToFinallyTaskData = {
@@ -248,7 +248,7 @@ export const useNodes = (
 ): PipelineMixedNodeModel[] => {
   const { clusterTasks, namespacedTasks } = taskResources;
 
-  const taskGroupRef = React.useRef(taskGroup);
+  const taskGroupRef = useRef(taskGroup);
   taskGroupRef.current = taskGroup;
 
   const onNewListNode = (task: PipelineTask, direction: AddNodeDirection) => {
@@ -398,7 +398,7 @@ export const useExplicitPipelineTaskTouch = () => {
   const workspacesTouched = !!touched.formData?.workspaces;
   const resourcesTouched = !!touched.formData?.resources;
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (workspacesTouched) {
       setTouched({
         formData: {
@@ -425,7 +425,7 @@ export const useLoadingTaskCleanup = (
 ) => {
   const { values } = useFormikContext<PipelineBuilderFormikValues>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const { loadingTasks } = values.formData;
     loadingTasks.forEach((task) => {
       const installedTask = values.taskResources.namespacedTasks.find(
@@ -455,7 +455,7 @@ export const useCleanupOnFailure = (
   taskGroup: PipelineBuilderTaskGroup,
 ) => {
   const { values } = useFormikContext<PipelineBuilderFormikValues>();
-  React.useEffect(() => {
+  useEffect(() => {
     const { loadingTasks } = values.formData;
     loadingTasks.forEach((task) => {
       if (failedTasks.includes(task?.taskRef.name)) {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/utils/pipeline-operator.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/utils/pipeline-operator.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { compare, gt, gte, parse, SemVer } from 'semver';
 import { SetFeatureFlag, useAccessReview } from '@console/dynamic-plugin-sdk';
 import { k8sList } from '@console/dynamic-plugin-sdk/src/utils/k8s';
@@ -42,8 +42,8 @@ export const getPipelineOperatorVersion = async (namespace: string): Promise<Sem
 };
 
 export const usePipelineOperatorVersion = (namespace: string): SemVer | null => {
-  const [version, setVersion] = React.useState<SemVer | null>(null);
-  React.useEffect(() => {
+  const [version, setVersion] = useState<SemVer | null>(null);
+  useEffect(() => {
     getPipelineOperatorVersion(namespace)
       .then(setVersion)
       .catch((error) =>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/utils/triggers.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/utils/triggers.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { flatten, mapValues } from 'lodash';
 import {
   WatchK8sResource,
@@ -44,7 +44,7 @@ const useEventListenerRoutes = (
   namespace: string,
   eventListenerResources: EventListenerKind[],
 ): RouteMap => {
-  const memoResources: WatchK8sResources<RouteMap> = React.useMemo(() => {
+  const memoResources: WatchK8sResources<RouteMap> = useMemo(() => {
     return (eventListenerResources || []).map(getEventListenerGeneratedName).reduce(
       (acc, generatedName) => ({
         ...acc,
@@ -65,7 +65,7 @@ const useEventListenerRoutes = (
 };
 
 const useAllEventListeners = (namespace: string) => {
-  const eventListenerResource: WatchK8sResource = React.useMemo(
+  const eventListenerResource: WatchK8sResource = useMemo(
     () => ({
       kind: referenceForModel(EventListenerModel),
       isList: true,
@@ -91,7 +91,7 @@ export const usePipelineTriggerTemplateNames = (
 ): RouteTemplate[] | null => {
   const eventListenerResources = useAllEventListeners(namespace);
 
-  const triggerTemplateResources: WatchK8sResources<TriggerTemplateMapping> = React.useMemo(() => {
+  const triggerTemplateResources: WatchK8sResources<TriggerTemplateMapping> = useMemo(() => {
     if (!eventListenerResources) {
       return {};
     }

--- a/frontend/packages/pipelines-plugin/src/components/repository/hooks/pac-hook.ts
+++ b/frontend/packages/pipelines-plugin/src/components/repository/hooks/pac-hook.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
 import { ConfigMapModel } from '@console/internal/models';
 import { ConfigMapKind, k8sList } from '@console/internal/module/k8s';
@@ -10,9 +10,9 @@ export const usePacInfo = () =>
   useK8sGet<ConfigMapKind>(ConfigMapModel, PAC_INFO, PIPELINE_NAMESPACE);
 
 export const useRepositoryPresent = (repoURL: string) => {
-  const [repoAlreadyExists, setRepoAlreadyExists] = React.useState(false);
+  const [repoAlreadyExists, setRepoAlreadyExists] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     k8sList(RepositoryModel)
       .then((repos) => {
         setRepoAlreadyExists(repos.some((r) => r.spec.url === repoURL));

--- a/frontend/packages/pipelines-plugin/src/components/repository/hooks/useBuilderImages.ts
+++ b/frontend/packages/pipelines-plugin/src/components/repository/hooks/useBuilderImages.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import * as _ from 'lodash';
 import {
   normalizeBuilderImages,
@@ -19,11 +19,9 @@ export const useBuilderImages = (): [NormalizedBuilderImages, boolean, any] => {
     resourceSelector,
   );
 
-  const builderImageStreams = React.useMemo(() => _.filter(imageStreams, isBuilder), [
-    imageStreams,
-  ]);
+  const builderImageStreams = useMemo(() => _.filter(imageStreams, isBuilder), [imageStreams]);
 
-  const normalizedBuilderImages = React.useMemo(() => normalizeBuilderImages(builderImageStreams), [
+  const normalizedBuilderImages = useMemo(() => normalizeBuilderImages(builderImageStreams), [
     builderImageStreams,
   ]);
 

--- a/frontend/packages/pipelines-plugin/src/components/repository/sections/AdvancedConfigurations.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/repository/sections/AdvancedConfigurations.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { useFormikContext } from 'formik';
 import { GitProvider } from '@console/git-service';
 import { PacConfigurationTypes } from '../consts';
@@ -8,11 +8,11 @@ import ConfigTypeSection from './ConfigTypeSection';
 import WebhookSection from './WebhookSection';
 
 const AdvancedConfigurations = () => {
-  const [githubAppAvailable, setGithubAppAvailable] = React.useState(false);
+  const [githubAppAvailable, setGithubAppAvailable] = useState(false);
   const { values, setFieldValue } = useFormikContext<RepositoryFormValues>();
   const [pac, loaded] = usePacInfo();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (loaded && !!pac && pac.data['app-link']) {
       setGithubAppAvailable(true);
       setFieldValue('githubAppAvailable', true);

--- a/frontend/packages/shipwright-plugin/src/actions/useBuildActions.ts
+++ b/frontend/packages/shipwright-plugin/src/actions/useBuildActions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { CommonActionCreator } from '@console/app/src/actions/hooks/types';
@@ -22,7 +22,7 @@ const useBuildActions = (build: Build) => {
     CommonActionCreator.Delete,
   ] as const);
 
-  const actionsMenu = React.useMemo<Action[]>(() => {
+  const actionsMenu = useMemo<Action[]>(() => {
     if (!isReady) {
       return [];
     }

--- a/frontend/packages/shipwright-plugin/src/actions/useBuildRunActions.ts
+++ b/frontend/packages/shipwright-plugin/src/actions/useBuildRunActions.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { useCommonResourceActions } from '@console/app/src/actions//hooks/useCommonResourceActions';
@@ -17,7 +17,7 @@ const useBuildRunActions = (buildRun: BuildRun) => {
   const [kindObj, inFlight] = useK8sModel(referenceFor(buildRun));
   const commonActions = useCommonResourceActions(kindObj, buildRun);
 
-  const actions = React.useMemo<Action[]>(() => {
+  const actions = useMemo<Action[]>(() => {
     const rerun: Action = {
       id: 'shipwright-buildrun-rerun',
       label: t('shipwright-plugin~Rerun'),

--- a/frontend/packages/topology/src/actions/contextMenuActions.tsx
+++ b/frontend/packages/topology/src/actions/contextMenuActions.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { Fragment } from 'react';
 import { Title } from '@patternfly/react-core';
 import { Node, ContextSubMenuItem, ContextMenuItem, Graph } from '@patternfly/react-topology';
 import {
@@ -26,14 +26,14 @@ export const createContextMenuItems = (actions: MenuOption[]) => {
         );
       case MenuOptionType.GROUP_MENU:
         return (
-          <React.Fragment key={option.id}>
+          <Fragment key={option.id}>
             {option.label && (
               <Title headingLevel="h1" className="pf-v6-c-dropdown__group-title">
                 {option.label}
               </Title>
             )}
             {createContextMenuItems((option as GroupedMenuOption).children)}
-          </React.Fragment>
+          </Fragment>
         );
       default:
         return (

--- a/frontend/packages/topology/src/behavior/useHover.ts
+++ b/frontend/packages/topology/src/behavior/useHover.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { useCallbackRef } from '@patternfly/react-topology';
 
 //
@@ -13,28 +13,28 @@ const useHover = <T extends Element>(
   delayOut: number = 200,
   dependencies: any[] = EMPTY,
 ): [boolean, (node: T) => (() => void) | undefined] => {
-  const [hover, setHover] = React.useState<boolean>(false);
-  const mountRef = React.useRef(true);
+  const [hover, setHover] = useState<boolean>(false);
+  const mountRef = useRef(true);
 
   // need to ensure we do not start the unset timer on unmount
-  React.useEffect(
+  useEffect(
     () => () => {
       mountRef.current = false;
     },
     [],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     setHover(false);
     // dynamic dependencies
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, dependencies);
 
   // The unset handle needs to be referred by listeners in different closures.
-  const unsetHandle = React.useRef<number>();
+  const unsetHandle = useRef<number>();
 
   const callbackRef = useCallbackRef(
-    React.useCallback(
+    useCallback(
       (node: T) => {
         if (node) {
           // store locally instead of a ref because it only needs to be referred by inner closures

--- a/frontend/packages/topology/src/components/export-app/export-app-context.ts
+++ b/frontend/packages/topology/src/components/export-app/export-app-context.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { createContext, useState, useMemo, useCallback, useEffect } from 'react';
 import { AlertVariant } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -10,21 +10,19 @@ import { USERSETTINGS_PREFIX, useToast, useUserSettings } from '@console/shared/
 import { ExportModel } from '../../models';
 import { ExportAppUserSettings } from './types';
 
-export const ExportAppContext = React.createContext({});
+export const ExportAppContext = createContext({});
 
 export const ExportAppContextProvider = ExportAppContext.Provider;
 
 export const useExportAppFormToast = () => {
   const toast = useToast();
   const { t } = useTranslation();
-  const [currentToasts, setCurrentToasts] = React.useState<{ [key: string]: { toastId: string } }>(
-    {},
-  );
+  const [currentToasts, setCurrentToasts] = useState<{ [key: string]: { toastId: string } }>({});
   const [exportAppToast, setExportAppToast, exportAppToastLoaded] = useUserSettings<
     ExportAppUserSettings
   >(`${USERSETTINGS_PREFIX}.exportApp`, {}, true);
 
-  const exportAppWatchResources = React.useMemo<Record<string, WatchK8sResource>>(() => {
+  const exportAppWatchResources = useMemo<Record<string, WatchK8sResource>>(() => {
     if (!exportAppToastLoaded || _.isEmpty(exportAppToast)) return {};
     const keys = Object.keys(exportAppToast);
     const watchRes = keys.reduce((acc, k) => {
@@ -46,7 +44,7 @@ export const useExportAppFormToast = () => {
     exportAppWatchResources,
   );
 
-  const cleanToast = React.useCallback(
+  const cleanToast = useCallback(
     (k: string) => {
       const toastDismiss = currentToasts[k];
       if (toastDismiss) {
@@ -57,7 +55,7 @@ export const useExportAppFormToast = () => {
     [currentToasts, toast],
   );
 
-  const cleanToastConfig = React.useCallback(
+  const cleanToastConfig = useCallback(
     (k: string) => {
       if (exportAppToastLoaded) {
         setExportAppToast(_.omit(exportAppToast, k));
@@ -66,7 +64,7 @@ export const useExportAppFormToast = () => {
     [exportAppToast, exportAppToastLoaded, setExportAppToast],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (exportResources) {
       const keys = Object.keys(exportResources);
       keys.forEach((k) => {
@@ -78,7 +76,7 @@ export const useExportAppFormToast = () => {
     }
   }, [cleanToast, cleanToastConfig, exportResources]);
 
-  const showDownloadToast = React.useCallback(
+  const showDownloadToast = useCallback(
     (expNamespace: string, routeUrl: string, key: string) => {
       const toastId = toast.addToast({
         variant: AlertVariant.info,
@@ -110,7 +108,7 @@ export const useExportAppFormToast = () => {
     [cleanToast, cleanToastConfig, t, toast],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (exportAppToastLoaded) {
       const keys = Object.keys(exportAppToast);
       keys.forEach((k) => {

--- a/frontend/packages/topology/src/components/page/DroppableTopologyComponent.tsx
+++ b/frontend/packages/topology/src/components/page/DroppableTopologyComponent.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useContext } from 'react';
 import { Model } from '@patternfly/react-topology';
 import { DropTarget, DropTargetConnector } from 'react-dnd';
 import { NativeTypes } from 'react-dnd-html5-backend';
@@ -33,9 +33,7 @@ const DroppableTopology = DropTarget(
 
 export const DroppableTopologyComponent = withDragDropContext<DroppableTopologyComponentProps>(
   (props) => {
-    const { setFileUpload, extensions } = React.useContext<FileUploadContextType>(
-      FileUploadContext,
-    );
+    const { setFileUpload, extensions } = useContext<FileUploadContextType>(FileUploadContext);
 
     const handleFileDrop = (monitor: DropTargetMonitor) => {
       if (!monitor) {

--- a/frontend/packages/topology/src/components/quick-search/topology-quick-search-utils.tsx
+++ b/frontend/packages/topology/src/components/quick-search/topology-quick-search-utils.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { QuickStart } from '@patternfly/quickstarts';
 import { Content, Title } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
@@ -8,7 +8,7 @@ import { useQuickStartContext } from '@console/shared/src/hooks/useQuickStartCon
 export const useTransformedQuickStarts = (quickStarts: QuickStart[]): CatalogItem[] => {
   const { setActiveQuickStart } = useQuickStartContext();
   const { t } = useTranslation();
-  return React.useMemo(
+  return useMemo(
     () =>
       quickStarts.map((qs: QuickStart) => {
         const prerequisites = qs.spec.prerequisites?.filter((p) => p);

--- a/frontend/packages/topology/src/components/side-bar/providers/useDetailsTab.tsx
+++ b/frontend/packages/topology/src/components/side-bar/providers/useDetailsTab.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { DetailsTab, isDetailsTab } from '@console/dynamic-plugin-sdk';
 import { useExtensions } from '@console/plugin-sdk';
 import { orderExtensionBasedOnInsertBeforeAndAfter } from '@console/shared';
 
 export const useDetailsTab = (): DetailsTab['properties'][] => {
   const extensions = useExtensions<DetailsTab>(isDetailsTab);
-  const ordered = React.useMemo<DetailsTab['properties'][]>(
+  const ordered = useMemo<DetailsTab['properties'][]>(
     () =>
       orderExtensionBasedOnInsertBeforeAndAfter<DetailsTab['properties']>(
         extensions.map(({ properties }) => properties),

--- a/frontend/packages/topology/src/components/side-bar/providers/useDetailsTabSection.tsx
+++ b/frontend/packages/topology/src/components/side-bar/providers/useDetailsTabSection.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import {
   DetailsTabSection,
   isDetailsTabSection,
@@ -12,7 +12,7 @@ export const useDetailsTabSection = (): [
   boolean,
 ] => {
   const [extensions, resolved] = useResolvedExtensions<DetailsTabSection>(isDetailsTabSection);
-  const ordered = React.useMemo<ResolvedExtension<DetailsTabSection>['properties'][]>(
+  const ordered = useMemo<ResolvedExtension<DetailsTabSection>['properties'][]>(
     () =>
       resolved
         ? orderExtensionBasedOnInsertBeforeAndAfter<

--- a/frontend/packages/topology/src/components/svg/SvgResourceIcon.tsx
+++ b/frontend/packages/topology/src/components/svg/SvgResourceIcon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { forwardRef } from 'react';
 import { css } from '@patternfly/react-styles';
 import { useSize } from '@patternfly/react-topology';
 import { get } from 'lodash';
@@ -20,7 +20,7 @@ function getKindStringAndAbbreviation(kind: string) {
   return { kindStr, kindAbbr, kindColor };
 }
 
-const SvgResourceIcon = React.forwardRef<SVGRectElement, ResourceIconProps>(
+const SvgResourceIcon = forwardRef<SVGRectElement, ResourceIconProps>(
   ({ x, y, kind, leftJustified }, iconRef) => {
     const { kindAbbr, kindStr, kindColor } = getKindStringAndAbbreviation(kind);
     const [textSize, textRef] = useSize([]);

--- a/frontend/packages/topology/src/components/workload/ResolveAdapter.ts
+++ b/frontend/packages/topology/src/components/workload/ResolveAdapter.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 import { K8sResourceCommon } from '@console/dynamic-plugin-sdk/src';
 
 type ResolveAdapterProps<D, T> = {
@@ -16,7 +16,7 @@ const ResolveAdapter = <D extends {}, T = {}>({
 }: ResolveAdapterProps<D, T>) => {
   const data = useAdapterHook(resource, customData);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (data) {
       onAdapterDataResolved(data);
     }

--- a/frontend/packages/topology/src/components/workload/utils.ts
+++ b/frontend/packages/topology/src/components/workload/utils.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { GraphElement } from '@patternfly/react-topology';
 import {
   AdapterDataType,
@@ -42,7 +42,7 @@ export const getDataFromAdapter = <T extends { resource: K8sResourceCommon }, E 
 const usePodsAdapterForWorkloads = (resource: K8sResourceCommon): PodsAdapterDataType => {
   const buildConfigData = useBuildConfigsWatcher(resource);
   const { podData, loaded, loadError } = usePodsWatcher(resource);
-  return React.useMemo(() => ({ pods: podData?.pods, loaded, loadError, buildConfigData }), [
+  return useMemo(() => ({ pods: podData?.pods, loaded, loadError, buildConfigData }), [
     buildConfigData,
     loadError,
     loaded,
@@ -120,16 +120,16 @@ const usePodsAdapterForCronJobWorkloads = (resource: K8sResourceCommon): PodsAda
     metadata: { namespace },
   } = resource;
 
-  const [pods, setPods] = React.useState([]);
-  const [loaded, setLoaded] = React.useState<boolean>(false);
-  const [loadError, setLoadError] = React.useState<string>('');
-  const watchedResources = React.useMemo(() => getResourcesToWatchForPods('CronJob', namespace), [
+  const [pods, setPods] = useState([]);
+  const [loaded, setLoaded] = useState<boolean>(false);
+  const [loadError, setLoadError] = useState<string>('');
+  const watchedResources = useMemo(() => getResourcesToWatchForPods('CronJob', namespace), [
     namespace,
   ]);
 
   const resources = useK8sWatchResources(watchedResources);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const errorKey = Object.keys(resources).find((key) => resources[key].loadError);
     if (errorKey) {
       setLoadError(resources[errorKey].loadError);

--- a/frontend/packages/topology/src/data-transforms/useMonitoringAlerts.tsx
+++ b/frontend/packages/topology/src/data-transforms/useMonitoringAlerts.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { Alert } from '@console/dynamic-plugin-sdk';
 import { usePrometheusRulesPoll } from '@console/internal/components/graphs/prometheus-rules-hook';
 import { getAlertsAndRules } from '@console/internal/components/monitoring/utils';
@@ -12,7 +12,7 @@ export const useMonitoringAlerts = (
   loadError: string;
 } => {
   const [alertsResponse, alertsError, alertsLoading] = usePrometheusRulesPoll({ namespace });
-  const response = React.useMemo(() => {
+  const response = useMemo(() => {
     let alertData;
     if (!alertsLoading && !alertsError) {
       alertData = getAlertsAndRules(alertsResponse?.data).alerts;

--- a/frontend/packages/topology/src/data-transforms/useRoutesURL.ts
+++ b/frontend/packages/topology/src/data-transforms/useRoutesURL.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { useRoutesWatcher } from '@console/shared';
 import { ROUTE_DISABLED_ANNOTATION, ROUTE_URL_ANNOTATION } from '../const';
@@ -9,11 +9,11 @@ export const useRoutesURL = (resource: K8sResourceKind): string => {
   const annotationURL = resource?.metadata?.annotations?.[ROUTE_URL_ANNOTATION];
 
   const routeResources = useRoutesWatcher(resource);
-  const routes = React.useMemo(
+  const routes = useMemo(
     () => (routeResources.loaded && !routeResources.loadError ? routeResources.routes : []),
     [routeResources],
   );
-  const watchedURL = React.useMemo(() => getRoutesURL(resource, routes), [resource, routes]);
+  const watchedURL = useMemo(() => getRoutesURL(resource, routes), [resource, routes]);
 
   const url = annotationURL || watchedURL;
   if (disabled || !url || !(url.startsWith('http://') || url.startsWith('https://'))) {

--- a/frontend/packages/topology/src/filters/useSearchFilter.ts
+++ b/frontend/packages/topology/src/filters/useSearchFilter.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import * as fuzzy from 'fuzzysearch';
 import { toLower } from 'lodash';
 import { useQueryParams } from '@console/shared/src';
@@ -15,15 +15,12 @@ const useSearchFilter = (
   const searchQuery = queryParams.get('searchQuery');
   const labelsQuery = queryParams.get('labels')?.split(',') ?? EMPTY_QUERY_PARAMS;
 
-  const labelsMatched = React.useMemo(() => {
+  const labelsMatched = useMemo(() => {
     const labelsString = Object.entries(labels).map((label) => label.join('='));
     return labelsQuery.every((label) => labelsString.includes(label));
   }, [labels, labelsQuery]);
 
-  const filtered = React.useMemo(() => fuzzyCaseInsensitive(searchQuery, name), [
-    searchQuery,
-    name,
-  ]);
+  const filtered = useMemo(() => fuzzyCaseInsensitive(searchQuery, name), [searchQuery, name]);
 
   return [(filtered && !!searchQuery) || (labelsMatched && labelsQuery.length > 0), searchQuery];
 };

--- a/frontend/packages/topology/src/utils/useMetricStats.ts
+++ b/frontend/packages/topology/src/utils/useMetricStats.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import * as _ from 'lodash';
 import { MetricStats } from '@console/dynamic-plugin-sdk/src/extensions/topology-types';
 import { K8sResourceKind } from '@console/internal/module/k8s';
@@ -9,7 +9,7 @@ import { useOverviewMetrics } from './useOverviewMetrics';
 export const useMetricStats = (resource: K8sResourceKind): MetricStats => {
   const metrics = useOverviewMetrics();
   const { podData, loaded } = usePodsWatcher(resource, resource.kind, resource.metadata.namespace);
-  const memoryStats = React.useMemo(() => {
+  const memoryStats = useMemo(() => {
     if (_.isEmpty(metrics) || !loaded) {
       return null;
     }

--- a/frontend/packages/topology/src/utils/usePodsForVM.ts
+++ b/frontend/packages/topology/src/utils/usePodsForVM.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useRef, useMemo, useCallback, useEffect } from 'react';
 import { useK8sWatchResources } from '@console/dynamic-plugin-sdk/dist/core/lib/utils/k8s/hooks';
 import { getGroupVersionKindForModel } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { PodModel, ReplicationControllerModel } from '@console/internal/models';
@@ -17,13 +17,13 @@ export const usePodsForVm = (
   vm: K8sResourceKind,
 ): { loaded: boolean; loadError: string; podData: PodRCData } => {
   const { namespace } = vm.metadata;
-  const [loaded, setLoaded] = React.useState<boolean>(false);
-  const [loadError, setLoadError] = React.useState<string>('');
-  const [podData, setPodData] = React.useState<PodRCData>();
+  const [loaded, setLoaded] = useState<boolean>(false);
+  const [loadError, setLoadError] = useState<string>('');
+  const [podData, setPodData] = useState<PodRCData>();
   const vmName = vm.metadata.name;
-  const vmRef = React.useRef<K8sResourceKind>(vm);
+  const vmRef = useRef<K8sResourceKind>(vm);
 
-  const watchedResources = React.useMemo(
+  const watchedResources = useMemo(
     () => ({
       replicationControllers: {
         isList: true,
@@ -47,7 +47,7 @@ export const usePodsForVm = (
 
   const resources = useK8sWatchResources<{ [key: string]: K8sResourceCommon[] }>(watchedResources);
 
-  const updateResults = React.useCallback(
+  const updateResults = useCallback(
     (updatedResources) => {
       const errorKey = Object.keys(updatedResources).find((key) => updatedResources[key].loadError);
       if (errorKey) {
@@ -85,7 +85,7 @@ export const usePodsForVm = (
 
   const debouncedUpdateResources = useDebounceCallback(updateResults, 250);
 
-  React.useEffect(() => {
+  useEffect(() => {
     debouncedUpdateResources(resources);
   }, [debouncedUpdateResources, resources]);
 

--- a/frontend/packages/vsphere-plugin/src/components/VSphereConnectionForm.tsx
+++ b/frontend/packages/vsphere-plugin/src/components/VSphereConnectionForm.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useRef, useEffect } from 'react';
 import { Form, FormGroup } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import { Trans, useTranslation } from 'react-i18next';
@@ -10,10 +10,10 @@ import './VSphereConnectionForm.css';
 
 export const VSphereConnectionForm = () => {
   const { t } = useTranslation('vsphere-plugin');
-  const vcenterRef = React.useRef<HTMLInputElement>(null);
+  const vcenterRef = useRef<HTMLInputElement>(null);
   const { setFieldTouched } = useFormikContext<ConnectionFormFormikValues>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     vcenterRef?.current?.focus();
   }, []);
 

--- a/frontend/packages/vsphere-plugin/src/flag.ts
+++ b/frontend/packages/vsphere-plugin/src/flag.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 import { SetFeatureFlag } from '@console/dynamic-plugin-sdk';
 import { k8sGet, useK8sModel } from '@console/dynamic-plugin-sdk/src/api/core-api';
 import { VSPHERE_FEATURE_FLAG, VSPHERE_PLATFORM } from './constants';
@@ -11,7 +11,7 @@ export const useVSphereFlagHandler = (setFeatureFlag: SetFeatureFlag) => {
     kind: 'Infrastructure',
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     const doItAsync = async () => {
       try {
         const infra = await k8sGet<Infrastructure>({

--- a/frontend/packages/vsphere-plugin/src/hooks/use-connection-form.ts
+++ b/frontend/packages/vsphere-plugin/src/hooks/use-connection-form.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { K8sModel, k8sGet } from '@console/dynamic-plugin-sdk/src/api/core-api';
 import { ConnectionFormFormikValues } from '../components/types';
@@ -89,12 +89,12 @@ const initialLoad = async (
 
 export const useConnectionForm = () => {
   const { t } = useTranslation('vsphere-plugin');
-  const [isLoaded, setIsLoaded] = React.useState(false);
-  const [error, setError] = React.useState<{ title: string; message: string }>();
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [error, setError] = useState<{ title: string; message: string }>();
   const { secretModel, infrastructureModel } = useConnectionModels();
-  const [result, setResult] = React.useState<ConnectionFormFormikValues>();
+  const [result, setResult] = useState<ConnectionFormFormikValues>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const doItAsync = async () => {
       if (isLoaded) {
         return;

--- a/frontend/packages/vsphere-plugin/src/hooks/use-popup-visibility.ts
+++ b/frontend/packages/vsphere-plugin/src/hooks/use-popup-visibility.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 
 const setPopupVisibility = (v: 'visible' | 'hidden') => {
   const popup = document.getElementsByClassName('plugin-vsphere-status-popup');
@@ -8,7 +8,7 @@ const setPopupVisibility = (v: 'visible' | 'hidden') => {
 };
 
 export const usePopupVisibility = () => {
-  React.useEffect(
+  useEffect(
     // Hack to stick with the Health status popup
     () => {
       setPopupVisibility('hidden');

--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/Terminal.tsx
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/Terminal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { forwardRef, useRef, useEffect, useCallback, useImperativeHandle } from 'react';
 import { Terminal as XTerminal, ITerminalOptions, ITerminalAddon } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
@@ -25,78 +25,76 @@ export type ImperativeTerminalType = {
   loadAttachAddon: (addOn: ITerminalAddon) => void;
 };
 
-const Terminal = React.forwardRef<ImperativeTerminalType, TerminalProps>(
-  ({ onData, onResize }, ref) => {
-    const terminal = React.useRef<XTerminal>();
-    const terminalRef = React.useRef<HTMLDivElement>();
+const Terminal = forwardRef<ImperativeTerminalType, TerminalProps>(({ onData, onResize }, ref) => {
+  const terminal = useRef<XTerminal>();
+  const terminalRef = useRef<HTMLDivElement>();
 
-    React.useEffect(() => {
-      const term: XTerminal = new XTerminal(terminalOptions);
-      const fitAddon = new FitAddon();
-      term.open(terminalRef.current);
-      term.loadAddon(fitAddon);
-      term.focus();
+  useEffect(() => {
+    const term: XTerminal = new XTerminal(terminalOptions);
+    const fitAddon = new FitAddon();
+    term.open(terminalRef.current);
+    term.loadAddon(fitAddon);
+    term.focus();
 
-      const resizeObserver: ResizeObserver = new ResizeObserver(() => {
-        window.requestAnimationFrame(() => fitAddon.fit());
-      });
+    const resizeObserver: ResizeObserver = new ResizeObserver(() => {
+      window.requestAnimationFrame(() => fitAddon.fit());
+    });
 
-      resizeObserver.observe(terminalRef.current);
+    resizeObserver.observe(terminalRef.current);
 
-      if (terminal.current !== term) {
-        terminal.current && terminal.current.dispose();
-        terminal.current = term;
-      }
+    if (terminal.current !== term) {
+      terminal.current && terminal.current.dispose();
+      terminal.current = term;
+    }
 
-      return () => {
-        term.dispose();
-        resizeObserver.disconnect();
-      };
-    }, []);
+    return () => {
+      term.dispose();
+      resizeObserver.disconnect();
+    };
+  }, []);
 
-    const handleResize = React.useCallback(
-      ({ cols, rows }: { cols: number; rows: number }) => {
-        onResize(cols, rows);
-      },
-      [onResize],
-    );
+  const handleResize = useCallback(
+    ({ cols, rows }: { cols: number; rows: number }) => {
+      onResize(cols, rows);
+    },
+    [onResize],
+  );
 
-    React.useEffect(() => {
-      const term = terminal.current;
-      const data = term.onData(onData);
-      const resize = term.onResize(handleResize);
-      return () => {
-        data.dispose();
-        resize.dispose();
-      };
-    }, [onData, handleResize]);
+  useEffect(() => {
+    const term = terminal.current;
+    const data = term.onData(onData);
+    const resize = term.onResize(handleResize);
+    return () => {
+      data.dispose();
+      resize.dispose();
+    };
+  }, [onData, handleResize]);
 
-    React.useImperativeHandle(ref, () => ({
-      focus: () => {
-        terminal.current && terminal.current.focus();
-      },
-      reset: () => {
-        if (!terminal.current) return;
-        terminal.current.reset();
-        terminal.current.clear();
-        terminal.current.setOption('disableStdin', false);
-      },
-      onDataReceived: (data) => {
-        terminal.current && terminal.current.write(data);
-      },
-      onConnectionClosed: (msg) => {
-        if (!terminal.current) return;
-        terminal.current.write(`\x1b[31m${msg || 'disconnected'}\x1b[m\r\n`);
-        terminal.current.setOption('disableStdin', true);
-      },
-      loadAttachAddon: (addOn: ITerminalAddon) => {
-        if (!terminal.current) return;
-        terminal.current.loadAddon(addOn);
-      },
-    }));
+  useImperativeHandle(ref, () => ({
+    focus: () => {
+      terminal.current && terminal.current.focus();
+    },
+    reset: () => {
+      if (!terminal.current) return;
+      terminal.current.reset();
+      terminal.current.clear();
+      terminal.current.setOption('disableStdin', false);
+    },
+    onDataReceived: (data) => {
+      terminal.current && terminal.current.write(data);
+    },
+    onConnectionClosed: (msg) => {
+      if (!terminal.current) return;
+      terminal.current.write(`\x1b[31m${msg || 'disconnected'}\x1b[m\r\n`);
+      terminal.current.setOption('disableStdin', true);
+    },
+    loadAttachAddon: (addOn: ITerminalAddon) => {
+      if (!terminal.current) return;
+      terminal.current.loadAddon(addOn);
+    },
+  }));
 
-    return <div className="co-terminal" ref={terminalRef} />;
-  },
-);
+  return <div className="co-terminal" ref={terminalRef} />;
+});
 
 export default Terminal;

--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/useActivityTick.ts
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/useActivityTick.ts
@@ -1,13 +1,13 @@
-import * as React from 'react';
+import { useRef, useCallback } from 'react';
 import { sendActivityTick } from './cloud-shell-utils';
 
 // 1 minute
 export const TICK_INTERVAL = 60000;
 
 const useActivityTick = (workspaceName: string, namespace: string) => {
-  const lastTick = React.useRef<number>(0);
+  const lastTick = useRef<number>(0);
 
-  const tick = React.useCallback(() => {
+  const tick = useCallback(() => {
     const now = Date.now();
     if (now - lastTick.current >= TICK_INTERVAL) {
       sendActivityTick(workspaceName, namespace);

--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/useCloudShellAvailable.ts
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/useCloudShellAvailable.ts
@@ -1,12 +1,12 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { useFlag } from '@console/shared/src/hooks/flag';
 import { FLAG_DEVWORKSPACE } from '../../const';
 import { checkTerminalAvailable } from './cloud-shell-utils';
 
 const useCloudShellAvailable = () => {
-  const [terminalAvailable, setTerminalAvailable] = React.useState(false);
+  const [terminalAvailable, setTerminalAvailable] = useState(false);
   const flagEnabled = useFlag(FLAG_DEVWORKSPACE);
-  React.useEffect(() => {
+  useEffect(() => {
     let mounted = true;
     if (flagEnabled) {
       checkTerminalAvailable()

--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/useCloudShellNamespace.ts
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/useCloudShellNamespace.ts
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 import { useSafetyFirst } from '@console/dynamic-plugin-sdk';
 import { getTerminalInstalledNamespace } from './cloud-shell-utils';
 
 const useCloudShellNamespace = (): [string, string] => {
   const [terminalNamespace, setTerminalNamespace] = useSafetyFirst<string>(undefined);
   const [fetchError, setFetchError] = useSafetyFirst<string>(undefined);
-  React.useEffect(() => {
+  useEffect(() => {
     const fetchNamespace = async () => {
       try {
         if (!terminalNamespace) {

--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/useCloudShellWorkspace.ts
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/useCloudShellWorkspace.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect, useMemo } from 'react';
 import { WatchK8sResource, WatchK8sResult, useSafetyFirst } from '@console/dynamic-plugin-sdk';
 import { useAccessReview2 } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
@@ -34,7 +34,7 @@ const useCloudShellWorkspace = (
   const [noNamespaceFound, setNoNamespaceFound] = useSafetyFirst<boolean>(false);
 
   // sync defaultNamespace to namespace
-  React.useEffect(() => {
+  useEffect(() => {
     setNamespace(defaultNamespace);
     // a new namespace means we can start a new search
     defaultNamespace && setNoNamespaceFound(false);
@@ -49,7 +49,7 @@ const useCloudShellWorkspace = (
   const uid = user?.uid;
   const username = user?.username;
   const isKubeAdmin = !uid && username === 'kube:admin';
-  const resource = React.useMemo<WatchK8sResource>(() => {
+  const resource = useMemo<WatchK8sResource>(() => {
     if (loadingAccessReview || (!canListWorkspaces && !namespace)) {
       return undefined;
     }
@@ -100,7 +100,7 @@ const useCloudShellWorkspace = (
       !noNamespaceFound);
 
   // FIXME need to use a service account on the backend to find the workspace instead of inefficiently looping through namespaces
-  React.useEffect(() => {
+  useEffect(() => {
     let unmounted = false;
     if (searchNamespaces) {
       (async () => {

--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import { Component } from 'react';
 import * as fuzzy from 'fuzzysearch';
 import { useLocation, useParams } from 'react-router-dom-v5-compat';
 import { RoleModel, RoleBindingModel, ClusterRoleBindingModel } from '../../models';
@@ -87,7 +87,7 @@ const RolesTableRow = ({ obj: role }) => {
   );
 };
 
-class Details extends React.Component {
+class Details extends Component {
   constructor(props) {
     super(props);
     this.state = {};

--- a/frontend/public/components/app.tsx
+++ b/frontend/public/components/app.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import { useState, useRef, useCallback, useEffect, useLayoutEffect, memo, Suspense } from 'react';
 import { render } from 'react-dom';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 import { linkify } from 'react-linkify';
@@ -102,16 +102,16 @@ const App = (props) => {
     return window.innerWidth < PF_BREAKPOINT_MD;
   };
 
-  const [prevLocation, setPrevLocation] = React.useState(location);
-  const [prevParams, setPrevParams] = React.useState(params);
+  const [prevLocation, setPrevLocation] = useState(location);
+  const [prevParams, setPrevParams] = useState(params);
 
-  const [isMastheadStacked, setIsMastheadStacked] = React.useState(isMobile());
-  const [isNavOpen, setIsNavOpen] = React.useState(isDesktop());
+  const [isMastheadStacked, setIsMastheadStacked] = useState(isMobile());
+  const [isNavOpen, setIsNavOpen] = useState(isDesktop());
 
-  const previousDesktopState = React.useRef(isDesktop());
-  const previousMobileState = React.useRef(isMobile());
+  const previousDesktopState = useRef(isDesktop());
+  const previousMobileState = useRef(isMobile());
 
-  const onResize = React.useCallback(() => {
+  const onResize = useCallback(() => {
     const desktop = isDesktop();
     const mobile = isMobile();
     if (previousDesktopState.current !== desktop) {
@@ -127,14 +127,14 @@ const App = (props) => {
   useCSPViolationDetector();
   useNotificationPoller();
 
-  React.useEffect(() => {
+  useEffect(() => {
     window.addEventListener('resize', onResize);
     return () => {
       window.removeEventListener('resize', onResize);
     };
   }, [onResize]);
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     // Prevent infinite loop in case React Router decides to destroy & recreate the component (changing key)
     const oldLocation = _.omit(prevLocation, ['key']);
     const newLocation = _.omit(location, ['key']);
@@ -153,7 +153,7 @@ const App = (props) => {
     'openshift-marketplace',
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     const lightspeedButtonCapability = window.SERVER_FLAGS?.capabilities?.find(
       (capability) => capability.name === 'LightspeedButton',
     );
@@ -212,7 +212,7 @@ const App = (props) => {
     ({ UI }: RootState) => !!UI.getIn(['notifications', 'isExpanded']),
   );
 
-  const drawerRef = React.useRef<HTMLElement | null>(null);
+  const drawerRef = useRef<HTMLElement | null>(null);
 
   const focusDrawer = () => {
     if (drawerRef.current === null) {
@@ -345,23 +345,23 @@ const AppRouter = () => {
   );
 };
 
-const CaptureTelemetry = React.memo(function CaptureTelemetry() {
+const CaptureTelemetry = memo(function CaptureTelemetry() {
   const [perspective] = useActivePerspective();
   const fireTelemetryEvent = useTelemetry();
-  const [debounceTime, setDebounceTime] = React.useState(5000);
-  const [titleOnLoad, setTitleOnLoad] = React.useState('');
+  const [debounceTime, setDebounceTime] = useState(5000);
+  const [titleOnLoad, setTitleOnLoad] = useState('');
   // notify of identity change
   const user = useSelector(getUser);
   const telemetryTitle = getTelemetryTitle();
 
-  React.useEffect(() => {
+  useEffect(() => {
     setTimeout(() => {
       setTitleOnLoad(telemetryTitle);
       setDebounceTime(500);
     }, 5000);
   }, [telemetryTitle]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (user?.uid || user?.username) {
       fireTelemetryEvent('identify', { perspective, user });
     }
@@ -379,7 +379,7 @@ const CaptureTelemetry = React.memo(function CaptureTelemetry() {
       ...withoutSensitiveInformations(location),
     });
   }, debounceTime);
-  React.useEffect(() => {
+  useEffect(() => {
     if (!titleOnLoad) {
       return;
     }
@@ -491,7 +491,7 @@ graphQLReady.onReady(() => {
   }
 
   render(
-    <React.Suspense fallback={<LoadingBox />}>
+    <Suspense fallback={<LoadingBox />}>
       <Provider store={store}>
         <ThemeProvider>
           <AppInitSDK
@@ -509,7 +509,7 @@ graphQLReady.onReady(() => {
           </AppInitSDK>
         </ThemeProvider>
       </Provider>
-    </React.Suspense>,
+    </Suspense>,
     document.getElementById('app'),
   );
 });

--- a/frontend/public/components/cluster-settings/github-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/github-idp-form.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
 import { useTranslation, Trans } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
@@ -15,15 +15,15 @@ import { IDPCAFileInput } from './idp-cafile-input';
 
 export const AddGitHubPage = () => {
   const navigate = useNavigate();
-  const [inProgress, setInProgress] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState('');
-  const [name, setName] = React.useState('github');
-  const [clientID, setClientID] = React.useState('');
-  const [clientSecret, setClientSecret] = React.useState('');
-  const [hostname, setHostname] = React.useState('');
-  const [organizations, setOrganizations] = React.useState([]);
-  const [teams, setTeams] = React.useState([]);
-  const [caFileContent, setCaFileContent] = React.useState('');
+  const [inProgress, setInProgress] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [name, setName] = useState('github');
+  const [clientID, setClientID] = useState('');
+  const [clientSecret, setClientSecret] = useState('');
+  const [hostname, setHostname] = useState('');
+  const [organizations, setOrganizations] = useState([]);
+  const [teams, setTeams] = useState([]);
+  const [caFileContent, setCaFileContent] = useState('');
 
   const { t } = useTranslation();
 

--- a/frontend/public/components/cluster-settings/gitlab-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/gitlab-idp-form.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
@@ -15,13 +15,13 @@ import { IDPCAFileInput } from './idp-cafile-input';
 
 export const AddGitLabPage = () => {
   const navigate = useNavigate();
-  const [inProgress, setInProgress] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState('');
-  const [name, setName] = React.useState('gitlab');
-  const [clientID, setClientID] = React.useState('');
-  const [clientSecret, setClientSecret] = React.useState('');
-  const [url, setUrl] = React.useState('');
-  const [caFileContent, setCaFileContent] = React.useState('');
+  const [inProgress, setInProgress] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [name, setName] = useState('gitlab');
+  const [clientID, setClientID] = useState('');
+  const [clientSecret, setClientSecret] = useState('');
+  const [url, setUrl] = useState('');
+  const [caFileContent, setCaFileContent] = useState('');
 
   const { t } = useTranslation();
 

--- a/frontend/public/components/cluster-settings/google-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/google-idp-form.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
@@ -14,12 +14,12 @@ import { IDPNameInput } from './idp-name-input';
 
 export const AddGooglePage = () => {
   const navigate = useNavigate();
-  const [inProgress, setInProgress] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState('');
-  const [name, setName] = React.useState('google');
-  const [clientID, setClientID] = React.useState('');
-  const [clientSecret, setClientSecret] = React.useState('');
-  const [hostedDomain, setHostedDomain] = React.useState('');
+  const [inProgress, setInProgress] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [name, setName] = useState('google');
+  const [clientID, setClientID] = useState('');
+  const [clientSecret, setClientSecret] = useState('');
+  const [hostedDomain, setHostedDomain] = useState('');
 
   const { t } = useTranslation();
 

--- a/frontend/public/components/cluster-settings/htpasswd-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/htpasswd-idp-form.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
@@ -21,10 +21,10 @@ export const DroppableFileInput = (props: any) => (
 
 export const AddHTPasswdPage = () => {
   const navigate = useNavigate();
-  const [inProgress, setInProgress] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState('');
-  const [name, setName] = React.useState('htpasswd');
-  const [htpasswdFileContent, setHtpasswdFileContent] = React.useState('');
+  const [inProgress, setInProgress] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [name, setName] = useState('htpasswd');
+  const [htpasswdFileContent, setHtpasswdFileContent] = useState('');
 
   const { t } = useTranslation();
 

--- a/frontend/public/components/cluster-settings/keystone-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/keystone-idp-form.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
@@ -22,14 +22,14 @@ export const DroppableFileInput = (props: any) => (
 
 export const AddKeystonePage = () => {
   const navigate = useNavigate();
-  const [inProgress, setInProgress] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState('');
-  const [name, setName] = React.useState('keystone');
-  const [domainName, setDomainName] = React.useState('');
-  const [url, setUrl] = React.useState('');
-  const [caFileContent, setCaFileContent] = React.useState('');
-  const [certFileContent, setCertFileContent] = React.useState('');
-  const [keyFileContent, setKeyFileContent] = React.useState('');
+  const [inProgress, setInProgress] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [name, setName] = useState('keystone');
+  const [domainName, setDomainName] = useState('');
+  const [url, setUrl] = useState('');
+  const [caFileContent, setCaFileContent] = useState('');
+  const [certFileContent, setCertFileContent] = useState('');
+  const [keyFileContent, setKeyFileContent] = useState('');
 
   const { t } = useTranslation();
 

--- a/frontend/public/components/cluster-settings/ldap-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/ldap-idp-form.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import * as _ from 'lodash-es';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
 import { useTranslation } from 'react-i18next';
@@ -16,17 +16,17 @@ import { IDPCAFileInput } from './idp-cafile-input';
 
 export const AddLDAPPage = () => {
   const navigate = useNavigate();
-  const [inProgress, setInProgress] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState('');
-  const [name, setName] = React.useState('ldap');
-  const [url, setUrl] = React.useState('');
-  const [bindDN, setBindDN] = React.useState('');
-  const [bindPassword, setBindPassword] = React.useState('');
-  const [attributesID, setAttributesID] = React.useState(['dn']);
-  const [attributesPreferredUsername, setAttributesPreferredUsername] = React.useState(['uid']);
-  const [attributesName, setAttributesName] = React.useState(['cn']);
-  const [attributesEmail, setAttributesEmail] = React.useState([]);
-  const [caFileContent, setCaFileContent] = React.useState('');
+  const [inProgress, setInProgress] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [name, setName] = useState('ldap');
+  const [url, setUrl] = useState('');
+  const [bindDN, setBindDN] = useState('');
+  const [bindPassword, setBindPassword] = useState('');
+  const [attributesID, setAttributesID] = useState(['dn']);
+  const [attributesPreferredUsername, setAttributesPreferredUsername] = useState(['uid']);
+  const [attributesName, setAttributesName] = useState(['cn']);
+  const [attributesEmail, setAttributesEmail] = useState([]);
+  const [caFileContent, setCaFileContent] = useState('');
 
   const { t } = useTranslation();
 

--- a/frontend/public/components/cluster-settings/openid-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/openid-idp-form.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
@@ -15,19 +15,17 @@ import { IDPCAFileInput } from './idp-cafile-input';
 
 export const AddOpenIDIDPPage = () => {
   const navigate = useNavigate();
-  const [inProgress, setInProgress] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState('');
-  const [name, setName] = React.useState('openid');
-  const [clientID, setClientID] = React.useState('');
-  const [clientSecret, setClientSecret] = React.useState('');
-  const [claimPreferredUsernames, setClaimPreferredUsernames] = React.useState([
-    'preferred_username',
-  ]);
-  const [claimNames, setClaimNames] = React.useState(['name']);
-  const [claimEmails, setClaimEmails] = React.useState(['email']);
-  const [issuer, setIssuer] = React.useState('');
-  const [caFileContent, setCaFileContent] = React.useState('');
-  const [extraScopes, setExtraScopes] = React.useState([]);
+  const [inProgress, setInProgress] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [name, setName] = useState('openid');
+  const [clientID, setClientID] = useState('');
+  const [clientSecret, setClientSecret] = useState('');
+  const [claimPreferredUsernames, setClaimPreferredUsernames] = useState(['preferred_username']);
+  const [claimNames, setClaimNames] = useState(['name']);
+  const [claimEmails, setClaimEmails] = useState(['email']);
+  const [issuer, setIssuer] = useState('');
+  const [caFileContent, setCaFileContent] = useState('');
+  const [extraScopes, setExtraScopes] = useState([]);
 
   const { t } = useTranslation();
 

--- a/frontend/public/components/cluster-settings/request-header-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/request-header-idp-form.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
@@ -15,17 +15,17 @@ import { IDPCAFileInput } from './idp-cafile-input';
 
 export const AddRequestHeaderPage = () => {
   const navigate = useNavigate();
-  const [inProgress, setInProgress] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState('');
-  const [name, setName] = React.useState('request-header');
-  const [challengeURL, setChallengeURL] = React.useState('');
-  const [loginURL, setLoginURL] = React.useState('');
-  const [clientCommonNames, setClientCommonNames] = React.useState([]);
-  const [headers, setHeaders] = React.useState([]);
-  const [preferredUsernameHeaders, setPreferredUsernameHeaders] = React.useState([]);
-  const [nameHeaders, setNameHeaders] = React.useState([]);
-  const [emailHeaders, setEmailHeaders] = React.useState([]);
-  const [caFileContent, setCaFileContent] = React.useState('');
+  const [inProgress, setInProgress] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [name, setName] = useState('request-header');
+  const [challengeURL, setChallengeURL] = useState('');
+  const [loginURL, setLoginURL] = useState('');
+  const [clientCommonNames, setClientCommonNames] = useState([]);
+  const [headers, setHeaders] = useState([]);
+  const [preferredUsernameHeaders, setPreferredUsernameHeaders] = useState([]);
+  const [nameHeaders, setNameHeaders] = useState([]);
+  const [emailHeaders, setEmailHeaders] = useState([]);
+  const [caFileContent, setCaFileContent] = useState('');
 
   const { t } = useTranslation();
 

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/context.ts
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/context.ts
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import { createContext } from 'react';
 import { K8sResourceKind } from '../../../../module/k8s';
 
-export const ClusterDashboardContext = React.createContext<ClusterDashboardContext>({
+export const ClusterDashboardContext = createContext<ClusterDashboardContext>({
   infrastructureLoaded: true,
   infrastructureError: null,
 });

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/inventory-card.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { memo, useMemo, useState, useEffect, useCallback } from 'react';
 import { Card, CardBody, CardHeader, CardTitle, Stack, StackItem } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import {
@@ -54,7 +54,7 @@ const getFirehoseResource = (model: K8sKind) => ({
 });
 
 const ClusterInventoryItem = withDashboardResources<ClusterInventoryItemProps>(
-  React.memo(
+  memo(
     ({
       model,
       resolvedMapper,
@@ -62,14 +62,14 @@ const ClusterInventoryItem = withDashboardResources<ClusterInventoryItemProps>(
       additionalResources,
       expandedComponent,
     }: ClusterInventoryItemProps) => {
-      const mainResource = React.useMemo(() => getFirehoseResource(model), [model]);
-      const otherResources = React.useMemo(() => additionalResources || {}, [additionalResources]);
-      const [mapper, setMapper] = React.useState<StatusGroupMapper>();
+      const mainResource = useMemo(() => getFirehoseResource(model), [model]);
+      const otherResources = useMemo(() => additionalResources || {}, [additionalResources]);
+      const [mapper, setMapper] = useState<StatusGroupMapper>();
       const [resourceData, resourceLoaded, resourceLoadError] = useK8sWatchResource<
         K8sResourceCommon[]
       >(mainResource);
       const resources = useK8sWatchResources(otherResources);
-      React.useEffect(() => {
+      useEffect(() => {
         mapperLoader &&
           mapperLoader()
             .then((res) => setMapper(() => res))
@@ -83,7 +83,7 @@ const ClusterInventoryItem = withDashboardResources<ClusterInventoryItemProps>(
         additionalResourcesData,
         additionalResourcesLoaded,
         additionalResourcesLoadError,
-      ] = React.useMemo(() => {
+      ] = useMemo(() => {
         const resourcesData = {};
         let resourcesLoaded = true;
         let resourcesLoadError = false;
@@ -103,7 +103,7 @@ const ClusterInventoryItem = withDashboardResources<ClusterInventoryItemProps>(
         return [resourcesData, resourcesLoaded, resourcesLoadError];
       }, [additionalResources, resources]);
 
-      const ExpandedComponent = React.useCallback(
+      const ExpandedComponent = useCallback(
         () => (
           <AsyncComponent
             loader={expandedComponent}
@@ -149,12 +149,12 @@ export const InventoryCard = () => {
     isClusterOverviewInventoryItem,
   );
 
-  const mergedItems = React.useMemo(() => mergeItems(itemExtensions, replacementExtensions), [
+  const mergedItems = useMemo(() => mergeItems(itemExtensions, replacementExtensions), [
     itemExtensions,
     replacementExtensions,
   ]);
 
-  const dynamicMergedItems = React.useMemo(
+  const dynamicMergedItems = useMemo(
     () => mergeDynamicItems(dynamicItemExtensions, dynamicReplacementExtensions),
     [dynamicItemExtensions, dynamicReplacementExtensions],
   );

--- a/frontend/public/components/dashboard/project-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/inventory-card.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect, useContext } from 'react';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { DashboardItemProps, withDashboardResources } from '../with-dashboard-resources';
@@ -63,7 +63,7 @@ const ProjectInventoryItem = withDashboardResources(
     additionalResources,
     additionalDynamicResources,
   }: ProjectInventoryItemProps) => {
-    React.useEffect(() => {
+    useEffect(() => {
       if (projectName) {
         const resource = createFirehoseResource(model, projectName);
         watchK8sResource(resource);
@@ -137,7 +137,7 @@ export const InventoryCard = () => {
     isProjectOverviewInventoryItem,
   );
 
-  const { obj } = React.useContext(ProjectDashboardContext);
+  const { obj } = useContext(ProjectDashboardContext);
   const projectName = getName(obj);
   const canListSecrets = useAccessReview({
     group: SecretModel.apiGroup,

--- a/frontend/public/components/dashboard/project-dashboard/project-dashboard-context.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/project-dashboard-context.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import { createContext } from 'react';
 import { K8sResourceKind } from '../../../module/k8s';
 
-export const ProjectDashboardContext = React.createContext<ProjectDashboardContext>({});
+export const ProjectDashboardContext = createContext<ProjectDashboardContext>({});
 
 // eslint-disable-next-line no-redeclare
 type ProjectDashboardContext = {

--- a/frontend/public/components/dashboard/project-dashboard/resource-quota-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/resource-quota-card.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Card, CardBody, CardHeader, CardTitle, Stack, StackItem } from '@patternfly/react-core';
@@ -11,7 +11,7 @@ import { ProjectDashboardContext } from './project-dashboard-context';
 import { ResourceQuotaKind, AppliedClusterResourceQuotaKind } from '../../../module/k8s';
 
 export const ResourceQuotaCard = () => {
-  const { obj } = React.useContext(ProjectDashboardContext);
+  const { obj } = useContext(ProjectDashboardContext);
 
   const [quotas, rqLoaded, rqLoadError] = useK8sWatchResource<ResourceQuotaKind[]>({
     groupVersionKind: {

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define, tsdoc/syntax */
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import { useEffect, useState, useRef, useMemo } from 'react';
 import { css } from '@patternfly/react-styles';
 import * as PropTypes from 'prop-types';
 import { Link, useParams } from 'react-router-dom-v5-compat';
@@ -96,7 +96,7 @@ const kindFilter = (reference, { involvedObject }) => {
 };
 
 const Actions = ({ actions, options, list, cache, index }) => {
-  React.useEffect(() => {
+  useEffect(() => {
     // Actions contents will render after the initial row height calculation,
     // so recompute the row height.
     cache.clear(index);
@@ -229,10 +229,10 @@ const Inner = connectToFlags(FLAGS.CAN_LIST_NODE)((props) => {
 
 export const EventsList = (props) => {
   const { t } = useTranslation();
-  const [type, setType] = React.useState('all');
-  const [textFilter, setTextFilter] = React.useState('');
+  const [type, setType] = useState('all');
+  const [textFilter, setTextFilter] = useState('');
   const { ns } = useParams();
-  const [selected, setSelected] = React.useState(new Set([]));
+  const [selected, setSelected] = useState(new Set([]));
   const eventTypes = {
     all: t('public~All types'),
     normal: t('public~Normal'),
@@ -372,18 +372,18 @@ const EventStream = ({
   textFilter,
 }) => {
   const { t } = useTranslation();
-  const [active, setActive] = React.useState(true);
-  const [sortedEvents, setSortedEvents] = React.useState([]);
-  const [error, setError] = React.useState(null);
-  const [loading, setLoading] = React.useState(true);
-  const ws = React.useRef(null);
+  const [active, setActive] = useState(true);
+  const [sortedEvents, setSortedEvents] = useState([]);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const ws = useRef(null);
 
-  const filteredEvents = React.useMemo(() => {
+  const filteredEvents = useMemo(() => {
     return filterEvents(sortedEvents, { kind, type, filter, textFilter }).slice(0, maxMessages);
   }, [sortedEvents, kind, type, filter, textFilter]);
 
   // Handle websocket setup and teardown when dependent props change
-  React.useEffect(() => {
+  useEffect(() => {
     ws.current?.destroy();
     if (!mock) {
       const webSocketID = `${namespace || 'all'}-sysevents`;
@@ -452,7 +452,7 @@ const EventStream = ({
   }, [namespace, fieldSelector, mock, t]);
 
   // Pause/unpause the websocket when the active state changes
-  React.useEffect(() => {
+  useEffect(() => {
     if (active) {
       ws.current?.unpause();
     } else {

--- a/frontend/public/components/factory/ListPage/filter-hook.ts
+++ b/frontend/public/components/factory/ListPage/filter-hook.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import * as _ from 'lodash';
 import { useLocation } from 'react-router-dom-v5-compat';
 import {
@@ -22,11 +22,11 @@ const filterData = <D>(
 };
 
 export const useListPageFilter: UseListPageFilter = (data, rowFilters, staticFilters) => {
-  const [filter, setFilter] = React.useState<{ [key: string]: FilterValue }>();
+  const [filter, setFilter] = useState<{ [key: string]: FilterValue }>();
   const [isExactSearch] = useExactSearch();
   const location = useLocation();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const params = new URLSearchParams(location.search);
     const name = params.get('name');
     if (!_.isNil(name) && name !== filter?.name?.selected?.[0]) {
@@ -34,12 +34,12 @@ export const useListPageFilter: UseListPageFilter = (data, rowFilters, staticFil
     }
   }, [filter, location]);
 
-  const onFilterChange = React.useCallback(
+  const onFilterChange = useCallback(
     (type, value) => setFilter((state) => ({ ...state, [type]: value })),
     [],
   );
 
-  return React.useMemo(() => {
+  return useMemo(() => {
     const tableFilters = getAllTableFilters(rowFilters, isExactSearch);
 
     const staticData = filterData(data, staticFilters, tableFilters);

--- a/frontend/public/components/factory/Table/active-columns-hook.ts
+++ b/frontend/public/components/factory/Table/active-columns-hook.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import {
   ALL_NAMESPACES_KEY,
   COLUMN_MANAGEMENT_CONFIGMAP_KEY,
@@ -25,7 +25,7 @@ export const useActiveColumns = <D = any>({
   );
   const [namespace] = useActiveNamespace();
 
-  return React.useMemo(() => {
+  return useMemo(() => {
     const activeColumnIDs: Set<string> =
       tableColumns?.[columnManagementID]?.length > 0
         ? new Set(tableColumns[columnManagementID])

--- a/frontend/public/components/factory/table-data-hook.ts
+++ b/frontend/public/components/factory/table-data-hook.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import * as _ from 'lodash';
 import { useSelector } from 'react-redux';
 import { createSelectorCreator, defaultMemoize } from 'reselect';
@@ -88,7 +88,7 @@ export const useTableData = ({
 
   const [isExactSearch] = useExactSearch();
 
-  const tableSelectorCreator = React.useMemo(
+  const tableSelectorCreator = useMemo(
     () =>
       createSelectorCreator(
         defaultMemoize as any,
@@ -99,7 +99,7 @@ export const useTableData = ({
 
   const listId = reduxIDs ? reduxIDs.join(',') : reduxID;
 
-  const sortSelector = React.useMemo(
+  const sortSelector = useMemo(
     () =>
       tableSelectorCreator(
         (state: RootState) => state.UI.getIn(['listSorts', listId]),
@@ -116,7 +116,7 @@ export const useTableData = ({
     sortSelector,
   );
 
-  return React.useMemo(() => {
+  return useMemo(() => {
     const allFilters = staticFilters ? Object.assign({}, filters, ...staticFilters) : filters;
     const data = getFilteredRows(allFilters, rowFilters, propData, isExactSearch);
 

--- a/frontend/public/components/graphs/status.jsx
+++ b/frontend/public/components/graphs/status.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable tsdoc/syntax */
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import { Component } from 'react';
 import { css } from '@patternfly/react-styles';
 import { Link } from 'react-router-dom-v5-compat';
 import { Title } from '@patternfly/react-core';
@@ -40,7 +40,7 @@ const fetchQuery = (q, long, namespace) => {
 };
 
 /** @augments {React.Component<{fetch?: () => Promise<any>, query?: string, title: string, href?: string, rel?: string, target?: string}}>} */
-export class Status extends React.Component {
+export class Status extends Component {
   constructor(props) {
     super(props);
     this.interval = null;

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useContext, useState, useRef, useCallback, createRef, useEffect } from 'react';
 import * as _ from 'lodash-es';
 import { useSelector, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
@@ -74,7 +74,7 @@ const defaultHelpLinks = [
 
 const FeedbackModalLocalized = ({ isOpen, onClose, reportBugLink }) => {
   const feedbackLocales = useFeedbackLocal(reportBugLink);
-  const theme = React.useContext(ThemeContext);
+  const theme = useContext(ThemeContext);
   return (
     <FeedbackModal
       onShareFeedback="https://console.redhat.com/self-managed-feedback-form?source=openshift"
@@ -123,26 +123,25 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
     alertCount: state.observe.getIn(['alertCount']),
     canAccessNS: !!state[featureReducerName].get(FLAGS.CAN_GET_NS),
   }));
-  const [isAppLauncherDropdownOpen, setIsAppLauncherDropdownOpen] = React.useState(false);
-  const [isUserDropdownOpen, setIsUserDropdownOpen] = React.useState(false);
-  const [isKebabDropdownOpen, setIsKebabDropdownOpen] = React.useState(false);
-  const [isHelpDropdownOpen, setIsHelpDropdownOpen] = React.useState(false);
-  const [statusPageData, setStatusPageData] = React.useState(null);
-  const [showAboutModal, setshowAboutModal] = React.useState(false);
-  const [isFeedbackModalOpen, setIsFeedbackModalOpen] = React.useState(false);
-  const applicationLauncherMenuRef = React.useRef(null);
-  const helpMenuRef = React.useRef(null);
-  const userMenuRef = React.useRef(null);
-  const kebabMenuRef = React.useRef(null);
+  const [isAppLauncherDropdownOpen, setIsAppLauncherDropdownOpen] = useState(false);
+  const [isUserDropdownOpen, setIsUserDropdownOpen] = useState(false);
+  const [isKebabDropdownOpen, setIsKebabDropdownOpen] = useState(false);
+  const [isHelpDropdownOpen, setIsHelpDropdownOpen] = useState(false);
+  const [statusPageData, setStatusPageData] = useState(null);
+  const [showAboutModal, setshowAboutModal] = useState(false);
+  const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);
+  const applicationLauncherMenuRef = useRef(null);
+  const helpMenuRef = useRef(null);
+  const userMenuRef = useRef(null);
+  const kebabMenuRef = useRef(null);
   const reportBugLink = cv?.data ? getReportBugLink(cv.data, t) : null;
-  const userInactivityTimeout = React.useRef(null);
+  const userInactivityTimeout = useRef(null);
   const username = user?.username ?? '';
   const isKubeAdmin = username === 'kube:admin';
 
-  const drawerToggle = React.useCallback(
-    () => dispatch(UIActions.notificationDrawerToggleExpanded()),
-    [dispatch],
-  );
+  const drawerToggle = useCallback(() => dispatch(UIActions.notificationDrawerToggleExpanded()), [
+    dispatch,
+  ]);
 
   const getImportYAMLPath = () => formatNamespacedRouteForResource('import', activeNamespace);
   const onFeedbackModal = () => setIsFeedbackModalOpen(true);
@@ -283,7 +282,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
 
   const getHelpActions = (additionalHelpActions) => {
     const helpActions = [];
-    const tourRef = React.createRef();
+    const tourRef = createRef();
 
     helpActions.push({
       isSection: true,
@@ -587,7 +586,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
     );
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (window.SERVER_FLAGS.statuspageID) {
       fetch(`https://${window.SERVER_FLAGS.statuspageID}.statuspage.io/api/v2/summary.json`, {
         headers: { Accept: 'application/json' },
@@ -600,7 +599,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
   const setLastConsoleActivityTimestamp = () =>
     localStorage.setItem(LAST_CONSOLE_ACTIVITY_TIMESTAMP_LOCAL_STORAGE_KEY, Date.now().toString());
 
-  const resetInactivityTimeout = React.useCallback(() => {
+  const resetInactivityTimeout = useCallback(() => {
     setLastConsoleActivityTimestamp();
     clearTimeout(userInactivityTimeout.current);
     userInactivityTimeout.current = setTimeout(() => {
@@ -608,7 +607,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
     }, window.SERVER_FLAGS.inactivityTimeout * 1000);
   }, [isKubeAdmin]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const onStorageChange = (e) => {
       const { key, oldValue, newValue } = e;
       if (key === LAST_CONSOLE_ACTIVITY_TIMESTAMP_LOCAL_STORAGE_KEY && oldValue < newValue) {

--- a/frontend/public/components/modals/configure-machine-autoscaler-modal.tsx
+++ b/frontend/public/components/modals/configure-machine-autoscaler-modal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import * as _ from 'lodash-es';
 import { useTranslation, Trans } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
@@ -16,8 +16,8 @@ import { k8sCreate, K8sResourceKind } from '../../module/k8s';
 const ConfigureMachineAutoscalerModal = withHandlePromise(
   (props: ConfigureMachineAutoscalerModalProps) => {
     const navigate = useNavigate();
-    const [minReplicas, setMinReplicas] = React.useState(1);
-    const [maxReplicas, setMaxReplicas] = React.useState(12);
+    const [minReplicas, setMinReplicas] = useState(1);
+    const [maxReplicas, setMaxReplicas] = useState(12);
 
     const changeMinReplicas = (event) => {
       setMinReplicas(_.toInteger(event.target.value));

--- a/frontend/public/components/modals/expand-pvc-modal.tsx
+++ b/frontend/public/components/modals/expand-pvc-modal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
@@ -19,10 +19,10 @@ import { getRequestedPVCSize } from '@console/shared';
 const ExpandPVCModal = withHandlePromise((props: ExpandPVCModalProps) => {
   const baseValue = convertToBaseValue(getRequestedPVCSize(props.resource));
   const defaultSize = validate.split(humanizeBinaryBytesWithoutB(baseValue).string);
-  const [requestSizeValue, setRequestSizeValue] = React.useState(defaultSize[0] || '');
-  const [requestSizeUnit, setRequestSizeUnit] = React.useState(defaultSize[1] || 'Gi');
-  const [errorMessage, setErrorMessage] = React.useState<string>();
-  const [inProgress, setInProgress] = React.useState(false);
+  const [requestSizeValue, setRequestSizeValue] = useState(defaultSize[0] || '');
+  const [requestSizeUnit, setRequestSizeUnit] = useState(defaultSize[1] || 'Gi');
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const [inProgress, setInProgress] = useState(false);
 
   const { t } = useTranslation();
   const navigate = useNavigate();

--- a/frontend/public/components/modals/rollback-modal.jsx
+++ b/frontend/public/components/modals/rollback-modal.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import * as _ from 'lodash-es';
 import { Trans, useTranslation } from 'react-i18next';
 import { getDeploymentConfigVersion, getOwnerNameByKind } from '@console/shared/src';
@@ -25,9 +25,9 @@ const BaseRollbackModal = withHandlePromise((props) => {
     props.resource,
     isDCRollback ? DeploymentConfigModel : DeploymentModel,
   );
-  const [changeScaleSettings, setChangeScaleSettings] = React.useState(false);
-  const [changeStrategy, setChangeStrategy] = React.useState(false);
-  const [changeTriggers, setChangeTriggers] = React.useState(false);
+  const [changeScaleSettings, setChangeScaleSettings] = useState(false);
+  const [changeStrategy, setChangeStrategy] = useState(false);
+  const [changeTriggers, setChangeTriggers] = useState(false);
   const deploymentResource = {
     kind: isDCRollback ? DeploymentConfigModel.kind : DeploymentModel.kind,
     isList: false,
@@ -35,7 +35,7 @@ const BaseRollbackModal = withHandlePromise((props) => {
     namespace: props.resource.metadata.namespace,
   };
   const [deployment, loaded, loadError] = useK8sWatchResource(deploymentResource);
-  const [deploymentError, setDeploymentError] = React.useState();
+  const [deploymentError, setDeploymentError] = useState();
 
   const submitDCRollback = () => {
     const dcVersion = getDeploymentConfigVersion(props.resource);
@@ -109,7 +109,7 @@ const BaseRollbackModal = withHandlePromise((props) => {
     return submitDeploymentRollback();
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (loaded && !loadError && deployment) {
       if (deployment.spec.paused) {
         setDeploymentError(

--- a/frontend/public/components/monitoring/hooks/useBoolean.ts
+++ b/frontend/public/components/monitoring/hooks/useBoolean.ts
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import { useState, useCallback } from 'react';
 
 export const useBoolean = (
   initialValue: boolean,
 ): [boolean, () => void, () => void, () => void] => {
-  const [value, setValue] = React.useState(initialValue);
-  const toggle = React.useCallback(() => setValue((v) => !v), []);
-  const setTrue = React.useCallback(() => setValue(true), []);
-  const setFalse = React.useCallback(() => setValue(false), []);
+  const [value, setValue] = useState(initialValue);
+  const toggle = useCallback(() => setValue((v) => !v), []);
+  const setTrue = useCallback(() => setValue(true), []);
+  const setFalse = useCallback(() => setValue(false), []);
   return [value, toggle, setTrue, setFalse];
 };

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable tsdoc/syntax */
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
 import { css } from '@patternfly/react-styles';
 import { sortable } from '@patternfly/react-table';
@@ -424,7 +424,7 @@ export const NamespacesList = (props) => {
   );
 
   // TODO Utilize usePoll hook
-  React.useEffect(() => {
+  useEffect(() => {
     const updateMetrics = () =>
       fetchNamespaceMetrics().then((result) => dispatch(UIActions.setNamespaceMetrics(result)));
     updateMetrics();
@@ -436,7 +436,7 @@ export const NamespacesList = (props) => {
       ? new Set(tableColumns[NamespacesColumnManagementID])
       : null;
 
-  const customData = React.useMemo(
+  const customData = useMemo(
     () => ({
       tableColumns: tableColumns?.[NamespacesColumnManagementID],
     }),
@@ -743,7 +743,7 @@ ProjectTableRow.displayName = 'ProjectTableRow';
 
 export const ProjectsTable = (props) => {
   const { t } = useTranslation();
-  const customData = React.useMemo(
+  const customData = useMemo(
     () => ({
       ProjectLinkComponent: ProjectLink,
       actionsEnabled: false,
@@ -787,7 +787,7 @@ export const ProjectList = ({ data, ...tableProps }) => {
   );
   const isPrometheusAvailable = usePrometheusGate();
   const showMetrics = isPrometheusAvailable && canGetNS && window.screen.width >= 1200;
-  const customData = React.useMemo(
+  const customData = useMemo(
     () => ({
       showMetrics,
       tableColumns: tableColumns?.[projectColumnManagementID],
@@ -796,7 +796,7 @@ export const ProjectList = ({ data, ...tableProps }) => {
   );
 
   // TODO Utilize usePoll hook
-  React.useEffect(() => {
+  useEffect(() => {
     if (showMetrics) {
       const updateMetrics = () =>
         fetchNamespaceMetrics().then((result) => dispatch(UIActions.setNamespaceMetrics(result)));
@@ -877,13 +877,13 @@ export const ProjectsPage = (props) => {
 
 /** @type {React.SFC<{namespace: K8sResourceKind}>} */
 export const PullSecret = (props) => {
-  const [isLoading, setIsLoading] = React.useState(true);
-  const [data, setData] = React.useState([]);
-  const [error, setError] = React.useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [data, setData] = useState([]);
+  const [error, setError] = useState(false);
   const { t } = useTranslation();
   const { namespace, canViewSecrets } = props;
 
-  React.useEffect(() => {
+  useEffect(() => {
     k8sGet(ServiceAccountModel, 'default', namespace.metadata.name, {})
       .then((serviceAccount) => {
         setIsLoading(false);

--- a/frontend/public/components/pod-logs.jsx
+++ b/frontend/public/components/pod-logs.jsx
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import { Component } from 'react';
 
 import PaneBody from '@console/shared/src/components/layout/PaneBody';
 import {
@@ -54,7 +54,7 @@ const containerToLogSourceStatus = (container) => {
   return LOG_SOURCE_RUNNING;
 };
 
-export class PodLogs extends React.Component {
+export class PodLogs extends Component {
   constructor(props) {
     super(props);
     this._selectContainer = this._selectContainer.bind(this);

--- a/frontend/public/components/poll-console-updates.tsx
+++ b/frontend/public/components/poll-console-updates.tsx
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import { memo, useState, useCallback, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { coFetchJSON } from '../co-fetch';
 import { usePoll, useSafeFetch } from './utils';
@@ -16,32 +16,30 @@ interface CheckUpdatesApiResult {
   contentSecurityPolicy?: string;
 }
 
-export const PollConsoleUpdates = React.memo(function PollConsoleUpdates() {
+export const PollConsoleUpdates = memo(function PollConsoleUpdates() {
   const toastContext = useToast();
   const { t } = useTranslation();
 
-  const [isToastOpen, setToastOpen] = React.useState(false);
-  const [pluginsChanged, setPluginsChanged] = React.useState(false);
-  const [pluginVersionsChanged, setPluginVersionsChanged] = React.useState(false);
-  const [consoleChanged, setConsoleChanged] = React.useState(false);
-  const [isFetchingPluginEndpoints, setIsFetchingPluginEndpoints] = React.useState(false);
-  const [allPluginEndpointsReady, setAllPluginEndpointsReady] = React.useState(false);
+  const [isToastOpen, setToastOpen] = useState(false);
+  const [pluginsChanged, setPluginsChanged] = useState(false);
+  const [pluginVersionsChanged, setPluginVersionsChanged] = useState(false);
+  const [consoleChanged, setConsoleChanged] = useState(false);
+  const [isFetchingPluginEndpoints, setIsFetchingPluginEndpoints] = useState(false);
+  const [allPluginEndpointsReady, setAllPluginEndpointsReady] = useState(false);
 
-  const [updateData, setUpdateData] = React.useState<CheckUpdatesApiResult>();
-  const [updateError, setUpdateError] = React.useState<Error>();
-  const [newPlugins, setNewPlugins] = React.useState<CheckUpdatesApiResult['plugins']>(null);
-  const [pluginManifestsData, setPluginManifestsData] = React.useState<
-    ConsolePluginManifestJSON[]
-  >();
+  const [updateData, setUpdateData] = useState<CheckUpdatesApiResult>();
+  const [updateError, setUpdateError] = useState<Error>();
+  const [newPlugins, setNewPlugins] = useState<CheckUpdatesApiResult['plugins']>(null);
+  const [pluginManifestsData, setPluginManifestsData] = useState<ConsolePluginManifestJSON[]>();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const safeFetch = React.useCallback(useSafeFetch(), []);
+  const safeFetch = useCallback(useSafeFetch(), []);
   const fetchPluginManifest = (pluginName: string): Promise<ConsolePluginManifestJSON> =>
     coFetchJSON(
       `${window.SERVER_FLAGS.basePath}api/plugins/${pluginName}/plugin-manifest.json`,
       'get',
       { cache: 'no-cache' },
     );
-  const tick = React.useCallback(() => {
+  const tick = useCallback(() => {
     safeFetch(`${window.SERVER_FLAGS.basePath}api/check-updates`)
       .then((response) => {
         setUpdateData(response);
@@ -59,9 +57,9 @@ export const PollConsoleUpdates = React.memo(function PollConsoleUpdates() {
   }, [safeFetch]);
   usePoll(tick, URL_POLL_DEFAULT_DELAY);
 
-  const prevUpdateDataRef = React.useRef<CheckUpdatesApiResult>();
-  const prevPluginManifestsDataRef = React.useRef<ConsolePluginManifestJSON[]>();
-  React.useEffect(() => {
+  const prevUpdateDataRef = useRef<CheckUpdatesApiResult>();
+  const prevPluginManifestsDataRef = useRef<ConsolePluginManifestJSON[]>();
+  useEffect(() => {
     prevUpdateDataRef.current = updateData;
     prevPluginManifestsDataRef.current = pluginManifestsData;
   });

--- a/frontend/public/components/useLabelSelectionFix.ts
+++ b/frontend/public/components/useLabelSelectionFix.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import useMirroredLocalState, { UseMirroredLocalStateReturn } from './useMirroredLocalState';
 import { setOrRemoveQueryArgument } from './utils';
 
@@ -14,7 +14,7 @@ const useLabelSelectorFix = (
   params: URLSearchParams,
   labelFilterQueryArgumentKey: string,
 ): UseMirroredLocalStateReturn<string[]> => {
-  const syncSearchParams = React.useCallback(
+  const syncSearchParams = useCallback(
     (values: string[]) => {
       setOrRemoveQueryArgument(labelFilterQueryArgumentKey, values.join(','));
     },

--- a/frontend/public/components/useMirroredLocalState.ts
+++ b/frontend/public/components/useMirroredLocalState.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import * as _ from 'lodash';
 
 export type UseMirroredLocalStateReturn<S> = [S, (state: S) => void, boolean];
@@ -17,9 +17,9 @@ const useMirroredLocalState = <S>({
   externalChangeHandler: (state: S) => void;
   defaultState: S;
 }): UseMirroredLocalStateReturn<S> => {
-  const [localState, setLocalState] = React.useState<S>(null);
+  const [localState, setLocalState] = useState<S>(null);
 
-  const onExternalChange = React.useCallback(
+  const onExternalChange = useCallback(
     (state: S) => {
       setLocalState(state);
       externalChangeHandler(state);
@@ -27,7 +27,7 @@ const useMirroredLocalState = <S>({
     [externalChangeHandler],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (localState === null) {
       // We don't have local data, fresh mount
       if (_.isEmpty(externalState)) {

--- a/frontend/public/components/useRowFilterFix.ts
+++ b/frontend/public/components/useRowFilterFix.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import * as _ from 'lodash';
 import useMirroredLocalState, { UseMirroredLocalStateReturn } from './useMirroredLocalState';
 import { setOrRemoveQueryArgument } from './utils';
@@ -17,7 +17,7 @@ const useRowFilterFix = (
   filterKeys: { [key: string]: string },
   defaultSelections: string[],
 ): UseMirroredLocalStateReturn<string[]> => {
-  const syncRowFilterParams = React.useCallback(
+  const syncRowFilterParams = useCallback(
     (selected) => {
       _.forIn(filters, (value, key) => {
         const recognized = _.filter(selected, (item) => value.includes(item));

--- a/frontend/public/components/utils/branding.ts
+++ b/frontend/public/components/utils/branding.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useContext, useEffect } from 'react';
 import {
   ThemeContext,
   THEME_DARK,
@@ -64,11 +64,11 @@ export const getBrandingDetails = () => {
  * @returns Returns logoURL blob URL and the loading state of the API request.
  */
 export const useCustomLogoURL = (type: CUSTOM_LOGO): { logoUrl: string; loading: Boolean } => {
-  const [logoUrl, setLogoUrl] = React.useState('');
-  const [loading, setLoading] = React.useState(false);
-  const theme = React.useContext(ThemeContext);
+  const [logoUrl, setLogoUrl] = useState('');
+  const [loading, setLoading] = useState(false);
+  const theme = useContext(ThemeContext);
 
-  React.useEffect(() => {
+  useEffect(() => {
     // return when requested custom logo type is not configured
     if (
       (type === MASTHEAD_TYPE && !window.SERVER_FLAGS.customLogosConfigured) ||

--- a/frontend/public/components/utils/file-input.tsx
+++ b/frontend/public/components/utils/file-input.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { Component } from 'react';
 import { css } from '@patternfly/react-styles';
 import { NativeTypes } from 'react-dnd-html5-backend';
 import { DropTarget } from 'react-dnd';
@@ -13,7 +13,7 @@ import withDragDropContext from './drag-drop-context';
 // Maximal file size, in bytes, that user can upload
 const maxFileUploadSize = 4000000;
 
-class FileInputWithTranslation extends React.Component<FileInputProps, FileInputState> {
+class FileInputWithTranslation extends Component<FileInputProps, FileInputState> {
   constructor(props) {
     super(props);
     this.onDataChange = this.onDataChange.bind(this);
@@ -151,10 +151,7 @@ const FileInputComponent = DropTarget(NativeTypes.FILE, boxTarget, (connect, mon
 }))(FileInput);
 
 const DroppableFileInputWithTranslation = withDragDropContext(
-  class DroppableFileInput extends React.Component<
-    DroppableFileInputProps,
-    DroppableFileInputState
-  > {
+  class DroppableFileInput extends Component<DroppableFileInputProps, DroppableFileInputState> {
     constructor(props) {
       super(props);
       this.state = {

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable tsdoc/syntax */
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import { memo, Component } from 'react';
 import * as PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
@@ -113,7 +113,7 @@ const propsAreEqual = (prevProps, nextProps) => {
 // A wrapper Component that takes data out of redux for a list or object at some reduxID ...
 // passing it to children
 const ConnectToState = connect(mapStateToProps)(
-  React.memo(({ k8s, reduxes, children }) => {
+  memo(({ k8s, reduxes, children }) => {
     const resources = {};
 
     reduxes.forEach((redux) => {
@@ -178,7 +178,7 @@ export const Firehose = connect(
   },
 )(
   /** @augments {React.Component<React.PropsWithChildren<{k8sModels?: Map<string, K8sKind>, doNotConnectToState?: boolean}>> */
-  class Firehose extends React.Component {
+  class Firehose extends Component {
     state = {
       firehoses: [],
     };

--- a/frontend/public/components/utils/inject.js
+++ b/frontend/public/components/utils/inject.js
@@ -1,15 +1,15 @@
-import * as React from 'react';
+import { Children, cloneElement } from 'react';
 import * as _ from 'lodash-es';
 
 import { modelFor, kindForReference } from '../../module/k8s';
 
 export const inject = (children, props) => {
   const safeProps = _.omit(props, ['children']);
-  return React.Children.map(children, (c) => {
+  return Children.map(children, (c) => {
     if (!_.isObject(c)) {
       return c;
     }
-    return React.cloneElement(c, safeProps);
+    return cloneElement(c, safeProps);
   });
 };
 

--- a/frontend/public/components/utils/k8s-get-hook.ts
+++ b/frontend/public/components/utils/k8s-get-hook.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { k8sGet, K8sKind, K8sResourceCommon } from '../../module/k8s';
 
 export const useK8sGet = <R extends K8sResourceCommon = K8sResourceCommon>(
@@ -7,10 +7,10 @@ export const useK8sGet = <R extends K8sResourceCommon = K8sResourceCommon>(
   namespace?: string,
   opts?: { [k: string]: string },
 ): [R, boolean, any] => {
-  const [data, setData] = React.useState<R>();
-  const [loaded, setLoaded] = React.useState(false);
-  const [loadError, setLoadError] = React.useState();
-  React.useEffect(() => {
+  const [data, setData] = useState<R>();
+  const [loaded, setLoaded] = useState(false);
+  const [loadError, setLoadError] = useState();
+  useEffect(() => {
     const fetch = async () => {
       try {
         setLoadError(null);

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import * as React from 'react';
+import { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import * as _ from 'lodash-es';
 import { css } from '@patternfly/react-styles';
@@ -25,7 +25,7 @@ import { ValueFromPair } from './value-from-pair';
 import withDragDropContext from './drag-drop-context';
 
 const NameValueEditor_ = withDragDropContext(
-  class NameValueEditor extends React.Component {
+  class NameValueEditor extends Component {
     constructor(props) {
       super(props);
       this._append = this._append.bind(this);
@@ -227,7 +227,7 @@ NameValueEditor.defaultProps = {
 NameValueEditor.displayName = 'Name Value Editor';
 
 const EnvFromEditor_ = withDragDropContext(
-  class EnvFromEditor extends React.Component {
+  class EnvFromEditor extends Component {
     constructor(props) {
       super(props);
       this._append = this._append.bind(this);
@@ -451,7 +451,7 @@ const PairElement_ = DragSource(
     itemTarget,
     collectTargetPair,
   )(
-    class PairElement extends React.Component {
+    class PairElement extends Component {
       constructor(props) {
         super(props);
 
@@ -617,7 +617,7 @@ const EnvFromPairElement_ = DragSource(
     itemTarget,
     collectTargetPair,
   )(
-    class EnvFromPairElement extends React.Component {
+    class EnvFromPairElement extends Component {
       constructor(props) {
         super(props);
         this._onRemove = this._onRemove.bind(this);

--- a/frontend/public/components/utils/scroll-to-top-on-mount.tsx
+++ b/frontend/public/components/utils/scroll-to-top-on-mount.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import { Component, useEffect } from 'react';
 
 // When pages share a resource (e.g., pod.jsx and container.jsx),
 // the scroll position will be maintained when navigating between
 // pages.  Use <ScrollToTopOnMount /> to always reset the scroll position
 // back to the top of the navigated to page when pages share a resource.
-export class ScrollToTopOnMount extends React.Component {
+export class ScrollToTopOnMount extends Component {
   componentDidMount() {
     document.getElementById('content-scrollable').scrollTop = 0;
   }
@@ -15,6 +15,6 @@ export class ScrollToTopOnMount extends React.Component {
 }
 
 export const useScrollToTopOnMount = () =>
-  React.useEffect(() => {
+  useEffect(() => {
     document.getElementById('content-scrollable').scrollTop = 0;
   }, []);

--- a/frontend/public/components/utils/selector-input.jsx
+++ b/frontend/public/components/utils/selector-input.jsx
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import * as React from 'react';
+import { Component } from 'react';
 import { css } from '@patternfly/react-styles';
 import * as TagsInput from 'react-tagsinput';
 import { Label as PfLabel } from '@patternfly/react-core';
@@ -12,7 +12,7 @@ import { selectorToString } from '@console/dynamic-plugin-sdk/src/utils/k8s';
 const cleanSelectorStr = (tag) => selectorToString(selectorFromString(tag));
 const cleanTags = (tags) => split(cleanSelectorStr(tags.join(',')));
 
-export class SelectorInput extends React.Component {
+export class SelectorInput extends Component {
   constructor(props) {
     super(props);
     this.isBasic = !!_.get(this.props.options, 'basic');

--- a/frontend/public/components/utils/tile-view-page.jsx
+++ b/frontend/public/components/utils/tile-view-page.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useRef, useState, useCallback, useEffect } from 'react';
 import * as _ from 'lodash-es';
 import i18n from '@console/internal/i18n';
 import { useTranslation } from 'react-i18next';
@@ -493,16 +493,16 @@ export const TileViewPage = (props) => {
 
   const { t } = useTranslation();
   const [, setSearchParams] = useSearchParams();
-  const filterByKeywordInput = React.useRef();
-  const [prevProps, setPrevProps] = React.useState(props);
+  const filterByKeywordInput = useRef();
+  const [prevProps, setPrevProps] = useState(props);
 
-  const [categories, setCategories] = React.useState(
+  const [categories, setCategories] = useState(
     categorizeItems(items, itemsSorter, getAvailableCategories(items)),
   );
-  const [selectedCategoryId, setSelectedCategoryId] = React.useState('all');
-  const [activeFilters, setActiveFilters] = React.useState(defaultFilters);
-  const [filterCounts, setFilterCounts] = React.useState(null);
-  const [filterGroupsShowAll, setFilterGroupsShowAll] = React.useState({});
+  const [selectedCategoryId, setSelectedCategoryId] = useState('all');
+  const [activeFilters, setActiveFilters] = useState(defaultFilters);
+  const [filterCounts, setFilterCounts] = useState(null);
+  const [filterGroupsShowAll, setFilterGroupsShowAll] = useState({});
 
   const updateURLParams = (paramName, value) => {
     const params = new URLSearchParams(window.location.search);
@@ -525,7 +525,7 @@ export const TileViewPage = (props) => {
     setSearchParams(params);
   };
 
-  const getUpdatedState = React.useCallback((selectedCategories, categoryId, filters) => {
+  const getUpdatedState = useCallback((selectedCategories, categoryId, filters) => {
     if (!items) {
       return;
     }
@@ -574,9 +574,9 @@ export const TileViewPage = (props) => {
   };
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  React.useEffect(initState, []);
+  useEffect(initState, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!_.isEqual(items, prevProps?.items)) {
       const availableFilters = getAvailableFilters(defaultFilters, items, filterGroups);
       const availableCategories = getAvailableCategories(items);

--- a/frontend/public/components/utils/useToggleLineBuffer.ts
+++ b/frontend/public/components/utils/useToggleLineBuffer.ts
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import { useRef, useEffect } from 'react';
 import { LineBuffer } from './line-buffer';
 
 const useToggleLineBuffer = (bufferSize: number | null) => {
-  const buffer = React.useRef(null);
-  React.useEffect(() => {
+  const buffer = useRef(null);
+  useEffect(() => {
     buffer.current = new LineBuffer(bufferSize);
   }, [bufferSize]);
 

--- a/frontend/public/components/utils/value-from-pair.jsx
+++ b/frontend/public/components/utils/value-from-pair.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { PureComponent } from 'react';
 import * as PropTypes from 'prop-types';
 import * as _ from 'lodash-es';
 import * as fuzzy from 'fuzzysearch';
@@ -321,7 +321,7 @@ const keyStringToComponent = {
   },
 };
 
-export class ValueFromPair extends React.PureComponent {
+export class ValueFromPair extends PureComponent {
   constructor(props) {
     super(props);
 

--- a/frontend/public/module/k8s/network.ts
+++ b/frontend/public/module/k8s/network.ts
@@ -1,5 +1,5 @@
 /* eslint-disable tsdoc/syntax */
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { useK8sGet } from '../../components/utils/k8s-get-hook';
 import { K8sResourceKind } from './types';
 import { ConfigMapModel } from '../../models';
@@ -34,14 +34,14 @@ const getFeatureState = (data: { [key: string]: string }, key: string): boolean 
  *  returned)
  */
 export const useClusterNetworkFeatures = (): [ClusterNetworkFeatures, boolean] => {
-  const [features, setFeatures] = React.useState<ClusterNetworkFeatures>({});
-  const [featuresLoaded, setFeaturesLoaded] = React.useState(false);
+  const [features, setFeatures] = useState<ClusterNetworkFeatures>({});
+  const [featuresLoaded, setFeaturesLoaded] = useState(false);
   const [config, configLoaded] = useK8sGet<K8sResourceKind>(
     ConfigMapModel,
     networkConfigMapName,
     networkConfigMapNamespace,
   );
-  React.useEffect(() => {
+  useEffect(() => {
     if (configLoaded) {
       if (config?.data) {
         setFeatures({


### PR DESCRIPTION
runs the codemod `npx react-codemod update-react-imports` [1]

note that this only updates the codemod. there are still a bunch of other places where this import is used (in about 1606 more files), but out of desire to not create an even larger PR, I will address those in a follow-up

only rewriting imports (no logic changes), so i'm adding the labels

/label px-approved
/label docs-approved
/label qe-approved

[1]: https://github.com/reactjs/react-codemod#update-react-imports