### PR TITLE
OCPBUGS-58118: fix namespace path generation for non-namespaced resources

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-utils.ts
@@ -31,7 +31,7 @@ const getK8sAPIPath = ({ apiGroup = 'core', apiVersion }: K8sModel): string => {
 export const getK8sResourcePath = (model: K8sModel, options: Options): string => {
   let u = getK8sAPIPath(model);
 
-  if (options.ns) {
+  if (model.namespaced && options.ns) {
     u += `/namespaces/${options.ns}`;
   }
   u += `/${model.plural}`;


### PR DESCRIPTION

Only add namespace path segment when the resource model is actually namespaced. This prevents incorrect API paths for cluster-scoped resources.

🤖 Generated with [Claude Code](https://claude.ai/code)