### PR TITLE
OCPBUGS-82513: Enable Topology e2e tests

### DIFF
--- a/frontend/packages/topology/integration-tests/features/e2e/topology-ci.feature
+++ b/frontend/packages/topology/integration-tests/features/e2e/topology-ci.feature
@@ -1,5 +1,4 @@
-# Disabled due to createRoot concurrent rendering failures (OCPBUGS-82513)
-@topology @smoke @manual
+@topology @smoke
 Feature: Perform actions on topology
     User will be able to create workloads and perform actions on topology page
 

--- a/frontend/packages/topology/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/topology/integration-tests/support/commands/hooks.ts
@@ -2,12 +2,7 @@ import { checkErrors } from '@console/cypress-integration-tests/support';
 
 /* eslint-disable no-console, promise/catch-or-return */
 before(() => {
-  cy.exec('../../../../contrib/create-user.sh');
-  const bridgePasswordIDP: string = Cypress.expose('BRIDGE_HTPASSWD_IDP') || 'test';
-  const bridgePasswordUsername: string = Cypress.expose('BRIDGE_HTPASSWD_USERNAME') || 'test';
-  cy.env(['BRIDGE_HTPASSWD_PASSWORD']).then(({ BRIDGE_HTPASSWD_PASSWORD }) => {
-    cy.login(bridgePasswordIDP, bridgePasswordUsername, BRIDGE_HTPASSWD_PASSWORD || 'test');
-  });
+  cy.login();
   cy.document().its('readyState').should('eq', 'complete');
 });
 


### PR DESCRIPTION
**Analysis / Root cause**:
Topology e2e tests were previously disabled with the `@manual` tag due to OCPBUGS-82513 (createRoot concurrent rendering failures). The underlying issue causing React concurrent rendering failures in the Cypress test environment has been resolved, allowing these tests to be re-enabled for automated CI execution.

**Solution description**:
Re-enable Topology e2e tests by removing the `@manual` tag and simplifying the test setup.

**Changes**:
- **topology-ci.feature**: Remove `@manual` tag and OCPBUGS-82513 comment to re-enable automated test execution
- **hooks.ts**: Simplify before() hook by replacing custom login logic with the standard `cy.login()` command
  - Remove explicit `cy.exec('create-user.sh')` call
  - Remove manual environment variable handling (BRIDGE_HTPASSWD_IDP, BRIDGE_HTPASSWD_USERNAME, BRIDGE_HTPASSWD_PASSWORD)
  - Delegate to Cypress's built-in login command which already handles test user authentication

**Benefits**:
- Topology e2e tests now run automatically in CI instead of requiring manual execution
- Simplified test setup reduces maintenance overhead
- Aligns with standard Cypress testing patterns used across other test suites

**Screenshots / screen recording**:
N/A - Test infrastructure change only

**Test setup:**
Prerequisites to test this PR:
1. Have an OpenShift cluster running
2. Build and deploy the console
3. Run the Topology e2e tests via Cypress

**Test cases:**
- [ ] Run Topology e2e tests: `cd frontend/packages/topology && yarn run test-cypress-ci`
- [ ] Verify tests execute without createRoot concurrent rendering failures
- [ ] Verify all Topology e2e test scenarios pass
- [ ] Confirm test setup uses standard `cy.login()` without custom authentication code
- [ ] Verify tests run successfully in CI environment

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
- This PR specifically addresses OCPBUGS-82513 by re-enabling tests that were disabled as a workaround
- The underlying concurrent rendering issue has been resolved, making these workarounds unnecessary
- Tests use the standard Cypress login mechanism instead of custom authentication logic
- No functional changes to the Topology feature itself - only test infrastructure improvements

**Reviewers and assignees:**
<!--
Console Approver:
/assign <gh-user>
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)