### PR TITLE
[release-4.17] OCPBUGS-78672: Namespace is not persisting when switching to developer view from the topology page of admin page

### DIFF
--- a/frontend/packages/console-app/src/components/detect-namespace/__tests__/getValueForNamespace.spec.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/__tests__/getValueForNamespace.spec.ts
@@ -8,6 +8,7 @@ jest.mock('../checkNamespaceExists', () => ({
 
 const checkNamespaceExistsMock = checkNamespaceExists as jest.Mock;
 
+const activeNamespace: string = 'active-ns';
 const preferredNamespace: string = 'preferred-ns';
 const lastNamespace: string = 'last-ns';
 
@@ -16,16 +17,31 @@ describe('getValueForNamespace', () => {
     jest.resetAllMocks();
   });
 
-  it(`should return preferredNamespace if it is defined and exists`, async () => {
+  it(`should return activeNamespace if it is defined and exists`, async () => {
     checkNamespaceExistsMock.mockReturnValueOnce(Promise.resolve(true));
 
+    const namespace = await getValueForNamespace(
+      preferredNamespace,
+      lastNamespace,
+      true,
+      activeNamespace,
+    );
+
+    expect(namespace).toEqual(activeNamespace);
+  });
+
+  it(`should return preferredNamespace if activeNamespace does not exist and preferredNamespace is defined and exists`, async () => {
+    checkNamespaceExistsMock
+      .mockReturnValueOnce(Promise.resolve(false))
+      .mockReturnValueOnce(Promise.resolve(true));
     const namespace = await getValueForNamespace(preferredNamespace, lastNamespace, true);
 
     expect(namespace).toEqual(preferredNamespace);
   });
 
-  it('should return lastNamespace if preferred namespace does not exist and last namespace is defined and exists', async () => {
+  it('should return lastNamespace if activeNamespace and preferred namespace does not exist and last namespace is defined and exists', async () => {
     checkNamespaceExistsMock
+      .mockReturnValueOnce(Promise.resolve(false))
       .mockReturnValueOnce(Promise.resolve(false))
       .mockReturnValueOnce(Promise.resolve(true));
 
@@ -34,8 +50,9 @@ describe('getValueForNamespace', () => {
     expect(namespace).toEqual(lastNamespace);
   });
 
-  it(`should return ${ALL_NAMESPACES_KEY} if preferred and last namespace does not exists`, async () => {
+  it(`should return ${ALL_NAMESPACES_KEY} if activeNamespace, preferred and last namespace does not exists`, async () => {
     checkNamespaceExistsMock
+      .mockReturnValueOnce(Promise.resolve(false))
       .mockReturnValueOnce(Promise.resolve(false))
       .mockReturnValueOnce(Promise.resolve(false));
 

--- a/frontend/packages/console-app/src/components/detect-namespace/getValueForNamespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/getValueForNamespace.ts
@@ -5,7 +5,11 @@ export const getValueForNamespace = async (
   preferredNamespace: string,
   lastNamespace: string,
   useProjects: boolean,
+  activeNamespace?: string,
 ): Promise<string> => {
+  if (await checkNamespaceExists(activeNamespace, useProjects)) {
+    return activeNamespace;
+  }
   if (await checkNamespaceExists(preferredNamespace, useProjects)) {
     return preferredNamespace;
   }

--- a/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
@@ -57,7 +57,7 @@ export const useValuesForNamespaceContext: UseValuesForNamespaceContext = () => 
     !flagPending(useProjects) && preferredNamespaceLoaded && lastNamespaceLoaded;
   React.useEffect(() => {
     if (!urlNamespace && resourcesLoaded) {
-      getValueForNamespace(preferredNamespace, lastNamespace, useProjects)
+      getValueForNamespace(preferredNamespace, lastNamespace, useProjects, activeNamespace)
         .then((ns: string) => {
           updateNamespace(ns);
         })


### PR DESCRIPTION
Manual backport from [PR](https://github.com/openshift/console/pull/16160).

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Test cases:**
<!-- List possible test cases to validate the changes. -->

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->
