### PR TITLE
CONSOLE-4846: add Trusted Software Supply Chain to Getting Started card

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartCatalogPage.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartCatalogPage.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
-import { QuickStartCatalogPage as PfQuickStartCatalogPage } from '@patternfly/quickstarts';
+import {
+  QuickStartCatalogPage as PfQuickStartCatalogPage,
+  QuickStartContext,
+  QuickStartContextValues,
+} from '@patternfly/quickstarts';
 import { useTranslation } from 'react-i18next';
+import { getQueryArgument } from '@console/internal/components/utils/router';
 import { LoadingBox } from '@console/internal/components/utils/status-box';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
 import { PageHeading } from '@console/shared/src/components/heading/PageHeading';
@@ -9,6 +14,15 @@ import { QuickStartEmptyState } from './QuickStartEmptyState';
 
 const QuickStartCatalogPage: React.FC = () => {
   const { t } = useTranslation('console-app');
+  const { setFilter } = React.useContext<QuickStartContextValues>(QuickStartContext);
+
+  React.useEffect(() => {
+    const keyword = getQueryArgument('keyword');
+    if (keyword && setFilter) {
+      setFilter('keyword', keyword);
+    }
+  }, [setFilter]);
+
   return (
     <>
       <DocumentTitle>{t('Quick Starts')}</DocumentTitle>

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/explore-admin-features-getting-started-card.spec.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/explore-admin-features-getting-started-card.spec.tsx
@@ -31,6 +31,10 @@ describe('ExploreAdminFeaturesGettingStartedCard', () => {
 
     expect(screen.getByText('OpenShift AI')).toBeVisible();
     expect(screen.getByText('Build, deploy, and manage AI-enabled applications.')).toBeVisible();
+    expect(screen.getByText('Trusted Software Supply Chain')).toBeVisible();
+    expect(
+      screen.getByText('Assess risk, validate integrity, secure artifacts, release safely.'),
+    ).toBeVisible();
     expect(screen.getByText("See what's new in OpenShift 4.16")).toBeVisible();
   });
 
@@ -39,11 +43,17 @@ describe('ExploreAdminFeaturesGettingStartedCard', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('item openshift-ai')).toBeTruthy();
+      expect(screen.getByTestId('item trusted-software-supply-chain')).toBeTruthy();
     });
 
     expect(screen.getByTestId('item openshift-ai')).toHaveAttribute(
       'href',
       '/catalog?catalogType=operator&keyword=openshift+ai&selectedId=rhods-operator-redhat-operators-openshift-marketplace',
+    );
+
+    expect(screen.getByTestId('item trusted-software-supply-chain')).toHaveAttribute(
+      'href',
+      '/quickstart?keyword=trusted',
     );
 
     expectExternalLinkAttributes(

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
@@ -32,6 +32,12 @@ export const ExploreAdminFeaturesGettingStartedCard: React.FC = () => {
         href:
           '/catalog?catalogType=operator&keyword=openshift+ai&selectedId=rhods-operator-redhat-operators-openshift-marketplace',
       },
+      {
+        id: 'trusted-software-supply-chain',
+        title: t('public~Trusted Software Supply Chain'),
+        description: t('public~Assess risk, validate integrity, secure artifacts, release safely.'),
+        href: '/quickstart?keyword=trusted',
+      },
       ...(showLightSpeedLink
         ? [
             {

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -426,6 +426,8 @@
   "Add identity providers": "Add identity providers",
   "OpenShift AI": "OpenShift AI",
   "Build, deploy, and manage AI-enabled applications.": "Build, deploy, and manage AI-enabled applications.",
+  "Trusted Software Supply Chain": "Trusted Software Supply Chain",
+  "Assess risk, validate integrity, secure artifacts, release safely.": "Assess risk, validate integrity, secure artifacts, release safely.",
   "OpenShift Lightspeed": "OpenShift Lightspeed",
   "Your personal AI helper.": "Your personal AI helper.",
   "French and Spanish now available": "French and Spanish now available",


### PR DESCRIPTION
Note the associated `QuickStarts` were added to the console-operator with https://github.com/openshift/console-operator/pull/1062, but they may not yet be appearing in builds.

After

https://github.com/user-attachments/assets/0b4cbb59-65bb-4fc3-a438-ebbacb5947cb

