### PR TITLE
OCPBUGS-84558: Bump immutable.js to v3.8.3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -188,7 +188,7 @@
     "i18next-conv": "16.0.0",
     "i18next-http-backend": "^1.0.21",
     "i18next-v4-format-converter": "^1.1.1",
-    "immutable": "3.x",
+    "immutable": "3.8.3",
     "istextorbinary": "^9.5.0",
     "js-base64": "^3.7.7",
     "js-yaml": "^3.13.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -13176,10 +13176,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:*, immutable@npm:3.x":
+"immutable@npm:*":
   version: 3.8.2
   resolution: "immutable@npm:3.8.2"
   checksum: 10c0/fb6a2999ad3bda9e51741721e42547076dd492635ee4df9241224055fe953ec843583a700088cc4915f23dc326e5084f4e17f1bbd7388c3e872ef5a242e0ac5e
+  languageName: node
+  linkType: hard
+
+"immutable@npm:3.8.3":
+  version: 3.8.3
+  resolution: "immutable@npm:3.8.3"
+  checksum: 10c0/bafa7b8371b7622bc3d128cd9e6bba3a654b968f09a237929629f43ac26f7e974a5879cd38baad0c26f6f0628753968611bf832add7bf0c44d647bf4306a2988
   languageName: node
   linkType: hard
 
@@ -17390,7 +17397,7 @@ __metadata:
     i18next-parser: "npm:^9.4.0"
     i18next-pseudo: "npm:^2.2.1"
     i18next-v4-format-converter: "npm:^1.1.1"
-    immutable: "npm:3.x"
+    immutable: "npm:3.8.3"
     istextorbinary: "npm:^9.5.0"
     jest: "npm:^30.2.0"
     jest-cli: "npm:^30.2.0"


### PR DESCRIPTION
This PR bumps immutable.js from v3.8.2 to v3.8.3. It resolves **_CVE-2026-29063 openshift4/ose-console-rhel9: Immutable.js: Arbitrary code execution via Prototype Pollution_**  security vulnerability.

All unit and linting tests have passed locally

✅ All tests passed!
Summary:
- Test Suites: 483 passed, 483 total
- Tests: 3,839 passed, 3,839 total
- Snaphosts: 5 passed, 5 total 
- -Time: 219.7 seconds (~3.7 minutes)

