### PR TITLE
OCPBUGS-72260: '0 of pods' are shown in Status column on DaemonSets list page.

### DIFF
--- a/frontend/public/components/workload-table.tsx
+++ b/frontend/public/components/workload-table.tsx
@@ -86,11 +86,21 @@ const tableColumnInfo = [
 
 export const ReplicasCount: React.FCC<ReplicasCountProps> = ({ obj, kind }) => {
   const { t } = useTranslation();
+
+  // DaemonSets use different status fields than Deployments
+  const isDaemonSet = kind?.includes('DaemonSet');
+  const statusReplicas = isDaemonSet
+    ? obj.status?.currentNumberScheduled ?? 0
+    : obj.status?.replicas ?? 0;
+  const specReplicas = isDaemonSet
+    ? obj.status?.desiredNumberScheduled ?? 0
+    : obj.spec?.replicas ?? 0;
+
   return (
     <Link to={`${resourcePath(kind, obj.metadata.name, obj.metadata.namespace)}/pods`} title="pods">
       {t('public~{{statusReplicas}} of {{specReplicas}} pods', {
-        statusReplicas: obj.status.replicas || 0,
-        specReplicas: obj.spec.replicas,
+        statusReplicas,
+        specReplicas,
       })}
     </Link>
   );


### PR DESCRIPTION
### Before:
<img width="1788" height="934" alt="Screenshot 2026-01-20 at 8 51 52 AM" src="https://github.com/user-attachments/assets/b0377a9b-3f06-46a4-891f-a308267c696c" />

### After:
<img width="1500" height="624" alt="Screenshot 2026-01-20 at 8 52 00 AM" src="https://github.com/user-attachments/assets/1359a64c-7e29-435c-8e41-d0e68b0b46ab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pod count display for DaemonSet resources to show accurate current and desired replica counts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->