### PR TITLE
OCPBUGS-85242, OCPBUGS-84047: Add Suspense boundary to LazyRoutePage for plugin routes

### DIFF
--- a/frontend/packages/console-app/src/hooks/usePluginRoutes.tsx
+++ b/frontend/packages/console-app/src/hooks/usePluginRoutes.tsx
@@ -1,11 +1,12 @@
 import type { FC, ReactElement, ComponentType } from 'react';
-import { useMemo, lazy, useEffect } from 'react';
+import { useMemo, lazy, useEffect, Suspense } from 'react';
 import type { RouteProps } from 'react-router';
 import { createPath, Route, useLocation } from 'react-router';
 import { RoutePage, isRoutePage } from '@console/dynamic-plugin-sdk/src/extensions/pages';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk/src/perspective';
 import type { LoadedExtension } from '@console/dynamic-plugin-sdk/src/types';
 import { useExtensions } from '@console/plugin-sdk/src/api/useExtensions';
+import { LoadingBox } from '@console/shared/src/components/loading/LoadingBox';
 
 const isRoutePageExtensionActive: IsRouteExtensionActive = (extension, activePerspective) =>
   (extension.properties.perspective ?? activePerspective) === activePerspective;
@@ -14,7 +15,7 @@ const isRoutePageExtensionActive: IsRouteExtensionActive = (extension, activePer
 const lazyComponentCache = new Map<string, React.LazyExoticComponent<ComponentType<any>>>();
 
 const LazyRoutePage: FC<LazyRoutePageProps> = ({ extension }) => {
-  const { uid, properties } = extension;
+  const { pluginName, uid, properties } = extension;
   const { component } = properties;
   const LazyComponent = useMemo(() => {
     if (!lazyComponentCache.has(uid)) {
@@ -29,7 +30,11 @@ const LazyRoutePage: FC<LazyRoutePageProps> = ({ extension }) => {
     return lazyComponentCache.get(uid);
   }, [uid, component]);
 
-  return <LazyComponent />;
+  return (
+    <Suspense fallback={<LoadingBox blame={`${pluginName}: ${extension.uid}`} />}>
+      <LazyComponent />
+    </Suspense>
+  );
 };
 
 const InactiveRoutePage: FC<InactiveRoutePageProps> = ({

--- a/frontend/public/components/app.tsx
+++ b/frontend/public/components/app.tsx
@@ -374,7 +374,7 @@ const AppRouter: FC = () => {
   );
 
   return (
-    <BrowserRouter basename={window.SERVER_FLAGS.basePath}>
+    <BrowserRouter unstable_useTransitions={false} basename={window.SERVER_FLAGS.basePath}>
       <Routes>
         {/*
           Treat the authentication error page as a standalone route.


### PR DESCRIPTION
**Analysis / Root cause**:
`LazyRoutePage` renders `React.lazy` components without its own `<Suspense>` boundary. 

It relies on the outer `<Suspense>` in `app-contents.tsx`, but React Router uses `startTransition` for navigations. 

During a transition, React keeps the previous UI visible rather than re-showing a fallback on an already-resolved `<Suspense>` boundary — so no loading indicator appears while plugin JS chunks are fetched.

Built-in routes don't have this problem because `AsyncComponent` wraps each lazy component with its own `<Suspense fallback={<LoadingBox />}>`.

**Solution description**:

- Add a local `Suspense` wrapping the lazy component inside `LazyRoutePage`.
- Revert to the legacy `unstable_useTransitions` behaviour from react-router v6 so that the suspense is shown

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
Load a cluster with a dynamic plugin installed (e.g. OpenShift Pipelines).

**Test cases:**
- Navigate to a dynamic plugin page (e.g. OpenShift Pipelines) — loading spinner should appear while chunks load
- Navigate between plugin pages — loading spinner should appear during each transition
- Navigate to built-in pages — behavior unchanged

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced plugin loading experience by displaying a loading indicator while plugin routes are being fetched, providing better visual feedback to users during the loading process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->