### PR TITLE
OCPBUGS-70329: Auto-linkify URLs in status card alert messages

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
@@ -8,6 +8,7 @@ import { AlertItemProps } from '@console/dynamic-plugin-sdk/src/api/internal-typ
 import { useModal } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { alertURL } from '@console/internal/components/monitoring/utils';
 import { getAlertActions } from '@console/internal/components/notification-drawer';
+import { LinkifyExternal } from '@console/internal/components/utils/link';
 import { Timestamp } from '@console/shared/src/components/datetime/Timestamp';
 import { ExternalLink } from '@console/shared/src/components/links/ExternalLink';
 import {
@@ -73,7 +74,9 @@ export const StatusItem: FC<StatusItemProps> = ({
               <Timestamp simple timestamp={timestamp} />
             </div>
           )}
-          <span className="co-status-card__health-item-text co-break-word">{message}</span>
+          <span className="co-status-card__health-item-text co-break-word">
+            <LinkifyExternal>{message}</LinkifyExternal>
+          </span>
           {documentationLink && (
             <ExternalLink className="co-status-card__alert-item-doc-link" href={documentationLink}>
               {t('console-shared~Go to documentation')}


### PR DESCRIPTION
## Summary
- Wrap alert messages in `LinkifyExternal` component to automatically convert URLs in status card alert messages into clickable links

## Test plan
- [ ] Verify alert messages with URLs display as clickable links
- [ ] Verify alert messages without URLs display normally
- [ ] Verify external links open in new tab

Screenshot of the problem being fixed:
<img width="1038" height="558" alt="Screenshot-ARO-Console-First-Run-InsightsDisabled" src="https://github.com/user-attachments/assets/66bde606-2b8b-4f31-97c8-9bf6b123880f" />
