### PR TITLE
OCPBUGS-87055: fixing severity not showing number of issues

### DIFF
--- a/frontend/e2e/pages/cluster-dashboard-page.ts
+++ b/frontend/e2e/pages/cluster-dashboard-page.ts
@@ -1,0 +1,45 @@
+import type { Locator } from '@playwright/test';
+
+import BasePage from './base-page';
+
+export class ClusterDashboardPage extends BasePage {
+  private readonly statusCard = this.page.locator('[data-test-id="status-card"]');
+  private readonly insightsHealthItem = this.page.locator(
+    '[data-item-id="Insights-health-item"]',
+  );
+  private readonly insightsButton = this.page
+    .getByTestId('Insights')
+    .locator('button');
+  private readonly popover = this.page.locator('.pf-v6-c-popover');
+
+  async navigateToDashboard(): Promise<void> {
+    await this.goTo('/dashboards');
+    await this.waitForLoadingComplete();
+  }
+
+  async waitForStatusCardLoaded(): Promise<void> {
+    await this.statusCard.waitFor({ state: 'visible', timeout: 30_000 });
+    // Wait for all health item skeleton loaders to disappear
+    const skeletons = this.statusCard.locator('.skeleton-health');
+    await skeletons.first().waitFor({ state: 'hidden', timeout: 30_000 }).catch(() => {
+      // Skeletons may have already disappeared
+    });
+  }
+
+  getInsightsHealthItem(): Locator {
+    return this.insightsHealthItem;
+  }
+
+  getInsightsButton(): Locator {
+    return this.insightsButton;
+  }
+
+  getPopover(): Locator {
+    return this.popover;
+  }
+
+  async openInsightsPopup(): Promise<void> {
+    await this.robustClick(this.insightsButton);
+    await this.popover.waitFor({ state: 'visible', timeout: 10_000 });
+  }
+}

--- a/frontend/e2e/pages/cluster-dashboard-page.ts
+++ b/frontend/e2e/pages/cluster-dashboard-page.ts
@@ -19,9 +19,7 @@ export class ClusterDashboardPage extends BasePage {
 
   async waitForStatusCardLoaded(): Promise<void> {
     await this.statusCard.waitFor({ state: 'visible', timeout: 30_000 });
-    // Wait for all health item skeleton loaders to disappear
-    const skeletons = this.statusCard.locator('.skeleton-health');
-    await skeletons.first().waitFor({ state: 'hidden', timeout: 30_000 }).catch(() => {
+    await this.statusCard.locator('.skeleton-health').waitFor({ state: 'hidden', timeout: 30_000 }).catch(() => {
       // Skeletons may have already disappeared
     });
   }

--- a/frontend/e2e/tests/console/dashboards/insights-popup.spec.ts
+++ b/frontend/e2e/tests/console/dashboards/insights-popup.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '../../../fixtures';
+import { ClusterDashboardPage } from '../../../pages/cluster-dashboard-page';
+
+test.describe('Insights Popup on Cluster Dashboard', { tag: ['@admin'] }, () => {
+  let dashboard: ClusterDashboardPage;
+
+  test.beforeEach(async ({ page }) => {
+    dashboard = new ClusterDashboardPage(page);
+    await dashboard.navigateToDashboard();
+    await dashboard.waitForStatusCardLoaded();
+  });
+
+  test('displays the Insights health item in the status card', async () => {
+    await expect(dashboard.getInsightsHealthItem()).toBeVisible();
+    await expect(dashboard.getInsightsButton()).toBeVisible();
+  });
+
+  test('opens the Insights popup when clicking the health item', async () => {
+    await dashboard.openInsightsPopup();
+
+    await expect(dashboard.getPopover()).toBeVisible();
+    await expect(dashboard.getPopover()).toContainText('Red Hat Lightspeed Advisor status');
+  });
+
+  test('shows last refresh timestamp in the popup', async () => {
+    await dashboard.openInsightsPopup();
+
+    await expect(dashboard.getPopover().getByText('Last refresh')).toBeVisible();
+  });
+
+  test('shows the advisor description text', async () => {
+    await dashboard.openInsightsPopup();
+
+    await expect(
+      dashboard
+        .getPopover()
+        .getByText('Red Hat Lightspeed Advisor identifies and prioritizes'),
+    ).toBeVisible();
+  });
+
+  test('renders severity links pointing to the correct Red Hat Insights advisor URL', async () => {
+    await dashboard.openInsightsPopup();
+
+    const advisorLinks = dashboard
+      .getPopover()
+      .locator('a[href*="console.redhat.com/openshift/insights/advisor"]');
+    await expect(advisorLinks.first()).toBeVisible();
+    await expect(advisorLinks.first()).toHaveAttribute('target', '_blank');
+  });
+
+  test('severity links include total_risk query parameter', async () => {
+    await dashboard.openInsightsPopup();
+
+    const riskLinks = dashboard.getPopover().locator('a[href*="total_risk="]');
+    const count = await riskLinks.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      const href = await riskLinks.nth(i).getAttribute('href');
+      const totalRisk = new URL(href, 'https://placeholder').searchParams.get('total_risk');
+      expect(['1', '2', '3', '4']).toContain(totalRisk);
+    }
+  });
+
+  test('shows advisor recommendations link', async () => {
+    await dashboard.openInsightsPopup();
+
+    const popover = dashboard.getPopover();
+    const advisorLink = popover.getByText(/View (all recommendations|more) in Red Hat Lightspeed Advisor/);
+    await expect(advisorLink).toBeVisible();
+  });
+});

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/__tests__/index.spec.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/__tests__/index.spec.tsx
@@ -36,17 +36,18 @@ describe('LabelComponent', () => {
     );
   });
 
-  it('should compute correct totalRisk for each severity', () => {
-    const expected = { low: 1, moderate: 2, important: 3, critical: 4 };
-
-    Object.entries(expected).forEach(([riskId, expectedTotalRisk]) => {
-      render(<LabelComponent clusterID="cluster-1" datum={{ id: riskId }} />);
-      const link = screen.getByRole('link');
-      expect(link).toHaveAttribute(
-        'href',
-        `https://console.redhat.com/openshift/insights/advisor/clusters/cluster-1?total_risk=${expectedTotalRisk}`,
-      );
-    });
+  it.each([
+    ['low', 1],
+    ['moderate', 2],
+    ['important', 3],
+    ['critical', 4],
+  ])('should compute totalRisk=%s as %i', (riskId, expectedTotalRisk) => {
+    render(<LabelComponent clusterID="cluster-1" datum={{ id: riskId }} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute(
+      'href',
+      `https://console.redhat.com/openshift/insights/advisor/clusters/cluster-1?total_risk=${expectedTotalRisk}`,
+    );
   });
 
   it('should not render a link when clusterID is empty', () => {

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/__tests__/index.spec.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/__tests__/index.spec.tsx
@@ -1,0 +1,209 @@
+import { render, screen } from '@testing-library/react';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import { LabelComponent, InsightsPopup } from '../index';
+
+jest.mock('@patternfly/react-charts/victory', () => ({
+  ChartDonut: jest.fn(() => null),
+  ChartLegend: jest.fn(() => null),
+  ChartLabel: jest.fn(() => null),
+}));
+
+jest.mock('@console/internal/components/error', () => ({
+  ErrorState: jest.fn(() => 'ErrorState'),
+}));
+
+jest.mock('@console/shared/src/components/datetime/Timestamp', () => ({
+  Timestamp: jest.fn(() => 'Timestamp'),
+}));
+
+jest.mock('@console/shared/src/components/links/ExternalLink', () => ({
+  ExternalLink: jest.fn(({ text }) => text),
+}));
+
+jest.mock('@console/internal/components/utils', () => ({
+  documentationURLs: { usingInsights: 'usingInsights' },
+  getDocumentationURL: jest.fn(() => 'https://docs.example.com'),
+  isManaged: jest.fn(() => false),
+}));
+
+describe('LabelComponent', () => {
+  it('should generate correct href for a valid clusterID and risk level', () => {
+    const { container } = render(
+      <LabelComponent clusterID="cluster-abc" datum={{ id: 'critical' }} />,
+    );
+    const link = container.querySelector('a');
+    expect(link).toHaveAttribute(
+      'href',
+      'https://console.redhat.com/openshift/insights/advisor/clusters/cluster-abc?total_risk=4',
+    );
+  });
+
+  it('should compute correct totalRisk for each severity', () => {
+    const expected = { low: 1, moderate: 2, important: 3, critical: 4 };
+
+    Object.entries(expected).forEach(([riskId, expectedTotalRisk]) => {
+      const { container } = render(<LabelComponent clusterID="cluster-1" datum={{ id: riskId }} />);
+      const link = container.querySelector('a');
+      expect(link).toHaveAttribute(
+        'href',
+        `https://console.redhat.com/openshift/insights/advisor/clusters/cluster-1?total_risk=${expectedTotalRisk}`,
+      );
+    });
+  });
+
+  it('should not set href when clusterID is empty', () => {
+    const { container } = render(<LabelComponent clusterID="" datum={{ id: 'critical' }} />);
+    const link = container.querySelector('a');
+    expect(link).not.toHaveAttribute('href');
+  });
+
+  it('should not set href when datum is undefined', () => {
+    const { container } = render(<LabelComponent clusterID="cluster-1" />);
+    const link = container.querySelector('a');
+    expect(link).not.toHaveAttribute('href');
+  });
+
+  it('should not set href when datum.id is an unknown risk level', () => {
+    const { container } = render(
+      <LabelComponent clusterID="cluster-1" datum={{ id: 'unknown-risk' }} />,
+    );
+    const link = container.querySelector('a');
+    expect(link).not.toHaveAttribute('href');
+  });
+
+  it('should set target="_blank" and rel="noopener noreferrer"', () => {
+    const { container } = render(<LabelComponent clusterID="cluster-1" datum={{ id: 'low' }} />);
+    const link = container.querySelector('a');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('should set tabIndex=0 for keyboard accessibility', () => {
+    const { container } = render(<LabelComponent clusterID="cluster-1" datum={{ id: 'low' }} />);
+    const link = container.querySelector('a');
+    expect(link).toHaveAttribute('tabindex', '0');
+  });
+});
+
+const makePrometheusResponse = (
+  results: { metric: Record<string, string>; value: [number, string] }[],
+) => ({
+  status: 'success' as const,
+  data: {
+    resultType: 'vector' as const,
+    result: results,
+  },
+});
+
+const metricsResponse = makePrometheusResponse([
+  { metric: { metric: 'low' }, value: [0, '3'] },
+  { metric: { metric: 'moderate' }, value: [0, '2'] },
+  { metric: { metric: 'important' }, value: [0, '1'] },
+  { metric: { metric: 'critical' }, value: [0, '0'] },
+]);
+
+const operatorAvailable = makePrometheusResponse([
+  { metric: { condition: 'Available' }, value: [0, '1'] },
+]);
+
+const lastGatherResponse = makePrometheusResponse([
+  { metric: {}, value: [0, `${Math.floor(Date.now() / 1000)}`] },
+]);
+
+const k8sCluster = {
+  data: {
+    apiVersion: 'config.openshift.io/v1',
+    kind: 'ClusterVersion',
+    spec: { clusterID: 'test-cluster-id' },
+  },
+  loaded: true,
+  loadError: null,
+} as any;
+
+describe('InsightsPopup', () => {
+  const baseResponses = [
+    { response: metricsResponse, error: null },
+    { response: operatorAvailable, error: null },
+    { response: lastGatherResponse, error: null },
+  ];
+
+  it('should render ErrorState when upload is degraded', () => {
+    const degradedOperator = makePrometheusResponse([
+      { metric: { condition: 'Degraded' }, value: [0, '1'] },
+      { metric: { condition: 'UploadDegraded' }, value: [0, '1'] },
+    ]);
+    const responses = [
+      { response: metricsResponse, error: null },
+      { response: degradedOperator, error: null },
+      { response: lastGatherResponse, error: null },
+    ];
+
+    renderWithProviders(
+      <InsightsPopup responses={responses} k8sResult={k8sCluster} hide={jest.fn()} />,
+    );
+    expect(screen.getByText('ErrorState')).toBeInTheDocument();
+  });
+
+  it('should show "Temporarily unavailable" on metrics error', () => {
+    const responses = [
+      { response: metricsResponse, error: new Error('fail') },
+      { response: operatorAvailable, error: null },
+      { response: lastGatherResponse, error: null },
+    ];
+
+    renderWithProviders(
+      <InsightsPopup responses={responses} k8sResult={k8sCluster} hide={jest.fn()} />,
+    );
+    expect(screen.getByText('Temporarily unavailable.')).toBeInTheDocument();
+  });
+
+  it('should show "Disabled." when operator is disabled', () => {
+    const disabledOperator = makePrometheusResponse([
+      { metric: { condition: 'Disabled' }, value: [0, '1'] },
+    ]);
+    const responses = [
+      { response: metricsResponse, error: null },
+      { response: disabledOperator, error: null },
+      { response: lastGatherResponse, error: null },
+    ];
+
+    renderWithProviders(
+      <InsightsPopup responses={responses} k8sResult={k8sCluster} hide={jest.fn()} />,
+    );
+    expect(screen.getByText('Disabled.')).toBeInTheDocument();
+  });
+
+  it('should show "Waiting for results." when operator status is not yet available', () => {
+    const responses = [
+      { response: metricsResponse, error: null },
+      { response: null, error: null },
+      { response: lastGatherResponse, error: null },
+    ];
+
+    renderWithProviders(
+      <InsightsPopup responses={responses} k8sResult={k8sCluster} hide={jest.fn()} />,
+    );
+    expect(screen.getByText('Waiting for results.')).toBeInTheDocument();
+  });
+
+  it('should render chart area when metrics are available', () => {
+    renderWithProviders(
+      <InsightsPopup responses={baseResponses} k8sResult={k8sCluster} hide={jest.fn()} />,
+    );
+    expect(screen.getByText('Fixable issues')).toBeInTheDocument();
+    expect(
+      screen.getByText('View all recommendations in Red Hat Lightspeed Advisor'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render generic advisor link when clusterID is missing', () => {
+    renderWithProviders(
+      <InsightsPopup
+        responses={baseResponses}
+        k8sResult={{ loaded: true, loadError: null } as any}
+        hide={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('View more in Red Hat Lightspeed Advisor')).toBeInTheDocument();
+  });
+});

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/__tests__/index.spec.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/__tests__/index.spec.tsx
@@ -28,10 +28,8 @@ jest.mock('@console/internal/components/utils', () => ({
 
 describe('LabelComponent', () => {
   it('should generate correct href for a valid clusterID and risk level', () => {
-    const { container } = render(
-      <LabelComponent clusterID="cluster-abc" datum={{ id: 'critical' }} />,
-    );
-    const link = container.querySelector('a');
+    render(<LabelComponent clusterID="cluster-abc" datum={{ id: 'critical' }} />);
+    const link = screen.getByRole('link');
     expect(link).toHaveAttribute(
       'href',
       'https://console.redhat.com/openshift/insights/advisor/clusters/cluster-abc?total_risk=4',
@@ -42,8 +40,8 @@ describe('LabelComponent', () => {
     const expected = { low: 1, moderate: 2, important: 3, critical: 4 };
 
     Object.entries(expected).forEach(([riskId, expectedTotalRisk]) => {
-      const { container } = render(<LabelComponent clusterID="cluster-1" datum={{ id: riskId }} />);
-      const link = container.querySelector('a');
+      render(<LabelComponent clusterID="cluster-1" datum={{ id: riskId }} />);
+      const link = screen.getByRole('link');
       expect(link).toHaveAttribute(
         'href',
         `https://console.redhat.com/openshift/insights/advisor/clusters/cluster-1?total_risk=${expectedTotalRisk}`,
@@ -51,36 +49,31 @@ describe('LabelComponent', () => {
     });
   });
 
-  it('should not set href when clusterID is empty', () => {
-    const { container } = render(<LabelComponent clusterID="" datum={{ id: 'critical' }} />);
-    const link = container.querySelector('a');
-    expect(link).not.toHaveAttribute('href');
+  it('should not render a link when clusterID is empty', () => {
+    render(<LabelComponent clusterID="" datum={{ id: 'critical' }} />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
-  it('should not set href when datum is undefined', () => {
-    const { container } = render(<LabelComponent clusterID="cluster-1" />);
-    const link = container.querySelector('a');
-    expect(link).not.toHaveAttribute('href');
+  it('should not render a link when datum is undefined', () => {
+    render(<LabelComponent clusterID="cluster-1" />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
-  it('should not set href when datum.id is an unknown risk level', () => {
-    const { container } = render(
-      <LabelComponent clusterID="cluster-1" datum={{ id: 'unknown-risk' }} />,
-    );
-    const link = container.querySelector('a');
-    expect(link).not.toHaveAttribute('href');
+  it('should not render a link when datum.id is an unknown risk level', () => {
+    render(<LabelComponent clusterID="cluster-1" datum={{ id: 'unknown-risk' }} />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
   it('should set target="_blank" and rel="noopener noreferrer"', () => {
-    const { container } = render(<LabelComponent clusterID="cluster-1" datum={{ id: 'low' }} />);
-    const link = container.querySelector('a');
+    render(<LabelComponent clusterID="cluster-1" datum={{ id: 'low' }} />);
+    const link = screen.getByRole('link');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('should set tabIndex=0 for keyboard accessibility', () => {
-    const { container } = render(<LabelComponent clusterID="cluster-1" datum={{ id: 'low' }} />);
-    const link = container.querySelector('a');
+    render(<LabelComponent clusterID="cluster-1" datum={{ id: 'low' }} />);
+    const link = screen.getByRole('link');
     expect(link).toHaveAttribute('tabindex', '0');
   });
 });

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -30,20 +30,24 @@ const DataComponent: FC<DataComponentProps> = ({ x, y, datum }) => {
   return <Icon x={x} y={y - 5} fill={legendColorScale[datum.id]} />;
 };
 
-const LabelComponent = ({ clusterID, ...props }) => (
-  <ExternalLink
-    href={`https://console.redhat.com/openshift/insights/advisor/clusters/${clusterID}?total_risk=${
-      riskSorting[props.datum.id] + 1
-    }`}
-  >
-    <ChartLabel
-      {...props}
-      style={{
-        fill: 'var(--pf-t--global--text--color--link--default)',
-      }}
-    />
-  </ExternalLink>
-);
+const LabelComponent = ({ clusterID, ...props }) => {
+  const href = `https://console.redhat.com/openshift/insights/advisor/clusters/${clusterID}?total_risk=${
+    riskSorting[props.datum?.id] + 1
+  }`;
+
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      <ChartLabel
+        {...props}
+        style={{
+          ...props.style,
+          fill: 'var(--pf-t--global--text--color--link--default)',
+          cursor: 'pointer',
+        }}
+      />
+    </a>
+  );
+};
 
 const SubTitleComponent = (props) => (
   <ChartLabel

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -31,18 +31,22 @@ const DataComponent: FC<DataComponentProps> = ({ x, y, datum }) => {
 };
 
 const LabelComponent = ({ clusterID, ...props }) => {
-  const href = `https://console.redhat.com/openshift/insights/advisor/clusters/${clusterID}?total_risk=${
-    riskSorting[props.datum?.id] + 1
-  }`;
+  const riskId = props.datum?.id;
+  const riskIndex = riskId != null ? riskSorting[riskId] : undefined;
+  const totalRisk = Number.isFinite(riskIndex) ? riskIndex + 1 : undefined;
+  const href =
+    clusterID && totalRisk != null
+      ? `https://console.redhat.com/openshift/insights/advisor/clusters/${clusterID}?total_risk=${totalRisk}`
+      : undefined;
 
   return (
-    <a href={href} target="_blank" rel="noopener noreferrer">
+    <a href={href} target="_blank" rel="noopener noreferrer" tabIndex={0}>
       <ChartLabel
         {...props}
         style={{
           ...props.style,
           fill: 'var(--pf-t--global--text--color--link--default)',
-          cursor: 'pointer',
+          cursor: href ? 'pointer' : undefined,
         }}
       />
     </a>

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -30,7 +30,7 @@ const DataComponent: FC<DataComponentProps> = ({ x, y, datum }) => {
   return <Icon x={x} y={y - 5} fill={legendColorScale[datum.id]} />;
 };
 
-const LabelComponent = ({ clusterID, ...props }) => {
+export const LabelComponent = ({ clusterID, ...props }) => {
   const riskId = props.datum?.id;
   const riskIndex = riskId != null ? riskSorting[riskId] : undefined;
   const totalRisk = Number.isFinite(riskIndex) ? riskIndex + 1 : undefined;

--- a/frontend/packages/integration-tests/tests/dashboards/insights-popup.cy.ts
+++ b/frontend/packages/integration-tests/tests/dashboards/insights-popup.cy.ts
@@ -1,0 +1,80 @@
+import { checkErrors } from '../../support';
+
+const INSIGHTS_HEALTH_ITEM = '[data-item-id="Insights-health-item"]';
+const INSIGHTS_BUTTON = '[data-test="Insights"]';
+
+describe('Insights Popup on Cluster Dashboard', () => {
+  before(() => {
+    cy.login();
+    cy.visit('/dashboards');
+    cy.byLegacyTestID('status-card').should('be.visible');
+    // Wait until all health items have finished loading (no skeleton loaders remain)
+    cy.byLegacyTestID('status-card').within(() => {
+      cy.get('.skeleton-health', { timeout: 30000 }).should('not.exist');
+    });
+  });
+
+  afterEach(() => {
+    checkErrors();
+  });
+
+  it('displays the Insights health item in the status card', () => {
+    cy.get(INSIGHTS_HEALTH_ITEM).should('be.visible');
+    cy.get(INSIGHTS_BUTTON).filter('button').should('be.visible');
+  });
+
+  it('opens the Insights popup when clicking the health item', () => {
+    cy.get(INSIGHTS_BUTTON).filter('button').click();
+    cy.get('.pf-v6-c-popover').should('be.visible');
+    cy.get('.pf-v6-c-popover').should('contain.text', 'Red Hat Lightspeed Advisor status');
+  });
+
+  it('shows last refresh timestamp in the popup', () => {
+    cy.get(INSIGHTS_BUTTON).filter('button').click();
+    cy.get('.pf-v6-c-popover').within(() => {
+      cy.contains('Last refresh').should('be.visible');
+    });
+  });
+
+  it('shows the advisor description text', () => {
+    cy.get(INSIGHTS_BUTTON).filter('button').click();
+    cy.get('.pf-v6-c-popover').within(() => {
+      cy.contains('Red Hat Lightspeed Advisor identifies and prioritizes').should('be.visible');
+    });
+  });
+
+  it('renders severity links pointing to the correct Red Hat Insights advisor URL', () => {
+    cy.get(INSIGHTS_BUTTON).filter('button').click();
+    cy.get('.pf-v6-c-popover').within(() => {
+      cy.get('a[href*="console.redhat.com/openshift/insights/advisor"]').should('exist');
+      cy.get('a[href*="console.redhat.com/openshift/insights/advisor"]')
+        .first()
+        .should('have.attr', 'target', '_blank');
+    });
+  });
+
+  it('severity links include total_risk query parameter', () => {
+    cy.get(INSIGHTS_BUTTON).filter('button').click();
+    cy.get('.pf-v6-c-popover').within(() => {
+      cy.get('a[href*="total_risk="]').each(($link) => {
+        const href = $link.attr('href');
+        expect(href).to.match(/total_risk=[1-4]/);
+      });
+    });
+  });
+
+  it('shows "View all recommendations" or "View more" link', () => {
+    cy.get(INSIGHTS_BUTTON).filter('button').click();
+    cy.get('.pf-v6-c-popover').then(($popover) => {
+      if (
+        $popover.find('a[href*="console.redhat.com/openshift/insights/advisor/clusters/"]').length
+      ) {
+        cy.wrap($popover)
+          .contains('View all recommendations in Red Hat Lightspeed Advisor')
+          .should('be.visible');
+      } else {
+        cy.wrap($popover).contains('View more in Red Hat Lightspeed Advisor').should('be.visible');
+      }
+    });
+  });
+});

--- a/frontend/packages/integration-tests/tests/dashboards/insights-popup.cy.ts
+++ b/frontend/packages/integration-tests/tests/dashboards/insights-popup.cy.ts
@@ -56,10 +56,13 @@ describe('Insights Popup on Cluster Dashboard', () => {
   it('severity links include total_risk query parameter', () => {
     cy.get(INSIGHTS_BUTTON).filter('button').click();
     cy.get('.pf-v6-c-popover').within(() => {
-      cy.get('a[href*="total_risk="]').each(($link) => {
-        const href = $link.attr('href');
-        expect(href).to.match(/total_risk=[1-4]/);
-      });
+      cy.get('a[href*="total_risk="]')
+        .should('have.length.greaterThan', 0)
+        .each(($link) => {
+          const href = $link.attr('href');
+          const totalRisk = new URL(href, 'https://placeholder').searchParams.get('total_risk');
+          expect(['1', '2', '3', '4']).to.include(totalRisk);
+        });
     });
   });
 


### PR DESCRIPTION
As described in [RHINENG-19549](https://issues.redhat.com/browse/RHINENG-19549) there is currently bug in the plugin where the severity numbers and links are not showing but the icons are. 
As part of the investigation i have noticed that the main issue was with ExternalLink which did not render the text and the link correctly. Changin the ExternalLink to simple a link element seems to have fixed the problem.

Screenshot before fix: 
<img width="332" height="394" alt="Snímka obrazovky 2026-01-26 o 13 32 11" src="https://github.com/user-attachments/assets/62337c13-d72a-4f2b-8276-7aa0d126d67d" />

Screenshot after fix:
<img width="330" height="390" alt="Snímka obrazovky 2026-01-26 o 13 37 59" src="https://github.com/user-attachments/assets/e80ea5a0-41ba-4b8a-ab1b-213ad57ee7ad" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features / UX Improvements**
  * Better Insights popup link behavior: links open in a new tab when available, are inert when target data is missing, preserve styling, and show appropriate cursor affordance.
  * More reliable Cluster Dashboard navigation and status-card loading to improve Insights popup availability.

* **Tests**
  * Added unit, integration, and end-to-end tests covering popup rendering, interactions, content, and severity link/query-parameter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->