### PR TITLE
OCPBUGS-66254: VAC on PVC details page is displayed for failed state

### DIFF
--- a/frontend/public/components/persistent-volume-claim.tsx
+++ b/frontend/public/components/persistent-volume-claim.tsx
@@ -154,6 +154,7 @@ const Details: React.FC<PVCDetailsProps> = ({ obj: pvc }) => {
   const labelSelector = pvc?.spec?.selector;
   const storageClassName = pvc?.spec?.storageClassName;
   const volumeAttributesClassName = pvc?.spec?.volumeAttributesClassName;
+  const currentVolumeAttributesClassName = pvc?.status?.currentVolumeAttributesClassName;
   const volumeName = pvc?.spec?.volumeName;
   const storage = pvc?.status?.capacity?.storage;
   const requestedStorage = getRequestedPVCSize(pvc);
@@ -290,17 +291,19 @@ const Details: React.FC<PVCDetailsProps> = ({ obj: pvc }) => {
                   )}
                 </DescriptionListDescription>
               </DescriptionListGroup>
-              {isVACSupported && volumeAttributesClassName && (
-                <DescriptionListGroup>
-                  <DescriptionListTerm>{t('public~VolumeAttributesClass')}</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <ResourceLink
-                      kind={referenceFor(VolumeAttributesClassModel)}
-                      name={volumeAttributesClassName}
-                    />
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-              )}
+              {isVACSupported &&
+                !!volumeAttributesClassName &&
+                volumeAttributesClassName === currentVolumeAttributesClassName && (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>{t('public~VolumeAttributesClass')}</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <ResourceLink
+                        kind={referenceFor(VolumeAttributesClassModel)}
+                        name={volumeAttributesClassName}
+                      />
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                )}
               {volumeName && canListPV && (
                 <DescriptionListGroup>
                   <DescriptionListTerm>{t('public~PersistentVolumes')}</DescriptionListTerm>

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -1154,6 +1154,7 @@ export type PersistentVolumeClaimKind = K8sResourceCommon & {
     capacity?: { storage: string };
     phase: string;
     conditions?: K8sResourceCondition[];
+    currentVolumeAttributesClassName?: string;
   };
 };
 


### PR DESCRIPTION
### After:

<img width="3164" height="1554" alt="Screenshot 2025-12-02 at 4 09 23 PM" src="https://github.com/user-attachments/assets/22f17b47-d52c-47e3-a2dd-c057804cda06" />

<img width="1576" height="757" alt="Screenshot 2025-12-02 at 4 09 42 PM" src="https://github.com/user-attachments/assets/61a55256-f6d1-4745-a570-54087b8a307d" />


### Manifests for VACs and Deployment:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-deployment
  labels:
    app: my-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: my-app
  template:
    metadata:
      labels:
        app: my-app
    spec:
      containers:
      - name: app-container
        image: image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest
        ports:
        - containerPort: 80
        volumeMounts:
        - name: persistent-storage
          mountPath: /data
        resources:
          requests:
            memory: "128Mi"
            cpu: "100m"
          limits:
            memory: "256Mi"
            cpu: "200m"
      volumes:
      - name: persistent-storage
        persistentVolumeClaim:
          claimName: my-pvc
---
kind: VolumeAttributesClass
apiVersion: storage.k8s.io/v1
metadata:
  name: ebs-blog-gp3-standard-performance
  finalizers:
  - kubernetes.io/vac-protection
driverName: ebs.csi.aws.com
parameters:
  iops: '3000'
  throughput: '125'
  type: gp3
---
kind: VolumeAttributesClass
apiVersion: storage.k8s.io/v1
metadata:
  name: ebs-low-iops
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"storage.k8s.io/v1","driverName":"ebs.csi.aws.com","kind":"VolumeAttributesClass","metadata":{"annotations":{},"name":"ebs-low-iops"},"parameters":{"iops":"500","throughput":"125","type":"gp3"}}
driverName: ebs.csi.aws.com
parameters:
  iops: '500'
  throughput: '125'
  type: gp3