### PR TITLE
OCPBUGS-84047: Fix perspective stuck issue with transition guard

### DIFF
--- a/frontend/packages/console-app/src/components/detect-context/useValuesForPerspectiveContext.ts
+++ b/frontend/packages/console-app/src/components/detect-context/useValuesForPerspectiveContext.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useRef } from 'react';
 import { useNavigate } from 'react-router';
 import type { PerspectiveType, UseActivePerspective } from '@console/dynamic-plugin-sdk';
 import {
@@ -34,13 +34,36 @@ export const useValuesForPerspectiveContext = (): [
   const isValidPerspective =
     loaded && perspectiveExtensions.some((p) => p.properties.id === perspective);
 
+  // Track which perspective we're transitioning to - prevents plugins from
+  // forcing the same perspective back during the transition, but allows
+  // switching to a different perspective
+  const transitioningTo = useRef<string | null>(null);
+
   const setPerspective = useCallback<SetActivePerspective>(
     (newPerspective, next) => {
-      setLastPerspective(newPerspective);
-      setActivePerspective(newPerspective);
-      // Navigate to next or root and let the default page determine where to go to next
-      navigate(next || '/');
-      fireTelemetryEvent('Perspective Changed', { perspective: newPerspective });
+      // Ignore calls trying to switch to the same perspective we're already transitioning to
+      // This blocks plugin interference, but allows legitimate switches to different perspectives
+      if (transitioningTo.current === newPerspective) {
+        return;
+      }
+
+      // Set guard to track which perspective we're transitioning to
+      transitioningTo.current = newPerspective;
+
+      try {
+        setLastPerspective(newPerspective);
+        setActivePerspective(newPerspective);
+        // Navigate to next or root and let the default page determine where to go to next
+
+        navigate(next || '/');
+        fireTelemetryEvent('Perspective Changed', { perspective: newPerspective });
+      } finally {
+        // Clear guard after navigation and state updates complete
+        // Use setTimeout to ensure this runs after all synchronous effects
+        setTimeout(() => {
+          transitioningTo.current = null;
+        }, 0);
+      }
     },
     [setLastPerspective, setActivePerspective, navigate, fireTelemetryEvent],
   );


### PR DESCRIPTION
Fixes perspective getting stuck when switching away from plugin-registered perspectives (e.g., Fleet Management). Plugins watch activePerspective changes and force back to their perspective, preventing user-initiated switches.

# **Analysis / Root cause**
Plugin effects fire during perspective transitions and override the user's switch by calling setActivePerspective with the plugin's perspective.

# **Solution description**
Add transition guard (isTransitioning ref) that blocks setPerspective calls during active transitions, preventing plugin interference.

# **Screenshots / screen recording**:
https://github.com/user-attachments/assets/2d4444a9-ae46-43e2-b9a7-078462d6e952




# **Test setup**
1. Launch a cluster with the changes from this PR using cluster bot
2. Install ACM operator and create a multiclusterhub resource


# **Test cases**
## Test Case 1: Switching Away from Plugin Perspective (Primary Bug Fix)                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
  Objective: Verify user can switch away from Fleet Management perspective
                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
  Steps:                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
  1. Navigate to Fleet Management perspective (ACM)                                                                                                                                                                                                                                                                                                                                                                                                                            
  2. Click on any ACM page (e.g., /multicloud/infrastructure/clusters/managed)                                                                                                                                                                                                                                                                                                                                                                                                 
  3. Open perspective switcher dropdown                                       
  4. Click "Administrator" or "Developer" perspective                                                                                                                                                                                                                                                                                                                                                                                                                          
   
  Expected Result:                                                                                                                                                                                                                                                                                                                                                                                                                                                             
  - ✅ Console switches to selected perspective             
  - ✅ Perspective stays on selected perspective (does NOT snap back to Fleet Management)                                                                                                                                                                                                                                                                                                                                                                                      
  - ✅ Page navigates to appropriate landing page for selected perspective               
                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
  Failure Scenario (without fix):                                                                                                                                                                                                                                                                                                                                                                                                                                              
  - ❌ Briefly switches then snaps back to Fleet Management                                                                                                                                                                                                                                                                                                                                                                                                                    
  - ❌ Gets stuck on Fleet Management perspective                                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
  ---                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
## Test Case 2: Switching TO Plugin Perspective
                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
Objective: Verify switching TO Fleet Management still works
                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
Steps:                                                    
1. Start on Administrator or Developer perspective
2. Open perspective switcher dropdown                                                                                                                                                                                                                                                                                                                                                                                                                                        
3. Click "Fleet Management" (ACM) perspective
                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
Expected Result:                                                                                                                                                                                                                                                                                                                                                                                                                                                             
- ✅ Console switches to Fleet Management
- ✅ Displays Fleet Management landing page                                                                                                                                                                                                                                                                                                                                                                                                                                  
- ✅ No errors in console                                 
                         
---                                                                                                                                                                                                                                                                                                                                                                                                                                                                          ## Test Case 3: Rapid Perspective Switching                                                                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
Objective: Verify transition guard handles rapid clicks                                                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Steps:
1. Start on Fleet Management perspective                                                                                                                                                                                                                                                                                                                                                                                                                                     
2. Quickly switch: Fleet Management → Admin → Developer → Fleet Management → Admin
3. Try clicking another perspective while navigation is in progress               
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Expected Result:                                                                                                                                                                                                                                                                                                                                                                                                                                                             
- ✅ Each switch completes successfully                                                                                                                                                                                                                                                                                                                                                                                                                                      
- ✅ Final perspective matches last click                                                                                                                                                                                                                                                                                                                                                                                                                                    
- ✅ No perspective fighting or flickering                
- ✅ No console errors                                                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
---                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
## Test Case 4: Query Param Preservation                                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Objective: Verify query params (except ?perspective=) are preserved during switches
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Steps:                                                    
1. Navigate to Developer perspective
2. Go to Topology page: /topology/ns/default?view=graph                                                                                                                                                                                                                                                                                                                                                                                                                      
3. Open perspective switcher
4. Switch to Administrator perspective                                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                        
Expected Result:                                                                                                                                                                                                                                                                                                                                                                                                                                                             
- ✅ URL params like ?view=graph should be stripped (navigates to clean admin page)
- ✅ Check browser console - no errors about lost query params                                                                                                                                                                                                                                                                                                                                                                                                               
                                                            
Note: The navigation goes to perspective landing page (/ or /dashboards), so query params from previous page aren't expected to transfer. The fix ensures we don't carry over ?perspective= which caused loops.                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
---                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
## Test Case 5: Hash Fragment Preservation                                                                                                                                                                                                                                                                                                                                                                                                                                      
                                                        
Objective: Verify URL hash is handled correctly
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Steps:
1. Navigate to a page with hash: /some/page#section                                                                                                                                                                                                                                                                                                                                                                                                                          
2. Switch perspectives                                                                                                                                                                                                                                                                                                                                                                                                                                                       

Expected Result:                                                                                                                                                                                                                                                                                                                                                                                                                                                             
- ✅ Navigation completes without errors                  
- ✅ No hash-related loops or issues                                                                                                                                                                                                                                                                                                                                                                                                                                         

---                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
## Test Case 6: Initial Load with ACM Installed              
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Objective: Verify ACM default on first visit
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Steps:                                                    
1. Clear browser local storage (or use incognito)                                                                                                                                                                                                                                                                                                                                                                                                                            
2. Navigate to console for first time with ACM installed                                                                                                                                                                                                                                                                                                                                                                                                                     
3. Observe which perspective loads                      
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Expected Result:                                                                                                                                                                                                                                                                                                                                                                                                                                                             
- ✅ If no previous perspective preference exists, defaults to Fleet Management (ACM)                                                                                                                                                                                                                                                                                                                                                                                        
- ✅ User can then switch to other perspectives normally                                                                                                                                                                                                                                                                                                                                                                                                                     
                                                        
---                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
## Test Case 7: Built-in Perspective Switching (Regression Test)
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Objective: Verify switching between Admin/Dev still works normally
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Steps:                                                    
1. Switch from Administrator to Developer                                                                                                                                                                                                                                                                                                                                                                                                                                    
2. Switch from Developer to Administrator                 
3. Repeat several times                  

Expected Result:                                                                                                                                                                                                                                                                                                                                                                                                                                                             
- ✅ Switches work smoothly both directions
- ✅ No delays or errors                                                                                                                                                                                                                                                                                                                                                                                                                                                     
- ✅ Perspective preference is saved                      
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
---                                                       
## Test Case 8: Browser Console Check                                                                                                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Objective: Verify no unexpected errors or warnings
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Steps:                                                    
1. Open browser DevTools console (F12)
2. Perform Test Cases 1-3 above                                                                                                                                                                                                                                                                                                                                                                                                                                              
3. Monitor console for errors  
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Expected Result:                                                                                                                                                                                                                                                                                                                                                                                                                                                             
- ✅ No JavaScript errors related to perspective switching                                                                                                                                                                                                                                                                                                                                                                                                                   
- ✅ No "BLOCKED during transition" logs (debug logs removed)                                                                                                                                                                                                                                                                                                                                                                                                                
- ✅ Only normal telemetry and navigation logs               
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
---                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
## Test Case 9: Multiple Plugin Perspectives                                                                                                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Objective: If multiple plugins register perspectives, verify switching works
                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Steps:
1. In environment with multiple plugin perspectives (e.g., ACM + another plugin)                                                                                                                                                                                                                                                                                                                                                                                             
2. Switch between: Admin → Plugin1 → Developer → Plugin2 → Admin                                                                                                                                                                                                                                                                                                                                                                                                             

Expected Result:                                                                                                                                                                                                                                                                                                                                                                                                                                                             
- ✅ All switches work correctly                          
- ✅ No perspective gets stuck                                                                                                                                                                                                                                                                                                                                                                                                                                               
- ✅ Each perspective's routes load properly
       
# **Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

# **Additional info:**

# **Reviewers and assignees:**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate perspective switches during an ongoing transition, avoiding unnecessary navigation and duplicate events.
  * Ensures smoother, more reliable perspective transitions and reduces race-condition related glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->