### PR TITLE
OCPBUGS-63382: Display missing environment var values and correct styling

### DIFF
--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -887,7 +887,12 @@ const Details: React.FC<PodDetailsProps> = ({ obj: pod }) => {
   );
 };
 
-const EnvironmentPage = (props: { obj: PodKind; envPath: string[]; readOnly: boolean }) => (
+const EnvironmentPage = (props: {
+  obj: PodKind;
+  rawEnvData?: any;
+  envPath: string[];
+  readOnly: boolean;
+}) => (
   <AsyncComponent
     loader={() => import('./environment.jsx').then((c) => c.EnvironmentPage)}
     {...(props as Record<string, unknown>)}
@@ -896,7 +901,7 @@ const EnvironmentPage = (props: { obj: PodKind; envPath: string[]; readOnly: boo
 
 const envPath = ['spec', 'containers'];
 const PodEnvironmentComponent = (props: { obj: PodKind }) => (
-  <EnvironmentPage obj={props.obj} envPath={envPath} readOnly={true} />
+  <EnvironmentPage obj={props.obj} rawEnvData={props.obj.spec} envPath={envPath} readOnly={true} />
 );
 
 export const PodConnectLoader: React.FC<PodConnectLoaderProps> = ({


### PR DESCRIPTION
Pods are always existing resources when viewing their Environment tab, so `isCreate` should always be false, but the
missing rawEnvData prop made the component think it was in "create mode" causing the page to not display the `EnvFromEditorComponent` and `NameValueEditorComponent` sections correctly, as well as missing a styling class for content margin.

**Before**
<img width="1011" height="577" alt="EnVar bugg before 2025-10-21 at 5 22 15 PM" src="https://github.com/user-attachments/assets/e824d253-47d0-48af-9f36-09a10331845f" />


**After**
<img width="1012" height="899" alt="Screenshot 2025-10-21 at 5 23 04 PM" src="https://github.com/user-attachments/assets/0d0f2937-70a5-442c-b5f5-f0828c2c16bd" />

