### PR TITLE
OCPBUGS-86508: Remove ErrorBoundaryInline div wrapper

### DIFF
--- a/frontend/packages/console-app/src/components/cluster-configuration/__tests__/ClusterConfigurationCustomField.spec.tsx
+++ b/frontend/packages/console-app/src/components/cluster-configuration/__tests__/ClusterConfigurationCustomField.spec.tsx
@@ -7,6 +7,10 @@ import ClusterConfigurationCustomField from '../ClusterConfigurationCustomField'
 import type { ResolvedClusterConfigurationItem } from '../types';
 
 describe('ClusterConfigurationCustomField', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   const MockCustomComponent = () => <div>Custom Component Content</div>;
 
   const createMockItem = (readonly: boolean): ResolvedClusterConfigurationItem => ({
@@ -39,13 +43,21 @@ describe('ClusterConfigurationCustomField', () => {
     expect(screen.getByText('Custom Component Content')).toBeVisible();
   });
 
-  it('should wrap content in error boundary', () => {
+  it('should catch errors and render error boundary fallback', () => {
+    const ThrowingComponent = () => {
+      throw new Error('test error');
+    };
     const item = createMockItem(false);
-    const field = createMockField();
+    const field: ResolvedCodeRefProperties<ClusterConfigurationCustomFieldType> = {
+      type: ClusterConfigurationFieldType.custom,
+      component: ThrowingComponent,
+    };
 
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     renderWithProviders(<ClusterConfigurationCustomField item={item} field={field} />);
 
-    expect(screen.getByRole('region', { name: 'Inline error boundary' })).toBeVisible();
+    expect(screen.getByText('Extension error')).toBeVisible();
+    expect(screen.queryByText('Custom Component Content')).not.toBeInTheDocument();
   });
 
   it('should wrap content in form layout', () => {

--- a/frontend/packages/console-app/src/components/nav/__tests__/NavHeader.spec.tsx
+++ b/frontend/packages/console-app/src/components/nav/__tests__/NavHeader.spec.tsx
@@ -87,8 +87,43 @@ describe('NavHeader', () => {
     });
   });
 
-  // Note: Edge cases for single/no perspectives are not tested here because
-  // static plugin data (loaded via renderWithProviders) always provides
-  // multiple perspectives. These edge cases would require mocking usePerspectives
-  // which is an antipattern per review feedback.
+  describe('when only one perspective is available', () => {
+    beforeEach(() => {
+      window.SERVER_FLAGS.perspectives = JSON.stringify([
+        { id: 'admin', visibility: { state: 'Enabled' } },
+        { id: 'dev', visibility: { state: 'Disabled' } },
+      ]);
+    });
+
+    afterEach(() => {
+      delete window.SERVER_FLAGS.perspectives;
+    });
+
+    it('should render static label instead of dropdown', () => {
+      renderWithProviders(<NavHeader onPerspectiveSelected={mockOnPerspectiveSelected} />);
+
+      expect(screen.getByRole('heading', { name: 'Core platform' })).toBeVisible();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when all perspectives are disabled', () => {
+    beforeEach(() => {
+      window.SERVER_FLAGS.perspectives = JSON.stringify([
+        { id: 'admin', visibility: { state: 'Disabled' } },
+        { id: 'dev', visibility: { state: 'Disabled' } },
+      ]);
+    });
+
+    afterEach(() => {
+      delete window.SERVER_FLAGS.perspectives;
+    });
+
+    it('should fall back to static label for admin perspective', () => {
+      renderWithProviders(<NavHeader onPerspectiveSelected={mockOnPerspectiveSelected} />);
+
+      expect(screen.getByRole('heading', { name: 'Core platform' })).toBeVisible();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -135,7 +135,6 @@
   "Something wrong happened": "Something wrong happened",
   "An error occurred. Please try again.": "An error occurred. Please try again.",
   "Reload page": "Reload page",
-  "Inline error boundary": "Inline error boundary",
   "You made changes to this page.": "You made changes to this page.",
   "Click {{submit}} to save changes or {{reset}} to cancel changes.": "Click {{submit}} to save changes or {{reset}} to cancel changes.",
   "Reload": "Reload",

--- a/frontend/packages/console-shared/src/components/error/fallbacks/ErrorBoundaryInline.tsx
+++ b/frontend/packages/console-shared/src/components/error/fallbacks/ErrorBoundaryInline.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode, ComponentType, FC } from 'react';
-import { useTranslation } from 'react-i18next';
 import { ErrorBoundary } from '../error-boundary';
 import { ErrorBoundaryFallbackInline } from './ErrorBoundaryFallbackInline';
 
@@ -17,7 +16,6 @@ export const ErrorBoundaryInline: FC<ErrorBoundaryInlineProps> = ({
   children,
   ...props
 }) => {
-  const { t } = useTranslation('console-shared');
   let fallback = ErrorBoundaryFallbackInline;
   if (Wrapper) {
     fallback = (innerProps) => (
@@ -28,10 +26,8 @@ export const ErrorBoundaryInline: FC<ErrorBoundaryInlineProps> = ({
   }
 
   return (
-    <div role="region" aria-label={t('console-shared~Inline error boundary')}>
-      <ErrorBoundary {...props} FallbackComponent={fallback}>
-        {children}
-      </ErrorBoundary>
-    </div>
+    <ErrorBoundary {...props} FallbackComponent={fallback}>
+      {children}
+    </ErrorBoundary>
   );
 };


### PR DESCRIPTION
<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

div wrapper in InlineErrorBoundary added in https://github.com/openshift/console/pull/16452 introduces regression as it messes with the yaml editor flexbox

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

Users do not need to be notified of an error boundary via an `aria-label` as it is an internal implementation detail.

Remove it because it is causing a regression in the YAML editor.

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->
<img width="1646" height="982" alt="image" src="https://github.com/user-attachments/assets/daa1c806-9433-4a7a-8087-502644daf14e" />

**Test cases:**
<!-- List possible test cases to validate the changes. -->

YAML editor should look normal

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari (or Epiphany on Linux)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for error handling in custom-rendered fields: runtime errors now show the fallback UI (“Extension error”) and prevent faulty component content from rendering; tests restore mocks and suppress noisy console output.
  * Added edge-case tests for the navigation header when perspective options are limited or fully disabled.

* **Refactor**
  * Simplified inline error-boundary rendering and removed an unused translation/localization entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->