### PR TITLE
CONSOLE-5229: Enable RTL ESLint rules in Knative tests by removing file-level no-container / no-node-access suppressions

### DIFF
--- a/frontend/packages/knative-plugin/src/__tests__/rtl-stub-components.tsx
+++ b/frontend/packages/knative-plugin/src/__tests__/rtl-stub-components.tsx
@@ -1,0 +1,24 @@
+import type { HTMLAttributes, PropsWithChildren } from 'react';
+
+/**
+ * Knative-plugin RTL stubs for `@console/internal/components/utils` jest mocks.
+ * Uses data-test (see frontend/setup-tests.js). Props are forwarded as DOM attrs for assertions.
+ */
+export const knativeInternalUtilsStubs = {
+  /** Mirrors string-mock ResourceLink DOM attrs; cast avoids TS span prop strictness. */
+  ResourceLink: (props: Record<string, unknown>) => (
+    <span {...(props as HTMLAttributes<HTMLSpanElement>)} data-test="mock-ResourceLink" />
+  ),
+  SidebarSectionHeading: ({
+    text,
+    children,
+    className,
+  }: PropsWithChildren<{ text?: string; className?: string }>) => (
+    <div data-test="mock-SidebarSectionHeading" className={className}>
+      {text ? <h2>{text}</h2> : null}
+      {children}
+    </div>
+  ),
+};
+
+export const createKnativeTextStub = (text: string) => () => <span>{text}</span>;

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSink.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSink.spec.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
+import { screen } from '@testing-library/react';
 import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
 import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
 import {
@@ -15,8 +15,7 @@ jest.mock('@console/shared/src/hooks/useConsoleSelector', () => ({
 }));
 
 jest.mock('formik', () => ({
-  ...jest.requireActual('formik'),
-  Formik: 'Formik',
+  Formik: () => <span data-test="mock-Formik" />,
 }));
 
 describe('EventSinkSpec', () => {
@@ -24,7 +23,7 @@ describe('EventSinkSpec', () => {
 
   it('should render form with proper initialvalues', () => {
     useSelectorMock.mockReturnValue('appGroup');
-    const { container } = renderWithProviders(
+    renderWithProviders(
       <EventSink
         namespace={namespace}
         normalizedSink={mockNormalizedSink}
@@ -32,18 +31,18 @@ describe('EventSinkSpec', () => {
         sinkKind={'KameletBinding'}
       />,
     );
-    expect(container.querySelector('Formik')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-Formik')).toBeInTheDocument();
   });
 
   it('should render form with proper initialvalues for kafkaSink', () => {
     useSelectorMock.mockReturnValue('appGroup');
-    const { container } = renderWithProviders(
+    renderWithProviders(
       <EventSink
         namespace={namespace}
         normalizedSink={mockNormalizedKafkaSink}
         sinkKind={'KafkaSink'}
       />,
     );
-    expect(container.querySelector('Formik')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-Formik')).toBeInTheDocument();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSinkAlert.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSinkAlert.spec.tsx
@@ -1,34 +1,29 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import EventSinkAlert from '../EventSinkAlert';
 
 jest.mock('@patternfly/react-core', () => ({
-  Alert: 'Alert',
+  Alert: () => 'mock-Alert',
 }));
 
 describe('EventSinkAlert', () => {
   it('should not alert if eventSinks are there', () => {
-    const { container } = render(
-      <EventSinkAlert isValidSink createSinkAccessLoading={false} createSinkAccess />,
-    );
-    expect(container.querySelector('Alert')).not.toBeInTheDocument();
+    render(<EventSinkAlert isValidSink createSinkAccessLoading={false} createSinkAccess />);
+    expect(screen.queryByText('mock-Alert')).not.toBeInTheDocument();
   });
 
   it('should show alert if eventSink is present but do not have create access', () => {
-    const { container } = render(
-      <EventSinkAlert isValidSink createSinkAccessLoading={false} createSinkAccess={false} />,
-    );
-    expect(container.querySelector('Alert')).toBeInTheDocument();
+    render(<EventSinkAlert isValidSink createSinkAccessLoading={false} createSinkAccess={false} />);
+    expect(screen.getByText('mock-Alert')).toBeVisible();
   });
 
   it('should show alert if eventSink is not present', () => {
-    const { container } = render(
+    render(
       <EventSinkAlert
         isValidSink={false}
         createSinkAccessLoading={false}
         createSinkAccess={false}
       />,
     );
-    expect(container.querySelector('Alert')).toBeInTheDocument();
+    expect(screen.getByText('mock-Alert')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSinkForm.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSinkForm.spec.tsx
@@ -1,27 +1,31 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import type { ComponentProps } from 'react';
-import { render } from '@testing-library/react';
+import type { ComponentProps, ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
 import { CamelKameletBindingModel } from '../../../models';
 import { mockKameletSink } from '../__mocks__/Kamelet-data';
 import EventSinkForm from '../EventSinkForm';
 
-jest.mock('@console/shared', () => ({
-  FormFooter: 'FormFooter',
-  SyncedEditorField: 'SyncedEditorField',
-  FlexForm: 'FlexForm',
-  FormBody: 'FormBody',
-  CodeEditorField: 'CodeEditorField',
+jest.mock('@console/shared', () => {
+  const { createKnativeTextStub: createTextStub } = jest.requireActual(
+    '@console/knative-plugin/src/__tests__/rtl-stub-components',
+  );
+  return {
+    FormFooter: createTextStub('mock-FormFooter'),
+    SyncedEditorField: createTextStub('mock-SyncedEditorField'),
+    FlexForm: ({ children }: { children?: ReactNode }) => children ?? null,
+    FormBody: ({ children }: { children?: ReactNode }) => children ?? null,
+    CodeEditorField: createTextStub('mock-CodeEditorField'),
+  };
+});
+
+jest.mock('../event-sinks/EventSinkSection', () => ({
+  __esModule: true,
+  default: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-EventSinkSection'),
 }));
 
-jest.mock('../event-sinks/EventSinkSection', () => 'EventSinkSection');
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-  withTranslation: () => (Component: any) => Component,
-}));
+jest.mock('react-i18next');
 
 let eventSinkFormProps: ComponentProps<typeof EventSinkForm>;
 
@@ -40,10 +44,9 @@ describe('EventSinkForm', () => {
     };
   });
 
-  it('should render FlexForm, SyncedEditorField and FormFooter', () => {
-    const { container } = render(<EventSinkForm {...eventSinkFormProps} />);
-    expect(container.querySelector('FlexForm')).toBeInTheDocument();
-    expect(container.querySelector('SyncedEditorField')).toBeInTheDocument();
-    expect(container.querySelector('FormFooter')).toBeInTheDocument();
+  it('should render SyncedEditorField and FormFooter', () => {
+    render(<EventSinkForm {...eventSinkFormProps} />);
+    expect(screen.getByText('mock-SyncedEditorField')).toBeVisible();
+    expect(screen.getByText('mock-FormFooter')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSinkPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSinkPage.spec.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import * as Router from 'react-router';
 import { useEventSinkStatus } from '../../../hooks/useEventSinkStatus';
 import {
@@ -20,23 +20,23 @@ jest.mock('react-router', () => ({
 }));
 
 jest.mock('@console/internal/components/utils', () => ({
-  LoadingBox: 'LoadingBox',
+  LoadingBox: () => 'mock-LoadingBox',
 }));
 
 jest.mock('@console/dev-console/src/components/NamespacedPage', () => ({
   __esModule: true,
-  default: 'NamespacedPage',
+  default: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   NamespacedPageVariants: {
     light: 'light',
   },
 }));
 
 jest.mock('@console/shared/src/components/document-title/DocumentTitle', () => ({
-  DocumentTitle: 'DocumentTitle',
+  DocumentTitle: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
 }));
 
 jest.mock('@console/shared/src/components/heading/PageHeading', () => ({
-  PageHeading: 'PageHeading',
+  PageHeading: () => <div />,
 }));
 
 jest.mock('@console/dev-console/src/const', () => ({
@@ -46,20 +46,16 @@ jest.mock('@console/dev-console/src/const', () => ({
   },
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 jest.mock('../EventSink', () => ({
   __esModule: true,
-  default: 'EventSink',
+  default: () => 'mock-EventSink',
 }));
 
 jest.mock('../EventSinkAlert', () => ({
   __esModule: true,
-  default: 'EventSinkAlert',
+  default: () => 'mock-EventSinkAlert',
 }));
 
 const useEventSinkStatusMock = useEventSinkStatus as jest.Mock;
@@ -81,10 +77,10 @@ describe('EventSinkPage', () => {
 
   it('should show loading if resource is not loaded yet', () => {
     useEventSinkStatusMock.mockReturnValue({ isValidSink: false, loaded: false });
-    const { container } = render(<EventSinkPage />);
-    expect(container.querySelector('LoadingBox')).toBeInTheDocument();
-    expect(container.querySelector('EventSinkAlert')).not.toBeInTheDocument();
-    expect(container.querySelector('EventSink')).not.toBeInTheDocument();
+    render(<EventSinkPage />);
+    expect(screen.getByText('mock-LoadingBox')).toBeVisible();
+    expect(screen.queryByText('mock-EventSinkAlert')).not.toBeInTheDocument();
+    expect(screen.queryByText('mock-EventSink')).not.toBeInTheDocument();
   });
 
   it('should render EventSink if resource is loaded and is valid', () => {
@@ -96,10 +92,10 @@ describe('EventSinkPage', () => {
       normalizedSink: mockNormalizedSink,
       kamelet: mockKameletSink,
     });
-    const { container } = render(<EventSinkPage />);
-    expect(container.querySelector('EventSink')).toBeInTheDocument();
-    expect(container.querySelector('EventSinkAlert')).not.toBeInTheDocument();
-    expect(container.querySelector('LoadingBox')).not.toBeInTheDocument();
+    render(<EventSinkPage />);
+    expect(screen.getByText('mock-EventSink')).toBeVisible();
+    expect(screen.queryByText('mock-EventSinkAlert')).not.toBeInTheDocument();
+    expect(screen.queryByText('mock-LoadingBox')).not.toBeInTheDocument();
   });
 
   it('should render EventSinkAlert if resource is loaded but user doesnot have create access', () => {
@@ -111,10 +107,10 @@ describe('EventSinkPage', () => {
       normalizedSink: mockNormalizedSink,
       kamelet: mockKameletSink,
     });
-    const { container } = render(<EventSinkPage />);
-    expect(container.querySelector('EventSinkAlert')).toBeInTheDocument();
-    expect(container.querySelector('EventSink')).not.toBeInTheDocument();
-    expect(container.querySelector('LoadingBox')).not.toBeInTheDocument();
+    render(<EventSinkPage />);
+    expect(screen.getByText('mock-EventSinkAlert')).toBeVisible();
+    expect(screen.queryByText('mock-EventSink')).not.toBeInTheDocument();
+    expect(screen.queryByText('mock-LoadingBox')).not.toBeInTheDocument();
   });
 
   it('should render EventSink if resource is loaded and is valid for kafka sink', () => {
@@ -137,9 +133,9 @@ describe('EventSinkPage', () => {
       key: 'default',
       unstable_mask: undefined,
     });
-    const { container } = render(<EventSinkPage />);
-    expect(container.querySelector('EventSink')).toBeInTheDocument();
-    expect(container.querySelector('EventSinkAlert')).not.toBeInTheDocument();
-    expect(container.querySelector('LoadingBox')).not.toBeInTheDocument();
+    render(<EventSinkPage />);
+    expect(screen.getByText('mock-EventSink')).toBeVisible();
+    expect(screen.queryByText('mock-EventSinkAlert')).not.toBeInTheDocument();
+    expect(screen.queryByText('mock-LoadingBox')).not.toBeInTheDocument();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSource.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSource.spec.tsx
@@ -1,13 +1,27 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
+import type { ReactNode } from 'react';
+import { screen } from '@testing-library/react';
 import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
 import { EVENT_SOURCE_CONTAINER_KIND } from '../../../const';
 import { getEventSourceIcon } from '../../../utils/get-knative-icon';
 import { EventSource } from '../EventSource';
 
-jest.mock('formik', () => ({
-  ...jest.requireActual('formik'),
-  Formik: 'Formik',
-}));
+global.ResizeObserver = class ResizeObserver {
+  observe = () => {};
+
+  unobserve = () => {};
+
+  disconnect = () => {};
+};
+
+jest.mock('@console/shared', () => {
+  const actual = jest.requireActual('@console/shared');
+  return {
+    ...actual,
+    SyncedEditorField: ({ formContext }: { formContext?: { editor?: ReactNode } }) => (
+      <>{formContext?.editor}</>
+    ),
+  };
+});
 
 describe('EventSourceSpec', () => {
   const namespaceName = 'myApp';
@@ -24,31 +38,47 @@ describe('EventSourceSpec', () => {
       },
       type: 'EventSource',
       provider: 'Red hat',
-      cta: { label: 'knative-plugin~Create Event Source', href: '/' },
+      cta: { label: 'Create Event Source', href: '/' },
     },
   };
 
   it('should render form with proper initialvalues if contextSource is not passed', () => {
-    const { container } = renderWithProviders(
+    renderWithProviders(
       <EventSource
         namespace={namespaceName}
         normalizedSource={eventSourceStatusData.eventSource}
         activeApplication={activeApplicationName}
+        sourceKind={EVENT_SOURCE_CONTAINER_KIND}
       />,
     );
-    expect(container.querySelector('Formik')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 1, name: EVENT_SOURCE_CONTAINER_KIND }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /Target/ })).toBeInTheDocument();
+    expect(
+      screen.getByText(/This resource will be the sink for the Event source/),
+    ).toBeInTheDocument();
   });
 
   it('should render form with proper initialvalues for sink if contextSource is passed', () => {
     const contextSourceData = 'serving.knative.dev~v1~Service/svc-display';
-    const { container } = renderWithProviders(
+    renderWithProviders(
       <EventSource
         namespace={namespaceName}
         normalizedSource={eventSourceStatusData.eventSource}
         contextSource={contextSourceData}
         activeApplication={activeApplicationName}
+        sourceKind={EVENT_SOURCE_CONTAINER_KIND}
       />,
     );
-    expect(container.querySelector('Formik')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 1, name: EVENT_SOURCE_CONTAINER_KIND }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /Target/ })).toBeInTheDocument();
+    expect(
+      screen.queryByText(/This resource will be the sink for the Event source/),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSourceAlert.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSourceAlert.spec.tsx
@@ -1,38 +1,35 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import EventSourceAlert from '../EventSourceAlert';
 
 jest.mock('@patternfly/react-core', () => ({
-  Alert: 'Alert',
+  Alert: () => 'mock-Alert',
 }));
 
 describe('EventSourceAlert', () => {
   it('should not alert if eventSources are there', () => {
-    const { container } = render(
-      <EventSourceAlert isValidSource createSourceAccessLoading={false} createSourceAccess />,
-    );
-    expect(container.querySelector('Alert')).not.toBeInTheDocument();
+    render(<EventSourceAlert isValidSource createSourceAccessLoading={false} createSourceAccess />);
+    expect(screen.queryByText('mock-Alert')).not.toBeInTheDocument();
   });
 
   it('should show alert if eventSource is present but do not have create access', () => {
-    const { container } = render(
+    render(
       <EventSourceAlert
         isValidSource
         createSourceAccessLoading={false}
         createSourceAccess={false}
       />,
     );
-    expect(container.querySelector('Alert')).toBeInTheDocument();
+    expect(screen.getByText('mock-Alert')).toBeVisible();
   });
 
   it('should show alert if eventSource is not present', () => {
-    const { container } = render(
+    render(
       <EventSourceAlert
         isValidSource={false}
         createSourceAccessLoading={false}
         createSourceAccess={false}
       />,
     );
-    expect(container.querySelector('Alert')).toBeInTheDocument();
+    expect(screen.getByText('mock-Alert')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSourceForm.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSourceForm.spec.tsx
@@ -1,26 +1,31 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import type { ComponentProps } from 'react';
-import { render } from '@testing-library/react';
+import type { ComponentProps, ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
 import { kameletSourceTelegram } from '../../../utils/__tests__/knative-eventing-data';
 import EventSourceForm from '../EventSourceForm';
 
-jest.mock('@console/shared', () => ({
-  FormFooter: 'FormFooter',
-  SyncedEditorField: 'SyncedEditorField',
-  FlexForm: 'FlexForm',
-  CodeEditorField: 'CodeEditorField',
-  FormBody: 'FormBody',
+jest.mock('@console/shared', () => {
+  const { createKnativeTextStub: createTextStub } = jest.requireActual(
+    '@console/knative-plugin/src/__tests__/rtl-stub-components',
+  );
+  return {
+    FormFooter: createTextStub('mock-FormFooter'),
+    SyncedEditorField: ({ formContext }: { formContext?: { editor?: ReactNode } }) =>
+      formContext?.editor ?? null,
+    FlexForm: ({ children }: { children?: ReactNode }) => children ?? null,
+    CodeEditorField: createTextStub('mock-CodeEditorField'),
+    FormBody: ({ children }: { children?: ReactNode }) => children ?? null,
+  };
+});
+
+jest.mock('../event-sources/EventSourceSection', () => ({
+  __esModule: true,
+  default: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-EventSourceSection'),
 }));
 
-jest.mock('../event-sources/EventSourceSection', () => 'EventSourceSection');
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-  withTranslation: () => (Component: any) => Component,
-}));
+jest.mock('react-i18next');
 
 let eventSourceFormProps: ComponentProps<typeof EventSourceForm>;
 
@@ -38,19 +43,15 @@ describe('EventSourceForm', () => {
     };
   });
 
-  it('should render FlexForm, SyncedEditorField and FormFooter if Source is valid', () => {
-    const { container } = render(<EventSourceForm {...eventSourceFormProps} />);
-    expect(container.querySelector('FlexForm')).toBeInTheDocument();
-    expect(container.querySelector('SyncedEditorField')).toBeInTheDocument();
-    expect(container.querySelector('FormFooter')).toBeInTheDocument();
+  it('should render EventSourceSection and FormFooter if Source is valid', () => {
+    render(<EventSourceForm {...eventSourceFormProps} />);
+    expect(screen.getByText('mock-FormFooter')).toBeVisible();
+    expect(screen.getByText('mock-EventSourceSection')).toBeVisible();
   });
 
-  it('should render FlexForm, SyncedEditorField and FormFooter if is a Kamelet', () => {
-    const { container } = render(
-      <EventSourceForm {...eventSourceFormProps} kameletSource={kameletSourceTelegram} />,
-    );
-    expect(container.querySelector('FlexForm')).toBeInTheDocument();
-    expect(container.querySelector('SyncedEditorField')).toBeInTheDocument();
-    expect(container.querySelector('FormFooter')).toBeInTheDocument();
+  it('should render EventSourceSection and FormFooter if is a Kamelet', () => {
+    render(<EventSourceForm {...eventSourceFormProps} kameletSource={kameletSourceTelegram} />);
+    expect(screen.getByText('mock-FormFooter')).toBeVisible();
+    expect(screen.getByText('mock-EventSourceSection')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/event-sinks/__tests__/EventSinkSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sinks/__tests__/EventSinkSection.spec.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { useFormikContext } from 'formik';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { mockKameletSink } from '../../__mocks__/Kamelet-data';
@@ -8,21 +7,29 @@ import EventSinkSection from '../EventSinkSection';
 
 jest.mock('../KafkaSinkSection', () => ({
   __esModule: true,
-  default: 'KafkaSinkSection',
+  default: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-KafkaSinkSection'),
 }));
 
 jest.mock('../SourceSection', () => ({
   __esModule: true,
-  default: 'SourceSection',
+  default: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-SourceSection'),
 }));
 
 jest.mock('@console/dev-console/src/components/import/app/AppSection', () => ({
   __esModule: true,
-  default: 'AppSection',
+  default: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-AppSection'),
 }));
 
 jest.mock('@console/shared', () => ({
-  DynamicFormField: 'DynamicFormField',
+  DynamicFormField: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-DynamicFormField'),
   useFormikValidationFix: jest.fn(),
 }));
 
@@ -88,27 +95,25 @@ describe('EventSinkSection', () => {
 
   it('should render SourceSection, AppSection, DynamicFormField for Kamelet sink', () => {
     (useK8sWatchResource as jest.Mock).mockReturnValue([[], true]);
-    const { container } = render(
-      <EventSinkSection namespace={namespace} kameletSink={mockKameletSink} />,
-    );
-    expect(container.querySelector('SourceSection')).toBeInTheDocument();
-    expect(container.querySelector('AppSection')).toBeInTheDocument();
-    expect(container.querySelector('DynamicFormField')).toBeInTheDocument();
+    render(<EventSinkSection namespace={namespace} kameletSink={mockKameletSink} />);
+    expect(screen.getByText('mock-SourceSection')).toBeVisible();
+    expect(screen.getByText('mock-AppSection')).toBeVisible();
+    expect(screen.getByText('mock-DynamicFormField')).toBeVisible();
   });
 
   it('should render AppSection and KafkaSinkSection for Kafka sink', () => {
     (useK8sWatchResource as jest.Mock).mockReturnValue([[], true]);
     mockFormikContext.mockReturnValue(formikMockDataKafkaSink);
-    const { container } = render(<EventSinkSection namespace={namespace} />);
-    expect(container.querySelector('KafkaSinkSection')).toBeInTheDocument();
-    expect(container.querySelector('AppSection')).toBeInTheDocument();
+    render(<EventSinkSection namespace={namespace} />);
+    expect(screen.getByText('mock-KafkaSinkSection')).toBeVisible();
+    expect(screen.getByText('mock-AppSection')).toBeVisible();
   });
 
   it('should not render SourceSection and DynamicFormField for Kafka sink', () => {
     (useK8sWatchResource as jest.Mock).mockReturnValue([[], true]);
     mockFormikContext.mockReturnValue(formikMockDataKafkaSink);
-    const { container } = render(<EventSinkSection namespace={namespace} />);
-    expect(container.querySelector('SourceSection')).not.toBeInTheDocument();
-    expect(container.querySelector('DynamicFormField')).not.toBeInTheDocument();
+    render(<EventSinkSection namespace={namespace} />);
+    expect(screen.queryByText('mock-SourceSection')).not.toBeInTheDocument();
+    expect(screen.queryByText('mock-DynamicFormField')).not.toBeInTheDocument();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/event-sinks/__tests__/KafkaSinkSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sinks/__tests__/KafkaSinkSection.spec.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import KafkaSinkSection from '../KafkaSinkSection';
 
@@ -9,7 +8,12 @@ jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
 
 jest.mock('@console/dev-console/src/components/import/section/FormSection', () => ({
   __esModule: true,
-  default: ({ children }) => children,
+  default: ({ title, children }: { title?: string; children?: React.ReactNode }) => (
+    <>
+      {title}
+      {children}
+    </>
+  ),
 }));
 
 jest.mock('@console/shared', () => ({
@@ -18,11 +22,7 @@ jest.mock('@console/shared', () => ({
   MultiTypeaheadField: 'MultiTypeaheadField',
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 jest.mock('../../../../hooks', () => ({
   useBootstrapServers: jest.fn(() => [[], 'placeholder']),
@@ -37,36 +37,24 @@ describe('KafkaSinkSection', () => {
     });
   });
 
-  it('should render KafkaSink FormSection', () => {
-    const { container } = render(<KafkaSinkSection title={title} namespace="my-app" />);
-    expect(container).toBeInTheDocument();
+  it('should render KafkaSink FormSection title', () => {
+    render(<KafkaSinkSection title={title} namespace="my-app" />);
+    expect(screen.getByText(title)).toBeVisible();
   });
 
   it('should render BootstrapServers and Topic fields with required and secret as not required', () => {
-    const { container } = render(<KafkaSinkSection title={title} namespace="my-app" />);
-    const bootstrapServersField = container.querySelector(
-      '[data-test="kafkasink-bootstrapservers-field"]',
-    );
-    expect(bootstrapServersField).toBeInTheDocument();
-
-    const topicsField = container.querySelector('[data-test="kafkasink-topic-field"]');
-    expect(topicsField).toBeInTheDocument();
-
-    const secretField = container.querySelector('[data-test="kafkasink-secret-field"]');
-    expect(secretField).toBeInTheDocument();
+    render(<KafkaSinkSection title={title} namespace="my-app" />);
+    expect(screen.getByTestId('kafkasink-bootstrapservers-field')).toBeInTheDocument();
+    expect(screen.getByTestId('kafkasink-topic-field')).toBeInTheDocument();
+    expect(screen.getByTestId('kafkasink-secret-field')).toBeInTheDocument();
   });
 
   it('should render BootstrapServers and topic fields even if secrets loaded failed', () => {
     (useK8sWatchResources as jest.Mock).mockReturnValueOnce({
       secrets: { data: [], loaded: false, loadError: 'Error' },
     });
-    const { container } = render(<KafkaSinkSection title={title} namespace="my-app" />);
-    const bootstrapServersField = container.querySelector(
-      '[data-test="kafkasink-bootstrapservers-field"]',
-    );
-    expect(bootstrapServersField).toBeInTheDocument();
-
-    const topicsField = container.querySelector('[data-test="kafkasink-topic-field"]');
-    expect(topicsField).toBeInTheDocument();
+    render(<KafkaSinkSection title={title} namespace="my-app" />);
+    expect(screen.getByTestId('kafkasink-bootstrapservers-field')).toBeInTheDocument();
+    expect(screen.getByTestId('kafkasink-topic-field')).toBeInTheDocument();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/ApiServerSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/ApiServerSection.spec.tsx
@@ -1,25 +1,33 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
+import type { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import ApiServerSection from '../ApiServerSection';
 
 jest.mock('@console/dev-console/src/components/import/section/FormSection', () => ({
   __esModule: true,
-  default: 'FormSection',
+  default: ({ children }: { children?: ReactNode }) => children ?? null,
 }));
 
 jest.mock('@console/internal/components/utils/async', () => ({
-  AsyncComponent: 'AsyncComponent',
+  AsyncComponent: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-AsyncComponent'),
 }));
 
 jest.mock('../../../dropdowns/ServiceAccountDropdown', () => ({
   __esModule: true,
-  default: 'ServiceAccountDropdown',
+  default: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-ServiceAccountDropdown'),
 }));
 
 jest.mock('@console/shared', () => ({
-  DropdownField: 'DropdownField',
+  DropdownField: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-DropdownField'),
   getFieldId: jest.fn(() => 'mocked-field-id'),
 }));
+
+jest.mock('react-i18next');
 
 jest.mock('formik', () => ({
   useField: jest.fn(() => [{}, {}]),
@@ -39,17 +47,17 @@ describe('ApiServerSection', () => {
 
   it('should render FormSection', () => {
     render(<ApiServerSection title={title} />);
-    expect(screen.getByText('Resource')).toBeInTheDocument();
+    expect(screen.getByText('Resource')).toBeVisible();
   });
 
   it('should render NameValueEditor', () => {
     render(<ApiServerSection title={title} />);
-    expect(screen.getByText('The list of resources to watch.')).toBeInTheDocument();
+    expect(screen.getByText('The list of resources to watch.')).toBeVisible();
   });
 
   it('should render ServiceAccountDropdown', () => {
-    const { container } = render(<ApiServerSection title={title} />);
-    expect(container.querySelector('dropdownfield')).toBeInTheDocument();
-    expect(container.querySelector('serviceaccountdropdown')).toBeInTheDocument();
+    render(<ApiServerSection title={title} />);
+    expect(screen.getByText('mock-DropdownField')).toBeVisible();
+    expect(screen.getByText('mock-ServiceAccountDropdown')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/ContainerSourceSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/ContainerSourceSection.spec.tsx
@@ -1,20 +1,26 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import ContainerSourceSection from '../ContainerSourceSection';
 
 jest.mock('@console/dev-console/src/components/import/section/FormSection', () => ({
   __esModule: true,
-  default: 'FormSection',
+  default: ({ children }: { children?: ReactNode }) => children ?? null,
 }));
 
 jest.mock('@console/internal/components/utils/async', () => ({
-  AsyncComponent: 'AsyncComponent',
+  AsyncComponent: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-AsyncComponent'),
 }));
 
 jest.mock('@console/shared', () => ({
-  TextColumnField: 'TextColumnField',
-  InputField: 'InputField',
+  TextColumnField: ({ label }: { label?: string }) => label ?? null,
+  InputField: ({ label, ...rest }: { label?: string; [k: string]: unknown }) => (
+    <input type="text" aria-label={label} {...(rest as ComponentPropsWithoutRef<'input'>)} />
+  ),
 }));
+
+jest.mock('react-i18next');
 
 jest.mock('formik', () => ({
   useField: jest.fn(() => [{}, {}]),
@@ -47,26 +53,23 @@ describe('ContainerSourceSection', () => {
   const title = 'Container Source';
 
   it('should render ContainerSource FormSection', () => {
-    const { container } = render(<ContainerSourceSection title={title} />);
-    expect(container.querySelector('FormSection')).toBeInTheDocument();
+    render(<ContainerSourceSection title={title} />);
     expect(screen.getByText('Container')).toBeInTheDocument();
   });
 
   it('should render Container image and name input fields', () => {
-    const { container } = render(<ContainerSourceSection title={title} />);
-    const imageInputField = container.querySelector('[data-test-id="container-image-field"]');
-    const nameInputField = container.querySelector('[data-test-id="container-name-field"]');
-    expect(imageInputField).toBeInTheDocument();
-    expect(nameInputField).toBeInTheDocument();
+    render(<ContainerSourceSection title={title} />);
+    expect(screen.getByRole('textbox', { name: 'Image' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Name' })).toBeInTheDocument();
   });
 
   it('should render Container args field', () => {
-    const { container } = render(<ContainerSourceSection title={title} />);
-    expect(container.querySelector('TextColumnField')).toBeInTheDocument();
+    render(<ContainerSourceSection title={title} />);
+    expect(screen.getByText('Arguments')).toBeInTheDocument();
   });
 
   it('should render environment variables section', () => {
-    const { container } = render(<ContainerSourceSection title={title} />);
-    expect(container.querySelector('AsyncComponent')).toBeInTheDocument();
+    render(<ContainerSourceSection title={title} />);
+    expect(screen.getByText('mock-AsyncComponent')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/EventSourceSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/EventSourceSection.spec.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import type { FormikValues } from 'formik';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { getDefaultEventingData } from '../../../../utils/__tests__/knative-serving-data';
@@ -10,12 +9,16 @@ const mockEventingData = getDefaultEventingData(EventSources.PingSource);
 
 jest.mock('@console/dev-console/src/components/import/app/AppSection', () => ({
   __esModule: true,
-  default: 'AppSection',
+  default: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-AppSection'),
 }));
 
 jest.mock('../SinkSection', () => ({
   __esModule: true,
-  default: 'SinkSection',
+  default: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-SinkSection'),
 }));
 
 jest.mock('formik', () => ({
@@ -36,8 +39,8 @@ describe('EventSource Section', () => {
 
   it('should render SinkSection, AppSection for CronjobSource', () => {
     (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
-    const { container } = render(<EventSourceSection namespace={namespace} />);
-    expect(container.querySelector('SinkSection')).toBeInTheDocument();
-    expect(container.querySelector('AppSection')).toBeInTheDocument();
+    render(<EventSourceSection namespace={namespace} />);
+    expect(screen.getByText('mock-SinkSection')).toBeVisible();
+    expect(screen.getByText('mock-AppSection')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/KafkaSourceNetSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/KafkaSourceNetSection.spec.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import KafkaSourceNetSection from '../KafkaSourceNetSection';
 
 jest.mock('../../SecretKeySelector', () => ({
   __esModule: true,
-  default: 'SecretKeySelector',
+  default: () => <span data-test="mock-SecretKeySelector" />,
 }));
 
 jest.mock('formik', () => ({
@@ -36,8 +35,7 @@ jest.mock('formik', () => ({
 
 describe('KafkaSourceNetSection', () => {
   it('should render SecretKeySelector field for tls and sasl when they are enabled', () => {
-    const { container } = render(<KafkaSourceNetSection />);
-    const secretKeySelectors = container.querySelectorAll('SecretKeySelector');
-    expect(secretKeySelectors).toHaveLength(5);
+    render(<KafkaSourceNetSection />);
+    expect(screen.getAllByTestId('mock-SecretKeySelector')).toHaveLength(5);
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/KafkaSourceSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/KafkaSourceSection.spec.tsx
@@ -1,23 +1,36 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import KafkaSourceSection from '../KafkaSourceSection';
 
 jest.mock('@console/dev-console/src/components/import/section/FormSection', () => ({
   __esModule: true,
-  default: 'FormSection',
+  default: ({ children, title }: { children?: ReactNode; title?: ReactNode }) => (
+    <div>
+      {title != null ? <h2>{title}</h2> : null}
+      {children}
+    </div>
+  ),
 }));
 
 jest.mock('../KafkaSourceNetSection', () => ({
   __esModule: true,
-  default: 'KafkaSourceNetSection',
+  default: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-KafkaSourceNetSection'),
 }));
 
 jest.mock('@console/shared', () => ({
-  MultiTypeaheadField: 'MultiTypeaheadField',
+  MultiTypeaheadField: ({ label, ...rest }: { label?: string; [k: string]: unknown }) => (
+    <input type="text" aria-label={label} {...(rest as ComponentPropsWithoutRef<'input'>)} />
+  ),
   ResourceDropdownField: 'ResourceDropdownField',
-  InputField: 'InputField',
+  InputField: ({ label, ...rest }: { label?: string; [k: string]: unknown }) => (
+    <input type="text" aria-label={label} {...(rest as ComponentPropsWithoutRef<'input'>)} />
+  ),
 }));
+
+jest.mock('react-i18next');
 
 jest.mock('formik', () => ({
   useField: jest.fn(() => [{}, {}]),
@@ -41,8 +54,8 @@ describe('KafkaSourceSection', () => {
       kafkatopics: { data: [], loaded: true },
       kafkaconnections: { data: [], loaded: true },
     });
-    const { container } = render(<KafkaSourceSection title={title} namespace="my-app" />);
-    expect(container.querySelector('FormSection')).toBeInTheDocument();
+    render(<KafkaSourceSection title={title} namespace="my-app" />);
+    expect(screen.getByRole('heading', { name: title })).toBeInTheDocument();
   });
 
   it('should render BootstrapServers and Topics fields with ', () => {
@@ -51,16 +64,16 @@ describe('KafkaSourceSection', () => {
       kafkatopics: { data: [], loaded: true },
       kafkaconnections: { data: [], loaded: true },
     });
-    const { container } = render(<KafkaSourceSection title={title} namespace="my-app" />);
-    const bootstrapServersField = container.querySelector(
-      '[data-test-id="kafkasource-bootstrapservers-field"]',
-    );
+    render(<KafkaSourceSection title={title} namespace="my-app" />);
+    const bootstrapServersField = screen.getByRole('textbox', {
+      name: 'Bootstrap servers',
+    });
     expect(bootstrapServersField).toBeInTheDocument();
-    expect(bootstrapServersField).toHaveAttribute('required');
+    expect(bootstrapServersField).toBeRequired();
 
-    const topicsField = container.querySelector('[data-test-id="kafkasource-topics-field"]');
+    const topicsField = screen.getByRole('textbox', { name: 'Topics' });
     expect(topicsField).toBeInTheDocument();
-    expect(topicsField).toHaveAttribute('required');
+    expect(topicsField).toBeRequired();
   });
 
   it('should render consumergroup, netsection', () => {
@@ -69,13 +82,13 @@ describe('KafkaSourceSection', () => {
       kafkatopics: { data: [], loaded: true },
       kafkaconnections: { data: [], loaded: true },
     });
-    const { container } = render(<KafkaSourceSection title={title} namespace="my-app" />);
-    const consumerGroupField = container.querySelector(
-      '[data-test-id="kafkasource-consumergroup-field"]',
-    );
+    render(<KafkaSourceSection title={title} namespace="my-app" />);
+    const consumerGroupField = screen.getByRole('textbox', {
+      name: 'Consumer group',
+    });
     expect(consumerGroupField).toBeInTheDocument();
-    expect(consumerGroupField).toHaveAttribute('required');
-    expect(container.querySelector('KafkaSourceNetSection')).toBeInTheDocument();
+    expect(consumerGroupField).toBeRequired();
+    expect(screen.getByText('mock-KafkaSourceNetSection')).toBeVisible();
   });
 
   it('should render BootstrapServers and Topics fields with even if kafkaconnections loaded failed', () => {
@@ -84,15 +97,15 @@ describe('KafkaSourceSection', () => {
       kafkatopics: { data: [], loaded: true },
       kafkaconnections: { data: null, loaded: false, loadError: 'Error' },
     });
-    const { container } = render(<KafkaSourceSection title={title} namespace="my-app" />);
-    const bootstrapServersField = container.querySelector(
-      '[data-test-id="kafkasource-bootstrapservers-field"]',
-    );
+    render(<KafkaSourceSection title={title} namespace="my-app" />);
+    const bootstrapServersField = screen.getByRole('textbox', {
+      name: 'Bootstrap servers',
+    });
     expect(bootstrapServersField).toBeInTheDocument();
-    expect(bootstrapServersField).toHaveAttribute('required');
+    expect(bootstrapServersField).toBeRequired();
 
-    const topicsField = container.querySelector('[data-test-id="kafkasource-topics-field"]');
+    const topicsField = screen.getByRole('textbox', { name: 'Topics' });
     expect(topicsField).toBeInTheDocument();
-    expect(topicsField).toHaveAttribute('required');
+    expect(topicsField).toBeRequired();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/SinkBindingSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/SinkBindingSection.spec.tsx
@@ -1,18 +1,25 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import SinkBindingSection from '../SinkBindingSection';
 
 jest.mock('@console/dev-console/src/components/import/section/FormSection', () => ({
   __esModule: true,
-  default: 'FormSection',
+  default: ({ children, title }: { children?: ReactNode; title?: ReactNode }) => (
+    <>
+      {title}
+      {children}
+    </>
+  ),
 }));
 
 jest.mock('@console/internal/components/utils/async', () => ({
-  AsyncComponent: 'AsyncComponent',
+  AsyncComponent: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-AsyncComponent'),
 }));
 
 jest.mock('@console/shared', () => ({
-  InputField: 'InputField',
+  InputField: () => <span data-test="mock-InputField" />,
   DropdownField: 'DropdownField',
   getFieldId: jest.fn(() => 'mocked-field-id'),
 }));
@@ -22,11 +29,7 @@ jest.mock('@console/shared/src/components/heading/TertiaryHeading', () => ({
   default: 'TertiaryHeading',
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 jest.mock('formik', () => ({
   useField: jest.fn(() => [{}, {}]),
@@ -45,18 +48,17 @@ describe('SinkBindingSection', () => {
   const title = 'Sink Binding';
 
   it('should render FormSection', () => {
-    const { container } = render(<SinkBindingSection title={title} />);
-    expect(container.querySelector('FormSection')).toBeInTheDocument();
+    render(<SinkBindingSection title={title} />);
+    expect(screen.getByText(title)).toBeInTheDocument();
   });
 
   it('should render NameValueEditor', () => {
-    const { container } = render(<SinkBindingSection title={title} />);
-    expect(container.querySelector('AsyncComponent')).toBeInTheDocument();
+    render(<SinkBindingSection title={title} />);
+    expect(screen.getByText('mock-AsyncComponent')).toBeVisible();
   });
 
   it('should render InputFields', () => {
-    const { container } = render(<SinkBindingSection title={title} />);
-    const inputFields = container.querySelectorAll('InputField');
-    expect(inputFields).toHaveLength(2);
+    render(<SinkBindingSection title={title} />);
+    expect(screen.getAllByTestId('mock-InputField')).toHaveLength(2);
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/form-fields/__tests__/SinkResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/form-fields/__tests__/SinkResources.spec.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
+import { screen } from '@testing-library/react';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
 import SinkResources from '../SinkResources';
 
-// Mock PatternFly topology to prevent console warnings during tests
 jest.mock('@patternfly/react-topology', () => ({}));
 
 jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
@@ -15,7 +14,9 @@ jest.mock('../../../../../utils/fetch-dynamic-eventsources-utils', () => ({
 }));
 
 jest.mock('@console/shared', () => ({
-  ResourceDropdownField: 'ResourceDropdownField',
+  ResourceDropdownField: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-ResourceDropdownField'),
   getFieldId: jest.fn(() => 'mocked-field-id'),
 }));
 
@@ -46,14 +47,12 @@ describe('SinkResources', () => {
   });
 
   it('should be able to sink to k8s service', () => {
-    const { container } = renderWithProviders(<SinkResources isMoveSink namespace="test" />);
-    const resourceDropdownField = container.querySelector('ResourceDropdownField');
-    expect(resourceDropdownField).toBeInTheDocument();
+    renderWithProviders(<SinkResources isMoveSink namespace="test" />);
+    expect(screen.getByText('mock-ResourceDropdownField')).toBeVisible();
   });
 
   it('should be able to sink to knative service, broker, k8s service and channels', async () => {
-    const { container } = renderWithProviders(<SinkResources isMoveSink namespace="test" />);
-    const resourceDropdownField = container.querySelector('ResourceDropdownField');
-    expect(resourceDropdownField).toBeInTheDocument();
+    renderWithProviders(<SinkResources isMoveSink namespace="test" />);
+    expect(await screen.findByText('mock-ResourceDropdownField')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/eventing/__tests__/EventingListPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/eventing/__tests__/EventingListPage.spec.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import * as Router from 'react-router';
 import * as ConsoleShared from '@console/shared';
 import EventingListPage from '../EventingListPage';
@@ -10,19 +9,15 @@ jest.mock('react-router', () => ({
 }));
 
 jest.mock('@console/internal/components/namespace-bar', () => ({
-  NamespaceBar: 'NamespaceBar',
+  NamespaceBar: () => <div data-test="mock-NamespaceBar" />,
 }));
 
 jest.mock('@console/shared', () => ({
-  MultiTabListPage: jest.fn(() => 'MultiTabListPage'),
+  MultiTabListPage: jest.fn(() => <div data-test="mock-MultiTabListPage" />),
   isCatalogTypeEnabled: jest.fn(() => true),
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 jest.mock('../brokers-list/BrokerListPage', () => ({
   __esModule: true,
@@ -60,9 +55,9 @@ describe('EventingListPage', () => {
   });
 
   it('should render NamespaceBar and MultiTabListPage', () => {
-    const { container } = render(<EventingListPage />);
-    expect(container.querySelector('NamespaceBar')).toBeInTheDocument();
-    expect(container.textContent).toContain('MultiTabListPage');
+    render(<EventingListPage />);
+    expect(screen.getByTestId('mock-NamespaceBar')).toBeVisible();
+    expect(screen.getByTestId('mock-MultiTabListPage')).toBeVisible();
   });
 
   it('should render MultiTabListPage with correct props', () => {
@@ -70,7 +65,7 @@ describe('EventingListPage', () => {
 
     expect(mockMultiTabListPage).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'knative-plugin~Eventing',
+        title: 'Eventing',
         pages: expect.arrayContaining([
           expect.objectContaining({
             component: expect.any(String),
@@ -84,15 +79,15 @@ describe('EventingListPage', () => {
         ]),
         menuActions: expect.objectContaining({
           eventSource: expect.objectContaining({
-            label: 'knative-plugin~Event Source',
+            label: 'Event Source',
             onSelection: expect.any(Function),
           }),
           brokers: expect.objectContaining({
-            label: 'knative-plugin~Broker',
+            label: 'Broker',
             onSelection: expect.any(Function),
           }),
           channels: expect.objectContaining({
-            label: 'knative-plugin~Channel',
+            label: 'Channel',
             onSelection: expect.any(Function),
           }),
         }),

--- a/frontend/packages/knative-plugin/src/components/knatify/__tests__/CreateKnatifyPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/knatify/__tests__/CreateKnatifyPage.spec.tsx
@@ -68,12 +68,7 @@ jest.mock('react-router', () => ({
   useNavigate: jest.fn(() => jest.fn()),
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-  withTranslation: () => (Component: any) => Component,
-}));
+jest.mock('react-i18next');
 
 const useK8sWatchResourcesMock = useK8sWatchResources as jest.Mock;
 const useRelatedHPAMock = useRelatedHPA as jest.Mock;

--- a/frontend/packages/knative-plugin/src/components/knatify/__tests__/KnatifyForm.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/knatify/__tests__/KnatifyForm.spec.tsx
@@ -1,44 +1,49 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import type { ComponentProps } from 'react';
-import { render } from '@testing-library/react';
+import type { ComponentProps, ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
 import KnatifyForm from '../KnatifyForm';
 
 jest.mock('@console/dev-console/src/components/import/advanced/AdvancedSection', () => ({
   __esModule: true,
-  default: 'AdvancedSection',
+  default: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-AdvancedSection'),
 }));
 
 jest.mock('@console/dev-console/src/components/import/app/AppSection', () => ({
   __esModule: true,
-  default: 'AppSection',
+  default: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-AppSection'),
 }));
 
 jest.mock('@console/dev-console/src/components/import/image-search/ImageSearchSection', () => ({
   __esModule: true,
-  default: 'ImageSearchSection',
+  default: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-ImageSearchSection'),
 }));
 
 jest.mock('@console/dev-console/src/components/import/section/IconSection', () => ({
   __esModule: true,
-  default: 'IconSection',
+  default: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-IconSection'),
 }));
 
 jest.mock('@console/shared/src/components/form-utils', () => ({
-  FormFooter: 'FormFooter',
-  FlexForm: 'FlexForm',
-  FormBody: 'FormBody',
+  FormFooter: jest
+    .requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .createKnativeTextStub('mock-FormFooter'),
+  FlexForm: ({ children }: { children?: ReactNode }) => children ?? null,
+  FormBody: ({ children }: { children?: ReactNode }) => children ?? null,
 }));
 
 jest.mock('@console/internal/components/utils', () => ({
   usePreventDataLossLock: jest.fn(),
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 let knatifyFormProps: ComponentProps<typeof KnatifyForm>;
 
@@ -54,11 +59,11 @@ describe('KnatifyForm', () => {
   });
 
   it('should render ImageSearchSection, IconSection, AppSection, AdvancedSection and FormFooter', () => {
-    const { container } = render(<KnatifyForm {...knatifyFormProps} />);
-    expect(container.querySelector('ImageSearchSection')).toBeInTheDocument();
-    expect(container.querySelector('IconSection')).toBeInTheDocument();
-    expect(container.querySelector('AppSection')).toBeInTheDocument();
-    expect(container.querySelector('AdvancedSection')).toBeInTheDocument();
-    expect(container.querySelector('FormFooter')).toBeInTheDocument();
+    render(<KnatifyForm {...knatifyFormProps} />);
+    expect(screen.getByText('mock-ImageSearchSection')).toBeVisible();
+    expect(screen.getByText('mock-IconSection')).toBeVisible();
+    expect(screen.getByText('mock-AppSection')).toBeVisible();
+    expect(screen.getByText('mock-AdvancedSection')).toBeVisible();
+    expect(screen.getByText('mock-FormFooter')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewListItem.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewListItem.tsx
@@ -44,7 +44,7 @@ const RevisionsOverviewListItem: FC<RevisionsOverviewListItemProps> = ({ revisio
         )}
       </Grid>
       {deploymentData.name && (
-        <div className="odc-revision-deployment-list">
+        <div className="odc-revision-deployment-list" data-test="revision-deployment-list">
           <Grid hasGutter>
             <GridItem span={9} sm={8}>
               <ResourceLink

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/ConfigurationsOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/ConfigurationsOverviewList.spec.tsx
@@ -1,11 +1,10 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
 import { render, screen } from '@testing-library/react';
 import { sampleKnativeConfigurations } from '../../../topology/__tests__/topology-knative-test-data';
 import ConfigurationsOverviewList from '../ConfigurationsOverviewList';
 
 jest.mock('../ConfigurationsOverviewListItem', () => ({
   __esModule: true,
-  default: 'ConfigurationsOverviewListItem',
+  default: () => <span data-test="mock-ConfigurationsOverviewListItem" />,
 }));
 
 describe('ConfigurationsOverviewList', () => {
@@ -15,9 +14,7 @@ describe('ConfigurationsOverviewList', () => {
   });
 
   it('should render ConfigurationsOverviewListItem', () => {
-    const { container } = render(
-      <ConfigurationsOverviewList configurations={sampleKnativeConfigurations.data} />,
-    );
-    expect(container.querySelector('ConfigurationsOverviewListItem')).toBeInTheDocument();
+    render(<ConfigurationsOverviewList configurations={sampleKnativeConfigurations.data} />);
+    expect(screen.getByTestId('mock-ConfigurationsOverviewListItem')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/ConfigurationsOverviewListItem.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/ConfigurationsOverviewListItem.spec.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
+import type { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { ConfigurationModel } from '../../../models';
@@ -6,27 +6,28 @@ import { sampleKnativeConfigurations } from '../../../topology/__tests__/topolog
 import ConfigurationsOverviewListItem from '../ConfigurationsOverviewListItem';
 
 jest.mock('@patternfly/react-core', () => ({
-  ListItem: 'ListItem',
+  ListItem: ({ children }: { children?: ReactNode }) => (
+    <div data-test="mock-ListItem">{children}</div>
+  ),
 }));
 
-jest.mock('@console/internal/components/utils', () => ({
-  ResourceLink: 'ResourceLink',
-}));
+jest.mock(
+  '@console/internal/components/utils',
+  () =>
+    jest.requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+      .knativeInternalUtilsStubs,
+);
 
 describe('ConfigurationsOverviewListItem', () => {
   it('should list the Configuration', () => {
-    const { container } = render(
-      <ConfigurationsOverviewListItem configuration={sampleKnativeConfigurations.data[0]} />,
-    );
-    expect(container.querySelector('ListItem')).toBeInTheDocument();
+    render(<ConfigurationsOverviewListItem configuration={sampleKnativeConfigurations.data[0]} />);
+    expect(screen.getByTestId('mock-ListItem')).toBeVisible();
   });
 
   it('should have ResourceLink with proper kind', () => {
-    const { container } = render(
-      <ConfigurationsOverviewListItem configuration={sampleKnativeConfigurations.data[0]} />,
-    );
-    const resourceLink = container.querySelector('ResourceLink');
-    expect(resourceLink).toBeInTheDocument();
+    render(<ConfigurationsOverviewListItem configuration={sampleKnativeConfigurations.data[0]} />);
+    const resourceLink = screen.getByTestId('mock-ResourceLink');
+    expect(resourceLink).toBeVisible();
     expect(resourceLink).toHaveAttribute('kind', referenceForModel(ConfigurationModel));
   });
 
@@ -37,15 +38,12 @@ describe('ConfigurationsOverviewListItem', () => {
       status: { latestCreatedRevisionName },
     } = sampleKnativeConfigurations.data[0];
 
-    // Check for the labels and the revision names
     expect(screen.getByText('Latest created Revision name:')).toBeInTheDocument();
     expect(screen.getByText('Latest ready Revision name:')).toBeInTheDocument();
 
-    // Use getAllByText to handle duplicate revision names
     const revisionNameElements = screen.getAllByText(latestCreatedRevisionName);
-    expect(revisionNameElements).toHaveLength(2); // Should appear twice if they're the same
+    expect(revisionNameElements).toHaveLength(2);
 
-    // Or verify just that the text content includes both revision names
     expect(screen.getByText('Latest created Revision name:')).toBeInTheDocument();
     expect(screen.getByText('Latest ready Revision name:')).toBeInTheDocument();
   });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/DeploymentOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/DeploymentOverviewList.spec.tsx
@@ -1,13 +1,14 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { revisionObj } from '../../../topology/__tests__/topology-knative-test-data';
 import { usePodsForRevisions } from '../../../utils/usePodsForRevisions';
 import DeploymentOverviewList from '../DeploymentOverviewList';
 
-jest.mock('@console/internal/components/utils', () => ({
-  ResourceLink: 'ResourceLink',
-  SidebarSectionHeading: 'SidebarSectionHeading',
-}));
+jest.mock(
+  '@console/internal/components/utils',
+  () =>
+    jest.requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+      .knativeInternalUtilsStubs,
+);
 
 jest.mock('../../../utils/usePodsForRevisions', () => ({
   usePodsForRevisions: jest.fn(),
@@ -50,8 +51,8 @@ describe('DeploymentOverviewList', () => {
   });
 
   it('should render DeploymentOverviewList with ResourceLink', () => {
-    const { container } = render(<DeploymentOverviewList resource={revisionObj} />);
-    expect(container.querySelector('SidebarSectionHeading')).toBeInTheDocument();
-    expect(container.querySelector('ResourceLink')).toBeInTheDocument();
+    render(<DeploymentOverviewList resource={revisionObj} />);
+    expect(screen.getByTestId('mock-SidebarSectionHeading')).toBeVisible();
+    expect(screen.getByTestId('mock-ResourceLink')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/EventPubSubResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/EventPubSubResources.spec.tsx
@@ -1,27 +1,29 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { render, screen } from '@testing-library/react';
 import type { K8sResourceKind } from '@console/internal/module/k8s';
-import type { Subscriber } from 'packages/knative-plugin/src/topology/topology-types';
 import {
   EventSubscriptionObj,
   EventIMCObj,
   knativeServiceObj,
   EventBrokerObj,
   EventTriggerObj,
-} from '../../../topology/__tests__/topology-knative-test-data';
+} from '@console/knative-plugin/src/topology/__tests__/topology-knative-test-data';
+import type { Subscriber } from '@console/knative-plugin/src/topology/topology-types';
 import EventPubSubResources, { PubSubResourceOverviewList } from '../EventPubSubResources';
 
-jest.mock('@console/internal/components/utils', () => ({
-  ResourceLink: 'ResourceLink',
-  SidebarSectionHeading: 'SidebarSectionHeading',
-}));
+jest.mock(
+  '@console/internal/components/utils',
+  () =>
+    jest.requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+      .knativeInternalUtilsStubs,
+);
 
 jest.mock('../EventPubSubSubscribers', () => ({
   __esModule: true,
-  default: 'PubSubSubscribers',
+  default: () => <div data-test="mock-PubSubSubscribers" />,
 }));
 
-type EventPubSubResourcesProps = React.ComponentProps<typeof EventPubSubResources>;
+type EventPubSubResourcesProps = ComponentProps<typeof EventPubSubResources>;
 let sampleItemData: EventPubSubResourcesProps;
 
 const sampleSubscribers: Subscriber[] = [
@@ -50,14 +52,11 @@ describe('EventPubSubResources', () => {
   };
 
   it('should render related resources for the Subscription', () => {
-    const { container } = render(<EventPubSubResources item={sampleItemData.item} />);
-    const sidebarHeadings = container.querySelectorAll('SidebarSectionHeading');
-    expect(sidebarHeadings).toHaveLength(3);
-    expect(
-      container.querySelector('SidebarSectionHeading[text="Event Sources"]'),
-    ).toBeInTheDocument();
-    expect(container.querySelector('SidebarSectionHeading[text="Channel"]')).toBeInTheDocument();
-    expect(container.querySelector('SidebarSectionHeading[text="Subscriber"]')).toBeInTheDocument();
+    render(<EventPubSubResources item={sampleItemData.item} />);
+    expect(screen.getAllByTestId('mock-SidebarSectionHeading')).toHaveLength(3);
+    expect(screen.getByRole('heading', { name: 'Event Sources' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Channel' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Subscriber' })).toBeInTheDocument();
   });
 
   it('should render related resources for channel without subscribers', () => {
@@ -67,12 +66,9 @@ describe('EventPubSubResources', () => {
       ksservices: [knativeServiceObj],
       eventingsubscription: [EventSubscriptionObj],
     };
-    const { container } = render(<EventPubSubResources item={channelItemData} />);
-    const sidebarHeadings = container.querySelectorAll('SidebarSectionHeading');
-    expect(sidebarHeadings).toHaveLength(1); // Only Event Sources
-    expect(
-      container.querySelector('SidebarSectionHeading[text="Event Sources"]'),
-    ).toBeInTheDocument();
+    render(<EventPubSubResources item={channelItemData} />);
+    expect(screen.getAllByTestId('mock-SidebarSectionHeading')).toHaveLength(1);
+    expect(screen.getByRole('heading', { name: 'Event Sources' })).toBeInTheDocument();
   });
 
   it('should render related resources for channel with subscribers', () => {
@@ -83,14 +79,10 @@ describe('EventPubSubResources', () => {
       eventingsubscription: [EventSubscriptionObj],
       subscribers: sampleSubscribers,
     };
-    const { container } = render(<EventPubSubResources item={channelItemData} />);
-    const sidebarHeadings = container.querySelectorAll('SidebarSectionHeading');
-    const pubSubSubscribers = container.querySelectorAll('PubSubSubscribers');
-    expect(sidebarHeadings).toHaveLength(1); // Only Event Sources (PubSubSubscribers doesn't add SidebarSectionHeading to the count)
-    expect(
-      container.querySelector('SidebarSectionHeading[text="Event Sources"]'),
-    ).toBeInTheDocument();
-    expect(pubSubSubscribers).toHaveLength(1);
+    render(<EventPubSubResources item={channelItemData} />);
+    expect(screen.getAllByTestId('mock-SidebarSectionHeading')).toHaveLength(1);
+    expect(screen.getByRole('heading', { name: 'Event Sources' })).toBeInTheDocument();
+    expect(screen.getAllByTestId('mock-PubSubSubscribers')).toHaveLength(1);
   });
 
   it('should render broker section if the kind is Broker and  without subscribers ', () => {
@@ -100,16 +92,11 @@ describe('EventPubSubResources', () => {
       ksservices: [knativeServiceObj],
       triggers: [EventTriggerObj],
     };
-    const { container } = render(<EventPubSubResources item={brokerItemData} />);
-    const sidebarHeadings = container.querySelectorAll('SidebarSectionHeading');
-    expect(sidebarHeadings).toHaveLength(3); // Event Sources + Pods + Deployments
-    expect(
-      container.querySelector('SidebarSectionHeading[text="Event Sources"]'),
-    ).toBeInTheDocument();
-    expect(container.querySelector('SidebarSectionHeading[text="Pods"]')).toBeInTheDocument();
-    expect(
-      container.querySelector('SidebarSectionHeading[text="Deployments"]'),
-    ).toBeInTheDocument();
+    render(<EventPubSubResources item={brokerItemData} />);
+    expect(screen.getAllByTestId('mock-SidebarSectionHeading')).toHaveLength(3);
+    expect(screen.getByRole('heading', { name: 'Event Sources' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Pods' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Deployments' })).toBeInTheDocument();
   });
 
   it('should render broker section with Subscribers if the kind is Broker and subscribers available ', () => {
@@ -120,11 +107,9 @@ describe('EventPubSubResources', () => {
       triggers: [EventTriggerObj],
       subscribers: sampleSubscribers,
     };
-    const { container } = render(<EventPubSubResources item={brokerItemData} />);
-    const pubSubSubscribers = container.querySelectorAll('PubSubSubscribers');
-    const sidebarHeadings = container.querySelectorAll('SidebarSectionHeading');
-    expect(sidebarHeadings).toHaveLength(3); // Event Sources + Pods + Deployments (PubSubSubscribers doesn't add to count)
-    expect(pubSubSubscribers).toHaveLength(1);
+    render(<EventPubSubResources item={brokerItemData} />);
+    expect(screen.getAllByTestId('mock-PubSubSubscribers')).toHaveLength(1);
+    expect(screen.getAllByTestId('mock-SidebarSectionHeading')).toHaveLength(3);
   });
 });
 
@@ -132,20 +117,18 @@ describe('PubSubResourceOverviewList', () => {
   const itemsData: K8sResourceKind[] = [EventIMCObj, knativeServiceObj];
 
   it('should render ResourceLink respective for each resources, SidebarSectionHeading and no span', () => {
-    const { container } = render(
-      <PubSubResourceOverviewList items={itemsData} title="Connections" />,
-    );
-    const resourceLinks = container.querySelectorAll('ResourceLink');
+    render(<PubSubResourceOverviewList items={itemsData} title="Connections" />);
+    const resourceLinks = screen.getAllByTestId('mock-ResourceLink');
     expect(resourceLinks).toHaveLength(2);
     expect(resourceLinks[0]).toHaveAttribute('name', 'testchannel');
-    expect(container.querySelector('SidebarSectionHeading')).toBeInTheDocument();
-    expect(container.querySelector('.pf-v6-u-text-color-subtle')).not.toBeInTheDocument();
+    expect(screen.getByTestId('mock-SidebarSectionHeading')).toBeVisible();
+    expect(screen.queryByText('No Connections found for this resource.')).not.toBeInTheDocument();
   });
 
   it('should render SidebarSectionHeading, pf-v6-u-text-color-subtle and not ResourceLink if no resources exists', () => {
-    const { container } = render(<PubSubResourceOverviewList items={[]} title="Connections" />);
-    expect(container.querySelector('ResourceLink')).not.toBeInTheDocument();
-    expect(container.querySelector('SidebarSectionHeading')).toBeInTheDocument();
-    expect(container.querySelector('.pf-v6-u-text-color-subtle')).toBeInTheDocument();
+    render(<PubSubResourceOverviewList items={[]} title="Connections" />);
+    expect(screen.queryByTestId('mock-ResourceLink')).not.toBeInTheDocument();
+    expect(screen.getByTestId('mock-SidebarSectionHeading')).toBeVisible();
+    expect(screen.getByText('No Connections found for this resource.')).toBeInTheDocument();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSourceOwnedList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSourceOwnedList.spec.tsx
@@ -1,14 +1,15 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import type { K8sResourceKind } from '@console/internal/module/k8s';
 import { EVENT_SOURCE_SINK_BINDING_KIND, KNATIVE_EVENT_SOURCE_APIGROUP } from '../../../const';
 import { getEventSourceResponse } from '../../../topology/__tests__/topology-knative-test-data';
 import EventSourceOwnedList from '../EventSourceOwnedList';
 
-jest.mock('@console/internal/components/utils', () => ({
-  ResourceLink: 'ResourceLink',
-  SidebarSectionHeading: 'SidebarSectionHeading',
-}));
+jest.mock(
+  '@console/internal/components/utils',
+  () =>
+    jest.requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+      .knativeInternalUtilsStubs,
+);
 
 describe('EventSourceOwnedList', () => {
   const mockData: K8sResourceKind = getEventSourceResponse(
@@ -18,8 +19,8 @@ describe('EventSourceOwnedList', () => {
   ).data[0];
 
   it('should render SidebarSectionHeading, ResourceLink', () => {
-    const { container } = render(<EventSourceOwnedList source={mockData} />);
-    expect(container.querySelector('SidebarSectionHeading')).toBeInTheDocument();
-    expect(container.querySelector('ResourceLink')).toBeInTheDocument();
+    render(<EventSourceOwnedList source={mockData} />);
+    expect(screen.getByTestId('mock-SidebarSectionHeading')).toBeVisible();
+    expect(screen.getByTestId('mock-ResourceLink')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSourceResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSourceResources.spec.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
+import type { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import * as _ from 'lodash';
 import { referenceForModel } from '@console/internal/module/k8s';
@@ -13,30 +13,32 @@ import { ServiceModel } from '../../../models';
 import { getEventSourceResponse } from '../../../topology/__tests__/topology-knative-test-data';
 import { EventSourceTarget } from '../EventSourceResources';
 
-jest.mock('@console/internal/components/utils', () => ({
-  ResourceLink: 'ResourceLink',
-  SidebarSectionHeading: 'SidebarSectionHeading',
-}));
+jest.mock(
+  '@console/internal/components/utils',
+  () =>
+    jest.requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+      .knativeInternalUtilsStubs,
+);
 
 jest.mock('@console/shared/src/components/links/ExternalLink', () => ({
-  ExternalLink: 'ExternalLink',
+  ExternalLink: ({ href, children }: { href?: string; children?: ReactNode }) => (
+    <a data-test="mock-ExternalLink" href={href}>
+      {children}
+    </a>
+  ),
 }));
 
 jest.mock('../EventSourceOwnedList', () => ({
   __esModule: true,
-  default: 'EventSourceOwnedList',
+  default: () => <div data-test="mock-EventSourceOwnedList" />,
 }));
 
 jest.mock('@patternfly/react-core', () => ({
-  List: 'List',
-  ListItem: 'ListItem',
+  List: ({ children }: { children?: ReactNode }) => children ?? null,
+  ListItem: ({ children }: { children?: ReactNode }) => children ?? null,
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 jest.mock('@console/shared', () => {
   const ActualShared = jest.requireActual('@console/shared');
@@ -60,7 +62,7 @@ describe('EventSinkServicesOverviewList', () => {
   });
 
   it('should have ResourceLink with proper kind for sink to knSvc', () => {
-    const { container } = render(
+    render(
       <EventSourceTarget
         obj={
           getEventSourceResponse(KNATIVE_EVENT_SOURCE_APIGROUP, 'v1', EVENT_SOURCE_API_SERVER_KIND)
@@ -68,8 +70,8 @@ describe('EventSinkServicesOverviewList', () => {
         }
       />,
     );
-    const resourceLink = container.querySelector('ResourceLink');
-    expect(resourceLink).toBeInTheDocument();
+    const resourceLink = screen.getByTestId('mock-ResourceLink');
+    expect(resourceLink).toBeVisible();
     expect(resourceLink).toHaveAttribute('kind', referenceForModel(ServiceModel));
   });
 
@@ -86,9 +88,9 @@ describe('EventSinkServicesOverviewList', () => {
         .data[0],
       ...{ spec: sinkData },
     };
-    const { container } = render(<EventSourceTarget obj={sinkChannelData} />);
-    const resourceLink = container.querySelector('ResourceLink');
-    expect(resourceLink).toBeInTheDocument();
+    render(<EventSourceTarget obj={sinkChannelData} />);
+    const resourceLink = screen.getByTestId('mock-ResourceLink');
+    expect(resourceLink).toBeVisible();
     expect(resourceLink).toHaveAttribute('kind', 'messaging.knative.dev~v1~InMemoryChannel');
   });
 
@@ -100,13 +102,13 @@ describe('EventSinkServicesOverviewList', () => {
         uri: 'http://overlayimage.testproject3.svc.cluster.local',
       },
     };
-    const { container } = render(<EventSourceTarget obj={mockData} />);
-    expect(container.querySelector('ExternalLink')).toBeInTheDocument();
-    expect(container.querySelector('ResourceLink')).not.toBeInTheDocument();
+    render(<EventSourceTarget obj={mockData} />);
+    expect(screen.getByTestId('mock-ExternalLink')).toBeVisible();
+    expect(screen.queryByTestId('mock-ResourceLink')).not.toBeInTheDocument();
   });
 
   it('should have ExternalLink when sinkUri is present', () => {
-    const { container } = render(
+    render(
       <EventSourceTarget
         obj={
           getEventSourceResponse(KNATIVE_EVENT_SOURCE_APIGROUP, 'v1', EVENT_SOURCE_API_SERVER_KIND)
@@ -114,7 +116,7 @@ describe('EventSinkServicesOverviewList', () => {
         }
       />,
     );
-    expect(container.querySelector('ExternalLink')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-ExternalLink')).toBeVisible();
   });
 
   it('should not have ExternalLink when no sinkUri is present', () => {
@@ -123,7 +125,7 @@ describe('EventSinkServicesOverviewList', () => {
         .data[0],
       'status',
     );
-    const { container } = render(<EventSourceTarget obj={mockEventSourceDataNoURI} />);
-    expect(container.querySelector('ExternalLink')).not.toBeInTheDocument();
+    render(<EventSourceTarget obj={mockEventSourceDataNoURI} />);
+    expect(screen.queryByTestId('mock-ExternalLink')).not.toBeInTheDocument();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KSRouteSplitListItem.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KSRouteSplitListItem.spec.tsx
@@ -1,17 +1,25 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import { MockKnativeResources } from '../../../topology/__tests__/topology-knative-test-data';
 import { getKnativeRoutesLinks } from '../../../utils/resource-overview-utils';
 import KSRouteSplitListItem from '../KSRouteSplitListItem';
 
 jest.mock('@patternfly/react-core', () => ({
-  ListItem: 'ListItem',
-  Grid: 'Grid',
-  GridItem: 'GridItem',
+  ListItem: ({ children }: { children?: ReactNode }) => (
+    <div data-test="mock-ListItem">{children}</div>
+  ),
+  Grid: ({ children }: { children?: ReactNode }) => <div data-test="mock-Grid">{children}</div>,
+  GridItem: ({ children }: { children?: ReactNode }) => (
+    <div data-test="mock-GridItem">{children}</div>
+  ),
 }));
 
 jest.mock('@console/shared/src/components/links/ExternalLink', () => ({
-  ExternalLink: 'ExternalLink',
+  ExternalLink: ({ href, children }: { href?: string; children?: ReactNode }) => (
+    <a data-test="mock-ExternalLink" href={href}>
+      {children}
+    </a>
+  ),
 }));
 
 describe('KSRouteSplitListItem', () => {
@@ -25,15 +33,15 @@ describe('KSRouteSplitListItem', () => {
 
   it('should list the Route', () => {
     const route = getRouteData();
-    const { container } = render(<KSRouteSplitListItem route={route} />);
-    expect(container.querySelector('ListItem')).toBeInTheDocument();
+    render(<KSRouteSplitListItem route={route} />);
+    expect(screen.getByTestId('mock-ListItem')).toBeVisible();
   });
 
   it('should have route ExternalLink with proper href', () => {
     const route = getRouteData();
-    const { container } = render(<KSRouteSplitListItem route={route} />);
-    const externalLink = container.querySelector('ExternalLink');
-    expect(externalLink).toBeInTheDocument();
+    render(<KSRouteSplitListItem route={route} />);
+    const externalLink = screen.getByTestId('mock-ExternalLink');
+    expect(externalLink).toBeVisible();
     expect(externalLink).toHaveAttribute(
       'href',
       'http://overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com',
@@ -56,8 +64,8 @@ describe('KSRouteSplitListItem', () => {
       },
     };
     const [route] = getKnativeRoutesLinks(mockRouteData, MockKnativeResources.revisions.data[0]);
-    const { container } = render(<KSRouteSplitListItem route={route} />);
-    expect(container.querySelector('ExternalLink')).not.toBeInTheDocument();
+    render(<KSRouteSplitListItem route={route} />);
+    expect(screen.queryByTestId('mock-ExternalLink')).not.toBeInTheDocument();
   });
 
   it('should not render if percent is not available', () => {
@@ -76,7 +84,7 @@ describe('KSRouteSplitListItem', () => {
       },
     };
     const [route] = getKnativeRoutesLinks(mockRouteData, MockKnativeResources.revisions.data[0]);
-    const { container } = render(<KSRouteSplitListItem route={route} />);
-    expect(container.querySelector('ExternalLink')).not.toBeInTheDocument();
+    render(<KSRouteSplitListItem route={route} />);
+    expect(screen.queryByTestId('mock-ExternalLink')).not.toBeInTheDocument();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KSRoutesOverviewListItem.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KSRoutesOverviewListItem.spec.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import * as _ from 'lodash';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { RouteModel } from '../../../models';
@@ -7,9 +7,13 @@ import { MockKnativeResources } from '../../../topology/__tests__/topology-knati
 import KSRoutesOverviewListItem from '../KSRoutesOverviewListItem';
 
 jest.mock('@patternfly/react-core', () => ({
-  ListItem: 'ListItem',
-  Grid: 'Grid',
-  GridItem: 'GridItem',
+  ListItem: ({ children }: { children?: ReactNode }) => (
+    <div data-test="mock-ListItem">{children}</div>
+  ),
+  Grid: ({ children }: { children?: ReactNode }) => <div data-test="mock-Grid">{children}</div>,
+  GridItem: ({ children }: { children?: ReactNode }) => (
+    <div data-test="mock-GridItem">{children}</div>
+  ),
 }));
 
 jest.mock('@patternfly/react-core/dist/dynamic/components/ClipboardCopy', () => ({
@@ -17,58 +21,58 @@ jest.mock('@patternfly/react-core/dist/dynamic/components/ClipboardCopy', () => 
 }));
 
 jest.mock('@console/internal/components/utils', () => ({
-  ResourceLink: 'ResourceLink',
-  ExternalLinkWithCopy: 'ExternalLinkWithCopy',
+  ResourceLink: jest.requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .knativeInternalUtilsStubs.ResourceLink,
+  ExternalLinkWithCopy: ({ href, text }: { href?: string; text?: string }) => (
+    <a data-test="mock-ExternalLinkWithCopy" href={href ?? '#'}>
+      {text}
+    </a>
+  ),
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 describe('KSRoutesOverviewListItem', () => {
   const [ksroute] = MockKnativeResources.ksroutes.data;
 
   it('should list the Route', () => {
-    const { container } = render(<KSRoutesOverviewListItem ksroute={ksroute} />);
-    expect(container.querySelector('ListItem')).toBeInTheDocument();
+    render(<KSRoutesOverviewListItem ksroute={ksroute} />);
+    expect(screen.getByTestId('mock-ListItem')).toBeVisible();
   });
 
   it('should have ResourceLink with proper kind', () => {
-    const { container } = render(<KSRoutesOverviewListItem ksroute={ksroute} />);
-    const resourceLink = container.querySelector('ResourceLink');
-    expect(resourceLink).toBeInTheDocument();
+    render(<KSRoutesOverviewListItem ksroute={ksroute} />);
+    const resourceLink = screen.getByTestId('mock-ResourceLink');
+    expect(resourceLink).toBeVisible();
     expect(resourceLink).toHaveAttribute('kind', referenceForModel(RouteModel));
   });
 
   it('should have route ExternalLink with proper href', () => {
-    const { container } = render(<KSRoutesOverviewListItem ksroute={ksroute} />);
-    const externalLink = container.querySelector('ExternalLinkWithCopy');
-    expect(externalLink).toBeInTheDocument();
+    render(<KSRoutesOverviewListItem ksroute={ksroute} />);
+    const externalLink = screen.getByTestId('mock-ExternalLinkWithCopy');
+    expect(externalLink).toBeVisible();
     expect(externalLink).toHaveAttribute(
       'href',
       'http://overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com',
     );
-    expect(externalLink).toHaveAttribute(
-      'text',
+    expect(externalLink).toHaveTextContent(
       'http://overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com',
     );
   });
 
   it('should not show the route url if it is not available', () => {
     const ksrouteNoUrl = { ...MockKnativeResources.ksroutes.data[0], status: { url: '' } };
-    const { container } = render(<KSRoutesOverviewListItem ksroute={ksrouteNoUrl} />);
-    expect(container.querySelector('ResourceLink')).toBeInTheDocument();
-    expect(container.querySelector('ExternalLinkWithCopy')).not.toBeInTheDocument();
+    render(<KSRoutesOverviewListItem ksroute={ksrouteNoUrl} />);
+    expect(screen.getByTestId('mock-ResourceLink')).toBeVisible();
+    expect(screen.queryByTestId('mock-ExternalLinkWithCopy')).not.toBeInTheDocument();
   });
 
   it('should have ResourceLink with proper kind and not external link if status is not preset on route', () => {
     const ksrouteNoStatus = _.omit(MockKnativeResources.ksroutes.data[0], 'status');
-    const { container } = render(<KSRoutesOverviewListItem ksroute={ksrouteNoStatus} />);
-    const resourceLink = container.querySelector('ResourceLink');
-    expect(resourceLink).toBeInTheDocument();
+    render(<KSRoutesOverviewListItem ksroute={ksrouteNoStatus} />);
+    const resourceLink = screen.getByTestId('mock-ResourceLink');
+    expect(resourceLink).toBeVisible();
     expect(resourceLink).toHaveAttribute('kind', referenceForModel(RouteModel));
-    expect(container.querySelector('ExternalLinkWithCopy')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-ExternalLinkWithCopy')).not.toBeInTheDocument();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/RevisionsOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/RevisionsOverviewList.spec.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
+import type { ComponentType } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as _ from 'lodash';
@@ -13,11 +13,11 @@ import {
 import * as TrafficSplittingController from '../../traffic-splitting/TrafficSplittingController';
 import RevisionsOverviewList from '../RevisionsOverviewList';
 
-// Mock Kebab factory at the very top to avoid hoisting issues
 jest.mock('@console/internal/components/utils', () => ({
-  SidebarSectionHeading: 'SidebarSectionHeading',
+  ...jest.requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .knativeInternalUtilsStubs,
   useAccessReview: jest.fn(),
-  withHandlePromise: () => (Component: React.ComponentType) => Component,
+  withHandlePromise: () => (Component: ComponentType) => Component,
   Kebab: {
     factory: {
       common: [],
@@ -31,30 +31,45 @@ jest.mock('../../traffic-splitting/TrafficSplittingController', () => ({
 }));
 
 jest.mock('@patternfly/react-core', () => ({
-  Button: 'Button',
-  List: 'List',
+  Button: ({ children, isDisabled, onClick, ...rest }: any) => (
+    <button
+      type="button"
+      data-test="mock-Button"
+      disabled={!!isDisabled}
+      onClick={onClick}
+      {...rest}
+    >
+      {children}
+    </button>
+  ),
+  List: ({ children, ...rest }: any) => (
+    <div data-test="mock-List" {...rest}>
+      {children}
+    </div>
+  ),
 }));
 
 jest.mock('react-router', () => ({
-  Link: 'Link',
+  Link: ({ children, to, className, ...rest }: any) => {
+    const href = typeof to === 'string' ? to : '#';
+    return (
+      <a data-test="mock-Link" href={href} className={className} {...rest}>
+        {children}
+      </a>
+    );
+  },
 }));
 
 jest.mock('../RevisionsOverviewListItem', () => ({
   __esModule: true,
-  default: 'RevisionsOverviewListItem',
+  default: () => <div data-test="mock-RevisionsOverviewListItem" />,
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-  withTranslation: () => (Component: React.ComponentType) => Component,
-}));
+jest.mock('react-i18next');
 
 const useTrafficSplittingModalLauncherMock = TrafficSplittingController.useTrafficSplittingModalLauncher as jest.Mock;
 
 describe('RevisionsOverviewList', () => {
-  // Get the mocked function using the imported function
   const mockUseAccessReview = useAccessReview as any;
 
   beforeEach(() => {
@@ -66,36 +81,35 @@ describe('RevisionsOverviewList', () => {
   });
 
   it('should have title Revisions', () => {
-    const { container } = render(
+    render(
       <RevisionsOverviewList
         revisions={MockKnativeResources.revisions.data}
         service={MockKnativeResources.ksservices.data[0]}
       />,
     );
-    const sidebarHeading = container.querySelector('SidebarSectionHeading');
-    expect(sidebarHeading).toBeInTheDocument();
-    expect(sidebarHeading).toHaveAttribute('text', expect.stringContaining('Revisions'));
+    expect(screen.getByRole('heading', { name: 'Revisions' })).toBeInTheDocument();
   });
 
   it('should show info if no Revisions present, link for all revisions should not be shown and traffic split button should be disabled', () => {
-    const { container } = render(
+    render(
       <RevisionsOverviewList revisions={[]} service={MockKnativeResources.revisions.data[0]} />,
     );
-    expect(container.querySelector('Link')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-Link')).not.toBeInTheDocument();
     expect(screen.getByText(/No Revisions found for this resource/)).toBeInTheDocument();
-    const button = container.querySelector('Button');
-    expect(button).toBeInTheDocument();
+    const button = screen.getByTestId('mock-Button');
+    expect(button).toBeVisible();
+    expect(button).toBeDisabled();
   });
 
   it('should show Resource Link if number of revisions is more than MAX_REVISIONS', () => {
-    const { container } = render(
+    render(
       <RevisionsOverviewList
         revisions={mockRevisions}
         service={MockKnativeResources.ksservices.data[0]}
       />,
     );
-    const link = container.querySelector('Link');
-    expect(link).toBeInTheDocument();
+    const link = screen.getByTestId('mock-Link');
+    expect(link).toBeVisible();
     const url = `/search/ns/${MockKnativeResources.ksservices.data[0].metadata?.namespace}`;
     const params = new URLSearchParams();
     params.append('kind', referenceForModel(RevisionModel));
@@ -103,70 +117,68 @@ describe('RevisionsOverviewList', () => {
       'q',
       `serving.knative.dev/service=${MockKnativeResources.ksservices.data[0].metadata?.name}`,
     );
-    expect(link).toHaveAttribute('to', `${url}?${params.toString()}`);
-    expect(link?.textContent).toContain('View all');
+    expect(link).toHaveAttribute('href', `${url}?${params.toString()}`);
+    expect(link.textContent).toContain('View all');
   });
 
   it('should not show Resource Link if number of revisions is less than MAX_REVISIONS', () => {
-    const { container } = render(
+    render(
       <RevisionsOverviewList
         revisions={MockKnativeResources.revisions.data}
         service={MockKnativeResources.ksservices.data[0]}
       />,
     );
-    expect(container.querySelector('Link')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-Link')).not.toBeInTheDocument();
   });
 
   it('should have button for traffic distribution and enabled', () => {
-    const { container } = render(
+    render(
       <RevisionsOverviewList
         revisions={MockKnativeResources.revisions.data}
         service={MockKnativeResources.ksservices.data[0]}
       />,
     );
-    const button = container.querySelector('Button');
-    expect(button).toBeInTheDocument();
+    const button = screen.getByTestId('mock-Button');
+    expect(button).toBeVisible();
     expect(button).toHaveTextContent(/Set traffic distribution/);
-    // Check that button is NOT disabled (no isdisabled attribute)
-    expect(button?.outerHTML).not.toContain('isdisabled');
+    expect(button).not.toBeDisabled();
   });
 
   it('should call setTrafficDistributionModal on click', async () => {
     const user = userEvent.setup();
     const trafficSplitModalLauncherMock = jest.fn();
     useTrafficSplittingModalLauncherMock.mockImplementation(() => trafficSplitModalLauncherMock);
-    const { container } = render(
+    render(
       <RevisionsOverviewList
         revisions={MockKnativeResources.revisions.data}
         service={MockKnativeResources.ksservices.data[0]}
       />,
     );
-    const button = container.querySelector('Button');
-    expect(button).toBeInTheDocument();
-    await user.click(button as HTMLElement);
+    const button = screen.getByTestId('mock-Button');
+    expect(button).toBeVisible();
+    await user.click(button);
     expect(trafficSplitModalLauncherMock).toHaveBeenCalled();
   });
 
   it('should not show button for traffic distribution if access is not there', () => {
     mockUseAccessReview.mockReturnValue(false);
-    const { container } = render(
+    render(
       <RevisionsOverviewList
         revisions={MockKnativeResources.revisions.data}
         service={MockKnativeResources.revisions.data[0]}
       />,
     );
-    expect(container.querySelector('Button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-Button')).not.toBeInTheDocument();
   });
 
   it('should render RevisionsOverviewListItem for revisions as many as MAX_REVISION if number of revisions receiving traffic is less than MAX_REVISION', () => {
-    const { container } = render(
+    render(
       <RevisionsOverviewList
         revisions={mockRevisions}
         service={MockKnativeResources.ksservices.data[0]}
       />,
     );
-    const listItems = container.querySelectorAll('RevisionsOverviewListItem');
-    expect(listItems).toHaveLength(3);
+    expect(screen.getAllByTestId('mock-RevisionsOverviewListItem')).toHaveLength(3);
   });
 
   it('should render RevisionsOverviewListItem for all revisions receiving traffic', () => {
@@ -175,10 +187,7 @@ describe('RevisionsOverviewList', () => {
       'status.traffic',
       mockTrafficData,
     );
-    const { container } = render(
-      <RevisionsOverviewList revisions={mockRevisions} service={serviceWithTraffic} />,
-    );
-    const listItems = container.querySelectorAll('RevisionsOverviewListItem');
-    expect(listItems).toHaveLength(4);
+    render(<RevisionsOverviewList revisions={mockRevisions} service={serviceWithTraffic} />);
+    expect(screen.getAllByTestId('mock-RevisionsOverviewListItem')).toHaveLength(4);
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/RevisionsOverviewListItem.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/RevisionsOverviewListItem.spec.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { MockKnativeResources } from '../../../topology/__tests__/topology-knative-test-data';
 import { usePodsForRevisions } from '../../../utils/usePodsForRevisions';
@@ -37,22 +36,37 @@ jest.mock('@patternfly/react-charts/victory', () => ({
 }));
 
 jest.mock('@patternfly/react-core', () => ({
-  ListItem: 'ListItem',
-  Grid: 'Grid',
-  GridItem: 'GridItem',
+  ListItem: ({ children, ...rest }: any) => (
+    <div data-test="mock-ListItem" {...rest}>
+      {children}
+    </div>
+  ),
+  Grid: ({ children, ...rest }: any) => (
+    <div data-test="mock-Grid" {...rest}>
+      {children}
+    </div>
+  ),
+  GridItem: ({ children, ...rest }: any) => <div {...rest}>{children}</div>,
 }));
 
-jest.mock('@console/internal/components/utils', () => ({
-  ResourceLink: 'ResourceLink',
-}));
+jest.mock(
+  '@console/internal/components/utils',
+  () =>
+    jest.requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+      .knativeInternalUtilsStubs,
+);
 
 jest.mock('@console/shared', () => ({
-  PodStatus: 'PodStatus',
+  PodStatus: ({ title }: { title?: string }) => (
+    <div data-test="mock-PodStatus" title={title}>
+      {title}
+    </div>
+  ),
 }));
 
 jest.mock('../RoutesUrlLink', () => ({
   __esModule: true,
-  default: 'RoutesUrlLink',
+  default: () => <div data-test="mock-RoutesUrlLink" />,
 }));
 
 jest.mock('../../../utils/usePodsForRevisions', () => ({
@@ -77,47 +91,47 @@ describe('RevisionsOverviewListItem', () => {
   });
 
   it('should list the Revision', () => {
-    const { container } = render(
+    render(
       <RevisionsOverviewListItem
         revision={MockKnativeResources.revisions.data[0]}
         service={MockKnativeResources.ksservices.data[0]}
       />,
     );
-    expect(container.querySelector('ListItem')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-ListItem')).toBeVisible();
   });
 
   it('should have ResourceLink with proper kind', () => {
-    const { container } = render(
+    render(
       <RevisionsOverviewListItem
         revision={MockKnativeResources.revisions.data[0]}
         service={MockKnativeResources.ksservices.data[0]}
       />,
     );
-    const resourceLink = container.querySelector('ResourceLink');
-    expect(resourceLink).toBeInTheDocument();
+    const resourceLink = screen.getByTestId('mock-ResourceLink');
+    expect(resourceLink).toBeVisible();
     expect(resourceLink).toHaveAttribute('kind', 'RevisionModel');
   });
 
   it('should show traffic percent', () => {
-    const { container } = render(
+    render(
       <RevisionsOverviewListItem
         revision={MockKnativeResources.revisions.data[0]}
         service={MockKnativeResources.ksservices.data[0]}
       />,
     );
-    const trafficPercent = container.querySelector('[data-test="revision-traffic-percent"]');
+    const trafficPercent = screen.getByTestId('revision-traffic-percent');
     expect(trafficPercent).toBeInTheDocument();
     expect(trafficPercent).toHaveTextContent('100%');
   });
 
   it('should not show deployments if not present', () => {
-    const { container } = render(
+    render(
       <RevisionsOverviewListItem
         revision={MockKnativeResources.revisions.data[0]}
         service={MockKnativeResources.ksservices.data[0]}
       />,
     );
-    expect(container.querySelector('.odc-revision-deployment-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('revision-deployment-list')).not.toBeInTheDocument();
   });
 
   it('should sum the traffic percentage for the same revision', () => {
@@ -132,14 +146,14 @@ describe('RevisionsOverviewListItem', () => {
         ],
       },
     };
-    const { container } = render(
+    render(
       <RevisionsOverviewListItem
         revision={MockKnativeResources.revisions.data[0]}
         service={mockServiceData}
       />,
     );
-    expect(container.querySelector('ResourceLink')).toBeInTheDocument();
-    const trafficPercent = container.querySelector('[data-test="revision-traffic-percent"]');
+    expect(screen.getByTestId('mock-ResourceLink')).toBeVisible();
+    const trafficPercent = screen.getByTestId('revision-traffic-percent');
     expect(trafficPercent).toHaveTextContent('100%');
   });
 
@@ -191,14 +205,14 @@ describe('RevisionsOverviewListItem', () => {
         },
       };
       const mockRevisionsDepData = { ...MockKnativeResources.revisions.data[0], resources };
-      const { container } = render(
+      render(
         <RevisionsOverviewListItem
           revision={mockRevisionsDepData}
           service={MockKnativeResources.ksservices.data[0]}
         />,
       );
-      expect(container.querySelector('.odc-revision-deployment-list')).toBeInTheDocument();
-      const resourceLinks = container.querySelectorAll('ResourceLink');
+      expect(screen.getByTestId('revision-deployment-list')).toBeInTheDocument();
+      const resourceLinks = screen.getAllByTestId('mock-ResourceLink');
       expect(resourceLinks).toHaveLength(2);
       expect(resourceLinks[1]).toHaveAttribute('kind', 'Deployment');
     });
@@ -224,14 +238,14 @@ describe('RevisionsOverviewListItem', () => {
         },
       };
       const mockRevisionsDepData = { ...MockKnativeResources.revisions.data[0], resources };
-      const { container } = render(
+      render(
         <RevisionsOverviewListItem
           revision={mockRevisionsDepData}
           service={MockKnativeResources.ksservices.data[0]}
         />,
       );
-      const podStatus = container.querySelector('PodStatus');
-      expect(podStatus).toBeInTheDocument();
+      const podStatus = screen.getByTestId('mock-PodStatus');
+      expect(podStatus).toBeVisible();
       expect(podStatus).toHaveAttribute('title', '1');
     });
   });
@@ -241,12 +255,12 @@ describe('RevisionsOverviewListItem', () => {
       ...MockKnativeResources.ksservices.data[0],
     };
     delete mockKsvc.status;
-    const { container } = render(
+    render(
       <RevisionsOverviewListItem
         revision={MockKnativeResources.revisions.data[0]}
         service={mockKsvc}
       />,
     );
-    expect(container.querySelector('RoutesUrlLink')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-RoutesUrlLink')).not.toBeInTheDocument();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/RoutesOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/RoutesOverviewList.spec.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
+import type { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import type { K8sResourceKind } from '@console/internal/module/k8s/types';
 import { MockKnativeResources } from '../../../topology/__tests__/topology-knative-test-data';
@@ -8,24 +8,23 @@ jest.mock('@console/internal/components/utils/rbac', () => ({
   useAccessReview: jest.fn(() => true),
 }));
 
-jest.mock('@console/internal/components/utils', () => ({
-  SidebarSectionHeading: 'SidebarSectionHeading',
-}));
+jest.mock(
+  '@console/internal/components/utils',
+  () =>
+    jest.requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+      .knativeInternalUtilsStubs,
+);
 
 jest.mock('@patternfly/react-core', () => ({
-  List: 'List',
+  List: ({ children }: { children?: ReactNode }) => <>{children}</>,
 }));
 
 jest.mock('../KSRoutes', () => ({
   __esModule: true,
-  default: 'KSRoutes',
+  default: () => null,
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 jest.mock('../../../utils/resource-overview-utils', () => ({
   getKnativeRoutesLinks: jest.fn(() => [{ url: 'test-url' }]),
@@ -34,7 +33,7 @@ jest.mock('../../../utils/resource-overview-utils', () => ({
 
 jest.mock('../RoutesOverviewListItem', () => ({
   __esModule: true,
-  default: 'RoutesOverviewListItem',
+  default: () => <div data-test="mock-RoutesOverviewListItem" />,
 }));
 
 describe('RoutesOverviewList', () => {
@@ -44,24 +43,23 @@ describe('RoutesOverviewList', () => {
   });
 
   it('should render RoutesOverviewListItem', () => {
-    const { container } = render(
+    render(
       <RoutesOverviewList
         ksroutes={MockKnativeResources.ksroutes.data}
         resource={MockKnativeResources.revisions.data[0]}
       />,
     );
-    expect(container.querySelector('list')).toBeInTheDocument();
-    expect(container.querySelector('routesoverviewlistitem')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-RoutesOverviewListItem')).toBeVisible();
   });
 
   it('should render multiple RoutesOverviewListItem when multiple routes', () => {
-    const { container } = render(
+    render(
       <RoutesOverviewList
         ksroutes={MockKnativeResources.ksroutes.data}
         resource={MockKnativeResources.revisions.data[0]}
       />,
     );
-    expect(container.querySelector('routesoverviewlistitem')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-RoutesOverviewListItem')).toBeVisible();
   });
 
   it('should render with different route data', () => {
@@ -79,13 +77,13 @@ describe('RoutesOverviewList', () => {
       },
     };
 
-    const { container } = render(
+    render(
       <RoutesOverviewList
         ksroutes={[mockRouteData]}
         resource={MockKnativeResources.revisions.data[0]}
       />,
     );
-    expect(container.querySelector('routesoverviewlistitem')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-RoutesOverviewListItem')).toBeVisible();
   });
 
   it('should handle complex route configurations', () => {
@@ -110,12 +108,12 @@ describe('RoutesOverviewList', () => {
       },
     };
 
-    const { container } = render(
+    render(
       <RoutesOverviewList
         ksroutes={[mockRouteData]}
         resource={MockKnativeResources.revisions.data[0]}
       />,
     );
-    expect(container.querySelector('routesoverviewlistitem')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-RoutesOverviewListItem')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/RoutesOverviewListItem.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/RoutesOverviewListItem.spec.tsx
@@ -1,18 +1,25 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import { MockKnativeResources } from '../../../topology/__tests__/topology-knative-test-data';
 import { getKnativeRoutesLinks } from '../../../utils/resource-overview-utils';
 import RoutesOverviewListItem from '../RoutesOverviewListItem';
 
 jest.mock('@patternfly/react-core', () => ({
-  ListItem: 'ListItem',
-  Grid: 'Grid',
-  GridItem: 'GridItem',
+  ListItem: ({ children }: { children?: ReactNode }) => (
+    <div data-test="mock-ListItem">{children}</div>
+  ),
+  Grid: ({ children }: { children?: ReactNode }) => <div data-test="mock-Grid">{children}</div>,
+  GridItem: ({ children }: { children?: ReactNode }) => (
+    <div data-test="mock-GridItem">{children}</div>
+  ),
 }));
 
-jest.mock('@console/internal/components/utils', () => ({
-  ResourceLink: 'ResourceLink',
-}));
+jest.mock(
+  '@console/internal/components/utils',
+  () =>
+    jest.requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+      .knativeInternalUtilsStubs,
+);
 
 jest.mock('@console/internal/module/k8s', () => ({
   referenceForModel: jest.fn(() => 'RouteModel'),
@@ -28,20 +35,15 @@ jest.mock('../../../utils/resource-overview-utils', () => ({
   getKnativeRoutesLinks: jest.fn(),
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
-// Variable to capture RoutesUrlLink props for testing
 let mockCapturedRoutesUrlLinkProps: any[] = [];
 
 jest.mock('../RoutesUrlLink', () => ({
   __esModule: true,
   default: (props: any) => {
     mockCapturedRoutesUrlLinkProps.push(props);
-    return 'RoutesUrlLink';
+    return <div data-test="mock-RoutesUrlLink" />;
   },
 }));
 
@@ -65,8 +67,8 @@ describe('RoutesOverviewListItem', () => {
       MockKnativeResources.ksroutes.data[0],
       MockKnativeResources.revisions.data[0],
     );
-    const { container } = render(<RoutesOverviewListItem routeLink={routeLink} />);
-    expect(container.querySelector('ListItem')).toBeInTheDocument();
+    render(<RoutesOverviewListItem routeLink={routeLink} />);
+    expect(screen.getByTestId('mock-ListItem')).toBeVisible();
   });
 
   it('should have ResourceLink with proper kind', () => {
@@ -74,9 +76,9 @@ describe('RoutesOverviewListItem', () => {
       MockKnativeResources.ksroutes.data[0],
       MockKnativeResources.revisions.data[0],
     );
-    const { container } = render(<RoutesOverviewListItem routeLink={routeLink} />);
-    const resourceLink = container.querySelector('ResourceLink');
-    expect(resourceLink).toBeInTheDocument();
+    render(<RoutesOverviewListItem routeLink={routeLink} />);
+    const resourceLink = screen.getByTestId('mock-ResourceLink');
+    expect(resourceLink).toBeVisible();
     expect(resourceLink).toHaveAttribute('kind', 'RouteModel');
   });
 
@@ -87,12 +89,11 @@ describe('RoutesOverviewListItem', () => {
     );
     render(<RoutesOverviewListItem routeLink={routeLink} />);
 
-    // Check that the mock was called
     expect(mockCapturedRoutesUrlLinkProps).toHaveLength(1);
     expect(mockCapturedRoutesUrlLinkProps[0].urls).toEqual([
       'http://overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com',
     ]);
-    expect(mockCapturedRoutesUrlLinkProps[0].title).toEqual('knative-plugin~Location');
+    expect(mockCapturedRoutesUrlLinkProps[0].title).toEqual('Location');
   });
 
   it('should render with unique routes', () => {
@@ -119,10 +120,9 @@ describe('RoutesOverviewListItem', () => {
       />,
     );
 
-    // Should render two RoutesUrlLink components (location + unique route)
     expect(mockCapturedRoutesUrlLinkProps).toHaveLength(2);
-    expect(mockCapturedRoutesUrlLinkProps[0].title).toEqual('knative-plugin~Location');
-    expect(mockCapturedRoutesUrlLinkProps[1].title).toEqual('knative-plugin~Unique Route');
+    expect(mockCapturedRoutesUrlLinkProps[0].title).toEqual('Location');
+    expect(mockCapturedRoutesUrlLinkProps[1].title).toEqual('Unique Route');
   });
 
   it('should render with total percent', () => {
@@ -131,7 +131,7 @@ describe('RoutesOverviewListItem', () => {
       MockKnativeResources.revisions.data[0],
     );
 
-    const { container } = render(
+    render(
       <RoutesOverviewListItem
         routeLink={routeLink}
         uniqueRoutes={['https://tag1.test.com', 'https://tag2.test.com']}
@@ -139,13 +139,9 @@ describe('RoutesOverviewListItem', () => {
       />,
     );
 
-    // Should render two RoutesUrlLink components (location + unique route)
     expect(mockCapturedRoutesUrlLinkProps).toHaveLength(2);
 
-    // Check percentage element
-    const percentElement = container.querySelector('[data-test="route-percent"]');
-    expect(percentElement).toBeInTheDocument();
-    expect(percentElement).toHaveTextContent('50%');
+    expect(screen.getByText('50%')).toBeInTheDocument();
   });
 
   it('should not show route url when no data available', () => {
@@ -162,10 +158,10 @@ describe('RoutesOverviewListItem', () => {
       MockKnativeResources.ksroutes.data[0],
       MockKnativeResources.revisions.data[0],
     );
-    const { container } = render(<RoutesOverviewListItem routeLink={routeLink} />);
+    render(<RoutesOverviewListItem routeLink={routeLink} />);
 
-    expect(container.querySelector('ResourceLink')).toBeInTheDocument();
-    expect(container.querySelector('routesurllink')).not.toBeInTheDocument();
-    expect(container.querySelector('[data-test="route-percent"]')).not.toBeInTheDocument();
+    expect(screen.getByTestId('mock-ResourceLink')).toBeVisible();
+    expect(screen.queryByTestId('mock-RoutesUrlLink')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('route-percent')).not.toBeInTheDocument();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/serving-list/__tests__/ServingListPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/serving-list/__tests__/ServingListPage.spec.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import * as Router from 'react-router';
 import ServingListPage from '../ServingListsPage';
 
@@ -9,18 +8,14 @@ jest.mock('react-router', () => ({
 }));
 
 jest.mock('@console/internal/components/namespace-bar', () => ({
-  NamespaceBar: 'NamespaceBar',
+  NamespaceBar: () => <div data-test="mock-NamespaceBar" />,
 }));
 
 jest.mock('@console/shared', () => ({
-  MultiTabListPage: 'MultiTabListPage',
+  MultiTabListPage: () => <div data-test="mock-MultiTabListPage" />,
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 jest.mock('@console/internal/module/k8s', () => ({
   referenceForModel: jest.fn(() => 'serving.knative.dev~v1~Service'),
@@ -49,14 +44,14 @@ describe('ServingListPage', () => {
   });
 
   it('should render NamespaceBar and MultiTabListPage', () => {
-    const { container } = render(<ServingListPage />);
-    expect(container.querySelector('namespacebar')).toBeInTheDocument();
-    expect(container.querySelector('multitablistpage')).toBeInTheDocument();
+    render(<ServingListPage />);
+    expect(screen.getByTestId('mock-NamespaceBar')).toBeVisible();
+    expect(screen.getByTestId('mock-MultiTabListPage')).toBeVisible();
   });
 
   it('should render the main components without errors', () => {
-    const { container } = render(<ServingListPage />);
-    expect(container.querySelector('namespacebar')).toBeInTheDocument();
-    expect(container.querySelector('multitablistpage')).toBeInTheDocument();
+    render(<ServingListPage />);
+    expect(screen.getByTestId('mock-NamespaceBar')).toBeVisible();
+    expect(screen.getByTestId('mock-MultiTabListPage')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/pub-sub/details/__test__/DynamicResourceLink.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/details/__test__/DynamicResourceLink.spec.tsx
@@ -1,10 +1,12 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import DynamicResourceLink from '../DynamicResourceLink';
 
-jest.mock('@console/internal/components/utils', () => ({
-  ResourceLink: 'ResourceLink',
-}));
+jest.mock(
+  '@console/internal/components/utils',
+  () =>
+    jest.requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+      .knativeInternalUtilsStubs,
+);
 
 type DynamicResourceLinkProps = React.ComponentProps<typeof DynamicResourceLink>;
 let sampleProps: DynamicResourceLinkProps;
@@ -20,8 +22,8 @@ describe('DynamicResourceLink', () => {
   });
 
   it('should render ResourceLink with proper kind based on model', () => {
-    const { container } = render(<DynamicResourceLink {...sampleProps} />);
-    expect(container.querySelector('resourcelink')).toBeInTheDocument();
+    render(<DynamicResourceLink {...sampleProps} />);
+    expect(screen.getByTestId('mock-ResourceLink')).toBeVisible();
   });
 
   it('should render ResourceLink with proper kind based on refResource', () => {
@@ -33,7 +35,7 @@ describe('DynamicResourceLink', () => {
         name: 'ksvc-display0',
       },
     };
-    const { container } = render(<DynamicResourceLink {...sampleResourceRef} />);
-    expect(container.querySelector('resourcelink')).toBeInTheDocument();
+    render(<DynamicResourceLink {...sampleResourceRef} />);
+    expect(screen.getByTestId('mock-ResourceLink')).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/pub-sub/details/__test__/SubscriptionDetails.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/details/__test__/SubscriptionDetails.spec.tsx
@@ -1,21 +1,21 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import * as _ from 'lodash';
 import { subscriptionData } from '../../../../utils/__tests__/knative-eventing-data';
 import SubscriptionDetails from '../SubscriptionDetails';
 
 jest.mock('../DynamicResourceLink', () => ({
   __esModule: true,
-  default: 'DynamicResourceLink',
+  default: () => <div data-test="mock-DynamicResourceLink" />,
 }));
 
 jest.mock('@console/internal/components/conditions', () => ({
-  Conditions: 'Conditions',
+  Conditions: () => <div data-test="mock-Conditions" />,
 }));
 
 jest.mock('@console/internal/components/utils', () => ({
-  SectionHeading: 'SectionHeading',
-  ResourceSummary: 'ResourceSummary',
+  SectionHeading: ({ text }: { text?: string }) => <h2 data-test="mock-SectionHeading">{text}</h2>,
+  ResourceSummary: () => <div data-test="mock-ResourceSummary" />,
 }));
 
 jest.mock('@console/internal/module/k8s', () => ({
@@ -24,30 +24,27 @@ jest.mock('@console/internal/module/k8s', () => ({
 
 jest.mock('@console/shared/src/components/layout/PaneBody', () => ({
   __esModule: true,
-  default: 'PaneBody',
+  default: ({ children }: { children?: ReactNode }) => (
+    <div data-test="mock-PaneBody">{children}</div>
+  ),
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 describe('SubscriptionDetails', () => {
   it('should render two DynamicResourceLink with respective props', () => {
-    const { container } = render(<SubscriptionDetails obj={subscriptionData} />);
-    const dynamicResourceLinks = container.querySelectorAll('dynamicresourcelink');
-    expect(dynamicResourceLinks).toHaveLength(2);
+    render(<SubscriptionDetails obj={subscriptionData} />);
+    expect(screen.getAllByTestId('mock-DynamicResourceLink')).toHaveLength(2);
   });
 
   it('should render Conditions if status is present', () => {
-    const { container } = render(<SubscriptionDetails obj={subscriptionData} />);
-    expect(container.querySelector('conditions')).toBeInTheDocument();
+    render(<SubscriptionDetails obj={subscriptionData} />);
+    expect(screen.getByTestId('mock-Conditions')).toBeVisible();
   });
 
   it('should not render Conditions if status is not present', () => {
     const subscriptionDataClone = _.omit(_.cloneDeep(subscriptionData), 'status');
-    const { container } = render(<SubscriptionDetails obj={subscriptionDataClone} />);
-    expect(container.querySelector('conditions')).not.toBeInTheDocument();
+    render(<SubscriptionDetails obj={subscriptionDataClone} />);
+    expect(screen.queryByTestId('mock-Conditions')).not.toBeInTheDocument();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/pub-sub/details/__test__/TriggerDetails.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/details/__test__/TriggerDetails.spec.tsx
@@ -1,21 +1,21 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import * as _ from 'lodash';
 import { triggerData } from '../../../../utils/__tests__/knative-eventing-data';
 import TriggerDetails from '../TriggerDetails';
 
 jest.mock('../DynamicResourceLink', () => ({
   __esModule: true,
-  default: 'DynamicResourceLink',
+  default: () => <div data-test="mock-DynamicResourceLink" />,
 }));
 
 jest.mock('@console/internal/components/conditions', () => ({
-  Conditions: 'Conditions',
+  Conditions: () => <div data-test="mock-Conditions" />,
 }));
 
 jest.mock('@console/internal/components/utils', () => ({
-  SectionHeading: 'SectionHeading',
-  ResourceSummary: 'ResourceSummary',
+  SectionHeading: ({ text }: { text?: string }) => <h2 data-test="mock-SectionHeading">{text}</h2>,
+  ResourceSummary: () => <div data-test="mock-ResourceSummary" />,
 }));
 
 jest.mock('@console/internal/module/k8s', () => ({
@@ -25,20 +25,17 @@ jest.mock('@console/internal/module/k8s', () => ({
 
 jest.mock('@console/shared/src/components/layout/PaneBody', () => ({
   __esModule: true,
-  default: 'PaneBody',
+  default: ({ children }: { children?: ReactNode }) => (
+    <div data-test="mock-PaneBody">{children}</div>
+  ),
 }));
 
 jest.mock('../../../overview/FilterTable', () => ({
   __esModule: true,
-  default: 'FilterTable',
+  default: () => <div data-test="mock-FilterTable" />,
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-  withTranslation: () => (Component: any) => Component,
-}));
+jest.mock('react-i18next');
 
 jest.mock('../../../../topology/knative-topology-utils', () => ({
   getTriggerFilters: jest.fn(() => ({ filters: [{ key: 'test', value: 'value' }] })),
@@ -46,30 +43,29 @@ jest.mock('../../../../topology/knative-topology-utils', () => ({
 
 describe('TriggerDetails', () => {
   it('should render two DynamicResourceLink with respective props', () => {
-    const { container } = render(<TriggerDetails obj={triggerData} />);
-    const dynamicResourceLinks = container.querySelectorAll('dynamicresourcelink');
-    expect(dynamicResourceLinks).toHaveLength(2);
+    render(<TriggerDetails obj={triggerData} />);
+    expect(screen.getAllByTestId('mock-DynamicResourceLink')).toHaveLength(2);
   });
 
   it('should render FilterTable if filter is present', () => {
-    const { container } = render(<TriggerDetails obj={triggerData} />);
-    expect(container.querySelector('filtertable')).toBeInTheDocument();
+    render(<TriggerDetails obj={triggerData} />);
+    expect(screen.getByTestId('mock-FilterTable')).toBeVisible();
   });
 
   it('should render Conditions if status is present', () => {
-    const { container } = render(<TriggerDetails obj={triggerData} />);
-    expect(container.querySelector('conditions')).toBeInTheDocument();
+    render(<TriggerDetails obj={triggerData} />);
+    expect(screen.getByTestId('mock-Conditions')).toBeVisible();
   });
 
   it('should not render FilterTable if filter is not present', () => {
     const triggerDataClone = _.omit(_.cloneDeep(triggerData), 'spec.filter');
-    const { container } = render(<TriggerDetails obj={triggerDataClone} />);
-    expect(container.querySelector('filtertable')).toBeInTheDocument();
+    render(<TriggerDetails obj={triggerDataClone} />);
+    expect(screen.getByTestId('mock-FilterTable')).toBeVisible();
   });
 
   it('should not render Conditions if status is not present', () => {
     const triggerDataClone = _.omit(_.cloneDeep(triggerData), 'status');
-    const { container } = render(<TriggerDetails obj={triggerDataClone} />);
-    expect(container.querySelector('conditions')).not.toBeInTheDocument();
+    render(<TriggerDetails obj={triggerDataClone} />);
+    expect(screen.queryByTestId('mock-Conditions')).not.toBeInTheDocument();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/revisions/__tests__/RevisionRow.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/__tests__/RevisionRow.spec.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import * as _ from 'lodash';
 import type { RowFunctionArgs } from '@console/internal/components/factory';
 import { revisionObj } from '../../../topology/__tests__/topology-knative-test-data';
@@ -7,11 +7,16 @@ import type { RevisionKind } from '../../../types';
 import RevisionRow from '../RevisionRow';
 
 jest.mock('@console/internal/components/factory', () => ({
-  TableData: 'TableData',
+  TableData: ({ children, className }: { children?: ReactNode; className?: string }) => (
+    <td data-test="mock-TableData" className={className}>
+      {children}
+    </td>
+  ),
 }));
 
 jest.mock('@console/internal/components/utils', () => ({
-  ResourceLink: 'ResourceLink',
+  ResourceLink: jest.requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .knativeInternalUtilsStubs.ResourceLink,
   Kebab: {
     columnClass: 'pf-c-table__action',
   },
@@ -52,15 +57,13 @@ describe('RevisionRow', () => {
   });
 
   it('should render the revision row with all TableData elements', () => {
-    const { container } = render(<RevisionRow {...revData} />);
-    const tableDatas = container.querySelectorAll('tabledata');
-    expect(tableDatas).toHaveLength(8);
+    render(<RevisionRow {...revData} />);
+    expect(screen.getAllByTestId('mock-TableData')).toHaveLength(8);
   });
 
   it('should show ResourceLink for associated service when service exists in labels', () => {
-    const { container } = render(<RevisionRow {...revData} />);
-    const resourceLinks = container.querySelectorAll('resourcelink');
-    expect(resourceLinks.length).toBeGreaterThan(0);
+    render(<RevisionRow {...revData} />);
+    expect(screen.getAllByTestId('mock-ResourceLink').length).toBeGreaterThan(0);
   });
 
   it('should handle case when service is not found in labels', () => {
@@ -77,14 +80,13 @@ describe('RevisionRow', () => {
         },
       },
     };
-    const { container } = render(<RevisionRow {...modifiedRevData} />);
-    const tableDatas = container.querySelectorAll('tabledata');
-    expect(tableDatas).toHaveLength(8);
+    render(<RevisionRow {...modifiedRevData} />);
+    expect(screen.getAllByTestId('mock-TableData')).toHaveLength(8);
   });
 
   it('should render conditions when status is present', () => {
-    const { container } = render(<RevisionRow {...revData} />);
-    expect(container.querySelector('tabledata')).toBeInTheDocument();
+    render(<RevisionRow {...revData} />);
+    expect(screen.getAllByTestId('mock-TableData')[0]).toBeVisible();
   });
 
   it('should handle case when status is not present', () => {
@@ -92,13 +94,12 @@ describe('RevisionRow', () => {
       ...revData,
       obj: _.omit(revData.obj, 'status'),
     };
-    const { container } = render(<RevisionRow {...noStatusRevData} />);
-    const tableDatas = container.querySelectorAll('tabledata');
-    expect(tableDatas).toHaveLength(8);
+    render(<RevisionRow {...noStatusRevData} />);
+    expect(screen.getAllByTestId('mock-TableData')).toHaveLength(8);
   });
 
   it('should render ready status properly', () => {
-    const { container } = render(<RevisionRow {...revData} />);
-    expect(container.querySelector('tabledata')).toBeInTheDocument();
+    render(<RevisionRow {...revData} />);
+    expect(screen.getAllByTestId('mock-TableData')[0]).toBeVisible();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/routes/__tests__/RouteRow.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/__tests__/RouteRow.spec.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import * as _ from 'lodash';
 import type { RowFunctionArgs } from '@console/internal/components/factory';
 import { knativeRouteObj } from '../../../topology/__tests__/topology-knative-test-data';
@@ -7,12 +7,19 @@ import type { RouteKind } from '../../../types';
 import RouteRow from '../RouteRow';
 
 jest.mock('@console/internal/components/factory', () => ({
-  TableData: 'TableData',
+  TableData: ({ children, className }: { children?: ReactNode; className?: string }) => (
+    <td data-test="mock-TableData" className={className}>
+      {children}
+    </td>
+  ),
 }));
 
 jest.mock('@console/internal/components/utils', () => ({
-  ResourceLink: 'ResourceLink',
-  ExternalLinkWithCopy: 'ExternalLinkWithCopy',
+  ResourceLink: jest.requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .knativeInternalUtilsStubs.ResourceLink,
+  ExternalLinkWithCopy: ({ link }: { link?: string }) => (
+    <span data-test="mock-ExternalLinkWithCopy" data-link={link} />
+  ),
   Kebab: {
     columnClass: 'pf-c-table__action',
   },
@@ -51,38 +58,33 @@ describe('RouteRow', () => {
   });
 
   it('should render the route row with all TableData elements', () => {
-    const { container } = render(<RouteRow {...routeData} />);
-    const tableDatas = container.querySelectorAll('tabledata');
-    expect(tableDatas).toHaveLength(7);
+    render(<RouteRow {...routeData} />);
+    expect(screen.getAllByTestId('mock-TableData')).toHaveLength(7);
   });
 
   it('should show ExternalLinkWithCopy when route URL exists in status', () => {
-    const { container } = render(<RouteRow {...routeData} />);
-    const externalLinks = container.querySelectorAll('externallinkwithcopy');
-    expect(externalLinks.length).toBeGreaterThan(0);
+    render(<RouteRow {...routeData} />);
+    expect(screen.getAllByTestId('mock-ExternalLinkWithCopy').length).toBeGreaterThan(0);
   });
 
   it('should handle case when status is not present', () => {
     const { status, ...objWithoutStatus } = routeData.obj;
     const noStatusRouteData = {
       ...routeData,
-      // intentionally creating invalid object for testing
       obj: objWithoutStatus as RouteKind,
     };
-    const { container } = render(<RouteRow {...noStatusRouteData} />);
-    const tableDatas = container.querySelectorAll('tabledata');
-    expect(tableDatas).toHaveLength(7);
+    render(<RouteRow {...noStatusRouteData} />);
+    expect(screen.getAllByTestId('mock-TableData')).toHaveLength(7);
   });
 
   it('should render conditions when status is present', () => {
-    const { container } = render(<RouteRow {...routeData} />);
-    expect(container.querySelector('tabledata')).toBeInTheDocument();
+    render(<RouteRow {...routeData} />);
+    expect(screen.getAllByTestId('mock-TableData')[0]).toBeVisible();
   });
 
   it('should show ResourceLink for traffic when traffic exists', () => {
-    const { container } = render(<RouteRow {...routeData} />);
-    const resourceLinks = container.querySelectorAll('resourcelink');
-    expect(resourceLinks.length).toBeGreaterThan(0);
+    render(<RouteRow {...routeData} />);
+    expect(screen.getAllByTestId('mock-ResourceLink').length).toBeGreaterThan(0);
   });
 
   it('should handle case when traffic is not present', () => {
@@ -93,8 +95,7 @@ describe('RouteRow', () => {
         status: _.omit(routeData.obj.status, 'traffic'),
       },
     };
-    const { container } = render(<RouteRow {...noTrafficRouteData} />);
-    const tableDatas = container.querySelectorAll('tabledata');
-    expect(tableDatas).toHaveLength(7);
+    render(<RouteRow {...noTrafficRouteData} />);
+    expect(screen.getAllByTestId('mock-TableData')).toHaveLength(7);
   });
 });

--- a/frontend/packages/knative-plugin/src/components/services/__tests__/ServiceRow.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/__tests__/ServiceRow.spec.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import * as _ from 'lodash';
 import type { RowFunctionArgs } from '@console/internal/components/factory';
 import { knativeServiceObj } from '../../../topology/__tests__/topology-knative-test-data';
@@ -7,11 +7,16 @@ import type { ServiceKind } from '../../../types';
 import ServiceRow from '../ServiceRow';
 
 jest.mock('@console/internal/components/factory', () => ({
-  TableData: 'TableData',
+  TableData: ({ children, className }: { children?: ReactNode; className?: string }) => (
+    <td data-test="mock-TableData" className={className}>
+      {children}
+    </td>
+  ),
 }));
 
 jest.mock('@console/internal/components/utils', () => ({
-  ResourceLink: 'ResourceLink',
+  ResourceLink: jest.requireActual('@console/knative-plugin/src/__tests__/rtl-stub-components')
+    .knativeInternalUtilsStubs.ResourceLink,
   Kebab: {
     columnClass: 'pf-c-table__action',
   },
@@ -37,7 +42,11 @@ jest.mock('@console/shared/src/components/datetime/Timestamp', () => ({
 }));
 
 jest.mock('@console/shared/src/components/links/ExternalLink', () => ({
-  ExternalLink: 'ExternalLink',
+  ExternalLink: ({ href, children }: { href?: string; children?: ReactNode }) => (
+    <a data-test="mock-ExternalLink" href={href}>
+      {children}
+    </a>
+  ),
 }));
 
 jest.mock('../../../utils/condition-utils', () => ({
@@ -60,15 +69,13 @@ describe('ServiceRow', () => {
   });
 
   it('should render the service row with all TableData elements', () => {
-    const { container } = render(<ServiceRow {...svcData} />);
-    const tableDatas = container.querySelectorAll('tabledata');
-    expect(tableDatas).toHaveLength(9);
+    render(<ServiceRow {...svcData} />);
+    expect(screen.getAllByTestId('mock-TableData')).toHaveLength(9);
   });
 
   it('should show ExternalLink when service URL exists', () => {
-    const { container } = render(<ServiceRow {...svcData} />);
-    const externalLinks = container.querySelectorAll('externallink');
-    expect(externalLinks.length).toBeGreaterThan(0);
+    render(<ServiceRow {...svcData} />);
+    expect(screen.getAllByTestId('mock-ExternalLink').length).toBeGreaterThan(0);
   });
 
   it('should handle case when URL is not present', () => {
@@ -79,14 +86,13 @@ describe('ServiceRow', () => {
         status: _.omit(svcData.obj.status, 'url'),
       },
     };
-    const { container } = render(<ServiceRow {...noUrlSvcData} />);
-    const tableDatas = container.querySelectorAll('tabledata');
-    expect(tableDatas).toHaveLength(9);
+    render(<ServiceRow {...noUrlSvcData} />);
+    expect(screen.getAllByTestId('mock-TableData')).toHaveLength(9);
   });
 
   it('should render generation when present', () => {
-    const { container } = render(<ServiceRow {...svcData} />);
-    expect(container.querySelector('tabledata')).toBeInTheDocument();
+    render(<ServiceRow {...svcData} />);
+    expect(screen.getAllByTestId('mock-TableData')[0]).toBeVisible();
   });
 
   it('should handle case when generation is not present', () => {
@@ -97,9 +103,8 @@ describe('ServiceRow', () => {
         metadata: _.omit(svcData.obj.metadata, 'generation'),
       },
     };
-    const { container } = render(<ServiceRow {...noGenerationSvcData} />);
-    const tableDatas = container.querySelectorAll('tabledata');
-    expect(tableDatas).toHaveLength(9);
+    render(<ServiceRow {...noGenerationSvcData} />);
+    expect(screen.getAllByTestId('mock-TableData')).toHaveLength(9);
   });
 
   it('should handle case when status is not present', () => {
@@ -107,14 +112,13 @@ describe('ServiceRow', () => {
       ...svcData,
       obj: _.omit(svcData.obj, 'status'),
     };
-    const { container } = render(<ServiceRow {...noStatusSvcData} />);
-    const tableDatas = container.querySelectorAll('tabledata');
-    expect(tableDatas).toHaveLength(9);
+    render(<ServiceRow {...noStatusSvcData} />);
+    expect(screen.getAllByTestId('mock-TableData')).toHaveLength(9);
   });
 
   it('should render ready status when conditions are present', () => {
-    const { container } = render(<ServiceRow {...svcData} />);
-    expect(container.querySelector('tabledata')).toBeInTheDocument();
+    render(<ServiceRow {...svcData} />);
+    expect(screen.getAllByTestId('mock-TableData')[0]).toBeVisible();
   });
 
   it('should render properly when conditions indicate not ready state', () => {
@@ -136,8 +140,7 @@ describe('ServiceRow', () => {
         },
       },
     };
-    const { container } = render(<ServiceRow {...notReadySvcData} />);
-    const tableDatas = container.querySelectorAll('tabledata');
-    expect(tableDatas).toHaveLength(9);
+    render(<ServiceRow {...notReadySvcData} />);
+    expect(screen.getAllByTestId('mock-TableData')).toHaveLength(9);
   });
 });

--- a/frontend/packages/knative-plugin/src/components/sink-pubsub/__tests__/SinkPubsub.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-pubsub/__tests__/SinkPubsub.spec.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
-import type { ComponentProps } from 'react';
-import { render } from '@testing-library/react';
+import type { ComponentProps, ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import {
   EventTriggerObj,
   EventSubscriptionObj,
@@ -8,14 +7,32 @@ import {
 import SinkPubsub from '../SinkPubsub';
 
 jest.mock('formik', () => ({
-  Formik: 'Formik',
+  Formik: ({
+    children,
+  }: {
+    children?: ((p: Record<string, unknown>) => ReactNode) | ReactNode;
+  }) => (
+    <div data-test="mock-Formik">
+      {typeof children === 'function'
+        ? children({
+            values: { ref: { name: '' } },
+            errors: {},
+            touched: {},
+            handleChange: jest.fn(),
+            handleBlur: jest.fn(),
+            handleSubmit: jest.fn(),
+            handleReset: jest.fn(),
+            setFieldValue: jest.fn(),
+            setStatus: jest.fn(),
+            status: { error: '' },
+            isSubmitting: false,
+          })
+        : children}
+    </div>
+  ),
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 jest.mock('@console/internal/module/k8s', () => ({
   k8sUpdate: jest.fn(),
@@ -44,7 +61,7 @@ jest.mock('../../pub-sub/pub-sub-utils', () => ({
 
 jest.mock('../SinkPubsubModal', () => ({
   __esModule: true,
-  default: 'SinkPubsubModal',
+  default: () => null,
 }));
 
 type SinkPubsubProps = ComponentProps<typeof SinkPubsub>;
@@ -56,23 +73,23 @@ describe('SinkPubsub', () => {
   };
 
   it('should render the component with Formik', () => {
-    const { container } = render(<SinkPubsub {...formProps} />);
-    expect(container.querySelector('formik')).toBeInTheDocument();
+    render(<SinkPubsub {...formProps} />);
+    expect(screen.getByTestId('mock-Formik')).toBeInTheDocument();
   });
 
   it('should render properly for Subscription resource type', () => {
-    const { container } = render(<SinkPubsub {...formProps} />);
-    expect(container.querySelector('formik')).toBeInTheDocument();
+    render(<SinkPubsub {...formProps} />);
+    expect(screen.getByTestId('mock-Formik')).toBeInTheDocument();
   });
 
   it('should render properly for Trigger resource type', () => {
     const triggerProps = { source: EventTriggerObj, resourceType: 'Trigger' };
-    const { container } = render(<SinkPubsub {...triggerProps} />);
-    expect(container.querySelector('formik')).toBeInTheDocument();
+    render(<SinkPubsub {...triggerProps} />);
+    expect(screen.getByTestId('mock-Formik')).toBeInTheDocument();
   });
 
   it('should handle different source objects', () => {
-    const { container } = render(<SinkPubsub {...formProps} />);
-    expect(container.querySelector('formik')).toBeInTheDocument();
+    render(<SinkPubsub {...formProps} />);
+    expect(screen.getByTestId('mock-Formik')).toBeInTheDocument();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/sink-pubsub/__tests__/SinkPubsubModal.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-pubsub/__tests__/SinkPubsubModal.spec.tsx
@@ -23,10 +23,8 @@ jest.mock('@console/dev-console/src/components/import/section/FormSection', () =
 }));
 
 jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-  Trans: jest.fn(() => null),
+  ...jest.requireActual('../../../../../../__mocks__/react-i18next'),
+  Trans: () => null,
 }));
 
 describe('SinkPubsubModal', () => {

--- a/frontend/packages/knative-plugin/src/components/sink-source/__tests__/SinkSource.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-source/__tests__/SinkSource.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
 import type { ComponentProps } from 'react';
 import { render } from '@testing-library/react';
 import { sampleEventSourceSinkbinding } from '../../../topology/__tests__/topology-knative-test-data';
@@ -16,11 +15,7 @@ jest.mock('formik', () => ({
   },
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 jest.mock('@console/internal/module/k8s', () => ({
   k8sUpdate: jest.fn(),
@@ -64,8 +59,9 @@ describe('SinkSource', () => {
   });
 
   it('should render Formik child with proper props', () => {
-    const { container } = render(<SinkSource {...formProps} />);
-    expect(container).toBeInTheDocument();
-    expect(mockCapturedFormikProps.children).toBeDefined();
+    render(<SinkSource {...formProps} />);
+    expect(mockCapturedFormikProps).toEqual(
+      expect.objectContaining({ children: expect.any(Function) }),
+    );
   });
 });

--- a/frontend/packages/knative-plugin/src/components/sink-source/__tests__/SinkSourceModal.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-source/__tests__/SinkSourceModal.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
 import type { ComponentProps } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -21,7 +20,11 @@ jest.mock('@patternfly/react-core', () => ({
       </button>
     ),
   ),
-  Form: jest.fn(({ children, ...props }) => <form {...props}>{children}</form>),
+  Form: jest.fn(({ children, ...props }) => (
+    <form data-test={props.id} {...props}>
+      {children}
+    </form>
+  )),
 }));
 
 jest.mock('@console/shared/src/components/modals/ModalFooterWithAlerts', () => ({
@@ -39,10 +42,8 @@ jest.mock('@console/dev-console/src/components/import/section/FormSection', () =
 }));
 
 jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-  Trans: jest.fn(() => null),
+  ...jest.requireActual('../../../../../../__mocks__/react-i18next'),
+  Trans: () => null,
 }));
 
 type SinkSourceModalProps = ComponentProps<typeof SinkSourceModal>;
@@ -74,8 +75,8 @@ describe('SinkSourceModal Form', () => {
   });
 
   it('should render form with id', () => {
-    const { container } = render(<SinkSourceModal {...formProps} />);
-    const form = container.querySelector('form');
+    render(<SinkSourceModal {...formProps} />);
+    const form = screen.getByTestId('sink-source-form');
     expect(form).toBeInTheDocument();
     expect(form).toHaveAttribute('id', 'sink-source-form');
   });
@@ -94,14 +95,14 @@ describe('SinkSourceModal Form', () => {
       },
     };
     render(<SinkSourceModal {...formProps} values={dirtyValues} initialValues={formValues} />);
-    await user.click(screen.getByRole('button', { name: 'knative-plugin~Save' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
     expect(formProps.handleSubmit).toHaveBeenCalled();
   });
 
   it('should call cancel when Cancel is clicked', async () => {
     const user = userEvent.setup();
     render(<SinkSourceModal {...formProps} />);
-    await user.click(screen.getByRole('button', { name: 'knative-plugin~Cancel' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(formProps.cancel).toHaveBeenCalled();
   });
 

--- a/frontend/packages/knative-plugin/src/components/sink-uri/__tests__/SinkUri.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-uri/__tests__/SinkUri.spec.tsx
@@ -12,11 +12,7 @@ jest.mock('formik', () => ({
   },
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 jest.mock('@console/internal/module/k8s', () => ({
   k8sUpdate: jest.fn(),

--- a/frontend/packages/knative-plugin/src/components/sink-uri/__tests__/SinkUriModal.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-uri/__tests__/SinkUriModal.spec.tsx
@@ -33,11 +33,7 @@ jest.mock('@console/dev-console/src/components/import/section/FormSection', () =
   default: jest.fn(() => null),
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 type SinkUriModalProps = ComponentProps<typeof SinkUriModal>;
 

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/__tests__/TrafficSplittingFields.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/__tests__/TrafficSplittingFields.spec.tsx
@@ -16,11 +16,7 @@ jest.mock('../TrafficModalRevisionsDropdownField', () => ({
   default: jest.fn(() => null),
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 const formProps = {
   ...formikFormProps,

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/__tests__/TrafficSplittingModal.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/__tests__/TrafficSplittingModal.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access -- Mocked components require container queries */
 import type { ComponentProps } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -24,7 +23,11 @@ jest.mock('@patternfly/react-core', () => ({
       </button>
     ),
   ),
-  Form: jest.fn(({ children, ...props }) => <form {...props}>{children}</form>),
+  Form: jest.fn(({ children, ...props }) => (
+    <form data-test={props.id} {...props}>
+      {children}
+    </form>
+  )),
 }));
 
 jest.mock('@console/shared/src/components/modals/ModalFooterWithAlerts', () => ({
@@ -36,11 +39,7 @@ jest.mock('../TrafficSplittingFields', () => ({
   default: jest.fn(() => null),
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 type TrafficSplittingModalProps = ComponentProps<typeof TrafficSplittingModal>;
 
@@ -60,22 +59,23 @@ describe('TrafficSplittingModal', () => {
   });
 
   it('should render form with modal structure', () => {
-    const { container } = render(<TrafficSplittingModal {...formProps} />);
-    expect(container.querySelector('form')).toBeInTheDocument();
-    expect(container.querySelector('form')).toHaveAttribute('id', 'traffic-splitting-form');
+    render(<TrafficSplittingModal {...formProps} />);
+    const form = screen.getByTestId('traffic-splitting-form');
+    expect(form).toBeInTheDocument();
+    expect(form).toHaveAttribute('id', 'traffic-splitting-form');
   });
 
   it('should call handleSubmit on form submit', async () => {
     const user = userEvent.setup();
     render(<TrafficSplittingModal {...formProps} />);
-    await user.click(screen.getByRole('button', { name: 'knative-plugin~Save' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
     expect(formProps.handleSubmit).toHaveBeenCalled();
   });
 
   it('should call cancel when Cancel is clicked', async () => {
     const user = userEvent.setup();
     render(<TrafficSplittingModal {...formProps} />);
-    await user.click(screen.getByRole('button', { name: 'knative-plugin~Cancel' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(formProps.cancel).toHaveBeenCalled();
   });
 });

--- a/frontend/packages/knative-plugin/src/topology/sidebar/__tests__/KnativeOverviewSections.spec.tsx
+++ b/frontend/packages/knative-plugin/src/topology/sidebar/__tests__/KnativeOverviewSections.spec.tsx
@@ -71,11 +71,7 @@ jest.mock('@console/internal/module/k8s', () => ({
   },
 }));
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+jest.mock('react-i18next');
 
 describe('KnativeOverview', () => {
   let item: OverviewItem;


### PR DESCRIPTION
[CONSOLE-5229](https://redhat.atlassian.net/browse/CONSOLE-5229): Enable RTL ESLint rules in Knative tests by removing file-level no-container / no-node-access suppressions

**Analysis / Root cause**:
Tech-Debt

**Solution description**:
Cleanup

**Screenshots / screen recording**:
N/A

**Test setup:**
Run `yarn test <Knative tests>`

**Test cases:**
N/A

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
  /assign @vikram-raj 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test suite to use React Testing Library best practices, replacing DOM container queries with accessible queries and data-test attributes for more reliable testing.
  * Improved mock implementations for improved test clarity and maintainability across Knative plugin components.

* **Chores**
  * Enhanced test infrastructure with shared RTL stub components for consistent test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->