### PR TITLE
[release-4.20 ]OCPBUGS-84041: Fix template placeholder {{name}} not resolved and runtime error on Group details page

### DIFF
--- a/frontend/public/components/group.tsx
+++ b/frontend/public/components/group.tsx
@@ -57,9 +57,9 @@ const getImpersonateAction = (
   startImpersonate: StartImpersonate,
   navigate: NavigateFunction,
 ): KebabAction => (kind: K8sKind, group: GroupKind) => ({
-  label: i18next.t('public~Impersonate Group {{name}}', group.metadata),
+  label: i18next.t('public~Impersonate Group {{name}}', { name: group?.metadata?.name }),
   callback: () => {
-    startImpersonate('Group', group.metadata.name);
+    startImpersonate('Group', group?.metadata?.name);
     navigate(window.SERVER_FLAGS.basePath);
   },
   // Must use API group authorization.k8s.io, NOT user.openshift.io
@@ -67,7 +67,7 @@ const getImpersonateAction = (
   accessReview: {
     group: 'authorization.k8s.io',
     resource: 'groups',
-    name: group.metadata.name,
+    name: group?.metadata?.name,
     verb: 'impersonate',
   },
 });

--- a/frontend/public/components/modals/add-users-modal.tsx
+++ b/frontend/public/components/modals/add-users-modal.tsx
@@ -1,4 +1,3 @@
-import * as _ from 'lodash-es';
 import * as React from 'react';
 
 import { GroupModel } from '../../models';
@@ -17,22 +16,30 @@ import { usePromiseHandler } from '@console/shared/src/hooks/promise-handler';
 export const AddUsersModal = (props: AddUsersModalProps) => {
   const [values, setValues] = React.useState(['']);
   const [handlePromise, inProgress, errorMessage] = usePromiseHandler();
+  const { t } = useTranslation();
 
   const submit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
-    // Append to an existing array, but handle the special case when the array is null.
+    if (!props.group?.metadata?.name) {
+      return;
+    }
+    const validUsers = values.map((v) => v.trim()).filter((v) => v.length > 0);
+    if (validUsers.length === 0) {
+      return;
+    }
     const patch = props.group.users
-      ? _.map(values, (value: string) => ({ op: 'add', path: '/users/-', value }))
-      : [{ op: 'add', path: '/users', value: values }];
+      ? validUsers.map((value: string) => ({ op: 'add', path: '/users/-', value }))
+      : [{ op: 'add', path: '/users', value: validUsers }];
     handlePromise(k8sPatch(GroupModel, props.group, patch)).then(() => props.close());
   };
-  const { t } = useTranslation();
 
   return (
     <form onSubmit={submit} name="form" className="modal-content ">
       <ModalTitle>{t('public~Add Users')}</ModalTitle>
       <ModalBody>
-        <p>{t('public~Add new Users to Group {{name}}.', props.group.metadata)}</p>
+        <p>
+          {t('public~Add new users to group {{name}}', { name: props.group?.metadata?.name })}
+        </p>
         <ListInput label={t('public~Users')} required initialValues={values} onChange={setValues} />
       </ModalBody>
       <ModalSubmitFooter

--- a/frontend/public/components/modals/add-users-modal.tsx
+++ b/frontend/public/components/modals/add-users-modal.tsx
@@ -37,9 +37,7 @@ export const AddUsersModal = (props: AddUsersModalProps) => {
     <form onSubmit={submit} name="form" className="modal-content ">
       <ModalTitle>{t('public~Add Users')}</ModalTitle>
       <ModalBody>
-        <p>
-          {t('public~Add new users to group {{name}}', { name: props.group?.metadata?.name })}
-        </p>
+        <p>{t('public~Add new users to group {{name}}', { name: props.group?.metadata?.name })}</p>
         <ListInput label={t('public~Users')} required initialValues={values} onChange={setValues} />
       </ModalBody>
       <ModalSubmitFooter

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -830,7 +830,6 @@
   "Add secret as": "Add secret as",
   "Prefix": "Prefix",
   "Volume": "Volume",
-  "Add new Users to Group {{name}}.": "Add new Users to Group {{name}}.",
   "Add new users to group {{name}}": "Add new users to group {{name}}",
   "Edit routing configuration": "Edit routing configuration",
   "Group by": "Group by",

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -831,6 +831,7 @@
   "Prefix": "Prefix",
   "Volume": "Volume",
   "Add new Users to Group {{name}}.": "Add new Users to Group {{name}}.",
+  "Add new users to group {{name}}": "Add new users to group {{name}}",
   "Edit routing configuration": "Edit routing configuration",
   "Group by": "Group by",
   "Group wait": "Group wait",


### PR DESCRIPTION
## Summary
Cherry-pick of #15780 to release-4.20 (manually adapted due to code structure differences between main and release-4.20).

- Fix impersonate action in `group.tsx` to pass group name as a named i18n parameter (`{ name: group?.metadata?.name }`) instead of the whole metadata object, preventing raw `{{name}}` placeholder display
- Add optional chaining to guard against undefined metadata in impersonate action
- Add input validation in `AddUsersModal` — guard against undefined group and filter empty user entries before submitting
- Add new i18n string for the updated modal text

## Bug
https://redhat.atlassian.net/browse/OCPBUGS-84041

## Test plan
- [ ] Navigate to Group details page, click the Action list → verify "Impersonate Group <actual-name>" shows correctly
- [ ] Click "Add Users" → verify the modal shows "Add new users to group <actual-name>"
- [ ] Add users and click Save → verify no runtime error occurs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when group data may be unavailable, preventing crashes during group operations.
  * Enhanced input validation in user addition modal to filter invalid entries.

* **Improvements**
  * Updated modal description text for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->