### PR TITLE
OCPBUGS-59529: Prevent the topology context menu items from truncating

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/components/ContextMenu.scss
+++ b/frontend/packages/topology/src/components/graph-view/components/ContextMenu.scss
@@ -6,6 +6,9 @@
     --pf-v6-c-dropdown__menu-item--PaddingBottom: 0;
     --pf-v6-c-dropdown__menu-item--PaddingLeft: 0;
   }
+  .pf-v6-c-menu__list-item {
+    min-width: auto; // prevent topology content menu items from truncating
+  }
 }
 
 :root:where(.pf-v6-theme-dark) .pf-v6-c-dropdown__menu-item-icon {

--- a/frontend/packages/topology/src/components/graph-view/components/ContextMenu.scss
+++ b/frontend/packages/topology/src/components/graph-view/components/ContextMenu.scss
@@ -7,7 +7,7 @@
     --pf-v6-c-dropdown__menu-item--PaddingLeft: 0;
   }
   .pf-v6-c-menu__list-item {
-    min-width: auto; // prevent topology content menu items from truncating
+    min-width: auto; // prevent topology content menu items from truncating: https://github.com/patternfly/react-topology/issues/293
   }
 }
 


### PR DESCRIPTION
Work around to this is an upstream issue in PatternFly/react-topology. https://github.com/patternfly/react-topology/issues/293

**before**
<img width="441" height="492" alt="Screenshot 2025-09-22 at 3 53 01 PM" src="https://github.com/user-attachments/assets/53f677f3-7c9a-4c2f-9324-5dcc1dcd10f8" />

**after**
<img width="473" height="526" alt="Screenshot 2025-09-22 at 3 52 06 PM" src="https://github.com/user-attachments/assets/f54365aa-4780-4c15-8015-58ef7ace2c0f" />

