### PR TITLE
OCPBUGS-82508, OCPBUGS-82509: Fix and re-enable operator e2e tests disabled for createRoot

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-install-single-namespace.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-install-single-namespace.cy.ts
@@ -40,8 +40,7 @@ const cleanupOperatorResources = (namespace: string) => {
   );
 };
 
-// Disabled due to createRoot concurrent rendering failures (OCPBUGS-82508)
-xdescribe(`Installing "${testOperator.name}" operator in test namespace`, () => {
+describe(`Installing "${testOperator.name}" operator in test namespace`, () => {
   before(() => {
     cy.login();
     cy.createProjectWithCLI(testName);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-uninstall.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-uninstall.cy.ts
@@ -22,8 +22,7 @@ const alertExists = (titleText: string) => {
   cy.get('.co-alert').contains(titleText).should('exist');
 };
 
-// Disabled due to createRoot concurrent rendering failures (OCPBUGS-82509)
-xdescribe(`Testing uninstall of ${testOperator.name} Operator`, () => {
+describe(`Testing uninstall of ${testOperator.name} Operator`, () => {
   before(() => {
     cy.login();
     cy.createProjectWithCLI(testName);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/views/operator.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/views/operator.view.ts
@@ -25,10 +25,9 @@ export const operator = {
     // Wait for the Install button to be visible and have a valid href before clicking.
     // The button is conditionally rendered based on useCtaLink hook, which processes
     // the CTA href asynchronously. Clicking before href is set causes navigation to fail.
-    cy.byTestID('catalog-details-modal-cta')
-      .should('be.visible')
-      .should('have.attr', 'href')
-      .click();
+    cy.byTestID('catalog-details-modal-cta').should('be.visible');
+    cy.byTestID('catalog-details-modal-cta').should('have.attr', 'href').and('not.be.empty');
+    cy.byTestID('catalog-details-modal-cta').click();
     cy.log('verify the channel selection is displayed');
     cy.byTestID('operator-channel-select-toggle').should('exist');
     cy.log('verify the version selection is displayed');
@@ -46,7 +45,9 @@ export const operator = {
     if (installToNamespace !== GlobalInstalledNamespace) {
       cy.log('configure Operator install for single namespace');
       // Wait for radio button to be visible before checking to avoid race conditions
-      cy.byTestID('A specific namespace on the cluster-radio-input').should('be.visible').check();
+      cy.byTestID('A specific namespace on the cluster-radio-input', { timeout: 30000 })
+        .should('be.visible')
+        .check();
       if (useOperatorRecommendedNamespace) {
         cy.log('configure Operator install for operator recommended namespace');
         cy.byTestID('Operator recommended Namespace:-radio-input').check();
@@ -59,7 +60,9 @@ export const operator = {
         });
       }
     } else {
-      cy.byTestID('All namespaces on the cluster-radio-input').should('be.checked');
+      cy.byTestID('All namespaces on the cluster-radio-input', { timeout: 30000 }).should(
+        'be.checked',
+      );
     }
     if (installToNamespace !== GlobalInstalledNamespace && !useOperatorRecommendedNamespace) {
       cy.byTestID('dropdown-selectbox').click();


### PR DESCRIPTION
**Analysis / Root cause**:

The `operator-install-single-namespace.cy.ts` e2e test was disabled during the React 18 `createRoot` migration ([CONSOLE-4512](https://redhat.atlassian.net/browse/CONSOLE-4512)) due to concurrent rendering timing issues:

1. **Radio button timeout**: Under React 18 concurrent rendering, the namespace scope radio button group (`A specific namespace on the cluster-radio-input`) mounts asynchronously and was not found within the default 40-second Cypress timeout
2. **Install CTA navigation failure**: The Install button's `href` attribute is set asynchronously via the `useCtaLink` hook, and clicking before the href is ready causes navigation to fail
3. **Cypress chain break**: `.should('have.attr', 'href')` yields the attribute string value instead of the DOM element, causing `.click()` to fail with "requires a DOM element" error

**Solution description**:

Three fixes applied to re-enable the test:

1. **Add explicit 30s timeout to radio selectors** (operator.view.ts:48, 63):
   - `cy.byTestID('A specific namespace on the cluster-radio-input', { timeout: 30000 })`
   - `cy.byTestID('All namespaces on the cluster-radio-input', { timeout: 30000 })`
   - Gives Cypress time to wait for async mount completion

2. **Split Install CTA interaction into separate commands** (operator.view.ts:28-30):
   ```typescript
   cy.byTestID('catalog-details-modal-cta').should('be.visible');
   cy.byTestID('catalog-details-modal-cta').should('have.attr', 'href').and('not.be.empty');
   cy.byTestID('catalog-details-modal-cta').click();
   ```
   - First verify element visible
   - Assert href exists and not empty (yields href, discarded)
   - Re-query fresh element and click (avoids chain break)

3. **Re-enable test** (operator-install-single-namespace.cy.ts:43):
   - Changed `xdescribe` → `describe`
   - Removed disable comment

Matches pattern from other createRoot e2e fixes: OCPBUGS-82512 (knative), OCPBUGS-82504 (cluster-settings).

**Screenshots / screen recording**:
N/A - e2e test fix, no UI changes

**Test setup:**
Requires OpenShift cluster with OperatorHub configured and Data Grid operator available in catalog.

**Test cases:**
1. Run `yarn test-cypress-olm-headless` with spec filter for `operator-install-single-namespace.cy.ts`
2. Verify test passes:
   - Navigates to OperatorHub catalog
   - Searches for Data Grid operator  
   - Clicks operator card and Install CTA
   - Selects "A specific namespace" radio button
   - Completes installation to test namespace
   - Creates Backup operand instance
   - Deletes operand and uninstalls operator
3. Verify no CSP violations or console errors

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info**:
- Related Jira: https://redhat.atlassian.net/browse/OCPBUGS-82508
- Test was disabled in commit c18637a6d7 (March 31, 2026)
- CSP img-src violations from operator icons resolved by backend CSP change in 5afddf4f15

**Reviewers and assigners:**
<!-- Tag OCP console engineer for review -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Re-enabled previously disabled operator installation and uninstallation test suites
  * Improved test determinism by adding visibility assertions and wait conditions for interactive elements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->