### PR TITLE
OCPBUGS-62315: Correct the width of the cluster config toolbar filter input

### DIFF
--- a/frontend/public/components/cluster-settings/global-config.tsx
+++ b/frontend/public/components/cluster-settings/global-config.tsx
@@ -8,6 +8,7 @@ import {
   ContentVariants,
   Toolbar,
   ToolbarContent,
+  ToolbarItem,
 } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
@@ -203,11 +204,13 @@ export const GlobalConfigPage: React.FCC = () => {
           </Content>
           <Toolbar>
             <ToolbarContent>
-              <TextFilter
-                value={textFilter}
-                label={t('public~by name or description')}
-                onChange={(_event, val) => setTextFilter(val)}
-              />
+              <ToolbarItem>
+                <TextFilter
+                  value={textFilter}
+                  label={t('public~by name or description')}
+                  onChange={(_event, val) => setTextFilter(val)}
+                />
+              </ToolbarItem>
             </ToolbarContent>
           </Toolbar>
         </>


### PR DESCRIPTION
Filter input should get the same default width for consistency across list views.

**After**
<img width="956" height="376" alt="Screenshot 2025-09-29 at 3 25 24 PM" src="https://github.com/user-attachments/assets/c446035a-35ea-4aba-a75a-20378cd6b599" />

