### PR TITLE
CONSOLE-4728: Create a cached server endpoint for operator icons with OLMv1

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/utils/catalog-utils.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/utils/catalog-utils.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import type { ReactNode } from 'react';
 import * as _ from 'lodash';
 import type { CatalogItemType } from '@console/dynamic-plugin-sdk';
 import { isCatalogItemType } from '@console/dynamic-plugin-sdk';
@@ -282,10 +283,16 @@ export const sortCatalogItems = (
   }
 };
 
-export const getIconProps = (item: CatalogItem) => {
+interface IconProps {
+  iconImg?: string | null;
+  iconClass?: string | null;
+  icon?: ReactNode;
+}
+
+export const getIconProps = (item: CatalogItem): IconProps => {
   const { icon } = item;
   if (!icon) {
-    return {};
+    return { iconImg: catalogImg, iconClass: null };
   }
   if (icon.url) {
     return { iconImg: icon.url, iconClass: null };

--- a/frontend/packages/operator-lifecycle-manager-v1/src/types.ts
+++ b/frontend/packages/operator-lifecycle-manager-v1/src/types.ts
@@ -6,6 +6,7 @@ export type OLMCatalogItem = {
   createdAt: string;
   description: string;
   displayName: string;
+  hasIcon: boolean;
   image: string;
   infrastructureFeatures: string[];
   keywords: string[];

--- a/frontend/packages/operator-lifecycle-manager-v1/src/utils/catalog-item.tsx
+++ b/frontend/packages/operator-lifecycle-manager-v1/src/utils/catalog-item.tsx
@@ -21,6 +21,7 @@ export const normalizeCatalogItem: NormalizeExtensionCatalogItem = (item) => {
     createdAt,
     description,
     displayName,
+    hasIcon,
     image,
     infrastructureFeatures,
     keywords,
@@ -99,9 +100,11 @@ export const normalizeCatalogItem: NormalizeExtensionCatalogItem = (item) => {
       descriptions: [{ value: <SyncMarkdownView content={markdownDescription || description} /> }],
     },
     displayName,
-    // Remove icon until we have an endpoint to lazy load cached icons.
-    // TODO Add icon back once https://issues.redhat.com/browse/CONSOLE-4728 is completed.
-    // icon: { url: '/api/olm/catalog-icons/<catalog-name>/<package-name> },
+    ...(hasIcon && {
+      icon: {
+        url: `/api/olm/catalog-icons/${encodeURIComponent(catalog)}/${encodeURIComponent(name)}`,
+      },
+    }),
     name: displayName || name,
     supportUrl: support,
     provider,

--- a/pkg/controllers/clustercatalog_controller.go
+++ b/pkg/controllers/clustercatalog_controller.go
@@ -64,9 +64,14 @@ func (r *ClusterCatalogReconciler) Reconcile(ctx context.Context, req reconcile.
 
 	err = r.catalogService.UpdateCatalog(req.Name, baseURL)
 	if err != nil {
+		// Log the error but return nil error with RequeueAfter. Returning both
+		// a non-zero Result and a non-nil error causes controller-runtime to
+		// ignore RequeueAfter and use exponential backoff instead, which can
+		// delay recovery for minutes after a transient failure.
+		klog.Errorf("Failed to update catalog %s: %v, retrying in 30s", req.Name, err)
 		return ctrl.Result{
 			RequeueAfter: 30 * time.Second,
-		}, err
+		}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/controllers/clustercatalog_controller_test.go
+++ b/pkg/controllers/clustercatalog_controller_test.go
@@ -182,7 +182,10 @@ func TestReconcileUpdateCatalogError(t *testing.T) {
 
 	result, err := reconciler.Reconcile(context.Background(), req)
 
-	require.Error(t, err)
+	// The reconciler should NOT return an error (which would trigger exponential
+	// backoff in controller-runtime). Instead it returns nil error with RequeueAfter
+	// to ensure a predictable 30s retry interval.
+	require.NoError(t, err)
 	assert.Equal(t, reconcile.Result{
 		RequeueAfter: 30 * time.Second,
 	}, result)

--- a/pkg/olm/catalog.go
+++ b/pkg/olm/catalog.go
@@ -12,6 +12,14 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// CachedIcon represents a cached operator icon.
+type CachedIcon struct {
+	Data         []byte
+	MediaType    string
+	LastModified string
+	ETag         string
+}
+
 // ConsoleCatalogItem represents a single item in the catalog.
 type ConsoleCatalogItem struct {
 	ID                     string   `json:"id"`
@@ -21,6 +29,7 @@ type ConsoleCatalogItem struct {
 	CreatedAt              string   `json:"createdAt,omitempty"`
 	Description            string   `json:"description,omitempty"`
 	DisplayName            string   `json:"displayName,omitempty"`
+	HasIcon                bool     `json:"hasIcon"`
 	Image                  string   `json:"image,omitempty"`
 	InfrastructureFeatures []string `json:"infrastructureFeatures,omitempty"`
 	Keywords               []string `json:"keywords,omitempty"`
@@ -78,6 +87,7 @@ func CreateCatalogItem(catalogName string, pkg *declcfg.Package, bundle *declcfg
 	withCreatedAt(item, csvMetadata)
 	withDescription(item, csvMetadata, pkg)
 	withDisplayName(item, csvMetadata, pkg)
+	withHasIcon(item, pkg)
 	withImage(item, bundle)
 	withInfrastructureFeatures(item, csvMetadata)
 	withKeywords(item, csvMetadata)
@@ -213,6 +223,10 @@ func withDisplayName(item *ConsoleCatalogItem, csvMetadata *property.CSVMetadata
 	if csvMetadata.DisplayName != "" {
 		item.DisplayName = csvMetadata.DisplayName
 	}
+}
+
+func withHasIcon(item *ConsoleCatalogItem, pkg *declcfg.Package) {
+	item.HasIcon = pkg.Icon != nil && len(pkg.Icon.Data) > 0
 }
 
 func withImage(item *ConsoleCatalogItem, bundle *declcfg.Bundle) {

--- a/pkg/olm/catalog_service.go
+++ b/pkg/olm/catalog_service.go
@@ -1,8 +1,12 @@
 package olm
 
 import (
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -48,6 +52,10 @@ func getCatalogBaseURLKey(catalog string) string {
 	return keyPrefix + catalog + ":baseURL"
 }
 
+func getCatalogIconKey(catalog, packageName string) string {
+	return keyPrefix + catalog + ":icon:" + packageName
+}
+
 func NewCatalogService(serviceClient *http.Client, proxyConfig *proxy.Config, cache *cache.Cache) *CatalogService {
 	c := &CatalogService{
 		cache:  cache,
@@ -68,6 +76,106 @@ func (s *CatalogService) GetMetas(catalog string, r *http.Request) (*http.Respon
 	return s.client.FetchMetas(catalog, baseURL, r)
 }
 
+// GetPackageIcon retrieves the icon for a package from the cache or fetches it from catalogd.
+// Returns the cached icon data, or nil if the package or icon is not found.
+func (s *CatalogService) GetPackageIcon(catalog, packageName string) (*CachedIcon, error) {
+	iconKey := getCatalogIconKey(catalog, packageName)
+
+	// Check cache first
+	if cachedIcon, ok := s.cache.Get(iconKey); ok {
+		if icon, ok := cachedIcon.(*CachedIcon); ok {
+			klog.V(4).Infof("Cache hit for icon: %s/%s", catalog, packageName)
+			return icon, nil
+		}
+		// Malformed cache entry, remove it
+		s.cache.Delete(iconKey)
+	}
+
+	// Cache miss - fetch from catalogd
+	klog.V(4).Infof("Cache miss for icon: %s/%s, fetching from catalogd", catalog, packageName)
+
+	var baseURL string
+	baseURLKey := getCatalogBaseURLKey(catalog)
+	if cachedBaseURL, ok := s.cache.Get(baseURLKey); ok {
+		if baseURL, ok = cachedBaseURL.(string); !ok {
+			return nil, fmt.Errorf("cached base URL for catalog %s is not a string", catalog)
+		}
+	}
+
+	resp, err := s.client.FetchPackageIcon(catalog, baseURL, packageName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch package icon: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("catalogd request failed with status: %d", resp.StatusCode)
+	}
+
+	// Parse the response to extract the package icon
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	icon, err := s.parsePackageIcon(body)
+	if err != nil {
+		return nil, err
+	}
+
+	if icon == nil {
+		// Package found but has no icon
+		klog.V(4).Infof("Package %s/%s has no icon", catalog, packageName)
+		return nil, nil
+	}
+
+	// Cache the icon
+	s.cache.Set(iconKey, icon, cacheExpiration)
+	klog.V(4).Infof("Cached icon for %s/%s", catalog, packageName)
+
+	return icon, nil
+}
+
+// parsePackageIcon extracts icon data from the catalogd metas response.
+func (s *CatalogService) parsePackageIcon(body []byte) (*CachedIcon, error) {
+	var pkg declcfg.Package
+
+	// The response is a JSON stream, we need to parse the first (and only) package
+	reader := io.NopCloser(bytes.NewReader(body))
+	if err := declcfg.WalkMetasReader(reader, func(meta *declcfg.Meta, err error) error {
+		if err != nil {
+			return err
+		}
+		if meta.Schema == declcfg.SchemaPackage {
+			if err := json.Unmarshal(meta.Blob, &pkg); err != nil {
+				return fmt.Errorf("failed to unmarshal package: %w", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to parse package metadata: %w", err)
+	}
+
+	if pkg.Icon == nil || len(pkg.Icon.Data) == 0 {
+		return nil, nil
+	}
+
+	// Generate ETag from icon data
+	hash := md5.Sum(pkg.Icon.Data)
+	etag := hex.EncodeToString(hash[:])
+
+	return &CachedIcon{
+		Data:         pkg.Icon.Data,
+		MediaType:    pkg.Icon.MediaType,
+		LastModified: time.Now().UTC().Format(http.TimeFormat),
+		ETag:         etag,
+	}, nil
+}
+
 // Start begins the polling process.
 func (s *CatalogService) UpdateCatalog(catalog string, baseURL string) error {
 	itemsKey := getCatalogItemsKey(catalog)
@@ -85,7 +193,10 @@ func (s *CatalogService) UpdateCatalog(catalog string, baseURL string) error {
 	resp, err := s.client.FetchAll(catalog, baseURL, ifModifiedSince, cacheExpiration)
 
 	if err != nil {
-		s.RemoveCatalog(catalog)
+		// Don't remove cached data on transient network errors (e.g. connection refused).
+		// The reconciler will requeue and retry. Stale cached data is preferable
+		// to no data, which causes icon 404s for the frontend.
+		klog.V(4).Infof("failed to fetch catalog %s: %v (keeping existing cache)", catalog, err)
 		return err
 	}
 	defer resp.Body.Close()
@@ -112,8 +223,9 @@ func (s *CatalogService) UpdateCatalog(catalog string, baseURL string) error {
 
 	packages, bundles, err := s.processCatalog(resp)
 	if err != nil {
-		klog.V(4).Infof("error processing catalog %s: %v", catalog, err)
-		defer s.RemoveCatalog(catalog)
+		// Don't remove cached data on processing errors. The reconciler will
+		// requeue and retry. Serving stale data is better than serving nothing.
+		klog.V(4).Infof("error processing catalog %s: %v (keeping existing cache)", catalog, err)
 		return err
 	}
 

--- a/pkg/olm/catalog_service_test.go
+++ b/pkg/olm/catalog_service_test.go
@@ -18,14 +18,55 @@ import (
 )
 
 type mockCatalogdClient struct {
-	packages []declcfg.Package
-	bundles  []declcfg.Bundle
-	err      error
+	packages         []declcfg.Package
+	bundles          []declcfg.Bundle
+	packageIconMap   map[string]*declcfg.Package // packageName -> package with icon
+	err              error
+	fetchPackageErr  error
+	fetchPackageCode int
 }
 
 func (m *mockCatalogdClient) FetchMetas(catalog string, baseURL string, r *http.Request) (*http.Response, error) {
 	// This mock implementation is not used in these tests, but required by the interface
 	return nil, fmt.Errorf("FetchMetas not implemented in mock")
+}
+
+func (m *mockCatalogdClient) FetchPackageIcon(catalog, baseURL, packageName string) (*http.Response, error) {
+	if m.fetchPackageErr != nil {
+		return nil, m.fetchPackageErr
+	}
+
+	if m.fetchPackageCode == http.StatusNotFound {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
+		}, nil
+	}
+
+	pkg, ok := m.packageIconMap[packageName]
+	if !ok {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
+		}, nil
+	}
+
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	pkgMap := map[string]any{
+		"schema":         declcfg.SchemaPackage,
+		"name":           pkg.Name,
+		"defaultChannel": pkg.DefaultChannel,
+		"icon":           pkg.Icon,
+	}
+	if err := encoder.Encode(pkgMap); err != nil {
+		return nil, err
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(buf.Bytes())),
+	}, nil
 }
 
 func (m *mockCatalogdClient) FetchAll(catalog, baseURL, ifNotModifiedSince string, maxAge time.Duration) (*http.Response, error) {
@@ -196,6 +237,43 @@ func TestUpdateCatalog(t *testing.T) {
 		err := service.UpdateCatalog("test-catalog", "")
 		assert.Error(t, err)
 	})
+
+	t.Run("should preserve existing cache on fetch failure", func(t *testing.T) {
+		c := cache.New(5*time.Minute, 10*time.Minute)
+		// Pre-populate cache with existing data
+		existingItems := []ConsoleCatalogItem{{Name: "existing-item", Catalog: "test-catalog"}}
+		c.Set(getCatalogItemsKey("test-catalog"), existingItems, cache.DefaultExpiration)
+		c.Set(getCatalogBaseURLKey("test-catalog"), "http://catalogd.test", cache.NoExpiration)
+		c.Set(getCatalogLastModifiedKey("test-catalog"), "Thu, 01 Jan 2026 00:00:00 GMT", cache.NoExpiration)
+
+		client := &mockCatalogdClient{
+			err: fmt.Errorf("connection refused"),
+		}
+		service := &CatalogService{
+			cache:  c,
+			client: client,
+			index:  map[string]struct{}{"test-catalog": {}},
+		}
+
+		err := service.UpdateCatalog("test-catalog", "http://catalogd.test")
+		assert.Error(t, err)
+
+		// Verify existing cache data is still intact
+		items, found := c.Get(getCatalogItemsKey("test-catalog"))
+		assert.True(t, found, "cached items should be preserved on transient error")
+		assert.Equal(t, existingItems, items)
+
+		baseURL, found := c.Get(getCatalogBaseURLKey("test-catalog"))
+		assert.True(t, found, "cached baseURL should be preserved on transient error")
+		assert.Equal(t, "http://catalogd.test", baseURL)
+
+		_, found = c.Get(getCatalogLastModifiedKey("test-catalog"))
+		assert.True(t, found, "cached last-modified should be preserved on transient error")
+
+		// Verify index is still intact
+		_, inIndex := service.index["test-catalog"]
+		assert.True(t, inIndex, "catalog should remain in index on transient error")
+	})
 }
 
 func TestGetCatalogItems(t *testing.T) {
@@ -226,5 +304,134 @@ func TestGetCatalogItems(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, items, returnedItems)
+	})
+}
+
+func TestGetPackageIcon(t *testing.T) {
+	t.Run("should return icon from cache", func(t *testing.T) {
+		c := cache.New(5*time.Minute, 10*time.Minute)
+		cachedIcon := &CachedIcon{
+			Data:         []byte("cached-icon-data"),
+			MediaType:    "image/svg+xml",
+			LastModified: time.Now().UTC().Format(http.TimeFormat),
+			ETag:         "cached-etag",
+		}
+		c.Set(getCatalogIconKey("test-catalog", "test-package"), cachedIcon, cache.NoExpiration)
+
+		service := &CatalogService{
+			cache: c,
+			index: make(map[string]struct{}),
+		}
+
+		icon, err := service.GetPackageIcon("test-catalog", "test-package")
+
+		require.NoError(t, err)
+		assert.Equal(t, cachedIcon, icon)
+	})
+
+	t.Run("should fetch icon from catalogd on cache miss", func(t *testing.T) {
+		c := cache.New(5*time.Minute, 10*time.Minute)
+		// Set the base URL so the service knows where to fetch from
+		c.Set(getCatalogBaseURLKey("test-catalog"), "http://catalogd.test", cache.NoExpiration)
+
+		iconData := []byte("test-icon-data")
+		client := &mockCatalogdClient{
+			packageIconMap: map[string]*declcfg.Package{
+				"test-package": {
+					Name: "test-package",
+					Icon: &declcfg.Icon{
+						Data:      iconData,
+						MediaType: "image/png",
+					},
+				},
+			},
+		}
+
+		service := &CatalogService{
+			cache:  c,
+			client: client,
+			index:  make(map[string]struct{}),
+		}
+
+		icon, err := service.GetPackageIcon("test-catalog", "test-package")
+
+		require.NoError(t, err)
+		require.NotNil(t, icon)
+		assert.Equal(t, iconData, icon.Data)
+		assert.Equal(t, "image/png", icon.MediaType)
+		assert.NotEmpty(t, icon.ETag)
+		assert.NotEmpty(t, icon.LastModified)
+
+		// Verify the icon was cached
+		cachedIcon, found := c.Get(getCatalogIconKey("test-catalog", "test-package"))
+		assert.True(t, found)
+		assert.Equal(t, icon, cachedIcon)
+	})
+
+	t.Run("should return nil when package not found", func(t *testing.T) {
+		c := cache.New(5*time.Minute, 10*time.Minute)
+		c.Set(getCatalogBaseURLKey("test-catalog"), "http://catalogd.test", cache.NoExpiration)
+
+		client := &mockCatalogdClient{
+			packageIconMap:   map[string]*declcfg.Package{},
+			fetchPackageCode: http.StatusNotFound,
+		}
+
+		service := &CatalogService{
+			cache:  c,
+			client: client,
+			index:  make(map[string]struct{}),
+		}
+
+		icon, err := service.GetPackageIcon("test-catalog", "nonexistent-package")
+
+		require.NoError(t, err)
+		assert.Nil(t, icon)
+	})
+
+	t.Run("should return nil when package has no icon", func(t *testing.T) {
+		c := cache.New(5*time.Minute, 10*time.Minute)
+		c.Set(getCatalogBaseURLKey("test-catalog"), "http://catalogd.test", cache.NoExpiration)
+
+		client := &mockCatalogdClient{
+			packageIconMap: map[string]*declcfg.Package{
+				"test-package": {
+					Name: "test-package",
+					Icon: nil, // No icon
+				},
+			},
+		}
+
+		service := &CatalogService{
+			cache:  c,
+			client: client,
+			index:  make(map[string]struct{}),
+		}
+
+		icon, err := service.GetPackageIcon("test-catalog", "test-package")
+
+		require.NoError(t, err)
+		assert.Nil(t, icon)
+	})
+
+	t.Run("should return error when fetch fails", func(t *testing.T) {
+		c := cache.New(5*time.Minute, 10*time.Minute)
+		c.Set(getCatalogBaseURLKey("test-catalog"), "http://catalogd.test", cache.NoExpiration)
+
+		client := &mockCatalogdClient{
+			fetchPackageErr: fmt.Errorf("network error"),
+		}
+
+		service := &CatalogService{
+			cache:  c,
+			client: client,
+			index:  make(map[string]struct{}),
+		}
+
+		icon, err := service.GetPackageIcon("test-catalog", "test-package")
+
+		require.Error(t, err)
+		assert.Nil(t, icon)
+		assert.Contains(t, err.Error(), "network error")
 	})
 }

--- a/pkg/olm/catalog_test.go
+++ b/pkg/olm/catalog_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCreateCatalogItem(t *testing.T) {
-	t.Run("should create a catalog item from a valid bundle", func(t *testing.T) {
+	t.Run("should create a catalog item from a valid bundle without icon", func(t *testing.T) {
 		pkg := declcfg.Package{
 			Schema:         "olm.package",
 			Name:           "test-package",
@@ -73,6 +73,36 @@ func TestCreateCatalogItem(t *testing.T) {
 		assert.Equal(t, []string{"test", "example"}, item.Keywords)
 		assert.Equal(t, "Test Provider", item.Provider)
 		assert.Equal(t, "0.1.0", item.Version)
+		assert.False(t, item.HasIcon)
+	})
+
+	t.Run("should set HasIcon to true when package has icon", func(t *testing.T) {
+		pkg := declcfg.Package{
+			Schema:         "olm.package",
+			Name:           "test-package",
+			DefaultChannel: "stable",
+			Icon: &declcfg.Icon{
+				Data:      []byte("icon-data"),
+				MediaType: "image/png",
+			},
+		}
+
+		csvMetadataBytes, err := json.Marshal(property.CSVMetadata{})
+		require.NoError(t, err)
+
+		bundle := declcfg.Bundle{
+			Schema:  "olm.bundle",
+			Name:    "test-package.v0.1.0",
+			Package: "test-package",
+			Properties: []property.Property{
+				{Type: property.TypeCSVMetadata, Value: csvMetadataBytes},
+				{Type: property.TypePackage, Value: json.RawMessage(`{"packageName":"test-package","version":"0.1.0"}`)},
+			},
+		}
+
+		item := CreateCatalogItem("test-catalog", &pkg, &bundle)
+		require.NotNil(t, item)
+		assert.True(t, item.HasIcon)
 	})
 }
 func TestCreateConsoleCatalog(t *testing.T) {


### PR DESCRIPTION
## Description
 - Add backend endpoint /api/olm/catalog-icons/{catalogName}/{packageName} to serve cached operator icons
  - Icons are fetched from catalogd on-demand and cached in memory with ETag/Last-Modified support
  - Frontend uses lazy loading (loading="lazy") for efficient icon loading in catalog tiles


## How to test it
1. Turn on the OLMv1 feature gate. Wait a moment until the reconciler finish working on your request.
```
oc patch featuregate/cluster --type=merge -p '{"spec":{"featureSet":"TechPreviewNoUpgrade"}}'
```

2. Start port forwarding, so that the locally build console can access catalogd service. 
```
   oc port-forward -n openshift-catalogd svc/catalogd-service 8080:443
```
4. Set the env var to enable the bridge tech preview
```
export BRIDGE_TECH_PREVIEW=true
```
5. Start your local bridge server
```
./examples/run-bridge.sh --k8s-mode-off-cluster-catalogd="https://localhost:8080"
```
6. Go to User Preferences in the kebab menu on the top right corner, and make sure OLMv1 is enabled.
7.  Visit http://localhost:9000/catalog/ns/default?catalogType=operator
8. You should see all the icons are correctly displaying. You can inspect the network requests to test that the cache is actually working.