### PR TITLE
OCPBUGS-65690: Visiting Group Detail Page > RoleBindings will show error

### DIFF
--- a/frontend/public/components/RBAC/bindings.tsx
+++ b/frontend/public/components/RBAC/bindings.tsx
@@ -297,8 +297,11 @@ export const BindingsList: React.FCC<BindingsListTableProps> = (props) => {
 
     const filtersMap = tableFilters(false); // false for fuzzy search
 
+    // Convert staticFilters to array format if it's an object
+    const filtersArray = Array.isArray(staticFilters) ? staticFilters : [staticFilters];
+
     return data.filter((binding) => {
-      return staticFilters.every((filter) => {
+      return filtersArray.every((filter) => {
         const filterKey = Object.keys(filter)[0];
         const filterValue = filter[filterKey];
 

--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -279,8 +279,11 @@ const BindingsListComponent = (props) => {
 
     const filtersMap = tableFilters(false); // false for fuzzy search
 
+    // Convert staticFilters to array format if it's an object
+    const filtersArray = Array.isArray(staticFilters) ? staticFilters : [staticFilters];
+
     return data.filter((binding) => {
-      return staticFilters.every((filter) => {
+      return filtersArray.every((filter) => {
         const filterKey = Object.keys(filter)[0];
         const filterValue = filter[filterKey];
 

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -54,7 +54,7 @@ export const tableFilters = (isExactSearch: boolean): FilterMap => {
     },
 
     alerts: (values, alert: Alert) => {
-      if (!values.all) {
+      if (!values.all || !Array.isArray(values.all)) {
         return true;
       }
       const labels = getLabelsAsString(alert, 'labels');
@@ -62,7 +62,7 @@ export const tableFilters = (isExactSearch: boolean): FilterMap => {
     },
 
     'observe-rules': (values, rule: Rule) => {
-      if (!values.all) {
+      if (!values.all || !Array.isArray(values.all)) {
         return true;
       }
       const labels = getLabelsAsString(rule, 'labels');
@@ -70,7 +70,9 @@ export const tableFilters = (isExactSearch: boolean): FilterMap => {
     },
 
     'observe-target-labels': (values, target: Target) =>
-      !values.all || values.all.every((v) => getLabelsAsString(target, 'labels').includes(v)),
+      !values.all ||
+      (Array.isArray(values.all) &&
+        values.all.every((v) => getLabelsAsString(target, 'labels').includes(v))),
 
     // Filter role by role kind
     'role-kind': (filter, role) =>
@@ -95,7 +97,7 @@ export const tableFilters = (isExactSearch: boolean): FilterMap => {
     'role-binding-group': (groupName, { subject }) => subject.name === groupName,
 
     labels: (values, obj) => {
-      if (!values.all) {
+      if (!values.all || !Array.isArray(values.all)) {
         return true;
       }
       const labels = getLabelsAsString(obj);


### PR DESCRIPTION
## Description
Visiting Group Detail Page > RoleBindings will show error: XXX.every is not a function

## How to reproduce?
1. Create a group, you can just use the default yaml without changing anything
2. Go to Groups and click on the group you just created. (If you are using the default yaml, its name should be example)
3. The page will show "Something wrong happened d.every is not a function" And the detailed react error is displayed to user. 

This pr fixed the issue mentioned above.

## Root Cause
The code tried to call .every() on an object, which caused the crash. Converting it to array and adding the check to return early if it's not an array solve the problem.