### PR TITLE
OCPBUGS-63390: show DASH to routing labels column when receiver doesn't have routing labels

### DIFF
--- a/frontend/public/components/monitoring/alertmanager/alertmanager-config.tsx
+++ b/frontend/public/components/monitoring/alertmanager/alertmanager-config.tsx
@@ -52,6 +52,7 @@ import {
   ResourceMetadata,
 } from '@console/app/src/components/data-view/types';
 import { RowProps, TableColumn } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
+import { DASH } from '@console/shared/src/constants/ui';
 
 export enum InitialReceivers {
   Critical = 'Critical',
@@ -229,12 +230,9 @@ const RoutingLabels: React.FC<RoutingLabelsProps> = ({ data }) => {
   const { labels, matchers } = data;
   const lbls = _.map(labels || {}, (value, key) => `${key}=${value}`);
   const values = [...lbls, ...(matchers ?? [])];
-
   return values.length > 0 ? (
     <PfLabelGroup>
-      {values.map((value, i) => (
-        <PfLabel key={`label-${i}`}>{value}</PfLabel>
-      ))}
+      {values.map((value, i) => (value ? <PfLabel key={`label-${i}`}>{value}</PfLabel> : DASH))}
     </PfLabelGroup>
   ) : null;
 };


### PR DESCRIPTION
**Before:**
<img width="1587" height="813" alt="image" src="https://github.com/user-attachments/assets/c2dadb31-2133-4412-8cba-78ab4d7971e9" />


**After:** 
<img width="1589" height="808" alt="image" src="https://github.com/user-attachments/assets/5ca60d3e-0a37-473e-bac9-ad61e412f6d9" />
