### PR TITLE
[release-4.20] OCPBUGS-67136: Spread operand details across 2 col 

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.cy.ts
@@ -129,6 +129,6 @@ describe('Using OLM descriptor components', () => {
     cy.byTestID('create-dynamic-form').click();
     // TODO figure out why this element is detaching
     cy.byTestOperandLink(testCR.metadata.name).click({ force: true });
-    cy.get('.co-operand-details__section--info').should('exist');
+    cy.byTestID('operand-details__section--info').should('exist');
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/index.tsx
@@ -111,11 +111,14 @@ const DescriptorDetailsItemGroup: React.FC<DescriptorDetailsItemGroupProps> = ({
   const label = descriptor?.displayName || groupSchema?.title || _.startCase(groupPath);
   const arrayGroups = _.pickBy(nested, 'isArrayGroup');
   const primitives = _.omitBy(nested, 'isArrayGroup');
-  const span = _.isEmpty(arrayGroups) || _.isEmpty(primitives) ? 6 : 12;
+  const spanRow = !(_.isEmpty(arrayGroups) || _.isEmpty(primitives));
   return (
-    <GridItem sm={span}>
+    <GridItem style={spanRow ? { gridColumn: '1 / -1' } : undefined}>
       <DetailsItem description={description} label={label} obj={obj} path={`${type}.${groupPath}`}>
-        <DescriptionList className="olm-descriptors__group co-editable-label-group">
+        <DescriptionList
+          className="co-editable-label-group"
+          columnModifier={spanRow ? { default: '2Col' } : undefined}
+        >
           {!_.isEmpty(primitives) &&
             _.map(primitives, ({ descriptor: primitiveDescriptor }) => (
               <DescriptorDetailsItem

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
@@ -28,11 +28,15 @@ const PodStatuses: React.FC<StatusCapabilityProps<PodStatusChartProps['statuses'
     return <PodStatusChart statuses={value} subTitle={descriptor.path} />;
   }, [descriptor.path, t, value]);
   return (
-    <div className="co-operand-details__section--info">
-      <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
-        {detail}
-      </DetailsItem>
-    </div>
+    <DetailsItem
+      description={description}
+      label={label}
+      obj={obj}
+      path={fullPath}
+      data-test="operand-details__section--info"
+    >
+      {detail}
+    </DetailsItem>
   );
 };
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -244,7 +244,7 @@ describe(OperandDetails.displayName, () => {
   });
 
   it('renders info section', () => {
-    const section = wrapper.find('.co-operand-details__section.co-operand-details__section--info');
+    const section = wrapper.find('[data-test="operand-details__section--info"]');
 
     expect(section.exists()).toBe(true);
   });

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -668,57 +668,52 @@ export const OperandDetails = connectToModel(({ crd, csv, kindObj, obj }: Operan
           schema={schema}
           podStatusDescriptors={podStatuses}
         />
-        <div className="co-operand-details__section co-operand-details__section--info">
-          <Grid hasGutter>
+        <Grid hasGutter data-test="operand-details__section--info">
+          <GridItem sm={6}>
+            <ResourceSummary resource={obj} />
+          </GridItem>
+          {mainStatusDescriptor || otherStatusDescriptors?.length > 0 ? (
             <GridItem sm={6}>
-              <ResourceSummary resource={obj} />
+              <DescriptionList>
+                {mainStatusDescriptor && (
+                  <DescriptorDetailsItem
+                    key={mainStatusDescriptor.path}
+                    descriptor={mainStatusDescriptor}
+                    model={kindObj}
+                    obj={obj}
+                    schema={schema}
+                    type={DescriptorType.status}
+                  />
+                )}
+                {otherStatusDescriptors?.length > 0 && (
+                  <DescriptorDetailsItems
+                    descriptors={otherStatusDescriptors}
+                    model={kindObj}
+                    obj={obj}
+                    schema={schema}
+                    type={DescriptorType.status}
+                  />
+                )}
+              </DescriptionList>
             </GridItem>
-            {mainStatusDescriptor || otherStatusDescriptors?.length > 0 ? (
-              <GridItem sm={6}>
-                <DescriptionList>
-                  {mainStatusDescriptor && (
-                    <DescriptorDetailsItem
-                      key={mainStatusDescriptor.path}
-                      descriptor={mainStatusDescriptor}
-                      model={kindObj}
-                      obj={obj}
-                      schema={schema}
-                      type={DescriptorType.status}
-                    />
-                  )}
-                  {otherStatusDescriptors?.length > 0 && (
-                    <DescriptorDetailsItems
-                      descriptors={otherStatusDescriptors}
-                      model={kindObj}
-                      obj={obj}
-                      schema={schema}
-                      type={DescriptorType.status}
-                    />
-                  )}
-                </DescriptionList>
-              </GridItem>
-            ) : null}
-          </Grid>
-        </div>
+          ) : null}
+        </Grid>
       </PaneBody>
       {!_.isEmpty(specDescriptors) && (
         <PaneBody>
-          <div className="co-operand-details__section co-operand-details__section--info">
-            <Grid hasGutter>
-              <GridItem sm={6}>
-                <DescriptionList>
-                  <DescriptorDetailsItems
-                    descriptors={specDescriptors}
-                    model={kindObj}
-                    obj={obj}
-                    onError={handleError}
-                    schema={schema}
-                    type={DescriptorType.spec}
-                  />
-                </DescriptionList>
-              </GridItem>
-            </Grid>
-          </div>
+          <DescriptionList
+            columnModifier={{ default: '2Col' }}
+            data-test="operand-details__section--info"
+          >
+            <DescriptorDetailsItems
+              descriptors={specDescriptors}
+              model={kindObj}
+              obj={obj}
+              onError={handleError}
+              schema={schema}
+              type={DescriptorType.spec}
+            />
+          </DescriptionList>
         </PaneBody>
       )}
       {Array.isArray(status?.conditions) &&


### PR DESCRIPTION
This is an ~~automated~~ cherry-pick of https://github.com/openshift/console/pull/15815

<img width="1638" height="978" alt="image" src="https://github.com/user-attachments/assets/d659b7cf-536c-4b24-ab8f-87abb89947bc" />
<img width="1638" height="978" alt="image" src="https://github.com/user-attachments/assets/5d963142-95b2-4586-ac53-3f47dd2dc59f" />
<img width="1638" height="978" alt="image" src="https://github.com/user-attachments/assets/f812f25a-daad-49fe-b21d-dc40a2cf21a2" />
<img width="1638" height="978" alt="image" src="https://github.com/user-attachments/assets/9399605d-4d66-471f-a595-6baee4ae24c8" />
<img width="1638" height="978" alt="image" src="https://github.com/user-attachments/assets/077ebd9f-b94e-41f4-94d2-dd23cf9b456e" />
