### PR TITLE
NO-JIRA: Add a .gitattributes file, and mark the vendor folder as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+vendor/* linguist-generated=true


### PR DESCRIPTION
This will prevent vendored code from being included in diffs and language statistics in our repo. See https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github