### PR TITLE
[release-4.18] OCPBUGS-81648: Fix orphaned shell processes in pod terminal on WebSocket disconnect

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -230,7 +230,18 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, errMsg, statusCode)
 		return
 	}
-	defer backend.Close()
+	isExec := strings.HasSuffix(r.URL.Path, "/exec")
+	var backendWriteMutex sync.Mutex // Protects backend writes from copyMsgs and deferred exec cleanup
+	defer func() {
+		if isExec {
+			backendWriteMutex.Lock()
+			sendExecExitCommand(backend)
+			backendWriteMutex.Unlock()
+		}
+		closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
+		_ = backend.WriteControl(websocket.CloseMessage, closeMsg, time.Now().Add(websocketTimeout))
+		backend.Close()
+	}()
 
 	upgrader := &websocket.Upgrader{
 		Subprotocols: []string{subProtocol},
@@ -269,7 +280,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Can't just use io.Copy here since browsers care about frame headers.
 	go func() { errc <- copyMsgs(nil, frontend, backend) }()
-	go func() { errc <- copyMsgs(&writeMutex, backend, frontend) }()
+	go func() { errc <- copyMsgs(&backendWriteMutex, backend, frontend) }()
 
 	for {
 		select {
@@ -285,6 +296,31 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+	}
+}
+
+// sendExecExitCommand sends "exit\r" to the exec session's STDIN channel
+// to terminate the shell process and prevent orphaned processes when the
+// frontend WebSocket disconnects.
+func sendExecExitCommand(backend *websocket.Conn) {
+	var msg []byte
+	var msgType int
+
+	switch backend.Subprotocol() {
+	case "base64.channel.k8s.io":
+		exitCmd := base64.StdEncoding.EncodeToString([]byte("exit\r"))
+		msg = []byte("0" + exitCmd)
+		msgType = websocket.TextMessage
+	case "v4.channel.k8s.io", "v5.channel.k8s.io":
+		msg = append([]byte{0}, []byte("exit\r")...)
+		msgType = websocket.BinaryMessage
+	default:
+		klog.V(4).Infof("Skipping exec exit command for unsupported websocket subprotocol: %q", backend.Subprotocol())
+		return
+	}
+
+	if err := backend.WriteMessage(msgType, msg); err != nil {
+		klog.V(4).Infof("Failed to send exit command to exec session: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- When a pod terminal WebSocket connection drops, the shell process inside the container was never terminated, leading to accumulation of orphaned `sh` processes
- Root cause: gorilla/websocket's `Close()` only drops the TCP connection without sending a WebSocket close frame, and no `exit` command was sent to the shell on disconnect
- Fix: send `exit` through the exec STDIN channel (`base64.channel.k8s.io` protocol) and a proper WebSocket close frame to the Kubernetes API server when the proxy connection closes

## Details
The cleanup in `componentWillUnmount` (frontend) only runs when the user navigates away from the terminal page. When the WebSocket drops while the page stays loaded (e.g., load balancer idle timeout, network interruption), the shell process inside the container survives indefinitely. Each reconnection spawns a new shell, causing orphaned processes to accumulate. This is especially impactful for high-usage pods like DB2U.

The fix adds cleanup at the proxy layer (`pkg/proxy/proxy.go`), which handles all disconnect scenarios regardless of how the frontend behaves.

## Test plan
- [x] Verified on a live OpenShift 4.18 cluster by running a local console bridge with the fix
- [x] Opened pod terminal, confirmed shell process created (`ps aux` via `oc exec`)
- [x] Forced WebSocket disconnect via browser DevTools
- [x] Confirmed old shell process was terminated (no longer in `ps aux`)
- [x] Confirmed reconnected terminal created a fresh shell process
- [x] All existing proxy unit tests pass (`go test ./pkg/proxy/`)
- [ ] CLI access (`oc rsh` / `oc exec`) unaffected (fix only targets `/exec` WebSocket path in the proxy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced websocket exec session termination with improved cleanup procedures, including proper termination signaling and graceful connection closure handshakes for more reliable session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->