### PR TITLE
NO-JIRA: Suppress ResizeObserver-related e2e errors

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/dev-console/integration-tests/support/commands/hooks.ts
@@ -1,16 +1,5 @@
 import { quickStartSidebarPO } from '../pageObjects/quickStarts-po';
 
-//  To ignore the resizeObserverLoopErrors on CI, adding below code
-const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
-/* eslint-disable consistent-return */
-Cypress.on('uncaught:exception', (err, runnable, promise) => {
-  /* returning false here prevents Cypress from failing the test */
-  if (resizeObserverLoopErrRe.test(err.message)) {
-    return false;
-  }
-  cy.log('uncaught:exception', err, runnable, promise);
-});
-
 before(() => {
   cy.exec('../../../../contrib/create-user.sh');
   const bridgePasswordIDP: string = Cypress.env('BRIDGE_HTPASSWD_IDP') || 'test';

--- a/frontend/packages/helm-plugin/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/commands/hooks.ts
@@ -1,14 +1,3 @@
-//  To ignore the resizeObserverLoopErrors on CI, adding below code
-const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
-/* eslint-disable consistent-return */
-Cypress.on('uncaught:exception', (err, runnable, promise) => {
-  /* returning false here prevents Cypress from failing the test */
-  if (resizeObserverLoopErrRe.test(err.message)) {
-    return false;
-  }
-  cy.log('uncaught:exception', err, runnable, promise);
-});
-
 before(() => {
   const bridgePasswordIDP: string = Cypress.env('BRIDGE_HTPASSWD_IDP') || 'test';
   const bridgePasswordUsername: string = Cypress.env('BRIDGE_HTPASSWD_USERNAME') || 'test';

--- a/frontend/packages/integration-tests-cypress/support/index.ts
+++ b/frontend/packages/integration-tests-cypress/support/index.ts
@@ -23,6 +23,12 @@ Cypress.Cookies.debug(true);
 
 Cypress.on('uncaught:exception', (err) => {
   console.error('Uncaught exception', err);
+
+  // ResizeObserver loop errors are non-actionable and can be ignored
+  if (err.message && err.message.includes('ResizeObserver loop')) {
+    return false;
+  }
+
   return true; // test fails
 });
 

--- a/frontend/packages/knative-plugin/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/commands/hooks.ts
@@ -9,16 +9,6 @@ before(() => {
   cy.login(bridgePasswordIDP, bridgePasswordUsername, bridgePasswordPassword);
   cy.document().its('readyState').should('eq', 'complete');
   installKnativeOperatorUsingCLI();
-  //  To ignore the resizeObserverLoopErrors on CI, adding below code
-  const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
-  /* eslint-disable consistent-return */
-  Cypress.on('uncaught:exception', (err, runnable, promise) => {
-    /* returning false here prevents Cypress from failing the test */
-    if (resizeObserverLoopErrRe.test(err.message)) {
-      return false;
-    }
-    cy.log('uncaught:exception', err, runnable, promise);
-  });
 });
 
 beforeEach(() => {

--- a/frontend/packages/shipwright-plugin/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/shipwright-plugin/integration-tests/support/commands/hooks.ts
@@ -1,17 +1,6 @@
 import { checkDeveloperPerspective } from '@console/dev-console/integration-tests/support/pages/functions/checkDeveloperPerspective';
 import { installShipwrightOperatorUsingCLI } from '@console/dev-console/integration-tests/support/pages/functions/installOperatorOnClusterUsingCLI';
 
-//  To ignore the resizeObserverLoopErrors on CI, adding below code
-const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
-/* eslint-disable consistent-return */
-Cypress.on('uncaught:exception', (err, runnable, promise) => {
-  /* returning false here prevents Cypress from failing the test */
-  if (resizeObserverLoopErrRe.test(err.message)) {
-    return false;
-  }
-  cy.log('uncaught:exception', err, runnable, promise);
-});
-
 before(() => {
   cy.exec('../../../../contrib/create-user.sh');
   cy.login();


### PR DESCRIPTION
Since https://github.com/openshift/console/pull/15555 we have been seeing more ResizeObserver-related e2e errors, that don't seem to affect the UI. 

These issues are beyond our control, so let's suppress it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test stability by refining error handling in the test suite to ignore non-actionable errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->