### PR TITLE
CONSOLE-4709: Remove kebab factory uses from console-app plugin

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -450,28 +450,28 @@
       "provider": { "$codeRef": "bindingProvider.useBindingActionsProvider" }
     }
   },
-      {
-      "type": "console.action/resource-provider",
-      "properties": {
-        "model": {
-          "version": "v1",
-          "kind": "ClusterRoleBinding",
-          "group": "rbac.authorization.k8s.io"
-        },
-        "provider": { "$codeRef": "bindingProvider.useBindingActionsProvider" }
-      }
-    },
-    {
-      "type": "console.action/resource-provider",
-      "properties": {
-        "model": {
-          "version": "v1",
-          "kind": "Build",
-          "group": "build.openshift.io"
-        },
-        "provider": { "$codeRef": "buildProvider.useBuildActionsProvider" }
-      }
-    },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "version": "v1",
+        "kind": "ClusterRoleBinding",
+        "group": "rbac.authorization.k8s.io"
+      },
+      "provider": { "$codeRef": "bindingProvider.useBindingActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "version": "v1",
+        "kind": "Build",
+        "group": "build.openshift.io"
+      },
+      "provider": { "$codeRef": "buildProvider.useBuildActionsProvider" }
+    }
+  },
   {
     "type": "console.action/resource-provider",
     "properties": {
@@ -1308,6 +1308,28 @@
       }
     },
     "flags": { "required": ["OPENSHIFT_BUILD"] }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "config.openshift.io",
+        "version": "v1",
+        "kind": "OAuth"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "snapshot.storage.k8s.io",
+        "version": "v1",
+        "kind": "VolumeSnapshotContent"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
+    }
   },
   {
     "type": "console.navigation/resource-ns",

--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -211,6 +211,7 @@
   "Edit Pod count": "Edit Pod count",
   "Edit Pod selector": "Edit Pod selector",
   "Edit tolerations": "Edit tolerations",
+  "Edit taints": "Edit taints",
   "Add storage": "Add storage",
   "Edit update strategy": "Edit update strategy",
   "Resume rollouts": "Resume rollouts",

--- a/frontend/packages/console-app/src/actions/hooks/types.ts
+++ b/frontend/packages/console-app/src/actions/hooks/types.ts
@@ -12,6 +12,7 @@ export enum CommonActionCreator {
   ModifyCount = 'ModifyCount',
   ModifyPodSelector = 'ModifyPodSelector',
   ModifyTolerations = 'ModifyTolerations',
+  ModifyTaints = 'ModifyTaints',
   AddStorage = 'AddStorage',
 }
 

--- a/frontend/packages/console-app/src/actions/hooks/useCommonActions.ts
+++ b/frontend/packages/console-app/src/actions/hooks/useCommonActions.ts
@@ -7,6 +7,7 @@ import {
   deleteModal,
   labelsModalLauncher,
   podSelectorModal,
+  taintsModal,
   tolerationsModal,
 } from '@console/internal/components/modals';
 import { useConfigureCountModal } from '@console/internal/components/modals/configure-count-modal';
@@ -143,6 +144,16 @@ export const useCommonActions = <T extends readonly CommonActionCreator[]>(
             resourceKind: kind,
             resource,
             modalClassName: 'modal-lg',
+          }),
+        accessReview: asAccessReview(kind as K8sModel, resource as K8sResourceKind, 'patch'),
+      }),
+      [CommonActionCreator.ModifyTaints]: (): Action => ({
+        id: 'edit-taints',
+        label: t('console-app~Edit taints'),
+        cta: () =>
+          taintsModal({
+            resourceKind: kind,
+            resource,
           }),
         accessReview: asAccessReview(kind as K8sModel, resource as K8sResourceKind, 'patch'),
       }),

--- a/frontend/packages/console-app/src/components/nodes/NodeDetailsOverview.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeDetailsOverview.tsx
@@ -17,7 +17,6 @@ import {
 } from '@console/internal/components/utils/cloud-provider';
 import { DetailsItem } from '@console/internal/components/utils/details-item';
 import { SectionHeading } from '@console/internal/components/utils/headings';
-import { Kebab } from '@console/internal/components/utils/kebab';
 import { LabelList } from '@console/internal/components/utils/label-list';
 import { useAccessReview } from '@console/internal/components/utils/rbac';
 import { ResourceLink } from '@console/internal/components/utils/resource-link';
@@ -30,6 +29,8 @@ import {
   getNodeMachineNameAndNamespace,
   getNodeAddresses,
 } from '@console/shared/src/selectors/node';
+import { CommonActionCreator } from '../../actions/hooks/types';
+import { useCommonActions } from '../../actions/hooks/useCommonActions';
 import NodeUptime from './node-dashboard/NodeUptime';
 import NodeIPList from './NodeIPList';
 import NodeStatus from './NodeStatus';
@@ -49,6 +50,10 @@ const NodeDetailsOverview: React.FC<NodeDetailsOverviewProps> = ({ node }) => {
     namespace: node.metadata.namespace,
   });
   const { t } = useTranslation();
+  const [modifyTaints] = useCommonActions(NodeModel, node, [CommonActionCreator.ModifyTaints]);
+  const [modifyAnnotations] = useCommonActions(NodeModel, node, [
+    CommonActionCreator.ModifyAnnotations,
+  ]);
 
   return (
     <PaneBody>
@@ -104,7 +109,12 @@ const NodeDetailsOverview: React.FC<NodeDetailsOverviewProps> = ({ node }) => {
                     variant="link"
                     type="button"
                     isInline
-                    onClick={Kebab.factory.ModifyTaints(NodeModel, node).callback}
+                    onClick={() => {
+                      const action = modifyTaints[CommonActionCreator.ModifyTaints]?.cta;
+                      if (typeof action === 'function') {
+                        action();
+                      }
+                    }}
                   >
                     {_.size(node.spec.taints)}{' '}
                     {t('console-app~Taint', { count: _.size(node.spec.taints) })}
@@ -127,7 +137,12 @@ const NodeDetailsOverview: React.FC<NodeDetailsOverviewProps> = ({ node }) => {
                     variant="link"
                     type="button"
                     isInline
-                    onClick={Kebab.factory.ModifyAnnotations(NodeModel, node).callback}
+                    onClick={() => {
+                      const action = modifyAnnotations[CommonActionCreator.ModifyAnnotations]?.cta;
+                      if (typeof action === 'function') {
+                        action();
+                      }
+                    }}
                   >
                     {_.size(node.metadata.annotations)}{' '}
                     {t('console-app~Annotation', { count: _.size(node.metadata.annotations) })}

--- a/frontend/packages/console-app/src/components/oauth-config/OAuthConfigDetailsPage.tsx
+++ b/frontend/packages/console-app/src/components/oauth-config/OAuthConfigDetailsPage.tsx
@@ -1,20 +1,16 @@
 import * as React from 'react';
 import { DetailsPage } from '@console/internal/components/factory';
 import { navFactory } from '@console/internal/components/utils/horizontal-nav';
-import { Kebab } from '@console/internal/components/utils/kebab';
 import { OAuthModel } from '@console/internal/models';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { OAuthConfigDetails } from './OAuthConfigDetails';
 
-const { common } = Kebab.factory;
-const menuActions = [...common];
 const oAuthReference = referenceForModel(OAuthModel);
 
 const OAuthConfigDetailsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (props) => (
   <DetailsPage
     {...props}
     kind={oAuthReference}
-    menuActions={menuActions}
     pages={[navFactory.details(OAuthConfigDetails), navFactory.editYaml()]}
   />
 );

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content-details.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content-details.tsx
@@ -13,7 +13,6 @@ import { DetailsPage, DetailsPageProps } from '@console/internal/components/fact
 import { ResourceSummary } from '@console/internal/components/utils/details-page';
 import { SectionHeading } from '@console/internal/components/utils/headings';
 import { navFactory } from '@console/internal/components/utils/horizontal-nav';
-import { Kebab } from '@console/internal/components/utils/kebab';
 import { ResourceLink } from '@console/internal/components/utils/resource-link';
 import { humanizeBinaryBytes } from '@console/internal/components/utils/units';
 import { VolumeSnapshotClassModel, VolumeSnapshotModel } from '@console/internal/models';
@@ -112,14 +111,7 @@ const VolumeSnapshotContentDetailsPage: React.FC<DetailsPageProps> = (props) => 
     editYaml(),
     events(ResourceEventStream),
   ];
-  return (
-    <DetailsPage
-      {...props}
-      getResourceStatus={volumeSnapshotStatus}
-      menuActions={Kebab.factory.common}
-      pages={pages}
-    />
-  );
+  return <DetailsPage {...props} getResourceStatus={volumeSnapshotStatus} pages={pages} />;
 };
 
 type DetailsProps = {

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content.tsx
@@ -16,7 +16,7 @@ import { TableData } from '@console/internal/components/factory';
 import { useActiveColumns } from '@console/internal/components/factory/Table/active-columns-hook';
 import type { PageComponentProps } from '@console/internal/components/utils/horizontal-nav';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
-import { Kebab, ResourceKebab } from '@console/internal/components/utils/kebab';
+import { Kebab } from '@console/internal/components/utils/kebab';
 import { ResourceLink } from '@console/internal/components/utils/resource-link';
 import { humanizeBinaryBytes } from '@console/internal/components/utils/units';
 import {
@@ -25,6 +25,7 @@ import {
   VolumeSnapshotContentModel,
 } from '@console/internal/models';
 import { referenceForModel, VolumeSnapshotContentKind } from '@console/internal/module/k8s';
+import LazyActionMenu from '@console/shared/src/components/actions/LazyActionMenu';
 import { Timestamp } from '@console/shared/src/components/datetime/Timestamp';
 import { Status } from '@console/shared/src/components/status/Status';
 import { snapshotStatusFilters, volumeSnapshotStatus } from '../../status';
@@ -73,11 +74,7 @@ const Row: React.FC<RowProps<VolumeSnapshotContentKind>> = ({ obj }) => {
         <Timestamp timestamp={creationTimestamp} />
       </TableData>
       <TableData {...tableColumnInfo[6]}>
-        <ResourceKebab
-          kind={referenceForModel(VolumeSnapshotContentModel)}
-          resource={obj}
-          actions={Kebab.factory.common}
-        />
+        <LazyActionMenu context={{ [referenceForModel(VolumeSnapshotContentModel)]: obj }} />
       </TableData>
     </>
   );


### PR DESCRIPTION
Remove the use of the kebab factory from the following pages of the console-app plugin

- NodeDetailsOverview.tsx
- OAuthConfigDetailsPage.tsx
- volume-snapshot-content-details.tsx
- volume-snapshot-content.tsx


Changes from the big PR https://github.com/openshift/console/pull/15520