### PR TITLE
CONSOLE-4808: update resource-log.cy.ts

### DIFF
--- a/frontend/packages/integration-tests-cypress/fixtures/pod-with-space.yaml
+++ b/frontend/packages/integration-tests-cypress/fixtures/pod-with-space.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: examplepod1
+  labels:
+    app: httpd
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: container1
+      image: 'image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest'
+      args:
+      - /bin/sh
+      - -c
+      - >
+        i=0;
+        while true;
+        do
+          echo "$i:Log   TEST   $(date)" >> /var/log/1.log;
+          echo "$(date):Log    INFO     $i" >> /var/log/2.log;
+          i=$((i+1));
+          sleep 1;
+        done
+      volumeMounts:
+      - name: varlog
+        mountPath: /var/log
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+    - name: container2
+      image: 'image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest'
+      args: [/bin/sh, -c, 'tail -n+1 -f /var/log/1.log']
+      volumeMounts:
+      - name: varlog
+        mountPath: /var/log
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+  volumes:
+  - name: varlog
+    emptyDir: {}

--- a/frontend/packages/integration-tests-cypress/fixtures/pod-with-wrap-annotation.yaml
+++ b/frontend/packages/integration-tests-cypress/fixtures/pod-with-wrap-annotation.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: wraplogpod
+  annotations:
+    console.openshift.io/wrap-log-lines: 'true'
+  labels:
+    app: hello-openshift
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: hello-openshift
+      image: quay.io/openshifttest/hello-openshift@sha256:b6296396b632d15daf9b5e62cf26da20d76157161035fefddbd0e7f7749f4167
+      ports:
+        - containerPort: 80
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL

--- a/frontend/packages/integration-tests-cypress/tests/app/resource-log.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/resource-log.cy.ts
@@ -1,12 +1,18 @@
-import { checkErrors } from '../../support';
+import { checkErrors, testName } from '../../support';
 import { detailsPage } from '../../views/details-page';
 import { guidedTour } from '../../views/guided-tour';
 import { listPage } from '../../views/list-page';
+import { logs } from '../../views/logs';
 
 describe('Pod log viewer tab', () => {
+  const POD_NAME = 'examplepod1';
+  const POD_ANNO_NAME = 'wraplogpod';
+  const examplepodFilename = 'pod-with-space.yaml';
+  const podAnnoFilename = 'pod-with-wrap-annotation.yaml';
   before(() => {
     cy.login();
     guidedTour.close();
+    cy.createProjectWithCLI(testName);
   });
 
   afterEach(() => {
@@ -29,5 +35,36 @@ describe('Pod log viewer tab', () => {
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(5000);
     cy.byTestID('resource-log-no-lines').should('not.contain', '1000 lines');
+  });
+
+  it('Enable white space retain in resource logs', () => {
+    cy.exec(`oc create -f ./fixtures/${examplepodFilename} -n ${testName}`).then((result) => {
+      expect(result.stdout).includes('created');
+    });
+    cy.visit(`/k8s/ns/${testName}/pods/${POD_NAME}/logs`);
+    cy.byTestID('container-select').click();
+    cy.byTestDropDownMenu('container2').click();
+    logs.setLogWrap(true);
+    cy.get('span[class$=c-log-viewer__text]').as('log-text').should('contain', 'Log   TEST');
+    logs.setLogWrap(false);
+    cy.get('@log-text').should('contain', 'Log   TEST');
+    logs.searchLogs('test');
+    cy.get('.pf-m-match').its('length').should('be.greaterThan', 0);
+  });
+
+  it('Pod annotation could change default behavior for Wrap lines', () => {
+    cy.exec(`oc create -f ./fixtures/${podAnnoFilename} -n ${testName}`);
+    cy.visit(`/k8s/ns/${testName}/pods/${POD_NAME}/logs`);
+    logs.setLogWrap(false);
+    logs.checkLogWraped(false);
+    cy.visit(`/k8s/ns/${testName}/pods/${POD_ANNO_NAME}/logs`);
+    logs.checkLogWraped(true);
+    logs.setLogWrap(false);
+    cy.visit(`/k8s/ns/${testName}/pods/${POD_NAME}/logs`);
+    logs.checkLogWraped(false);
+    cy.visit(`/k8s/ns/${testName}/pods/${POD_ANNO_NAME}/logs`);
+    logs.checkLogWraped(true);
+    cy.pause();
+    logs.setLogWrap(false);
   });
 });

--- a/frontend/packages/integration-tests-cypress/views/logs.ts
+++ b/frontend/packages/integration-tests-cypress/views/logs.ts
@@ -1,0 +1,37 @@
+export const logs = {
+  toggleOptions: () => {
+    // click configuration dropdown
+    cy.byTestID('resource-log-options-toggle').click();
+  },
+  checkLogWraped: (flag: boolean) => {
+    // open options
+    logs.toggleOptions();
+    if (flag) {
+      cy.byTestDropDownMenu('wrap-lines').within(() => {
+        cy.get('input').should('be.checked');
+      });
+    } else {
+      cy.byTestDropDownMenu('wrap-lines').within(() => {
+        cy.get('input').should('not.be.checked');
+      });
+    }
+    // close options
+    logs.toggleOptions();
+  },
+  setLogWrap: (flag: boolean) => {
+    logs.toggleOptions();
+    if (flag) {
+      cy.byTestDropDownMenu('wrap-lines').within(() => {
+        cy.get('input').check();
+      });
+    } else {
+      cy.byTestDropDownMenu('wrap-lines').within(() => {
+        cy.get('input').uncheck();
+      });
+    }
+    logs.toggleOptions();
+  },
+  searchLogs: (text: string) => {
+    cy.get('input[placeholder="Search logs"]').clear().type(text);
+  },
+};

--- a/frontend/public/components/utils/container-select.tsx
+++ b/frontend/public/components/utils/container-select.tsx
@@ -22,7 +22,7 @@ export const ContainerLabel: React.FC<ContainerLabelProps> = ({ name }) => (
 const ContainerSelectOptions: React.FC<ContainerSelectOptionsProps> = ({ containers }) => (
   <>
     {Object.values(containers ?? {}).map(({ name }) => (
-      <SelectOption key={name} value={name}>
+      <SelectOption key={name} value={name} data-test-dropdown-menu={name}>
         <ContainerLabel name={name} />
       </SelectOption>
     ))}


### PR DESCRIPTION
- Add checkpoints about space retain in viewing and space removal in searching, also the corresponding test file
- Add tests checking `console.openshift.io/wrap-log-lines: 'true'` functionality and test file
- Add `logs.ts` view file in which we have logs related definitions