### PR TITLE
[release-4.17] NO-JIRA: Increase the timeout on the cypress test

### DIFF
--- a/frontend/packages/shipwright-plugin/integration-tests/cypress.config.js
+++ b/frontend/packages/shipwright-plugin/integration-tests/cypress.config.js
@@ -9,7 +9,7 @@ module.exports = defineConfig({
   viewportWidth: 1920,
   viewportHeight: 1080,
   animationDistanceThreshold: 20,
-  execTimeout: 90000,
+  execTimeout: 180000,
   pageLoadTimeout: 90000,
   requestTimeout: 15000,
   responseTimeout: 15000,


### PR DESCRIPTION
## Description
Currently on [release-17](https://issues.redhat.com//browse/release-17) branch, in the `openshift/console-operator` repo, all the CI tests are failing due the same error:

```
1) Shipwright build details page
       "after all" hook for "Checking error for failed build runs : SWB-01-TC08":
     CypressError: `cy.exec('oc delete namespace aut-shipwright-build-details')` timed out after waiting `90000ms`.
```

Thanks to @sanketpathak for helping validated that the test was passing locally with release-4.17 build.

<img width="2972" height="1538" alt="image" src="https://github.com/user-attachments/assets/3eacfc1f-4672-4971-847d-21c1c8652995" />


## Next step
Therefore, the next attempt to resolve this issue is: updating the timeout for cypress test to give enough time for oc delete. Will decide on the next step based on the actual time that the oc delete command finish.

If it is finished within a reasonable time range, we will modify the timeout value.
If it is finished with a abnormal time, we will further investigate the reason why `oc delete` command here is taking too long.

Will use the test result on https://github.com/openshift/console-operator/pull/1033 as measure of success.

/cc @logonoff @jhadvig @TheRealJon 

