### PR TITLE
OCPBUGS-62483: limit node log length to 1000 lines

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
@@ -13,6 +13,7 @@ import {
   SelectList,
   SelectOption,
   Switch,
+  Banner,
 } from '@patternfly/react-core';
 import { LogViewer, LogViewerSearch } from '@patternfly/react-log-viewer';
 import { css } from '@patternfly/react-styles';
@@ -33,6 +34,9 @@ import { ExternalLink } from '@console/shared/src/components/links/ExternalLink'
 import { LOG_WRAP_LINES_USERSETTINGS_KEY } from '@console/shared/src/constants';
 import NodeLogsUnitFilter from './NodeLogsUnitFilter';
 import './node-logs.scss';
+
+const MAX_LINE_COUNT = 1000;
+const MAX_LINE_LENGTH = 500000;
 
 type NodeLogsProps = {
   obj: NodeKind;
@@ -166,6 +170,13 @@ const LogControls: React.FC<LogControlsProps> = ({
   );
 };
 
+const HeaderBanner: React.FCC<{ lineCount: number }> = ({ lineCount }) => {
+  const { t } = useTranslation('public');
+  const count = lineCount === 0 ? lineCount : lineCount - 1;
+  const headerText = t('{{count}} line', { count });
+  return <Banner>{headerText}</Banner>;
+};
+
 const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
   const {
     kind,
@@ -193,6 +204,8 @@ const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
   const [isPathOpen, setPathOpen] = React.useState(false);
   const [isFilenameOpen, setFilenameOpen] = React.useState(false);
   const [content, setContent] = React.useState('');
+  const [trimmedContent, setTrimmedContent] = React.useState('');
+  const [lineCount, setLineCount] = React.useState(0);
   const [isWrapLines, setWrapLines] = useUserSettings<boolean>(
     LOG_WRAP_LINES_USERSETTINGS_KEY,
     false,
@@ -223,6 +236,11 @@ const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
     const unitsArray = unitText?.split(',');
     const unitQueryParams = unitsArray?.map((val) => `unit=${val}`);
     return unitQueryParams?.join('&');
+  };
+  const addTailLinesToURL = (url: string) => {
+    const urlObj = new URL(url, window.location.origin);
+    urlObj.searchParams.set('tailLines', MAX_LINE_COUNT.toString());
+    return urlObj.toString();
   };
   const getLogURL = React.useCallback(
     (ext?: string, unitText?: string) => {
@@ -277,16 +295,21 @@ const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
 
   React.useEffect(() => {
     if (logURL) {
-      fetchLog(logURL);
+      fetchLog(addTailLinesToURL(logURL));
     }
   }, [logURL, fetchLog]);
 
-  let trimmedContent = '';
-  const MAX_LENGTH = 500000;
-  if (content.length > MAX_LENGTH) {
-    const index = content.indexOf('\n', content.length - MAX_LENGTH);
-    trimmedContent = content.substr(index + 1);
-  }
+  React.useEffect(() => {
+    if (content.length > MAX_LINE_LENGTH) {
+      const index = content.indexOf('\n', content.length - MAX_LINE_LENGTH);
+      const newTrimmedContent = content.substr(index + 1);
+      setTrimmedContent(newTrimmedContent);
+      setLineCount(newTrimmedContent.split('\n').length);
+    } else {
+      setTrimmedContent('');
+      setLineCount(content.split('\n').length);
+    }
+  }, [content]);
 
   const onChangePath = (event: React.MouseEvent<Element, MouseEvent>, newAPI: string) => {
     event.preventDefault();
@@ -300,7 +323,6 @@ const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
     removeQueryArgument(logQueryArgument);
     setLoadingFilenames(true);
     setLoadingLog(true);
-    trimmedContent = '';
   };
   const onTogglePath = () => setPathOpen(!isPathOpen);
   const onChangeUnit = (value: string) => {
@@ -316,8 +338,6 @@ const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
     setLoadingLog(true);
     setQueryArgument(logQueryArgument, newFilename);
     setLogURL(getLogURL(`/${newFilename}`));
-    fetchLog(getLogURL(`/${newFilename}`));
-    trimmedContent = '';
   };
   const onToggleFilename = () => setFilenameOpen(!isFilenameOpen);
   const errorExists = error.length > 0;
@@ -352,7 +372,7 @@ const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
     <PaneBody fullHeight>
       <div className="log-window-wrapper">
         {(isLoadingLog || errorExists) && logControls}
-        {trimmedContent?.length > 0 && !isLoadingLog && (
+        {(lineCount >= MAX_LINE_COUNT || trimmedContent?.length > 0) && !isLoadingLog && (
           <Alert
             isInline
             className="co-alert co-alert--margin-bottom-sm"
@@ -401,6 +421,7 @@ const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
             toolbar={logControls}
             theme={theme}
             initialIndexWidth={7}
+            header={<HeaderBanner lineCount={lineCount} />}
           />
         )}
       </div>


### PR DESCRIPTION
Changes
* add a banner to the top of the log viewer showing the line total
* limit the log length to the latest 1000 lines
* display the existing abridged log alert if the log length is >= 1000 lines (note there is a minor bug here:  if the unabridged log length is exactly 1000 lines, the alert will also display, but think this is an acceptable bug to keep this fix as simple as possible)

After

https://github.com/user-attachments/assets/ecd58c6a-02af-4ebd-9fa8-5d5321f23eff

