### PR TITLE
OCPBUGS-82140: Remove PII from events

### DIFF
--- a/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
@@ -20,8 +20,16 @@ jest.mock('@console/shared/src/hooks/useUserPreference', () => ({
 
 jest.mock('@console/shared/src/hooks/useUser', () => ({
   useUser: jest.fn(() => ({
-    user: {},
-    userResource: {},
+    user: {
+      username: 'shadowman',
+    },
+    userResource: {
+      metadata: {
+        annotations: {
+          'toolchain.dev.openshift.com/sso-user-id': 'sandbox-user-id-123',
+        },
+      },
+    },
     userResourceLoaded: true,
     userResourceError: null,
     username: 'testuser',
@@ -30,21 +38,14 @@ jest.mock('@console/shared/src/hooks/useUser', () => ({
   })),
 }));
 
-const mockUserResource = {};
-
 const exampleReturnValue = {
-  accountMail: undefined,
+  accountMailDomain: '',
   clusterId: undefined,
   clusterType: undefined,
   consoleVersion: undefined,
   organizationId: undefined,
   path: undefined,
-  userResource: mockUserResource,
 };
-
-jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
-  useK8sGet: () => [mockUserResource, true],
-}));
 
 const mockUserPreference = useUserPreference as jest.Mock;
 
@@ -220,6 +221,7 @@ describe('useTelemetry', () => {
       ...exampleReturnValue,
       clusterType: 'DEVSANDBOX',
       consoleVersion: 'x.y.z',
+      sandboxUserId: 'sandbox-user-id-123',
     });
   });
 
@@ -346,4 +348,52 @@ describe('useTelemetry', () => {
     fireTelemetryEvent('test 11');
     expect(listener).toHaveBeenCalledTimes(1);
   });
+
+  it('anonymizes email to only return the domain', () => {
+    const email = 'shadowman@redhat.com';
+    const expectedDomain = 'redhat.com';
+
+    window.SERVER_FLAGS = {
+      ...originServerFlags,
+      telemetry: {
+        ACCOUNT_MAIL: email,
+      },
+    };
+    updateClusterPropertiesFromTests();
+    const { result } = renderHook(() => useTelemetry());
+    const fireTelemetryEvent = result.current;
+    fireTelemetryEvent('test 12');
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith('test 12', {
+      ...exampleReturnValue,
+      accountMailDomain: expectedDomain,
+    });
+
+    // assert PII is not sent
+    const callArgs = listener.mock.calls[0][1];
+    expect(callArgs.user).toBeUndefined();
+    expect(callArgs.userResource).toBeUndefined();
+    expect(callArgs.accountMail).toBeUndefined();
+    expect(callArgs.sandboxUserId).toBeUndefined();
+  });
+
+  it.each(['invalid-email', 'shadowman@', 'red@hat@redhat.com', '@@', ''])(
+    'should not extract domains from invalid emails (%s)',
+    (email) => {
+      window.SERVER_FLAGS = {
+        ...originServerFlags,
+        telemetry: {
+          ACCOUNT_MAIL: email,
+        },
+      };
+      updateClusterPropertiesFromTests();
+      const { result } = renderHook(() => useTelemetry());
+      const fireTelemetryEvent = result.current;
+      fireTelemetryEvent('test 12');
+      expect(listener).toHaveBeenCalledWith('test 12', {
+        ...exampleReturnValue,
+        accountMailDomain: '',
+      });
+    },
+  );
 });

--- a/frontend/packages/console-shared/src/hooks/useTelemetry.ts
+++ b/frontend/packages/console-shared/src/hooks/useTelemetry.ts
@@ -19,12 +19,13 @@ export interface ClusterProperties {
   clusterType?: string;
   consoleVersion?: string;
   organizationId?: string;
-  accountMail?: string;
+  accountMailDomain?: string;
 }
 
 export type TelemetryEventProperties = {
   user?: UserInfo;
-  userResource?: UserKind;
+  /** Only sent if in a sandbox cluster */
+  sandboxUserId?: string;
 } & ClusterProperties &
   Record<string, any>;
 
@@ -34,6 +35,11 @@ export interface TelemetryEvent {
 }
 
 let telemetryEvents: TelemetryEvent[] = [];
+
+const getEmailDomain = (email: string = ''): string => {
+  const emailParts = email.split('@');
+  return emailParts.length === 2 ? emailParts[1] : '';
+};
 
 export const getClusterProperties = () => {
   const clusterProperties: ClusterProperties = {};
@@ -46,7 +52,7 @@ export const getClusterProperties = () => {
   clusterProperties.consoleVersion =
     window.SERVER_FLAGS.releaseVersion || window.SERVER_FLAGS.consoleVersion;
   clusterProperties.organizationId = window.SERVER_FLAGS.telemetry?.ORGANIZATION_ID;
-  clusterProperties.accountMail = window.SERVER_FLAGS.telemetry?.ACCOUNT_MAIL;
+  clusterProperties.accountMailDomain = getEmailDomain(window.SERVER_FLAGS.telemetry?.ACCOUNT_MAIL);
   return clusterProperties;
 };
 
@@ -65,6 +71,20 @@ const userIsOptedInToTelemetry = (currentUserPreferenceTelemetryValue: USER_TELE
 let clusterProperties = getClusterProperties();
 
 export const updateClusterPropertiesFromTests = () => (clusterProperties = getClusterProperties());
+
+const injectSandboxProperties = (
+  properties: TelemetryEventProperties,
+  userResource: UserKind,
+): TelemetryEventProperties => {
+  if (clusterProperties.clusterType === 'DEVSANDBOX') {
+    return {
+      ...properties,
+      sandboxUserId:
+        userResource?.metadata?.annotations?.['toolchain.dev.openshift.com/sso-user-id'],
+    };
+  }
+  return properties;
+};
 
 export const useTelemetry = () => {
   // TODO use usePluginInfo() hook to tell whether all dynamic plugins have been processed
@@ -89,7 +109,10 @@ export const useTelemetry = () => {
       userResourceIsLoaded
     ) {
       telemetryEvents.forEach(({ eventType, event }) => {
-        extensions.forEach((e) => e.properties.listener(eventType, { ...event, userResource }));
+        // Sends the telemetry event to all the listeners
+        extensions.forEach((e) =>
+          e.properties.listener(eventType, injectSandboxProperties(event, userResource)),
+        );
       });
       telemetryEvents = [];
     }
@@ -120,7 +143,10 @@ export const useTelemetry = () => {
         return;
       }
 
-      extensions.forEach((e) => e.properties.listener(eventType, { ...event, userResource }));
+      // Sends the telemetry event to all the listeners
+      extensions.forEach((e) =>
+        e.properties.listener(eventType, injectSandboxProperties(event, userResource)),
+      );
     },
     [extensions, currentUserPreferenceTelemetryValue, userResource, userResourceIsLoaded],
   );

--- a/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts
@@ -45,7 +45,7 @@ export const eventListener: TelemetryEventListener = async (
   switch (eventType) {
     case 'identify':
       {
-        const { user, userResource, ...otherProperties }: TelemetryEventProperties = properties;
+        const { user, sandboxUserId, ...otherProperties }: TelemetryEventProperties = properties;
         const clusterId = otherProperties?.clusterId;
         const organizationId = otherProperties?.organizationId;
         const username = user?.username;
@@ -65,8 +65,7 @@ export const eventListener: TelemetryEventListener = async (
 
           // anonymize user ID if cluster is not a DEVSANDBOX cluster
           if (getClusterProperties().clusterType === 'DEVSANDBOX') {
-            processedUserId =
-              userResource?.metadata?.annotations?.['toolchain.dev.openshift.com/sso-user-id'];
+            processedUserId = sandboxUserId;
           } else {
             processedUserId = await anonymizeId(userId);
           }


### PR DESCRIPTION
<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

`accountMail` is too much PII and the entire user resource is being sent to segment.ts

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

Strip the username from the email and only send the sandbox user ID instead of the whole resource

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

n/a

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

- Enable telemetry: https://github.com/openshift/console/pull/15201#issuecomment-3077603483

**Test cases:**
<!-- List possible test cases to validate the changes. -->

- Test in a sandbox cluster and ensure the sandbox user ID is still being sent
- Ensure `user` and `userResource` objects are not sent ever
- Ensure `accountMailDomain` is sent instead of `accountMail`, which only sends the content after the `@` symbol instead of the whole email


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced email privacy in telemetry tracking—now captures only email domain instead of full email addresses.
  * Improved telemetry collection for sandbox environments with proper user identification.

* **Bug Fixes**
  * Removed personally identifiable information (PII) fields from telemetry payloads to strengthen data privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->