### PR TITLE
HELM-598: Add new server endpoint for installing OCI charts without Helm repository

### DIFF
--- a/pkg/helm/actions/setup_test.go
+++ b/pkg/helm/actions/setup_test.go
@@ -5,11 +5,16 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"regexp"
+	"runtime/debug"
+	"strings"
 	"testing"
 	"time"
 
 	"helm.sh/helm/v3/pkg/cli"
 )
+
+const helmModulePath = "helm.sh/helm/v3"
 
 func setSettings(settings *cli.EnvSettings) {
 	settings.RepositoryCache = os.TempDir()
@@ -17,9 +22,79 @@ func setSettings(settings *cli.EnvSettings) {
 	settings.RepositoryConfig = "/RepositoryConfig"
 }
 
+// helmVersionFromGoMod reads go.mod to find the Helm Go package version.
+// Test binaries often have no build info (see https://go.dev/issue/33976), so we parse go.mod instead.
+func helmVersionFromGoMod() string {
+	for _, path := range []string{"go.mod", "../go.mod", "../../go.mod", "../../../go.mod"} {
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		// Match line like "	helm.sh/helm/v3 v3.18.5" or "	helm.sh/helm/v3 v3.18.5 // indirect".
+		re := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(helmModulePath) + `\s+(\S+)`)
+		if m := re.FindSubmatch(data); len(m) >= 2 {
+			return strings.TrimSpace(string(m[1]))
+		}
+	}
+	return ""
+}
+
+// setHelmVersionFromBuildInfo sets HELM_VERSION from the Go module's helm.sh/helm/v3
+// dependency. Prefers debug.ReadBuildInfo(); when that is empty for test binaries (Go #33976),
+// falls back to parsing go.mod.
+func setHelmVersionFromBuildInfo() error {
+	var version string
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range info.Deps {
+			if dep.Path == helmModulePath && dep.Version != "" {
+				version = dep.Version
+				break
+			}
+		}
+	}
+	if version == "" {
+		version = helmVersionFromGoMod()
+	}
+	if version != "" {
+		err := os.Setenv("HELM_VERSION", version)
+		if err != nil {
+			return fmt.Errorf("Error setting HELM_VERSION: %w", err)
+		}
+	}
+	return nil
+}
+
 func TestMain(m *testing.M) {
 	setSettings(settings)
 	time.Sleep(10 * time.Second)
+	if err := setHelmVersionFromBuildInfo(); err != nil {
+		panic(err)
+	}
+	retCode := startTests(m)
+	os.Exit(retCode)
+}
+
+func startTests(m *testing.M) (exitCode int) {
+	defer func() {
+		// Cleanup: log errors but don't fail — best-effort teardown
+		if err := ExecuteScript("./testdata/chartmuseum-stop.sh", false); err != nil {
+			fmt.Println("Warning: chartmuseum-stop.sh failed:", err)
+			exitCode = 1
+		}
+		if err := ExecuteScript("./testdata/zot-stop.sh", false); err != nil {
+			fmt.Println("Warning: zot-stop.sh failed:", err)
+			exitCode = 1
+		}
+		if err := ExecuteScript("./testdata/cleanupNonTls.sh", false); err != nil {
+			fmt.Println("Warning: cleanupNonTls.sh failed:", err)
+			exitCode = 1
+		}
+		if err := ExecuteScript("./testdata/cleanup.sh", false); err != nil {
+			fmt.Println("Warning: cleanup.sh failed:", err)
+			exitCode = 1
+		}
+
+	}()
 	if err := setupTestWithTls(); err != nil {
 		panic(err)
 	}
@@ -29,17 +104,7 @@ func TestMain(m *testing.M) {
 	if err := setupTestBasicAuth(); err != nil {
 		panic(err)
 	}
-	retCode := m.Run()
-	if err := ExecuteScript("./testdata/chartmuseum-stop.sh", false); err != nil {
-		panic(err)
-	}
-	if err := ExecuteScript("./testdata/cleanupNonTls.sh", false); err != nil {
-		panic(err)
-	}
-	if err := ExecuteScript("./testdata/cleanup.sh", false); err != nil {
-		panic(err)
-	}
-	os.Exit(retCode)
+	return m.Run()
 }
 
 func setupTestWithTls() error {
@@ -52,11 +117,23 @@ func setupTestWithTls() error {
 	if err := ExecuteScript("./testdata/chartmuseum.sh", false); err != nil {
 		return err
 	}
+	if err := ExecuteScript("./testdata/downloadZot.sh", true); err != nil {
+		return err
+	}
+	if err := ExecuteScript("./testdata/zot.sh", false); err != nil {
+		return err
+	}
+	if err := ExecuteScript("./testdata/downloadHelm.sh", true); err != nil {
+		return err
+	}
 	time.Sleep(5 * time.Second)
 	if err := ExecuteScript("./testdata/cacertCreate.sh", true); err != nil {
 		return err
 	}
 	if err := ExecuteScript("./testdata/uploadCharts.sh", true); err != nil {
+		return err
+	}
+	if err := ExecuteScript("./testdata/uploadOciCharts.sh", true, "--tls"); err != nil {
 		return err
 	}
 	return nil
@@ -66,8 +143,14 @@ func setupTestWithoutTls() error {
 	if err := ExecuteScript("./testdata/chartmuseumWithoutTls.sh", false); err != nil {
 		return err
 	}
+	if err := ExecuteScript("./testdata/zotWithoutTls.sh", false); err != nil {
+		return err
+	}
 	time.Sleep(5 * time.Second)
 	if err := ExecuteScript("./testdata/uploadChartsWithoutTls.sh", true); err != nil {
+		return err
+	}
+	if err := ExecuteScript("./testdata/uploadOciCharts.sh", true, "--no-tls"); err != nil {
 		return err
 	}
 	return nil
@@ -85,8 +168,8 @@ func setupTestBasicAuth() error {
 	return nil
 }
 
-func ExecuteScript(filepath string, waitForCompletion bool) error {
-	tlsCmd := exec.Command(filepath)
+func ExecuteScript(filepath string, waitForCompletion bool, args ...string) error {
+	tlsCmd := exec.Command(filepath, args...)
 	tlsCmd.Stdout = os.Stdout
 	tlsCmd.Stderr = os.Stderr
 	err := tlsCmd.Start()

--- a/pkg/helm/actions/testdata/cleanup.sh
+++ b/pkg/helm/actions/testdata/cleanup.sh
@@ -11,3 +11,5 @@ GOOS=${GOOS:-$(go env GOOS)}
 GOARCH=${GOARCH:-$(go env GOARCH)}
 rm -rf ./$GOOS-$GOARCH
 rm -rf ./chartmuseum.tar.gz
+rm -rf ./helm.tar.gz
+rm -rf ./zot-storage-*

--- a/pkg/helm/actions/testdata/downloadHelm.sh
+++ b/pkg/helm/actions/testdata/downloadHelm.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+# Download Helm CLI for pushing OCI charts
+
+GOOS=${GOOS:-$(go env GOOS)}
+GOARCH=${GOARCH:-$(go env GOARCH)}
+
+if [[ -z "${HELM_VERSION}" ]]; then
+  echo "Error: HELM_VERSION environment variable is not set."
+  echo "Please set HELM_VERSION (e.g., export HELM_VERSION=v3.19.0)"
+  exit 1
+fi
+
+HELM_ARTIFACT_URL="https://get.helm.sh/helm-${HELM_VERSION}-${GOOS}-${GOARCH}.tar.gz"
+
+mkdir -p "$GOOS-$GOARCH"
+
+if [[ ! -f "$GOOS-$GOARCH/helm" ]]; then
+  echo "Downloading Helm ${HELM_VERSION}..."
+  curl -L -o helm.tar.gz "$HELM_ARTIFACT_URL"
+  tar xzf helm.tar.gz --strip-components=1 -C "$GOOS-$GOARCH" "${GOOS}-${GOARCH}/helm"
+  chmod +x "$GOOS-$GOARCH/helm"
+fi
+
+exit 0

--- a/pkg/helm/actions/testdata/downloadZot.sh
+++ b/pkg/helm/actions/testdata/downloadZot.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+GOOS=${GOOS:-$(go env GOOS)}
+GOARCH=${GOARCH:-$(go env GOARCH)}
+ZOT_VERSION=${ZOT_VERSION:-2.1.6}
+ZOT_ARTIFACT_URL="https://github.com/project-zot/zot/releases/download/v$ZOT_VERSION/zot-$GOOS-$GOARCH"
+
+mkdir -p "$GOOS-$GOARCH"
+
+if [[ ! -f "$GOOS-$GOARCH/zot" ]]; then
+  curl -fL -o "$GOOS-$GOARCH/zot" "$ZOT_ARTIFACT_URL"
+  chmod +x "$GOOS-$GOARCH/zot"
+fi
+
+exit 0

--- a/pkg/helm/actions/testdata/uploadOciCharts.sh
+++ b/pkg/helm/actions/testdata/uploadOciCharts.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+# Upload Helm charts as OCI artifacts to zot registry (with TLS)
+
+# Change to the script's directory (pkg/helm/actions/testdata/)
+cd "$(dirname "$0")"
+
+if [[ $1 == "--tls" ]]; then
+  REGISTRY="localhost:5443"
+else
+  REGISTRY="localhost:5000"
+fi
+
+CACERT="../cacert.pem"
+CHARTS_DIR="../../testdata"
+GOOS=${GOOS:-$(go env GOOS)}
+GOARCH=${GOARCH:-$(go env GOARCH)}
+
+# Use local helm binary if available, otherwise use system helm
+if [[ -x "../$GOOS-$GOARCH/helm" ]]; then
+  HELM="../$GOOS-$GOARCH/helm"
+elif command -v helm &> /dev/null; then
+  HELM="helm"
+else
+  echo "Error: Helm not found. Run ./downloadHelm.sh first or install helm."
+  exit 1
+fi
+
+# Push charts to OCI registry using helm push
+if [[ $1 == "--tls" ]]; then
+  echo "Pushing mariadb-7.3.5.tgz to oci://$REGISTRY/helm-charts..."
+  $HELM push $CHARTS_DIR/mariadb-7.3.5.tgz oci://$REGISTRY/helm-charts --ca-file=$CACERT
+else
+  echo "Pushing mychart-0.1.0.tgz to oci://$REGISTRY/helm-charts..."
+  $HELM push $CHARTS_DIR/mychart-0.1.0.tgz oci://$REGISTRY/helm-charts --plain-http
+fi
+
+echo "Charts pushed successfully!"

--- a/pkg/helm/actions/testdata/zot-config-tls.json
+++ b/pkg/helm/actions/testdata/zot-config-tls.json
@@ -1,0 +1,18 @@
+{
+  "distSpecVersion": "1.1.0",
+  "storage": {
+    "rootDirectory": "./zot-storage-5443",
+    "gc": false
+  },
+  "http": {
+    "address": "127.0.0.1",
+    "port": "5443",
+    "tls": {
+      "cert": "./server.crt",
+      "key": "./server.key"
+    }
+  },
+  "log": {
+    "level": "debug"
+  }
+}

--- a/pkg/helm/actions/testdata/zot-config.json
+++ b/pkg/helm/actions/testdata/zot-config.json
@@ -1,0 +1,15 @@
+{
+  "distSpecVersion": "1.1.0",
+  "storage": {
+    "rootDirectory": "./zot-storage-5000",
+    "gc": false
+  },
+  "http": {
+    "address": "127.0.0.1",
+    "port": "5000"
+  },
+  "log": {
+    "level": "debug"
+  }
+}
+

--- a/pkg/helm/actions/testdata/zot-stop.sh
+++ b/pkg/helm/actions/testdata/zot-stop.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+kill -TERM $(< zot.pid) || echo "Zot is not currently running."
+kill -TERM $(< zot-no-tls.pid) || echo "Zot is not currently running."
+rm -f zot.pid zot-no-tls.pid

--- a/pkg/helm/actions/testdata/zot.sh
+++ b/pkg/helm/actions/testdata/zot.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+# Start zot OCI registry server with TLS
+GOOS=${GOOS:-$(go env GOOS)}
+GOARCH=${GOARCH:-$(go env GOARCH)}
+
+mkdir -p ./zot-storage-5443
+
+./$GOOS-$GOARCH/zot serve ./testdata/zot-config-tls.json &
+echo $! > ./zot.pid

--- a/pkg/helm/actions/testdata/zotWithoutTls.sh
+++ b/pkg/helm/actions/testdata/zotWithoutTls.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+# Start zot OCI registry server without TLS
+GOOS=${GOOS:-$(go env GOOS)}
+GOARCH=${GOARCH:-$(go env GOARCH)}
+
+mkdir -p ./zot-storage-5000
+
+./$GOOS-$GOARCH/zot serve ./testdata/zot-config.json &
+echo $! > ./zot-no-tls.pid

--- a/pkg/helm/handlers/request.go
+++ b/pkg/helm/handlers/request.go
@@ -1,12 +1,13 @@
 package handlers
 
 type HelmRequest struct {
-	Name       string                 `json:"name"`
-	Namespace  string                 `json:"namespace"`
-	ChartUrl   string                 `json:"chart_url"`
-	Values     map[string]interface{} `json:"values"`
-	Version    int                    `json:"version"`
-	IndexEntry string                 `json:"indexEntry"`
+	Name         string                 `json:"name"`
+	Namespace    string                 `json:"namespace"`
+	ChartUrl     string                 `json:"chart_url"`
+	ChartVersion string                 `json:"chart_version"` // optional; for OCI/direct URL install, used when chart_url has no tag
+	Values       map[string]interface{} `json:"values"`
+	Version      int                    `json:"version"`
+	IndexEntry   string                 `json:"indexEntry"`
 }
 
 type HelmVerifierRequest struct {


### PR DESCRIPTION
Add dedicated endpoint and handler for installing Helm charts from OCI
registries. This provides a simplified installation flow for OCI charts
that doesn't require HelmChartRepository lookup.

Changes:
- Add InstallOCIChart function in actions for OCI-only installations
- Add HandleInstallOCIChart handler with OCI URL validation
- Register /api/helm/oci-chart endpoint in server routes
- Add tests for both the methods

[HELM-598](https://issues.redhat.com//browse/HELM-598)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Install Helm charts directly from URLs, supporting both OCI format and HTTP tarball sources
- New API endpoint for Helm OCI chart installation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->