### PR TITLE
[release-4.19] OCPBUGS-81736: Migrate InstallPlan components table to PatternFly Table

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.spec.tsx
@@ -1,4 +1,5 @@
 import { Button, Hint } from '@patternfly/react-core';
+import { Tbody, Tr, Td } from '@patternfly/react-table';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';
 import { Link } from 'react-router-dom-v5-compat';
@@ -21,6 +22,7 @@ import {
 } from '@console/internal/components/utils';
 import { CustomResourceDefinitionModel } from '@console/internal/models';
 import { referenceForModel, K8sResourceKind } from '@console/internal/module/k8s';
+import PaneBody from '@console/shared/src/components/layout/PaneBody';
 import { testInstallPlan } from '../../mocks';
 import { InstallPlanModel, ClusterServiceVersionModel, OperatorGroupModel } from '../models';
 import { InstallPlanKind, InstallPlanApproval } from '../types';
@@ -316,31 +318,31 @@ describe('InstallPlanPreview', () => {
 
   it('renders section for each resolving `ClusterServiceVersion`', () => {
     const wrapper = shallow(<InstallPlanPreview obj={obj} />);
-    expect(wrapper.find('.co-m-pane__body').length).toEqual(1);
-    wrapper.find('.co-m-pane__body').forEach((section) => {
-      expect(section.find('tbody').find('tr').length).toEqual(2);
+    expect(wrapper.find(PaneBody).length).toEqual(1);
+    wrapper.find(PaneBody).forEach((section) => {
+      expect(section.find(Tbody).find(Tr).length).toEqual(2);
     });
   });
 
   it('renders link to view install plan component if it exists', () => {
     const wrapper = shallow(<InstallPlanPreview obj={obj} />);
-    const row = wrapper.find('.co-m-pane__body').find('tbody').find('tr').at(0);
+    const row = wrapper.find(PaneBody).find(Tbody).find(Tr).at(0);
 
-    expect(row.find('td').at(0).find(ResourceLink).props().name).toEqual(
+    expect(row.find(Td).at(0).find(ResourceLink).props().name).toEqual(
       obj.status.plan[0].resource.name,
     );
   });
 
   it('renders link to open preview modal for install plan component if not created yet', () => {
     const wrapper = shallow(<InstallPlanPreview obj={obj} />);
-    const row = wrapper.find('.co-m-pane__body').find('tbody').find('tr').at(1);
+    const row = wrapper.find(PaneBody).find(Tbody).find(Tr).at(1);
     const modalSpy = spyOn(modal, 'installPlanPreviewModal').and.returnValue(null);
 
-    expect(row.find('td').at(0).find(ResourceIcon).props().kind).toEqual(
+    expect(row.find(Td).at(0).find(ResourceIcon).props().kind).toEqual(
       referenceForStepResource(obj.status.plan[1].resource),
     );
 
-    row.find('td').at(0).find(Button).simulate('click');
+    row.find(Td).at(0).find(Button).simulate('click');
 
     expect(modalSpy.calls.argsFor(0)[0].stepResource).toEqual(obj.status.plan[1].resource);
   });

--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
@@ -11,7 +11,7 @@ import {
   DescriptionListTerm,
   DescriptionListDescription,
 } from '@patternfly/react-core';
-import { sortable } from '@patternfly/react-table';
+import { sortable, Table as PFTable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import classNames from 'classnames';
 import { Map as ImmutableMap, Set as ImmutableSet, fromJS } from 'immutable';
 import * as _ from 'lodash';
@@ -482,56 +482,51 @@ export const InstallPlanPreview: React.FC<InstallPlanPreviewProps> = ({
         </PaneBody>
       )}
       {stepsByCSV.map((steps) => (
-        <div key={steps[0].resolving} className="co-m-pane__body">
+        <PaneBody key={steps[0].resolving}>
           <SectionHeading text={steps[0].resolving} />
-          <div className="co-table-container">
-            <table className="pf-v6-c-table pf-m-compact pf-m-border-rows">
-              <thead className="pf-v6-c-table__thead">
-                <tr className="pf-v6-c-table__tr">
-                  <th className={componentsTableColumnClasses[0]}>{t('olm~Name')}</th>
-                  <th className={componentsTableColumnClasses[1]}>{t('olm~Kind')}</th>
-                  <th className={componentsTableColumnClasses[2]}>{t('olm~Status')}</th>
-                  <th className={componentsTableColumnClasses[3]}>{t('olm~API version')}</th>
-                </tr>
-              </thead>
-              <tbody className="pf-v6-c-table__tbody">
-                {steps.map((step) => (
-                  <tr
-                    key={`${referenceForStepResource(step.resource)}-${step.resource.name}`}
-                    className="pf-v6-c-table__tr"
-                  >
-                    <td className={componentsTableColumnClasses[0]}>
-                      {['Present', 'Created'].includes(step.status) ? (
-                        <ResourceLink
-                          kind={referenceForStepResource(step.resource)}
-                          namespace={obj.metadata.namespace}
-                          name={step.resource.name}
-                          title={step.resource.name}
-                        />
-                      ) : (
-                        <>
-                          <ResourceIcon kind={referenceForStepResource(step.resource)} />
-                          <Button
-                            type="button"
-                            onClick={() => installPlanPreviewModal({ stepResource: step.resource })}
-                            variant="link"
-                          >
-                            {step.resource.name}
-                          </Button>
-                        </>
-                      )}
-                    </td>
-                    <td className={componentsTableColumnClasses[1]}>{step.resource.kind}</td>
-                    <td className={componentsTableColumnClasses[2]}>{stepStatus(step.status)}</td>
-                    <td className={componentsTableColumnClasses[3]}>
-                      {apiVersionForReference(referenceForStepResource(step.resource))}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
+          <PFTable variant="compact" borders>
+            <Thead>
+              <Tr>
+                <Th className={componentsTableColumnClasses[0]}>{t('olm~Name')}</Th>
+                <Th className={componentsTableColumnClasses[1]}>{t('olm~Kind')}</Th>
+                <Th className={componentsTableColumnClasses[2]}>{t('olm~Status')}</Th>
+                <Th className={componentsTableColumnClasses[3]}>{t('olm~API version')}</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {steps.map((step) => (
+                <Tr key={`${referenceForStepResource(step.resource)}-${step.resource.name}`}>
+                  <Td className={componentsTableColumnClasses[0]}>
+                    {['Present', 'Created'].includes(step.status) ? (
+                      <ResourceLink
+                        kind={referenceForStepResource(step.resource)}
+                        namespace={obj.metadata.namespace}
+                        name={step.resource.name}
+                        title={step.resource.name}
+                      />
+                    ) : (
+                      <>
+                        <ResourceIcon kind={referenceForStepResource(step.resource)} />
+                        <Button
+                          type="button"
+                          onClick={() => installPlanPreviewModal({ stepResource: step.resource })}
+                          variant="link"
+                        >
+                          {step.resource.name}
+                        </Button>
+                      </>
+                    )}
+                  </Td>
+                  <Td className={componentsTableColumnClasses[1]}>{step.resource.kind}</Td>
+                  <Td className={componentsTableColumnClasses[2]}>{stepStatus(step.status)}</Td>
+                  <Td className={componentsTableColumnClasses[3]}>
+                    {apiVersionForReference(referenceForStepResource(step.resource))}
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </PFTable>
+        </PaneBody>
       ))}
     </>
   ) : (


### PR DESCRIPTION
## Summary
Cherry-pick of the InstallPlan components table migration to PatternFly v6 Table components to the release-4.19 branch.

This PR:
- Replaces HTML table markup with PatternFly Table components (`PFTable`, `Thead`, `Tr`, `Th`, `Tbody`, `Td`) in the InstallPlanPreview component
- Replaces raw `co-m-pane__body` div wrapper with the proper `PaneBody` component for consistency
- Resolves merge conflict by ensuring both PatternFly Table imports and classNames utility are included

## Related Issues
- OCPBUGS-78253

## Test Plan
- [ ] Verify InstallPlan preview page renders correctly
- [ ] Verify table displays components with proper styling
- [ ] Verify approve/deny actions work as expected
- [ ] Verify no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)