### PR TITLE
OCPBUGS-55136: Fix cluster:console_plugins_info:max metrics has two entries for one dynamic plugin

### DIFF
--- a/pkg/serverconfig/metrics_test.go
+++ b/pkg/serverconfig/metrics_test.go
@@ -177,9 +177,7 @@ func TestPluginMetricsRunningTwice(t *testing.T) {
 			console_plugins_info{name="demo",state="enabled"} 1
 			`,
 			expectedMetricsAfterUpdate: `
-			console_plugins_info{name="acm",state="enabled"} 0
 			console_plugins_info{name="acm",state="notfound"} 1
-			console_plugins_info{name="demo",state="enabled"} 0
 			console_plugins_info{name="demo",state="notfound"} 1
 			`,
 		},
@@ -239,7 +237,6 @@ func TestPluginMetricsRunningTwice(t *testing.T) {
 			console_plugins_info{name="acm",state="enabled"} 1
 			console_plugins_info{name="demo",state="disabled"} 1
 			console_plugins_info{name="unknown",state="disabled"} 1
-			console_plugins_info{name="unknown",state="enabled"} 0
 			console_plugins_info{name="unknown",state="notfound"} 1
 			`,
 		},


### PR DESCRIPTION
When the plugin state changes (e.g., enabled -> disabled), we must delete the old label combination to prevent stale time series in Prometheus.