### PR TITLE
OCPBUGS-61519: Fix improper DescriptionList refactor

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/index.tsx
@@ -147,7 +147,8 @@ const DescriptorDetailsItemGroup: React.FC<DescriptorDetailsItemGroupProps> = ({
   );
 };
 
-export const DescriptorDetailsItemList: React.FC<DescriptorDetailsItemListProps> = ({
+/** Note: MUST be used inside a `<DescriptionList>` */
+export const DescriptorDetailsItems: React.FC<DescriptorDetailsItemsProps> = ({
   descriptors,
   model,
   obj,
@@ -160,7 +161,7 @@ export const DescriptorDetailsItemList: React.FC<DescriptorDetailsItemListProps>
     descriptors,
   ]);
   return (
-    <DescriptionList className={`olm-descriptors olm-descriptors--${type}`}>
+    <>
       {_.map(groupedDescriptors, (group, groupPath) => {
         const groupProps = {
           group,
@@ -205,7 +206,7 @@ export const DescriptorDetailsItemList: React.FC<DescriptorDetailsItemListProps>
           />
         );
       })}
-    </DescriptionList>
+    </>
   );
 };
 
@@ -225,14 +226,11 @@ type DescriptorDetailsItemGroupProps = Omit<DescriptorDetailsItemProps, 'descrip
   className?: string;
 };
 
-type DescriptorDetailsItemListProps = Omit<
-  DescriptorDetailsItemGroupProps,
-  'groupPath' | 'group'
-> & {
+type DescriptorDetailsItemsProps = Omit<DescriptorDetailsItemGroupProps, 'groupPath' | 'group'> & {
   descriptors: Descriptor[];
   itemClassName?: string;
 };
 
 DescriptorDetailsItem.displayName = 'DescriptorDetailsItem';
 DescriptorDetailsItemGroup.displayName = 'DescriptorDetailsItemGroup';
-DescriptorDetailsItemList.displayName = 'DescriptorDetailsItemList';
+DescriptorDetailsItems.displayName = 'DescriptorDetailsItems';

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -29,7 +29,7 @@ import {
   testConditionsDescriptor,
 } from '../../../mocks';
 import { ClusterServiceVersionModel } from '../../models';
-import { DescriptorDetailsItem, DescriptorDetailsItemList } from '../descriptors';
+import { DescriptorDetailsItem, DescriptorDetailsItems } from '../descriptors';
 import { Resources } from '../k8s-resource';
 import { OperandLink } from './operand-link';
 import {
@@ -271,7 +271,7 @@ describe(OperandDetails.displayName, () => {
 
   xit('[CONSOLE-2336] renders spec descriptor fields if the custom resource is `owned`', () => {
     expect(
-      wrapper.find(DescriptorDetailsItemList).last().shallow().find(DescriptorDetailsItem).length,
+      wrapper.find(DescriptorDetailsItems).last().shallow().find(DescriptorDetailsItem).length,
     ).toEqual(
       testClusterServiceVersion.spec.customresourcedefinitions.owned[0].specDescriptors.length,
     );
@@ -286,7 +286,7 @@ describe(OperandDetails.displayName, () => {
     wrapper = wrapper.setProps({ csv });
 
     expect(
-      wrapper.find(DescriptorDetailsItemList).last().shallow().find(DescriptorDetailsItem).length,
+      wrapper.find(DescriptorDetailsItems).last().shallow().find(DescriptorDetailsItem).length,
     ).toEqual(csv.spec.customresourcedefinitions.required[0].specDescriptors.length);
   });
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Grid, GridItem } from '@patternfly/react-core';
+import { DescriptionList, Grid, GridItem } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { sortable } from '@patternfly/react-table';
 import { JSONSchema7 } from 'json-schema';
@@ -77,7 +77,7 @@ import { RouteParams } from '@console/shared/src/types';
 import { ClusterServiceVersionModel } from '../../models';
 import { ClusterServiceVersionKind, ProvidedAPI } from '../../types';
 import { useClusterServiceVersion } from '../../utils/useClusterServiceVersion';
-import { DescriptorDetailsItem, DescriptorDetailsItemList } from '../descriptors';
+import { DescriptorDetailsItem, DescriptorDetailsItems } from '../descriptors';
 import { DescriptorConditions } from '../descriptors/status/conditions';
 import { DescriptorType, StatusCapability, StatusDescriptor } from '../descriptors/types';
 import { isMainStatusDescriptor } from '../descriptors/utils';
@@ -673,29 +673,31 @@ export const OperandDetails = connectToModel(({ crd, csv, kindObj, obj }: Operan
             <GridItem sm={6}>
               <ResourceSummary resource={obj} />
             </GridItem>
-            {mainStatusDescriptor && (
+            {mainStatusDescriptor || otherStatusDescriptors?.length > 0 ? (
               <GridItem sm={6}>
-                <DescriptorDetailsItem
-                  key={mainStatusDescriptor.path}
-                  descriptor={mainStatusDescriptor}
-                  model={kindObj}
-                  obj={obj}
-                  schema={schema}
-                  type={DescriptorType.status}
-                />
+                <DescriptionList>
+                  {mainStatusDescriptor && (
+                    <DescriptorDetailsItem
+                      key={mainStatusDescriptor.path}
+                      descriptor={mainStatusDescriptor}
+                      model={kindObj}
+                      obj={obj}
+                      schema={schema}
+                      type={DescriptorType.status}
+                    />
+                  )}
+                  {otherStatusDescriptors?.length > 0 && (
+                    <DescriptorDetailsItems
+                      descriptors={otherStatusDescriptors}
+                      model={kindObj}
+                      obj={obj}
+                      schema={schema}
+                      type={DescriptorType.status}
+                    />
+                  )}
+                </DescriptionList>
               </GridItem>
-            )}
-            {otherStatusDescriptors?.length > 0 && (
-              <GridItem sm={6}>
-                <DescriptorDetailsItemList
-                  descriptors={otherStatusDescriptors}
-                  model={kindObj}
-                  obj={obj}
-                  schema={schema}
-                  type={DescriptorType.status}
-                />
-              </GridItem>
-            )}
+            ) : null}
           </Grid>
         </div>
       </PaneBody>
@@ -704,14 +706,16 @@ export const OperandDetails = connectToModel(({ crd, csv, kindObj, obj }: Operan
           <div className="co-operand-details__section co-operand-details__section--info">
             <Grid hasGutter>
               <GridItem sm={6}>
-                <DescriptorDetailsItemList
-                  descriptors={specDescriptors}
-                  model={kindObj}
-                  obj={obj}
-                  onError={handleError}
-                  schema={schema}
-                  type={DescriptorType.spec}
-                />
+                <DescriptionList>
+                  <DescriptorDetailsItems
+                    descriptors={specDescriptors}
+                    model={kindObj}
+                    obj={obj}
+                    onError={handleError}
+                    schema={schema}
+                    type={DescriptorType.spec}
+                  />
+                </DescriptionList>
               </GridItem>
             </Grid>
           </div>


### PR DESCRIPTION
Closes #15455

After
Note in 4.20+, the bug manifested slightly differently and the additional items appeared below the left column rather than off the page.
<img width="3552" height="2426" alt="localhost_9000_k8s_ns_ibm-connect_clusterserviceversions_ibm-appconnect v5 0 22_appconnect ibm com~v1beta1~Dashboard_db-01-quickstart" src="https://github.com/user-attachments/assets/7be4d910-4a42-48be-9a8a-63bd1492a240" />

