### PR TITLE
OCPBUGS-59404: Allow VolumeSnapshot restore when parent PVC is deleted

### DIFF
--- a/frontend/packages/console-app/src/components/modals/restore-pvc/restore-pvc-modal.tsx
+++ b/frontend/packages/console-app/src/components/modals/restore-pvc/restore-pvc-modal.tsx
@@ -80,10 +80,16 @@ const RestorePVCModal: FC<RestorePVCModalProps> = ({ close, cancel, resource }) 
   >(PersistentVolumeClaimModel, resource?.spec?.source?.persistentVolumeClaimName, namespace);
 
   const pvcStorageClassName = pvcResource?.spec?.storageClassName;
+  const pvcNotFound = pvcResourceLoaded && !pvcResource;
   const [scResource, scResourceLoaded, scResourceLoadError] = useK8sGet<StorageClassResourceKind>(
     StorageClassModel,
     pvcStorageClassName,
   );
+
+  // Form is ready when either:
+  // - PVC was found and its StorageClass has loaded
+  // - PVC was not found (deleted) — annotations and snapshot status provide sufficient data
+  const formReady = pvcNotFound || (!!pvcStorageClassName && scResourceLoaded);
 
   const [volumeMode, setVolumeMode] = useState('');
   const requestedSizeInputChange = ({ value, unit }) => {
@@ -156,13 +162,16 @@ const RestorePVCModal: FC<RestorePVCModalProps> = ({ close, cancel, resource }) 
             />
           </FormGroup>
           <FormGroup fieldId="restore-storage-class">
-            {!pvcStorageClassName || !scResourceLoaded ? (
+            {!formReady ? (
               <div className="skeleton-text" />
             ) : (
               <StorageClassDropdown
                 onChange={handleStorageClass}
-                filter={(scObj: StorageClassResourceKind) =>
-                  onlyPvcSCs(scObj, scResourceLoadError, scResource)
+                filter={
+                  pvcNotFound
+                    ? undefined
+                    : (scObj: StorageClassResourceKind) =>
+                        onlyPvcSCs(scObj, scResourceLoadError, scResource)
                 }
                 id="restore-storage-class"
                 required
@@ -190,14 +199,17 @@ const RestorePVCModal: FC<RestorePVCModalProps> = ({ close, cancel, resource }) 
             availableVolumeMode={volumeSnapshotAnnotations?.[snapshotPVCVolumeModeAnnotation]}
           />
           <FormGroup label={t('console-app~Size')} isRequired fieldId="pvc-size">
-            {!!pvcStorageClassName && scResourceLoaded ? (
+            {formReady ? (
               <RequestSizeInput
                 name="requestSize"
                 onChange={requestedSizeInputChange}
                 defaultRequestSizeUnit={requestedUnit}
                 defaultRequestSizeValue={requestedSize}
                 dropdownUnits={dropdownUnits}
-                isInputDisabled={scResourceLoadError || isCephProvisioner(scResource?.provisioner)}
+                isInputDisabled={
+                  !pvcNotFound &&
+                  (scResourceLoadError || isCephProvisioner(scResource?.provisioner))
+                }
                 required
               />
             ) : (


### PR DESCRIPTION
**Analysis / Root cause**:

The "Restore as new PVC" modal for VolumeSnapshots gates the StorageClass dropdown and Size input on `pvcStorageClassName` — a value derived exclusively from the parent PVC. When the parent PVC is deleted, `useK8sGet` returns a 404, `pvcStorageClassName` becomes `undefined`, and both fields permanently show skeleton loaders. The Restore button stays disabled because no storage class can be selected.

The snapshot already carries all necessary metadata via annotations (storage class, access modes, volume mode) set at creation time, plus `status.restoreSize` for the size — but the modal's rendering conditionals never fall through to use them.

**Solution description**:

Added two computed booleans to `restore-pvc-modal.tsx`:
- `pvcNotFound`: detects when the PVC fetch completed with a 404
- `formReady`: true when PVC is confirmed deleted OR when PVC and its StorageClass have loaded

Changed three rendering conditionals:
1. StorageClass dropdown gate: `!pvcStorageClassName || !scResourceLoaded` → `!formReady`
2. When PVC is deleted, StorageClass dropdown shows all available storage classes (unfiltered) with the annotated value pre-selected
3. Size input gate: `!!pvcStorageClassName && scResourceLoaded` → `formReady`, with `isInputDisabled` skipping SC-based checks when PVC is not found

When the parent PVC exists, `pvcNotFound=false` and `formReady` reduces to the original condition — zero behavioral change.

**Screenshots with fix**:
[Restore as new PVC form](https://drive.google.com/file/d/1zz2M6mUQku8l5iEKKft2X8DBdwP40aXS/view?usp=sharing)
[New PVC details](https://drive.google.com/file/d/1xcJpud0kZ9R5nXDBQfvs54BctF_FeP9n/view?usp=sharing)


**Test setup:**

A cluster with CSI snapshot support (e.g., AWS with `gp3-csi` and `csi-aws-vsc`). Adjust `storageClassName` and `volumeSnapshotClassName` for your environment.

```bash
# Create test namespace and PVC
oc create namespace snapshot-restore-test

oc apply -f - <<EOF
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-pvc
  namespace: snapshot-restore-test
spec:
  storageClassName: gp3-csi
  accessModes: [ReadWriteOnce]
  volumeMode: Filesystem
  resources:
    requests:
      storage: 1Gi
EOF

# PVC needs a consumer to bind (WaitForFirstConsumer)
oc apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
  namespace: snapshot-restore-test
spec:
  containers:
    - name: test
      image: registry.access.redhat.com/ubi9/ubi-minimal:latest
      command: ["sleep", "infinity"]
      volumeMounts:
        - name: data
          mountPath: /data
  volumes:
    - name: data
      persistentVolumeClaim:
        claimName: test-pvc
EOF

# Wait for PVC to bind
oc get pvc -n snapshot-restore-test -w
# Ctrl+C when STATUS = Bound

# Create snapshot
oc apply -f - <<EOF
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  name: test-snapshot
  namespace: snapshot-restore-test
spec:
  volumeSnapshotClassName: csi-aws-vsc
  source:
    persistentVolumeClaimName: test-pvc
EOF

# Wait for snapshot to be ready
oc get volumesnapshot -n snapshot-restore-test -w
# Ctrl+C when READYTOUSE = true
```

**Test cases:**

1. **Regression check (PVC exists):**
   - Go to Storage > VolumeSnapshots in project `snapshot-restore-test`
   - Kebab menu on `test-snapshot` > "Restore as new PVC"
   - Verify: StorageClass dropdown shows `gp3-csi`, Access mode and Volume mode selectors render, Size shows `1 GiB`, Restore button is enabled
   - Cancel the modal

2. **Bug fix verification (PVC deleted):**
   ```bash
   oc delete pod test-pod -n snapshot-restore-test
   oc delete pvc test-pvc -n snapshot-restore-test
   ```
   - Kebab menu on `test-snapshot` > "Restore as new PVC"
   - Verify: StorageClass dropdown renders with available storage classes (pre-selects `gp3-csi`), Access mode and Volume mode selectors render, Size shows `1 GiB`, Restore button is enabled
   - Click Restore — a new PVC should be created successfully

3. **Cleanup:**
   ```bash
   oc delete namespace snapshot-restore-test
   ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the restore PVC modal to handle missing source PVCs. The form now displays all necessary controls and allows restoration to proceed using snapshot annotations and metadata, even when the original PVC no longer exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->