### PR TITLE
[release-4.20] OCPBUGS-83495: remove dev to admin links as dev monitoring views are enabled

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/TopConsumerPopover.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/TopConsumerPopover.tsx
@@ -3,20 +3,19 @@ import * as React from 'react';
 import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
-import { useActivePerspective, LIMIT_STATE, Humanize } from '@console/dynamic-plugin-sdk';
+import { Humanize, LIMIT_STATE, useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { getPrometheusQueryResponse } from '@console/internal/actions/dashboards';
 import {
-  withDashboardResources,
   DashboardItemProps,
+  withDashboardResources,
 } from '@console/internal/components/dashboard/with-dashboard-resources';
 import { DataPoint } from '@console/internal/components/graphs';
 import { getInstantVectorStats } from '@console/internal/components/graphs/utils';
 import { resourcePathFromModel } from '@console/internal/components/utils';
 import { ConsoleSelect } from '@console/internal/components/utils/console-select';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
-import { K8sKind, referenceForModel, K8sResourceCommon } from '@console/internal/module/k8s';
-import { getName, getNamespace, useFlag } from '../../..';
-import { FLAGS } from '../../../constants';
+import { K8sKind, K8sResourceCommon, referenceForModel } from '@console/internal/module/k8s';
+import { FLAGS, getName, getNamespace, useFlag } from '../../..';
 import { RedExclamationCircleIcon, YellowExclamationTriangleIcon } from '../../status';
 import Status from '../status-card/StatusPopup';
 
@@ -198,7 +197,7 @@ export const PopoverBody = withDashboardResources<DashboardItemProps & PopoverBo
       const monitoringURL =
         canAccessMonitoring && activePerspective === 'admin'
           ? `/monitoring/query-browser?${monitoringParams.toString()}`
-          : `/dev-monitoring/ns/${namespace}/metrics?${monitoringParams.toString()}`;
+          : `/dev-monitoring/ns/${namespace}/query-browser?${monitoringParams.toString()}`;
 
       let body: React.ReactNode;
       if (error || consumersLoadError) {

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom-v5-compat';
+import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { QueryBrowser } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { dashboardsSetEndTime, dashboardsSetTimespan } from '@console/internal/actions/observe';
 import { Humanize } from '@console/internal/components/utils';
@@ -17,6 +18,7 @@ export enum GraphTypes {
 
 const PrometheusGraphLink = ({ query, namespace, ariaChartLinkLabel }) => {
   const { t } = useTranslation();
+  const [perspective] = useActivePerspective();
   const queries = _.compact(_.castArray(query));
   if (!queries.length) {
     return null;
@@ -26,7 +28,11 @@ const PrometheusGraphLink = ({ query, namespace, ariaChartLinkLabel }) => {
   return (
     <Link
       aria-label={ariaChartLinkLabel}
-      to={`/dev-monitoring/ns/${namespace}/metrics?${params.toString()}`}
+      to={
+        perspective === 'dev'
+          ? `/dev-monitoring/ns/${namespace}/metrics?${params.toString()}`
+          : `/monitoring/query-browser?${params.toString()}`
+      }
     >
       {t('devconsole~Inspect')}
     </Link>

--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.tsx
@@ -13,7 +13,7 @@ import {
 import { InfoCircleIcon } from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
-import { Alert } from '@console/dynamic-plugin-sdk';
+import { Alert, useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { sortEvents } from '@console/internal/components/events';
 import { FirehoseResult, LoadingBox } from '@console/internal/components/utils';
 import { DeploymentConfigModel } from '@console/internal/models';
@@ -34,11 +34,26 @@ type MonitoringOverviewProps = {
 const MonitoringOverview: React.FC<MonitoringOverviewProps> = (props) => {
   const { t } = useTranslation();
   const { resource, pods, resourceEvents, monitoringAlerts } = props;
+  const [perspective] = useActivePerspective();
   const firingAlerts = getFiringAlerts(monitoringAlerts);
   const [expanded, setExpanded] = React.useState([
     'metrics',
     ...(firingAlerts.length > 0 ? ['monitoring-alerts'] : []),
   ]);
+
+  const resourceLink = React.useMemo(() => {
+    const params = new URLSearchParams({
+      namespace: resource?.metadata?.namespace,
+      type: resource?.kind?.toLowerCase(),
+    });
+
+    if (perspective === 'dev') {
+      params.set('dashboard', 'dashboard-k8s-resources-workloads-namespace');
+      return `/dev-monitoring/ns/${resource?.metadata?.namespace}?${params.toString()}`;
+    }
+
+    return `/monitoring/dashboards/dashboard-k8s-resources-workloads-namespace?${params.toString()}`;
+  }, [resource, perspective]);
 
   if (
     !resourceEvents ||
@@ -128,14 +143,7 @@ const MonitoringOverview: React.FC<MonitoringOverviewProps> = (props) => {
             ) : (
               <>
                 <div className="odc-monitoring-overview__view-monitoring-dashboards">
-                  <Link
-                    to={`/dev-monitoring/ns/${
-                      resource?.metadata?.namespace
-                    }?dashboard=grafana-dashboard-k8s-resources-workload&workload=${
-                      resource?.metadata?.name
-                    }&type=${resource?.kind?.toLowerCase()}`}
-                    data-test="observe-dashboards-link"
-                  >
+                  <Link to={resourceLink} data-test="observe-dashboards-link">
                     {t('devconsole~View dashboards')}
                   </Link>
                 </div>

--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverviewAlerts.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverviewAlerts.tsx
@@ -27,22 +27,28 @@ const MonitoringOverviewAlerts: React.FC<MonitoringOverviewAlertsProps> = ({ ale
           rule: { name, id },
         } = alert;
         const alertDetailsPageLink =
-          activePerspective === 'admin'
-            ? `/monitoring/alerts/${id}?${labelsToParams(alert.labels)}`
-            : `/dev-monitoring/ns/${namespace}/alerts/${id}?${labelsToParams(alert.labels)}`;
+          activePerspective === 'dev'
+            ? `/dev-monitoring/ns/${namespace}/alerts/${id}?${labelsToParams(alert.labels)}`
+            : `/monitoring/alerts/${id}?${labelsToParams(alert.labels)}`;
         return (
           <Alert
             variant={getAlertType(severity)}
             isInline
-            title={<Link to={alertDetailsPageLink}>{name}</Link>}
-            onClick={() => {
-              if (
-                alertDetailsPageLink.startsWith('/dev-monitoring') &&
-                activePerspective !== 'dev'
-              ) {
-                setActivePerspective('dev');
-              }
-            }}
+            title={
+              <Link
+                onClick={() => {
+                  if (
+                    alertDetailsPageLink.startsWith('/dev-monitoring') &&
+                    activePerspective !== 'dev'
+                  ) {
+                    setActivePerspective('dev');
+                  }
+                }}
+                to={alertDetailsPageLink}
+              >
+                {name}
+              </Link>
+            }
             key={`${alertname}-${id}`}
           >
             {message}

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -33,7 +33,9 @@ import {
   WatchK8sResource,
 } from '@console/dynamic-plugin-sdk';
 import { Gallery, GalleryItem, Card, CardHeader, CardTitle } from '@patternfly/react-core';
-import { BlueArrowCircleUpIcon, FLAGS, useCanClusterUpgrade } from '@console/shared';
+import { BlueArrowCircleUpIcon } from '@console/shared/src/components/status/icons';
+import { ALL_NAMESPACES_KEY, FLAGS } from '@console/shared/src/constants/common';
+import { useCanClusterUpgrade } from '@console/shared/src/hooks/useCanClusterUpgrade';
 
 import AlertsBody from '@console/shared/src/components/dashboard/status-card/AlertsBody';
 import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
@@ -62,6 +64,7 @@ import {
   useNamespacedNotificationAlerts,
   useNotificationAlerts,
 } from '@console/shared/src/hooks/useNotificationAlerts';
+import { useActiveNamespace } from '@console/shared/src';
 
 const filterSubsystems = (
   subsystems: (
@@ -150,6 +153,7 @@ export const StatusCard = connect<StatusCardProps>(mapStateToProps)(({ k8sModels
   const [dynamicSubsystemExtensions] = useResolvedExtensions<
     DynamicDashboardsOverviewHealthSubsystem
   >(isDynamicDashboardsOverviewHealthSubsystem);
+  const [, setActiveNamespace] = useActiveNamespace();
 
   const subsystems = React.useMemo(() => {
     const filteredSubsystems = filterSubsystems(
@@ -251,7 +255,14 @@ export const StatusCard = connect<StatusCardProps>(mapStateToProps)(({ k8sModels
         actions={{
           actions: (
             <>
-              <Link to="/monitoring/alerts" data-test="status-card-view-alerts">
+              <Link
+                to="/monitoring/alerts"
+                data-test="status-card-view-alerts"
+                onClick={() => {
+                  // Set all namespaces selection so alert list is unfiltered
+                  setActiveNamespace(ALL_NAMESPACES_KEY);
+                }}
+              >
                 {t('public~View alerts')}
               </Link>
             </>

--- a/frontend/public/components/graphs/__tests__/prometheus-graph.spec.tsx
+++ b/frontend/public/components/graphs/__tests__/prometheus-graph.spec.tsx
@@ -94,15 +94,9 @@ describe('PrometheusGraphLink', () => {
       },
       {
         perspective: 'dev',
-        canGetNS: false,
-        expectedUrl: '/dev-monitoring/ns/default/metrics?query0=test',
-        description: 'dev perspective with CAN_GET_NS=false',
-      },
-      {
-        perspective: 'dev',
         canGetNS: true,
         expectedUrl: '/dev-monitoring/ns/default/metrics?query0=test',
-        description: 'dev perspective with CAN_GET_NS=true',
+        description: 'dev perspective graph link',
       },
     ];
 

--- a/frontend/public/components/graphs/prometheus-graph.tsx
+++ b/frontend/public/components/graphs/prometheus-graph.tsx
@@ -34,7 +34,7 @@ const PrometheusGraphLink_: React.FC<PrometheusGraphLinkProps> = ({
   queries.forEach((q, index) => params.set(`query${index}`, q));
 
   const url =
-    canAccessMonitoring && activePerspective === 'admin'
+    canAccessMonitoring && activePerspective !== 'dev'
       ? `/monitoring/query-browser?${params.toString()}`
       : `/dev-monitoring/ns/${namespace}/metrics?${params.toString()}`;
 


### PR DESCRIPTION
Manual backport of https://github.com/openshift/console/pull/16163

Related change from the monitoring plugin side:
- https://github.com/openshift/monitoring-plugin/pull/855