### PR TITLE
OCPBUGS-64939: Fix logo max-height not respected on Safari

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -191,6 +191,10 @@ $masthead-logo-max-height: 60px;
 .pf-v6-c-masthead__logo {
   --pf-v6-c-masthead__logo--MaxHeight: #{$masthead-logo-max-height}; // Restore the max-height from PageHeader to maintain backwards compatibility
   --pf-v6-c-masthead__logo--Width: auto; // Do not set a width to maintain backwards compatibility
+
+  img.pf-v6-c-brand {
+    max-height: #{$masthead-logo-max-height}; // Explicit image max height for browser compatibility
+  }
 }
 
 // PF components that calculate their correct height based on --pf-t--global--font--size--md: 1rem


### PR DESCRIPTION
<img width="1080" height="903" alt="Untitled" src="https://github.com/user-attachments/assets/e2deb7f4-7d84-4bcb-9e45-6dc1fd16c132" />


Safari does not properly constrain images using max-height: 100% when the parent element has a fixed max-height. As a result, the custom masthead logo ignores the intended 60 px limit on Safari.

This change explicitly applies max-height: 60px to the child img element to ensure consistent behavior across browsers.