### PR TITLE
OCPBUGS-76378: fix display of Lightspeed button

### DIFF
--- a/frontend/packages/console-app/src/components/lightspeed/Lightspeed.scss
+++ b/frontend/packages/console-app/src/components/lightspeed/Lightspeed.scss
@@ -20,7 +20,8 @@
 
 .lightspeed__popover {
   border-radius: 12px;
-  border: var(--pf-t--global--border--width--regular) solid var(--pf-t--global--border--color--default);
+  border: var(--pf-t--global--border--width--regular) solid
+    var(--pf-t--global--border--color--default);
   background-color: var(--pf-t--global--background--color--primary--default);
   bottom: var(--popover-bottom);
   overflow: auto;
@@ -72,17 +73,15 @@
 }
 
 .lightspeed__popover-button {
-  background-image: url('logo.svg');
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: calc(var(--popover-button-size) + 3px);
+  background-image: url('logo.svg') !important;
+  background-position: center !important;
+  background-repeat: no-repeat !important;
+  background-size: calc(var(--popover-button-size) + 3px) !important;
   border-radius: var(--popover-border-radius) !important;
   bottom: var(--popover-margin);
-  box-shadow: var(--pf-t--global--box-shadow--lg);
   height: var(--popover-button-size);
   padding: 0;
   position: absolute !important;
-  right: var(--popover-margin);
   width: var(--popover-button-size);
 
   &::after {
@@ -90,7 +89,7 @@
   }
 
   .pf-v6-theme-dark & {
-    background-image: url('logo-dark.svg');
+    background-image: url('logo-dark.svg') !important;
     background-color: var(--pf-t--global--background--color--primary--default) !important;
   }
 }


### PR DESCRIPTION
## After

https://github.com/user-attachments/assets/bafde539-5b8a-4412-9f5f-af03e28f1422

## Summary
- Adds `!important` flags to background-image properties to ensure the Lightspeed logo displays correctly
- Adds `!important` flags to background positioning properties for consistent styling
- Removes `right` property and `box-shadow` that were unnecessarily duplicated

## Test plan
- [ ] Verify the Lightspeed button displays correctly in light mode
- [ ] Verify the Lightspeed button displays correctly in dark mode (uses logo-dark.svg)
- [ ] Verify button positioning is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined styling specificity for the Lightspeed popover button to ensure consistent visual presentation.
  * Updated dark theme styling for the Lightspeed component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->