### PR TITLE
[release-4.20] OCPBUGS-77037: Fix QueryBrowser import to use SDK path to avoid circular dependency

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
@@ -4,9 +4,9 @@ import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom-v5-compat';
+import { QueryBrowser } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { dashboardsSetEndTime, dashboardsSetTimespan } from '@console/internal/actions/observe';
 import { Humanize } from '@console/internal/components/utils';
-import { QueryBrowser } from '@console/shared/src/components/query-browser';
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 import './MonitoringDashboardGraph.scss';
 

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboardGraph.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboardGraph.spec.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import '@testing-library/jest-dom';
 import * as redux from 'react-redux';
 import { BrowserRouter } from 'react-router-dom-v5-compat';
-import { QueryBrowser } from '@console/shared/src/components/query-browser';
+import { QueryBrowser } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { t } from '../../../../../../../__mocks__/i18next';
 import { monitoringDashboardQueries } from '../../queries';
 import { MonitoringDashboardGraph, GraphTypes } from '../MonitoringDashboardGraph';


### PR DESCRIPTION
## Summary
- Custom fix for release-4.20 replacing the failed cherry-pick in #16040
- Imports `QueryBrowser` from `@console/dynamic-plugin-sdk/src/lib-core` instead of `@console/shared/src/components/query-browser` to break the circular import that causes React error #306 on the Metrics page
- Updates the test file to import from the same SDK path so Enzyme's `find(QueryBrowser)` matches by reference, fixing the 3 test failures in `MonitoringDashboardGraph.spec.tsx`

## Context
The automated cherry-pick PR #16040 (from #16016) changed the component import but not the test import, causing a reference mismatch where Enzyme could not find the `QueryBrowser` component in the shallow-rendered tree.

## Test plan
- [ ] CI `ci/prow/frontend` tests pass (the 3 previously failing `MonitoringDashboardGraph` tests)
- [ ] Navigate to Observe → Metrics page — no React error #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)