### PR TITLE
OCPBUGS-59634: Fix the events search input width, and incorporate PF Toolbar component

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -12,7 +12,9 @@ import {
   ButtonSize,
   ButtonVariant,
   PageSection,
-  Flex,
+  Toolbar,
+  ToolbarItem,
+  ToolbarContent,
 } from '@patternfly/react-core';
 
 import { Trans, useTranslation } from 'react-i18next';
@@ -263,45 +265,54 @@ export const EventsList = (props) => {
     <>
       <PageHeading title={props.title} />
       <PageSection>
-        <Flex>
-          <ResourceListDropdown
-            onChange={toggleSelected}
-            selected={Array.from(selected)}
-            clearSelection={clearSelection}
-          />
-          <ConsoleSelect
-            items={eventTypes}
-            onChange={(v) => setType(v)}
-            selectedKey={type}
-            title={t('public~All types')}
-          />
-          <TextFilter
-            autoFocus={props.autoFocus}
-            label={t('public~Events by name or message')}
-            onChange={(_event, val) => setTextFilter(val || '')}
-          />
-        </Flex>
-        {selected.size > 0 && (
-          <LabelGroup
-            key="resources-category"
-            categoryName={t('public~Resource')}
-            defaultIsOpen={false}
-            collapsedText={t('public~{{numRemaining}} more', { numRemaining: '${remaining}' })}
-            expandedText={t('public~Show less')}
-            isClosable
-            onClick={clearSelection}
-            className="pf-v6-u-mt-md"
-          >
-            {[...selected].map((chip) => {
-              return (
-                <Label variant="outline" key={chip} onClose={() => removeResource(chip)}>
-                  <ResourceIcon kind={chip} />
-                  {kindForReference(chip)}
-                </Label>
-              );
-            })}
-          </LabelGroup>
-        )}
+        <Toolbar id="toolbar-component-managed-toggle-groups">
+          <ToolbarContent>
+            <ResourceListDropdown
+              onChange={toggleSelected}
+              selected={Array.from(selected)}
+              clearSelection={clearSelection}
+            />
+            <ToolbarItem>
+              <ConsoleSelect
+                items={eventTypes}
+                onChange={(v) => setType(v)}
+                selectedKey={type}
+                title={t('public~All types')}
+              />
+            </ToolbarItem>
+            <ToolbarItem className="pf-v6-u-w-100 pf-v6-u-w-50-on-sm pf-v6-u-w-25-on-xl">
+              <TextFilter
+                autoFocus={props.autoFocus}
+                label={t('public~Events by name or message')}
+                onChange={(_event, val) => setTextFilter(val || '')}
+              />
+            </ToolbarItem>
+          </ToolbarContent>
+          {selected.size > 0 && (
+            <ToolbarContent>
+              <LabelGroup
+                key="resources-category"
+                categoryName={t('public~Resource')}
+                defaultIsOpen={false}
+                collapsedText={t('public~{{numRemaining}} more', {
+                  numRemaining: '${remaining}',
+                })}
+                expandedText={t('public~Show less')}
+                isClosable
+                onClick={clearSelection}
+              >
+                {[...selected].map((chip) => {
+                  return (
+                    <Label variant="outline" key={chip} onClose={() => removeResource(chip)}>
+                      <ResourceIcon kind={chip} />
+                      {kindForReference(chip)}
+                    </Label>
+                  );
+                })}
+              </LabelGroup>
+            </ToolbarContent>
+          )}
+        </Toolbar>
       </PageSection>
       <EventStream
         {...props}


### PR DESCRIPTION
Prevent events search input from taking full width. 

**Before**
<img width="1621" height="827" alt="Screenshot from 2025-07-22 17-46-58" src="https://github.com/user-attachments/assets/aa95ebac-3aea-4078-ab22-bec2738d249d" />


**After**
<img width="1801" height="533" alt="Screenshot 2025-09-15 at 5 00 43 PM" src="https://github.com/user-attachments/assets/82b33483-54f1-45d4-9ac1-eb7ae3942b56" />
<img width="1023" height="573" alt="Screenshot 2025-09-15 at 5 36 10 PM" src="https://github.com/user-attachments/assets/a638244f-1813-45c4-9bea-62476fd8c65a" />
<img width="417" height="630" alt="Screenshot 2025-09-16 at 10 00 19 AM" src="https://github.com/user-attachments/assets/2a3aa854-56cc-4f34-90de-5a4303ee8f10" />

