### PR TITLE
NO-JIRA: Capitalize "Basic" in secret dropdown label

### DIFF
--- a/frontend/packages/helm-plugin/locales/en/helm-plugin.json
+++ b/frontend/packages/helm-plugin/locales/en/helm-plugin.json
@@ -126,7 +126,7 @@
   "The OCI URL or HTTP/HTTPS tar file for the Helm chart; for example - oci://registry.example.com/charts/mychart or https://example.com/chart-1.0.0.tgz.": "The OCI URL or HTTP/HTTPS tar file for the Helm chart; for example - oci://registry.example.com/charts/mychart or https://example.com/chart-1.0.0.tgz.",
   "Unique name for Helm release.": "Unique name for Helm release.",
   "The version of chart to install.": "The version of chart to install.",
-  "Secret for basic authentication": "Secret for basic authentication",
+  "Secret for Basic authentication": "Secret for Basic authentication",
   "Select a secret": "Select a secret",
   "A secret with \"username\" and \"password\" keys for OCI/HTTP(S) authentication": "A secret with \"username\" and \"password\" keys for OCI/HTTP(S) authentication",
   "Next": "Next",

--- a/frontend/packages/helm-plugin/src/components/forms/url-chart/HelmURLChartForm.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/url-chart/HelmURLChartForm.tsx
@@ -131,7 +131,7 @@ const HelmURLChartForm: FC<FormikProps<HelmURLChartFormData> & HelmURLChartFormP
             <GridItem md={12}>
               <ResourceDropdownField
                 name="basicAuthSecretName"
-                label={t('helm-plugin~Secret for basic authentication')}
+                label={t('helm-plugin~Secret for Basic authentication')}
                 resources={secretResources}
                 dataSelector={['metadata', 'name']}
                 fullWidth

--- a/frontend/packages/helm-plugin/src/components/forms/url-chart/HelmURLInstallForm.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/url-chart/HelmURLInstallForm.tsx
@@ -153,7 +153,7 @@ const HelmURLInstallForm: FC<FormikProps<HelmURLInstallFormData> & HelmURLInstal
             <GridItem xl={3} lg={3} md={12}>
               <ResourceDropdownField
                 name="basicAuthSecretName"
-                label={t('helm-plugin~Secret for basic authentication')}
+                label={t('helm-plugin~Secret for Basic authentication')}
                 resources={secretResources}
                 dataSelector={['metadata', 'name']}
                 fullWidth


### PR DESCRIPTION
Align with content guidelines that capitalize protocol names in UI labels ("Basic authentication" instead of "basic authentication").



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized the capitalization of Basic authentication labels throughout Helm plugin forms. Updated secret dropdown label text and corresponding translation strings to consistently use proper title case formatting, resulting in improved visual consistency and a more polished, professional appearance across the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->