### PR TITLE
OCPBUGS-66147: Make folder field optional for vsphere

### DIFF
--- a/frontend/packages/vsphere-plugin/src/components/VSphereConnectionForm.tsx
+++ b/frontend/packages/vsphere-plugin/src/components/VSphereConnectionForm.tsx
@@ -141,7 +141,6 @@ export const VSphereConnectionForm = () => {
             }
           />
         }
-        isRequired
         fieldId="connection-folder"
       >
         <TextField name="folder" />

--- a/frontend/packages/vsphere-plugin/src/components/VSphereConnectionModal.tsx
+++ b/frontend/packages/vsphere-plugin/src/components/VSphereConnectionModal.tsx
@@ -121,7 +121,6 @@ const validationSchema = Yup.lazy((values: ConnectionFormFormikValues) =>
       )
       .matches(datastoreRegex, `Must match regex ${datastoreRegex}`),
     folder: Yup.string()
-      .required('Virtual Machine Folder is required.')
       .test('Correct prefix', `Must start with /${values.datacenter}/vm/`, (value: string) => {
         if (!value || !values.datacenter) {
           return true;

--- a/frontend/packages/vsphere-plugin/src/components/persist.ts
+++ b/frontend/packages/vsphere-plugin/src/components/persist.ts
@@ -503,7 +503,12 @@ const getPersistInfrastructureOp = async (
   if (values.network) {
     vCenterDomainCfg.topology.networks = [values.network];
   }
-  vCenterDomainCfg.topology.folder = values.folder;
+  // Folder is optional, so we need to handle the case where it's unset
+  if (values.folder) {
+    vCenterDomainCfg.topology.folder = values.folder;
+  } else {
+    delete vCenterDomainCfg.topology.folder;
+  }
 
   vCenterDomainCfg.topology.resourcePool = getInfrastructureResourcePoolPath(
     values,


### PR DESCRIPTION
According to the official [documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/installing_on_vmware_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere), the `platform.vsphere.failureDomains.topology.folder:` is optional.

The Vsphere Console Plugin will now allow users to have an empty value for this field.

<img width="1223" height="1535" alt="ocpbugs-66147-optional-folder" src="https://github.com/user-attachments/assets/ccca217e-a68f-4b63-b1d5-79b452ba3741" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Virtual Machine Folder field is now optional when configuring vSphere connections, providing flexibility in setup configurations. The validation for the folder path remains in place when the field is populated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->