### PR TITLE
CONSOLE-4727: Update OWNERS files across the repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,6 @@ reviewers:
   - rhamilto
   - spadgett
 approvers:
-  - christoph-jerolimov
   - jhadvig
   - rhamilto
   - spadgett

--- a/cmd/OWNERS
+++ b/cmd/OWNERS
@@ -1,6 +1,7 @@
 reviewers:
   - TheRealJon
   - jhadvig
+  - Leo6Leo
 approvers:
   - TheRealJon
   - jhadvig

--- a/dynamic-demo-plugin/OWNERS
+++ b/dynamic-demo-plugin/OWNERS
@@ -1,15 +1,2 @@
-reviewers:
-  - glekner
-  - rawagner
-  - spadgett
-  - vojtechszocs
-approvers:
-  - christoph-jerolimov
-  - invincibleJai
-  - jhadvig
-  - kyoto
-  - rawagner
-  - rhamilto
-  - rohitkrai03
-  - spadgett
-  - vojtechszocs
+labels:
+  - kind/demo-plugin

--- a/frontend/OWNERS
+++ b/frontend/OWNERS
@@ -1,17 +1,17 @@
 reviewers:
   - jhadvig
-  - kyoto
   - rhamilto
   - spadgett
   - TheRealJon
   - cajieh
+  - logonoff
   - Mylanos
+  - Leo6Leo
+  - krishagarwal278
+  - sg00dwin
 approvers:
-  - christoph-jerolimov
   - cajieh
-  - invincibleJai
   - jhadvig
-  - kyoto
   - rawagner
   - rhamilto
   - spadgett

--- a/frontend/packages/console-app/locales/OWNERS
+++ b/frontend/packages/console-app/locales/OWNERS
@@ -1,6 +1,2 @@
-reviewers:
-  - cajieh
-approvers:
-  - jotak
 labels:
   - kind/i18n

--- a/frontend/packages/console-dynamic-plugin-sdk/OWNERS
+++ b/frontend/packages/console-dynamic-plugin-sdk/OWNERS
@@ -1,8 +1,2 @@
-reviewers:
-  - spadgett
-  - vojtechszocs
-approvers:
-  - spadgett
-  - vojtechszocs
 labels:
   - component/sdk

--- a/frontend/packages/console-plugin-sdk/OWNERS
+++ b/frontend/packages/console-plugin-sdk/OWNERS
@@ -1,8 +1,2 @@
-reviewers:
-  - spadgett
-  - vojtechszocs
-approvers:
-  - spadgett
-  - vojtechszocs
 labels:
   - component/sdk

--- a/frontend/packages/console-plugin-shared/OWNERS
+++ b/frontend/packages/console-plugin-shared/OWNERS
@@ -1,12 +1,2 @@
-reviewers:
-  - spadgett
-  - vojtechszocs
-  - mareklibra
-  - rawagner
-approvers:
-  - spadgett
-  - vojtechszocs
-  - mareklibra
-  - rawagner
 labels:
   component/plugin-shared

--- a/frontend/packages/console-telemetry-plugin/OWNERS
+++ b/frontend/packages/console-telemetry-plugin/OWNERS
@@ -1,17 +1,2 @@
-reviewers:
-  - christoph-jerolimov
-  - lokanandaprabhu
-  - vikram-raj
-approvers:
-  - christoph-jerolimov
-  - debsmita1
-  - divyanshiGupta
-  - invincibleJai
-  - karthikjeeyar
-  - lokanandaprabhu
-  - lucifergene
-  - rohitkrai03
-  - sahil143
-  - vikram-raj
 labels:
   - component/telemetry

--- a/frontend/packages/dev-console/OWNERS
+++ b/frontend/packages/dev-console/OWNERS
@@ -1,17 +1,2 @@
-reviewers:
-  - jerolimov
-  - lokanandaprabhu
-  - vikram-raj
-approvers:
-  - debsmita1
-  - divyanshiGupta
-  - invincibleJai
-  - jerolimov
-  - karthikjeeyar
-  - lokanandaprabhu
-  - lucifergene
-  - rohitkrai03
-  - sahil143
-  - vikram-raj
 labels:
   - component/dev-console

--- a/frontend/packages/git-service/OWNERS
+++ b/frontend/packages/git-service/OWNERS
@@ -1,18 +1,2 @@
-reviewers:
-  - jerolimov
-  - lokanandaprabhu
-  - vikram-raj
-approvers:
-  - debsmita1
-  - divyanshiGupta
-  - invincibleJai
-  - jerolimov
-  - karthikjeeyar
-  - lokanandaprabhu
-  - lucifergene
-  - rohitkrai03
-  - sahil143
-  - vikram-raj
 labels:
-  - component/dev-console
   - component/git-service

--- a/frontend/packages/gitops-plugin/OWNERS
+++ b/frontend/packages/gitops-plugin/OWNERS
@@ -1,17 +1,2 @@
-reviewers:
-  - christoph-jerolimov
-  - lokanandaprabhu
-  - vikram-raj
-approvers:
-  - christoph-jerolimov
-  - debsmita1
-  - divyanshiGupta
-  - invincibleJai
-  - karthikjeeyar
-  - lokanandaprabhu
-  - lucifergene
-  - rohitkrai03
-  - sahil143
-  - vikram-raj
 labels:
   - component/gitops

--- a/frontend/packages/helm-plugin/OWNERS
+++ b/frontend/packages/helm-plugin/OWNERS
@@ -1,17 +1,2 @@
-reviewers:
-  - christoph-jerolimov
-  - lokanandaprabhu
-  - vikram-raj
-approvers:
-  - christoph-jerolimov
-  - debsmita1
-  - divyanshiGupta
-  - invincibleJai
-  - karthikjeeyar
-  - lokanandaprabhu
-  - lucifergene
-  - rohitkrai03
-  - sahil143
-  - vikram-raj
 labels:
   - component/helm

--- a/frontend/packages/integration-tests-cypress/OWNERS
+++ b/frontend/packages/integration-tests-cypress/OWNERS
@@ -1,12 +1,2 @@
-reviewers:
-  - rhamilto
-  - TheRealJon
-  - jhadvig
-  - cajieh
-approvers:
-  - rhamilto
-  - TheRealJon
-  - jhadvig
-  - cajieh
 labels:
   - kind/cypress

--- a/frontend/packages/knative-plugin/OWNERS
+++ b/frontend/packages/knative-plugin/OWNERS
@@ -1,17 +1,2 @@
-reviewers:
-  - christoph-jerolimov
-  - lokanandaprabhu
-  - vikram-raj
-approvers:
-  - christoph-jerolimov
-  - debsmita1
-  - divyanshiGupta
-  - invincibleJai
-  - karthikjeeyar
-  - lokanandaprabhu
-  - lucifergene
-  - rohitkrai03
-  - sahil143
-  - vikram-raj
 labels:
   - component/knative

--- a/frontend/packages/operator-lifecycle-manager-v1/OWNERS
+++ b/frontend/packages/operator-lifecycle-manager-v1/OWNERS
@@ -1,10 +1,2 @@
-reviewers:
-  - TheRealJon
-  - rhamilto
-  - jhadvig
-approvers:
-  - TheRealJon
-  - rhamilto
-  - jhadvig
 labels:
   - component/olm

--- a/frontend/packages/operator-lifecycle-manager/OWNERS
+++ b/frontend/packages/operator-lifecycle-manager/OWNERS
@@ -1,8 +1,2 @@
-reviewers:
-  - TheRealJon
-  - spadgett
-approvers:
-  - TheRealJon
-  - spadgett
 labels:
   - component/olm

--- a/frontend/packages/pipelines-plugin/OWNERS
+++ b/frontend/packages/pipelines-plugin/OWNERS
@@ -1,18 +1,2 @@
-reviewers:
-  - christoph-jerolimov
-  - karthikjeeyar
-  - lokanandaprabhu
-  - vikram-raj
-approvers:
-  - christoph-jerolimov
-  - debsmita1
-  - divyanshiGupta
-  - invincibleJai
-  - karthikjeeyar
-  - lokanandaprabhu
-  - lucifergene
-  - rohitkrai03
-  - sahil143
-  - vikram-raj
 labels:
   - component/pipelines

--- a/frontend/packages/shipwright-plugin/OWNERS
+++ b/frontend/packages/shipwright-plugin/OWNERS
@@ -1,17 +1,2 @@
-reviewers:
-  - christoph-jerolimov
-  - lokanandaprabhu
-  - vikram-raj
-approvers:
-  - christoph-jerolimov
-  - debsmita1
-  - divyanshiGupta
-  - invincibleJai
-  - karthikjeeyar
-  - lokanandaprabhu
-  - lucifergene
-  - rohitkrai03
-  - sahil143
-  - vikram-raj
 labels:
   - component/shipwright

--- a/frontend/packages/topology/OWNERS
+++ b/frontend/packages/topology/OWNERS
@@ -1,17 +1,2 @@
-reviewers:
-  - christoph-jerolimov
-  - lokanandaprabhu
-  - vikram-raj
-approvers:
-  - christoph-jerolimov
-  - debsmita1
-  - divyanshiGupta
-  - invincibleJai
-  - karthikjeeyar
-  - lokanandaprabhu
-  - lucifergene
-  - rohitkrai03
-  - sahil143
-  - vikram-raj
 labels:
   - component/topology

--- a/frontend/packages/webterminal-plugin/OWNERS
+++ b/frontend/packages/webterminal-plugin/OWNERS
@@ -1,17 +1,2 @@
-reviewers:
-  - christoph-jerolimov
-  - lokanandaprabhu
-  - vikram-raj
-approvers:
-  - christoph-jerolimov
-  - debsmita1
-  - divyanshiGupta
-  - invincibleJai
-  - karthikjeeyar
-  - lokanandaprabhu
-  - lucifergene
-  - rohitkrai03
-  - sahil143
-  - vikram-raj
 labels:
   - component/webterminal

--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -1,6 +1,7 @@
 reviewers:
   - TheRealJon
   - jhadvig
+  - Leo6Leo
 approvers:
   - TheRealJon
   - jhadvig

--- a/pkg/helm/OWNERS
+++ b/pkg/helm/OWNERS
@@ -1,9 +1,4 @@
 approvers:
 - baijum
-- webbnh
-- dperaza4dustbit
-
 reviewers:
 - baijum
-- webbnh
-- dperaza4dustbit


### PR DESCRIPTION
Acceptance Criteria:

**Static plugins:**
- In plugins owned by the Console team, remove the approvers and reviewers sections.
- Keep only the labels section for ownership tracking.

**Helm plugin:**
- Update the OWNERS file with the correct maintainers from the Helm team.

**Public folder:**
- Review the OWNERS file under _frontend/_ and Remove inactive owners who are no longer participating.

/assign @rhamilto 