### PR TITLE
[release-4.20] OCPBUGS-67221: Disallowed Pipelines-plugin Pipelines navigation section

### DIFF
--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -1365,7 +1365,8 @@
       }
     },
     "flags": {
-      "required": ["OPENSHIFT_PIPELINE"]
+      "required": ["OPENSHIFT_PIPELINE"],
+      "disallowed": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_NAV_OPTION"]
     }
   },
   {


### PR DESCRIPTION
Prevent duplicate Pipelines navigation links in older consoles (v4.20 and below). This was caused by the missing disallowed flag on the `console.navigation/section` extension.