### PR TITLE
NO-JIRA: SDK post-publish tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,8 +495,6 @@ Currently this feature is behind feature gate.
 [[API]](./frontend/packages/console-dynamic-plugin-sdk/docs/api.md)
 [[Console Extensions]](./frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md)
 
-- [console-plugin-shared](./frontend/packages/console-plugin-shared/README.md)
-
 - [dev-console](./frontend/packages/dev-console/README.md)
 
 - [eslint-plugin-console](./frontend/packages/eslint-plugin-console/README.md)

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -70,7 +70,6 @@ as a reference point for writing an OLM operator that ships with its own Console
 | `@openshift-console/dynamic-plugin-sdk` ★         | Provides core APIs, types and utilities used by dynamic plugins at runtime.      |
 | `@openshift-console/dynamic-plugin-sdk-webpack` ★ | Provides webpack `ConsoleRemotePlugin` used to build all dynamic plugin assets.  |
 | `@openshift-console/dynamic-plugin-sdk-internal`   | Internal package exposing additional Console code.                               |
-| `@openshift-console/plugin-shared`                 | Provides reusable components and utility functions to build OCP dynamic plugins. |
 
 Packages marked with ★ provide essential plugin APIs with backwards compatibility. Other packages may be
 used with multiple versions of OpenShift Console but don't provide any backwards compatibility guarantees.

--- a/frontend/packages/console-dynamic-plugin-sdk/release-notes/4.22.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/release-notes/4.22.md
@@ -12,6 +12,12 @@ Additional updates to these shared modules might occur before the 4.22 release i
 - Upgraded from `react-redux` v7 to v8. Plugins must use `react-redux` v8 to remain compatible with Console.
 - Upgraded from `react-i18next` v11 to v15. Plugins must use `react-i18next` v15 to remain compatible with Console.
 
+## Removal of `@openshift-console/plugin-shared`
+
+The `@openshift-console/plugin-shared` package has been removed from the Console codebase, and the
+corresponding npm package is deprecated. Plugins should remove this dependency from their `package.json`
+if present.
+
 ## React 18 upgrade tips
 
 Console now uses React 18. The following guidance highlights common update considerations

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
@@ -41,7 +41,6 @@ const commonFiles: Record<string, string> = {
 
 const docFiles: Record<string, string> = {
   docs: 'docs',
-  'upgrade-PatternFly.md': 'upgrade-PatternFly.md',
 };
 
 const getReferencedAssets = (outDir: string) => {

--- a/frontend/packages/console-dynamic-plugin-sdk/upgrade-PatternFly.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/upgrade-PatternFly.md
@@ -1,4 +1,0 @@
-# PatternFly Upgrade Notes
-
-For information about upgrading plugins to use PatternFly 6.x, see the
-[4.19 Release Notes](https://github.com/openshift/console/blob/main/frontend/packages/console-dynamic-plugin-sdk/release-notes/4.19.md).


### PR DESCRIPTION
- Forgot to remove console-plugin-shared from docs, add removal of this package to 4.22 notes
- Remove `upgrade-PatternFly.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Deprecated the `@openshift-console/plugin-shared` package. Plugins should remove this dependency from their package.json.
  * Updated and removed related documentation reflecting the package deprecation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->