### PR TITLE
OCPBUGS-27309: i18n missing keys error in devtools console

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/utils/__tests__/extension-i18n.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/utils/__tests__/extension-i18n.spec.ts
@@ -1,5 +1,10 @@
 import type { Extension } from '@console/dynamic-plugin-sdk/src/types';
-import { isTranslatableString, getTranslationKey, translateExtension } from '../extension-i18n';
+import {
+  isTranslatableString,
+  getTranslationKey,
+  getNamespacesFromExtensions,
+  translateExtension,
+} from '../extension-i18n';
 
 const nonTranslatableStrings: string[] = ['', null, undefined, '%', 'a%', '%a', '%%', 'foo'];
 
@@ -24,6 +29,44 @@ describe('getTranslationKey', () => {
     nonTranslatableStrings.forEach((s) => {
       expect(getTranslationKey(s)).toBe(undefined);
     });
+  });
+});
+
+describe('getNamespacesFromExtensions', () => {
+  it('extracts unique namespaces from translatable strings across extensions', () => {
+    const extensions: Extension[] = [
+      {
+        type: 'Nav/Item',
+        properties: { name: '%plugin__acm~Home%', section: '%plugin__acm~Overview%' },
+      },
+      {
+        type: 'Nav/Item',
+        properties: { name: '%plugin__mce~Clusters%' },
+      },
+    ];
+    expect(getNamespacesFromExtensions(extensions).sort()).toEqual(['plugin__acm', 'plugin__mce']);
+  });
+
+  it('returns an empty array when no translatable strings have namespaces', () => {
+    const extensions: Extension[] = [
+      { type: 'Foo/Bar', properties: { name: '%keyWithoutNs%' } },
+      { type: 'Foo/Bar', properties: { name: 'plain string' } },
+    ];
+    expect(getNamespacesFromExtensions(extensions)).toEqual([]);
+  });
+
+  it('returns an empty array for extensions with no translatable strings', () => {
+    const extensions: Extension[] = [{ type: 'Foo/Bar', properties: { count: 42, flag: true } }];
+    expect(getNamespacesFromExtensions(extensions)).toEqual([]);
+  });
+
+  it('deduplicates namespaces across multiple extensions', () => {
+    const extensions: Extension[] = [
+      { type: 'Nav/Item', properties: { name: '%plugin__acm~Home%' } },
+      { type: 'Nav/Item', properties: { name: '%plugin__acm~Overview%' } },
+      { type: 'Nav/Item', properties: { name: '%plugin__acm~Search%' } },
+    ];
+    expect(getNamespacesFromExtensions(extensions)).toEqual(['plugin__acm']);
   });
 });
 

--- a/frontend/packages/console-plugin-sdk/src/utils/extension-i18n.ts
+++ b/frontend/packages/console-plugin-sdk/src/utils/extension-i18n.ts
@@ -4,6 +4,8 @@ import type { ConsoleTFunction } from '@console/dynamic-plugin-sdk/src/extension
 import type { Extension } from '@console/dynamic-plugin-sdk/src/types';
 import { deepForOwn } from '@console/dynamic-plugin-sdk/src/utils/object';
 
+const NS_SEPARATOR = '~';
+
 export const isTranslatableString = (value): value is string => {
   return (
     typeof value === 'string' && value.length > 2 && value.startsWith('%') && value.endsWith('%')
@@ -12,6 +14,28 @@ export const isTranslatableString = (value): value is string => {
 
 export const getTranslationKey = (value: string) =>
   isTranslatableString(value) ? value.substr(1, value.length - 2) : undefined;
+
+/**
+ * Collects the unique i18next namespaces referenced by translatable strings across all
+ * extensions. Useful for passing to `useTranslation(ns)` so Suspense waits for them.
+ */
+export const getNamespacesFromExtensions = <TExtension extends Extension>(
+  extensions: TExtension[],
+): string[] => {
+  const namespaces = new Set<string>();
+  extensions.forEach((extension) => {
+    deepForOwn(extension, isTranslatableString, (value) => {
+      const key = getTranslationKey(value);
+      if (key) {
+        const separatorIndex = key.indexOf(NS_SEPARATOR);
+        if (separatorIndex > 0) {
+          namespaces.add(key.substring(0, separatorIndex));
+        }
+      }
+    });
+  });
+  return Array.from(namespaces);
+};
 
 /**
  * Recursively updates the extension's properties, replacing all `%key%` placeholders within

--- a/frontend/packages/console-plugin-sdk/src/utils/useTranslatedExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/utils/useTranslatedExtensions.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
-import { translateExtension } from './extension-i18n';
+import { getNamespacesFromExtensions, translateExtension } from './extension-i18n';
 import useTranslationExt from './useTranslationExt';
 
 /**
@@ -17,7 +17,8 @@ import useTranslationExt from './useTranslationExt';
 export const useTranslatedExtensions = <TExtension extends Extension>(
   extensions: LoadedExtension<TExtension>[],
 ) => {
-  const { t } = useTranslationExt();
+  const namespaces = useMemo(() => getNamespacesFromExtensions(extensions), [extensions]);
+  const { t } = useTranslationExt(namespaces);
 
   return useMemo(() => extensions.map((e) => translateExtension(e, t)), [extensions, t]);
 };


### PR DESCRIPTION
Resolves i18n missing keys errors when ACM and MCE plugins are enabled.

**Analysis / Root cause**:

`useTranslatedExtensions` calls `t()` on extension properties containing keys like `%plugin__acm~Home%` before the corresponding plugin namespace (`plugin__acm`) has finished loading via HTTP. `useTranslationExt()` is called with no namespace argument, so `useTranslation()` only suspends on the default namespace (`public`) — i18next has no way to know plugin namespaces are needed until `t()` is actually called. When the namespace isn't loaded yet, `missingKeyHandler` fires a `console.error()` for every key on every render.

**Solution description**:

1. **`extension-i18n.ts`** — Add `getNamespacesFromExtensions()` which walks extension properties using the existing `deepForOwn` + `isTranslatableString` pattern to collect unique i18n namespaces from translatable strings (e.g., `plugin__acm` from `%plugin__acm~Home%`).

2. **`useTranslatedExtensions.ts`** — Extract namespaces from the extensions array via useMemo and pass them to useTranslationExt(namespaces). Since useSuspense: true is already configured in i18n.js, useTranslation(namespaces) suspends until all plugin namespaces are loaded — the existing <Suspense> boundaries in app.tsx catch the suspension. This gives correct translations from first paint with no flash of untranslated text.

3. **`extension-i18n.spec.ts`** — Add 4 unit tests for `getNamespacesFromExtensions` covering namespace extraction, deduplication, and edge cases.

**Additional info**
  - This is a simplified rewrite based on reviewer feedback which uses react-i18next's built-in Suspense mechanism instead of imperative loadNamespaces/safeT guards.
  - When namespaces are already loaded (e.g., via -i18n-namespaces bridge flag), the Suspense resolves immediately — no behavior change.
  - The getNamespacesFromExtensions utility reuses the same deepForOwn + isTranslatableString pattern already used by translateExtension.

**Screenshots / screen recording**:
**before**
<img width="2537" height="1011" alt="Screenshot 2026-05-26 at 3 17 05 PM" src="https://github.com/user-attachments/assets/6fd6b83c-04af-4ecb-8a39-ef71e64a9e42" />


**after**
<img width="2531" height="763" alt="Screenshot 2026-05-26 at 3 19 08 PM" src="https://github.com/user-attachments/assets/0831392f-4dfa-4f28-be80-a48b252769a7" />



**Test setup:**

Run console with ACM and MCE dynamic plugins enabled:
```
./bin/bridge -plugins mce=http://localhost:3001 -plugins acm=http://localhost:3002 \
  --plugin-proxy='{"services":[{"consoleAPIPath":"/api/proxy/plugin/mce/console/","endpoint":"https://localhost:4000","authorize":true},{"consoleAPIPath":"/api/proxy/plugin/acm/console/","endpoint":"https://localhost:4000","authorize":true}]}'
```

**Test scenarios:**

- [x] Load console with ACM/MCE plugins enabled — verify no `Missing i18n key` errors for plugin namespace keys in browser console
- [x] Switch to the Fleet management perspective — verify nav items (Home, Welcome, Overview, Clusters, etc.) are correctly translated
- [x] Filter browser console for "missing" — verify no plugin namespace translation errors
- [x] Verify nav items render without visible flash of untranslated keys
- [x] Load console without dynamic plugins — verify no regressions in core console translation

Assisted by: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extensions now automatically expose translation namespaces so only relevant translation resources are requested.

* **Bug Fixes**
  * Translation hook now uses the derived namespaces to avoid missing or incorrect lookups when resources load.

* **Tests**
  * Added tests for namespace extraction, deduplication, and edge cases (no namespaces or no translatable strings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->