### PR TITLE
CONSOLE-4235: Update Xterm.js CSS

### DIFF
--- a/frontend/public/components/_terminal.scss
+++ b/frontend/public/components/_terminal.scss
@@ -1,4 +1,4 @@
-@import '~xterm/css/xterm.css';
+@import '~@xterm/xterm/css/xterm.css';
 
 $console-z-index: $zindex-navbar-fixed + 20;
 $console-collapse-link-z-index: $console-z-index + 20;


### PR DESCRIPTION
there should be no visual changes, but there was some additional CSS that was added in the new xterm version which I missed when updating:

```diff
< .xterm .xterm-accessibility,
---
> .xterm .xterm-accessibility:not(.debug),
152a153,161
> }
> 
> .xterm .xterm-accessibility-tree:not(.debug) *::selection {
>   color: transparent;
> }
> 
> .xterm .xterm-accessibility-tree {
>   user-select: text;
>   white-space: pre;
```

/label px-approved
/label docs-approved
/label qe-approved