### PR TITLE
OCPBUGS-74387: "Import from Git" forces HTTPS, port 443

### DIFF
--- a/frontend/packages/git-service/src/services/gitea-service.ts
+++ b/frontend/packages/git-service/src/services/gitea-service.ts
@@ -62,9 +62,13 @@ export class GiteaService extends BaseService {
   };
 
   getRepoMetadata = (): RepoMetadata => {
-    const { name, owner, resource, full_name: fullName } = GitUrlParse(this.gitsource.url);
+    const { name, owner, protocols, port, resource, full_name: fullName } = GitUrlParse(
+      this.gitsource.url,
+    );
     const contextDir = this.gitsource.contextDir?.replace(/\/$/, '') || '';
-    const host = `https://${resource}`;
+    const host = _.isEmpty(port)
+      ? `${protocols[0]}://${resource}`
+      : `${protocols[0]}://${resource}:${port}`;
     return {
       repoName: name,
       owner,


### PR DESCRIPTION
Make sure "Import from Git" works fine if we specify anything other than HTTPS and port 443 when using Gitea

Fixes https://issues.redhat.com/browse/OCPBUGS-74387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repository connection handling to properly support various Git protocols and custom port configurations instead of defaulting to HTTPS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->