### PR TITLE
OCPBUGS-83812: Fix race conditions in OLM descriptors Cypress test

### DIFF
--- a/frontend/packages/integration-tests/support/admin.ts
+++ b/frontend/packages/integration-tests/support/admin.ts
@@ -15,6 +15,7 @@ Cypress.Commands.add('initAdmin', () => {
   cy.log('redirect to home');
   cy.visit('/');
   cy.byTestID('loading-indicator').should('not.exist');
+  cy.document().its('readyState').should('eq', 'complete');
   cy.log('ensure perspective switcher is set to Core platform');
   nav.sidenav.switcher.changePerspectiveTo('Core platform');
   nav.sidenav.switcher.shouldHaveText('Core platform');

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/tests/descriptors.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/tests/descriptors.cy.ts
@@ -16,7 +16,9 @@ describe('Using OLM descriptor components', () => {
 
   afterEach(() => {
     cy.visit('/');
-    cy.exec(`oc delete ${testCRD.spec.names.kind} ${testCR.metadata.name} -n ${testName}`);
+    cy.exec(
+      `oc delete ${testCRD.spec.names.kind} ${testCR.metadata.name} -n ${testName} --ignore-not-found=true`,
+    );
     checkErrors();
   });
 


### PR DESCRIPTION
## Summary
Fixes race conditions in the OLM descriptors Cypress test:
- Adds explicit document ready check in `initAdmin()` to prevent early test execution
- Improves cleanup error handling by adding `--ignore-not-found=true`

These changes allow real errors (auth failures, CLI issues) to surface while properly handling expected "not found" scenarios during cleanup, consistent with patterns in other OLM integration tests.

## Test plan
- [x] Verify test cleanup handles missing resources gracefully
- [x] Verify real errors are not masked during cleanup
- [x] Verify document ready check prevents early test execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)