### PR TITLE
OCPBUGS-72571: remove "OperatorHub" from OLM integration tests where …

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/app/auth-multiuser-login.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/auth-multiuser-login.cy.ts
@@ -42,7 +42,7 @@ describe('Auth test', () => {
       nav.sidenav.shouldNotHaveNavSection(['Administration', 'Custom Resource Definitions']);
 
       cy.log('does not show admin nav items in Ecosystem to test user');
-      nav.sidenav.shouldNotHaveNavSection(['Ecosystem', 'OperatorHub']);
+      nav.sidenav.shouldNotHaveNavSection(['Ecosystem', 'Software Catalog']);
 
       cy.log('does not show admin nav items in Storage to test user');
       nav.sidenav.shouldNotHaveNavSection(['Storage', 'Persistent Volumes']);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/catalog-source-details.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/catalog-source-details.cy.ts
@@ -23,7 +23,7 @@ describe(`Interacting with CatalogSource page`, () => {
     cy.byTestID('loading-indicator').should('not.exist');
     cy.byLegacyTestID('OperatorHub').scrollIntoView().click();
 
-    // verfiy operatorHub details page is open
+    // verfiy OperatorHub details page is open
     detailsPage.sectionHeaderShouldExist('OperatorHub details');
 
     // navigate to Catalog Sources list

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/deprecated-operator-warnings.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/deprecated-operator-warnings.cy.ts
@@ -6,7 +6,6 @@ const TIMEOUT = { timeout: 300000 };
 const testOperatorName = 'Kiali Community Operator';
 const testOperator = {
   name: 'Kiali Operator',
-  operatorHubCardTestID: 'datagrid-redhat-operators-openshift-marketplace',
 };
 const deprecatedBadge = 'Deprecated';
 const deprecatedPackageMessage =
@@ -53,7 +52,7 @@ describe('Deprecated operator warnings', () => {
     checkErrors();
   });
 
-  it('verify deprecated operator warning badge on the OperatorHub tile', () => {
+  it('verify deprecated Operator warning badge on the Operator tile', () => {
     cy.visit(
       `/k8s/ns/${testDeprecatedCatalogSource.metadata.namespace}/operators.coreos.com~v1alpha1~CatalogSource/test-community-operator-deprecation`,
     );
@@ -74,7 +73,8 @@ describe('Deprecated operator warnings', () => {
     cy.log('verify the Deprecated badge on Kiali Community Operator tile');
     cy.byTestID('Deprecated-badge').contains(deprecatedBadge).should('exist');
   });
-  it('verify deprecated operator warnings in the OperatorHub details panel', () => {
+
+  it('verify deprecated Operator warnings in the Operator details panel', () => {
     cy.visit(
       `/catalog/ns/${testName}?catalogType=operator&keyword=kia&selectedId=kiali-test-community-operator-deprecation-openshift-marketplace&channel=stable&version=1.83.0`,
     );
@@ -87,7 +87,7 @@ describe('Deprecated operator warnings', () => {
       .should('exist');
   });
 
-  it('verify deprecated channel warnings in the OperatorHub details panel', () => {
+  it('verify deprecated channel warnings in the Operator details panel', () => {
     cy.visit(
       `/catalog/ns/${testName}?catalogType=operator&keyword=kia&selectedId=kiali-test-community-operator-deprecation-openshift-marketplace&channel=stable&version=1.83.0`,
     );
@@ -112,7 +112,7 @@ describe('Deprecated operator warnings', () => {
       .should('exist');
   });
 
-  it('verify deprectaed version warnings in the OperatorHub details panel', () => {
+  it('verify deprecated version warnings in the Operator details panel', () => {
     cy.visit(
       `/catalog/ns/${testName}?catalogType=operator&keyword=kia&selectedId=kiali-test-community-operator-deprecation-openshift-marketplace&channel=stable&version=1.83.0`,
     );
@@ -138,7 +138,7 @@ describe('Deprecated operator warnings', () => {
       .should('exist');
   });
 
-  it('verify deprecated operator warnings on Install Operator details page', () => {
+  it('verify deprecated Operator warnings on Install Operator details page', () => {
     cy.log('visit the Install Operator details page');
     cy.visit(
       '/operatorhub/subscribe?pkg=kiali&catalog=test-community-operator-deprecation&catalogNamespace=openshift-marketplace&targetNamespace=undefined&channel=alpha&version=1.68.0',
@@ -159,7 +159,7 @@ describe('Deprecated operator warnings', () => {
       .should('exist');
   });
 
-  it('verify deprecated operator warning badge on Installed Operators page', () => {
+  it('verify deprecated Operator warning badge on Installed Operators page', () => {
     cy.log(
       'install the Kiali Community Operator with the deprecated package, channel and version messages',
     );
@@ -181,14 +181,14 @@ describe('Deprecated operator warnings', () => {
       `oc patch installplan $(oc get installplan -n ${testDeprecatedSubscription.metadata.namespace} --no-headers | grep kiali-operator.v1.68.0 | grep Manual | awk '{print $1}') -n ${testDeprecatedSubscription.metadata.namespace} --type merge --patch '{"spec":{"approved":true}}'`,
     );
 
-    cy.log('visit the Installed Operators details page and verify the deprecated operator badge');
+    cy.log('visit the Installed Operators details page and verify the deprecated Operator badge');
     operator.installedSucceeded(testOperator.name, 'openshift-operators');
     cy.byTestID(DEPRECATED_OPERATOR_WARNING_BADGE_ID, TIMEOUT)
       .contains(deprecatedBadge)
       .should('exist');
   });
 
-  it('verify deprecated operator warnings on installed operator details page', () => {
+  it('verify deprecated operator warnings on Installed Operator details page', () => {
     cy.log('visit the Installed Operators details page');
     cy.visit(
       `/k8s/ns/${testDeprecatedSubscription.metadata.namespace}/operators.coreos.com~v1alpha1~ClusterServiceVersion/kiali-operator.v1.68.0`,
@@ -198,7 +198,7 @@ describe('Deprecated operator warnings', () => {
     cy.byTestID(DEPRECATED_OPERATOR_WARNING_BADGE_ID).contains(deprecatedBadge).should('exist');
 
     cy.log(
-      'verify that the deprecated messages for package, channel, and version are displayed on the installed operator details tab.',
+      'verify that the deprecated messages for package, channel, and version are displayed on the Installed Operator details tab.',
     );
     cy.byTestID(DEPRECATED_OPERATOR_WARNING_PACKAGE_ID)
       .contains(deprecatedPackageMessage)
@@ -211,14 +211,14 @@ describe('Deprecated operator warnings', () => {
       .should('exist');
   });
 
-  it('verify deprecated operator warnings on installed operator details subscription tab', () => {
+  it('verify deprecated operator warnings on Installed Operator details subscription tab', () => {
     cy.log('visit the Installed Operators subscription tab');
     cy.visit(
       `/k8s/ns/${testDeprecatedSubscription.metadata.namespace}/operators.coreos.com~v1alpha1~ClusterServiceVersion/kiali-operator.v1.68.0/subscription`,
     );
 
     cy.log(
-      'verify that the deprecated messages for package, channel, and version are displayed on the installed operator subscription tab.',
+      'verify that the deprecated messages for package, channel, and version are displayed on the Installed Operator subscription tab.',
     );
     cy.byTestID(DEPRECATED_OPERATOR_WARNING_PACKAGE_ID)
       .contains(deprecatedPackageMessage)

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/edit-default-sources.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/edit-default-sources.cy.ts
@@ -15,13 +15,13 @@ describe('Create namespace from install operators', () => {
     checkErrors();
   });
 
-  it('disables default catalog sources from operatorHub details page', () => {
-    cy.log('navigate to operatorHub page');
+  it('disables default catalog sources from OperatorHub details page', () => {
+    cy.log('navigate to OperatorHub page');
     cy.visit(`/settings/cluster`);
     cy.byLegacyTestID('horizontal-link-Configuration').click();
     cy.byLegacyTestID('OperatorHub').click();
 
-    // verfiy operatorHub details page is open
+    // verfiy OperatorHub details page is open
     detailsPage.sectionHeaderShouldExist('OperatorHub details');
 
     // Toggle default sources modal

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.cy.ts
@@ -1,6 +1,6 @@
 import { checkErrors, testName } from '../../../integration-tests-cypress/support';
 
-describe('Interacting with OperatorHub', () => {
+describe('Interacting with Operators', () => {
   before(() => {
     cy.login();
     cy.createProjectWithCLI(testName);
@@ -14,7 +14,7 @@ describe('Interacting with OperatorHub', () => {
     cy.deleteProjectWithCLI(testName);
   });
 
-  it('displays OperatorHub catalog items with expected available Operators', () => {
+  it('displays Operator catalog items with expected available Operators', () => {
     cy.log('navigate to Software Catalog');
     cy.visit(`/catalog/ns/${testName}`);
     cy.byTestID('page-heading').should('contain.text', 'Software Catalog');

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.cy.ts
@@ -3,7 +3,7 @@ import { operator, GlobalInstalledNamespace, TestOperandProps } from '../views/o
 
 const testOperator = {
   name: 'Data Grid',
-  operatorHubCardTestID: 'operator-Data Grid',
+  operatorCardTestID: 'operator-Data Grid',
 };
 
 const testOperand: TestOperandProps = {
@@ -18,7 +18,7 @@ const testOperand: TestOperandProps = {
 describe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
   before(() => {
     cy.login();
-    operator.install(testOperator.name, testOperator.operatorHubCardTestID);
+    operator.install(testOperator.name, testOperator.operatorCardTestID);
   });
 
   afterEach(() => {

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.cy.ts
@@ -5,7 +5,7 @@ import { GlobalInstalledNamespace, operator, TestOperandProps } from '../views/o
 
 const testOperator = {
   name: 'Data Grid',
-  operatorHubCardTestID: 'operator-Data Grid',
+  operatorCardTestID: 'operator-Data Grid',
   installedNamespace: testName,
 };
 
@@ -34,7 +34,7 @@ describe(`Installing "${testOperator.name}" operator in test namespace`, () => {
   it(`Installs ${testOperator.name} operator in test namespace and creates ${testOperand.name} operand instance`, () => {
     operator.install(
       testOperator.name,
-      testOperator.operatorHubCardTestID,
+      testOperator.operatorCardTestID,
       testOperator.installedNamespace,
     );
     operator.installedSucceeded(testOperator.name, testName);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-uninstall.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-uninstall.cy.ts
@@ -5,7 +5,7 @@ import { operator, TestOperandProps } from '../views/operator.view';
 
 const testOperator = {
   name: 'Data Grid',
-  operatorHubCardTestID: 'operator-Data Grid',
+  operatorCardTestID: 'operator-Data Grid',
   installedNamespace: testName,
 };
 
@@ -27,7 +27,7 @@ describe(`Testing uninstall of ${testOperator.name} Operator`, () => {
     cy.createProjectWithCLI(testName);
     operator.install(
       testOperator.name,
-      testOperator.operatorHubCardTestID,
+      testOperator.operatorCardTestID,
       testOperator.installedNamespace,
     );
     operator.installedSucceeded(testOperator.name, testName);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator.view.ts
@@ -11,7 +11,7 @@ export const GlobalInstalledNamespace = 'openshift-operators';
 export const operator = {
   install: (
     operatorName: string,
-    operatorHubCardTestID: string,
+    operatorCardTestID: string,
     installToNamespace: string = GlobalInstalledNamespace,
     useOperatorRecommendedNamespace: boolean = false,
   ) => {
@@ -20,7 +20,7 @@ export const operator = {
     cy.byTestID('tab operator').click();
     cy.byTestID('search-catalog').type(operatorName);
     cy.log('go to operator overview panel');
-    cy.byTestID(operatorHubCardTestID).click();
+    cy.byTestID(operatorCardTestID).click();
     cy.log('go to the install form');
     cy.byTestID('catalog-details-modal-cta').click({ force: true });
     cy.log('verify the channel selection is displayed');


### PR DESCRIPTION
…appropriate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated Cypress integration tests to reflect unified terminology (OperatorHub → Operator/Software Catalog).
  * Renamed test identifiers for consistency across operator-related suites.
  * Standardized test descriptions, log messages, and assertions for clearer, consistent wording.
  * Minor non-functional text and comment adjustments to improve readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->