### PR TITLE
CONSOLE-5309: Refactor Node Details static tables to PatternFly React Table

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeDetailsConditions.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeDetailsConditions.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { CamelCaseWrap } from '@console/dynamic-plugin-sdk';
@@ -17,36 +18,36 @@ const NodeDetailsConditions: FC<NodeDetailsConditionsProps> = ({ node }) => {
     <PaneBody>
       <SectionHeading text={t('console-app~Node conditions')} />
       <div className="co-table-container">
-        <table className="pf-v6-c-table pf-m-compact pf-m-border-rows">
-          <thead className="pf-v6-c-table__thead">
-            <tr className="pf-v6-c-table__tr">
-              <th className="pf-v6-c-table__th">{t('console-app~Type')}</th>
-              <th className="pf-v6-c-table__th">{t('console-app~Status')}</th>
-              <th className="pf-v6-c-table__th">{t('console-app~Reason')}</th>
-              <th className="pf-v6-c-table__th">{t('console-app~Updated')}</th>
-              <th className="pf-v6-c-table__th">{t('console-app~Changed')}</th>
-            </tr>
-          </thead>
-          <tbody className="pf-v6-c-table__tbody">
+        <Table variant="compact" borders gridBreakPoint="">
+          <Thead>
+            <Tr>
+              <Th>{t('console-app~Type')}</Th>
+              <Th>{t('console-app~Status')}</Th>
+              <Th>{t('console-app~Reason')}</Th>
+              <Th>{t('console-app~Updated')}</Th>
+              <Th>{t('console-app~Changed')}</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
             {_.map(node.status.conditions, (c, i) => (
-              <tr className="pf-v6-c-table__tr" key={i}>
-                <td className="pf-v6-c-table__td">
+              <Tr key={i}>
+                <Td>
                   <CamelCaseWrap value={c.type} />
-                </td>
-                <td className="pf-v6-c-table__td">{c.status || '-'}</td>
-                <td className="pf-v6-c-table__td">
+                </Td>
+                <Td>{c.status || '-'}</Td>
+                <Td>
                   <CamelCaseWrap value={c.reason} />
-                </td>
-                <td className="pf-v6-c-table__td">
+                </Td>
+                <Td>
                   <Timestamp timestamp={c.lastHeartbeatTime} />
-                </td>
-                <td className="pf-v6-c-table__td">
+                </Td>
+                <Td>
                   <Timestamp timestamp={c.lastTransitionTime} />
-                </td>
-              </tr>
+                </Td>
+              </Tr>
             ))}
-          </tbody>
-        </table>
+          </Tbody>
+        </Table>
       </div>
     </PaneBody>
   );

--- a/frontend/packages/console-app/src/components/nodes/NodeDetailsConditions.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeDetailsConditions.tsx
@@ -18,7 +18,7 @@ const NodeDetailsConditions: FC<NodeDetailsConditionsProps> = ({ node }) => {
     <PaneBody>
       <SectionHeading text={t('console-app~Node conditions')} />
       <div className="co-table-container">
-        <Table variant="compact" borders gridBreakPoint="">
+        <Table variant="compact" gridBreakPoint="">
           <Thead>
             <Tr>
               <Th>{t('console-app~Type')}</Th>
@@ -31,17 +31,17 @@ const NodeDetailsConditions: FC<NodeDetailsConditionsProps> = ({ node }) => {
           <Tbody>
             {_.map(node.status.conditions, (c, i) => (
               <Tr key={i}>
-                <Td>
+                <Td dataLabel={t('console-app~Type')}>
                   <CamelCaseWrap value={c.type} />
                 </Td>
-                <Td>{c.status || '-'}</Td>
-                <Td>
+                <Td dataLabel={t('console-app~Status')}>{c.status || '-'}</Td>
+                <Td dataLabel={t('console-app~Reason')}>
                   <CamelCaseWrap value={c.reason} />
                 </Td>
-                <Td>
+                <Td dataLabel={t('console-app~Updated')}>
                   <Timestamp timestamp={c.lastHeartbeatTime} />
                 </Td>
-                <Td>
+                <Td dataLabel={t('console-app~Changed')}>
                   <Timestamp timestamp={c.lastTransitionTime} />
                 </Td>
               </Tr>

--- a/frontend/packages/console-app/src/components/nodes/NodeDetailsGpuMetrics.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeDetailsGpuMetrics.tsx
@@ -248,7 +248,6 @@ const NodeDetailsGpuMetrics: FC<NodeDetailsGpuMetricsProps> = ({ node }) => {
         <div className="co-table-container pf-v6-u-mt-md">
           <Table
             variant="compact"
-            borders
             gridBreakPoint=""
             aria-label={t('console-app~Per-device GPU metrics')}
           >
@@ -265,12 +264,12 @@ const NodeDetailsGpuMetrics: FC<NodeDetailsGpuMetricsProps> = ({ node }) => {
             <Tbody>
               {rows.map((row) => (
                 <Tr key={row.id}>
-                  <Td>{row.label}</Td>
-                  <Td>{row.utilization}</Td>
-                  <Td>{row.temperature}</Td>
-                  <Td>{row.power}</Td>
-                  <Td>{row.fbUsed}</Td>
-                  <Td>{row.fbFree}</Td>
+                  <Td dataLabel={t('console-app~GPU device')}>{row.label}</Td>
+                  <Td dataLabel={t('console-app~Utilization')}>{row.utilization}</Td>
+                  <Td dataLabel={t('console-app~Temperature')}>{row.temperature}</Td>
+                  <Td dataLabel={t('console-app~Power usage')}>{row.power}</Td>
+                  <Td dataLabel={t('console-app~Framebuffer memory used')}>{row.fbUsed}</Td>
+                  <Td dataLabel={t('console-app~Framebuffer memory free')}>{row.fbFree}</Td>
                 </Tr>
               ))}
             </Tbody>

--- a/frontend/packages/console-app/src/components/nodes/NodeDetailsGpuMetrics.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeDetailsGpuMetrics.tsx
@@ -10,6 +10,7 @@ import {
   GridItem,
   Spinner,
 } from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 import type { PrometheusResponse, PrometheusResult } from '@console/internal/components/graphs';
 import { PrometheusEndpoint } from '@console/internal/components/graphs/helpers';
@@ -245,33 +246,35 @@ const NodeDetailsGpuMetrics: FC<NodeDetailsGpuMetricsProps> = ({ node }) => {
 
       {!isLoading && hasMetrics && (
         <div className="co-table-container pf-v6-u-mt-md">
-          <table
-            className="pf-v6-c-table pf-m-compact pf-m-border-rows"
+          <Table
+            variant="compact"
+            borders
+            gridBreakPoint=""
             aria-label={t('console-app~Per-device GPU metrics')}
           >
-            <thead className="pf-v6-c-table__thead">
-              <tr className="pf-v6-c-table__tr">
-                <th className="pf-v6-c-table__th">{t('console-app~GPU device')}</th>
-                <th className="pf-v6-c-table__th">{t('console-app~Utilization')}</th>
-                <th className="pf-v6-c-table__th">{t('console-app~Temperature')}</th>
-                <th className="pf-v6-c-table__th">{t('console-app~Power usage')}</th>
-                <th className="pf-v6-c-table__th">{t('console-app~Framebuffer memory used')}</th>
-                <th className="pf-v6-c-table__th">{t('console-app~Framebuffer memory free')}</th>
-              </tr>
-            </thead>
-            <tbody className="pf-v6-c-table__tbody">
+            <Thead>
+              <Tr>
+                <Th>{t('console-app~GPU device')}</Th>
+                <Th>{t('console-app~Utilization')}</Th>
+                <Th>{t('console-app~Temperature')}</Th>
+                <Th>{t('console-app~Power usage')}</Th>
+                <Th>{t('console-app~Framebuffer memory used')}</Th>
+                <Th>{t('console-app~Framebuffer memory free')}</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
               {rows.map((row) => (
-                <tr className="pf-v6-c-table__tr" key={row.id}>
-                  <td className="pf-v6-c-table__td">{row.label}</td>
-                  <td className="pf-v6-c-table__td">{row.utilization}</td>
-                  <td className="pf-v6-c-table__td">{row.temperature}</td>
-                  <td className="pf-v6-c-table__td">{row.power}</td>
-                  <td className="pf-v6-c-table__td">{row.fbUsed}</td>
-                  <td className="pf-v6-c-table__td">{row.fbFree}</td>
-                </tr>
+                <Tr key={row.id}>
+                  <Td>{row.label}</Td>
+                  <Td>{row.utilization}</Td>
+                  <Td>{row.temperature}</Td>
+                  <Td>{row.power}</Td>
+                  <Td>{row.fbUsed}</Td>
+                  <Td>{row.fbFree}</Td>
+                </Tr>
               ))}
-            </tbody>
-          </table>
+            </Tbody>
+          </Table>
         </div>
       )}
 

--- a/frontend/packages/console-app/src/components/nodes/NodeDetailsImages.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeDetailsImages.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { SectionHeading } from '@console/internal/components/utils/headings';
@@ -17,28 +18,26 @@ const NodeDetailsImages: FC<NodeDetailsImagesProps> = ({ node }) => {
     <PaneBody>
       <SectionHeading text={t('console-app~Images')} />
       <div className="co-table-container">
-        <table className="pf-v6-c-table pf-m-compact pf-m-border-rows">
-          <thead className="pf-v6-c-table__thead">
-            <tr className="pf-v6-c-table__tr">
-              <th className="pf-v6-c-table__th">{t('console-app~Name')}</th>
-              <th className="pf-v6-c-table__th">{t('console-app~Size')}</th>
-            </tr>
-          </thead>
-          <tbody className="pf-v6-c-table__tbody">
+        <Table variant="compact" borders gridBreakPoint="">
+          <Thead>
+            <Tr>
+              <Th>{t('console-app~Name')}</Th>
+              <Th>{t('console-app~Size')}</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
             {_.map(images, (image, i) => (
-              <tr className="pf-v6-c-table__tr" key={i}>
-                <td className="pf-v6-c-table__td pf-m-break-word co-select-to-copy">
+              <Tr key={i}>
+                <Td className="pf-m-break-word co-select-to-copy">
                   {image.names.find(
                     (name: string) => !name.includes('@') && !name.includes('<none>'),
                   ) || image.names[0]}
-                </td>
-                <td className="pf-v6-c-table__td">
-                  {humanizeBinaryBytes(image.sizeBytes).string || '-'}
-                </td>
-              </tr>
+                </Td>
+                <Td>{humanizeBinaryBytes(image.sizeBytes).string || '-'}</Td>
+              </Tr>
             ))}
-          </tbody>
-        </table>
+          </Tbody>
+        </Table>
       </div>
     </PaneBody>
   );

--- a/frontend/packages/console-app/src/components/nodes/NodeDetailsImages.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeDetailsImages.tsx
@@ -18,7 +18,7 @@ const NodeDetailsImages: FC<NodeDetailsImagesProps> = ({ node }) => {
     <PaneBody>
       <SectionHeading text={t('console-app~Images')} />
       <div className="co-table-container">
-        <Table variant="compact" borders gridBreakPoint="">
+        <Table variant="compact" gridBreakPoint="">
           <Thead>
             <Tr>
               <Th>{t('console-app~Name')}</Th>
@@ -28,12 +28,18 @@ const NodeDetailsImages: FC<NodeDetailsImagesProps> = ({ node }) => {
           <Tbody>
             {_.map(images, (image, i) => (
               <Tr key={i}>
-                <Td className="pf-m-break-word co-select-to-copy">
+                <Td
+                  dataLabel={t('console-app~Name')}
+                  modifier="breakWord"
+                  className="co-select-to-copy"
+                >
                   {image.names.find(
                     (name: string) => !name.includes('@') && !name.includes('<none>'),
                   ) || image.names[0]}
                 </Td>
-                <Td>{humanizeBinaryBytes(image.sizeBytes).string || '-'}</Td>
+                <Td dataLabel={t('console-app~Size')}>
+                  {humanizeBinaryBytes(image.sizeBytes).string || '-'}
+                </Td>
               </Tr>
             ))}
           </Tbody>

--- a/frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsConditions.spec.tsx
+++ b/frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsConditions.spec.tsx
@@ -40,6 +40,50 @@ describe('NodeDetailsConditions', () => {
     expect(screen.getByText('Node conditions')).toBeVisible();
   });
 
+  it('should render a PatternFly table with five column headers', () => {
+    const node = createMockNode([
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'KubeletReady',
+        lastHeartbeatTime: '2024-01-15T10:00:00Z',
+        lastTransitionTime: '2024-01-15T10:00:00Z',
+      },
+    ]);
+    render(<NodeDetailsConditions node={node} />);
+
+    const columnHeaders = screen.getAllByRole('columnheader');
+    expect(columnHeaders).toHaveLength(5);
+    expect(screen.getByRole('columnheader', { name: 'Type' })).toBeVisible();
+    expect(screen.getByRole('columnheader', { name: 'Status' })).toBeVisible();
+    expect(screen.getByRole('columnheader', { name: 'Reason' })).toBeVisible();
+    expect(screen.getByRole('columnheader', { name: 'Updated' })).toBeVisible();
+    expect(screen.getByRole('columnheader', { name: 'Changed' })).toBeVisible();
+  });
+
+  it('should render the correct number of rows for conditions', () => {
+    const node = createMockNode([
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'KubeletReady',
+        lastHeartbeatTime: '2024-01-15T10:00:00Z',
+        lastTransitionTime: '2024-01-15T10:00:00Z',
+      },
+      {
+        type: 'MemoryPressure',
+        status: 'False',
+        reason: 'KubeletHasSufficientMemory',
+        lastHeartbeatTime: '2024-01-15T09:00:00Z',
+        lastTransitionTime: '2024-01-15T09:00:00Z',
+      },
+    ]);
+    render(<NodeDetailsConditions node={node} />);
+
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(3);
+  });
+
   it('should render condition type', () => {
     const node = createMockNode([
       {

--- a/frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsConditions.spec.tsx
+++ b/frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsConditions.spec.tsx
@@ -40,7 +40,7 @@ describe('NodeDetailsConditions', () => {
     expect(screen.getByText('Node conditions')).toBeVisible();
   });
 
-  it('should render a PatternFly table with five column headers', () => {
+  it('should render a table with five column headers', () => {
     const node = createMockNode([
       {
         type: 'Ready',

--- a/frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsGpuMetrics.spec.tsx
+++ b/frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsGpuMetrics.spec.tsx
@@ -148,6 +148,43 @@ describe('NodeDetailsGpuMetrics', () => {
     expect(screen.getAllByText('8.0 GiB')).toHaveLength(2);
   });
 
+  it('renders a PatternFly table with six column headers and correct row count', () => {
+    const countResp = makeScalarResponse('2');
+    const utilResp = makeResponse([
+      { gpu: '0', value: '45', modelName: 'Tesla T4' },
+      { gpu: '1', value: '78', modelName: 'Tesla T4' },
+    ]);
+
+    mockUsePrometheusPoll
+      .mockReturnValueOnce([countResp, null, false])
+      .mockReturnValueOnce([utilResp, null, false])
+      .mockReturnValueOnce([emptyResponse, null, false])
+      .mockReturnValueOnce([emptyResponse, null, false])
+      .mockReturnValueOnce([emptyResponse, null, false])
+      .mockReturnValueOnce([emptyResponse, null, false]);
+
+    render(<NodeDetailsGpuMetrics node={baseNode} />);
+
+    const table = screen.getByRole('grid', { name: 'Per-device GPU metrics' });
+    expect(table).toBeInTheDocument();
+
+    const columnHeaders = screen.getAllByRole('columnheader');
+    expect(columnHeaders).toHaveLength(6);
+    expect(screen.getByRole('columnheader', { name: 'GPU device' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Utilization' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Temperature' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Power usage' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Framebuffer memory used' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Framebuffer memory free' }),
+    ).toBeInTheDocument();
+
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(3);
+  });
+
   it('shows the not-available message when node has capacity but no metric data', () => {
     mockUsePrometheusPoll.mockReturnValue([emptyResponse, null, false]);
     render(<NodeDetailsGpuMetrics node={baseNode} />);

--- a/frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsGpuMetrics.spec.tsx
+++ b/frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsGpuMetrics.spec.tsx
@@ -148,7 +148,7 @@ describe('NodeDetailsGpuMetrics', () => {
     expect(screen.getAllByText('8.0 GiB')).toHaveLength(2);
   });
 
-  it('renders a PatternFly table with six column headers and correct row count', () => {
+  it('renders a table with six column headers and correct row count', () => {
     const countResp = makeScalarResponse('2');
     const utilResp = makeResponse([
       { gpu: '0', value: '45', modelName: 'Tesla T4' },

--- a/frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsImages.spec.tsx
+++ b/frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsImages.spec.tsx
@@ -31,10 +31,13 @@ describe('NodeDetailsImages', () => {
     expect(screen.getByText('Images')).toBeVisible();
   });
 
-  it('should render table headers', () => {
+  it('should render a PatternFly table with correct column headers', () => {
     const node = createMockNode([]);
     render(<NodeDetailsImages node={node} />);
 
+    expect(screen.getByRole('grid')).toBeVisible();
+    const columnHeaders = screen.getAllByRole('columnheader');
+    expect(columnHeaders).toHaveLength(2);
     expect(screen.getByRole('columnheader', { name: 'Name' })).toBeVisible();
     expect(screen.getByRole('columnheader', { name: 'Size' })).toBeVisible();
   });

--- a/frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsImages.spec.tsx
+++ b/frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsImages.spec.tsx
@@ -31,7 +31,7 @@ describe('NodeDetailsImages', () => {
     expect(screen.getByText('Images')).toBeVisible();
   });
 
-  it('should render a PatternFly table with correct column headers', () => {
+  it('should render a table with correct column headers', () => {
     const node = createMockNode([]);
     render(<NodeDetailsImages node={node} />);
 


### PR DESCRIPTION
## Summary

- Refactors three Node Details static tables (Conditions, Images, GPU Metrics) from native HTML `<table>` elements with PatternFly v6 CSS classes to PatternFly React Table components (`Table`, `Thead`, `Tbody`, `Tr`, `Th`, `Td`)
- Uses `variant="compact"` and `borders` props for equivalent styling; no visual or behavioral changes
- Adds structural table assertions to unit tests to guard against regressions

## JIRA

[CONSOLE-5309](https://redhat.atlassian.net/browse/CONSOLE-5309)

## Changes

| File | Change |
| --- | --- |
| frontend/.../NodeDetailsConditions.tsx | Replace native `<table>` with PF React Table (`Table`, `Thead`, `Tbody`, `Tr`, `Th`, `Td`); `variant="compact"`, `borders` |
| frontend/.../NodeDetailsImages.tsx | Same PF React Table migration; retain `pf-m-break-word co-select-to-copy` on image name cells |
| frontend/.../NodeDetailsGpuMetrics.tsx | Same PF React Table migration; retain `aria-label` for accessibility |
| frontend/.../__tests__/NodeDetailsConditions.spec.tsx | Add structural assertions: 5 column headers, row count matches conditions |
| frontend/.../__tests__/NodeDetailsImages.spec.tsx | Add `grid` role assertion and 2-column header validation |
| frontend/.../__tests__/NodeDetailsGpuMetrics.spec.tsx | Add GPU table structure assertions: `grid` role with aria-label, 6 column headers, row count |

## Screenshots / Recordings

_To be added by author_

## Test plan

- [ ] Unit tests pass: `yarn test frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsConditions.spec.tsx`
- [ ] Unit tests pass: `yarn test frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsImages.spec.tsx`
- [ ] Unit tests pass: `yarn test frontend/packages/console-app/src/components/nodes/__tests__/NodeDetailsGpuMetrics.spec.tsx`
- [ ] ESLint passes for all changed files
- [ ] Manual verification: Node conditions table renders identically on OCP cluster
- [ ] Manual verification: Images table renders identically on OCP cluster
- [ ] Manual verification: GPU metrics table renders on GPU-enabled nodes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated node detail tables (conditions, per-device GPU metrics, container images) to PatternFly table components for consistent styling, responsive labeling, and improved accessibility while preserving displayed data.

* **Tests**
  * Added and updated unit tests to validate table structure, accessible roles/labels, column headers, and row counts for the updated views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->