### PR TITLE
[release-4.21] OCPBUGS-86314: Show empty state instead of 403 error for users without projects

### DIFF
--- a/frontend/packages/console-app/src/components/pdb/PDBList.tsx
+++ b/frontend/packages/console-app/src/components/pdb/PDBList.tsx
@@ -167,4 +167,5 @@ type PodDisruptionBudgetsListProps = {
   data: PodDisruptionBudgetKind[];
   loaded: boolean;
   loadError?: any;
+  mock?: boolean;
 };

--- a/frontend/packages/console-app/src/components/pdb/PDBPage.tsx
+++ b/frontend/packages/console-app/src/components/pdb/PDBPage.tsx
@@ -10,20 +10,25 @@ import PodDisruptionBudgetList from './PDBList';
 import { PodDisruptionBudgetKind } from './types';
 
 export const PodDisruptionBudgetsPage: React.FC<PodDisruptionBudgetsPageProps> = ({
+  mock,
   namespace,
   showTitle = true,
 }) => {
   const { t } = useTranslation();
-  const [resources, loaded, loadError] = useK8sWatchResource<PodDisruptionBudgetKind[]>({
-    groupVersionKind: {
-      group: PodDisruptionBudgetModel.apiGroup,
-      kind: PodDisruptionBudgetModel.kind,
-      version: PodDisruptionBudgetModel.apiVersion,
-    },
-    isList: true,
-    namespaced: true,
-    namespace,
-  });
+  const [resources, loaded, loadError] = useK8sWatchResource<PodDisruptionBudgetKind[]>(
+    mock
+      ? null
+      : {
+          groupVersionKind: {
+            group: PodDisruptionBudgetModel.apiGroup,
+            kind: PodDisruptionBudgetModel.kind,
+            version: PodDisruptionBudgetModel.apiVersion,
+          },
+          isList: true,
+          namespaced: true,
+          namespace,
+        },
+  );
 
   const resourceKind = referenceForModel(PodDisruptionBudgetModel);
   const accessReview = {
@@ -33,18 +38,26 @@ export const PodDisruptionBudgetsPage: React.FC<PodDisruptionBudgetsPageProps> =
   return (
     <>
       <ListPageHeader title={showTitle ? t(PodDisruptionBudgetModel.labelPluralKey) : undefined}>
-        <ListPageCreate groupVersionKind={resourceKind} createAccessReview={accessReview}>
-          {t('console-app~Create PodDisruptionBudget')}
-        </ListPageCreate>
+        {!mock && (
+          <ListPageCreate groupVersionKind={resourceKind} createAccessReview={accessReview}>
+            {t('console-app~Create PodDisruptionBudget')}
+          </ListPageCreate>
+        )}
       </ListPageHeader>
       <ListPageBody>
-        <PodDisruptionBudgetList data={resources} loaded={loaded} loadError={loadError} />
+        <PodDisruptionBudgetList
+          data={resources}
+          loaded={loaded}
+          loadError={loadError}
+          mock={mock}
+        />
       </ListPageBody>
     </>
   );
 };
 
 type PodDisruptionBudgetsPageProps = {
+  mock?: boolean;
   namespace: string;
   showTitle?: boolean;
 };

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
@@ -298,6 +298,7 @@ const VolumeSnapshotTable: React.FCC<VolumeSnapshotTableProps> = ({ data, loaded
 
 export const VolumeSnapshotPage: React.FCC<VolumeSnapshotPageProps> = ({
   canCreate = true,
+  mock,
   showTitle = true,
   namespace,
   selector,
@@ -306,29 +307,33 @@ export const VolumeSnapshotPage: React.FCC<VolumeSnapshotPageProps> = ({
 
   const createPath = `/k8s/ns/${namespace || 'default'}/${VolumeSnapshotModel.plural}/~new/form`;
 
-  const [resources, loaded, loadError] = useK8sWatchResource<VolumeSnapshotKind[]>({
-    groupVersionKind: {
-      group: VolumeSnapshotModel.apiGroup,
-      kind: VolumeSnapshotModel.kind,
-      version: VolumeSnapshotModel.apiVersion,
-    },
-    isList: true,
-    namespaced: true,
-    namespace,
-    selector,
-  });
+  const [resources, loaded, loadError] = useK8sWatchResource<VolumeSnapshotKind[]>(
+    mock
+      ? null
+      : {
+          groupVersionKind: {
+            group: VolumeSnapshotModel.apiGroup,
+            kind: VolumeSnapshotModel.kind,
+            version: VolumeSnapshotModel.apiVersion,
+          },
+          isList: true,
+          namespaced: true,
+          namespace,
+          selector,
+        },
+  );
 
   return (
     <>
       <ListPageHeader title={showTitle ? t(VolumeSnapshotModel.labelPluralKey || '') : ''}>
-        {canCreate && (
+        {canCreate && !mock && (
           <ListPageCreateLink to={createPath}>
             {t('console-app~Create VolumeSnapshot')}
           </ListPageCreateLink>
         )}
       </ListPageHeader>
       <ListPageBody>
-        <VolumeSnapshotTable data={resources} loaded={loaded} loadError={loadError} />
+        <VolumeSnapshotTable data={resources} loaded={loaded} loadError={loadError} mock={mock} />
       </ListPageBody>
     </>
   );
@@ -375,6 +380,7 @@ type VolumeSnapshotFilters = ResourceFilters & {
 };
 
 type VolumeSnapshotPageProps = {
+  mock?: boolean;
   namespace?: string;
   canCreate?: boolean;
   showTitle?: boolean;
@@ -390,6 +396,7 @@ type VolumeSnapshotTableProps = {
   data: VolumeSnapshotKind[];
   loaded: boolean;
   loadError: unknown;
+  mock?: boolean;
 };
 
 type VolumeSnapshotRowData = {

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseList.tsx
@@ -120,7 +120,7 @@ const getObjectMetadata = (release: HelmRelease) => ({
   name: release.name,
 });
 
-const HelmReleaseList: React.FC = () => {
+const HelmReleaseList: React.FC<{ mock?: boolean }> = ({ mock }) => {
   const { t } = useTranslation();
   const params = useParams();
   const namespace = params.ns;
@@ -144,7 +144,7 @@ const HelmReleaseList: React.FC = () => {
     [namespace],
   );
   const [secretsData, secretsLoaded, secretsLoadError] = useK8sWatchResource<K8sResourceKind[]>(
-    secretResource,
+    mock ? null : secretResource,
   );
   const newCount = secretsData?.length ?? 0;
 
@@ -255,7 +255,7 @@ const HelmReleaseList: React.FC = () => {
       <DocumentTitle>{t('helm-plugin~Helm Releases')}</DocumentTitle>
       <PaneBody>
         <React.Suspense fallback={<LoadingBox />}>
-          {hasNoReleases ? (
+          {!mock && hasNoReleases ? (
             emptyState()
           ) : (
             <ConsoleDataView<HelmRelease, { obj: HelmRelease }, HelmReleaseFilters>
@@ -271,6 +271,7 @@ const HelmReleaseList: React.FC = () => {
               getDataViewRows={getDataViewRows}
               hideLabelFilter
               hideColumnManagement
+              mock={mock}
             />
           )}
         </React.Suspense>

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseListPage.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseListPage.tsx
@@ -3,12 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { PageHeading } from '@console/shared/src/components/heading/PageHeading';
 import HelmReleaseList from './HelmReleaseList';
 
-const HelmReleaseListPage: React.FC = () => {
+const HelmReleaseListPage: React.FC<{ mock?: boolean }> = ({ mock }) => {
   const { t } = useTranslation();
   return (
     <div>
       <PageHeading title={t('helm-plugin~Helm Releases')} />
-      <HelmReleaseList />
+      <HelmReleaseList mock={mock} />
     </div>
   );
 };

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmTabbedPage.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmTabbedPage.tsx
@@ -16,7 +16,10 @@ import HelmReleaseList from './HelmReleaseList';
 import HelmReleaseListPage from './HelmReleaseListPage';
 import RepositoriesPage from './RepositoriesListPage';
 
-const HelmPage: React.FC<{ namespace: string | undefined }> = ({ namespace }) => {
+const HelmPage: React.FC<{ mock?: boolean; namespace: string | undefined }> = ({
+  mock,
+  namespace,
+}) => {
   const { t } = useTranslation();
   const isHelmVisible = useFlag('HELM_CHARTS_CATALOG_TYPE');
   const [showTitle, canCreate] = [false, false];
@@ -75,6 +78,9 @@ const HelmPage: React.FC<{ namespace: string | undefined }> = ({ namespace }) =>
       // t('helm-plugin~Helm Releases')
       nameKey: 'helm-plugin~Helm Releases',
       component: HelmReleaseList,
+      pageData: {
+        mock,
+      },
     },
     {
       href: 'repositories',
@@ -110,17 +116,19 @@ const HelmPage: React.FC<{ namespace: string | undefined }> = ({ namespace }) =>
       telemetryPrefix="Helm"
     />
   ) : (
-    <HelmReleaseListPage />
+    <HelmReleaseListPage mock={mock} />
   );
 };
 
-export const PageContents: React.FC = () => {
+export const PageContents: React.FC<{ noProjectsAvailable?: boolean }> = ({
+  noProjectsAvailable,
+}) => {
   const { t } = useTranslation();
   const { ns: namespace } = useParams();
   const [activePerspective] = useActivePerspective();
 
   return activePerspective === 'admin' || namespace ? (
-    <HelmPage namespace={namespace} />
+    <HelmPage namespace={namespace} mock={noProjectsAvailable} />
   ) : (
     <CreateProjectListPage title={t('helm-plugin~Helm')}>
       {(openProjectModal) => (

--- a/frontend/public/components/RBAC/bindings.tsx
+++ b/frontend/public/components/RBAC/bindings.tsx
@@ -345,25 +345,34 @@ export const RoleBindingsPage: React.FCC<RoleBindingsPageProps> = ({
   }`,
 }) => {
   const { t } = useTranslation();
-  const resources = useK8sWatchResources({
-    RoleBinding: {
-      kind: 'RoleBinding',
-      namespaced: true,
-      namespace,
-      isList: true,
-    },
-    ClusterRoleBinding: {
-      kind: 'ClusterRoleBinding',
-      namespaced: false,
-      isList: true,
-    },
-  });
+  const watchResources = React.useMemo(
+    () =>
+      mock
+        ? {}
+        : {
+            RoleBinding: {
+              kind: 'RoleBinding',
+              namespaced: true,
+              namespace,
+              isList: true,
+            },
+            ClusterRoleBinding: {
+              kind: 'ClusterRoleBinding',
+              namespaced: false,
+              isList: true,
+            },
+          },
+    [mock, namespace],
+  );
+  const resources = useK8sWatchResources(watchResources);
 
   const data = React.useMemo(() => flatten(resources), [resources]);
 
   const loaded = Object.values(resources)
     .filter((r) => !r.loadError)
     .every((r) => r.loaded);
+
+  const loadError = Object.values(resources).find((r) => r.loadError)?.loadError;
 
   return (
     <>
@@ -376,7 +385,8 @@ export const RoleBindingsPage: React.FCC<RoleBindingsPageProps> = ({
         <BindingsList
           data={data}
           loaded={loaded}
-          loadError={resources.RoleBinding.loadError}
+          loadError={loadError}
+          mock={mock}
           staticFilters={staticFilters}
         />
       </ListPageBody>

--- a/frontend/public/components/pod-list.tsx
+++ b/frontend/public/components/pod-list.tsx
@@ -437,6 +437,7 @@ export const PodList: FC<PodListProps> = ({
   data,
   loaded,
   loadError,
+  mock,
   hideNameLabelFilters,
   hideLabelFilter,
   hideColumnManagement,
@@ -541,6 +542,7 @@ export const PodList: FC<PodListProps> = ({
         data={data}
         loaded={loaded}
         loadError={loadError}
+        mock={mock}
         columns={columns}
         columnLayout={columnLayout}
         columnManagementID={columnManagementID}
@@ -561,6 +563,7 @@ export const PodList: FC<PodListProps> = ({
 export const PodsPage: FC<PodPageProps> = ({
   canCreate = true,
   namespace,
+  mock,
   showNodes,
   showTitle = true,
   selector,
@@ -580,7 +583,7 @@ export const PodsPage: FC<PodPageProps> = ({
   );
 
   useEffect(() => {
-    if (showMetrics) {
+    if (showMetrics && !mock) {
       const updateMetrics = () =>
         fetchPodMetrics(namespace || '')
           .then((result) => dispatch(UIActions.setPodMetrics(result)))
@@ -597,16 +600,20 @@ export const PodsPage: FC<PodPageProps> = ({
       return () => clearInterval(id);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [namespace]);
+  }, [mock, namespace]);
 
-  const [pods, loaded, loadError] = useK8sWatchResource<PodKind[]>({
-    kind: PodModel.kind,
-    isList: true,
-    namespaced: true,
-    namespace,
-    selector,
-    fieldSelector,
-  });
+  const [pods, loaded, loadError] = useK8sWatchResource<PodKind[]>(
+    mock
+      ? null
+      : {
+          kind: PodModel.kind,
+          isList: true,
+          namespaced: true,
+          namespace,
+          selector,
+          fieldSelector,
+        },
+  );
 
   const resourceKind = referenceForModel(PodModel);
   const accessReview = {
@@ -620,7 +627,7 @@ export const PodsPage: FC<PodPageProps> = ({
   return (
     <>
       <ListPageHeader title={showTitle ? t('public~Pods') : ''}>
-        {canCreate && (
+        {canCreate && !mock && (
           <ListPageCreate groupVersionKind={resourceKind} createAccessReview={accessReview}>
             {t('public~Create Pod')}
           </ListPageCreate>
@@ -631,6 +638,7 @@ export const PodsPage: FC<PodPageProps> = ({
           data={pods}
           loaded={loaded}
           loadError={loadError}
+          mock={mock}
           showNamespaceOverride={showNamespaceOverride}
           showNodes={showNodes}
           namespace={namespace}
@@ -672,6 +680,7 @@ type PodListProps = {
   data: PodKind[];
   loaded: boolean;
   loadError: unknown;
+  mock?: boolean;
   showNodes?: boolean;
   showNamespaceOverride?: boolean;
   hideNameLabelFilters?: boolean;
@@ -684,6 +693,7 @@ type PodListProps = {
 type PodPageProps = {
   canCreate?: boolean;
   fieldSelector?: string;
+  mock?: boolean;
   namespace?: string;
   selector?: Selector;
   showTitle?: boolean;


### PR DESCRIPTION
## Summary
- Cherry-pick of 6b84bc12b8 from main to release-4.21
- Resource list pages that use `useK8sWatchResource` directly were ignoring the `mock` prop passed by `withStartGuide` when no projects are available, causing 403 errors displayed as "Restricted access" instead of the expected empty state
- Accept and respect the `mock` prop in `PodsPage`, `PodDisruptionBudgetsPage`, `VolumeSnapshotPage`, `RoleBindingsPage`, and Helm release pages to skip API calls and render an `EmptyBox` when mock is true

## Test plan
- [ ] Log in as a user with no project access
- [ ] Navigate to Pods, PodDisruptionBudgets, VolumeSnapshots, RoleBindings, and Helm Releases pages
- [ ] Verify each page shows an empty state ("No {resource} found") instead of a 403 "Restricted access" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)