### PR TITLE
CONSOLE-4688: Remove maxMenuHeight from ConsoleSelect

### DIFF
--- a/frontend/public/components/utils/console-select.tsx
+++ b/frontend/public/components/utils/console-select.tsx
@@ -301,7 +301,6 @@ export const ConsoleSelect: React.FCC<ConsoleSelectProps> = ({
         onOpenChangeKeys={autocompleteFilter ? ['Escape'] : ['Escape', 'Tab']} // tab is used to access the search input
         onSelect={onClick}
         selected={selectedKey}
-        maxMenuHeight="60vh"
         shouldFocusToggleOnSelect
         toggle={(toggleRef: React.RefObject<MenuToggleElement>) => (
           <MenuToggle


### PR DESCRIPTION
previously, the `60vh` height of the new ConsoleSelect component, inherited from `dropdown.jsx`, would unintentionally cause the main content to scroll. this PR fixes that bug by removing the `maxMenuHeight` pro

before:
<img width="1415" height="1194" alt="image" src="https://github.com/user-attachments/assets/a38c8277-1d01-44b4-b754-177f23818b86" />

after:
<img width="1415" height="978" alt="image" src="https://github.com/user-attachments/assets/7b811f7f-6d73-423f-8a8d-44d983536e05" />
