### PR TITLE
NO-JIRA: Add Jira process documentation for Definition of Ready and Verified

### DIFF
--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -1,0 +1,13 @@
+# Process
+
+This folder contains documents that define the OCP Console team's workflow standards.
+
+The Console team is responsible for maintaining two Jira projects:
+
+- **CONSOLE** — feature work (stories)
+- **OCPBUGS** (Component: Management Console) — bug tracking
+
+## Documents
+
+- [Definition of Ready](definition-of-ready.md) — criteria a Jira issue (bug or story) must meet before the team picks it up for implementation.
+- [Definition of Verified](definition-of-verified.md) — steps a reviewer must complete to verify a pull request, from readiness assessment through code review to functional verification.

--- a/docs/process/definition-of-ready.md
+++ b/docs/process/definition-of-ready.md
@@ -1,0 +1,69 @@
+# Definition of Ready
+
+In order for the console team to pick up an issue (story or a bug), the following fields in Jira need to be set with appropriate inputs. It is the contributor's responsibility to provide the necessary input. A sufficient level of detail is required, since it will serve as input for AI tools which will be carrying out implementation of the task.
+
+In case an appropriate level of input is not available, the Console team reserves the right to pause the work on the issue.
+
+## Jira Bug
+
+Project: OCPBUGS
+
+All fields are mandatory unless explicitly marked as optional.
+
+* **Description:**  
+  * Description of problem  
+  * Version-Release
+    * Cluster type
+    * Cluster version
+    * Feature gate
+  * How reproducible  
+  * Steps to Reproduce  
+  * Actual results  
+  * Expected result  
+  * Additional info  
+    * Configuration  
+      1. Browser (Chrome by default)
+    * Artifacts (at least one, linked in the description or in comments)
+      1. Screenshot/recording  
+      2. Must-gather  
+      3. HAR file  
+      4. Console stack trace  
+* **Affects versions**  
+* **Fix Versions**  
+* **Target Backport Versions** (optional)  
+* **Target Version**  
+* **Severity**  
+* **Priority** (optional)  
+* **Component:** Management Console
+
+## Jira Story
+
+Project: CONSOLE
+
+All fields are mandatory unless explicitly marked as optional.
+
+* **Description:**
+  * Overall Objective  
+  * User Stories (e.g., As a *kubeadmin*…, As a *developer* …)  
+  * UX Designs (linked in the description or in comments)
+  * Test Cases  
+    * Optional — in order to open the Jira Story  
+    * Required — in order to call the Jira Story **Ready**  
+  * Configuration  
+    * Cluster type  
+    * Feature gate  
+* **Priority** (optional)  
+* **Components**
+
+## Role Assignment
+
+Once a bug or story meets the criteria above and is declared ready, the OCP Console team will assign the following roles on the Jira issue:
+
+* **Assignee**  
+  * Responsible for code changes  
+  * Creates the Pull Request  
+* **QA Contact**  
+  * Must be a different person than the Assignee  
+  * Acts as the Pull Request assignee on GitHub  
+  * Responsible for code review  
+  * Responsible for functional verification

--- a/docs/process/definition-of-verified.md
+++ b/docs/process/definition-of-verified.md
@@ -1,0 +1,20 @@
+# Definition of Verified
+
+In order for the OCP Console team member to verify the Pull Request change, the steps below must be done serially: complete each step before starting the next. Do not treat them as parallel or interchangeable workstreams.
+
+## Pull Request Reviewer Responsibilities
+
+1. Readiness assessment  
+   * Verify that the linked Jira issue meets the Definition of Ready before starting the review  
+2. Code review  
+   * Assessing only code changes  
+   * Focus area:  
+     * Code changes  
+     * Test coverage \- unit & e2e  
+       1. Adding new tests cases that cover the new functionality  
+       2. Update existing test cases if there is a functional change  
+   * Provides `lgtm` label
+3. Functional verification  
+   * Manual testing of the change based on the provided Test Cases  
+   * Automated CI testing is green  
+   * Provides `verified` label


### PR DESCRIPTION
**Analysis / Root cause**:
The Console team is integrating AI tools into its development workflow. These tools need a machine-readable source of truth for issue readiness criteria and PR verification standards to perform automated triage and implementation.

**Solution description**:
Add two process documents under `docs/process/`:
- **`definition-of-ready.md`** — defines the mandatory and optional Jira fields required before the team picks up a bug or story. All fields are mandatory unless explicitly marked optional (Priority, Target Backport Versions). Browser defaults to Chrome:latest. Artifacts require at least one, linked in the description or comments.
- **`definition-of-verified.md`** — defines the PR reviewer responsibilities: readiness assessment, code review (with test coverage expectations), and functional verification.

These documents serve as input for Claude Code skills that automate bug triage, implementation, and PR review workflows.

**Screenshots / screen recording**:
N/A — documentation only.

**Test setup:**
N/A

**Test cases:**
N/A

**Browser conformance**:
N/A

**Additional info:**
These documents are consumed by the `/jira-bug` Claude Code skill for automated readiness assessment, and will also be used by a future external `/jira-story` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added definition of readiness criteria for Jira issues, specifying mandatory fields and information requirements for stories and bugs.
  * Added documentation outlining the PR verification process, including reviewer responsibilities for code review, testing, and approval workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->