### PR TITLE
NO-JIRA: Suppress ResizeObserver-related windowError

### DIFF
--- a/frontend/packages/integration-tests-cypress/support/index.ts
+++ b/frontend/packages/integration-tests-cypress/support/index.ts
@@ -25,7 +25,7 @@ Cypress.on('uncaught:exception', (err) => {
   console.error('Uncaught exception', err);
 
   // ResizeObserver loop errors are non-actionable and can be ignored
-  if (err.message && err.message.includes('ResizeObserver loop')) {
+  if (typeof err.message === 'string' && err.message.includes('ResizeObserver loop')) {
     return false;
   }
 

--- a/frontend/public/components/app.tsx
+++ b/frontend/public/components/app.tsx
@@ -461,6 +461,11 @@ graphQLReady.onReady(() => {
   // Used by GUI tests to check for unhandled exceptions
   window.windowError = null;
   window.onerror = (message, source, lineno, colno, error) => {
+    // ResizeObserver loop errors are non-actionable and can be ignored
+    if (typeof message === 'string' && message.includes('ResizeObserver loop')) {
+      return undefined;
+    }
+
     const formattedStack = error?.stack?.replace(/\\n/g, '\n');
     const formattedMessage = `unhandled error: ${message} ${formattedStack || ''}`;
     window.windowError = `${window.windowError ?? ''};${formattedMessage}`;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for ResizeObserver loop errors to reduce unnecessary console warnings and enhance type safety in error processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->