### PR TITLE
OCPBUGS-85032,OCPBUGS-85002,OCPBUGS-84986: CVE-2026-42041 openshift4/ose-console: Axios: Authentication bypass due to prototype pollution of HTTP error handling [openshift-4.14.z]

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -163,7 +163,7 @@
     "apollo-client": "^2.6.8",
     "apollo-link-http": "^1.0.20",
     "apollo-link-ws": "^1.0.20",
-    "axios": "^0.31.0",
+    "axios": "0.31.1",
     "classnames": "2.x",
     "d3": "^5.16.0",
     "file-saver": "1.3.x",
@@ -359,7 +359,7 @@
     "@types/jest": "21.x",
     "glob-parent": "^5.1.2",
     "postcss": "^8.2.13",
-    "axios": "0.31.0"
+    "axios": "0.31.1"
   },
   "husky": {
     "hooks": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7184,14 +7184,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:0.31.0":
-  version: 0.31.0
-  resolution: "axios@npm:0.31.0"
+"axios@npm:0.31.1":
+  version: 0.31.1
+  resolution: "axios@npm:0.31.1"
   dependencies:
     follow-redirects: "npm:^1.15.4"
     form-data: "npm:^4.0.4"
     proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/772e7cb67c95d0f189fbead5e3fc5a26b5de467ae05c92196e3cdf56642e7586376fb91ff0355a91a07987bbdd3db1e1005feca2ae469a862c918dceca293ac5
+  checksum: 10c0/0193483f680a893955d203d26951fc427c407415d273bba5a2450e3d0ed7261a403eb5fe86f28a7e66c42d98597cbf8e17e3a6c324d294bd143a6a68bc10f8ef
   languageName: node
   linkType: hard
 
@@ -20829,7 +20829,7 @@ __metadata:
     apollo-client: "npm:^2.6.8"
     apollo-link-http: "npm:^1.0.20"
     apollo-link-ws: "npm:^1.0.20"
-    axios: "npm:^0.31.0"
+    axios: "npm:0.31.1"
     babel-loader: "npm:^8.2.1"
     browser-env: "npm:3.x"
     cache-loader: "npm:^4.1.0"


### PR DESCRIPTION
…cation bypass due to prototype pollution of HTTP error handling [openshift-4.14.z]

CVE-2026-42041 is a Prototype Pollution vulnerability in axios that allows authentication bypass via prototype pollution of the validateStatus config property. When Object.prototype.validateStatus is polluted with () => true, all HTTP error responses (401, 403, 500) are silently treated as successful, completely bypassing application authentication and error handling.

Changes:
- Updated axios from 0.31.0 to 0.31.1 in dependencies
- Updated axios from 0.31.0 to 0.31.1 in resolutions
- Updated yarn.lock to lock axios@npm:0.31.1

Verification:
- yarn lint: ✅ Passed (5 pre-existing warnings, none related to axios)
- yarn test: ✅ Passed (all test suites passed, exit code 0)
- yarn build: ✅ Passed (all assets generated successfully, exit code 0)

The axios 0.31.1 release fixes this vulnerability in the 0.x branch. No breaking changes or test failures introduced by this update.

Related: OCPBUGS-85032

