### PR TITLE
OCPBUGS-65950: Update template whenever settings are updated

### DIFF
--- a/frontend/packages/vsphere-plugin/src/components/persist.ts
+++ b/frontend/packages/vsphere-plugin/src/components/persist.ts
@@ -511,6 +511,12 @@ const getPersistInfrastructureOp = async (
     vCenterDomainCfg.topology.resourcePool,
   );
 
+  // Template is in the form: /<datacenter>/vm/<extraPart>
+  const extraPartMatch = (vCenterDomainCfg.topology.template || '').match(/\/vm\/(.+)$/);
+  if (extraPartMatch) {
+    vCenterDomainCfg.topology.template = `/${values.datacenter}/vm/${extraPartMatch[1]}`;
+  }
+
   const vCenterCfg = initValues.vcenter
     ? infrastructure.spec.platformSpec.vsphere.vcenters.find((c) => c.server === initValues.vcenter)
     : infrastructure.spec.platformSpec.vsphere.vcenters[0];

--- a/frontend/packages/vsphere-plugin/src/resources/infrastructure.ts
+++ b/frontend/packages/vsphere-plugin/src/resources/infrastructure.ts
@@ -20,6 +20,7 @@ export type Infrastructure = K8sResourceCommon & {
             datastore?: string;
             networks?: string[];
             resourcePool?: string;
+            template?: string;
           };
           zone?: string;
         }[];


### PR DESCRIPTION
The Vsphere Plugin was not managing the `platform.vsphere.failureDomains.topology.template` field.

If it's defined, we'll ensure it has the expected pattern `/<datacenter>/vm/<existing-value>`. 

This covers all possible cases:
- The settings are defined initially with a placeholder value (eg. `datacenterplaceholder` from [Assisted Installer](https://github.com/openshift/assisted-service/blob/master/internal/provider/vsphere/consts.go#L10))
- The `datacenter` value is modified later by the user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional template field support to vSphere infrastructure topology configuration
  * Implemented automatic template path normalization for vCenter domain configurations, now automatically prefixing template paths with the selected datacenter information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->