### PR TITLE
OCPBUGS-84324: Update outdated documentation links and references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ This document outlines some of the conventions on development workflow.
 
 This is a rough outline of what a contributor's workflow looks like:
 
-- Create a topic branch from where you want to base your work (usually master).
+- Create a topic branch from where you want to base your work (usually main).
 - Make commits of logical units.
 - Make sure your commit messages are in the proper format (see below).
 - Push your changes to a topic branch in your fork of the repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ a link to the issue in the commit description to make it easy to get to the issu
 ### Backporting Fixes
 
 Branches for previous releases follow the format `release-X.Y`, for example,
-`release-4.1`. Typically, bugs are fixed in the master branch first then
+`release-4.1`. Typically, bugs are fixed in the main branch first then
 backported to the appropriate release branches. Fixes backported to previous
 releases should have a Bugzilla bug for each version fixed.
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ The console is a more friendly `kubectl` in the form of a single page webapp. It
 ### Dependencies:
 
 1. [node.js](https://nodejs.org/) >= 22 with [corepack](https://npmjs.com/package/corepack) enabled for [yarn berry](https://yarnpkg.com/)
-2. [go](https://golang.org/) >= 1.25
-3. [oc](https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/) or [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and an OpenShift or Kubernetes cluster
-4. [jq](https://stedolan.github.io/jq/download/) (for `contrib/environment.sh`)
+2. [go](https://go.dev/) >= 1.25
+3. [oc](https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/) or [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and an OpenShift or Kubernetes cluster
+4. [jq](https://stedolan.github.io/jq/download/) (used by scripts and tests; see [code usage](https://github.com/search?q=repo%3Aopenshift%2Fconsole+%2F+jq+%2F+-path%3A**%2F*.md+-path%3A**%2FDockerfile*&type=code))
 
 ### Build everything:
 
-This project uses [Go modules](https://github.com/golang/go/wiki/Modules),
+This project uses [Go modules](https://go.dev/wiki/Modules),
 so you should clone the project outside of your `GOPATH`. To build both the
 frontend and backend, run:
 
@@ -38,7 +38,7 @@ The following instructions assume you have an existing cluster you can connect
 to. OpenShift 4.x clusters can be installed using the
 [OpenShift Installer](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/). More information about installing OpenShift can be found at
 <https://try.openshift.com/>.
-You can also use [CodeReady Containers](https://github.com/code-ready/crc)
+You can also use [CodeReady Containers](https://github.com/crc-org/crc)
 for local installs, or native Kubernetes clusters.
 
 #### OpenShift (no authentication)
@@ -139,7 +139,7 @@ In order to update the `tectonic-console-builder` to a new version (e.g., v29), 
 
 #### CodeReady Containers
 
-If you want to use CodeReady for local development, first make sure [it is set up](https://crc.dev/crc/#setting-up-codeready-containers_gsg), and the [OpenShift cluster is started](https://crc.dev/crc/#starting-the-virtual-machine_gsg).
+If you want to use CodeReady for local development, first make sure [it is set up](https://crc.dev/docs/networking/#setting-up-on-a-remote-server), and the [OpenShift cluster is started](https://crc.dev/docs/getting-started/#creating-openshift-preset).
 
 To login to the cluster's API server, you can use the following command:
 
@@ -309,7 +309,7 @@ When running in headless mode, Cypress will test using its integrated Electron b
 #### How the Integration Tests Run in CI
 
 The end-to-end tests run against pull requests using [ci-operator](https://github.com/openshift/ci-operator/).
-The tests are defined in [this manifest](https://github.com/openshift/release/blob/master/ci-operator/jobs/openshift/console/openshift-console-master-presubmits.yaml)
+The tests are defined in [this manifest](https://github.com/openshift/release/blob/main/ci-operator/jobs/openshift/console/openshift-console-main-presubmits.yaml)
 in the [openshift/release](https://github.com/openshift/release) repo and were generated with [ci-operator-prowgen](https://github.com/openshift/ci-operator-prowgen).
 
 CI runs the [test-prow-e2e.sh](test-prow-e2e.sh) script, which runs [frontend/integration-tests/test-cypress.sh](frontend/integration-tests/test-cypress.sh).

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -33,7 +33,7 @@
 - Scope all classes with a recognizable prefix to avoid collisions with any imported CSS (this project uses `co-` by convention).
 - Class names should be all lowercase and dash-separated.
 - All SCSS variables should be scoped within their component.
-- We use [BEM](http://getbem.com) naming conventions.
+- We use [BEM](https://getbem.com/) naming conventions.
 
 ## TypeScript and JavaScript
 


### PR DESCRIPTION
- Fix 404 links and redirects on README file
- Fix outdated CI manifest reference to use main branch in README file

Jira bug: https://issues.redhat.com/browse/OCPBUGS-84324

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
Some links in the project's main documentation files (README.md, CONTRIBUTING.md, STYLEGUIDE.md) are broken, redirecting, or outdated. These create a poor onboarding experience for new contributors and can lead to confusion when following setup instructions.

**Additional info:**
Redirects are not necessarily a 'not found' case per se, but they could eventually become invalid in the future; therefore, it is better to replace them with their current URLs if possible.

**Reviewers and assignees:**


  Docs approver:
  /assign @Leo6Leo 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guide to reference the current main branch workflow and backport order
  * Updated external resource links (Go, Go modules, kubectl, CodeReady Containers) and CI presubmit reference to main
  * Clarified jq usage in scripts and tests with a code-usage link
  * Switched style guide BEM reference to HTTPS for improved link security
<!-- end of auto-generated comment: release notes by coderabbit.ai -->