### PR TITLE
HELM-611: add OCI registry client for chart operations

### DIFF
--- a/pkg/helm/actions/get_registry.go
+++ b/pkg/helm/actions/get_registry.go
@@ -1,7 +1,9 @@
 package actions
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/registry"
@@ -14,14 +16,27 @@ func GetDefaultOCIRegistry(conf *action.Configuration) error {
 	return GetOCIRegistry(conf, false, false)
 }
 
-func GetOCIRegistry(conf *action.Configuration, insecure bool, plainHTTP bool) error {
+func GetOCIRegistry(conf *action.Configuration, skipTLSVerify bool, plainHTTP bool) error {
 	if conf == nil {
 		return fmt.Errorf("action configuration cannot be nil")
 	}
-	registryclient, err := newRegistryClient(registry.ClientOptDebug(false))
+	opts := []registry.ClientOption{
+		registry.ClientOptDebug(false),
+	}
+	if plainHTTP {
+		opts = append(opts, registry.ClientOptPlainHTTP())
+	}
+	if skipTLSVerify {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+		opts = append(opts, registry.ClientOptHTTPClient(&http.Client{Transport: transport}))
+	}
+	registryClient, err := newRegistryClient(opts...)
 	if err != nil {
 		return fmt.Errorf("failed to create registry client: %w", err)
 	}
-	conf.RegistryClient = registryclient
+	conf.RegistryClient = registryClient
 	return nil
 }

--- a/pkg/helm/actions/get_registry_test.go
+++ b/pkg/helm/actions/get_registry_test.go
@@ -40,10 +40,71 @@ func TestGetDefaultOCIRegistry_Success(t *testing.T) {
 
 }
 
-func TestGetDefaultOCIRegistry_NilConfig(t *testing.T) {
-	err := GetDefaultOCIRegistry(nil)
+func TestGetOCIRegistry_NilConfig(t *testing.T) {
+	err := GetOCIRegistry(nil, false, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "action configuration cannot be nil")
+}
+
+func TestGetOCIRegistry_Success(t *testing.T) {
+	tests := []struct {
+		name          string
+		skipTLSVerify bool
+		plainHTTP     bool
+	}{
+		{
+			name:          "default options",
+			skipTLSVerify: false,
+			plainHTTP:     false,
+		},
+		{
+			name:          "with skipTLSVerify",
+			skipTLSVerify: true,
+			plainHTTP:     false,
+		},
+		{
+			name:          "with plainHTTP",
+			skipTLSVerify: false,
+			plainHTTP:     true,
+		},
+		{
+			name:          "with both skipTLSVerify and plainHTTP",
+			skipTLSVerify: true,
+			plainHTTP:     true,
+		},
+	}
+	originalNewRegistryClient := newRegistryClient
+	defer func() {
+		newRegistryClient = originalNewRegistryClient
+	}()
+
+	for _, tt := range tests {
+		newRegistryClient = func(options ...registry.ClientOption) (*registry.Client, error) {
+			count := 0
+			if tt.plainHTTP {
+				count += 1
+			}
+			if tt.skipTLSVerify {
+				count += 1
+			}
+			require.Equal(t, count, len(options)-1, "Expected %d options, got %d", count, len(options))
+			return &registry.Client{}, nil
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			store := storage.Init(driver.NewMemory())
+			conf := &action.Configuration{
+				RESTClientGetter: FakeConfig{},
+				Releases:         store,
+				KubeClient:       &kubefake.PrintingKubeClient{Out: io.Discard},
+				Capabilities:     chartutil.DefaultCapabilities,
+			}
+			require.Nil(t, conf.RegistryClient, "Registry Client should be nil initially")
+
+			err := GetOCIRegistry(conf, tt.skipTLSVerify, tt.plainHTTP)
+			require.NoError(t, err)
+			require.NotNil(t, conf.RegistryClient, "Registry Client should not be nil after GetOCIRegistry")
+		})
+	}
 }
 
 func TestGetOCIRegistry_NewClientError(t *testing.T) {

--- a/pkg/helm/handlers/handler_test.go
+++ b/pkg/helm/handlers/handler_test.go
@@ -63,7 +63,6 @@ var fakeReleaseManifest = "manifest-data"
 func fakeHelmHandler() helmHandlers {
 	return helmHandlers{
 		getActionConfigurations: getFakeActionConfigurations,
-		getDefaultOCIRegistry:   fakeGetDefaultOCIRegistry,
 	}
 }
 
@@ -200,10 +199,6 @@ func getFakeActionConfigurations(string, string, string, *http.RoundTripper) *ac
 	return &action.Configuration{
 		RESTClientGetter: FakeConfig{},
 	}
-}
-
-func fakeGetDefaultOCIRegistry(conf *action.Configuration) error {
-	return nil
 }
 
 func TestHelmHandlers_HandleHelmList(t *testing.T) {


### PR DESCRIPTION
OCI-based Helm charts were failing to install because the action configuration lacked a registry client. This change:

- Add GetDefaultOCIRegistry() to create and attach a registry client to the Helm action configuration
- Integrate registry client initialization into all Helm handlers: install, upgrade, uninstall, rollback, and chart get operations
- Add unit tests for the new registry client function
- Update older tests to use mock registry Client function

Without a registry client, operations on OCI charts (oci://) would fail with errors about missing registry support.

Fixes: [HELM-611](https://issues.redhat.com//browse/HELM-611)
Original PR on #15830

**Steps to test:**

1. Create a helmrepository object in the cluster. The helmrepository object can be either cluster or namespaced, it does not matter.
2. Add repo link as https://charts.bitnami.com/bitnami . Bitnami has many OCI helm charts.
3. Once added, go to Releases and create a Helm release.
4. Sort by the newly added bitnami repository. Select nginx as the chart.
5. Click on create. Wait for the release to create and verify when created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OCI registry integration with configurable TLS verification and plain-HTTP options.

* **Improvements**
  * Registry client is now initialized during configuration; failures are logged at debug level but do not prevent operation.

* **Tests**
  * Added tests covering registry initialization success, nil-configuration errors, option combinations, and client-creation error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->