### PR TITLE
OCPBUGS-61139: Correct the ordering of Catalog categories to be alphabetized

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogView.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogView.tsx
@@ -154,7 +154,8 @@ const CatalogView: React.FC<CatalogViewProps> = ({
   const catalogCategories = React.useMemo<CatalogCategory[]>(() => {
     const allCategory = { id: ALL_CATEGORY, label: t('console-shared~All items') };
     const otherCategory = { id: OTHER_CATEGORY, label: t('console-shared~Other') };
-    return [allCategory, ...(categories ?? []), otherCategory];
+    const sortedCategories = [...(categories ?? [])].sort((a, b) => a.label.localeCompare(b.label));
+    return [allCategory, ...sortedCategories, otherCategory];
   }, [categories, t]);
 
   const categorizedIds = React.useMemo(() => categorize(items, catalogCategories), [


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-61139

After
<img width="271" height="744" alt="Screenshot 2025-09-02 at 5 23 31 PM" src="https://github.com/user-attachments/assets/917afd34-a53f-4c03-ae64-e2961a9ac228" />

