### PR TITLE
[release-4.17] OCPBUGS-52372: VolumeSnapshots are not displayed in OpenShift Web Console

### DIFF
--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
@@ -214,13 +214,12 @@ const VolumeSnapshotTable: React.FC<VolumeSnapshotTableProps> = (props) => {
 const VolumeSnapshotPage: React.FC<VolumeSnapshotPageProps> = ({
   canCreate = true,
   showTitle = true,
-  namespace = 'default',
+  namespace,
 }) => {
   const { t } = useTranslation();
   const canListVSC = useFlag(FLAGS.CAN_LIST_VSC);
 
-  const createPath = `/k8s/ns/${namespace}/${VolumeSnapshotModel.plural}/~new/form`;
-
+  const createPath = `/k8s/ns/${namespace || 'default'}/${VolumeSnapshotModel.plural}/~new/form`;
   const [resources, loaded, loadError] = useK8sWatchResource<VolumeSnapshotKind[]>({
     groupVersionKind: {
       group: VolumeSnapshotModel.apiGroup,


### PR DESCRIPTION
after:
<img width="1217" height="612" alt="Screenshot 2025-09-05 at 13 14 17" src="https://github.com/user-attachments/assets/c4fdc94c-f562-42e9-a746-48801d3344c7" />
