### PR TITLE
OCPBUGS-62296 Preserve path on perspective switch

### DIFF
--- a/frontend/packages/console-app/src/hooks/usePluginRoutes.tsx
+++ b/frontend/packages/console-app/src/hooks/usePluginRoutes.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Route } from 'react-router-dom-v5-compat';
+import { Route, useLocation } from 'react-router-dom-v5-compat';
 import {
   useActivePerspective,
   RoutePage as DynamicRoutePageExtension,
@@ -50,18 +50,18 @@ const InactiveRoutePage: React.FCC<InactiveRoutePageProps> = ({
 };
 
 const RoutePage: React.FCC<RoutePageProps> = ({
-  path,
   extension,
   activePerspective,
   setActivePerspective,
 }) => {
   const active = isRoutePageExtensionActive(extension, activePerspective);
+  const { pathname } = useLocation();
   return active ? (
     <LazyRoutePage extension={extension} />
   ) : (
     <InactiveRoutePage
       extension={extension}
-      path={path}
+      path={pathname}
       setActivePerspective={setActivePerspective}
     />
   );
@@ -82,7 +82,6 @@ export const usePluginRoutes: UsePluginRoutes = () => {
             element={
               <RoutePage
                 extension={extension}
-                path={path}
                 activePerspective={activePerspective}
                 setActivePerspective={setActivePerspective}
               />
@@ -98,7 +97,6 @@ export const usePluginRoutes: UsePluginRoutes = () => {
           element={
             <RoutePage
               extension={extension}
-              path={extension.properties.path}
               activePerspective={activePerspective}
               setActivePerspective={setActivePerspective}
             />
@@ -149,7 +147,6 @@ type InactiveRoutePageProps = {
 };
 
 type RoutePageProps = {
-  path: string;
   extension: LoadedRoutePageExtension;
   activePerspective: string;
   setActivePerspective: SetActivePerspective;

--- a/frontend/packages/console-app/src/hooks/usePluginRoutes.tsx
+++ b/frontend/packages/console-app/src/hooks/usePluginRoutes.tsx
@@ -73,27 +73,14 @@ export const usePluginRoutes: UsePluginRoutes = () => {
   const [activePerspective, setActivePerspective] = useActivePerspective();
   const getRoutesForExtension = React.useCallback(
     (extension: LoadedRoutePageExtension): React.ReactElement[] => {
-      if (Array.isArray(extension.properties.path)) {
-        return extension.properties.path.map((path) => (
-          <Route
-            {...extension.properties}
-            path={`${path}${extension.properties.exact ? '' : '/*'}`}
-            key={path}
-            element={
-              <RoutePage
-                extension={extension}
-                activePerspective={activePerspective}
-                setActivePerspective={setActivePerspective}
-              />
-            }
-          />
-        ));
-      }
-      return [
+      const paths = Array.isArray(extension.properties.path)
+        ? extension.properties.path
+        : [extension.properties.path];
+      return paths.map((path) => (
         <Route
           {...extension.properties}
-          path={`${extension.properties.path}${extension.properties.exact ? '' : '/*'}`}
-          key={extension.properties.path}
+          path={`${path}${extension.properties.exact ? '' : '/*'}`}
+          key={path}
           element={
             <RoutePage
               extension={extension}
@@ -101,8 +88,8 @@ export const usePluginRoutes: UsePluginRoutes = () => {
               setActivePerspective={setActivePerspective}
             />
           }
-        />,
-      ];
+        />
+      ));
     },
     [activePerspective, setActivePerspective],
   );


### PR DESCRIPTION
When navigating to a dynamic plugin route directly, if the route is associated with a perspective, the path is often truncated to just what is registered in the extension. Any subpath is discarded.

This always happens if the console is not already in the target perspective, and it happens intermittently when the console is already in the target perspective.

In the examples below, I enter the URL `http://localhost:9000/multicloud/governance/policies` but I get frequently get redirected to `http://localhost:9000/multicloud/governance` before the fixed code.

## Before
https://github.com/user-attachments/assets/9dba2026-80ed-48f2-ab97-ec73208b87d1

## After

https://github.com/user-attachments/assets/b6ad30d2-a66d-4072-8b42-1d21320f8488



