### PR TITLE
OCPBUGS-65892: Correct the position of the divider in the events card footer

### DIFF
--- a/frontend/public/components/dashboard/project-dashboard/activity-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/activity-card.tsx
@@ -157,11 +157,14 @@ const RecentEventFooter = withDashboardResources(
     }
 
     return (
-      <CardFooter>
-        <Link to={viewEvents} data-test="events-view-all-link">
-          {t('console-shared~View all events')}
-        </Link>
-      </CardFooter>
+      <>
+        <Divider />
+        <CardFooter>
+          <Link to={viewEvents} data-test="events-view-all-link">
+            {t('console-shared~View all events')}
+          </Link>
+        </CardFooter>
+      </>
     );
   },
 );
@@ -173,7 +176,6 @@ export const ActivityCard: React.FC = () => {
   const { t } = useTranslation();
   return (
     <>
-      <Divider />
       <Card data-test-id="activity-card">
         <CardHeader>
           <CardTitle>{t('public~Activity')}</CardTitle>


### PR DESCRIPTION
@coderabbitai ignore  

**Before**
<img width="469" height="643" alt="Screenshot 2025-11-21 at 3 24 14 PM" src="https://github.com/user-attachments/assets/7bea505f-d865-4cbf-a5ff-e4dc28b04609" />


**After**
<img width="468" height="683" alt="Screenshot 2025-11-21 at 3 04 45 PM" src="https://github.com/user-attachments/assets/d84aa57c-e19c-45dc-a262-48db228ca91f" />
