### PR TITLE
OCPBUGS-61087: Updation of label from edit label doesn't work

### DIFF
--- a/frontend/public/components/modals/labels-modal.tsx
+++ b/frontend/public/components/modals/labels-modal.tsx
@@ -43,6 +43,7 @@ const BaseLabelsModal: React.FC<BaseLabelsModalProps> = ({
     namespace: resource?.metadata?.namespace,
   });
   const [stale, setStale] = React.useState(false);
+  const [isInputValid, setIsInputValid] = React.useState(true);
   const createPath = !labels.length;
   const { t } = useTranslation();
 
@@ -111,6 +112,7 @@ const BaseLabelsModal: React.FC<BaseLabelsModalProps> = ({
             </label>
             <SelectorInput
               onChange={(l) => setLabels(l)}
+              onValidationChange={setIsInputValid}
               tags={labels}
               labelClassName={labelClassName || `co-m-${kind.id}`}
               autoFocus
@@ -127,7 +129,7 @@ const BaseLabelsModal: React.FC<BaseLabelsModalProps> = ({
         }
         inProgress={false}
         submitText={t('public~Save')}
-        submitDisabled={stale}
+        submitDisabled={stale || !isInputValid}
         cancel={cancel}
       />
     </form>

--- a/frontend/public/components/utils/selector-input.jsx
+++ b/frontend/public/components/utils/selector-input.jsx
@@ -24,9 +24,14 @@ export class SelectorInput extends Component {
     };
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     if (!_.isEqual(prevProps.tags, this.props.tags)) {
       this.setState({ tags: this.props.tags });
+    }
+
+    // Call onValidationChange callback when isInputValid changes
+    if (prevState.isInputValid !== this.state.isInputValid && this.props.onValidationChange) {
+      this.notifyValidationChange(this.state.isInputValid);
     }
   }
   static arrayify(obj) {
@@ -70,6 +75,12 @@ export class SelectorInput extends Component {
     return !!(requirement && (!this.isBasic || requirement.operator === 'Equals'));
   }
 
+  notifyValidationChange = (isValid) => {
+    if (this.props.onValidationChange) {
+      this.props.onValidationChange(isValid);
+    }
+  };
+
   handleInputChange(e) {
     // We track the input field value in state so we can retain the input value when an invalid tag is entered.
     // Otherwise, the default behaviour of TagsInput is to clear the input field.
@@ -81,7 +92,8 @@ export class SelectorInput extends Component {
       return;
     }
 
-    this.setState({ inputValue, isInputValid: this.isTagValid(inputValue) });
+    const isValid = this.isTagValid(inputValue);
+    this.setState({ inputValue, isInputValid: isValid });
   }
 
   handleChange(tags, changed) {


### PR DESCRIPTION
Resolved a bug that allowed non-valid input to be submitted. Previously, if the invalid input contained keys that matched existing labels, those labels would be mistakenly deleted. This update prevents the submission of invalid data, protecting your labels from being removed. The label modals `save` button is only enabled once there is at least one valid label entered.
before:

https://github.com/user-attachments/assets/ee3884d3-6ce0-4c9e-bc1a-e7ce99f3bfab



after:

https://github.com/user-attachments/assets/bde5ccdb-a53c-495a-8f7e-28217855637f

