### PR TITLE
OCPBUGS-84669: Fix ProjectLink to update active namespace in Redux

### DIFF
--- a/frontend/public/components/__tests__/namespace.spec.tsx
+++ b/frontend/public/components/__tests__/namespace.spec.tsx
@@ -1,7 +1,8 @@
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
-import { PullSecret } from '../namespace';
+import { PullSecret, ProjectLink } from '../namespace';
 import * as k8sResourceModule from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-resource';
 import { testNamespace } from '../../../__mocks__/k8sResourcesMocks';
 import { ServiceAccountModel } from '../../models';
@@ -9,6 +10,12 @@ import { ServiceAccountModel } from '../../models';
 jest.mock('@console/dynamic-plugin-sdk/src/utils/k8s/k8s-resource', () => ({
   ...jest.requireActual('@console/dynamic-plugin-sdk/src/utils/k8s/k8s-resource'),
   k8sGet: jest.fn(),
+}));
+
+const mockSetActiveNamespace = jest.fn();
+jest.mock('@console/shared/src/hooks/useActiveNamespace', () => ({
+  ...jest.requireActual('@console/shared/src/hooks/useActiveNamespace'),
+  useActiveNamespace: jest.fn(() => ['default', mockSetActiveNamespace]),
 }));
 
 const k8sGetMock = k8sResourceModule.k8sGet as jest.Mock;
@@ -48,5 +55,44 @@ describe('PullSecret', () => {
 
     const button = await screen.findByRole('button', { name: 'Not configured' });
     expect(button).toBeVisible();
+  });
+});
+
+// Regression test: ProjectLink must update the active namespace via useActiveNamespace
+// so that pages like API Explorer (which read activeNamespace from Redux) reflect the
+// namespace selected on the Projects list page.
+describe('ProjectLink', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls setActiveNamespace when a project link is clicked', async () => {
+    const project = {
+      metadata: { name: 'my-project', uid: 'test-uid' },
+    };
+    const user = userEvent.setup();
+
+    renderWithProviders(<ProjectLink project={project} />);
+
+    const link = screen.getByRole('link', { name: 'my-project' });
+    await user.click(link);
+
+    expect(mockSetActiveNamespace).toHaveBeenCalledWith('my-project');
+  });
+
+  it('does not call setActiveNamespace on modified click (Ctrl+Click)', async () => {
+    const project = {
+      metadata: { name: 'my-project', uid: 'test-uid' },
+    };
+    const user = userEvent.setup();
+
+    renderWithProviders(<ProjectLink project={project} />);
+
+    const link = screen.getByRole('link', { name: 'my-project' });
+    await user.keyboard('{Control>}');
+    await user.click(link);
+    await user.keyboard('{/Control}');
+
+    expect(mockSetActiveNamespace).not.toHaveBeenCalled();
   });
 });

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -27,14 +27,13 @@ import { getRequester, getDescription } from '@console/shared/src/selectors/name
 import {
   FLAGS,
   COLUMN_MANAGEMENT_USER_PREFERENCE_KEY,
-  LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
-  LAST_NAMESPACE_NAME_USER_PREFERENCE_KEY,
   REQUESTER_FILTER,
 } from '@console/shared/src/constants/common';
 import { GreenCheckCircleIcon } from '@console/shared/src/components/status/icons';
 import { getName } from '@console/shared/src/selectors/common';
 import { useUserPreference } from '@console/shared/src/hooks/useUserPreference';
 import { isModifiedEvent } from '@console/shared/src/utils/utils';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useFlag } from '@console/shared/src/hooks/useFlag';
 import { usePrometheusGate } from '@console/shared/src/hooks/usePrometheusGate';
 import { DASH } from '@console/shared/src/constants/ui';
@@ -689,9 +688,9 @@ const getProjectDataViewRows = (
   });
 };
 
-const ProjectLink = ({ project }) => {
+export const ProjectLink = ({ project }) => {
   const dispatch = useConsoleDispatch();
-  const [, setLastNamespace] = useUserPreference(LAST_NAMESPACE_NAME_USER_PREFERENCE_KEY);
+  const [, setActiveNamespace] = useActiveNamespace();
   const url = new URL(window.location.href);
   const params = new URLSearchParams(url.search);
   const basePath = url.pathname;
@@ -710,15 +709,10 @@ const ProjectLink = ({ project }) => {
     if (isModifiedEvent(e)) {
       return;
     }
-    setLastNamespace(project.metadata.name);
-    // update last namespace in session storage (persisted only for current browser tab). Used to remember/restore if
-    // "All Projects" was selected when returning to the list view (typically from details view) via breadcrumb or
-    // sidebar navigation
-    sessionStorage.setItem(LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY, project.metadata.name);
-    // clear project-name filter when active namespace is changed
+
+    setActiveNamespace(project.metadata.name);
     dispatch(k8sActions.filterList(referenceForModel(ProjectModel), 'project-name', ''));
   };
-
   return (
     <span className="co-resource-item co-resource-item--truncate">
       <ResourceIcon kind="Project" />


### PR DESCRIPTION
<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:  ProjectLink.handleClick updates sessionStorage but never dispatches the Redux setActiveNamespace action. API Explorer reads from Redux, so it shows a stale namespace.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution description**: Replace setLastNamespace/sessionStorage calls with useActiveNamespace hook, which syncs Redux, context, and preferences in one call.
<!-- Describe your code changes in detail and explain the solution or functionality -->

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Test cases:** Navigate to Home > Projects, click a project name (e.g., openshift-monitoring), then navigate to API Explorer — the namespace should reflect openshift-monitoring.
Use the namespace dropdown to select Namespace A, then go to Home > Projects and click Namespace B, then navigate to API Explorer — it should show Namespace B.
Ctrl+Click on a project name — should open in a new tab without changing the active namespace.
<!-- List possible test cases to validate the changes. -->

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed project link behavior to properly update the active namespace when clicked.
  * Modified clicks (Ctrl+Click) no longer trigger unintended namespace changes.

* **Tests**
  * Added regression tests for project link selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->