### PR TITLE
CONSOLE-4786: 02-Redux Type Extensions for multi-group impersonation

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/actions/core.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/actions/core.ts
@@ -12,8 +12,13 @@ export enum ActionType {
 }
 
 export const setUser = (userInfo: UserInfo) => action(ActionType.SetUser, { userInfo });
-export const beginImpersonate = (kind: string, name: string, subprotocols: string[]) =>
-  action(ActionType.BeginImpersonate, { kind, name, subprotocols });
+
+export const beginImpersonate = (
+  kind: string,
+  name: string,
+  subprotocols: string[],
+  groups?: string[],
+) => action(ActionType.BeginImpersonate, { kind, name, subprotocols, groups });
 export const endImpersonate = () => action(ActionType.EndImpersonate);
 export const setAdmissionWebhookWarning = (id: string, warning: AdmissionWebhookWarning) =>
   action(ActionType.SetAdmissionWebhookWarning, { id, warning });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/core.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/core.ts
@@ -26,6 +26,7 @@ export const coreReducer = (
           kind: action.payload.kind,
           name: action.payload.name,
           subprotocols: action.payload.subprotocols,
+          groups: action.payload.groups,
         },
       };
     case ActionType.EndImpersonate: {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/redux-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/redux-types.ts
@@ -12,6 +12,7 @@ export type ImpersonateKind = {
   kind: string;
   name: string;
   subprotocols: string[];
+  groups?: string[];
 };
 
 export type CoreState = {


### PR DESCRIPTION
## Description
Currently in the [codebase](https://github.com/Leo6Leo/console/blob/7e80de20e5573fb39cf999f453c1d967961d4b3c/frontend/packages/console-dynamic-plugin-sdk/src/app/redux-types.ts#L11-L15): ImpersonateKind has kind: string, name: string, subprotocols: string[]. We will need to extend it so that the type will be able to support multiple groups.