### PR TITLE
CONSOLE-5212: Fix ESM compatibility for Playwright e2e tests

### DIFF
--- a/.claude/migration-context.md
+++ b/.claude/migration-context.md
@@ -10,22 +10,11 @@ Shared reference for migrating Console's Cypress e2e tests to Playwright. Used b
 4. **Leverage the framework.** Use existing page objects, and clients. Create new ones only when needed — always search first.
 5. **Live verification.** Use Playwright MCP browser tools to verify selectors, navigation flows, and element presence against the live UI before finalizing code.
 
-## Console Custom Selector Commands
+## Test Selectors
 
-All 10 custom commands from `packages/integration-tests/support/selectors.ts`. Config: `testIdAttribute: 'data-test'` in `playwright.config.ts` — `page.getByTestId('x')` queries `[data-test="x"]`.
+Config: `testIdAttribute: 'data-test'` in `playwright.config.ts` — `page.getByTestId('x')` queries `[data-test="x"]`.
 
-| Cypress Command                | CSS Selector                             | Playwright Equivalent                                          |
-| :----------------------------- | :--------------------------------------- | :------------------------------------------------------------- |
-| `cy.byTestID('x')`             | `[data-test="x"]`                        | `page.getByTestId('x')`                                        |
-| `cy.byLegacyTestID('x')`       | `[data-test-id="x"]`                     | Change source to `data-test="x"`, then `page.getByTestId('x')` |
-| `cy.byTestActionID('x')`       | `[data-test-action="x"]:not([disabled])` | `page.locator('[data-test-action="x"]:not([disabled])')`       |
-| `cy.byButtonText('x')`         | `button` containing text                 | `page.getByRole('button', { name: 'x' })`                      |
-| `cy.byDataID('x')`             | `[data-id="x"]`                          | `page.locator('[data-id="x"]')`                                |
-| `cy.byTestSelector('x')`       | `[data-test-selector="x"]`               | `page.locator('[data-test-selector="x"]')`                     |
-| `cy.byTestDropDownMenu('x')`   | `[data-test-dropdown-menu="x"]`          | `page.locator('[data-test-dropdown-menu="x"]')`                |
-| `cy.byTestOperatorRow('x')`    | `[data-test-operator-row="x"]`           | `page.locator('[data-test-operator-row="x"]')`                 |
-| `cy.byTestSectionHeading('x')` | `[data-test-section-heading="x"]`        | `page.locator('[data-test-section-heading="x"]')`              |
-| `cy.byTestOperandLink('x')`    | `[data-test-operand-link="x"]`           | `page.locator('[data-test-operand-link="x"]')`                 |
+**Always use `page.getByTestId('x')`** for element selection. If a React element only has a legacy test attribute (`data-test-id`, `data-test-selector`, `data-test-action`, `data-test-dropdown-menu`, etc.), add `data-test="x"` to the element. Never remove legacy `data-test-*` attributes — external consumers may depend on them.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -133,7 +133,28 @@ afterEach(() => {
 jest.spyOn(module, "function");
 ```
 
-## End-to-End Testing
+## End-to-End Testing with Playwright
+
+E2E tests validate full user workflows against a real OpenShift cluster using Playwright. Tests live in `frontend/e2e/tests/<package>/`.
+
+- **Self-contained tests**: Each `test()` block creates its own resources, asserts independently, and cleans up via the `cleanup` fixture.
+- **Selectors**: Always use `page.getByTestId('x')` which queries `[data-test="x"]`. If a React element only has a legacy test attribute (`data-test-id`, `data-test-selector`, etc.), add `data-test` to the element. Never remove legacy attributes — external consumers may depend on them.
+- **Page Objects**: Extend `BasePage` (`e2e/pages/base-page.ts`) which provides `robustClick()`, `waitForLoadingComplete()`, and `goTo()`. Locators are `private readonly` properties; actions are `async` methods.
+- **Cluster Interactions**: Use `KubernetesClient` (`e2e/clients/kubernetes-client.ts`) — never shell commands in tests.
+- **Fixtures**: Import `test` and `expect` from `e2e/fixtures`, not from `@playwright/test`. Custom fixtures provide `cleanup`, `testConfig`, and `k8sClient`.
+
+### Running Playwright Tests
+
+Prerequisites: `oc login` to a cluster, set `BRIDGE_KUBEADMIN_PASSWORD` and `WEB_CONSOLE_URL` (or configure `e2e/.env`).
+
+- `yarn test-playwright` — run all tests in headless mode
+- `yarn test-playwright-headed` — run with a visible browser
+- `yarn test-playwright-debug` — run in debug mode (Playwright Inspector)
+- `yarn test-playwright-ui` — run in interactive UI mode
+- `yarn test-playwright-admin` — run only admin persona tests
+- `yarn test-playwright-developer` — run only developer persona tests
+
+## End-to-End Testing with Cypress (legacy)
 
 Integration/E2E tests validate full user workflows against a real/simulated OpenShift cluster using Cypress + Cucumber (Gherkin BDD).
 

--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -13,3 +13,4 @@ dynamic-demo-plugin
 .eslintrc.js
 tsconfig.json
 e2e/tsconfig.json
+e2e/package.json

--- a/frontend/e2e/fixtures/cleanup-fixture.ts
+++ b/frontend/e2e/fixtures/cleanup-fixture.ts
@@ -37,7 +37,7 @@ export function createCleanupFixture(testName: string): CleanupFixture {
 
   function getClient(): KubernetesClient | null {
     try {
-      const configPath = path.resolve(__dirname, '..', '.test-config.json');
+      const configPath = path.resolve(import.meta.dirname, '..', '.test-config.json');
       let kubeConfigPath: string | undefined;
       let authToken: string | undefined;
       if (fs.existsSync(configPath)) {

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -24,6 +24,15 @@ type WorkerFixtures = {
 };
 
 export const test = base.extend<TestFixtures, WorkerFixtures>({
+  context: async ({ context }, use) => {
+    await context.addInitScript(() => {
+      Object.defineProperty(navigator, 'userAgent', {
+        get: () => 'ConsoleIntegrationTestEnvironment',
+      });
+    });
+    await use(context);
+  },
+
   testConfig: [
     async ({}, use) => {
       const configPath = path.resolve(import.meta.dirname, '..', '.test-config.json');

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -26,7 +26,7 @@ type WorkerFixtures = {
 export const test = base.extend<TestFixtures, WorkerFixtures>({
   testConfig: [
     async ({}, use) => {
-      const configPath = path.resolve(__dirname, '..', '.test-config.json');
+      const configPath = path.resolve(import.meta.dirname, '..', '.test-config.json');
       let config: SharedTestConfig = {
         testNamespace: 'default',
       };

--- a/frontend/e2e/package.json
+++ b/frontend/e2e/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/frontend/e2e/setup/admin-auth.setup.ts
+++ b/frontend/e2e/setup/admin-auth.setup.ts
@@ -4,7 +4,7 @@ import { test as setup } from '@playwright/test';
 
 import { performLogin, saveStorageState } from './login-helper';
 
-const adminStorageState = path.resolve(__dirname, '..', '.auth', 'kubeadmin.json');
+const adminStorageState = path.resolve(import.meta.dirname, '..', '.auth', 'kubeadmin.json');
 
 setup('login as kubeadmin', async ({ page }) => {
   setup.skip(process.env.SKIP_GLOBAL_SETUP === 'true', 'SKIP_GLOBAL_SETUP is set');

--- a/frontend/e2e/setup/cluster.setup.ts
+++ b/frontend/e2e/setup/cluster.setup.ts
@@ -5,7 +5,7 @@ import { test as setup } from '@playwright/test';
 
 import KubernetesClient from '../clients/kubernetes-client';
 
-const CONFIG_FILE = path.resolve(__dirname, '..', '.test-config.json');
+const CONFIG_FILE = path.resolve(import.meta.dirname, '..', '.test-config.json');
 
 let k8sClient: KubernetesClient | null = null;
 let clusterAvailable = false;

--- a/frontend/e2e/setup/developer-auth.setup.ts
+++ b/frontend/e2e/setup/developer-auth.setup.ts
@@ -4,7 +4,7 @@ import { test as setup } from '@playwright/test';
 
 import { performLogin, saveStorageState } from './login-helper';
 
-const developerStorageState = path.resolve(__dirname, '..', '.auth', 'developer.json');
+const developerStorageState = path.resolve(import.meta.dirname, '..', '.auth', 'developer.json');
 
 setup('login as developer', async ({ page }) => {
   setup.skip(process.env.SKIP_GLOBAL_SETUP === 'true', 'SKIP_GLOBAL_SETUP is set');

--- a/frontend/e2e/setup/login-helper.ts
+++ b/frontend/e2e/setup/login-helper.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
-const STORAGE_STATE_DIR = path.resolve(__dirname, '..', '.auth');
+const STORAGE_STATE_DIR = path.resolve(import.meta.dirname, '..', '.auth');
 
 export async function performLogin(
   page: Page,

--- a/frontend/e2e/setup/teardown.setup.ts
+++ b/frontend/e2e/setup/teardown.setup.ts
@@ -5,7 +5,7 @@ import { test as teardown, expect } from '@playwright/test';
 
 import KubernetesClient from '../clients/kubernetes-client';
 
-const CONFIG_FILE = path.resolve(__dirname, '..', '.test-config.json');
+const CONFIG_FILE = path.resolve(import.meta.dirname, '..', '.test-config.json');
 
 teardown('delete test namespace', async () => {
   teardown.skip(

--- a/frontend/e2e/tsconfig.json
+++ b/frontend/e2e/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2021",
+    "target": "es2022",
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": false,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- Fix `require()` of ESM module error on CI for `@kubernetes/client-node` v1.4.0 (pure ESM) by adding `frontend/e2e/package.json` with `"type": "module"` so Playwright loads e2e files as ESM
- Replace `__dirname` (CJS-only) with `import.meta.dirname` (Node 21.2.0+) in 7 e2e files
- Update `e2e/tsconfig.json` target to `es2022` and moduleResolution to `bundler`
- Set `ConsoleIntegrationTestEnvironment` user agent in Playwright fixtures to activate the `INTEGRATION_TEST` feature flag, disabling the guided tour during tests
- Add Playwright e2e testing section to `TESTING.md`
- Simplify test selector guidance in migration context to always prefer `getByTestId`

## Details
**ESM fix:** The `@kubernetes/client-node` v1.4.0 declares `"type": "module"`. On CI, Playwright finds `frontend/package.json` (CJS default), loads test files via `require()`, and Babel transforms imports into `require()` calls. Node.js rejects the `require()` of the ESM-only package. Adding `e2e/package.json` with `"type": "module"` makes Playwright load e2e files as ESM, preserving `import` statements for native resolution.

**Integration test user agent:** Override `navigator.userAgent` via `context.addInitScript()` in the test fixtures to `ConsoleIntegrationTestEnvironment`. This activates the existing `INTEGRATION_TEST` feature flag which disables the guided tour (same mechanism used by Cypress).

## Test plan
- [ ] `cd frontend && npx tsc -p e2e/tsconfig.json --noEmit` passes
- [ ] `cd frontend && npx playwright test --list` discovers all tests without errors
- [ ] CI Playwright job passes (no more `require() of ES Module` error)
- [ ] Guided tour does not appear during Playwright tests

## Screenshots / Recordings
N/A — no UI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)