### PR TITLE
OCPBUGS-79067: Fix crash when switching language to English

### DIFF
--- a/frontend/packages/console-app/src/components/user-preferences/language/LanguageDropdown.tsx
+++ b/frontend/packages/console-app/src/components/user-preferences/language/LanguageDropdown.tsx
@@ -12,7 +12,6 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 import { supportedLocales } from './const';
-import { useLanguage } from './useLanguage';
 import {
   PREFERRED_LANGUAGE_USER_PREFERENCE_KEY,
   usePreferredLanguage,
@@ -59,8 +58,6 @@ const LanguageDropdown: FC = () => {
       setPreferredLanguage('');
     }
   };
-
-  useLanguage(preferredLanguage, preferredLanguageLoaded); // sync the preferred language with local storage and set the console language
 
   useEffect(() => {
     if (preferredLanguageLoaded) {


### PR DESCRIPTION
**Analysis / Root cause**:

When switching the language back to English via User Preferences (with ConfigMap-based user settings), the page crashes with `Maximum update depth exceeded`. The root cause is that both `LanguageDropdown` and `DetectLanguage` called `useLanguage`, creating duplicate i18n event listeners and effect cycles. On the ConfigMap code path, the extra re-renders from the k8s watch amplified these duplicate effects into an infinite re-render loop that exceeded React's update depth limit.

This does not reproduce when `alwaysUseFallbackLocalStorage` is `true` because the localStorage path does not trigger the additional re-renders from ConfigMap watch events.

**Solution description**:

Remove the `useLanguage` call from `LanguageDropdown`. The `DetectLanguage` component (mounted at the app root) already calls `useLanguage` to handle global i18n synchronization — syncing the preferred language with localStorage, calling `i18n.changeLanguage`, and updating QuickStart resource bundles. The duplicate call in `LanguageDropdown` was redundant and caused conflicting effect cycles.

**Test setup:**

Set `userSettingsLocation` to a value other than `localstorage` so that ConfigMap-based user settings are used (this is the default for most clusters).

**Test cases:**

- [ ] Switch language from English to another language (e.g. Japanese) in User Preferences — verify the UI switches to the selected language without errors
- [ ] Switch language back to English (check "Use the default browser language setting") — verify the page does not crash and the language reverts successfully
- [ ] Repeat the above cycle multiple times — verify no errors in the browser console
- [ ] Verify language preference persists after page reload
- [ ] Test this both on a cluster and locally (when running locally, console users localStorage and not a ConfigMap. The bug only exists when storing settings in a ConfigMap)

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified language preference handling in the console app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->