### PR TITLE
OCPBUGS-95606, CONSOLE-5159: Replace deprecated Node10 moduleResolution with Bundler for TS6 compatibility

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/dynamic-module-parser.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/dynamic-module-parser.ts
@@ -8,7 +8,7 @@ import * as ts from 'typescript';
 const defaultCompilerOptions: ts.CompilerOptions = {
   target: ts.ScriptTarget.ES2020,
   module: ts.ModuleKind.ESNext,
-  moduleResolution: ts.ModuleResolutionKind.NodeJs,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
   allowJs: true,
   strict: false,
   esModuleInterop: true,


### PR DESCRIPTION
<h2 id="feature-fix">CONSOLE Features and Fixes:</h2>

Fixes TypeScript 6+ compatibility for `@openshift-console/dynamic-plugin-sdk-webpack`.

Jira: https://issues.redhat.com/browse/CONSOLE-5159

<h2 id="solution-description">Solution description</h2>

`getDynamicModuleMap()` in `dynamic-module-parser.ts` hardcodes
`moduleResolution: ts.ModuleResolutionKind.NodeJs` (alias for `Node10`).
TypeScript 6 treats this as a hard error (TS5107), breaking all consumers.

This replaces it with `ts.ModuleResolutionKind.Bundler`, which is functionally
equivalent -- the SDK only resolves relative paths within PatternFly packages'
`dist/esm/` and `dist/dynamic/` directories.

This also prepares for TypeScript 7, where `node10` will stop functioning entirely.

Closes #16258

<h2 id="test-cases">Test cases:</h2>

- Build an OCP plugin project with TypeScript 6.0.2 -- webpack config loads successfully
- PatternFly dynamic module exports are parsed correctly (765 exports from `@patternfly/react-core`, zero errors)

<h2 id="additional-info">Additional info:</h2>

- No visual/content/interaction changes
- Alternative fix: add `ignoreDeprecations: '6.0'` instead, but that only suppresses the warning without removing the deprecated option
- All published versions of `@openshift-console/dynamic-plugin-sdk-webpack` are affected, including latest `4.22.0-prerelease.2`

<h2 id="screenshots">Screen shots / gifs / design review:</h2>

N/A -- no UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module resolution handling for dynamic plugin modules in the SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->