### PR TITLE
OCPBUGS-61246: Updated the RolesPage to dynamically fetch resources based on selected filters from URL parameters

### DIFF
--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -1,4 +1,4 @@
-import * as _ from 'lodash-es';
+import * as _ from 'lodash';
 import { Component, useState, useMemo, useEffect, useCallback, Suspense } from 'react';
 import * as fuzzy from 'fuzzysearch';
 import { useLocation, useParams } from 'react-router-dom-v5-compat';


### PR DESCRIPTION
## Description
ClusterRoles doesn't show up under the "User Management → Roles" tab, when user has the access to ClusterRoles but not Roles.

## Steps to Test out
1. Create a new test user with htpasswd.
2. Login at least once with this newly created user to activate the account
3. Create the role that only allows to list ClusterRoles not Role
4. Create the rolebinding with the newly created user and the view role.
5. Login to the console and navigate to "User Management → Roles" tab. Before this fix, you should be expecting 403 not authorized error. But with this fix, you should be able to see all the ClusterRoles are being correctly returned, and leave the namespace role empty. (You can see the role count in the filter is equal to 0 for that)

