### PR TITLE
CONSOLE-5203: Remove old QE team from our repos

### DIFF
--- a/frontend/integration-tests/OWNERS
+++ b/frontend/integration-tests/OWNERS
@@ -1,8 +1,0 @@
-reviewers:
-  - sanketpathak
-  - the-anton
-  - yapei
-approvers:
-  - jrichter1
-  - psrna
-  - sanketpathak

--- a/frontend/packages/console-telemetry-plugin/integration-tests/OWNERS
+++ b/frontend/packages/console-telemetry-plugin/integration-tests/OWNERS
@@ -1,7 +1,0 @@
-reviewers:
-  - sanketpathak
-  - the-anton
-approvers:
-  - jrichter1
-  - psrna
-  - sanketpathak

--- a/frontend/packages/dev-console/integration-tests/OWNERS
+++ b/frontend/packages/dev-console/integration-tests/OWNERS
@@ -1,7 +1,0 @@
-reviewers:
-  - sanketpathak
-  - the-anton
-approvers:
-  - jrichter1
-  - psrna
-  - sanketpathak

--- a/frontend/packages/dev-console/integration-tests/README.md
+++ b/frontend/packages/dev-console/integration-tests/README.md
@@ -131,24 +131,21 @@ export const devFilePO = {
 
 ### Feature files Review
 
-- Epic related feature files needs to reviewed in 3 phases
+- Epic related feature files needs to reviewed in 2 phases
 
-1. Review by QE team for standardization & Functional check [Peer Review]
+1. Review by Dev team for standardization & Functional check [Peer Review]
 2. Review by Dev team [Preferably Feature owner]
-3. Assign to QE Lead for review
 
 - To update the feature files not related to epics
 
-1. Review by QE team for standardization & Functional check [Peer Review]
-2. Assign to QE Lead for review
+1. Review by team for standardization & Functional check [Peer Review]
 
 ### Code Review Process
 
 - Github adds a reviewer automatically for the PR
 
-1. Review by QE team for standardization [Peer Review]
+1. Review by Dev team for standardization [Peer Review]
 2. Review by Dev team [Optional]
-3. Assign to QE Lead for review
 
 ### What needs to be reviewed as part of Code Review
 
@@ -238,7 +235,7 @@ If you need to execute "smoke" tagged scripts present in single feature file the
 2. Comments should be included wherever required
 3. Don't include console.log statements while raising PR
 4. .gherkin-lintrc configuration file present in frontend folder is used to set Gherkin standards
-5. Execute the "yarn run gherkin-lint" command for every QE pr
+5. Execute the "yarn run gherkin-lint" command for every PR
 
 ## References
    [Cypress Cucumber Handbook](https://docs.google.com/document/d/1hL_k5r6CVxbY5va6RPPCJfndQjLwSdt6SUKj-kWLqig/edit#)

--- a/frontend/packages/dev-console/integration-tests/features/service-mesh/OWNERS
+++ b/frontend/packages/dev-console/integration-tests/features/service-mesh/OWNERS
@@ -1,3 +1,0 @@
-reviewers:
-  - pbajjuri20
-  - mattmahoneyrh

--- a/frontend/packages/helm-plugin/integration-tests/OWNERS
+++ b/frontend/packages/helm-plugin/integration-tests/OWNERS
@@ -1,7 +1,0 @@
-reviewers:
-  - sanketpathak
-  - the-anton
-approvers:
-  - jrichter1
-  - psrna
-  - sanketpathak

--- a/frontend/packages/knative-plugin/integration-tests/OWNERS
+++ b/frontend/packages/knative-plugin/integration-tests/OWNERS
@@ -1,7 +1,0 @@
-reviewers:
-  - sanketpathak
-  - the-anton
-approvers:
-  - jrichter1
-  - psrna
-  - sanketpathak

--- a/frontend/packages/shipwright-plugin/integration-tests/OWNERS
+++ b/frontend/packages/shipwright-plugin/integration-tests/OWNERS
@@ -1,7 +1,0 @@
-reviewers:
-  - sanketpathak
-  - the-anton
-approvers:
-  - jrichter1
-  - psrna
-  - sanketpathak

--- a/frontend/packages/topology/integration-tests/OWNERS
+++ b/frontend/packages/topology/integration-tests/OWNERS
@@ -1,7 +1,0 @@
-reviewers:
-  - sanketpathak
-  - the-anton
-approvers:
-  - jrichter1
-  - psrna
-  - sanketpathak

--- a/frontend/packages/webterminal-plugin/integration-tests/OWNERS
+++ b/frontend/packages/webterminal-plugin/integration-tests/OWNERS
@@ -1,7 +1,0 @@
-reviewers:
-  - sanketpathak
-  - the-anton
-approvers:
-  - jrichter1
-  - psrna
-  - sanketpathak

--- a/frontend/packages/webterminal-plugin/integration-tests/features/web-terminal/OWNERS
+++ b/frontend/packages/webterminal-plugin/integration-tests/features/web-terminal/OWNERS
@@ -1,3 +1,0 @@
-reviewers:
-  - musienko-maxim
-  - sleshchenko


### PR DESCRIPTION

 [CONSOLE-5203](https://redhat.atlassian.net/browse/CONSOLE-5203) - Remove old QE team from our repos

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Cleanup: Remove old QE team from our repos
**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->
Cleanup: Remove old QE team and other unused usernames from the repo.
**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->
N/A
**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
N/A
**Test cases:**
<!-- List possible test cases to validate the changes. -->
N/A
**Reviewers and assignees:**
  Console Approver:
  /assign @jhadvig 

  Docs approver:
  /assign <gh-user> N/A
  PX approver:
  /assign <gh-user> N/A
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal integration test configurations and documentation to streamline code review processes across various components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->