### PR TITLE
OCPBUGS-61458: fix MachineSet YAML template

### DIFF
--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -775,9 +775,8 @@ spec:
       labels:
         foo: bar
     spec:
-      providerSpec: {}
-      versions:
-        kubelet: ""
+      providerSpec:
+        value: {}
 `,
   )
   .setIn(


### PR DESCRIPTION
```
$ oc explain machineset.spec.template.spec.providerSpec
GROUP:      machine.openshift.io
KIND:       MachineSet
VERSION:    v1beta1

FIELD: providerSpec <Object>


DESCRIPTION:
    providerSpec details Provider-specific configuration to use during node
    creation.
    
FIELDS:
  value	<Object>
    value is an inlined, serialized representation of the resource
    configuration. It is recommended that providers maintain their own
    versioned API types that should be serialized/deserialized from this
    field, akin to component config.
```

Before:
<img width="1458" height="766" alt="default-machineset" src="https://github.com/user-attachments/assets/ba3a09f4-0d30-42ad-929c-519603d05fce" />

After:
<img width="1029" height="769" alt="Screenshot 2025-09-10 at 10 32 07 AM" src="https://github.com/user-attachments/assets/410bdceb-8e8c-43f0-a32a-936539458ad3" />

