### PR TITLE
Updated PromQL to include component specific namespace

### DIFF
--- a/frontend/packages/console-app/src/queries.ts
+++ b/frontend/packages/console-app/src/queries.ts
@@ -12,10 +12,10 @@ import { PodModel } from '@console/internal/models';
 // to rely on the number of kube-apiserver pods instead of the number of
 // Prometheus targets it has.
 export const API_SERVERS_UP =
-  '(sum(up{job="apiserver"} == 1) / count(kube_pod_labels{label_app="openshift-kube-apiserver",label_apiserver="true",namespace="openshift-kube-apiserver"})) * 100';
+  '(sum(up{job="apiserver",namespace="default"} == 1) / count(kube_pod_labels{label_app="openshift-kube-apiserver",label_apiserver="true",namespace="openshift-kube-apiserver"})) * 100';
 export const CONTROLLER_MANAGERS_UP =
-  '(sum(up{job="kube-controller-manager"} == 1) / count(up{job="kube-controller-manager"})) * 100';
-export const SCHEDULERS_UP = '(sum(up{job="scheduler"} == 1) / count(up{job="scheduler"})) * 100';
+  '(sum(up{job="kube-controller-manager",namespace="openshift-kube-controller-manager"} == 1) / count(up{job="kube-controller-manager",namespace="openshift-kube-controller-manager"})) * 100';
+export const SCHEDULERS_UP = '(sum(up{job="scheduler",namespace="openshift-kube-scheduler"} == 1) / count(up{job="scheduler",namespace="openshift-kube-scheduler"})) * 100';
 export const API_SERVER_REQUESTS_SUCCESS =
   '(1 - (sum(rate(apiserver_request_total{code=~"5.."}[5m])) or vector(0))/ sum(rate(apiserver_request_total[5m]))) * 100';
 


### PR DESCRIPTION
Control plane status should be calculated based on only hub cluster data not for the edge clusters