### PR TITLE
OCPBUGS-86564: Use stable username hash for user-settings ConfigMap names

### DIFF
--- a/frontend/packages/console-shared/src/hooks/__tests__/useGetUserSettingConfigMap.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useGetUserSettingConfigMap.spec.ts
@@ -45,21 +45,20 @@ describe('useGetUserSettingConfigMap', () => {
 
   describe('user identification scenarios', () => {
     it('should use impersonated user name when present', () => {
-      const impersonateUserInfo = {
-        impersonateName: 'impersonate-user',
-        uid: 'test-uid',
-        username: 'test-username',
-      };
-
-      useSelectorMock.mockReturnValue(impersonateUserInfo);
+      useSelectorMock.mockImplementation((selector) =>
+        selector({
+          sdkCore: {
+            user: { uid: 'test-uid', username: 'test-username' },
+            impersonate: { name: 'impersonate-user' },
+          },
+        }),
+      );
       useK8sWatchResourceMock.mockReturnValue([mockConfigMapData, true, null]);
 
       const { result } = renderHook(() => useGetUserSettingConfigMap());
 
-      // Should use impersonate name directly and return config map data
       expect(result.current).toEqual([mockConfigMapData, true, null]);
 
-      // Verify the correct resource spec was passed to useK8sWatchResource
       expect(useK8sWatchResourceMock).toHaveBeenCalledWith({
         kind: ConfigMapModel.kind,
         namespace: USER_SETTING_CONFIGMAP_NAMESPACE,
@@ -68,73 +67,76 @@ describe('useGetUserSettingConfigMap', () => {
       });
     });
 
-    it('should use uid when no impersonation and uid is available', () => {
-      const userInfoWithUid = {
-        impersonateName: null,
-        uid: 'test-uid-123',
-        username: 'test-username',
-      };
-
-      useSelectorMock.mockReturnValue(userInfoWithUid);
+    it('should use hashed username when no impersonation and uid is available', () => {
+      useSelectorMock.mockImplementation((selector) =>
+        selector({
+          sdkCore: {
+            user: { uid: 'test-uid-123', username: 'test-username' },
+          },
+        }),
+      );
       useK8sWatchResourceMock.mockReturnValue([mockConfigMapData, true, null]);
 
       const { result } = renderHook(() => useGetUserSettingConfigMap());
 
-      // Should use uid directly and return config map data
       expect(result.current).toEqual([mockConfigMapData, true, null]);
 
-      // Verify the correct resource spec was passed
+      // SHA256("test-username")
       expect(useK8sWatchResourceMock).toHaveBeenCalledWith({
         kind: ConfigMapModel.kind,
         namespace: USER_SETTING_CONFIGMAP_NAMESPACE,
         isList: false,
-        name: 'user-settings-test-uid-123',
+        name: 'user-settings-70609918baaace3eb22057bbae6dfbd7d0d2c34eaeecd5968ef455a64caee242',
       });
     });
 
     it('should handle empty user info gracefully', () => {
-      const emptyUserInfo = {
-        impersonateName: null,
-        uid: null,
-        username: null,
-      };
-
-      useSelectorMock.mockReturnValue(emptyUserInfo);
+      useSelectorMock.mockImplementation((selector) =>
+        selector({
+          sdkCore: {
+            user: {},
+          },
+        }),
+      );
 
       const { result } = renderHook(() => useGetUserSettingConfigMap());
 
-      // Should return null config map resource when no user identifier
       expect(result.current).toEqual([null, true, null]);
-
-      // Verify null resource was passed to useK8sWatchResource
       expect(useK8sWatchResourceMock).toHaveBeenCalledWith(null);
     });
 
     it('should handle username-only scenario', () => {
-      const userInfoWithUsername = {
-        impersonateName: null,
-        uid: null,
-        username: 'test-username',
-      };
-
-      useSelectorMock.mockReturnValue(userInfoWithUsername);
+      useSelectorMock.mockImplementation((selector) =>
+        selector({
+          sdkCore: {
+            user: { username: 'test-username' },
+          },
+        }),
+      );
+      useK8sWatchResourceMock.mockReturnValue([mockConfigMapData, true, null]);
 
       const { result } = renderHook(() => useGetUserSettingConfigMap());
 
-      // Initially, should return null since hashing is async
-      expect(result.current[0]).toBeNull();
+      // SHA256("test-username") - sync, no longer async
+      expect(result.current).toEqual([mockConfigMapData, true, null]);
+      expect(useK8sWatchResourceMock).toHaveBeenCalledWith({
+        kind: ConfigMapModel.kind,
+        namespace: USER_SETTING_CONFIGMAP_NAMESPACE,
+        isList: false,
+        name: 'user-settings-70609918baaace3eb22057bbae6dfbd7d0d2c34eaeecd5968ef455a64caee242',
+      });
     });
   });
 
   describe('integration with useK8sWatchResource', () => {
     it('should pass through loading state', () => {
-      const userInfoWithUid = {
-        impersonateName: null,
-        uid: 'test-uid',
-        username: 'test-username',
-      };
-
-      useSelectorMock.mockReturnValue(userInfoWithUid);
+      useSelectorMock.mockImplementation((selector) =>
+        selector({
+          sdkCore: {
+            user: { uid: 'test-uid', username: 'test-username' },
+          },
+        }),
+      );
       useK8sWatchResourceMock.mockReturnValue([null, false, null]);
 
       const { result } = renderHook(() => useGetUserSettingConfigMap());
@@ -143,14 +145,15 @@ describe('useGetUserSettingConfigMap', () => {
     });
 
     it('should pass through error state', () => {
-      const userInfoWithUid = {
-        impersonateName: null,
-        uid: 'test-uid',
-        username: 'test-username',
-      };
+      useSelectorMock.mockImplementation((selector) =>
+        selector({
+          sdkCore: {
+            user: { uid: 'test-uid', username: 'test-username' },
+          },
+        }),
+      );
 
       const error = new Error('K8s API error');
-      useSelectorMock.mockReturnValue(userInfoWithUid);
       useK8sWatchResourceMock.mockReturnValue([null, false, error]);
 
       const { result } = renderHook(() => useGetUserSettingConfigMap());
@@ -159,13 +162,13 @@ describe('useGetUserSettingConfigMap', () => {
     });
 
     it('should pass through successful data', () => {
-      const userInfoWithUid = {
-        impersonateName: null,
-        uid: 'test-uid',
-        username: 'test-username',
-      };
-
-      useSelectorMock.mockReturnValue(userInfoWithUid);
+      useSelectorMock.mockImplementation((selector) =>
+        selector({
+          sdkCore: {
+            user: { uid: 'test-uid', username: 'test-username' },
+          },
+        }),
+      );
       useK8sWatchResourceMock.mockReturnValue([mockConfigMapData, true, null]);
 
       const { result } = renderHook(() => useGetUserSettingConfigMap());
@@ -174,39 +177,38 @@ describe('useGetUserSettingConfigMap', () => {
     });
 
     it('should create ConfigMap resource with correct parameters', () => {
-      const userInfo = {
-        impersonateName: null,
-        uid: 'test-uid-456',
-        username: 'test-user',
-      };
-
-      useSelectorMock.mockReturnValue(userInfo);
+      useSelectorMock.mockImplementation((selector) =>
+        selector({
+          sdkCore: {
+            user: { uid: 'test-uid-456', username: 'test-user' },
+          },
+        }),
+      );
       useK8sWatchResourceMock.mockReturnValue([mockConfigMapData, true, null]);
 
       renderHook(() => useGetUserSettingConfigMap());
 
-      // Verify useK8sWatchResource was called with correct resource spec
+      // SHA256("test-user")
       expect(useK8sWatchResourceMock).toHaveBeenCalledWith({
         kind: ConfigMapModel.kind,
         namespace: USER_SETTING_CONFIGMAP_NAMESPACE,
         isList: false,
-        name: 'user-settings-test-uid-456',
+        name: 'user-settings-f85ac825d102b9f2d546aa1679ea991ae845994c1343730d564f3fcd0a2168c3',
       });
     });
 
     it('should use null resource when no user identifier is available', () => {
-      const emptyUserInfo = {
-        impersonateName: null,
-        uid: null,
-        username: '',
-      };
-
-      useSelectorMock.mockReturnValue(emptyUserInfo);
+      useSelectorMock.mockImplementation((selector) =>
+        selector({
+          sdkCore: {
+            user: {},
+          },
+        }),
+      );
       useK8sWatchResourceMock.mockReturnValue([null, true, null]);
 
       const { result } = renderHook(() => useGetUserSettingConfigMap());
 
-      // Should call useK8sWatchResource with null
       expect(useK8sWatchResourceMock).toHaveBeenCalledWith(null);
       expect(result.current).toEqual([null, true, null]);
     });

--- a/frontend/packages/console-shared/src/hooks/__tests__/useUserPreference.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useUserPreference.spec.ts
@@ -47,7 +47,7 @@ const emptyConfigMap: ConfigMapKind = {
   apiVersion: 'v1',
   kind: 'ConfigMap',
   metadata: {
-    name: `user-settings-1234`,
+    name: `user-settings-ae5deb822e0d71992900471a7199d0d95b8e7c9d05c40a8245a281fd2c1d6684`,
     namespace: USER_SETTING_CONFIGMAP_NAMESPACE,
   },
 };
@@ -61,7 +61,9 @@ const savedDataConfigMap: ConfigMapKind = {
 
 beforeEach(() => {
   jest.resetAllMocks();
-  useSelectorMock.mockImplementation((selector) => selector({ sdkCore: { user: { uid: 'foo' } } }));
+  useSelectorMock.mockImplementation((selector) =>
+    selector({ sdkCore: { user: { uid: 'foo', username: 'testuser' } } }),
+  );
   useFavoritesOptionsMock.mockReturnValue([[], jest.fn(), true]);
 
   // eslint-disable-next-line no-console

--- a/frontend/packages/console-shared/src/hooks/useGetUserSettingConfigMap.ts
+++ b/frontend/packages/console-shared/src/hooks/useGetUserSettingConfigMap.ts
@@ -1,53 +1,18 @@
-import { useMemo, useState, useEffect } from 'react';
-import { shallowEqual } from 'react-redux';
+import { useMemo } from 'react';
 import type { K8sResourceKind } from '@console/dynamic-plugin-sdk/src';
 import { getImpersonate, getUser } from '@console/dynamic-plugin-sdk/src';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ConfigMapModel } from '@console/internal/models';
 import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
-import { USER_SETTING_CONFIGMAP_NAMESPACE } from '../utils/user-settings';
+import { hashUsernameForSettings, USER_SETTING_CONFIGMAP_NAMESPACE } from '../utils/user-settings';
 
 export const useGetUserSettingConfigMap = () => {
-  const [hashedUsername, setHashedUsername] = useState<string | null>(null);
-
-  const hashNameOrKubeadmin = async (name: string): Promise<string | null> => {
-    if (!name) {
-      return null;
-    }
-
-    if (name === 'kube:admin') {
-      return 'kubeadmin';
-    }
-
-    const encoder = new TextEncoder();
-    const data = encoder.encode(name);
-    const hashBuffer = await window.crypto.subtle.digest('SHA-256', data);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-  };
-
-  // User and impersonate info
-  const userInfo = useConsoleSelector((state) => {
+  const userUid = useConsoleSelector((state) => {
     const impersonateName = getImpersonate(state)?.name;
     const { uid, username } = getUser(state) ?? {};
-    return { impersonateName, uid, username };
-  }, shallowEqual);
-
-  // Hash the username asynchronously
-  useEffect(() => {
-    if (userInfo.username) {
-      hashNameOrKubeadmin(userInfo.username)
-        .then(setHashedUsername)
-        .catch(() => {
-          setHashedUsername(null);
-        });
-    } else {
-      setHashedUsername(null);
-    }
-  }, [userInfo.username]);
-
-  // Compute the final user UID
-  const userUid = userInfo.impersonateName || userInfo.uid || hashedUsername || '';
+    const hashName = hashUsernameForSettings(username, uid);
+    return impersonateName || hashName || '';
+  });
 
   const configMapResource = useMemo(
     () =>

--- a/frontend/packages/console-shared/src/hooks/useUserPreference.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserPreference.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'crypto';
 import type { SetStateAction } from 'react';
 import { useRef, useCallback, useEffect, useState, useMemo } from 'react';
 import type { UseUserPreference } from '@console/dynamic-plugin-sdk';
@@ -10,6 +9,7 @@ import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector
 import {
   createConfigMap,
   deserializeData,
+  hashUsernameForSettings,
   seralizeData,
   updateConfigMap,
   USER_SETTING_CONFIGMAP_NAMESPACE,
@@ -70,25 +70,12 @@ export const useUserPreference: UseUserPreference = <T>(
   // Request counter
   const [isRequestPending, increaseRequest, decreaseRequest] = useCounterRef();
 
-  const hashNameOrKubeadmin = (name: string): string | null => {
-    if (!name) {
-      return null;
-    }
-
-    if (name === 'kube:admin') {
-      return 'kubeadmin';
-    }
-    const hash = createHash('sha256');
-    hash.update(name);
-    return hash.digest('hex');
-  };
-
   // User and impersonate
   const userUid = useConsoleSelector((state) => {
     const impersonateName = getImpersonate(state)?.name;
     const { uid, username } = getUser(state) ?? {};
-    const hashName = hashNameOrKubeadmin(username);
-    return impersonateName || uid || hashName || '';
+    const hashName = hashUsernameForSettings(username, uid);
+    return impersonateName || hashName || '';
   });
 
   const impersonate: boolean = useConsoleSelector((state) => !!getImpersonate(state));

--- a/frontend/packages/console-shared/src/utils/user-settings.ts
+++ b/frontend/packages/console-shared/src/utils/user-settings.ts
@@ -1,9 +1,22 @@
+import { createHash } from 'crypto';
 import { resourceURL } from '@console/dynamic-plugin-sdk/src/utils/k8s';
 import { ConfigMapModel } from '@console/internal/models';
 import type { ConfigMapKind } from '@console/internal/module/k8s/types';
 import { coFetch } from '@console/shared/src/utils/console-fetch';
 
 export const USER_SETTING_CONFIGMAP_NAMESPACE = 'openshift-console-user-settings';
+
+export const hashUsernameForSettings = (name: string, uid?: string): string | null => {
+  if (!name) {
+    return null;
+  }
+  if (name === 'kube:admin' && !uid) {
+    return 'kubeadmin';
+  }
+  const hash = createHash('sha256');
+  hash.update(name);
+  return hash.digest('hex');
+};
 
 export const createConfigMap = async (): Promise<ConfigMapKind> => {
   try {

--- a/pkg/usersettings/handlers.go
+++ b/pkg/usersettings/handlers.go
@@ -20,11 +20,11 @@ import (
 const namespace = "openshift-console-user-settings"
 
 type UserSettingsHandler struct {
-	internalProxiedClient *kubernetes.Clientset
+	internalProxiedClient kubernetes.Interface
 	anonClientConfig      *rest.Config
 }
 
-func NewUserSettingsHandler(kubeClient *kubernetes.Clientset, anonymousRoundTripper http.RoundTripper, k8sProxiedEndpoint string) *UserSettingsHandler {
+func NewUserSettingsHandler(kubeClient kubernetes.Interface, anonymousRoundTripper http.RoundTripper, k8sProxiedEndpoint string) *UserSettingsHandler {
 	return &UserSettingsHandler{
 		internalProxiedClient: kubeClient,
 		anonClientConfig: &rest.Config{
@@ -89,13 +89,37 @@ func (h *UserSettingsHandler) getUserSettings(ctx context.Context, userSettingMe
 }
 
 // Create a new user-setting ConfigMap, incl. Role and RoleBinding for the current user.
-// Returns the existing ConfigMap if it is already exist.
+// Returns the existing ConfigMap immediately if it already exists.
+// Migrates data from the most recent old ConfigMap if any exist for this user.
 func (h *UserSettingsHandler) createUserSettings(ctx context.Context, userSettingMeta *UserSettingMeta) (*core.ConfigMap, error) {
+	existing, err := h.internalProxiedClient.CoreV1().ConfigMaps(namespace).Get(ctx, userSettingMeta.getConfigMapName(), meta.GetOptions{})
+	if err == nil {
+		return existing, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	// OCPBUGS-86564: find old UID-based ConfigMaps that were created before
+	// the switch to stable SHA256(username) naming.
+	oldCMs := h.findOldUserSettingsConfigMaps(ctx, userSettingMeta)
+
+	var migrateFrom *core.ConfigMap
+	for i := range oldCMs {
+		if migrateFrom == nil || oldCMs[i].CreationTimestamp.After(migrateFrom.CreationTimestamp.Time) {
+			migrateFrom = &oldCMs[i]
+		}
+	}
+
+	configMap := createConfigMap(userSettingMeta)
+	if migrateFrom != nil {
+		configMap.Data = migrateFrom.Data
+	}
+
 	role := createRole(userSettingMeta)
 	roleBinding := createRoleBinding(userSettingMeta)
-	configMap := createConfigMap(userSettingMeta)
 
-	_, err := h.internalProxiedClient.RbacV1().Roles(namespace).Create(ctx, role, meta.CreateOptions{})
+	_, err = h.internalProxiedClient.RbacV1().Roles(namespace).Create(ctx, role, meta.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		h.deleteUserSettings(ctx, userSettingMeta)
 		return nil, err
@@ -109,15 +133,63 @@ func (h *UserSettingsHandler) createUserSettings(ctx context.Context, userSettin
 
 	configMap, err = h.internalProxiedClient.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, meta.CreateOptions{})
 	if err != nil {
-		// Return actual ConfigMap if it is already created
 		if apierrors.IsAlreadyExists(err) {
-			klog.Infof("User settings ConfigMap \"%s\" already exist, will return existing data.", userSettingMeta.getConfigMapName())
+			klog.Infof("User settings ConfigMap %q already exists, will return existing data.", userSettingMeta.getConfigMapName())
+			h.cleanupOldUserSettings(ctx, oldCMs)
 			return h.internalProxiedClient.CoreV1().ConfigMaps(namespace).Get(ctx, userSettingMeta.getConfigMapName(), meta.GetOptions{})
 		}
 		h.deleteUserSettings(ctx, userSettingMeta)
 		return nil, err
 	}
+
+	h.cleanupOldUserSettings(ctx, oldCMs)
+
 	return configMap, nil
+}
+
+// findOldUserSettingsConfigMaps lists ConfigMaps in the user-settings namespace
+// and returns all that are owned by this user but don't match the current
+// naming scheme.
+func (h *UserSettingsHandler) findOldUserSettingsConfigMaps(ctx context.Context, userSettingMeta *UserSettingMeta) []core.ConfigMap {
+	configMaps, err := h.internalProxiedClient.CoreV1().ConfigMaps(namespace).List(ctx, meta.ListOptions{})
+	if err != nil {
+		klog.Warningf("Failed to list ConfigMaps for migration: %v", err)
+		return nil
+	}
+
+	newName := userSettingMeta.getConfigMapName()
+	var old []core.ConfigMap
+	for _, cm := range configMaps.Items {
+		if cm.Name == newName {
+			continue
+		}
+		for _, ref := range cm.OwnerReferences {
+			if ref.Kind == "User" && ref.Name == userSettingMeta.Username {
+				klog.V(4).Infof("Found old user settings ConfigMap %q for migration to %q.", cm.Name, newName)
+				old = append(old, cm)
+				break
+			}
+		}
+	}
+	return old
+}
+
+// cleanupOldUserSettings removes old ConfigMaps and their associated Roles
+// and RoleBindings after a successful migration. Errors are best-effort.
+func (h *UserSettingsHandler) cleanupOldUserSettings(ctx context.Context, oldCMs []core.ConfigMap) {
+	for _, cm := range oldCMs {
+		name := cm.Name
+		if err := h.internalProxiedClient.RbacV1().RoleBindings(namespace).Delete(ctx, name+"-rolebinding", meta.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			klog.Warningf("Failed to clean up old user settings RoleBinding %q: %v", name+"-rolebinding", err)
+		}
+		if err := h.internalProxiedClient.RbacV1().Roles(namespace).Delete(ctx, name+"-role", meta.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			klog.Warningf("Failed to clean up old user settings Role %q: %v", name+"-role", err)
+		}
+		if err := h.internalProxiedClient.CoreV1().ConfigMaps(namespace).Delete(ctx, name, meta.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			klog.Warningf("Failed to clean up old user settings ConfigMap %q: %v", name, err)
+		}
+		klog.V(4).Infof("Cleaned up old user settings resources (old name: %s).", name)
+	}
 }
 
 // Deletes the user-setting ConfigMap, Role and RoleBinding of the current user.

--- a/pkg/usersettings/handlers_test.go
+++ b/pkg/usersettings/handlers_test.go
@@ -1,0 +1,250 @@
+package usersettings
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	core "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func newTestHandler(objects ...runtime.Object) *UserSettingsHandler {
+	return &UserSettingsHandler{
+		internalProxiedClient: k8sfake.NewSimpleClientset(objects...),
+	}
+}
+
+func testUserSettingMeta(t *testing.T, username, uid string) *UserSettingMeta {
+	t.Helper()
+	m, err := newUserSettingMeta(authenticationv1.UserInfo{Username: username, UID: uid})
+	if err != nil {
+		t.Fatalf("newUserSettingMeta: %v", err)
+	}
+	return m
+}
+
+func oldUserSettingsResources(baseName, username, uid string, createdAt time.Time, data map[string]string) []runtime.Object {
+	ownerRefs := []meta.OwnerReference{
+		{
+			APIVersion: "user.openshift.io/v1",
+			Kind:       "User",
+			Name:       username,
+			UID:        "unused",
+		},
+	}
+
+	cm := &core.ConfigMap{
+		ObjectMeta: meta.ObjectMeta{
+			Name:              baseName,
+			Namespace:         namespace,
+			CreationTimestamp: meta.NewTime(createdAt),
+			OwnerReferences:   ownerRefs,
+		},
+		Data: data,
+	}
+
+	role := &rbac.Role{
+		ObjectMeta: meta.ObjectMeta{
+			Name:            baseName + "-role",
+			Namespace:       namespace,
+			OwnerReferences: ownerRefs,
+		},
+	}
+
+	rb := &rbac.RoleBinding{
+		ObjectMeta: meta.ObjectMeta{
+			Name:            baseName + "-rolebinding",
+			Namespace:       namespace,
+			OwnerReferences: ownerRefs,
+		},
+	}
+
+	return []runtime.Object{cm, role, rb}
+}
+
+func assertConfigMapExists(t *testing.T, h *UserSettingsHandler, name string) {
+	t.Helper()
+	_, err := h.internalProxiedClient.CoreV1().ConfigMaps(namespace).Get(context.Background(), name, meta.GetOptions{})
+	if err != nil {
+		t.Errorf("expected ConfigMap %q to exist, got: %v", name, err)
+	}
+}
+
+func assertConfigMapNotFound(t *testing.T, h *UserSettingsHandler, name string) {
+	t.Helper()
+	_, err := h.internalProxiedClient.CoreV1().ConfigMaps(namespace).Get(context.Background(), name, meta.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected ConfigMap %q to be deleted, got err: %v", name, err)
+	}
+}
+
+func assertRoleNotFound(t *testing.T, h *UserSettingsHandler, name string) {
+	t.Helper()
+	_, err := h.internalProxiedClient.RbacV1().Roles(namespace).Get(context.Background(), name, meta.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected Role %q to be deleted, got err: %v", name, err)
+	}
+}
+
+func assertRoleBindingNotFound(t *testing.T, h *UserSettingsHandler, name string) {
+	t.Helper()
+	_, err := h.internalProxiedClient.RbacV1().RoleBindings(namespace).Get(context.Background(), name, meta.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected RoleBinding %q to be deleted, got err: %v", name, err)
+	}
+}
+
+func TestCreateUserSettings(t *testing.T) {
+	usm := testUserSettingMeta(t, "developer", "uid-1")
+	newCMName := usm.getConfigMapName()
+	newRoleName := usm.getRoleName()
+	newRBName := usm.getRoleBindingName()
+
+	t.Run("fresh creation with no existing resources", func(t *testing.T) {
+		h := newTestHandler()
+
+		cm, err := h.createUserSettings(context.Background(), usm)
+		if err != nil {
+			t.Fatalf("createUserSettings: %v", err)
+		}
+
+		if cm.Name != newCMName {
+			t.Errorf("expected ConfigMap name %q, got %q", newCMName, cm.Name)
+		}
+		if cm.Data != nil {
+			t.Errorf("expected nil Data for fresh ConfigMap, got %v", cm.Data)
+		}
+
+		assertConfigMapExists(t, h, newCMName)
+		if _, err := h.internalProxiedClient.RbacV1().Roles(namespace).Get(context.Background(), newRoleName, meta.GetOptions{}); err != nil {
+			t.Errorf("expected Role %q to exist: %v", newRoleName, err)
+		}
+		if _, err := h.internalProxiedClient.RbacV1().RoleBindings(namespace).Get(context.Background(), newRBName, meta.GetOptions{}); err != nil {
+			t.Errorf("expected RoleBinding %q to exist: %v", newRBName, err)
+		}
+	})
+
+	t.Run("short-circuit when new ConfigMap already exists", func(t *testing.T) {
+		existingCM := &core.ConfigMap{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      newCMName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{"existing-key": "existing-value"},
+		}
+		h := newTestHandler(existingCM)
+
+		cm, err := h.createUserSettings(context.Background(), usm)
+		if err != nil {
+			t.Fatalf("createUserSettings: %v", err)
+		}
+
+		if cm.Data["existing-key"] != "existing-value" {
+			t.Errorf("expected existing data to be preserved, got %v", cm.Data)
+		}
+
+		// Role and RoleBinding should NOT have been created
+		_, roleErr := h.internalProxiedClient.RbacV1().Roles(namespace).Get(context.Background(), newRoleName, meta.GetOptions{})
+		if !apierrors.IsNotFound(roleErr) {
+			t.Errorf("expected Role not to be created during short-circuit, got err: %v", roleErr)
+		}
+	})
+
+	t.Run("migrate single old ConfigMap", func(t *testing.T) {
+		oldName := "user-settings-uid-1"
+		objs := oldUserSettingsResources(oldName, "developer", "uid-1", time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), map[string]string{"theme": "dark"})
+		h := newTestHandler(objs...)
+
+		cm, err := h.createUserSettings(context.Background(), usm)
+		if err != nil {
+			t.Fatalf("createUserSettings: %v", err)
+		}
+
+		if cm.Name != newCMName {
+			t.Errorf("expected ConfigMap name %q, got %q", newCMName, cm.Name)
+		}
+		if cm.Data["theme"] != "dark" {
+			t.Errorf("expected migrated data {theme: dark}, got %v", cm.Data)
+		}
+
+		assertConfigMapNotFound(t, h, oldName)
+		assertRoleNotFound(t, h, oldName+"-role")
+		assertRoleBindingNotFound(t, h, oldName+"-rolebinding")
+	})
+
+	t.Run("migrate latest of multiple old ConfigMaps", func(t *testing.T) {
+		older := oldUserSettingsResources("user-settings-old-uid-1", "developer", "old-uid-1",
+			time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), map[string]string{"theme": "light"})
+		newer := oldUserSettingsResources("user-settings-old-uid-2", "developer", "old-uid-2",
+			time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC), map[string]string{"theme": "dark", "lang": "en"})
+
+		var objs []runtime.Object
+		objs = append(objs, older...)
+		objs = append(objs, newer...)
+		h := newTestHandler(objs...)
+
+		cm, err := h.createUserSettings(context.Background(), usm)
+		if err != nil {
+			t.Fatalf("createUserSettings: %v", err)
+		}
+
+		if cm.Data["theme"] != "dark" || cm.Data["lang"] != "en" {
+			t.Errorf("expected data from newer ConfigMap, got %v", cm.Data)
+		}
+
+		// Both old sets of resources should be cleaned up
+		assertConfigMapNotFound(t, h, "user-settings-old-uid-1")
+		assertRoleNotFound(t, h, "user-settings-old-uid-1-role")
+		assertRoleBindingNotFound(t, h, "user-settings-old-uid-1-rolebinding")
+		assertConfigMapNotFound(t, h, "user-settings-old-uid-2")
+		assertRoleNotFound(t, h, "user-settings-old-uid-2-role")
+		assertRoleBindingNotFound(t, h, "user-settings-old-uid-2-rolebinding")
+	})
+
+	t.Run("ignores ConfigMap owned by different user", func(t *testing.T) {
+		otherName := "user-settings-other-uid"
+		objs := oldUserSettingsResources(otherName, "other-user", "other-uid",
+			time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), map[string]string{"theme": "blue"})
+		h := newTestHandler(objs...)
+
+		cm, err := h.createUserSettings(context.Background(), usm)
+		if err != nil {
+			t.Fatalf("createUserSettings: %v", err)
+		}
+
+		if cm.Data != nil {
+			t.Errorf("expected nil Data (no migration), got %v", cm.Data)
+		}
+
+		// Other user's resources must be untouched
+		assertConfigMapExists(t, h, otherName)
+	})
+
+	t.Run("ignores ConfigMap without OwnerReference", func(t *testing.T) {
+		orphanCM := &core.ConfigMap{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "user-settings-orphan",
+				Namespace: namespace,
+			},
+			Data: map[string]string{"theme": "orphan"},
+		}
+		h := newTestHandler(orphanCM)
+
+		cm, err := h.createUserSettings(context.Background(), usm)
+		if err != nil {
+			t.Fatalf("createUserSettings: %v", err)
+		}
+
+		if cm.Data != nil {
+			t.Errorf("expected nil Data (no migration), got %v", cm.Data)
+		}
+
+		assertConfigMapExists(t, h, "user-settings-orphan")
+	})
+}

--- a/pkg/usersettings/helpers.go
+++ b/pkg/usersettings/helpers.go
@@ -14,29 +14,26 @@ import (
 func newUserSettingMeta(userInfo authenticationv1.UserInfo) (*UserSettingMeta, error) {
 	uid := userInfo.UID
 	name := userInfo.Username
-	resourceIdentifier := name
-	ownerReferences := []meta.OwnerReference{
-		{
-			APIVersion: "user.openshift.io/v1",
-			Kind:       "User",
-			Name:       name,
-			UID:        types.UID(uid),
-		},
-	}
 
-	if uid != "" {
-		resourceIdentifier = string(uid)
-	} else if name == "kube:admin" {
+	var resourceIdentifier string
+	ownerReferences := []meta.OwnerReference{}
+
+	if name == "kube:admin" && uid == "" {
 		resourceIdentifier = "kubeadmin"
-		ownerReferences = []meta.OwnerReference{}
 	} else {
-		// to avoid issues when the username contains special characters like '@'
-		// that are not allowed in kube resource names
-		// we also can't use base64 encoding because only lowercase chars are allowed
-		// in CM names
-		sha256Hash := sha256.New()
-		sha256Hash.Write([]byte(resourceIdentifier))
-		resourceIdentifier = hex.EncodeToString(sha256Hash.Sum(nil))
+		sum := sha256.Sum256([]byte(name))
+		resourceIdentifier = hex.EncodeToString(sum[:])
+
+		if uid != "" {
+			ownerReferences = []meta.OwnerReference{
+				{
+					APIVersion: "user.openshift.io/v1",
+					Kind:       "User",
+					Name:       name,
+					UID:        types.UID(uid),
+				},
+			}
+		}
 	}
 
 	return &UserSettingMeta{

--- a/pkg/usersettings/helpers_test.go
+++ b/pkg/usersettings/helpers_test.go
@@ -16,7 +16,7 @@ func TestNewUserSettingsMeta(t *testing.T) {
 		expectedData  *UserSettingMeta
 	}{
 		{
-			testcase: "returns -kubeadmin for kube:admin",
+			testcase: "returns kubeadmin for kube:admin without uid",
 			userInfo: authenticationv1.UserInfo{
 				Username: "kube:admin",
 				UID:      "",
@@ -30,7 +30,7 @@ func TestNewUserSettingsMeta(t *testing.T) {
 			},
 		},
 		{
-			testcase: "returns -kubeadmin for fake kube:admin with uid",
+			testcase: "returns SHA256 hash for kube:admin with uid (fake kubeadmin)",
 			userInfo: authenticationv1.UserInfo{
 				Username: "kube:admin",
 				UID:      "1234",
@@ -39,7 +39,7 @@ func TestNewUserSettingsMeta(t *testing.T) {
 			expectedData: &UserSettingMeta{
 				Username:           "kube:admin",
 				UID:                "1234",
-				ResourceIdentifier: "1234",
+				ResourceIdentifier: "547a4b6a78942df67733f5a36aaf80a9f81605e51928d23108ee623042b2a065",
 				OwnerReferences: []meta.OwnerReference{
 					{
 						APIVersion: "user.openshift.io/v1",
@@ -51,7 +51,7 @@ func TestNewUserSettingsMeta(t *testing.T) {
 			},
 		},
 		{
-			testcase: "returns uid for non kube:admin users",
+			testcase: "returns SHA256 hash of username for non kube:admin users",
 			userInfo: authenticationv1.UserInfo{
 				Username: "developer",
 				UID:      "1234",
@@ -60,7 +60,7 @@ func TestNewUserSettingsMeta(t *testing.T) {
 			expectedData: &UserSettingMeta{
 				Username:           "developer",
 				UID:                "1234",
-				ResourceIdentifier: "1234",
+				ResourceIdentifier: "88fa0d759f845b47c044c2cd44e29082cf6fea665c30c146374ec7c8f3d699e3",
 				OwnerReferences: []meta.OwnerReference{
 					{
 						APIVersion: "user.openshift.io/v1",
@@ -69,6 +69,62 @@ func TestNewUserSettingsMeta(t *testing.T) {
 						UID:        "1234",
 					},
 				},
+			},
+		},
+		{
+			testcase: "same username with different UIDs produces same ResourceIdentifier",
+			userInfo: authenticationv1.UserInfo{
+				Username: "developer",
+				UID:      "different-uid-5678",
+			},
+			expectedError: nil,
+			expectedData: &UserSettingMeta{
+				Username:           "developer",
+				UID:                "different-uid-5678",
+				ResourceIdentifier: "88fa0d759f845b47c044c2cd44e29082cf6fea665c30c146374ec7c8f3d699e3",
+				OwnerReferences: []meta.OwnerReference{
+					{
+						APIVersion: "user.openshift.io/v1",
+						Kind:       "User",
+						Name:       "developer",
+						UID:        "different-uid-5678",
+					},
+				},
+			},
+		},
+		{
+			testcase: "username with special characters produces valid hash",
+			userInfo: authenticationv1.UserInfo{
+				Username: "user@example.com",
+				UID:      "uid-99",
+			},
+			expectedError: nil,
+			expectedData: &UserSettingMeta{
+				Username:           "user@example.com",
+				UID:                "uid-99",
+				ResourceIdentifier: "b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514",
+				OwnerReferences: []meta.OwnerReference{
+					{
+						APIVersion: "user.openshift.io/v1",
+						Kind:       "User",
+						Name:       "user@example.com",
+						UID:        "uid-99",
+					},
+				},
+			},
+		},
+		{
+			testcase: "user without uid gets empty OwnerReferences",
+			userInfo: authenticationv1.UserInfo{
+				Username: "developer",
+				UID:      "",
+			},
+			expectedError: nil,
+			expectedData: &UserSettingMeta{
+				Username:           "developer",
+				UID:                "",
+				ResourceIdentifier: "88fa0d759f845b47c044c2cd44e29082cf6fea665c30c146374ec7c8f3d699e3",
+				OwnerReferences:    []meta.OwnerReference{},
 			},
 		},
 	}
@@ -95,7 +151,7 @@ func TestCreateUserSettingsResources(t *testing.T) {
 		expectedConfigMapName   string
 	}{
 		{
-			testcase: "for kubeadmin",
+			testcase: "for kubeadmin without uid",
 			userInfo: authenticationv1.UserInfo{
 				Username: "kube:admin",
 				UID:      "",
@@ -105,24 +161,24 @@ func TestCreateUserSettingsResources(t *testing.T) {
 			expectedRoleBindingName: "user-settings-kubeadmin-rolebinding",
 		},
 		{
-			testcase: "for fake kubeadmin we use uid",
+			testcase: "for fake kubeadmin we use SHA256 hash",
 			userInfo: authenticationv1.UserInfo{
 				Username: "kube:admin",
 				UID:      "1234",
 			},
-			expectedConfigMapName:   "user-settings-1234",
-			expectedRoleName:        "user-settings-1234-role",
-			expectedRoleBindingName: "user-settings-1234-rolebinding",
+			expectedConfigMapName:   "user-settings-547a4b6a78942df67733f5a36aaf80a9f81605e51928d23108ee623042b2a065",
+			expectedRoleName:        "user-settings-547a4b6a78942df67733f5a36aaf80a9f81605e51928d23108ee623042b2a065-role",
+			expectedRoleBindingName: "user-settings-547a4b6a78942df67733f5a36aaf80a9f81605e51928d23108ee623042b2a065-rolebinding",
 		},
 		{
-			testcase: "for non kubeadmin",
+			testcase: "for non kubeadmin we use SHA256 hash",
 			userInfo: authenticationv1.UserInfo{
 				Username: "developer",
 				UID:      "1234",
 			},
-			expectedConfigMapName:   "user-settings-1234",
-			expectedRoleName:        "user-settings-1234-role",
-			expectedRoleBindingName: "user-settings-1234-rolebinding",
+			expectedConfigMapName:   "user-settings-88fa0d759f845b47c044c2cd44e29082cf6fea665c30c146374ec7c8f3d699e3",
+			expectedRoleName:        "user-settings-88fa0d759f845b47c044c2cd44e29082cf6fea665c30c146374ec7c8f3d699e3-role",
+			expectedRoleBindingName: "user-settings-88fa0d759f845b47c044c2cd44e29082cf6fea665c30c146374ec7c8f3d699e3-rolebinding",
 		},
 	}
 

--- a/pkg/usersettings/types.go
+++ b/pkg/usersettings/types.go
@@ -7,7 +7,8 @@ import (
 type UserSettingMeta struct {
 	Username string
 	UID      string
-	// The resource identifier contains "kubeadmin" for the kubeadmin and the user uid otherwise.
+	// ResourceIdentifier contains "kubeadmin" for the real kubeadmin (no UID)
+	// and SHA256(username) as hex for all other users.
 	ResourceIdentifier string
 	OwnerReferences    []meta.OwnerReference
 }


### PR DESCRIPTION
**Analysis / Root cause**:

The `SelfSubjectReview` API returns the identity UID, not the stable User
resource UID. With `mappingMethod: add` and multiple identity providers
(e.g. LDAP + OpenID), the same user receives different identity UIDs
across logins, causing a new `user-settings-*` ConfigMap (plus Role and
RoleBinding) to be created each time. A customer observed ~21,594
ConfigMaps for ~3,869 users.

Introduced in commit a186aa17d4 which migrated from the OCP User API
(`Users().Get("~")`) to `SelfSubjectReview`.

https://redhat.atlassian.net/browse/OCPBUGS-86564

**Solution description**:

- **Backend (`pkg/usersettings/`)**: Change `ResourceIdentifier` from
  `UID` to `SHA256(username)`. The username is stable across identity
  providers for the same OpenShift user. UID is still used in
  OwnerReferences for garbage collection.
- **Migration**: On first login post-upgrade, if the new ConfigMap does
  not yet exist, the backend lists all ConfigMaps in the namespace and
  finds old ones via OwnerReference (matching `Kind: User` and the
  username). If multiple old ConfigMaps exist (e.g. from different
  identity provider UIDs), data is migrated from the most recently
  created one. All old ConfigMaps and their associated Roles and
  RoleBindings are cleaned up. If the new ConfigMap already exists,
  the handler short-circuits without listing.
  Best-effort — errors are logged but never block creation.
- **Frontend (`console-shared/src/hooks/`)**: Remove `uid` from the
  ConfigMap name priority chain so the frontend watches the same
  hash-based name the backend creates. Extract duplicated
  `hashNameOrKubeadmin` into a shared `hashUsernameForSettings` utility.

**Screenshots / screen recording**:
<!-- N/A — no visual changes. Backend naming and migration logic only. -->

**Test setup:**
Cluster with multiple identity providers configured with
`mappingMethod: add` (e.g. LDAP + OpenID).

**Test cases:**
- Log in, verify ConfigMap created as `user-settings-{SHA256(username)}`
- Log out and back in — same ConfigMap reused, no new one created
- Log in via a different identity provider — same ConfigMap reused
- On a cluster with existing UID-based ConfigMaps: upgrade, log in,
  verify old settings are preserved in the new ConfigMap and old
  resources are cleaned up
- On a cluster with multiple old ConfigMaps for the same user: verify
  the most recent one is migrated and all old ones are removed
- `kube:admin` (no UID) still uses `user-settings-kubeadmin`
- Backend: `go test ./pkg/usersettings/...`
- Frontend: `cd frontend && yarn test packages/console-shared/src/hooks/__tests__/useUserPreference.spec.ts packages/console-shared/src/hooks/__tests__/useGetUserSettingConfigMap.spec.ts`

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic migration of legacy user settings into new hash-named resources with best-effort cleanup; preserves existing settings when a target already exists.

* **Bug Fixes**
  * Stable, deterministic naming for user settings (hash-based, stable across UID changes).
  * Impersonation now takes precedence when selecting a user settings resource.
  * Username-only resolution is synchronous (no initial async null).

* **Tests**
  * Expanded tests covering creation, migration, preservation, selection, and cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->