### PR TITLE
OCPBUGS-86755: use a clip path instead of overlapping triangles

### DIFF
--- a/frontend/public/components/cluster-settings/_cluster-settings.scss
+++ b/frontend/public/components/cluster-settings/_cluster-settings.scss
@@ -1,4 +1,4 @@
-$co-channel-background-color: var(--pf-t--global--background--color--primary--default);
+$co-channel-background-color: var(--pf-t--global--background--color--floating--default);
 $co-channel-color: var(--pf-t--global--border--color--disabled);
 $co-channel-current-color: var(--pf-t--global--border--color--brand--default);
 $co-channel-height: 60px;
@@ -109,35 +109,18 @@ $co-channel-height: 60px;
 }
 
 .co-channel-start::before {
-  position: absolute;
-  right: 0;
-  width: 25%;
+  content: unset;
 }
 
 .co-channel-switch {
-  position: absolute;
-  top: -28px;
-  width: 100%;
+  background-color: $co-channel-color;
   height: $co-channel-height;
+  clip-path: polygon(0 0, 2px 0, 100% calc(100% - 2px), 100% 100%, calc(100% - 4px) 100%, 0 4px);
+  position: absolute;
+  right: -4px;
+  top: -28px;
+  width: 50%;
   z-index: 1;
-
-  &::after,
-  &::before {
-    background: linear-gradient(to left bottom, transparent 50%, $co-channel-color 50%);
-    content: '';
-    display: block;
-    height: $co-channel-height;
-    position: absolute;
-    right: 0;
-    top: -3px;
-    width: 50%;
-  }
-
-  &::after {
-    background: linear-gradient(to left bottom, transparent 50%, $co-channel-background-color 50%);
-    right: 3px;
-    top: 0;
-  }
 }
 
 .co-channel-version {
@@ -207,7 +190,7 @@ $co-channel-height: 60px;
 
   &,
   &__section {
-    border-color: var(--pf-t--chart--theme--colorscales--gray--colorscale--200);
+    border-color: var(--pf-t--global--border--color--default);
     border-style: solid;
   }
 


### PR DESCRIPTION
**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

Can't rely on overlapping elements anymore because the background colour is transparent

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

Use a clip path

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

|before|after|
|--|--|
|<img width="945" height="982" alt="image" src="https://github.com/user-attachments/assets/98b98656-cf45-4b74-b892-bc883818af86" />|<img width="945" height="982" alt="image" src="https://github.com/user-attachments/assets/06592c53-9efc-4169-896f-a9df2a0b7161" />|
|<img width="945" height="982" alt="image" src="https://github.com/user-attachments/assets/eca8e872-9ccf-438c-b426-ecda85690f68" />|<img width="945" height="982" alt="image" src="https://github.com/user-attachments/assets/c6be606e-6fd4-40c9-8c08-cf02af35b691" />|
|<img width="945" height="982" alt="image" src="https://github.com/user-attachments/assets/d4e92b27-3db6-48a9-91c6-689512037d5f" />|<img width="945" height="982" alt="image" src="https://github.com/user-attachments/assets/5f6e1df7-8ae3-4b9f-8833-3df1fff17b42" />|

bonus fix

|before|after|
|--|--|
|<img width="945" height="982" alt="image" src="https://github.com/user-attachments/assets/0e8c1225-75ea-4f03-bd86-37563236540c" />|<img width="945" height="982" alt="image" src="https://github.com/user-attachments/assets/c3350d01-2339-44e9-960f-acdf4e83c384" />|
|<img width="945" height="982" alt="image" src="https://github.com/user-attachments/assets/11a4ed69-de9a-4a80-964f-e865ee65b900" />|<img width="945" height="982" alt="image" src="https://github.com/user-attachments/assets/4c2698c5-d880-4513-89f5-b92dd4e44fd0" />|
|<img width="945" height="982" alt="image" src="https://github.com/user-attachments/assets/d48c635b-638b-4bd1-8ed8-8c6308c09622" />|<img width="945" height="982" alt="image" src="https://github.com/user-attachments/assets/8dba82bd-f683-4412-855b-2c1fb5e5cc1d" />|






**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

Claude wrote this diff to apply mock data:

```tsx
diff --git a/frontend/public/components/cluster-settings/cluster-settings.tsx b/frontend/public/components/cluster-settings/cluster-settings.tsx
index 6e412b019e..0775ef133d 100644
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import type { FC, ReactNode } from 'react';
-import { useEffect, useRef, useMemo } from 'react';
+import { useEffect, useRef, useMemo, useState } from 'react';
 import * as _ from 'lodash';
 import { css } from '@patternfly/react-styles';
 import * as semver from 'semver';
@@ -124,6 +124,255 @@ import { UpdateStatus } from './cluster-status';
 import { ErrorModal } from '../modals/error-modal';
 import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 
+// DEV ONLY: inline mock data for testing cluster version states
+/* eslint-disable @typescript-eslint/naming-convention */
+const _baseCv = {
+  apiVersion: 'config.openshift.io/v1',
+  kind: 'ClusterVersion',
+  metadata: {
+    creationTimestamp: '2024-01-04T05:14:57Z',
+    generation: 4,
+    name: 'version',
+    resourceVersion: '370626',
+    uid: '40b1ad1b-13d2-4c7c-932a-ce78c4447ed8',
+  },
+  spec: {
+    channel: 'stable-4.16',
+    clusterID: '4976480a-15e1-4c94-bafe-aafb96bc0248',
+    upstream: 'https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/graph',
+  },
+  status: {
+    availableUpdates: [],
+    conditions: [
+      { lastTransitionTime: '2024-01-04T05:37:10Z', status: 'True', type: 'RetrievedUpdates' },
+      {
+        lastTransitionTime: '2024-01-04T05:15:00Z',
+        message: 'Capabilities match configured spec',
+        reason: 'AsExpected',
+        status: 'False',
+        type: 'ImplicitlyEnabledCapabilities',
+      },
+      {
+        lastTransitionTime: '2024-01-04T05:15:00Z',
+        message:
+          'Payload loaded version="4.16.0" image="registry.ci.openshift.org/ocp/release@sha256:ff486203f5b065836105fcd56f29467229bfc6258e5d8ba7f479ac575d81c721" architecture="amd64"',
+        reason: 'PayloadLoaded',
+        status: 'True',
+        type: 'ReleaseAccepted',
+      },
+      {
+        lastTransitionTime: '2024-01-04T05:35:14Z',
+        message: 'Done applying 4.16.0',
+        status: 'True',
+        type: 'Available',
+      },
+      { lastTransitionTime: '2024-01-04T05:35:14Z', status: 'False', type: 'Failing' },
+      {
+        lastTransitionTime: '2024-01-04T05:35:14Z',
+        message: 'Cluster version is 4.16.0',
+        status: 'False',
+        type: 'Progressing',
+      },
+    ],
+    desired: {
+      image:
+        'registry.ci.openshift.org/ocp/release@sha256:ff486203f5b065836105fcd56f29467229bfc6258e5d8ba7f479ac575d81c721',
+      version: '4.16.0',
+    },
+    history: [
+      {
+        completionTime: '2024-01-04T05:35:14Z',
+        image:
+          'registry.ci.openshift.org/ocp/release@sha256:ff486203f5b065836105fcd56f29467229bfc6258e5d8ba7f479ac575d81c721',
+        startedTime: '2024-01-04T05:15:00Z',
+        state: 'Completed',
+        verified: false,
+        version: '4.16.0',
+      },
+    ],
+    observedGeneration: 3,
+    versionHash: 'rqBs61ZyVwQ=',
+  },
+};
+
+const _clone = (o: any) => JSON.parse(JSON.stringify(o));
+const _upsert = (conditions: any[], c: any) => [
+  ...conditions.filter((x: any) => x.type !== c.type),
+  c,
+];
+
+const _availableUpdates = [
+  {
+    image:
+      'registry.ci.openshift.org/ocp/release@sha256:f31d5b0e23c8f978b57f5ef74c8811e7f87103187aa1895880f67eac4eb76f6d',
+    version: '4.16.1',
+  },
+  {
+    image:
+      'registry.ci.openshift.org/ocp/release@sha256:f31d5b0e23c8f978b57f5ef74c8811e7f87103187aa1895880f67eac4eb76f6e',
+    version: '4.16.2',
+  },
+  {
+    image:
+      'registry.ci.openshift.org/ocp/release@sha256:06cd433ae0036e3b79e2ecd08512abca540fbefe9805b225a6a9c33ca9456ad3',
+    version: '4.17.0',
+  },
+  {
+    image:
+      'registry.ci.openshift.org/ocp/release@sha256:06cd433ae0036e3b79e2ecd08512abca540fbefe9805b225a6a9c33ca9456ad4',
+    version: '4.17.1',
+  },
+];
+
+const _conditionalUpdates = [
+  {
+    release: {
+      version: '4.16.3',
+      image:
+        'quay.io/openshift-release-dev/ocp-release@sha256:7082f01282a07f4033308ccadb1ca0c6acacadd83812d7cc1135a022f5382391',
+      channels: ['candidate-4.16'],
+    },
+    risks: [
+      {
+        url: 'https://bugzilla.redhat.com/show_bug.cgi?id=2047190',
+        name: 'AlibabaStorageDriverDemo',
+        message:
+          'The Alibaba storage driver was updated from a patched 1.1.4 to a patched 1.1.6 in 4.10.0-rc.0.',
+        matchingRules: [
+          {
+            type: 'PromQL',
+            promql: {
+              promql:
+                'cluster_infrastructure_provider{type="AlibabaCloud"} or 0 * cluster_infrastructure_provider',
+            },
+          },
+        ],
+      },
+    ],
+    conditions: [
+      {
+        type: 'Recommended',
+        status: 'False',
+        lastTransitionTime: '2024-02-03T22:53:33Z',
+        reason: 'AlibabaStorageDriverDemo',
+        message:
+          'The Alibaba storage driver was updated from a patched 1.1.4 to a patched 1.1.6 in 4.10.0-rc.0.',
+      },
+    ],
+  },
+  {
+    release: {
+      version: '4.16.4',
+      image:
+        'quay.io/openshift-release-dev/ocp-release@sha256:7082f01282a07f4033308ccadb1ca0c6acacadd83812d7cc1135a022f5382391',
+      channels: ['candidate-4.14'],
+    },
+    risks: [
+      {
+        url: 'https://bugzilla.redhat.com/show_bug.cgi?id=2047190',
+        name: 'AlibabaStorageDriverDemo',
+        message:
+          'The Alibaba storage driver was updated from a patched 1.1.4 to a patched 1.1.6 in 4.10.0-rc.0.',
+        matchingRules: [
+          {
+            type: 'PromQL',
+            promql: {
+              promql:
+                'cluster_infrastructure_provider{type="AlibabaCloud"} or 0 * cluster_infrastructure_provider',
+            },
+          },
+        ],
+      },
+    ],
+    conditions: [
+      {
+        type: 'Recommended',
+        status: 'False',
+        lastTransitionTime: '2024-02-03T22:53:33Z',
+        reason: 'AsExpected',
+        message:
+          'The update is recommended, because none of the conditional update risks apply to this cluster.',
+      },
+    ],
+  },
+];
+
+const _mockWithoutChannel = (() => {
+  const cv = _clone(_baseCv);
+  cv.spec.channel = '';
+  cv.status.conditions = _upsert(cv.status.conditions, {
+    lastTransitionTime: '2024-01-10T18:10:53Z',
+    message: 'The update channel has not been configured.',
+    reason: 'NoChannel',
+    status: 'False',
+    type: 'RetrievedUpdates',
+  });
+  return cv;
+})();
+
+const _mockWithDesiredChannels = (() => {
+  const cv = _clone(_baseCv);
+  cv.status.desired.channels = [
+    'stable-4.16',
+    'candidate-4.16',
+    'fast-4.16',
+    'stable-4.17',
+    'candidate-4.17',
+    'fast-4.17',
+  ];
+  return cv;
+})();
+
+const _mockProgressing = (() => {
+  const cv = _clone(_baseCv);
+  cv.status.conditions = _upsert(cv.status.conditions, {
+    lastTransitionTime: '2024-01-11T13:45:34Z',
+    message: 'Cluster version is 4.16.0',
+    status: 'True',
+    type: 'Progressing',
+  });
+  const desired = {
+    image:
+      'registry.ci.openshift.org/ocp/release@sha256:ff486203f5b065836105fcd56f29467229bfc6258e5d8ba7f479ac575d81c721',
+    version: '4.16.2',
+  };
+  cv.spec.desired = desired;
+  cv.status.desired = desired;
+  return cv;
+})();
+
+const _mockAvailableUpdates = (() => {
+  const cv = _clone(_baseCv);
+  cv.status.availableUpdates = _availableUpdates;
+  return cv;
+})();
+
+const _mockAvailableAndConditional = (() => {
+  const cv = _clone(_mockAvailableUpdates);
+  cv.status.conditionalUpdates = _conditionalUpdates;
+  return cv;
+})();
+
+const _mockConditionalOnly = (() => {
+  const cv = _clone(_baseCv);
+  cv.status.conditionalUpdates = _conditionalUpdates;
+  return cv;
+})();
+
+const _mockUpgradeableFalse = (() => {
+  const cv = _clone(_mockAvailableUpdates);
+  cv.status.conditions.push({
+    lastTransitionTime: '2024-01-04T05:45:29Z',
+    message:
+      'Cluster operator operator-lifecycle-manager should not be upgraded between minor versions: ClusterServiceVersions blocking cluster upgrade: openshift-operators/openshift-pipelines-operator-rh.v1.12.2 is incompatible with OpenShift minor versions greater than 4.14',
+    reason: 'IncompatibleOperatorsInstalled',
+    status: 'False',
+    type: 'Upgradeable',
+  });
+  return cv;
+})();
+/* eslint-enable @typescript-eslint/naming-convention */
+
 export const clusterAutoscalerReference = referenceForModel(ClusterAutoscalerModel);
 
 const getMCPByName = (
@@ -1180,10 +1429,22 @@ export const ClusterOperatorTabPage: FC<ClusterOperatorTabPageProps> = ({ obj: c
   <ClusterOperatorPage cv={cv} autoFocus={false} showTitle={false} />
 );
 
+const mockClusterVersions: Record<string, any> = {
+  '': null,
+  'Without Channel': _mockWithoutChannel,
+  'With Desired Channels': _mockWithDesiredChannels,
+  'Progressing': _mockProgressing,
+  'Available Updates': _mockAvailableUpdates,
+  'Available + Conditional Updates': _mockAvailableAndConditional,
+  'Conditional Updates Only': _mockConditionalOnly,
+  'Upgradeable=False': _mockUpgradeableFalse,
+};
+
 export const ClusterSettingsPage: FC = () => {
   const { t } = useTranslation();
   const hasClusterAutoscaler = useFlag(FLAGS.CLUSTER_AUTOSCALER);
   const title = t('public~Cluster Settings');
+  const [selectedMock, setSelectedMock] = useState('');
 
   const [objData, objLoaded, objLoadError] = useK8sWatchResource<ClusterVersionKind>({
     kind: clusterVersionReference,
@@ -1230,10 +1491,14 @@ export const ClusterSettingsPage: FC = () => {
   const loaded = hasClusterAutoscaler ? objLoaded && autoscalersLoaded : objLoaded;
   const loadError = objLoadError || autoscalersLoadError;
 
+  const effectiveObjData = selectedMock
+    ? (mockClusterVersions[selectedMock] as ClusterVersionKind)
+    : objData;
+
   const horizontalNavProps = {
     pages,
     resourceKeys,
-    obj: { data: objData, loaded: objLoaded },
+    obj: { data: effectiveObjData, loaded: selectedMock ? true : objLoaded },
     ...(hasClusterAutoscaler && {
       autoscalers: { data: autoscalersData, loaded: autoscalersLoaded },
     }),
@@ -1253,6 +1518,22 @@ export const ClusterSettingsPage: FC = () => {
           </div>
         }
       />
+      <div style={{ padding: '16px', background: '#fff3cd', borderBottom: '1px solid #ffc107' }}>
+        <label htmlFor="mock-cv-select" style={{ fontWeight: 'bold', marginRight: '8px' }}>
+          DEV: Mock ClusterVersion
+        </label>
+        <select
+          id="mock-cv-select"
+          value={selectedMock}
+          onChange={(e) => setSelectedMock(e.target.value)}
+        >
+          {Object.keys(mockClusterVersions).map((key) => (
+            <option key={key} value={key}>
+              {key || '(Live data)'}
+            </option>
+          ))}
+        </select>
+      </div>
       <HorizontalNav {...horizontalNavProps} />
     </PageTitleContext.Provider>
   );
```

**Test cases:**
<!-- List possible test cases to validate the changes. -->

Go through the cases and make sure they look good in all 6 theme combinations

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated channel background for improved visual consistency with floating surface styles.
  * Redesigned channel switch for simpler visuals and more accurate positioning (cleaner shape clipping and sizing).
  * Adjusted channel-start connector rendering to remove unintended generated content.
  * Updated cluster settings section border color for better visual alignment with global borders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->