### PR TITLE
NO-JIRA: Convert useTechPreviewFlagProvider to static function

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -2646,9 +2646,9 @@
     }
   },
   {
-    "type": "console.flag/hookProvider",
+    "type": "console.flag",
     "properties": {
-      "handler": { "$codeRef": "useTechPreviewFlagProvider" }
+      "handler": { "$codeRef": "techPreviewFlag.handler" }
     }
   },
   {

--- a/frontend/packages/console-app/package.json
+++ b/frontend/packages/console-app/package.json
@@ -79,7 +79,7 @@
       "consolePluginBackendDetail": "src/components/console-operator/ConsolePluginBackendDetail.tsx",
       "consolePluginProxyDetail": "src/components/console-operator/ConsolePluginProxyDetail.tsx",
       "getConsoleOperatorConfigFlag": "src/hooks/useCanGetConsoleOperatorConfig.ts",
-      "useTechPreviewFlagProvider": "src/hooks/useTechPreviewFlagProvider.ts",
+      "techPreviewFlag": "src/features/tech-preview.ts",
       "usePerspectivesAvailable": "src/components/user-preferences/perspective/usePerspectivesAvailable.ts",
       "defaultProvider": "src/actions/providers/default-provider.ts",
       "OperatorStatus": "src/components/dashboards-page/OperatorStatus.tsx",

--- a/frontend/packages/console-app/src/features/tech-preview.ts
+++ b/frontend/packages/console-app/src/features/tech-preview.ts
@@ -1,0 +1,6 @@
+import type { FeatureFlagHandler } from '@console/dynamic-plugin-sdk/src/extensions/feature-flags';
+import { FLAG_TECH_PREVIEW } from '../consts';
+
+export const handler: FeatureFlagHandler = (setFeatureFlag) => {
+  setFeatureFlag(FLAG_TECH_PREVIEW, !!window.SERVER_FLAGS.techPreview);
+};

--- a/frontend/packages/console-app/src/hooks/useTechPreviewFlagProvider.ts
+++ b/frontend/packages/console-app/src/hooks/useTechPreviewFlagProvider.ts
@@ -1,9 +1,0 @@
-import { SetFeatureFlag } from '@console/dynamic-plugin-sdk/src/extensions/feature-flags';
-import { FLAG_TECH_PREVIEW } from '../consts';
-
-type UseTechPreviewFlagProvider = (setFeatureFlag: SetFeatureFlag) => void;
-const useTechPreviewFlagProvider: UseTechPreviewFlagProvider = (setFeatureFlag) => {
-  setFeatureFlag(FLAG_TECH_PREVIEW, !!window.SERVER_FLAGS.techPreview);
-};
-
-export default useTechPreviewFlagProvider;


### PR DESCRIPTION
(s3e5 "Initiation")

`window.SERVER_FLAGS` is generated by the backend server and is known to not change. Thus, we do not need a hook and ReactNode for this flag, and we can simplify this to a simple `console.flag` for performance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured tech preview feature flag initialization and registration for improved code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->