### PR TITLE
OCPBUGS-79521: Restore list page text and row filter functionality

### DIFF
--- a/frontend/public/components/factory/__tests__/list-page.spec.tsx
+++ b/frontend/public/components/factory/__tests__/list-page.spec.tsx
@@ -1,6 +1,8 @@
+import type { FC } from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TextFilter } from '@console/internal/components/factory/text-filter';
+import { getFilteredRows } from '@console/internal/components/factory/table-data-hook';
 import {
   ListPageWrapper,
   FireMan,
@@ -149,6 +151,49 @@ describe('ListPageWrapper component', () => {
     renderWithProviders(<ListPageWrapper {...defaultProps} />);
 
     expect(screen.getByText('List Content')).toBeVisible();
+  });
+
+  it('filters visible items when user types in the search field', async () => {
+    const user = userEvent.setup();
+    const items = [
+      { metadata: { name: 'alpha-pod' } },
+      { metadata: { name: 'beta-pod' } },
+      { metadata: { name: 'gamma-node' } },
+    ];
+
+    const FilteredList: FC<{ data: any[]; filters: any }> = ({ data, filters }) => {
+      const filtered = getFilteredRows(filters, [], data);
+      return (
+        <ul>
+          {filtered.map((item) => (
+            <li key={item.metadata.name}>{item.metadata.name}</li>
+          ))}
+        </ul>
+      );
+    };
+
+    renderWithProviders(
+      <ListPageWrapper
+        {...defaultProps}
+        flatten={() => items}
+        ListComponent={FilteredList}
+        reduxIDs={['test-id']}
+        textFilter="name"
+      />,
+    );
+
+    expect(screen.getByText('alpha-pod')).toBeVisible();
+    expect(screen.getByText('beta-pod')).toBeVisible();
+    expect(screen.getByText('gamma-node')).toBeVisible();
+
+    const searchInput = screen.getByPlaceholderText('Search by name...');
+    await user.type(searchInput, 'alpha');
+
+    await waitFor(() => {
+      expect(screen.getByText('alpha-pod')).toBeVisible();
+      expect(screen.queryByText('beta-pod')).not.toBeInTheDocument();
+      expect(screen.queryByText('gamma-node')).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/frontend/public/components/factory/list-page.tsx
+++ b/frontend/public/components/factory/list-page.tsx
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import type { ComponentType, FC, ReactNode } from 'react';
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { useConsoleDispatch } from '@console/shared/src/hooks/useConsoleDispatch';
+import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
 import { useParams, useNavigate } from 'react-router';
 import { Button, Grid, GridItem } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
@@ -106,6 +107,22 @@ export const ListPageWrapper: FC<ListPageWrapperProps> = (props) => {
     }
   }, [dispatch, nameFilter, memoizedIds]);
 
+  const rawFilters = useConsoleSelector((state) => {
+    if (!memoizedIds?.length) {
+      return undefined;
+    }
+    return memoizedIds.reduce((acc, id) => {
+      const idFilters = state.k8s.getIn([id, 'filters']);
+      if (idFilters) {
+        idFilters.forEach((value, key) => {
+          acc[key] = value;
+        });
+      }
+      return acc;
+    }, {});
+  });
+  const filters = useDeepCompareMemoize(rawFilters);
+
   const data = flatten ? flatten(watchedResources) : [];
   const Filter = (
     <FilterToolbar
@@ -128,7 +145,7 @@ export const ListPageWrapper: FC<ListPageWrapperProps> = (props) => {
       {!omitFilterToolbar && !_.isEmpty(data) && Filter}
       <Grid>
         <GridItem>
-          <ListComponent {...props} {...watchedResources} data={data} />
+          <ListComponent {...props} {...watchedResources} filters={filters} data={data} />
         </GridItem>
       </Grid>
     </div>


### PR DESCRIPTION

**Analysis / Root cause**:
The Firehose removal refactor (`70de9e58d3`) replaced `<Firehose>` with `useK8sWatchResources` in `MultiListPage`, but severed the filter data path. Previously, `Firehose` read filtered data from the Redux store and passed it down. After the refactor, `ListPageWrapper` receives raw unfiltered data from the watch hook and passes it straight to the `Table` component. `FilterToolbar` still dispatches filter state to Redux via `filterList`, but nothing reads the result — so text search and row filters have no effect.

**Solution description**:
Added a `useConsoleSelector` in `ListPageWrapper` to read the merged filter state from the Redux k8s store across all `reduxIDs`, memoized with `useDeepCompareMemoize` for performance. This filter state is passed as the `filters` prop to `ListComponent`, which flows into `Table` → `useTableData` → `getFilteredRows` where the existing filter logic applies it.
Adds unit test.

This is a single-file, minimal fix that restores filtering for **all** `MultiListPage`/`ListPage` consumers that use `FilterToolbar`, including:
- Installed Operators (`cluster-service-version`)
- Package Manifests (`packagemanifest-name`)
- Catalog Sources (`catalog-source-name`)

Note: Pages that manage their own filtering (e.g., Projects via `useListPageFilter`, Software Catalog → Operators) or hide the name filter toolbar (e.g., Image Manifest Vulnerabilities with `hideNameLabelFilters=true`) are not affected by this bug.

**Screenshots (Before/After)**:
  1. [Installed Operators](https://drive.google.com/file/d/1bqk2620go2pHq2yzv4wYNB4tL0yaBx5M/view?usp=sharing) — Ecosystem → Installed Operators
  2. [Catalog Sources](https://drive.google.com/file/d/10LS6C-x81hp5nXMoKneaD4_ztaN38tNr/view?usp=sharing) — Administration → Cluster Settings → Configuration → OperatorHub → Sources tab
  3. [Package Manifests](https://drive.google.com/file/d/12SYmwGEG9zUUT41zEq_jFi6e2UPsEc9s/view?usp=sharing) — click into a catalog source → Operators tab



**Test setup:**
Install at least two operators. No special setup needed for Catalog Sources or Package Manifests — they have multiple items by default.

**Test cases:**

*Installed Operators (Ecosystem → Installed Operators):*
- [x] Type an operator name in "Search by name" — list should filter to matching operators
- [x] Clear the search — full list should restore
- [x] If row filters (dropdown filters) are present, select a value — list should filter
- [x] Combine text search with row filter — both should apply together

*Catalog Sources (Administration → Cluster Settings → Configuration → OperatorHub → Sources tab):*
- [x] Type a catalog source name in the search field — list should filter
- [x] Clear the search — full list should restore

*Package Manifests (click into a catalog source → Operators tab):*
- [x] Type an operator name in "Search by name" — list should filter
- [x] Clear the search — full list should restore

*General:*
- [x] Verify URL query parameter updates when filtering
- [x] Verify label filters still work

**Additional info:**
Jira: https://issues.redhat.com/browse/OCPBUGS-79521

### Backports needed
Regression introduced in commit `70de9e58d3` which is present in `release-4.22`, `release-4.23`, and `main` only (4.21 is NOT affected). Backports needed for 4.22 and 4.23.

Assisted by Claude Code (Opus 4.6)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the list component was not properly receiving and applying filter parameters, ensuring filtered results now display correctly across all relevant views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->