### PR TITLE
[release-4.21] OCPBUGS-81504: Impersonating user loads extra pages that user not authorized to view

### DIFF
--- a/frontend/public/actions/features.ts
+++ b/frontend/public/actions/features.ts
@@ -122,20 +122,23 @@ const ssarCheckActions = ssarChecks.map(({ flag, resourceAttributes, after }) =>
             after(dispatch, allowed);
           }
         },
-        (err) => handleError({ response: err.graphQLErrors[0]?.extensions }, flag, dispatch, fn),
+        (err) => {
+          handleError({ response: err.graphQLErrors[0]?.extensions }, flag, dispatch, fn);
+        },
       );
   return fn;
 });
 
-export const detectFeatures = () => (dispatch: Dispatch) => {
-  [
-    detectOpenShift,
-    detectCanCreateProject,
-    detectClusterVersion,
-    detectUser,
-    ...ssarCheckActions,
-  ].forEach((detect) => detect(dispatch));
-};
+export const detectFeatures = () => (dispatch: Dispatch) =>
+  Promise.all(
+    [
+      detectOpenShift,
+      detectCanCreateProject,
+      detectClusterVersion,
+      detectUser,
+      ...ssarCheckActions,
+    ].map((detect) => detect(dispatch)),
+  );
 
 export const featureFlagController: SetFeatureFlag = (flag, enabled) => {
   store.dispatch(setFlag(flag, enabled));

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -15,7 +15,7 @@ import { detectFeatures } from './features';
 import { clearSSARFlags } from './flags';
 import { OverviewSpecialGroup } from '../components/overview/constants';
 import { setClusterID, setCreateProjectMessage, ActionType } from './common';
-import { subsClient } from '../graphql/client';
+import { subsClient, setForceHTTP } from '../graphql/client';
 import {
   beginImpersonate,
   endImpersonate,
@@ -249,17 +249,16 @@ export const startImpersonate = (kind: string, name: string, groups?: string[]) 
   // This ensures flags refresh happens in sync with React's render cycle
 };
 
-// Action to refresh features after impersonation change
-// Don't clear flags - just re-detect them. Old values remain until new ones are fetched.
-// This prevents components from seeing PENDING state and showing loading spinners.
 export const refreshFeaturesAfterImpersonation = () => (dispatch) => {
-  dispatch(detectFeatures());
+  setForceHTTP(true);
+  dispatch(detectFeatures()).then(() => setForceHTTP(false));
 };
 export const stopImpersonate = () => (dispatch) => {
   dispatch(endImpersonate());
   subsClient.close(false, true);
+  setForceHTTP(true);
   dispatch(clearSSARFlags());
-  dispatch(detectFeatures());
+  dispatch(detectFeatures()).then(() => setForceHTTP(false));
 };
 export const sortList = (listId: string, field: string, func: string, orderBy: string) => {
   // const url = new URL(window.location.href);

--- a/frontend/public/graphql/client.ts
+++ b/frontend/public/graphql/client.ts
@@ -12,6 +12,11 @@ import { URLQueryType, URLQueryVariables } from '../../@types/console/generated/
 import { getConsoleRequestHeaders, coFetch } from '../co-fetch';
 
 let wssErrors = 0;
+let forceHTTP = false;
+
+export const setForceHTTP = (force: boolean) => {
+  forceHTTP = force;
+};
 
 class GraphQLReady {
   private callback: VoidFunction;
@@ -68,7 +73,7 @@ const wsLink = new WebSocketLink(subsClient);
 
 // fallback to http connection if websocket connection was not successful
 // iOS does not allow wss with self signed certificate
-const link = split(() => wssErrors > 4, httpLink, wsLink);
+const link = split(() => wssErrors > 4 || forceHTTP, httpLink, wsLink);
 
 const client = new ApolloClient({
   link,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -381,9 +381,21 @@ func (s *Server) HTTPHandler() (http.Handler, error) {
 	handler.InitPayload = resolver.InitPayload
 	graphQLHandler := handler.NewHandlerFunc(schema, gql.NewHttpHandler(schema))
 	handle("/api/graphql", authHandlerWithUser(func(user *auth.User, w http.ResponseWriter, r *http.Request) {
-		ctx := context.WithValue(context.Background(), resolver.HeadersKey, map[string]interface{}{
+		headers := map[string]interface{}{
 			"Authorization": fmt.Sprintf("Bearer %s", user.Token),
-		})
+		}
+		if impUser := r.Header.Get("Impersonate-User"); impUser != "" {
+			headers["Impersonate-User"] = impUser
+		}
+		if consoleGroups := r.Header.Get("X-Console-Impersonate-Groups"); consoleGroups != "" {
+			groups := strings.Split(consoleGroups, ",")
+			groups = append(groups, "system:authenticated")
+			headers["Impersonate-Group"] = groups
+		} else if impGroups := r.Header.Values("Impersonate-Group"); len(impGroups) > 0 {
+			impGroups = append(impGroups, "system:authenticated")
+			headers["Impersonate-Group"] = impGroups
+		}
+		ctx := context.WithValue(context.Background(), resolver.HeadersKey, headers)
 		graphQLHandler(w, r.WithContext(ctx))
 	}))
 


### PR DESCRIPTION
## Summary
Cherry-pick of #16088 to release-4.21.

- The backend GraphQL HTTP handler wasn't forwarding impersonation headers to the Kubernetes API, so K8s API always evaluated permissions as kube:admin instead of the impersonated user.
- `detectFeatures` now returns a `Promise.all` so impersonation-triggered re-detection can be awaited before re-rendering tabs.
- Impersonation headers are injected into the GraphQL resolver's request context in `pkg/server/server.go`.

## Steps to QA
1. kube:admin user impersonate a normal user
2. Wait until the message `You are impersonating User testuser-1...` appears in the masthead, then check the pages
3. You should not be able to see tabs that `testuser-1` doesn't have access to (e.g., Home -> Overview, Compute, Administration -> Cluster Settings, Namespaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)