### PR TITLE
OCPBUGS-66166: Add `data-checked-state` to ConfigModalSwitch

### DIFF
--- a/frontend/public/components/modals/edit-yaml-settings-modal.tsx
+++ b/frontend/public/components/modals/edit-yaml-settings-modal.tsx
@@ -161,6 +161,7 @@ const ConfigModalSwitch: React.FunctionComponent<ConfigModalSwitchProps> = ({
       <Switch
         aria-labelledby={`${id}-title`}
         aria-describedby={`${id}-description`}
+        data-checked-state={isChecked}
         ouiaId={`${id}-switch`}
         isChecked={isChecked}
         isReversed


### PR DESCRIPTION
For consistency we need `data-checked-state` in all the switches

