### PR TITLE
OCPBUGS-77864: Add gRPC probe support to container details view

### DIFF
--- a/frontend/public/components/__tests__/probe.spec.ts
+++ b/frontend/public/components/__tests__/probe.spec.ts
@@ -53,12 +53,42 @@ describe('k8sProbe', () => {
         });
       });
     });
+
+    describe('for grpc', () => {
+      it('returns port and service', () => {
+        expect(parseCmd('grpc', '5000:my-service')).toEqual({ port: 5000, service: 'my-service' });
+      });
+
+      it('returns port only when no service specified', () => {
+        expect(parseCmd('grpc', '5000')).toEqual({ port: 5000 });
+      });
+
+      it('returns null for empty string', () => {
+        expect(parseCmd('grpc', '')).toBeNull();
+      });
+    });
   });
 
   describe('#flattenCmd', () => {
     describe('for tcpSocket', () => {
       it('casts port number to string', () => {
         expect(flattenCmd('tcpSocket', { port: 8080 })).toEqual('8080');
+      });
+    });
+
+    describe('for grpc', () => {
+      it('returns port as string', () => {
+        expect(flattenCmd('grpc', { port: 5000 })).toEqual('5000');
+      });
+
+      it('returns port with service when service is specified', () => {
+        expect(flattenCmd('grpc', { port: 5000, service: 'my-service' })).toEqual(
+          '5000 (my-service)',
+        );
+      });
+
+      it('returns empty string when port is missing', () => {
+        expect(flattenCmd('grpc', {})).toEqual('');
       });
     });
   });

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1734,6 +1734,7 @@
   "Exec command": "Exec command",
   "HTTP GET": "HTTP GET",
   "TCP socket (port)": "TCP socket (port)",
+  "gRPC": "gRPC",
   "Delete {{label}} subject?": "Delete {{label}} subject?",
   "Are you sure you want to delete subject {{name}} of type {{kind}}?": "Are you sure you want to delete subject {{name}} of type {{kind}}?",
   "Impersonate {{kind}} \"{{name}}\"": "Impersonate {{kind}} \"{{name}}\"",

--- a/frontend/public/module/k8s/probe.ts
+++ b/frontend/public/module/k8s/probe.ts
@@ -6,6 +6,7 @@ import {
   ContainerLifecycleStage,
   ContainerProbe,
   ExecProbe,
+  GRPCProbe,
   Handler,
   HTTPGetProbe,
   TCPSocketProbe,
@@ -60,6 +61,22 @@ const parsers = {
       port: /^\d+$/.test(str) ? +str : str,
     };
   },
+
+  grpc: function (str: string) {
+    if (!str) {
+      return null;
+    }
+    const parts = str.split(':');
+    const port = parseInt(parts[0], 10);
+    if (isNaN(port)) {
+      return null;
+    }
+    const result: { port: number; service?: string } = { port };
+    if (parts[1]) {
+      result.service = parts[1];
+    }
+    return result;
+  },
 };
 
 const flatteners = {
@@ -97,6 +114,16 @@ const flatteners = {
     }
     return `${cmd.port}`;
   },
+
+  grpc: function (cmd: GRPCProbe): string {
+    if (!cmd || !cmd.port) {
+      return '';
+    }
+    if (cmd.service) {
+      return `${cmd.port} (${cmd.service})`;
+    }
+    return `${cmd.port}`;
+  },
 };
 
 function inferAction(obj: Handler) {
@@ -112,6 +139,10 @@ function inferAction(obj: Handler) {
     tcpSocket: {
       id: 'tcpSocket',
       label: i18next.t('public~TCP socket (port)'),
+    },
+    grpc: {
+      id: 'grpc',
+      label: i18next.t('public~gRPC'),
     },
   });
 

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -85,10 +85,16 @@ export type TCPSocketProbe = {
   host?: string;
 };
 
+export type GRPCProbe = {
+  port: number;
+  service?: string;
+};
+
 export type Handler = {
   exec?: ExecProbe;
   httpGet?: HTTPGetProbe;
   tcpSocket?: TCPSocketProbe;
+  grpc?: GRPCProbe;
 };
 
 export type ContainerProbe = {


### PR DESCRIPTION
Container details page crashes with TypeError when viewing workloads
that use Kubernetes gRPC probes (GA since v1.24). Adds gRPC to the
probe flatteners, parsers, HookAction labels, and Handler type.

## Summary
- Fixes a crash (`TypeError: flatteners[type] is not a function`) on the
  Container Details page when a pod uses gRPC liveness, readiness, or
  startup probes
- Adds `GRPCProbe` type to `Handler` and gRPC entries to the probe
  `flatteners`, `parsers`, and `HookAction` label map
- Adds unit tests for gRPC `parseCmd` and `flattenCmd`

## Test plan
- [ ] Deploy a pod with gRPC liveness/readiness probes
- [ ] Navigate to Container Details and confirm probes render
      (e.g. `gRPC 5000 (my-service)`)
- [ ] Verify existing probe types (exec, httpGet, tcpSocket) still
      render correctly
- [ ] `yarn test public/components/__tests__/probe.spec.ts` — 14/14 pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for gRPC probes, enabling container health checks via gRPC with configurable port and optional service specification.

* **Tests**
  * Added test coverage for gRPC probe parsing and serialization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->