### PR TITLE
OCPBUGS-61569: Fix bug with Console provided PatternFly shared modules

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
@@ -74,9 +74,10 @@ const getWebpackSharedModules = (pkg: ConsolePluginPackageJSON) => {
     const moduleConfig: WebpackSharedConfig = { singleton };
 
     // Console provides PatternFly 4 shared modules to its plugins for backwards compatibility.
-    // Plugins using PatternFly 5 and higher share the PatternFly code bits via dynamic modules.
-    // TODO(vojtech): remove this code when Console drops support for PatternFly 4
-    if (moduleName.startsWith('@patternfly/') && pfMajorVersion > 4) {
+    // Plugins using PatternFly 5 and higher share the PatternFly code bits via dynamic modules,
+    // *except* for modules where we explicitly disallow plugins to provide their own fallback
+    // version of that module (i.e. any singleton Console provided shared modules).
+    if (moduleName.startsWith('@patternfly/') && pfMajorVersion > 4 && allowFallback) {
       return acc;
     }
 


### PR DESCRIPTION
Bug fix for 4.18 Console plugin SDK related to recent addition of `@patternfly/react-topology` shared module in #15371.

This affects the package `@openshift-console/dynamic-plugin-sdk-webpack` containing code for processing shared module configuration.

The original assumption was
> If 4.18 compatible Console plugins use PatternFly 5+ (as indicated by their `@patternfly/react-core` major version), exclude any Console provided PatternFly shared module configs.

The updated assumption is now
> If 4.18 compatible Console plugins use PatternFly 5+ (as indicated by their `@patternfly/react-core` major version), exclude any Console provided PatternFly shared module configs **except for modules where we explicitly disallow plugins to provide their own fallback version of that module** (i.e. any singleton Console provided shared modules).