### PR TITLE
OCPBUGS-77115: [release-4.13] CVE-2026-26996 Bump minimatch library

### DIFF
--- a/dynamic-demo-plugin/package.json
+++ b/dynamic-demo-plugin/package.json
@@ -76,5 +76,9 @@
       "@console/demo-plugin"
     ]
   },
+  "resolutions": {
+    "minimatch@^3.0.2": "^3.1.3",
+    "minimatch@^3.0.4": "^3.1.3"
+  },
   "packageManager": "yarn@4.12.0"
 }

--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -169,7 +169,7 @@ __metadata:
     "@patternfly/react-core": "npm:4.276.6"
     "@patternfly/react-table": "npm:4.112.39"
     classnames: "npm:2.x"
-    immutable: "npm:3.x"
+    immutable: "npm:^3.8.3"
     lodash: "npm:^4.17.23"
     react: "npm:^17.0.1"
     react-helmet: "npm:^6.1.0"
@@ -255,25 +255,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-core@npm:^4.135.15":
-  version: 4.221.3
-  resolution: "@patternfly/react-core@npm:4.221.3"
-  dependencies:
-    "@patternfly/react-icons": "npm:^4.72.3"
-    "@patternfly/react-styles": "npm:^4.71.3"
-    "@patternfly/react-tokens": "npm:^4.73.3"
-    focus-trap: "npm:6.9.2"
-    react-dropzone: "npm:9.0.0"
-    tippy.js: "npm:5.1.2"
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: 10c0/a8bd1a41a064e64a97f538adb35980d24efd01703a5a6d78de7a6190f9afda1f6d586234e4947c9f41a35836d371f38d603fee1867a783021dc743537f8fb551
-  languageName: node
-  linkType: hard
-
-"@patternfly/react-core@npm:^4.276.6":
+"@patternfly/react-core@npm:^4.135.15, @patternfly/react-core@npm:^4.276.6":
   version: 4.278.1
   resolution: "@patternfly/react-core@npm:4.278.1"
   dependencies:
@@ -288,16 +270,6 @@ __metadata:
     react: ^16.8 || ^17 || ^18
     react-dom: ^16.8 || ^17 || ^18
   checksum: 10c0/71984ac2c11aea295f348d2d4ee4291b2f3d495a76fd6f2817681cef89a64962793631020963777d08e19768198e5ddc90e2c10f6b81aeb5cb4676fcde5224e4
-  languageName: node
-  linkType: hard
-
-"@patternfly/react-icons@npm:^4.72.3":
-  version: 4.72.3
-  resolution: "@patternfly/react-icons@npm:4.72.3"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: 10c0/5fe915c5fffea8ed4cc44adab7bba46ae1ca246db4a1c5b4142762564bc95435f848c564a136d155ac836235ac45c5feb70469580d88ef44e4928e5eadbcc34b
   languageName: node
   linkType: hard
 
@@ -321,10 +293,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-styles@npm:^4.11.4, @patternfly/react-styles@npm:^4.71.3":
-  version: 4.71.3
-  resolution: "@patternfly/react-styles@npm:4.71.3"
-  checksum: 10c0/a5ebb7f4dc1dd5bdada83e37a8838addcac0bd9b338a276aad9c23de058670df3903585530dd7de8c4c5893511f6e7ea15f057ee28a8efb089ba2273303b5d98
+"@patternfly/react-styles@npm:^4.11.4, @patternfly/react-styles@npm:^4.92.8":
+  version: 4.92.8
+  resolution: "@patternfly/react-styles@npm:4.92.8"
+  checksum: 10c0/01b492920e6e0603b9cd5898dac451baa0a2d764a79d36a725bab81211f99d6663baaa56840631f1ce2fb62da287804d2861328ff54c2701c71ea4f3d8490f2c
   languageName: node
   linkType: hard
 
@@ -332,13 +304,6 @@ __metadata:
   version: 4.92.6
   resolution: "@patternfly/react-styles@npm:4.92.6"
   checksum: 10c0/a3f114da88888acd1d549028b976bffcb2390a5ab1615eb9a692c077deca14b1bbd09e609fb802982d02870ef49101df255a1b03d6b725df11ca958db52762ec
-  languageName: node
-  linkType: hard
-
-"@patternfly/react-styles@npm:^4.92.8":
-  version: 4.92.8
-  resolution: "@patternfly/react-styles@npm:4.92.8"
-  checksum: 10c0/01b492920e6e0603b9cd5898dac451baa0a2d764a79d36a725bab81211f99d6663baaa56840631f1ce2fb62da287804d2861328ff54c2701c71ea4f3d8490f2c
   languageName: node
   linkType: hard
 
@@ -356,13 +321,6 @@ __metadata:
     react: ^16.8 || ^17 || ^18
     react-dom: ^16.8 || ^17 || ^18
   checksum: 10c0/244bbe00f6dc775f273d8850479fb8c706c210ef0651fa3b80452b694e2173d66c5ee613377f8c8a0764b6f938de632eb334799750cb28c5d0e2fdc95f9896d9
-  languageName: node
-  linkType: hard
-
-"@patternfly/react-tokens@npm:^4.73.3":
-  version: 4.73.3
-  resolution: "@patternfly/react-tokens@npm:4.73.3"
-  checksum: 10c0/9fa3b5bf86255b36ca96f9ce519a1ec227fe0394be49b589cbbc39a3b9c4d9cf9b14b6043f8e1eb523b63a30626ecce8949663c4437eb43d9560e6bb7e067424
   languageName: node
   linkType: hard
 
@@ -1217,10 +1175,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:2.x, classnames@npm:^2.2.5":
+"classnames@npm:2.x":
   version: 2.3.1
   resolution: "classnames@npm:2.3.1"
   checksum: 10c0/e3b832219042802464e648c41c2e8be96c2c64d2522cfa22fbb5ec088418406c61ab351a682c077c07f691c8b00c9f0ee7939b20fabc6c23da69063252a4ab89
+  languageName: node
+  linkType: hard
+
+"classnames@npm:^2.2.5":
+  version: 2.5.1
+  resolution: "classnames@npm:2.5.1"
+  checksum: 10c0/afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
   languageName: node
   linkType: hard
 
@@ -2713,10 +2678,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:3.x":
-  version: 3.8.2
-  resolution: "immutable@npm:3.8.2"
-  checksum: 10c0/fb6a2999ad3bda9e51741721e42547076dd492635ee4df9241224055fe953ec843583a700088cc4915f23dc326e5084f4e17f1bbd7388c3e872ef5a242e0ac5e
+"immutable@npm:^3.8.3":
+  version: 3.8.3
+  resolution: "immutable@npm:3.8.3"
+  checksum: 10c0/bafa7b8371b7622bc3d128cd9e6bba3a654b968f09a237929629f43ac26f7e974a5879cd38baad0c26f6f0628753968611bf832add7bf0c44d647bf4306a2988
   languageName: node
   linkType: hard
 
@@ -3418,12 +3383,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.2, minimatch@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "minimatch@npm:3.0.4"
+"minimatch@npm:^3.1.3":
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
   dependencies:
     brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/d0a2bcd93ebec08a9eef3ca83ba33c9fb6feb93932e0b4dc6aa46c5f37a9404bea7ad9ff7cafe23ce6634f1fe3b206f5315ecbb05812da6e692c21d8ecfd3dae
+  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
   languageName: node
   linkType: hard
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -356,7 +356,11 @@
     "glob-parent": "^5.1.2",
     "postcss": "^8.2.13",
     "axios@npm:^0.21.1": "patch:axios@npm%3A0.33.0#~/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch",
-    "immutable": "3.8.3"
+    "immutable": "3.8.3",
+    "minimatch@^3.0.2": "^3.1.3",
+    "minimatch@^3.0.3": "^3.1.3",
+    "minimatch@^3.0.4": "^3.1.3",
+    "minimatch@3.0.4": "^3.1.3"
   },
   "husky": {
     "hooks": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -19254,21 +19254,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:3.0.4, minimatch@npm:^3.0.2, minimatch@npm:^3.0.3, minimatch@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "minimatch@npm:3.0.4"
-  dependencies:
-    brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/d0a2bcd93ebec08a9eef3ca83ba33c9fb6feb93932e0b4dc6aa46c5f37a9404bea7ad9ff7cafe23ce6634f1fe3b206f5315ecbb05812da6e692c21d8ecfd3dae
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:^10.2.2":
   version: 10.2.2
   resolution: "minimatch@npm:10.2.2"
   dependencies:
     brace-expansion: "npm:^5.0.2"
   checksum: 10c0/098831f2f542cb802e1f249c809008a016e1fef6b3a9eda9cf9ecb2b3d7979083951bd47c0c82fcf34330bd3b36638a493d4fa8e24cce58caf5b481de0f4e238
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^3.1.3":
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
+  dependencies:
+    brace-expansion: "npm:^1.1.7"
+  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
To remediate https://github.com/isaacs/minimatch/security/advisories/GHSA-3ppc-4f35-3m26 this PR bumps the minimatch library to the patched version.