### PR TITLE
CONSOLE-4447: Update SecretFormWrapper modal to use ModalFooterWithAlerts

### DIFF
--- a/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
+++ b/frontend/public/components/secrets/create-secret/SecretFormWrapper.tsx
@@ -15,13 +15,13 @@ import {
   HelperTextItem,
   Modal,
   ModalBody,
-  ModalFooter,
   ModalHeader,
   ModalVariant,
   ButtonVariant,
 } from '@patternfly/react-core';
 import { useParams, useNavigate } from 'react-router';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';
+import { ModalFooterWithAlerts } from '@console/shared/src/components/modals/ModalFooterWithAlerts';
 import { k8sCreate, k8sUpdate, K8sResourceKind, referenceFor } from '../../../module/k8s';
 import { ButtonBar } from '../../utils/button-bar';
 import { PageHeading } from '@console/shared/src/components/heading/PageHeading';
@@ -171,7 +171,7 @@ export const SecretFormWrapper: FC<BaseEditSecretProps_> = (props) => {
     <Modal isOpen={true} onClose={onCancel || cancel} title={title} variant={ModalVariant.medium}>
       <ModalHeader title={title} />
       <ModalBody>{renderBody()}</ModalBody>
-      <ModalFooter>
+      <ModalFooterWithAlerts errorMessage={error}>
         <Button
           type="submit"
           variant={ButtonVariant.primary}
@@ -184,8 +184,7 @@ export const SecretFormWrapper: FC<BaseEditSecretProps_> = (props) => {
         <Button variant={ButtonVariant.link} onClick={onCancel || cancel} isDisabled={inProgress}>
           {t('public~Cancel')}
         </Button>
-        {error && <div className="pf-v6-u-danger-color-100 pf-v6-u-mt-md">{error}</div>}
-      </ModalFooter>
+      </ModalFooterWithAlerts>
     </Modal>
   ) : (
     <>


### PR DESCRIPTION
Replace raw `<div>` error display with `ModalFooterWithAlerts` in `SecretFormWrapper` modal
Error messages now show with proper Alert styling, matching other modals in the codebase

**After**
<img width="855" height="938" alt="Screenshot 2026-03-18 at 1 28 08 PM" src="https://github.com/user-attachments/assets/2761c2a7-8bb1-449b-b685-844e98f5143a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling in the secret creation and editing modals to provide better visibility and user experience when validation errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->