### PR TITLE
OCPBUGS-67319: Fix duplicate telemetry events on page load

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/segment-analytics.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/segment-analytics.ts
@@ -106,7 +106,6 @@ const initSegmentAnalytics = () => {
     options.integrations = { 'Segment.io': { apiHost: TELEMETRY_API_HOST } };
   }
   analytics.load(TELEMETRY_API_KEY, options);
-  analytics.page(); // Make the first page call to load the integrations
 };
 
 if (!SAMPLE_SESSION) {

--- a/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
@@ -12,6 +12,7 @@ import { testHook } from '@console/shared/src/test-utils/hooks-utils';
 import {
   getClusterProperties,
   updateClusterPropertiesFromTests,
+  clearTelemetryEventsForTests,
   useTelemetry,
 } from '../useTelemetry';
 
@@ -135,6 +136,7 @@ describe('useTelemetry', () => {
 
   beforeEach(() => {
     listener.mockReset();
+    clearTelemetryEventsForTests();
     const extensions: ResolvedExtension<TelemetryListener>[] = [
       {
         type: 'console.telemetry/listener',


### PR DESCRIPTION
Stabilize the useTelemetry hook callback using the "latest ref" pattern to prevent re-renders from causing duplicate identify and page events. Previously, the callback had four dependencies that changed frequently, triggering multiple effect re-runs.

Key changes:
- Use refs to store current values, allowing a stable callback
- Fix CaptureTelemetry to track fired events and prevent duplicates
- Remove duplicate analytics.page() call from Segment initialization
- Add test isolation for module-level telemetry event queue

**Root cause:** The `fireTelemetryEvent` callback had 4 dependencies (`extensions`, `currentUserPreferenceTelemetryValue`, `userResource`, `userResourceIsLoaded`) that changed frequently, causing effects to re-run and fire duplicate events.

Fixes https://issues.redhat.com/browse/OCPBUGS-67319