### PR TITLE
OCPBUGS-84876: Remove DataViewToolbar wrapper from bottom pagination

### DIFF
--- a/frontend/packages/console-app/src/components/data-view/ConsoleDataView.tsx
+++ b/frontend/packages/console-app/src/components/data-view/ConsoleDataView.tsx
@@ -251,15 +251,11 @@ export const ConsoleDataView = <
             isResizable={isResizable}
           />
         </InnerScrollContainer>
-        <DataViewToolbar
-          pagination={
-            <Pagination
-              itemCount={filteredData.length}
-              titles={paginationTitles}
-              variant={PaginationVariant.bottom}
-              {...pagination}
-            />
-          }
+        <Pagination
+          itemCount={filteredData.length}
+          titles={paginationTitles}
+          variant={PaginationVariant.bottom}
+          {...pagination}
         />
       </DataView>
     </StatusBox>


### PR DESCRIPTION
**Analysis / Root cause**:

Follow-on fix for [OCPBUGS-84876](https://redhat.atlassian.net/browse/OCPBUGS-84876). The initial PR (#16391) added bottom pagination to ConsoleDataView but wrapped it in a `DataViewToolbar`, which is unnecessary.

**Solution description**:

Remove the `DataViewToolbar` wrapper from the bottom `Pagination` component and render it directly as a child of `DataView`. The `DataViewToolbar` wrapper added unnecessary DOM structure — `Pagination` works correctly as a direct child of `DataView`.

**Screenshots / screen recording**:
Before
<img width="724" height="654" alt="Screenshot 2026-05-21 at 9 00 35 AM" src="https://github.com/user-attachments/assets/130f7ca9-e68d-4752-b06c-cf16f1980f62" />
After
<img width="711" height="654" alt="Screenshot 2026-05-21 at 9 00 28 AM" src="https://github.com/user-attachments/assets/1a217efe-f925-4ca6-a2b4-fb7cbcf7fd69" />

**Test setup:**
Navigate to any page using ConsoleDataView (e.g., Nodes page).

**Test cases:**
- Verify bottom pagination is still visible and functional
- Verify top pagination still works
- Verify pagination syncs between top and bottom
- Verify mobile viewport still shows full controls in the bottom pagination

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal refactoring of pagination component integration with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->