### PR TITLE
OCPBUGS-65890: redirect catalog traffic as needed

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/CatalogDefaultNamespaceRedirect.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/CatalogDefaultNamespaceRedirect.tsx
@@ -1,8 +1,6 @@
-import * as React from 'react';
 import { Navigate, useSearchParams } from 'react-router-dom-v5-compat';
 
-// Redirect all-namespaces catalog to default namespace
-// TODO: Make Software Catalog work with all namespaces. https://issues.redhat.com/browse/CONSOLE-4827
+// Redirect catalog to default namespace
 const CatalogDefaultNamespaceRedirect: React.FCC = () => {
   const [params] = useSearchParams();
   return <Navigate to={`/catalog/ns/default?${params.toString()}`} replace />;

--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -1069,14 +1069,6 @@
     "type": "console.page/route",
     "properties": {
       "exact": true,
-      "path": ["/catalog/all-namespaces"],
-      "component": { "$codeRef": "CatalogDefaultNamespaceRedirect" }
-    }
-  },
-  {
-    "type": "console.page/route",
-    "properties": {
-      "exact": true,
       "path": ["/catalog/ns/:ns"],
       "component": { "$codeRef": "CatalogPage" }
     }

--- a/frontend/packages/dev-console/package.json
+++ b/frontend/packages/dev-console/package.json
@@ -32,7 +32,6 @@
       "CatalogTypesConfiguration": "src/components/catalog/CatalogTypesConfiguration.tsx",
       "PinnedResourcesConfiguration": "src/components/catalog/PinnedResourcesConfiguration.tsx",
       "CatalogPage": "src/components/catalog/CatalogPage.tsx",
-      "CatalogDefaultNamespaceRedirect": "src/components/catalog/CatalogDefaultNamespaceRedirect.tsx",
       "fileUpload": "src/components/jar-file-upload/jar-file-upload-utils.ts",
       "devConsoleComponentFactory": "src/components/topology/components/devConsoleComponentFactory.ts",
       "hpaTabSection": "src/components/topology/hpa-tab-section.tsx",

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -17,6 +17,7 @@ import {
   usePerspectives,
 } from '@console/shared/src/hooks/perspective-utils';
 import { ErrorBoundaryPage } from '@console/shared/src/components/error';
+import CatalogDefaultNamespaceRedirect from '@console/shared/src/components/catalog/CatalogDefaultNamespaceRedirect';
 import { getReferenceForModel } from '@console/dynamic-plugin-sdk/src/utils/k8s';
 import { connectToFlags } from '../reducers/connectToFlags';
 import { flagPending, FlagsObject } from '../reducers/features';
@@ -257,6 +258,9 @@ const AppContents: React.FC<{}> = () => {
         }
       />
 
+      <Route path="/catalog" element={<CatalogDefaultNamespaceRedirect />} />
+      {/* TODO: Make Software Catalog work with all namespaces. https://issues.redhat.com/browse/CONSOLE-4827 */}
+      <Route path="/catalog/all-namespaces" element={<CatalogDefaultNamespaceRedirect />} />
       <Route
         path="/catalog/instantiate-template"
         element={


### PR DESCRIPTION
After:

* Links that include query parameters such as OpenShift AI correctly redirect
* The `Ecosystem > Software Catalog` nav link is unchanged
* `/catalog/all-namespaces` redirects to `/catalog/ns/default` as it did before
* `/catalog/instantiate-template` is unchanged

https://github.com/user-attachments/assets/91be6170-f489-417d-9df0-ed116da00d07

* `/operatorhub` is unchanged and redirects to `/catalog/ns/default` as it did before

https://github.com/user-attachments/assets/1b43528e-20e6-43a8-96ef-8af2107edb55

