### PR TITLE
CONSOLE-5197: Add Playwright E2E test infrastructure for Prow/CI

### DIFF
--- a/frontend/integration-tests/test-playwright-e2e.sh
+++ b/frontend/integration-tests/test-playwright-e2e.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Run Playwright E2E tests against OpenShift Console from the frontend workspace.
+# Uses frontend/playwright.config.ts: tests live under e2e/tests/<project>/; pick a suite with
+# Playwright's --project flag (project names match the `packages` array in playwright.config.ts).
+#
+# Usage (from repo frontend/):
+#   ./integration-tests/test-playwright-e2e.sh [playwright test args...]
+#   ./integration-tests/test-playwright-e2e.sh --project=helm
+#   ./integration-tests/test-playwright-e2e.sh --project=smoke
+#   ./integration-tests/test-playwright-e2e.sh -c [--] [playwright test args...]
+#
+# -c  Run contrib/create-user.sh before tests.
+#
+# Environment:
+#   BRIDGE_BASE_ADDRESS, BRIDGE_BASE_PATH, WEB_CONSOLE_URL
+#   INSTALLER_DIR, ARTIFACT_DIR, KUBEADMIN_PASSWORD_FILE
+#
+
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/tmp/artifacts}
+INSTALLER_DIR=${INSTALLER_DIR:-${ARTIFACT_DIR}/installer}
+
+if [ "$(basename "$(pwd)")" != "frontend" ]; then
+  echo "This script must be run from the frontend folder" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+RUN_CREATE_USER=false
+
+while getopts "c" flag; do
+  case "${flag}" in
+    c) RUN_CREATE_USER=true ;;
+    *)
+      echo "Usage: $0 [-c] [--] [playwright test args...]" >&2
+      echo "Example: $0 --project=helm" >&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ -z "${BRIDGE_KUBEADMIN_PASSWORD:-}" ]; then
+  pass_file="${KUBEADMIN_PASSWORD_FILE:-${INSTALLER_DIR}/auth/kubeadmin-password}"
+  if [ -f "$pass_file" ]; then
+    export BRIDGE_KUBEADMIN_PASSWORD="$(cat "$pass_file")"
+  fi
+fi
+
+if [ -z "${BRIDGE_BASE_ADDRESS:-}" ]; then
+  if ! command -v oc >/dev/null 2>&1; then
+    echo "error: BRIDGE_BASE_ADDRESS is unset and oc was not found in PATH." >&2
+    exit 1
+  fi
+  if ! BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}' 2>/dev/null)" ||
+    [ -z "$BRIDGE_BASE_ADDRESS" ]; then
+    echo "error: BRIDGE_BASE_ADDRESS is unset and oc could not read consoles.config.openshift.io cluster status.consoleURL." >&2
+    echo "       Log in with oc or export BRIDGE_BASE_ADDRESS (e.g. http://localhost:9000)." >&2
+    exit 1
+  fi
+  export BRIDGE_BASE_ADDRESS
+fi
+
+BRIDGE_BASE_PATH=${BRIDGE_BASE_PATH:-/}
+export BRIDGE_BASE_PATH
+export WEB_CONSOLE_URL="${WEB_CONSOLE_URL:-${BRIDGE_BASE_ADDRESS}${BRIDGE_BASE_PATH}}"
+
+if [ ! -d node_modules ]; then
+  yarn install
+fi
+
+if [ "$RUN_CREATE_USER" = true ]; then
+  "${REPO_ROOT}/contrib/create-user.sh"
+fi
+
+FRONTEND_ABS="$(pwd)"
+playwright_bin="${FRONTEND_ABS}/node_modules/.bin/playwright"
+if [ ! -f "$playwright_bin" ]; then
+  echo "error: Playwright CLI not found. Install at frontend root:" >&2
+  echo "       yarn add -D @playwright/test && yarn playwright install" >&2
+  exit 1
+fi
+
+exec "$playwright_bin" test "$@"

--- a/frontend/integration-tests/test-playwright-e2e.sh
+++ b/frontend/integration-tests/test-playwright-e2e.sh
@@ -75,6 +75,9 @@ fi
 
 if [ "$RUN_CREATE_USER" = true ]; then
   "${REPO_ROOT}/contrib/create-user.sh"
+  export BRIDGE_HTPASSWD_IDP="${BRIDGE_HTPASSWD_IDP:-test}"
+  export BRIDGE_HTPASSWD_USERNAME="${BRIDGE_HTPASSWD_USERNAME:-test}"
+  export BRIDGE_HTPASSWD_PASSWORD="${BRIDGE_HTPASSWD_PASSWORD:-test}"
 fi
 
 FRONTEND_ABS="$(pwd)"
@@ -84,5 +87,7 @@ if [ ! -f "$playwright_bin" ]; then
   echo "       yarn add -D @playwright/test && yarn playwright install" >&2
   exit 1
 fi
+
+export CI=true
 
 exec "$playwright_bin" test "$@"

--- a/frontend/integration-tests/test-playwright-e2e.sh
+++ b/frontend/integration-tests/test-playwright-e2e.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Run Playwright E2E tests against OpenShift Console from the frontend workspace.
+# Same operational idea as test-cypress.sh: run from ./frontend, optional cluster-derived
+# BRIDGE_* / PLAYWRIGHT_BASE_URL, optional kubeadmin + create-user, then invoke Playwright
+# in frontend/ or a subdirectory package.
+#
+# Prerequisites (typical):
+#   - oc logged in (unless BRIDGE_BASE_ADDRESS is already set)
+#   - In the target directory: yarn add -D @playwright/test && yarn playwright install
+#   - playwright.config.{ts,js,mts,mjs} under that directory
+#
+# Usage (always from repo frontend/):
+#   ./integration-tests/test-playwright-e2e.sh [playwright test arguments...]
+#   ./integration-tests/test-playwright-e2e.sh -d packages/my-plugin/e2e tests/smoke.spec.ts
+#   ./integration-tests/test-playwright-e2e.sh -c
+#
+# Options:
+#   -d <path>   Directory relative to frontend/ where Playwright is installed (default: .)
+#   -c          Run contrib/create-user.sh first (Prow-style htpasswd idp; needs repo root)
+#
+# Environment:
+#   BRIDGE_BASE_ADDRESS           If unset, from oc get consoles.config.openshift.io cluster
+#   BRIDGE_BASE_PATH              Default /
+#   PLAYWRIGHT_BASE_URL           Default ${BRIDGE_BASE_ADDRESS}${BRIDGE_BASE_PATH}
+#   INSTALLER_DIR, ARTIFACT_DIR, KUBEADMIN_PASSWORD_FILE   Kubeadmin password for login flows
+#   OPENSHIFT_CI                  If true, sets NO_COLOR=1 (same as test-cypress.sh)
+#
+
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/tmp/artifacts}
+INSTALLER_DIR=${INSTALLER_DIR:-${ARTIFACT_DIR}/installer}
+OPENSHIFT_CI=${OPENSHIFT_CI:-false}
+
+if [ "$(basename "$(pwd)")" != "frontend" ]; then
+  echo "This script must be run from the frontend folder" >&2
+  exit 1
+fi
+
+if [ "$OPENSHIFT_CI" = true ]; then
+  export NO_COLOR=1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# integration-tests/ -> frontend/ -> openshift/console repo root
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if [ -z "${BRIDGE_KUBEADMIN_PASSWORD:-}" ]; then
+  pass_file="${KUBEADMIN_PASSWORD_FILE:-${INSTALLER_DIR}/auth/kubeadmin-password}"
+  if [ -f "$pass_file" ]; then
+    set +x
+    export BRIDGE_KUBEADMIN_PASSWORD="$(cat "$pass_file")"
+    set -x
+  fi
+fi
+
+if [ -z "${BRIDGE_BASE_ADDRESS:-}" ]; then
+  if ! command -v oc >/dev/null 2>&1; then
+    echo "error: BRIDGE_BASE_ADDRESS is unset and oc was not found in PATH." >&2
+    exit 1
+  fi
+  if ! BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}' 2>/dev/null)" ||
+    [ -z "$BRIDGE_BASE_ADDRESS" ]; then
+    echo "error: BRIDGE_BASE_ADDRESS is unset and oc could not read consoles.config.openshift.io cluster status.consoleURL." >&2
+    echo "       Log in with oc or export BRIDGE_BASE_ADDRESS (e.g. http://localhost:9000)." >&2
+    exit 1
+  fi
+  export BRIDGE_BASE_ADDRESS
+fi
+
+BRIDGE_BASE_PATH=${BRIDGE_BASE_PATH:-/}
+export BRIDGE_BASE_PATH
+export PLAYWRIGHT_BASE_URL="${PLAYWRIGHT_BASE_URL:-${BRIDGE_BASE_ADDRESS}${BRIDGE_BASE_PATH}}"
+
+PLAYWRIGHT_REL_DIR="."
+RUN_CREATE_USER=false
+while getopts "d:c" flag; do
+  case "${flag}" in
+    d) PLAYWRIGHT_REL_DIR="${OPTARG}" ;;
+    c) RUN_CREATE_USER=true ;;
+    *) echo "Usage: $0 [-d <dir-under-frontend>] [-c] [--] [playwright test args...]" >&2
+       exit 1
+       ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ ! -d node_modules ]; then
+  yarn install
+fi
+
+if [ "$RUN_CREATE_USER" = true ]; then
+  "${REPO_ROOT}/contrib/create-user.sh"
+fi
+
+FRONTEND_ABS="$(pwd)"
+TARGET_DIR="${FRONTEND_ABS}/${PLAYWRIGHT_REL_DIR}"
+if [ ! -d "$TARGET_DIR" ]; then
+  echo "error: Playwright directory does not exist: $TARGET_DIR" >&2
+  exit 1
+fi
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+if [[ "${TARGET_DIR}" != "${FRONTEND_ABS}" && "${TARGET_DIR}" != "${FRONTEND_ABS}/"* ]]; then
+  echo "error: resolved path must stay under ${FRONTEND_ABS}" >&2
+  exit 1
+fi
+
+cd "$TARGET_DIR"
+
+playwright_bin="${TARGET_DIR}/node_modules/.bin/playwright"
+if [ ! -f "$playwright_bin" ]; then
+  # When running from a subfolder without its own node_modules, fall back to frontend root bin
+  playwright_bin="${FRONTEND_ABS}/node_modules/.bin/playwright"
+fi
+if [ ! -f "$playwright_bin" ]; then
+  echo "error: Playwright CLI not found. Install in $TARGET_DIR or frontend root:" >&2
+  echo "       yarn add -D @playwright/test && yarn playwright install" >&2
+  exit 1
+fi
+
+exec "$playwright_bin" test "$@"

--- a/test-prow-playwright-e2e.sh
+++ b/test-prow-playwright-e2e.sh
@@ -43,7 +43,8 @@ fi
 if [ "$SCENARIO" == "e2e" ] || [ "$SCENARIO" == "release" ]; then
   ./integration-tests/test-playwright-e2e.sh "$@"
 elif [ "$SCENARIO" == "smoke" ]; then
-  ./integration-tests/test-playwright-e2e.sh --project=smoke "$@"
+  # End of script flags before Playwright's --project (test-playwright-e2e.sh only parses -c).
+  ./integration-tests/test-playwright-e2e.sh -- --project=smoke "$@"
 else
   echo "error: unknown scenario '$SCENARIO' (use: e2e, release, or smoke)" >&2
   exit 1

--- a/test-prow-playwright-e2e.sh
+++ b/test-prow-playwright-e2e.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Prow / CI entrypoint for Playwright E2E against a live OpenShift cluster console.
+# Mirrors test-prow-e2e.sh: kubeadmin password, BRIDGE_BASE_ADDRESS from the cluster,
+# contrib/create-user.sh, then tests under frontend/, and the same CSP check as Cypress Prow.
+#
+# Run from the openshift/console repository root (same as test-prow-e2e.sh).
+#
+# Usage:
+#   ./test-prow-playwright-e2e.sh [e2e|release|smoke] [arguments passed to: playwright test ...]
+#
+# Scenarios (first argument; default: e2e):
+#   e2e, release  — full Playwright suite (default project / config)
+#   smoke         — Playwright smoke project (--project=smoke)
+#
+# Environment (typical Prow / installer):
+#   ARTIFACT_DIR, INSTALLER_DIR, KUBEADMIN_PASSWORD_FILE   same as test-prow-e2e.sh
+#
+
+set -exuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${REPO_ROOT}"
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/tmp/artifacts}
+INSTALLER_DIR=${INSTALLER_DIR:=${ARTIFACT_DIR}/installer}
+
+# don't log kubeadmin-password
+set +x
+export BRIDGE_KUBEADMIN_PASSWORD="$(cat "${KUBEADMIN_PASSWORD_FILE:-${INSTALLER_DIR}/auth/kubeadmin-password}")"
+set -x
+export BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"
+
+./contrib/create-user.sh
+
+pushd frontend
+
+SCENARIO="${1:-e2e}"
+if [ $# -gt 0 ]; then
+  shift
+fi
+
+if [ "$SCENARIO" == "e2e" ] || [ "$SCENARIO" == "release" ]; then
+  ./integration-tests/test-playwright-e2e.sh "$@"
+elif [ "$SCENARIO" == "smoke" ]; then
+  ./integration-tests/test-playwright-e2e.sh --project=smoke "$@"
+else
+  echo "error: unknown scenario '$SCENARIO' (use: e2e, release, or smoke)" >&2
+  exit 1
+fi
+
+env NO_SANDBOX=true yarn test-puppeteer-csp
+
+popd

--- a/test-prow-playwright-e2e.sh
+++ b/test-prow-playwright-e2e.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Prow / CI entrypoint for Playwright E2E against a live OpenShift cluster console.
+# Mirrors test-prow-e2e.sh: kubeadmin password, BRIDGE_BASE_ADDRESS from the cluster,
+# contrib/create-user.sh, then tests under frontend/, and the same CSP check as Cypress Prow.
+#
+# Run from the openshift/console repository root (same as test-prow-e2e.sh).
+#
+# Usage:
+#   ./test-prow-playwright-e2e.sh [e2e|release|smoke] [arguments passed to: playwright test ...]
+#
+# Scenarios (first argument; default: e2e):
+#   e2e, release  — full Playwright suite (default project / config)
+#   smoke         — only e2e smoke specs
+#
+# Environment (typical Prow / installer):
+#   ARTIFACT_DIR, INSTALLER_DIR, KUBEADMIN_PASSWORD_FILE   same as test-prow-e2e.sh
+#   OPENSHIFT_CI                                           forwarded to frontend test-playwright-e2e.sh (NO_COLOR when true)
+#
+
+set -exuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${REPO_ROOT}"
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/tmp/artifacts}
+INSTALLER_DIR=${INSTALLER_DIR:=${ARTIFACT_DIR}/installer}
+
+# don't log kubeadmin-password
+set +x
+export BRIDGE_KUBEADMIN_PASSWORD="$(cat "${KUBEADMIN_PASSWORD_FILE:-${INSTALLER_DIR}/auth/kubeadmin-password}")"
+set -x
+export BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"
+
+./contrib/create-user.sh
+
+pushd frontend
+
+SCENARIO="${1:-e2e}"
+if [ $# -gt 0 ]; then
+  shift
+fi
+
+if [ "$SCENARIO" == "e2e" ] || [ "$SCENARIO" == "release" ]; then
+  ./integration-tests/test-playwright-e2e.sh "$@"
+elif [ "$SCENARIO" == "smoke" ]; then
+  ./integration-tests/test-playwright-e2e.sh e2e/tests/smoke "$@"
+else
+  echo "error: unknown scenario '$SCENARIO' (use: e2e, release, or smoke)" >&2
+  exit 1
+fi
+
+env NO_SANDBOX=true yarn test-puppeteer-csp
+
+popd


### PR DESCRIPTION
**Analysis / Root cause**:
OpenShift Console currently uses Cypress for E2E testing in Prow/CI. This PR adds Playwright E2E testing infrastructure for Prow/CI, providing an alternative E2E testing framework that can run in the CI environment.

**Solution description**:
Added Playwright E2E testing infrastructure for OpenShift CI/Prow, mirroring the existing Cypress test-prow-e2e.sh workflow.

### Files Added

**test-prow-playwright-e2e.sh** (Prow/CI wrapper at repository root):
- Mirrors test-prow-e2e.sh workflow for consistency
- Handles kubeadmin password securely (set +x to avoid logging)
- Gets BRIDGE_BASE_ADDRESS from cluster using oc CLI
- Runs contrib/create-user.sh for test user setup
- Supports three scenarios: e2e, release, and smoke
- Smoke scenario uses Playwright's native `--project=smoke` flag
- Includes same CSP validation (test-puppeteer-csp) as Cypress Prow script
- Delegates to frontend/integration-tests/test-playwright-e2e.sh for test execution

**frontend/integration-tests/test-playwright-e2e.sh** (Frontend test runner):
- Run from frontend/ directory, similar to test-cypress.sh
- Supports `-c` flag to run contrib/create-user.sh before tests
- Sets up environment variables: BRIDGE_BASE_ADDRESS, BRIDGE_BASE_PATH, WEB_CONSOLE_URL
- Validates running from correct directory
- Checks for oc availability when auto-detecting cluster URL
- Uses Playwright's native `--project` flag for test selection (e.g., `--project=helm`, `--project=smoke`)
- Delegates all Playwright arguments directly to the Playwright CLI
- Installs Playwright if not present (yarn install check)

### Usage Examples

**Prow/CI (from repository root)**:
```bash
./test-prow-playwright-e2e.sh e2e
./test-prow-playwright-e2e.sh smoke
```

**Frontend (from frontend/ directory)**:
```bash
./integration-tests/test-playwright-e2e.sh --project=helm
./integration-tests/test-playwright-e2e.sh --project=smoke
./integration-tests/test-playwright-e2e.sh -c --project=dev-console
./integration-tests/test-playwright-e2e.sh --help    # Shows Playwright's native help
```

### Design Decisions

- **Uses Playwright's native --project flag**: Rather than implementing custom package selection, the script delegates to Playwright's built-in project selection, reducing maintenance overhead and aligning with standard Playwright workflows
- **Mirrors Cypress patterns**: Follows the established test-prow-e2e.sh patterns for consistency and familiarity
- **Simple delegation**: Scripts focus on environment setup and delegate test execution to Playwright CLI

**Screenshots / screen recording**:
N/A - Infrastructure/tooling change only

**Test setup:**
Prerequisites to test this PR:
1. Have an OpenShift cluster running
2. Be logged in with `oc` CLI, or set BRIDGE_BASE_ADDRESS
3. Install Playwright in frontend directory:
   ```bash
   cd frontend
   yarn add -D @playwright/test
   yarn playwright install
   ```

**Test cases:**
- [ ] Run `./frontend/integration-tests/test-playwright-e2e.sh --project=smoke` to test with smoke project
- [ ] Run `./frontend/integration-tests/test-playwright-e2e.sh -c` to verify user creation works
- [ ] Run `./test-prow-playwright-e2e.sh e2e` from repo root (Prow/CI entry point)
- [ ] Run `./test-prow-playwright-e2e.sh smoke` from repo root
- [ ] Verify WEB_CONSOLE_URL is set correctly from BRIDGE_BASE_ADDRESS + BRIDGE_BASE_PATH
- [ ] Verify script discovers cluster console URL correctly from oc CLI when BRIDGE_BASE_ADDRESS unset
- [ ] Verify script fails gracefully when oc is not available and BRIDGE_BASE_ADDRESS unset
- [ ] Verify kubeadmin password is not logged (set +x / set -x works correctly)
- [ ] Verify CSP validation runs after tests (test-puppeteer-csp)

**Browser conformance**:
N/A - Infrastructure/tooling change (scripts support any browser Playwright supports)

**Additional info:**
- Scripts mirror existing Cypress infrastructure for consistency
- Playwright's native --project flag provides flexibility for test selection
- Prow script uses set -exuo pipefail for command tracing (matches Cypress pattern)
- Frontend script uses set -euo pipefail (no tracing)
- Clear error messages guide users to correct usage
- Scripts are marked executable (chmod +x)
- Comprehensive usage documentation in script header comments

**Reviewers and assignees:**
<!--
Console Approver:
/assign <gh-user>
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)