### PR TITLE
OCPBUGS-74506: Remove ConsolePluginSecurityPolicy featuregate

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -156,7 +156,6 @@ func main() {
 	fPluginProxy := fs.String("plugin-proxy", "", "Defines various service types to which will console proxy plugins requests. (JSON as string)")
 	fI18NamespacesFlags := fs.String("i18n-namespaces", "", "List of namespaces separated by comma. Example --i18n-namespaces=plugin__acm,plugin__kubevirt")
 
-	fContentSecurityPolicyEnabled := fs.Bool("content-security-policy-enabled", true, "Flag to indicate if Content Secrity Policy features should be enabled.")
 	consoleCSPFlags := serverconfig.MultiKeyValue{}
 	fs.Var(&consoleCSPFlags, "content-security-policy", "List of CSP directives that are enabled for the console. Each entry consist of csp-directive-name as a key and csp-directive-value as a value. Example --content-security-policy script-src='localhost:9000',font-src='localhost:9001'")
 
@@ -346,7 +345,6 @@ func main() {
 		EnabledPluginsOrder:          enabledPluginsOrder,
 		I18nNamespaces:               i18nNamespaces,
 		PluginProxy:                  *fPluginProxy,
-		ContentSecurityPolicyEnabled: *fContentSecurityPolicyEnabled,
 		ContentSecurityPolicy:        consoleCSPFlags,
 		QuickStarts:                  *fQuickStarts,
 		AddPage:                      *fAddPage,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -166,7 +166,6 @@ type Server struct {
 	ClusterManagementProxyConfig        *proxy.Config
 	CookieEncryptionKey                 []byte
 	CookieAuthenticationKey             []byte
-	ContentSecurityPolicyEnabled        bool
 	ContentSecurityPolicy               serverconfig.MultiKeyValue
 	ControlPlaneTopology                string
 	CopiedCSVsDisabled                  bool
@@ -719,18 +718,16 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		panic(err)
 	}
 
-	if s.ContentSecurityPolicyEnabled {
-		cspDirectives, err := utils.BuildCSPDirectives(
-			s.K8sMode,
-			s.ContentSecurityPolicy,
-			indexPageScriptNonce,
-			r.Header.Get("Test-CSP-Reporting-Endpoint"),
-		)
-		if err != nil {
-			klog.Fatalf("Error building Content Security Policy directives: %s", err)
-		}
-		w.Header().Set("Content-Security-Policy-Report-Only", strings.Join(cspDirectives, "; "))
+	cspDirectives, err := utils.BuildCSPDirectives(
+		s.K8sMode,
+		s.ContentSecurityPolicy,
+		indexPageScriptNonce,
+		r.Header.Get("Test-CSP-Reporting-Endpoint"),
+	)
+	if err != nil {
+		klog.Fatalf("Error building Content Security Policy directives: %s", err)
 	}
+	w.Header().Set("Content-Security-Policy-Report-Only", strings.Join(cspDirectives, "; "))
 
 	jsg := &jsGlobals{
 		AddPage:                   s.AddPage,

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -178,7 +178,6 @@ func SetFlagsFromConfig(fs *flag.FlagSet, config *Config) (err error) {
 		return err
 	}
 
-	addContentSecurityPolicyEnabled(fs, &config.ContentSecurityPolicyEnabled)
 	addContentSecurityPolicy(fs, config.ContentSecurityPolicy)
 	addTelemetry(fs, config.Telemetry)
 
@@ -479,12 +478,6 @@ func addTelemetry(fs *flag.FlagSet, telemetry MultiKeyValue) {
 
 func addI18nNamespaces(fs *flag.FlagSet, i18nNamespaces []string) {
 	fs.Set("i18n-namespaces", strings.Join(i18nNamespaces, ","))
-}
-
-func addContentSecurityPolicyEnabled(fs *flag.FlagSet, enabled *bool) {
-	if enabled != nil && *enabled {
-		fs.Set("content-security-policy-enabled", "true")
-	}
 }
 
 func SetIfUnset(flagVal *string, val string) {

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -13,23 +13,22 @@ import (
 
 // Config is the top-level console server cli configuration.
 type Config struct {
-	APIVersion                   string `yaml:"apiVersion"`
-	Kind                         string `yaml:"kind"`
-	ServingInfo                  `yaml:"servingInfo"`
-	ClusterInfo                  `yaml:"clusterInfo"`
-	Auth                         `yaml:"auth"`
-	Session                      `yaml:"session"`
-	Customization                `yaml:"customization"`
-	Providers                    `yaml:"providers"`
-	Helm                         `yaml:"helm"`
-	MonitoringInfo               `yaml:"monitoringInfo,omitempty"`
-	Plugins                      MultiKeyValue                        `yaml:"plugins,omitempty"`
-	I18nNamespaces               []string                             `yaml:"i18nNamespaces,omitempty"`
-	Proxy                        Proxy                                `yaml:"proxy,omitempty"`
-	ContentSecurityPolicyEnabled bool                                 `yaml:"contentSecurityPolicyEnabled,omitempty"`
-	ContentSecurityPolicy        map[consolev1.DirectiveType][]string `yaml:"contentSecurityPolicy,omitempty"`
-	Telemetry                    MultiKeyValue                        `yaml:"telemetry,omitempty"`
-	PluginsOrder                 []string                             `yaml:"pluginsOrder,omitempty"`
+	APIVersion            string `yaml:"apiVersion"`
+	Kind                  string `yaml:"kind"`
+	ServingInfo           `yaml:"servingInfo"`
+	ClusterInfo           `yaml:"clusterInfo"`
+	Auth                  `yaml:"auth"`
+	Session               `yaml:"session"`
+	Customization         `yaml:"customization"`
+	Providers             `yaml:"providers"`
+	Helm                  `yaml:"helm"`
+	MonitoringInfo        `yaml:"monitoringInfo,omitempty"`
+	Plugins               MultiKeyValue                        `yaml:"plugins,omitempty"`
+	I18nNamespaces        []string                             `yaml:"i18nNamespaces,omitempty"`
+	Proxy                 Proxy                                `yaml:"proxy,omitempty"`
+	ContentSecurityPolicy map[consolev1.DirectiveType][]string `yaml:"contentSecurityPolicy,omitempty"`
+	Telemetry             MultiKeyValue                        `yaml:"telemetry,omitempty"`
+	PluginsOrder          []string                             `yaml:"pluginsOrder,omitempty"`
 }
 
 type Proxy struct {


### PR DESCRIPTION
This PR needs to get merged together with [console-operator PR](https://github.com/openshift/console-operator/pull/1108) in order to get https://github.com/openshift/api/pull/2683 merged

/assign @TheRealJon 
@spadgett FYI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KMSEncryption feature gate support for API server encryption.
  * Added IBMCloud and External as supported platform types.

* **Deprecations**
  * Removed ConsolePluginContentSecurityPolicy feature gate.

* **Improvements**
  * Enhanced boot image validation rules for automatic mode.
  * Updated API documentation and validation descriptions for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->