### PR TITLE
OCPBUGS-86875: Always use RHUI icons

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="no-js">
+<html lang="en" class="no-js pf-v6-icon-set-rh-ui">
   <head>
     <base href="[[ .ServerFlags.BasePath ]]" />
     <meta charset="utf-8" />
@@ -51,7 +51,7 @@
       [[ if not (and .ServerFlags.ReleaseVersion (eq (slice .ServerFlags.ReleaseVersion 0 1) "4")) ]]
 
       [[ if ne .ServerFlags.Branding "okd" ]]
-      document.documentElement.classList.add('pf-v6-theme-felt', 'pf-v6-icon-set-rh-ui');
+      document.documentElement.classList.add('pf-v6-theme-felt');
       [[ end ]]
 
       let contrast = localStorage.getItem('bridge/contrast') || 'systemDefault';


### PR DESCRIPTION
**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

Per the PatternFly community meeting: 

> Upstream: Use the Default (blue) PatternFly theme, the generic backgrounds, and Red Hat icons. Glass mode is optional.
> 
> Red Hat Products: Use the Project Felt theme, generic product or product-specific (both brand-approved) images for backgrounds, and Red Hat icons. Glass mode is optional but encouraged.

Currently upstream (OKD) uses font awesome and Red Hat (OpenShift) uses RH icons. 

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

Before:
- 4.22: font awesome
- OKD: font awesome
- OpenShift: RHUI

After:
- 4.22: RHUI
- OKD: RHUI
- OpenShift: RHUI

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test cases:**
<!-- List possible test cases to validate the changes. -->

Icons should match the "after" case 

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated HTML styling class application for improved UI theme and icon set handling, reorganizing how styling classes are applied to enhance rendering consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->