### PR TITLE
CONSOLE-5200: add qa-verify skill for automated PR visual verification

### DIFF
--- a/.claude/skills/qa-verify/SKILL.md
+++ b/.claude/skills/qa-verify/SKILL.md
@@ -1,0 +1,474 @@
+---
+name: qa-verify
+description: >-
+  Automated QA verification for OpenShift Console PRs. Builds and runs the console on both main
+  and the PR branch, captures before/after screenshots and GIFs via Playwright MCP, then posts a
+  side-by-side comparison as a GitHub PR comment. Use when the user asks to verify a PR, QA changes,
+  capture visual proof, or show before/after evidence.
+argument-hint: "[GitHub PR URL or number]"
+arguments: [pr]
+disable-model-invocation: true
+effort: max
+allowed-tools:
+  - Bash(git *)
+  - Bash(gh *)
+  - Bash(go test *)
+  - Bash(curl *)
+  - Bash(mkdir *)
+  - Bash(kill *)
+  - Bash(bash *)
+  - Bash(nohup *)
+  - Bash(cp *)
+  - Bash(python3 *)
+  - Bash(sips *)
+  - Bash(oc whoami)
+  - Bash(./build-frontend.sh)
+  - Bash(./build-backend.sh)
+  - Bash(cat *)
+  - Bash(sleep *)
+  - Bash(date *)
+  - Bash(find *)
+  - Bash(wc *)
+  - AskUserQuestion
+  - mcp__playwright__browser_navigate
+  - mcp__playwright__browser_snapshot
+  - mcp__playwright__browser_take_screenshot
+  - mcp__playwright__browser_click
+  - mcp__playwright__browser_type
+  - mcp__playwright__browser_wait_for
+  - mcp__playwright__browser_resize
+  - mcp__playwright__browser_close
+  - mcp__playwright__browser_console_messages
+  - mcp__playwright__browser_evaluate
+  - mcp__atlassian__getJiraIssue
+---
+
+# /qa-verify
+
+Capture before/after visual evidence of PR changes using Playwright MCP and post a comparison
+to the GitHub PR.
+
+## Current State
+
+Branch: !`git rev-parse --abbrev-ref HEAD`
+
+PR:
+!`gh pr view $pr --json number,title,body,headRefName,baseRefName 2>/dev/null || echo "No PR found"`
+
+Base branch:
+!`gh pr view $pr --json baseRefName -q '.baseRefName' 2>/dev/null || echo "main"`
+
+Commits since base:
+!`git log "$(gh pr view $pr --json baseRefName -q '.baseRefName' 2>/dev/null || echo main)..HEAD" --oneline --no-merges 2>/dev/null || echo "No commits ahead of base"`
+
+Changed files:
+!`git diff "$(gh pr view $pr --json baseRefName -q '.baseRefName' 2>/dev/null || echo main)...HEAD" --stat 2>/dev/null || echo "Unable to diff"`
+
+## Phase 0: Prerequisites
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/check-prerequisites.sh"
+```
+
+If any tools are missing, the script outputs an `INSTALL_COMMANDS` section with platform-specific
+install commands (brew, dnf, or apt). Use `AskUserQuestion` to offer to run them. If the user
+agrees, run each install command, then re-run the prerequisites check to confirm everything passes.
+
+Verify Playwright MCP is available by calling `browser_snapshot`. If unavailable, the user needs
+to configure it **before starting this session** — adding MCP servers requires a session restart.
+Configure with `--ignore-https-errors` and `--save-video` for video recording:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest", "--ignore-https-errors", "--save-video=1920x1080"]
+    }
+  }
+}
+```
+
+The `--save-video=1920x1080` flag records a video of the entire browser session from page
+creation to `browser_close`. Videos are saved as `.webm` files automatically.
+
+## Phase 1: Gather Context
+
+Use the injected state above. Additionally:
+
+Extract the Jira key from the PR title or branch name (`CONSOLE-\d+` or `OCPBUGS-\d+`).
+If Atlassian MCP is available, call `getJiraIssue` with `cloudId: "redhat.atlassian.net"`.
+
+From the PR body, parse:
+- **Test setup** section (between `**Test setup:**` and the next `**` header)
+- **Test cases** section (between `**Test cases:**` and the next `**` header)
+- **Solution description** section
+
+## Phase 2: Verification Plan
+
+Derive verification steps and present to the user with `AskUserQuestion`. Wait for confirmation.
+
+Sources (use what's available):
+1. PR test cases → each becomes a verification step with route, action, expected result
+2. Jira ticket → bug repro steps or acceptance criteria map to pages
+3. Diff → changed components map to affected routes
+4. Fallback → dashboard and pages related to changed files
+5. **Backend-only changes** — if the diff only touches `pkg/`, `cmd/`, or `*.go` files:
+   - Check whether the fix depends on cluster resources (CRDs, operators) that may not exist
+     in the local dev environment. If so, note this limitation in the plan.
+   - Offer the user a choice: (a) run `go test ./pkg/...` on both branches and compare results
+     instead of the full build-and-screenshot flow, or (b) proceed with UI verification but
+     focus on functional behavior (button states, API responses) rather than pixel comparison.
+   - If the user chooses test comparison, run the tests, diff the results, and skip Phases 3-4.
+
+**Route guidelines:**
+- Use namespace-scoped routes (`/k8s/ns/default/...`) instead of `/k8s/all-namespaces/...` for
+  any page with forms or project selectors. With all-namespaces, no project is selected, so form
+  validation independently disables submit buttons — making verification useless.
+- Pick a namespace that exists on the cluster (e.g., `default`, `openshift-console`).
+
+Present as a table:
+
+| # | Route | Action | Expected Result |
+|---|-------|--------|-----------------|
+| 1 | /dashboards | Navigate, wait load | Dashboard renders |
+| 2 | /k8s/ns/default/pods | Click a pod | Pod detail page opens |
+| 3 | /k8s/ns/openshift-console/deployments/console/environment | View env tab, click Add from ConfigMap | Value-from-pair form opens |
+
+The `$pr` argument (from `/qa-verify <url-or-number>`) is expanded by skill substitution into
+the content before you see it. If provided, it is used for `gh pr view` and `gh pr checkout`.
+It may be a full GitHub URL or just a number.
+
+**PR suitability:** This skill works best for PRs with visible UI changes (new components, layout
+changes, styling) where before/after screenshots show a clear diff. For logic-only PRs (state
+management, hooks, refactors), the skill still provides value as a regression check — identical
+screenshots confirm the refactor didn't break anything visually. In these cases, also check for
+console errors via `browser_console_messages` after each navigation step to catch runtime
+regressions that don't produce visible changes.
+
+**Data-loading pages:** Pages like `/k8s/cluster/projects` load data via WebSocket — the page
+may render before data arrives. Use `browser_wait_for` with `time: 5` (longer) for data-heavy
+pages, or poll for a specific element via `browser_evaluate`. For paginated lists, append
+`?perPage=200` to show all items, or use the filter/search input to find specific items instead
+of scrolling through pages.
+
+**Verification depth:** Err on the side of comprehensive testing over simplicity. Think about
+corner cases the PR might affect — empty states, error states, loading states, boundary
+conditions (e.g., very long names, special characters, zero items, maximum items). If the PR
+touches a component, verify it in multiple contexts where it appears, not just the most obvious
+one. A false negative (missing a regression) is worse than spending extra time on verification.
+
+## Phase 3: Capture Evidence
+
+Run the verification plan twice: baseline (`${BASE_BRANCH}`) first, then candidate (PR branch).
+
+### Setup
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+ORIGINAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+# $pr is expanded by skill substitution to the argument value (URL or number)
+PR_NUMBER=$(echo "$pr" | grep -oE '[0-9]+' | tail -1)
+if [ -z "$PR_NUMBER" ]; then
+  PR_NUMBER=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
+fi
+PR_BRANCH=$(gh pr view --json headRefName -q '.headRefName' 2>/dev/null || echo "$ORIGINAL_BRANCH")
+# Derive baseline branch from PR target — release-4.x for backports, main otherwise
+BASE_BRANCH=$(gh pr view ${PR_NUMBER} --json baseRefName -q '.baseRefName' 2>/dev/null || echo "main")
+# Track whether the candidate branch already exists locally (for cleanup)
+PR_BRANCH_LOCAL=$(gh pr view ${PR_NUMBER} --json headRefName -q '.headRefName' 2>/dev/null || echo "")
+CANDIDATE_BRANCH_EXISTED=$(git rev-parse --verify "${PR_BRANCH_LOCAL}" >/dev/null 2>&1 && echo "yes" || echo "no")
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+ARTIFACTS="${REPO_ROOT}/.artifacts/qa-verify/${TIMESTAMP}"
+mkdir -p "${ARTIFACTS}/baseline/screenshots" "${ARTIFACTS}/candidate/screenshots"
+```
+
+Use `PR_BRANCH` (the PR's actual head ref name) in metadata, not `ORIGINAL_BRANCH` (which is
+whatever local branch you happen to be on).
+
+Copy skill scripts to the artifacts directory so they survive branch switches (the scripts
+live on the PR branch and disappear when checking out the base branch):
+
+```bash
+cp -R "${CLAUDE_SKILL_DIR}/scripts" "${ARTIFACTS}/scripts"
+chmod +x "${ARTIFACTS}/scripts/"*.sh
+```
+
+All subsequent script calls MUST use `${ARTIFACTS}/scripts/` instead of `${CLAUDE_SKILL_DIR}/scripts/`.
+
+### For each lane (baseline first, then candidate):
+
+#### 3.1 Switch branch
+
+**Baseline:**
+```bash
+STASH_COUNT_BEFORE=$(git stash list 2>/dev/null | wc -l | tr -d ' ')
+git stash --include-untracked -m "qa-verify-stash" 2>/dev/null || true
+STASH_COUNT_AFTER=$(git stash list 2>/dev/null | wc -l | tr -d ' ')
+QA_STASH_CREATED=$([ "$STASH_COUNT_AFTER" -gt "$STASH_COUNT_BEFORE" ] && echo "yes" || echo "no")
+git checkout "${BASE_BRANCH}"
+```
+
+**Candidate** (after baseline is complete): use `gh pr checkout` to handle forks correctly.
+External contributor PRs come from forks — `git checkout <branch>` will fail because the branch
+doesn't exist on origin. `gh pr checkout` fetches the correct ref automatically.
+
+```bash
+gh pr checkout "${PR_NUMBER}" 2>/dev/null || git checkout "${ORIGINAL_BRANCH}"
+CANDIDATE_CHECKOUT_SHA=$(git rev-parse HEAD)
+if [ "${QA_STASH_CREATED}" = "yes" ]; then
+  git stash pop 2>/dev/null || true
+fi
+```
+
+#### 3.2 Build
+
+Clean and rebuild frontend + backend in parallel (use `timeout: 600000`):
+```bash
+bash "${ARTIFACTS}/scripts/rebuild.sh"
+```
+
+#### 3.3 Start server
+
+Replace `<LANE>` with `baseline` or `candidate`:
+```bash
+bash "${ARTIFACTS}/scripts/backend.sh" --start <LANE>
+```
+
+#### 3.4 Navigate and capture
+
+Set viewport: `browser_resize` → width: 1920, height: 1080
+
+For each verification step:
+1. `browser_navigate` to `http://localhost:9000{route}` — note that the console may append query
+   params (e.g., `?page=1&perPage=50`). This is normal and expected.
+2. `browser_wait_for` with `time: 3` to let the page settle (do NOT use text matching — it
+   frequently matches hidden elements and times out)
+3. `browser_snapshot` for READ-ONLY verification of page state. Do NOT use snapshot refs as
+   click targets — refs go stale instantly on pages with live data (CPU/memory counters, pod
+   status). Instead, use `browser_evaluate` with `document.querySelector` for all interactions:
+   ```
+   browser_evaluate: () => document.querySelector('[data-test="create-button"]').click()
+   browser_evaluate: () => document.querySelector('input[aria-label="Filter"]').value = 'test'
+   ```
+4. `browser_take_screenshot` → `${ARTIFACTS}/<LANE>/screenshots/NN-description.png`
+
+Use **identical filenames** for both lanes.
+
+**Checking element states:** To verify a button is enabled/disabled, use `browser_snapshot` with
+a `target` selector (e.g., `[data-test-id="submit-button"]`). If the snapshot output includes
+`[disabled]`, the element is disabled. Verify enablement by confirming the attribute is absent.
+
+**Avoiding resource conflicts:** Prefer verifying element states (enabled, visible, correct text)
+over performing destructive actions (Create, Delete). If you must create a resource, use a unique
+name per lane (e.g., `test-baseline-{timestamp}`, `test-candidate-{timestamp}`) and delete it
+after capturing evidence.
+
+#### 3.5 Finalize video and stop server
+
+Call `browser_close` to finalize the video recording. Playwright saves the `.webm` file when the
+browser context closes. After closing, find and copy the recorded video:
+
+```bash
+# Search working dir and common Playwright temp locations for the most recent webm
+VIDEO=$(find . /tmp/playwright* /var/folders/*/T/playwright* \
+  -path ./.artifacts -prune -o -name "*.webm" -print 2>/dev/null \
+  | xargs ls -t 2>/dev/null | head -1)
+if [ -n "$VIDEO" ]; then
+  cp "$VIDEO" "${ARTIFACTS}/<LANE>/session.webm"
+  echo "Video saved: $(du -h "${ARTIFACTS}/<LANE>/session.webm" | cut -f1)"
+else
+  echo "No video found — ensure Playwright MCP is configured with --save-video=1920x1080"
+fi
+```
+
+Then stop the server:
+```bash
+bash "${ARTIFACTS}/scripts/backend.sh" --stop <LANE>
+```
+
+## Phase 4: Compile Evidence
+
+### Convert session videos
+
+If session videos were recorded, convert them to GIF when it reduces file size:
+
+```bash
+for lane in baseline candidate; do
+  if [ -f "${ARTIFACTS}/${lane}/session.webm" ]; then
+    bash "${ARTIFACTS}/scripts/convert-video.sh" \
+      "${ARTIFACTS}/${lane}/session.webm" "${ARTIFACTS}/${lane}"
+  fi
+done
+```
+
+The script keeps whichever format (webm or GIF) is smaller. GIFs render inline in GitHub
+comments; webm files are uploaded as links.
+
+### Create screenshot GIFs (if ffmpeg available)
+
+```bash
+bash "${ARTIFACTS}/scripts/screenshots-to-gif.sh" \
+  "${ARTIFACTS}/baseline/screenshots" "${ARTIFACTS}/baseline/evidence.gif"
+bash "${ARTIFACTS}/scripts/screenshots-to-gif.sh" \
+  "${ARTIFACTS}/candidate/screenshots" "${ARTIFACTS}/candidate/evidence.gif"
+```
+
+Write metadata and verification steps for the comment builder:
+
+Capture the candidate SHA while still on the candidate branch (before switching back):
+```bash
+CANDIDATE_SHA=$(git rev-parse --short HEAD)
+```
+
+Then write metadata:
+```bash
+cat > "${ARTIFACTS}/metadata.json" << METAEOF
+{
+  "branch": "${PR_BRANCH}",
+  "baseline_sha": "$(git rev-parse --short ${BASE_BRANCH})",
+  "candidate_sha": "${CANDIDATE_SHA}",
+  "pr_number": "${PR_NUMBER}",
+  "jira_key": "<JIRA_KEY_OR_EMPTY>",
+  "os": "$(uname -s) $(uname -r)",
+  "browser": "$(python3 -c "
+import subprocess
+pw = subprocess.run(['npx', 'playwright', '--version'], capture_output=True, text=True).stdout.strip().replace('Version ', '')
+dr = subprocess.run(['npx', 'playwright', 'install', '--dry-run'], capture_output=True, text=True).stdout.strip().split('\n')
+chrome = next((l.strip() for l in dr if 'Chrome' in l or 'Chromium' in l), 'Chromium')
+chrome = chrome.split('Install')[0].strip() if 'Install' in chrome else chrome
+print(f'Playwright {pw} / {chrome}')
+" 2>/dev/null || echo 'unknown')"
+}
+METAEOF
+```
+
+Write verification steps as TSV to `${ARTIFACTS}/steps.tsv` with columns:
+`number\troute\taction\tstatus\tdescription`
+
+The description column provides a human-readable label for each step (e.g., "Dashboard overview",
+"Mobile responsive view"). It is used in collapsible `<details>` sections in the PR comment.
+
+## Phase 5: Publish and Comment
+
+### Upload evidence
+
+```bash
+bash "${ARTIFACTS}/scripts/upload-evidence.sh" "${ARTIFACTS}" "${ARTIFACTS}/evidence-map.txt"
+```
+
+The script tries the `gh-image` extension first (native GitHub CDN URLs, works with SSH remotes
+via `--repo` flag). If `gh-image` is not installed, the output includes `MISSING_GH_IMAGE=true` —
+use `AskUserQuestion` to offer installing it (`gh extension install drogers0/gh-image`). Mention
+that it is a **third-party community extension**. If the user declines or it fails, the script
+falls back to base64 data URIs with progressive downsizing to fit the 65KB comment limit.
+
+### Build and post comment
+
+```bash
+bash "${ARTIFACTS}/scripts/build-comment.sh" \
+  "${ARTIFACTS}/evidence-map.txt" \
+  "${ARTIFACTS}/metadata.json" \
+  "${ARTIFACTS}/steps.tsv" \
+  /tmp/qa-verify-comment.md
+```
+
+The script builds the comment markdown from the evidence map, metadata, and steps. If the base64
+payload exceeds 65KB, it automatically splits into `/tmp/qa-verify-comment.md` (main comment)
+and `.part2`, `.part3` etc. (reply comments with the images).
+
+### Upsert PR comment
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+
+EXISTING_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+  -q '.[] | select(.body | contains("<!-- qa-verify-evidence -->")) | .id' 2>/dev/null | tail -1)
+
+if [ -n "$EXISTING_ID" ]; then
+  gh api --method PATCH "repos/${REPO}/issues/comments/${EXISTING_ID}" \
+    -F body=@/tmp/qa-verify-comment.md
+else
+  gh pr comment "${PR_NUMBER}" --body-file /tmp/qa-verify-comment.md
+fi
+
+# Post split parts as replies if they exist
+for part in /tmp/qa-verify-comment.md.part*; do
+  [ -f "$part" ] && gh pr comment "${PR_NUMBER}" --body-file "$part"
+done
+```
+
+After posting, summarize the results for the user:
+1. List artifact paths (`${ARTIFACTS}/baseline/screenshots/`, `${ARTIFACTS}/candidate/screenshots/`)
+2. Note whether visual differences were observed or screenshots were identical
+3. Show the PR comment URL
+4. Use `AskUserQuestion` to offer opening the PR comment in the browser. If the
+user agrees, open the PR page:
+```bash
+# macOS
+open "https://github.com/${REPO}/pull/${PR_NUMBER}"
+# Linux
+xdg-open "https://github.com/${REPO}/pull/${PR_NUMBER}"
+```
+
+## Cleanup
+
+**Always** ensure, even on error:
+1. Stop server: `bash "${ARTIFACTS}/scripts/backend.sh" --stop <LANE>`
+2. Restore branch: `git checkout "${ORIGINAL_BRANCH}"`
+3. Restore stash (only if one was created): `[ "${QA_STASH_CREATED}" = "yes" ] && git stash pop 2>/dev/null || true`
+4. Clean up unstaged artifacts: `git checkout -- .artifacts/ .playwright-mcp/ 2>/dev/null || true`
+5. Delete the candidate branch if it was created by `gh pr checkout` (didn't exist before) AND
+   has no additional commits beyond what was checked out:
+   ```bash
+   if [ "${CANDIDATE_BRANCH_EXISTED}" = "no" ] && [ -n "${PR_BRANCH_LOCAL}" ]; then
+     CURRENT_SHA=$(git rev-parse "${PR_BRANCH_LOCAL}" 2>/dev/null || echo "")
+     if [ "${CURRENT_SHA}" = "${CANDIDATE_CHECKOUT_SHA}" ]; then
+       git branch -D "${PR_BRANCH_LOCAL}" 2>/dev/null || true
+     fi
+   fi
+   ```
+
+## Limitations
+
+This skill runs the console via `contrib/oc-environment.sh` + `./bin/bridge -branding openshift`,
+which is a minimal off-cluster dev setup. The following features require additional bridge flags
+or infrastructure that this skill does **not** configure:
+
+- **Dynamic plugins** (`--plugins`, `--plugins-order`, `--plugin-proxy`) — plugins are not loaded
+- **Telemetry** (`--telemetry`) — no telemetry config is passed
+- **OIDC authentication** (`--user-auth=oidc`, `--cookie-*-key-file`) — auth is disabled entirely
+- **Custom branding** (`--custom-logo-files`, `--custom-favicon-files`, `--custom-product-name`)
+- **Perspectives** (`--perspectives`) — all perspectives enabled by default
+- **Capabilities** (`--capabilities`) — all capabilities enabled by default
+- **Developer catalog customization** (`--developer-catalog-categories`, `--developer-catalog-types`)
+- **QuickStarts customization** (`--quickstarts`)
+- **Inactivity timeout** (`--inactivity-timeout`)
+- **i18n plugin namespaces** (`--i18n-namespaces`)
+- **Control plane topology** (`--control-plane-topology-mode`)
+
+If a PR changes behavior that depends on any of these flags, the verification will not reflect
+the actual production behavior. Note this in the verification plan and suggest the user test
+manually with the required flags.
+
+**Backport PRs** (targeting `release-4.x` branches) have additional constraints:
+- The baseline is the release branch, not `main`. The skill auto-detects this from `baseRefName`.
+- Release branches may not have the `.claude/skills/qa-verify` directory or the repo's Playwright
+  config. The skill copies scripts to the artifacts dir before switching, so scripts survive.
+- Older release branches may use different Node.js versions, Yarn configs, or build tooling.
+  If `build-frontend.sh` fails on the release branch, note this in the verification plan and
+  consider skipping the baseline build (verify the candidate against manual inspection instead).
+
+## Notes
+
+- Console runs on `http://localhost:9000`
+- Auth is disabled via `contrib/oc-environment.sh` — no login needed
+- `.artifacts/` and `.playwright-mcp/` are gitignored
+- Evidence images are uploaded via `gh-image` (if installed) or embedded as base64 data URIs
+- If no PR exists, save evidence locally and skip comment posting
+- Fork PRs are handled via `gh pr checkout` which creates a local tracking branch
+- **Scope**: This skill captures visual evidence and performs regression verification. It does
+  not analyze code or assess test coverage. For logic-only changes and refactors, identical
+  screenshots between baseline and candidate is itself evidence that no visual regressions were
+  introduced. The skill can also check for console errors via `browser_console_messages` to
+  catch runtime regressions that don't produce visible UI changes.

--- a/.claude/skills/qa-verify/scripts/backend.sh
+++ b/.claude/skills/qa-verify/scripts/backend.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# backend.sh — Start or stop the OpenShift Console backend server
+# Usage: backend.sh --start <id>     Start server, save PID/log
+#        backend.sh --stop <id>      Stop server by saved PID
+#        backend.sh --status <id>    Check if server is running
+set -euo pipefail
+
+ACTION=""
+ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --start)  ACTION="start";  shift; ID="${1:-}"; shift || true ;;
+    --stop)   ACTION="stop";   shift; ID="${1:-}"; shift || true ;;
+    --status) ACTION="status"; shift; ID="${1:-}"; shift || true ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$ACTION" ] || [ -z "$ID" ]; then
+  echo "Usage: backend.sh --start|--stop|--status <id>" >&2
+  exit 1
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+RUN_DIR="${REPO_ROOT}/.artifacts/qa-verify/servers/${ID}"
+
+case "$ACTION" in
+  start)
+    # Fail fast if port 9000 is already in use
+    if lsof -ti :9000 >/dev/null 2>&1; then
+      echo "ERROR: Port 9000 is already in use (PID: $(lsof -ti :9000 | head -1))" >&2
+      echo "Stop the existing process first: kill $(lsof -ti :9000 | head -1)" >&2
+      exit 1
+    fi
+
+    mkdir -p "$RUN_DIR"
+
+    cd "$REPO_ROOT"
+    nohup bash -c "source ./contrib/oc-environment.sh && ./bin/bridge -branding openshift" \
+      > "${RUN_DIR}/server.log" 2>&1 &
+    echo $! > "${RUN_DIR}/server.pid"
+
+    echo "Waiting for server on port 9000..."
+    for i in $(seq 1 90); do
+      if ! kill -0 "$(cat "${RUN_DIR}/server.pid")" 2>/dev/null; then
+        echo "ERROR: Server process exited unexpectedly. Last log:" >&2
+        tail -20 "${RUN_DIR}/server.log" >&2
+        rm -f "${RUN_DIR}/server.pid"
+        exit 1
+      fi
+      if curl -s --max-time 5 --connect-timeout 3 http://localhost:9000 >/dev/null 2>&1; then
+        echo "Server ready (PID: $(cat "${RUN_DIR}/server.pid"))"
+        exit 0
+      fi
+      sleep 2
+    done
+
+    echo "ERROR: Server did not start within 3 minutes" >&2
+    kill "$(cat "${RUN_DIR}/server.pid")" 2>/dev/null || true
+    rm -f "${RUN_DIR}/server.pid"
+    exit 1
+    ;;
+
+  stop)
+    if [ -f "${RUN_DIR}/server.pid" ]; then
+      PID=$(cat "${RUN_DIR}/server.pid")
+      kill "$PID" 2>/dev/null || true
+      rm -f "${RUN_DIR}/server.pid"
+      sleep 3
+      if kill -0 "$PID" 2>/dev/null; then
+        echo "WARNING: Process $PID still running after SIGTERM, sending SIGKILL" >&2
+        kill -9 "$PID" 2>/dev/null || true
+        sleep 1
+      fi
+      echo "Server stopped (was PID: $PID)"
+    else
+      echo "No server found for id: $ID (already stopped)" >&2
+      exit 0
+    fi
+    ;;
+
+  status)
+    if [ -f "${RUN_DIR}/server.pid" ] && kill -0 "$(cat "${RUN_DIR}/server.pid")" 2>/dev/null; then
+      echo "Running (PID: $(cat "${RUN_DIR}/server.pid"))"
+      exit 0
+    else
+      echo "Not running"
+      exit 1
+    fi
+    ;;
+esac

--- a/.claude/skills/qa-verify/scripts/build-comment.sh
+++ b/.claude/skills/qa-verify/scripts/build-comment.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# build-comment.sh — Build the QA verification PR comment markdown
+# Usage: build-comment.sh <evidence_map> <metadata_json> <steps_file> [output_file]
+#
+# evidence_map:  output from upload-evidence.sh (lines prefixed with MAP: are entries)
+# metadata_json: JSON with branch, baseline_sha, candidate_sha, pr_number, jira_key
+# steps_file:    TSV file with verification steps (number\troute\taction\tstatus\tdescription)
+# output_file:   where to write the comment (default: /tmp/qa-verify-comment.md)
+#
+# Compatible with macOS bash 3.2 (no associative arrays).
+set -euo pipefail
+
+EVIDENCE_MAP="$1"
+METADATA="$2"
+STEPS_FILE="$3"
+OUTPUT="${4:-/tmp/qa-verify-comment.md}"
+COMMENT_LIMIT=61440
+
+if [ -z "$EVIDENCE_MAP" ] || [ -z "$METADATA" ] || [ -z "$STEPS_FILE" ]; then
+  echo "Usage: build-comment.sh <evidence_map> <metadata_json> <steps_file> [output_file]" >&2
+  exit 1
+fi
+
+BRANCH=$(python3 -c "import json; print(json.load(open('$METADATA')).get('branch',''))")
+BASELINE_SHA=$(python3 -c "import json; print(json.load(open('$METADATA')).get('baseline_sha',''))")
+CANDIDATE_SHA=$(python3 -c "import json; print(json.load(open('$METADATA')).get('candidate_sha',''))")
+JIRA_KEY=$(python3 -c "import json; print(json.load(open('$METADATA')).get('jira_key',''))")
+OS_INFO=$(python3 -c "import json; print(json.load(open('$METADATA')).get('os',''))")
+BROWSER_INFO=$(python3 -c "import json; print(json.load(open('$METADATA')).get('browser',''))")
+VERIFIED_DATE=$(date +%Y-%m-%d)
+
+# URL lookup — || true prevents pipefail from killing the script when grep finds nothing
+url_for() {
+  grep "^MAP: $1 " "$EVIDENCE_MAP" 2>/dev/null | head -1 | sed 's/^MAP: [^ ]* //' || true
+}
+
+METHOD=$(grep '^METHOD=' "$EVIDENCE_MAP" 2>/dev/null | tail -1 | cut -d= -f2 || echo "unknown")
+
+# --- Header ---
+HEADER="<!-- qa-verify-evidence -->
+## QA Verification Evidence
+
+| | Details |
+|---|---|
+| **Branch** | \`${BRANCH}\` |
+| **Baseline** | \`main\` @ \`${BASELINE_SHA}\` |
+| **Candidate** | \`${BRANCH}\` @ \`${CANDIDATE_SHA}\` |
+| **Verified** | ${VERIFIED_DATE} |
+| **Browser** | ${BROWSER_INFO} |
+| **OS** | ${OS_INFO} |"
+
+if [ -n "$JIRA_KEY" ]; then
+  HEADER="${HEADER}
+| **Jira** | [${JIRA_KEY}](https://redhat.atlassian.net/browse/${JIRA_KEY}) |"
+fi
+
+# --- Steps table ---
+STEPS="
+### Verification Steps
+
+| # | Route | Action | Status |
+|---|-------|--------|--------|"
+while IFS=$'\t' read -r num route action status desc rest; do
+  STEPS="${STEPS}
+| ${num} | ${route} | ${action} | ${status} |"
+done < "$STEPS_FILE"
+
+# --- Screenshot pairs in collapsible sections ---
+# Build one <details> block per step, matching screenshots by step number prefix
+EVIDENCE_SECTIONS=""
+STEP_NUM=0
+while IFS=$'\t' read -r num route action status desc rest; do
+  STEP_NUM=$((STEP_NUM + 1))
+  padded=$(printf '%02d' "$STEP_NUM")
+  step_desc="${desc:-${action}}"
+
+  # Find baseline screenshot(s) matching this step number
+  bl_keys=$(grep "^MAP: baseline-screenshots-${padded}" "$EVIDENCE_MAP" 2>/dev/null | sed 's/^MAP: //' | cut -d' ' -f1 || true)
+  [ -z "$bl_keys" ] && continue
+
+  section="
+<details>
+<summary>Step ${STEP_NUM}: ${step_desc} (${status})</summary>
+
+| Baseline (\`main\`) | Candidate (\`${BRANCH}\`) |
+| :---: | :---: |"
+
+  for bl_key in $bl_keys; do
+    suffix="${bl_key#baseline-screenshots-}"
+    ca_key="candidate-screenshots-${suffix}"
+    bl_url=$(url_for "$bl_key")
+    ca_url=$(url_for "$ca_key")
+    if [ -n "$bl_url" ] && [ -n "$ca_url" ]; then
+      section="${section}
+| <img src=\"${bl_url}\" width=\"480\"> | <img src=\"${ca_url}\" width=\"480\"> |"
+    fi
+  done
+
+  section="${section}
+
+</details>"
+  EVIDENCE_SECTIONS="${EVIDENCE_SECTIONS}${section}"
+done < "$STEPS_FILE"
+
+# Fallback: if no step-matched pairs found, show all pairs flat
+if [ -z "$EVIDENCE_SECTIONS" ]; then
+  grep '^MAP: baseline-screenshots-' "$EVIDENCE_MAP" 2>/dev/null | while IFS= read -r line; do
+    key=$(echo "$line" | sed 's/^MAP: //' | cut -d' ' -f1)
+    suffix="${key#baseline-screenshots-}"
+    ca_key="candidate-screenshots-${suffix}"
+    bl_url=$(echo "$line" | sed 's/^MAP: [^ ]* //')
+    ca_url=$(url_for "$ca_key")
+    if [ -n "$ca_url" ]; then
+      echo "| <img src=\"${bl_url}\" width=\"480\"> | <img src=\"${ca_url}\" width=\"480\"> |"
+    fi
+  done > "${OUTPUT}.pairs.tmp" || true
+
+  FLAT_PAIRS=$(cat "${OUTPUT}.pairs.tmp" 2>/dev/null || true)
+  rm -f "${OUTPUT}.pairs.tmp"
+
+  if [ -n "$FLAT_PAIRS" ]; then
+    EVIDENCE_SECTIONS="
+### Before / After
+
+| Baseline (\`main\`) | Candidate (\`${BRANCH}\`) |
+| :---: | :---: |
+${FLAT_PAIRS}"
+  fi
+fi
+
+# --- GIF pairs ---
+GIFS=""
+BL_GIF=$(url_for "baseline-evidence.gif")
+CA_GIF=$(url_for "candidate-evidence.gif")
+if [ -n "$BL_GIF" ] && [ -n "$CA_GIF" ]; then
+  GIFS="
+<details>
+<summary>Animated overview (click to expand)</summary>
+
+| Baseline | Candidate |
+| :---: | :---: |
+| <img src=\"${BL_GIF}\" width=\"480\"> | <img src=\"${CA_GIF}\" width=\"480\"> |
+
+</details>"
+fi
+
+FOOTER="
+---
+> [!WARNING]
+> This verification was performed by an AI agent. Results may contain false positives or miss
+> regressions that require human judgment. Always review the screenshots manually before approving.
+
+*Automated QA verification by [Claude Code](https://claude.ai/code)*"
+
+# --- Assemble ---
+FULL="${HEADER}
+${STEPS}
+${GIFS}
+${EVIDENCE_SECTIONS}
+${FOOTER}"
+
+FULL_BYTES=$(printf '%s' "$FULL" | wc -c | tr -d ' ')
+
+if [ "$METHOD" != "base64" ] || [ "$FULL_BYTES" -le "$COMMENT_LIMIT" ]; then
+  printf '%s\n' "$FULL" > "$OUTPUT"
+  echo "Written to $OUTPUT (${FULL_BYTES} bytes, single comment)"
+else
+  MAIN="${HEADER}
+${STEPS}
+
+> Evidence images split across reply comments due to GitHub's 65KB comment limit.
+${FOOTER}"
+  printf '%s\n' "$MAIN" > "$OUTPUT"
+  echo "Written to $OUTPUT (main comment)"
+
+  PART=2
+  if [ -n "$EVIDENCE_SECTIONS" ]; then
+    printf '<!-- qa-verify-evidence -->%s\n' "$EVIDENCE_SECTIONS" > "${OUTPUT}.part${PART}"
+    echo "Written to ${OUTPUT}.part${PART} (screenshots)"
+    PART=$((PART + 1))
+  fi
+  if [ -n "$GIFS" ]; then
+    printf '<!-- qa-verify-evidence -->%s\n' "$GIFS" > "${OUTPUT}.part${PART}"
+    echo "Written to ${OUTPUT}.part${PART} (GIFs)"
+  fi
+fi

--- a/.claude/skills/qa-verify/scripts/check-prerequisites.sh
+++ b/.claude/skills/qa-verify/scripts/check-prerequisites.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# check-prerequisites.sh — Validate all prerequisites for QA verification
+set -euo pipefail
+
+ERRORS=0
+WARNINGS=0
+INSTALL_CMDS=""
+
+# Detect package manager
+detect_pkg_manager() {
+  if command -v brew >/dev/null 2>&1; then
+    echo "brew"
+  elif command -v dnf >/dev/null 2>&1; then
+    echo "dnf"
+  elif command -v apt >/dev/null 2>&1; then
+    echo "apt"
+  else
+    echo "unknown"
+  fi
+}
+
+PKG_MGR=$(detect_pkg_manager)
+
+# Map tool → install command per package manager
+install_cmd_for() {
+  local tool="$1"
+  case "$PKG_MGR" in
+    brew)
+      case "$tool" in
+        oc)      echo "brew install openshift-cli" ;;
+        go)      echo "brew install go" ;;
+        node)    echo "brew install node" ;;
+        gh)      echo "brew install gh" ;;
+        jq)      echo "brew install jq" ;;
+        python3) echo "brew install python3" ;;
+        ffmpeg)  echo "brew install ffmpeg" ;;
+        *)      echo "" ;;
+      esac
+      ;;
+    dnf)
+      case "$tool" in
+        oc)      echo "# Download from https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/" ;;
+        go)      echo "sudo dnf install -y golang" ;;
+        node)    echo "sudo dnf install -y nodejs" ;;
+        gh)      echo "sudo dnf install -y gh" ;;
+        jq)      echo "sudo dnf install -y jq" ;;
+        python3) echo "sudo dnf install -y python3" ;;
+        ffmpeg)  echo "sudo dnf install -y ffmpeg-free" ;;
+        *)      echo "" ;;
+      esac
+      ;;
+    apt)
+      case "$tool" in
+        oc)      echo "# Download from https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/" ;;
+        go)      echo "sudo apt install -y golang" ;;
+        node)    echo "sudo apt install -y nodejs" ;;
+        gh)      echo "sudo apt install -y gh" ;;
+        jq)      echo "sudo apt install -y jq" ;;
+        python3) echo "sudo apt install -y python3" ;;
+        ffmpeg)  echo "sudo apt install -y ffmpeg" ;;
+        *)      echo "" ;;
+      esac
+      ;;
+    *)
+      echo ""
+      ;;
+  esac
+}
+
+check_cmd() {
+  local cmd="$1"
+  local install
+  install=$(install_cmd_for "$cmd")
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    if [ -n "$install" ]; then
+      echo "MISSING: $cmd — install with: $install"
+      INSTALL_CMDS="${INSTALL_CMDS}${install}\n"
+    else
+      echo "MISSING: $cmd — no auto-install available for this platform"
+    fi
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "OK: $cmd ($(command -v "$cmd"))"
+  fi
+}
+
+echo "=== QA Verify Prerequisites ==="
+echo "Package manager: $PKG_MGR"
+echo ""
+
+echo "OK: bash ${BASH_VERSION}"
+
+check_cmd "python3"
+check_cmd "curl"
+check_cmd "oc"
+check_cmd "go"
+check_cmd "node"
+check_cmd "gh"
+check_cmd "jq"
+
+# yarn is installed via corepack, not a package manager
+if ! command -v yarn >/dev/null 2>&1; then
+  echo "MISSING: yarn — install with: corepack enable && corepack prepare yarn@stable --activate"
+  INSTALL_CMDS="${INSTALL_CMDS}corepack enable && corepack prepare yarn@stable --activate\n"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK: yarn ($(command -v yarn))"
+fi
+
+FFMPEG_INSTALL=$(install_cmd_for ffmpeg)
+if command -v ffmpeg >/dev/null 2>&1; then
+  echo "OK: ffmpeg ($(command -v ffmpeg))"
+else
+  echo "OPTIONAL: ffmpeg not found — GIF creation will be skipped${FFMPEG_INSTALL:+ (install with: $FFMPEG_INSTALL)}"
+  INSTALL_CMDS="${INSTALL_CMDS}${FFMPEG_INSTALL}\n"
+  WARNINGS=$((WARNINGS + 1))
+fi
+
+echo ""
+
+# Node.js version
+if command -v node >/dev/null 2>&1; then
+  NODE_MAJOR=$(node -v | sed 's/v//' | cut -d. -f1)
+  if [ "$NODE_MAJOR" -lt 22 ]; then
+    echo "ERROR: Node.js >= 22.x required, found $(node -v)"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "OK: Node.js $(node -v)"
+  fi
+fi
+
+# OpenShift cluster login
+if command -v oc >/dev/null 2>&1; then
+  OC_USER=$(oc whoami 2>/dev/null) || true
+  if [ -z "$OC_USER" ]; then
+    echo "ERROR: Not logged in to OpenShift cluster — run 'oc login'"
+    ERRORS=$((ERRORS + 1))
+  elif echo "$OC_USER" | grep -qi "kubeadmin\|kube:admin"; then
+    echo "OK: Logged in as $OC_USER"
+  else
+    echo "WARNING: Logged in as '$OC_USER' — expected kubeadmin"
+    WARNINGS=$((WARNINGS + 1))
+  fi
+fi
+
+# Git repository
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "ERROR: Not inside a git repository"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Current branch
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+if [ "$BRANCH" = "main" ]; then
+  echo "ERROR: Currently on 'main' branch — switch to your PR branch first"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK: On branch '$BRANCH'"
+fi
+
+# GitHub CLI auth
+if command -v gh >/dev/null 2>&1; then
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "ERROR: GitHub CLI not authenticated — run 'gh auth login'"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "OK: GitHub CLI authenticated"
+  fi
+fi
+
+# Playwright browsers (Playwright MCP manages its own browser, this is informational)
+if command -v npx >/dev/null 2>&1; then
+  PW_VERSION=$(npx playwright --version 2>/dev/null || echo "")
+  if [ -n "$PW_VERSION" ]; then
+    echo "OK: Playwright $PW_VERSION"
+  else
+    echo "WARNING: Playwright not found — Playwright MCP will install it on first run"
+    WARNINGS=$((WARNINGS + 1))
+  fi
+fi
+
+echo ""
+if [ $ERRORS -gt 0 ]; then
+  echo "FAILED: $ERRORS prerequisite(s) missing, $WARNINGS warning(s)"
+  if [ -n "$INSTALL_CMDS" ]; then
+    echo ""
+    echo "INSTALL_COMMANDS:"
+    echo -e "$INSTALL_CMDS" | grep -v '^$'
+  fi
+  exit 1
+else
+  echo "ALL PREREQUISITES MET ($WARNINGS warning(s))"
+  exit 0
+fi

--- a/.claude/skills/qa-verify/scripts/convert-video.sh
+++ b/.claude/skills/qa-verify/scripts/convert-video.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# convert-video.sh — Convert Playwright video (webm) to GIF if it reduces file size
+# Usage: convert-video.sh <input.webm> [output_dir]
+#
+# When gh-image is available, keeps the webm as-is (can be uploaded directly as video).
+# When using base64 fallback, converts to GIF only if the GIF is smaller.
+# Requires ffmpeg for conversion.
+set -euo pipefail
+
+INPUT="$1"
+OUTPUT_DIR="${2:-$(dirname "$INPUT")}"
+
+if [ -z "$INPUT" ] || [ ! -f "$INPUT" ]; then
+  echo "Usage: convert-video.sh <input.webm> [output_dir]" >&2
+  exit 1
+fi
+
+# If gh-image is available, prefer keeping webm — it uploads as native video
+if command -v gh >/dev/null 2>&1 && gh image --help >/dev/null 2>&1; then
+  echo "$INPUT"
+  echo "Keeping webm (gh-image can upload video directly)" >&2
+  exit 0
+fi
+
+BASENAME=$(basename "$INPUT" .webm)
+GIF_OUT="${OUTPUT_DIR}/${BASENAME}.gif"
+WEBM_SIZE=$(wc -c < "$INPUT" | tr -d ' ')
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo "$INPUT"
+  exit 0
+fi
+
+# Convert to GIF with palette optimization, capped at 480px wide
+ffmpeg -y -i "$INPUT" \
+  -filter_complex "[0:v]fps=5,scale=480:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=128[p];[s1][p]paletteuse=dither=bayer:bayer_scale=3" \
+  "$GIF_OUT" 2>/dev/null
+
+GIF_SIZE=$(wc -c < "$GIF_OUT" | tr -d ' ')
+
+if [ "$GIF_SIZE" -lt "$WEBM_SIZE" ]; then
+  echo "$GIF_OUT"
+  echo "Converted: ${BASENAME}.webm (${WEBM_SIZE}B) -> ${BASENAME}.gif (${GIF_SIZE}B, $(( (WEBM_SIZE - GIF_SIZE) * 100 / WEBM_SIZE ))% smaller)" >&2
+else
+  rm -f "$GIF_OUT"
+  echo "$INPUT"
+  echo "Kept webm: ${BASENAME}.webm (${WEBM_SIZE}B) is smaller than GIF (${GIF_SIZE}B)" >&2
+fi

--- a/.claude/skills/qa-verify/scripts/rebuild.sh
+++ b/.claude/skills/qa-verify/scripts/rebuild.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# rebuild.sh — Clean and rebuild frontend + backend in parallel
+# Usage: rebuild.sh
+# Runs clean then build for both frontend and backend concurrently.
+# Exits non-zero if either build fails.
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+echo "==> Cleaning..."
+./clean-frontend.sh &
+CLEAN_FE=$!
+./clean-backend.sh &
+CLEAN_BE=$!
+wait $CLEAN_FE $CLEAN_BE
+
+echo "==> Building frontend + backend in parallel..."
+./build-frontend.sh &
+BUILD_FE=$!
+./build-backend.sh &
+BUILD_BE=$!
+
+FE_OK=0
+BE_OK=0
+wait $BUILD_FE || FE_OK=$?
+wait $BUILD_BE || BE_OK=$?
+
+if [ $FE_OK -ne 0 ]; then
+  echo "ERROR: Frontend build failed (exit $FE_OK)" >&2
+fi
+if [ $BE_OK -ne 0 ]; then
+  echo "ERROR: Backend build failed (exit $BE_OK)" >&2
+fi
+
+if [ $FE_OK -ne 0 ] || [ $BE_OK -ne 0 ]; then
+  exit 1
+fi
+
+echo "==> Build complete"

--- a/.claude/skills/qa-verify/scripts/screenshots-to-gif.sh
+++ b/.claude/skills/qa-verify/scripts/screenshots-to-gif.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# screenshots-to-gif.sh — Convert numbered PNG screenshots to an animated GIF
+# Usage: screenshots-to-gif.sh <input_dir> <output.gif> [framerate]
+# Default framerate adapts to frame count: 2 seconds per frame, minimum 0.25fps
+set -euo pipefail
+
+INPUT_DIR="${1:-}"
+OUTPUT="${2:-}"
+
+if [ -z "$INPUT_DIR" ] || [ -z "$OUTPUT" ]; then
+  echo "Usage: screenshots-to-gif.sh <input_dir> <output.gif> [framerate]" >&2
+  exit 1
+fi
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo "SKIP: ffmpeg not found, cannot create GIF" >&2
+  exit 0
+fi
+
+PNG_COUNT=$(find "$INPUT_DIR" -maxdepth 1 -name "*.png" | wc -l | tr -d ' ')
+if [ "$PNG_COUNT" -eq 0 ]; then
+  echo "SKIP: No PNG files found in $INPUT_DIR" >&2
+  exit 0
+fi
+
+# Default: 0.5fps (2 seconds per frame). For many frames, slow down further.
+if [ -n "${3:-}" ]; then
+  FRAMERATE="$3"
+elif [ "$PNG_COUNT" -gt 8 ]; then
+  FRAMERATE="0.25"
+else
+  FRAMERATE="0.5"
+fi
+
+# Find max width and max height across all frames so the canvas fits every image.
+# Mixed sizes (e.g., 1920x1080 desktop + 600x1080 mobile) are common.
+MAX_W=0
+MAX_H=0
+for f in "${INPUT_DIR}"/*.png; do
+  if command -v sips >/dev/null 2>&1; then
+    W=$(sips -g pixelWidth "$f" 2>/dev/null | tail -1 | awk '{print $2}')
+    H=$(sips -g pixelHeight "$f" 2>/dev/null | tail -1 | awk '{print $2}')
+  elif command -v identify >/dev/null 2>&1; then
+    W=$(identify -format '%w' "$f" 2>/dev/null)
+    H=$(identify -format '%h' "$f" 2>/dev/null)
+  else
+    W=0; H=0
+  fi
+  [ "${W:-0}" -gt "$MAX_W" ] && MAX_W="$W"
+  [ "${H:-0}" -gt "$MAX_H" ] && MAX_H="$H"
+done
+MAX_W="${MAX_W:-960}"
+MAX_H="${MAX_H:-1080}"
+
+# Uniform scale (force_original_aspect_ratio=decrease) ensures no stretching —
+# each frame is scaled to fit within MAX_WxMAX_H preserving its aspect ratio,
+# then padded with white to fill the canvas. No distortion.
+ffmpeg -y -framerate "$FRAMERATE" \
+  -pattern_type glob -i "${INPUT_DIR}/*.png" \
+  -filter_complex "[0:v]scale=${MAX_W}:${MAX_H}:force_original_aspect_ratio=decrease:flags=lanczos,pad=${MAX_W}:${MAX_H}:(ow-iw)/2:(oh-ih)/2:color=white,split[s0][s1];[s0]palettegen=max_colors=128[p];[s1][p]paletteuse=dither=bayer:bayer_scale=3" \
+  "$OUTPUT"
+
+SECS=$(python3 -c "print(f'{$PNG_COUNT / $FRAMERATE:.0f}')" 2>/dev/null || echo "?")
+echo "Created GIF: $OUTPUT (${PNG_COUNT} frames at ${FRAMERATE}fps, ~${SECS}s)"

--- a/.claude/skills/qa-verify/scripts/upload-evidence.sh
+++ b/.claude/skills/qa-verify/scripts/upload-evidence.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# upload-evidence.sh — Upload QA evidence images for use in GitHub PR comments
+# Usage: upload-evidence.sh <artifacts_dir> [evidence_map_output]
+# Outputs: writes evidence map to evidence_map_output (default: <artifacts_dir>/evidence-map.txt)
+#
+# Strategy:
+#   1. Try gh-image extension with --repo flag (works with SSH remotes)
+#   2. Fall back to base64 data URIs, aggressively compressed to fit 65KB limit
+#
+# IMPORTANT: Original files are NEVER modified. Resizing for base64 works on
+# copies in a temporary directory.
+#
+# Evidence map format:
+#   METHOD=gh-image|base64           (metadata line)
+#   MISSING_GH_IMAGE=true            (metadata line, optional)
+#   TOTAL_BYTES=<n>                  (metadata line, base64 only)
+#   MAP: flat-name URL_OR_DATA_URI   (entry lines, prefixed with MAP:)
+set -euo pipefail
+
+ARTIFACTS_DIR="${1:-}"
+EVIDENCE_MAP="${2:-${ARTIFACTS_DIR:+${ARTIFACTS_DIR}/evidence-map.txt}}"
+COMMENT_BUDGET=61440
+
+if [ -z "$ARTIFACTS_DIR" ]; then
+  echo "Usage: upload-evidence.sh <artifacts_dir> [evidence_map_output]" >&2
+  exit 1
+fi
+
+# Resolve repo name once (works regardless of SSH vs HTTPS remote)
+REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
+
+# Collect all image files
+FILES=()
+while IFS= read -r f; do
+  FILES+=("$f")
+done < <(find "$ARTIFACTS_DIR" -type f \( -name "*.png" -o -name "*.gif" -o -name "*.webm" \) | sort)
+
+if [ ${#FILES[@]} -eq 0 ]; then
+  echo "No image files found in $ARTIFACTS_DIR" >&2
+  exit 1
+fi
+
+# Derive flat name: .../baseline/screenshots/01-foo.png → baseline-screenshots-01-foo.png
+flat_name() {
+  python3 - "$1" "$ARTIFACTS_DIR" <<'PYEOF'
+import sys, os.path
+print(os.path.relpath(sys.argv[1], sys.argv[2]).replace('/', '-'))
+PYEOF
+}
+
+# --- Method 1: gh-image with --repo flag (no resizing — images are CDN-hosted) ---
+# Skips individual files that fail and continues. Only returns 1 if ALL uploads fail.
+use_gh_image() {
+  command -v gh >/dev/null 2>&1 || return 1
+  gh image --help >/dev/null 2>&1 || return 1
+  [ -n "$REPO" ] || return 1
+
+  local succeeded=0
+  for f in "${FILES[@]}"; do
+    local name
+    name=$(flat_name "$f")
+    local gh_err raw_output url
+    gh_err=$(mktemp)
+    if raw_output=$(gh image --repo "$REPO" "$f" 2>"$gh_err"); then
+      rm -f "$gh_err"
+      url=$(echo "$raw_output" | sed -n 's/.*(\(http[^)]*\)).*/\1/p')
+      [ -z "$url" ] && url="$raw_output"
+      echo "MAP: ${name} ${url}"
+      succeeded=$((succeeded + 1))
+    else
+      echo "SKIP: ${name} — $(cat "$gh_err")" >&2
+      rm -f "$gh_err"
+    fi
+  done
+
+  [ "$succeeded" -gt 0 ] && return 0 || return 1
+}
+
+# Create resized copies in a temp directory. NEVER modifies originals.
+# Returns the temp directory path (caller must clean up).
+create_resized_copies() {
+  local max_width="$1"
+  local tmpdir
+  tmpdir=$(mktemp -d)
+
+  for f in "${FILES[@]}"; do
+    local name
+    name=$(flat_name "$f")
+    cp "$f" "${tmpdir}/${name}"
+
+    if [[ "$f" == *.png ]]; then
+      local copy="${tmpdir}/${name}"
+      if command -v sips >/dev/null 2>&1; then
+        local W
+        W=$(sips -g pixelWidth "$copy" 2>/dev/null | tail -1 | awk '{print $2}')
+        if [ -n "$W" ] && [ "$W" -gt "$max_width" ]; then
+          sips --resampleWidth "$max_width" "$copy" >/dev/null 2>&1 || true
+        fi
+      elif command -v convert >/dev/null 2>&1; then
+        convert "$copy" -resize "${max_width}>" "$copy" 2>/dev/null || true
+      fi
+    fi
+  done
+
+  echo "$tmpdir"
+}
+
+# --- Method 2: base64 data URIs ---
+# Resizes copies to 960px (readable but not full-res). Never goes below 960px —
+# if the total payload exceeds 65KB, build-comment.sh handles splitting across
+# multiple comments. Shrinking images to 120px made them useless.
+use_base64() {
+  local tmpdir
+  tmpdir=$(create_resized_copies 960)
+
+  local total_bytes=0
+  local output=""
+
+  for f in "${FILES[@]}"; do
+    # Skip webm in base64 mode — GitHub doesn't render video data URIs
+    [[ "$f" == *.webm ]] && continue
+    local name mime b64 entry copy
+    name=$(flat_name "$f")
+    copy="${tmpdir}/${name}"
+    case "$f" in
+      *.png) mime="image/png" ;;
+      *.gif) mime="image/gif" ;;
+      *)     mime="application/octet-stream" ;;
+    esac
+    b64=$(base64 < "$copy" | tr -d '\n')
+    entry="data:${mime};base64,${b64}"
+    total_bytes=$((total_bytes + ${#entry}))
+    output="${output}MAP: ${name} ${entry}\n"
+  done
+
+  printf '%b' "$output" | grep -v '^$' || true
+  echo "TOTAL_BYTES=${total_bytes}"
+
+  if [ "$total_bytes" -gt "$COMMENT_BUDGET" ]; then
+    echo "NOTE: base64 payload is ${total_bytes} bytes (exceeds 65KB). build-comment.sh will split across multiple comments." >&2
+  fi
+
+  rm -rf "$tmpdir"
+}
+
+# --- Main ---
+: > "$EVIDENCE_MAP"
+
+if command -v gh >/dev/null 2>&1 && gh image --help >/dev/null 2>&1; then
+  echo "METHOD=gh-image" | tee -a "$EVIDENCE_MAP"
+  if use_gh_image >> "$EVIDENCE_MAP"; then
+    cat "$EVIDENCE_MAP"
+    exit 0
+  fi
+  echo "gh-image upload failed for all files, falling back to base64" >&2
+  : > "$EVIDENCE_MAP"
+else
+  echo "MISSING_GH_IMAGE=true"
+  echo "gh-image extension not installed. Install it for native GitHub CDN image URLs:" >&2
+  echo "  gh extension install drogers0/gh-image" >&2
+  echo "(Note: gh-image is a third-party community extension)" >&2
+fi
+
+echo "METHOD=base64" | tee -a "$EVIDENCE_MAP"
+use_base64 >> "$EVIDENCE_MAP"
+cat "$EVIDENCE_MAP"

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ cypress-a11y-report.json
 /dynamic-demo-plugin/**/dist
 **/.claude/settings.local.json
 **/chartstore-*/
+.artifacts/
+.playwright-mcp/


### PR DESCRIPTION
**Analysis / Root cause**:
There is no automated way to visually verify PR changes against a baseline. Reviewers must manually build, run, and screenshot the console on both `main` and the PR branch to compare behavior — a process that takes 30+ minutes per PR.

**Solution description**:
Adds a Claude Code skill (`/qa-verify`) that automates visual QA verification for OpenShift Console PRs using Playwright MCP. The skill:

- Gathers context from the PR description (test setup/cases), Jira ticket, and commit diff
- Derives a verification plan and presents it for user approval
- Builds and runs the console on the baseline branch and the PR branch (in parallel via `rebuild.sh`)
- Uses Playwright MCP to navigate routes, interact with the UI, and capture before/after screenshots
- Compiles evidence into GIFs and structured collapsible PR comments
- Uploads images via `gh-image` (CDN) with base64 data URI fallback
- Posts a side-by-side comparison as an upsertable GitHub PR comment

Helper scripts:
- `backend.sh` — server lifecycle management (`--start`/`--stop`/`--status`)
- `rebuild.sh` — parallel clean + build for frontend and backend
- `upload-evidence.sh` — image upload with `gh-image` / base64 fallback (never modifies originals)
- `build-comment.sh` — constructs the PR comment markdown with collapsible step sections
- `screenshots-to-gif.sh` — creates animated GIFs from screenshots with uniform scaling
- `convert-video.sh` — converts Playwright session videos to GIF when smaller
- `check-prerequisites.sh` — validates all required tools with OS-aware install hints

**Screenshots / screen recording**:
<!-- Screenshots will be added after testing -->

**Test setup:**
1. Ensure `oc`, `go`, `node` (>=22), `yarn`, `gh`, `python3`, `ffmpeg` are installed
2. Install the `gh-image` extension: `gh extension install drogers0/gh-image` (third-party, optional)
3. Configure Playwright MCP with `--ignore-https-errors` (and optionally `--save-video=1920x1080`)
4. Log in to an OpenShift cluster as kubeadmin: `oc login`
5. Run `/qa-verify <PR-URL-or-number>` from the repo root

**Test cases:**
1. Run `/qa-verify https://github.com/openshift/console/pull/16412` on a frontend-only PR — verify screenshots are captured for both baseline and candidate, GIFs are generated, and a PR comment is posted
2. Run `/qa-verify` without arguments on a branch with an open PR — verify the skill auto-detects the PR number
3. Run on a backend-only PR (Go changes only) — verify the skill offers `go test` comparison as an alternative
4. Run on a fork PR — verify `gh pr checkout` handles the fork correctly
5. Verify the PR comment upsert: run twice on the same PR and confirm the comment is updated, not duplicated
6. Verify cleanup: after the skill completes, confirm the original branch is restored, stash is popped only if created, and the candidate branch is deleted only if it was created by the skill

**Browser conformance**:
- [x] Chrome (Playwright Chromium)
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
- The skill is invoked manually (`disable-model-invocation: true`) to prevent accidental triggering
- Uses the `arguments: [pr]` frontmatter for named parameter substitution
- Dynamic context injection (`!` syntax) pre-fetches PR details at invocation time
- See Limitations section in SKILL.md for features not testable with the local dev setup (dynamic plugins, telemetry, OIDC, etc.)
- Backport PRs targeting `release-4.x` branches are supported — baseline is auto-detected from `baseRefName`


<details>

<summary>Original prompt</summary>

```
As an expert in Claude skills, develop a claude skill and potentially a series of subagents which provide automatic QA verification using Playwright MCP. 

The skill when run should verify the current branch and compare it against a result in main. Verification should be done either based on a combionation of the following information if applicable: "test setup" or "test cases" section of a PR, description of the ticket provided using Jira MCP, and commit details.

The agent should provide video proof of the verification using Playwright MCP.

For inspiration for what a similar workflow already does, refer to the OpenClaw repo in /tmp/openclaw and refer to their telegram user proof script. However we aren't using crabbox and will be using Playwright.

Also refer to `/tmp/kubevirt-ui` for a cursor-specifc example which uses Playwright MCP to acheive a similar outcome.

The end result should produce a GitHub comment on the open PR (if applicable) containing before/after videos, such as this: https://github.com/openclaw/openclaw/pull/76999#issuecomment-4415012577

The skill, if possible, should be responsible for also running all services (such as the backend), when required. The skill should be responsible for switching branches (e.g., from main to the PR branch), running `build-frontend.sh` to build a production build of the application, then running `bash -c "source ./contrib/oc-environment.sh && ./bin/bridge -branding openshift"` in the background to start a backend server running on port 9000. No development frontend server is required after `build-frontend.sh` is run, the backend automatically serves all frontend files and artifacts.

Ensure a connection is valid and is running under `kubeadmin` by running `oc whoami` prior to starting the backend server.

Of course this skill has prerequisites such as `oc` (install via `openshift-cli` in homebrew), `go`, `nodejs`, JIRA mcp, `gh` cli, etc. determine everything that is required and ensure that the agent has access to it before the skill can run.
```

</details>