### PR TITLE
NOJIRA: Revert Cypress Cloud enablement for release-4.22

### DIFF
--- a/frontend/packages/console-telemetry-plugin/integration-tests/package.json
+++ b/frontend/packages/console-telemetry-plugin/integration-tests/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run ${CYPRESS_RECORD_KEY:+--record} --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/*/*.feature\"",
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/*/*.feature\"",
     "test-cypress-headless-all": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/*/*.feature\";"
   }
 }

--- a/frontend/packages/dev-console/integration-tests/package.json
+++ b/frontend/packages/dev-console/integration-tests/package.json
@@ -11,7 +11,7 @@
     "clean-reports": "rm -rf ../../../gui_test_screenshots",
     "cypress-merge": "../../../node_modules/.bin/mochawesome-merge ../../../gui_test_screenshots/cypress_report*.json > ../../../gui_test_screenshots/cypress.json",
     "cypress-generate": "../../../node_modules/.bin/marge -o ../../../gui_test_screenshots/ -f cypress-report -t 'OpenShift DevConsole Cypress Test Results' -p 'OpenShift Cypress Test Results' --showPassed false --assetsDir ../../../gui_test_screenshots/cypress/assets ../../../gui_test_screenshots/cypress.json",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run ${CYPRESS_RECORD_KEY:+--record} --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/e2e/enable-dev-perspective-ci.feature,features/e2e/add-flow-ci.feature\"; yarn posttest-cypress-headless",
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/e2e/enable-dev-perspective-ci.feature,features/e2e/add-flow-ci.feature\"; yarn posttest-cypress-headless",
     "test-headless-all": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless",
     "test-cypress-nightly": "yarn run test-headless-all && yarn run cypress-merge && yarn run cypress-generate",
     "posttest-cypress-headless": "yarn run cypress-merge && yarn run cypress-generate"

--- a/frontend/packages/helm-plugin/integration-tests/package.json
+++ b/frontend/packages/helm-plugin/integration-tests/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run ${CYPRESS_RECORD_KEY:+--record} --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/helm-release.feature\"",
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/helm-release.feature\"",
     "test-cypress-headless-all": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless"
   }
 }

--- a/frontend/packages/integration-tests/cypress-common-config.js
+++ b/frontend/packages/integration-tests/cypress-common-config.js
@@ -105,7 +105,6 @@ function setupNodeEvents(on, config) {
 
 /** @type {Cypress.ConfigOptions} */
 const commonConfig = {
-  projectId: 'yfeyv6',
   viewportWidth: 1920,
   viewportHeight: 1080,
   defaultCommandTimeout: 40000,

--- a/frontend/packages/integration-tests/package.json
+++ b/frontend/packages/integration-tests/package.json
@@ -5,6 +5,6 @@
   "private": true,
   "scripts": {
     "test-cypress": "cypress open --env openshift=true",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../node_modules/.bin/cypress run ${CYPRESS_RECORD_KEY:+--record} --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron}"
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron}"
   }
 }

--- a/frontend/packages/knative-plugin/integration-tests/package.json
+++ b/frontend/packages/knative-plugin/integration-tests/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run ${CYPRESS_RECORD_KEY:+--record} --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/e2e/knative-ci.feature\"",
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/e2e/knative-ci.feature\"",
     "test-cypress-headless-all": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless"
   }
 }

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/package.json
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/package.json
@@ -5,6 +5,6 @@
   "private": true,
   "scripts": {
     "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run ${CYPRESS_RECORD_KEY:+--record} --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless"
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless"
   }
 }

--- a/frontend/packages/shipwright-plugin/integration-tests/package.json
+++ b/frontend/packages/shipwright-plugin/integration-tests/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run ${CYPRESS_RECORD_KEY:+--record} --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/e2e/shipwright-ci.feature\";",
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/e2e/shipwright-ci.feature\";",
     "test-cypress-headless-all": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless"
   }
 }

--- a/frontend/packages/topology/integration-tests/package.json
+++ b/frontend/packages/topology/integration-tests/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run ${CYPRESS_RECORD_KEY:+--record} --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/*/topology-ci.feature\"",
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/*/topology-ci.feature\"",
     "test-cypress-headless-all": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless"
   }
 }

--- a/frontend/packages/webterminal-plugin/integration-tests/package.json
+++ b/frontend/packages/webterminal-plugin/integration-tests/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run ${CYPRESS_RECORD_KEY:+--record} --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/web-terminal/web-terminal-adminuser.feature\"",
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/web-terminal/web-terminal-adminuser.feature\"",
     "test-cypress-headless-all": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:-electron} --headless --spec \"features/*/*.feature\";"
   }
 }


### PR DESCRIPTION
## Description
This reverts the Cypress Cloud enablement from the release-4.22 branch.

## Changes
- Removes `--cloud` flag from Cypress test runs
- Reverts package.json changes that added Cypress Cloud configuration

## Testing
CI should run normally without Cypress Cloud integration.

## Related PRs
- Original PR: #16277
- Companion revert for release-4.23: #16368