### PR TITLE
OCPBUGS-85043: Remove `@console` imports from SDK dist

### DIFF
--- a/frontend/__tests__/sdk-dist-imports.spec.ts
+++ b/frontend/__tests__/sdk-dist-imports.spec.ts
@@ -1,0 +1,60 @@
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import { join, relative, resolve } from 'path';
+
+const DIST_DIR = resolve(__dirname, '../packages/console-dynamic-plugin-sdk/dist');
+
+const getDistFiles = (root: string, extensions: string[]): string[] => {
+  const results: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (extensions.some((ext) => entry.name.endsWith(ext))) {
+        results.push(full);
+      }
+    }
+  };
+  walk(root);
+  return results;
+};
+
+// Matches ES import/export statements with a @console/* module specifier.
+// Does NOT match require() calls -- those are resolved dynamically at runtime via webpack
+// module federation and are expected in the dist output.
+const importFromConsoleRe = /\b(?:import|export)\s+(?:[\s\S]*?\s+)?from\s+['"](@console\/[^'"]*)['"]/g;
+
+describe('dist files must not contain monorepo-specific imports', () => {
+  if (!existsSync(DIST_DIR)) {
+    it.skip('dist directory not found, skipping SDK dist checks', () => {});
+    return;
+  }
+
+  it('should not have ES import/export statements referencing @console packages', () => {
+    const distFiles = getDistFiles(DIST_DIR, ['.js', '.jsx', '.d.ts', '.d.tsx']);
+    expect(distFiles.length).toBeGreaterThan(0);
+
+    const violations: { file: string; line: number; specifier: string }[] = [];
+
+    for (const filePath of distFiles) {
+      const content = readFileSync(filePath, 'utf-8');
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        importFromConsoleRe.lastIndex = 0;
+        for (
+          let match = importFromConsoleRe.exec(lines[i]);
+          match !== null;
+          match = importFromConsoleRe.exec(lines[i])
+        ) {
+          violations.push({
+            file: relative(DIST_DIR, filePath),
+            line: i + 1,
+            specifier: match[1],
+          });
+        }
+      }
+    }
+
+    expect(violations.map((v) => `${v.file}:${v.line} -- ${v.specifier}`)).toEqual([]);
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -288,7 +288,7 @@ A promise that resolves to the response.
 
 ### Source
 
-[`frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts`](https://github.com/openshift/console/tree/main/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts)
+[`frontend/packages/console-dynamic-plugin-sdk/src/api/console-fetch.ts`](https://github.com/openshift/console/tree/main/frontend/packages/console-dynamic-plugin-sdk/src/api/console-fetch.ts)
 
 ---
 
@@ -319,7 +319,7 @@ A promise that resolves to the response as text or JSON object.
 
 ### Source
 
-[`frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts`](https://github.com/openshift/console/tree/main/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts)
+[`frontend/packages/console-dynamic-plugin-sdk/src/api/console-fetch.ts`](https://github.com/openshift/console/tree/main/frontend/packages/console-dynamic-plugin-sdk/src/api/console-fetch.ts)
 
 ---
 
@@ -349,7 +349,7 @@ A promise that resolves to the response as text or JSON object.
 
 ### Source
 
-[`frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts`](https://github.com/openshift/console/tree/main/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts)
+[`frontend/packages/console-dynamic-plugin-sdk/src/api/console-fetch.ts`](https://github.com/openshift/console/tree/main/frontend/packages/console-dynamic-plugin-sdk/src/api/console-fetch.ts)
 
 ---
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/console-fetch.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/console-fetch.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import type { ConsoleFetch, ConsoleFetchJSON, ConsoleFetchText } from '../extensions/console-types';
+
+/**
+ * A custom wrapper around `fetch` that adds console-specific headers and allows for retries and timeouts.
+ * It also validates the response status code and throws an appropriate error or logs out the user if required.
+ * @param url - The URL to fetch
+ * @param options - The options to pass to fetch
+ * @param timeout - The timeout in milliseconds
+ * @returns A promise that resolves to the response.
+ * @throws {@link HttpError} when the response status code indicates an error
+ */
+export const consoleFetch: ConsoleFetch = require('@console/shared/src/utils/console-fetch')
+  .coFetch;
+
+/**
+ * A custom wrapper around `fetch` that adds console-specific headers and allows for retries and timeouts.
+ * It also validates the response status code and throws an appropriate error or logs out the user if required.
+ * It returns the response as a JSON object.
+ * Uses consoleFetch internally.
+ * @param url The URL to fetch
+ * @param method  The HTTP method to use. Defaults to GET
+ * @param options The options to pass to fetch
+ * @param timeout The timeout in milliseconds
+ * @returns A promise that resolves to the response as text or JSON object.
+ * @throws {@link HttpError} when the response status code indicates an error
+ */
+export const consoleFetchJSON: ConsoleFetchJSON = require('@console/shared/src/utils/console-fetch')
+  .coFetchJSON;
+
+/**
+ * A custom wrapper around `fetch` that adds console-specific headers and allows for retries and timeouts.
+ * It also validates the response status code and throws an appropriate error or logs out the user if required.
+ * It returns the response as a text.
+ * Uses `consoleFetch` internally.
+ * @param url The URL to fetch
+ * @param options The options to pass to fetch
+ * @param timeout The timeout in milliseconds
+ * @returns A promise that resolves to the response as text or JSON object.
+ * @throws {@link HttpError} when the response status code indicates an error
+ */
+export const consoleFetchText: ConsoleFetchText = require('@console/shared/src/utils/console-fetch')
+  .coFetchText;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
@@ -39,9 +39,6 @@ import {
   UseResolvedExtensions,
   UseUserPreference,
   VirtualizedTableFC,
-  ConsoleFetch,
-  ConsoleFetchJSON,
-  ConsoleFetchText
 } from '../extensions/console-types';
 import { StatusPopupSectionProps, StatusPopupItemProps } from '../extensions/dashboard-types';
 
@@ -404,46 +401,7 @@ export {
 // Error thrown by consoleFetch and consoleFetchJSON. Exposed for `instanceOf` checks
 export { HttpError } from '../utils/error/http-error';
 
-/**
- * A custom wrapper around `fetch` that adds console-specific headers and allows for retries and timeouts.
- * It also validates the response status code and throws an appropriate error or logs out the user if required.
- * @param url - The URL to fetch
- * @param options - The options to pass to fetch
- * @param timeout - The timeout in milliseconds
- * @returns A promise that resolves to the response.
- * @throws {@link HttpError} when the response status code indicates an error
- */
-export const consoleFetch: ConsoleFetch = require('@console/shared/src/utils/console-fetch')
-  .coFetch;
-
-/**
- * A custom wrapper around `fetch` that adds console-specific headers and allows for retries and timeouts.
- * It also validates the response status code and throws an appropriate error or logs out the user if required.
- * It returns the response as a JSON object.
- * Uses consoleFetch internally.
- * @param url The URL to fetch
- * @param method  The HTTP method to use. Defaults to GET
- * @param options The options to pass to fetch
- * @param timeout The timeout in milliseconds
- * @returns A promise that resolves to the response as text or JSON object.
- * @throws {@link HttpError} when the response status code indicates an error
- */
-export const consoleFetchJSON: ConsoleFetchJSON = require('@console/shared/src/utils/console-fetch')
-  .coFetchJSON;
-
-/**
- * A custom wrapper around `fetch` that adds console-specific headers and allows for retries and timeouts.
- * It also validates the response status code and throws an appropriate error or logs out the user if required.
- * It returns the response as a text.
- * Uses `consoleFetch` internally.
- * @param url The URL to fetch
- * @param options The options to pass to fetch
- * @param timeout The timeout in milliseconds
- * @returns A promise that resolves to the response as text or JSON object.
- * @throws {@link HttpError} when the response status code indicates an error
- */
-export const consoleFetchText: ConsoleFetchText = require('@console/shared/src/utils/console-fetch')
-  .coFetchText;
+export { consoleFetch, consoleFetchJSON, consoleFetchText } from './console-fetch';
 
 // Expose K8s CRUD utilities as below
 export {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/factory/ListPage/ListPageBody.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/factory/ListPage/ListPageBody.tsx
@@ -1,12 +1,14 @@
 import type { FC, ReactNode } from 'react';
-import PaneBody from '@console/shared/src/components/layout/PaneBody';
+import { PageSection } from '@patternfly/react-core';
 
 interface ListPageBodyProps {
   children?: ReactNode;
 }
 
-const ListPageBody: FC<ListPageBodyProps> = ({ children }) => {
-  return <PaneBody>{children}</PaneBody>;
-};
+const ListPageBody: FC<ListPageBodyProps> = ({ children }) => (
+  <PageSection className="co-m-pane__body" hasBodyWrapper={false}>
+    {children}
+  </PageSection>
+);
 
 export default ListPageBody;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/actions/core.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/actions/core.ts
@@ -1,7 +1,6 @@
 import type { ActionType as Action } from 'typesafe-actions';
 import { action } from 'typesafe-actions';
-import type { UserKind } from '@console/internal/module/k8s/types';
-import type { UserInfo } from '../../../extensions';
+import type { UserInfo, UserKind } from '../../../extensions';
 import type { AdmissionWebhookWarning } from '../../redux-types';
 
 export enum ActionType {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/coreSelectors.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/coreSelectors.ts
@@ -1,6 +1,5 @@
 import type { Map as ImmutableMap } from 'immutable';
-import type { UserKind } from '@console/internal/module/k8s/types';
-import type { UserInfo } from '../../../extensions';
+import type { UserInfo, UserKind } from '../../../extensions';
 import type { ImpersonateKind, SDKStoreState, AdmissionWebhookWarning } from '../../redux-types';
 
 type GetImpersonate = (state: SDKStoreState) => ImpersonateKind;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/redux-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/redux-types.ts
@@ -1,8 +1,7 @@
 import type { Map as ImmutableMap } from 'immutable';
 import type { AnyAction } from 'redux';
 import type { ThunkDispatch } from 'redux-thunk';
-import type { UserKind } from '@console/internal/module/k8s/types';
-import type { UserInfo } from '../extensions/console-types';
+import type { UserInfo, UserKind } from '../extensions/console-types';
 
 export type K8sState = ImmutableMap<string, any>;
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -1184,6 +1184,12 @@ export type ExtPodKind = {
   status?: ExtPodStatus;
 } & K8sResourceKind;
 
+/** Describes `user.openshift.io~v1~User` */
+export type UserKind = {
+  fullName?: string;
+  identities: string[];
+} & K8sResourceCommon;
+
 export type PodControllerOverviewItem = {
   alerts: OverviewItemAlerts;
   revision: number;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-resource.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-resource.ts
@@ -1,8 +1,8 @@
 import * as _ from 'lodash';
 import type { K8sModel } from '../../api/common-types';
+import { consoleFetchJSON as coFetchJSON } from '../../api/console-fetch';
 import type { Options } from '../../api/internal-types';
 import type { K8sResourceCommon, Patch, QueryParams } from '../../extensions/console-types';
-import { consoleFetchJSON as coFetchJSON } from '../../lib-core';
 import { selectorToString, resourceURL } from './k8s-utils';
 
 type BaseOptions = {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-resource.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-resource.ts
@@ -1,8 +1,8 @@
 import * as _ from 'lodash';
-import { coFetchJSON } from '@console/shared/src/utils/console-fetch';
 import type { K8sModel } from '../../api/common-types';
 import type { Options } from '../../api/internal-types';
 import type { K8sResourceCommon, Patch, QueryParams } from '../../extensions/console-types';
+import { consoleFetchJSON as coFetchJSON } from '../../lib-core';
 import { selectorToString, resourceURL } from './k8s-utils';
 
 type BaseOptions = {

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -1006,11 +1006,6 @@ export type UserInfo = {
   extra?: object;
 };
 
-export type UserKind = {
-  fullName?: string;
-  identities: string[];
-} & K8sResourceCommon;
-
 export type GroupKind = {
   users: string[];
 } & K8sResourceCommon;

--- a/frontend/public/redux.ts
+++ b/frontend/public/redux.ts
@@ -2,12 +2,10 @@ import { applyMiddleware, combineReducers, createStore, compose, ReducersMapObje
 import { featureFlagMiddleware } from '@console/internal/plugins';
 import * as _ from 'lodash';
 import { thunk } from 'redux-thunk';
-import {
-  ResolvedExtension,
-  ReduxReducer,
-  SDKReducers,
-  SDKStoreState,
-} from '@console/dynamic-plugin-sdk';
+import type { ReduxReducer } from '@console/dynamic-plugin-sdk/src/extensions/redux';
+import { SDKReducers } from '@console/dynamic-plugin-sdk/src/app/redux';
+import type { SDKStoreState } from '@console/dynamic-plugin-sdk/src/app/redux-types';
+import type { ResolvedExtension } from '@console/dynamic-plugin-sdk/src/types';
 import { FeatureSubStore } from '@console/dynamic-plugin-sdk/src/app/features';
 import { featureReducer, featureReducerName } from './reducers/features';
 import ObserveReducers, { ObserveState } from './reducers/observe';


### PR DESCRIPTION
**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

`@console` monorepo imports do not work in the dist package and so should not be included

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

- Define and export UserKind in extensions/console-types, remove the duplicate definition from public k8s types, and update affected files to import UserKind/UserInfo from the extensions path. 
- Replace PaneBody with PatternFly PageSection in ListPageBody. 
- Change k8s resource fetch import to use consoleFetchJSON (aliased as coFetchJSON) from lib-core. 
- Add a test (sdk-dist-imports.spec.ts) that scans the SDK dist output to ensure no ES import/export statements reference monorepo packages, preventing accidental bundling of internal module specifiers.

**Test cases:**
<!-- List possible test cases to validate the changes. -->

- Run CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation test for SDK distribution imports to detect forbidden module specifiers.

* **Refactor**
  * Updated ListPageBody component to use PatternFly's PageSection instead of PaneBody.
  * Reorganized type imports across SDK modules.

* **Updates**
  * Extended UserInfo type with optional metadata field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->