### PR TITLE
OCPBUGS-62142: Fix cookie size limit error with large OIDC refresh tokens

### DIFF
--- a/pkg/auth/sessions/loginstate.go
+++ b/pkg/auth/sessions/loginstate.go
@@ -21,15 +21,16 @@ type IDTokenVerifier func(context.Context, string) (*oidc.IDToken, error)
 // and should be safe to send as a non-http-only cookie.
 type LoginState struct {
 	// IMPORTANT: if adding any ref type, change the DeepCopy() implementation
-	userID       string
-	name         string
-	email        string
-	exp          time.Time
-	rotateAt     time.Time // 80% of token's lifetime
-	now          nowFunc
-	sessionToken string
-	rawToken     string
-	refreshToken string
+	userID         string
+	name           string
+	email          string
+	exp            time.Time
+	rotateAt       time.Time // 80% of token's lifetime
+	now            nowFunc
+	sessionToken   string
+	rawToken       string
+	refreshToken   string
+	refreshTokenID string // Small reference ID for the refresh token (stored in cookie)
 }
 
 type LoginJSON struct {
@@ -162,6 +163,10 @@ func (ls *LoginState) SessionToken() string {
 
 func (ls *LoginState) RefreshToken() string {
 	return ls.refreshToken
+}
+
+func (ls *LoginState) RefreshTokenID() string {
+	return ls.refreshTokenID
 }
 
 func (ls *LoginState) IsExpired() bool {


### PR DESCRIPTION
Some OIDC providers (e.g., Windows ADFS) return very large refresh tokens (6KB+) that exceed browser cookie size limits (~4KB), causing authentication to fail with "securecookie: the value is too long" errors.

Instead of storing the full OAuth2 refresh token in cookies, generate a small 32-byte reference ID and store only the reference in the cookie. The actual refresh token is stored server-side in a new byRefreshTokenReference map. This approach:

- Fixes cookie size limit errors for any OIDC provider
- Maintains session recovery during token rotation race conditions
- Requires no infrastructure changes (uses existing in-memory session store)
- Preserves backward compatibility with existing session management logic

The implementation properly handles cleanup of old references and tokens accumulated during token rotations, using helper functions to ensure all orphaned entries are removed when sessions are deleted or pruned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)