### PR TITLE
OCPBUGS-80940: Fix SDK publish workflow for Yarn Berry

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -522,13 +522,19 @@ Build all distributable [SDK packages](#sdk-packages) into `dist` directory:
 yarn build
 ```
 
+Set the version in all dist packages (the source `package.json` uses a placeholder version):
+
+```sh
+yarn set-dist-version <version>
+```
+
 Finally, publish relevant packages to [npm registry](https://www.npmjs.com/):
 
 ```sh
-yarn publish dist/<pkg> --no-git-tag-version --new-version <version>
+npm publish ./dist/<pkg>
 ```
 
-If the given package doesn't exist in npm registry, add `--access public` to `yarn publish` command.
+If the given package doesn't exist in npm registry, add `--access public` to `npm publish`.
 
 If the newly published version comes before the latest published version in terms of semver rules
 (e.g. hotfix release 1.0.2 for an older minor version stream 1.0.x), ensure the `latest` dist-tag

--- a/frontend/packages/console-dynamic-plugin-sdk/package.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/package.json
@@ -15,6 +15,7 @@
     "generate-schema": "yarn ts-node scripts/generate-schema.ts",
     "generate-doc": "yarn ts-node scripts/generate-doc.ts",
     "generate-pkg-assets": "yarn ts-node scripts/generate-pkg-assets.ts",
+    "set-dist-version": "sh -c 'for pkg in core internal webpack; do npm version --no-git-tag-version --prefix dist/$pkg $0; done'",
     "validate": "yarn ts-node scripts/validate-extensions.ts",
     "ts-node": "../../node_modules/.bin/ts-node -O '{\"module\":\"commonjs\"}'"
   },

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
@@ -13,7 +13,7 @@ import { resolvePath } from './utils/path';
 type GeneratedPackage = {
   /** Package output directory. */
   outDir: string;
-  /** Package manifest. Note: `version` is updated via the publish script. */
+  /** Package manifest. Note: `version` must be set before publishing. */
   manifest: PackageJson;
   /** Additional files or directories to copy to the package output directory. */
   filesToCopy: Record<string, string>;


### PR DESCRIPTION
**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

Yarn Berry changed `yarn publish` to `yarn npm publish`, but the dist packages aren't part of the yarn workspace so `npm publish` is used directly.

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

Adds a `set-version` script to set the version across all three dist packages before publishing, since Yarn Berry dropped the `--new-version` flag.

**Test cases:**
<!-- List possible test cases to validate the changes. -->

- Follow the new steps and publish with `--dry-run`. 
- Then try the old steps by removing "yarnPath" from `.yarnrc.yml` and `"packageManager"` from `package.json`
- Compare the `--dry-run` results and make sure they're the same


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated publishing workflow to clarify the version assignment process before package distribution.

* **Chores**
  * Enhanced distribution package versioning automation with a new pre-publish step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->