### PR TITLE
OCPBUGS-63429: Expose prometheus tenancy label path as a proxy

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -385,6 +385,7 @@ func (s *Server) HTTPHandler() (http.Handler, error) {
 			targetAPIPath               = prometheusProxyEndpoint + "/api/"
 			tenancyQuerySourcePath      = prometheusTenancyProxyEndpoint + "/api/v1/query"
 			tenancyQueryRangeSourcePath = prometheusTenancyProxyEndpoint + "/api/v1/query_range"
+			tenancyLabelSourcePath      = prometheusTenancyProxyEndpoint + "/api/v1/label/"
 			tenancyRulesSourcePath      = prometheusTenancyProxyEndpoint + "/api/v1/rules"
 			tenancyTargetAPIPath        = prometheusTenancyProxyEndpoint + "/api/"
 			thanosProxy                 = proxy.NewProxy(s.ThanosProxyConfig)
@@ -422,6 +423,7 @@ func (s *Server) HTTPHandler() (http.Handler, error) {
 		// tenancy queries and query ranges have to be proxied via thanos
 		handle(tenancyQuerySourcePath, handleThanosTenancyRequest)
 		handle(tenancyQueryRangeSourcePath, handleThanosTenancyRequest)
+		handle(tenancyLabelSourcePath, handleThanosTenancyRequest)
 
 		// tenancy rules have to be proxied via thanos
 		handle(tenancyRulesSourcePath, handleThanosTenancyForRulesRequest)


### PR DESCRIPTION
This PR looks to proxy the Prometheus tenancy label path through the console backend. This change is needed to allow non-admin users to use the autocomplete functionality in the `observe/metrics` pages. The thanos-querier service ([link](https://github.com/openshift/cluster-monitoring-operator/blob/main/assets/thanos-querier/service.yaml)) already provides support for this functionality, we are just looking to expose a way for the console users to access this existing endpoint. Since all other prometheus proxies are done through the console, I believe it makes the most sense to add this here.

```yaml
      * Port 9092 provides access to the [...]  `/api/v1/label/*/values` [...] endpoints restricted to a given project. Granting access requires binding a user to the `view` cluster role in the project.
```

This PR is being made in conjunction with a second one in the monitoring-plugin (openshift/monitoring-plugin#608) which then uses this newly exposed proxy. This PR MUST merge before the one in the monitoring-plugin