### PR TITLE
NO-JIRA: enable multi-architecture yarn builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,51 +7,19 @@ ADD . /go/src/github.com/openshift/console/
 WORKDIR /go/src/github.com/openshift/console/
 RUN ./build-backend.sh
 
-
 ##################################################
 #
 # nodejs frontend build
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.22 AS nodebuilder
 
 ADD . .
-
 USER 0
 
-ARG COREPACK_VERSION=0.34.6
-
-# bootstrap corepack so we can install and run the other tools.
-RUN CACHED_COREPACK=./artifacts/corepack-${COREPACK_VERSION}.tar.gz; \
-    if [ -f ${CACHED_COREPACK} ]; then \
-      npm install --global ${CACHED_COREPACK}; \
-    else \
-      npm install --global https://github.com/nodejs/corepack/releases/download/v${COREPACK_VERSION}/corepack.tgz; \
-    fi
-
-RUN npx corepack enable
-
-# assume our package manager is safe to download
-ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
-
-# The REMOTE_SOURCES value is set by the build system to indicate the location of the cachito-backed artifacts cache.
-# As cachito might not be available in all environments, we need to make sure the value is set before trying to use it and
-# that the COPY layer below doesn't fail. Setting it to be the Dockerfile itself is fairly safe, as it will always be
-# available.
-ARG REMOTE_SOURCES=./Dockerfile.product
-ARG REMOTE_SOURCE_DIR=/tmp/remote-sources
-
-COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-
-# use dependencies provided by Cachito
-RUN test -d ${REMOTE_SOURCES}/cachito-gomod-with-deps || exit 0; \
-    cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem . \
- && cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/frontend/{.npmrc,.yarnrc.yml,yarn.lock} frontend/
-
-# prevent download of cypress binary as part of module installs
+WORKDIR frontend
 ENV CYPRESS_INSTALL_BINARY=0
 
-# run the build
-RUN container-entrypoint ./build-frontend.sh
-
+RUN node .yarn/releases/yarn-4.12.0.cjs install --immutable && \
+    node .yarn/releases/yarn-4.12.0.cjs build
 
 ##################################################
 #

--- a/frontend/.yarnrc.yml
+++ b/frontend/.yarnrc.yml
@@ -10,4 +10,8 @@ nodeLinker: node-modules
 
 npmMinimalAgeGate: 3d
 
+supportedArchitectures:
+  os: ["linux", "darwin"]
+  cpu: ["x64", "arm64", "s390x", "ppc64"]
+
 yarnPath: .yarn/releases/yarn-4.12.0.cjs


### PR DESCRIPTION
## Summary
Enable multi-architecture yarn builds with hermetic build support

## Changes
Convert Dockerfile to use hermetic build approach with cachi2 and add support for multiple architectures (x64, arm64, s390x, ppc64) in yarn configuration. This resolves hermetic build failures on non-x86_64 architectures by ensuring all required architecture-specific packages are included in dependency resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined frontend build pipeline for improved maintainability
  * Extended platform architecture support for Linux deployments (x64, arm64, s390x, ppc64)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->