### PR TITLE
OCPBUGS-82510: Fix web-terminal-adminuser e2e tests broken by createRoot

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/search-resources/search-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/search-resources/search-page.ts
@@ -25,7 +25,7 @@ export const searchResource = {
         navigateToAdminMenu(adminNavigationBar.Home);
       }
     });
-    cy.get(adminNavigationMenuPO.home.search).click();
+    cy.get(adminNavigationMenuPO.home.search).scrollIntoView().click();
     performResourceSearching(resourceName);
     cy.get('[id="resource-dropdown-listbox"]').scrollTo('top', { ensureScrollable: false });
     cy.byLegacyTestID('close-icon').should('be.visible').click({ force: true });

--- a/frontend/packages/integration-tests/views/nav.ts
+++ b/frontend/packages/integration-tests/views/nav.ts
@@ -11,6 +11,7 @@ export const nav = {
         // dropdown menu inside the toggle element, so .text() on the toggle
         // itself would include menu item labels.
         cy.byLegacyTestID('perspective-switcher-toggle')
+          .scrollIntoView()
           .should('be.visible')
           .then(($toggle) => {
             if (text === switchPerspective.Administrator) {
@@ -32,6 +33,7 @@ export const nav = {
           case 'Admin':
           case 'admin':
             cy.byLegacyTestID('perspective-switcher-toggle')
+              .scrollIntoView()
               .should('be.visible')
               .then(($toggle) => {
                 if ($toggle.attr('id') === 'core-platform-perspective') {
@@ -76,6 +78,7 @@ export const nav = {
             // dropdown menu item text (PF appends the menu inside the toggle
             // element via popperProps.appendTo).
             cy.byLegacyTestID('perspective-switcher-toggle')
+              .scrollIntoView()
               .should('be.visible')
               .find('.pf-v6-c-menu-toggle__text')
               .invoke('text')

--- a/frontend/packages/webterminal-plugin/integration-tests/features/web-terminal/web-terminal-adminuser.feature
+++ b/frontend/packages/webterminal-plugin/integration-tests/features/web-terminal/web-terminal-adminuser.feature
@@ -1,13 +1,11 @@
-# Disabled due to createRoot concurrent rendering failures (OCPBUGS-82510)
-@web-terminal @manual
+@web-terminal
 Feature: Web Terminal for Admin user
               As a user with admin rights, I should be able to use web terminal
 
 
         Background:
             Given user has logged in
-            #   And user is at administrator perspective
-            #   And user has created or selected namespace "aut-terminal"
+              And user has closed existing terminal workspace
 
 
         @regression @ODC-6463
@@ -33,7 +31,6 @@ Feature: Web Terminal for Admin user
               And user clicks on Start button
              Then user will see the terminal instance for namespace "openshift-terminal"
               And user ID obtained by API should match with user id in yaml editor for "openshift-terminal" namespace
-              And user has closed existing terminal workspace
 
 
         @smoke @ODC-6745
@@ -44,4 +41,3 @@ Feature: Web Terminal for Admin user
              Then user will see the terminal window
               And user will see the terminal instance for namespace "openshift-terminal"
               And user ID obtained by API should match with user id in yaml editor for "openshift-terminal" namespace
-              And user has closed existing terminal workspace

--- a/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/common/webTerminal.ts
+++ b/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/common/webTerminal.ts
@@ -48,7 +48,7 @@ Given('user can see terminal icon on masthead', () => {
 
 When('user clicks on the Web Terminal icon on the Masthead', () => {
   webTerminalPage.clickOpenCloudShellBtn();
-  cy.get('cos-status-box cos-status-box--loading').should('not.exist');
+  cy.get('[data-test="loading-box"]').should('not.exist');
 });
 
 Then('user will see the terminal window', () => {

--- a/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/pages/web-terminal/initTerminal-page.ts
+++ b/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/pages/web-terminal/initTerminal-page.ts
@@ -1,13 +1,6 @@
-import { switchPerspective } from '@console/dev-console/integration-tests/support/constants';
 import { formPO } from '@console/dev-console/integration-tests/support/pageObjects';
 import { webTerminalPO } from '@console/dev-console/integration-tests/support/pageObjects/webterminal-po';
-import {
-  app,
-  perspective,
-  projectNameSpace,
-} from '@console/dev-console/integration-tests/support/pages/app';
-import { searchResource } from '@console/dev-console/integration-tests/support/pages/search-resources/search-page';
-import { webTerminalPage } from './webTerminal-page';
+import { app } from '@console/dev-console/integration-tests/support/pages/app';
 
 export const initTerminalPage = {
   clickOnProjectDropDown: () => {
@@ -25,26 +18,7 @@ export const initTerminalPage = {
 
   clickStartButton: () => {
     cy.get(formPO.create).should('be.enabled').click({ force: true });
-    cy.get('body').then(($body) => {
-      cy.wait(5000);
-      // Due to initialization issue if multiple operators present OCPBUGS-44891
-      if ($body.find('[data-test="loading-box-body"]').length === 0) {
-        cy.log('loading did not go through');
-        cy.wait(10000);
-        cy.get(webTerminalPO.closeTerminalIcon).click();
-        cy.reload();
-        app.waitForDocumentLoad();
-        perspective.switchTo(switchPerspective.Administrator);
-        cy.byLegacyTestID('topology-header').should('exist').click({ force: true });
-        projectNameSpace.selectProject('openshift-terminal');
-        webTerminalPage.clickOpenCloudShellBtn();
-        searchResource.searchResourceByNameAsAdmin('DevWorkspace');
-        searchResource.selectSearchedItem('terminal');
-        // cy.get('[data-test="loading-indicator"]').should('not.exist', { timeout: 210000 });
-      } else {
-        cy.wait(5000);
-      }
-    });
+    cy.get('[data-test="loading-box-body"]').should('exist');
   },
 
   selectProject: (projectName: string) => {

--- a/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/web-terminal/web-terminal-adminuser.ts
+++ b/frontend/packages/webterminal-plugin/integration-tests/support/step-definitions/web-terminal/web-terminal-adminuser.ts
@@ -16,22 +16,15 @@ import {
 import { checkTerminalIcon } from '@console/dev-console/integration-tests/support/pages/functions/checkTerminalIcon';
 import { operatorsPage } from '@console/dev-console/integration-tests/support/pages/operators-page';
 import { searchResource } from '@console/dev-console/integration-tests/support/pages/search-resources/search-page';
-import { webTerminalPage } from '../pages/web-terminal/webTerminal-page';
 
 Given('user has logged in', () => {
   cy.login();
 });
 
 Given('user has closed existing terminal workspace', () => {
-  searchResource.searchResourceByNameAsAdmin('DevWorkspace');
-  cy.get('.loading-box').then(($body) => {
-    if ($body.find('[data-test="empty-box-body"]').length === 0) {
-      cy.log($body.find('[data-test="empty-box-body"]').length.toString());
-      searchResource.selectSearchedItem('terminal');
-      webTerminalPage.deleteTerminalInstanceActionMenu();
-    } else {
-      cy.log('No DevWorkspaces found');
-    }
+  cy.exec('oc delete devworkspaces --all -n openshift-terminal', {
+    failOnNonZeroExit: false,
+    timeout: 30000,
   });
 });
 
@@ -42,7 +35,7 @@ Given('user can see terminal icon on masthead', () => {
 
 When('user clicks on the Web Terminal icon on the Masthead', () => {
   cy.get(webTerminalPO.webTerminalIcon).click();
-  cy.get('cos-status-box cos-status-box--loading').should('not.exist');
+  cy.get('[data-test="loading-box"]').should('not.exist');
 });
 
 When('user clicks advanced option for Timeout', () => {


### PR DESCRIPTION
## Summary

The `web-terminal-adminuser.feature` e2e tests were disabled after the createRoot migration ([CONSOLE-4512](https://redhat.atlassian.net/browse/CONSOLE-4512)) because they started failing consistently. Root cause analysis (via CI Cypress Cloud replays and local reproduction) revealed:

- `clickStartButton` in `initTerminal-page.ts` used a synchronous `$body.find()` jQuery check to detect a loading indicator. Under legacy `ReactDOM.render`, React committed updates synchronously after a click, so the indicator was in the DOM when the check ran. Under `createRoot`, renders are deferred — the check always fails and triggers an OCPBUGS-44891 recovery path that leaves the app in a broken state (drawer open, sidebar scrolled, workspace already created), causing cascading failures on retry.
- `cos-status-box cos-status-box--loading` selectors matched nonexistent HTML elements (should be CSS class selectors), passing immediately as no-ops.
- Workspace cleanup ran at the end of each test — if a test failed before reaching cleanup, subsequent tests found leftover workspaces and never saw the setup form.

### Changes

- **`initTerminal-page.ts`**: Replace synchronous `$body.find()` + recovery path with a Cypress retry-based `cy.get().should('exist')` that waits for the loading indicator
- **`web-terminal-adminuser.ts`, `webTerminal.ts`**: Replace broken `cos-status-box` selectors with `[data-test="loading-box"]`
- **`web-terminal-adminuser.feature`**: Move workspace cleanup to Background (runs before each test), remove disabling comment
- **`web-terminal-adminuser.ts`**: Replace UI-based workspace cleanup (`searchResourceByNameAsAdmin` + delete via action menu) with `oc delete devworkspaces --all -n openshift-terminal` to avoid sidebar navigation issues (Search link not visible when favorites push nav items out of view)
- **`nav.ts`**: Add `scrollIntoView()` to perspective switcher toggle — on CI, sidebar favorites from earlier specs can push it out of view
- **`search-page.ts`**: Add `scrollIntoView()` to Search nav link for the same reason

## Test plan

- [ ] Verify `web-terminal-adminuser.feature` tests pass on CI (e2e-gcp-console job)
- [ ] Manual verification: on a cluster with Web Terminal Operator, open terminal drawer as admin -> setup form renders, Start creates a workspace successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)