### PR TITLE
CONSOLE-4709: part 2 - Remove kebab factory uses from Public

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -457,28 +457,28 @@
       "provider": { "$codeRef": "bindingProvider.useBindingActionsProvider" }
     }
   },
-      {
-      "type": "console.action/resource-provider",
-      "properties": {
-        "model": {
-          "version": "v1",
-          "kind": "ClusterRoleBinding",
-          "group": "rbac.authorization.k8s.io"
-        },
-        "provider": { "$codeRef": "bindingProvider.useBindingActionsProvider" }
-      }
-    },
-    {
-      "type": "console.action/resource-provider",
-      "properties": {
-        "model": {
-          "version": "v1",
-          "kind": "Build",
-          "group": "build.openshift.io"
-        },
-        "provider": { "$codeRef": "buildProvider.useBuildActionsProvider" }
-      }
-    },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "version": "v1",
+        "kind": "ClusterRoleBinding",
+        "group": "rbac.authorization.k8s.io"
+      },
+      "provider": { "$codeRef": "bindingProvider.useBindingActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "version": "v1",
+        "kind": "Build",
+        "group": "build.openshift.io"
+      },
+      "provider": { "$codeRef": "buildProvider.useBuildActionsProvider" }
+    }
+  },
   {
     "type": "console.action/resource-provider",
     "properties": {
@@ -2382,6 +2382,149 @@
     "type": "console.flag/hookProvider",
     "properties": {
       "handler": { "$codeRef": "getConsoleOperatorConfigFlag" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "",
+        "version": "v1",
+        "kind": "ConfigMap"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "machine.openshift.io",
+        "version": "v1",
+        "kind": "ControlPlaneMachineSet"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "autoscaling",
+        "version": "v2",
+        "kind": "HorizontalPodAutoscaler"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "image.openshift.io",
+        "version": "v1",
+        "kind": "ImageStreamTag"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "image.openshift.io",
+        "version": "v1",
+        "kind": "ImageStream"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "",
+        "version": "v1",
+        "kind": "LimitRange"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "autoscaling.openshift.io",
+        "version": "v1beta1",
+        "kind": "MachineAutoscaler"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "machineconfiguration.openshift.io",
+        "version": "v1",
+        "kind": "MachineConfig"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "machine.openshift.io",
+        "version": "v1beta1",
+        "kind": "MachineHealthCheck"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "machine.openshift.io",
+        "version": "v1beta1",
+        "kind": "Machine"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "",
+        "version": "v1",
+        "kind": "PersistentVolume"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "",
+        "version": "v1",
+        "kind": "ServiceAccount"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "template.openshift.io",
+        "version": "v1",
+        "kind": "TemplateInstance"
+      },
+      "provider": { "$codeRef": "defaultProvider.useDefaultActionsProvider" }
     }
   },
   {

--- a/frontend/public/components/configmap.tsx
+++ b/frontend/public/components/configmap.tsx
@@ -6,7 +6,6 @@ import { DetailsPage } from './factory/details';
 import { ListPage } from './factory/list-page';
 import { ConfigMapData, ConfigMapBinaryData } from './configmap-and-secret-data';
 import { DASH } from '@console/shared/src/constants/ui';
-import { Kebab, ResourceKebab } from './utils/kebab';
 import { SectionHeading } from './utils/headings';
 import { navFactory } from './utils/horizontal-nav';
 import { ResourceLink } from './utils/resource-link';
@@ -27,8 +26,8 @@ import { GetDataViewRows } from '@console/app/src/components/data-view/types';
 import { LoadingBox } from '@console/shared/src/components/loading';
 import { sortResourceByValue } from './factory/Table/sort';
 import { sorts } from './factory/table';
+import LazyActionMenu from '@console/shared/src/components/actions/LazyActionMenu';
 
-const menuActions = [...Kebab.factory.common];
 const kind = referenceForModel(ConfigMapModel);
 const tableColumnInfo = [
   { id: 'name' },
@@ -63,7 +62,7 @@ const getDataViewRows: GetDataViewRows<ConfigMapKind, undefined> = (data, column
         cell: <Timestamp timestamp={configMap.metadata.creationTimestamp} />,
       },
       [tableColumnInfo[4].id]: {
-        cell: <ResourceKebab actions={menuActions} kind={kind} resource={configMap} />,
+        cell: <LazyActionMenu context={{ [kind]: configMap }} />,
         props: actionsCellProps,
       },
     };
@@ -192,7 +191,6 @@ export const ConfigMapsDetailsPage: React.FCC = (props) => {
     <DetailsPage
       {...props}
       kind={kind}
-      menuActions={menuActions}
       pages={[navFactory.details(ConfigMapDetails), navFactory.editYaml()]}
     />
   );

--- a/frontend/public/components/control-plane-machine-set.tsx
+++ b/frontend/public/components/control-plane-machine-set.tsx
@@ -24,13 +24,11 @@ import {
   ConsoleDataView,
 } from '@console/app/src/components/data-view/ConsoleDataView';
 import { GetDataViewRows } from '@console/app/src/components/data-view/types';
-
 import { Conditions } from './conditions';
 import { ControlPlaneMachineSetModel } from '../models';
 import { ControlPlaneMachineSetKind, referenceForModel } from '../module/k8s';
 import { DetailsPage } from './factory/details';
 import { ListPage } from './factory/list-page';
-import { Kebab, ResourceKebab } from './utils/kebab';
 import { LoadingBox } from './utils/status-box';
 import { navFactory } from './utils/horizontal-nav';
 import { ResourceLink, resourcePath } from './utils/resource-link';
@@ -40,9 +38,9 @@ import { Selector } from './utils/selector';
 import { ResourceEventStream } from './events';
 import { MachinePage, machineReference } from './machine';
 import { MachineTabPageProps } from './machine-set';
+import LazyActionMenu from '@console/shared/src/components/actions/LazyActionMenu';
 
 const controlPlaneMachineSetReference = referenceForModel(ControlPlaneMachineSetModel);
-const controlPlaneMachineSetMenuActions = [...Kebab.factory.common];
 const getDesiredReplicas = (resource: ControlPlaneMachineSetKind) => {
   return resource.spec.replicas;
 };
@@ -194,12 +192,7 @@ const pages = [
 ];
 
 export const ControlPlaneMachineSetDetailsPage: React.FC<any> = (props) => (
-  <DetailsPage
-    {...props}
-    kind={controlPlaneMachineSetReference}
-    menuActions={controlPlaneMachineSetMenuActions}
-    pages={pages}
-  />
+  <DetailsPage {...props} kind={controlPlaneMachineSetReference} pages={pages} />
 );
 
 const tableColumnInfo = [
@@ -316,13 +309,7 @@ const getDataViewRows: GetDataViewRows<ControlPlaneMachineSetKind, undefined> = 
         cell: obj.spec?.state || DASH,
       },
       [tableColumnInfo[5].id]: {
-        cell: (
-          <ResourceKebab
-            actions={controlPlaneMachineSetMenuActions}
-            kind={controlPlaneMachineSetReference}
-            resource={obj}
-          />
-        ),
+        cell: <LazyActionMenu context={{ [controlPlaneMachineSetReference]: obj }} />,
         props: actionsCellProps,
       },
     };

--- a/frontend/public/components/cron-job.tsx
+++ b/frontend/public/components/cron-job.tsx
@@ -25,7 +25,6 @@ import { ContainerTable } from './utils/container-table';
 import { DetailsItem } from './utils/details-item';
 import { Firehose } from './utils/firehose';
 import { FirehoseResourcesResult } from './utils/types';
-import { Kebab } from './utils/kebab';
 import { ResourceLink } from './utils/resource-link';
 import { ResourceSummary } from './utils/details-page';
 import { SectionHeading } from './utils/headings';
@@ -48,9 +47,6 @@ import { GetDataViewRows } from '@console/app/src/components/data-view/types';
 import { getGroupVersionKindForModel } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';
 import { LoadingBox } from './utils/status-box';
 import * as _ from 'lodash';
-
-const { common } = Kebab.factory;
-export const menuActions = [...common];
 
 const kind = referenceForModel(CronJobModel);
 

--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -15,7 +15,6 @@ import { Conditions } from './conditions';
 import { DetailsPage } from './factory/details';
 import { ListPage } from './factory/list-page';
 import { DetailsItem } from './utils/details-item';
-import { Kebab, ResourceKebab } from './utils/kebab';
 import { LabelList } from './utils/label-list';
 import { LoadingBox } from './utils/status-box';
 import { ResourceLink } from './utils/resource-link';
@@ -34,13 +33,11 @@ import {
 } from '@console/app/src/components/data-view/ConsoleDataView';
 import { GetDataViewRows } from '@console/app/src/components/data-view/types';
 import { DASH } from '@console/shared/src/constants/ui';
+import LazyActionMenu from '@console/shared/src/components/actions/LazyActionMenu';
 
 const HorizontalPodAutoscalersReference: K8sResourceKindReference = referenceForModel(
   HorizontalPodAutoscalerModel,
 );
-
-const { common } = Kebab.factory;
-const menuActions = [...common];
 
 const MetricsRow: React.FC<MetricsRowProps> = ({ type, current, target }) => (
   <Tr>
@@ -253,12 +250,7 @@ const pages = [
   navFactory.events(ResourceEventStream),
 ];
 export const HorizontalPodAutoscalersDetailsPage: React.FC = (props) => (
-  <DetailsPage
-    {...props}
-    kind={HorizontalPodAutoscalersReference}
-    menuActions={menuActions}
-    pages={pages}
-  />
+  <DetailsPage {...props} kind={HorizontalPodAutoscalersReference} pages={pages} />
 );
 HorizontalPodAutoscalersDetailsPage.displayName = 'HorizontalPodAutoscalersDetailsPage';
 
@@ -314,11 +306,7 @@ const getDataViewRows: GetDataViewRows<HorizontalPodAutoscalerKind, undefined> =
       },
       [tableColumnInfo[6].id]: {
         cell: (
-          <ResourceKebab
-            actions={menuActions}
-            kind={HorizontalPodAutoscalersReference}
-            resource={obj}
-          />
+          <LazyActionMenu context={{ [referenceForModel(HorizontalPodAutoscalerModel)]: obj }} />
         ),
         props: actionsCellProps,
       },

--- a/frontend/public/components/image-stream-tag.tsx
+++ b/frontend/public/components/image-stream-tag.tsx
@@ -16,7 +16,6 @@ import PaneBody from '@console/shared/src/components/layout/PaneBody';
 import PaneBodyGroup from '@console/shared/src/components/layout/PaneBodyGroup';
 import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { DetailsPage } from './factory/details';
-import { Kebab } from './utils/kebab';
 import { SectionHeading } from './utils/headings';
 import { navFactory } from './utils/horizontal-nav';
 import { ResourceSummary } from './utils/details-page';
@@ -28,9 +27,6 @@ import { getBreadcrumbPath } from '@console/internal/components/utils/breadcrumb
 
 const ImageStreamTagsReference: K8sResourceKindReference = 'ImageStreamTag';
 const ImageStreamsReference: K8sResourceKindReference = 'ImageStream';
-
-const { common } = Kebab.factory;
-const menuActions = [...common];
 
 // Splits a name/value pair separated by an `=`
 const splitEnv = (nameValue: string) => {
@@ -311,7 +307,6 @@ export const ImageStreamTagsDetailsPage: React.FCC<ImageStreamTagsDetailsPagePro
         ];
       }}
       kind={ImageStreamTagsReference}
-      menuActions={menuActions}
       resources={[
         {
           kind: ImageStreamsReference,

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -38,7 +38,6 @@ import { DOC_URL_PODMAN } from './utils/documentation';
 import { CopyToClipboard } from './utils/copy-to-clipboard';
 import { ExpandableAlert } from './utils/alerts';
 import { ExternalLink } from '@console/shared/src/components/links/ExternalLink';
-import { Kebab, ResourceKebab } from './utils/kebab';
 import { SectionHeading } from './utils/headings';
 import { LabelList } from './utils/label-list';
 import { navFactory } from './utils/horizontal-nav';
@@ -48,6 +47,7 @@ import { Timestamp } from '@console/shared/src/components/datetime/Timestamp';
 import { ImageStreamTimeline, getImageStreamTagName } from './image-stream-timeline';
 import { YellowExclamationTriangleIcon } from '@console/shared/src/components/status/icons';
 import { LoadingBox } from './utils/status-box';
+import LazyActionMenu from '@console/shared/src/components/actions/LazyActionMenu';
 
 const ImageStreamsReference: K8sResourceKindReference = 'ImageStream';
 const ImageStreamTagsReference: K8sResourceKindReference = 'ImageStreamTag';
@@ -99,9 +99,6 @@ export const getMostRecentBuilderTag = (imageStream: K8sResourceKind) => {
 // - It has a spec tag annotated with `builder` and not `hidden`
 // - It has a corresponding status tag
 export const isBuilder = (imageStream: K8sResourceKind) => !_.isEmpty(getBuilderTags(imageStream));
-
-const { common } = Kebab.factory;
-const menuActions = [...common];
 
 const ImageStreamTagsRow: React.FCC<ImageStreamTagsRowProps> = ({
   imageStream,
@@ -338,7 +335,7 @@ const pages = [
   navFactory.history(ImageStreamHistory),
 ];
 export const ImageStreamsDetailsPage: React.FCC = (props) => (
-  <DetailsPage {...props} kind={ImageStreamsReference} menuActions={menuActions} pages={pages} />
+  <DetailsPage {...props} kind={referenceForModel(ImageStreamModel)} pages={pages} />
 );
 ImageStreamsDetailsPage.displayName = 'ImageStreamsDetailsPage';
 
@@ -369,13 +366,7 @@ const getDataViewRows: GetDataViewRows<K8sResourceKind, undefined> = (data, colu
         cell: <Timestamp timestamp={creationTimestamp} />,
       },
       [tableColumnInfo[4].id]: {
-        cell: (
-          <ResourceKebab
-            actions={menuActions}
-            kind={ImageStreamsReference}
-            resource={imageStream}
-          />
-        ),
+        cell: <LazyActionMenu context={{ [referenceForModel(ImageStreamModel)]: imageStream }} />,
         props: actionsCellProps,
       },
     };

--- a/frontend/public/components/limit-range.tsx
+++ b/frontend/public/components/limit-range.tsx
@@ -2,11 +2,10 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';
-import { K8sResourceKindReference, K8sResourceKind } from '../module/k8s';
+import { K8sResourceKindReference, K8sResourceKind, referenceForModel } from '../module/k8s';
 import { LimitRangeModel } from '../models';
 import { DetailsPage } from './factory/details';
 import { ListPage } from './factory/list-page';
-import { Kebab, ResourceKebab } from './utils/kebab';
 import { navFactory } from './utils/horizontal-nav';
 import { SectionHeading } from './utils/headings';
 import { ResourceLink } from './utils/resource-link';
@@ -30,9 +29,7 @@ import {
 } from '@console/app/src/components/data-view/types';
 import { RowProps } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { DASH } from '@console/shared/src/constants/ui';
-
-const { common } = Kebab.factory;
-const menuActions = [...common];
+import LazyActionMenu from '@console/shared/src/components/actions/LazyActionMenu';
 
 const LimitRangeReference: K8sResourceKindReference = LimitRangeModel.kind;
 
@@ -57,7 +54,7 @@ const getDataViewRows: GetDataViewRows<K8sResourceKind, undefined> = (
         cell: <Timestamp timestamp={creationTimestamp} />,
       },
       [tableColumnInfo[3].id]: {
-        cell: <ResourceKebab actions={menuActions} kind={LimitRangeReference} resource={obj} />,
+        cell: <LazyActionMenu context={{ [referenceForModel(LimitRangeModel)]: obj }} />,
         props: actionsCellProps,
       },
     };
@@ -228,7 +225,7 @@ export const LimitRangeDetailsPage = (props) => {
   return (
     <DetailsPage
       {...props}
-      menuActions={menuActions}
+      kind={referenceForModel(LimitRangeModel)}
       pages={[navFactory.details(Details), navFactory.editYaml()]}
     />
   );

--- a/frontend/public/components/machine-autoscaler.tsx
+++ b/frontend/public/components/machine-autoscaler.tsx
@@ -22,7 +22,6 @@ import {
 } from '../module/k8s';
 import { DetailsPage } from './factory/details';
 import { ListPage } from './factory/list-page';
-import { Kebab, ResourceKebab } from './utils/kebab';
 import { LoadingBox } from './utils/status-box';
 import { navFactory } from './utils/horizontal-nav';
 import { ResourceLink } from './utils/resource-link';
@@ -35,9 +34,8 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core';
+import LazyActionMenu from '@console/shared/src/components/actions/LazyActionMenu';
 
-const { common } = Kebab.factory;
-const menuActions = [...common];
 const machineAutoscalerReference = referenceForModel(MachineAutoscalerModel);
 
 const MachineAutoscalerTargetLink: React.FC<MachineAutoscalerTargetLinkProps> = ({ obj }) => {
@@ -86,9 +84,7 @@ const getDataViewRows: GetDataViewRows<K8sResourceKind, undefined> = (data, colu
         cell: _.get(obj, 'spec.maxReplicas') || DASH,
       },
       [tableColumnInfo[5].id]: {
-        cell: (
-          <ResourceKebab actions={menuActions} kind={machineAutoscalerReference} resource={obj} />
-        ),
+        cell: <LazyActionMenu context={{ [machineAutoscalerReference]: obj }} />,
         props: actionsCellProps,
       },
     };
@@ -234,7 +230,6 @@ export const MachineAutoscalerPage: React.FC<MachineAutoscalerPageProps> = (prop
 export const MachineAutoscalerDetailsPage: React.FC = (props) => (
   <DetailsPage
     {...props}
-    menuActions={menuActions}
     kind={machineAutoscalerReference}
     pages={[navFactory.details(MachineAutoscalerDetails), navFactory.editYaml()]}
   />

--- a/frontend/public/components/machine-config.tsx
+++ b/frontend/public/components/machine-config.tsx
@@ -32,7 +32,6 @@ import { MachineConfigModel } from '../models';
 import { DetailsPage } from './factory/details';
 import { ListPage } from './factory/list-page';
 import { CopyToClipboard } from './utils/copy-to-clipboard';
-import { Kebab, ResourceKebab } from './utils/kebab';
 import { LoadingBox } from './utils/status-box';
 import { navFactory } from './utils/horizontal-nav';
 import { ResourceLink } from './utils/resource-link';
@@ -40,9 +39,9 @@ import { ResourceSummary } from './utils/details-page';
 import { SectionHeading } from './utils/headings';
 import { Timestamp } from '@console/shared/src/components/datetime/Timestamp';
 import { ResourceEventStream } from './events';
+import LazyActionMenu from '@console/shared/src/components/actions/LazyActionMenu';
 
 export const machineConfigReference = referenceForModel(MachineConfigModel);
-const machineConfigMenuActions = [...Kebab.factory.common];
 
 const MachineConfigSummary: React.FCC<MachineConfigSummaryProps> = ({ obj, t }) => (
   <ResourceSummary resource={obj}>
@@ -129,14 +128,7 @@ const pages = [
 ];
 
 export const MachineConfigDetailsPage: React.FCC<any> = (props) => {
-  return (
-    <DetailsPage
-      {...props}
-      kind={machineConfigReference}
-      menuActions={machineConfigMenuActions}
-      pages={pages}
-    />
-  );
+  return <DetailsPage {...props} kind={machineConfigReference} pages={pages} />;
 };
 
 const tableColumnInfo = [
@@ -184,13 +176,7 @@ const getDataViewRows: GetDataViewRows<MachineConfigKind, undefined> = (data, co
         cell: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
       },
       [tableColumnInfo[5].id]: {
-        cell: (
-          <ResourceKebab
-            actions={machineConfigMenuActions}
-            kind={machineConfigReference}
-            resource={obj}
-          />
-        ),
+        cell: <LazyActionMenu context={{ [machineConfigReference]: obj }} />,
         props: actionsCellProps,
       },
     };

--- a/frontend/public/components/machine-health-check.tsx
+++ b/frontend/public/components/machine-health-check.tsx
@@ -12,7 +12,6 @@ import { DASH } from '@console/shared/src/constants';
 import { DetailsItem } from './utils/details-item';
 import { ResourceSummary } from './utils/details-page';
 import { EmptyBox, LoadingBox } from './utils/status-box';
-import { Kebab, ResourceKebab } from './utils/kebab';
 import { ResourceLink } from './utils/resource-link';
 import { SectionHeading } from './utils/headings';
 import { Selector } from './utils/selector';
@@ -29,20 +28,15 @@ import {
   ConsoleDataView,
 } from '@console/app/src/components/data-view/ConsoleDataView';
 import { GetDataViewRows } from '@console/app/src/components/data-view/types';
+import LazyActionMenu from '@console/shared/src/components/actions/LazyActionMenu';
 
-const { common } = Kebab.factory;
-const menuActions = [...common];
 const machineHealthCheckReference = referenceForModel(MachineHealthCheckModel);
 
 const tableColumnInfo = [{ id: 'name' }, { id: 'namespace' }, { id: 'created' }, { id: '' }];
 
-const getDataViewRows: GetDataViewRows<MachineHealthCheckKind, typeof menuActions> = (
-  data,
-  columns,
-) => {
-  return data.map(({ obj, rowData }) => {
+const getDataViewRows: GetDataViewRows<MachineHealthCheckKind, undefined> = (data, columns) => {
+  return data.map(({ obj }) => {
     const { name, namespace } = obj.metadata;
-    const actions = rowData;
 
     const rowCells = {
       [tableColumnInfo[0].id]: {
@@ -56,7 +50,7 @@ const getDataViewRows: GetDataViewRows<MachineHealthCheckKind, typeof menuAction
         cell: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
       },
       [tableColumnInfo[3].id]: {
-        cell: <ResourceKebab actions={actions} kind={machineHealthCheckReference} resource={obj} />,
+        cell: <LazyActionMenu context={{ [machineHealthCheckReference]: obj }} />,
         props: actionsCellProps,
       },
     };
@@ -123,7 +117,7 @@ const MachineHealthCheckList: React.FC<MachineHealthCheckListProps> = ({
 
   return (
     <React.Suspense fallback={<LoadingBox />}>
-      <ConsoleDataView<MachineHealthCheckKind, typeof menuActions>
+      <ConsoleDataView<MachineHealthCheckKind>
         {...props}
         label={MachineHealthCheckModel.labelPlural}
         data={data}
@@ -132,7 +126,6 @@ const MachineHealthCheckList: React.FC<MachineHealthCheckListProps> = ({
         columns={columns}
         initialFilters={initialFiltersDefault}
         getDataViewRows={getDataViewRows}
-        customRowData={menuActions}
         hideColumnManagement={true}
       />
     </React.Suspense>
@@ -221,7 +214,6 @@ export const MachineHealthCheckPage: React.FC<MachineHealthCheckPageProps> = (pr
 export const MachineHealthCheckDetailsPage: React.FC = (props) => (
   <DetailsPage
     {...props}
-    menuActions={menuActions}
     kind={machineHealthCheckReference}
     pages={[navFactory.details(MachineHealthCheckDetails), navFactory.editYaml()]}
   />

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -21,7 +21,6 @@ import { DetailsPage } from './factory/details';
 import ListPageHeader from './factory/ListPage/ListPageHeader';
 import ListPageCreate from './factory/ListPage/ListPageCreate';
 import { DetailsItem } from './utils/details-item';
-import { Kebab, ResourceKebab } from './utils/kebab';
 import { NodeLink, ResourceLink } from './utils/resource-link';
 import { ResourceSummary } from './utils/details-page';
 import { SectionHeading } from './utils/headings';
@@ -45,9 +44,8 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core';
+import LazyActionMenu from '@console/shared/src/components/actions/LazyActionMenu';
 
-const { common } = Kebab.factory;
-const menuActions = [...common];
 export const machineReference = referenceForModel(MachineModel);
 
 const tableColumnInfo = [
@@ -96,7 +94,7 @@ const getDataViewRows = (data: { obj: MachineKind }[], columns: TableColumn<Mach
         cell: zone || DASH,
       },
       [tableColumnInfo[7].id]: {
-        cell: <ResourceKebab actions={menuActions} kind={machineReference} resource={obj} />,
+        cell: <LazyActionMenu context={{ [machineReference]: obj }} />,
         props: actionsCellProps,
       },
     };
@@ -341,7 +339,6 @@ export const MachineDetailsPage: React.FCC = (props) => (
   <DetailsPage
     {...props}
     kind={machineReference}
-    menuActions={menuActions}
     pages={[
       navFactory.details(MachineDetails),
       navFactory.editYaml(),

--- a/frontend/public/components/persistent-volume.tsx
+++ b/frontend/public/components/persistent-volume.tsx
@@ -10,7 +10,7 @@ import { Table, TableData } from './factory/table';
 import type { DetailsPageProps } from './factory/details';
 import type { ListPageProps } from './factory/list-page';
 import type { TableProps } from './factory/table';
-import { Kebab, ResourceKebab } from './utils/kebab';
+import { Kebab } from './utils/kebab';
 import { LabelList } from './utils/label-list';
 import { navFactory } from './utils/horizontal-nav';
 import { SectionHeading } from './utils/headings';
@@ -26,10 +26,10 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core';
-import { PersistentVolumeKind } from '@console/internal/module/k8s';
+import { PersistentVolumeKind, referenceForModel } from '@console/internal/module/k8s';
+import LazyActionMenu from '@console/shared/src/components/actions/LazyActionMenu';
 
-const { common } = Kebab.factory;
-const menuActions = [...common];
+const persistentVolumeReference = referenceForModel(PersistentVolumeModel);
 
 const PVStatus = ({ pv }: { pv: PersistentVolumeKind }) => (
   <Status status={pv.metadata.deletionTimestamp ? 'Terminating' : pv.status.phase} />
@@ -79,14 +79,7 @@ const PVTableRow = ({ obj }: { obj: PersistentVolumeKind }) => {
         <Timestamp timestamp={obj.metadata.creationTimestamp} />
       </TableData>
       <TableData className={tableColumnClasses[6]}>
-        <ResourceKebab
-          actions={menuActions}
-          kind={kind}
-          resource={obj}
-          terminatingTooltip={t(
-            'public~The corresponding PersistentVolumeClaim must be deleted first.',
-          )}
-        />
+        <LazyActionMenu context={{ [persistentVolumeReference]: obj }} />
       </TableData>
     </>
   );
@@ -235,7 +228,7 @@ export const PersistentVolumesPage = (props: ListPageProps) => (
 export const PersistentVolumesDetailsPage = (props: DetailsPageProps) => (
   <DetailsPage
     {...props}
-    menuActions={menuActions}
+    kind={persistentVolumeReference}
     pages={[navFactory.details(Details), navFactory.editYaml()]}
   />
 );

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -2,7 +2,6 @@ import { useMemo, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';
 import { DetailsPage, ListPage } from './factory';
-import { Kebab, ResourceKebab } from './utils/kebab';
 import { SectionHeading } from './utils/headings';
 import { navFactory } from './utils/horizontal-nav';
 import { ResourceLink } from './utils/resource-link';
@@ -17,12 +16,13 @@ import {
   actionsCellProps,
   cellIsStickyProps,
 } from '@console/app/src/components/data-view/ConsoleDataView';
+import LazyActionMenu from '@console/shared/src/components/actions/LazyActionMenu';
 import { DASH } from '@console/shared/src/constants/ui';
-
-const { common } = Kebab.factory;
-const menuActions = [...common];
+import { referenceForModel } from '../module/k8s';
+import { ServiceAccountModel } from '../models';
 
 const kind = 'ServiceAccount';
+const serviceAccountReference = referenceForModel(ServiceAccountModel);
 
 const tableColumnInfo = [
   { id: 'name' },
@@ -54,7 +54,7 @@ const getDataViewRows = (data, columns) => {
         cell: <Timestamp timestamp={creationTimestamp} />,
       },
       [tableColumnInfo[4].id]: {
-        cell: <ResourceKebab actions={menuActions} kind={kind} resource={obj} />,
+        cell: <LazyActionMenu context={{ [serviceAccountReference]: obj }} />,
         props: actionsCellProps,
       },
     };
@@ -89,7 +89,7 @@ const Details = ({ obj: serviceaccount }) => {
 const ServiceAccountsDetailsPage = (props) => (
   <DetailsPage
     {...props}
-    menuActions={menuActions}
+    kind={serviceAccountReference}
     pages={[navFactory.details(Details), navFactory.editYaml()]}
   />
 );

--- a/frontend/public/components/template-instance.tsx
+++ b/frontend/public/components/template-instance.tsx
@@ -10,9 +10,13 @@ import { DetailsPage } from './factory/details';
 import { ListPage } from './factory/list-page';
 import { sorts } from './factory/table';
 import { Conditions } from './conditions';
-import { getTemplateInstanceStatus, referenceFor, TemplateInstanceKind } from '../module/k8s';
+import {
+  getTemplateInstanceStatus,
+  referenceFor,
+  referenceForModel,
+  TemplateInstanceKind,
+} from '../module/k8s';
 import { EmptyBox, LoadingBox } from './utils/status-box';
-import { Kebab, ResourceKebab } from './utils/kebab';
 import { navFactory } from './utils/horizontal-nav';
 import { ResourceLink } from './utils/resource-link';
 import { ResourceSummary } from './utils/details-page';
@@ -43,8 +47,9 @@ import {
 import { DataViewFilterOption } from '@patternfly/react-data-view/dist/cjs/DataViewFilters';
 import { RowProps, TableColumn } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { sortResourceByValue } from './factory/Table/sort';
+import LazyActionMenu from '@console/shared/src/components/actions/LazyActionMenu';
 
-const menuActions = Kebab.factory.common;
+const templateInstanceReference = referenceForModel(TemplateInstanceModel);
 
 const tableColumnInfo = [{ id: 'name' }, { id: 'namespace' }, { id: 'status' }, { id: '' }];
 
@@ -74,7 +79,7 @@ const getTemplateInstanceDataViewRows = (
         cell: <Status status={status} />,
       },
       [tableColumnInfo[3].id]: {
-        cell: <ResourceKebab actions={menuActions} kind="TemplateInstance" resource={obj} />,
+        cell: <LazyActionMenu context={{ [templateInstanceReference]: obj }} />,
         props: actionsCellProps,
       },
     };
@@ -293,8 +298,7 @@ const TemplateInstanceDetails: React.FCC<TemplateInstanceDetailsProps> = ({ obj 
 export const TemplateInstanceDetailsPage: React.FCC = (props) => (
   <DetailsPage
     {...props}
-    kind="TemplateInstance"
-    menuActions={menuActions}
+    kind={templateInstanceReference}
     pages={[navFactory.details(TemplateInstanceDetails), navFactory.editYaml()]}
   />
 );

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -7,7 +7,6 @@ import { useCanClusterUpgrade } from '@console/shared/src/hooks/useCanClusterUpg
 import { useAnnotationsModal } from '@console/shared/src/hooks/useAnnotationsModal';
 import { useLabelsModal } from '@console/shared/src/hooks/useLabelsModal';
 import { DetailsItem } from './details-item';
-import { Kebab } from './kebab';
 import { LabelList } from './label-list';
 import { OwnerReferences } from './owner-references';
 import { ResourceLink } from './resource-link';
@@ -23,6 +22,8 @@ import {
   Toleration,
 } from '../../module/k8s';
 import { configureClusterUpstreamModal } from '../modals';
+import { CommonActionCreator } from '@console/app/src/actions/hooks/types';
+import { useCommonActions } from '@console/app/src/actions/hooks/useCommonActions';
 
 export const pluralize = (
   i: number,
@@ -73,6 +74,9 @@ export const ResourceSummary: React.FC<ResourceSummaryProps> = ({
     namespace: metadata.namespace,
   });
   const canUpdate = canUpdateAccess && canUpdateResource;
+  const [modifyTolerationsAction] = useCommonActions(model, resource, [
+    CommonActionCreator.ModifyTolerations,
+  ]);
 
   return (
     <DescriptionList data-test-id="resource-summary">
@@ -122,7 +126,12 @@ export const ResourceSummary: React.FC<ResourceSummaryProps> = ({
               iconPosition="end"
               type="button"
               isInline
-              onClick={Kebab.factory.ModifyTolerations(model, resource).callback}
+              onClick={() => {
+                const action = modifyTolerationsAction[CommonActionCreator.ModifyTolerations]?.cta;
+                if (typeof action === 'function') {
+                  action();
+                }
+              }}
               variant="link"
             >
               {t('public~{{count}} toleration', { count: _.size(tolerations) })}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1112,7 +1112,6 @@
   "StorageClass": "StorageClass",
   "PersistentVolumeClaims": "PersistentVolumeClaims",
   "No claim": "No claim",
-  "The corresponding PersistentVolumeClaim must be deleted first.": "The corresponding PersistentVolumeClaim must be deleted first.",
   "PersistentVolume details": "PersistentVolume details",
   "Reclaim policy": "Reclaim policy",
   "PersistentVolumeClaim": "PersistentVolumeClaim",


### PR DESCRIPTION
Part 2: Remove the use of the kebab factory from the following pages of the public package. This PR addresses resources that have details and list pages, but share common actions.

- configmap.tsx
- control-plane-machine-set.tsx
- cron-job.tsx
- hpa.tsx
- image-stream-tag.tsx
- image-stream.tsx
- limit-range.tsx
- machine-autoscaler.tsx
- machine-config.tsx
- machine-health-check.tsx
- machine.tsx
- persistent-volume.tsx
- pod.tsx
- service-account.jsx
- template-instance.tsx
- Edit ModifyTolerations action on details-page

Changes from the big PR https://github.com/openshift/console/pull/15520