### PR TITLE
OCPBUGS-70273: Prevent binary secret data corruption when editing

### DIFF
--- a/frontend/packages/integration-tests/tests/crud/secrets/key-value.cy.ts
+++ b/frontend/packages/integration-tests/tests/crud/secrets/key-value.cy.ts
@@ -157,4 +157,62 @@ data:
     secrets.detailsPageIsLoaded(tlsSecretName);
     secrets.checkKeyValueExist('keyfortest', 'valuefortest');
   });
+
+  it('Validate editing text field does not corrupt binary data (OCPBUGS-70273)', () => {
+    const mixedSecretName = `key-value-mixed-secret-${testName}`;
+    const textKey = 'textfield';
+    const textValue = 'original-password';
+    const updatedTextValue = 'updated-password';
+    const binaryKey = 'binaryfield';
+
+    // Create a secret with both text and binary data using CLI
+    cy.exec(
+      `oc create secret generic ${mixedSecretName} -n ${testName} --from-literal=${textKey}=${textValue} --from-file=${binaryKey}=${Cypress.config(
+        'fileServerFolder',
+      )}/fixtures/${binaryFilename}`,
+    );
+
+    // Capture the original binary data
+    cy.exec(
+      `oc get secret -n ${testName} ${mixedSecretName} --template '{{.data.${binaryKey}}}'`,
+    ).then((originalBinary) => {
+      // Edit the secret via the console
+      cy.visit(`/k8s/ns/${testName}/secrets/${mixedSecretName}`);
+      detailsPage.isLoaded();
+      detailsPage.clickPageActionFromDropdown('Edit Secret');
+
+      // Modify only the text field
+      cy.byTestID('secret-key')
+        .should('have.length', 2)
+        .each(($el) => {
+          if ($el.val() === textKey) {
+            // Find the corresponding value textarea and update it
+            cy.byLegacyTestID('file-input-textarea').first().clear().type(updatedTextValue);
+          }
+        });
+
+      // Verify binary field shows the binary alert (indicates it's still treated as binary)
+      cy.byTestID('file-input-binary-alert').should('exist');
+
+      secrets.save();
+      cy.byTestID('loading-indicator').should('not.exist');
+      detailsPage.isLoaded();
+
+      // Verify the text field was updated
+      secrets.clickRevealValues();
+      cy.byTestID('copy-to-clipboard').should('contain.text', updatedTextValue);
+
+      // Verify the binary data was NOT corrupted
+      cy.exec(
+        `oc get secret -n ${testName} ${mixedSecretName} --template '{{.data.${binaryKey}}}'`,
+      ).then((updatedBinary) => {
+        expect(updatedBinary.stdout).to.equal(originalBinary.stdout);
+      });
+
+      // Cleanup
+      cy.exec(`oc delete secret -n ${testName} ${mixedSecretName}`, {
+        failOnNonZeroExit: false,
+      });
+    });
+  });
 });

--- a/frontend/public/components/secrets/create-secret/OpaqueSecretFormEntry.tsx
+++ b/frontend/public/components/secrets/create-secret/OpaqueSecretFormEntry.tsx
@@ -62,7 +62,8 @@ export const OpaqueSecretFormEntry: FC<OpaqueSecretFormEntryProps> = ({
       </FormGroup>
       <DroppableFileInput
         onChange={handleValueChange}
-        inputFileData={Base64.decode(entry.value)}
+        inputFileData={entry.isBinary_ ? entry.value : Base64.decode(entry.value)}
+        isBase64Input={entry.isBinary_}
         id={`${entry.uid}-value`}
         label={t('public~Value')}
         filenamePlaceholder={t(

--- a/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
+++ b/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import * as _ from 'lodash';
-import { useState, FormEvent } from 'react';
+import { useState, useMemo, FormEvent } from 'react';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
 import { useTranslation } from 'react-i18next';
 import { Base64 } from 'js-base64';
@@ -67,6 +67,17 @@ export const SecretFormWrapper: FC<BaseEditSecretProps_> = (props) => {
       return acc;
     }, {}),
   );
+  // Store binary data separately to preserve it during edits
+  const binaryData = useMemo(
+    () =>
+      Object.entries(props.obj?.data ?? {}).reduce<Record<string, string>>((acc, [key, value]) => {
+        if (isBinary(null, Buffer.from(value, 'base64'))) {
+          acc[key] = value;
+        }
+        return acc;
+      }, {}),
+    [props.obj?.data],
+  );
   const [base64StringData, setBase64StringData] = useState(props?.obj?.data ?? {});
   const [disableForm, setDisableForm] = useState(false);
   const title = useSecretTitle(isCreate, formType);
@@ -75,7 +86,20 @@ export const SecretFormWrapper: FC<BaseEditSecretProps_> = (props) => {
 
   const onDataChanged = (secretsData) => {
     setStringData({ ...secretsData?.stringData });
-    setBase64StringData({ ...secretsData?.base64StringData });
+    // Preserve binary values by merging them with form data
+    // Only backfill missing keys from binaryData, don't overwrite edited entries
+    const mergedData = Object.entries(binaryData).reduce(
+      (acc, [key, value]) => {
+        // Only add binary entry if it's missing from form data
+        if (acc[key] === undefined) {
+          acc[key] = value;
+        }
+        // Otherwise keep the existing value from form data
+        return acc;
+      },
+      { ...secretsData?.base64StringData },
+    );
+    setBase64StringData(mergedData);
   };
 
   const onError = (err) => {

--- a/frontend/public/components/utils/file-input.tsx
+++ b/frontend/public/components/utils/file-input.tsx
@@ -25,6 +25,8 @@ const MAX_UPLOAD_SIZE = 4000000;
 export interface DroppableFileInputProps {
   /** The content of the input file, either as a UTF-8 string or a base64-encoded string if the file is binary */
   inputFileData: string;
+  /** Whether inputFileData is base64-encoded (true) or UTF-8 text (false) */
+  isBase64Input?: boolean;
   /** Callback function invoked when the file content changes */
   onChange: (inputFileData: string, inputFileIsBinary: boolean) => void;
   /** Label for the file input field */
@@ -43,6 +45,7 @@ export interface DroppableFileInputProps {
 
 export const DroppableFileInput: FC<DroppableFileInputProps> = ({
   inputFileData,
+  isBase64Input = false,
   onChange,
   label,
   id,
@@ -54,7 +57,10 @@ export const DroppableFileInput: FC<DroppableFileInputProps> = ({
   const [filename, setFilename] = useState<string>('');
   const [uploadErrorMessage, setUploadErrorMessage] = useState<string>('');
   const [inputFileIsBinary, setInputFileIsBinary] = useState<boolean>(
-    isBinary(filename, Buffer.from(inputFileData)),
+    isBinary(
+      filename,
+      isBase64Input ? Buffer.from(inputFileData, 'base64') : Buffer.from(inputFileData),
+    ),
   );
   const [isLoading, setIsLoading] = useState<boolean>(false);
 


### PR DESCRIPTION
## Summary
- Fixes corruption of binary secret data when editing text fields in the same secret
- Binary data was being decoded as UTF-8 text, which inserted replacement characters for non-printable bytes

## Changes
- Pass base64 data directly to `DroppableFileInput` for binary entries instead of decoding as UTF-8
- Add `isBase64Input` prop to handle base64-encoded input properly
- Preserve original binary values when form updates using immutable reducer pattern
- Use `useMemo` for derived `binaryData` value instead of `useState`
- Add Cypress regression test to verify editing text fields doesn't corrupt binary data

## Test plan
- [ ] Run Cypress test: `yarn run test-cypress-headless --spec packages/integration-tests-cypress/tests/crud/secrets/key-value.cy.ts`
- [ ] Verify test "Validate editing text field does not corrupt binary data (OCPBUGS-70273)" passes
- [ ] Manually test: Create secret with binary file, edit text field, verify binary unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where editing text fields in secrets could corrupt binary data. Binary files now remain unmodified when users update only text content in mixed secrets.

* **Tests**
  * Added test coverage validating binary data integrity during secret editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->