### PR TITLE
OCPBUGS-65612: API Explorer list and Access review tab pagination

### DIFF
--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -420,7 +420,7 @@ const APIResourcesList = compose(
             />
           </ToolbarItem>
           <ToolbarItem variant="pagination">
-            <Pagination itemCount={sortedResources.length} {...pagination} isCompact />
+            <Pagination itemCount={sortedResources.length} {...pagination} />
           </ToolbarItem>
         </ToolbarContent>
       </Toolbar>
@@ -497,13 +497,6 @@ const APIResourcesList = compose(
           />
         </InnerScrollContainer>
       </DataView>
-      <Toolbar>
-        <ToolbarContent>
-          <ToolbarItem variant="pagination">
-            <Pagination itemCount={sortedResources.length} {...pagination} variant="bottom" />
-          </ToolbarItem>
-        </ToolbarContent>
-      </Toolbar>
     </PaneBody>
   );
 });
@@ -827,7 +820,7 @@ const APIResourceAccessReview: FC<APIResourceTabProps> = ({
             />
           </FlexItem>
           <FlexItem align={{ default: 'alignRight' }}>
-            <Pagination itemCount={filteredData.length} {...pagination} isCompact />
+            <Pagination itemCount={filteredData.length} {...pagination} />
           </FlexItem>
         </Flex>
         <RowFilter
@@ -924,13 +917,6 @@ const APIResourceAccessReview: FC<APIResourceTabProps> = ({
             />
           </InnerScrollContainer>
         </DataView>
-        <Toolbar>
-          <ToolbarContent>
-            <ToolbarItem variant="pagination">
-              <Pagination itemCount={filteredData.length} {...pagination} variant="bottom" />
-            </ToolbarItem>
-          </ToolbarContent>
-        </Toolbar>
       </PaneBody>
     </>
   );


### PR DESCRIPTION
For both API Explorer list and Access review tab
- Removed `isCompact` prop from the top pagination to show full controls including navigation
- Removed the entire bottom pagination toolbar 


Before:
<img width="1237" height="447" alt="API-Explorer-Before" src="https://github.com/user-attachments/assets/78f07134-b7e7-4e2c-bbe1-3b9a306ef4f1" />
<img width="1235" height="497" alt="Access-review-before" src="https://github.com/user-attachments/assets/15bd1e02-454d-4d7f-bc93-225f1eeb84b0" />

After:
<img width="1455" height="599" alt="API-Explorer-After" src="https://github.com/user-attachments/assets/43e8cde1-8df9-4eef-93d7-c23bc735fd7d" />
<img width="1456" height="567" alt="Access-review-after" src="https://github.com/user-attachments/assets/5dc97c52-c7e0-42db-98aa-7094f41a9175" />
