### PR TITLE
NO-JIRA: Add approvers and reviewers to helm-plugin OWNERS

### DIFF
--- a/frontend/packages/helm-plugin/OWNERS
+++ b/frontend/packages/helm-plugin/OWNERS
@@ -1,2 +1,12 @@
 labels:
   - component/helm
+approvers:
+- baijum
+- martinszuc
+- sowmya-sl
+- webbnh
+reviewers:
+- baijum
+- martinszuc
+- sowmya-sl
+- webbnh


### PR DESCRIPTION
The helm-plugin OWNERS file only had a component label. Add dedicated approvers and reviewers to ensure helm-plugin changes are reviewed by helm team.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OWNERS file to explicitly define approvers and reviewers for the helm-plugin package, establishing clearer governance and review responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->