### PR TITLE
OCPBUGS-78802: Fix token auth annotation to use opt-in instead of opt-out

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/__tests__/operator-hub-utils.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/__tests__/operator-hub-utils.spec.ts
@@ -481,6 +481,7 @@ describe('getInfrastructureFeatures', () => {
     const result = getInfrastructureFeatures(
       {
         [OLMAnnotation.InfrastructureFeatures]: '["tokenAuth"]',
+        [OLMAnnotation.TokenAuthAWS]: 'true',
       },
       { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
     );
@@ -493,6 +494,7 @@ describe('getInfrastructureFeatures', () => {
     const result = getInfrastructureFeatures(
       {
         [OLMAnnotation.InfrastructureFeatures]: '["TokenAuth"]',
+        [OLMAnnotation.TokenAuthAWS]: 'true',
       },
       { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
     );
@@ -505,6 +507,7 @@ describe('getInfrastructureFeatures', () => {
     const result = getInfrastructureFeatures(
       {
         [OLMAnnotation.InfrastructureFeatures]: '["tokenAuth"]',
+        [OLMAnnotation.TokenAuthAzure]: 'true',
       },
       { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
     );
@@ -517,6 +520,7 @@ describe('getInfrastructureFeatures', () => {
     const result = getInfrastructureFeatures(
       {
         [OLMAnnotation.InfrastructureFeatures]: '["TokenAuth"]',
+        [OLMAnnotation.TokenAuthAzure]: 'true',
       },
       { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
     );
@@ -614,6 +618,30 @@ describe('getInfrastructureFeatures', () => {
       [OLMAnnotation.Disconnected]: 'false',
     });
     expect(result).toEqual([InfrastructureFeature.FIPSMode]);
+  });
+  it(`excludes TokenAuth when token-auth-aws is explicitly false on AWS STS cluster`, () => {
+    const clusterIsAWSSTS = true;
+    const clusterIsAzureWIF = false;
+    const clusterIsGCPWIF = false;
+    const result = getInfrastructureFeatures(
+      {
+        [OLMAnnotation.TokenAuthAWS]: 'false',
+      },
+      { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
+    );
+    expect(result).toEqual([]);
+  });
+  it(`excludes TokenAuth when token-auth-aws annotation is missing on AWS STS cluster`, () => {
+    const clusterIsAWSSTS = true;
+    const clusterIsAzureWIF = false;
+    const clusterIsGCPWIF = false;
+    const result = getInfrastructureFeatures(
+      {
+        [OLMAnnotation.Disconnected]: 'true',
+      },
+      { clusterIsAWSSTS, clusterIsAzureWIF, clusterIsGCPWIF },
+    );
+    expect(result).toEqual([InfrastructureFeature.Disconnected]);
   });
   it(`returns empty array when ${OLMAnnotation.InfrastructureFeatures} is empty`, () => {
     const result = getInfrastructureFeatures({

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.ts
@@ -222,9 +222,9 @@ export const getInfrastructureFeatures: AnnotationParser<
     onError,
   });
   const azureTokenAuthIsSupported =
-    clusterIsAzureWIF && annotations[OLMAnnotation.TokenAuthAzure] !== 'false';
+    clusterIsAzureWIF && annotations[OLMAnnotation.TokenAuthAzure] === 'true';
   const awsTokenAuthIsSupported =
-    clusterIsAWSSTS && annotations[OLMAnnotation.TokenAuthAWS] !== 'false';
+    clusterIsAWSSTS && annotations[OLMAnnotation.TokenAuthAWS] === 'true';
   return [...parsedInfrastructureFeatures, ...Object.keys(annotations ?? {})].reduce(
     (supportedFeatures, key) => {
       const feature = infrastructureFeatureMap[key];


### PR DESCRIPTION
## Summary
Fixes regression where operators without explicit `token-auth-aws: "true"` annotation incorrectly show the ARN role field in the subscription form on AWS STS clusters.

## Problem
Cluster Observability Operator (and similar operators) have `features.operators.openshift.io/token-auth-aws: "false"` but the ARN field was still showing in the subscription form on 4.21, even though it worked correctly in 4.20.

## Root Cause
Regression introduced in commit a931fbdc3b (Sep 9, 2024) during the "Fix JSON annotation parsing issue and harden related code" refactor.

**Before refactor (correct opt-in behavior):**
```javascript
if (tokenAuthAWS === 'true' && isAWSSTSCluster(...)) {
  infrastructureFeatures.push(InfraFeatures.tokenAuth);
}
```

**After refactor (buggy opt-out behavior):**
```typescript
const awsTokenAuthIsSupported =
  clusterIsAWSSTS && annotations[OLMAnnotation.TokenAuthAWS] !== 'false';
```

This changed the logic from opt-in to opt-out:
- ❌ Missing annotation → defaults to supported (shows ARN field)
- ❌ `undefined !== 'false'` → `true` (shows ARN field)
- ✅ `'false' !== 'false'` → `false` (hides ARN field)

## Solution
Restore opt-in behavior by changing condition from `!== 'false'` to `=== 'true'`:

```typescript
const awsTokenAuthIsSupported =
  clusterIsAWSSTS && annotations[OLMAnnotation.TokenAuthAWS] === 'true';
```

Now operators must **explicitly opt-in** by setting the annotation to `"true"` to show credential fields.

## Changes
- Fixed token auth logic for both AWS and Azure annotations in `operator-hub-utils.ts`
- Updated 4 existing tests to include explicit `'true'` annotations
- Added 2 new regression tests:
  - Verifies TokenAuth excluded when annotation is `"false"`
  - Verifies TokenAuth excluded when annotation is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token authentication feature gating logic for AWS STS and Azure workload identity federation clusters to require explicit 'true' configuration values instead of accepting any non-false values.

* **Tests**
  * Added test coverage validating token authentication feature behavior across different cluster configurations and annotation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->