### PR TITLE
OCPBUGS-56892: Console can only show user name instead of full name as the display name

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/actions/core.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/actions/core.ts
@@ -4,6 +4,7 @@ import { AdmissionWebhookWarning } from '../../redux-types';
 
 export enum ActionType {
   SetUser = 'setUser',
+  SetUserResource = 'setUserResource',
   BeginImpersonate = 'beginImpersonate',
   EndImpersonate = 'endImpersonate',
   SetActiveCluster = 'setActiveCluster',
@@ -12,6 +13,8 @@ export enum ActionType {
 }
 
 export const setUser = (userInfo: UserInfo) => action(ActionType.SetUser, { userInfo });
+export const setUserResource = (userResource: any) =>
+  action(ActionType.SetUserResource, { userResource });
 export const beginImpersonate = (kind: string, name: string, subprotocols: string[]) =>
   action(ActionType.BeginImpersonate, { kind, name, subprotocols });
 export const endImpersonate = () => action(ActionType.EndImpersonate);
@@ -21,6 +24,7 @@ export const removeAdmissionWebhookWarning = (id) =>
   action(ActionType.RemoveAdmissionWebhookWarning, { id });
 const coreActions = {
   setUser,
+  setUserResource,
   beginImpersonate,
   endImpersonate,
   setAdmissionWebhookWarning,

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/core.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/core.ts
@@ -14,6 +14,7 @@ import { ActionType, CoreAction } from '../actions/core';
 export const coreReducer = (
   state: CoreState = {
     user: {},
+    userResource: null,
     admissionWebhookWarnings: ImmutableMap<string, AdmissionWebhookWarning>(),
   },
   action: CoreAction,
@@ -45,6 +46,12 @@ export const coreReducer = (
       return {
         ...state,
         user: action.payload.userInfo,
+      };
+
+    case ActionType.SetUserResource:
+      return {
+        ...state,
+        userResource: action.payload.userResource,
       };
 
     case ActionType.SetAdmissionWebhookWarning:

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/coreSelectors.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/coreSelectors.ts
@@ -4,6 +4,7 @@ import { ImpersonateKind, SDKStoreState, AdmissionWebhookWarning } from '../../r
 
 type GetImpersonate = (state: SDKStoreState) => ImpersonateKind;
 type GetUser = (state: SDKStoreState) => UserInfo;
+type GetUserResource = (state: SDKStoreState) => any;
 type GetAdmissionWebhookWarnings = (
   state: SDKStoreState,
 ) => ImmutableMap<string, AdmissionWebhookWarning>;
@@ -30,6 +31,13 @@ export const impersonateStateToProps = (state: SDKStoreState) => {
  * @returns The the user state.
  */
 export const getUser: GetUser = (state) => state.sdkCore.user;
+
+/**
+ * It provides user resource details from the redux store.
+ * @param state the root state
+ * @returns The the user resource state.
+ */
+export const getUserResource: GetUserResource = (state) => state.sdkCore.userResource;
 
 /**
  * It provides admission webhook warning data from the redux store.

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/redux-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/redux-types.ts
@@ -16,6 +16,7 @@ export type ImpersonateKind = {
 
 export type CoreState = {
   user?: UserInfo;
+  userResource?: any; // UserKind from k8s API
   impersonate?: ImpersonateKind;
   admissionWebhookWarnings?: ImmutableMap<string, AdmissionWebhookWarning>;
 };

--- a/frontend/packages/console-shared/src/hooks/__tests__/useUser.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useUser.spec.ts
@@ -1,0 +1,82 @@
+import { useSelector, useDispatch } from 'react-redux';
+import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
+import { testHook } from '@console/shared/src/test-utils/hooks-utils';
+import { useUser } from '../useUser';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
+  useK8sGet: jest.fn(),
+}));
+
+jest.mock('@console/dynamic-plugin-sdk', () => ({
+  ...jest.requireActual('@console/dynamic-plugin-sdk'),
+  getUser: jest.fn(),
+  getUserResource: jest.fn(),
+  setUserResource: jest.fn(),
+}));
+
+const mockDispatch = jest.fn();
+const mockUseSelector = useSelector as jest.Mock;
+const mockUseK8sGet = useK8sGet as jest.Mock;
+const mockUseDispatch = useDispatch as jest.Mock;
+
+describe('useUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDispatch.mockReturnValue(mockDispatch);
+  });
+
+  it('should return user data with displayName from fullName when available', () => {
+    const mockUser = { username: 'testuser@example.com', uid: '123' };
+    const mockUserResource = { fullName: 'Test User', identities: ['testuser'] };
+
+    mockUseSelector
+      .mockReturnValueOnce(mockUser) // for getUser
+      .mockReturnValueOnce(mockUserResource); // for getUserResource
+
+    mockUseK8sGet.mockReturnValue([mockUserResource, true, null]);
+
+    const { result } = testHook(() => useUser());
+
+    expect(result.current.user).toEqual(mockUser);
+    expect(result.current.userResource).toEqual(mockUserResource);
+    expect(result.current.username).toBe('testuser@example.com');
+    expect(result.current.fullName).toBe('Test User');
+    expect(result.current.displayName).toBe('Test User'); // Should prefer fullName
+  });
+
+  it('should fallback to username when fullName is not available', () => {
+    const mockUser = { username: 'testuser@example.com', uid: '123' };
+    const mockUserResource = { identities: ['testuser'] }; // No fullName
+
+    mockUseSelector.mockReturnValueOnce(mockUser).mockReturnValueOnce(mockUserResource);
+
+    mockUseK8sGet.mockReturnValue([mockUserResource, true, null]);
+
+    const { result } = testHook(() => useUser());
+
+    expect(result.current.displayName).toBe('testuser@example.com'); // Should fallback to username
+    expect(result.current.fullName).toBeUndefined();
+  });
+
+  it('should dispatch setUserResource when user resource is loaded', () => {
+    const mockUser = { username: 'testuser@example.com' };
+    const mockUserResource = { fullName: 'Test User' };
+
+    mockUseSelector.mockReturnValueOnce(mockUser).mockReturnValueOnce(null); // No userResource in Redux yet
+
+    mockUseK8sGet.mockReturnValue([mockUserResource, true, null]);
+
+    testHook(() => useUser());
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'setUserResource',
+      payload: { userResource: mockUserResource },
+    });
+  });
+});

--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -37,3 +37,4 @@ export * from './usePrometheusGate';
 export * from './useCopyCodeModal';
 export * from './useCopyLoginCommands';
 export * from './useQuickStartContext';
+export * from './useUser';

--- a/frontend/packages/console-shared/src/hooks/useTelemetry.ts
+++ b/frontend/packages/console-shared/src/hooks/useTelemetry.ts
@@ -6,14 +6,13 @@ import {
   TelemetryEventListener,
   UserInfo,
 } from '@console/dynamic-plugin-sdk';
-import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
-import { UserModel } from '@console/internal/models';
 import type { UserKind } from '@console/internal/module/k8s/types';
 import {
   CLUSTER_TELEMETRY_ANALYTICS,
   PREFERRED_TELEMETRY_USER_SETTING_KEY,
   USER_TELEMETRY_ANALYTICS,
 } from '../constants';
+import { useUser } from './useUser';
 import { useUserSettings } from './useUserSettings';
 
 export interface ClusterProperties {
@@ -81,7 +80,8 @@ export const useTelemetry = () => {
     true,
   );
 
-  const [userResource, userResourceIsLoaded] = useK8sGet<UserKind>(UserModel, '~');
+  // Use centralized user data instead of fetching directly
+  const { userResource, userResourceLoaded: userResourceIsLoaded } = useUser();
 
   const [extensions] = useResolvedExtensions<TelemetryListener>(isTelemetryListener);
 

--- a/frontend/packages/console-shared/src/hooks/useUser.ts
+++ b/frontend/packages/console-shared/src/hooks/useUser.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { getUser, getUserResource, setUserResource } from '@console/dynamic-plugin-sdk';
+import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
+import { UserModel } from '@console/internal/models';
+import type { UserKind } from '@console/internal/module/k8s/types';
+
+/**
+ * Custom hook that provides centralized user data fetching and management.
+ * This hook fetches both the UserInfo (from authentication) and UserKind (from k8s API)
+ * and stores them in Redux for use throughout the application.
+ *
+ * @returns Object containing user info, user resource, and loading states
+ */
+export const useUser = () => {
+  const dispatch = useDispatch();
+
+  // Get current user info from Redux (username, groups, etc.)
+  const user = useSelector(getUser);
+
+  // Get current user resource from Redux (fullName, identities, etc.)
+  const userResource = useSelector(getUserResource);
+
+  // Fetch user resource from k8s API
+  const [userResourceData, userResourceLoaded, userResourceError] = useK8sGet<UserKind>(
+    UserModel,
+    '~',
+  );
+
+  // Update Redux when user resource is loaded
+  useEffect(() => {
+    if (userResourceLoaded && userResourceData && !userResourceError) {
+      dispatch(setUserResource(userResourceData));
+    }
+  }, [dispatch, userResourceData, userResourceLoaded, userResourceError]);
+
+  return {
+    user,
+    userResource: userResource || userResourceData,
+    userResourceLoaded,
+    userResourceError,
+    // Computed properties for convenience
+    username: user?.username,
+    fullName: (userResource || userResourceData)?.fullName,
+    displayName: (userResource || userResourceData)?.fullName || user?.username || '',
+  };
+};

--- a/frontend/public/components/masthead/masthead-toolbar.tsx
+++ b/frontend/public/components/masthead/masthead-toolbar.tsx
@@ -27,6 +27,7 @@ import {
   useCopyLoginCommands,
   useFlag,
   useTelemetry,
+  useUser,
   YellowExclamationTriangleIcon,
 } from '@console/shared';
 import { formatNamespacedRouteForResource } from '@console/shared/src/utils';
@@ -34,7 +35,7 @@ import { ExternalLinkButton } from '@console/shared/src/components/links/Externa
 import { LinkTo } from '@console/shared/src/components/links/LinkTo';
 import { CloudShellMastheadButton } from '@console/webterminal-plugin/src/components/cloud-shell/CloudShellMastheadButton';
 import { CloudShellMastheadAction } from '@console/webterminal-plugin/src/components/cloud-shell/CloudShellMastheadAction';
-import { getUser, useActivePerspective } from '@console/dynamic-plugin-sdk';
+import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import * as UIActions from '../../actions/ui';
 import { flagPending, featureReducerName } from '../../reducers/features';
 import { authSvc } from '../../module/auth';
@@ -162,12 +163,15 @@ const MastheadToolbarContents: React.FCC<MastheadToolbarContentsProps> = ({
     t('public~Login with this command'),
     externalLoginCommand,
   );
-  const { clusterID, user, alertCount, canAccessNS } = useSelector((state: RootState) => ({
+  const { clusterID, alertCount, canAccessNS } = useSelector((state: RootState) => ({
     clusterID: state.UI.get('clusterID'),
-    user: getUser(state),
     alertCount: state.observe.getIn(['alertCount']),
     canAccessNS: !!state[featureReducerName].get(FLAGS.CAN_GET_NS),
   }));
+
+  // Use centralized user hook for user data
+  const { displayName, username } = useUser();
+
   const [isAppLauncherDropdownOpen, setIsAppLauncherDropdownOpen] = useState(false);
   const [isUserDropdownOpen, setIsUserDropdownOpen] = useState(false);
   const [isKebabDropdownOpen, setIsKebabDropdownOpen] = useState(false);
@@ -181,7 +185,6 @@ const MastheadToolbarContents: React.FCC<MastheadToolbarContentsProps> = ({
   const kebabMenuRef = useRef(null);
   const reportBugLink = cv ? getReportBugLink(cv) : null;
   const userInactivityTimeout = useRef(null);
-  const username = user?.username ?? '';
   const isKubeAdmin = username === 'kube:admin';
 
   const drawerToggle = useCallback(() => dispatch(UIActions.notificationDrawerToggleExpanded()), [
@@ -614,7 +617,7 @@ const MastheadToolbarContents: React.FCC<MastheadToolbarContentsProps> = ({
 
     const userToggle = (
       <span className="co-username" data-test="username">
-        {authEnabledFlag ? username : t('public~Auth disabled')}
+        {authEnabledFlag ? displayName : t('public~Auth disabled')}
       </span>
     );
 


### PR DESCRIPTION
## Description
After logging in with Google OAuth OIDC, the Console can only show username instead of full name as the display name on the top right corner in the console.

## Step to test out the changes
1. Have a cluster that configure the Google OIDC login. If you don't have one, you can follow the instructions I wrote in the Appendix which locates at the bottom of this PR description.

2. Choose `Google-OpenID-Connect` as your login option and login with your google account

<img width="1100" height="394" alt="Screenshot 2025-09-22 at 1 43 35 PM" src="https://github.com/user-attachments/assets/8c8949cf-0af2-4337-a64d-9a4f287646ba" />

3. After your success login, you will see on the right top corner is displaying your full name, **instead of** your email address.


## Special Note
Thanks to @logonoff for the discussion on what would be the better way to resolve this issue.

## Appendix: How to configure Google OAuth on your cluster for testing purpose
### Prerequisites
Before you begin, you'll need:
- Administrator access to your OpenShift cluster using the oc and kubectl CLI.
- A Google Cloud project with an OAuth 2.0 Client ID and Client Secret created. If you need to create one, follow [Google's official documentation.](https://developers.google.com/workspace/guides/configure-oauth-consent)

### Step 1: Create the Google Client Secret in OpenShift
First, create a k8s secret in the openshift-config namespace to securely store your Google OAuth client secret. This prevents storing sensitive values directly in the main cluster configuration.

Replace `<your-google-client-secret>` with the actual client secret from your Google Cloud project.

```
oc create secret generic google-secret \
  --from-literal=clientSecret=<your-google-client-secret> \
  -n openshift-config
```

### Step 2: Configure the Cluster OAuth Identity Provider
Next, edit the cluster-wide OAuth configuration to add Google as an identity provider.
```
oc edit oauth cluster
```

Replace <your-google-client-id> with the Client ID from your Google Cloud project.

```
spec:
  identityProviders:
  - name: Google                 # This is the name that will appear on the login page
    mappingMethod: claim
    type: OpenID
    openID:
      clientID: <your-google-client-id>
      clientSecret:
        name: google-secret      # The name of the secret you created in Step 1
      extraScopes:
      - email
      - profile
      issuer: https://accounts.google.com
      claims:
        preferredUsername:
        - email
        name:
        - name
        email:
        - email
```
Save and close the editor. Then wait until the authentication operator finish reconciling.

## Step 3: Get the redirect_uri and Update Google Cloud
This is a crucial step. OpenShift generates a unique callback URL that Google needs to know about for security.

1. Open your OpenShift cluster's web console in a browser. You should now see the "Google" login option.

2. Click the Google login button. You will likely be redirected to a Google error page saying something like "Error 400: redirect_uri_mismatch". This is expected!

3. Copy the entire URL from your browser's address bar. Find the redirect_uri parameter within that URL. It will look something like this:
https://oauth-openshift.apps.<your-cluster-name>.<your-base-domain>/oauth2callback/Google

4. Go to your project in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials).

5. Navigate to your OAuth 2.0 Client ID.

6. Under the "Authorized redirect URIs" section, click "ADD URI" and paste the full redirect_uri you copied.

7. Click Save.

8. Login with your google account again and you will see it works!
