### PR TITLE
OCPBUGS-63389: Remove asterisk from Routing label field in alertManager receiver form

### DIFF
--- a/frontend/public/components/monitoring/receiver-forms/routing-labels-editor.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/routing-labels-editor.tsx
@@ -63,19 +63,7 @@ export const RoutingLabelEditor = ({ formValues, dispatchFormChange, isDefaultRe
   const { t } = useTranslation();
 
   return (
-    <FormSection
-      title={
-        <>
-          {t('public~Routing labels')}{' '}
-          {!isDefaultReceiver && (
-            <span className="pf-v6-c-form__label-required" aria-hidden="true">
-              {' '}
-              *
-            </span>
-          )}
-        </>
-      }
-    >
+    <FormSection title={t('public~Routing labels')}>
       <Content component={ContentVariants.p} className="pf-v6-u-mb-0">
         <Trans ns="public">
           Firing alerts with labels that match all of these{' '}
@@ -88,7 +76,7 @@ export const RoutingLabelEditor = ({ formValues, dispatchFormChange, isDefaultRe
           {isDefaultReceiver && (
             <InputGroup>
               <InputGroupItem isFill>
-                <TextInput type="text" value={DEFAULT_RECEIVER_LABEL} isDisabled isRequired />
+                <TextInput type="text" value={DEFAULT_RECEIVER_LABEL} isDisabled />
               </InputGroupItem>
             </InputGroup>
           )}


### PR DESCRIPTION
Remove the asterisk as the routing label is not a required field in API. And the console is not validating the field in the UI. We should rely on the API server







