### PR TITLE
OCPBUGS-74538: User without  access on  causes NamespaceBar to reset to All projects when used via dynamic plugin

### DIFF
--- a/frontend/public/components/namespace-bar.tsx
+++ b/frontend/public/components/namespace-bar.tsx
@@ -63,7 +63,18 @@ export const NamespaceBarDropdowns: FC<NamespaceBarDropdownsProps> = ({
           setActiveNamespaceError(false);
         })
         .catch((err) => {
-          if (err?.response?.status === 404) {
+          if (err?.response?.status === 403 && useProjects) {
+            k8sGet(NamespaceModel, activeNamespace)
+              .then(() => {
+                setActiveNamespace(activeNamespace);
+                setActiveNamespaceError(false);
+              })
+              .catch(() => {
+                /* This would redirect to "/all-namespaces" to show the Project List */
+                setActiveNamespace(ALL_NAMESPACES_KEY);
+                setActiveNamespaceError(true);
+              });
+          } else if (err?.response?.status === 404) {
             /* This would redirect to "/all-namespaces" to show the Project List */
             setActiveNamespace(ALL_NAMESPACES_KEY);
             setActiveNamespaceError(true);


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-74538

Problem:

When a dynamic plugin renders a <NamespaceBar> component and the current user does not have "get" permissions on "projects"s the component performs auth checks that fail, and reset the active namespace to "All projects"

**Fix:** 

https://github.com/user-attachments/assets/43519389-c187-4065-b280-09b4071895cf





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when accessing namespaces in projects mode. The application now performs additional validation when permission errors occur and gracefully falls back to viewing all namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->