### PR TITLE
OCPBUGS-60245: Fix EditURL link for private git in Topology

### DIFF
--- a/frontend/packages/topology/src/utils/topology-utils.ts
+++ b/frontend/packages/topology/src/utils/topology-utils.ts
@@ -44,6 +44,9 @@ export const getCheDecoratorData = (consoleLinks: K8sResourceKind[]): CheDecorat
 
 const getFullGitURL = (gitUrl: GitUrlParse.GitUrl, branch?: string, contextDir?: string) => {
   const baseUrl = `https://${gitUrl.resource}/${gitUrl.owner}/${gitUrl.name}`;
+  if (!gitUrl.owner || gitUrl.port) {
+    return gitUrl.href;
+  }
   if (!branch) {
     return baseUrl;
   }


### PR DESCRIPTION
Fixes an issue where the generated edit URL for private Git repositories was missing the necessary port number. This PR modifies the URL creation logic only when a port is absent and a valid repository owner is found, preserving existing URLs where a port or owner is already set.

**Before:**
<img width="1512" height="982" alt="Screenshot 2025-12-02 at 4 42 21 PM" src="https://github.com/user-attachments/assets/a292ae16-6dcd-4621-bd76-dea258f29fb2" />


**After:**
<img width="1512" height="982" alt="Screenshot 2025-12-02 at 4 40 46 PM" src="https://github.com/user-attachments/assets/e7bd58e3-1a31-41ce-8fe9-c7819dd4c6a5" />
