### PR TITLE
[release-4.18] OCPBUGS-81520: Console can only show user name instead of full name as the display name

### DIFF
--- a/frontend/packages/console-app/src/components/user-preferences/__tests__/UserPreferenceCheckboxField.spec.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/__tests__/UserPreferenceCheckboxField.spec.tsx
@@ -2,14 +2,19 @@ import * as React from 'react';
 import { Checkbox, Skeleton } from '@patternfly/react-core';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { UserPreferenceFieldType } from '@console/dynamic-plugin-sdk/src/extensions/user-preferences';
-import { useUserSettings } from '@console/shared';
+import { useUserSettings, useTelemetry } from '@console/shared';
 import UserPreferenceCheckboxField from '../UserPreferenceCheckboxField';
 
 jest.mock('@console/shared/src/hooks/useUserSettings', () => ({
   useUserSettings: jest.fn(),
 }));
 
+jest.mock('@console/shared/src/hooks/useTelemetry', () => ({
+  useTelemetry: jest.fn(),
+}));
+
 const mockUserSettings = useUserSettings as jest.Mock;
+const mockUseTelemetry = useTelemetry as jest.Mock;
 
 describe('UserPreferenceCheckboxField', () => {
   type UserPreferenceCheckboxFieldProps = React.ComponentProps<typeof UserPreferenceCheckboxField>;
@@ -22,6 +27,10 @@ describe('UserPreferenceCheckboxField', () => {
     falseValue: 'falseValue',
   };
   let wrapper: ShallowWrapper<UserPreferenceCheckboxFieldProps>;
+
+  beforeEach(() => {
+    mockUseTelemetry.mockReturnValue(jest.fn());
+  });
 
   afterEach(() => {
     jest.resetAllMocks();

--- a/frontend/packages/console-app/src/components/user-preferences/__tests__/UserPreferenceDropdownField.spec.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/__tests__/UserPreferenceDropdownField.spec.tsx
@@ -2,14 +2,19 @@ import * as React from 'react';
 import { Select, SelectProps } from '@patternfly/react-core';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { UserPreferenceFieldType } from '@console/dynamic-plugin-sdk/src/extensions/user-preferences';
-import { useUserSettings } from '@console/shared';
+import { useUserSettings, useTelemetry } from '@console/shared';
 import UserPreferenceDropdownField from '../UserPreferenceDropdownField';
 
 jest.mock('@console/shared/src/hooks/useUserSettings', () => ({
   useUserSettings: jest.fn(),
 }));
 
+jest.mock('@console/shared/src/hooks/useTelemetry', () => ({
+  useTelemetry: jest.fn(),
+}));
+
 const mockUserSettings = useUserSettings as jest.Mock;
+const mockUseTelemetry = useTelemetry as jest.Mock;
 
 describe('UserPreferenceDropdownField', () => {
   type UserPreferenceDropdownFieldProps = React.ComponentProps<typeof UserPreferenceDropdownField>;
@@ -23,6 +28,10 @@ describe('UserPreferenceDropdownField', () => {
     ],
   };
   let wrapper: ShallowWrapper<UserPreferenceDropdownFieldProps>;
+
+  beforeEach(() => {
+    mockUseTelemetry.mockReturnValue(jest.fn());
+  });
 
   afterEach(() => {
     jest.resetAllMocks();

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/actions/core.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/actions/core.ts
@@ -1,9 +1,11 @@
 import { action, ActionType as Action } from 'typesafe-actions';
+import type { UserKind } from '@console/internal/module/k8s/types';
 import { UserInfo } from '../../../extensions';
 import { AdmissionWebhookWarning } from '../../redux-types';
 
 export enum ActionType {
   SetUser = 'setUser',
+  SetUserResource = 'setUserResource',
   BeginImpersonate = 'beginImpersonate',
   EndImpersonate = 'endImpersonate',
   SetActiveCluster = 'setActiveCluster',
@@ -12,6 +14,8 @@ export enum ActionType {
 }
 
 export const setUser = (userInfo: UserInfo) => action(ActionType.SetUser, { userInfo });
+export const setUserResource = (userResource: UserKind) =>
+  action(ActionType.SetUserResource, { userResource });
 export const beginImpersonate = (kind: string, name: string, subprotocols: string[]) =>
   action(ActionType.BeginImpersonate, { kind, name, subprotocols });
 export const endImpersonate = () => action(ActionType.EndImpersonate);
@@ -21,6 +25,7 @@ export const removeAdmissionWebhookWarning = (id) =>
   action(ActionType.RemoveAdmissionWebhookWarning, { id });
 const coreActions = {
   setUser,
+  setUserResource,
   beginImpersonate,
   endImpersonate,
   setAdmissionWebhookWarning,

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/core.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/core.ts
@@ -14,6 +14,7 @@ import { ActionType, CoreAction } from '../actions/core';
 export const coreReducer = (
   state: CoreState = {
     user: {},
+    userResource: null,
     admissionWebhookWarnings: ImmutableMap<string, AdmissionWebhookWarning>(),
   },
   action: CoreAction,
@@ -45,6 +46,12 @@ export const coreReducer = (
       return {
         ...state,
         user: action.payload.userInfo,
+      };
+
+    case ActionType.SetUserResource:
+      return {
+        ...state,
+        userResource: action.payload.userResource,
       };
 
     case ActionType.SetAdmissionWebhookWarning:

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/coreSelectors.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/coreSelectors.ts
@@ -1,9 +1,11 @@
 import { Map as ImmutableMap } from 'immutable';
+import type { UserKind } from '@console/internal/module/k8s/types';
 import { UserInfo } from '../../../extensions';
 import { ImpersonateKind, SDKStoreState, AdmissionWebhookWarning } from '../../redux-types';
 
 type GetImpersonate = (state: SDKStoreState) => ImpersonateKind;
 type GetUser = (state: SDKStoreState) => UserInfo;
+type GetUserResource = (state: SDKStoreState) => UserKind;
 type GetAdmissionWebhookWarnings = (
   state: SDKStoreState,
 ) => ImmutableMap<string, AdmissionWebhookWarning>;
@@ -30,6 +32,13 @@ export const impersonateStateToProps = (state: SDKStoreState) => {
  * @returns The the user state.
  */
 export const getUser: GetUser = (state) => state.sdkCore.user;
+
+/**
+ * It provides user resource details from the redux store.
+ * @param state the root state
+ * @returns The user resource state.
+ */
+export const getUserResource: GetUserResource = (state) => state.sdkCore.userResource;
 
 /**
  * It provides admission webhook warning data from the redux store.

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/redux-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/redux-types.ts
@@ -1,4 +1,5 @@
 import { Map as ImmutableMap } from 'immutable';
+import type { UserKind } from '@console/internal/module/k8s/types';
 import { UserInfo } from '../extensions/console-types';
 
 export type K8sState = ImmutableMap<string, any>;
@@ -16,6 +17,7 @@ export type ImpersonateKind = {
 
 export type CoreState = {
   user?: UserInfo;
+  userResource?: UserKind;
   impersonate?: ImpersonateKind;
   admissionWebhookWarnings?: ImmutableMap<string, AdmissionWebhookWarning>;
 };

--- a/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
@@ -24,6 +24,24 @@ jest.mock('@console/shared/src/hooks/useUserSettings', () => ({
   useUserSettings: jest.fn(),
 }));
 
+jest.mock('@console/shared/src/hooks/useUser', () => ({
+  useUser: jest.fn(() => ({
+    user: {},
+    userResource: {},
+    userResourceLoaded: true,
+    userResourceError: null,
+    username: 'testuser',
+    fullName: 'Test User',
+    displayName: 'Test User',
+  })),
+}));
+
+const mockUserResource = {};
+
+jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
+  useK8sGet: () => [mockUserResource, true],
+}));
+
 const mockUserSettings = useUserSettings as jest.Mock;
 
 const useResolvedExtensionsMock = useResolvedExtensions as jest.Mock;
@@ -135,10 +153,13 @@ describe('useTelemetry', () => {
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 1');
     expect(listener).toHaveBeenCalledTimes(1);
-    expect(listener).toBeCalledWith('test 1', {
-      consoleVersion: undefined,
-      clusterType: undefined,
-    });
+    expect(listener).toBeCalledWith(
+      'test 1',
+      expect.objectContaining({
+        consoleVersion: undefined,
+        clusterType: undefined,
+      }),
+    );
   });
 
   it('calls the listener with console version and clusterType when they are configured (x.y.z and OSD)', () => {
@@ -152,10 +173,13 @@ describe('useTelemetry', () => {
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 2');
     expect(listener).toHaveBeenCalledTimes(1);
-    expect(listener).toBeCalledWith('test 2', {
-      consoleVersion: 'x.y.z',
-      clusterType: 'OSD',
-    });
+    expect(listener).toBeCalledWith(
+      'test 2',
+      expect.objectContaining({
+        consoleVersion: 'x.y.z',
+        clusterType: 'OSD',
+      }),
+    );
   });
 
   it('calls the listener with the optional properties', () => {
@@ -169,12 +193,15 @@ describe('useTelemetry', () => {
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 3', { 'a-string': 'works fine', 'a-boolean': true });
     expect(listener).toHaveBeenCalledTimes(1);
-    expect(listener).toBeCalledWith('test 3', {
-      consoleVersion: 'x.y.z',
-      clusterType: 'OSD',
-      'a-string': 'works fine',
-      'a-boolean': true,
-    });
+    expect(listener).toBeCalledWith(
+      'test 3',
+      expect.objectContaining({
+        consoleVersion: 'x.y.z',
+        clusterType: 'OSD',
+        'a-string': 'works fine',
+        'a-boolean': true,
+      }),
+    );
   });
 
   it('calls the listener with clusterType DEVSANDBOX when CLUSTER_TYPE is OSD and DEVSANDBOX is "true"', () => {
@@ -192,10 +219,13 @@ describe('useTelemetry', () => {
     const fireTelemetryEvent = result.current;
     fireTelemetryEvent('test 4');
     expect(listener).toHaveBeenCalledTimes(1);
-    expect(listener).toBeCalledWith('test 4', {
-      consoleVersion: 'x.y.z',
-      clusterType: 'DEVSANDBOX',
-    });
+    expect(listener).toBeCalledWith(
+      'test 4',
+      expect.objectContaining({
+        consoleVersion: 'x.y.z',
+        clusterType: 'DEVSANDBOX',
+      }),
+    );
   });
 
   it('Should not send telemetry event when cluster configuration telemetry state is set to disabled', () => {

--- a/frontend/packages/console-shared/src/hooks/__tests__/useUser.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useUser.spec.ts
@@ -1,0 +1,121 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { useSelector, useDispatch } from 'react-redux';
+import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
+import { testHook } from '../../../../../__tests__/utils/hooks-utils';
+import { useUser } from '../useUser';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('react-redux', () => ({
+  ...(jest as any).requireActual('react-redux'),
+  useSelector: jest.fn(),
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
+  useK8sGet: jest.fn(),
+}));
+
+const mockSetUserResource = jest.fn((userResource) => ({
+  type: 'setUserResource',
+  payload: { userResource },
+}));
+
+jest.mock('@console/dynamic-plugin-sdk', () => ({
+  ...(jest as any).requireActual('@console/dynamic-plugin-sdk'),
+  getUser: jest.fn(),
+  getUserResource: jest.fn(),
+  setUserResource: (...args) => mockSetUserResource(...args),
+}));
+
+const mockDispatch = jest.fn();
+const mockUseSelector = useSelector as jest.Mock;
+const mockUseK8sGet = useK8sGet as jest.Mock;
+const mockUseDispatch = useDispatch as jest.Mock;
+
+describe('useUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDispatch.mockReturnValue(mockDispatch);
+  });
+
+  it('should return user data with displayName from fullName when available', () => {
+    const mockUser = { username: 'testuser@example.com', uid: '123' };
+    const mockUserResource = { fullName: 'Test User', identities: ['testuser'] };
+
+    mockUseSelector
+      .mockReturnValueOnce(mockUser) // for getUser
+      .mockReturnValueOnce(mockUserResource); // for getUserResource
+
+    mockUseK8sGet.mockReturnValue([mockUserResource, true, null]);
+
+    const { result } = testHook(() => useUser());
+
+    expect(result.current.user).toEqual(mockUser);
+    expect(result.current.userResource).toEqual(mockUserResource);
+    expect(result.current.username).toBe('testuser@example.com');
+    expect(result.current.fullName).toBe('Test User');
+    expect(result.current.displayName).toBe('Test User'); // Should prefer fullName
+  });
+
+  it('should fallback to username when fullName is not available', () => {
+    const mockUser = { username: 'testuser@example.com', uid: '123' };
+    const mockUserResource = { identities: ['testuser'] }; // No fullName
+
+    mockUseSelector.mockReturnValueOnce(mockUser).mockReturnValueOnce(mockUserResource);
+
+    mockUseK8sGet.mockReturnValue([mockUserResource, true, null]);
+
+    const { result } = testHook(() => useUser());
+
+    expect(result.current.displayName).toBe('testuser@example.com'); // Should fallback to username
+    expect(result.current.fullName).toBeUndefined();
+  });
+
+  it('should dispatch setUserResource when user resource is loaded', () => {
+    const mockUser = { username: 'testuser@example.com' };
+    const mockUserResource = { fullName: 'Test User' };
+
+    mockUseSelector.mockReturnValueOnce(mockUser).mockReturnValueOnce(null); // No userResource in Redux yet
+
+    mockUseK8sGet.mockReturnValue([mockUserResource, true, null]);
+
+    testHook(() => useUser());
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'setUserResource',
+      payload: { userResource: mockUserResource },
+    });
+  });
+
+  it('should handle edge cases with empty strings and fallback to "Unknown user"', () => {
+    const mockUser = { username: '' }; // Empty username
+    const mockUserResource = { fullName: '   ' }; // Whitespace-only fullName
+
+    mockUseSelector.mockReturnValueOnce(mockUser).mockReturnValueOnce(mockUserResource);
+
+    mockUseK8sGet.mockReturnValue([mockUserResource, true, null]);
+
+    const { result } = testHook(() => useUser());
+
+    expect(result.current.displayName).toBe('Unknown user'); // Should fallback to translated "Unknown user"
+  });
+
+  it('should trim whitespace from fullName and username', () => {
+    const mockUser = { username: '  testuser@example.com  ' };
+    const mockUserResource = { fullName: '  Test User  ' };
+
+    mockUseSelector.mockReturnValueOnce(mockUser).mockReturnValueOnce(mockUserResource);
+
+    mockUseK8sGet.mockReturnValue([mockUserResource, true, null]);
+
+    const { result } = testHook(() => useUser());
+
+    expect(result.current.displayName).toBe('Test User'); // Should be trimmed
+  });
+});

--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -38,3 +38,4 @@ export * from './usePrometheusGate';
 export * from './useCopyCodeModal';
 export * from './useCopyLoginCommands';
 export * from './useQuickStartContext';
+export * from './useUser';

--- a/frontend/packages/console-shared/src/hooks/useTelemetry.ts
+++ b/frontend/packages/console-shared/src/hooks/useTelemetry.ts
@@ -4,22 +4,36 @@ import {
   isTelemetryListener,
   TelemetryListener,
   TelemetryEventListener,
+  UserInfo,
 } from '@console/dynamic-plugin-sdk';
+import type { UserKind } from '@console/internal/module/k8s/types';
 import {
   CLUSTER_TELEMETRY_ANALYTICS,
   PREFERRED_TELEMETRY_USER_SETTING_KEY,
   USER_TELEMETRY_ANALYTICS,
 } from '../constants';
+import { useUser } from './useUser';
 import { useUserSettings } from './useUserSettings';
 
-let telemetryEvents: { eventType: string; event: Record<string, any> }[] = [];
-
-interface ClusterProperties {
+export interface ClusterProperties {
   clusterId?: string;
   clusterType?: string;
   consoleVersion?: string;
   organizationId?: string;
 }
+
+export type TelemetryEventProperties = {
+  user?: UserInfo;
+  userResource?: UserKind;
+} & ClusterProperties &
+  Record<string, any>;
+
+export interface TelemetryEvent {
+  eventType: string;
+  event: TelemetryEventProperties;
+}
+
+let telemetryEvents: TelemetryEvent[] = [];
 
 export const getClusterProperties = () => {
   const clusterProperties: ClusterProperties = {};
@@ -38,6 +52,18 @@ export const getClusterProperties = () => {
   return clusterProperties;
 };
 
+const clusterIsOptedInToTelemetry = () =>
+  window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.OPTIN;
+
+const isOptedOutFromTelemetry = (currentUserPreferenceTelemetryValue: USER_TELEMETRY_ANALYTICS) =>
+  window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.DISABLED ||
+  (currentUserPreferenceTelemetryValue === USER_TELEMETRY_ANALYTICS.DENY &&
+    (clusterIsOptedInToTelemetry() ||
+      window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.OPTOUT));
+
+const userIsOptedInToTelemetry = (currentUserPreferenceTelemetryValue: USER_TELEMETRY_ANALYTICS) =>
+  currentUserPreferenceTelemetryValue === USER_TELEMETRY_ANALYTICS.ALLOW;
+
 let clusterProperties = getClusterProperties();
 
 export const updateClusterPropertiesFromTests = () => (clusterProperties = getClusterProperties());
@@ -52,50 +78,52 @@ export const useTelemetry = () => {
     true,
   );
 
+  // Use centralized user data instead of fetching directly
+  const { userResource, userResourceLoaded: userResourceIsLoaded } = useUser();
+
   const [extensions] = useResolvedExtensions<TelemetryListener>(isTelemetryListener);
 
   React.useEffect(() => {
     if (
-      currentUserPreferenceTelemetryValue === USER_TELEMETRY_ANALYTICS.ALLOW &&
-      window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.OPTIN &&
-      telemetryEvents.length > 0
+      userIsOptedInToTelemetry(currentUserPreferenceTelemetryValue) &&
+      clusterIsOptedInToTelemetry() &&
+      telemetryEvents.length > 0 &&
+      userResourceIsLoaded
     ) {
       telemetryEvents.forEach(({ eventType, event }) => {
-        extensions.forEach((e) => e.properties.listener(eventType, event));
+        extensions.forEach((e) => e.properties.listener(eventType, { ...event, userResource }));
       });
       telemetryEvents = [];
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentUserPreferenceTelemetryValue]);
+  }, [currentUserPreferenceTelemetryValue, userResourceIsLoaded]);
 
   return React.useCallback<TelemetryEventListener>(
     (eventType, properties: Record<string, any>) => {
+      if (isOptedOutFromTelemetry(currentUserPreferenceTelemetryValue)) return;
+
       const event = {
         ...clusterProperties,
         ...properties,
         // This is required to ensure that the replayed events uses the right path.
         path: properties?.pathname,
       };
+
       if (
-        window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.DISABLED ||
-        (currentUserPreferenceTelemetryValue === USER_TELEMETRY_ANALYTICS.DENY &&
-          (window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.OPTIN ||
-            window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.OPTOUT))
-      ) {
-        return;
-      }
-      if (
-        !currentUserPreferenceTelemetryValue &&
-        window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.OPTIN
+        (clusterIsOptedInToTelemetry() && !currentUserPreferenceTelemetryValue) ||
+        !userResourceIsLoaded
       ) {
         telemetryEvents.push({ eventType, event });
+
         if (telemetryEvents.length > 10) {
           telemetryEvents.shift(); // Remove the first element
         }
+
         return;
       }
-      extensions.forEach((e) => e.properties.listener(eventType, event));
+
+      extensions.forEach((e) => e.properties.listener(eventType, { ...event, userResource }));
     },
-    [extensions, currentUserPreferenceTelemetryValue],
+    [extensions, currentUserPreferenceTelemetryValue, userResource, userResourceIsLoaded],
   );
 };

--- a/frontend/packages/console-shared/src/hooks/useUser.ts
+++ b/frontend/packages/console-shared/src/hooks/useUser.ts
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { useDispatch, useSelector } from 'react-redux';
+import { getUser, getUserResource, setUserResource } from '@console/dynamic-plugin-sdk';
+import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
+import { UserModel } from '@console/internal/models';
+import type { UserKind } from '@console/internal/module/k8s/types';
+
+/**
+ * Custom hook that provides centralized user data fetching and management.
+ * This hook fetches both the UserInfo (from authentication) and UserKind (from k8s API)
+ * and stores them in Redux for use throughout the application.
+ *
+ * @returns Object containing user info, user resource, and loading states
+ */
+export const useUser = () => {
+  const { t } = useTranslation('public');
+  const dispatch = useDispatch();
+
+  // Get current user info from Redux (username, groups, etc.)
+  const user = useSelector(getUser);
+
+  // Get current user resource from Redux (fullName, identities, etc.)
+  const userResource = useSelector(getUserResource);
+
+  // Fetch user resource from k8s API
+  const [userResourceData, userResourceLoaded, userResourceError] = useK8sGet<UserKind>(
+    UserModel,
+    '~',
+  );
+
+  // Update Redux when user resource is loaded
+  React.useEffect(() => {
+    if (userResourceLoaded && userResourceData && !userResourceError) {
+      dispatch(setUserResource(userResourceData));
+    }
+  }, [dispatch, userResourceData, userResourceLoaded, userResourceError]);
+
+  const currentUserResource = userResource || userResourceData;
+  const currentUsername = user?.username;
+  const currentFullName = currentUserResource?.fullName;
+
+  // Create a robust display name that always has a fallback
+  const getDisplayName = () => {
+    // Prefer fullName if it exists and is not empty
+    if (currentFullName && currentFullName.trim()) {
+      return currentFullName.trim();
+    }
+    // Fallback to username if it exists and is not empty
+    if (currentUsername && currentUsername.trim()) {
+      return currentUsername.trim();
+    }
+    // Final fallback for edge cases
+    return t('Unknown user');
+  };
+
+  return {
+    user,
+    userResource: currentUserResource,
+    userResourceLoaded,
+    userResourceError,
+    // Computed properties for convenience
+    username: currentUsername,
+    fullName: currentFullName,
+    displayName: getDisplayName(),
+  };
+};

--- a/frontend/packages/topology/src/components/export-app/__tests__/ExportApplicationModal.spec.tsx
+++ b/frontend/packages/topology/src/components/export-app/__tests__/ExportApplicationModal.spec.tsx
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 import { act } from 'react-dom/test-utils';
 import * as k8sResourceModule from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-resource';
 import * as useToastModule from '@console/shared/src/components/toast/useToast';
+import * as useUserModule from '@console/shared/src/hooks/useUser';
 import * as useUserSettingsModule from '@console/shared/src/hooks/useUserSettings';
 import { getExportAppData } from '@console/topology/src/utils/export-app-utils';
 import { ExportModel } from '../../../models';
@@ -11,13 +12,25 @@ import { ExportApplicationModal } from '../ExportApplicationModal';
 import ExportViewLogButton from '../ExportViewLogButton';
 import { mockExportData } from './export-data';
 
+const mockUseUserData = {
+  user: {},
+  userResource: {},
+  userResourceLoaded: true,
+  userResourceError: null,
+  username: 'testuser',
+  fullName: 'Test User',
+  displayName: 'Test User',
+};
+
 describe('ExportApplicationModal', () => {
   const spyUseToast = jest.spyOn(useToastModule, 'default');
   const spyUseUserSettings = jest.spyOn(useUserSettingsModule, 'useUserSettings');
+  const spyUseUser = jest.spyOn(useUserModule, 'useUser');
 
   beforeEach(() => {
     spyUseToast.mockReturnValue({ addToast: (v) => ({ v }) });
     spyUseUserSettings.mockReturnValue([{}, jest.fn(), false]);
+    ((spyUseUser as unknown) as jest.Mock).mockReturnValue(mockUseUserData);
   });
 
   afterEach(() => {

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -29,12 +29,12 @@ import {
   useFlag,
   usePerspectiveExtension,
   useTelemetry,
+  useUser,
   YellowExclamationTriangleIcon,
 } from '@console/shared';
 import { formatNamespacedRouteForResource } from '@console/shared/src/utils';
 import CloudShellMastheadButton from '@console/webterminal-plugin/src/components/cloud-shell/CloudShellMastheadButton';
 import CloudShellMastheadAction from '@console/webterminal-plugin/src/components/cloud-shell/CloudShellMastheadAction';
-import { getUser } from '@console/dynamic-plugin-sdk';
 import { history } from '@console/internal/components/utils';
 import * as UIActions from '../actions/ui';
 import { flagPending, featureReducerName } from '../reducers/features';
@@ -128,12 +128,15 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
     t('public~Login with this command'),
     externalLoginCommand,
   );
-  const { clusterID, user, alertCount, canAccessNS } = useSelector((state) => ({
+  const { clusterID, alertCount, canAccessNS } = useSelector((state) => ({
     clusterID: state.UI.get('clusterID'),
-    user: getUser(state),
     alertCount: state.observe.getIn(['alertCount']),
     canAccessNS: !!state[featureReducerName].get(FLAGS.CAN_GET_NS),
   }));
+
+  // Use centralized user hook for user data
+  const { displayName, username } = useUser();
+
   const [isAppLauncherDropdownOpen, setIsAppLauncherDropdownOpen] = React.useState(false);
   const [isUserDropdownOpen, setIsUserDropdownOpen] = React.useState(false);
   const [isKebabDropdownOpen, setIsKebabDropdownOpen] = React.useState(false);
@@ -147,7 +150,6 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
   const kebabMenuRef = React.useRef(null);
   const reportBugLink = cv?.data ? getReportBugLink(cv.data, t) : null;
   const userInactivityTimeout = React.useRef(null);
-  const username = user?.username ?? '';
   const isKubeAdmin = username === 'kube:admin';
 
   const drawerToggle = React.useCallback(
@@ -574,7 +576,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
     const userToggle = (
       <span className="pf-v5-c-dropdown__toggle">
         <span className="co-username" data-test="username">
-          {authEnabledFlag ? username : t('public~Auth disabled')}
+          {authEnabledFlag ? displayName : t('public~Auth disabled')}
         </span>
         <CaretDownIcon className="pf-c-dropdown__toggle-icon" />
       </span>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1953,6 +1953,7 @@
   "Query result is a string, which cannot be graphed.": "Query result is a string, which cannot be graphed.",
   "The resulting dataset is too large to graph.": "The resulting dataset is too large to graph.",
   "Stacked": "Stacked",
+  "Unknown user": "Unknown user",
   "Disable": "Disable",
   "default": "default",
   "Disabled": "Disabled",


### PR DESCRIPTION
## Summary
- Backport of [OCPBUGS-56892](https://issues.redhat.com/browse/OCPBUGS-56892) / PR #15743 to `release-4.18`
- Adds a centralized `useUser` hook that fetches the user resource and provides `displayName`, `username`, and `fullName`
- Updates the masthead toolbar to display the user's full name (when available) instead of just the username
- Refactors `useTelemetry` to include `userResource` in telemetry events via the new `useUser` hook

## Test plan
- [ ] Verify the masthead toolbar displays the user's full name when set (e.g. via an identity provider that provides full names)
- [ ] Verify the masthead toolbar falls back to username when no full name is available
- [ ] Verify `kube:admin` still displays correctly
- [ ] Verify telemetry events include the `userResource` data
- [ ] Run unit tests: `yarn test` passes for `useUser.spec.ts` and `useTelemetry.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)