### PR TITLE
OCPBUGS-74557: Fixed Metrics page React error #306 by exporting QueryBrowser component

### DIFF
--- a/frontend/public/components/utils/resource-metrics.tsx
+++ b/frontend/public/components/utils/resource-metrics.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Grid, GridItem, Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 
 import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
-import { QueryBrowser } from '@console/dynamic-plugin-sdk/src/lib-core';
+import { QueryBrowser } from '@console/shared/src/components/query-browser';
 import {
   ResourceUtilizationQuery,
   useResourceMetricsQueries,


### PR DESCRIPTION
<img width="1430" height="700" alt="Screenshot 2026-02-10 at 1 56 57 PM" src="https://github.com/user-attachments/assets/9b11b0c7-b379-4207-9e4d-d8702283626e" />
After:
<img width="1250" height="650" alt="Screenshot 2026-02-10 at 1 56 32 PM" src="https://github.com/user-attachments/assets/f36b835a-ceb0-46bf-9961-d5c6db6a7017" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query browser component is now available in the public API for developers to use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->