### PR TITLE
CONSOLE-3769: Install `@openshift/dynamic-plugin-sdk`

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
@@ -10,6 +10,10 @@ For current development version of Console, use `4.x.0-prerelease.n` packages.
 For older 1.x plugin SDK packages, refer to "OpenShift Console Versions vs SDK Versions" compatibility
 table in [Console dynamic plugins README](./README.md).
 
+## 4.21.0-prerelease.x - TBD
+
+- Begin alignment of plugin SDK types with `@openshift/dynamic-plugin-sdk` ([CONSOLE-3769], [#15509])
+
 ## 4.20.0-prerelease.1 - 2025-08-15
 
 - Add fullscreen toggle button to `ResourceYAMLEditor` component ([CONSOLE-4656], [#15254])
@@ -110,6 +114,7 @@ table in [Console dynamic plugins README](./README.md).
 [CONSOLE-3662]: https://issues.redhat.com/browse/CONSOLE-3662
 [CONSOLE-3693]: https://issues.redhat.com/browse/CONSOLE-3693
 [CONSOLE-3695]: https://issues.redhat.com/browse/CONSOLE-3695
+[CONSOLE-3769]: https://issues.redhat.com/browse/CONSOLE-3769
 [CONSOLE-3792]: https://issues.redhat.com/browse/CONSOLE-3792
 [CONSOLE-3883]: https://issues.redhat.com/browse/CONSOLE-3883
 [CONSOLE-3899]: https://issues.redhat.com/browse/CONSOLE-3899
@@ -180,3 +185,4 @@ table in [Console dynamic plugins README](./README.md).
 [#15231]: https://github.com/openshift/console/pull/15231
 [#15254]: https://github.com/openshift/console/pull/15254
 [#15386]: https://github.com/openshift/console/pull/15386
+[#15509]: https://github.com/openshift/console/pull/15509

--- a/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md
@@ -741,10 +741,10 @@ This extension can be used to define a new section of navigation items in the na
 | Name | Value Type | Optional | Description |
 | ---- | ---------- | -------- | ----------- |
 | `id` | `string` | no | A unique identifier for this item. |
-| `perspective` | `string` | yes | The perspective ID to which this item belongs to. If not specified, contributes to the default perspective. |
-| `dataAttributes` | `{ [key: string]: string; }` | yes | Adds data attributes to the DOM. |
 | `insertBefore` | `string \| string[]` | yes | Insert this item before the item referenced here. For arrays, the first one found in order is used. |
 | `insertAfter` | `string \| string[]` | yes | Insert this item after the item referenced here. For arrays, the first one found in order is used. `insertBefore` takes precedence. |
+| `perspective` | `string` | yes | The perspective ID to which this item belongs to. If not specified, contributes to the default perspective. |
+| `dataAttributes` | `{ [key: string]: string; }` | yes | Adds data attributes to the DOM. |
 | `name` | `string` | yes | Name of this section. If not supplied, only a separator will be shown above the section. |
 
 ---
@@ -760,11 +760,11 @@ This extension can be used to add a separator between navigation items in the na
 | Name | Value Type | Optional | Description |
 | ---- | ---------- | -------- | ----------- |
 | `id` | `string` | no | A unique identifier for this item. |
+| `insertBefore` | `string \| string[]` | yes | Insert this item before the item referenced here. For arrays, the first one found in order is used. |
+| `insertAfter` | `string \| string[]` | yes | Insert this item after the item referenced here. For arrays, the first one found in order is used. `insertBefore` takes precedence. |
 | `section` | `string` | yes | Navigation section to which this item belongs to. If not specified, render this item as a top level link. |
 | `perspective` | `string` | yes | The perspective ID to which this item belongs to. If not specified, contributes to the default perspective. |
 | `dataAttributes` | `{ [key: string]: string; }` | yes | Adds data attributes to the DOM. |
-| `insertBefore` | `string \| string[]` | yes | Insert this item before the item referenced here. For arrays, the first one found in order is used. |
-| `insertAfter` | `string \| string[]` | yes | Insert this item after the item referenced here. For arrays, the first one found in order is used. `insertBefore` takes precedence. |
 
 ---
 

--- a/frontend/packages/console-dynamic-plugin-sdk/package.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/package.json
@@ -17,7 +17,8 @@
   },
   "devDependencies": {
     "@microsoft/tsdoc": "0.14.2",
-    "@openshift/dynamic-plugin-sdk-webpack": "^4.0.2",
+    "@openshift/dynamic-plugin-sdk": "^5.0.1",
+    "@openshift/dynamic-plugin-sdk-webpack": "^4.1.0",
     "@types/ejs": "3.x",
     "@types/fs-extra": "9.x",
     "ejs": "3.x",

--- a/frontend/packages/console-shared/src/hooks/useDetailsItemExtensionsForResource.ts
+++ b/frontend/packages/console-shared/src/hooks/useDetailsItemExtensionsForResource.ts
@@ -22,9 +22,10 @@ export const useDetailsItemExtensionsForResource: UseDetailsItemExtensionsForRes
 ) => {
   const typeGuard = useCallback<ExtensionTypeGuard<DetailsItem>>(
     (e): e is DetailsItem => {
+      if (!isDetailsItem(e)) return false;
       const columnMatches = e.properties.column === column;
       const modelMatches = referenceFor(obj) === referenceForExtensionModel(e.properties.model);
-      return isDetailsItem(e) && modelMatches && columnMatches;
+      return modelMatches && columnMatches;
     },
     [obj, column],
   );

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1739,13 +1739,23 @@
     once "^1.4.0"
     universal-user-agent "^4.0.0"
 
-"@openshift/dynamic-plugin-sdk-webpack@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@openshift/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-4.0.2.tgz#0304911c9c27ecff7ba5d2df5ca24f781fd445ec"
-  integrity sha512-zgRLt9WM63aGYygrQEtd8QtWoP5zYWr67kzlRKzGcHeRbWDgiHnY7FOiDUM04bYeb4lL6qv3iErEnrtvVpyh0Q==
+"@openshift/dynamic-plugin-sdk-webpack@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@openshift/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-4.1.0.tgz#eb62ee18d975431411b78da15c9774d95dbe1fa7"
+  integrity sha512-Pkq6R+fkoE0llgv9WJBcotViAPywrzDkpWK0HSTmrVyfEuWS5cuZUs8ono6L5w9BqDBRXm3ceEuUAZA/Zrar1w==
   dependencies:
     lodash "^4.17.21"
     semver "^7.3.7"
+    yup "^0.32.11"
+
+"@openshift/dynamic-plugin-sdk@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-5.0.1.tgz#3487afe57d07a28b9aba393e643d86ca13a3735c"
+  integrity sha512-+azUBN6FgcDmlcWMzG0bthcRUJC1u12wf9xa2aJGFbC/uTiOXwjrkcQ7LW/PyK5Em7wDhwaUdapaeOgh8I6Kjg==
+  dependencies:
+    lodash "^4.17.21"
+    semver "^7.3.7"
+    uuid "^8.3.2"
     yup "^0.32.11"
 
 "@patternfly-5/patternfly@npm:@patternfly/patternfly@5.4.2":


### PR DESCRIPTION
## Dependency changes

- Bump `@openshift/dynamic-plugin-sdk-webpack` to latest
- Install `@openshift/dynamic-plugin-sdk`

## Alignment of `openshift-console/dynamic-plugin-sdk` with `openshift/dynamic-plugin-sdk` types:

The following types are now exported directly from the plugin SDK:
- ExtensionFlags,
- MapCodeRefsToEncodedCodeRefs as ResolvedCodeRefProperties,
- PluginEntryModule as RemoteEntryModule,
- ReplaceProperties as Update,

Extension type is made more strict to fix some type errors

These ones are re-exported with our custom Extension type:
- ExtensionPredicate as ExtensionTypeGuard
- LoadedExtension
- Extension as ExtensionDeclaration

This one is reexported to retain tsdoc:
- CodeRef