### PR TITLE
OCPBUGS-81518: Fix ResourceListDropdown performance on large clusters

### DIFF
--- a/frontend/public/components/__tests__/resource-dropdown.spec.tsx
+++ b/frontend/public/components/__tests__/resource-dropdown.spec.tsx
@@ -1,0 +1,241 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { Map as ImmutableMap } from 'immutable';
+
+import { useUserPreference } from '@console/shared/src/hooks/useUserPreference';
+import type { K8sModel } from '@console/dynamic-plugin-sdk/src/api/common-types';
+import { getReferenceForModel } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';
+import { ResourceListDropdown_ } from '../resource-dropdown';
+
+jest.mock('../utils/resource-icon', () => ({
+  ResourceIcon: jest.fn(() => null),
+}));
+
+jest.mock('../../module/k8s', () => ({
+  referenceForModel: jest.requireActual('@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref')
+    .getReferenceForModel,
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      const text = key.replace('public~', '');
+      if (opts) {
+        return Object.entries(opts).reduce(
+          (acc, [k, v]) => acc.replace(`{{${k}}}`, String(v)),
+          text,
+        );
+      }
+      return text;
+    },
+  }),
+}));
+
+jest.mock('@console/shared/src/hooks/useUserPreference', () => ({
+  useUserPreference: jest.fn(),
+}));
+
+const mockUseUserPreference = useUserPreference as jest.Mock;
+
+type K8sKind = K8sModel;
+
+const makeModel = (
+  kind: string,
+  apiGroup: string,
+  apiVersion: string,
+  overrides: Partial<K8sKind> = {},
+): K8sKind => ({
+  kind,
+  apiGroup,
+  apiVersion,
+  abbr: kind.substring(0, 2).toUpperCase(),
+  label: kind,
+  labelPlural: `${kind}s`,
+  plural: `${kind.toLowerCase()}s`,
+  ...overrides,
+});
+
+const buildModelsMap = (models: K8sKind[]): ImmutableMap<string, K8sKind> =>
+  ImmutableMap<string, K8sKind>().withMutations((map) => {
+    models.forEach((m) => {
+      map.set(getReferenceForModel(m), m);
+    });
+  });
+
+const defaultProps = {
+  selected: [] as string[],
+  onChange: jest.fn(),
+  recentList: false,
+};
+
+const renderDropdown = (models: K8sKind[], groupToVersionMap = {}, props = {}) => {
+  const allModels = buildModelsMap(models);
+  return render(
+    <ResourceListDropdown_
+      {...defaultProps}
+      allModels={allModels}
+      groupToVersionMap={groupToVersionMap}
+      {...props}
+    />,
+  );
+};
+
+const openDropdown = () => {
+  fireEvent.click(screen.getByRole('combobox'));
+};
+
+const typeInSearch = (text: string) => {
+  const input = screen.getByRole('combobox');
+  fireEvent.change(input, { target: { value: text } });
+};
+
+const getMenuItems = () => screen.getAllByRole('menuitem');
+
+describe('ResourceListDropdown', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseUserPreference.mockReturnValue(['[]', jest.fn(), true]);
+    defaultProps.onChange = jest.fn();
+  });
+
+  describe('preferred version filtering', () => {
+    it('shows only the preferred version when groupToVersionMap is provided', () => {
+      const models = [
+        makeModel('Deployment', 'apps', 'v1'),
+        makeModel('Deployment', 'apps', 'v1beta1'),
+      ];
+      const groupToVersionMap = {
+        apps: { preferredVersion: 'v1' },
+      };
+
+      renderDropdown(models, groupToVersionMap);
+      openDropdown();
+
+      const items = getMenuItems();
+      expect(items).toHaveLength(1);
+      expect(items[0]).toHaveTextContent('Deployment');
+    });
+
+    it('shows all versions when no preferred version exists', () => {
+      const models = [
+        makeModel('Deployment', 'apps', 'v1'),
+        makeModel('Deployment', 'apps', 'v1beta1'),
+      ];
+
+      renderDropdown(models, {});
+      openDropdown();
+
+      expect(getMenuItems()).toHaveLength(2);
+    });
+  });
+
+  describe('search filtering', () => {
+    it('filters resources by reference name (case-insensitive)', () => {
+      const models = [
+        makeModel('Pod', 'core', 'v1'),
+        makeModel('Deployment', 'apps', 'v1'),
+        makeModel('Service', 'core', 'v1'),
+      ];
+
+      renderDropdown(models);
+      openDropdown();
+      typeInSearch('pod');
+
+      const items = getMenuItems();
+      expect(items).toHaveLength(1);
+      expect(items[0]).toHaveTextContent('Pod');
+    });
+
+    it('filters resources by short name', () => {
+      const models = [
+        makeModel('Pod', 'core', 'v1', { shortNames: ['po'] }),
+        makeModel('Deployment', 'apps', 'v1', { shortNames: ['deploy'] }),
+      ];
+
+      renderDropdown(models);
+      openDropdown();
+      typeInSearch('deploy');
+
+      const items = getMenuItems();
+      expect(items).toHaveLength(1);
+      expect(items[0]).toHaveTextContent('Deployment');
+    });
+
+    it('shows "No results found" when no resources match', () => {
+      const models = [makeModel('Pod', 'core', 'v1')];
+
+      renderDropdown(models);
+      openDropdown();
+      typeInSearch('nonexistent');
+
+      expect(screen.getByText('No results found')).toBeInTheDocument();
+    });
+
+    it('shows all resources when search is cleared', () => {
+      const models = [makeModel('Pod', 'core', 'v1'), makeModel('Deployment', 'apps', 'v1')];
+
+      renderDropdown(models);
+      openDropdown();
+      typeInSearch('pod');
+      expect(getMenuItems()).toHaveLength(1);
+
+      typeInSearch('');
+      expect(getMenuItems()).toHaveLength(2);
+    });
+  });
+
+  describe('MAX_VISIBLE_ITEMS cap', () => {
+    it('caps rendered items at 100 and shows truncation message', () => {
+      const models = Array.from({ length: 150 }, (_, i) =>
+        makeModel(`Resource${String(i).padStart(3, '0')}`, 'test.io', 'v1'),
+      );
+
+      renderDropdown(models);
+      openDropdown();
+
+      const menu = screen.getByRole('menu');
+      const items = within(menu).getAllByRole('menuitem');
+      // 100 resource items + 1 truncation message (rendered as menuitem)
+      expect(items.length).toBeLessThanOrEqual(101);
+
+      expect(screen.getByText('Showing 100 of 150 resources. Type to filter.')).toBeInTheDocument();
+    });
+
+    it('does not show truncation message when items fit within the cap', () => {
+      const models = Array.from({ length: 50 }, (_, i) =>
+        makeModel(`Resource${i}`, 'test.io', 'v1'),
+      );
+
+      renderDropdown(models);
+      openDropdown();
+
+      expect(screen.queryByText(/Showing .* of .* resources/)).not.toBeInTheDocument();
+    });
+
+    it('filtering below the cap removes the truncation message', () => {
+      const models = Array.from({ length: 150 }, (_, i) =>
+        makeModel(`Resource${String(i).padStart(3, '0')}`, 'test.io', 'v1'),
+      );
+
+      renderDropdown(models);
+      openDropdown();
+      expect(screen.getByText(/Showing 100 of 150/)).toBeInTheDocument();
+
+      typeInSearch('Resource00');
+      expect(screen.queryByText(/Showing .* of .* resources/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('auto-open on typing', () => {
+    it('opens the dropdown when the user starts typing', () => {
+      const models = [makeModel('Pod', 'core', 'v1')];
+
+      renderDropdown(models);
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+
+      typeInSearch('pod');
+
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -1,5 +1,5 @@
 import type { FC, FormEvent, KeyboardEvent, Ref } from 'react';
-import { useState, useRef, useEffect, Fragment } from 'react';
+import { useState, useRef, useEffect, useMemo, Fragment } from 'react';
 import * as _ from 'lodash';
 import { connect } from 'react-redux';
 import { Map as ImmutableMap, Set as ImmutableSet } from 'immutable';
@@ -28,33 +28,34 @@ import {
 import { TimesIcon } from '@patternfly/react-icons';
 
 const RECENT_SEARCH_ITEMS = 5;
+const MAX_VISIBLE_ITEMS = 100;
 
-// Blacklist known duplicate resources.
-const blacklistGroups = ImmutableSet([
+// Blocklist known duplicate resources.
+const blocklistGroups = ImmutableSet([
   // Prefer rbac.authorization.k8s.io/v1, which has the same resources.
   'authorization.openshift.io',
 ]);
 
-const blacklistResources = ImmutableSet([
+const blocklistResources = ImmutableSet([
   // Prefer core/v1
   'events.k8s.io/v1beta1.Event',
 ]);
 
-const ResourceListDropdown_: FC<ResourceListDropdownProps> = (props) => {
+const isVisible = (m: K8sKind) =>
+  !blocklistGroups.has(m.apiGroup) &&
+  !blocklistResources.has(`${m.apiGroup}/${m.apiVersion}.${m.kind}`) &&
+  (_.isEmpty(m.verbs) || _.includes(m.verbs, 'list'));
+
+export const ResourceListDropdown_: FC<ResourceListDropdownProps> = (props) => {
   const { selected, onChange, recentList, allModels, groupToVersionMap, className } = props;
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
-  const [clearItems, setClearItems] = useState(false);
   const [recentSelected, setRecentSelected] = useUserPreference<string>(
     'console.search.recentlySearched',
     '[]',
     true,
   );
   const [selectedOptions, setSelectedOptions] = useState(selected);
-  const [initialSelectOptions, setInitialSelectOptions] = useState<ExtendedSelectOptionProps[]>([]);
-  const [selectOptions, setSelectOptions] = useState<ExtendedSelectOptionProps[]>(
-    initialSelectOptions,
-  );
   const [inputValue, setInputValue] = useState<string>('');
   const [focusedItemIndex, setFocusedItemIndex] = useState<number | null>(null);
   const [activeItemId, setActiveItemId] = useState<string | null>(null);
@@ -62,41 +63,52 @@ const ResourceListDropdown_: FC<ResourceListDropdownProps> = (props) => {
   const [placeholder, setPlaceholder] = useState(placeholderTextDefault);
   const textInputRef = useRef<HTMLInputElement>();
 
-  const resources = allModels
-    .filter(({ apiGroup, apiVersion, kind, verbs }) => {
-      // Remove blacklisted items.
-      if (
-        blacklistGroups.has(apiGroup) ||
-        blacklistResources.has(`${apiGroup}/${apiVersion}.${kind}`)
-      ) {
-        return false;
+  const resources = useMemo(() => {
+    // Pre-compute which group+kind combinations have a visible preferred version (O(n))
+    const preferredGroupKinds = new Set<string>();
+    allModels.forEach((m) => {
+      if (groupToVersionMap?.[m.apiGroup]?.preferredVersion === m.apiVersion && isVisible(m)) {
+        preferredGroupKinds.add(`${m.kind}~${m.apiGroup}`);
       }
-
-      // Only show resources that can be listed.
-      if (!_.isEmpty(verbs) && !_.includes(verbs, 'list')) {
-        return false;
-      }
-
-      // Only show preferred version for resources in the same API group.
-      const preferred = (m: K8sKind) =>
-        groupToVersionMap?.[m.apiGroup]?.preferredVersion === m.apiVersion;
-
-      const sameGroupKind = (m: K8sKind) =>
-        m.kind === kind && m.apiGroup === apiGroup && m.apiVersion !== apiVersion;
-
-      return !allModels.find((m) => sameGroupKind(m) && preferred(m));
-    })
-    .toOrderedMap()
-    .sortBy(({ kind, apiGroup }) => `${kind} ${apiGroup}`);
-
-  useEffect(() => {
-    const resourcesToOption: SelectOptionProps[] = resources.toArray().map((resource) => {
-      const reference = referenceForModel(resource);
-      return { value: reference, children: reference, shortNames: resource.shortNames };
     });
-    setInitialSelectOptions(resourcesToOption);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+
+    return allModels
+      .filter((m) => {
+        if (!isVisible(m)) {
+          return false;
+        }
+
+        // Only show preferred version for resources in the same API group.
+        // If a preferred version exists for this group+kind and this isn't it, skip.
+        const key = `${m.kind}~${m.apiGroup}`;
+        if (
+          preferredGroupKinds.has(key) &&
+          groupToVersionMap?.[m.apiGroup]?.preferredVersion !== m.apiVersion
+        ) {
+          return false;
+        }
+
+        return true;
+      })
+      .toOrderedMap()
+      .sortBy(({ kind, apiGroup }) => `${kind} ${apiGroup}`);
+  }, [allModels, groupToVersionMap]);
+
+  const initialSelectOptions = useMemo<ExtendedSelectOptionProps[]>(
+    () =>
+      resources.toArray().map((resource) => {
+        const reference = referenceForModel(resource);
+        return {
+          value: reference,
+          children: reference,
+          shortNames: resource.shortNames,
+          // Pre-compute lowercase for filtering so we don't repeat it on every keystroke
+          searchableText: reference.toLowerCase(),
+          searchableShortNames: resource.shortNames?.map((s) => s.toLowerCase()),
+        };
+      }),
+    [resources],
+  );
 
   const filterGroupVersionKind = (resourceList: string[]): string[] => {
     return resourceList.filter((resource) => {
@@ -116,40 +128,18 @@ const ResourceListDropdown_: FC<ResourceListDropdownProps> = (props) => {
 
   useEffect(() => {
     setSelectedOptions(selected);
-    !_.isEmpty(selected) &&
-      setRecentSelected(
-        JSON.stringify(
-          _.union(
-            !clearItems ? filterGroupVersionKind(selected.reverse()) : [],
-            recentSelectedList(recentSelected),
-          ),
-        ),
-      );
-    setClearItems(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selected, setRecentSelected]);
+  }, [selected]);
 
-  useEffect(() => {
-    let newSelectOptions: SelectOptionProps[] = initialSelectOptions;
-
-    // Filter menu items based on the text input value when one exists
-    if (inputValue) {
-      newSelectOptions = initialSelectOptions.filter(
-        (menuItem) =>
-          String(menuItem.children).toLowerCase().includes(inputValue.toLowerCase()) ||
-          menuItem.shortNames?.some((shortName) =>
-            shortName.toLowerCase().includes(inputValue.toLowerCase()),
-          ),
-      );
-
-      // Open the menu when the input value changes and the new value is not empty
-      if (!isOpen) {
-        setIsOpen(true);
-      }
+  const selectOptions = useMemo(() => {
+    if (!inputValue) {
+      return initialSelectOptions;
     }
-
-    setSelectOptions(newSelectOptions);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const lower = inputValue.toLowerCase();
+    return initialSelectOptions.filter(
+      (menuItem) =>
+        menuItem.searchableText?.includes(lower) ||
+        menuItem.searchableShortNames?.some((shortName) => shortName.includes(lower)),
+    );
   }, [inputValue, initialSelectOptions]);
 
   useEffect(() => {
@@ -161,27 +151,38 @@ const ResourceListDropdown_: FC<ResourceListDropdownProps> = (props) => {
   }, [placeholderTextDefault, selectedOptions, t]);
 
   const createItemId = (value: any) => `resource-dropdown-${value.replace(' ', '-')}`;
+
+  // Pre-compute a reference-to-model lookup map (O(1) per lookup instead of O(n))
+  const referenceToModelMap = useMemo(() => {
+    const map = new Map<string, K8sKind>();
+    resources.forEach((r) => map.set(referenceForModel(r), r));
+    return map;
+  }, [resources]);
+
   // Track duplicate names so we know when to show the group.
-  const kinds = resources.groupBy((m) => m.kind);
+  const kinds = useMemo(() => resources.groupBy((m) => m.kind), [resources]);
   const isDup = (kind) => kinds.get(kind).size > 1;
 
-  const items = selectOptions.map((option: SelectOptionProps, index) => {
-    const model = resources.toArray().find((resource: K8sKind) => {
-      return option.value === referenceForModel(resource);
-    });
+  const visibleSelectOptions = selectOptions.slice(0, MAX_VISIBLE_ITEMS);
+  const items = visibleSelectOptions.map((option: SelectOptionProps, index) => {
+    const ref = option.value as string;
+    const model = referenceToModelMap.get(ref);
+    if (!model) {
+      return null;
+    }
 
     return (
       <SelectOption
-        key={referenceForModel(model)}
-        value={referenceForModel(model)}
+        key={ref}
+        value={ref}
         hasCheckbox
-        isSelected={selected.includes(referenceForModel(model))}
+        isSelected={selected.includes(ref)}
         isFocused={focusedItemIndex === index}
-        id={createItemId(referenceForModel(model))}
+        id={createItemId(ref)}
       >
         <span className="co-resource-item">
           <span className="co-resource-icon--fixed-width">
-            <ResourceIcon kind={referenceForModel(model)} />
+            <ResourceIcon kind={ref} />
           </span>
           <span className="co-resource-item__resource-name">
             <span>
@@ -206,9 +207,9 @@ const ResourceListDropdown_: FC<ResourceListDropdownProps> = (props) => {
   const recentSearches: JSX.Element[] =
     !_.isEmpty(recentSelectedList(recentSelected)) &&
     recentSelectedList(recentSelected)
-      .splice(0, RECENT_SEARCH_ITEMS)
+      .slice(0, RECENT_SEARCH_ITEMS)
       .map((modelRef: K8sResourceKindReference) => {
-        const model: K8sKind = resources.find((m) => referenceForModel(m) === modelRef);
+        const model = referenceToModelMap.get(modelRef);
         if (model) {
           return (
             <SelectOption
@@ -245,7 +246,6 @@ const ResourceListDropdown_: FC<ResourceListDropdownProps> = (props) => {
       .filter((item) => item !== null);
 
   const onClear = () => {
-    setClearItems(true);
     setRecentSelected(JSON.stringify([]));
   };
   const NO_RESULTS = 'no results';
@@ -273,10 +273,11 @@ const ResourceListDropdown_: FC<ResourceListDropdownProps> = (props) => {
       );
       options.push(<Divider key={3} className="co-select-group-divider" />);
     }
+    const cleanItems = items.filter(Boolean);
     options.push(
       <Fragment key="resource-items">
-        {items.length > 0
-          ? items
+        {cleanItems.length > 0
+          ? cleanItems
           : [
               <SelectOption
                 value={NO_RESULTS}
@@ -286,6 +287,18 @@ const ResourceListDropdown_: FC<ResourceListDropdownProps> = (props) => {
                 {t('public~No results found')}
               </SelectOption>,
             ]}
+        {selectOptions.length > MAX_VISIBLE_ITEMS && (
+          <SelectOption
+            value="type-to-filter"
+            key="select-multi-typeahead-type-to-filter"
+            isAriaDisabled={true}
+          >
+            {t('public~Showing {{visible}} of {{total}} resources. Type to filter.', {
+              visible: MAX_VISIBLE_ITEMS,
+              total: selectOptions.length,
+            })}
+          </SelectOption>
+        )}
       </Fragment>,
     );
     return options;
@@ -318,16 +331,30 @@ const ResourceListDropdown_: FC<ResourceListDropdownProps> = (props) => {
   const onTextInputChange = (_event: FormEvent<HTMLInputElement>, value: string) => {
     setInputValue(value);
     resetActiveAndFocusedItem();
+    if (value && !isOpen) {
+      setIsOpen(true);
+    }
   };
 
   const onSelect = (value: string) => {
     if (value && value !== NO_RESULTS) {
-      setSelectedOptions(
-        selected.includes(value)
-          ? selected.filter((selection) => selection !== value)
-          : [...selected, value],
-      );
+      const newSelected = selected.includes(value)
+        ? selected.filter((selection) => selection !== value)
+        : [...selected, value];
+      setSelectedOptions(newSelected);
       onChange(value);
+
+      // Update recently used resources
+      if (!_.isEmpty(newSelected)) {
+        setRecentSelected(
+          JSON.stringify(
+            _.union(
+              filterGroupVersionKind([...newSelected].reverse()),
+              recentSelectedList(recentSelected),
+            ),
+          ),
+        );
+      }
     }
 
     textInputRef.current?.focus();
@@ -335,19 +362,20 @@ const ResourceListDropdown_: FC<ResourceListDropdownProps> = (props) => {
 
   const handleMenuArrowKeys = (key: string) => {
     let indexToFocus = 0;
+    const maxIndex = Math.min(selectOptions.length, MAX_VISIBLE_ITEMS) - 1;
 
     if (!isOpen) {
       setIsOpen(true);
     }
 
-    if (selectOptions.every((option) => option.isDisabled)) {
+    if (maxIndex < 0 || selectOptions.every((option) => option.isDisabled)) {
       return;
     }
 
     if (key === 'ArrowUp') {
       // When no index is set or at the first index, focus to the last, otherwise decrement focus index
       if (focusedItemIndex === null || focusedItemIndex === 0) {
-        indexToFocus = selectOptions.length - 1;
+        indexToFocus = maxIndex;
       } else {
         indexToFocus = focusedItemIndex - 1;
       }
@@ -356,14 +384,14 @@ const ResourceListDropdown_: FC<ResourceListDropdownProps> = (props) => {
       while (selectOptions[indexToFocus].isDisabled) {
         indexToFocus--;
         if (indexToFocus === -1) {
-          indexToFocus = selectOptions.length - 1;
+          indexToFocus = maxIndex;
         }
       }
     }
 
     if (key === 'ArrowDown') {
       // When no index is set or at the last index, focus to the first, otherwise increment focus index
-      if (focusedItemIndex === null || focusedItemIndex === selectOptions.length - 1) {
+      if (focusedItemIndex === null || focusedItemIndex === maxIndex) {
         indexToFocus = 0;
       } else {
         indexToFocus = focusedItemIndex + 1;
@@ -372,7 +400,7 @@ const ResourceListDropdown_: FC<ResourceListDropdownProps> = (props) => {
       // Skip disabled options
       while (selectOptions[indexToFocus].isDisabled) {
         indexToFocus++;
-        if (indexToFocus === selectOptions.length) {
+        if (indexToFocus > maxIndex) {
           indexToFocus = 0;
         }
       }
@@ -479,6 +507,10 @@ const ResourceListDropdown_: FC<ResourceListDropdownProps> = (props) => {
 interface ExtendedSelectOptionProps extends SelectOptionProps {
   /** Searchable short names for the select options */
   shortNames?: string[];
+  /** Pre-computed lowercase text for filtering */
+  searchableText?: string;
+  /** Pre-computed lowercase short names for filtering */
+  searchableShortNames?: string[];
 }
 
 const resourceListDropdownStateToProps = ({ k8s }) => ({

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1257,6 +1257,7 @@
   "Tech Preview": "Tech Preview",
   "Clear history": "Clear history",
   "Recently used": "Recently used",
+  "Showing {{visible}} of {{total}} resources. Type to filter.": "Showing {{visible}} of {{total}} resources. Type to filter.",
   "Clear input value": "Clear input value",
   "{{count}} resource reached quota_one": "{{count}} resource reached quota",
   "{{count}} resource reached quota_other": "{{count}} resource reached quotas",


### PR DESCRIPTION
## Summary

The Search page Resources dropdown is unusable on clusters with 1000+ API resources. Typing causes multi-second delays with 100% CPU utilization. This PR fixes multiple compounding performance issues in `ResourceListDropdown`.

## Root Cause

- **O(n²) model filtering** — nested `.filter()` + `.find()` on `allModels` producing ~1M comparisons for 1000 resources
- **No memoization** — expensive computations (filtering, sorting, grouping, reference lookups) re-run on every render
- **Double re-renders per keystroke** — filter logic in a `useEffect` that calls `setSelectOptions`, causing a second render cycle
- **Redundant work in render loops** — `referenceForModel()` called 5 times per item; `toLowerCase()` called inside every filter iteration
- **All items rendered to DOM** — 1,234 `<SelectOption>` components (~12,000 DOM nodes) inserted at once, triggering 1.2s style recalculation and 1.4s forced reflow
- **Unnecessary JSX creation** — JSX/icon/i18n work performed for all 1,200+ items, then all but 200 discarded

## Changes

- Eliminate O(n²) filtering by pre-computing preferred group+kind pairs in a `Set` for O(1) lookups
- Memoize `resources`, `initialSelectOptions`, `kinds`, and `referenceToModelMap` with `useMemo`
- Replace state + `useEffect` pattern with `useMemo` for `selectOptions` to avoid double re-renders
- Pre-compute lowercase strings for filtering to avoid repeated `toLowerCase()` calls
- Build a reference-to-model `Map` for O(1) lookups instead of O(n) `Array.find()` per item
- Cap visible items at 100 and apply the cap before creating JSX to avoid unnecessary component creation
- Constrain keyboard navigation to visible items so focus cannot land off-DOM
- Filter out null entries from items before rendering
- Move recent selection update from effect into `onSelect` event handler, removing `clearItems` state and an `eslint-disable-next-line react-hooks/exhaustive-deps` suppression
- Move auto-open logic from effect into `onTextInputChange` event handler, removing another `eslint-disable` suppression

Removing the `eslint-disable-next-line react-hooks/exhaustive-deps` suppressions is significant because they were masking missing or incorrect dependency arrays — the original root cause of several performance issues in this component. With these suppressions gone, the linter can now catch future dependency mistakes that could reintroduce performance regressions.

## Performance Results

Tested on a cluster with 1,260 API resources (1,000 synthetic CRDs + 260 built-in).
Profiled using Chrome DevTools Performance traces on Intel Core Ultra 7 165H (22) @ 5.00 GHz.

[INP (Interaction to Next Paint)](https://web.dev/articles/inp) measures the latency of the worst user interaction on the page. It is a Core Web Vital metric with thresholds: good (≤200ms), needs improvement (≤500ms), bad (>500ms). INP breaks down into three phases:

1. **Input delay** — time before event callbacks begin
2. **Processing duration** — time for event callbacks to run
3. **Presentation delay** — time for the browser to paint the next frame

### Phase 1: Baseline (original code)

| Metric | Value |
|---|---|
| **INP** | **2,562ms** (bad) |
| Input delay | 0.7ms |
| Processing duration | 2,476ms |
| Presentation delay | 86ms |
| Total DOM elements | 16,443 |
| Dropdown children | 1,234 |
| Style recalculation | 1,214ms (17,334 elements) |
| Layout updates | 215ms + 107ms |
| Forced reflow (`refCallback`) | 1,539ms |

### Phase 2: After memoization + algorithm fixes

Eliminated O(n²) filtering, redundant `referenceForModel` calls, and double re-renders.

| Metric | Value | Change |
|---|---|---|
| **INP** | **1,438ms** (bad) | -44% |
| Input delay | 4ms | — |
| Processing duration | 1,397ms | -44% |
| Presentation delay | 38ms | -56% |
| Total DOM elements | 16,443 | — |
| Dropdown children | 1,234 | — |
| Style recalculation | 730ms (17,334 elements) | -40% |
| Layout updates | 139ms + 47ms | -42% |
| Forced reflow (`refCallback`) | 919ms | -40% |

### Phase 3: After item cap (100 max, applied before JSX creation)

Reduced DOM nodes by limiting rendered items and avoiding unnecessary JSX creation.

| Metric | Value | Change vs baseline |
|---|---|---|
| **INP (dropdown open)** | **270ms** (needs improvement) | **-89%** |
| Processing duration | 259ms | -90% |
| Presentation delay | 10ms | -88% |
| Total DOM elements | 1,691 | -90% |
| Dropdown children | 101 | -92% |
| Style recalculation | 65ms (1,449 elements) | -95% |
| Layout updates | not flagged | -100% |

### Remaining bottleneck

The remaining processing duration is primarily PatternFly's `Select` component overhead — `refCallback` measuring dropdown geometry after items are inserted into the DOM. Further improvement would require virtualized list support in PatternFly's Select component.

Note: during profiling we observed a separate `keypress` INP of 521ms unrelated to the dropdown. This is caused by the parent `SearchPage` component (state mutation bug, component remounts on filter change, no memoization) and is tracked separately in [OCPBUGS-81519](https://issues.redhat.com/browse/OCPBUGS-81519).

### Known limitation

The 100-item cap means users cannot browse the full unfiltered resource list by scrolling — they must type to filter. If this trade-off is unacceptable, the proper solution would be to implement a virtualized list component in `@patternfly/react-virtualized-extension` and integrate it with PatternFly's Select.

## Test Plan

- [x] Deploy cluster with many operators (`oc api-resources | wc -l > 1000`)
- [x] Navigate to Home > Search, click Resources dropdown — should open without multi-second delay
- [x] Type "deploy" — filtering should feel responsive with no perceptible lag
- [x] Clear input — dropdown should re-render without freezing
- [x] Select multiple resources, verify selection works correctly
- [x] Verify "Showing 100 of X resources. Type to filter." message appears when list is truncated
- [x] Arrow keys only navigate within visible items (cannot focus past item 100)
- [x] Verify recently used resources section still works (selections saved, clear history works, persists across page loads)
- [x] Type without opening dropdown first — dropdown should auto-open
- [x] On a standard cluster (~300 resources), verify no behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dropdown now caps visible results at 100 and shows an informational "Showing X of Y…" message when more matches exist.
  * Menu opens automatically when typing into a non-empty input.

* **Performance**
  * Much faster filtering and search responsiveness via memoized computations and cached searchable fields.
  * Faster option-to-model lookups to reduce UI lag.

* **Bug Fixes**
  * Recent-selections update made non-mutating and moved to selection handler to improve reliability.

* **Documentation**
  * Added English text for the "Showing X of Y…" informational message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->