### PR TITLE
OCPBUGS-84338: Update resolveDynamicModuleMaps to skip unavailable packages

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
@@ -44,6 +44,9 @@ const getPackageDependencies = (pkg: readPkg.PackageJson) => ({
   ...pkg.dependencies,
 });
 
+const hasPackageDependency = (pkg: readPkg.PackageJson, depName: string) =>
+  Object.keys(getPackageDependencies(pkg)).includes(depName);
+
 const getPluginSDKPackagePeerDependencies = () =>
   loadVendorPackageJSON('@openshift-console/dynamic-plugin-sdk').peerDependencies;
 
@@ -133,13 +136,12 @@ export const validateConsoleExtensionsFileSchema = (
 };
 
 const getDeprecatedSharedModuleWarnings = (pkg: ConsolePluginPackageJSON): string[] => {
-  const pluginDeps = getPackageDependencies(pkg);
   const warnings: string[] = [];
 
   sharedPluginModules.forEach((moduleName) => {
     const { deprecated } = getSharedModuleMetadata(moduleName);
 
-    if (deprecated && pluginDeps[moduleName]) {
+    if (deprecated && hasPackageDependency(pkg, moduleName)) {
       warnings.push(
         `[DEPRECATION WARNING] Console provided shared module ${moduleName} has been deprecated: ${deprecated}`,
       );
@@ -150,7 +152,6 @@ const getDeprecatedSharedModuleWarnings = (pkg: ConsolePluginPackageJSON): strin
 };
 
 const validateConsoleProvidedSharedModules = (pkg: ConsolePluginPackageJSON) => {
-  const pluginDeps = getPackageDependencies(pkg);
   const sdkPkgDeps = getPluginSDKPackagePeerDependencies();
   const result = new ValidationResult('package.json');
 
@@ -159,7 +160,7 @@ const validateConsoleProvidedSharedModules = (pkg: ConsolePluginPackageJSON) => 
 
     // Skip modules that allow a fallback version to be provided by the plugin.
     // Also skip modules which are not explicitly listed in the plugin's dependencies.
-    if (allowFallback || !pluginDeps[moduleName]) {
+    if (allowFallback || !hasPackageDependency(pkg, moduleName)) {
       return;
     }
 
@@ -381,6 +382,7 @@ export class ConsoleRemotePlugin implements WebpackPluginInstance {
     this.dynamicModuleMaps = resolveDynamicModuleMaps(
       this.adaptedOptions.sharedDynamicModuleSettings.packageSpecs ?? dynamicModulePackageSpecs,
       resolvedModulePaths,
+      (pkgName) => hasPackageDependency(this.pkg, pkgName),
     );
   }
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/DynamicModuleImportPlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/DynamicModuleImportPlugin.ts
@@ -34,6 +34,8 @@ export const resolveDynamicModuleMaps = (
   packageSpecs: DynamicModulePackageSpecs,
   /** Absolute paths to `node_modules` directories to search. */
   modulePaths: string[],
+  /** Optional check if the package is available. */
+  isPackageAvailable: (pkgName: string) => boolean = () => true,
 ) =>
   Object.entries(packageSpecs).reduce<Record<string, DynamicModuleMap>>(
     (
@@ -48,6 +50,10 @@ export const resolveDynamicModuleMaps = (
         },
       ],
     ) => {
+      if (!isPackageAvailable(pkgName)) {
+        return acc;
+      }
+
       const basePath = modulePaths
         .map((p) => path.resolve(p, pkgName))
         .find((p) => fs.existsSync(p) && fs.statSync(p).isDirectory());


### PR DESCRIPTION
### Analysis / Root cause

When a Console plugin does not install **all** packages in `dynamicModulePatternFlyPackages` ([default list](https://github.com/openshift/console/blob/main/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts)) or **all** packages in `ConsoleRemotePlugin` setting `sharedDynamicModuleSettings.packageSpecs` (override list) then it causes a confusing message during the webpack build:
```
Cannot resolve base path for package @patternfly/react-data-view
```
In other words, if a Console plugin does not use e.g. `@patternfly/react-data-view` then we should not attempt to process dynamic modules for that vendor package.

### Solution description

Update `resolveDynamicModuleMaps` function to skip unavailable vendor packages.

### Screenshots / screen recording

When building [Console Networking plugin](https://github.com/openshift/networking-console-plugin)

<img width="1080" height="144" src="https://github.com/user-attachments/assets/ff45b588-6ea2-44ac-9672-36dc9a6ccc94" />

### Test setup

Clone [Console Networking plugin](https://github.com/openshift/networking-console-plugin) and run `npm run build` to see the above message.

### Reviewers and assignees

/assign @logonoff 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved dependency detection and validation across the plugin SDK's module resolution system, ensuring more consistent behavior when handling shared modules and dynamic module imports during plugin builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->