### PR TITLE
OCPBUGS-86894: reduce startup API calls and prioritize critical fetches

### DIFF
--- a/frontend/e2e/pages/alertmanager-page.ts
+++ b/frontend/e2e/pages/alertmanager-page.ts
@@ -51,13 +51,16 @@ export class AlertmanagerPage extends BasePage {
   async save(): Promise<void> {
     await expect(this.saveChangesButton).toBeEnabled();
     await this.robustClick(this.saveChangesButton);
-    // Wait for the save to complete and redirect back to the receiver list
-    await this.createReceiverButton.waitFor({ state: 'visible', timeout: 30_000 });
+    await this.createReceiverButton.waitFor({ state: 'visible', timeout: 60_000 });
   }
 
   async showAdvancedConfiguration(): Promise<void> {
+    const sendResolved = this.page.getByTestId('send-resolved-alerts');
+    if (await sendResolved.isVisible()) return;
+
     const button = this.advancedConfigButton.locator('button');
     await this.robustClick(button);
+    await sendResolved.waitFor({ state: 'visible', timeout: 15_000 });
   }
 
   async getYAMLContent(): Promise<string> {

--- a/frontend/e2e/tests/console/cluster-settings/alertmanager/alertmanager.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/alertmanager/alertmanager.spec.ts
@@ -34,6 +34,7 @@ test.describe('Alertmanager', { tag: ['@admin'] }, () => {
   test.beforeEach(async ({ page, k8sClient: client }) => {
     alertmanager = new AlertmanagerPage(page);
     k8sClient = client;
+    await resetAlertmanagerConfig(k8sClient);
   });
 
   test.afterEach(async () => {

--- a/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/pagerduty.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/pagerduty.spec.ts
@@ -28,6 +28,7 @@ test.describe('Alertmanager PagerDuty Receiver Form', { tag: ['@admin'] }, () =>
   test.beforeEach(async ({ page, k8sClient: client }) => {
     alertmanager = new AlertmanagerPage(page);
     k8sClient = client;
+    await resetAlertmanagerConfig(k8sClient);
   });
 
   test.afterEach(async () => {
@@ -35,6 +36,8 @@ test.describe('Alertmanager PagerDuty Receiver Form', { tag: ['@admin'] }, () =>
   });
 
   test('creates and edits PagerDuty Receiver correctly', async ({ page }) => {
+    test.setTimeout(180_000);
+
     await test.step('Create PagerDuty Receiver with basic configuration', async () => {
       await alertmanager.navigateToAlertmanager();
       await alertmanager.createReceiver(receiverName, configName);

--- a/frontend/packages/console-app/src/components/detect-context/DetectContext.tsx
+++ b/frontend/packages/console-app/src/components/detect-context/DetectContext.tsx
@@ -2,6 +2,9 @@ import type { FC, Provider as ProviderComponent, ReactNode } from 'react';
 import { createContext, Suspense, useContext, useEffect } from 'react';
 import type { LoadedAndResolvedExtension } from '@openshift/dynamic-plugin-sdk';
 import {
+  Button,
+  Content,
+  ContentVariants,
   Masthead,
   MastheadContent,
   MastheadMain,
@@ -10,6 +13,7 @@ import {
   PageSidebar,
   PageSidebarBody,
 } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
 import { createPath, useLocation } from 'react-router';
 import type { Perspective, ReduxReducer, ContextProvider } from '@console/dynamic-plugin-sdk';
 import {
@@ -52,29 +56,67 @@ const EnhancedProvider: FC<{
 
 const PF_BREAKPOINT_XL = 1200;
 
-/** Empty PatternFly Page shell shown while DetectContext is initializing. */
-export const PageSkeleton: FC<{ blame: string }> = ({ blame }) => (
-  <Page
-    isContentFilled
-    masthead={
-      <Masthead>
-        <MastheadMain />
-        <MastheadContent>
-          <div className="co-page-skeleton__masthead-spacer" />
-        </MastheadContent>
-      </Masthead>
-    }
-    sidebar={
-      <PageSidebar isSidebarOpen={window.innerWidth >= PF_BREAKPOINT_XL}>
-        <PageSidebarBody />
-      </PageSidebar>
-    }
-  >
-    <PageSection isFilled hasBodyWrapper={false}>
-      <LoadingBox blame={blame} />
-    </PageSection>
-  </Page>
-);
+const SlowLoadingMessage: FC<{ message: string }> = ({ message }) => {
+  const { t } = useTranslation('public');
+  return (
+    <Content className="co-page-skeleton__slow-msg pf-v6-u-text-align-center pf-v6-u-mt-lg">
+      <Content component={ContentVariants.p}>{message}</Content>
+      <Button
+        variant="link"
+        isInline
+        className="pf-v6-u-mt-sm"
+        onClick={() => window.location.reload()}
+      >
+        {t('Refresh')}
+      </Button>
+    </Content>
+  );
+};
+
+/**
+ * Empty PatternFly Page shell shown while DetectContext is initializing. Intended to
+ * only be rendered once at the start of page load
+ */
+const PageSkeleton: FC<{ blame: string }> = ({ blame }) => {
+  const { t } = useTranslation('public');
+
+  return (
+    <>
+      <div className="co-page-skeleton__auth-pending">
+        <LoadingBox blame={blame}>
+          <SlowLoadingMessage
+            message={t(
+              'Unable to connect to the server. This could be due to network or server issues.',
+            )}
+          />
+        </LoadingBox>
+      </div>
+      <Page
+        className="co-page-skeleton__authenticated"
+        isContentFilled
+        masthead={
+          <Masthead>
+            <MastheadMain />
+            <MastheadContent>
+              <div className="co-page-skeleton__masthead-spacer" />
+            </MastheadContent>
+          </Masthead>
+        }
+        sidebar={
+          <PageSidebar isSidebarOpen={window.innerWidth >= PF_BREAKPOINT_XL}>
+            <PageSidebarBody />
+          </PageSidebar>
+        }
+      >
+        <PageSection isFilled hasBodyWrapper={false}>
+          <LoadingBox blame={blame}>
+            <SlowLoadingMessage message={t('The console is taking longer than usual to load.')} />
+          </LoadingBox>
+        </PageSection>
+      </Page>
+    </>
+  );
+};
 
 /** Wraps children in plugin-provided context providers resolved by DetectContext. */
 export const ContextProviderExtensionWrapper: FC<{ children: ReactNode }> = ({ children }) => {

--- a/frontend/packages/console-shared/src/hooks/__tests__/useUser.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useUser.spec.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { useConsoleDispatch } from '@console/shared/src/hooks/useConsoleDispatch';
 import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
 import { useUser } from '../useUser';
@@ -18,8 +18,8 @@ jest.mock('@console/shared/src/hooks/useConsoleDispatch', () => ({
   useConsoleDispatch: jest.fn(),
 }));
 
-jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
-  useK8sGet: jest.fn(),
+jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
+  useK8sWatchResource: jest.fn(),
 }));
 
 const mockSetUserResource = jest.fn((userResource) => ({
@@ -36,7 +36,7 @@ jest.mock('@console/dynamic-plugin-sdk', () => ({
 
 const mockDispatch = jest.fn();
 const mockUseSelector = useConsoleSelector as jest.Mock;
-const mockUseK8sGet = useK8sGet as jest.Mock;
+const mockUseK8sWatchResource = useK8sWatchResource as jest.Mock;
 const mockUseDispatch = useConsoleDispatch as jest.Mock;
 
 describe('useUser', () => {
@@ -53,7 +53,7 @@ describe('useUser', () => {
       .mockReturnValueOnce(mockUser) // for getUser
       .mockReturnValueOnce(mockUserResource); // for getUserResource
 
-    mockUseK8sGet.mockReturnValue([mockUserResource, true, null]);
+    mockUseK8sWatchResource.mockReturnValue([mockUserResource, true, null]);
 
     const { result } = renderHook(() => useUser());
 
@@ -70,7 +70,7 @@ describe('useUser', () => {
 
     mockUseSelector.mockReturnValueOnce(mockUser).mockReturnValueOnce(mockUserResource);
 
-    mockUseK8sGet.mockReturnValue([mockUserResource, true, null]);
+    mockUseK8sWatchResource.mockReturnValue([mockUserResource, true, null]);
 
     const { result } = renderHook(() => useUser());
 
@@ -84,7 +84,7 @@ describe('useUser', () => {
 
     mockUseSelector.mockReturnValueOnce(mockUser).mockReturnValueOnce(null); // No userResource in Redux yet
 
-    mockUseK8sGet.mockReturnValue([mockUserResource, true, null]);
+    mockUseK8sWatchResource.mockReturnValue([mockUserResource, true, null]);
 
     renderHook(() => useUser());
 
@@ -100,7 +100,7 @@ describe('useUser', () => {
 
     mockUseSelector.mockReturnValueOnce(mockUser).mockReturnValueOnce(mockUserResource);
 
-    mockUseK8sGet.mockReturnValue([mockUserResource, true, null]);
+    mockUseK8sWatchResource.mockReturnValue([mockUserResource, true, null]);
 
     const { result } = renderHook(() => useUser());
 
@@ -113,10 +113,56 @@ describe('useUser', () => {
 
     mockUseSelector.mockReturnValueOnce(mockUser).mockReturnValueOnce(mockUserResource);
 
-    mockUseK8sGet.mockReturnValue([mockUserResource, true, null]);
+    mockUseK8sWatchResource.mockReturnValue([mockUserResource, true, null]);
 
     const { result } = renderHook(() => useUser());
 
     expect(result.current.displayName).toBe('Test User'); // Should be trimmed
+  });
+
+  it('should use a static watch resource so useK8sWatchResource can deduplicate across instances', () => {
+    const mockUser = { username: 'user1' };
+
+    mockUseSelector.mockReturnValueOnce(mockUser).mockReturnValueOnce(null);
+    mockUseK8sWatchResource.mockReturnValue([null, false, null]);
+
+    renderHook(() => useUser());
+
+    const watchArg = mockUseK8sWatchResource.mock.calls[0][0];
+    expect(watchArg).toEqual({
+      groupVersionKind: {
+        group: 'user.openshift.io',
+        version: 'v1',
+        kind: 'User',
+      },
+      name: '~',
+    });
+
+    // Render a second instance and verify it receives the same object reference,
+    // which is required for useK8sWatchResource deduplication.
+    mockUseSelector.mockReturnValueOnce(mockUser).mockReturnValueOnce(null);
+    mockUseK8sWatchResource.mockReturnValue([null, false, null]);
+
+    renderHook(() => useUser());
+
+    const watchArg2 = mockUseK8sWatchResource.mock.calls[1][0];
+    expect(watchArg).toBe(watchArg2);
+  });
+
+  it('should update Redux when watch returns new data after impersonation change', () => {
+    const originalUser = { username: 'admin' };
+    const impersonatedUserResource = { fullName: 'Developer User' };
+
+    // Simulate: Redux has no cached user resource (cleared on impersonation change),
+    // and useK8sWatchResource returns the new impersonated user data.
+    mockUseSelector.mockReturnValueOnce(originalUser).mockReturnValueOnce(null);
+    mockUseK8sWatchResource.mockReturnValue([impersonatedUserResource, true, null]);
+
+    renderHook(() => useUser());
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'setUserResource',
+      payload: { userResource: impersonatedUserResource },
+    });
   });
 });

--- a/frontend/packages/console-shared/src/hooks/useUser.ts
+++ b/frontend/packages/console-shared/src/hooks/useUser.ts
@@ -1,11 +1,20 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getUser, getUserResource, setUserResource } from '@console/dynamic-plugin-sdk';
-import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { UserModel } from '@console/internal/models';
-import type { UserKind } from '@console/internal/module/k8s/types';
+import type { UserKind, WatchK8sResource } from '@console/internal/module/k8s/types';
 import { useConsoleDispatch } from '@console/shared/src/hooks/useConsoleDispatch';
 import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
+
+const userWatchResource: WatchK8sResource = {
+  groupVersionKind: {
+    group: UserModel.apiGroup,
+    version: UserModel.apiVersion,
+    kind: UserModel.kind,
+  },
+  name: '~',
+};
 
 /**
  * Custom hook that provides centralized user data fetching and management.
@@ -25,9 +34,8 @@ export const useUser = () => {
   const userResource = useConsoleSelector(getUserResource);
 
   // Fetch user resource from k8s API
-  const [userResourceData, userResourceLoaded, userResourceError] = useK8sGet<UserKind>(
-    UserModel,
-    '~',
+  const [userResourceData, userResourceLoaded, userResourceError] = useK8sWatchResource<UserKind>(
+    userWatchResource,
   );
 
   // Update Redux when user resource is loaded

--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/cloud-shell-utils.ts
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/cloud-shell-utils.ts
@@ -199,7 +199,7 @@ export const sendActivityTick = (workspaceName: string, namespace: string): void
   );
 };
 
-export const checkTerminalAvailable = () => coFetch('/api/terminal/available');
+export const checkTerminalAvailable = () => coFetch('/api/terminal/available', { priority: 'low' });
 
 export const getCloudShellCR = (workspaceModel: K8sKind, name: string, ns: string) => {
   return k8sGet(workspaceModel, name, ns);

--- a/frontend/public/actions/k8s.ts
+++ b/frontend/public/actions/k8s.ts
@@ -4,7 +4,7 @@ import { Dispatch } from 'redux';
 import { checkAccess } from '@console/internal/components/utils/rbac';
 
 import { cacheResources, getResources as getResources_ } from '../module/k8s/get-resources';
-import { fetchSwagger, CustomResourceDefinitionKind, K8sResourceKind } from '../module/k8s';
+import { CustomResourceDefinitionKind, K8sResourceKind } from '../module/k8s';
 import { makeReduxID } from '../components/utils/k8s-watcher';
 import { CustomResourceDefinitionModel } from '../models';
 import {
@@ -36,15 +36,7 @@ export const getResources = () => (dispatch: Dispatch) => {
       dispatch(receivedResources(resources));
     })
     // eslint-disable-next-line no-console
-    .catch((err) => console.error('Fetching resource failed:', err))
-    .finally(() => {
-      setTimeout(() => {
-        fetchSwagger().catch((e) => {
-          // eslint-disable-next-line no-console
-          console.error('Could not fetch OpenAPI yaml after fetching all resources.', e);
-        });
-      }, 10000);
-    });
+    .catch((err) => console.error('Fetching resource failed:', err));
 };
 
 export const startAPIDiscovery = () => (dispatch) => {

--- a/frontend/public/components/app.tsx
+++ b/frontend/public/components/app.tsx
@@ -86,7 +86,9 @@ root.render(<LoadingBox blame="Init" />);
 // Trigger an early authenticated fetch so unauthenticated users are redirected
 // to the login page immediately, before the app shell renders. coFetch's 401
 // interceptor calls authSvc.handle401() which handles the redirect.
-coFetch(`${window.SERVER_FLAGS.basePath}api/kubernetes/api`).catch(() => {});
+coFetch(`${window.SERVER_FLAGS.basePath}api/kubernetes/api`, {
+  priority: 'high',
+}).catch(() => {});
 
 // TODO: remove when upgrading to @xterm/xterm 7.0.0 - github.com/openshift/console/issues/16486
 delete process.title;

--- a/frontend/public/components/app.tsx
+++ b/frontend/public/components/app.tsx
@@ -41,7 +41,6 @@ import CloudShellDrawer from '@console/webterminal-plugin/src/components/cloud-s
 import {
   ContextProviderExtensionWrapper,
   DetectContext,
-  PageSkeleton,
 } from '@console/app/src/components/detect-context/DetectContext';
 import { FeatureFlagExtensionLoader } from '@console/app/src/components/flags/FeatureFlagExtensionLoader';
 import { useExtensions } from '@console/plugin-sdk/src/api/useExtensions';
@@ -88,7 +87,9 @@ root.render(<LoadingBox blame="Init" />);
 // interceptor calls authSvc.handle401() which handles the redirect.
 coFetch(`${window.SERVER_FLAGS.basePath}api/kubernetes/api`, {
   priority: 'high',
-}).catch(() => {});
+})
+  .then(() => document.documentElement.classList.remove('co-auth-pending'))
+  .catch(() => {});
 
 // TODO: remove when upgrading to @xterm/xterm 7.0.0 - github.com/openshift/console/issues/16486
 delete process.title;
@@ -100,7 +101,7 @@ initI18n();
 linkify.set({ fuzzyLink: false });
 
 const App: FC = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation('public');
   const location = useLocation();
   const params = useParams();
 
@@ -248,7 +249,7 @@ const App: FC = () => {
   };
 
   const content = (
-    <Suspense fallback={<PageSkeleton blame="AppContent" />}>
+    <Suspense fallback={<LoadingBox blame="AppContent" />}>
       <ConsoleNotifier location="BannerTop" />
       <QuickStartDrawer>
         <CloudShellDrawer>
@@ -278,7 +279,7 @@ const App: FC = () => {
               }
               skipToContent={
                 <SkipToContent href={`${location.pathname}${location.search}#content-scrollable`}>
-                  {t('public~Skip to content')}
+                  {t('Skip to content')}
                 </SkipToContent>
               }
               notificationDrawer={

--- a/frontend/public/components/cluster-settings/_cluster-settings.scss
+++ b/frontend/public/components/cluster-settings/_cluster-settings.scss
@@ -114,8 +114,8 @@ $co-channel-height: 60px;
 
 .co-channel-switch {
   background-color: $co-channel-color;
-  height: $co-channel-height;
   clip-path: polygon(0 0, 2px 0, 100% calc(100% - 2px), 100% 100%, calc(100% - 4px) 100%, 0 4px);
+  height: $co-channel-height;
   position: absolute;
   right: -4px;
   top: -28px;

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="no-js pf-v6-icon-set-rh-ui">
+<html lang="en" class="no-js pf-v6-icon-set-rh-ui co-auth-pending">
   <head>
     <base href="[[ .ServerFlags.BasePath ]]" />
     <meta charset="utf-8" />

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1756,6 +1756,8 @@
   "Select all <1>{{count}}</1> {{label}}.": "Select all <1>{{count}}</1> {{label}}.",
   "{{label}} table": "{{label}} table",
   "Filter by label": "Filter by label",
+  "Unable to connect to the server. This could be due to network or server issues.": "Unable to connect to the server. This could be due to network or server issues.",
+  "The console is taking longer than usual to load.": "The console is taking longer than usual to load.",
   "Selected group is unavailable": "Selected group is unavailable",
   "Enter at least one user": "Enter at least one user",
   "Error occurred": "Error occurred",

--- a/frontend/public/module/k8s/__tests__/swagger.spec.ts
+++ b/frontend/public/module/k8s/__tests__/swagger.spec.ts
@@ -63,6 +63,7 @@ describe('fetchSwagger', () => {
     expect(result).toEqual(mockDefinitions);
     expect(mockCoFetch).toHaveBeenCalledWith('api/kubernetes/openapi/v2', {
       headers: { Accept: 'application/json' },
+      priority: 'low',
     });
   });
 
@@ -76,7 +77,7 @@ describe('fetchSwagger', () => {
     expect(mockCoFetch).toHaveBeenCalledTimes(2);
     expect(mockCoFetch.mock.calls[1]).toEqual([
       'api/kubernetes/openapi/v2',
-      { headers: { Accept: 'application/json', 'If-None-Match': '"abc123"' } },
+      { headers: { Accept: 'application/json', 'If-None-Match': '"abc123"' }, priority: 'low' },
     ]);
   });
 
@@ -158,7 +159,7 @@ describe('fetchSwagger', () => {
 
     expect(mockCoFetch.mock.calls[1]).toEqual([
       'api/kubernetes/openapi/v2',
-      { headers: { Accept: 'application/json' } },
+      { headers: { Accept: 'application/json' }, priority: 'low' },
     ]);
   });
 });

--- a/frontend/public/module/k8s/swagger.ts
+++ b/frontend/public/module/k8s/swagger.ts
@@ -31,6 +31,7 @@ export const fetchSwagger = async (): Promise<SwaggerDefinitions> => {
         Accept: 'application/json',
         ...(cachedETag && { 'If-None-Match': cachedETag }),
       },
+      priority: 'low',
     });
     if (response.status === 304) {
       return swaggerDefinitions;

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -19,6 +19,39 @@ body,
   visibility: hidden;
 }
 
+.co-page-skeleton__auth-pending {
+  display: none;
+}
+
+.co-auth-pending {
+  .co-page-skeleton__auth-pending {
+    display: contents;
+  }
+
+  .co-page-skeleton__authenticated {
+    display: none;
+  }
+}
+
+@keyframes co-page-skeleton-fade-in {
+  to {
+    opacity: 1;
+  }
+}
+
+.co-page-skeleton__slow-msg {
+  animation: var(--pf-t--global--motion--duration--fade--long) ease-in 20s forwards
+    co-page-skeleton-fade-in;
+  left: 50%;
+  opacity: 0;
+  position: absolute;
+  transform: translateX(-50%);
+
+  @media (prefers-reduced-motion: reduce) {
+    animation-duration: 0s;
+  }
+}
+
 .co-p-has-sidebar {
   display: flex;
   flex: 1;


### PR DESCRIPTION
**Analysis / Root cause**:

Profiling startup network activity revealed that the `useUser` hook (which fetches `users/~` from the k8s API) uses `useK8sGet` — a hook with no cross-instance deduplication. Every component that calls `useUser()` (directly or via `useTelemetry()`) triggers an independent fetch. With ~10+ component instances mounting during startup, this produced **22 duplicate API calls** to the same endpoint.

Additionally, the 3 MB `openapi/v2` fetch and multiple `terminal/available` checks were competing with critical startup resources for bandwidth, with no fetch priority hints to let the browser schedule them appropriately.

**Solution description**:

1. **`useUser`**: Switch from `useK8sGet` to `useK8sWatchResource`, which deduplicates at the Redux/watch infrastructure level. All hook instances share a single underlying watch, reducing `users/~` calls from **22 to 1**. This also correctly handles impersonation changes since the watch infrastructure reconnects when auth context changes.

2. **Fetch Priority hints** ([Fetch Priority API](https://web.dev/articles/fetch-priority)):
   - `priority: 'high'` on the early auth check (`api/kubernetes/api`) so the browser prioritizes the authentication redirect check
   - `priority: 'low'` on `openapi/v2` (3 MB, used only for form field descriptions — not needed for initial render)
   - `priority: 'low'` on `terminal/available` checks (not render-critical)

3. **Remove duplicate `fetchSwagger`** call from `actions/k8s.ts` — `app.tsx` already handles the initial fetch and 5-minute polling, so the second call 10 seconds after discovery was redundant.

### Performance results

Tested under simulated Fast 3G (1.5 Mbps, 562ms RTT) + 4x CPU throttle, 5 runs each, browser cache cleared between runs. App-ready measured as time until `[data-test="page-heading"] h1` is visible.

| Metric | Before (main) | After (this PR) | Improvement |
|---|---|---|---|
| **App ready (median)** | 37.0s | 29.8s | **-7.1s (19% faster)** |
| **App ready (avg)** | 36.2s | 29.2s | **-7.0s (19% faster)** |
| **Total API calls** | 73 | 47 | **-26 calls (36% fewer)** |
| **Total resources loaded** | 134 | 107 | **-27 resources (20% fewer)** |
| **`users/~` calls** | 22 | 1 | **-21 calls** |
| **`terminal/available` calls** | 8 | 3 | **-5 calls** |
| **Total transfer** | 2,974 KB | 2,933 KB | -41 KB |

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**

Two console instances running against the same cluster:
- `:9000` — this PR (`OCPBUGS-86894-useuser` branch)
- `:9001` — HEAD of `main`

Both running over HTTP/1.1 with auth disabled, localhost bridge, same OCP 5.0 cluster.

Benchmarked with Playwright using Chrome DevTools Protocol for CPU/network throttling.

**Test cases:**
- Verified `users/~` is fetched exactly once during startup (was 22x)
- Verified `terminal/available` uses `priority: 'low'` and yields to critical resources
- Verified `openapi/v2` uses `priority: 'low'` and downloads after critical resources
- Verified impersonation still works correctly (useK8sWatchResource reconnects on auth change)
- Verified the app renders the same UI with all features functional
- Impersonation still works
- `yarn test` passes

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**

The `useK8sGet` hook creates a new `useState` + `useEffect` per instance with no shared state — every component that mounts independently fetches the same resource. `useK8sWatchResource` uses the console's watch infrastructure which deduplicates at the Redux store level, so multiple hook instances share a single underlying fetch/watch.

The Fetch Priority API (`priority: 'low'` / `'high'`) is supported in Chrome 101+, Edge 101+, and Safari 17.2+. Unsupported browsers silently ignore the hint with no behavioral change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Early auth API request is now prioritized; OpenAPI/Swagger fetches moved to low‑priority/background.

* **Updates**
  * User data now syncs via a watch-based mechanism for more timely updates.
  * Terminal availability checks use lower‑priority network requests.

* **UI / UX**
  * New auth‑pending skeleton, slow‑loading message with a refresh action, updated loading fallback, and two new English strings.
  
* **Tests**
  * Updated tests to reflect watch-based user loading and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->