### PR TITLE
OCPBUGS-78775: Add namespace constraints to scheduler and controller-manager PromQL queries

### DIFF
--- a/frontend/packages/console-app/src/queries.ts
+++ b/frontend/packages/console-app/src/queries.ts
@@ -14,8 +14,9 @@ import { PodModel } from '@console/internal/models';
 export const API_SERVERS_UP =
   '(sum(up{job="apiserver"} == 1) / count(kube_pod_labels{label_app="openshift-kube-apiserver",label_apiserver="true",namespace="openshift-kube-apiserver"})) * 100';
 export const CONTROLLER_MANAGERS_UP =
-  '(sum(up{job="kube-controller-manager"} == 1) / count(up{job="kube-controller-manager"})) * 100';
-export const SCHEDULERS_UP = '(sum(up{job="scheduler"} == 1) / count(up{job="scheduler"})) * 100';
+  '(sum(up{job="kube-controller-manager",namespace="openshift-kube-controller-manager"} == 1) / count(up{job="kube-controller-manager",namespace="openshift-kube-controller-manager"})) * 100';
+export const SCHEDULERS_UP =
+  '(sum(up{job="scheduler",namespace="openshift-kube-scheduler"} == 1) / count(up{job="scheduler",namespace="openshift-kube-scheduler"})) * 100';
 export const API_SERVER_REQUESTS_SUCCESS =
   '(1 - (sum(rate(apiserver_request_total{code=~"5.."}[5m])) or vector(0))/ sum(rate(apiserver_request_total[5m]))) * 100';
 


### PR DESCRIPTION
## Summary

- Add `namespace="openshift-kube-scheduler"` constraint to the `SCHEDULERS_UP` PromQL query
- Add `namespace="openshift-kube-controller-manager"` constraint to the `CONTROLLER_MANAGERS_UP` PromQL query
- Prevents false positive control plane degradation when user workloads create Prometheus scrape targets with `job="scheduler"` or `job="kube-controller-manager"`

## Root Cause

The `SCHEDULERS_UP` and `CONTROLLER_MANAGERS_UP` queries lacked namespace selectors, matching **any** Prometheus target with the corresponding job label across all namespaces. When a user creates a `Service` named `scheduler` with a `ServiceMonitor`, Prometheus assigns `job="scheduler"` to that scrape target. Since the user workload doesn't expose valid Prometheus metrics, the `up` metric returns `0`, diluting the response rate calculation (e.g., `3/4 * 100 = 75%`) and triggering a false "Degraded" status in Overview > Control Plane.

This fix aligns both queries with the existing `API_SERVERS_UP` query, which already constrains to `namespace="openshift-kube-apiserver"`.

## Reproduction Steps

1. Enable user workload monitoring
2. Create a namespace with a `Service` named `scheduler` and a `ServiceMonitor` targeting it
3. Observe Overview > Status > Control Plane shows "Degraded" / Schedulers at 75%

## Verification

Tested on a live 4.18 cluster with the fake workload present:
- **Old query** (no namespace filter): `75%` — false degradation
- **Fixed query** (with namespace filter): `100%` — correct

## Test plan

- [ ] Deploy the fix to a 4.18 cluster with user workload monitoring enabled
- [ ] Create a fake scheduler workload (Service + ServiceMonitor with `job="scheduler"`) in a user namespace
- [ ] Verify Overview > Control Plane > Schedulers remains at 100% and shows no degradation
- [ ] Verify that with no fake workload, all control plane components still report correctly
- [ ] Verify the Control Plane popup shows correct response rates for all 4 components

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of control plane component uptime metrics by refining the scope of metric queries to specific namespaces for controller managers and schedulers. This ensures more precise monitoring and visibility of component health.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="370" height="232" alt="Screenshot 2026-04-16 at 5 20 30 PM" src="https://github.com/user-attachments/assets/765c8e1d-de2f-4c24-81ff-cc0a9c6890ed" />

