### PR TITLE
CONSOLE-4764: Add tech preview feature flag support

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -180,7 +180,7 @@ func main() {
 	}
 
 	if *fTechPreview {
-		klog.Warning("Tech preview features are enabled")
+		klog.Warning("Technology Preview features are enabled. These features are experimental and not supported for production use. If you encounter issues, send feedback through the usual support or bug-reporting channels.")
 	}
 
 	authOptions.ApplyConfig(&cfg.Auth)

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -166,6 +166,7 @@ func main() {
 	fNodeArchitectures := fs.String("node-architectures", "", "List of node architectures. Example --node-architecture=amd64,arm64")
 	fNodeOperatingSystems := fs.String("node-operating-systems", "", "List of node operating systems. Example --node-operating-system=linux,windows")
 	fCopiedCSVsDisabled := fs.Bool("copied-csvs-disabled", false, "Flag to indicate if OLM copied CSVs are disabled.")
+	fTechPreview := fs.Bool("tech-preview", false, "Flag to indicate if tech preview features should be enabled.")
 
 	cfg, err := serverconfig.Parse(fs, os.Args[1:], "BRIDGE")
 	if err != nil {
@@ -176,6 +177,10 @@ func main() {
 	if err := serverconfig.Validate(fs); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
+	}
+
+	if *fTechPreview {
+		klog.Warning("Tech preview features are enabled")
 	}
 
 	authOptions.ApplyConfig(&cfg.Auth)

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -166,7 +166,7 @@ func main() {
 	fNodeArchitectures := fs.String("node-architectures", "", "List of node architectures. Example --node-architecture=amd64,arm64")
 	fNodeOperatingSystems := fs.String("node-operating-systems", "", "List of node operating systems. Example --node-operating-system=linux,windows")
 	fCopiedCSVsDisabled := fs.Bool("copied-csvs-disabled", false, "Flag to indicate if OLM copied CSVs are disabled.")
-	fTechPreview := fs.Bool("tech-preview", false, "Flag to indicate if tech preview features should be enabled.")
+	fTechPreview := fs.Bool("tech-preview", false, "Enable console Technology Preview features.")
 
 	cfg, err := serverconfig.Parse(fs, os.Args[1:], "BRIDGE")
 	if err != nil {

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -288,6 +288,10 @@ func addClusterInfo(fs *flag.FlagSet, clusterInfo *ClusterInfo) {
 	if clusterInfo.CopiedCSVsDisabled {
 		fs.Set("copied-csvs-disabled", "true")
 	}
+
+	if clusterInfo.TechPreviewEnabled {
+		fs.Set("tech-preview", "true")
+	}
 }
 
 func addProviders(fs *flag.FlagSet, providers *Providers) {

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -81,6 +81,7 @@ type ClusterInfo struct {
 	NodeArchitectures    []string              `yaml:"nodeArchitectures,omitempty"`
 	NodeOperatingSystems []string              `yaml:"nodeOperatingSystems,omitempty"`
 	CopiedCSVsDisabled   bool                  `yaml:"copiedCSVsDisabled,omitempty"`
+	TechPreviewEnabled   bool                  `yaml:"techPreviewEnabled,omitempty"`
 }
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".


### PR DESCRIPTION
- Add --tech-preview command line flag to enable tech preview features
- Include TechPreviewEnabled field in ClusterInfo configuration
- Log warning when tech preview features are enabled

🤖 Generated with [Claude Code](https://claude.ai/code)