### PR TITLE
CONSOLE-4861: Sync 'techPreview' server configuration to frontend fea…

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -358,6 +358,7 @@ func main() {
 		NodeOperatingSystems:         nodeOperatingSystems,
 		K8sMode:                      *fK8sMode,
 		CopiedCSVsDisabled:           *fCopiedCSVsDisabled,
+		TechPreview:                  *fTechPreview,
 		Capabilities:                 capabilities,
 	}
 

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -71,6 +71,7 @@ declare interface Window {
     nodeOperatingSystems: string[];
     hubConsoleURL: string;
     k8sMode: string;
+    techPreview: boolean;
     capabilities: {
       name: string;
       visibility: { state: 'Enabled' | 'Disabled' };

--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -2400,6 +2400,12 @@
     }
   },
   {
+    "type": "console.flag/hookProvider",
+    "properties": {
+      "handler": { "$codeRef": "useTechPreviewFlagProvider" }
+    }
+  },
+  {
     "type": "console.navigation/href",
     "properties": {
       "perspective": "admin",

--- a/frontend/packages/console-app/package.json
+++ b/frontend/packages/console-app/package.json
@@ -77,6 +77,7 @@
       "consolePluginBackendDetail": "src/components/console-operator/ConsolePluginBackendDetail.tsx",
       "consolePluginProxyDetail": "src/components/console-operator/ConsolePluginProxyDetail.tsx",
       "getConsoleOperatorConfigFlag": "src/hooks/useCanGetConsoleOperatorConfig.ts",
+      "useTechPreviewFlagProvider": "src/hooks/useTechPreviewFlagProvider.ts",
       "usePerspectivesAvailable": "src/components/user-preferences/perspective/usePerspectivesAvailable.ts",
       "defaultProvider": "src/actions/providers/default-provider.ts",
       "OperatorStatus": "src/components/dashboards-page/OperatorStatus.tsx",

--- a/frontend/packages/console-app/src/consts.ts
+++ b/frontend/packages/console-app/src/consts.ts
@@ -8,6 +8,7 @@ export const FLAG_DEVELOPER_PERSPECTIVE = 'DEVELOPER_PERSPECTIVE';
 export const ACM_PERSPECTIVE_ID = 'acm';
 export const ADMIN_PERSPECTIVE_ID = 'admin';
 export const FLAG_CAN_GET_CONSOLE_OPERATOR_CONFIG = 'CAN_GET_CONSOLE_OPERATOR_CONFIG';
+export const FLAG_TECH_PREVIEW = 'TECH_PREVIEW';
 
 export const FAVORITES_CONFIG_MAP_KEY = 'console.favorites';
 export const FAVORITES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/favorites`;

--- a/frontend/packages/console-app/src/hooks/useTechPreviewFlagProvider.ts
+++ b/frontend/packages/console-app/src/hooks/useTechPreviewFlagProvider.ts
@@ -1,0 +1,9 @@
+import { SetFeatureFlag } from '@console/dynamic-plugin-sdk/src/extensions/feature-flags';
+import { FLAG_TECH_PREVIEW } from '../consts';
+
+type UseTechPreviewFlagProvider = (setFeatureFlag: SetFeatureFlag) => void;
+const useTechPreviewFlagProvider: UseTechPreviewFlagProvider = (setFeatureFlag) => {
+  setFeatureFlag(FLAG_TECH_PREVIEW, !!window.SERVER_FLAGS.techPreview);
+};
+
+export default useTechPreviewFlagProvider;

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -140,6 +140,7 @@ type jsGlobals struct {
 	StatuspageID                    string                     `json:"statuspageID"`
 	Telemetry                       serverconfig.MultiKeyValue `json:"telemetry"`
 	ThanosPublicURL                 string                     `json:"thanosPublicURL"`
+	TechPreview                     bool                       `json:"techPreview"`
 	UserSettingsLocation            string                     `json:"userSettingsLocation"`
 	DevConsoleProxyAvailable        bool                       `json:"devConsoleProxyAvailable"`
 }
@@ -170,6 +171,7 @@ type Server struct {
 	CopiedCSVsDisabled                  bool
 	CSRFVerifier                        *csrfverifier.CSRFVerifier
 	CustomLogoFiles                     serverconfig.LogosKeyValue
+	TechPreview                         bool
 	CustomFaviconFiles                  serverconfig.LogosKeyValue
 	CustomProductName                   string
 	DevCatalogCategories                string
@@ -771,6 +773,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		StatuspageID:              s.StatuspageID,
 		Telemetry:                 s.Telemetry,
 		ThanosPublicURL:           s.ThanosPublicURL.String(),
+		TechPreview:               s.TechPreview,
 		UserSettingsLocation:      s.UserSettingsLocation,
 		DevConsoleProxyAvailable:  true,
 	}


### PR DESCRIPTION
…ture flag service

This change exposes the backend --tech-preview CLI flag to the frontend as a feature flag, enabling UI components to conditionally render features based on whether tech preview mode is enabled.

Backend changes:
- Pass TechPreview flag from bridge CLI to server configuration
- Expose techPreview via jsGlobals to make it available to frontend

Frontend changes:
- Add FLAG_TECH_PREVIEW constant for use throughout the console
- Create useTechPreviewFlagProvider hook to sync server flag to feature flag service
- Register the flag provider extension in console-app

🤖 Generated with [Claude Code](https://claude.com/claude-code)