### PR TITLE
OCPBUGS-82506, OCPBUGS-82507: Re-enable OLM Cypress tests disabled for createRoot

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-hub.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-hub.cy.ts
@@ -1,7 +1,6 @@
 import { checkErrors, testName } from '@console/cypress-integration-tests/support';
 
-// Disabled due to createRoot concurrent rendering failures (OCPBUGS-82506)
-xdescribe('Interacting with Operators', () => {
+describe('Interacting with Operators', () => {
   before(() => {
     cy.login();
     cy.createProjectWithCLI(testName);
@@ -40,11 +39,16 @@ xdescribe('Interacting with Operators', () => {
         cy.log('more than one tile should be present');
         cy.get('.co-catalog-tile').its('length').should('be.gt', 0);
         cy.log('the first tile title text for Certified should not be the same as Community');
+        // Wait for catalog to re-render with new filter - under React 18 concurrent rendering,
+        // tile updates are batched and happen asynchronously. Use .should() callback to retry
+        // until the tile content actually changes.
         cy.get('.co-catalog-tile')
           .first()
           .find('.catalog-tile-pf-title')
-          .invoke('text')
-          .should('not.equal', origCatalogTitleTxt);
+          .should(($title) => {
+            const newTitleTxt = $title.text();
+            expect(newTitleTxt).not.to.equal(origCatalogTitleTxt);
+          });
       });
 
     cy.log('filters Operators by name');

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-install-global.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-install-global.cy.ts
@@ -38,8 +38,7 @@ const cleanupOperatorResources = () => {
   );
 };
 
-// Disabled due to createRoot concurrent rendering failures (OCPBUGS-82507)
-xdescribe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
+describe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
   before(() => {
     cy.login();
     cleanupOperatorResources();

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/views/operator.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/views/operator.view.ts
@@ -44,8 +44,9 @@ export const operator = {
      */
     if (installToNamespace !== GlobalInstalledNamespace) {
       cy.log('configure Operator install for single namespace');
-      // Wait for radio button to be visible before checking to avoid race conditions
-      cy.byTestID('A specific namespace on the cluster-radio-input', { timeout: 30000 })
+      // Under React 18 concurrent rendering, install mode radios mount after async data loads.
+      // Increase timeout to handle deferred rendering.
+      cy.byTestID('A specific namespace on the cluster-radio-input', { timeout: 60000 })
         .should('be.visible')
         .check();
       if (useOperatorRecommendedNamespace) {
@@ -60,7 +61,9 @@ export const operator = {
         });
       }
     } else {
-      cy.byTestID('All namespaces on the cluster-radio-input', { timeout: 30000 }).should(
+      // Under React 18 concurrent rendering, install mode radios mount after async data loads.
+      // Increase timeout to handle deferred rendering.
+      cy.byTestID('All namespaces on the cluster-radio-input', { timeout: 60000 }).should(
         'be.checked',
       );
     }


### PR DESCRIPTION
## Summary
Re-enable `operator-hub.cy.ts` and `operator-install-global.cy.ts` e2e tests that were disabled during the React 18 createRoot migration ([CONSOLE-4512](https://redhat.atlassian.net/browse/CONSOLE-4512)).

## Changes
### OCPBUGS-82506: operator-hub.cy.ts
- **Root cause:** React 18 concurrent rendering batches catalog tile updates asynchronously via `startTransition` (CatalogView.tsx:132). Test asserted tile content changed immediately after filter click without waiting for async re-render.
- **Fix:** Changed filter assertion at lines 42-51 from immediate `invoke('text').should()` to retry-based `.should()` callback that re-executes text extraction on each retry attempt. Properly handles async tile re-rendering under concurrent mode.

### OCPBUGS-82507: operator-install-global.cy.ts  
- **Root cause:** Install mode radio buttons mount after async data loads via `useK8sWatchResource` hooks in `operator-hub-subscribe.tsx`. Concurrent rendering batches these async operations, causing 30s timeout to be insufficient.
- **Fix:** Increased install mode radio timeout from 30s to 60s in `operator.view.ts` (lines 48, 63) to handle deferred rendering timing.

## Test Plan
- [ ] `operator-hub.cy.ts` passes in CI under createRoot
- [ ] `operator-install-global.cy.ts` passes in CI under createRoot  
- [ ] No regressions in other OLM Cypress tests

## Related
- Blocks: [CONSOLE-5237](https://redhat.atlassian.net/browse/CONSOLE-5237) (Migrate OLM integration-tests to Playwright)
- Related: [CONSOLE-4512](https://redhat.atlassian.net/browse/CONSOLE-4512) (Update to React 18 - Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for operator installation and catalog filtering scenarios with enhanced timeout handling.
  * Re-enabled integration test coverage for global operator installation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->