### PR TITLE
NO-JIRA: chore(OWNERS): remove logonoff from reviewers

### DIFF
--- a/frontend/OWNERS
+++ b/frontend/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - spadgett
   - TheRealJon
   - cajieh
-  - logonoff
   - Mylanos
   - Leo6Leo
   - krishagarwal278


### PR DESCRIPTION
I frequently check https://github.com/openshift/console/pulls and Slack for unreviewed PRs and would prefer to pick which PRs I review vs. getting them via automatic bot assignment 
