### PR TITLE
OCPBUGS-64652: Duplicate words in Console UI 'See breakdown' breakdown

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -363,7 +363,6 @@
   "Inventory": "Inventory",
   "Image": "Image",
   "Images": "Images",
-  "See breakdown": "See breakdown",
   "Health checks": "Health checks",
   "See details": "See details",
   "{{ cpuMessage }}": "{{ cpuMessage }}",

--- a/frontend/packages/console-app/locales/es/console-app.json
+++ b/frontend/packages/console-app/locales/es/console-app.json
@@ -351,7 +351,6 @@
   "Inventory": "Inventario",
   "Image": "Imagen",
   "Images": "Imágenes",
-  "See breakdown": "Ver desglose",
   "Health checks": "Controles de estado",
   "See details": "Ver detalles",
   "{{ cpuMessage }}": "{{ cpuMessage }}",

--- a/frontend/packages/console-app/locales/fr/console-app.json
+++ b/frontend/packages/console-app/locales/fr/console-app.json
@@ -351,7 +351,6 @@
   "Inventory": "Inventaire",
   "Image": "Image",
   "Images": "Images",
-  "See breakdown": "Afficher la répartition",
   "Health checks": "Contrôles d’intégrité",
   "See details": "Afficher les détails",
   "{{ cpuMessage }}": "{{ cpuMessage }}",

--- a/frontend/packages/console-app/locales/ja/console-app.json
+++ b/frontend/packages/console-app/locales/ja/console-app.json
@@ -351,7 +351,6 @@
   "Inventory": "インベントリー",
   "Image": "イメージ",
   "Images": "イメージ",
-  "See breakdown": "内訳を参照",
   "Health checks": "ヘルスチェック",
   "See details": "詳細を参照",
   "{{ cpuMessage }}": "{{ cpuMessage }}",

--- a/frontend/packages/console-app/locales/ko/console-app.json
+++ b/frontend/packages/console-app/locales/ko/console-app.json
@@ -351,7 +351,6 @@
   "Inventory": "인벤토리",
   "Image": "이미지",
   "Images": "이미지",
-  "See breakdown": "분석보기",
   "Health checks": "상태 검사",
   "See details": "상세 내용 보기",
   "{{ cpuMessage }}": "{{ cpuMessage }}",

--- a/frontend/packages/console-app/locales/zh/console-app.json
+++ b/frontend/packages/console-app/locales/zh/console-app.json
@@ -351,7 +351,6 @@
   "Inventory": "库存",
   "Image": "镜像",
   "Images": "镜像",
-  "See breakdown": "查看分解",
   "Health checks": "健康检查",
   "See details": "查看详情",
   "{{ cpuMessage }}": "{{ cpuMessage }}",

--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/NodeAlerts.tsx
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/NodeAlerts.tsx
@@ -69,7 +69,6 @@ const LimitLink: React.FC<LimitLinkProps> = ({
   return (
     <NodeUtilizationContext.Provider value={{ nodeName, nodeIP }}>
       <Popover
-        title={t('console-app~See breakdown')}
         current={currentError ? t('console-app~Not available') : current.string}
         total={totalError ? t('console-app~Not available') : total.string}
         limit={limitError ? t('console-app~Not available') : limit.string}


### PR DESCRIPTION
### Before:
<img width="1800" height="884" alt="Screenshot 2025-11-25 at 11 59 56 AM" src="https://github.com/user-attachments/assets/e63c7104-fa74-4e80-8652-8db54a5ddfec" />

### After:
<img width="1595" height="645" alt="Screenshot 2025-11-25 at 12 00 03 PM" src="https://github.com/user-attachments/assets/7876e5b1-cd6d-4b11-84a1-6440d0e6b80d" />


### To reproduce:
```
apiVersion: v1
kind: Namespace
metadata:
  name: test-breakdown-bug
---
apiVersion: v1
kind: ResourceQuota
metadata:
  name: test-quota
  namespace: test-breakdown-bug
spec:
  hard:
    requests.cpu: "1"
    requests.memory: 2Gi
    limits.cpu: "2"
    limits.memory: 4Gi
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: high-resource-app
  namespace: test-breakdown-bug
spec:
  replicas: 2
  selector:
    matchLabels:
      app: test-app
  template:
    metadata:
      labels:
        app: test-app
    spec:
      containers:
      - name: app
        image: nginxinc/nginx-unprivileged:latest
        resources:
          requests:
            memory: "900Mi"    # High request: 900Mi x 2 = 1.8Gi (90% of 2Gi quota)
            cpu: "450m"        # High request: 450m x 2 = 900m (90% of 1 CPU quota)
          limits:
            memory: "1800Mi"   # High limit: 1.8Gi x 2 = 3.6Gi (90% of 4Gi limit)
            cpu: "950m"        # High limit: 950m x 2 = 1.9 CPU (95% of 2 CPU limit)
        ports:
        - containerPort: 8080

```