### PR TITLE
[release-4.17]OCPBUGS-60441: Filtering nodes in OCP 4.16-17 shows all the nodes in the cluster

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -44,6 +44,7 @@ import {
   referenceForModel,
   CertificateSigningRequestKind,
   referenceFor,
+  Selector,
 } from '@console/internal/module/k8s';
 import {
   getName,
@@ -655,7 +656,7 @@ const useWatchCSRs = (): [CertificateSigningRequestKind[], boolean, unknown] => 
   return [csrs, !checkIsLoading && loaded, error];
 };
 
-const NodesPage = () => {
+const NodesPage: React.FCC<NodesPageProps> = ({ selector }) => {
   const dispatch = useDispatch();
 
   const [selectedColumns, , userSettingsLoaded] = useUserSettingsCompatibility<TableColumnsType>(
@@ -671,6 +672,7 @@ const NodesPage = () => {
       version: 'v1',
     },
     isList: true,
+    selector,
   });
 
   const [csrs, csrsLoaded, csrsLoadError] = useWatchCSRs();
@@ -740,6 +742,10 @@ const NodesPage = () => {
       </>
     )
   );
+};
+
+type NodesPageProps = {
+  selector?: Selector;
 };
 
 export default NodesPage;

--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -45,7 +45,6 @@ import {
   CertificateSigningRequestKind,
   referenceFor,
   Selector,
-  Selector,
 } from '@console/internal/module/k8s';
 import {
   getName,

--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -45,6 +45,7 @@ import {
   CertificateSigningRequestKind,
   referenceFor,
   Selector,
+  Selector,
 } from '@console/internal/module/k8s';
 import {
   getName,


### PR DESCRIPTION
**Before:**
Filtering nodes in Openshift Web Console shows all the nodes in the cluster, when it should only filter the affected roles.

**Version-Release number of selected component (if applicable):**
4.16, 4.17 only

**Steps to reproduce:**

1. In OCP Console, Go to:
2. Compute > Nodes
3. Choose a Node,
4. In that Node, go to Details. 
5. Click on a role inside  Labels box, e.g. 
     "node-role.kubernetes.io/worker"
     
**After:**

https://github.com/user-attachments/assets/346add8c-5516-48bb-8923-bb348eaee952


