### PR TITLE
OCPBUGS-65967: Clean up old session cookies to prevent accumulation

### DIFF
--- a/pkg/auth/sessions/combined_sessions.go
+++ b/pkg/auth/sessions/combined_sessions.go
@@ -43,24 +43,34 @@ func NewSessionStore(authnKey, encryptKey []byte, secureCookies bool, cookiePath
 	}
 }
 
+// expireOldPodCookies expires session cookies from other pods to prevent cookie accumulation
+// when users are load-balanced across multiple pods.
+func (cs *CombinedSessionStore) expireOldPodCookies(w http.ResponseWriter, r *http.Request) {
+	currentCookieName := SessionCookieName()
+	for _, cookie := range r.Cookies() {
+		// Expire any session cookies that are not for the current pod
+		if strings.HasPrefix(cookie.Name, OpenshiftAccessTokenCookieName) && cookie.Name != currentCookieName {
+			// Must match all attributes of the original cookie for browsers to properly delete it
+			http.SetCookie(w, &http.Cookie{
+				Name:     cookie.Name,
+				Value:    "",
+				Path:     cs.clientStore.Options.Path,
+				MaxAge:   -1,
+				Secure:   cs.clientStore.Options.Secure,
+				HttpOnly: cs.clientStore.Options.HttpOnly,
+				SameSite: cs.clientStore.Options.SameSite,
+			})
+		}
+	}
+}
+
 func (cs *CombinedSessionStore) AddSession(w http.ResponseWriter, r *http.Request, tokenVerifier IDTokenVerifier, token *oauth2.Token) (*LoginState, error) {
 	cs.sessionLock.Lock()
 	defer cs.sessionLock.Unlock()
 
 	// Clean up old session cookies from previous pods before creating new session
 	// This prevents cookie accumulation when users are load-balanced across multiple pods
-	currentCookieName := SessionCookieName()
-	for _, cookie := range r.Cookies() {
-		// Expire any session cookies that are not for the current pod
-		if strings.HasPrefix(cookie.Name, OpenshiftAccessTokenCookieName) && cookie.Name != currentCookieName {
-			http.SetCookie(w, &http.Cookie{
-				Name:   cookie.Name,
-				Value:  "",
-				Path:   cs.clientStore.Options.Path,
-				MaxAge: -1,
-			})
-		}
-	}
+	cs.expireOldPodCookies(w, r)
 
 	ls, err := cs.serverStore.AddSession(tokenVerifier, token)
 	if err != nil {
@@ -101,6 +111,11 @@ func (s *session) save(r *http.Request, w http.ResponseWriter) error {
 func (cs *CombinedSessionStore) GetSession(w http.ResponseWriter, r *http.Request) (*LoginState, error) {
 	cs.sessionLock.Lock()
 	defer cs.sessionLock.Unlock()
+
+	// Clean up old session cookies from previous pods
+	// This is done here because GetSession is called on /api/* requests where
+	// session cookies (with Path=/api) are actually sent by the browser
+	cs.expireOldPodCookies(w, r)
 
 	// Get always returns a session, even if empty.
 	clientSession := cs.getCookieSession(r)
@@ -150,6 +165,10 @@ func (cs *CombinedSessionStore) UpdateCookieRefreshToken(w http.ResponseWriter, 
 func (cs *CombinedSessionStore) UpdateTokens(w http.ResponseWriter, r *http.Request, tokenVerifier IDTokenVerifier, tokenResponse *oauth2.Token) (*LoginState, error) {
 	cs.sessionLock.Lock()
 	defer cs.sessionLock.Unlock()
+
+	// Clean up old session cookies from previous pods when refreshing tokens
+	// This handles the case where a user is load-balanced to a different pod
+	cs.expireOldPodCookies(w, r)
 
 	clientSession := cs.getCookieSession(r)
 	var oldRefreshTokenID string
@@ -210,10 +229,13 @@ func (cs *CombinedSessionStore) DeleteSession(w http.ResponseWriter, r *http.Req
 	for _, cookie := range r.Cookies() {
 		if strings.HasPrefix(cookie.Name, OpenshiftAccessTokenCookieName) {
 			http.SetCookie(w, &http.Cookie{
-				Name:   cookie.Name,
-				Value:  "",
-				Path:   cs.clientStore.Options.Path,
-				MaxAge: -1,
+				Name:     cookie.Name,
+				Value:    "",
+				Path:     cs.clientStore.Options.Path,
+				MaxAge:   -1,
+				Secure:   cs.clientStore.Options.Secure,
+				HttpOnly: cs.clientStore.Options.HttpOnly,
+				SameSite: cs.clientStore.Options.SameSite,
 			})
 		}
 	}

--- a/pkg/auth/sessions/combined_sessions_test.go
+++ b/pkg/auth/sessions/combined_sessions_test.go
@@ -743,3 +743,87 @@ func TestCombinedSessionStore_AddSession_CleansUpOldPodCookies(t *testing.T) {
 	require.Equal(t, 2, expiredCookies, "Both old pod cookies should be expired")
 	require.True(t, newSessionCookie, "New session cookie should be created")
 }
+
+func TestCombinedSessionStore_GetSession_CleansUpOldPodCookies(t *testing.T) {
+	encryptionKey := []byte(randomString(32))
+	authnKey := []byte(randomString(64))
+	cs := NewSessionStore(authnKey, encryptionKey, true, "/")
+
+	// Simulate request with old session cookies from different pods
+	// This is the primary cleanup path since GetSession is called on /api/* requests
+	// where session cookies (with Path=/api) are actually sent by the browser
+	req := httptest.NewRequest(http.MethodGet, "/api/some-endpoint", nil)
+	req.AddCookie(&http.Cookie{Name: OpenshiftAccessTokenCookieName + "-console-old-pod-1", Value: "old-value-1"})
+	req.AddCookie(&http.Cookie{Name: OpenshiftAccessTokenCookieName + "-console-old-pod-2", Value: "old-value-2"})
+	req.AddCookie(&http.Cookie{Name: "other-cookie", Value: "other-value"})
+
+	testWriter := httptest.NewRecorder()
+	_, _ = cs.GetSession(testWriter, req)
+
+	// Verify old pod cookies were expired
+	cookies := testWriter.Result().Cookies()
+	expiredCookies := 0
+	for _, c := range cookies {
+		if c.Name == OpenshiftAccessTokenCookieName+"-console-old-pod-1" ||
+			c.Name == OpenshiftAccessTokenCookieName+"-console-old-pod-2" {
+			require.Equal(t, -1, c.MaxAge, "Old pod cookie %s should be expired", c.Name)
+			expiredCookies++
+		}
+		if c.Name == "other-cookie" {
+			t.Errorf("Non-session cookie 'other-cookie' should not be modified")
+		}
+	}
+
+	require.Equal(t, 2, expiredCookies, "Both old pod cookies should be expired")
+}
+
+func TestCombinedSessionStore_UpdateTokens_CleansUpOldPodCookies(t *testing.T) {
+	currentTime := strconv.FormatInt(time.Now().Add(5*time.Minute).Unix(), 10)
+	testIDToken := createTestIDToken(`{"sub":"user-id-0","exp":` + currentTime + `}`)
+	testVerifier := newTestVerifier(`{"sub":"user-id-0","exp":` + currentTime + `}`)
+
+	encryptionKey := []byte(randomString(32))
+	authnKey := []byte(randomString(64))
+	cs := NewSessionStore(authnKey, encryptionKey, true, "/")
+
+	token := addIDToken(
+		&oauth2.Token{
+			RefreshToken: "new-refresh-token",
+		},
+		testIDToken,
+	)
+
+	// Simulate request with old session cookies from different pods
+	// This simulates the scenario where a user is load-balanced to a new pod
+	// and their token is being refreshed
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: OpenshiftAccessTokenCookieName + "-console-old-pod-1", Value: "old-value-1"})
+	req.AddCookie(&http.Cookie{Name: OpenshiftAccessTokenCookieName + "-console-old-pod-2", Value: "old-value-2"})
+	req.AddCookie(&http.Cookie{Name: "other-cookie", Value: "other-value"})
+
+	testWriter := httptest.NewRecorder()
+	_, err := cs.UpdateTokens(testWriter, req, testVerifier, token)
+	require.NoError(t, err)
+
+	// Verify old pod cookies were expired
+	cookies := testWriter.Result().Cookies()
+	expiredCookies := 0
+	newSessionCookie := false
+	for _, c := range cookies {
+		if c.Name == OpenshiftAccessTokenCookieName+"-console-old-pod-1" ||
+			c.Name == OpenshiftAccessTokenCookieName+"-console-old-pod-2" {
+			require.Equal(t, -1, c.MaxAge, "Old pod cookie %s should be expired", c.Name)
+			expiredCookies++
+		}
+		if c.Name == SessionCookieName() {
+			require.NotEqual(t, -1, c.MaxAge, "New session cookie should not be expired")
+			newSessionCookie = true
+		}
+		if c.Name == "other-cookie" {
+			t.Errorf("Non-session cookie 'other-cookie' should not be modified")
+		}
+	}
+
+	require.Equal(t, 2, expiredCookies, "Both old pod cookies should be expired")
+	require.True(t, newSessionCookie, "New session cookie should be created")
+}


### PR DESCRIPTION
## Problem

When users are load-balanced across multiple console pods, each pod creates a session cookie with a unique name based on `POD_NAME`: `openshift-session-token-<POD_NAME>`. 

With a 1-month cookie expiration, users accumulate cookies from different pods without old ones being removed. This is especially problematic with Azure AD SSO where new authentication tokens are issued on each login, causing OpenShift to create new session cookies instead of reusing old ones.

Over time, the cookie header can exceed 4096 bytes, causing errors.

## Solution

This fix cleans up session cookies from other pods when creating a new session, ensuring only one active session cookie exists at a time.

### Changes

- Modified `AddSession()` to expire old pod cookies before creating new session in `pkg/auth/sessions/combined_sessions.go:46-73`
- Updated `DeleteSession()` to use modern cookie expiration pattern (removed outdated Go loop variable capture) 
- Added test `TestCombinedSessionStore_AddSession_CleansUpOldPodCookies` to verify old pod cookies are properly expired

### Testing

- All existing session tests pass ✓
- New test verifies old pod cookies are expired on new session creation ✓

## Impact

- **Backward compatible**: Existing sessions continue to work
- **Low risk**: Only affects cookie cleanup during new session creation
- **Performance**: Minimal overhead - iterates through cookies once per login

Fixes: OCPBUGS-65967

🤖 Generated with [Claude Code](https://claude.com/claude-code)