### PR TITLE
OCPBUGS-84564: remove block volume mode in case of ocs-storagecluster-ceph-nfs

### DIFF
--- a/frontend/public/components/storage/shared.ts
+++ b/frontend/public/components/storage/shared.ts
@@ -121,6 +121,10 @@ export const provisionerAccessModeMapping: ProvisionerAccessModeMapping = Object
     Filesystem: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany', 'ReadWriteOncePod'],
     Block: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany', 'ReadWriteOncePod'],
   },
+  'nfs.csi.ceph.com': {
+    Filesystem: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany', 'ReadWriteOncePod'],
+    partialMatch: true,
+  },
 });
 
 export const getAccessModeOptions = () => [


### PR DESCRIPTION
Jira link: https://redhat.atlassian.net/browse/OCPBUGS-84564

Description: Removed the option for block volume mode when the storage class is set to ocs-storagecluster-ceph-nfs.

SS: 
<img width="2560" height="1329" alt="image" src="https://github.com/user-attachments/assets/2d515c44-91a3-4ba6-89b0-dbaa59548e88" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for NFS CSI (Ceph) as a storage provisioner, enabling users to provision persistent storage with both Filesystem and Block access modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->