### PR TITLE
OCPBUGS-66247: make cloudCredentials optional so operators load when …

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/hooks/useOperatorCatalogItems.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/hooks/useOperatorCatalogItems.tsx
@@ -72,11 +72,8 @@ export const useOperatorCatalogItems = () => {
     clusterServiceVersionsLoaded,
     clusterServiceVersionsLoadError,
   ] = useClusterServiceVersions(namespace);
-  const [
-    cloudCredentials,
-    cloudCredentialsLoaded,
-    cloudCredentialsLoadError,
-  ] = useClusterCloudCredentialConfig();
+  // cloudCredentials are optional
+  const [cloudCredentials] = useClusterCloudCredentialConfig();
   const [
     infrastructure,
     infrastructureLoaded,
@@ -98,12 +95,10 @@ export const useOperatorCatalogItems = () => {
       operatorHubPackageManifestsLoaded &&
       subscriptionsLoaded &&
       clusterServiceVersionsLoaded &&
-      cloudCredentialsLoaded &&
       infrastructureLoaded &&
       authenticationLoaded,
     [
       authenticationLoaded,
-      cloudCredentialsLoaded,
       clusterServiceVersionsLoaded,
       infrastructureLoaded,
       operatorGroupsLoaded,
@@ -119,13 +114,11 @@ export const useOperatorCatalogItems = () => {
         operatorHubPackageManifestsLoadError,
         subscriptionsLoadError,
         clusterServiceVersionsLoadError,
-        cloudCredentialsLoadError,
         infrastructureLoadError,
         authenticationLoadError,
       ),
     [
       authenticationLoadError,
-      cloudCredentialsLoadError,
       clusterServiceVersionsLoadError,
       infrastructureLoadError,
       operatorHubPackageManifestsLoadError,


### PR DESCRIPTION
…cloudCredential isn't present on the cluster

Tested against CRC version: 2.57.0+ae41f6 and Operators now display in Software Catalog.

https://github.com/user-attachments/assets/007b017e-f009-49c9-865d-314ac75c8950

