### PR TITLE
NO-JIRA: Update Dockerfile.dev to use latest base images

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,11 +1,11 @@
 # Dockerfile to build console image from pre-built front end.
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.20 AS build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS build
 RUN mkdir -p /go/src/github.com/openshift/console/
 ADD . /go/src/github.com/openshift/console/
 WORKDIR /go/src/github.com/openshift/console/
 RUN ./build-backend.sh
 
-FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.22
 COPY --from=build /go/src/github.com/openshift/console/bin/bridge /opt/bridge/bin/bridge
 COPY ./frontend/public/dist /opt/bridge/static
 COPY ./pkg/graphql/schema.graphql /pkg/graphql/schema.graphql


### PR DESCRIPTION
## Summary
- Update Dockerfile.dev to use OpenShift 4.22 base images with Go 1.25
- Aligns with the main Dockerfile for consistency

## Changes
- Builder image: `rhel-9-golang-1.23-openshift-4.20` → `rhel-9-golang-1.25-openshift-4.22`
- Runtime image: `ocp/4.20:base-rhel9` → `ocp/builder:rhel-9-base-nodejs-openshift-4.22`

## Test plan
- [ ] Verify Dockerfile.dev builds successfully with updated images
- [ ] Confirm runtime container starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment with the latest development tools and platform versions to ensure improved performance and enhanced compatibility.
  * Upgraded runtime base image with an enhanced Node.js toolchain to improve application stability, strengthen security, and support better deployment practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->