### PR TITLE
OCPBUGS-78904: Mark notification drawer title for translation

### DIFF
--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -452,7 +452,10 @@ export const NotificationDrawer: FC<NotificationDrawerProps> = ({
 
   return (
     <PfNotificationDrawer ref={drawerRef}>
-      <NotificationDrawerHeader onClose={toggleNotificationDrawer} />
+      <NotificationDrawerHeader
+        title={t('public~Notifications')}
+        onClose={toggleNotificationDrawer}
+      />
       <NotificationDrawerBody>
         <NotificationDrawerGroupList>
           {[criticalAlertCategory, nonCriticalAlertCategory, recommendationsCategory]}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1124,6 +1124,7 @@
   "Notifications in the other alerts group": "Notifications in the other alerts group",
   "Recommendations": "Recommendations",
   "Notifications in the recommendations group": "Notifications in the recommendations group",
+  "Notifications": "Notifications",
   "No PersistentVolume": "No PersistentVolume",
   "PersistentVolume": "PersistentVolume",
   "Capacity": "Capacity",


### PR DESCRIPTION
The NotificationDrawerHeader was rendered without a title prop, falling back to PatternFly's hardcoded English "Notifications" string. Pass an explicit translated title so pseudolocalization and i18n work
correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The notification drawer now displays a localized "Notifications" title for improved clarity and visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->