### PR TITLE
CONSOLE-4564: normalize ConsoleDataView columns and rows props

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -232,6 +232,7 @@ const useNodesColumns = (): TableColumn<NodeRowItem>[] => {
         sort: 'metadata.labels',
         props: {
           modifier: 'nowrap',
+          width: 15,
         },
         additional: true,
       },
@@ -385,9 +386,6 @@ const getNodeDataViewRows = (
       },
       [nodeColumnInfo.labels.id]: {
         cell: <LabelList kind={kind} labels={labels} />,
-        props: {
-          width: 15,
-        },
       },
       [nodeColumnInfo.zone.id]: {
         cell: zone,
@@ -397,9 +395,7 @@ const getNodeDataViewRows = (
       },
       [nodeColumnInfo.actions.id]: {
         cell: node ? <LazyActionMenu context={context} /> : null,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseListHeader.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseListHeader.tsx
@@ -58,7 +58,6 @@ const useHelmReleaseListColumns = (): TableColumn<any>[] => {
         sort: 'info.status',
         props: {
           modifier: 'nowrap',
-          visibility: ['hiddenOnMd', 'visibleOnLg'],
         },
       },
       {
@@ -67,7 +66,6 @@ const useHelmReleaseListColumns = (): TableColumn<any>[] => {
         sort: 'chart.metadata.name',
         props: {
           modifier: 'nowrap',
-          visibility: ['hiddenOnMd', 'visibleOnXl'],
         },
       },
       {
@@ -76,7 +74,6 @@ const useHelmReleaseListColumns = (): TableColumn<any>[] => {
         sort: 'chart.metadata.version',
         props: {
           modifier: 'nowrap',
-          visibility: ['hiddenOnMd', 'visibleOnXl'],
         },
       },
       {
@@ -85,7 +82,6 @@ const useHelmReleaseListColumns = (): TableColumn<any>[] => {
         sort: 'chart.metadata.appVersion',
         props: {
           modifier: 'nowrap',
-          visibility: ['hiddenOnMd', 'visibleOnXl'],
         },
       },
       {

--- a/frontend/packages/helm-plugin/src/components/list-page/RepositoriesHeader.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/RepositoriesHeader.tsx
@@ -56,7 +56,6 @@ export const useRepositoriesColumns = (): TableColumn<K8sResourceKind>[] => {
         sort: 'spec.connectionConfig.url',
         props: {
           modifier: 'nowrap',
-          visibility: ['hiddenOnMd', 'visibleOnXl'],
         },
       },
       {
@@ -65,7 +64,6 @@ export const useRepositoriesColumns = (): TableColumn<K8sResourceKind>[] => {
         sort: 'metadata.creationTimestamp',
         props: {
           modifier: 'nowrap',
-          visibility: ['hiddenOnMd', 'visibleOnXl'],
         },
       },
       {

--- a/frontend/public/components/RBAC/bindings.tsx
+++ b/frontend/public/components/RBAC/bindings.tsx
@@ -215,9 +215,7 @@ const getDataViewRows: GetDataViewRows<BindingKind, undefined> = (data, columns)
       },
       [tableColumnInfo[5].id]: {
         cell: <BindingKebab binding={binding} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/alert-manager.tsx
+++ b/frontend/public/components/alert-manager.tsx
@@ -147,20 +147,12 @@ const getDataViewRows: GetDataViewRows<K8sResourceKind, undefined> = (data, colu
       },
       [tableColumnInfo[2].id]: {
         cell: <LabelList kind={AlertmanagerModel.kind} labels={metadata.labels} />,
-        props: {
-          modifier: 'nowrap',
-          width: 20,
-        },
       },
       [tableColumnInfo[3].id]: {
         cell: spec.version || DASH,
       },
       [tableColumnInfo[4].id]: {
         cell: <Selector selector={spec.nodeSelector} kind="Node" />,
-        props: {
-          modifier: 'nowrap',
-          width: 20,
-        },
       },
     };
 
@@ -202,6 +194,7 @@ const useAlertManagerColumns = (): TableColumn<K8sResourceKind>[] => {
         sort: 'metadata.labels',
         props: {
           modifier: 'nowrap',
+          width: 20,
         },
       },
       {
@@ -210,6 +203,7 @@ const useAlertManagerColumns = (): TableColumn<K8sResourceKind>[] => {
         sort: 'spec.version',
         props: {
           modifier: 'nowrap',
+          width: 20,
         },
       },
       {

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -258,9 +258,7 @@ const getDataViewRows: GetDataViewRows<BuildConfig, undefined> = (data, columns)
       },
       [tableColumnInfo[6].id]: {
         cell: <BuildConfigKebabActions buildConfig={obj} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/configmap.tsx
+++ b/frontend/public/components/configmap.tsx
@@ -64,9 +64,7 @@ const getDataViewRows: GetDataViewRows<ConfigMapKind, undefined> = (data, column
       },
       [tableColumnInfo[4].id]: {
         cell: <ResourceKebab actions={menuActions} kind={kind} resource={configMap} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/control-plane-machine-set.tsx
+++ b/frontend/public/components/control-plane-machine-set.tsx
@@ -323,9 +323,7 @@ const getDataViewRows: GetDataViewRows<ControlPlaneMachineSetKind, undefined> = 
             resource={obj}
           />
         ),
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -340,9 +340,7 @@ const getDataViewRows: GetDataViewRows<CustomResourceDefinitionKind, undefined> 
             resource={obj}
           />
         ),
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/default-resource.tsx
+++ b/frontend/public/components/default-resource.tsx
@@ -218,9 +218,7 @@ const getDataViewRows = (
             )}
           </>
         ),
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/group.tsx
+++ b/frontend/public/components/group.tsx
@@ -67,9 +67,7 @@ const getDataViewRows: GetDataViewRows<GroupKind, undefined> = (
       },
       [tableColumnInfo[3].id]: {
         cell: <LazyActionMenu context={context} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -320,9 +320,7 @@ const getDataViewRows: GetDataViewRows<HorizontalPodAutoscalerKind, undefined> =
             resource={obj}
           />
         ),
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -376,9 +376,7 @@ const getDataViewRows: GetDataViewRows<K8sResourceKind, undefined> = (data, colu
             resource={imageStream}
           />
         ),
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/job.tsx
+++ b/frontend/public/components/job.tsx
@@ -110,9 +110,7 @@ const getDataViewRows: GetDataViewRows<JobKind, undefined> = (data, columns) => 
       },
       [tableColumnInfo[6].id]: {
         cell: <LazyActionMenu context={context} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/limit-range.tsx
+++ b/frontend/public/components/limit-range.tsx
@@ -58,9 +58,7 @@ const getDataViewRows: GetDataViewRows<K8sResourceKind, undefined> = (
       },
       [tableColumnInfo[3].id]: {
         cell: <ResourceKebab actions={menuActions} kind={LimitRangeReference} resource={obj} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/machine-autoscaler.tsx
+++ b/frontend/public/components/machine-autoscaler.tsx
@@ -89,9 +89,7 @@ const getDataViewRows: GetDataViewRows<K8sResourceKind, undefined> = (data, colu
         cell: (
           <ResourceKebab actions={menuActions} kind={machineAutoscalerReference} resource={obj} />
         ),
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/machine-config-pool.tsx
+++ b/frontend/public/components/machine-config-pool.tsx
@@ -396,23 +396,15 @@ const getDataViewRows: GetDataViewRows<MachineConfigPoolKind, KebabAction[]> = (
       },
       [tableColumnInfo[2].id]: {
         cell: getConditionStatus(obj, MachineConfigPoolConditionType.Degraded),
-        props: {
-          modifier: 'nowrap',
-        },
       },
       [tableColumnInfo[3].id]: {
         cell: <MachineConfigPoolUpdateStatus obj={obj} />,
-        props: {
-          modifier: 'nowrap',
-        },
       },
       [tableColumnInfo[4].id]: {
         cell: (
           <ResourceKebab actions={menuActions} kind={machineConfigPoolReference} resource={obj} />
         ),
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/machine-config.tsx
+++ b/frontend/public/components/machine-config.tsx
@@ -191,9 +191,7 @@ const getDataViewRows: GetDataViewRows<MachineConfigKind, undefined> = (data, co
             resource={obj}
           />
         ),
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/machine-health-check.tsx
+++ b/frontend/public/components/machine-health-check.tsx
@@ -51,21 +51,13 @@ const getDataViewRows: GetDataViewRows<MachineHealthCheckKind, typeof menuAction
       },
       [tableColumnInfo[1].id]: {
         cell: <ResourceLink kind="Namespace" name={namespace} />,
-        props: {
-          modifier: 'nowrap',
-        },
       },
       [tableColumnInfo[2].id]: {
         cell: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
-        props: {
-          modifier: 'nowrap',
-        },
       },
       [tableColumnInfo[3].id]: {
         cell: <ResourceKebab actions={actions} kind={machineHealthCheckReference} resource={obj} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -390,9 +390,7 @@ const getDataViewRows = (
       },
       [tableColumnInfo[6].id]: {
         cell: <LazyActionMenu context={{ [machineSetReference]: obj }} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -97,9 +97,7 @@ const getDataViewRows = (data: { obj: MachineKind }[], columns: TableColumn<Mach
       },
       [tableColumnInfo[7].id]: {
         cell: <ResourceKebab actions={menuActions} kind={machineReference} resource={obj} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/monitoring/alertmanager/alertmanager-config.tsx
+++ b/frontend/public/components/monitoring/alertmanager/alertmanager-config.tsx
@@ -389,9 +389,7 @@ const getReceiverDataViewRows = (
       },
       [tableColumnInfo[3].id]: {
         cell: <Kebab options={receiverMenuItems(receiver.name)} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -360,9 +360,7 @@ const getNamespaceDataViewRows = (rowData, tableColumns, namespaceMetrics, t) =>
       },
       [namespaceColumnInfo[9].id]: {
         cell: <ResourceKebab actions={nsMenuActions} kind="Namespace" resource={ns} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 
@@ -674,9 +672,7 @@ const getProjectDataViewRows = (
       },
       [projectColumnInfo[9].id]: {
         cell: <ResourceKebab actions={projectMenuActions} kind="Project" resource={project} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/pod-list.tsx
+++ b/frontend/public/components/pod-list.tsx
@@ -419,9 +419,7 @@ const getPodDataViewRows = (
       },
       [tableColumnInfo[13].id]: {
         cell: <LazyActionMenu context={context} isDisabled={phase === 'Terminating'} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/prometheus.tsx
+++ b/frontend/public/components/prometheus.tsx
@@ -78,9 +78,7 @@ const getDataViewRows: GetDataViewRows<K8sResourceKind, undefined> = (
       },
       [tableColumnInfo[5].id]: {
         cell: <LazyActionMenu context={context} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -184,9 +184,7 @@ const getDataViewRows = (data, columns) => {
       },
       [tableColumnInfo[6].id]: {
         cell: <LazyActionMenu context={context} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -200,9 +200,7 @@ const getDataViewRows = (data, columns) => {
       },
       [tableColumnInfo[6].id]: {
         cell: <LazyActionMenu context={context} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -488,9 +488,7 @@ const getResourceQuotaDataViewRows = (data, columns, namespace) => {
             resource={obj}
           />
         ),
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 
@@ -560,9 +558,7 @@ const getAppliedClusterResourceQuotaDataViewRows = (data, columns, namespace) =>
             resource={obj}
           />
         ),
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -55,9 +55,7 @@ const getDataViewRows = (data, columns) => {
       },
       [tableColumnInfo[4].id]: {
         cell: <ResourceKebab actions={menuActions} kind={kind} resource={obj} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/service-monitor.jsx
+++ b/frontend/public/components/service-monitor.jsx
@@ -85,9 +85,7 @@ const getServiceMonitorDataViewRows = (data, columns) => {
       },
       [serviceMonitorTableColumnInfo[4].id]: {
         cell: <ResourceKebab actions={menuActions} kind={resourceKind} resource={obj} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/template-instance.tsx
+++ b/frontend/public/components/template-instance.tsx
@@ -75,9 +75,7 @@ const getTemplateInstanceDataViewRows = (
       },
       [tableColumnInfo[3].id]: {
         cell: <ResourceKebab actions={menuActions} kind="TemplateInstance" resource={obj} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 

--- a/frontend/public/components/workload-table.tsx
+++ b/frontend/public/components/workload-table.tsx
@@ -132,9 +132,7 @@ export const getWorkloadDataViewRows = <T extends K8sResourceKind>(
       },
       [tableColumnInfo[5].id]: {
         cell: <LazyActionMenu context={context} />,
-        props: {
-          ...actionsCellProps,
-        },
+        props: actionsCellProps,
       },
     };
 


### PR DESCRIPTION
Note I used the epic Jira issue for this story since the changes span multiple stories within the epic.

There is some inconsistency in where `props` are applied in the various `ConsoleDataView` implementations that have already merged.  This PR looks to normalize the application of `props` across the various implementations.

* `width` and `modifier` `props` are applied only on columns
* `visibility` `props` are removed since the tables scroll horizontally
* usage of `actionsCellProps` is standardized

Thanks to @sg00dwin for noticing the the inconsistency in https://github.com/openshift/console/pull/15696