### PR TITLE
OCPBUGS-84296: fix Helm list page redirect after upgrade/rollback

### DIFF
--- a/frontend/packages/helm-plugin/src/components/details-page/HelmReleaseDetailsPage.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/HelmReleaseDetailsPage.tsx
@@ -13,9 +13,9 @@ const HelmReleaseDetailsPage: FC = () => {
   const handleNamespaceChange = useCallback(
     (newNamespace: string): void => {
       if (newNamespace === ALL_NAMESPACES_KEY) {
-        navigate('/helm-releases/all-namespaces');
+        navigate('/helm/all-namespaces');
       } else {
-        navigate(`/helm-releases/ns/${newNamespace}`);
+        navigate(`/helm/ns/${newNamespace}`);
       }
     },
     [navigate],

--- a/frontend/packages/helm-plugin/src/utils/helm-utils.ts
+++ b/frontend/packages/helm-plugin/src/utils/helm-utils.ts
@@ -222,11 +222,11 @@ export const getOriginRedirectURL = (
     case HelmActionOrigins.topology:
       return `/topology/ns/${namespace}`;
     case HelmActionOrigins.list:
-      return `/helm-releases/ns/${namespace}`;
+      return `/helm/ns/${namespace}`;
     case HelmActionOrigins.details:
       return `/helm-releases/ns/${namespace}/release/${releaseName}`;
     default:
-      return `/helm-releases/ns/${namespace}`;
+      return `/helm/ns/${namespace}`;
   }
 };
 


### PR DESCRIPTION
## Summary
Fixes redirect after Helm upgrade/rollback to use the correct list page route.

## Details
The Helm list page is at `/helm/ns/{namespace}` for all perspectives. There is no `/helm-releases/ns/{namespace}` route - only detail and form routes use the `/helm-releases` prefix.

**Updated:**
- `getOriginRedirectURL` to always redirect to `/helm/ns/{namespace}` for list page
- `HelmReleaseDetailsPage` namespace change handler to use `/helm/ns/{namespace}` instead of `/helm-releases/ns/{namespace}`

## Test plan
1. Navigate to Helm list page at `/helm/ns/{namespace}`
2. Click on a Helm release kebab menu
3. Select "Upgrade" action
4. Submit the upgrade form
5. Verify redirect goes to `/helm/ns/{namespace}` (not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Helm release navigation paths for improved route structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->