### PR TITLE
OCPBUGS-65598: fix invalid project resource link in ProjectList

### DIFF
--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -854,14 +854,7 @@ export const ProjectList = (props) => {
         additionalFilterNodes={additionalFilterNodes}
         matchesAdditionalFilters={matchesAdditionalFilters}
         getDataViewRows={(rowData, tableColumns) =>
-          getProjectDataViewRows(
-            rowData,
-            tableColumns,
-            namespaceMetrics,
-            showMetrics,
-            ProjectLink,
-            t,
-          )
+          getProjectDataViewRows(rowData, tableColumns, namespaceMetrics, showMetrics, undefined, t)
         }
         NoDataEmptyMsg={OpenShiftGettingStarted}
       />


### PR DESCRIPTION
`<ProjectList>` was incorrectly passing `ProjectLink`, which should only [be done in `<ProjectsTable>`](https://github.com/openshift/console/blob/d512c56ae79869ca2f85c44737be8b4702f1301c/frontend/public/components/namespace.jsx#L748).

After

https://github.com/user-attachments/assets/1f97175b-572a-4cda-8a8b-df272c7c65a4




