### PR TITLE
[release-4.22] OCPBUGS-86410: Fix Shipwright detail pages crashing with React error #310

### DIFF
--- a/frontend/packages/shipwright-plugin/src/components/build-details/BuildDetailsPage.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/build-details/BuildDetailsPage.tsx
@@ -9,12 +9,15 @@ import {
   ActionMenuVariant,
   ActionServiceProvider,
 } from '@console/shared/src/components/actions';
-import { useShipwrightBreadcrumbsFor } from '../../utils';
+import { useBuildModel, useShipwrightBreadcrumbsFor } from '../../utils';
 import BuildDetailsTab from './BuildDetailsTab';
 import BuildEventsTab from './BuildEventsTab';
 import BuildRunsTab from './BuildRunsTab';
 
 const BuildDetailsPage: FC<DetailsPageProps> = (props) => {
+  const model = useBuildModel();
+  const breadcrumbs = useShipwrightBreadcrumbsFor(model);
+
   const customActionMenu = (_, build) => {
     const kindReference = referenceFor(build);
     const context = { [kindReference]: build };
@@ -46,7 +49,7 @@ const BuildDetailsPage: FC<DetailsPageProps> = (props) => {
       {...props}
       customActionMenu={customActionMenu}
       pages={pages}
-      breadcrumbsFor={useShipwrightBreadcrumbsFor}
+      breadcrumbsFor={() => breadcrumbs}
     />
   );
 };

--- a/frontend/packages/shipwright-plugin/src/components/buildrun-details/BuildRunDetailsPage.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/buildrun-details/BuildRunDetailsPage.tsx
@@ -9,13 +9,16 @@ import {
   ActionMenuVariant,
   ActionServiceProvider,
 } from '@console/shared/src/components/actions';
-import { useShipwrightBreadcrumbsFor } from '../../utils';
+import { useBuildRunModel, useShipwrightBreadcrumbsFor } from '../../utils';
 import { getBuildRunStatus } from '../buildrun-status/BuildRunStatus';
 import BuildRunDetailsTab from './BuildRunDetailsTab';
 import BuildRunEventsTab from './BuildRunEventsTab';
 import BuildRunLogsTab from './BuildRunLogsTab';
 
 const BuildRunDetailsPage: FC<DetailsPageProps> = (props) => {
+  const model = useBuildRunModel();
+  const breadcrumbs = useShipwrightBreadcrumbsFor(model);
+
   const customActionMenu = (_, buildRun) => {
     const kindReference = referenceFor(buildRun);
     const context = { [kindReference]: buildRun };
@@ -43,7 +46,7 @@ const BuildRunDetailsPage: FC<DetailsPageProps> = (props) => {
       getResourceStatus={getBuildRunStatus}
       customActionMenu={customActionMenu}
       pages={pages}
-      breadcrumbsFor={useShipwrightBreadcrumbsFor}
+      breadcrumbsFor={() => breadcrumbs}
     />
   );
 };

--- a/frontend/packages/shipwright-plugin/src/components/buildstrategy-details/BuildStrategyDetailsPage.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/buildstrategy-details/BuildStrategyDetailsPage.tsx
@@ -4,12 +4,14 @@ import type { DetailsPageProps } from '@console/internal/components/factory';
 import { DetailsPage } from '@console/internal/components/factory';
 import type { Page } from '@console/internal/components/utils';
 import { navFactory } from '@console/internal/components/utils';
-import { useShipwrightBreadcrumbsFor } from '../../utils';
+import { useBuildStrategyModel, useShipwrightBreadcrumbsFor } from '../../utils';
 
 const BuildStrategyPage: FC<DetailsPageProps> = (props) => {
+  const model = useBuildStrategyModel();
+  const breadcrumbs = useShipwrightBreadcrumbsFor(model);
   const pages: Page[] = [navFactory.details(DetailsForKind), navFactory.editYaml()];
 
-  return <DetailsPage {...props} pages={pages} breadcrumbsFor={useShipwrightBreadcrumbsFor} />;
+  return <DetailsPage {...props} pages={pages} breadcrumbsFor={() => breadcrumbs} />;
 };
 
 export default BuildStrategyPage;

--- a/frontend/packages/shipwright-plugin/src/components/clusterbuildstrategy-details/ClusterBuildStrategyDetailsPage.tsx
+++ b/frontend/packages/shipwright-plugin/src/components/clusterbuildstrategy-details/ClusterBuildStrategyDetailsPage.tsx
@@ -4,12 +4,14 @@ import type { DetailsPageProps } from '@console/internal/components/factory';
 import { DetailsPage } from '@console/internal/components/factory';
 import type { Page } from '@console/internal/components/utils';
 import { navFactory } from '@console/internal/components/utils';
-import { useShipwrightBreadcrumbsFor } from '../../utils';
+import { useClusterBuildStrategyModel, useShipwrightBreadcrumbsFor } from '../../utils';
 
 const ClusterBuildStrategyPage: FC<DetailsPageProps> = (props) => {
+  const model = useClusterBuildStrategyModel();
+  const breadcrumbs = useShipwrightBreadcrumbsFor(model);
   const pages: Page[] = [navFactory.details(DetailsForKind), navFactory.editYaml()];
 
-  return <DetailsPage {...props} pages={pages} breadcrumbsFor={useShipwrightBreadcrumbsFor} />;
+  return <DetailsPage {...props} pages={pages} breadcrumbsFor={() => breadcrumbs} />;
 };
 
 export default ClusterBuildStrategyPage;

--- a/frontend/packages/shipwright-plugin/src/utils.ts
+++ b/frontend/packages/shipwright-plugin/src/utils.ts
@@ -194,46 +194,16 @@ const kindToTabMap = {
   [ClusterBuildStrategyModelV1Alpha1.kind]: 'clusterbuildstrategies',
 };
 
-/** convert a resource using a shipwright model to its corresponding k8s model */
-const resourceToModel = (obj: K8sResourceKind): K8sModel => {
-  if (obj?.apiVersion === 'shipwright.io/v1alpha1') {
-    switch (obj?.kind) {
-      case 'Build':
-        return BuildModelV1Alpha1;
-      case 'BuildRun':
-        return BuildRunModelV1Alpha1;
-      case 'BuildStrategy':
-        return BuildStrategyModelV1Alpha1;
-      case 'ClusterBuildStrategy':
-        return ClusterBuildStrategyModelV1Alpha1;
-      default:
-        return null;
-    }
-  }
-  switch (obj?.kind) {
-    case 'Build':
-      return BuildModel;
-    case 'BuildRun':
-      return BuildRunModel;
-    case 'BuildStrategy':
-      return BuildStrategyModel;
-    case 'ClusterBuildStrategy':
-      return ClusterBuildStrategyModel;
-    default:
-      return null;
-  }
-};
-
-export const useShipwrightBreadcrumbsFor = (obj: K8sResourceKind) => {
+export const useShipwrightBreadcrumbsFor = (kindObj: K8sModel) => {
   const isAdminPerspective = useActivePerspective()[0] === 'admin';
   const params = useParams();
   const location = useLocation();
   return useTabbedTableBreadcrumbsFor(
-    resourceToModel(obj),
+    kindObj ?? ({} as K8sModel),
     location,
     params,
     'k8s',
-    `shipwright.io/${kindToTabMap[obj.kind]}`,
+    kindObj ? `shipwright.io/${kindToTabMap[kindObj.kind]}` : null,
     undefined,
     isAdminPerspective,
   );


### PR DESCRIPTION
**Analysis / Root cause**:

`useShipwrightBreadcrumbsFor` is a React hook containing 6 sub-hooks (`useActivePerspective`, `useParams`, `useLocation`, `useTranslation`, `useConsoleSelector`, `useMemo`) that was incorrectly passed as a plain callback via the `breadcrumbsFor` prop to `DetailsPage`.

Inside `ConnectedPageHeading`, `breadcrumbsFor` is called conditionally based on data loading state:
```tsx
breadcrumbs={!_.isEmpty(data) ? breadcrumbsFor(data) : null}
```

This violates React's Rules of Hooks. On the first render (data empty), 0 hooks are invoked via `breadcrumbsFor`; on re-render (data loaded), 6 hooks are invoked.

This bug was latent since commit `e98f1e58b1` (Aug 2024, [ODC-7632](https://redhat.atlassian.net/browse/ODC-7632)). On OCP 4.19, `ConnectedPageHeading` had no hooks of its own, so React couldn't detect the violation. On OCP 4.20+, commit `f803a25cb7` added 3 hooks to `ConnectedPageHeading`, causing React to detect the hook count mismatch (3 → 9) and throw error #310: "Rendered more hooks than during the previous render."

All 4 Shipwright detail pages are affected: Build, BuildRun, BuildStrategy, and ClusterBuildStrategy.

**Linked Jira:** https://issues.redhat.com/browse/OCPBUGS-84214
**Support Cases:** 04362500, 04425432, 04430794

### **Solution description**:

Refactored all 4 affected detail pages to call `useShipwrightBreadcrumbsFor` unconditionally at the component level using their existing `use*Model()` hooks, and pass the result as a closure:

```tsx
// Before (broken — hook passed as callback, called conditionally)
<DetailsPage breadcrumbsFor={useShipwrightBreadcrumbsFor} />

// After (fixed — hook called at top level, result passed as closure)
const model = useBuildModel();
const breadcrumbs = useShipwrightBreadcrumbsFor(model);
<DetailsPage breadcrumbsFor={() => breadcrumbs} />
```

This follows the established pattern used by the knative plugin (`ServiceDetailsPage.tsx`).

Also changed `useShipwrightBreadcrumbsFor` to accept a `K8sModel` directly instead of a `K8sResourceKind`, and removed the now-dead `resourceToModel` function (30 lines).

**Test setup:**

1. OCP 4.20+ cluster with the **Builds for Red Hat OpenShift Operator** installed (v1.7.1 or v1.7.2)
2. At least one `ClusterBuildStrategy` deployed (e.g., `buildah` — typically installed by the operator automatically)

**Test cases:**

1. Navigate to `/k8s/cluster/shipwright.io~v1beta1~ClusterBuildStrategy/buildah` — page should render without crash, breadcrumbs should show correctly
2. Navigate to a namespaced BuildStrategy, Build, and BuildRun detail page — all should render without crash
3. Verify breadcrumb links navigate back to the correct list pages
4. Verify tab switching (Details, YAML, BuildRuns, Events, Logs) works without errors
5. Verify no React warnings or errors in the browser console

**Browser conformance**:
- [x] Chrome
- [x] Firefox
- [x] Safari

### Backport plan
4.22, 4.21, 4.20

**Additional info:**

- 5 files changed, 21 insertions, 41 deletions — all changes confined to `shipwright-plugin`
- Zero console core changes
- All existing unit tests pass (49 tests across 9 suites)
- TypeScript compiles clean with zero errors
