### PR TITLE
OCPBUGS-83532: Fix race condition in CRD Cypress test

### DIFF
--- a/frontend/packages/integration-tests/tests/crud/customresourcedefinition.cy.ts
+++ b/frontend/packages/integration-tests/tests/crud/customresourcedefinition.cy.ts
@@ -99,6 +99,8 @@ describe('CustomResourceDefinitions', () => {
     listPage.isCreateButtonVisible();
     listPage.dvRows.shouldBeLoaded();
     listPage.dvRows.clickKebabAction(`CRD${testName}`, 'View instances');
+    cy.url().should('include', `/k8s/all-namespaces/test.example.com~v1~CRD${testName}`);
+    listPage.isCreateButtonVisible();
     listPage.clickCreateYAMLbutton();
     yamlEditor.isLoaded();
     yamlEditor.getEditorContent().then((content) => {


### PR DESCRIPTION
## Summary
- Fixes intermittent test failures in `customresourcedefinition.cy.ts`
- Adds URL validation and page load synchronization after navigation

## Problem
The test was failing intermittently because it attempted to click the "Create YAML" button immediately after clicking "View instances" in the kebab menu, without waiting for:
1. Navigation to complete to the instances page
2. The page to fully load and render

This created a race condition where the button might not exist yet when Cypress tried to interact with it.

## Solution
Added two synchronization points after the `clickKebabAction` call:
1. `cy.url().should('include', ...)` - Ensures navigation completed to the correct URL
2. `listPage.isCreateButtonVisible()` - Ensures the page loaded and the Create button exists

## Test plan
- [ ] Run the test multiple times to verify it no longer flakes: `cd frontend && yarn test:cypress --spec 'packages/integration-tests/tests/crud/customresourcedefinition.cy.ts'`
- [ ] Verify CI passes
- [ ] Consider auditing other tests using `clickKebabAction` for similar race conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for CustomResourceDefinition instance navigation and visibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->