### PR TITLE
HELM-728: Persist secrets for Helm upgrade

### DIFF
--- a/pkg/helm/actions/get_chart.go
+++ b/pkg/helm/actions/get_chart.go
@@ -77,7 +77,7 @@ func GetChartFromURL(url string, conf *action.Configuration, namespace string, c
 		if err != nil {
 			return nil, err
 		}
-		if err := applyBasicAuthFromUserCredentials(cmd, userCredentials); err != nil {
+		if err := applyBasicAuthFromUserCredentials(&cmd.ChartPathOptions, cmd, userCredentials); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/helm/actions/install_chart.go
+++ b/pkg/helm/actions/install_chart.go
@@ -14,6 +14,7 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/release"
 	kv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,6 +48,14 @@ var (
 	ociURLRe  = regexp.MustCompile(`(?i)^oci://` + hostPort)
 	httpURLRe = regexp.MustCompile(`(?i)^https?://` + hostPort + `/.+\.(?:tar\.gz|tgz)$`)
 )
+
+const (
+	helmAuthSecretAnnotation = "helm.openshift.io/auth-secret"
+)
+
+type RegistryClientSetter interface {
+	SetRegistryClient(rc *registry.Client)
+}
 
 // isValidChartURL validates chart URLs using RFC-compliant hostname labels.
 // Accepts oci://<registry>/<path> and http(s)://<host>/<path>.tgz|tar.gz URLs.
@@ -281,15 +290,23 @@ func GetUserCredentials(coreClient corev1client.CoreV1Interface, ns, secretName 
 }
 
 // applyBasicAuthFromSecret sets cmd.Username and cmd.Password from a userCredentials and sets the registry client
-func applyBasicAuthFromUserCredentials(cmd *action.Install, userCredentials *UserCredentials) error {
+func applyBasicAuthFromUserCredentials(cmd *action.ChartPathOptions, setter RegistryClientSetter, userCredentials *UserCredentials) error {
 	cmd.Username = userCredentials.Username
 	cmd.Password = userCredentials.Password
 	rc, err := GetOCIRegistry(false, false, userCredentials)
 	if err != nil {
 		return fmt.Errorf("failed to configure OCI registry client: %w", err)
 	}
-	cmd.SetRegistryClient(rc)
+	setter.SetRegistryClient(rc)
 	return nil
+}
+
+// addAuthSecretAnnotation adds the auth secret reference to the release annotations via chart metadata.
+func addAuthSecretAnnotation(ch *chart.Chart, secretName string) {
+	if secretName == "" {
+		return
+	}
+	ch.Metadata.Annotations[helmAuthSecretAnnotation] = secretName
 }
 
 // InstallChartFromURL installs a chart from an OCI or direct HTTP(S) chart URL.
@@ -312,7 +329,7 @@ func InstallChartFromURL(ns, name, url string, vals map[string]interface{}, conf
 		if err != nil {
 			return nil, err
 		}
-		if err := applyBasicAuthFromUserCredentials(cmd, userCredentials); err != nil {
+		if err := applyBasicAuthFromUserCredentials(&cmd.ChartPathOptions, cmd, userCredentials); err != nil {
 			return nil, err
 		}
 	}
@@ -345,6 +362,7 @@ func InstallChartFromURL(ns, name, url string, vals map[string]interface{}, conf
 	}
 	ch.Metadata.Annotations["chart_url"] = url
 	ch.Metadata.Annotations["installation"] = "url_install"
+	addAuthSecretAnnotation(ch, basicAuthSecretName)
 	go func() {
 		_, err := cmd.Run(ch, vals)
 		if err == nil {

--- a/pkg/helm/actions/install_chart_test.go
+++ b/pkg/helm/actions/install_chart_test.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
+	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
@@ -23,6 +25,14 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 )
+
+type mockRegistryClientSetter struct {
+	client *registry.Client
+}
+
+func (m *mockRegistryClientSetter) SetRegistryClient(rc *registry.Client) {
+	m.client = rc
+}
 
 type FakeConfig struct {
 	action.RESTClientGetter
@@ -650,4 +660,140 @@ func TestIsValidChartURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAddAuthSecretAnnotation(t *testing.T) {
+	t.Run("sets annotation when secretName is non-empty", func(t *testing.T) {
+		ch := &chart.Chart{
+			Metadata: &chart.Metadata{
+				Annotations: make(map[string]string),
+			},
+		}
+		addAuthSecretAnnotation(ch, "my-auth-secret")
+		require.Equal(t, "my-auth-secret", ch.Metadata.Annotations[helmAuthSecretAnnotation])
+	})
+
+	t.Run("no-op when secretName is empty", func(t *testing.T) {
+		ch := &chart.Chart{
+			Metadata: &chart.Metadata{
+				Annotations: make(map[string]string),
+			},
+		}
+		addAuthSecretAnnotation(ch, "")
+		_, exists := ch.Metadata.Annotations[helmAuthSecretAnnotation]
+		require.False(t, exists)
+	})
+
+	t.Run("preserves existing annotations", func(t *testing.T) {
+		ch := &chart.Chart{
+			Metadata: &chart.Metadata{
+				Annotations: map[string]string{
+					"chart_url":    "oci://registry.example.com/charts/mychart:1.0.0",
+					"installation": "url_install",
+				},
+			},
+		}
+		addAuthSecretAnnotation(ch, "my-auth-secret")
+		require.Equal(t, "my-auth-secret", ch.Metadata.Annotations[helmAuthSecretAnnotation])
+		require.Equal(t, "oci://registry.example.com/charts/mychart:1.0.0", ch.Metadata.Annotations["chart_url"])
+		require.Equal(t, "url_install", ch.Metadata.Annotations["installation"])
+	})
+}
+
+func TestGetUserCredentials(t *testing.T) {
+	t.Run("returns credentials from valid secret", func(t *testing.T) {
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "auth-secret",
+				Namespace: "test-ns",
+			},
+			Data: map[string][]byte{
+				"username": []byte("admin"),
+				"password": []byte("s3cret"),
+			},
+		}
+		clientset := k8sfake.NewSimpleClientset(secret)
+		coreClient := clientset.CoreV1()
+
+		creds, err := GetUserCredentials(coreClient, "test-ns", "auth-secret")
+		require.NoError(t, err)
+		require.Equal(t, "admin", creds.Username)
+		require.Equal(t, "s3cret", creds.Password)
+	})
+
+	t.Run("returns error when secret not found", func(t *testing.T) {
+		clientset := k8sfake.NewSimpleClientset()
+		coreClient := clientset.CoreV1()
+
+		_, err := GetUserCredentials(coreClient, "test-ns", "nonexistent")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to get secret")
+	})
+
+	t.Run("returns error when username key is missing", func(t *testing.T) {
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bad-secret",
+				Namespace: "test-ns",
+			},
+			Data: map[string][]byte{
+				"password": []byte("s3cret"),
+			},
+		}
+		clientset := k8sfake.NewSimpleClientset(secret)
+		coreClient := clientset.CoreV1()
+
+		_, err := GetUserCredentials(coreClient, "test-ns", "bad-secret")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to find \"username\" key in secret")
+	})
+
+	t.Run("returns error when password key is missing", func(t *testing.T) {
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bad-secret",
+				Namespace: "test-ns",
+			},
+			Data: map[string][]byte{
+				"username": []byte("admin"),
+			},
+		}
+		clientset := k8sfake.NewSimpleClientset(secret)
+		coreClient := clientset.CoreV1()
+
+		_, err := GetUserCredentials(coreClient, "test-ns", "bad-secret")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to find \"password\" key in secret")
+	})
+}
+
+func TestApplyBasicAuthFromUserCredentials(t *testing.T) {
+	t.Run("sets credentials and registry client", func(t *testing.T) {
+		opts := &action.ChartPathOptions{}
+		setter := &mockRegistryClientSetter{}
+		creds := &UserCredentials{Username: "admin", Password: "s3cret"}
+
+		err := applyBasicAuthFromUserCredentials(opts, setter, creds)
+		require.NoError(t, err)
+		require.Equal(t, "admin", opts.Username)
+		require.Equal(t, "s3cret", opts.Password)
+		require.NotNil(t, setter.client)
+	})
+
+	t.Run("returns error when registry client creation fails", func(t *testing.T) {
+		original := newRegistryClient
+		defer func() { newRegistryClient = original }()
+		newRegistryClient = func(opts ...registry.ClientOption) (*registry.Client, error) {
+			return nil, errors.New("mock registry error")
+		}
+
+		opts := &action.ChartPathOptions{}
+		setter := &mockRegistryClientSetter{}
+		creds := &UserCredentials{Username: "admin", Password: "s3cret"}
+
+		err := applyBasicAuthFromUserCredentials(opts, setter, creds)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to configure OCI registry client")
+		require.Nil(t, setter.client)
+	})
 }

--- a/pkg/helm/actions/upgrade_release.go
+++ b/pkg/helm/actions/upgrade_release.go
@@ -17,6 +17,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
 )
 
 func UpgradeRelease(
@@ -158,10 +159,14 @@ func UpgradeReleaseAsync(
 		return nil, err
 	}
 
+	auth_secret := ""
 	// Before proceeding, check if chart URL is present as an annotation
 	if rel.Chart.Metadata.Annotations != nil {
 		if chart_url, ok := rel.Chart.Metadata.Annotations["chart_url"]; chartUrl == "" && ok {
 			chartUrl = chart_url
+		}
+		if authSecret, ok := rel.Chart.Metadata.Annotations[helmAuthSecretAnnotation]; ok {
+			auth_secret = authSecret
 		}
 	}
 
@@ -223,6 +228,20 @@ func UpgradeReleaseAsync(
 			ch.Metadata.Annotations = make(map[string]string)
 		}
 		ch.Metadata.Annotations["chart_url"] = chartUrl
+	}
+	if auth_secret != "" {
+		klog.Infof("Found persisted auth secret %s for release %s/%s, applying credentials for upgrade", auth_secret, releaseNamespace, releaseName)
+		userCredentials, err := GetUserCredentials(coreClient, releaseNamespace, auth_secret)
+		if err != nil {
+			klog.Infof("Failed to get user credentials for release upgrade %s/%s: %v", releaseNamespace, releaseName, err)
+
+		} else {
+			if err := applyBasicAuthFromUserCredentials(&client.ChartPathOptions, client, userCredentials); err != nil {
+				klog.Errorf("Failed to apply auth from secret %s for release %s/%s: %v", auth_secret, releaseNamespace, releaseName, err)
+				// Continue with upgrade but log the error - the upgrade may still work if auth is not required
+			}
+		}
+
 	}
 	go func() {
 		_, err := client.Run(releaseName, ch, vals)

--- a/pkg/helm/actions/upgrade_release.go
+++ b/pkg/helm/actions/upgrade_release.go
@@ -204,6 +204,17 @@ func UpgradeReleaseAsync(
 				}
 			}
 		}
+		if auth_secret != "" {
+			klog.Infof("Found persisted auth secret %s for release %s/%s, applying credentials for upgrade", auth_secret, releaseNamespace, releaseName)
+			userCredentials, err := GetUserCredentials(coreClient, releaseNamespace, auth_secret)
+			if err != nil {
+				klog.Errorf("Failed to get user credentials for release upgrade %s/%s: %v", releaseNamespace, releaseName, err)
+			} else {
+				if err := applyBasicAuthFromUserCredentials(&client.ChartPathOptions, client, userCredentials); err != nil {
+					klog.Errorf("Failed to apply auth from secret %s for release %s/%s: %v", auth_secret, releaseNamespace, releaseName, err)
+				}
+			}
+		}
 		chartLocation = chartUrl
 		client.ChartPathOptions.Version = chartInfo.Version
 		cp, err = client.ChartPathOptions.LocateChart(chartLocation, settings)
@@ -229,19 +240,6 @@ func UpgradeReleaseAsync(
 		}
 		ch.Metadata.Annotations["chart_url"] = chartUrl
 		addAuthSecretAnnotation(ch, auth_secret)
-	}
-	if auth_secret != "" {
-		klog.Infof("Found persisted auth secret %s for release %s/%s, applying credentials for upgrade", auth_secret, releaseNamespace, releaseName)
-		userCredentials, err := GetUserCredentials(coreClient, releaseNamespace, auth_secret)
-		if err != nil {
-			klog.Infof("Failed to get user credentials for release upgrade %s/%s: %v", releaseNamespace, releaseName, err)
-
-		} else {
-			if err := applyBasicAuthFromUserCredentials(&client.ChartPathOptions, client, userCredentials); err != nil {
-				klog.Errorf("Failed to apply auth from secret %s for release %s/%s: %v", auth_secret, releaseNamespace, releaseName, err)
-				// Continue with upgrade but log the error - the upgrade may still work if auth is not required
-			}
-		}
 	}
 	go func() {
 		_, err := client.Run(releaseName, ch, vals)

--- a/pkg/helm/actions/upgrade_release.go
+++ b/pkg/helm/actions/upgrade_release.go
@@ -205,13 +205,12 @@ func UpgradeReleaseAsync(
 			}
 		}
 		if auth_secret != "" {
-			klog.Infof("Found persisted auth secret %s for release %s/%s, applying credentials for upgrade", auth_secret, releaseNamespace, releaseName)
 			userCredentials, err := GetUserCredentials(coreClient, releaseNamespace, auth_secret)
 			if err != nil {
-				klog.Errorf("Failed to get user credentials for release upgrade %s/%s: %v", releaseNamespace, releaseName, err)
+				klog.Errorf("Failed to get user credentials Secret %s for release upgrade %s/%s: %v", auth_secret, releaseNamespace, releaseName, err)
 			} else {
 				if err := applyBasicAuthFromUserCredentials(&client.ChartPathOptions, client, userCredentials); err != nil {
-					klog.Errorf("Failed to apply auth from secret %s for release %s/%s: %v", auth_secret, releaseNamespace, releaseName, err)
+					klog.Errorf("Failed to apply auth from Secret %s for release upgrade %s/%s: %v", auth_secret, releaseNamespace, releaseName, err)
 				}
 			}
 		}
@@ -234,10 +233,13 @@ func UpgradeReleaseAsync(
 	}
 
 	// Ensure chart URL is properly set in the upgrade chart
+	if ch.Metadata == nil {
+		ch.Metadata = &chart.Metadata{}
+	}
+	if ch.Metadata.Annotations == nil {
+		ch.Metadata.Annotations = make(map[string]string)
+	}
 	if chartUrl != "" {
-		if ch.Metadata.Annotations == nil {
-			ch.Metadata.Annotations = make(map[string]string)
-		}
 		ch.Metadata.Annotations["chart_url"] = chartUrl
 		addAuthSecretAnnotation(ch, auth_secret)
 	}

--- a/pkg/helm/actions/upgrade_release.go
+++ b/pkg/helm/actions/upgrade_release.go
@@ -228,6 +228,7 @@ func UpgradeReleaseAsync(
 			ch.Metadata.Annotations = make(map[string]string)
 		}
 		ch.Metadata.Annotations["chart_url"] = chartUrl
+		addAuthSecretAnnotation(ch, auth_secret)
 	}
 	if auth_secret != "" {
 		klog.Infof("Found persisted auth secret %s for release %s/%s, applying credentials for upgrade", auth_secret, releaseNamespace, releaseName)
@@ -241,7 +242,6 @@ func UpgradeReleaseAsync(
 				// Continue with upgrade but log the error - the upgrade may still work if auth is not required
 			}
 		}
-
 	}
 	go func() {
 		_, err := client.Run(releaseName, ch, vals)

--- a/pkg/helm/actions/upgrade_release_test.go
+++ b/pkg/helm/actions/upgrade_release_test.go
@@ -705,3 +705,96 @@ func TestUpgradeReleaseWithCustomValuesAsync(t *testing.T) {
 		})
 	}
 }
+
+func TestUpgradeAfterURLInstallWithSecrets(t *testing.T) {
+	tests := []struct {
+		testName         string
+		chartPath        string
+		chartName        string
+		chartVersion     string
+		releaseName      string
+		releaseNamespace string
+		secretName       string
+		secretData       map[string][]byte
+	}{
+		{
+			testName:         "upgrade valid release with custom values should return successful response",
+			chartPath:        "http://localhost:8181/charts/mychart-0.1.0.tgz",
+			chartName:        "mychart",
+			chartVersion:     "0.1.0",
+			releaseName:      "auth-persist-test",
+			releaseNamespace: "test-namespace",
+			secretName:       "test-secret",
+			secretData:       map[string][]byte{username: []byte("AzureDiamond"), password: []byte("hunter2")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			store := storage.Init(driver.NewMemory())
+			actionConfig := &action.Configuration{
+				RESTClientGetter: FakeConfig{},
+				Releases:         store,
+				KubeClient:       &kubefake.PrintingKubeClient{Out: io.Discard},
+				Capabilities:     chartutil.DefaultCapabilities,
+				Log:              func(format string, v ...interface{}) {},
+			}
+			authSecret := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.secretName,
+					Namespace: tt.releaseNamespace,
+				},
+				Data: tt.secretData,
+			}
+			clientInterface := k8sfake.NewSimpleClientset(authSecret)
+			coreClient := clientInterface.CoreV1()
+			registryClient, err := GetDefaultOCIRegistry()
+			require.NoError(t, err)
+			actionConfig.RegistryClient = registryClient
+			dynamicClient := K8sDynamicClientFromCRs()
+
+			// Simulate a URL install by creating the release with auth annotation
+			installRelease := release.Release{
+				Name:      tt.releaseName,
+				Namespace: tt.releaseNamespace,
+				Info: &release.Info{
+					FirstDeployed: helmTime.Time{},
+					Status:        "deployed",
+				},
+				Version: 1,
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Name:    tt.chartName,
+						Version: tt.chartVersion,
+						Annotations: map[string]string{
+							"chart_url":              tt.chartPath,
+							helmAuthSecretAnnotation: tt.secretName,
+						},
+					},
+				},
+			}
+			store.Create(&installRelease)
+
+			// Verify the installed release has the auth annotation
+			rel, err := GetRelease(tt.releaseName, actionConfig)
+			require.NoError(t, err)
+			require.Equal(t, tt.secretName, rel.Chart.Metadata.Annotations[helmAuthSecretAnnotation])
+
+			// Upgrade — chartUrl is recovered from the annotation, auth credentials are applied
+			secretsDriver := driver.NewSecrets(coreClient.Secrets(tt.releaseNamespace))
+			go func() {
+				upgradeResult, upgradeErr := UpgradeReleaseAsync(tt.releaseNamespace, tt.releaseName, "", nil, actionConfig, dynamicClient, coreClient, true, "")
+				require.NoError(t, upgradeErr)
+				require.Equal(t, fmt.Sprintf("sh.helm.release.v1.%v.v2", tt.releaseName), upgradeResult.ObjectMeta.Name)
+			}()
+			time.Sleep(10 * time.Second)
+			installRelease.Version = 2
+			err = secretsDriver.Create(fmt.Sprintf("sh.helm.release.v1.%v.v2", tt.releaseName), &installRelease)
+			require.NoError(t, err)
+
+			// Verify the upgraded release preserved the auth annotation
+			rel, err = GetRelease(tt.releaseName, actionConfig)
+			require.NoError(t, err)
+			require.Equal(t, tt.secretName, rel.Chart.Metadata.Annotations[helmAuthSecretAnnotation])
+		})
+	}
+}


### PR DESCRIPTION
<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
Helm releases are installed via URL charts which use authentication. This authentication is stored as a generic secret. But this is not persisted during upgrade, which leads to upgrade failing.  
**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->
The secret for authentication is added as a metadata for the Helm release. So while upgrade, it is fetched and used for authentication.

## Summary by Coderabbit
* **New Features**
  * Chart installations now record a reference to stored basic-auth credentials

* **Bug Fixes**
  * Improved basic-auth handling for installing and upgrading charts from URLs
  * Persisted user credentials are automatically reapplied during upgrades, avoiding manual re-entry
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed basic-auth so credentials are correctly applied for Helm chart installs, and re-applied during release upgrades when an auth secret reference is present.
  * Improved upgrade behavior when credential lookup or application fails by logging issues without aborting the upgrade.
* **New Features**
  * Added support for OCI registry client configuration for Helm chart URL installs.
  * Chart metadata now persists the basic-auth secret reference across upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->