### PR TITLE
OCPBUGS-85033,OCPBUGS-85003,OCPBUGS-84987: CVE-2026-42041 - Bump axios to 1.15.1 for CVE-2026-42041

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -166,7 +166,7 @@
     "apollo-client": "^2.6.8",
     "apollo-link-http": "^1.0.20",
     "apollo-link-ws": "^1.0.20",
-    "axios": "^1.13.5",
+    "axios": "1.15.1",
     "classnames": "2.x",
     "crypto-browserify": "3.12.0",
     "d3": "^5.16.0",
@@ -361,7 +361,7 @@
     "jest": "21.x",
     "glob-parent": "^5.1.2",
     "postcss": "^8.2.13",
-    "axios": "1.15.0",
+    "axios": "1.15.1",
     "get-intrinsic": "1.3.0"
   },
   "lint-staged": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6114,14 +6114,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.15.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+"axios@npm:1.15.1":
+  version: 1.15.1
+  resolution: "axios@npm:1.15.1"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
+  checksum: 10c0/f8b5f3aa954cc1da283e32ad81882967a371dfec7dcc75174fcae93093daeb5399aec2ec587d04779f46b00ff1c297ac9edf3fa596452d6a3d455ce5b58093a4
   languageName: node
   linkType: hard
 
@@ -18626,7 +18626,7 @@ __metadata:
     apollo-client: "npm:^2.6.8"
     apollo-link-http: "npm:^1.0.20"
     apollo-link-ws: "npm:^1.0.20"
-    axios: "npm:^1.13.5"
+    axios: "npm:1.15.1"
     babel-loader: "npm:^8.2.1"
     babel-plugin-transform-imports: "npm:1.5.1"
     browser-env: "npm:3.x"


### PR DESCRIPTION
Update axios from 1.15.0 to 1.15.1 to address https://github.com/advisories/GHSA-w9j2-pvgh-6h63, a prototype pollution gadget vulnerability that could bypass authentication if Object.prototype is polluted.

The vulnerability affects the validateStatus merge strategy, which uses the 'in' operator that traverses the prototype chain. This could cause all HTTP error responses (401, 403, 500, etc.) to be treated as successful, bypassing authentication checks.

Axios is used in the kubevirt-plugin for PVC file uploads with Bearer token authentication. While exploitation requires a pre-existing prototype pollution vulnerability, updating eliminates this gadget from the attack surface.

Related: https://github.com/advisories/GHSA-w9j2-pvgh-6h63

  ✅ Verification Complete

  Lint: ✅ Passed (1 pre-existing warning unrelated to axios)
  Test: ✅ Passed (exit code 0, all test suites passed)
  Build: ✅ Passed (exit code 0, all assets generated)
