### PR TITLE
OCPBUGS-70302: Fix handling of binary data in SecretFormWrapper

### DIFF
--- a/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
+++ b/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
@@ -60,7 +60,7 @@ export const SecretFormWrapper: React.FCC<BaseEditSecretProps_> = (props) => {
   const [stringData, setStringData] = useState(
     Object.entries(props.obj?.data ?? {}).reduce<Record<string, string>>((acc, [key, value]) => {
       if (isBinary(null, Buffer.from(value, 'base64'))) {
-        return null;
+        return acc;
       }
       acc[key] = value ? Base64.decode(value) : '';
       return acc;


### PR DESCRIPTION
## Description
Fixed a JavaScript error that occurred when attempting to edit a Secret containing both binary files and text literals. The Console would crash with "Something wrong happened: Cannot set properties of null" instead of loading the Edit Secret form.

## Root Cause
In SecretFormWrapper.tsx, the stringData initialization used a reduce function that returned null when encountering binary data. This broke the accumulator chain, causing subsequent text entries to fail when trying to set properties on null.

## Steps to Reproduce
1. Create a binary file and a Secret with mixed data:
```
   head -c 256 /dev/urandom > binary_file.bin
   oc create secret generic test-ocp-secret \
     --from-file=JGROUPS_ENCRYPTION=binary_file.bin \
     --from-literal=JGROUPS_KEYSTORE_PASSWORD=abcd1234
```
2. Log into the OpenShift Web Console
3. Navigate to Workloads → Secrets, find test-ocp-secret
4. Click Actions → Edit Secret

**Before**: Console crashes with "Cannot set properties of null (setting 'JGROUPS_KEYSTORE_PASSWORD')"
**After**: Edit Secret form loads successfully, displaying both entries


Note: this PR need to get backported to older versions to 4.14.
