### PR TITLE
OCPBUGS-83767: Helm upgrade — preserve release values when changing chart version

### DIFF
--- a/frontend/packages/helm-plugin/locales/en/helm-plugin.json
+++ b/frontend/packages/helm-plugin/locales/en/helm-plugin.json
@@ -101,7 +101,7 @@
   "{{chartVersion}} provided by {{provider}}": "{{chartVersion}} provided by {{provider}}",
   "Change chart version?": "Change chart version?",
   "Are you sure you want to change the chart version from <2>{{currentVersion}}</2> to <4>{{newVersion}}</4>? ": "Are you sure you want to change the chart version from <2>{{currentVersion}}</2> to <4>{{newVersion}}</4>? ",
-  "All data entered for version <1>{{currentVersion}}</1> will be reset": "All data entered for version <1>{{currentVersion}}</1> will be reset",
+  "Values from your current release are merged with the new chart's defaults. Review the YAML or form before upgrading.": "Values from your current release are merged with the new chart's defaults. Review the YAML or form before upgrading.",
   "Proceed": "Proceed",
   "Cancel": "Cancel",
   "Select the version to upgrade to.": "Select the version to upgrade to.",

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartVersionDropdown.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartVersionDropdown.tsx
@@ -4,7 +4,7 @@ import { GridItem } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import type { FormikValues } from 'formik';
 import { useFormikContext } from 'formik';
-import { safeLoad } from 'js-yaml';
+import { safeDump, safeLoad } from 'js-yaml';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
 import type { WatchK8sResource } from '@console/dynamic-plugin-sdk';
@@ -22,12 +22,12 @@ import { HelmActionType } from '../../../types/helm-types';
 import {
   getChartURL,
   getChartVersions,
-  getChartValuesYAML,
   getChartReadme,
   concatVersions,
   getChartEntriesByName,
   getChartRepositoryTitle,
   getChartIndexEntry,
+  mergeHelmValuesOnChartVersionChange,
 } from '../../../utils/helm-utils';
 
 export type HelmChartVersionDropdownProps = {
@@ -54,7 +54,7 @@ const HelmChartVersionDropdown: FC<HelmChartVersionDropdownProps> = ({
   const { t } = useTranslation();
   const {
     setFieldValue,
-    values: { chartRepoName, yamlData, formData, appVersion },
+    values: { chartRepoName, yamlData, formData, appVersion, editorType },
     setFieldTouched,
   } = useFormikContext<FormikValues>();
   const [helmChartVersions, setHelmChartVersions] = useState({});
@@ -88,7 +88,8 @@ const HelmChartVersionDropdown: FC<HelmChartVersionDropdownProps> = ({
         <p>
           <InfoCircleIcon color="var(--pf-t--global--icon--color--status--info--default)" />{' '}
           <Trans t={t} ns="helm-plugin">
-            All data entered for version <strong>{{ currentVersion }}</strong> will be reset
+            Values from your current release are merged with the new chart{"'"}s defaults. Review
+            the YAML or form before upgrading.
           </Trans>
         </p>
       </>
@@ -180,17 +181,33 @@ const HelmChartVersionDropdown: FC<HelmChartVersionDropdownProps> = ({
         onVersionChange(res);
 
         const chartReadme = getChartReadme(res);
-        const valuesYAML = getChartValuesYAML(res);
         const valuesJSON = res?.values;
         const valuesSchema = res?.schema && JSON.parse(atob(res?.schema));
-        const editorType = valuesSchema ? EditorType.Form : EditorType.YAML;
-        setFieldValue('editorType', editorType);
-        setFieldValue('formSchema', valuesSchema);
-        setFieldValue('yamlData', valuesYAML);
-        setFieldValue('formData', valuesJSON);
-        setFieldValue('chartReadme', chartReadme);
-        setInitialYamlData(valuesYAML);
-        setInitialFormData(valuesJSON);
+        const nextEditorType = valuesSchema ? EditorType.Form : EditorType.YAML;
+        const mergedValues = mergeHelmValuesOnChartVersionChange(
+          valuesJSON as Record<string, unknown> | undefined,
+          yamlData as string,
+          formData,
+          editorType as EditorType,
+        );
+        try {
+          const mergedYaml = safeDump(mergedValues);
+          setFieldValue('editorType', nextEditorType);
+          setFieldValue('formSchema', valuesSchema);
+          setFieldValue('yamlData', mergedYaml);
+          setFieldValue('formData', mergedValues);
+          setFieldValue('chartReadme', chartReadme);
+          setInitialYamlData(mergedYaml);
+          setInitialFormData(mergedValues);
+        } catch (err) {
+          console.error('Failed to serialize merged values:', err); // eslint-disable-line no-console
+          // Fall back to using the merged values object without YAML serialization
+          setFieldValue('editorType', nextEditorType);
+          setFieldValue('formSchema', valuesSchema);
+          setFieldValue('formData', mergedValues);
+          setFieldValue('chartReadme', chartReadme);
+          setInitialFormData(mergedValues);
+        }
       })
       .catch((err) => {
         console.error(`Could not fetch helm chart with chart URL ${chartURL}:`, err); // eslint-disable-line no-console

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartVersionDropdown.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartVersionDropdown.tsx
@@ -4,7 +4,7 @@ import { GridItem } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import type { FormikValues } from 'formik';
 import { useFormikContext } from 'formik';
-import { safeLoad } from 'js-yaml';
+import { safeDump, safeLoad } from 'js-yaml';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
 import type { WatchK8sResource } from '@console/dynamic-plugin-sdk';
@@ -22,12 +22,12 @@ import { HelmActionType } from '../../../types/helm-types';
 import {
   getChartURL,
   getChartVersions,
-  getChartValuesYAML,
   getChartReadme,
   concatVersions,
   getChartEntriesByName,
   getChartRepositoryTitle,
   getChartIndexEntry,
+  mergeHelmValuesOnChartVersionChange,
 } from '../../../utils/helm-utils';
 
 export type HelmChartVersionDropdownProps = {
@@ -54,7 +54,7 @@ const HelmChartVersionDropdown: FC<HelmChartVersionDropdownProps> = ({
   const { t } = useTranslation();
   const {
     setFieldValue,
-    values: { chartRepoName, yamlData, formData, appVersion },
+    values: { chartRepoName, yamlData, formData, appVersion, editorType },
     setFieldTouched,
   } = useFormikContext<FormikValues>();
   const [helmChartVersions, setHelmChartVersions] = useState({});
@@ -88,7 +88,8 @@ const HelmChartVersionDropdown: FC<HelmChartVersionDropdownProps> = ({
         <p>
           <InfoCircleIcon color="var(--pf-t--global--icon--color--status--info--default)" />{' '}
           <Trans t={t} ns="helm-plugin">
-            All data entered for version <strong>{{ currentVersion }}</strong> will be reset
+            Values from your current release are merged with the new chart{"'"}s defaults. Review
+            the YAML or form before upgrading.
           </Trans>
         </p>
       </>
@@ -180,17 +181,36 @@ const HelmChartVersionDropdown: FC<HelmChartVersionDropdownProps> = ({
         onVersionChange(res);
 
         const chartReadme = getChartReadme(res);
-        const valuesYAML = getChartValuesYAML(res);
         const valuesJSON = res?.values;
         const valuesSchema = res?.schema && JSON.parse(atob(res?.schema));
-        const editorType = valuesSchema ? EditorType.Form : EditorType.YAML;
-        setFieldValue('editorType', editorType);
-        setFieldValue('formSchema', valuesSchema);
-        setFieldValue('yamlData', valuesYAML);
-        setFieldValue('formData', valuesJSON);
-        setFieldValue('chartReadme', chartReadme);
-        setInitialYamlData(valuesYAML);
-        setInitialFormData(valuesJSON);
+        const nextEditorType = valuesSchema ? EditorType.Form : EditorType.YAML;
+        const mergedValues = mergeHelmValuesOnChartVersionChange(
+          valuesJSON as Record<string, unknown> | undefined,
+          yamlData as string,
+          formData,
+          editorType as EditorType,
+        );
+        try {
+          const mergedYaml = safeDump(mergedValues);
+          setFieldValue('editorType', nextEditorType);
+          setFieldValue('formSchema', valuesSchema);
+          setFieldValue('yamlData', mergedYaml);
+          setFieldValue('formData', mergedValues);
+          setFieldValue('chartReadme', chartReadme);
+          setInitialYamlData(mergedYaml);
+          setInitialFormData(mergedValues);
+        } catch (err) {
+          console.error('Failed to serialize merged values:', err); // eslint-disable-line no-console
+          // Fall back to using the merged values object without YAML serialization
+          setFieldValue('editorType', nextEditorType);
+          setFieldValue('formSchema', valuesSchema);
+          // Keep yamlData in sync as best we can - use empty or preserve previous
+          setFieldValue('yamlData', '');
+          setInitialYamlData('');
+          setFieldValue('formData', mergedValues);
+          setFieldValue('chartReadme', chartReadme);
+          setInitialFormData(mergedValues);
+        }
       })
       .catch((err) => {
         console.error(`Could not fetch helm chart with chart URL ${chartURL}:`, err); // eslint-disable-line no-console

--- a/frontend/packages/helm-plugin/src/utils/__tests__/helm-utils.spec.ts
+++ b/frontend/packages/helm-plugin/src/utils/__tests__/helm-utils.spec.ts
@@ -1,3 +1,4 @@
+import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
 import { t } from '../../../../../__mocks__/i18next';
 import {
   mockHelmReleases,
@@ -24,6 +25,9 @@ import {
   loadHelmManifestResources,
   getChartIndexEntry,
   isGoingToTopology,
+  mergeHelmChartVersionUpgradeValues,
+  getCurrentHelmUserValuesForUpgradeMerge,
+  mergeHelmValuesOnChartVersionChange,
 } from '../helm-utils';
 
 describe('Helm Releases Utils', () => {
@@ -304,6 +308,91 @@ metadata:
           metadata: { name: 'second' },
         },
       ]);
+    });
+  });
+
+  describe('Helm upgrade values merge on chart version change', () => {
+    it('mergeHelmChartVersionUpgradeValues should keep user overrides over new chart defaults', () => {
+      const newChart = { replicas: 1, image: { tag: 'v2' } };
+      const user = { replicas: 5, extra: true };
+      expect(mergeHelmChartVersionUpgradeValues(newChart, user)).toEqual({
+        replicas: 5,
+        image: { tag: 'v2' },
+        extra: true,
+      });
+    });
+
+    it('mergeHelmChartVersionUpgradeValues should add keys that exist only on the new chart', () => {
+      const newChart = { newFlag: false, service: { type: 'ClusterIP' } };
+      const user = { replicas: 2 };
+      expect(mergeHelmChartVersionUpgradeValues(newChart, user)).toEqual({
+        newFlag: false,
+        service: { type: 'ClusterIP' },
+        replicas: 2,
+      });
+    });
+
+    it('mergeHelmChartVersionUpgradeValues should replace arrays instead of merging by index', () => {
+      const newChart = { tolerations: [{ key: 'node' }, { key: 'disk' }], env: ['DEFAULT=1'] };
+      const user = { tolerations: [{ key: 'custom' }], env: [] };
+      expect(mergeHelmChartVersionUpgradeValues(newChart, user)).toEqual({
+        tolerations: [{ key: 'custom' }],
+        env: [],
+      });
+    });
+
+    it('mergeHelmChartVersionUpgradeValues should preserve user arrays even when chart has none', () => {
+      const newChart = { replicas: 1 };
+      const user = { customList: ['a', 'b', 'c'] };
+      expect(mergeHelmChartVersionUpgradeValues(newChart, user)).toEqual({
+        replicas: 1,
+        customList: ['a', 'b', 'c'],
+      });
+    });
+
+    it('getCurrentHelmUserValuesForUpgradeMerge should prefer formData in Form editor mode', () => {
+      const yaml = 'replicas: 99\n';
+      const form = { replicas: 1, fromForm: true };
+      expect(getCurrentHelmUserValuesForUpgradeMerge(yaml, form, EditorType.Form)).toEqual({
+        replicas: 1,
+        fromForm: true,
+      });
+    });
+
+    it('getCurrentHelmUserValuesForUpgradeMerge should parse YAML in YAML editor mode', () => {
+      const yaml = 'replicas: 3\ncustom:\n  path: kept\n';
+      const form = { replicas: 1 };
+      expect(getCurrentHelmUserValuesForUpgradeMerge(yaml, form, EditorType.YAML)).toEqual({
+        replicas: 3,
+        custom: { path: 'kept' },
+      });
+    });
+
+    it('getCurrentHelmUserValuesForUpgradeMerge should fall back to formData when YAML is invalid', () => {
+      expect(
+        getCurrentHelmUserValuesForUpgradeMerge('[ broken: ', { ok: true }, EditorType.YAML),
+      ).toEqual({ ok: true });
+    });
+
+    it('getCurrentHelmUserValuesForUpgradeMerge should return an empty object when nothing usable is present', () => {
+      expect(getCurrentHelmUserValuesForUpgradeMerge('', undefined, EditorType.YAML)).toEqual({});
+      expect(getCurrentHelmUserValuesForUpgradeMerge('', null, EditorType.Form)).toEqual({});
+    });
+
+    it('mergeHelmValuesOnChartVersionChange should merge chart defaults with the active editor values (upgrade regression)', () => {
+      const newChartValues = { image: { tag: '2.0.0' }, replicas: 1 };
+      const yamlData = 'replicas: 7\nimage:\n  tag: 1.0.0\nflight:\n  enabled: true\n';
+      const merged = mergeHelmValuesOnChartVersionChange(
+        newChartValues,
+        yamlData,
+        { replicas: 0 },
+        EditorType.YAML,
+      );
+      expect(merged).toEqual({
+        image: { tag: '1.0.0' },
+        replicas: 7,
+        flight: { enabled: true },
+      });
     });
   });
 });

--- a/frontend/packages/helm-plugin/src/utils/helm-utils.ts
+++ b/frontend/packages/helm-plugin/src/utils/helm-utils.ts
@@ -1,11 +1,12 @@
 import * as fuzzy from 'fuzzysearch';
 import type { TFunction } from 'i18next';
-import { loadAll, safeDump, DEFAULT_SAFE_SCHEMA } from 'js-yaml';
+import { loadAll, safeDump, safeLoad, DEFAULT_SAFE_SCHEMA } from 'js-yaml';
 import * as _ from 'lodash';
 import type { Flatten } from '@console/internal/components/factory/list-page';
 import type { RowFilter } from '@console/internal/components/filter-toolbar';
 import type { K8sResourceKind } from '@console/internal/module/k8s';
 import { modelFor, referenceFor } from '@console/internal/module/k8s';
+import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
 import { coFetchJSON } from '@console/shared/src/utils/console-fetch';
 import { WORKLOAD_TYPES } from '@console/shared/src/utils/resource-utils';
 import { toTitleCase } from '@console/shared/src/utils/utils';
@@ -366,4 +367,65 @@ export const installChartFromURL = (
     ...(values ? { values } : {}),
     noRepo: true,
   });
+};
+
+/**
+ * Merges the new chart's default `values` with values already in use (release / user edits).
+ * Arrays from currentUserValues replace arrays from newChartDefaults instead of merging by index.
+ */
+export const mergeHelmChartVersionUpgradeValues = (
+  newChartDefaults: Record<string, unknown>,
+  currentUserValues: Record<string, unknown>,
+): Record<string, unknown> => {
+  const mergeCustomizer = (objValue: unknown, srcValue: unknown) => {
+    if (Array.isArray(srcValue)) {
+      return srcValue; // Replace arrays instead of merging by index
+    }
+    return undefined; // use default merge for non-arrays
+  };
+  return _.mergeWith({}, newChartDefaults, currentUserValues, mergeCustomizer);
+};
+
+/**
+ * Reads the effective values object from the install/upgrade form when changing chart version.
+ * Form mode prefers `formData`; YAML mode prefers parsed `yamlData`, then falls back to `formData`.
+ */
+export const getCurrentHelmUserValuesForUpgradeMerge = (
+  yamlData: string,
+  formData: unknown,
+  editorType: EditorType,
+): Record<string, unknown> => {
+  if (
+    editorType === EditorType.Form &&
+    formData &&
+    typeof formData === 'object' &&
+    !Array.isArray(formData)
+  ) {
+    return _.merge({}, formData as Record<string, unknown>);
+  }
+  if (yamlData) {
+    try {
+      const parsed = safeLoad(yamlData);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return _.merge({}, parsed as Record<string, unknown>);
+      }
+    } catch {
+      // ignore invalid YAML
+    }
+  }
+  if (formData && typeof formData === 'object' && !Array.isArray(formData)) {
+    return _.merge({}, formData as Record<string, unknown>);
+  }
+  return {};
+};
+
+/** Applies {@link mergeHelmChartVersionUpgradeValues} using the active editor source for current values. */
+export const mergeHelmValuesOnChartVersionChange = (
+  newChartValues: Record<string, unknown> | undefined,
+  yamlData: string,
+  formData: unknown,
+  editorType: EditorType,
+): Record<string, unknown> => {
+  const currentUserValues = getCurrentHelmUserValuesForUpgradeMerge(yamlData, formData, editorType);
+  return mergeHelmChartVersionUpgradeValues(newChartValues ?? {}, currentUserValues);
 };


### PR DESCRIPTION
Jira Bug fixes: https://redhat.atlassian.net/browse/OCPBUGS-83767

**Analysis / Root cause**:
On upgrade, changing the chart version replaced the editor with chart defaults only. The async upgrade API then received a non-empty values object, so Helm did not take the “empty new vals → reuse last release config” path and prior release settings were effectively dropped—unlike helm upgrade merge expectations and bad for Software Catalog charts (e.g. FlightControl/RHEM).

**Solution description**:
**What changed**

- `helm-utils.ts`: Added mergeHelmChartVersionUpgradeValues, getCurrentHelmUserValuesForUpgradeMerge, and mergeHelmValuesOnChartVersionChange (chart defaults merged under current form/YAML values so user/release wins).
- `HelmChartVersionDropdown.tsx`: Uses mergeHelmValuesOnChartVersionChange after fetching the new chart version.
Copy: version-change modal text updated to describe merge + review.
- `helm-utils.spec.ts`: Unit tests for merge behavior, editor precedence, invalid YA ML fallback, and an end-to-end merge scenario.
yarn i18n for new/changed strings (if included in the same PR).

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->
**Before:**

https://github.com/user-attachments/assets/be5c3ced-ad93-4ed2-b733-d8ebebc7d445

**After:**

https://github.com/user-attachments/assets/c165df52-06f8-451e-9fa5-f1e681f87d4d


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
- Install a release with non-default values.
- Upgrade, pick a new chart version without hand-editing YAML.
- Confirm submitted values (or resulting workload) still reflect prior settings plus new chart defaults where applicable.


**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Helm chart upgrades now merge your current release values with new chart defaults instead of resetting all configuration, preserving your existing settings during version changes.

* **Documentation**
  * Updated messaging guides users to review merged configuration in YAML or form view before proceeding with chart version upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->