### PR TITLE
OCPBUGS-84710: Fix ConsoleDataView filter order: Name and Label should appear first

### DIFF
--- a/frontend/packages/console-app/src/components/data-view/ConsoleDataView.tsx
+++ b/frontend/packages/console-app/src/components/data-view/ConsoleDataView.tsx
@@ -155,7 +155,7 @@ export const ConsoleDataView = <
     }
 
     return additionalFilterNodes?.length > 0
-      ? [...additionalFilterNodes, ...basicFilters]
+      ? [...basicFilters, ...additionalFilterNodes]
       : basicFilters;
 
     // Can't use data in the deps array as it will recompute the filters and will cause the selected category to reset

--- a/frontend/packages/integration-tests/tests/app/debug-pod.cy.ts
+++ b/frontend/packages/integration-tests/tests/app/debug-pod.cy.ts
@@ -102,7 +102,7 @@ describe('Debug pod', () => {
   it('Debug pod should be terminated after leaving debug container page', () => {
     cy.visit(`/k8s/ns/${testName}/pods`);
     listPage.dvRows.shouldExist(POD_NAME);
-    listPage.dvFilter.by('Running');
+    listPage.dvFilter.by('Status', 'Running');
     cy.exec(
       `oc get pods -n ${testName} -o jsonpath='{.items[0].metadata.name}{"#"}{.items[1].metadata.name}'`,
     ).then((result) => {

--- a/frontend/packages/integration-tests/tests/crud/roles-rolebindings.cy.ts
+++ b/frontend/packages/integration-tests/tests/crud/roles-rolebindings.cy.ts
@@ -90,7 +90,7 @@ const deleteClusterExamples = () => {
   nav.sidenav.clickNavLink(['User Management', 'Roles']);
   listPage.titleShouldHaveText('Roles');
   listPage.dvRows.shouldBeLoaded();
-  listPage.dvFilter.by('cluster');
+  listPage.dvFilter.by('Role', 'cluster');
   listPage.dvFilter.byName(clusterRoleName);
   listPage.dvRows.clickKebabAction(clusterRoleName, 'Delete ClusterRole');
   modal.shouldBeOpened();
@@ -101,7 +101,7 @@ const deleteClusterExamples = () => {
   nav.sidenav.clickNavLink(['User Management', 'RoleBindings']);
   listPage.titleShouldHaveText('RoleBindings');
   listPage.dvRows.shouldBeLoaded();
-  listPage.dvFilter.by('cluster');
+  listPage.dvFilter.by('Kind', 'cluster');
   listPage.dvFilter.byName(clusterRoleBindingName);
   listPage.dvRows.clickKebabAction(clusterRoleBindingName, 'Delete ClusterRoleBinding');
   modal.shouldBeOpened();
@@ -145,7 +145,7 @@ describe('Roles and RoleBindings', () => {
   it('displays Resource names column in ClusterRole rules table', () => {
     nav.sidenav.clickNavLink(['User Management', 'Roles']);
     listPage.dvRows.shouldBeLoaded();
-    listPage.dvFilter.by('cluster');
+    listPage.dvFilter.by('Role', 'cluster');
     listPage.dvFilter.byName(clusterRoleName);
     listPage.dvRows.clickRowByName(clusterRoleName);
     detailsPage.isLoaded();
@@ -165,7 +165,7 @@ describe('Roles and RoleBindings', () => {
       nav.sidenav.clickNavLink(['User Management', rolesOrBindings]);
       projectDropdown.selectProject(allProjectsDropdownLabel);
       listPage.dvRows.shouldBeLoaded();
-      listPage.dvFilter.by('namespace');
+      listPage.dvFilter.by(rolesOrBindings === 'Roles' ? 'Role' : 'Kind', 'namespace');
       listPage.dvFilter.byName(roleOrBindingName);
       listPage.dvRows.clickRowByName(roleOrBindingName);
       detailsPage.isLoaded();
@@ -180,7 +180,7 @@ describe('Roles and RoleBindings', () => {
       projectDropdown.selectProject(testName);
       projectDropdown.shouldContain(testName);
       listPage.dvRows.shouldBeLoaded();
-      listPage.dvFilter.by('namespace');
+      listPage.dvFilter.by(rolesOrBindings === 'Roles' ? 'Role' : 'Kind', 'namespace');
       listPage.dvFilter.byName(roleOrBindingName);
       listPage.dvRows.clickRowByName(roleOrBindingName);
       detailsPage.isLoaded();
@@ -194,7 +194,7 @@ describe('Roles and RoleBindings', () => {
       nav.sidenav.clickNavLink(['User Management', rolesOrBindings]);
       projectDropdown.selectProject(allProjectsDropdownLabel);
       listPage.dvRows.shouldBeLoaded();
-      listPage.dvFilter.by('cluster');
+      listPage.dvFilter.by(rolesOrBindings === 'Roles' ? 'Role' : 'Kind', 'cluster');
       listPage.dvFilter.byName(clusterRoleOrBindingName);
       listPage.dvRows.clickRowByName(clusterRoleOrBindingName);
       detailsPage.isLoaded();
@@ -210,7 +210,7 @@ describe('Roles and RoleBindings', () => {
       projectDropdown.selectProject(testName);
       projectDropdown.shouldContain(testName);
       listPage.dvRows.shouldBeLoaded();
-      listPage.dvFilter.by('cluster');
+      listPage.dvFilter.by(rolesOrBindings === 'Roles' ? 'Role' : 'Kind', 'cluster');
       listPage.dvFilter.byName(clusterRoleOrBindingName);
       listPage.dvRows.clickRowByName(clusterRoleOrBindingName);
       detailsPage.isLoaded();

--- a/frontend/packages/integration-tests/views/list-page.ts
+++ b/frontend/packages/integration-tests/views/list-page.ts
@@ -65,10 +65,14 @@ export const listPage = {
       cy.get('[aria-label="Filter by name"]').should('be.enabled').clear();
       cy.get('[aria-label="Filter by name"]').type(name);
     },
-    by: (checkboxLabel: string) => {
+    by: (filterName: string, checkboxLabel: string) => {
       // Wait for list data to settle before opening the filter, otherwise a
       // concurrent re-render (e.g. after a project switch) closes the menu.
       cy.byTestID('data-view-table').should('be.visible');
+      cy.get('[data-ouia-component-id="DataViewFilters"]').within(() =>
+        cy.get('.pf-v6-c-menu-toggle').first().click(),
+      );
+      cy.get('.pf-v6-c-menu__list-item').contains(filterName).click();
       cy.get('[data-ouia-component-id="DataViewCheckboxFilter"]').click();
       cy.get(`[data-ouia-component-id="DataViewCheckboxFilter-filter-item-${checkboxLabel}"]`)
         .should('be.visible')


### PR DESCRIPTION
Fixes the ConsoleDataView filter toolbar ordering so that Name and Label filters appear first, before additional filters like Status, Roles, and Architecture.

## What this PR does / why we need it

The ConsoleDataView component was displaying filter controls in an inconsistent order. When additionalFilterNodes were provided, they appeared before the standard Name and Label filters. This created a poor user experience as the most commonly used filters should always be first.

## Which Jira issue(s) this PR fixes

Fixes: https://issues.redhat.com/browse/OCPBUGS-84710

## Before

Filter toolbar displays: Status | Roles | Architecture | Machine set | MachineConfigPool | Name | Label

## After  

Filter toolbar displays: Name | Label | Status | Roles | Architecture | Machine set | MachineConfigPool

<img width="571" height="456" alt="Screenshot 2026-04-29 at 2 31 32 PM" src="https://github.com/user-attachments/assets/9256007d-ecb6-4e5c-980c-22deb30eaf02" />

## How to test this PR

1. Navigate to the Nodes list page (Compute > Nodes)
2. Observe the filter toolbar above the data table
3. Verify Name and Label filters appear first from left to right

## Screenshots/recordings

See Jira: https://drive.google.com/file/d/1JDWL68H6iqL8qpxijNLIQyHqI1O7gwLA/view?usp=sharing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the ordering of base filter elements in the data view for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->