### PR TITLE
OCPBUGS-86491: Fix macOS Option key in pod terminal

### DIFF
--- a/frontend/public/components/app.tsx
+++ b/frontend/public/components/app.tsx
@@ -88,6 +88,9 @@ root.render(<LoadingBox blame="Init" />);
 // interceptor calls authSvc.handle401() which handles the redirect.
 coFetch(`${window.SERVER_FLAGS.basePath}api/kubernetes/api`).catch(() => {});
 
+// TODO: remove when upgrading to @xterm/xterm 7.0.0 - github.com/openshift/console/issues/16486
+delete process.title;
+
 initI18n();
 
 // Disable linkify 'fuzzy links' across the app.


### PR DESCRIPTION
Closes https://github.com/openshift/console/issues/16486

**Analysis / Root cause**:

The `NodePolyfillPlugin` in `webpack.config.ts` injects a `process` polyfill (with `additionalAliases: ['process']`) that sets `process.title = 'browser'`. xterm.js 5.5.0 detects Node.js via `typeof process !== 'undefined' && 'title' in process`, which returns `true` due to the polyfill. This causes xterm to set `isMac = false`, so the macOS Option key is treated as Meta (sending ESC sequences) instead of functioning as a compose key.

**Solution description**:

Trick `@xterm/term` by deleting `process.title` at the `app.tsx` entrypoint, before any terminal gets loaded. That way `isNode` gets set to false

Thanks to @vojtechszocs for the elegant idea 

**Test setup:**

- macOS with a non-US keyboard layout (e.g., German QWERTZ) or any layout that uses Option as a compose key
- Navigate to a running Pod → Terminal tab

**Test cases:**

- Verify Option+key combinations produce the expected composed characters (e.g., `@`, `{`, `}`, `|`, `\`, `~`) instead of ESC sequences
- Verify the pod terminal still functions correctly on Linux and Windows
- Verify the web terminal operator terminal still functions correctly

**Browser conformance**:
- [x] Chrome
- [x] Firefox
- [x] Safari (or Epiphany on Linux)

**Additional info:**

This PR should be reverted when the upstream fix lands a stable xterm release (likely `@xterm/xterm` 7.0.0). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Applied a minor update to the application startup sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->