### PR TITLE
OCPBUGS-72585: Do not resolve disabled catalog type extensions

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/hooks/useCatalogExtensions.ts
+++ b/frontend/packages/console-shared/src/components/catalog/hooks/useCatalogExtensions.ts
@@ -15,6 +15,7 @@ import {
   isCatalogCategoriesProvider,
   CatalogCategoriesProvider,
 } from '@console/dynamic-plugin-sdk/src/extensions';
+import { useGetAllDisabledSubCatalogs } from '../utils';
 
 const useCatalogExtensions = (
   catalogId: string,
@@ -27,11 +28,27 @@ const useCatalogExtensions = (
   ResolvedExtension<CatalogCategoriesProvider>[],
   boolean,
 ] => {
+  const [disabledCatalogs] = useGetAllDisabledSubCatalogs();
+
+  const isEnabledType = useCallback(
+    (e: { properties: { type?: string } }) => {
+      // If no type is specified, we consider it not disabled
+      if (!e.properties.type) {
+        return true;
+      }
+
+      return !disabledCatalogs.includes(e.properties.type);
+    },
+    [disabledCatalogs],
+  );
+
   const [itemTypeExtensions, itemTypesResolved] = useResolvedExtensions<CatalogItemType>(
     useCallback(
       (e): e is CatalogItemType =>
-        isCatalogItemType(e) && (!catalogType || e.properties.type === catalogType),
-      [catalogType],
+        isCatalogItemType(e) &&
+        isEnabledType(e) &&
+        (!catalogType || e.properties.type === catalogType),
+      [catalogType, isEnabledType],
     ),
   );
 
@@ -40,8 +57,10 @@ const useCatalogExtensions = (
   >(
     useCallback(
       (e): e is CatalogItemTypeMetadata =>
-        isCatalogItemTypeMetadata(e) && (!catalogType || e.properties.type === catalogType),
-      [catalogType],
+        isCatalogItemTypeMetadata(e) &&
+        isEnabledType(e) &&
+        (!catalogType || e.properties.type === catalogType),
+      [catalogType, isEnabledType],
     ),
   );
 
@@ -49,9 +68,10 @@ const useCatalogExtensions = (
     useCallback(
       (e): e is CatalogItemProvider =>
         isCatalogItemProvider(e) &&
+        isEnabledType(e) &&
         _.castArray(e.properties.catalogId).includes(catalogId) &&
         (!catalogType || e.properties.type === catalogType),
-      [catalogId, catalogType],
+      [catalogId, catalogType, isEnabledType],
     ),
   );
 
@@ -59,9 +79,10 @@ const useCatalogExtensions = (
     useCallback(
       (e): e is CatalogItemFilter =>
         isCatalogItemFilter(e) &&
+        isEnabledType(e) &&
         _.castArray(e.properties.catalogId).includes(catalogId) &&
         (!catalogType || e.properties.type === catalogType),
-      [catalogId, catalogType],
+      [catalogId, catalogType, isEnabledType],
     ),
   );
 
@@ -71,11 +92,12 @@ const useCatalogExtensions = (
     useCallback(
       (e): e is CatalogCategoriesProvider =>
         isCatalogCategoriesProvider(e) &&
+        isEnabledType(e) &&
         (!e.properties.catalogId ||
           e.properties.catalogId === catalogId ||
           !e.properties.type ||
           e.properties.type === catalogType),
-      [catalogId, catalogType],
+      [catalogId, catalogType, isEnabledType],
     ),
   );
 
@@ -85,9 +107,10 @@ const useCatalogExtensions = (
     useCallback(
       (e): e is CatalogItemMetadataProvider =>
         isCatalogItemMetadataProvider(e) &&
+        isEnabledType(e) &&
         _.castArray(e.properties.catalogId).includes(catalogId) &&
         (!catalogType || e.properties.type === catalogType),
-      [catalogId, catalogType],
+      [catalogId, catalogType, isEnabledType],
     ),
   );
 
@@ -96,28 +119,30 @@ const useCatalogExtensions = (
       (catalogType
         ? itemTypeExtensions.filter((e) => e.properties.type === catalogType)
         : itemTypeExtensions
-      ).map((e) => {
-        const metadataExts = typeMetadataExtensions.filter(
-          (em) => e.properties.type === em.properties.type,
-        );
-        if (metadataExts.length > 0) {
-          return Object.assign({}, e, {
-            properties: {
-              ...e.properties,
-              filters: [
-                ...(e.properties.filters ?? []),
-                ..._.flatten(metadataExts.map((em) => em.properties.filters).filter((x) => x)),
-              ],
-              groupings: [
-                ...(e.properties.groupings ?? []),
-                ..._.flatten(metadataExts.map((em) => em.properties.groupings).filter((x) => x)),
-              ],
-            },
-          });
-        }
-        return e;
-      }),
-    [catalogType, itemTypeExtensions, typeMetadataExtensions],
+      )
+        .filter(isEnabledType)
+        .map((e) => {
+          const metadataExts = typeMetadataExtensions.filter(
+            (em) => e.properties.type === em.properties.type,
+          );
+          if (metadataExts.length > 0) {
+            return Object.assign({}, e, {
+              properties: {
+                ...e.properties,
+                filters: [
+                  ...(e.properties.filters ?? []),
+                  ..._.flatten(metadataExts.map((em) => em.properties.filters).filter((x) => x)),
+                ],
+                groupings: [
+                  ...(e.properties.groupings ?? []),
+                  ..._.flatten(metadataExts.map((em) => em.properties.groupings).filter((x) => x)),
+                ],
+              },
+            });
+          }
+          return e;
+        }),
+    [catalogType, itemTypeExtensions, typeMetadataExtensions, isEnabledType],
   );
 
   catalogProviderExtensions.sort((a, b) => {

--- a/frontend/packages/console-shared/src/utils/__tests__/isSubCatalogTypeEnabled.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/isSubCatalogTypeEnabled.spec.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
-import { useResolvedExtensions } from '@console/dynamic-plugin-sdk';
 import { HELM_CHART_CATALOG_TYPE_ID } from '@console/helm-plugin/src/const';
+import { useExtensions } from '@console/plugin-sdk/src/api/useExtensions';
 import {
   useGetAllDisabledSubCatalogs,
   isCatalogTypeEnabled,
@@ -8,12 +8,12 @@ import {
 } from '@console/shared';
 import { mockExtensions } from './catalogTypeExtensions.data';
 
-jest.mock('@console/dynamic-plugin-sdk/src/api/useResolvedExtensions', () => ({
-  useResolvedExtensions: jest.fn(),
+jest.mock('@console/plugin-sdk/src/api/useExtensions', () => ({
+  useExtensions: jest.fn(),
 }));
 
-const useResolvedExtensionsMock = useResolvedExtensions as jest.Mock;
-useResolvedExtensionsMock.mockReturnValue([mockExtensions, true]);
+const useExtensionsMock = useExtensions as jest.Mock;
+useExtensionsMock.mockReturnValue(mockExtensions);
 
 beforeEach(() => {
   delete window.SERVER_FLAGS.developerCatalogTypes;
@@ -100,7 +100,7 @@ describe('useIsSoftwareCatalogEnabled - check if software catalog is enabled or 
     const { result } = renderHook(() => useIsSoftwareCatalogEnabled());
     expect(result.current).toBe(true);
   });
-  it('should show software catalog as enabled when enabled attribute is not added', () => {
+  it('should show software catalog as disabled when disabled attribute is not added', () => {
     window.SERVER_FLAGS.developerCatalogTypes = '{"state" : "Disabled" }';
     const { result } = renderHook(() => useIsSoftwareCatalogEnabled());
     expect(result.current).toBe(false);


### PR DESCRIPTION
Previously, if a catalog/item-type was disabled in console-operator config, the hooks associated with that catalog type would still resolve and run. 

<img width="1865" height="1008" alt="image" src="https://github.com/user-attachments/assets/4ae06c13-0623-45b0-a4c5-8a060f53cc96" />

Now, if a catalog category is disabled, the associated hooks will not run.

<img width="1867" height="985" alt="image" src="https://github.com/user-attachments/assets/2201d7b7-caf2-4f17-bb07-0a8015846720" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added catalog relevance scoring, Red Hat prioritization, keyword-aware comparison, and stable sorting options.
  * Server-flag driven sub-catalog visibility with memoized computation for consistent, faster results.
  * New utilities exported to support sorting and relevance logic.

* **Bug Fixes**
  * Disabled catalog types are consistently filtered across extension flows so unavailable items no longer appear.

* **Tests**
  * Updated tests to align with the new extensions retrieval behavior and memoized visibility logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->