### PR TITLE
OCPBUGS-62937: Add telemetry events

### DIFF
--- a/frontend/packages/console-app/src/components/detect-perspective/PerspectiveConfiguration.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/PerspectiveConfiguration.tsx
@@ -242,7 +242,7 @@ const PerspectiveConfiguration: React.FC<{ readonly: boolean }> = ({ readonly })
           const perspectiveId = perspectiveExtension.properties.id;
           const value = configuredPerspectives?.find((p) => p.id === perspectiveId)?.visibility;
           const onChange = (selectedOption: PerspectiveVisibilitySelectOptions) => {
-            fireTelemetryEvent('Console cluster configuration changed', {
+            fireTelemetryEvent('Console cluster perspective configuration changed', {
               customize: 'Perspective',
               id: perspectiveExtension.properties.id,
               name: perspectiveExtension.properties.name,

--- a/frontend/packages/console-app/src/components/favorite/FavoriteButton.tsx
+++ b/frontend/packages/console-app/src/components/favorite/FavoriteButton.tsx
@@ -12,7 +12,7 @@ import {
 import { ModalVariant } from '@patternfly/react-core/deprecated';
 import { StarIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
-import { Modal, useUserSettingsCompatibility } from '@console/shared';
+import { Modal, useTelemetry, useUserSettingsCompatibility } from '@console/shared';
 import { FAVORITES_CONFIG_MAP_KEY, FAVORITES_LOCAL_STORAGE_KEY } from '../../consts';
 import { FavoritesType } from '../../types';
 
@@ -25,6 +25,7 @@ type FavoriteButtonProps = {
 
 export const FavoriteButton = ({ defaultName }: FavoriteButtonProps) => {
   const { t } = useTranslation('console-app');
+  const triggerTelemetry = useTelemetry();
   const [isStarred, setIsStarred] = React.useState(false);
   const [isModalOpen, setIsModalOpen] = React.useState(false);
   const [name, setName] = React.useState<string>('');
@@ -54,6 +55,9 @@ export const FavoriteButton = ({ defaultName }: FavoriteButtonProps) => {
       const updatedFavorites = favorites?.filter((favorite) => favorite.url !== currentUrlPath);
       setFavorites(updatedFavorites);
       setIsStarred(false);
+      triggerTelemetry('remove-favorite', {
+        url: currentUrlPath,
+      });
     } else {
       const currentUrlSplit = currentUrlPath.includes('~')
         ? currentUrlPath.split('~')
@@ -100,6 +104,10 @@ export const FavoriteButton = ({ defaultName }: FavoriteButtonProps) => {
     setError('');
     setName('');
     setIsModalOpen(false);
+    triggerTelemetry('add-favorite', {
+      name: name.trim(),
+      url: currentUrlPath,
+    });
   };
 
   const handleNameChange = (value: string) => {

--- a/frontend/packages/console-app/src/components/favorite/FavoriteNavItems.tsx
+++ b/frontend/packages/console-app/src/components/favorite/FavoriteNavItems.tsx
@@ -3,7 +3,7 @@ import { NavExpandable, Button, FlexItem, Flex, Truncate } from '@patternfly/rea
 import { StarIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { useTranslation } from 'react-i18next';
-import { useUserSettingsCompatibility } from '@console/shared';
+import { useTelemetry, useUserSettingsCompatibility } from '@console/shared';
 import { FAVORITES_CONFIG_MAP_KEY, FAVORITES_LOCAL_STORAGE_KEY } from '../../consts';
 import { FavoritesType } from '../../types';
 import { FavoriteNavItem } from './FavoriteNavItem';
@@ -12,6 +12,7 @@ import './FavoriteNavItems.scss';
 
 export const FavoriteNavItems: React.FC = () => {
   const { t } = useTranslation();
+  const triggerTelemetry = useTelemetry();
   const [activeGroup, setActiveGroup] = React.useState('');
   const [activeItem, setActiveItem] = React.useState('');
   const currentUrlPath = window.location.pathname;
@@ -42,6 +43,9 @@ export const FavoriteNavItems: React.FC = () => {
       if (activeItem === `favorites-item-${favoriteUrl}`) {
         setActiveItem('');
       }
+      triggerTelemetry('remove-favorite-from-nav', {
+        url: favoriteUrl,
+      });
     };
     if (!loaded) return null;
     if (!favorites || favorites.length === 0) {
@@ -86,7 +90,7 @@ export const FavoriteNavItems: React.FC = () => {
         </Flex>
       </FavoriteNavItem>
     ));
-  }, [favorites, activeItem, loaded, t, setFavorites]);
+  }, [favorites, activeItem, loaded, t, setFavorites, triggerTelemetry]);
 
   return (
     <NavExpandable

--- a/frontend/public/components/QuickCreate.tsx
+++ b/frontend/public/components/QuickCreate.tsx
@@ -8,7 +8,12 @@ import {
 } from '@patternfly/react-core';
 import { history } from '@console/internal/components/utils';
 import { PlusCircleIcon } from '@patternfly/react-icons';
-import { ALL_NAMESPACES_KEY, formatNamespacedRouteForResource, useFlag } from '@console/shared/src';
+import {
+  ALL_NAMESPACES_KEY,
+  formatNamespacedRouteForResource,
+  useFlag,
+  useTelemetry,
+} from '@console/shared/src';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { FLAGS } from '@console/shared/src/constants';
@@ -66,6 +71,7 @@ const useCanCreateResource = () => {
 
 const QuickCreate: React.FC<QuickCreateProps> = ({ namespace }) => {
   const { t } = useTranslation();
+  const fireTelemetryEvent = useTelemetry();
   const opeshiftStartGuideEnable = useFlag(FLAGS.SHOW_OPENSHIFT_START_GUIDE);
 
   const canCreate = useCanCreateResource();
@@ -111,6 +117,7 @@ const QuickCreate: React.FC<QuickCreateProps> = ({ namespace }) => {
           to={importYAMLURL}
           onClick={(ev: any) => {
             ev.preventDefault();
+            fireTelemetryEvent('quick-create-import-yaml');
             history.push(importYAMLURL);
           }}
           tooltipProps={{
@@ -129,6 +136,7 @@ const QuickCreate: React.FC<QuickCreateProps> = ({ namespace }) => {
               to={getImportFromGitURL(namespace)}
               onClick={(ev: any) => {
                 ev.preventDefault();
+                fireTelemetryEvent('quick-create-import-from-git');
                 history.push(getImportFromGitURL(namespace));
               }}
               tooltipProps={{
@@ -145,6 +153,7 @@ const QuickCreate: React.FC<QuickCreateProps> = ({ namespace }) => {
               to={getContainerImageURL(namespace)}
               onClick={(ev: any) => {
                 ev.preventDefault();
+                fireTelemetryEvent('quick-create-container-images');
                 history.push(getContainerImageURL(namespace));
               }}
               tooltipProps={{

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-getting-started-card.spec.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-getting-started-card.spec.tsx
@@ -28,6 +28,10 @@ jest.mock('@console/shared/src/hooks/useUserSettings', () => ({
   useUserSettings: jest.fn(),
 }));
 
+jest.mock('@console/shared/src/hooks/useTelemetry', () => ({
+  useTelemetry: () => jest.fn(),
+}));
+
 // Workaround because getting-started exports also QuickStartGettingStartedCard
 jest.mock(
   '@console/app/src/components/quick-starts/loader/QuickStartsLoader',

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ClipboardCheckIcon } from '@patternfly/react-icons/dist/esm/icons/clipboard-check-icon';
 
-import { useCanClusterUpgrade } from '@console/shared';
+import { useCanClusterUpgrade, useTelemetry } from '@console/shared';
 
 import {
   GettingStartedCard,
@@ -16,7 +16,7 @@ import { TourActions, TourContext } from '@console/app/src/components/tour';
 
 export const ClusterSetupGettingStartedCard: React.FC = () => {
   const { t } = useTranslation();
-
+  const fireTelemetryEvent = useTelemetry();
   const canUpgrade = useCanClusterUpgrade();
 
   const { tourDispatch, tour } = React.useContext(TourContext);
@@ -26,7 +26,10 @@ export const ClusterSetupGettingStartedCard: React.FC = () => {
   const takeConsoleTourAction: GettingStartedLink = {
     id: 'console-tour',
     title: t('public~Take console tour'),
-    onClick: () => tourDispatch({ type: TourActions.start }),
+    onClick: () => {
+      fireTelemetryEvent('launch-guided-tour-form-getting-started-card');
+      tourDispatch({ type: TourActions.start });
+    },
   };
 
   const links = [

--- a/frontend/public/components/masthead/masthead-toolbar.tsx
+++ b/frontend/public/components/masthead/masthead-toolbar.tsx
@@ -197,6 +197,10 @@ const MastheadToolbarContents: React.FCC<MastheadToolbarContentsProps> = ({
 
   const handleGuidedTourClick = (e) => {
     e.preventDefault();
+    fireTelemetryEvent('launch-guided-tour-form-help', {
+      id: 'guided-tour-help',
+      perspective: activePerspective,
+    });
     tourDispatch({ type: TourActions.start });
   };
 

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -20,7 +20,7 @@ import {
 } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import { MinusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';
-import { getBadgeFromType, usePinnedResources } from '@console/shared';
+import { getBadgeFromType, usePinnedResources, useTelemetry } from '@console/shared';
 import { DefaultPage } from './default-resource';
 import { requirementFromString } from '../module/k8s/selector-requirement';
 import { ResourceListDropdown } from './resource-dropdown';
@@ -88,6 +88,7 @@ const ResourceList = ({ kind, mock, namespace, selector, nameFilter }) => {
 
 const SearchPage_: React.FC<SearchProps> = (props) => {
   const [perspective] = useActivePerspective();
+  const fireTelemetryEvent = useTelemetry();
   const [selectedItems, setSelectedItems] = React.useState(new Set<string>([]));
   const [collapsedKinds, setCollapsedKinds] = React.useState(new Set<string>([]));
   const [labelFilter, setLabelFilter] = React.useState([]);
@@ -130,6 +131,9 @@ const SearchPage_: React.FC<SearchProps> = (props) => {
 
   const updateSelectedItems = (selection: string) => {
     const updateItems = selectedItems;
+    fireTelemetryEvent('search-resource-selected', {
+      resource: selection,
+    });
     updateItems.has(selection) ? updateItems.delete(selection) : updateItems.add(selection);
     setSelectedItems(updateItems);
     setQueryArgument('kind', [...updateItems].join(','));


### PR DESCRIPTION
Adds telemetry events to
- Add to favorites 
   - Event name: `add-favorite`
- Remove from favorites
   - Event name: `remove-favorite` and `remove-favorite-from-nav`
- Launch guided tour
   - Event name: `launch-guided-tour-form-help` and `launch-guided-tour-form-getting-started-card`
- Enable Developer perspective 
   - Event name: `Console cluster perspective configuration changed`
- Search page
   - Event name: `search-resource-selected`