### PR TITLE
[release-4.19] OCPBUGS-69677: Spread operand details across 2 col 

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/descriptors.cy.ts
@@ -129,6 +129,6 @@ describe('Using OLM descriptor components', () => {
     cy.byTestID('create-dynamic-form').click();
     // TODO figure out why this element is detaching
     cy.byTestOperandLink(testCR.metadata.name).click({ force: true });
-    cy.get('.co-operand-details__section--info').should('exist');
+    cy.byTestID('operand-details__section--info').should('exist');
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DescriptionList } from '@patternfly/react-core';
+import { DescriptionList, GridItem } from '@patternfly/react-core';
 import { JSONSchema7 } from 'json-schema';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -111,11 +111,14 @@ const DescriptorDetailsItemGroup: React.FC<DescriptorDetailsItemGroupProps> = ({
   const label = descriptor?.displayName || groupSchema?.title || _.startCase(groupPath);
   const arrayGroups = _.pickBy(nested, 'isArrayGroup');
   const primitives = _.omitBy(nested, 'isArrayGroup');
-  const className = _.isEmpty(arrayGroups) || _.isEmpty(primitives) ? 'col-sm-6' : 'col-sm-12';
+  const spanRow = !(_.isEmpty(arrayGroups) || _.isEmpty(primitives));
   return (
-    <div className={className}>
+    <GridItem style={spanRow ? { gridColumn: '1 / -1' } : undefined}>
       <DetailsItem description={description} label={label} obj={obj} path={`${type}.${groupPath}`}>
-        <DescriptionList className="olm-descriptors__group co-editable-label-group">
+        <DescriptionList
+          className="co-editable-label-group"
+          columnModifier={spanRow ? { default: '2Col' } : undefined}
+        >
           {!_.isEmpty(primitives) &&
             _.map(primitives, ({ descriptor: primitiveDescriptor }) => (
               <DescriptorDetailsItem
@@ -143,11 +146,11 @@ const DescriptorDetailsItemGroup: React.FC<DescriptorDetailsItemGroupProps> = ({
             ))}
         </DescriptionList>
       </DetailsItem>
-    </div>
+    </GridItem>
   );
 };
 
-/** Note: MUST be used inside a <DescriptionList> */
+/** Note: MUST be used inside a `<DescriptionList>` */
 export const DescriptorDetailsItems: React.FC<DescriptorDetailsItemsProps> = ({
   descriptors,
   model,

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
@@ -28,11 +28,15 @@ const PodStatuses: React.FC<StatusCapabilityProps<PodStatusChartProps['statuses'
     return <PodStatusChart statuses={value} subTitle={descriptor.path} />;
   }, [descriptor.path, t, value]);
   return (
-    <div className="co-operand-details__section--info">
-      <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
-        {detail}
-      </DetailsItem>
-    </div>
+    <DetailsItem
+      description={description}
+      label={label}
+      obj={obj}
+      path={fullPath}
+      data-test="operand-details__section--info"
+    >
+      {detail}
+    </DetailsItem>
   );
 };
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -244,7 +244,7 @@ describe(OperandDetails.displayName, () => {
   });
 
   it('renders info section', () => {
-    const section = wrapper.find('.co-operand-details__section.co-operand-details__section--info');
+    const section = wrapper.find('[data-test="operand-details__section--info"]');
 
     expect(section.exists()).toBe(true);
   });

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DescriptionList } from '@patternfly/react-core';
+import { DescriptionList, Grid, GridItem } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import classNames from 'classnames';
 import { JSONSchema7 } from 'json-schema';
@@ -447,12 +447,11 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
 
   return inFlight ? null : (
     <>
-      <ListPageHeader title={showTitle ? t('olm~All Instances') : undefined} hideFavoriteButton>
-        {managesAllNamespaces && (
-          <div className="co-operator-details__toggle-value pf-v6-u-ml-xl-on-md">
-            <ShowOperandsInAllNamespacesRadioGroup />
-          </div>
-        )}
+      <ListPageHeader
+        title={showTitle ? t('olm~All Instances') : undefined}
+        hideFavoriteButton
+        helpText={managesAllNamespaces && <ShowOperandsInAllNamespacesRadioGroup />}
+      >
         <ListPageCreateDropdown onClick={createNavigate} items={createItems}>
           {t('olm~Create new')}
         </ListPageCreateDropdown>
@@ -515,12 +514,11 @@ const DefaultProvidedAPIPage: React.FC<DefaultProvidedAPIPageProps> = (props) =>
 
   return (
     <>
-      <ListPageHeader title={showTitle ? `${labelPlural}` : undefined} hideFavoriteButton>
-        {managesAllNamespaces && (
-          <div className="co-operator-details__toggle-value pf-v6-u-ml-xl-on-md">
-            <ShowOperandsInAllNamespacesRadioGroup />
-          </div>
-        )}
+      <ListPageHeader
+        title={showTitle ? `${labelPlural}` : undefined}
+        hideFavoriteButton
+        helpText={managesAllNamespaces && <ShowOperandsInAllNamespacesRadioGroup />}
+      >
         <ListPageCreateLink to={createPath}>
           {t('public~Create {{label}}', { label })}
         </ListPageCreateLink>
@@ -587,21 +585,21 @@ export const ProvidedAPIPage = (props: ProvidedAPIPageProps) => {
 
 const PodStatuses: React.FC<PodStatusesProps> = ({ kindObj, obj, podStatusDescriptors, schema }) =>
   podStatusDescriptors?.length > 0 ? (
-    <div className="row">
+    <Grid hasGutter>
       {podStatusDescriptors.map((statusDescriptor: StatusDescriptor) => {
         return (
-          <DescriptorDetailsItem
-            className="col-sm-6"
-            key={statusDescriptor.path}
-            type={DescriptorType.status}
-            descriptor={statusDescriptor}
-            model={kindObj}
-            obj={obj}
-            schema={schema}
-          />
+          <GridItem sm={6} key={statusDescriptor.path}>
+            <DescriptorDetailsItem
+              type={DescriptorType.status}
+              descriptor={statusDescriptor}
+              model={kindObj}
+              obj={obj}
+              schema={schema}
+            />
+          </GridItem>
         );
       })}
-    </div>
+    </Grid>
   ) : null;
 
 export const OperandDetails = connectToModel(({ crd, csv, kindObj, obj }: OperandDetailsProps) => {
@@ -670,13 +668,13 @@ export const OperandDetails = connectToModel(({ crd, csv, kindObj, obj }: Operan
           schema={schema}
           podStatusDescriptors={podStatuses}
         />
-        <div className="co-operand-details__section co-operand-details__section--info">
-          <div className="row">
-            <div className="col-sm-6">
-              <ResourceSummary resource={obj} />
-            </div>
-            {(mainStatusDescriptor || otherStatusDescriptors?.length > 0) && (
-              <DescriptionList className="col-sm-6">
+        <Grid hasGutter data-test="operand-details__section--info">
+          <GridItem sm={6}>
+            <ResourceSummary resource={obj} />
+          </GridItem>
+          {mainStatusDescriptor || otherStatusDescriptors?.length > 0 ? (
+            <GridItem sm={6}>
+              <DescriptionList>
                 {mainStatusDescriptor && (
                   <DescriptorDetailsItem
                     key={mainStatusDescriptor.path}
@@ -697,27 +695,25 @@ export const OperandDetails = connectToModel(({ crd, csv, kindObj, obj }: Operan
                   />
                 )}
               </DescriptionList>
-            )}
-          </div>
-        </div>
+            </GridItem>
+          ) : null}
+        </Grid>
       </PaneBody>
       {!_.isEmpty(specDescriptors) && (
         <PaneBody>
-          <div className="co-operand-details__section co-operand-details__section--info">
-            <div className="row">
-              <DescriptionList>
-                <DescriptorDetailsItems
-                  descriptors={specDescriptors}
-                  itemClassName="col-sm-6"
-                  model={kindObj}
-                  obj={obj}
-                  onError={handleError}
-                  schema={schema}
-                  type={DescriptorType.spec}
-                />
-              </DescriptionList>
-            </div>
-          </div>
+          <DescriptionList
+            columnModifier={{ default: '2Col' }}
+            data-test="operand-details__section--info"
+          >
+            <DescriptorDetailsItems
+              descriptors={specDescriptors}
+              model={kindObj}
+              obj={obj}
+              onError={handleError}
+              schema={schema}
+              type={DescriptorType.spec}
+            />
+          </DescriptionList>
         </PaneBody>
       )}
       {Array.isArray(status?.conditions) &&


### PR DESCRIPTION
This is an ~~automated~~ cherry-pick of https://github.com/openshift/console/pull/15858

<img width="1638" height="978" alt="image" src="https://github.com/user-attachments/assets/02e7903b-f36c-45af-a205-3ae07dcc89fb" />
<img width="1638" height="978" alt="image" src="https://github.com/user-attachments/assets/a4943c23-2900-4673-ba0d-386857df3d81" />
<img width="1638" height="978" alt="image" src="https://github.com/user-attachments/assets/1ee755e2-36cc-41f6-ab3f-c0826c56bedb" />
<img width="1638" height="978" alt="image" src="https://github.com/user-attachments/assets/1eff4f4e-a4fb-4d36-adb1-867a6476e035" />
<img width="1638" height="978" alt="image" src="https://github.com/user-attachments/assets/c081f586-c0c0-40f6-beda-b36998974da8" />
