### PR TITLE
OCPBUGS-63339: HPA Form View in RHOCP Web Console Incorrectly Requires Both CPU and …

### DIFF
--- a/frontend/packages/dev-console/src/components/hpa/HPADetailsForm.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPADetailsForm.tsx
@@ -24,23 +24,47 @@ const HPADetailsForm: React.FC = () => {
     _event: React.FormEvent<HTMLInputElement>,
     value: string,
   ) => {
-    const numValue = parseInt(value, 10);
-
     const hpa: HorizontalPodAutoscalerKind = field.value;
     const { metric, index } = getMetricByType(hpa, type);
     const hpaMetrics = hpa.spec.metrics || [];
 
-    const updatedMetrics = [...hpaMetrics];
-    updatedMetrics[index] = {
-      ...metric,
-      resource: {
-        ...metric.resource,
-        target: {
-          ...metric.resource.target,
-          averageUtilization: numValue,
+    // If field is undefined, remove metric
+    if (!value) {
+      const updatedMetrics = hpaMetrics.filter((_, i) => i !== index);
+      setFieldValue(name, {
+        ...hpa,
+        spec: {
+          ...hpa.spec,
+          metrics: updatedMetrics,
         },
-      },
-    };
+      });
+      return;
+    }
+
+    // Create or update metric
+    const numValue = parseInt(value, 10);
+    const updatedMetrics = [...hpaMetrics];
+    updatedMetrics[index] = metric
+      ? {
+          ...metric,
+          resource: {
+            ...metric.resource,
+            target: {
+              ...metric.resource.target,
+              averageUtilization: numValue,
+            },
+          },
+        }
+      : {
+          type: 'Resource',
+          resource: {
+            name: type,
+            target: {
+              type: 'Utilization',
+              averageUtilization: numValue,
+            },
+          },
+        };
 
     setFieldValue(name, {
       ...hpa,

--- a/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils.spec.ts
@@ -103,18 +103,15 @@ describe('getYAMLData gets back an hpa structured editor string', () => {
 });
 
 describe('getMetricByType returns an appropriate metric and the index it is at', () => {
-  it('expect no metrics to return a default metric as a new metric on the end', () => {
-    const { metric } = getMetricByType(hpaExamples.noMetrics, 'memory');
-    expect(metric).toBeTruthy();
-    expect(metric.resource.name).toBe('memory');
-    expect(metric.resource.target.averageUtilization).toBe(50);
+  it('expect to return null when HPA has no metrics defined', () => {
+    const { metric, index } = getMetricByType(hpaExamples.noMetrics, 'memory');
+    expect(metric).toBeNull();
+    expect(index).toBe(0);
   });
 
-  it('expect to get back a default memory metric when only cpu metric is available', () => {
+  it('expect to get back no default memory metric when only cpu metric is available', () => {
     const { metric, index } = getMetricByType(hpaExamples.cpuScaled, 'memory');
-    expect(metric).toBeTruthy();
-    expect(metric.resource.name).toBe('memory');
-    expect(metric.resource.target.averageUtilization).toBe(50);
+    expect(metric).toBeNull();
     expect(index).toBe(1);
   });
 

--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -218,7 +218,7 @@ spec:
     resource:
       name: cpu
       target:
-        averageUtilization: 50
+        averageUtilization: 80
         type: Utilization
 `,
   )


### PR DESCRIPTION
### The Alignment Between HPA Form Behavior and the API

**A breakdown of the key points regarding the Horizontal Pod Autoscaler (HPA) form's behavior and how it aligns with API:**

**API Default Behavior:**
If the `spec.metrics` array in an HPA manifest is empty (`[]`) or omitted, API automatically defaults to scaling based on 80% average CPU utilization.

**API Validation Rule for Utilization:**
If you specify a metric with `target.type` utilization (like CPU or Memory), the `averageUtilization` value "must be greater than 0". A value of 0 is invalid and will be rejected by the Kubernetes API server.

**UI Form Behavior:**
**Empty Input Field:** If a user leaves the CPU or Memory utilization field empty, the UI omits that specific metric from the generated HPA manifest/request.
- This allows users to create single-metric HPAs (e.g., Memory only).
- If both fields are left empty, API applies its 80% CPU default.

**Input Value = '0':** If a user enters 0 in the CPU or Memory utilization field, the UI sends this value to the API server. The API server then rejects the request with the "must be greater than 0" error, which is the current and expected behavior.

**Input Value > 0:** The UI includes the specified metric values in the HPA manifest/request, which are then sent successfully to the API.
