### PR TITLE
OCPBUGS-62725: Fixes namespace-scoped operators that were not showing as installed when viewing OperatorHub in "All Projects" mode

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-group.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-group.spec.tsx
@@ -98,11 +98,37 @@ describe('subscriptionFor', () => {
     ).toBeUndefined();
   });
 
-  it('returns nothing if checking for `all-namespaces`', () => {
+  it('returns `Subscription` when checking for `all-namespaces` (empty string from default parameter)', () => {
     subscriptions = [testSubscription];
     operatorGroups = [{ ...testOperatorGroup, status: { namespaces: [ns], lastUpdated: null } }];
 
-    expect(subscriptionFor(subscriptions)(operatorGroups)(pkg)('')).toBeUndefined();
+    expect(subscriptionFor(subscriptions)(operatorGroups)(pkg)('')).toEqual(testSubscription);
+  });
+
+  it('returns `Subscription` when namespace is not provided (All Projects view) for namespace-scoped operator', () => {
+    subscriptions = [testSubscription];
+    operatorGroups = [
+      {
+        ...testOperatorGroup,
+        status: { namespaces: [ns], lastUpdated: null },
+      },
+    ];
+
+    const partialFunc = subscriptionFor(subscriptions)(operatorGroups)(pkg);
+    expect(partialFunc()).toEqual(testSubscription);
+  });
+
+  it('returns `Subscription` when namespace is not provided (All Projects view) for global operator', () => {
+    subscriptions = [testSubscription];
+    operatorGroups = [
+      {
+        ...testOperatorGroup,
+        status: { namespaces: [''], lastUpdated: null },
+      },
+    ];
+
+    const partialFunc = subscriptionFor(subscriptions)(operatorGroups)(pkg);
+    expect(partialFunc()).toEqual(testSubscription);
   });
 
   it('returns `Subscription` when it exists in the "global" `OperatorGroup`', () => {
@@ -147,11 +173,11 @@ describe('installedFor', () => {
     expect(installedFor(subscriptions)(operatorGroups)(pkg)(ns)).toBe(false);
   });
 
-  it('returns false if checking for `all-namespaces`', () => {
+  it('returns true if checking for `all-namespaces` (empty string from default parameter)', () => {
     subscriptions = [testSubscription];
     operatorGroups = [{ ...testOperatorGroup, status: { namespaces: [ns], lastUpdated: null } }];
 
-    expect(installedFor(subscriptions)(operatorGroups)(pkg)('')).toBe(false);
+    expect(installedFor(subscriptions)(operatorGroups)(pkg)('')).toBe(true);
   });
 
   it('returns false if `Subscription` is in a different namespace than the given package', () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
@@ -138,6 +138,8 @@ export const isSingle = (obj: OperatorGroupKind) =>
 /**
  * Determines if a given Operator package has a `Subscription` that makes it available in the given namespace.
  * Finds any `Subscriptions` for the given package, matches them to their `OperatorGroup`, and checks if the `OperatorGroup` is targeting the given namespace or if it is global.
+ *
+ * @param ns - Target namespace. If empty string (default, used in All Projects view), matches any installed operator.
  */
 export const subscriptionFor = (allSubscriptions: SubscriptionKind[] = []) => (
   allGroups: OperatorGroupKind[] = [],
@@ -153,7 +155,7 @@ export const subscriptionFor = (allSubscriptions: SubscriptionKind[] = []) => (
       allGroups.some(
         (og) =>
           og.metadata.namespace === sub.metadata.namespace &&
-          (isGlobal(og) || og.status?.namespaces?.includes(ns)),
+          (isGlobal(og) || ns === '' || og.status?.namespaces?.includes(ns)),
       ),
     );
 };


### PR DESCRIPTION
When navigating to `/operatorhub/all-namespaces`, and filtering by "Install State: Installed", the namespace-scoped operators tiles are not shown as "Installed" even though they are successfully installed. Only installed global operators are displayed.  This inconsistency can be seen when comparing between the OperatorHub catalog view and the Installed Operators list view.

- Added `ns === ''` condition to match all installed operators in All Projects view
- Updated existing tests and added new tests for All Projects view scenario.
- Updated JSDoc to document empty string behavior

**Before** 
<img width="2553" height="1356" alt="Before-fix-comparison-A 2025-12-04 at 11 10 32 PM" src="https://github.com/user-attachments/assets/02df887e-853a-4a45-a3f6-70e4b12abe3e" />

**After**
<img width="2542" height="1351" alt="After-fix-comparison-A 2025-12-04 at 11 23 10 PM" src="https://github.com/user-attachments/assets/2ed87dac-ad71-4b59-97ab-7938bfd8bb3e" />

Additionally the "Installed" label now correctly displays on installed namespace-scoped operators tiles in the catalog, when "All Projects" is selected.

**Before**
<img width="2553" height="1352" alt="Before-fix-comparison-B 2025-12-04 at 11 12 37 PM" src="https://github.com/user-attachments/assets/6267fb39-cdae-4bb2-977a-4c1854258cad" />

**After**
<img width="2549" height="1351" alt="After-fix-comparison-B 2025-12-04 at 10 51 32 PM" src="https://github.com/user-attachments/assets/31dbf1ea-1cea-4239-b7aa-3e219e7ba651" />
