### PR TITLE
OCPBUGS-63457:  Runtime error on switching to form view after invalid 'metrics' field on add/edit HPA yaml view page

### DIFF
--- a/frontend/packages/dev-console/src/components/hpa/hpa-utils.ts
+++ b/frontend/packages/dev-console/src/components/hpa/hpa-utils.ts
@@ -81,7 +81,7 @@ export const getMetricByType = (
   hpa: HorizontalPodAutoscalerKind,
   type: SupportedMetricTypes,
 ): { metric: HPAMetric | null; index: number } => {
-  const hpaMetrics = hpa.spec.metrics || [];
+  const hpaMetrics = Array.isArray(hpa.spec.metrics) ? hpa.spec.metrics : [];
   const metricIndex = hpaMetrics.findIndex((m) => m.resource?.name?.toLowerCase() === type);
   const metric: HPAMetric | null = hpaMetrics[metricIndex] || null;
 
@@ -116,7 +116,7 @@ export const sanityForSubmit = (
 
 export const hasCustomMetrics = (hpa?: HorizontalPodAutoscalerKind): boolean => {
   const metrics = hpa?.spec?.metrics;
-  if (!metrics) {
+  if (!Array.isArray(metrics)) {
     return false;
   }
 

--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -148,7 +148,7 @@ const MetricsTable: React.FC<MetricsTableProps> = ({ obj: hpa }) => {
           </Tr>
         </Thead>
         <Tbody>
-          {hpa.spec.metrics.map((metric, i) => {
+          {(Array.isArray(hpa.spec.metrics) ? hpa.spec.metrics : []).map((metric, i) => {
             // https://github.com/kubernetes/api/blob/master/autoscaling/v2beta1/types.go
             const current = _.get(hpa, ['status', 'currentMetrics', i]);
             switch (metric.type) {


### PR DESCRIPTION
### Summary
When 'metrics' field is set invalidly on add/edit HPA yaml view page, switching to form view will show runtime error.

### Before [ runtime error when switching to form field ]


https://github.com/user-attachments/assets/b6829f9b-bdd0-4cc0-a75a-2d6a09d7c012




### After [ no runtime error when switching to form field ]


https://github.com/user-attachments/assets/cdeae401-d1d0-401c-bf2d-a9903c694ebd


