### PR TITLE
CONSOLE-4710: use useOverlay to launch ErrorModal

### DIFF
--- a/frontend/packages/console-app/src/actions/hooks/useBuildsActions.ts
+++ b/frontend/packages/console-app/src/actions/hooks/useBuildsActions.ts
@@ -3,9 +3,10 @@ import { ButtonVariant } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { redirect } from 'react-router-dom-v5-compat';
 import { Action } from '@console/dynamic-plugin-sdk';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import { k8sPatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s';
 import { useDeepCompareMemoize } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useDeepCompareMemoize';
-import { errorModal } from '@console/internal/components/modals';
+import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import { asAccessReview, resourceObjPath } from '@console/internal/components/utils';
 import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 import { cloneBuild } from '@console/internal/module/k8s/builds';
@@ -76,6 +77,7 @@ export const useBuildsActions = (
   );
 
   const cancelBuildModal = useWarningModal(warningModalProps);
+  const launchModal = useOverlay();
 
   const factory = useMemo(
     () => ({
@@ -89,7 +91,7 @@ export const useBuildsActions = (
             })
             .catch((err) => {
               const error = err.message;
-              errorModal({ error });
+              launchModal(ErrorModal, { error });
             }),
         accessReview: {
           group: kindObj.apiGroup,
@@ -107,7 +109,7 @@ export const useBuildsActions = (
         accessReview: asAccessReview(kindObj, obj, 'patch'),
       }),
     }),
-    [t, obj, kindObj, cancelBuildModal],
+    [t, kindObj, obj, launchModal, cancelBuildModal],
   );
 
   const buildPhase = obj.status?.phase;

--- a/frontend/packages/console-app/src/actions/hooks/useRetryRolloutAction.ts
+++ b/frontend/packages/console-app/src/actions/hooks/useRetryRolloutAction.ts
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Action, K8sResourceCommon } from '@console/dynamic-plugin-sdk';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import { k8sPatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-resource';
-import { errorModal } from '@console/internal/components/modals';
+import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import {
   DeploymentConfigKind,
@@ -63,6 +64,7 @@ const useReplicationController = (resource: DeploymentConfigKind) => {
 
 export const useRetryRolloutAction = (resource: DeploymentConfigKind): Action => {
   const { t } = useTranslation();
+  const launchModal = useOverlay();
   const [dcModel] = useK8sModel(referenceFor(resource));
   const [rcModel] = useK8sModel('ReplicationController');
   const [rc] = useReplicationController(resource);
@@ -76,7 +78,8 @@ export const useRetryRolloutAction = (resource: DeploymentConfigKind): Action =>
     () => ({
       id: 'retry-rollout',
       label: t('console-app~Retry rollout'),
-      cta: () => retryRollout(rcModel, rc).catch((err) => errorModal({ error: err.message })),
+      cta: () =>
+        retryRollout(rcModel, rc).catch((err) => launchModal(ErrorModal, { error: err.message })),
       insertAfter: 'start-rollout',
       disabled: !canRetry,
       disabledTooltip: !canRetry
@@ -92,6 +95,6 @@ export const useRetryRolloutAction = (resource: DeploymentConfigKind): Action =>
         verb: 'patch',
       },
     }),
-    [t, dcModel, rcModel, rc, canRetry, resource],
+    [t, dcModel, rcModel, rc, canRetry, resource, launchModal],
   );
 };

--- a/frontend/packages/console-app/src/actions/providers/storageclass-provider.ts
+++ b/frontend/packages/console-app/src/actions/providers/storageclass-provider.ts
@@ -2,11 +2,12 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/api/dynamic-core-api';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import {
   getGroupVersionKindForModel,
   k8sPatchResource,
 } from '@console/dynamic-plugin-sdk/src/utils/k8s';
-import { errorModal } from '@console/internal/components/modals';
+import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import { defaultClassAnnotation } from '@console/internal/components/storage-class';
 import { asAccessReview } from '@console/internal/components/utils';
 import { K8sResourceCommon, K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
@@ -17,6 +18,7 @@ export const useStorageClassActions = (
   storageClass: K8sResourceKind,
 ): [Action[], boolean, boolean] => {
   const { t } = useTranslation();
+  const launchModal = useOverlay();
   const [storageClassModel, inFlight] = useK8sModel(referenceFor(storageClass));
   const commonActions = useCommonResourceActions(storageClassModel, storageClass);
   const [storageClasses] = useK8sWatchResource<K8sResourceCommon[]>({
@@ -77,7 +79,7 @@ export const useStorageClassActions = (
                 resource: existingDefaultStorageClass,
               });
           } catch (error) {
-            errorModal({ error });
+            launchModal(ErrorModal, { error: error.message });
           }
         },
         id: 'make-default-storageclass',
@@ -93,6 +95,7 @@ export const useStorageClassActions = (
       existingDefaultStorageClass,
       isDefaultStorageClass,
       commonActions,
+      launchModal,
     ],
   );
 

--- a/frontend/packages/console-app/src/components/nodes/status/SchedulableStatus.tsx
+++ b/frontend/packages/console-app/src/components/nodes/status/SchedulableStatus.tsx
@@ -7,7 +7,8 @@ import {
   StatusIconAndText,
   YellowExclamationTriangleIcon,
 } from '@console/dynamic-plugin-sdk';
-import { errorModal } from '@console/internal/components/modals';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
+import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import { makeNodeSchedulable } from '../../../k8s/requests/nodes';
 
 type NodeStatusResources = {};
@@ -19,13 +20,16 @@ export const MarkAsSchedulablePopover: React.FC<NodePopoverContentProps<NodeStat
   node,
 }) => {
   const { t } = useTranslation();
+  const launchModal = useOverlay();
   const [isExpanded, setExpanded] = React.useState(true);
 
   const onClickMarkAsSchedulable = async () => {
     try {
       await makeNodeSchedulable(node);
     } catch (err) {
-      errorModal({ error: err.message || t('console-app~An error occurred. Please try again') });
+      launchModal(ErrorModal, {
+        error: err.message || t('console-app~An error occurred. Please try again'),
+      });
     }
   };
 

--- a/frontend/packages/console-shared/src/components/formik-fields/EnvironmentField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/EnvironmentField.tsx
@@ -3,7 +3,8 @@ import { FormGroup, FormHelperText, HelperText, HelperTextItem } from '@patternf
 import { useFormikContext, FormikValues } from 'formik';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { errorModal } from '@console/internal/components/modals';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
+import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import { NameValueEditor } from '@console/internal/components/utils/name-value-editor';
 import { SecretModel, ConfigMapModel } from '@console/internal/models';
 import { k8sGet } from '@console/internal/module/k8s';
@@ -24,6 +25,7 @@ const EnvironmentField: React.FC<EnvironmentFieldProps> = ({
   } = props;
   const { setFieldValue, values } = useFormikContext<FormikValues>();
   const { t } = useTranslation();
+  const launchModal = useOverlay();
   const fieldId = getFieldId(props.name, 'env-input');
   const environmentVariables = React.useMemo(() => {
     return _.isEmpty(envs) ? [['', '']] : envs.map((env) => _.values(env));
@@ -67,12 +69,12 @@ const EnvironmentField: React.FC<EnvironmentFieldProps> = ({
       .catch(async (err) => {
         if (err?.response?.status !== 403) {
           try {
-            await errorModal({ error: err?.message });
+            await launchModal(ErrorModal, { error: err?.message });
             // eslint-disable-next-line no-empty
           } catch (e) {}
         }
       });
-  }, [namespace]);
+  }, [namespace, launchModal]);
 
   return (
     <FormGroup fieldId={fieldId} label={label} isRequired={required}>

--- a/frontend/packages/knative-plugin/src/components/add/SecretKeySelector.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/SecretKeySelector.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { FormGroup, FormHelperText, HelperText, HelperTextItem } from '@patternfly/react-core';
 import { useFormikContext, FormikValues, useField } from 'formik';
 import { connect } from 'react-redux';
-import { errorModal } from '@console/internal/components/modals/error-modal';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
+import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import { ValueFromPair } from '@console/internal/components/utils/value-from-pair';
 import { SecretModel } from '@console/internal/models';
 import { k8sGet } from '@console/internal/module/k8s';
@@ -29,6 +30,7 @@ const SecretKeySelector: React.FC<SecretKeySelectorProps & StateProps> = ({
   const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
   const [field, { touched, error }] = useField(name);
   const [secrets, setSecrets] = React.useState({});
+  const launchModal = useOverlay();
   const fieldId = getFieldId(name, 'secret-key-input');
   const isValid = !(touched && error);
 
@@ -52,10 +54,10 @@ const SecretKeySelector: React.FC<SecretKeySelectorProps & StateProps> = ({
       })
       .catch((err) => {
         if (err?.response?.status !== 403) {
-          errorModal({ error: err?.message });
+          launchModal(ErrorModal, { error: err?.message });
         }
       });
-  }, [namespace]);
+  }, [namespace, launchModal]);
 
   return (
     <FormGroup fieldId={fieldId} label={label} isRequired={isRequired}>

--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useParams, Link } from 'react-router-dom-v5-compat';
 import { getUser } from '@console/dynamic-plugin-sdk';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import { Conditions } from '@console/internal/components/conditions';
 import {
   MultiListPage,
@@ -29,7 +30,7 @@ import {
   TableData,
   RowFunctionArgs,
 } from '@console/internal/components/factory';
-import { errorModal } from '@console/internal/components/modals';
+import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import {
   SectionHeading,
   ConsoleEmptyState,
@@ -411,6 +412,7 @@ export const InstallPlanPreview: React.FC<InstallPlanPreviewProps> = ({
   hideApprovalBlock,
 }) => {
   const { t } = useTranslation();
+  const launchModal = useOverlay();
   const [needsApproval, setNeedsApproval] = React.useState(
     obj.spec.approval === InstallPlanApproval.Manual && obj.spec.approved === false,
   );
@@ -429,7 +431,7 @@ export const InstallPlanPreview: React.FC<InstallPlanPreviewProps> = ({
   const approve = () =>
     k8sPatch(InstallPlanModel, obj, [{ op: 'replace', path: '/spec/approved', value: true }])
       .then(() => setNeedsApproval(false))
-      .catch((error) => errorModal({ error: error.toString() }));
+      .catch((error) => launchModal(ErrorModal, { error: error.toString() }));
 
   const stepStatus = (status: Step['status']) => (
     <>

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
@@ -14,8 +14,9 @@ import { useTranslation } from 'react-i18next';
 import { useParams, Link, LinkProps } from 'react-router-dom-v5-compat';
 import { ResourceStatus, StatusIconAndText } from '@console/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/api/core-api';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import { SyncMarkdownView } from '@console/internal/components/markdown-view';
-import { errorModal } from '@console/internal/components/modals';
+import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import {
   Firehose,
   FirehoseResult,
@@ -246,8 +247,9 @@ const InstallSucceededMessage: React.FC<InstallSuccededMessageProps> = ({
   obj,
 }) => {
   const { t } = useTranslation();
+  const launchModal = useOverlay();
   const annotationParserOptions = {
-    onError: (error) => errorModal({ error }),
+    onError: (error) => launchModal(ErrorModal, { error }),
   };
   const initializationLink = getInitializationLink(obj?.metadata?.annotations);
   const initializationResource =
@@ -292,10 +294,11 @@ const InstallSucceededMessage: React.FC<InstallSuccededMessageProps> = ({
 
 const InstallingMessage: React.FC<InstallingMessageProps> = ({ namespace, obj }) => {
   const { t } = useTranslation();
+  const launchModal = useOverlay();
   const reason = (obj as ClusterServiceVersionKind)?.status?.reason || '';
   const message = (obj as ClusterServiceVersionKind)?.status?.message || '';
   const annotationParserOpts = {
-    onError: (error) => errorModal({ error }),
+    onError: (error) => launchModal(ErrorModal, { error }),
   };
   const initializationLink = getInitializationLink(obj?.metadata?.annotations);
   const initializationResource =
@@ -389,6 +392,7 @@ const OperatorInstallLogo = ({ subscription }) => {
 
 const OperatorInstallStatus: React.FC<OperatorInstallPageProps> = ({ resources }) => {
   const { t } = useTranslation();
+  const launchModal = useOverlay();
   const { currentCSV, targetNamespace } = useParams<OperatorInstallStatusPageRouteParams>();
   let loading = true;
   let status = '';
@@ -420,7 +424,7 @@ const OperatorInstallStatus: React.FC<OperatorInstallPageProps> = ({ resources }
     k8sPatch(InstallPlanModel, installObj, [
       { op: 'replace', path: '/spec/approved', value: true },
     ]).catch((error) => {
-      errorModal({ error: error.toString() });
+      launchModal(ErrorModal, { error: error.toString() });
     });
   };
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { Formik } from 'formik';
 import { useTranslation } from 'react-i18next';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import {
   createModalLauncher,
   ModalComponentProps,
 } from '@console/internal/components/factory/modal';
-import { errorModal } from '@console/internal/components/modals';
+import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import { LoadingBox } from '@console/internal/components/utils';
 import { PipelineKind, PipelineRunKind } from '../../../../types';
 import { useUserAnnotationForManualStart } from '../../../pipelineruns/triggered-by';
@@ -27,6 +28,7 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
   onSubmit,
 }) => {
   const { t } = useTranslation();
+  const launchModal = useOverlay();
   const userStartedAnnotation = useUserAnnotationForManualStart();
   const [pipelinePVC, pipelinePVCLoaded] = usePipelinePVC(
     pipeline.metadata?.name,
@@ -50,7 +52,7 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
       })
       .catch((err) => {
         actions.setStatus({ submitError: err.message });
-        errorModal({ error: err.message });
+        launchModal(ErrorModal, { error: err.message });
         close();
       });
   };

--- a/frontend/packages/shipwright-plugin/src/actions/useBuildActions.ts
+++ b/frontend/packages/shipwright-plugin/src/actions/useBuildActions.ts
@@ -3,8 +3,9 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { CommonActionCreator } from '@console/app/src/actions/hooks/types';
 import { useCommonActions } from '@console/app/src/actions/hooks/useCommonActions';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import { Action } from '@console/dynamic-plugin-sdk/src/extensions/actions';
-import { errorModal } from '@console/internal/components/modals';
+import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import { resourceObjPath } from '@console/internal/components/utils';
 import { referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
@@ -15,6 +16,7 @@ import { Build } from '../types';
 const useBuildActions = (build: Build) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const launchModal = useOverlay();
   const [kindObj, inFlight] = useK8sModel(referenceFor(build));
   const [commonActions, isReady] = useCommonActions(kindObj, build, [
     CommonActionCreator.ModifyLabels,
@@ -36,7 +38,7 @@ const useBuildActions = (build: Build) => {
             navigate(resourceObjPath(newBuildRun, referenceFor(newBuildRun)));
           })
           .catch((err) => {
-            errorModal({ error: err.message });
+            launchModal(ErrorModal, { error: err.message });
           });
       },
       accessReview: {
@@ -59,7 +61,7 @@ const useBuildActions = (build: Build) => {
             })
             .catch((err) => {
               const error = err.message;
-              errorModal({ error });
+              launchModal(ErrorModal, { error });
             });
         },
         accessReview: {
@@ -86,7 +88,7 @@ const useBuildActions = (build: Build) => {
     });
     actions.push(commonActions.Delete);
     return actions;
-  }, [t, build, navigate, commonActions, isReady]);
+  }, [t, build, navigate, commonActions, isReady, launchModal]);
 
   return [actionsMenu, !inFlight, undefined];
 };

--- a/frontend/packages/shipwright-plugin/src/actions/useBuildRunActions.ts
+++ b/frontend/packages/shipwright-plugin/src/actions/useBuildRunActions.ts
@@ -2,8 +2,9 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { useCommonResourceActions } from '@console/app/src/actions//hooks/useCommonResourceActions';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import { Action } from '@console/dynamic-plugin-sdk/src/extensions/actions';
-import { errorModal } from '@console/internal/components/modals';
+import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import { resourceObjPath } from '@console/internal/components/utils';
 import { referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
@@ -14,6 +15,7 @@ import { BuildRun } from '../types';
 const useBuildRunActions = (buildRun: BuildRun) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const launchModal = useOverlay();
   const [kindObj, inFlight] = useK8sModel(referenceFor(buildRun));
   const commonActions = useCommonResourceActions(kindObj, buildRun);
 
@@ -28,7 +30,7 @@ const useBuildRunActions = (buildRun: BuildRun) => {
           })
           .catch((err) => {
             const error = err.message;
-            errorModal({ error });
+            launchModal(ErrorModal, { error });
           });
       },
       accessReview: {
@@ -40,7 +42,7 @@ const useBuildRunActions = (buildRun: BuildRun) => {
     };
 
     return [...(canRerunBuildRun(buildRun) ? [rerun] : []), ...commonActions];
-  }, [t, buildRun, navigate, commonActions]);
+  }, [t, buildRun, navigate, commonActions, launchModal]);
 
   return [actions, !inFlight, undefined];
 };

--- a/frontend/packages/shipwright-plugin/src/components/build-tabsection/StartBuildButton.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/build-tabsection/StartBuildButton.tsx
@@ -3,7 +3,8 @@ import { Button } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { impersonateStateToProps, useAccessReview } from '@console/dynamic-plugin-sdk';
-import { errorModal } from '@console/internal/components/modals';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
+import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import { AccessReviewResourceAttributes } from '@console/internal/module/k8s';
 import { startBuild } from '../../api';
 import { BuildRunModel } from '../../models';
@@ -28,6 +29,7 @@ const StartBuildButton: React.FC<StartBuildButtonProps & StateProps> = ({
   impersonate,
 }) => {
   const { t } = useTranslation();
+  const launchModal = useOverlay();
   const defaultAccessReview: AccessReviewResourceAttributes = {
     group: BuildRunModel.apiGroup,
     resource: BuildRunModel.plural,
@@ -39,7 +41,7 @@ const StartBuildButton: React.FC<StartBuildButtonProps & StateProps> = ({
   const onClick = () => {
     startBuild(build).catch((err) => {
       const error = err.message;
-      errorModal({ error });
+      launchModal(ErrorModal, { error });
     });
   };
 

--- a/frontend/packages/shipwright-plugin/src/components/build-tabsection/TriggerLastBuildButton.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/build-tabsection/TriggerLastBuildButton.tsx
@@ -3,7 +3,8 @@ import { Button } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { impersonateStateToProps, useAccessReview } from '@console/dynamic-plugin-sdk';
-import { errorModal } from '@console/internal/components/modals';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
+import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import { AccessReviewResourceAttributes, K8sResourceKind } from '@console/internal/module/k8s';
 import { canRerunBuildRun, rerunBuildRun } from '../../api';
 import { BuildRunModel } from '../../models';
@@ -24,6 +25,7 @@ const TriggerLastBuildButton: React.FC<TriggerLastBuildButtonProps> = ({
   impersonate,
 }) => {
   const { t } = useTranslation();
+  const launchModal = useOverlay();
   const defaultAccessReview: AccessReviewResourceAttributes = {
     group: BuildRunModel.apiGroup,
     resource: BuildRunModel.plural,
@@ -36,7 +38,7 @@ const TriggerLastBuildButton: React.FC<TriggerLastBuildButtonProps> = ({
   const onClick = () => {
     rerunBuildRun(latestBuildRun).catch((err) => {
       const error = err.message;
-      errorModal({ error });
+      launchModal(ErrorModal, { error });
     });
   };
 

--- a/frontend/packages/topology/src/components/workload/BuildOverview.tsx
+++ b/frontend/packages/topology/src/components/workload/BuildOverview.tsx
@@ -4,8 +4,9 @@ import { SyncAltIcon } from '@patternfly/react-icons/dist/esm/icons/sync-alt-ico
 import { Trans, useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
 import { StatusIconAndText } from '@console/dynamic-plugin-sdk';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import { BuildLogLink, BuildNumberLink } from '@console/internal/components/build';
-import { errorModal } from '@console/internal/components/modals/error-modal';
+import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import {
   ResourceLink,
   resourcePath,
@@ -127,6 +128,7 @@ const BuildOverviewList: React.FC<BuildOverviewListProps> = ({ buildConfig }) =>
     builds,
   } = buildConfig;
   const { t } = useTranslation();
+  const launchModal = useOverlay();
 
   const canStartBuild = useAccessReview({
     group: BuildConfigModel.apiGroup,
@@ -139,7 +141,7 @@ const BuildOverviewList: React.FC<BuildOverviewListProps> = ({ buildConfig }) =>
   const onClick = () => {
     startBuild(buildConfig).catch((err) => {
       const error = err.message;
-      errorModal({ error });
+      launchModal(ErrorModal, { error });
     });
   };
   return (

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -37,12 +37,7 @@ import PaneBody from '@console/shared/src/components/layout/PaneBody';
 import PaneBodyGroup from '@console/shared/src/components/layout/PaneBodyGroup';
 
 import { ClusterOperatorPage } from './cluster-operator';
-import {
-  clusterChannelModal,
-  clusterMoreUpdatesModal,
-  clusterUpdateModal,
-  errorModal,
-} from '../modals';
+import { clusterChannelModal, clusterMoreUpdatesModal, clusterUpdateModal } from '../modals';
 import { GlobalConfigPage } from './global-config';
 import {
   ClusterAutoscalerModel,
@@ -128,6 +123,8 @@ import {
 } from '../utils/service-level';
 import { hasAvailableUpdates, hasNotRecommendedUpdates } from '../../module/k8s/cluster-settings';
 import { UpdateStatus } from './cluster-status';
+import { ErrorModal } from '../modals/error-modal';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 
 export const clusterAutoscalerReference = referenceForModel(ClusterAutoscalerModel);
 
@@ -472,6 +469,7 @@ export const NodesUpdatesGroup: React.FC<NodesUpdatesGroupProps> = ({
   name,
   updateStartedTime,
 }) => {
+  const launchModal = useOverlay();
   const [machineConfigOperator, machineConfigOperatorLoaded] = useK8sWatchResource<ClusterOperator>(
     {
       kind: referenceForModel(ClusterOperatorModel),
@@ -546,7 +544,7 @@ export const NodesUpdatesGroup: React.FC<NodesUpdatesGroupProps> = ({
               className="pf-v6-u-mt-md"
               onClick={() =>
                 togglePaused(MachineConfigPoolModel, machineConfigPool).catch((err) =>
-                  errorModal({ error: err.message }),
+                  launchModal(ErrorModal, { error: err.message }),
                 )
               }
               data-test="mcp-paused-button"

--- a/frontend/public/components/cluster-settings/cluster-status.tsx
+++ b/frontend/public/components/cluster-settings/cluster-status.tsx
@@ -22,8 +22,9 @@ import {
   k8sPatch,
   K8sResourceConditionStatus,
 } from '../../module/k8s';
-import { errorModal } from '../modals';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import { resourcePathFromModel, truncateMiddle } from '../utils';
+import { ErrorModal, ErrorModalProps } from '../modals/error-modal';
 
 export const ClusterVersionConditionsLink: React.FC<ClusterVersionConditionsLinkProps> = ({
   cv,
@@ -39,11 +40,14 @@ export const ClusterVersionConditionsLink: React.FC<ClusterVersionConditionsLink
   );
 };
 
-const cancelUpdate = (cv: ClusterVersionKind) => {
+const cancelUpdate = (
+  cv: ClusterVersionKind,
+  launchModal: (element: React.FC<ErrorModalProps>, props: ErrorModalProps) => void,
+) => {
   k8sPatch(ClusterVersionModel, cv, [{ path: '/spec/desiredUpdate', op: 'remove' }]).catch(
     (err) => {
       const error = err.message;
-      errorModal({ error });
+      launchModal(ErrorModal, { error });
     },
   );
 };
@@ -60,12 +64,17 @@ const StatusMessagePopover: React.FC<CVStatusMessagePopoverProps> = ({ bodyConte
 
 const InvalidMessage: React.FC<CVStatusMessageProps> = ({ cv }) => {
   const { t } = useTranslation();
+  const launchModal = useOverlay();
   return (
     <div data-test="cv-update-status-invalid">
       <div>
         <RedExclamationCircleIcon /> {t('public~Invalid cluster version')}
       </div>
-      <Button onClick={() => cancelUpdate(cv)} variant="primary" className="pf-v6-u-mt-xs">
+      <Button
+        onClick={() => cancelUpdate(cv, launchModal)}
+        variant="primary"
+        className="pf-v6-u-mt-xs"
+      >
         {t('public~Cancel update')}
       </Button>
     </div>

--- a/frontend/public/components/edit-yaml.tsx
+++ b/frontend/public/components/edit-yaml.tsx
@@ -40,7 +40,7 @@ import {
 } from '@console/dynamic-plugin-sdk';
 import { useResolvedExtensions } from '@console/dynamic-plugin-sdk/src/api/useResolvedExtensions';
 import { connectToFlags, WithFlagsProps } from '../reducers/connectToFlags';
-import { errorModal, managedResourceSaveModal } from './modals';
+import { managedResourceSaveModal } from './modals';
 import ReplaceCodeModal from './modals/replace-code-modal';
 import {
   checkAccess,
@@ -75,6 +75,8 @@ import { ExpandIcon } from '@patternfly/react-icons/dist/js/icons/expand-icon';
 import { ToggleSidebarButton } from '@console/shared/src/components/editor/ToggleSidebarButton';
 import { RootState } from '@console/internal/redux';
 import { getActiveNamespace } from '@console/internal/reducers/ui';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
+import { ErrorModal } from './modals/error-modal';
 
 const generateObjToLoad = (
   templateExtensions: Parameters<typeof getYAMLTemplates>[0],
@@ -184,6 +186,7 @@ const EditYAMLInner: React.FC<EditYAMLInnerProps> = (props) => {
   const [resourceObjects, setResourceObjects] = React.useState();
   const [editorMounted, setEditorMounted] = React.useState(false);
   const [fullscreenRef, toggleFullscreen, isFullscreen, canUseFullScreen] = useFullscreen();
+  const launchModal = useOverlay();
 
   const [templateExtensions, resolvedTemplates] = useResolvedExtensions<YAMLTemplate>(
     React.useCallback(
@@ -762,7 +765,7 @@ const EditYAMLInner: React.FC<EditYAMLInnerProps> = (props) => {
       setSampleObj(s);
       return s;
     } catch (error) {
-      errorModal({
+      launchModal(ErrorModal, {
         title: t('public~Failed to parse YAML sample'),
         error: (
           <div className="co-pre-line">

--- a/frontend/public/components/modals/error-modal.tsx
+++ b/frontend/public/components/modals/error-modal.tsx
@@ -1,6 +1,17 @@
-import { ActionGroup, Button } from '@patternfly/react-core';
+import { useCallback } from 'react';
+import {
+  ActionGroup,
+  Button,
+  ButtonVariant,
+  Modal,
+  ModalHeader,
+  ModalVariant,
+  ModalBody as PfModalBody,
+  ModalFooter as PfModalFooter,
+} from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-
+import { OverlayComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/OverlayProvider';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import {
   createModalLauncher,
   ModalTitle,
@@ -31,9 +42,32 @@ export const ModalErrorContent = (props: ErrorModalProps) => {
   );
 };
 
+export const ErrorModal: OverlayComponent<ErrorModalProps> = (props) => {
+  const { t } = useTranslation();
+  const { error, title } = props;
+  const titleText = title || t('public~Error');
+  return (
+    <Modal isOpen onClose={props.closeOverlay} variant={ModalVariant.small}>
+      <ModalHeader title={titleText} titleIconVariant="warning" labelId="title-icon-modal-title" />
+      <PfModalBody>{error}</PfModalBody>
+      <PfModalFooter>
+        <Button key="cancel" variant={ButtonVariant.primary} onClick={props.closeOverlay}>
+          {t('public~OK')}
+        </Button>
+      </PfModalFooter>
+    </Modal>
+  );
+};
+
+export const useErrorModalLauncher = (props) => {
+  const launcher = useOverlay();
+  return useCallback(() => launcher<ErrorModalProps>(ErrorModal, props), [launcher, props]);
+};
+
+/** @deprecated Use useErrorModalLauncher hook instead */
 export const errorModal = createModalLauncher(ModalErrorContent);
 
 export type ErrorModalProps = {
-  error: string;
+  error: string | React.ReactNode;
   title?: string;
 } & ModalComponentProps;

--- a/frontend/public/components/modals/index.ts
+++ b/frontend/public/components/modals/index.ts
@@ -30,6 +30,7 @@ export const deleteNamespaceModal = (props) =>
     m.deleteNamespaceModal(props),
   );
 
+/** @deprecated Use useErrorModalLauncher hook instead */
 export const errorModal = (props) =>
   import('./error-modal' /* webpackChunkName: "error-modal" */).then((m) => m.errorModal(props));
 

--- a/frontend/public/components/utils/workload-pause.tsx
+++ b/frontend/public/components/utils/workload-pause.tsx
@@ -2,7 +2,8 @@ import { Alert, AlertActionLink } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 
 import { K8sKind, k8sPatch, k8sUpdate, K8sResourceKind } from '../../module/k8s/index';
-import { errorModal } from '../modals/index';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
+import { ErrorModal } from '../modals/error-modal';
 
 export const togglePaused = (model: K8sKind, obj: K8sResourceKind) => {
   // a MachineConfigPool can be created without a spec, despite the API saying it is required
@@ -31,6 +32,7 @@ export const togglePaused = (model: K8sKind, obj: K8sResourceKind) => {
 
 export const WorkloadPausedAlert = ({ model, obj }) => {
   const { t } = useTranslation();
+  const launchModal = useOverlay();
   return (
     <Alert
       isInline
@@ -40,7 +42,7 @@ export const WorkloadPausedAlert = ({ model, obj }) => {
       actionLinks={
         <AlertActionLink
           onClick={() =>
-            togglePaused(model, obj).catch((err) => errorModal({ error: err.message }))
+            togglePaused(model, obj).catch((err) => launchModal(ErrorModal, { error: err.message }))
           }
         >
           {obj.kind === 'MachineConfigPool'


### PR DESCRIPTION
Story: https://issues.redhat.com/browse/CONSOLE-4710

Descriptions: Mark errorModal as deprecated and use ErrorModal and useOverlay to launch the error modal.
