### PR TITLE
OCPBUGS-76283: Show modal when downloading pod logs

### DIFF
--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -210,6 +210,7 @@
   "Component trace:": "Component trace:",
   "Stack trace:": "Stack trace:",
   "Show details": "Show details",
+  "The download exceeds the {{size}} processing limit.": "The download exceeds the {{size}} processing limit.",
   "Download canceled": "Download canceled",
   "The download was canceled.": "The download was canceled.",
   "Could not fetch data": "Could not fetch data",

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1526,6 +1526,7 @@
   "Preparing log...": "Preparing log...",
   "Log is ready. <1>Open log manually</1> if it does not open automatically.": "Log is ready. <1>Open log manually</1> if it does not open automatically.",
   "Could not download log. Check your connection and try again.": "Could not download log. Check your connection and try again.",
+  "You can also <1>open the raw log</1> without waiting. Some characters may not display correctly.": "You can also <1>open the raw log</1> without waiting. Some characters may not display correctly.",
   "No selector": "No selector",
   "Premium": "Premium",
   "Standard": "Standard",


### PR DESCRIPTION
Before this update, clicking **View raw logs** when a resource log is very long would cause the console to hang while it logs the logs. With this release, a modal now appears which shows the current log download progress, which also allows cancellation of the download.


https://github.com/user-attachments/assets/fd25286c-19bd-4535-a37a-1a43217b1f2a

