### PR TITLE
HELM-613: Reject basic auth over non-HTTPS for Helm chart repositories

### DIFF
--- a/pkg/helm/chartproxy/repos.go
+++ b/pkg/helm/chartproxy/repos.go
@@ -229,7 +229,7 @@ func (b helmRepoGetter) unmarshallConfig(repo unstructured.Unstructured, namespa
 
 	if basicAuthReference != "" {
 		if h.URL.Scheme != "https" {
-			return nil, fmt.Errorf("Basic authentication is only supported for HTTPS repositories")
+			return nil, fmt.Errorf("Basic authentication requires HTTPS repository for security")
 		}
 		secret, err := b.CoreClient.Secrets(basicAuthRefNamespace).Get(context.TODO(), basicAuthReference, v1.GetOptions{})
 		if err != nil {

--- a/pkg/helm/chartproxy/repos.go
+++ b/pkg/helm/chartproxy/repos.go
@@ -228,6 +228,9 @@ func (b helmRepoGetter) unmarshallConfig(repo unstructured.Unstructured, namespa
 	}
 
 	if basicAuthReference != "" {
+		if h.URL.Scheme != "https" {
+			return nil, fmt.Errorf("basic auth is only supported for https repository %s", h.Name)
+		}
 		secret, err := b.CoreClient.Secrets(basicAuthRefNamespace).Get(context.TODO(), basicAuthReference, v1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("Failed to GET secret %q from %q reason %v", basicAuthReference, basicAuthRefNamespace, err)

--- a/pkg/helm/chartproxy/repos.go
+++ b/pkg/helm/chartproxy/repos.go
@@ -229,7 +229,7 @@ func (b helmRepoGetter) unmarshallConfig(repo unstructured.Unstructured, namespa
 
 	if basicAuthReference != "" {
 		if h.URL.Scheme != "https" {
-			return nil, fmt.Errorf("basic auth is only supported for https repository %s", h.Name)
+			return nil, fmt.Errorf("Basic authentication is only supported for HTTPS repositories")
 		}
 		secret, err := b.CoreClient.Secrets(basicAuthRefNamespace).Get(context.TODO(), basicAuthReference, v1.GetOptions{})
 		if err != nil {

--- a/pkg/helm/chartproxy/repos_test.go
+++ b/pkg/helm/chartproxy/repos_test.go
@@ -588,7 +588,7 @@ func TestHelmRepoGetter_unmarshallConfig(t *testing.T) {
 			clusterScoped:   false,
 		},
 		{
-			name: "Basic auth over HTTP is not supported for cluster-scoped repositories",
+			name: "HTTPS is required for cluster-scoped repositories using basic authentication",
 			helmCRS: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "helm.openshift.io/v1beta1",
@@ -609,13 +609,13 @@ func TestHelmRepoGetter_unmarshallConfig(t *testing.T) {
 				},
 			},
 			repoName:        "repo6",
-			wantsErrMsg:     "Basic authentication is only supported for HTTPS repositories",
+			wantsErrMsg:     "Basic authentication requires HTTPS repository for security",
 			createSecret:    false,
 			createNamespace: false,
 			clusterScoped:   true,
 		},
 		{
-			name: "Basic auth over HTTP is not supported for namespace-scoped repositories",
+			name: "HTTPS is required for namespace-scoped repositories using basic authentication",
 			helmCRS: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "helm.openshift.io/v1beta1",
@@ -636,7 +636,7 @@ func TestHelmRepoGetter_unmarshallConfig(t *testing.T) {
 				},
 			},
 			repoName:        "repo7",
-			wantsErrMsg:     "Basic authentication is only supported for HTTPS repositories",
+			wantsErrMsg:     "Basic authentication requires HTTPS repository for security",
 			createSecret:    false,
 			createNamespace: true,
 			namespace:       "testing",

--- a/pkg/helm/chartproxy/repos_test.go
+++ b/pkg/helm/chartproxy/repos_test.go
@@ -527,7 +527,7 @@ func TestHelmRepoGetter_unmarshallConfig(t *testing.T) {
 		name            string
 		helmCRS         *unstructured.Unstructured
 		repoName        string
-		wantsErr        bool
+		wantsErrMsg     string
 		createSecret    bool
 		namespace       string
 		createNamespace bool
@@ -555,7 +555,7 @@ func TestHelmRepoGetter_unmarshallConfig(t *testing.T) {
 				},
 			},
 			repoName:        "repo4",
-			wantsErr:        false,
+			wantsErrMsg:     "",
 			createSecret:    true,
 			namespace:       "testing",
 			createNamespace: true,
@@ -582,13 +582,13 @@ func TestHelmRepoGetter_unmarshallConfig(t *testing.T) {
 				},
 			},
 			repoName:        "repo5",
-			wantsErr:        false,
+			wantsErrMsg:     "",
 			createSecret:    true,
 			createNamespace: false,
 			clusterScoped:   false,
 		},
 		{
-			name: "Basic auth is not supported for http repositories - cluster scope",
+			name: "Basic auth over HTTP is not supported for cluster-scoped repositories",
 			helmCRS: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "helm.openshift.io/v1beta1",
@@ -609,20 +609,20 @@ func TestHelmRepoGetter_unmarshallConfig(t *testing.T) {
 				},
 			},
 			repoName:        "repo6",
-			wantsErr:        true,
+			wantsErrMsg:     "Basic authentication is only supported for HTTPS repositories",
 			createSecret:    false,
 			createNamespace: false,
 			clusterScoped:   true,
 		},
 		{
-			name: "Basic auth is supported only for https respositories",
+			name: "Basic auth over HTTP is not supported for namespace-scoped repositories",
 			helmCRS: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "helm.openshift.io/v1beta1",
 					"kind":       "ProjectHelmChartRepository",
 					"metadata": map[string]interface{}{
-						"namespace": "",
-						"name":      "repo4",
+						"namespace": "testing",
+						"name":      "repo7",
 					},
 					"spec": map[string]interface{}{
 						"connectionConfig": map[string]interface{}{
@@ -636,9 +636,10 @@ func TestHelmRepoGetter_unmarshallConfig(t *testing.T) {
 				},
 			},
 			repoName:        "repo7",
-			wantsErr:        true,
+			wantsErrMsg:     "Basic authentication is only supported for HTTPS repositories",
 			createSecret:    false,
-			createNamespace: false,
+			createNamespace: true,
+			namespace:       "testing",
 			clusterScoped:   false,
 		},
 	}
@@ -668,8 +669,9 @@ func TestHelmRepoGetter_unmarshallConfig(t *testing.T) {
 				CoreClient: k8sfake.NewSimpleClientset(objs...).CoreV1(),
 			}
 			_, err := repoGetter.unmarshallConfig(*tt.helmCRS, tt.namespace, tt.clusterScoped)
-			if tt.wantsErr {
+			if tt.wantsErrMsg != "" {
 				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantsErrMsg)
 			} else {
 				require.NoError(t, err)
 			}

--- a/pkg/helm/chartproxy/repos_test.go
+++ b/pkg/helm/chartproxy/repos_test.go
@@ -531,6 +531,7 @@ func TestHelmRepoGetter_unmarshallConfig(t *testing.T) {
 		createSecret    bool
 		namespace       string
 		createNamespace bool
+		clusterScoped   bool
 	}{
 		{
 			name: "Namespace present",
@@ -558,6 +559,7 @@ func TestHelmRepoGetter_unmarshallConfig(t *testing.T) {
 			createSecret:    true,
 			namespace:       "testing",
 			createNamespace: true,
+			clusterScoped:   false,
 		},
 		{
 			name: "Namespace not present",
@@ -583,6 +585,61 @@ func TestHelmRepoGetter_unmarshallConfig(t *testing.T) {
 			wantsErr:        false,
 			createSecret:    true,
 			createNamespace: false,
+			clusterScoped:   false,
+		},
+		{
+			name: "Basic auth is not supported for http repositories - cluster scope",
+			helmCRS: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "helm.openshift.io/v1beta1",
+					"kind":       "HelmChartRepository",
+					"metadata": map[string]interface{}{
+						"namespace": "",
+						"name":      "repo6",
+					},
+					"spec": map[string]interface{}{
+						"connectionConfig": map[string]interface{}{
+							"url": "http://localhost:9553",
+							"basicAuthConfig": map[string]interface{}{
+								"name":      "fooSecret",
+								"namespace": "testing",
+							},
+						},
+					},
+				},
+			},
+			repoName:        "repo6",
+			wantsErr:        true,
+			createSecret:    false,
+			createNamespace: false,
+			clusterScoped:   true,
+		},
+		{
+			name: "Basic auth is supported only for https respositories",
+			helmCRS: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "helm.openshift.io/v1beta1",
+					"kind":       "ProjectHelmChartRepository",
+					"metadata": map[string]interface{}{
+						"namespace": "",
+						"name":      "repo4",
+					},
+					"spec": map[string]interface{}{
+						"connectionConfig": map[string]interface{}{
+							"url": "http://localhost:9553",
+							"basicAuthConfig": map[string]interface{}{
+								"name":      "fooSecret",
+								"namespace": "testing",
+							},
+						},
+					},
+				},
+			},
+			repoName:        "repo7",
+			wantsErr:        true,
+			createSecret:    false,
+			createNamespace: false,
+			clusterScoped:   false,
 		},
 	}
 	for _, tt := range tests {
@@ -610,7 +667,7 @@ func TestHelmRepoGetter_unmarshallConfig(t *testing.T) {
 				Client:     fake.K8sDynamicClient("helm.openshift.io/v1beta1", "HelmChartRepository", ""),
 				CoreClient: k8sfake.NewSimpleClientset(objs...).CoreV1(),
 			}
-			_, err := repoGetter.unmarshallConfig(*tt.helmCRS, tt.namespace, false)
+			_, err := repoGetter.unmarshallConfig(*tt.helmCRS, tt.namespace, tt.clusterScoped)
 			if tt.wantsErr {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
Enforce HTTPS when basic auth credentials are configured on HelmChartRepository and ProjectHelmChartRepository CRs to prevent sending credentials over plain HTTP. This adds backend server-side validation matching the existing frontend check.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject repository configurations where basic authentication is used with non-HTTPS URLs, failing early with clear error messages.

* **Tests**
  * Expanded test coverage for repository configuration validation, including scenarios for basic authentication with both HTTPS and HTTP connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->