### PR TITLE
NO-JIRA: Hack&Hustle - markdown link checker script and report

### DIFF
--- a/.claude/skills/check-md-links/SKILL.md
+++ b/.claude/skills/check-md-links/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: check-md-links
+description: Run the markdown link checker script, parse results, and interactively fix broken or redirected links.
+allowed-tools: Bash(./contrib/check-md-links.sh *), Bash(cat *), WebSearch, AskUserQuestion, Read, Edit
+argument-hint: "[file.md ...|--all]"
+---
+
+# /check-md-links
+
+Run `contrib/check-md-links.sh` on markdown files, parse the CSV report, and
+walk the user through each issue interactively — offering to fix what can be
+fixed automatically.
+
+## Usage
+
+```
+/check-md-links README.md
+/check-md-links README.md CONTRIBUTING.md TESTING.md
+/check-md-links --all
+```
+
+## Input
+
+$ARGUMENTS
+
+## Process
+
+### Step 1: Run the link checker
+
+Build the command from `$ARGUMENTS`:
+
+- If `$ARGUMENTS` is empty, ask the user what to check:
+
+```json
+{
+  "question": "Which markdown files should I check for broken links?",
+  "header": "Scope",
+  "multiSelect": false,
+  "options": [
+    {
+      "label": "All (--all)",
+      "description": "Find and check every .md file in the repo"
+    },
+    {
+      "label": "Root docs only",
+      "description": "README.md, CONTRIBUTING.md, TESTING.md, STYLEGUIDE.md, INTERNATIONALIZATION.md"
+    },
+    {
+      "label": "Specify files",
+      "description": "I'll provide specific file paths"
+    }
+  ]
+}
+```
+
+- If the user selects "Specify files", ask them to provide the paths.
+- If the user selects "Root docs only", use:
+  `README.md CONTRIBUTING.md TESTING.md STYLEGUIDE.md INTERNATIONALIZATION.md`
+
+Run the script:
+
+```bash
+./contrib/check-md-links.sh [arguments] -o /tmp/md-link-check.csv
+```
+
+Use `/tmp/md-link-check.csv` as the output path to avoid polluting the working tree.
+
+### Step 2: Parse the report
+
+Read the CSV output. If no issues were found (0 problems), report success and stop.
+
+Otherwise, group issues by file and present a summary table to the user:
+
+```
+Found N issue(s) across M file(s):
+
+| File | Status | Count |
+|------|--------|-------|
+| README.md | REDIRECT | 3 |
+| README.md | NOT_FOUND | 1 |
+| CONTRIBUTING.md | TIMEOUT/ERROR | 2 |
+```
+
+### Step 3: Walk through each issue
+
+Process issues **one file at a time**, and within each file, **one issue at a
+time**. For each issue, read the relevant line from the source file to show
+context, then take action based on the status:
+
+#### REDIRECT
+
+The link works but redirects to a different URL. The redirect target is known.
+
+- Show the user: the file, line number, original URL, and redirect target.
+- Display the redirect target URL clearly so the user can click and verify it:
+
+```
+Line 42: [link text](https://old-url.com)
+  ↳ Redirects to: https://new-url.com/updated-path
+```
+
+- Use `AskUserQuestion`:
+
+```json
+{
+  "question": "This link redirects to a new URL. Want to fix it now or check the destination first?",
+  "header": "Redirect",
+  "multiSelect": false,
+  "options": [
+    {
+      "label": "Fix it now",
+      "description": "Replace the old URL with the redirect target"
+    },
+    {
+      "label": "Let me check first",
+      "description": "I'll visit the link above and decide after"
+    },
+    {
+      "label": "Skip",
+      "description": "Leave the link as-is"
+    }
+  ]
+}
+```
+
+- If "Fix it now": use the Edit tool to replace the old URL with the redirect
+  URL in the markdown file.
+- If "Let me check first": print the redirect URL again on its own line so it
+  is easy to copy/click, then pause and ask:
+
+```json
+{
+  "question": "Did you check the link? What would you like to do?",
+  "header": "Verdict",
+  "multiSelect": false,
+  "options": [
+    {
+      "label": "Fix it",
+      "description": "Replace with the redirect target"
+    },
+    {
+      "label": "Skip",
+      "description": "Leave the link as-is"
+    }
+  ]
+}
+```
+
+#### NOT_FOUND (404)
+
+The link is broken and returns a 404.
+
+- Show the user: the file, line number, broken URL, and the surrounding
+  markdown context (the line from the file) so the purpose of the link is clear.
+- **Do not search the web automatically.** Ask the user first:
+
+```json
+{
+  "question": "This link is broken (404). Want me to search the web for an updated URL based on the context of the markdown?",
+  "header": "404",
+  "multiSelect": false,
+  "options": [
+    {
+      "label": "Search for it",
+      "description": "I'll look for the correct or updated link using the surrounding context"
+    },
+    {
+      "label": "Remove the link",
+      "description": "Convert to plain text (keep the link text, remove the URL)"
+    },
+    {
+      "label": "Skip",
+      "description": "Leave the link as-is for manual review"
+    }
+  ]
+}
+```
+
+- If "Search for it": use `WebSearch` with keywords from the broken URL's
+  domain/path and the surrounding markdown context (link text, heading, etc.)
+  to find the most relevant replacement.
+  - If a likely replacement is found, present it clearly and ask:
+
+  ```json
+  {
+    "question": "I found a possible replacement. What should I do?",
+    "header": "Replace?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "Use this URL",
+        "description": "Replace with: [suggested URL]"
+      },
+      {
+        "label": "Let me check first",
+        "description": "I'll visit the suggested link and decide after"
+      },
+      {
+        "label": "Skip",
+        "description": "Leave the link as-is"
+      }
+    ]
+  }
+  ```
+
+  - If "Let me check first": print the suggested URL on its own line, then
+    pause and ask for the user's verdict (same pattern as the REDIRECT flow).
+  - If no replacement is found, inform the user and offer to remove the link
+    or skip.
+
+- If "Remove the link": use the Edit tool to convert `[text](url)` to just `text`.
+- If "Skip": move on to the next issue.
+
+#### TIMEOUT/ERROR (000)
+
+The request timed out or failed to connect. This is often a false positive
+(firewalled sites, VPN-only URLs, rate limiting).
+
+- Show the user: the file, line number, and URL.
+- Flag it as a likely false positive and ask:
+
+```json
+{
+  "question": "This link timed out (could be a firewall, VPN-only, or transient issue). What should I do?",
+  "header": "Timeout",
+  "multiSelect": false,
+  "options": [
+    {
+      "label": "Skip",
+      "description": "Likely a false positive — leave it alone"
+    },
+    {
+      "label": "Remove the link",
+      "description": "Convert to plain text"
+    }
+  ]
+}
+```
+
+#### ERROR_4xx (403, 429, etc.)
+
+The server actively rejected the request. Common with bot detection, rate
+limiting, or authentication-required pages.
+
+- Show the user: the file, line number, URL, and HTTP status code.
+- Flag it as likely bot detection and ask:
+
+```json
+{
+  "question": "This link returned HTTP [code] (often bot detection or auth-required). What should I do?",
+  "header": "HTTP [code]",
+  "multiSelect": false,
+  "options": [
+    {
+      "label": "Skip",
+      "description": "Likely a false positive — leave it alone"
+    },
+    {
+      "label": "Search for alternative",
+      "description": "Search the web for an updated or public version of this resource"
+    },
+    {
+      "label": "Remove the link",
+      "description": "Convert to plain text"
+    }
+  ]
+}
+```
+
+- If "Search for alternative": use `WebSearch`, then present the result and
+  offer to replace.
+
+### Step 4: Summary
+
+After processing all issues, print a summary:
+
+```
+Done. Results:
+  - Fixed: N link(s)
+  - Skipped: N link(s)
+  - Removed: N link(s)
+
+Modified files:
+  - README.md
+  - CONTRIBUTING.md
+```
+
+If any files were modified, remind the user to review the changes with
+`git diff` before committing.

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ cypress-a11y-report.json
 /dynamic-demo-plugin/**/dist
 **/.claude/settings.local.json
 **/chartstore-*/
+link-markdown-check.csv

--- a/contrib/check-md-links.sh
+++ b/contrib/check-md-links.sh
@@ -42,6 +42,10 @@ EOF
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -o|--output)
+      if [ $# -lt 2 ] || [[ "$2" == -* ]]; then
+        echo "ERROR: -o/--output requires a value" >&2
+        exit 1
+      fi
       OUTPUT="$2"
       shift 2
       ;;
@@ -76,17 +80,12 @@ done
 # Start fresh
 echo "file,line,status,http_code,url,redirect_url" > "$OUTPUT"
 
-total=0
-problems=0
-
 for file in "${FILES[@]}"; do
   grep -noE 'https?://[^)> "]+' "$file" | sed 's/[).,]*$//' | while IFS=: read -r line url; do
     # Skip localhost / local-only URLs
     case "$url" in
       *localhost*|*127.0.0.1*|*api.crc.testing*) continue ;;
     esac
-
-    total=$((total + 1))
 
     result=$(curl -sL -o /dev/null -w "%{http_code}|%{url_effective}" --max-time 15 "$url" 2>/dev/null || echo "000|")
     http_code="${result%%|*}"
@@ -113,8 +112,7 @@ for file in "${FILES[@]}"; do
       continue
     fi
 
-    echo "$file,$line,$status,$http_code,$url,$redirect," >> "$OUTPUT"
-    problems=$((problems + 1))
+    echo "$file,$line,$status,$http_code,$url,$redirect" >> "$OUTPUT"
   done
 done
 

--- a/contrib/check-md-links.sh
+++ b/contrib/check-md-links.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+#
+# check-md-links.sh — Check markdown files for broken or redirected URLs.
+#
+# Extracts all http(s) URLs from the given markdown files, tests each one
+# with curl, and writes problems (404s, errors, redirects) to a CSV report.
+#
+# Usage:
+#   ./contrib/check-md-links.sh README.md
+#   ./contrib/check-md-links.sh CONTRIBUTING.md
+#   ./contrib/check-md-links.sh README.md TESTING.md STYLEGUIDE.md
+#   ./contrib/check-md-links.sh -o report.csv README.md
+#
+# Output:
+#   link-markdown-check.csv (or custom path via -o) in the current directory.
+#   Only problematic links (404, redirects, errors) are written.
+#
+# Idempotent: overwrites the output CSV on every run.
+
+set -uo pipefail
+
+OUTPUT="link-markdown-check.csv"
+FILES=()
+
+usage() {
+  cat <<'EOF'
+check-md-links.sh — Check markdown files for broken or redirected URLs.
+
+Usage:
+  ./contrib/check-md-links.sh README.md
+  ./contrib/check-md-links.sh CONTRIBUTING.md
+  ./contrib/check-md-links.sh README.md TESTING.md STYLEGUIDE.md
+  ./contrib/check-md-links.sh -o report.csv README.md
+
+Output:
+  link-markdown-check.csv (or custom path via -o) in the current directory.
+  Only problematic links (404, redirects, errors) are written.
+EOF
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--output)
+      OUTPUT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      FILES+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# Require at least one markdown file argument
+if [ ${#FILES[@]} -eq 0 ]; then
+  echo "ERROR: please provide at least one markdown file to check." >&2
+  echo "Usage: ./contrib/check-md-links.sh <file.md> [more.md ...]" >&2
+	echo ""
+	usage
+  exit 1
+fi
+
+# Validate inputs
+for f in "${FILES[@]}"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: $f not found" >&2
+    exit 1
+  fi
+done
+
+# Start fresh
+echo "file,line,status,http_code,url,redirect_url" > "$OUTPUT"
+
+total=0
+problems=0
+
+for file in "${FILES[@]}"; do
+  grep -noE 'https?://[^)> "]+' "$file" | sed 's/[).,]*$//' | while IFS=: read -r line url; do
+    # Skip localhost / local-only URLs
+    case "$url" in
+      *localhost*|*127.0.0.1*|*api.crc.testing*) continue ;;
+    esac
+
+    total=$((total + 1))
+
+    result=$(curl -sL -o /dev/null -w "%{http_code}|%{url_effective}" --max-time 15 "$url" 2>/dev/null || echo "000|")
+    http_code="${result%%|*}"
+    effective_url="${result#*|}"
+
+    if [ "$http_code" = "000" ]; then
+      status="TIMEOUT/ERROR"
+      redirect=""
+			echo "$status at line $line - url: $url"
+    elif [ "$http_code" = "404" ]; then
+      status="NOT_FOUND"
+      redirect=""
+			echo "Not found at line $line - url: $url"
+    elif [ "$http_code" -ge 400 ] 2>/dev/null; then
+      status="ERROR_${http_code}"
+      redirect=""
+			echo "$status at line $line - url: $url"
+    elif [ "$effective_url" != "$url" ] && [ "$effective_url" != "${url}/" ] && [ "${url}/" != "$effective_url" ]; then
+      status="REDIRECT"
+      redirect="$effective_url"
+			echo "$status at line $line - url: $url ==> $effective_url"
+    else
+      # Link is fine, skip
+      continue
+    fi
+
+    echo "$file,$line,$status,$http_code,$url,$redirect," >> "$OUTPUT"
+    problems=$((problems + 1))
+  done
+done
+
+lines=$(tail -n +2 "$OUTPUT" | wc -l | tr -d ' ')
+echo ""
+echo "Done. Found $lines problem(s). Results in $OUTPUT"

--- a/contrib/check-md-links.sh
+++ b/contrib/check-md-links.sh
@@ -10,6 +10,7 @@
 #   ./contrib/check-md-links.sh CONTRIBUTING.md
 #   ./contrib/check-md-links.sh README.md TESTING.md STYLEGUIDE.md
 #   ./contrib/check-md-links.sh -o report.csv README.md
+#   ./contrib/check-md-links.sh --all
 #
 # Output:
 #   link-markdown-check.csv (or custom path via -o) in the current directory.
@@ -21,6 +22,7 @@ set -uo pipefail
 
 OUTPUT="link-markdown-check.csv"
 FILES=()
+ALL=false
 
 usage() {
   cat <<'EOF'
@@ -31,10 +33,13 @@ Usage:
   ./contrib/check-md-links.sh CONTRIBUTING.md
   ./contrib/check-md-links.sh README.md TESTING.md STYLEGUIDE.md
   ./contrib/check-md-links.sh -o report.csv README.md
+  ./contrib/check-md-links.sh --all
 
-Output:
-  link-markdown-check.csv (or custom path via -o) in the current directory.
-  Only problematic links (404, redirects, errors) are written.
+Options:
+  -o, --output FILE   Write results to FILE (default: link-markdown-check.csv)
+  -a, --all           Find and check every .md file in the repo (excludes
+                      node_modules, vendor, and .yarn directories)
+  -h, --help          Show this help
 EOF
 }
 
@@ -49,6 +54,10 @@ while [[ $# -gt 0 ]]; do
       OUTPUT="$2"
       shift 2
       ;;
+    -a|--all)
+      ALL=true
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -60,8 +69,21 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Require at least one markdown file argument
-if [ ${#FILES[@]} -eq 0 ]; then
+# Collect files from --all or require explicit arguments
+if [ "$ALL" = true ]; then
+  while IFS= read -r -d '' f; do
+    FILES+=("$f")
+  done < <(find . -name '*.md' \
+    -not -path '*/node_modules/*' \
+    -not -path '*/vendor/*' \
+    -not -path '*/.yarn/*' \
+    -print0)
+  if [ ${#FILES[@]} -eq 0 ]; then
+    echo "ERROR: --all found no .md files" >&2
+    exit 1
+  fi
+  echo "Found ${#FILES[@]} markdown file(s) to check."
+elif [ ${#FILES[@]} -eq 0 ]; then
   echo "ERROR: please provide at least one markdown file to check." >&2
   echo "Usage: ./contrib/check-md-links.sh <file.md> [more.md ...]" >&2
 	echo ""


### PR DESCRIPTION
As part of my Hack & Hustle exploration, I added a new contrib script to scan Markdown files for URL issues and write identified problems (404s, errors, redirects) to a CSV report. This improves the quality of documentation links.

**Analysis / Root cause**:
The idea originated while working on #16362; links inside Markdown guidelines can become deprecated, broken, or modified over time.

**Solution description**:
This script simply iterates through every external link inside a Markdown file and quickly checks via `curl` whether the link reports a status code other than `200`. 

It requires human supervision at the end in order to decide whether a redirect is acceptable or not, or to find the replacement link in case the old one is broken. Hence, the CSV artifact is useful for manual review, whether run on a CI or locally.

**Reviewers and assignees:**
  Docs approver:
  /assign @Leo6Leo 