### PR TITLE
NO-JIRA: Update plugin SDK core package CHANGELOG

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
@@ -10,6 +10,10 @@ For current development version of Console, use `4.x.0-prerelease.n` packages.
 For older 1.x plugin SDK packages, refer to "OpenShift Console Versions vs SDK Versions" compatibility
 table in [Console dynamic plugins README](./README.md).
 
+## 4.23.0-prerelease.2 - 2026-05-27
+
+- Updated `@patternfly/react-topology` peer dependency semver range to `~6.5.0` ([OCPBUGS-86488], [#16491])
+
 ## 4.23.0-prerelease.1 - 2026-05-19
 
 - Add `useToast` hook for showing toast notifications ([CONSOLE-5273], [#16400])
@@ -234,6 +238,7 @@ table in [Console dynamic plugins README](./README.md).
 [OCPBUGS-58258]: https://issues.redhat.com/browse/OCPBUGS-58258
 [OCPBUGS-62126]: https://issues.redhat.com/browse/OCPBUGS-62126
 [OCPBUGS-81319]: https://issues.redhat.com/browse/OCPBUGS-81319
+[OCPBUGS-86488]: https://issues.redhat.com/browse/OCPBUGS-86488
 [ODC-7425]: https://issues.redhat.com/browse/ODC-7425
 [#12983]: https://github.com/openshift/console/pull/12983
 [#13233]: https://github.com/openshift/console/pull/13233
@@ -290,3 +295,4 @@ table in [Console dynamic plugins README](./README.md).
 [#16057]: https://github.com/openshift/console/pull/16057
 [#16097]: https://github.com/openshift/console/pull/16097
 [#16400]: https://github.com/openshift/console/pull/16400
+[#16491]: https://github.com/openshift/console/pull/16491

--- a/frontend/packages/console-dynamic-plugin-sdk/release-notes/4.23.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/release-notes/4.23.md
@@ -1,6 +1,7 @@
 # OpenShift Console 4.23 Release Notes
 
-This release contains no breaking changes. Existing plugins remain fully compatible without modification.
+This release contains no runtime breaking changes. Existing plugins built for Console 4.22 remain fully
+compatible without modification when loaded in Console 4.23.
 
 ## Changes to Content Security Policy (CSP)
 


### PR DESCRIPTION
### Analysis / Root cause

Ensure that Console plugin SDK CHANGELOG is up to date.

### Test cases

No testing needed, these changes have no impact on Console build or its functionality.

### Reviewers and assignees

/assign @logonoff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a 4.23.0-prerelease changelog entry documenting alignment of a peer dependency semver range and adding supporting reference links.
  * Updated 4.23 release notes to clarify there are no runtime breaking changes, confirm plugins built for 4.22 remain compatible in 4.23, and note that package peer dependency ranges may be adjusted to match Console shared module versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->