### PR TITLE
OCPBUGS-55746: Spread operand details across 2 col

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.cy.ts
@@ -129,6 +129,6 @@ describe('Using OLM descriptor components', () => {
     cy.byTestID('create-dynamic-form').click();
     // TODO figure out why this element is detaching
     cy.byTestOperandLink(testCR.metadata.name).click({ force: true });
-    cy.get('.co-operand-details__section--info').should('exist');
+    cy.byTestID('operand-details__section--info').should('exist');
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/index.tsx
@@ -111,11 +111,14 @@ const DescriptorDetailsItemGroup: React.FC<DescriptorDetailsItemGroupProps> = ({
   const label = descriptor?.displayName || groupSchema?.title || _.startCase(groupPath);
   const arrayGroups = _.pickBy(nested, 'isArrayGroup');
   const primitives = _.omitBy(nested, 'isArrayGroup');
-  const span = _.isEmpty(arrayGroups) || _.isEmpty(primitives) ? 6 : 12;
+  const spanRow = !(_.isEmpty(arrayGroups) || _.isEmpty(primitives));
   return (
-    <GridItem sm={span}>
+    <GridItem style={spanRow ? { gridColumn: '1 / -1' } : undefined}>
       <DetailsItem description={description} label={label} obj={obj} path={`${type}.${groupPath}`}>
-        <DescriptionList className="co-editable-label-group">
+        <DescriptionList
+          className="co-editable-label-group"
+          columnModifier={spanRow ? { default: '2Col' } : undefined}
+        >
           {!_.isEmpty(primitives) &&
             _.map(primitives, ({ descriptor: primitiveDescriptor }) => (
               <DescriptorDetailsItem

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
@@ -28,11 +28,15 @@ const PodStatuses: React.FC<StatusCapabilityProps<PodStatusChartProps['statuses'
     return <PodStatusChart statuses={value} subTitle={descriptor.path} />;
   }, [descriptor.path, t, value]);
   return (
-    <div className="co-operand-details__section--info">
-      <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
-        {detail}
-      </DetailsItem>
-    </div>
+    <DetailsItem
+      description={description}
+      label={label}
+      obj={obj}
+      path={fullPath}
+      data-test="operand-details__section--info"
+    >
+      {detail}
+    </DetailsItem>
   );
 };
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -668,57 +668,52 @@ export const OperandDetails = connectToModel(({ crd, csv, kindObj, obj }: Operan
           schema={schema}
           podStatusDescriptors={podStatuses}
         />
-        <div className="co-operand-details__section co-operand-details__section--info">
-          <Grid hasGutter>
+        <Grid hasGutter data-test="operand-details__section--info">
+          <GridItem sm={6}>
+            <ResourceSummary resource={obj} />
+          </GridItem>
+          {mainStatusDescriptor || otherStatusDescriptors?.length > 0 ? (
             <GridItem sm={6}>
-              <ResourceSummary resource={obj} />
+              <DescriptionList>
+                {mainStatusDescriptor && (
+                  <DescriptorDetailsItem
+                    key={mainStatusDescriptor.path}
+                    descriptor={mainStatusDescriptor}
+                    model={kindObj}
+                    obj={obj}
+                    schema={schema}
+                    type={DescriptorType.status}
+                  />
+                )}
+                {otherStatusDescriptors?.length > 0 && (
+                  <DescriptorDetailsItems
+                    descriptors={otherStatusDescriptors}
+                    model={kindObj}
+                    obj={obj}
+                    schema={schema}
+                    type={DescriptorType.status}
+                  />
+                )}
+              </DescriptionList>
             </GridItem>
-            {mainStatusDescriptor || otherStatusDescriptors?.length > 0 ? (
-              <GridItem sm={6}>
-                <DescriptionList>
-                  {mainStatusDescriptor && (
-                    <DescriptorDetailsItem
-                      key={mainStatusDescriptor.path}
-                      descriptor={mainStatusDescriptor}
-                      model={kindObj}
-                      obj={obj}
-                      schema={schema}
-                      type={DescriptorType.status}
-                    />
-                  )}
-                  {otherStatusDescriptors?.length > 0 && (
-                    <DescriptorDetailsItems
-                      descriptors={otherStatusDescriptors}
-                      model={kindObj}
-                      obj={obj}
-                      schema={schema}
-                      type={DescriptorType.status}
-                    />
-                  )}
-                </DescriptionList>
-              </GridItem>
-            ) : null}
-          </Grid>
-        </div>
+          ) : null}
+        </Grid>
       </PaneBody>
       {!_.isEmpty(specDescriptors) && (
         <PaneBody>
-          <div className="co-operand-details__section co-operand-details__section--info">
-            <Grid hasGutter>
-              <GridItem sm={6}>
-                <DescriptionList>
-                  <DescriptorDetailsItems
-                    descriptors={specDescriptors}
-                    model={kindObj}
-                    obj={obj}
-                    onError={handleError}
-                    schema={schema}
-                    type={DescriptorType.spec}
-                  />
-                </DescriptionList>
-              </GridItem>
-            </Grid>
-          </div>
+          <DescriptionList
+            columnModifier={{ default: '2Col' }}
+            data-test="operand-details__section--info"
+          >
+            <DescriptorDetailsItems
+              descriptors={specDescriptors}
+              model={kindObj}
+              obj={obj}
+              onError={handleError}
+              schema={schema}
+              type={DescriptorType.spec}
+            />
+          </DescriptionList>
         </PaneBody>
       )}
       {Array.isArray(status?.conditions) &&


### PR DESCRIPTION
<details>
<summary>PF5 (4.18)</summary>
  
<img width="1645" height="978" alt="image" src="https://github.com/user-attachments/assets/2eef73ac-86f0-482e-90b2-25e593a1e1f0" />
<img width="1645" height="978" alt="image" src="https://github.com/user-attachments/assets/c8141226-344c-43ef-b39f-945b17258d25" />
<img width="1645" height="978" alt="image" src="https://github.com/user-attachments/assets/5f00c4aa-a475-49fe-9383-35d5afa05143" />
<img width="1645" height="978" alt="image" src="https://github.com/user-attachments/assets/dd98e9fd-be21-4453-9e27-a8b9e627303c" />

</details>

<details>
<summary>PF6 (PR)</summary>
  
<img width="1645" height="1010" alt="image" src="https://github.com/user-attachments/assets/008abf12-b3c2-4914-8fe9-e6a98e31c9e0" />
<img width="1645" height="1010" alt="image" src="https://github.com/user-attachments/assets/732e36e4-d6ba-4fe9-89ad-626102ecaba6" />
<img width="1645" height="1010" alt="image" src="https://github.com/user-attachments/assets/7909d1ef-24c9-4e96-8c1e-6bfe96f9a90e" />
<img width="1645" height="1010" alt="image" src="https://github.com/user-attachments/assets/20783177-197a-40b9-860b-e1dc48e02d7b" />

</details>

