### PR TITLE
OCPBUGS-76328: fix CA/TLS dropdowns namespace in Helm Repository form

### DIFF
--- a/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/CreateHelmChartRepositoryFormEditor.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/CreateHelmChartRepositoryFormEditor.tsx
@@ -113,7 +113,11 @@ const CreateHelmChartRepositoryFormEditor: FC<CreateHelmChartRepositoryFormEdito
               {
                 isList: true,
                 kind: ConfigMapModel.kind,
-                namespace: 'openshift-config',
+                namespace:
+                  formData.scope === 'ProjectHelmChartRepository' ||
+                  existingRepo?.kind === 'ProjectHelmChartRepository'
+                    ? namespace
+                    : 'openshift-config',
                 optional: true,
                 prop: ConfigMapModel.id,
               },
@@ -132,7 +136,11 @@ const CreateHelmChartRepositoryFormEditor: FC<CreateHelmChartRepositoryFormEdito
               {
                 isList: true,
                 kind: SecretModel.kind,
-                namespace: 'openshift-config',
+                namespace:
+                  formData.scope === 'ProjectHelmChartRepository' ||
+                  existingRepo?.kind === 'ProjectHelmChartRepository'
+                    ? namespace
+                    : 'openshift-config',
                 optional: true,
                 prop: SecretModel.id,
               },


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-76328

## Problem
CA Certificate and TLS Client Config dropdowns hardcoded to `openshift-config` namespace. Users couldn't select ConfigMaps/Secrets from their project namespace when creating ProjectHelmChartRepository.

**Screenshot:** Left side shows fixed version listing `helm-repo-ca` from `helm-test` namespace. Right side shows bug - dropdown only shows ConfigMaps from `openshift-config`, missing the user's ConfigMap.

<img width="1844" height="1239" alt="Screenshot 2025-11-25 at 14 05 59 (1)" src="https://github.com/user-attachments/assets/d6418dca-161e-4b37-8369-1648445b6bfe" />


## Fix
Made namespace dynamic:
- **ProjectHelmChartRepository**: uses repo's namespace
- **HelmChartRepository**: uses `openshift-config`

## Testing

```
oc create configmap helm-repo-ca --from-literal=ca-bundle.crt="test" -n helm-test
```

- Create ProjectHelmChartRepository in helm-test namespace
- CA dropdown now shows helm-repo-ca (was missing before)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed namespace resolution for resource dropdowns in the Helm Chart Repository form. ConfigMap and Secret selections now intelligently use the current namespace for project-scoped repositories instead of always defaulting to the system namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->