### PR TITLE
[release-4.18] OCPBUGS-84479: Fix VolumeSnapshot and VolumeSnapshotContent table sorting

### DIFF
--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content-details.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content-details.tsx
@@ -13,7 +13,7 @@ import {
 import { VolumeSnapshotClassModel, VolumeSnapshotModel } from '@console/internal/models';
 import { referenceForModel, VolumeSnapshotContentKind } from '@console/internal/module/k8s';
 import { Status } from '@console/shared';
-import { volumeSnapshotStatus } from '../../status';
+import { snapshotStatus } from '@console/shared/src/sorts/snapshot';
 
 const { editYaml, events } = navFactory;
 
@@ -33,7 +33,7 @@ const Details: React.FC<DetailsProps> = ({ obj }) => {
           <ResourceSummary resource={obj}>
             <dt>{t('console-app~Status')}</dt>
             <dd>
-              <Status status={volumeSnapshotStatus(obj)} />
+              <Status status={snapshotStatus(obj)} />
             </dd>
           </ResourceSummary>
         </div>
@@ -97,7 +97,7 @@ const VolumeSnapshotContentDetailsPage: React.FC<DetailsPageProps> = (props) => 
   return (
     <DetailsPage
       {...props}
-      getResourceStatus={volumeSnapshotStatus}
+      getResourceStatus={snapshotStatus}
       menuActions={Kebab.factory.common}
       pages={pages}
     />

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content.tsx
@@ -12,8 +12,9 @@ import {
   TableColumn,
   RowProps,
 } from '@console/dynamic-plugin-sdk/src/lib-core';
-import { TableData } from '@console/internal/components/factory';
+import { sorts, TableData } from '@console/internal/components/factory';
 import { useActiveColumns } from '@console/internal/components/factory/Table/active-columns-hook';
+import { sortResourceByValue } from '@console/internal/components/factory/Table/sort';
 import {
   ResourceLink,
   ResourceKebab,
@@ -30,7 +31,8 @@ import {
 } from '@console/internal/models';
 import { referenceForModel, VolumeSnapshotContentKind } from '@console/internal/module/k8s';
 import { Status } from '@console/shared';
-import { snapshotStatusFilters, volumeSnapshotStatus } from '../../status';
+import { snapshotStatus } from '@console/shared/src/sorts/snapshot';
+import { snapshotStatusFilters } from '../../status';
 
 export const tableColumnInfo = [
   { id: 'name' },
@@ -54,7 +56,7 @@ const Row: React.FC<RowProps<VolumeSnapshotContentKind>> = ({ obj }) => {
         <ResourceLink kind={referenceForModel(VolumeSnapshotContentModel)} name={name} />
       </TableData>
       <TableData {...tableColumnInfo[1]}>
-        <Status status={volumeSnapshotStatus(obj)} />
+        <Status status={snapshotStatus(obj)} />
       </TableData>
       <TableData {...tableColumnInfo[2]}>{sizeMetrics}</TableData>
       <TableData {...tableColumnInfo[3]}>
@@ -95,14 +97,16 @@ const VolumeSnapshotContentTable: React.FC<VolumeSnapshotContentTableProps> = (p
     },
     {
       title: t('console-app~Status'),
-      sort: 'snapshotStatus',
+      sort: (data, direction) =>
+        data.sort(sortResourceByValue(direction, sorts.volumeSnapshotStatus)),
       transforms: [sortable],
       props: { className: tableColumnInfo[1].className },
       id: tableColumnInfo[1].id,
     },
     {
       title: t('console-app~Size'),
-      sort: 'volumeSnapshotSize',
+      sort: (data, direction) =>
+        data.sort(sortResourceByValue(direction, sorts.volumeSnapshotContentSize)),
       transforms: [sortable],
       props: { className: tableColumnInfo[2].className },
       id: tableColumnInfo[2].id,

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-details.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-details.tsx
@@ -19,7 +19,7 @@ import {
 import { referenceForModel, VolumeSnapshotKind } from '@console/internal/module/k8s';
 import { Status, snapshotSource, FLAGS } from '@console/shared';
 import { useFlag } from '@console/shared/src/hooks/flag';
-import { volumeSnapshotStatus } from '../../status';
+import { snapshotStatus } from '@console/shared/src/sorts/snapshot';
 
 const { editYaml, events } = navFactory;
 const { common, RestorePVC } = Kebab.factory;
@@ -48,7 +48,7 @@ const Details: React.FC<DetailsProps> = ({ obj }) => {
           <ResourceSummary resource={obj}>
             <dt>{t('console-app~Status')}</dt>
             <dd>
-              <Status status={volumeSnapshotStatus(obj)} />
+              <Status status={snapshotStatus(obj)} />
             </dd>
           </ResourceSummary>
         </div>
@@ -111,7 +111,7 @@ const VolumeSnapshotDetailsPage: React.FC<DetailsPageProps> = (props) => {
   return (
     <DetailsPage
       {...props}
-      getResourceStatus={volumeSnapshotStatus}
+      getResourceStatus={snapshotStatus}
       menuActions={menuActions}
       pages={pages}
     />

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
@@ -14,8 +14,9 @@ import {
   TableColumn,
   RowProps,
 } from '@console/dynamic-plugin-sdk/src/lib-core';
-import { TableData } from '@console/internal/components/factory';
+import { sorts, TableData } from '@console/internal/components/factory';
 import { useActiveColumns } from '@console/internal/components/factory/Table/active-columns-hook';
+import { sortResourceByValue } from '@console/internal/components/factory/Table/sort';
 import {
   ResourceLink,
   ResourceKebab,
@@ -41,7 +42,8 @@ import {
 } from '@console/internal/module/k8s';
 import { Status, getName, getNamespace, snapshotSource, FLAGS } from '@console/shared';
 import { useFlag } from '@console/shared/src/hooks/flag';
-import { snapshotStatusFilters, volumeSnapshotStatus } from '../../status';
+import { snapshotStatus } from '@console/shared/src/sorts/snapshot';
+import { snapshotStatusFilters } from '../../status';
 
 const { common, RestorePVC } = Kebab.factory;
 const menuActions = [RestorePVC, ...common];
@@ -74,21 +76,24 @@ const getTableColumns = (disableItems = {}): TableColumn<VolumeSnapshotKind>[] =
     },
     {
       title: i18next.t('console-app~Status'),
-      sort: 'snapshotStatus',
+      sort: (data, direction) =>
+        data.sort(sortResourceByValue(direction, sorts.volumeSnapshotStatus)),
       transforms: [sortable],
       props: { className: tableColumnInfo[2].className },
       id: tableColumnInfo[2].id,
     },
     {
       title: i18next.t('console-app~Size'),
-      sort: 'volumeSnapshotSize',
+      sort: (data, direction) =>
+        data.sort(sortResourceByValue(direction, sorts.volumeSnapshotSize)),
       transforms: [sortable],
       props: { className: tableColumnInfo[3].className },
       id: tableColumnInfo[3].id,
     },
     {
       title: i18next.t('console-app~Source'),
-      sort: 'volumeSnapshotSource',
+      sort: (data, direction) =>
+        data.sort(sortResourceByValue(direction, sorts.volumeSnapshotSource)),
       transforms: [sortable],
       props: { className: tableColumnInfo[4].className },
       id: tableColumnInfo[4].id,
@@ -149,7 +154,7 @@ const Row: React.FC<RowProps<VolumeSnapshotKind, VolumeSnapshotRowProsCustomData
         <ResourceLink kind={NamespaceModel.kind} name={namespace} />
       </TableData>
       <TableData {...tableColumnInfo[2]}>
-        <Status status={volumeSnapshotStatus(obj)} />
+        <Status status={snapshotStatus(obj)} />
       </TableData>
       <TableData {...tableColumnInfo[3]}>{sizeMetrics}</TableData>
       {!customData?.disableItems?.Source && (

--- a/frontend/packages/console-app/src/status/snapshot.ts
+++ b/frontend/packages/console-app/src/status/snapshot.ts
@@ -1,19 +1,13 @@
-import { TFunction } from 'i18next';
-import { RowFilter } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
-import { VolumeSnapshotStatus } from '@console/internal/module/k8s';
-
-export const volumeSnapshotStatus = ({ status }: { status?: VolumeSnapshotStatus }) => {
-  const readyToUse = status?.readyToUse;
-  const isError = !!status?.error?.message;
-  return readyToUse ? 'Ready' : isError ? 'Error' : 'Pending';
-};
+import type { TFunction } from 'i18next';
+import type { RowFilter } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
+import { snapshotStatus } from '@console/shared/src/sorts/snapshot';
 
 export const snapshotStatusFilters = (t: TFunction): RowFilter[] => {
   return [
     {
       filterGroupName: t('console-app~Status'),
       type: 'snapshot-status',
-      reducer: volumeSnapshotStatus,
+      reducer: snapshotStatus,
       filter: () => null,
       items: [
         { id: 'Ready', title: 'Ready' },

--- a/frontend/packages/console-shared/src/components/dashboard/inventory-card/utils.ts
+++ b/frontend/packages/console-shared/src/components/dashboard/inventory-card/utils.ts
@@ -1,7 +1,7 @@
 import { nodeStatus } from '@console/app/src/status/node';
-import { volumeSnapshotStatus } from '@console/app/src/status/snapshot';
 import { podPhaseFilterReducer } from '@console/internal/module/k8s';
-import { StatusGroupMapper } from './InventoryItem';
+import { snapshotStatus } from '@console/shared/src/sorts/snapshot';
+import type { StatusGroupMapper } from './InventoryItem';
 import { InventoryStatusGroup } from './status-group';
 
 const POD_PHASE_GROUP_MAPPING = {
@@ -69,4 +69,4 @@ export const getPVCStatusGroups: StatusGroupMapper = (resources) =>
 export const getPVStatusGroups: StatusGroupMapper = (resources) =>
   getStatusGroups(resources, PV_STATUS_GROUP_MAPPING, (pv) => pv.status.phase, 'pv-status');
 export const getVSStatusGroups: StatusGroupMapper = (resources) =>
-  getStatusGroups(resources, VS_STATUS_GROUP_MAPPING, volumeSnapshotStatus, 'snapshot-status');
+  getStatusGroups(resources, VS_STATUS_GROUP_MAPPING, snapshotStatus, 'status');

--- a/frontend/packages/console-shared/src/sorts/snapshot.ts
+++ b/frontend/packages/console-shared/src/sorts/snapshot.ts
@@ -1,5 +1,15 @@
-import { convertToBaseValue } from '@console/internal/components/utils';
-import { VolumeSnapshotKind } from '@console/internal/module/k8s';
+import { convertToBaseValue } from '@console/internal/components/utils/units';
+import type {
+  VolumeSnapshotContentKind,
+  VolumeSnapshotKind,
+  VolumeSnapshotStatus,
+} from '@console/internal/module/k8s';
+
+export const snapshotStatus = ({ status }: { status?: VolumeSnapshotStatus }): string => {
+  const readyToUse = status?.readyToUse;
+  const isError = !!status?.error?.message;
+  return readyToUse ? 'Ready' : isError ? 'Error' : 'Pending';
+};
 
 export const snapshotSize = (snapshot: VolumeSnapshotKind): number => {
   const size = snapshot?.status?.restoreSize;
@@ -9,3 +19,7 @@ export const snapshotSize = (snapshot: VolumeSnapshotKind): number => {
 export const snapshotSource = (snapshot: VolumeSnapshotKind): string =>
   snapshot.spec?.source?.persistentVolumeClaimName ??
   snapshot.spec?.source?.volumeSnapshotContentName;
+
+export const snapshotContentSize = (snapshot: VolumeSnapshotContentKind): number => {
+  return snapshot?.status?.restoreSize ?? 0;
+};

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.cy.ts
@@ -18,7 +18,6 @@ const testOperand: TestOperandProps = {
 describe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
   before(() => {
     cy.login();
-    operator.install(testOperator.name, testOperator.operatorHubCardTestID);
   });
 
   afterEach(() => {
@@ -26,6 +25,7 @@ describe(`Globally installing "${testOperator.name}" operator in ${GlobalInstall
   });
 
   it(`Globally installs ${testOperator.name} operator in ${GlobalInstalledNamespace} and creates ${testOperand.name} operand`, () => {
+    operator.install(testOperator.name, testOperator.operatorHubCardTestID);
     operator.installedSucceeded(testOperator.name);
     operator.navToDetailsPage(testOperator.name);
     cy.byTestSectionHeading('Provided APIs').should('exist');

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -1,7 +1,8 @@
 import * as _ from 'lodash-es';
 import * as fuzzy from 'fuzzysearch';
-import { nodeStatus, volumeSnapshotStatus } from '@console/app/src/status';
+import { nodeStatus } from '@console/app/src/status';
 import { getNodeRoles, getLabelsAsString } from '@console/shared';
+import { snapshotStatus } from '@console/shared/src/sorts/snapshot';
 import { Alert, AnyRowFilter, FilterValue, Rule } from '@console/dynamic-plugin-sdk';
 import { routeStatus } from '../routes';
 import { secretTypeFilterReducer } from '../secret';
@@ -213,7 +214,7 @@ export const tableFilters = (isExactSearch: boolean): FilterMap => {
         return true;
       }
 
-      const status = volumeSnapshotStatus(snapshot);
+      const status = snapshotStatus(snapshot);
       return statuses.selected.includes(status) || !_.includes(statuses.all, status);
     },
     'node-disk-name': (name, disks) => matchFn(name.selected?.[0], disks?.path),

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -22,7 +22,12 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import { getMachinePhase } from '@console/shared/src/selectors/machine';
 import { getMachineSetInstanceType } from '@console/shared/src/selectors/machineSet';
 import { pvcUsed } from '@console/shared/src/sorts/pvc';
-import { snapshotSize, snapshotSource } from '@console/shared/src/sorts/snapshot';
+import {
+  snapshotContentSize,
+  snapshotSize,
+  snapshotSource,
+  snapshotStatus,
+} from '@console/shared/src/sorts/snapshot';
 import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants/common';
 import { getName } from '@console/shared/src/selectors/common';
 import { useDeepCompareMemoize } from '@console/shared/src/hooks/deep-compare-memoize';
@@ -49,11 +54,12 @@ import {
   podRestarts,
   MachineKind,
   VolumeSnapshotKind,
+  VolumeSnapshotContentKind,
   ClusterOperator,
 } from '../../module/k8s';
 import { useTableData } from './table-data-hook';
 
-const sorts = {
+export const sorts = {
   alertingRuleStateOrder,
   alertSeverityOrder,
   crdLatestVersion: (crd: CustomResourceDefinitionKind): string => getLatestVersionForCRD(crd),
@@ -81,7 +87,11 @@ const sorts = {
   getTemplateInstanceStatus,
   machinePhase: (machine: MachineKind): string => getMachinePhase(machine),
   pvcUsed: (pvc: K8sResourceKind): number => pvcUsed(pvc),
+  volumeSnapshotStatus: (snapshot: VolumeSnapshotKind | VolumeSnapshotContentKind): string =>
+    snapshotStatus(snapshot),
   volumeSnapshotSize: (snapshot: VolumeSnapshotKind): number => snapshotSize(snapshot),
+  volumeSnapshotContentSize: (snapshot: VolumeSnapshotContentKind): number =>
+    snapshotContentSize(snapshot),
   volumeSnapshotSource: (snapshot: VolumeSnapshotKind): string => snapshotSource(snapshot),
   snapshotLastRestore: (snapshot: K8sResourceKind, { restores }) =>
     restores[getName(snapshot)]?.status?.restoreTime,

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -1041,6 +1041,7 @@ export type MachineHealthCheckKind = K8sResourceCommon & {
 export type VolumeSnapshotKind = K8sResourceCommon & {
   status?: VolumeSnapshotStatus & {
     boundVolumeSnapshotContentName?: string;
+    restoreSize?: string;
   };
   spec: {
     source: {
@@ -1054,6 +1055,7 @@ export type VolumeSnapshotKind = K8sResourceCommon & {
 export type VolumeSnapshotContentKind = K8sResourceCommon & {
   status: VolumeSnapshotStatus & {
     snapshotHandle?: string;
+    restoreSize?: number;
   };
   spec: {
     volumeSnapshotRef: {
@@ -1072,7 +1074,6 @@ export type VolumeSnapshotContentKind = K8sResourceCommon & {
 
 export type VolumeSnapshotStatus = {
   readyToUse: boolean;
-  restoreSize?: number;
   error?: {
     message: string;
     time: string;


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/console/pull/16335.

## Test plan

- [ ] Navigate to Storage → VolumeSnapshots in the OpenShift console
- [ ] Create test snapshots with different sizes and statuses
- [ ] Click Status column header and verify snapshots sort alphabetically by status
- [ ] Click Size column header and verify snapshots sort numerically by size (ascending/descending)
- [ ] Click Source column header and verify snapshots sort alphabetically by source PVC name
- [ ] Navigate to VolumeSnapshotContents tab and verify Status and Size sorting works
