### PR TITLE
CONSOLE-5308: Centralize ResizeObserver polyfill in Jest setup for unit tests

### DIFF
--- a/frontend/__mocks__/resizeObserver.js
+++ b/frontend/__mocks__/resizeObserver.js
@@ -1,0 +1,6 @@
+global.ResizeObserver = class {
+  constructor() {}
+  disconnect() {}
+  observe() {}
+  unobserve() {}
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -126,6 +126,7 @@
       "./__mocks__/localStorage.ts",
       "./__mocks__/matchMedia.js",
       "./__mocks__/mutationObserver.js",
+      "./__mocks__/resizeObserver.js",
       "./__mocks__/serverFlags.js",
       "./__mocks__/textEncoderDecoder.ts",
       "./__mocks__/webpack.ts",

--- a/frontend/packages/console-shared/src/components/form-utils/__tests__/FormFooter.spec.tsx
+++ b/frontend/packages/console-shared/src/components/form-utils/__tests__/FormFooter.spec.tsx
@@ -4,15 +4,6 @@ import { renderWithProviders } from '../../../test-utils/unit-test-utils';
 import type { FormFooterProps } from '../form-utils-types';
 import { FormFooter } from '../FormFooter';
 
-// Mock ResizeObserver
-global.ResizeObserver = class ResizeObserver {
-  observe = () => {};
-
-  unobserve = () => {};
-
-  disconnect = () => {};
-};
-
 describe('FormFooter', () => {
   let props: FormFooterProps;
 

--- a/frontend/packages/dev-console/src/components/deployments/__tests__/DeploymentForm.spec.tsx
+++ b/frontend/packages/dev-console/src/components/deployments/__tests__/DeploymentForm.spec.tsx
@@ -10,22 +10,6 @@ import MockForm from '../__mocks__/MockForm';
 import ContainerField from '../ContainerField';
 import DeploymentForm from '../DeploymentForm';
 
-class ResizeObserver {
-  observe() {
-    // do nothing
-  }
-
-  unobserve() {
-    // do nothing
-  }
-
-  disconnect() {
-    // do nothing
-  }
-}
-
-window.ResizeObserver = ResizeObserver;
-
 const mockContainerField: FC = () => {
   return <div>Container: xyz</div>;
 };

--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/EditApplicationForm.spec.tsx
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/EditApplicationForm.spec.tsx
@@ -4,14 +4,6 @@ import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-ut
 import { ApplicationFlowType } from '../edit-application-utils';
 import EditApplicationForm from '../EditApplicationForm';
 
-global.ResizeObserver = class ResizeObserver {
-  observe = () => {};
-
-  unobserve = () => {};
-
-  disconnect = () => {};
-};
-
 jest.mock('react-i18next', () => ({
   __esModule: true,
   useTranslation: () => ({

--- a/frontend/packages/dev-console/src/components/health-checks/__tests__/AddHealthChecks.spec.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/__tests__/AddHealthChecks.spec.tsx
@@ -6,14 +6,6 @@ import { getResourcesType } from '../../edit-application/edit-application-utils'
 import AddHealthChecks from '../AddHealthChecks';
 import { getHealthChecksData } from '../create-health-checks-probe-utils';
 
-global.ResizeObserver = class ResizeObserver {
-  observe = () => {};
-
-  unobserve = () => {};
-
-  disconnect = () => {};
-};
-
 jest.mock('react-i18next', () => ({
   __esModule: true,
   useTranslation: () => ({

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSource.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSource.spec.tsx
@@ -5,14 +5,6 @@ import { EVENT_SOURCE_CONTAINER_KIND } from '../../../const';
 import { getEventSourceIcon } from '../../../utils/get-knative-icon';
 import { EventSource } from '../EventSource';
 
-global.ResizeObserver = class ResizeObserver {
-  observe = () => {};
-
-  unobserve = () => {};
-
-  disconnect = () => {};
-};
-
 jest.mock('@console/shared/src/components/formik-fields/SyncedEditorField', () => ({
   SyncedEditorField: ({ formContext }: { formContext?: { editor?: ReactNode } }) => (
     <>{formContext?.editor}</>

--- a/frontend/public/components/__tests__/command-line-tools.spec.tsx
+++ b/frontend/public/components/__tests__/command-line-tools.spec.tsx
@@ -30,23 +30,7 @@ const obj = {
   loadError: null,
 };
 
-const nativeResizeObserver = window.ResizeObserver;
-class ResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-}
-
 describe('CommandLineTools', () => {
-  beforeAll(() => {
-    window.ResizeObserver = ResizeObserver;
-  });
-
-  afterAll(() => {
-    window.ResizeObserver = nativeResizeObserver;
-    jest.restoreAllMocks();
-  });
-
   describe('When ordering is correct', () => {
     it('shows oc CLI first in the displayed list', async () => {
       renderWithProviders(<CommandLineTools obj={obj} />);


### PR DESCRIPTION
[CONSOLE-5308](https://redhat.atlassian.net/browse/CONSOLE-5308): Centralize ResizeObserver polyfill in Jest setup for unit tests
**Analysis / Root cause**:
Unit test clean up

**Solution description**:
Centralize ResizeObserver polyfill in Jest setup for unit tests and removed from affected specs
**Screenshots / screen recording**:
N/A

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Test cases:**
N/A

**Browser conformance**:
N/A

**Additional info:**
N/A

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a global ResizeObserver mock that is loaded during test initialization.
  * Removed per-test ResizeObserver stubs across multiple test suites, consolidating the setup and reducing duplicated test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->