### PR TITLE
OCPBUGS-63388: fix breadcrumb link to ImageStream page

### DIFF
--- a/frontend/public/components/image-stream-tag.tsx
+++ b/frontend/public/components/image-stream-tag.tsx
@@ -7,7 +7,7 @@ import PaneBody from '@console/shared/src/components/layout/PaneBody';
 import PaneBodyGroup from '@console/shared/src/components/layout/PaneBodyGroup';
 import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { DetailsPage, Table } from './factory';
-import { Kebab, SectionHeading, navFactory, ResourceSummary } from './utils';
+import { Kebab, SectionHeading, navFactory, ResourceSummary, resourcePath } from './utils';
 import { humanizeBinaryBytes } from './utils/units';
 import { ExampleDockerCommandPopover } from './image-stream';
 import { ImageStreamTimeline } from './image-stream-timeline';
@@ -341,7 +341,7 @@ export const ImageStreamTagsDetailsPage: React.FCC<ImageStreamTagsDetailsPagePro
           },
           {
             name: imageStreamName,
-            path: `${getBreadcrumbPath(params, 'imagestreams')}/${imageStreamName}`,
+            path: resourcePath('ImageStream', imageStreamName, params.ns),
           },
           {
             name: t('public~ImageStreamTag details'),


### PR DESCRIPTION
ImageStreams are namespaced resources and need a specific namespace in the URL
This ensures that when "All Projects" is selected, the ImageStream breadcrumb link uses the actual namespace rather than trying to use all-namespaces.

Before:

https://github.com/user-attachments/assets/7550a4f3-c609-41dc-9a35-ddd61280a027



After:

https://github.com/user-attachments/assets/9093adc5-4533-4354-9774-605ff2eaf8a1

