### PR TITLE
OCPBUGS-74369: Bump lodash to latest

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -331,7 +331,7 @@
     "esbuild": "^0.27.2",
     "glob-parent": "^5.1.2",
     "hosted-git-info": "^3.0.8",
-    "lodash-es": "^4.17.21",
+    "lodash-es": "^4.17.23",
     "postcss": "^8.2.13",
     "async": "^3.2.5"
   },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11490,10 +11490,10 @@ locate-path@^7.1.0:
   dependencies:
     p-locate "^6.0.0"
 
-lodash-es@^4.17.15, lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+lodash-es@^4.17.15, lodash-es@^4.17.21, lodash-es@^4.17.23:
+  version "4.17.23"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.23.tgz#58c4360fd1b5d33afc6c0bbd3d1149349b1138e0"
+  integrity sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==
 
 lodash._baseassign@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated lodash-es dependency version from 4.17.21 to 4.17.23

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->