### PR TITLE
OCPBUGS-81654: Filter out isActionCell prop to fix React warning

### DIFF
--- a/frontend/packages/console-app/src/components/data-view/useConsoleDataViewData.tsx
+++ b/frontend/packages/console-app/src/components/data-view/useConsoleDataViewData.tsx
@@ -90,8 +90,11 @@ export const useConsoleDataViewData = <
   const dataViewColumns = useMemo<ConsoleDataViewColumn<TData>[]>(
     () =>
       activeColumns.map(({ id, title, sort, props, resizableProps }, index) => {
+        // Filter out custom Console props that aren't valid PatternFly ThProps
+        const { isActionCell, ...validThProps } = props || {};
+
         const headerProps: ThProps = {
-          ...props,
+          ...validThProps,
           dataLabel: title,
         };
 


### PR DESCRIPTION
## Summary
- Fixes React warning about unrecognized `isActionCell` prop on DOM elements
- Filters out custom Console props before spreading into PatternFly's `Th` component

## Details
The `actionsCellProps` object includes `isActionCell: true`, which was being passed through to PatternFly's `<Th>` component and ultimately to the native DOM `<th>` element. Since this is not a valid HTML attribute, React emits a warning.

This prop appears to be a marker/metadata property with no runtime purpose, so the fix filters it out before creating the `ThProps` object.

## Test plan
- [ ] Navigate to Nodes page (or any page using ConsoleDataView with action columns)
- [ ] Open browser console
- [ ] Verify no React warning about `isActionCell` prop
- [ ] Verify action columns render correctly
- [ ] Verify action menus still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Enhanced column management configuration for data tables with support for default column visibility control.

* **Refactor**
  - Standardized table column sorting configuration and text wrapping behavior across data view components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->