### PR TITLE
[release-4.20] OCPBUGS-76543: Use Actions button instead of kebab menu on Subscription details page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -67,6 +67,7 @@ import {
   WarningStatus,
   YellowExclamationTriangleIcon,
 } from '@console/shared';
+import { ActionMenuVariant } from '@console/shared/src/components/actions';
 import { DescriptionListTermHelp } from '@console/shared/src/components/description-list/DescriptionListTermHelp';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';
 import PaneBodyGroup from '@console/shared/src/components/layout/PaneBodyGroup';
@@ -776,6 +777,7 @@ export const SubscriptionDetailsPage: React.FC<SubscriptionDetailsPageProps> = (
           context={{
             [referenceFor(obj)]: obj,
           }}
+          variant={ActionMenuVariant.DROPDOWN}
         />
       )}
     />


### PR DESCRIPTION
The Subscription details page was displaying a kebab menu (three-dot icon) instead of a proper Actions button. This change updates the customActionMenu to use ActionMenuVariant.DROPDOWN, which renders as a labeled "Actions" button, matching the pattern used on the Operator details page.

Fixes: https://issues.redhat.com/browse/OCPBUGS-76543