### PR TITLE
OCPBUGS-62713: Prevent application filter in Topology view from resetting to all applications unexpectedly

### DIFF
--- a/frontend/public/components/namespace-bar.tsx
+++ b/frontend/public/components/namespace-bar.tsx
@@ -5,7 +5,11 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { NamespaceBarProps, useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { ALL_NAMESPACES_KEY } from '@console/dynamic-plugin-sdk/src/constants';
-import { FLAGS, KEYBOARD_SHORTCUTS } from '@console/shared/src/constants/common';
+import {
+  ALL_APPLICATIONS_KEY,
+  FLAGS,
+  KEYBOARD_SHORTCUTS,
+} from '@console/shared/src/constants/common';
 import { NamespaceDropdown } from '@console/shared/src/components/namespace/NamespaceDropdown';
 import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useFlag } from '@console/dynamic-plugin-sdk/src/utils/flags';
@@ -18,6 +22,7 @@ import { FirehoseResult } from './utils/types';
 import { removeQueryArgument } from './utils/router';
 import { useCreateNamespaceOrProjectModal } from '@console/shared/src/hooks/useCreateNamespaceOrProjectModal';
 import type { RootState } from '../redux';
+import { setActiveApplication } from '../actions/ui';
 
 export type NamespaceBarDropdownsProps = {
   children: React.ReactNode;
@@ -77,6 +82,7 @@ export const NamespaceBarDropdowns: React.FC<NamespaceBarDropdownsProps> = ({
           onNamespaceChange?.(newNamespace);
           setActiveNamespace(newNamespace);
           removeQueryArgument('project-name');
+          activeNamespace !== newNamespace && dispatch(setActiveApplication(ALL_APPLICATIONS_KEY));
         }}
         onCreateNew={() => {
           createNamespaceOrProjectModal({

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -63,9 +63,7 @@ export default (state: UIState, action: UIAction): UIState => {
         return state;
       }
 
-      return state
-        .set('activeApplication', ALL_APPLICATIONS_KEY)
-        .set('activeNamespace', action.payload.namespace);
+      return state.set('activeNamespace', action.payload.namespace);
 
     case ActionType.SetCurrentLocation: {
       state = state.set('location', action.payload.location);


### PR DESCRIPTION
**Before:**

https://github.com/user-attachments/assets/97b5d785-d188-41fc-8efd-2f9c6d9f3c27

**After:**

https://github.com/user-attachments/assets/329b1dab-b28d-445d-aa7a-807662c48e79