### PR TITLE
CONSOLE-4834: Clean up unused types in metal3

### DIFF
--- a/frontend/packages/metal3-plugin/src/plugin.tsx
+++ b/frontend/packages/metal3-plugin/src/plugin.tsx
@@ -6,11 +6,6 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import {
   DashboardsOverviewInventoryItem,
   Plugin,
-  ResourceListPage,
-  ResourceDetailsPage,
-  RoutePage,
-  ModelFeatureFlag,
-  ModelDefinition,
   DashboardsOverviewResourceActivity,
   DashboardsOverviewInventoryItemReplacement,
   DashboardsInventoryItemGroup,
@@ -37,15 +32,10 @@ import { getHostPowerStatus, hasPowerManagement, isDetached } from './selectors'
 import { BareMetalHostKind } from './types';
 
 type ConsumedExtensions =
+  | CustomFeatureFlag
+  | DashboardsInventoryItemGroup
   | DashboardsOverviewInventoryItem
   | DashboardsOverviewInventoryItemReplacement
-  | DashboardsInventoryItemGroup
-  | ResourceListPage
-  | ResourceDetailsPage
-  | RoutePage
-  | ModelFeatureFlag
-  | ModelDefinition
-  | CustomFeatureFlag
   | DashboardsOverviewResourceActivity;
 
 const METAL3_FLAG = 'METAL3';


### PR DESCRIPTION
Prep work to allow for removal of static extension handling code.

unblocks https://issues.redhat.com/browse/CONSOLE-4840

cc @vikram-raj 
