### PR TITLE
NO-JIRA: Add `eslint-plugin-no-barrel-files`

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
     extraFileExtensions: ['.json'],
     tsconfigRootDir: __dirname,
   },
-  plugins: ['react', 'react-hooks', '@typescript-eslint', 'graphql', 'eslint-plugin-tsdoc'],
+  plugins: ['react', 'react-hooks', '@typescript-eslint', 'graphql', 'eslint-plugin-tsdoc', 'no-barrel-files'],
   rules: {
     camelcase: [
       'error',
@@ -119,6 +119,7 @@ module.exports = {
     'no-constructor-return': 'off',
     'prefer-regex-literals': 'off',
     'no-restricted-exports': 'off',
+    'no-barrel-files/no-barrel-files': 'error',
   },
   settings: {
     'import/extensions': ['.js', '.jsx'],

--- a/frontend/packages/console-app/src/components/cluster-configuration/ClusterConfigurationCheckboxField.tsx
+++ b/frontend/packages/console-app/src/components/cluster-configuration/ClusterConfigurationCheckboxField.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { FC } from 'react';
 import {
   FormGroup,

--- a/frontend/packages/console-app/src/components/cluster-configuration/ClusterConfigurationCustomField.tsx
+++ b/frontend/packages/console-app/src/components/cluster-configuration/ClusterConfigurationCustomField.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { FC } from 'react';
 // import { UserPreferenceCustomField as CustomFieldType } from '@console/dynamic-plugin-sdk/src';
 import { ClusterConfigurationCustomField } from '@console/dynamic-plugin-sdk/src';

--- a/frontend/packages/console-app/src/components/cluster-configuration/ClusterConfigurationTextField.tsx
+++ b/frontend/packages/console-app/src/components/cluster-configuration/ClusterConfigurationTextField.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { FC } from 'react';
 import { useState } from 'react';
 import {

--- a/frontend/packages/console-app/src/components/cluster-configuration/hooks.ts
+++ b/frontend/packages/console-app/src/components/cluster-configuration/hooks.ts
@@ -1,1 +1,2 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { useDebounceCallback } from '@console/shared/src/hooks/useDebounceCallback';

--- a/frontend/packages/console-app/src/components/cluster-configuration/types.ts
+++ b/frontend/packages/console-app/src/components/cluster-configuration/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type {
   ResolvedExtension,
   ClusterConfigurationGroup,

--- a/frontend/packages/console-app/src/components/dashboards-page/inventoryItems.ts
+++ b/frontend/packages/console-app/src/components/dashboards-page/inventoryItems.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 // re-export to allow for usage in exposedModules
 export {
   NodeModel,

--- a/frontend/packages/console-app/src/components/data-view/types.ts
+++ b/frontend/packages/console-app/src/components/data-view/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 // Re-export types from internal-types to maintain backward compatibility
 export type {
   ResourceFilters,

--- a/frontend/packages/console-app/src/components/nodes/NodeStatus.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeStatus.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { FC } from 'react';
 import { useMemo } from 'react';
 import { Stack, StackItem } from '@patternfly/react-core';

--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import { useCallback } from 'react';
 import type { QuickStartContextValues } from '@patternfly/quickstarts';
 import {

--- a/frontend/packages/console-app/src/components/tour/index.ts
+++ b/frontend/packages/console-app/src/components/tour/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { default as GuidedTour } from './GuidedTour';
 export * from './type';
 export * from './const';

--- a/frontend/packages/console-app/src/status/index.ts
+++ b/frontend/packages/console-app/src/status/index.ts
@@ -1,2 +1,3 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './node';
 export * from './snapshot';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/common-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/common-types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export type { ResolvedExtension } from '../types';
 
 // Type for extension hook

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/components/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/components/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { default as CamelCaseWrap } from './utils/camel-case-wrap';
 export { default as GenericStatus } from './status/GenericStatus';
 export { default as ListPageBody } from './factory/ListPage/ListPageBody';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/actions/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/actions/index.ts
@@ -1,1 +1,2 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './core';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/index.ts
@@ -1,2 +1,3 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './actions';
 export * from './reducers';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/index.ts
@@ -1,2 +1,3 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { coreReducer } from './core';
 export * from './coreSelectors';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { SDKReducers } from './redux';
 export * from './components';
 export * from './core';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './actions';
 export * from './add-actions';
 export * from './alerts';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 /**
  * @file Entrypoint for the Console dynamic plugin SDK monorepo package.
  *

--- a/frontend/packages/console-dynamic-plugin-sdk/src/lib-core.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/lib-core.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 /**
  * @file Entrypoint for the `@openshift-console/dynamic-plugin-sdk` package published to npmjs.
  *

--- a/frontend/packages/console-dynamic-plugin-sdk/src/lib-internal.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/lib-internal.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 /**
  * @file Entrypoint for the `@openshift-console/dynamic-plugin-sdk-internal` package published to npmjs.
  *

--- a/frontend/packages/console-dynamic-plugin-sdk/src/lib-webpack.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/lib-webpack.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 /**
  * @file Entrypoint for the `@openshift-console/dynamic-plugin-sdk-webpack` package published to npmjs.
  *

--- a/frontend/packages/console-dynamic-plugin-sdk/src/perspective/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/perspective/index.ts
@@ -1,2 +1,3 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { default as useActivePerspective } from './useActivePerspective';
 export * from './perspective-context';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export type {
   CodeRef,
   EncodedCodeRef,

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResource.data.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResource.data.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { PodModel } from '@console/internal/models';
 
 export const podData = {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResources.data.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/__tests__/useK8sWatchResources.data.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { PodModel } from '@console/internal/models';
 
 export const podData = {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { useK8sModel } from './useK8sModel';
 export { useK8sModels } from './useK8sModels';
 export { useK8sWatchResource } from './useK8sWatchResource';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './k8s-resource';
 export * from './k8s-utils';
 export * from './k8s-ref';

--- a/frontend/packages/console-shared/src/components/actions/types.ts
+++ b/frontend/packages/console-shared/src/components/actions/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { ActionContext as ActionContextType } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 
 export { ActionMenuVariant } from '@console/dynamic-plugin-sdk/src/api/internal-types';

--- a/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogFilters.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/catalog-view/CatalogFilters.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { FC, ChangeEvent } from 'react';
 import {
   FilterSidePanel,

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/states.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/states.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { ReactElement } from 'react';
 import { InProgressIcon } from '@patternfly/react-icons';
 import type { TFunction } from 'i18next';

--- a/frontend/packages/console-shared/src/components/dynamic-form/DynamicForm.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/DynamicForm.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { FC } from 'react';
 import { useCallback } from 'react';
 import { Accordion, ActionGroup, Button, Alert } from '@patternfly/react-core';

--- a/frontend/packages/console-shared/src/components/links/ExternalLinkButton.tsx
+++ b/frontend/packages/console-shared/src/components/links/ExternalLinkButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { FC } from 'react';
 import type { ExternalLinkButtonProps } from '@patternfly/react-component-groups';
 import { ExternalLinkButton as PfExternalLinkButton } from '@patternfly/react-component-groups';

--- a/frontend/packages/console-shared/src/components/status/Status.tsx
+++ b/frontend/packages/console-shared/src/components/status/Status.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { FC } from 'react';
 import { StatusComponent as Status } from '@console/dynamic-plugin-sdk';
 

--- a/frontend/packages/console-shared/src/components/status/icons.tsx
+++ b/frontend/packages/console-shared/src/components/status/icons.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { FC } from 'react';
 import { Icon } from '@patternfly/react-core';
 import {

--- a/frontend/packages/console-shared/src/components/virtualized-grid/types.ts
+++ b/frontend/packages/console-shared/src/components/virtualized-grid/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { GridCellProps } from 'react-virtualized';
 import type { VirtualizedGridItem } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 

--- a/frontend/packages/console-shared/src/constants/common.ts
+++ b/frontend/packages/console-shared/src/constants/common.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 /* eslint-disable @typescript-eslint/naming-convention */
 
 export { ALL_NAMESPACES_KEY } from '@console/dynamic-plugin-sdk/src/constants';

--- a/frontend/packages/console-shared/src/constants/pod.ts
+++ b/frontend/packages/console-shared/src/constants/pod.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import {
   t_global_icon_color_status_warning_default as globalWarning100,
   t_color_white as globalWhite,

--- a/frontend/packages/console-shared/src/graph-helper/data-utils.ts
+++ b/frontend/packages/console-shared/src/graph-helper/data-utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import * as _ from 'lodash';
 import { ByteDataTypes } from '@console/dynamic-plugin-sdk/src/api/internal-types';
 import type { DataPoint } from '@console/internal/components/graphs';

--- a/frontend/packages/console-shared/src/hooks/useFlag.ts
+++ b/frontend/packages/console-shared/src/hooks/useFlag.ts
@@ -1,1 +1,2 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { useFlag } from '@console/dynamic-plugin-sdk/src/utils/flags';

--- a/frontend/packages/console-shared/src/hooks/useK8sModel.ts
+++ b/frontend/packages/console-shared/src/hooks/useK8sModel.ts
@@ -1,1 +1,2 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { useK8sModel } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks';

--- a/frontend/packages/console-shared/src/hooks/useK8sModels.ts
+++ b/frontend/packages/console-shared/src/hooks/useK8sModels.ts
@@ -1,1 +1,2 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { useK8sModels } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks';

--- a/frontend/packages/console-shared/src/types/pod.ts
+++ b/frontend/packages/console-shared/src/types/pod.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type {
   ExtPodKind,
   K8sResourceCommon,

--- a/frontend/packages/container-security/src/index.ts
+++ b/frontend/packages/container-security/src/index.ts
@@ -1,2 +1,3 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './components/summary';
 export * from './types';

--- a/frontend/packages/dev-console/integration-tests/support/constants/index.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './add';
 export * from './global';
 export * from './monitoring';

--- a/frontend/packages/dev-console/integration-tests/support/constants/staticText/index.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/staticText/index.ts
@@ -1,1 +1,2 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './global-text';

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/index.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './add-flow-po';
 export * from './addHealthChecks-po';
 export * from './gettingStarted-po';

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/index.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './add-page';
 export * from './catalog-page';
 export * from './container-image-page';

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/index.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './createGitWorkload';
 export * from './createHelmChartFromAddPage';
 export * from './createHelmRelease';

--- a/frontend/packages/dev-console/integration-tests/support/pages/index.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './add-flow/index';
 export * from '@console/topology/integration-tests/support/pages/topology';
 export * from '@console/topology/integration-tests/support/page-objects/export-applications-po';

--- a/frontend/packages/dev-console/integration-tests/support/pages/monitoring/index.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/monitoring/index.ts
@@ -1,1 +1,2 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './monitoring-page';

--- a/frontend/packages/dev-console/src/components/NamespaceRedirect.tsx
+++ b/frontend/packages/dev-console/src/components/NamespaceRedirect.tsx
@@ -1,2 +1,3 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 // Re-export so that the static plugin parser can find it
 export { NamespaceRedirect } from '@console/internal/components/utils/namespace-redirect';

--- a/frontend/packages/dev-console/src/components/buildconfig/form-utils/types.ts
+++ b/frontend/packages/dev-console/src/components/buildconfig/form-utils/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
 import type { EnvironmentVariablesSectionFormData } from '../sections/EnvironmentVariablesSection';
 import type { HooksSectionFormData } from '../sections/HooksSection';

--- a/frontend/packages/dev-console/src/components/buildconfig/types.ts
+++ b/frontend/packages/dev-console/src/components/buildconfig/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { ObjectMetadata, ObjectReference } from '@console/dynamic-plugin-sdk';
 import type {
   NameValueFromPair,

--- a/frontend/packages/dev-console/src/components/import/ImportYamlPage.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportYamlPage.tsx
@@ -1,2 +1,3 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 // Re-export so that the static plugin parser can find it
 export { ImportYamlPage } from '@console/internal/components/import-yaml';

--- a/frontend/packages/eslint-plugin-console/lib/config/base.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/base.js
@@ -11,11 +11,14 @@ module.exports = {
     es6: true,
   },
 
-  plugins: ['promise', 'sort-class-members'],
+  plugins: ['promise', 'sort-class-members', 'no-barrel-files'],
 
   rules: merge(
     require('./rules/promise'),
     require('./rules/sort-class-members'),
     require('./rules/airbnb-base-overrides'),
+    {
+      'no-barrel-files/no-barrel-files': 'error',
+    },
   ),
 };

--- a/frontend/packages/eslint-plugin-console/package.json
+++ b/frontend/packages/eslint-plugin-console/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-json": "^2.0.1",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-n": "^17.24.0",
+    "eslint-plugin-no-barrel-files": "^1.1.0",
     "eslint-plugin-playwright": "^2.10.2",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.6.0",

--- a/frontend/packages/helm-plugin/integration-tests/support/constants/index.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/constants/index.ts
@@ -1,2 +1,3 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './navigation';
 export * from './static-text/helm-text';

--- a/frontend/packages/helm-plugin/integration-tests/support/pages/helm/index.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/pages/helm/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './helm-details-page';
 export * from './helm-page';
 export * from './rollBack-helm-release-page';

--- a/frontend/packages/helm-plugin/integration-tests/support/pages/index.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/pages/index.ts
@@ -1,1 +1,2 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './helm/index';

--- a/frontend/packages/helm-plugin/src/components/NamespaceRedirect.tsx
+++ b/frontend/packages/helm-plugin/src/components/NamespaceRedirect.tsx
@@ -1,2 +1,3 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 // Re-export so that the static plugin parser can find it
 export { NamespaceRedirect } from '@console/internal/components/utils/namespace-redirect';

--- a/frontend/packages/knative-plugin/integration-tests/support/pageObjects/index.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/pageObjects/index.ts
@@ -1,1 +1,2 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './global-po';

--- a/frontend/packages/knative-plugin/integration-tests/support/pages/index.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/pages/index.ts
@@ -1,1 +1,2 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './admin-perspective/eventing-page';

--- a/frontend/packages/knative-plugin/src/components/namespaceRedirect.ts
+++ b/frontend/packages/knative-plugin/src/components/namespaceRedirect.ts
@@ -1,2 +1,3 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 // Re-export so that the static plugin parser can find it
 export { NamespaceRedirect } from '@console/internal/components/utils/namespace-redirect';

--- a/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewListItem.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewListItem.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { FC } from 'react';
 import { Grid, GridItem, ListItem } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/utils.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { MachineKind, NodeKind } from '@console/internal/module/k8s';
 import type { StatusGroupMapper } from '@console/shared/src/components/dashboard/inventory-card/InventoryItem';
 import { InventoryStatusGroup } from '@console/shared/src/components/dashboard/inventory-card/status-group';

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/dashboard/utils.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/dashboard/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { NodeKind } from '@console/internal/module/k8s';
 import type { StatusGroupMapper } from '@console/shared/src/components/dashboard/inventory-card/InventoryItem';
 import { InventoryStatusGroup } from '@console/shared/src/components/dashboard/inventory-card/status-group';

--- a/frontend/packages/operator-lifecycle-manager-v1/src/actions/providers/default-actions-provider.ts
+++ b/frontend/packages/operator-lifecycle-manager-v1/src/actions/providers/default-actions-provider.ts
@@ -1,1 +1,2 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { useDefaultActionsProvider } from '@console/app/src/actions/providers/default-provider';

--- a/frontend/packages/operator-lifecycle-manager-v1/src/components/cluster-extension/index.ts
+++ b/frontend/packages/operator-lifecycle-manager-v1/src/components/cluster-extension/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { default as ClusterExtensionListPage } from './ClusterExtensionListPage';
 export { default as CreateClusterExtension } from './CreateClusterExtension';
 export { default as ClusterExtensionForm } from './ClusterExtensionForm';

--- a/frontend/packages/operator-lifecycle-manager/src/actions/providers/default-actions-provider.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/actions/providers/default-actions-provider.ts
@@ -1,1 +1,2 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { useDefaultActionsProvider } from '@console/app/src/actions/providers/default-provider';

--- a/frontend/packages/operator-lifecycle-manager/src/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './models';
 export * from './components';
 export * from './types';

--- a/frontend/packages/shipwright-plugin/integration-tests/support/pageObjects/index.ts
+++ b/frontend/packages/shipwright-plugin/integration-tests/support/pageObjects/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './build-po';
 export * from '@console/dev-console/integration-tests/support/pageObjects/global-po';
 export * from '@console/topology/integration-tests/support/page-objects/topology-po';

--- a/frontend/packages/shipwright-plugin/src/actions.ts
+++ b/frontend/packages/shipwright-plugin/src/actions.ts
@@ -1,2 +1,3 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { default as useBuildActions } from './actions/useBuildActions';
 export { default as useBuildRunActions } from './actions/useBuildRunActions';

--- a/frontend/packages/shipwright-plugin/src/pages.ts
+++ b/frontend/packages/shipwright-plugin/src/pages.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { default as BuildListPage } from './components/build-list/BuildListPage';
 export { default as BuildRunListPage } from './components/buildrun-list/BuildRunListPage';
 export { default as BuildDetailsPage } from './components/build-details/BuildDetailsPage';

--- a/frontend/packages/shipwright-plugin/src/topology.ts
+++ b/frontend/packages/shipwright-plugin/src/topology.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { getShipWrightBuildDecorator } from './components/build-decorators/getShipWrightBuildDecorator';
 export { getShipwrightDataModelReconcilor } from './components/build-decorators/getShipwrightDataModelReconcilor';
 export { useBuildSideBarTabSection } from './components/build-tabsection/useBuildSideBarTabSection';

--- a/frontend/packages/topology/integration-tests/support/pages/topology/index.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './topology-page';
 export * from './topology-actions-page';
 export * from './topology-helper-page';

--- a/frontend/packages/topology/src/topology-types.ts
+++ b/frontend/packages/topology/src/topology-types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 // re-export for convenience
 export type {
   Point,

--- a/frontend/public/actions/k8s.ts
+++ b/frontend/public/actions/k8s.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import * as _ from 'lodash';
 import { Dispatch } from 'redux';
 import { ActionType as Action } from 'typesafe-actions';

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import { Base64 } from 'js-base64';
 import { action, ActionType as Action } from 'typesafe-actions';
 import * as _ from 'lodash';

--- a/frontend/public/components/RBAC/index.ts
+++ b/frontend/public/components/RBAC/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './bindings';
 // export * from './edit-rule';
 export * from './role';

--- a/frontend/public/components/factory/index.tsx
+++ b/frontend/public/components/factory/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './details';
 export * from './list-page';
 export * from './table';

--- a/frontend/public/components/graphs/graph-loader.ts
+++ b/frontend/public/components/graphs/graph-loader.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { Bar } from './bar';
 export { Gauge } from './gauge';
 export { Area } from './area';

--- a/frontend/public/components/graphs/helpers.ts
+++ b/frontend/public/components/graphs/helpers.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import * as _ from 'lodash';
 import {
   PROMETHEUS_BASE_PATH,

--- a/frontend/public/components/graphs/index.tsx
+++ b/frontend/public/components/graphs/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import { createContainer } from '@patternfly/react-charts/victory';
 import { AsyncComponent } from '../utils/async';
 

--- a/frontend/public/components/secrets/create-secret/index.tsx
+++ b/frontend/public/components/secrets/create-secret/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './utils';
 export * from './const';
 export * from './SecretFormWrapper';

--- a/frontend/public/components/utils/datetime.ts
+++ b/frontend/public/components/utils/datetime.ts
@@ -1,1 +1,2 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from '@console/shared/src/utils/datetime';

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './line-buffer';
 export * from './kebab';
 export * from './selector';

--- a/frontend/public/components/utils/k8s-watch-hook.ts
+++ b/frontend/public/components/utils/k8s-watch-hook.ts
@@ -1,2 +1,3 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResource';
 export { useK8sWatchResources } from '@console/dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources';

--- a/frontend/public/components/utils/k8s-watcher.ts
+++ b/frontend/public/components/utils/k8s-watcher.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export {
   makeReduxID,
   makeQuery,

--- a/frontend/public/components/utils/rbac.tsx
+++ b/frontend/public/components/utils/rbac.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import type { ReactNode, FC } from 'react';
 import { useState, useEffect } from 'react';
 import { connect } from 'react-redux';

--- a/frontend/public/components/utils/status-box.ts
+++ b/frontend/public/components/utils/status-box.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from '@console/shared/src/components/status/StatusBox';
 export * from '@console/shared/src/components/loading/LoadError';
 export * from '@console/shared/src/components/loading/Loading';

--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import detector from 'i18next-browser-languagedetector';

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import { K8sModel as K8sKind } from '@console/dynamic-plugin-sdk/src/api/common-types';
 
 export const PrometheusModel: K8sKind = {

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from './job';
 export * from './k8s';
 export * from './pods';

--- a/frontend/public/module/k8s/k8s-ref.ts
+++ b/frontend/public/module/k8s/k8s-ref.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import { getReference } from '@console/dynamic-plugin-sdk/src/utils/k8s';
 
 // TODO(alecmerdler): Replace all manual string building with this function

--- a/frontend/public/module/k8s/k8s.ts
+++ b/frontend/public/module/k8s/k8s.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import { ExtensionK8sGroupModel } from '@console/dynamic-plugin-sdk/src/api/common-types';
 import {
   GroupVersionKind,

--- a/frontend/public/module/k8s/pods.ts
+++ b/frontend/public/module/k8s/pods.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import * as _ from 'lodash';
 import i18next from 'i18next';
 import { PodPhase } from '@console/dynamic-plugin-sdk/src/extensions/console-types';

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import { JSONSchema7 } from 'json-schema';
 import {
   Selector,

--- a/frontend/public/module/ws-factory.ts
+++ b/frontend/public/module/ws-factory.ts
@@ -1,1 +1,2 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 export * from '@console/dynamic-plugin-sdk/src/utils/k8s/ws-factory';

--- a/frontend/public/reducers/features.ts
+++ b/frontend/public/reducers/features.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-barrel-files/no-barrel-files */
 import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash';
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5320,7 +5320,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.59.0, @typescript-eslint/utils@npm:^8.0.0, @typescript-eslint/utils@npm:^8.56.0":
+"@typescript-eslint/utils@npm:8.59.0, @typescript-eslint/utils@npm:^8.0.0, @typescript-eslint/utils@npm:^8.56.0, @typescript-eslint/utils@npm:^8.58.1":
   version: 8.59.0
   resolution: "@typescript-eslint/utils@npm:8.59.0"
   dependencies:
@@ -10940,6 +10940,7 @@ __metadata:
     eslint-plugin-json: "npm:^2.0.1"
     eslint-plugin-jsx-a11y: "npm:^6.8.0"
     eslint-plugin-n: "npm:^17.24.0"
+    eslint-plugin-no-barrel-files: "npm:^1.1.0"
     eslint-plugin-playwright: "npm:^2.10.2"
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.6.0"
@@ -11091,6 +11092,17 @@ __metadata:
   peerDependencies:
     eslint: ">=8.23.0"
   checksum: 10c0/65b6c9ccd4d69296df9bdc0517bdbbc71e5f1ec065e80623c49148ff7813829bd3568154a016fefc06749476f3fdadc0e1afa61a15695893a3ca3da161c9fe86
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-no-barrel-files@npm:^1.1.0":
+  version: 1.3.1
+  resolution: "eslint-plugin-no-barrel-files@npm:1.3.1"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^8.58.1"
+  peerDependencies:
+    eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
+  checksum: 10c0/283538555fd23347cb016841ac77ad0ea16b5a4dde5e155c7d8dd675a228a63c170a9d661ae2c7646d7a3e0b1d262fc28d860f024f4a7415c408b5c8943e6c60
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds an eslint plugin to ban future barrel files and disables the rule for all remaining ones

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code organization and tooling configuration across multiple packages to improve code maintainability.
  * Enhanced build and development infrastructure with updated linting tools and consolidated utility module exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->