### PR TITLE
OCPBUGS-83813: Fix race conditions in debug pod Cypress tests

### DIFF
--- a/frontend/packages/integration-tests/tests/app/debug-pod.cy.ts
+++ b/frontend/packages/integration-tests/tests/app/debug-pod.cy.ts
@@ -68,6 +68,9 @@ describe('Debug pod', () => {
     cy.visit(`/k8s/ns/${testName}/pods/${POD_NAME}`);
     detailsPage.isLoaded();
     cy.byTestID('popover-status-button', { timeout: 60000 }).click();
+    // Regression test for OCPBUGS-83813: Wait for popover content to be stable before clicking
+    // https://issues.redhat.com/browse/OCPBUGS-83813
+    cy.byTestID(`popup-debug-container-link-${CONTAINER_NAME}`).should('be.visible');
     cy.byTestID(`popup-debug-container-link-${CONTAINER_NAME}`).click();
     listPage.titleShouldHaveText(`Debug ${CONTAINER_NAME}`);
     cy.get(XTERM_CLASS).should('exist');
@@ -79,8 +82,9 @@ describe('Debug pod', () => {
     cy.visit(`/k8s/ns/${testName}/pods`);
     listPage.dvRows.shouldExist(POD_NAME);
     listPage.dvRows.clickStatusButton(POD_NAME);
-    // Click on first debug link
-    cy.byTestID(`popup-debug-container-link-${CONTAINER_NAME}`).click();
+    // Regression test for OCPBUGS-83813: Wait for popover content to be stable before clicking
+    // https://issues.redhat.com/browse/OCPBUGS-83813
+    cy.byTestID(`popup-debug-container-link-${CONTAINER_NAME}`).should('be.visible').click();
     listPage.titleShouldHaveText(`Debug ${CONTAINER_NAME}`);
     cy.get(XTERM_CLASS).should('exist');
 


### PR DESCRIPTION
## Summary
Fixes intermittent test failures in the debug pod Cypress tests caused by race conditions when clicking links inside PatternFly Popovers that re-render asynchronously.

## Changes
- Added proper wait conditions (`.should('be.visible')`) before clicking debug container links in popover content
- Applied fix to both test cases: Pod Details page and Pods Page
- Added regression test comments linking to OCPBUGS-83813

## Test plan
- [x] Run the affected Cypress tests to verify they no longer fail intermittently
- [x] Verify the tests properly wait for popover content to be stable before interaction
- [x] Confirm ESLint passes (no arbitrary `cy.wait()` calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test reliability with improved readiness verification during initialization.
  * Added visibility checks before user interactions in Cypress tests.
  * Strengthened error handling in test cleanup processes to improve stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->