### PR TITLE
OCPBUGS-71878: Show empty state instead of 403 error for users without projects

### DIFF
--- a/frontend/packages/console-app/src/components/pdb/PDBList.tsx
+++ b/frontend/packages/console-app/src/components/pdb/PDBList.tsx
@@ -180,4 +180,5 @@ type PodDisruptionBudgetsListProps = {
   data: PodDisruptionBudgetKind[];
   loaded: boolean;
   loadError?: any;
+  mock?: boolean;
 };

--- a/frontend/packages/console-app/src/components/pdb/PDBPage.tsx
+++ b/frontend/packages/console-app/src/components/pdb/PDBPage.tsx
@@ -10,20 +10,25 @@ import PodDisruptionBudgetList from './PDBList';
 import type { PodDisruptionBudgetKind } from './types';
 
 export const PodDisruptionBudgetsPage: FC<PodDisruptionBudgetsPageProps> = ({
+  mock,
   namespace,
   showTitle = true,
 }) => {
   const { t } = useTranslation();
-  const [resources, loaded, loadError] = useK8sWatchResource<PodDisruptionBudgetKind[]>({
-    groupVersionKind: {
-      group: PodDisruptionBudgetModel.apiGroup,
-      kind: PodDisruptionBudgetModel.kind,
-      version: PodDisruptionBudgetModel.apiVersion,
-    },
-    isList: true,
-    namespaced: true,
-    namespace,
-  });
+  const [resources, loaded, loadError] = useK8sWatchResource<PodDisruptionBudgetKind[]>(
+    mock
+      ? null
+      : {
+          groupVersionKind: {
+            group: PodDisruptionBudgetModel.apiGroup,
+            kind: PodDisruptionBudgetModel.kind,
+            version: PodDisruptionBudgetModel.apiVersion,
+          },
+          isList: true,
+          namespaced: true,
+          namespace,
+        },
+  );
 
   const resourceKind = referenceForModel(PodDisruptionBudgetModel);
   const accessReview = {
@@ -33,18 +38,26 @@ export const PodDisruptionBudgetsPage: FC<PodDisruptionBudgetsPageProps> = ({
   return (
     <>
       <ListPageHeader title={showTitle ? t(PodDisruptionBudgetModel.labelPluralKey) : undefined}>
-        <ListPageCreate groupVersionKind={resourceKind} createAccessReview={accessReview}>
-          {t('console-app~Create PodDisruptionBudget')}
-        </ListPageCreate>
+        {!mock && (
+          <ListPageCreate groupVersionKind={resourceKind} createAccessReview={accessReview}>
+            {t('console-app~Create PodDisruptionBudget')}
+          </ListPageCreate>
+        )}
       </ListPageHeader>
       <ListPageBody>
-        <PodDisruptionBudgetList data={resources} loaded={loaded} loadError={loadError} />
+        <PodDisruptionBudgetList
+          data={resources}
+          loaded={loaded}
+          loadError={loadError}
+          mock={mock}
+        />
       </ListPageBody>
     </>
   );
 };
 
 type PodDisruptionBudgetsPageProps = {
+  mock?: boolean;
   namespace: string;
   showTitle?: boolean;
 };

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
@@ -310,6 +310,7 @@ const VolumeSnapshotTable: FC<VolumeSnapshotTableProps> = ({ data, loaded, ...pr
 
 export const VolumeSnapshotPage: FC<VolumeSnapshotPageProps> = ({
   canCreate = true,
+  mock,
   showTitle = true,
   namespace,
   selector,
@@ -318,29 +319,33 @@ export const VolumeSnapshotPage: FC<VolumeSnapshotPageProps> = ({
 
   const createPath = `/k8s/ns/${namespace || 'default'}/${VolumeSnapshotModel.plural}/~new/form`;
 
-  const [resources, loaded, loadError] = useK8sWatchResource<VolumeSnapshotKind[]>({
-    groupVersionKind: {
-      group: VolumeSnapshotModel.apiGroup,
-      kind: VolumeSnapshotModel.kind,
-      version: VolumeSnapshotModel.apiVersion,
-    },
-    isList: true,
-    namespaced: true,
-    namespace,
-    selector,
-  });
+  const [resources, loaded, loadError] = useK8sWatchResource<VolumeSnapshotKind[]>(
+    mock
+      ? null
+      : {
+          groupVersionKind: {
+            group: VolumeSnapshotModel.apiGroup,
+            kind: VolumeSnapshotModel.kind,
+            version: VolumeSnapshotModel.apiVersion,
+          },
+          isList: true,
+          namespaced: true,
+          namespace,
+          selector,
+        },
+  );
 
   return (
     <>
       <ListPageHeader title={showTitle ? t(VolumeSnapshotModel.labelPluralKey || '') : ''}>
-        {canCreate && (
+        {canCreate && !mock && (
           <ListPageCreateLink to={createPath}>
             {t('console-app~Create VolumeSnapshot')}
           </ListPageCreateLink>
         )}
       </ListPageHeader>
       <ListPageBody>
-        <VolumeSnapshotTable data={resources} loaded={loaded} loadError={loadError} />
+        <VolumeSnapshotTable data={resources} loaded={loaded} loadError={loadError} mock={mock} />
       </ListPageBody>
     </>
   );
@@ -387,6 +392,7 @@ type VolumeSnapshotFilters = ResourceFilters & {
 };
 
 type VolumeSnapshotPageProps = {
+  mock?: boolean;
   namespace?: string;
   canCreate?: boolean;
   showTitle?: boolean;
@@ -402,6 +408,7 @@ type VolumeSnapshotTableProps = {
   data: VolumeSnapshotKind[];
   loaded: boolean;
   loadError: unknown;
+  mock?: boolean;
 };
 
 type VolumeSnapshotRowData = {

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
@@ -139,7 +139,7 @@ const getObjectMetadata = (release: HelmRelease) => ({
   name: release.name,
 });
 
-const HelmReleaseList: FC = () => {
+const HelmReleaseList: FC<{ mock?: boolean }> = ({ mock }) => {
   const { t } = useTranslation();
   const params = useParams();
   const namespace = params.ns;
@@ -163,7 +163,7 @@ const HelmReleaseList: FC = () => {
     [namespace],
   );
   const [secretsData, secretsLoaded, secretsLoadError] = useK8sWatchResource<K8sResourceKind[]>(
-    secretResource,
+    mock ? null : secretResource,
   );
   const newCount = secretsData?.length ?? 0;
 
@@ -274,7 +274,7 @@ const HelmReleaseList: FC = () => {
       <DocumentTitle>{t('helm-plugin~Helm Releases')}</DocumentTitle>
       <PaneBody>
         <Suspense fallback={<LoadingBox />}>
-          {hasNoReleases ? (
+          {!mock && hasNoReleases ? (
             emptyState()
           ) : (
             <ConsoleDataView<HelmRelease, { obj: HelmRelease }, HelmReleaseFilters>
@@ -292,6 +292,7 @@ const HelmReleaseList: FC = () => {
               hideColumnManagement
               isResizable
               resetAllColumnWidths={resetAllColumnWidths}
+              mock={mock}
             />
           )}
         </Suspense>

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseListPage.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseListPage.tsx
@@ -3,12 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { PageHeading } from '@console/shared/src/components/heading/PageHeading';
 import HelmReleaseList from './HelmReleaseList';
 
-const HelmReleaseListPage: FC = () => {
+const HelmReleaseListPage: FC<{ mock?: boolean }> = ({ mock }) => {
   const { t } = useTranslation();
   return (
     <div>
       <PageHeading title={t('helm-plugin~Helm Releases')} />
-      <HelmReleaseList />
+      <HelmReleaseList mock={mock} />
     </div>
   );
 };

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmTabbedPage.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmTabbedPage.tsx
@@ -19,7 +19,7 @@ import HelmReleaseList from './HelmReleaseList';
 import HelmReleaseListPage from './HelmReleaseListPage';
 import RepositoriesPage from './RepositoriesListPage';
 
-const HelmPage: FC<{ namespace: string | undefined }> = ({ namespace }) => {
+const HelmPage: FC<{ mock?: boolean; namespace: string | undefined }> = ({ mock, namespace }) => {
   const { t } = useTranslation();
   const isHelmVisible = useFlag('HELM_CHARTS_CATALOG_TYPE');
   const [showTitle, canCreate] = [false, false];
@@ -85,6 +85,9 @@ const HelmPage: FC<{ namespace: string | undefined }> = ({ namespace }) => {
       // t('helm-plugin~Helm Releases')
       nameKey: 'helm-plugin~Helm Releases',
       component: HelmReleaseList,
+      pageData: {
+        mock,
+      },
     },
     {
       href: 'repositories',
@@ -120,17 +123,17 @@ const HelmPage: FC<{ namespace: string | undefined }> = ({ namespace }) => {
       telemetryPrefix="Helm"
     />
   ) : (
-    <HelmReleaseListPage />
+    <HelmReleaseListPage mock={mock} />
   );
 };
 
-export const PageContents: FC = () => {
+export const PageContents: FC<{ noProjectsAvailable?: boolean }> = ({ noProjectsAvailable }) => {
   const { t } = useTranslation();
   const { ns: namespace } = useParams();
   const [activePerspective] = useActivePerspective();
 
   return activePerspective === 'admin' || namespace ? (
-    <HelmPage namespace={namespace} />
+    <HelmPage namespace={namespace} mock={noProjectsAvailable} />
   ) : (
     <CreateProjectListPage title={t('helm-plugin~Helm')}>
       {(openProjectModal) => (

--- a/frontend/public/components/RBAC/bindings.tsx
+++ b/frontend/public/components/RBAC/bindings.tsx
@@ -361,19 +361,26 @@ export const RoleBindingsPage: FC<RoleBindingsPageProps> = ({
   }`,
 }) => {
   const { t } = useTranslation();
-  const resources = useK8sWatchResources({
-    RoleBinding: {
-      kind: 'RoleBinding',
-      namespaced: true,
-      namespace,
-      isList: true,
-    },
-    ClusterRoleBinding: {
-      kind: 'ClusterRoleBinding',
-      namespaced: false,
-      isList: true,
-    },
-  });
+  const watchResources = useMemo(
+    () =>
+      mock
+        ? {}
+        : {
+            RoleBinding: {
+              kind: 'RoleBinding',
+              namespaced: true,
+              namespace,
+              isList: true,
+            },
+            ClusterRoleBinding: {
+              kind: 'ClusterRoleBinding',
+              namespaced: false,
+              isList: true,
+            },
+          },
+    [mock, namespace],
+  );
+  const resources = useK8sWatchResources(watchResources);
 
   // Only flatten when at least one resource has data to prevent undefined iteration
   const data = useMemo(() => {
@@ -406,6 +413,7 @@ export const RoleBindingsPage: FC<RoleBindingsPageProps> = ({
           data={data}
           loaded={loaded}
           loadError={loadError}
+          mock={mock}
           staticFilters={staticFilters}
         />
       </ListPageBody>

--- a/frontend/public/components/pod-list.tsx
+++ b/frontend/public/components/pod-list.tsx
@@ -454,6 +454,7 @@ export const PodList: FC<PodListProps> = ({
   data,
   loaded,
   loadError,
+  mock,
   hideNameLabelFilters,
   hideLabelFilter,
   hideColumnManagement,
@@ -558,6 +559,7 @@ export const PodList: FC<PodListProps> = ({
         data={data}
         loaded={loaded}
         loadError={loadError}
+        mock={mock}
         columns={columns}
         columnLayout={columnLayout}
         columnManagementID={columnManagementID}
@@ -580,6 +582,7 @@ export const PodList: FC<PodListProps> = ({
 export const PodsPage: FC<PodPageProps> = ({
   canCreate = true,
   namespace,
+  mock,
   showNodes,
   showTitle = true,
   selector,
@@ -598,7 +601,7 @@ export const PodsPage: FC<PodPageProps> = ({
   );
 
   useEffect(() => {
-    if (showMetrics) {
+    if (showMetrics && !mock) {
       const updateMetrics = () =>
         fetchPodMetrics(namespace || '')
           .then((result) => dispatch(UIActions.setPodMetrics(result)))
@@ -615,16 +618,20 @@ export const PodsPage: FC<PodPageProps> = ({
       return () => clearInterval(id);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [namespace]);
+  }, [mock, namespace]);
 
-  const [pods, loaded, loadError] = useK8sWatchResource<PodKind[]>({
-    kind: PodModel.kind,
-    isList: true,
-    namespaced: true,
-    namespace,
-    selector,
-    fieldSelector,
-  });
+  const [pods, loaded, loadError] = useK8sWatchResource<PodKind[]>(
+    mock
+      ? null
+      : {
+          kind: PodModel.kind,
+          isList: true,
+          namespaced: true,
+          namespace,
+          selector,
+          fieldSelector,
+        },
+  );
 
   const resourceKind = referenceForModel(PodModel);
   const accessReview = {
@@ -639,7 +646,7 @@ export const PodsPage: FC<PodPageProps> = ({
   return (
     <>
       <ListPageHeader title={showTitle ? t('public~Pods') : ''}>
-        {canCreate && (
+        {canCreate && !mock && (
           <ListPageCreate groupVersionKind={resourceKind} createAccessReview={accessReview}>
             {t('public~Create Pod')}
           </ListPageCreate>
@@ -650,6 +657,7 @@ export const PodsPage: FC<PodPageProps> = ({
           data={pods}
           loaded={loaded}
           loadError={loadError}
+          mock={mock}
           showNamespaceOverride={showNamespaceOverride}
           showNodes={showNodes}
           namespace={namespace}
@@ -691,6 +699,7 @@ type PodListProps = {
   data: PodKind[];
   loaded: boolean;
   loadError: unknown;
+  mock?: boolean;
   showNodes?: boolean;
   showNamespaceOverride?: boolean;
   hideNameLabelFilters?: boolean;
@@ -703,6 +712,7 @@ type PodListProps = {
 type PodPageProps = {
   canCreate?: boolean;
   fieldSelector?: string;
+  mock?: boolean;
   namespace?: string;
   selector?: Selector;
   showTitle?: boolean;


### PR DESCRIPTION
**Analysis / Root cause**:

Five resource list pages use `useK8sWatchResource` directly, bypassing the `mock` prop that `ResourceListPage_` passes via `withStartGuide` when a user has no projects (`SHOW_OPENSHIFT_START_GUIDE` flag). The API calls fire regardless and return 403, which `StatusBox` renders as "Restricted access / You don't have access to this section due to cluster policy."

Affected pages:
- Workloads → Pods (`PodsPage`)
- Workloads → PodDisruptionBudgets (`PodDisruptionBudgetsPage`)
- Storage → VolumeSnapshots (`VolumeSnapshotPage`)
- User Management → RoleBindings (`RoleBindingsPage`)
- Helm (`HelmReleaseList` via `HelmTabbedPage`)

Pages using `DefaultPage` → `ListPage` → `MultiListPage` (Services, Routes, Ingresses, NetworkPolicies, UserDefinedNetworks) already handle `mock` correctly.

**Solution description**:

Accept and respect the `mock` prop in each affected page:

1. **Skip API calls when `mock=true`** — pass `null` to `useK8sWatchResource` (returns `[undefined, true, undefined]`) or `{}` to `useK8sWatchResources` to prevent 403 errors.
2. **Forward `mock` to `ConsoleDataView`** — which already renders `<EmptyBox label={label} />` ("No {resource} found") when `mock=true`.
3. **Hide create buttons when `mock=true`** — users without projects shouldn't see resource creation actions.

For the Helm page, `mock` is threaded from `withStartGuide` → `PageContents` → `HelmPage` → `HelmReleaseList` via `pageData` (used by `HorizontalNav` to pass props to tab components) and via direct prop to the `HelmReleaseListPage` fallback path.

**Screenshots / screen recording**:
<img width="2756" height="1689" alt="localhost_9000_k8s_all-namespaces_core~v1~Pod_page=1 perPage=50" src="https://github.com/user-attachments/assets/43d3c276-f69d-476c-8ceb-ac7c221f5774" />
<img width="2756" height="1689" alt="localhost_9000_k8s_all-namespaces_core~v1~Pod_page=1 perPage=50 (1)" src="https://github.com/user-attachments/assets/5a93e72c-b882-4cbf-bbb0-c9f534c10d64" />
<img width="2756" height="1689" alt="localhost_9000_k8s_all-namespaces_core~v1~Pod_page=1 perPage=50 (2)" src="https://github.com/user-attachments/assets/08f75126-05a7-4eb1-b42c-0ad9dc331f9a" />
<img width="2756" height="1689" alt="localhost_9000_k8s_all-namespaces_core~v1~Pod_page=1 perPage=50 (3)" src="https://github.com/user-attachments/assets/a25a6a14-5aa2-4b40-89e6-0904a1a2722f" />
<img width="2756" height="1689" alt="localhost_9000_helm_all-namespaces_page=1 perPage=50" src="https://github.com/user-attachments/assets/d0870ff9-879b-46c9-9b3d-805d28f92e96" />

**Test setup:**

Log in as a normal user without any projects.

**Test cases:**

- [ ] Navigate to Workloads → Pods in admin perspective — verify "No Pods found" empty state (not "Restricted access")
- [ ] Navigate to Workloads → PodDisruptionBudgets — verify "No PodDisruptionBudgets found" empty state
- [ ] Navigate to Storage → VolumeSnapshots — verify "No VolumeSnapshots found" empty state
- [ ] Navigate to User Management → RoleBindings — verify "No RoleBindings found" empty state
- [ ] Navigate to Helm — verify "No Helm Releases found" empty state (not "Restricted access")
- [ ] Verify create buttons are hidden on all affected pages when no projects exist
- [ ] Verify the "Hello, world" getting started banner still appears above the empty state
- [ ] Log in as a user WITH projects and verify all affected pages load resources normally

**Browser conformance**:

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**

[OCPBUGS-71878](https://redhat.atlassian.net/browse/OCPBUGS-71878)