### PR TITLE
CONSOLE-5197: Collect Playwright test artifacts for Prow CI

### DIFF
--- a/frontend/integration-tests/test-playwright-e2e.sh
+++ b/frontend/integration-tests/test-playwright-e2e.sh
@@ -80,6 +80,16 @@ if [ "$RUN_CREATE_USER" = true ]; then
   export BRIDGE_HTPASSWD_PASSWORD="${BRIDGE_HTPASSWD_PASSWORD:-test}"
 fi
 
+function copyArtifacts {
+  local exit_code=$?
+  if [ -d "$ARTIFACT_DIR" ] && [ -d "test-results" ]; then
+    echo "Copying Playwright artifacts from $(pwd)/test-results..."
+    cp -r test-results "${ARTIFACT_DIR}/playwright-test-results" 2>/dev/null || echo "Warning: failed to copy Playwright artifacts" >&2
+  fi
+  exit "$exit_code"
+}
+trap copyArtifacts EXIT
+
 FRONTEND_ABS="$(pwd)"
 playwright_bin="${FRONTEND_ABS}/node_modules/.bin/playwright"
 if [ ! -f "$playwright_bin" ]; then
@@ -90,4 +100,4 @@ fi
 
 export CI=true
 
-exec "$playwright_bin" test "$@"
+"$playwright_bin" test "$@"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as dotenv from 'dotenv';
 
-dotenv.config({ path: path.resolve(__dirname, 'e2e', '.env') });
+dotenv.config({ path: path.resolve(__dirname, 'e2e', '.env'), quiet: true });
 
 import { defineConfig, devices } from '@playwright/test';
 


### PR DESCRIPTION
**Analysis / Root cause**:
The Playwright CI test runner (`test-playwright-e2e.sh`) was not copying test results to `$ARTIFACT_DIR`, so Prow had no artifacts to display in the job results page. Unlike the Cypress runner which has a `trap "copyArtifacts; generateReport" EXIT`, the Playwright script had no equivalent. Additionally, using `exec` to launch Playwright meant any trap would never fire.

**Solution description**:
- Add an `EXIT` trap in `test-playwright-e2e.sh` that copies the `test-results/` directory (JUnit XML, traces, screenshots, videos) to `$ARTIFACT_DIR/playwright-test-results`
- Replace `exec "$playwright_bin" test "$@"` with a direct invocation so the EXIT trap actually fires

**Screenshots / screen recording**:
N/A — CI script change, no visual impact.

**Test setup:**
Run a Playwright E2E job in Prow and verify artifacts appear in the job results page.

**Test cases:**
- [ ] Prow job artifacts include `playwright-test-results/` directory
- [ ] JUnit XML is present and parsed by Prow UI
- [ ] On test failure, traces/screenshots/videos are collected

**Browser conformance**:
N/A — CI infrastructure change.

**Additional info:**
Related Prow job with missing artifacts: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/78021/rehearse-78021-pull-ci-openshift-console-main-e2e-playwright/2055259618824687616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Playwright E2E test runner to automatically capture and archive test results, improving the artifact collection process for better debugging and test reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->