### PR TITLE
OCPBUGS-65812: Layout issue on YAML editor settings popup window

### DIFF
--- a/frontend/public/components/modals/edit-yaml-settings-modal.tsx
+++ b/frontend/public/components/modals/edit-yaml-settings-modal.tsx
@@ -68,7 +68,11 @@ const ConfigModalItem: React.FCC<ConfigModalItemProps> = ({
   return (
     <Split hasGutter>
       <SplitItem isFilled>
-        <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsMd' }}>
+        <Flex
+          alignItems={{ default: 'alignItemsCenter' }}
+          spaceItems={{ default: 'spaceItemsMd' }}
+          style={{ flexWrap: 'nowrap' }}
+        >
           <FlexItem>
             <Icon />
           </FlexItem>
@@ -78,7 +82,7 @@ const ConfigModalItem: React.FCC<ConfigModalItemProps> = ({
           </FlexItem>
         </Flex>
       </SplitItem>
-      <SplitItem>
+      <SplitItem style={{ whiteSpace: 'nowrap' }}>
         <Switch
           id={title}
           isReversed


### PR DESCRIPTION
Before:
<img width="820" height="393" alt="ai_2" src="https://github.com/user-attachments/assets/15c0066e-eaeb-4b60-899d-9830a3b5cd9b" />

Now:
<img width="885" height="375" alt="ai_2" src="https://github.com/user-attachments/assets/80acb4ab-893f-406f-9ccc-8feeee174015" />