### PR TITLE
OCPBUGS-62611: Fix editing secrets with mixed text and binary data

### DIFF
--- a/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
+++ b/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
@@ -60,7 +60,7 @@ export const SecretFormWrapper: FCC<BaseEditSecretProps_> = (props) => {
   const [stringData, setStringData] = useState(
     Object.entries(props.obj?.data ?? {}).reduce<Record<string, string>>((acc, [key, value]) => {
       if (isBinary(null, Buffer.from(value, 'base64'))) {
-        return null;
+        return acc;
       }
       acc[key] = value ? Base64.decode(value) : '';
       return acc;


### PR DESCRIPTION
When a secret contained both text and binary values, the edit form would fail due to a runtime error. The stringData initialization was returning null when any binary field was detected, breaking text field handling.

Now binary fields are skipped during stringData initialization while text fields are preserved, allowing proper editing of mixed-type secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)