### PR TITLE
OCPBUGS-77931: Loosen default `img-src` CSP

### DIFF
--- a/frontend/packages/console-app/src/hooks/useCSPViolationDetector.tsx
+++ b/frontend/packages/console-app/src/hooks/useCSPViolationDetector.tsx
@@ -67,11 +67,6 @@ export const newPluginCSPViolationEvent = (
  * Report CSP violation event for Cypress test purposes.
  */
 const reportCSPViolationToCypress = (event: SecurityPolicyViolationEvent) => {
-  // OCPBUGS-77931: Address CSP violations detected when running Cypress tests
-  if (event.effectiveDirective === 'img-src') {
-    return; // Catalog view links to arbitrary image URLs
-  }
-
   // Import from Git e2e tests make direct browser requests to api.github.com
   // which violates connect-src CSP. This is expected since git hosting can be
   // on any arbitrary hostname (e.g. Gitea) and cannot be allowlisted in CSP.

--- a/frontend/packages/console-dynamic-plugin-sdk/release-notes/4.23.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/release-notes/4.23.md
@@ -1,0 +1,7 @@
+# OpenShift Console 4.23 Release Notes
+
+This release contains no breaking changes. Existing plugins remain fully compatible without modification.
+
+## Changes to Content Security Policy (CSP)
+
+The default `img-src` CSP directive includes `https:` in addition to `'self'` and `data:`. This allows plugins to load images from any HTTPS origin without extending the `img-src` directive.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -28,6 +28,7 @@ const (
 	unsafeEval    = "'unsafe-eval'"
 	unsafeInline  = "'unsafe-inline'"
 	none          = "'none'"
+	https         = "https:"
 )
 
 // Generate a cryptographically secure random array of bytes.
@@ -62,11 +63,11 @@ func BuildCSPDirectives(k8sMode string, pluginsCSP serverconfig.MultiKeyValue, i
 	// The default sources are the sources that are allowed for all directives.
 	// When running on-cluster, the default sources are just 'self' and 'console.redhat.com'.
 	// When running off-cluster, 'http://localhost:8080' and 'ws://localhost:8080' are appended to the
-	// default sources. Image source, font source, and style source only use 'self' and
-	// 'http://localhost:8080'.
+	// default sources. Image source uses 'self' and 'https:'. Font source and style source only
+	// use 'self'.
 	baseUriDirective := []string{baseURI, self}
 	defaultSrcDirective := []string{defaultSrc, self, consoleDot}
-	imgSrcDirective := []string{imgSrc, self}
+	imgSrcDirective := []string{imgSrc, self, https}
 	fontSrcDirective := []string{fontSrc, self}
 	scriptSrcDirective := []string{scriptSrc, self, consoleDot}
 	styleSrcDirective := []string{styleSrc, self}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -10,7 +10,7 @@ import (
 const (
 	onClusterBaseUri        = "base-uri 'self'"
 	onClusterDefaultSrc     = "default-src 'self' console.redhat.com"
-	onClusterImgSrc         = "img-src 'self'"
+	onClusterImgSrc         = "img-src 'self' https:"
 	onClusterFontSrc        = "font-src 'self'"
 	onClusterScriptSrc      = "script-src 'self' console.redhat.com"
 	onClusterStyleSrc       = "style-src 'self'"
@@ -18,7 +18,7 @@ const (
 	onClusterConnectSrc     = "connect-src 'self' console.redhat.com"
 	offClusterBaseUri       = "base-uri 'self' http://localhost:8080 ws://localhost:8080"
 	offClusterDefaultSrc    = "default-src 'self' console.redhat.com http://localhost:8080 ws://localhost:8080"
-	offClusterImgSrc        = "img-src 'self' http://localhost:8080"
+	offClusterImgSrc        = "img-src 'self' https: http://localhost:8080"
 	offClusterFontSrc       = "font-src 'self' http://localhost:8080"
 	offClusterScriptSrc     = "script-src 'self' console.redhat.com http://localhost:8080 ws://localhost:8080"
 	offClusterStyleSrc      = "style-src 'self' http://localhost:8080"


### PR DESCRIPTION
**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

Changes the default `img-src` CSP from `self data:` to `self https: data:`.

There are multiple places where we explicitly allow icons any origin (e.g., helm charts, devfiles, templates, topology). Enforcing icons be `data-uri` only would be very difficult to achieve upstream, and proxying the icons would introduce SSRF risks.

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

I can imagine a few risks to this (e.g., IP fingerprinting, exposure to potential zero-days in browsers rendering images) but we already have these troubles today (as we're in report-only mode) and there have been no reported CVEs yet..

I've changed the policy to `https` and not `*` as all of our pre-existing icons are already linking to `https` endpoints and so we can at least prevent mixed-content warnings here

**Test cases:**
<!-- List possible test cases to validate the changes. -->

- Run e2e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Content Security Policy to allow images loaded over HTTPS by default, reducing configuration requirements for plugins.

* **Bug Fixes**
  * Improved CSP violation detection and reporting for image source issues.

* **Documentation**
  * Added release notes documenting CSP policy changes and plugin configuration guidance for HTTP image sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->