### PR TITLE
OCPBUGS-86455:[release-4.20] shell-quote: Arbitrary code execution via command injection due to unescaped line terminators

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -334,7 +334,8 @@
     "minimatch@3.0.4": "^3.1.3",
     "minimatch@3.0.5": "^3.1.3",
     "minimatch@^3.1.1": "^3.1.3",
-    "minimatch@^9.0.4": "^9.0.6"
+    "minimatch@^9.0.4": "^9.0.6",
+    "shell-quote": "^1.8.4"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -21665,10 +21665,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.4.2, shell-quote@npm:^1.6.1, shell-quote@npm:^1.8.1":
-  version: 1.8.1
-  resolution: "shell-quote@npm:1.8.1"
-  checksum: 10c0/8cec6fd827bad74d0a49347057d40dfea1e01f12a6123bf82c4649f3ef152fc2bc6d6176e6376bffcd205d9d0ccb4f1f9acae889384d20baff92186f01ea455a
+"shell-quote@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
While working on CVE-2026-9277 I have observed shell-quote package has been used as a transitive dependency and in addition to it is using the vulnerable version. So, in order to resolve this issue I have bumped the shell-quote package to the patched version (1.8.4)