### PR TITLE
OCPBUGS-61530: View instances links to CRD Instances tab

### DIFF
--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -64,18 +64,14 @@ import {
   ResourceDataView,
 } from '@console/app/src/components/data-view/ResourceDataView';
 import { GetDataViewRows } from '@console/app/src/components/data-view/types';
+import { resourcePathFromModel } from '@console/internal/components/utils/resource-link';
 
 const { common } = Kebab.factory;
-
-const crdInstancesPath = (crd: CustomResourceDefinitionKind) =>
-  _.get(crd, 'spec.scope') === 'Namespaced'
-    ? `/k8s/all-namespaces/${referenceForCRD(crd)}`
-    : `/k8s/cluster/${referenceForCRD(crd)}`;
 
 const instances = (kind: K8sKind, obj: CustomResourceDefinitionKind) => ({
   // t('public~View instances')
   labelKey: 'public~View instances',
-  href: crdInstancesPath(obj),
+  href: `${resourcePathFromModel(CustomResourceDefinitionModel, obj.metadata.name)}/instances`,
 });
 
 const menuActions: KebabAction[] = [


### PR DESCRIPTION
After: click on `View instances` will link to CRD -> Instances tab

https://github.com/user-attachments/assets/63352801-0a3f-461f-863c-2a936a64a549

