### PR TITLE
NO-JIRA: Update README.md with instructions for logging out kube:admin in local

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ source ./contrib/oc-environment.sh
 
 The console will be running at [localhost:9000](http://localhost:9000).
 
+**Note for kube:admin logout in local development:** If you wish to logout locally while signed in with `kube:admin`, you may need to manually clear the `ssn` cookie from your browser to prevent automatic re-authentication. This is due to cross-origin limitations when the console runs on localhost while the OAuth server runs on the cluster domain. To clear the cookie:
+
+1. Open browser Developer Tools (F12)
+2. Go to Application → Cookies (Chrome) or Storage → Cookies (Firefox)
+3. Find the OAuth server domain (e.g., `oauth-openshift.apps.your-cluster.com`)
+4. Delete the `ssn` cookie
+5. Click "Logout" in the console
+
 If you don't have `kubeadmin` access, you can use any user's API token,
 although you will be limited to that user's access and might not be able to run
 the full integration test suite.

--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ source ./contrib/oc-environment.sh
 
 The console will be running at [localhost:9000](http://localhost:9000).
 
-**Note for kube:admin logout in local development:** If you wish to logout locally while signed in with `kube:admin`, you may need to manually clear the `ssn` cookie from your browser to prevent automatic re-authentication. This is due to cross-origin limitations when the console runs on localhost while the OAuth server runs on the cluster domain. To clear the cookie:
+**NOTE**: When the OpenShift console runs on localhost while the OAuth server runs on the cluster domain, cross-origin restrictions can cause users signed in as kubeadmin in a local environment to be automatically reauthenticated when they attempt to log out. To work around this issue, clear the ssn cookie from your browser:
 
-1. Open browser Developer Tools (F12)
-2. Go to Application → Cookies (Chrome) or Storage → Cookies (Firefox)
-3. Find the OAuth server domain (e.g., `oauth-openshift.apps.your-cluster.com`)
-4. Delete the `ssn` cookie
-5. Click "Logout" in the console
+1. Press F12 to open your browser's developer tools.
+2. In Chrome, go to Application > Cookies. In Firefox, go to Storage > Cookies.
+3. Find the OAuth server domain; for example, oauth-openshift.apps.your-cluster.com.
+4. Delete the `ssn` cookie.
+5. From the OpenShift console, click Logout.
+
 
 If you don't have `kubeadmin` access, you can use any user's API token,
 although you will be limited to that user's access and might not be able to run


### PR DESCRIPTION
## Description
There is an issue with the session handling for the special kube:admin user. 

The kubeadmin logout function in local development (localhost:9000) doesn't clear OAuth server cookies, causing users (kubeadmin) to be automatically logged back in after clicking the logout button in the console.

This issue has been investigated, but no solid solution has been found yet, and now the further investigation has been paused. Therefore, by adding the instruction to the README.md as a temporary solution for now.