### PR TITLE
OCPBUGS-62126: Rename Administrator to Core platform perspective

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -4,7 +4,7 @@
     "properties": {
       "id": "admin",
       "default": true,
-      "name": "%console-app~Administrator%",
+      "name": "%console-app~Core platform%",
       "icon": { "$codeRef": "perspective.icon" },
       "landingPageURL": { "$codeRef": "perspective.getLandingPageURL" },
       "importRedirectURL": { "$codeRef": "perspective.getImportRedirectURL" }

--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -1,5 +1,5 @@
 {
-  "Administrator": "Administrator",
+  "Core platform": "Core platform",
   "PodDisruptionBudget": "PodDisruptionBudget",
   "PodDisruptionBudgets": "PodDisruptionBudgets",
   "VolumeSnapshots": "VolumeSnapshots",

--- a/frontend/packages/console-app/src/components/nav/NavHeader.tsx
+++ b/frontend/packages/console-app/src/components/nav/NavHeader.tsx
@@ -7,6 +7,8 @@ import {
   SelectOption,
   Title,
 } from '@patternfly/react-core';
+import { CogsIcon } from '@patternfly/react-icons/dist/esm/icons/cogs-icon';
+import { t } from 'i18next';
 import { Perspective, useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { usePerspectives } from '@console/shared/src/hooks/perspective-utils';
 
@@ -118,12 +120,12 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
       </Select>
     </div>
   ) : (
-    <div
-      className="pf-v6-u-display-none"
-      data-test-id="perspective-switcher-toggle"
-      aria-hidden="true"
-    />
-  ); // Empty div for e2e purposes
+    <div data-test-id="perspective-switcher-toggle" id="core-platform-perspective">
+      <Title headingLevel="h2" size="md">
+        <CogsIcon /> {t('console-app~Core platform')}
+      </Title>
+    </div>
+  );
 };
 
 export default NavHeader;

--- a/frontend/packages/console-app/src/components/user-preferences/__tests__/userPreferences.data.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/__tests__/userPreferences.data.tsx
@@ -32,7 +32,7 @@ export const userPreferenceItemWithDropdownField: ResolvedUserPreferenceItem = {
       },
       {
         value: 'admin',
-        label: 'Administrator',
+        label: 'Core platform',
       },
     ],
   },

--- a/frontend/packages/console-app/src/components/user-preferences/perspective/__tests__/perspective.data.ts
+++ b/frontend/packages/console-app/src/components/user-preferences/perspective/__tests__/perspective.data.ts
@@ -20,7 +20,7 @@ export const mockPerspectiveExtensions: LoadedExtension<Perspective>[] = [
     type: 'console.perspective',
     properties: {
       id: 'admin',
-      name: 'Administrator',
+      name: 'Core platform',
       icon: null,
       landingPageURL: async () => () => '',
       importRedirectURL: async () => () => '',

--- a/frontend/packages/console-dynamic-plugin-sdk/src/perspective/__tests__/perspective.data.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/perspective/__tests__/perspective.data.ts
@@ -37,7 +37,7 @@ export const mockPerspectiveExtensions: LoadedExtension<Perspective>[] = [
     uid: '',
     properties: {
       id: 'admin',
-      name: 'Administrator',
+      name: 'Core platform',
       icon: null,
       landingPageURL: async () => () => '',
       importRedirectURL: async () => () => '',

--- a/frontend/packages/console-shared/src/hooks/__tests__/perspective-utils.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/perspective-utils.spec.ts
@@ -21,7 +21,7 @@ describe('usePerspectives', () => {
         type: 'Perspective',
         properties: {
           id: 'admin',
-          name: 'Administrator',
+          name: 'Core platform',
         },
       },
       {
@@ -53,7 +53,7 @@ describe('usePerspectives', () => {
         type: 'Perspective',
         properties: {
           id: 'admin',
-          name: 'Administrator',
+          name: 'Core platform',
         },
       },
       {
@@ -85,7 +85,7 @@ describe('usePerspectives', () => {
         type: 'Perspective',
         properties: {
           id: 'admin',
-          name: 'Administrator',
+          name: 'Core platform',
         },
       },
       {
@@ -198,7 +198,7 @@ describe('usePerspectives', () => {
         type: 'Perspective',
         properties: {
           id: 'admin',
-          name: 'Administrator',
+          name: 'Core platform',
         },
       },
     ]);
@@ -439,7 +439,7 @@ describe('usePerspectives', () => {
         type: 'Perspective',
         properties: {
           id: 'admin',
-          name: 'Administrator',
+          name: 'Core platform',
         },
       },
       {

--- a/frontend/packages/dev-console/integration-tests/support/constants/global.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/global.ts
@@ -29,7 +29,7 @@ export enum adminNavigationBar {
 
 export enum switchPerspective {
   Developer = 'Developer',
-  Administrator = 'Administrator',
+  Administrator = 'Core platform',
 }
 
 export enum operators {

--- a/frontend/packages/integration-tests-cypress/support/admin.ts
+++ b/frontend/packages/integration-tests-cypress/support/admin.ts
@@ -16,9 +16,9 @@ Cypress.Commands.add('initAdmin', () => {
   cy.log('redirect to home');
   cy.visit('/');
   cy.byTestID('loading-indicator').should('not.exist');
-  cy.log('ensure perspective switcher is set to Administrator');
-  nav.sidenav.switcher.changePerspectiveTo('Administrator');
-  nav.sidenav.switcher.shouldHaveText('Administrator');
+  cy.log('ensure perspective switcher is set to Core platform');
+  nav.sidenav.switcher.changePerspectiveTo('Core platform');
+  nav.sidenav.switcher.shouldHaveText('Core platform');
   guidedTour.close();
 });
 

--- a/frontend/packages/integration-tests-cypress/tests/app/auth-multiuser-login.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/auth-multiuser-login.cy.ts
@@ -27,15 +27,14 @@ describe('Auth test', () => {
 
       // test Developer perspective is default for test user and guided tour is displayed
       // Below line to be uncommented after pr https://github.com/openshift/console-operator/pull/954 is merged
-      // nav.sidenav.switcher.shouldHaveText('Administrator');
       guidedTour.isOpen();
       guidedTour.close();
       masthead.username.shouldHaveText(username);
 
       cy.log('switches from dev to admin perspective');
       // nav.sidenav.switcher.shouldHaveText('Developer');
-      nav.sidenav.switcher.changePerspectiveTo('Administrator');
-      nav.sidenav.switcher.shouldHaveText('Administrator');
+      nav.sidenav.switcher.changePerspectiveTo('Core platform');
+      nav.sidenav.switcher.shouldHaveText('Core platform');
 
       cy.log('does not show admin nav items in Administration to test user');
       // eslint-disable-next-line cypress/no-unnecessary-waiting
@@ -67,7 +66,7 @@ describe('Auth test', () => {
     );
 
     // test Administrator perspective is default for kubeadmin
-    nav.sidenav.switcher.shouldHaveText('Administrator');
+    nav.sidenav.switcher.shouldHaveText('Core platform');
     // test guided tour is displayed first time switching to 'Developer' perspective
     // skip if running localhost
     if (!Cypress.config('baseUrl').includes('localhost')) {
@@ -75,8 +74,8 @@ describe('Auth test', () => {
       // nav.sidenav.switcher.shouldHaveText('Developer');
       guidedTour.isOpen();
       guidedTour.close();
-      nav.sidenav.switcher.changePerspectiveTo('Administrator');
-      nav.sidenav.switcher.shouldHaveText('Administrator');
+      nav.sidenav.switcher.changePerspectiveTo('Core platform');
+      nav.sidenav.switcher.shouldHaveText('Core platform');
     }
     cy.log('verify sidenav menus and Administration menu access for cluster admin user');
     nav.sidenav.shouldHaveNavSection(['Compute']);

--- a/frontend/packages/integration-tests-cypress/tests/crud/other-routes.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/other-routes.cy.ts
@@ -168,6 +168,6 @@ describe('Test perspective query parameters', () => {
         perspective: 'admin',
       },
     });
-    nav.sidenav.switcher.shouldHaveText('Administrator');
+    nav.sidenav.switcher.shouldHaveText('Core platform');
   });
 });

--- a/frontend/packages/integration-tests-cypress/views/nav.ts
+++ b/frontend/packages/integration-tests-cypress/views/nav.ts
@@ -10,9 +10,9 @@ export const nav = {
         cy.byLegacyTestID('perspective-switcher-toggle').then(($body) => {
           if (text === switchPerspective.Administrator) {
             // if the switcher is hidden it means we are in the admin perspective
-            if ($body.attr('aria-hidden') === 'true') {
+            if ($body.attr('id') === 'core-platform-perspective') {
               cy.log('Admin is the only perspective available');
-              cy.byLegacyTestID('perspective-switcher-toggle').should('not.be.visible');
+              cy.byLegacyTestID('perspective-switcher-toggle').should('be.visible');
               return;
             }
           }
@@ -22,18 +22,18 @@ export const nav = {
       changePerspectiveTo: (newPerspective: string) => {
         app.waitForDocumentLoad();
         switch (newPerspective) {
-          case 'Administrator':
-          case 'administrator':
+          case 'Core platform':
+          case 'core platform':
           case 'Admin':
           case 'admin':
             cy.byLegacyTestID('perspective-switcher-toggle').then(($body) => {
-              if ($body.attr('aria-hidden') === 'true') {
+              if ($body.attr('id') === 'core-platform-perspective') {
                 cy.log('Admin is the only perspective available');
-                cy.byLegacyTestID('perspective-switcher-toggle').should('not.be.visible');
+                cy.byLegacyTestID('perspective-switcher-toggle').should('be.visible');
                 return;
               }
 
-              if ($body.text().includes('Administrator')) {
+              if ($body.text().includes('Core platform')) {
                 cy.log('Already on admin perspective');
                 cy.byLegacyTestID('perspective-switcher-toggle')
                   .scrollIntoView()


### PR DESCRIPTION
If no additional perspective is enabled, then the Core platform title instead of the perspective switcher.

<img width="293" height="582" alt="image" src="https://github.com/user-attachments/assets/53e291d4-4335-4457-bb1d-b993d98b16c2" />


<img width="309" height="461" alt="image" src="https://github.com/user-attachments/assets/1abc98a3-e51c-4ae2-817d-988cf0040835" />
