### PR TITLE
OCPBUGS-83817: Fix orphaned shell processes in pod terminal on WebSocket disconnect

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -261,7 +261,9 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		if isExec {
 			backendWriteMutex.Lock()
+			_ = backend.SetWriteDeadline(time.Now().Add(websocketTimeout))
 			sendExecExitCommand(backend)
+			_ = backend.SetWriteDeadline(time.Time{})
 			backendWriteMutex.Unlock()
 		}
 		closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
@@ -361,7 +363,9 @@ func copyMsgs(writeMutex *sync.Mutex, dest, src *websocket.Conn) error {
 			err = dest.WriteMessage(messageType, msg)
 		} else {
 			writeMutex.Lock()
+			_ = dest.SetWriteDeadline(time.Now().Add(websocketTimeout))
 			err = dest.WriteMessage(messageType, msg)
+			_ = dest.SetWriteDeadline(time.Time{})
 			writeMutex.Unlock()
 		}
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -256,7 +256,18 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, errMsg, statusCode)
 		return
 	}
-	defer backend.Close()
+	isExec := strings.HasSuffix(r.URL.Path, "/exec")
+	var backendWriteMutex sync.Mutex // Protects backend writes from copyMsgs and deferred exec cleanup
+	defer func() {
+		if isExec {
+			backendWriteMutex.Lock()
+			sendExecExitCommand(backend)
+			backendWriteMutex.Unlock()
+		}
+		closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
+		_ = backend.WriteControl(websocket.CloseMessage, closeMsg, time.Now().Add(websocketTimeout))
+		backend.Close()
+	}()
 
 	upgrader := &websocket.Upgrader{
 		Subprotocols: []string{subProtocol},
@@ -295,7 +306,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Can't just use io.Copy here since browsers care about frame headers.
 	go func() { errc <- copyMsgs(nil, frontend, backend) }()
-	go func() { errc <- copyMsgs(&writeMutex, backend, frontend) }()
+	go func() { errc <- copyMsgs(&backendWriteMutex, backend, frontend) }()
 
 	for {
 		select {
@@ -311,6 +322,31 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+	}
+}
+
+// sendExecExitCommand sends "exit\r" to the exec session's STDIN channel
+// to terminate the shell process and prevent orphaned processes when the
+// frontend WebSocket disconnects.
+func sendExecExitCommand(backend *websocket.Conn) {
+	var msg []byte
+	var msgType int
+
+	switch backend.Subprotocol() {
+	case "base64.channel.k8s.io":
+		exitCmd := base64.StdEncoding.EncodeToString([]byte("exit\r"))
+		msg = []byte("0" + exitCmd)
+		msgType = websocket.TextMessage
+	case "v4.channel.k8s.io", "v5.channel.k8s.io":
+		msg = append([]byte{0}, []byte("exit\r")...)
+		msgType = websocket.BinaryMessage
+	default:
+		klog.V(4).Infof("Skipping exec exit command for unsupported websocket subprotocol: %q", backend.Subprotocol())
+		return
+	}
+
+	if err := backend.WriteMessage(msgType, msg); err != nil {
+		klog.V(4).Infof("Failed to send exit command to exec session: %v", err)
 	}
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -256,7 +256,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, errMsg, statusCode)
 		return
 	}
-	isExec := strings.HasSuffix(r.URL.Path, "/exec")
+	isExec := strings.HasSuffix(strings.TrimRight(r.URL.Path, "/"), "/exec")
 	var backendWriteMutex sync.Mutex // Protects backend writes from copyMsgs and deferred exec cleanup
 	defer func() {
 		if isExec {


### PR DESCRIPTION
## Summary
- When a pod terminal WebSocket connection drops, the shell process inside the container was never terminated, leading to accumulation of orphaned `sh` processes
- Root cause: gorilla/websocket's `Close()` only drops the TCP connection without sending a WebSocket close frame, and no `exit` command was sent to the shell on disconnect
- Fix: send `exit` through the exec STDIN channel and a proper WebSocket close frame to the Kubernetes API server when the proxy connection closes
- Use a dedicated `backendWriteMutex` to prevent concurrent writes to the backend connection (gorilla/websocket's one-writer contract)
- Check the negotiated subprotocol (`base64.channel.k8s.io` vs `v4`/`v5.channel.k8s.io`) to use the correct frame encoding

## Details
The cleanup in `componentWillUnmount` (frontend) only runs when the user navigates away from the terminal page. When the WebSocket drops while the page stays loaded (e.g., load balancer idle timeout, network interruption), the shell process inside the container survives indefinitely. Each reconnection spawns a new shell, causing orphaned processes to accumulate. This is especially impactful for high-usage pods like DB2U.

The fix adds cleanup at the proxy layer (`pkg/proxy/proxy.go`), which handles all disconnect scenarios regardless of how the frontend behaves.

## Test plan
- [x] Reproduced on live OpenShift 4.18 cluster — orphaned shells accumulate on each disconnect/reconnect
- [x] Reproduced on live OpenShift 4.21 cluster — same behavior confirmed
- [x] Verified fix on 4.18 cluster by running a local console bridge with the patch
- [x] Confirmed old shell process was terminated after WebSocket disconnect (`ps aux` via `oc exec`)
- [x] Confirmed reconnected terminal created a fresh shell process with no orphans
- [x] All existing proxy unit tests pass (`go test ./pkg/proxy/`)
- [ ] CLI access (`oc rsh` / `oc exec`) unaffected (fix only targets `/exec` WebSocket path in the proxy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved websocket connection cleanup and proper termination for remote execution sessions
  * Fixed potential race conditions in concurrent backend operations to enhance stability
  * Enhanced synchronization mechanisms to prevent connection conflicts and ensure reliable connections
  * Better support across different kubernetes websocket protocol implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->