### PR TITLE
OCPBUGS-33879: use tenancy path for project scoped status card

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useNotificationAlerts.ts
+++ b/frontend/packages/console-shared/src/hooks/useNotificationAlerts.ts
@@ -1,7 +1,8 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import * as _ from 'lodash';
 import { useSelector } from 'react-redux';
 import { HIDE_USER_WORKLOAD_NOTIFICATIONS_USER_SETTINGS_KEY } from '@console/app/src/consts';
+import { useNamespacedNotificationAlertsPoller } from '@console/app/src/hooks/useNotificationPoller';
 import { LabelSelector, ObjectMetadata } from '@console/internal/module/k8s';
 import { NotificationAlerts } from '@console/internal/reducers/observe';
 import { RootState } from '@console/internal/redux';
@@ -45,5 +46,46 @@ export const useNotificationAlerts = (
   useEffect(() => {
     setFilteredAlerts((current) => (_.isEqual(current, next) ? current : next));
   }, [next]);
+  return [filteredAlerts, loaded, loadError];
+};
+
+/** Fetches notification alerts using the prometheus tenancy api, filter by current user notification
+  settings OR the provided override labels. Alerts that match on override labels will not be fitlered even if
+  current user settings would normally exclude them.
+  @argument overrideMatchLabels optional, filter alerts by proviced labels. Overrides the current \
+  user settings.
+  @returns [filteredAlerts, loaded, loadError]
+*/
+export const useNamespacedNotificationAlerts = (
+  namespace: string,
+  overrideMatchLabels?: ObjectMetadata['labels'],
+): [NotificationAlerts['data'], NotificationAlerts['loaded'], NotificationAlerts['loadError']] => {
+  const [filteredAlerts, setFilteredAlerts] = useState<NotificationAlerts['data']>([]);
+
+  const { alerts, loaded, loadError } = useNamespacedNotificationAlertsPoller(namespace);
+
+  const [hideUserWorkloadNotifications] = useUserSettings(
+    HIDE_USER_WORKLOAD_NOTIFICATIONS_USER_SETTINGS_KEY,
+    true,
+    true,
+  );
+
+  const next = useMemo(() => {
+    const alertLabelSelector = new LabelSelector({ ...overrideMatchLabels, namespace });
+    const alertRuleLabelSelector = new LabelSelector(
+      hideUserWorkloadNotifications ? SYSTEM_ALERT_RULE_LABEL : {},
+      true,
+    );
+    return (alerts ?? []).filter(
+      (alert) =>
+        alertLabelSelector.matchesLabels(alert.labels ?? {}) ||
+        alertRuleLabelSelector.matchesLabels(alert.rule.labels ?? {}),
+    );
+  }, [alerts, overrideMatchLabels, hideUserWorkloadNotifications, namespace]);
+
+  useEffect(() => {
+    setFilteredAlerts((current) => (_.isEqual(current, next) ? current : next));
+  }, [next]);
+
   return [filteredAlerts, loaded, loadError];
 };

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -46,7 +46,10 @@ import {
 } from './health-item';
 import { useK8sWatchResource } from '../../../utils/k8s-watch-hook';
 import { useFlag } from '@console/shared/src/hooks/flag';
-import { useNotificationAlerts } from '@console/shared/src/hooks/useNotificationAlerts';
+import {
+  useNamespacedNotificationAlerts,
+  useNotificationAlerts,
+} from '@console/shared/src/hooks/useNotificationAlerts';
 
 const filterSubsystems = (
   subsystems: (
@@ -101,6 +104,20 @@ export const DashboardAlerts: React.FC<DashboardAlertsProps> = ({ labelSelector 
         </StatusItem>
       )}
       {alerts.map((alert) => (
+        <AlertItem key={alertURL(alert, alert.rule.id)} alert={alert} />
+      ))}
+    </AlertsBody>
+  );
+};
+
+export const DashboardNamespacedAlerts: React.FC<DashboardNamespacedAlertsProps> = ({
+  namespace,
+}) => {
+  const [namespacedAlerts, , loadError] = useNamespacedNotificationAlerts(namespace);
+
+  return (
+    <AlertsBody error={!_.isEmpty(loadError)}>
+      {namespacedAlerts.map((alert) => (
         <AlertItem key={alertURL(alert, alert.rule.id)} alert={alert} />
       ))}
     </AlertsBody>
@@ -205,4 +222,8 @@ type StatusCardProps = {
 
 type DashboardAlertsProps = {
   labelSelector?: ObjectMetadata['labels'];
+};
+
+type DashboardNamespacedAlertsProps = {
+  namespace: string;
 };

--- a/frontend/public/components/dashboard/project-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/status-card.tsx
@@ -1,18 +1,18 @@
-import * as React from 'react';
-import { useTranslation } from 'react-i18next';
-import { Card, CardHeader, CardTitle, Gallery } from '@patternfly/react-core';
-import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
-import { Status } from '@console/shared';
-import { LoadingInline } from '@console/internal/components/utils/status-box';
 import {
   DashboardsOverviewHealthResourceSubsystem,
   isDashboardsOverviewHealthResourceSubsystem,
   useResolvedExtensions,
 } from '@console/dynamic-plugin-sdk';
-import { ProjectDashboardContext } from './project-dashboard-context';
+import { LoadingInline } from '@console/internal/components/utils/status-box';
+import { Status } from '@console/shared';
+import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
+import { Card, CardHeader, CardTitle, Gallery } from '@patternfly/react-core';
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { ResourceHealthItem } from '../dashboards-page/cluster-dashboard/health-item';
+import { ProjectDashboardContext } from './project-dashboard-context';
 
-import { DashboardAlerts } from '../dashboards-page/cluster-dashboard/status-card';
+import { DashboardNamespacedAlerts } from '../dashboards-page/cluster-dashboard/status-card';
 
 export const StatusCard: React.FC = () => {
   const { obj } = React.useContext(ProjectDashboardContext);
@@ -45,7 +45,7 @@ export const StatusCard: React.FC = () => {
               )}
             </Gallery>
           </HealthBody>
-          <DashboardAlerts labelSelector={{ namespace }} />
+          {namespace && <DashboardNamespacedAlerts namespace={namespace} />}
         </>
       ) : (
         <LoadingInline />


### PR DESCRIPTION
This PR:

- creates a specific alert poller using the tenancy path
- Refactors the status card to use a namespaced based alert list that uses the namespaced poller

Rationale
I didn't refactor the current alert poller as it stores the state in redux. In the case of namespaced alerts, they are fetched only for the provided namespace and don't need to be shared.