### PR TITLE
OCPBUGS-81522: Reduce dashboard re-renders by memoizing cards and stabilizing prop references

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/cluster-dashboard.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/cluster-dashboard.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import { useMemo, memo } from 'react';
 import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
 import DashboardGrid from '@console/shared/src/components/dashboard/DashboardGrid';
 import { FLAGS } from '@console/shared/src/constants/common';
@@ -20,7 +20,7 @@ const mainCards = [{ Card: StatusCard }, { Card: UtilizationCard }];
 const leftCards = [{ Card: DetailsCard }, { Card: InventoryCard }];
 const rightCards = [{ Card: ActivityCard }];
 
-export const ClusterDashboard: FC<{}> = () => {
+export const ClusterDashboard = memo(() => {
   const [infrastructure, infrastructureLoaded, infrastructureError] = useK8sGet<K8sResourceKind>(
     InfrastructureModel,
     'cluster',
@@ -30,11 +30,11 @@ export const ClusterDashboard: FC<{}> = () => {
     FLAGS.CONSOLE_CAPABILITY_GETTINGSTARTEDBANNER_IS_ENABLED,
   );
 
-  const context = {
+  const context = useMemo(() => ({ infrastructure, infrastructureLoaded, infrastructureError }), [
     infrastructure,
     infrastructureLoaded,
     infrastructureError,
-  };
+  ]);
 
   return (
     <ClusterDashboardContext.Provider value={context}>
@@ -46,4 +46,4 @@ export const ClusterDashboard: FC<{}> = () => {
       </Dashboard>
     </ClusterDashboardContext.Provider>
   );
-};
+});

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useContext, useState, useEffect } from 'react';
+import { useContext, useState, useEffect, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Card, CardBody, CardHeader, CardTitle, DescriptionList } from '@patternfly/react-core';
 import { InProgressIcon } from '@patternfly/react-icons';
@@ -97,7 +97,7 @@ const clusterVersionResource: WatchK8sResource = {
   isList: false,
 };
 
-export const DetailsCard: React.FC = () => {
+export const DetailsCard = memo(() => {
   const { t } = useTranslation();
   const openshiftFlag = useFlag(FLAGS.OPENSHIFT);
   const { infrastructure, infrastructureLoaded, infrastructureError } = useContext(
@@ -287,7 +287,7 @@ export const DetailsCard: React.FC = () => {
       </CardBody>
     </Card>
   );
-};
+});
 
 type ClusterVersionProps = {
   cv: ClusterVersionKind;

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/inventory-card.tsx
@@ -91,7 +91,7 @@ const ClusterInventoryItem = memo<ClusterInventoryItemProps>(
   },
 );
 
-export const InventoryCard = () => {
+export const InventoryCard = memo(() => {
   const [itemExtensions] = useResolvedExtensions<DashboardsOverviewInventoryItem>(
     isDashboardsOverviewInventoryItem,
   );
@@ -138,7 +138,7 @@ export const InventoryCard = () => {
       </CardBody>
     </Card>
   );
-};
+});
 
 type ClusterInventoryItemProps = {
   model: K8sKind;

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/utilization-card.tsx
@@ -1,5 +1,5 @@
 import type { FC, Ref, MouseEvent, ComponentType } from 'react';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, memo } from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import {
@@ -257,7 +257,7 @@ const UtilizationCardNodeFilter: FC<UtilizationCardNodeFilterProps> = ({
   );
 };
 
-export const UtilizationCard = () => {
+export const UtilizationCard = memo(() => {
   const { t } = useTranslation();
   const [machineConfigPools, machineConfigPoolsLoaded] = useK8sWatchResource<
     MachineConfigPoolKind[]
@@ -386,7 +386,7 @@ export const UtilizationCard = () => {
       </Card>
     )
   );
-};
+});
 
 type PrometheusCommonProps = {
   title: string;

--- a/frontend/public/components/dashboard/dashboards-page/dashboards.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/dashboards.tsx
@@ -2,7 +2,6 @@ import type { FC } from 'react';
 import { useMemo } from 'react';
 import { useLocation } from 'react-router';
 import { connect } from 'react-redux';
-import { Map as ImmutableMap } from 'immutable';
 import { useTranslation } from 'react-i18next';
 
 import { ClusterDashboard } from './cluster-dashboard/cluster-dashboard';
@@ -62,7 +61,7 @@ export const getPluginTabPages = (
   });
 };
 
-const DashboardsPage_: FC<DashboardsPageProps> = ({ kindsInFlight, k8sModels }) => {
+const DashboardsPage_: FC<DashboardsPageProps> = ({ kindsInFlight, k8sModelsLoaded }) => {
   const { t } = useTranslation();
   const title = t('public~Overview');
   const tabExtensions = useExtensions<DashboardsTab>(isDashboardsTab);
@@ -97,7 +96,7 @@ const DashboardsPage_: FC<DashboardsPageProps> = ({ kindsInFlight, k8sModels }) 
     titlePrefix: title,
   };
 
-  return kindsInFlight && k8sModels.size === 0 ? (
+  return kindsInFlight && !k8sModelsLoaded ? (
     <LoadingBox />
   ) : (
     <>
@@ -111,12 +110,12 @@ const DashboardsPage_: FC<DashboardsPageProps> = ({ kindsInFlight, k8sModels }) 
 
 export const mapStateToProps = (state: RootState) => ({
   kindsInFlight: state.k8s.getIn(['RESOURCES', 'inFlight']),
-  k8sModels: state.k8s.getIn(['RESOURCES', 'models']),
+  k8sModelsLoaded: state.k8s.getIn(['RESOURCES', 'loaded']),
 });
 
 export const DashboardsPage = connect(mapStateToProps)(DashboardsPage_);
 
 export type DashboardsPageProps = {
   kindsInFlight: boolean;
-  k8sModels: ImmutableMap<string, any>;
+  k8sModelsLoaded: boolean;
 };

--- a/frontend/public/components/dashboard/project-dashboard/activity-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/activity-card.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useEffect, useMemo, useContext } from 'react';
+import { useEffect, useMemo, useContext, memo } from 'react';
 import * as _ from 'lodash';
 import { Map as ImmutableMap } from 'immutable';
 import { connect } from 'react-redux';
@@ -142,7 +142,7 @@ const OngoingActivityComponent: FC<OngoingActivityProps> = ({ projectName, model
 
 const OngoingActivity = connect(mapStateToProps)(OngoingActivityComponent);
 
-export const ActivityCard: FC = () => {
+export const ActivityCard = memo(() => {
   const { obj } = useContext(ProjectDashboardContext);
   const projectName = getName(obj);
   const viewEvents = `/k8s/ns/${projectName}/events`;
@@ -160,7 +160,7 @@ export const ActivityCard: FC = () => {
       </Card>
     </>
   );
-};
+});
 
 type OngoingActivityReduxProps = {
   models: ImmutableMap<string, K8sKind>;

--- a/frontend/public/components/dashboard/project-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/details-card.tsx
@@ -1,6 +1,5 @@
 import * as _ from 'lodash';
-import type { FC } from 'react';
-import { useContext } from 'react';
+import { useContext, memo } from 'react';
 import { css } from '@patternfly/react-styles';
 import { useTranslation } from 'react-i18next';
 import {
@@ -21,7 +20,7 @@ import { ProjectModel } from '../../../models';
 import { ProjectDashboardContext } from './project-dashboard-context';
 import { Link } from 'react-router';
 
-export const DetailsCard: FC = () => {
+export const DetailsCard = memo(() => {
   const { obj } = useContext(ProjectDashboardContext);
   const keys = _.keys(obj.metadata.labels).sort();
   const labelsSubset = _.take(keys, 3);
@@ -86,4 +85,4 @@ export const DetailsCard: FC = () => {
       </CardBody>
     </Card>
   );
-};
+});

--- a/frontend/public/components/dashboard/project-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/inventory-card.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useContext } from 'react';
+import { useEffect, useContext, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDynamicK8sWatchResources } from '@console/shared/src/hooks/useDynamicK8sWatchResources';
 import { Card, CardBody, CardHeader, CardTitle, Stack, StackItem } from '@patternfly/react-core';
@@ -50,84 +50,81 @@ const createWatchResource = (
   namespace: projectName,
 });
 
-const ProjectInventoryItem: React.FC<ProjectInventoryItemProps> = ({
-  projectName,
-  model,
-  mapper,
-  additionalResources,
-  additionalDynamicResources,
-}) => {
-  const { watchResource, stopWatchResource, results: resources } = useDynamicK8sWatchResources();
+const ProjectInventoryItem = memo<ProjectInventoryItemProps>(
+  ({ projectName, model, mapper, additionalResources, additionalDynamicResources }) => {
+    const { watchResource, stopWatchResource, results: resources } = useDynamicK8sWatchResources();
 
-  useEffect(() => {
-    if (!projectName) {
-      return;
-    }
-
-    const resource = createWatchResource(model, projectName);
-    const { prop, ...resourceConfig } = resource;
-    watchResource(prop, resourceConfig);
-    if (additionalResources) {
-      additionalResources.forEach((r) => {
-        const { prop: key, ...config } = { ...r, namespace: projectName };
-        watchResource(key, config);
-      });
-    }
-
-    return () => {
-      stopWatchResource(resource.prop);
-      if (additionalResources) {
-        additionalResources.forEach((r) => stopWatchResource(r.prop));
+    useEffect(() => {
+      if (!projectName) {
+        return;
       }
-    };
-  }, [watchResource, stopWatchResource, projectName, model, additionalResources]);
 
-  const resourceResult = resources.resource?.data;
-  const resourceData = Array.isArray(resourceResult) ? resourceResult : [];
-  const resourceLoaded = resources.resource?.loaded ?? false;
-  const resourceLoadError = resources.resource?.loadError;
+      const resource = createWatchResource(model, projectName);
+      const { prop, ...resourceConfig } = resource;
+      watchResource(prop, resourceConfig);
+      if (additionalResources) {
+        additionalResources.forEach((r) => {
+          const { prop: key, ...config } = { ...r, namespace: projectName };
+          watchResource(key, config);
+        });
+      }
 
-  const additionalResourcesData = additionalResources
-    ? additionalResources.reduce<{ [key: string]: K8sResourceCommon[] }>((acc, r) => {
-        const data = resources[r.prop]?.data;
-        acc[r.prop] = Array.isArray(data) ? data : [];
-        return acc;
-      }, {})
-    : {};
-  const additionalResourcesLoaded = additionalResources
-    ? additionalResources
-        .filter((r) => !r.optional)
-        .every((r) => resources[r.prop]?.loaded ?? false)
-    : true;
-  const additionalResourcesLoadError = additionalResources
-    ? additionalResources.filter((r) => !r.optional).some((r) => !!resources[r.prop]?.loadError)
-    : false;
-
-  const dynamicResources = useK8sWatchResources(additionalDynamicResources || {});
-  const dynamicResourcesError = Object.values(dynamicResources).find((r) => r.loadError)?.loadError;
-  const dynamicResourcesLoaded = Object.keys(dynamicResources).every(
-    (key) => dynamicResources[key].loaded,
-  );
-
-  return (
-    <StackItem>
-      <ResourceInventoryItem
-        kind={model}
-        isLoading={
-          !projectName || !resourceLoaded || !additionalResourcesLoaded || !dynamicResourcesLoaded
+      return () => {
+        stopWatchResource(resource.prop);
+        if (additionalResources) {
+          additionalResources.forEach((r) => stopWatchResource(r.prop));
         }
-        namespace={projectName}
-        error={!!resourceLoadError || additionalResourcesLoadError || dynamicResourcesError}
-        resources={resourceData}
-        additionalResources={additionalResourcesData}
-        mapper={mapper}
-        dataTest="resource-inventory-item"
-      />
-    </StackItem>
-  );
-};
+      };
+    }, [watchResource, stopWatchResource, projectName, model, additionalResources]);
 
-export const InventoryCard = () => {
+    const resourceResult = resources.resource?.data;
+    const resourceData = Array.isArray(resourceResult) ? resourceResult : [];
+    const resourceLoaded = resources.resource?.loaded ?? false;
+    const resourceLoadError = resources.resource?.loadError;
+
+    const additionalResourcesData = additionalResources
+      ? additionalResources.reduce<{ [key: string]: K8sResourceCommon[] }>((acc, r) => {
+          const data = resources[r.prop]?.data;
+          acc[r.prop] = Array.isArray(data) ? data : [];
+          return acc;
+        }, {})
+      : {};
+    const additionalResourcesLoaded = additionalResources
+      ? additionalResources
+          .filter((r) => !r.optional)
+          .every((r) => resources[r.prop]?.loaded ?? false)
+      : true;
+    const additionalResourcesLoadError = additionalResources
+      ? additionalResources.filter((r) => !r.optional).some((r) => !!resources[r.prop]?.loadError)
+      : false;
+
+    const dynamicResources = useK8sWatchResources(additionalDynamicResources || {});
+    const dynamicResourcesError = Object.values(dynamicResources).find((r) => r.loadError)
+      ?.loadError;
+    const dynamicResourcesLoaded = Object.keys(dynamicResources).every(
+      (key) => dynamicResources[key].loaded,
+    );
+
+    return (
+      <StackItem>
+        <ResourceInventoryItem
+          kind={model}
+          isLoading={
+            !projectName || !resourceLoaded || !additionalResourcesLoaded || !dynamicResourcesLoaded
+          }
+          namespace={projectName}
+          error={!!resourceLoadError || additionalResourcesLoadError || dynamicResourcesError}
+          resources={resourceData}
+          additionalResources={additionalResourcesData}
+          mapper={mapper}
+          dataTest="resource-inventory-item"
+        />
+      </StackItem>
+    );
+  },
+);
+
+export const InventoryCard = memo(() => {
   const [itemExtensions] = useResolvedExtensions<DashboardsProjectOverviewInventoryItem>(
     isDashboardsProjectOverviewInventoryItem,
   );
@@ -194,7 +191,7 @@ export const InventoryCard = () => {
       </CardBody>
     </Card>
   );
-};
+});
 
 type ProjectInventoryItemProps = {
   projectName: string;

--- a/frontend/public/components/dashboard/project-dashboard/launcher-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/launcher-card.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-import { useContext } from 'react';
+import { useContext, memo } from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
@@ -7,7 +6,7 @@ import LauncherBody from '@console/shared/src/components/dashboard/launcher-card
 import LauncherItem from '@console/shared/src/components/dashboard/launcher-card/LauncherItem';
 import { ProjectDashboardContext } from './project-dashboard-context';
 
-export const LauncherCard: FC = () => {
+export const LauncherCard = memo(() => {
   const { namespaceLinks } = useContext(ProjectDashboardContext);
   const { t } = useTranslation();
   return (
@@ -24,4 +23,4 @@ export const LauncherCard: FC = () => {
       </CardBody>
     </Card>
   );
-};
+});

--- a/frontend/public/components/dashboard/project-dashboard/project-dashboard.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/project-dashboard.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-import { useMemo } from 'react';
+import { useMemo, memo } from 'react';
 import { DocumentTitle } from '@console/shared/src/components/document-title/DocumentTitle';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -50,7 +49,7 @@ export const getNamespaceDashboardConsoleLinks = (
   });
 };
 
-export const ProjectDashboard: FC<ProjectDashboardProps> = ({ obj }) => {
+export const ProjectDashboard = memo<ProjectDashboardProps>(({ obj }) => {
   const { t } = useTranslation();
   const [perspective] = useActivePerspective();
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
@@ -58,11 +57,11 @@ export const ProjectDashboard: FC<ProjectDashboardProps> = ({ obj }) => {
     kind: referenceForModel(ConsoleLinkModel),
     optional: true,
   });
-  const namespaceLinks = getNamespaceDashboardConsoleLinks(obj, consoleLinks);
-  const context = {
+  const namespaceLinks = useMemo(() => getNamespaceDashboardConsoleLinks(obj, consoleLinks), [
     obj,
-    namespaceLinks,
-  };
+    consoleLinks,
+  ]);
+  const context = useMemo(() => ({ obj, namespaceLinks }), [obj, namespaceLinks]);
 
   const hasNamespaceLinks = !!namespaceLinks.length;
 
@@ -88,7 +87,7 @@ export const ProjectDashboard: FC<ProjectDashboardProps> = ({ obj }) => {
       </ProjectDashboardContext.Provider>
     </>
   );
-};
+});
 
 type ProjectDashboardProps = {
   obj: K8sResourceKind;

--- a/frontend/public/components/dashboard/project-dashboard/resource-quota-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/resource-quota-card.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Card, CardBody, CardHeader, CardTitle, Stack, StackItem } from '@patternfly/react-core';
@@ -10,7 +10,7 @@ import { AppliedClusterResourceQuotaModel, ResourceQuotaModel } from '../../../m
 import { ProjectDashboardContext } from './project-dashboard-context';
 import { ResourceQuotaKind, AppliedClusterResourceQuotaKind } from '../../../module/k8s';
 
-export const ResourceQuotaCard = () => {
+export const ResourceQuotaCard = memo(() => {
   const { obj } = useContext(ProjectDashboardContext);
 
   const [quotas, rqLoaded, rqLoadError] = useK8sWatchResource<ResourceQuotaKind[]>({
@@ -79,4 +79,4 @@ export const ResourceQuotaCard = () => {
       </CardBody>
     </Card>
   );
-};
+});

--- a/frontend/public/components/dashboard/project-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/status-card.tsx
@@ -7,15 +7,14 @@ import { LoadingInline } from '@console/internal/components/utils/status-box';
 import { Status } from '@console/shared/src/components/status/Status';
 import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
 import { Card, CardHeader, CardTitle, Gallery } from '@patternfly/react-core';
-import type { FC } from 'react';
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ResourceHealthItem } from '../dashboards-page/cluster-dashboard/health-item';
 import { ProjectDashboardContext } from './project-dashboard-context';
 
 import { DashboardNamespacedAlerts } from '../dashboards-page/cluster-dashboard/status-card';
 
-export const StatusCard: FC = () => {
+export const StatusCard = memo(() => {
   const { obj } = useContext(ProjectDashboardContext);
   const [subsystemExtensions, extensionsResolved] = useResolvedExtensions<
     DashboardsOverviewHealthResourceSubsystem
@@ -24,9 +23,7 @@ export const StatusCard: FC = () => {
     () => subsystemExtensions.find((s) => s.properties.title === 'Image Vulnerabilities'),
     [subsystemExtensions],
   );
-  const {
-    metadata: { name: namespace },
-  } = obj;
+  const namespace = obj?.metadata?.name;
   const { t } = useTranslation();
 
   return (
@@ -53,4 +50,4 @@ export const StatusCard: FC = () => {
       )}
     </Card>
   );
-};
+});

--- a/frontend/public/components/dashboard/project-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/utilization-card.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Card, CardHeader, CardTitle } from '@patternfly/react-core';
 import { UtilizationBody } from '@console/shared/src/components/dashboard/utilization-card/UtilizationBody';
@@ -37,7 +36,7 @@ import {
 
 const networkPopovers = [NetworkInPopover, NetworkOutPopover];
 
-export const UtilizationCard: FC = () => {
+export const UtilizationCard = memo(() => {
   const { t } = useTranslation();
   const { obj } = useContext(ProjectDashboardContext);
   const projectName = obj?.metadata?.name;
@@ -122,4 +121,4 @@ export const UtilizationCard: FC = () => {
       </UtilizationBody>
     </Card>
   );
-};
+});

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -28,6 +28,7 @@ import {
   NavPage,
 } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { useExtensions } from '@console/plugin-sdk/src/api/useExtensions';
+import { useDeepCompareMemoize } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useDeepCompareMemoize';
 
 export const editYamlComponent = (props) => (
   <AsyncComponent
@@ -235,7 +236,7 @@ export const NavBar: FC<NavBarProps> = ({ pages }) => {
 NavBar.displayName = 'NavBar';
 
 export const HorizontalNav = memo<HorizontalNavProps>((props) => {
-  const params = useParams();
+  const params = useDeepCompareMemoize(useParams());
 
   const renderContent = (routes: JSX.Element[]) => {
     const { noStatusBox, obj, EmptyMsg, label } = props;
@@ -283,15 +284,17 @@ export const HorizontalNav = memo<HorizontalNavProps>((props) => {
     );
   };
 
-  const componentProps = {
+  const componentProps = useDeepCompareMemoize({
     ..._.pick(props, ['filters', 'selected']),
     loaded: props.obj?.loaded,
     obj: _.get(props.obj, 'data'),
-  };
-  const extraResources = _.reduce(
-    props.resourceKeys,
-    (extraObjs, key) => ({ ...extraObjs, [key]: _.get(props[key], 'data') }),
-    {},
+  });
+  const extraResources = useDeepCompareMemoize(
+    _.reduce(
+      props.resourceKeys,
+      (extraObjs, key) => ({ ...extraObjs, [key]: _.get(props[key], 'data') }),
+      {},
+    ),
   );
 
   const objReference = props.obj?.data ? referenceFor(props.obj.data) : '';


### PR DESCRIPTION
## Summary

- **HorizontalNav** created new `params`, `componentProps`, and `extraResources` object references on every render (triggered by `useParams()` subscribing to router context). These were spread onto page components via `<p.component {...params} {...componentProps} {...extraResources} />`, defeating `React.memo()`. Fixed by stabilizing references with `useDeepCompareMemoize`. Note: this prop-spreading pattern is an architectural issue — page components like the dashboards don't use most of these props but still receive them. The proper long-term fix would be to stop spreading computed props and let page components fetch their own data via hooks (which they already do).
- **DashboardsPage** subscribed to the full `k8sModels` ImmutableMap via Redux `connect()` but only checked `k8sModels.size === 0`. Every API discovery poll (60s) created a new map reference, causing re-renders. Replaced with the existing `RESOURCES.loaded` boolean selector.
- **Dashboard cards** (both cluster and project) lacked `React.memo()`, allowing parent re-renders to cascade through the entire card tree. Wrapped all unmemoized cards in `memo()` and stabilized context values with `useMemo`.

## Measured results

Render counts measured with per-component `useRef` counters over 30-second windows.

### Cluster Dashboard (steady-state renders per 30s)

| Component | Before | After | Change |
|---|---|---|---|
| DashboardsPage | ~4 | 0 | -100% |
| ClusterDashboard | ~4 | 0 | -100% |
| DashboardGrid | 4 | 0 | -100% |
| DetailsCard | 4 | 0 | -100% |
| UtilizationCard | 0 | 0 | — |
| InventoryCard | 0 | 0 | — |
| **Total wasted renders** | **~12** | **0** | **-100%** |

### Project Dashboard (steady-state renders per 30s)

| Component | Before | After | Change |
|---|---|---|---|
| ProjectDashboard | 4 | 4 | — (own hooks, no cascade) |
| Proj-InventoryCard | 4 | 0 | -100% |
| ProjectInventoryItem(Deployment) | 4 | 0 | -100% |
| ProjectInventoryItem(DeploymentConfig) | 4 | 0 | -100% |
| ProjectInventoryItem(StatefulSet) | 4 | 0 | -100% |
| ProjectInventoryItem(Pod) | 4 | 0 | -100% |
| ProjectInventoryItem(PersistentVolumeClaim) | 4 | 0 | -100% |
| ProjectInventoryItem(Service) | 4 | 0 | -100% |
| ProjectInventoryItem(Route) | 4 | 0 | -100% |
| ProjectInventoryItem(ConfigMap) | 4 | 0 | -100% |
| ProjectInventoryItem(Secret) | 4 | 0 | -100% |
| ProjectInventoryItem(VolumeSnapshot) | 4 | 0 | -100% |
| Proj-DetailsCard | 4 | 0 | -100% |
| **Total wasted renders** | **~48** | **0** | **-100%** |

### Mount phase (first 30s after navigation)

| Component | Before | After | Change |
|---|---|---|---|
| Cluster DashboardGrid | 22 | 4 | -82% |
| Cluster DetailsCard | 24 | 8 | -67% |
| Project Proj-InventoryCard | 20 | 5 | -75% |
| Project ProjectInventoryItem (each) | 21 | 5 | -76% |
| Project Proj-DetailsCard | 18 | 1 | -94% |

## Test plan

- [ ] `yarn test --testPathPatterns='cluster-dashboard|DashboardGrid|dashboards|horizontal-nav|project-dashboard'` — 48 tests pass
- [ ] `yarn eslint` on all modified files passes
- [ ] Manual: navigate to Cluster Dashboard, verify cards render correctly
- [ ] Manual: navigate to Project Dashboard, verify cards render correctly
- [ ] Manual: verify LoadingBox shows on initial load before k8s models are discovered
- [ ] Manual: verify card data updates when cluster state changes (create/delete a pod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Wrapped dashboard components with React memoization to optimize rendering behavior across cluster and project dashboards.
  * Updated cluster dashboard model loading state detection to use an explicit loading flag instead of collection size checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->