### PR TITLE
NO-JIRA: Moving the oc and kubectl delete,apply,create commands from deny to ask permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -87,13 +87,6 @@
       "Bash(rm -rf:*)",
       "Bash(rm -fr:*)",
 
-      "Bash(oc delete:*)",
-      "Bash(oc apply:*)",
-      "Bash(oc create:*)",
-      "Bash(kubectl delete:*)",
-      "Bash(kubectl apply:*)",
-      "Bash(kubectl create:*)",
-
       "Bash(docker rm:*)",
       "Bash(docker rmi:*)",
       "Bash(docker stop:*)",
@@ -108,6 +101,13 @@
       "Bash(npm i:*)",
       "Bash(go get:*)",
       "Bash(go mod:*)",
+      
+      "Bash(oc delete:*)",
+      "Bash(oc apply:*)",
+      "Bash(oc create:*)",
+      "Bash(kubectl delete:*)",
+      "Bash(kubectl apply:*)",
+      "Bash(kubectl create:*)",
 
       "Bash(git commit:*)",
       "Bash(git push:*)",


### PR DESCRIPTION
I think setting them to `deny` is too restrictive for development workflows with claude.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI command permissions to require explicit user confirmation for certain operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->