### PR TITLE
OCPBUGS-86511: Fix flaky TestAsyncCache backend test

### DIFF
--- a/pkg/serverutils/asynccache/asyncccache_test.go
+++ b/pkg/serverutils/asynccache/asyncccache_test.go
@@ -28,49 +28,40 @@ func TestAsyncCache(t *testing.T) {
 		return &testItem{ctx: ctx, t: time.Now()}, nil
 	}
 
+	initializationRetryInterval = 5 * time.Millisecond
+	initializationTimeout = 10 * time.Millisecond
+
 	c, err := NewAsyncCache(context.Background(), 2*time.Second, cacheTime)
 	require.NoError(t, err)
 
-	initializationRetryInterval = 5 * time.Millisecond
-	initializationTimeout = 10 * time.Millisecond
-	// test that initialization was successful
 	item := c.GetItem()
-	if item.t.IsZero() {
-		t.Error("expected non-zero time")
-	}
+	require.False(t, item.t.IsZero(), "expected non-zero time")
 
 	time.Sleep(1 * time.Second)
-	if item.isContextCancelled() {
-		t.Error("expected usable context")
-	}
+	require.False(t, item.isContextCancelled(), "expected usable context")
 
-	timedCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	timedCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	c.Run(timedCtx)
 
-	// test the values get properly changed
-	var matches int
-	var changed bool
-	for i := 0; i < 3; i++ {
-		newItem := c.GetItem()
-		if newItem == item {
-			matches++
-		} else {
-			changed = true
-		}
+	// wait.UntilWithContext fires runCache immediately — let it settle
+	time.Sleep(100 * time.Millisecond)
+	item = c.GetItem()
 
-		time.Sleep(1 * time.Second)
-	}
+	// Cache should return the same item between reloads
+	require.Equal(t, item, c.GetItem(), "expected same item before next reload")
 
-	require.Greater(t, matches, 0)
-	require.True(t, changed)
+	// Cache should eventually return a different item after a reload cycle
+	require.Eventually(t, func() bool {
+		return c.GetItem() != item
+	}, 5*time.Second, 200*time.Millisecond, "expected cache to refresh")
+
 	cancel()
 
-	// test that the cache returns error properly
+	// Initialization returns error when caching func fails
 	errorCaching := func(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("test error")
 	}
-
 	_, err = NewAsyncCache(context.Background(), 2*time.Second, errorCaching)
 	require.Error(t, err)
 }


### PR DESCRIPTION
**Analysis / Root cause**:
The `TestAsyncCache` test fails intermittently in CI ([example failure](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_console/16462/pull-ci-openshift-console-main-backend/2056716995746861056)) with `Expected 0 to be greater than 0`. Two issues:

  1. `wait.UntilWithContext` fires `runCache` immediately when `Run()` is called, replacing the cached pointer before the test loop's first `GetItem()` — so `matches` is always 0 on fast machines.
  2. The fixed sleep-based loop (2s reload period, 1s sleeps, 3 iterations) has no margin for goroutine scheduling delays on loaded CI machines.

Additionally, `initializationRetryInterval` and `initializationTimeout` were set after the first `NewAsyncCache` call, having no effect on initialization.

**Solution description**:
  - Move retry/timeout overrides before `NewAsyncCache` so they take effect for the error-case test
  - Re-grab the reference item after `Run()` fires its immediate reload
  - Replace the fixed sleep loop with `require.Eventually` to tolerate slow CI
  - Verify cache stability between reloads with `require.Equal`

Verified with 50 consecutive runs (`go test -count=50`) — all passing.

**Screenshots / screen recording**:
  N/A — backend test only.

**Test setup:**
  No special setup required.

**Test cases:**
  - `go test -v -run TestAsyncCache ./pkg/serverutils/asynccache/` passes consistently
  - `go test -count=50 -run TestAsyncCache ./pkg/serverutils/asynccache/` — 50/50 passes

**Browser conformance**:
  N/A — backend test only.

**Additional info:**
  Jira: https://redhat.atlassian.net/browse/OCPBUGS-86511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced async cache test suite with improved assertion patterns and stricter validation logic. Adjusted timing parameters and added verification steps to better validate cache initialization, item persistence, and refresh behavior across reload cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->