### PR TITLE
OCPBUGS-84721: Fix WebSocket InvalidStateError in pod terminal

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/__tests__/ws-factory.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/__tests__/ws-factory.spec.ts
@@ -1,0 +1,86 @@
+import { WSFactory } from '../ws-factory';
+
+const CONNECTING = 0;
+const OPEN = 1;
+const CLOSING = 2;
+const CLOSED = 3;
+
+const createMockWS = () => ({
+  readyState: CONNECTING,
+  close: jest.fn(),
+  send: jest.fn(),
+  onopen: null,
+  onclose: null,
+  onerror: null,
+  onmessage: null,
+});
+
+let lastMockWS: ReturnType<typeof createMockWS>;
+
+const MockWebSocket = Object.assign(
+  jest.fn().mockImplementation(() => {
+    lastMockWS = createMockWS();
+    return lastMockWS;
+  }),
+  { CONNECTING, OPEN, CLOSING, CLOSED },
+);
+
+(global as any).WebSocket = MockWebSocket;
+
+const createWSFactory = () =>
+  new WSFactory('test', {
+    host: 'wss://localhost',
+    path: '/test',
+    subprotocols: [],
+  });
+
+describe('WSFactory', () => {
+  beforeEach(() => {
+    MockWebSocket.mockClear();
+  });
+
+  describe('send', () => {
+    it('should send data when readyState is OPEN', () => {
+      const ws = createWSFactory();
+      lastMockWS.readyState = OPEN;
+
+      ws.send('test-data');
+
+      expect(lastMockWS.send).toHaveBeenCalledWith('test-data');
+    });
+
+    it('should not send data when readyState is CONNECTING', () => {
+      const ws = createWSFactory();
+      lastMockWS.readyState = CONNECTING;
+
+      ws.send('test-data');
+
+      expect(lastMockWS.send).not.toHaveBeenCalled();
+    });
+
+    it('should not send data when readyState is CLOSING', () => {
+      const ws = createWSFactory();
+      lastMockWS.readyState = CLOSING;
+
+      ws.send('test-data');
+
+      expect(lastMockWS.send).not.toHaveBeenCalled();
+    });
+
+    it('should not send data when readyState is CLOSED', () => {
+      const ws = createWSFactory();
+      lastMockWS.readyState = CLOSED;
+
+      ws.send('test-data');
+
+      expect(lastMockWS.send).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when ws is destroyed', () => {
+      const ws = createWSFactory();
+      ws.destroy();
+
+      expect(() => ws.send('test-data')).not.toThrow();
+    });
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/ws-factory.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/ws-factory.ts
@@ -344,6 +344,8 @@ export class WSFactory {
   }
 
   send(data: Parameters<typeof WebSocket.prototype.send>[0]) {
-    this.ws && this.ws.send(data);
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(data);
+    }
   }
 }


### PR DESCRIPTION
**Analysis / Root cause**:
`WSFactory.send()` only checked if the WebSocket instance existed (`this.ws && this.ws.send(data)`) before sending. When the WebSocket is still in `CONNECTING` state (e.g. during terminal reconnects or container switches), resize/input events from xterm.js can fire `send()` before the handshake completes, throwing `InvalidStateError`. CLI `oc exec` is unaffected since this is purely a frontend timing issue.

**Solution description**:
Guard `send()` with `readyState === WebSocket.OPEN` so messages are silently dropped on connections that aren't ready. Added unit tests covering all WebSocket readyState values.

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes -->

**Test setup:**
1. Authenticate to a live OCP 4.18+ cluster
2. Run the console locally with `source ./contrib/oc-environment.sh && ./bin/bridge`
3. Open browser DevTools Console to monitor for errors

**Test cases:**
- Open pod terminal, throttle network to Slow 3G, switch containers rapidly — no `InvalidStateError`
- Resize browser window during reconnect — no error
- Type into terminal during reconnect — no error
- Unit tests: send succeeds when OPEN, silently dropped when CONNECTING/CLOSING/CLOSED/destroyed

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
Jira: https://redhat.atlassian.net/browse/OCPBUGS-84721
Backport to `release-4.18` planned.

**Reviewers and assignees:**
<!--
Tag reviewers as needed
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket communication reliability by ensuring data transmission only occurs when the connection is fully established, preventing send failures during connection setup or teardown phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->