### PR TITLE
OCPBUGS-83816: Fix race conditions in create-namespace Cypress tests

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests/tests/create-namespace.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/tests/create-namespace.cy.ts
@@ -26,13 +26,19 @@ describe('Create namespace from install operators', () => {
     cy.byTestID('search-catalog').type(operatorName);
     cy.url().should('include', 'keyword');
     cy.byTestID(operatorSelector).click();
-    cy.byTestID('catalog-details-modal-cta').click({ force: true });
+    // Wait for the Install button to be visible and have a valid href before clicking.
+    // The button is conditionally rendered based on useCtaLink hook, which processes
+    // the CTA href asynchronously. Clicking before href is set causes navigation to fail.
+    cy.byTestID('catalog-details-modal-cta').should('be.visible').and('have.attr', 'href');
+    cy.byTestID('catalog-details-modal-cta').click();
 
     // 3scale 2.11 supports only installation mode 'A specific namespace',
     // so it was automatically selected.
     // But starting with 2.12 it also supports 'All namespaces'.
     // So it is required to select this radio option to specify the namespace.
-    cy.byTestID('A specific namespace on the cluster-radio-input').click();
+    // Regression test: Wait for radio button to be visible before clicking to avoid race conditions
+    // where the form re-renders asynchronously after the channel/version selectors load.
+    cy.byTestID('A specific namespace on the cluster-radio-input').should('be.visible').click();
 
     // configure operator install ("^=Create_"" will match "Create_Namespace" and "Create_Project")
     cy.byTestID('dropdown-selectbox').click().get('[data-test-dropdown-menu^="Create_"]').click();

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/views/operator.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/views/operator.view.ts
@@ -22,7 +22,13 @@ export const operator = {
     cy.log('go to operator overview panel');
     cy.byTestID(operatorCardTestID).click();
     cy.log('go to the install form');
-    cy.byTestID('catalog-details-modal-cta').click({ force: true });
+    // Wait for the Install button to be visible and have a valid href before clicking.
+    // The button is conditionally rendered based on useCtaLink hook, which processes
+    // the CTA href asynchronously. Clicking before href is set causes navigation to fail.
+    cy.byTestID('catalog-details-modal-cta')
+      .should('be.visible')
+      .should('have.attr', 'href')
+      .click();
     cy.log('verify the channel selection is displayed');
     cy.byTestID('operator-channel-select-toggle').should('exist');
     cy.log('verify the version selection is displayed');
@@ -39,7 +45,8 @@ export const operator = {
      */
     if (installToNamespace !== GlobalInstalledNamespace) {
       cy.log('configure Operator install for single namespace');
-      cy.byTestID('A specific namespace on the cluster-radio-input').check();
+      // Wait for radio button to be visible before checking to avoid race conditions
+      cy.byTestID('A specific namespace on the cluster-radio-input').should('be.visible').check();
       if (useOperatorRecommendedNamespace) {
         cy.log('configure Operator install for operator recommended namespace');
         cy.byTestID('Operator recommended Namespace:-radio-input').check();


### PR DESCRIPTION
### What is this PR about?

Fixes intermittent failures in the `create-namespace.cy.ts` Cypress test caused by race conditions.

### Root Cause Analysis

Investigation revealed two distinct race conditions:

1. **Install button navigation failure**: The catalog modal Install button (`catalog-details-modal-cta`) is conditionally rendered based on the `useCtaLink` hook, which asynchronously processes the CTA href by parsing query parameters. Clicking the button before the `href` attribute is fully set causes navigation to the install form to fail silently.

2. **Radio button detachment**: The Installation mode radio buttons re-render asynchronously after the channel/version selectors load their data, causing the DOM element to be detached before Cypress can interact with it.

### Changes

- **catalog-details-modal-cta clicks**: Added `.should('have.attr', 'href')` assertion to wait for the href attribute to be set before clicking, ensuring navigation will succeed
- **Radio button interactions**: Added `.should('be.visible')` wait conditions before clicking/checking to ensure elements are stable after async re-renders
- **Scope**: Applied fixes to both `create-namespace.cy.ts` and `operator.view.ts` for consistency

### Testing

- [ ] Verified test passes locally
- [ ] Verified fix addresses both race conditions
- [ ] No changes to production code, test-only fix

### Related Issues

- Jira: [OCPBUGS-83816](https://issues.redhat.com/browse/OCPBUGS-83816)

🤖 Generated with [Claude Code](https://claude.com/claude-code)