### PR TITLE
OCPBUGS-74647: Fix referenceFor parameter in SubscriptionDetailsPage

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -769,7 +769,11 @@ export const SubscriptionDetailsPage: FC<SubscriptionDetailsPageProps> = (props)
         },
       ]}
       customActionMenu={(kindObj: K8sModel, obj: K8sResourceKind) => (
-        <LazyActionMenu context={{ [referenceFor(kindObj)]: obj }} />
+        <LazyActionMenu
+          context={{
+            [referenceFor(obj)]: obj,
+          }}
+        />
       )}
     />
   );


### PR DESCRIPTION
## After

<img width="1190" height="516" alt="Screenshot 2026-01-29 at 9 54 50 AM" src="https://github.com/user-attachments/assets/b2d184a7-10d5-46a7-ba7d-3320240fc09d" />

## Summary
- Fixed incorrect parameter passed to `referenceFor` function in `SubscriptionDetailsPage`
- Changed from `kindObj` to `obj` to align with proper `referenceFor` usage pattern

## Details
In the `customActionMenu` prop of `SubscriptionDetailsPage`, the `referenceFor` function was being called with `kindObj` instead of `obj`. The `referenceFor` utility expects a resource object, not a kind/model object, so this change ensures the correct parameter is passed.

## Test plan
- [ ] Verify that the Subscription details page loads correctly
- [ ] Verify that the action menu on the Subscription details page functions properly
- [ ] Check that the correct context is passed to `LazyActionMenu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subscription action menu context handling to correctly reference individual objects, improving functionality and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->