### PR TITLE
OCPBUGS-85121: Skip redundant navigate() in setPerspective when target matches current URL

### DIFF
--- a/frontend/packages/console-app/src/components/detect-perspective/DetectPerspective.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/DetectPerspective.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import { useEffect } from 'react';
-import { createPath, useLocation } from 'react-router';
+import { createPath, useLocation, useNavigate } from 'react-router';
 import type { Perspective } from '@console/dynamic-plugin-sdk';
 import { PerspectiveContext } from '@console/dynamic-plugin-sdk';
 import { LoadingBox } from '@console/shared/src/components/loading/LoadingBox';
@@ -27,11 +27,20 @@ const DetectPerspective: FC<DetectPerspectiveProps> = ({ children }) => {
   const perspectiveExtensions = usePerspectives();
   const perspectiveParam = getPerspectiveURLParam(perspectiveExtensions);
   const location = useLocation();
+  const navigate = useNavigate();
   useEffect(() => {
-    if (perspectiveParam && perspectiveParam !== activePerspective) {
-      setActivePerspective(perspectiveParam, createPath(location));
+    if (perspectiveParam) {
+      const params = new URLSearchParams(location.search);
+      params.delete('perspective');
+      const search = params.toString();
+      const cleanPath = createPath({ ...location, search: search ? `?${search}` : '' });
+      if (perspectiveParam !== activePerspective) {
+        setActivePerspective(perspectiveParam, cleanPath);
+      } else {
+        navigate(cleanPath, { replace: true });
+      }
     }
-  }, [perspectiveParam, activePerspective, setActivePerspective, location]);
+  }, [perspectiveParam, activePerspective, setActivePerspective, navigate, location]);
 
   return loaded ? (
     activePerspective ? (

--- a/frontend/packages/console-app/src/components/detect-perspective/__tests__/DetectPerspective.spec.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/__tests__/DetectPerspective.spec.tsx
@@ -20,7 +20,9 @@ jest.mock('@console/shared/src/hooks/usePerspectives', () => ({
 }));
 
 jest.mock('react-router', () => ({
+  createPath: jest.fn((loc) => `${loc.pathname}${loc.search || ''}${loc.hash || ''}`),
   useLocation: jest.fn(),
+  useNavigate: jest.fn(() => jest.fn()),
 }));
 
 const useValuesForPerspectiveContextMock = useValuesForPerspectiveContext as jest.Mock;

--- a/frontend/packages/console-app/src/components/detect-perspective/useValuesForPerspectiveContext.ts
+++ b/frontend/packages/console-app/src/components/detect-perspective/useValuesForPerspectiveContext.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { createPath, useNavigate } from 'react-router';
 import type { PerspectiveType, UseActivePerspective } from '@console/dynamic-plugin-sdk';
 import {
   usePerspectiveExtension,
@@ -38,8 +38,10 @@ export const useValuesForPerspectiveContext = (): [
     (newPerspective, next) => {
       setLastPerspective(newPerspective);
       setActivePerspective(newPerspective);
-      // Navigate to next or root and let the default page determine where to go to next
-      navigate(next || '/');
+      // Only navigate if a path is provided to avoid unnecessary navigation
+      if (next && next !== createPath(window.location)) {
+        navigate(next);
+      }
       fireTelemetryEvent('Perspective Changed', { perspective: newPerspective });
     },
     [setLastPerspective, setActivePerspective, navigate, fireTelemetryEvent],


### PR DESCRIPTION
Closes https://github.com/openshift/console/issues/16254

**Analysis / Root cause**:

setActivePerspective() always called navigate() unconditionally, causing redundant page reloads for custom perspective plugins. When the target URL matched the current location, this triggered namespace handler validation loops and visible re-renders. 

This also stripped the ?perspective= param in DetectPerspective to prevent it from persisting and re-triggering the effect.

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

Skip navigate() when the target URL matches the current location

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

Refer to reproduction steps in linked issue

**Test cases:**
<!-- List possible test cases to validate the changes. -->

Ensure reproduction steps in linked issue are no longer reproducible 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved perspective selection and URL query parameter synchronization.
  * Optimized navigation behavior when switching perspectives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->