### PR TITLE
OCPBUGS-74140: Prevent Chinese characters from rendering as unicode escape sequences in alert messages

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/__tests__/console-fetch.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/__tests__/console-fetch.spec.ts
@@ -1,6 +1,26 @@
 import { RetryError } from '../../error/http-error';
 import { consoleFetch } from '../console-fetch';
-import { shouldLogout, validateStatus } from '../console-fetch-utils';
+import { shouldLogout, unescapeGoUnicode, validateStatus } from '../console-fetch-utils';
+
+describe('unescapeGoUnicode', () => {
+  it('should unescape 4-digit Go unicode escapes', () => {
+    expect(unescapeGoUnicode('\\ue00f')).toBe('\ue00f');
+    expect(unescapeGoUnicode('\\ue4c8')).toBe('\ue4c8');
+  });
+
+  it('should unescape 8-digit Go unicode escapes for supplementary plane characters', () => {
+    expect(unescapeGoUnicode('\\U0002ebf0')).toBe(String.fromCodePoint(0x2ebf0));
+    expect(unescapeGoUnicode('\\U0002ebf1')).toBe(String.fromCodePoint(0x2ebf1));
+  });
+
+  it('should unescape mixed content with normal text and escapes', () => {
+    const input = 'a啊阿沸犯跃kg\\ue00f\\ue010\\ue011\\ue4c8丙乩h妖哪匸与f去\\U0002ebf0\\U0002ebf1';
+    const expected = `a啊阿沸犯跃kg\ue00f\ue010\ue011\ue4c8丙乩h妖哪匸与f去${String.fromCodePoint(
+      0x2ebf0,
+    )}${String.fromCodePoint(0x2ebf1)}`;
+    expect(unescapeGoUnicode(input)).toBe(expected);
+  });
+});
 
 describe('consoleFetch', () => {
   const json = async () => ({

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/__tests__/console-fetch.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/__tests__/console-fetch.spec.ts
@@ -20,6 +20,10 @@ describe('unescapeGoUnicode', () => {
     )}${String.fromCodePoint(0x2ebf1)}`;
     expect(unescapeGoUnicode(input)).toBe(expected);
   });
+
+  it('should not throw on out-of-range 8-digit escape sequences', () => {
+    expect(unescapeGoUnicode('\\UFFFFFFFF')).toBe('\\UFFFFFFFF');
+  });
 });
 
 describe('consoleFetch', () => {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch-utils.ts
@@ -152,7 +152,10 @@ export const shouldLogout = (url: string): boolean => {
  */
 export const unescapeGoUnicode = (str: string): string =>
   str
-    .replace(/\\U([0-9a-fA-F]{8})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/\\U([0-9a-fA-F]{8})/g, (match, hex) => {
+      const codePoint = parseInt(hex, 16);
+      return codePoint <= 0x10ffff ? String.fromCodePoint(codePoint) : match;
+    })
     .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)));
 
 export const validateStatus = async (
@@ -192,7 +195,7 @@ export const validateStatus = async (
   if (response.status === 403) {
     return response.json().then((json) => {
       throw new HttpError(
-        json.message || 'Access denied due to cluster policy.',
+        unescapeGoUnicode(json.message || 'Access denied due to cluster policy.'),
         response.status,
         response,
         json,

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch-utils.ts
@@ -146,6 +146,15 @@ export const shouldLogout = (url: string): boolean => {
   return false;
 };
 
+/**
+ * Converts Go-style Unicode escape sequences (\uXXXX, \UXXXXXXXX) in K8s API error
+ * messages back to actual Unicode characters for proper display in the browser.
+ */
+export const unescapeGoUnicode = (str: string): string =>
+  str
+    .replace(/\\U([0-9a-fA-F]{8})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)));
+
 export const validateStatus = async (
   response: Response,
   url: string,
@@ -217,6 +226,6 @@ export const validateStatus = async (
       reason = response.statusText;
     }
 
-    throw new HttpError(reason, response.status, response, json);
+    throw new HttpError(unescapeGoUnicode(reason), response.status, response, json);
   });
 };


### PR DESCRIPTION
The K8s API server escapes certain Unicode characters (PUA, CJK Extension I) using Go-style sequences (\uXXXX, \UXXXXXXXX) in validation error messages. These were displayed as literal text instead of actual characters.

  - Fix K8s API error messages displaying Go-style Unicode escape sequences (`\ue00f`, `\U0002ebf0`) as literal
  text instead of actual characters
  - Add `unescapeGoUnicode` utility to convert escape sequences back to Unicode characters in `validateStatus`

Assisted by: Claude Code

**After**
<img width="593" height="697" alt="Screenshot 2026-03-16 at 3 50 19 PM" src="https://github.com/user-attachments/assets/5f258bb4-0cd0-4cf8-9d1f-8cd4dacd42f1" />

**Before**
<img width="584" height="723" alt="Screenshot 2026-03-16 at 4 50 45 PM" src="https://github.com/user-attachments/assets/58c3a6ab-ea59-4c1f-ad66-cb1b838ddf3e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message display by properly handling Unicode escape sequences.

* **Tests**
  * Expanded test coverage for Unicode escape sequence handling in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->