### PR TITLE
OCPBUGS-83532: Add empty state visibility check to CRD test

### DIFF
--- a/frontend/packages/integration-tests/tests/crud/customresourcedefinition.cy.ts
+++ b/frontend/packages/integration-tests/tests/crud/customresourcedefinition.cy.ts
@@ -100,6 +100,7 @@ describe('CustomResourceDefinitions', () => {
     listPage.dvRows.shouldBeLoaded();
     listPage.dvRows.clickKebabAction(`CRD${testName}`, 'View instances');
     cy.url().should('include', `/k8s/all-namespaces/test.example.com~v1~CRD${testName}`);
+    cy.byTestID('empty-box').should('be.visible');
     listPage.isCreateButtonVisible();
     listPage.clickCreateYAMLbutton();
     yamlEditor.isLoaded();


### PR DESCRIPTION
## Summary
- Adds an explicit wait for the empty-box element to be visible after navigating to CRD instances
- Prevents race condition where the create button might not be interactive yet

## Why
This is a follow-up to the previous fix for OCPBUGS-83532. While the initial fix addressed a race condition by ensuring rows were loaded before clicking kebab actions, there was still a timing issue after navigation where the test could attempt to click the create button before the page was fully rendered.

## Test plan
- [x] Verify CRD Cypress test passes consistently
- [x] Confirm the empty state is visible before attempting to create
- [x] No regressions in other CRD test scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test coverage for CustomResourceDefinition instance viewing to verify proper UI element visibility and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->