### PR TITLE
OCPBUGS-62725: Fixes namespace-scoped operators that were not showing as installed when viewing OperatorHub in "All Projects" mode

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-group.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-group.spec.tsx
@@ -97,11 +97,37 @@ describe('subscriptionFor', () => {
     ).toBeUndefined();
   });
 
-  it('returns nothing if checking for `all-namespaces`', () => {
+  it('returns `Subscription` when checking for `all-namespaces`(empty string from default parameter)', () => {
     subscriptions = [testSubscription];
     operatorGroups = [{ ...testOperatorGroup, status: { namespaces: [ns], lastUpdated: null } }];
 
-    expect(subscriptionFor(subscriptions)(operatorGroups)(pkg)('')).toBeUndefined();
+    expect(subscriptionFor(subscriptions)(operatorGroups)(pkg)('')).toEqual(testSubscription);
+  });
+
+  it('returns `Subscription` when namespace is not provided (All Projects view) for namespace-scoped operator', () => {
+    subscriptions = [testSubscription];
+    operatorGroups = [
+      {
+        ...testOperatorGroup,
+        status: { namespaces: [ns], lastUpdated: null },
+      },
+    ];
+
+    const partialFunc = subscriptionFor(subscriptions)(operatorGroups)(pkg);
+    expect(partialFunc()).toEqual(testSubscription);
+  });
+
+  it('returns `Subscription` when namespace is not provided (All Projects view) for global operator', () => {
+    subscriptions = [testSubscription];
+    operatorGroups = [
+      {
+        ...testOperatorGroup,
+        status: { namespaces: [''], lastUpdated: null },
+      },
+    ];
+
+    const partialFunc = subscriptionFor(subscriptions)(operatorGroups)(pkg);
+    expect(partialFunc()).toEqual(testSubscription);
   });
 
   it('returns `Subscription` when it exists in the "global" `OperatorGroup`', () => {
@@ -146,11 +172,11 @@ describe('installedFor', () => {
     expect(installedFor(subscriptions)(operatorGroups)(pkg)(ns)).toBe(false);
   });
 
-  it('returns false if checking for `all-namespaces`', () => {
+  it('returns true if checking for `all-namespaces` (empty string from default parameter)', () => {
     subscriptions = [testSubscription];
     operatorGroups = [{ ...testOperatorGroup, status: { namespaces: [ns], lastUpdated: null } }];
 
-    expect(installedFor(subscriptions)(operatorGroups)(pkg)('')).toBe(false);
+    expect(installedFor(subscriptions)(operatorGroups)(pkg)('')).toBe(true);
   });
 
   it('returns false if `Subscription` is in a different namespace than the given package', () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
@@ -138,6 +138,8 @@ export const isSingle = (obj: OperatorGroupKind) =>
 /**
  * Determines if a given Operator package has a `Subscription` that makes it available in the given namespace.
  * Finds any `Subscriptions` for the given package, matches them to their `OperatorGroup`, and checks if the `OperatorGroup` is targeting the given namespace or if it is global.
+ *
+ * @param ns - Target namespace. If empty string (default, used in All Projects view), matches any installed operator.
  */
 export const subscriptionFor = (allSubscriptions: SubscriptionKind[] = []) => (
   allGroups: OperatorGroupKind[] = [],
@@ -153,7 +155,7 @@ export const subscriptionFor = (allSubscriptions: SubscriptionKind[] = []) => (
       allGroups.some(
         (og) =>
           og.metadata.namespace === sub.metadata.namespace &&
-          (isGlobal(og) || og.status?.namespaces?.includes(ns)),
+          (isGlobal(og) || ns === '' || og.status?.namespaces?.includes(ns)),
       ),
     );
 };


### PR DESCRIPTION
When navigating to `/operatorhub/all-namespaces`, and filtering by "Install State: Installed", the namespace-scoped operators tiles are not shown as "Installed" even though they are successfully installed. Only installed global operators are displayed.  This inconsistency can be seen when comparing between the OperatorHub catalog view and the Installed Operators list view.

- Added `ns === ''` condition to match all installed operators in All Projects view
- Updated existing tests and added new tests for All Projects view scenario.
- Updated JSDoc to document empty string behavior

**Before** 
<img width="2543" height="1350" alt="Before-fix-comparison-installed 2025-12-05 at 1 09 39 PM" src="https://github.com/user-attachments/assets/b4d95863-298d-4401-b601-357598140a0e" />

**After**
<img width="2547" height="1248" alt="After-fix-comparison-installed 2025-12-05 at 1 20 27 PM" src="https://github.com/user-attachments/assets/d547bb35-e448-4a92-ba3f-df1c21442b3b" />

---
Additionally the "Installed" label now correctly displays on installed namespace-scoped operators tiles in the catalog, when "All Projects" is selected.

**Before**
<img width="2539" height="863" alt="Before-fix-comparison-for-label 2025-12-05 at 1 39 00 PM" src="https://github.com/user-attachments/assets/7b50a30e-e58e-4485-9687-ab4f0a5e4024" />

**After**
<img width="2540" height="949" alt="After-fix-comparison-for-label 2025-12-05 at 1 29 33 PM" src="https://github.com/user-attachments/assets/89df65f4-1a99-40bc-baf9-94e670901a71" />

