### PR TITLE
OCPBUGS-76556: fix Developer Sandbox telemetry

### DIFF
--- a/frontend/@types/console/window.d.ts
+++ b/frontend/@types/console/window.d.ts
@@ -49,7 +49,9 @@ declare interface Window {
       /** One of the following should be always available on prod env. */
       SEGMENT_API_KEY: string;
       SEGMENT_PUBLIC_API_KEY: string;
+      // DevSandbox-specific configuration
       DEVSANDBOX_SEGMENT_API_KEY: string;
+      DEVSANDBOX: 'true' | 'false';
       /** Optional override for analytics.min.js script URL */
       SEGMENT_JS_URL: string;
       // Additional telemetry options passed to Console frontend

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/segment-analytics.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/segment-analytics.ts
@@ -1,10 +1,12 @@
 import type { GetSegmentAnalytics } from '../extensions/console-types';
 
 // Segment API key. Must be present for telemetry to be enabled.
+// When running in DevSandbox mode, prefer the DevSandbox-specific key.
 const TELEMETRY_API_KEY =
+  (window.SERVER_FLAGS.telemetry?.DEVSANDBOX === 'true' &&
+    window.SERVER_FLAGS.telemetry?.DEVSANDBOX_SEGMENT_API_KEY) ||
   window.SERVER_FLAGS.telemetry?.SEGMENT_API_KEY ||
   window.SERVER_FLAGS.telemetry?.SEGMENT_PUBLIC_API_KEY ||
-  window.SERVER_FLAGS.telemetry?.DEVSANDBOX_SEGMENT_API_KEY ||
   '';
 
 // Segment "apiHost" parameter, should be like "api.segment.io/v1"

--- a/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
@@ -102,7 +102,7 @@ describe('getClusterProperties', () => {
     expect(getClusterProperties().clusterType).toBe('TEST');
   });
 
-  it('returns DEVSANDBOX when CLUSTER_TYPE is "OSD" but and DEVSANDBOX is "true"', () => {
+  it('returns DEVSANDBOX when DEVSANDBOX is "true" regardless of CLUSTER_TYPE', () => {
     window.SERVER_FLAGS = {
       ...originServerFlags,
       telemetry: { CLUSTER_TYPE: 'OSD', DEVSANDBOX: 'true' },
@@ -110,15 +110,15 @@ describe('getClusterProperties', () => {
     expect(getClusterProperties().clusterType).toBe('DEVSANDBOX');
   });
 
-  it('returns the clusterType that it is configured if CLUSTER_TYPE is not OSD (in the future) but DEVSANDBOX is still "true"', () => {
+  it('returns DEVSANDBOX when DEVSANDBOX is "true" even if CLUSTER_TYPE is a different value', () => {
     window.SERVER_FLAGS = {
       ...originServerFlags,
       telemetry: { CLUSTER_TYPE: 'a_FUTURE_DEVSANDBOX_KEY', DEVSANDBOX: 'true' },
     };
-    expect(getClusterProperties().clusterType).toBe('a_FUTURE_DEVSANDBOX_KEY');
+    expect(getClusterProperties().clusterType).toBe('DEVSANDBOX');
   });
 
-  it('returns the clusterType that it is configured if CLUSTER_TYPE is OSD but DEVSANDBOX is not exactly "true"', () => {
+  it('returns the configured clusterType when DEVSANDBOX is not exactly "true"', () => {
     window.SERVER_FLAGS = {
       ...originServerFlags,
       telemetry: { CLUSTER_TYPE: 'OSD', DEVSANDBOX: 'false' },
@@ -204,7 +204,7 @@ describe('useTelemetry', () => {
     });
   });
 
-  it('calls the listener with clusterType DEVSANDBOX when CLUSTER_TYPE is OSD and DEVSANDBOX is "true"', () => {
+  it('calls the listener with clusterType DEVSANDBOX when DEVSANDBOX is "true"', () => {
     window.SERVER_FLAGS = {
       ...originServerFlags,
       consoleVersion: 'x.y.z',

--- a/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
@@ -105,7 +105,7 @@ describe('getClusterProperties', () => {
   it('returns DEVSANDBOX when DEVSANDBOX is "true" regardless of CLUSTER_TYPE', () => {
     window.SERVER_FLAGS = {
       ...originServerFlags,
-      telemetry: { CLUSTER_TYPE: 'OSD', DEVSANDBOX: 'true' },
+      telemetry: { CLUSTER_TYPE: 'ROSA', DEVSANDBOX: 'true' },
     };
     expect(getClusterProperties().clusterType).toBe('DEVSANDBOX');
   });
@@ -121,9 +121,9 @@ describe('getClusterProperties', () => {
   it('returns the configured clusterType when DEVSANDBOX is not exactly "true"', () => {
     window.SERVER_FLAGS = {
       ...originServerFlags,
-      telemetry: { CLUSTER_TYPE: 'OSD', DEVSANDBOX: 'false' },
+      telemetry: { CLUSTER_TYPE: 'ROSA', DEVSANDBOX: 'false' },
     };
-    expect(getClusterProperties().clusterType).toBe('OSD');
+    expect(getClusterProperties().clusterType).toBe('ROSA');
   });
 });
 
@@ -209,7 +209,7 @@ describe('useTelemetry', () => {
       ...originServerFlags,
       consoleVersion: 'x.y.z',
       telemetry: {
-        CLUSTER_TYPE: 'OSD',
+        CLUSTER_TYPE: 'ROSA',
         DEVSANDBOX: 'true',
         STATE: CLUSTER_TELEMETRY_ANALYTICS.ENFORCE,
       },

--- a/frontend/packages/console-shared/src/hooks/useTelemetry.ts
+++ b/frontend/packages/console-shared/src/hooks/useTelemetry.ts
@@ -39,10 +39,7 @@ export const getClusterProperties = () => {
   const clusterProperties: ClusterProperties = {};
   clusterProperties.clusterId = window.SERVER_FLAGS.telemetry?.CLUSTER_ID;
   clusterProperties.clusterType = window.SERVER_FLAGS.telemetry?.CLUSTER_TYPE;
-  if (
-    window.SERVER_FLAGS.telemetry?.CLUSTER_TYPE === 'OSD' &&
-    window.SERVER_FLAGS.telemetry?.DEVSANDBOX === 'true'
-  ) {
+  if (window.SERVER_FLAGS.telemetry?.DEVSANDBOX === 'true') {
     clusterProperties.clusterType = 'DEVSANDBOX';
   }
   // Prefer to report the OCP version (releaseVersion) if available.


### PR DESCRIPTION
This PR is fixing this issue: https://issues.redhat.com/browse/OCPBUGS-76556

## Context
The special DevSandbox telemetry is not being properly used in the Developer Sandbox clusters. This is caused by two things:

1. Developer Sandbox clusters were migrated from OSD to ROSA, thus the current if statement https://github.com/openshift/console/blob/a00af1a77a8a85f558733609a6dd8b258b1a6348/frontend/packages/console-shared/src/hooks/useTelemetry.ts#L44 is not applicable anymore. As a result, the cluster type is not marked as DEVSANDBOX, which means that any other DevSandbox-specific logic is not applied: https://github.com/openshift/console/blob/a00af1a77a8a85f558733609a6dd8b258b1a6348/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts#L68-L74

2. The priority of loading the telemetry keys has been changed so the `DEVSANDBOX_SEGMENT_API_KEY` is loaded as the last one - see: https://github.com/openshift/console/blob/aa30da36c804d9e523f51902ae123c02586551cc/frontend/packages/console-dynamic-plugin-sdk/src/api/segment-analytics.ts#L4-L7
However, since the managed ROSA clusters already come with the `SEGMENT_API_KEY` set (set by SD team and we cannot do anything with it), then the `DEVSANDBOX_SEGMENT_API_KEY` is never used.
The priority of the keys was changed in this commit https://github.com/openshift/console/commit/56139d0778e22d7c1dd428ce025800cb30d7006f

## Changes
This PR does the following:
* drops the condition relying on specific cluster type - having `telemetry.console.openshift.io/DEVSANDBOX: true` should be sufficient
* changes the priority of loading the telemetry api key so when `DEVSANDBOX: true` then it uses the `DEVSANDBOX_SEGMENT_API_KEY` (if set)

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved telemetry configuration for DevSandbox environments: when DevSandbox mode is enabled, the DevSandbox-specific analytics key is used and cluster type is reported as DEVSANDBOX, ensuring consistent environment identification.
  * Extended telemetry settings to recognize DevSandbox-specific flags.

* **Tests**
  * Updated telemetry tests to validate DevSandbox precedence, confirming cluster type is DEVSANDBOX when enabled regardless of other cluster settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->