### PR TITLE
OCPBUGS-74974: Use Actions button instead of kebab menu on Subscription details page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -67,6 +67,7 @@ import {
   WarningStatus,
   YellowExclamationTriangleIcon,
 } from '@console/shared';
+import { ActionMenuVariant } from '@console/shared/src/components/actions';
 import { KEBAB_COLUMN_CLASS } from '@console/shared/src/components/actions/LazyActionMenu';
 import { DescriptionListTermHelp } from '@console/shared/src/components/description-list/DescriptionListTermHelp';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';
@@ -773,6 +774,7 @@ export const SubscriptionDetailsPage: FC<SubscriptionDetailsPageProps> = (props)
           context={{
             [referenceFor(obj)]: obj,
           }}
+          variant={ActionMenuVariant.DROPDOWN}
         />
       )}
     />


### PR DESCRIPTION
## Summary
- Updates the Subscription details page to display an Actions button instead of a kebab menu
- Aligns the UI with the Operator details page pattern for consistency

<img width="1109" height="331" alt="Screenshot 2026-02-03 at 8 53 36 AM" src="https://github.com/user-attachments/assets/7ca255a8-e932-40b1-a4fb-cbb0d0a48142" />

## Details
The Subscription details page was displaying a kebab menu (three vertical dots) instead of a proper Actions button. This change updates the `customActionMenu` in `SubscriptionDetailsPage` to use `ActionMenuVariant.DROPDOWN`, which renders as a labeled "Actions" button.

This matches the pattern used on the ClusterServiceVersion (Operator) details page, providing a consistent user experience across the console.

## Changes
- Added import for `ActionMenuVariant` from `@console/shared/src/components/actions`
- Updated `customActionMenu` prop to include `variant={ActionMenuVariant.DROPDOWN}`

## Test plan
- [ ] Install an operator on a cluster to create a Subscription
- [ ] Navigate to Home → Search → Subscriptions
- [ ] Open a Subscription details page
- [ ] Verify that an "Actions" button appears in the page header (not a kebab menu)
- [ ] Click the Actions button and verify the menu opens with available actions
- [ ] Compare with the Operator details page to ensure visual consistency

Fixes: https://issues.redhat.com/browse/OCPBUGS-74974

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the action menu presentation in the subscription details view to display as a dropdown menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->