### PR TITLE
CONSOLE-5049: Migrate DeleteResourceModal to useOverlay pattern

### DIFF
--- a/frontend/packages/console-shared/src/components/modals/DeleteResourceModal.tsx
+++ b/frontend/packages/console-shared/src/components/modals/DeleteResourceModal.tsx
@@ -4,27 +4,18 @@ import type { FormikProps, FormikValues } from 'formik';
 import { Formik } from 'formik';
 import { useTranslation, Trans } from 'react-i18next';
 import { useNavigate } from 'react-router-dom-v5-compat';
+import type { OverlayComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/OverlayProvider';
 import {
-  createModalLauncher,
   ModalTitle,
   ModalBody,
   ModalSubmitFooter,
+  ModalWrapper,
 } from '@console/internal/components/factory/modal';
 import type { K8sResourceKind } from '@console/internal/module/k8s';
+import type { ModalComponentProps } from '@console/internal/components/factory/modal';
 import { usePromiseHandler } from '../../hooks/promise-handler';
 import { InputField } from '../formik-fields';
 import { YellowExclamationTriangleIcon } from '../status';
-
-type DeleteResourceModalProps = {
-  resourceName: string;
-  resourceType: string;
-  actionLabel?: string; // Used to send translated strings as action label.
-  actionLabelKey?: string; // Used to send translation key for action label.
-  redirect?: string;
-  onSubmit: (values: FormikValues) => Promise<K8sResourceKind[]>;
-  cancel?: () => void;
-  close?: () => void;
-};
 
 const DeleteResourceForm: FC<FormikProps<FormikValues> & DeleteResourceModalProps> = ({
   handleSubmit,
@@ -84,7 +75,9 @@ const DeleteResourceModal: FC<DeleteResourceModalProps> = (props) => {
       handlePromise(onSubmit(values))
         .then(() => {
           close();
-          redirect && navigate(redirect);
+          if (redirect) {
+            navigate(redirect);
+          }
         })
         .catch((errorMessage) => {
           actions.setStatus({ submitError: errorMessage });
@@ -103,6 +96,28 @@ const DeleteResourceModal: FC<DeleteResourceModalProps> = (props) => {
   );
 };
 
-export const deleteResourceModal = createModalLauncher((props: DeleteResourceModalProps) => (
-  <DeleteResourceModal {...props} />
-));
+export const DeleteResourceModalOverlay: OverlayComponent<DeleteResourceModalProps> = (props) => {
+  return (
+    <ModalWrapper blocking onClose={props.closeOverlay}>
+      <DeleteResourceModal
+        close={props.closeOverlay}
+        cancel={props.closeOverlay}
+        resourceName={props.resourceName}
+        resourceType={props.resourceType}
+        actionLabel={props.actionLabel}
+        actionLabelKey={props.actionLabelKey}
+        redirect={props.redirect}
+        onSubmit={props.onSubmit}
+      />
+    </ModalWrapper>
+  );
+};
+
+type DeleteResourceModalProps = ModalComponentProps & {
+  resourceName: string;
+  resourceType: string;
+  actionLabel?: string; // Used to send translated strings as action label.
+  actionLabelKey?: string; // Used to send translation key for action label.
+  redirect?: string;
+  onSubmit: (values: FormikValues) => Promise<K8sResourceKind[]>;
+};

--- a/frontend/packages/console-shared/src/components/modals/DeleteResourceModal.tsx
+++ b/frontend/packages/console-shared/src/components/modals/DeleteResourceModal.tsx
@@ -11,8 +11,8 @@ import {
   ModalSubmitFooter,
   ModalWrapper,
 } from '@console/internal/components/factory/modal';
-import type { K8sResourceKind } from '@console/internal/module/k8s';
 import type { ModalComponentProps } from '@console/internal/components/factory/modal';
+import type { K8sResourceKind } from '@console/internal/module/k8s';
 import { usePromiseHandler } from '../../hooks/promise-handler';
 import { InputField } from '../formik-fields';
 import { YellowExclamationTriangleIcon } from '../status';
@@ -99,16 +99,7 @@ const DeleteResourceModal: FC<DeleteResourceModalProps> = (props) => {
 export const DeleteResourceModalOverlay: OverlayComponent<DeleteResourceModalProps> = (props) => {
   return (
     <ModalWrapper blocking onClose={props.closeOverlay}>
-      <DeleteResourceModal
-        close={props.closeOverlay}
-        cancel={props.closeOverlay}
-        resourceName={props.resourceName}
-        resourceType={props.resourceType}
-        actionLabel={props.actionLabel}
-        actionLabelKey={props.actionLabelKey}
-        redirect={props.redirect}
-        onSubmit={props.onSubmit}
-      />
+      <DeleteResourceModal {...props} close={props.closeOverlay} cancel={props.closeOverlay} />
     </ModalWrapper>
   );
 };

--- a/frontend/packages/console-shared/src/components/modals/index.ts
+++ b/frontend/packages/console-shared/src/components/modals/index.ts
@@ -8,7 +8,7 @@ export const LazyConsolePluginModalOverlay = lazy(() =>
 );
 
 export const LazyDeleteResourceModalOverlay = lazy(() =>
-  import('./DeleteResourceModal' /* webpackChunkName: "delete-resource-modal" */).then((m) => ({
+  import('./DeleteResourceModal' /* webpackChunkName: "shared-modals" */).then((m) => ({
     default: m.DeleteResourceModalOverlay,
   })),
 );

--- a/frontend/packages/console-shared/src/components/modals/index.ts
+++ b/frontend/packages/console-shared/src/components/modals/index.ts
@@ -7,7 +7,8 @@ export const LazyConsolePluginModalOverlay = lazy(() =>
   })),
 );
 
-export const deleteResourceModal = (props) =>
-  import('./DeleteResourceModal' /* webpackChunkName: "shared-modals" */).then((m) =>
-    m.deleteResourceModal(props),
-  );
+export const LazyDeleteResourceModalOverlay = lazy(() =>
+  import('./DeleteResourceModal' /* webpackChunkName: "delete-resource-modal" */).then((m) => ({
+    default: m.DeleteResourceModalOverlay,
+  })),
+);

--- a/frontend/packages/dev-console/src/actions/context-menu.ts
+++ b/frontend/packages/dev-console/src/actions/context-menu.ts
@@ -1,42 +1,49 @@
 import { useMemo } from 'react';
-import i18next from 'i18next';
 import { useTranslation } from 'react-i18next';
 import type { Action, K8sModel } from '@console/dynamic-plugin-sdk';
 import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import type { TopologyApplicationObject } from '@console/dynamic-plugin-sdk/src/extensions/topology-types';
 import { LazyDeleteModalOverlay } from '@console/internal/components/modals';
 import { asAccessReview } from '@console/internal/components/utils';
-import type { K8sResourceKind } from '@console/internal/module/k8s';
-import { deleteResourceModal } from '@console/shared';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { LazyDeleteResourceModalOverlay } from '@console/shared';
 import { ApplicationModel } from '@console/topology/src/models';
 import { cleanUpWorkload } from '@console/topology/src/utils';
 
-export const DeleteApplicationAction = (
+export const useDeleteApplicationAction = (
   application: TopologyApplicationObject,
   resourceModel: K8sModel,
 ): Action => {
-  // accessReview needs a resource but group is not a k8s resource,
-  // so currently picking the first resource to do the rbac checks (might change in future)
-  const primaryResource = application.resources[0].resource;
-  return {
-    id: 'delete-application',
-    label: i18next.t('devconsole~Delete application'),
-    cta: () => {
-      const reqs = [];
-      deleteResourceModal({
-        blocking: true,
-        resourceName: application.name,
-        resourceType: ApplicationModel.label,
-        onSubmit: () => {
-          application.resources.forEach((resource) => {
-            reqs.push(cleanUpWorkload(resource.resource));
-          });
-          return Promise.all(reqs);
-        },
-      });
-    },
-    accessReview: asAccessReview(resourceModel, primaryResource, 'delete'),
-  };
+  const { t } = useTranslation();
+  const launchModal = useOverlay();
+
+  return useMemo(() => {
+    if (!application?.resources?.[0]?.resource) {
+      return null;
+    }
+
+    // accessReview needs a resource but group is not a k8s resource,
+    // so currently picking the first resource to do the rbac checks (might change in future)
+    const primaryResource = application.resources[0].resource;
+    return {
+      id: 'delete-application',
+      label: t('devconsole~Delete application'),
+      cta: () => {
+        const reqs = [];
+        launchModal(LazyDeleteResourceModalOverlay, {
+          resourceName: application.name,
+          resourceType: ApplicationModel.label,
+          onSubmit: () => {
+            application.resources.forEach((resource) => {
+              reqs.push(cleanUpWorkload(resource.resource));
+            });
+            return Promise.all(reqs);
+          },
+        });
+      },
+      accessReview: asAccessReview(resourceModel, primaryResource, 'delete'),
+    };
+  }, [application, resourceModel, t, launchModal]);
 };
 
 export const useDeleteResourceAction = (

--- a/frontend/packages/dev-console/src/actions/context-menu.ts
+++ b/frontend/packages/dev-console/src/actions/context-menu.ts
@@ -5,7 +5,7 @@ import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/us
 import type { TopologyApplicationObject } from '@console/dynamic-plugin-sdk/src/extensions/topology-types';
 import { LazyDeleteModalOverlay } from '@console/internal/components/modals';
 import { asAccessReview } from '@console/internal/components/utils';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import type { K8sResourceKind } from '@console/internal/module/k8s';
 import { LazyDeleteResourceModalOverlay } from '@console/shared';
 import { ApplicationModel } from '@console/topology/src/models';
 import { cleanUpWorkload } from '@console/topology/src/utils';
@@ -13,7 +13,7 @@ import { cleanUpWorkload } from '@console/topology/src/utils';
 export const useDeleteApplicationAction = (
   application: TopologyApplicationObject,
   resourceModel: K8sModel,
-): Action => {
+): Action | null => {
   const { t } = useTranslation();
   const launchModal = useOverlay();
 

--- a/frontend/packages/dev-console/src/actions/providers.tsx
+++ b/frontend/packages/dev-console/src/actions/providers.tsx
@@ -34,7 +34,7 @@ import {
   ADD_TO_PROJECT,
 } from '../const';
 import { AddActions, disabledActionsFilter } from './add-resources';
-import { DeleteApplicationAction } from './context-menu';
+import { useDeleteApplicationAction } from './context-menu';
 import { EditImportApplication } from './creators';
 
 type TopologyActionProvider = (data: {
@@ -295,6 +295,7 @@ export const useTopologyApplicationActionProvider: TopologyActionProvider = ({
   );
   const primaryResource = appData.resources?.[0]?.resource || {};
   const [kindObj, inFlight] = useK8sModel(referenceFor(primaryResource));
+  const deleteApplicationAction = useDeleteApplicationAction(appData, kindObj);
 
   return useMemo(() => {
     if (element.getType() === TYPE_APPLICATION_GROUP) {
@@ -305,7 +306,7 @@ export const useTopologyApplicationActionProvider: TopologyActionProvider = ({
         ? `${referenceFor(sourceObj)}/${sourceObj?.metadata?.name}`
         : undefined;
       const actions = [
-        ...(connectorSource ? [] : [DeleteApplicationAction(appData, kindObj)]),
+        ...(connectorSource ? [] : [deleteApplicationAction]),
         AddActions.FromGit(namespace, application, sourceReference, path, !isImportResourceAccess),
         AddActions.ContainerImage(
           namespace,
@@ -352,13 +353,12 @@ export const useTopologyApplicationActionProvider: TopologyActionProvider = ({
     element,
     inFlight,
     connectorSource,
-    appData,
-    kindObj,
     namespace,
     application,
     isImportResourceAccess,
     isCatalogImageResourceAccess,
     isServerlessEnabled,
     isJavaImageStreamEnabled,
+    deleteApplicationAction,
   ]);
 };

--- a/frontend/packages/helm-plugin/src/actions/creators.ts
+++ b/frontend/packages/helm-plugin/src/actions/creators.ts
@@ -1,23 +1,20 @@
 import { useMemo } from 'react';
-import { TFunction } from 'i18next';
-import { Action, K8sKind } from '@console/dynamic-plugin-sdk';
+import type { TFunction } from 'i18next';
+import type { Action, K8sKind } from '@console/dynamic-plugin-sdk';
 import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import { coFetchJSON } from '@console/internal/co-fetch';
-import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
+import type { K8sResourceKind } from '@console/internal/module/k8s';
+import { referenceFor } from '@console/internal/module/k8s';
 import { LazyDeleteResourceModalOverlay } from '@console/shared';
 import { ProjectHelmChartRepositoryModel } from '../models';
 import type { HelmActionsScope } from './types';
 
-export const useHelmDeleteAction = (scope: HelmActionsScope, t: TFunction): Action => {
+export const useHelmDeleteAction = (scope: HelmActionsScope, t: TFunction): Action | null => {
   const launchModal = useOverlay();
 
   return useMemo(() => {
     if (!scope?.release) {
-      return {
-        id: 'delete-helm',
-        label: t('helm-plugin~Delete Helm Release'),
-        cta: () => {},
-      };
+      return null;
     }
 
     const {

--- a/frontend/packages/helm-plugin/src/actions/creators.ts
+++ b/frontend/packages/helm-plugin/src/actions/creators.ts
@@ -1,39 +1,52 @@
-import type { TFunction } from 'i18next';
-import type { Action, K8sKind } from '@console/dynamic-plugin-sdk';
+import { useMemo } from 'react';
+import { TFunction } from 'i18next';
+import { Action, K8sKind } from '@console/dynamic-plugin-sdk';
+import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import { coFetchJSON } from '@console/internal/co-fetch';
-import type { K8sResourceKind } from '@console/internal/module/k8s';
-import { referenceFor } from '@console/internal/module/k8s';
-import { deleteResourceModal } from '@console/shared';
+import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
+import { LazyDeleteResourceModalOverlay } from '@console/shared';
 import { ProjectHelmChartRepositoryModel } from '../models';
 import type { HelmActionsScope } from './types';
 
-export const getHelmDeleteAction = (
-  {
-    release: { name: releaseName, namespace, version: releaseVersion },
-    redirect,
-  }: HelmActionsScope,
-  t: TFunction,
-): Action => ({
-  id: 'delete-helm',
-  label: t('helm-plugin~Delete Helm Release'),
-  cta: () => {
-    deleteResourceModal({
-      blocking: true,
-      resourceName: releaseName,
-      resourceType: 'Helm Release',
-      actionLabel: t('helm-plugin~Delete'),
+export const useHelmDeleteAction = (scope: HelmActionsScope, t: TFunction): Action => {
+  const launchModal = useOverlay();
+
+  return useMemo(() => {
+    if (!scope?.release) {
+      return {
+        id: 'delete-helm',
+        label: t('helm-plugin~Delete Helm Release'),
+        cta: () => {},
+      };
+    }
+
+    const {
+      release: { name: releaseName, namespace, version: releaseVersion },
       redirect,
-      onSubmit: () => {
-        return coFetchJSON.delete(
-          `/api/helm/release/async?name=${releaseName}&ns=${namespace}&version=${releaseVersion}`,
-          null,
-          null,
-          -1,
-        );
+    } = scope;
+
+    return {
+      id: 'delete-helm',
+      label: t('helm-plugin~Delete Helm Release'),
+      cta: () => {
+        launchModal(LazyDeleteResourceModalOverlay, {
+          resourceName: releaseName,
+          resourceType: 'Helm Release',
+          actionLabel: t('helm-plugin~Delete'),
+          redirect,
+          onSubmit: () => {
+            return coFetchJSON.delete(
+              `/api/helm/release/async?name=${releaseName}&ns=${namespace}&version=${releaseVersion}`,
+              null,
+              null,
+              -1,
+            );
+          },
+        });
       },
-    });
-  },
-});
+    };
+  }, [scope, t, launchModal]);
+};
 
 export const getHelmUpgradeAction = (
   { release: { name: releaseName, namespace }, actionOrigin }: HelmActionsScope,

--- a/frontend/packages/helm-plugin/src/actions/providers.ts
+++ b/frontend/packages/helm-plugin/src/actions/providers.ts
@@ -20,7 +20,7 @@ import { TYPE_HELM_RELEASE } from '../topology/components/const';
 import { HelmReleaseStatus } from '../types/helm-types';
 import { AddHelmChartAction } from './add-resources';
 import {
-  getHelmDeleteAction,
+  useHelmDeleteAction,
   getHelmRollbackAction,
   getHelmUpgradeAction,
   editChartRepository,
@@ -29,25 +29,26 @@ import type { HelmActionsScope } from './types';
 
 export const useHelmActionProvider = (scope: HelmActionsScope) => {
   const { t } = useTranslation();
+  const helmDeleteAction = useHelmDeleteAction(scope, t);
   const result = useMemo(() => {
     if (!scope) return [[], true, undefined];
     switch (scope?.release?.info?.status) {
       case HelmReleaseStatus.PendingInstall:
       case HelmReleaseStatus.PendingRollback:
       case HelmReleaseStatus.PendingUpgrade:
-        return [[getHelmDeleteAction(scope, t)], true, undefined];
+        return [[helmDeleteAction], true, undefined];
       default:
         return [
           [
             getHelmUpgradeAction(scope, t),
             ...(Number(scope.release.version) > 1 ? [getHelmRollbackAction(scope, t)] : []),
-            getHelmDeleteAction(scope, t),
+            helmDeleteAction,
           ],
           true,
           undefined,
         ];
     }
-  }, [scope, t]);
+  }, [scope, t, helmDeleteAction]);
   return result;
 };
 

--- a/frontend/packages/helm-plugin/src/actions/types.ts
+++ b/frontend/packages/helm-plugin/src/actions/types.ts
@@ -10,5 +10,5 @@ type HelmActionObj = {
 export type HelmActionsScope = {
   release: HelmRelease | HelmActionObj;
   actionOrigin?: string;
-  redirect?: boolean;
+  redirect?: string;
 };


### PR DESCRIPTION
This pull request migrates `DeleteResourceModal` from the legacy `createModalLauncher` pattern and React Router v5 `history.push()` to the modern `OverlayComponent` pattern with `useNavigate()`. This migration is part of **CONSOLE-5012** (modal migration) and removes blockers for the **React Router v7 upgrade** ([CONSOLE-5049](https://issues.redhat.com/browse/CONSOLE-5049)).

### Changes Made

#### Modal Migrated

**DeleteResourceModal** - Shared modal for deleting operator-managed resources
- Migrated from `createModalLauncher` to `OverlayComponent` pattern
- Replaced React Router v5 `history.push()` with `useNavigate()` hook
- Added lazy-loading with code splitting
- Wrapped in `ModalWrapper` for consistent overlay behavior

#### Files Modified

**1. Console Shared Package (2 files)**

`packages/console-shared/src/components/modals/DeleteResourceModal.tsx`
- Removed `createModalLauncher` import and export
- Added `useNavigate` hook from `react-router-dom-v5-compat`
- Added `OverlayComponent` type import
- Exported `DeleteResourceModalOverlay` component wrapping modal in `ModalWrapper`
- Updated type definition to extend `ModalComponentProps`
- Replaced `history.push(redirect)` with `navigate(redirect)`

`packages/console-shared/src/components/modals/index.ts`
- Removed legacy `deleteResourceModal` export
- Added `LazyDeleteResourceModalOverlay` lazy-loaded export
- Maintained `shared-modals` webpack chunk name for code splitting

**2. Dev Console Package (2 files)**

`packages/dev-console/src/actions/context-menu.ts`
- Converted `DeleteApplicationAction` function to `useDeleteApplicationAction` hook
- Added `useOverlay()` and `useTranslation()` hooks
- Wrapped action creation in `useMemo` for proper memoization
- Updated to use `launchModal(LazyDeleteResourceModalOverlay, {...})`
- Added null guard: returns `null` if application resources are missing

`packages/dev-console/src/actions/providers.tsx`
- Updated import from `DeleteApplicationAction` to `useDeleteApplicationAction`
- Called hook to get memoized action: `const deleteApplicationAction = useDeleteApplicationAction(appData, kindObj)`
- Updated action array to spread `deleteApplicationAction` instead of calling factory

**3. Helm Plugin Package (3 files)**

`packages/helm-plugin/src/actions/creators.ts`
- Converted `getHelmDeleteAction` function to `useHelmDeleteAction` hook
- Added `useOverlay()` and `useTranslation()` hooks
- Wrapped action creation in `useMemo` with proper dependencies
- Updated to use `launchModal(LazyDeleteResourceModalOverlay, {...})`
- Removed direct `i18next.t()` calls in favor of hook-based `t()`

`packages/helm-plugin/src/actions/providers.ts`
- Updated import from `getHelmDeleteAction` to `useHelmDeleteAction`
- Called hook to get memoized action: `const deleteAction = useHelmDeleteAction(...)`
- Updated `useMemo` dependency array to include `deleteAction`

`packages/helm-plugin/src/actions/types.ts`
- Changed `redirect` type from `boolean` to `string`
- Aligns with actual usage of redirect URLs throughout the codebase

### Technical Implementation

#### Migration Pattern

**Before (Legacy Pattern):**
```typescript
deleteResourceModal({
  resourceName: name,
  resourceType: type,
  onSubmit: () => Promise.resolve(),
});
```

**After (Modern Pattern):**
```typescript
const launchModal = useOverlay();
launchModal(LazyDeleteResourceModalOverlay, {
  resourceName: name,
  resourceType: type,
  onSubmit: () => Promise.resolve(),
});
```

#### Router Migration

**Before (React Router v5):**
```typescript
import { history } from '@console/internal/components/utils/router';
history.push(redirect);
```

**After (React Router v6 compatibility):**
```typescript
import { useNavigate } from 'react-router-dom-v5-compat';
const navigate = useNavigate();
navigate(redirect);
```

### Benefits

- ✅ **React Router v7 Ready** - No longer depends on `history.push()`
- ✅ **Consistent Modal Pattern** - Follows established `OverlayComponent` pattern
- ✅ **Code Splitting** - Lazy loading reduces initial bundle size
- ✅ **Type Safety** - Proper TypeScript integration with `ModalComponentProps`
- ✅ **Hook-based** - Modern React patterns with proper memoization
- ✅ **Null Safety** - Guards against missing application resources

### Testing

Manual testing verified:
- Delete application action in topology view
- Delete Helm release action
- Modal launches correctly with overlay
- Navigation after deletion works with `useNavigate()`
- Null guard prevents broken menu items when resources are missing

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling during resource deletion to prevent application crashes.
  * Fixed menu item rendering when application resources are missing.

* **Refactor**
  * Improved navigation reliability after completing deletion operations using React Router v6 hooks.
  * Optimized performance of modal components through lazy-loading enhancements.
  * Modernized internal modal architecture for better maintainability and stability.
  * Migrated action creators to React hooks pattern for better memoization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
