### PR TITLE
OCPBUGS-60141: Prevent the Software Catalog from reseting its scroll position, when closing the details view modal

### DIFF
--- a/frontend/packages/console-shared/src/components/virtualized-grid/VirtualizedGrid.tsx
+++ b/frontend/packages/console-shared/src/components/virtualized-grid/VirtualizedGrid.tsx
@@ -29,11 +29,15 @@ const VirtualizedGrid: React.FC<VirtualizedGridProps> = ({
   renderCell,
   renderHeader,
 }) => {
-  const cache: CellMeasurerCache = new CellMeasurerCache({
-    defaultHeight: celldefaultHeight,
-    minHeight: 200,
-    fixedWidth: true,
-  });
+  const cache: CellMeasurerCache = React.useMemo(
+    () =>
+      new CellMeasurerCache({
+        defaultHeight: celldefaultHeight,
+        minHeight: 200,
+        fixedWidth: true,
+      }),
+    [celldefaultHeight],
+  );
   return (
     <CellMeasurementContext.Provider
       value={{


### PR DESCRIPTION
![catalog-scroll-position-reset-bug](https://github.com/user-attachments/assets/03f80a6c-75c4-4182-968e-e3fa03bc2deb)
