### PR TITLE
OCPBUGS-65804: Update client initialization in checkPackageManifestHandler 

### DIFF
--- a/pkg/olm/handler.go
+++ b/pkg/olm/handler.go
@@ -109,7 +109,7 @@ func (o *OLMHandler) checkPackageManifestHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	client, _, err := o.getClientWithScheme(nil)
+	client, _, err := o.getClientWithScheme(r)
 	if err != nil {
 		klog.Error(err)
 		serverutils.SendResponse(w, http.StatusInternalServerError, serverutils.ApiError{Err: fmt.Sprint(err)})


### PR DESCRIPTION
## Description
The log in the console backend will print out this error:

```
failed to get new config for olm client
```
