### PR TITLE
NO-JIRA: Align Dockerfile.dev with multi-arch Dockerfile structure

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,14 +1,24 @@
 # Dockerfile to build console image from pre-built front end.
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS build
+##################################################
+#
+# go backend build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS gobuilder
 RUN mkdir -p /go/src/github.com/openshift/console/
 ADD . /go/src/github.com/openshift/console/
 WORKDIR /go/src/github.com/openshift/console/
 RUN ./build-backend.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.22
-COPY --from=build /go/src/github.com/openshift/console/bin/bridge /opt/bridge/bin/bridge
+##################################################
+#
+# actual base image for final product
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+RUN mkdir -p /opt/bridge/bin
+COPY --from=gobuilder /go/src/github.com/openshift/console/bin/bridge /opt/bridge/bin
 COPY ./frontend/public/dist /opt/bridge/static
-COPY ./pkg/graphql/schema.graphql /pkg/graphql/schema.graphql
+COPY --from=gobuilder /go/src/github.com/openshift/console/pkg/graphql/schema.graphql /pkg/graphql/schema.graphql
 
+WORKDIR /
+# doesn't require a root user.
 USER 1001
+
 CMD [ "/opt/bridge/bin/bridge", "--public-dir=/opt/bridge/static" ]


### PR DESCRIPTION
### What this PR does / why we need it

Updates `Dockerfile.dev` to match the multi-arch changes from commit ca9b15e50f.

The current `Dockerfile.dev` was causing runtime crashes with:
```
panic: open pkg/graphql/schema.graphql: no such file or directory
```

### Key changes:
- Rename build stage from `build` to `gobuilder` for consistency with main Dockerfile
- Change final base image from `rhel-9-base-nodejs-openshift-4.22` to `base-rhel9` (lightweight image without Node.js since frontend is pre-built)
- Fix `schema.graphql` COPY to use `gobuilder` stage instead of build context
- Add structure comments matching main Dockerfile
- Explicitly set `WORKDIR /` before `USER 1001`

This ensures `Dockerfile.dev` works correctly with the hermetic build approach and aligns with the multi-arch support added to the main Dockerfile.

### Which issue(s) this PR fixes

NOJIRA - maintenance fix

### How to test changes / Special notes to the reviewer

Build and deploy using `Dockerfile.dev`:
```bash
docker build --platform=linux/amd64 -f Dockerfile.dev -t <your-image> .
```

Verify the pod starts successfully without crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment configuration to optimize the application's containerized runtime environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->