### PR TITLE
OCPBUGS-70340: Ensure OpenAPI in monaco stays fresh

### DIFF
--- a/frontend/public/module/k8s/swagger.ts
+++ b/frontend/public/module/k8s/swagger.ts
@@ -37,6 +37,7 @@ export const fetchSwagger = async (): Promise<SwaggerDefinitions> => {
       return null;
     }
     swaggerDefinitions = response.definitions;
+    window.dispatchEvent(new Event('console_swagger_refresh'));
     return swaggerDefinitions;
   } catch (e) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
Changes:
- `registerYAMLinMonaco` returns a pointer to the monaco `yaml.configure` function, so that we can update the monaco integration at a later time
- `CodeEditor` now saves the `yaml.configure` pointer and will always update monaco YAML definitions on mount
- We introduce a `console_swagger_refresh` window event whenever swagger refreshes, and `CodeEditor` will listen to it on mount, calling `yaml.configure` whenever there is a change to the swagger definitions (which refresh every 5 minutes)
