### PR TITLE
OCPBUGS-83799: Fix Workloads sidebar ordering when DeploymentConfig capability is disabled

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -1153,7 +1153,7 @@
       "perspective": "admin",
       "section": "workloads",
       "id": "statefulsets",
-      "insertAfter": "deploymentconfigs",
+      "insertAfter": ["deploymentconfigs", "deployments"],
       "name": "%console-app~StatefulSets%",
       "model": {
         "group": "apps",

--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -1192,7 +1192,7 @@
       "perspective": "admin",
       "section": "workloads",
       "id": "statefulsets",
-      "insertAfter": "deploymentconfigs",
+      "insertAfter": ["deploymentconfigs", "deployments"],
       "name": "%console-app~StatefulSets%",
       "model": {
         "group": "apps",

--- a/frontend/packages/console-app/src/components/nav/__tests__/utils.spec.ts
+++ b/frontend/packages/console-app/src/components/nav/__tests__/utils.spec.ts
@@ -1,0 +1,79 @@
+import type { NavExtension } from '@console/dynamic-plugin-sdk';
+import type { LoadedExtension } from '@console/dynamic-plugin-sdk/src/types';
+import { getSortedNavExtensions } from '../utils';
+
+const createNavItem = (
+  id: string,
+  insertAfter?: string | string[],
+  insertBefore?: string | string[],
+): LoadedExtension<NavExtension> =>
+  ({
+    properties: {
+      id,
+      ...(insertAfter !== undefined && { insertAfter }),
+      ...(insertBefore !== undefined && { insertBefore }),
+    },
+  } as LoadedExtension<NavExtension>);
+
+const getIds = (items: LoadedExtension<NavExtension>[]): string[] =>
+  items.map((i) => i.properties.id);
+
+describe('getSortedNavExtensions', () => {
+  it('should maintain order when all insertAfter targets exist', () => {
+    const items = [
+      createNavItem('topology'),
+      createNavItem('pods', 'topology'),
+      createNavItem('deployments', 'pods'),
+      createNavItem('deploymentconfigs', 'deployments'),
+      createNavItem('statefulsets', ['deploymentconfigs', 'deployments']),
+      createNavItem('secrets', 'statefulsets'),
+    ];
+
+    expect(getIds(getSortedNavExtensions(items))).toEqual([
+      'topology',
+      'pods',
+      'deployments',
+      'deploymentconfigs',
+      'statefulsets',
+      'secrets',
+    ]);
+  });
+
+  it('should use fallback insertAfter target when primary target is missing', () => {
+    const items = [
+      createNavItem('topology'),
+      createNavItem('pods', 'topology'),
+      createNavItem('deployments', 'pods'),
+      // deploymentconfigs is absent (capability disabled)
+      createNavItem('statefulsets', ['deploymentconfigs', 'deployments']),
+      createNavItem('secrets', 'statefulsets'),
+    ];
+
+    expect(getIds(getSortedNavExtensions(items))).toEqual([
+      'topology',
+      'pods',
+      'deployments',
+      'statefulsets',
+      'secrets',
+    ]);
+  });
+
+  it('should push item to end when insertAfter target does not exist and no fallback', () => {
+    const items = [
+      createNavItem('topology'),
+      createNavItem('pods', 'topology'),
+      createNavItem('deployments', 'pods'),
+      // deploymentconfigs is absent, statefulsets has no fallback
+      createNavItem('statefulsets', 'deploymentconfigs'),
+      createNavItem('secrets', 'statefulsets'),
+    ];
+
+    const sorted = getIds(getSortedNavExtensions(items));
+    expect(sorted[0]).toBe('topology');
+    expect(sorted[1]).toBe('pods');
+    expect(sorted[2]).toBe('deployments');
+    // statefulsets and secrets end up after deployments but order may vary
+    expect(sorted).toContain('statefulsets');
+    expect(sorted).toContain('secrets');
+  });
+});

--- a/frontend/packages/console-app/src/components/nav/__tests__/utils.spec.ts
+++ b/frontend/packages/console-app/src/components/nav/__tests__/utils.spec.ts
@@ -205,6 +205,65 @@ describe('utils', () => {
       expect(sorted.map((i) => i.properties.id)).toContain('a');
       expect(sorted.map((i) => i.properties.id)).toContain('b');
     });
+
+    it('should maintain order when all insertAfter targets exist in workloads scenario', () => {
+      const items = [
+        createNavExtension('topology'),
+        createNavExtension('pods', { insertAfter: 'topology' }),
+        createNavExtension('deployments', { insertAfter: 'pods' }),
+        createNavExtension('deploymentconfigs', { insertAfter: 'deployments' }),
+        createNavExtension('statefulsets', { insertAfter: ['deploymentconfigs', 'deployments'] }),
+        createNavExtension('secrets', { insertAfter: 'statefulsets' }),
+      ];
+
+      const sorted = getSortedNavExtensions(items);
+
+      expect(sorted.map((i) => i.properties.id)).toEqual([
+        'topology',
+        'pods',
+        'deployments',
+        'deploymentconfigs',
+        'statefulsets',
+        'secrets',
+      ]);
+    });
+
+    it('should use fallback insertAfter target when primary target is missing', () => {
+      const items = [
+        createNavExtension('topology'),
+        createNavExtension('pods', { insertAfter: 'topology' }),
+        createNavExtension('deployments', { insertAfter: 'pods' }),
+        createNavExtension('statefulsets', { insertAfter: ['deploymentconfigs', 'deployments'] }),
+        createNavExtension('secrets', { insertAfter: 'statefulsets' }),
+      ];
+
+      const sorted = getSortedNavExtensions(items);
+
+      expect(sorted.map((i) => i.properties.id)).toEqual([
+        'topology',
+        'pods',
+        'deployments',
+        'statefulsets',
+        'secrets',
+      ]);
+    });
+
+    it('should push item to end when insertAfter target does not exist and no fallback', () => {
+      const items = [
+        createNavExtension('topology'),
+        createNavExtension('pods', { insertAfter: 'topology' }),
+        createNavExtension('deployments', { insertAfter: 'pods' }),
+        createNavExtension('statefulsets', { insertAfter: 'deploymentconfigs' }),
+        createNavExtension('secrets', { insertAfter: 'statefulsets' }),
+      ];
+
+      const sorted = getSortedNavExtensions(items);
+      expect(sorted[0].properties.id).toBe('topology');
+      expect(sorted[1].properties.id).toBe('pods');
+      expect(sorted[2].properties.id).toBe('deployments');
+      expect(sorted.map((i) => i.properties.id)).toContain('statefulsets');
+      expect(sorted.map((i) => i.properties.id)).toContain('secrets');
+    });
   });
 
   describe('sortExtensionItems', () => {


### PR DESCRIPTION
**Analysis / Root cause**:
The `StatefulSets` nav item in `console-extensions.json` uses `insertAfter: "deploymentconfigs"`. When the DeploymentConfig cluster capability is disabled, the `deploymentconfigs` nav item is filtered out entirely (via its `flags.required: ["OPENSHIFT_DEPLOYMENTCONFIG"]`), so the `insertAfter` target doesn't exist. The sorting algorithm in `nav/utils.ts` falls back to appending items with unresolved targets to the end of the list, which breaks the ordering chain for StatefulSets and everything after it (Secrets, ConfigMaps, etc.).

**Solution description**:
Change `insertAfter` from `"deploymentconfigs"` to `["deploymentconfigs", "deployments"]`. The `insertAfter` property already supports array fallbacks — the sorting logic takes the first matching ID found. When `deploymentconfigs` is absent, it falls back to inserting after `deployments`, maintaining the correct menu order.

**Screenshots / screen recording**:
<!-- Unable to produce screenshots — reviewer should verify on a cluster with DeploymentConfig capability disabled -->

**Test setup:**
Create or use a cluster with the DeploymentConfig capability disabled: [docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/installation_overview/cluster-capabilities#deployment-config-capability_cluster-capabilities)

**Test cases:**
- [ ] On a cluster with DeploymentConfig capability **enabled**, verify the Workloads sidebar order is unchanged: Topology, Pods, Deployments, DeploymentConfigs, StatefulSets, Secrets, ConfigMaps, ...
- [ ] On a cluster with DeploymentConfig capability **disabled**, verify the Workloads sidebar order is: Topology, Pods, Deployments, StatefulSets, Secrets, ConfigMaps, ... (same order, just missing DeploymentConfigs)
- [ ] Unit test added for `getSortedNavExtensions` covering both normal chain and missing-target fallback

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
Jira: https://redhat.atlassian.net/browse/OCPBUGS-83799

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Reviewers and assignees:**
<!-- Tag an OCP console engineer to review and verify -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated navigation configuration to improve positioning of console navigation items with multiple reference points.

* **Tests**
  * Added test coverage for navigation extension sorting logic, including fallback positioning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->