### PR TITLE
OCPBUGS-85545: Fix guided tour modal flash on page reload

### DIFF
--- a/frontend/packages/console-app/src/components/tour/__tests__/tour-context.spec.ts
+++ b/frontend/packages/console-app/src/components/tour/__tests__/tour-context.spec.ts
@@ -139,6 +139,21 @@ describe('guided-tour-context', () => {
       expect(tour).toEqual(null);
       expect(totalSteps).toEqual(undefined);
     });
+
+    it('should not flash startTour when loaded transitions to true with completed tour', () => {
+      useSelectorMock.mockReturnValue({ A: true, B: false });
+      useResolvedExtensionsMock.mockReturnValue(mockTourExtension);
+      // Start with loaded: false (async ConfigMap fetch in progress)
+      useUserPreferenceMock.mockReturnValue([{ dev: { completed: false } }, () => null, false]);
+      const { result, rerender } = renderHook(() => useTourValuesForContext());
+      expect(result.current.tour).toEqual(null);
+
+      // Simulate ConfigMap load completing with completed: true
+      useUserPreferenceMock.mockReturnValue([{ dev: { completed: true } }, () => null, true]);
+      rerender();
+      const { tourState } = result.current;
+      expect(tourState?.startTour).not.toBe(true);
+    });
   });
 
   describe('useTourStatePerspective', () => {

--- a/frontend/packages/console-app/src/components/tour/tour-context.ts
+++ b/frontend/packages/console-app/src/components/tour/tour-context.ts
@@ -1,5 +1,5 @@
 import type { Reducer, Dispatch, ReducerAction } from 'react';
-import { createContext, useReducer, useState, useEffect, useCallback } from 'react';
+import { createContext, useReducer, useRef, useState, useEffect, useCallback } from 'react';
 import { pick, union, isEqual } from 'lodash';
 import { createSelector } from 'reselect';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';
@@ -151,14 +151,18 @@ export const useTourValuesForContext = (): TourContextType => {
     startTour: !completed,
   });
 
+  const initializedWithLoadedData = useRef(false);
   useEffect(() => {
     tourDispatch({ type: TourActions.initialize, payload: { completed } });
     setPerspective(activePerspective);
+    if (loaded) {
+      initializedWithLoadedData.current = true;
+    }
     // only run effect when the active perspective changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activePerspective, loaded]);
 
-  if (!tour || !loaded) return { tour: null };
+  if (!tour || !loaded || !initializedWithLoadedData.current) return { tour: null };
   const {
     properties: {
       tour: { intro, steps: unfilteredSteps, end },


### PR DESCRIPTION
## Summary
- Fix the "Welcome to the new OpenShift experience" guided tour modal briefly appearing on every page reload for users who have already completed or skipped the tour
- Root cause: stale-frame race between `useReducer` initialization (defaults `startTour: true` while `completed` is `undefined`) and `useEffect`-based sync with user preferences
- Gate tour context on reducer state reflecting the loaded completion flag, not just on `loaded` being true

## Jira
https://redhat.atlassian.net/browse/OCPBUGS-85545

## Test plan
- [x] Unit tests added for tour-context initialization behavior
- [ ] Log in as a user who has completed/skipped the guided tour
- [ ] Hard reload the page (F5 / Cmd+R)
- [ ] Verify the "Welcome to the new OpenShift experience" modal does **not** flash
- [ ] Verify the tour still works correctly for first-time users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the tour feature would incorrectly auto-start when application data finished loading, even if the user had already completed the tour.

* **Tests**
  * Added test coverage to verify the tour does not automatically start upon data loading when previously marked as completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->