### PR TITLE
OCPBUGS-81512: Use ETag conditional requests for OpenAPI v2 fetching

### DIFF
--- a/frontend/public/module/k8s/__tests__/swagger.spec.ts
+++ b/frontend/public/module/k8s/__tests__/swagger.spec.ts
@@ -1,0 +1,164 @@
+import type { SwaggerAPISpec, SwaggerDefinitions } from '../swagger';
+
+const mockCoFetch = jest.fn();
+jest.mock('@console/shared/src/utils/console-fetch', () => ({
+  coFetch: mockCoFetch,
+}));
+
+const mockDefinitions: SwaggerDefinitions = {
+  'io.k8s.api.core.v1.Pod': {
+    description: 'Pod is a collection of containers.',
+    type: 'object',
+    properties: {
+      metadata: { $ref: '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta' },
+    },
+  },
+};
+
+const createMockResponse = (definitions: SwaggerDefinitions, etag?: string): Response =>
+  (({
+    status: 200,
+    ok: true,
+    headers: new Headers(etag ? { ETag: etag } : {}),
+    json: jest.fn().mockResolvedValue({
+      swagger: '2.0',
+      info: { title: 'Kubernetes', version: 'v1' },
+      paths: {},
+      definitions,
+    } as SwaggerAPISpec),
+  } as unknown) as Response);
+
+const create304Response = (): Response =>
+  (({
+    status: 304,
+    ok: true,
+    headers: new Headers(),
+    json: jest.fn(),
+  } as unknown) as Response);
+
+describe('fetchSwagger', () => {
+  let fetchSwagger: () => Promise<SwaggerDefinitions>;
+  let getSwaggerDefinitions: () => SwaggerDefinitions;
+
+  beforeEach(() => {
+    jest.isolateModules(() => {
+      // Fresh module to reset cachedETag and swaggerDefinitions
+      const swagger = require('../swagger');
+      fetchSwagger = swagger.fetchSwagger;
+      getSwaggerDefinitions = swagger.getSwaggerDefinitions;
+    });
+    mockCoFetch.mockReset();
+    jest.spyOn(window, 'dispatchEvent').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should fetch and return swagger definitions on first call', async () => {
+    mockCoFetch.mockResolvedValue(createMockResponse(mockDefinitions, '"abc123"'));
+
+    const result = await fetchSwagger();
+
+    expect(result).toEqual(mockDefinitions);
+    expect(mockCoFetch).toHaveBeenCalledWith('api/kubernetes/openapi/v2', {
+      headers: { Accept: 'application/json' },
+    });
+  });
+
+  it('should send If-None-Match header on subsequent requests', async () => {
+    mockCoFetch.mockResolvedValue(createMockResponse(mockDefinitions, '"abc123"'));
+    await fetchSwagger();
+
+    mockCoFetch.mockResolvedValue(create304Response());
+    await fetchSwagger();
+
+    expect(mockCoFetch).toHaveBeenCalledTimes(2);
+    expect(mockCoFetch.mock.calls[1]).toEqual([
+      'api/kubernetes/openapi/v2',
+      { headers: { Accept: 'application/json', 'If-None-Match': '"abc123"' } },
+    ]);
+  });
+
+  it('should return cached definitions on 304', async () => {
+    mockCoFetch.mockResolvedValue(createMockResponse(mockDefinitions, '"abc123"'));
+    await fetchSwagger();
+
+    const notModifiedResponse = create304Response();
+    mockCoFetch.mockResolvedValue(notModifiedResponse);
+    const result = await fetchSwagger();
+
+    expect(result).toEqual(mockDefinitions);
+    expect(notModifiedResponse.json).not.toHaveBeenCalled();
+  });
+
+  it('should update definitions when server returns new data', async () => {
+    mockCoFetch.mockResolvedValue(createMockResponse(mockDefinitions, '"abc123"'));
+    await fetchSwagger();
+
+    const updatedDefinitions: SwaggerDefinitions = {
+      ...mockDefinitions,
+      'io.k8s.api.apps.v1.Deployment': { description: 'A Deployment.', type: 'object' },
+    };
+    mockCoFetch.mockResolvedValue(createMockResponse(updatedDefinitions, '"def456"'));
+    const result = await fetchSwagger();
+
+    expect(result).toEqual(updatedDefinitions);
+    expect(getSwaggerDefinitions()).toEqual(updatedDefinitions);
+  });
+
+  it('should dispatch console_swagger_refresh on successful fetch', async () => {
+    mockCoFetch.mockResolvedValue(createMockResponse(mockDefinitions, '"abc123"'));
+    await fetchSwagger();
+
+    expect(window.dispatchEvent).toHaveBeenCalledWith(new Event('console_swagger_refresh'));
+  });
+
+  it('should not dispatch console_swagger_refresh on 304', async () => {
+    mockCoFetch.mockResolvedValue(createMockResponse(mockDefinitions, '"abc123"'));
+    await fetchSwagger();
+    (window.dispatchEvent as jest.Mock).mockClear();
+
+    mockCoFetch.mockResolvedValue(create304Response());
+    await fetchSwagger();
+
+    expect(window.dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it('should return null when definitions are missing from response', async () => {
+    const response = ({
+      status: 200,
+      ok: true,
+      headers: new Headers(),
+      json: jest.fn().mockResolvedValue({ swagger: '2.0', paths: {} }),
+    } as unknown) as Response;
+    mockCoFetch.mockResolvedValue(response);
+
+    const result = await fetchSwagger();
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null on fetch error', async () => {
+    mockCoFetch.mockRejectedValue(new Error('Network error'));
+
+    const result = await fetchSwagger();
+
+    expect(result).toBeNull();
+  });
+
+  it('should work without ETag header from server', async () => {
+    mockCoFetch.mockResolvedValue(createMockResponse(mockDefinitions));
+    const result = await fetchSwagger();
+
+    expect(result).toEqual(mockDefinitions);
+
+    mockCoFetch.mockResolvedValue(createMockResponse(mockDefinitions));
+    await fetchSwagger();
+
+    expect(mockCoFetch.mock.calls[1]).toEqual([
+      'api/kubernetes/openapi/v2',
+      { headers: { Accept: 'application/json' } },
+    ]);
+  });
+});

--- a/frontend/public/module/k8s/swagger.ts
+++ b/frontend/public/module/k8s/swagger.ts
@@ -29,7 +29,7 @@ export const fetchSwagger = async (): Promise<SwaggerDefinitions> => {
     const response = await coFetch('api/kubernetes/openapi/v2', {
       headers: {
         Accept: 'application/json',
-        'If-None-Match': cachedETag,
+        ...(cachedETag && { 'If-None-Match': cachedETag }),
       },
     });
     if (response.status === 304) {

--- a/frontend/public/module/k8s/swagger.ts
+++ b/frontend/public/module/k8s/swagger.ts
@@ -26,11 +26,12 @@ let cachedETag: string;
 
 export const fetchSwagger = async (): Promise<SwaggerDefinitions> => {
   try {
-    const headers: HeadersInit = { Accept: 'application/json' };
-    if (cachedETag) {
-      headers['If-None-Match'] = cachedETag;
-    }
-    const response = await coFetch('api/kubernetes/openapi/v2', { headers });
+    const response = await coFetch('api/kubernetes/openapi/v2', {
+      headers: {
+        Accept: 'application/json',
+        'If-None-Match': cachedETag,
+      },
+    });
     if (response.status === 304) {
       return swaggerDefinitions;
     }

--- a/frontend/public/module/k8s/swagger.ts
+++ b/frontend/public/module/k8s/swagger.ts
@@ -1,11 +1,8 @@
 import * as _ from 'lodash';
 
-import { STORAGE_PREFIX } from '@console/shared/src/constants/common';
-import { coFetchJSON } from '@console/shared/src/utils/console-fetch';
+import { coFetch } from '@console/shared/src/utils/console-fetch';
 import { K8sKind } from '@console/dynamic-plugin-sdk/src/api/common-types';
 import { referenceForModel } from '@console/internal/module/k8s/k8s';
-
-const SWAGGER_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/swagger-definitions`;
 
 export const getDefinitionKey = _.memoize(
   (model: K8sKind, definitions: SwaggerDefinitions): string => {
@@ -25,18 +22,26 @@ export const getDefinitionKey = _.memoize(
 let swaggerDefinitions: SwaggerDefinitions;
 export const getSwaggerDefinitions = (): SwaggerDefinitions => swaggerDefinitions;
 
+let cachedETag: string;
+
 export const fetchSwagger = async (): Promise<SwaggerDefinitions> => {
-  // Remove any old definitions from `localSotrage`. We rely on the browser cache now.
-  // TODO: We should be able to remove this in a future release.
-  localStorage.removeItem(SWAGGER_LOCAL_STORAGE_KEY);
   try {
-    const response: SwaggerAPISpec = await coFetchJSON('api/kubernetes/openapi/v2');
-    if (!response.definitions) {
+    const headers: HeadersInit = { Accept: 'application/json' };
+    if (cachedETag) {
+      headers['If-None-Match'] = cachedETag;
+    }
+    const response = await coFetch('api/kubernetes/openapi/v2', { headers });
+    if (response.status === 304) {
+      return swaggerDefinitions;
+    }
+    const data: SwaggerAPISpec = await response.json();
+    if (!data.definitions) {
       // eslint-disable-next-line no-console
       console.error('Definitions missing in OpenAPI response.');
       return null;
     }
-    swaggerDefinitions = response.definitions;
+    cachedETag = response.headers.get('ETag');
+    swaggerDefinitions = data.definitions;
     window.dispatchEvent(new Event('console_swagger_refresh'));
     return swaggerDefinitions;
   } catch (e) {


### PR DESCRIPTION
**Analysis / Root cause**:

The console fetches the full OpenAPI v2 schema (`/api/kubernetes/openapi/v2`) at startup, after every API discovery cycle, and on a 5-minute polling interval — all without HTTP conditional request headers (`ETag` / `If-None-Match`). On clusters with 1000+ CRDs, the OpenAPI spec grows to 50MB+, resulting in repeated full downloads of an unchanged payload.

The `fetchSwagger()` function used `coFetchJSON`, which discards the `Response` object (and its headers) after parsing JSON. This made it impossible to capture the `ETag` header for conditional requests.

**Solution description**:

- Switch from `coFetchJSON` to `coFetch` to access response headers
- Cache the `ETag` header from each successful response
- Send `If-None-Match` with the cached ETag on subsequent requests
- On `304 Not Modified`, return the already-cached definitions without re-downloading or re-parsing the payload
- Falls back gracefully when the server doesn't return an ETag (behavior identical to before)
- Remove the legacy `localStorage` cleanup code that was marked as safe to remove in a future release

**Screenshots / screen recording**:
<img width="1504" height="422" alt="Screenshot 2026-05-19 at 9 52 22 AM" src="https://github.com/user-attachments/assets/f9320c1c-4a32-48f9-ac5c-b2254ebd06cf" />
<img width="1109" height="604" alt="Screenshot 2026-05-19 at 9 52 55 AM" src="https://github.com/user-attachments/assets/b09dc683-5bc5-4f45-ae64-802e833f0b44" />
<img width="1107" height="626" alt="Screenshot 2026-05-19 at 9 53 02 AM" src="https://github.com/user-attachments/assets/09b3a989-9d21-48de-a837-ffcc4e0c41dc" />



**Test setup:**
A running OpenShift cluster. No special setup required for unit tests (`yarn test public/module/k8s/__tests__/swagger.spec.ts`).

**Test cases:**
- First load: 200 response with `ETag` header present, definitions returned
- Subsequent polls: `If-None-Match` header sent, 304 response, no payload transferred, cached definitions returned
- After CRD install/uninstall: server returns 200 with new ETag, definitions update
- Server without ETag support: no `If-None-Match` sent, behaves same as before
- Missing definitions in response: returns null
- Network error: returns null

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**

Jira: https://redhat.atlassian.net/browse/OCPBUGS-81512

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes OpenAPI specification caching behavior
  * Resolved unintended removal of locally cached specifications
  * Added support for efficient conditional requests to minimize bandwidth usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->