### PR TITLE
OCPBUGS-66048: only reveal values just before invoking text

### DIFF
--- a/frontend/packages/integration-tests-cypress/views/secret.ts
+++ b/frontend/packages/integration-tests-cypress/views/secret.ts
@@ -13,12 +13,12 @@ export const secrets = {
     cy.byTestID('console-select-item').click();
   },
   checkSecret: (keyValuesToCheck: object, jsonOutput: boolean = false) => {
-    secrets.clickRevealValues();
     const renderedKeyValues = {};
     cy.byTestID('secret-data')
       .find('[data-test="secret-data-term"]')
       .each(($el, index) => {
         const key = $el.text();
+        secrets.clickRevealValues();
         cy.get('[data-test="copy-to-clipboard"]')
           .eq(index)
           .invoke('text')


### PR DESCRIPTION
`Image pull secrets.Image pull secrets Creates, edits, and deletes an image registry credentials pull secret` is failing frequently due to the fact that secret data was already hidden upon checking secret data

<img width="432" height="418" alt="Screenshot 2025-11-26 at 3 02 16 PM" src="https://github.com/user-attachments/assets/b50ca057-fe21-4c22-81eb-263671ba6512" />
