### PR TITLE
OCPBUGS-85030: CVE-2026-42041 openshift4/ose-console: Axios: Authenti…

### DIFF
--- a/frontend/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch
+++ b/frontend/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch
@@ -1,0 +1,18 @@
+diff --git a/index.d.ts b/index.d.ts
+index 34bc02adf15581be666543f0d77fa845c04d25f9..5e7fb8eb8dcb902fd554428cd6aa533e5dc57db7 100644
+--- a/index.d.ts
++++ b/index.d.ts
+@@ -3,8 +3,12 @@ type HeaderValue = string | string[] | number | boolean;
+ 
+ type AxiosHeaders = Record<string, HeaderValue | Record<Method & CommonHeaders, HeaderValue>>;
+ 
++type LowercaseMethod =
++  | 'get' | 'delete' | 'head' | 'options' | 'post'
++  | 'put' | 'patch' | 'purge' | 'link' | 'unlink';
++
+ type MethodsHeaders = {
+-  [Key in Method as Lowercase<Key>]: AxiosHeaders;
++  [Key in LowercaseMethod]?: AxiosHeaders;
+ };
+ 
+ interface CommonHeaders  {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -159,7 +159,7 @@
     "apollo-client": "^2.6.8",
     "apollo-link-http": "^1.0.20",
     "apollo-link-ws": "^1.0.20",
-    "axios": "^0.21.2",
+    "axios": "patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch",
     "classnames": "2.x",
     "d3": "^5.16.0",
     "file-saver": "1.3.x",
@@ -353,6 +353,7 @@
     "@types/jest": "21.x",
     "glob-parent": "^5.1.2",
     "postcss": "^8.2.13",
+    "axios@npm:^0.21.1": "patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch",
     "immutable": "3.8.3"
   },
   "husky": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6987,12 +6987,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.21.1, axios@npm:^0.21.2":
-  version: 0.21.4
-  resolution: "axios@npm:0.21.4"
+"axios@npm:0.31.1":
+  version: 0.31.1
+  resolution: "axios@npm:0.31.1"
   dependencies:
-    follow-redirects: "npm:^1.14.0"
-  checksum: 10c0/fbcff55ec68f71f02d3773d467db2fcecdf04e749826c82c2427a232f9eba63242150a05f15af9ef15818352b814257541155de0281f8fb2b7e8a5b79f7f2142
+    follow-redirects: "npm:^1.15.4"
+    form-data: "npm:^4.0.4"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/0193483f680a893955d203d26951fc427c407415d273bba5a2450e3d0ed7261a403eb5fe86f28a7e66c42d98597cbf8e17e3a6c324d294bd143a6a68bc10f8ef
+  languageName: node
+  linkType: hard
+
+"axios@patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch":
+  version: 0.31.1
+  resolution: "axios@patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch::version=0.31.1&hash=21a978"
+  dependencies:
+    follow-redirects: "npm:^1.15.4"
+    form-data: "npm:^4.0.4"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/b148742c668c3cbc44c7a65e6aa5214efac23bff529f2f54d4c6c4fa917ea2fbed37ed915165fa3e1d011d94ebe6c1b7263610c28bb1af0de51ce8ad5188dd61
   languageName: node
   linkType: hard
 
@@ -8964,7 +8977,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.6, combined-stream@npm:~1.0.5, combined-stream@npm:~1.0.6":
+"combined-stream@npm:^1.0.6, combined-stream@npm:^1.0.8, combined-stream@npm:~1.0.5, combined-stream@npm:~1.0.6":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
   dependencies:
@@ -11751,6 +11764,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-set-tostringtag@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "es-set-tostringtag@npm:2.1.0"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.6"
+    has-tostringtag: "npm:^1.0.2"
+    hasown: "npm:^2.0.2"
+  checksum: 10c0/ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
+  languageName: node
+  linkType: hard
+
 "es-to-primitive@npm:^1.1.1, es-to-primitive@npm:^1.2.0":
   version: 1.2.0
   resolution: "es-to-primitive@npm:1.2.0"
@@ -13253,13 +13278,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.0":
-  version: 1.14.3
-  resolution: "follow-redirects@npm:1.14.3"
+"follow-redirects@npm:^1.15.4":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/02c94952aa0ce0b0d4fd45cb7af4cce5df37158a1757f9528f9488c3a2ed89b7d630764ba1e09918b98b5d9affbc3e06abc4fce90fb5608a79b10a9a81926e6c
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 
@@ -13318,6 +13343,19 @@ __metadata:
     combined-stream: "npm:^1.0.6"
     mime-types: "npm:^2.1.12"
   checksum: 10c0/7e8fb913b84a7ac04074781a18d0f94735bbe82815ff35348803331f6480956ff0035db5bcf15826edee09fe01e665cfac664678f1526646a6374ee13f960e56
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.4":
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10c0/43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
   languageName: node
   linkType: hard
 
@@ -13678,7 +13716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.3.0":
+"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.3.0":
   version: 1.3.1
   resolution: "get-intrinsic@npm:1.3.1"
   dependencies:
@@ -14645,6 +14683,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
   languageName: node
   linkType: hard
 
@@ -18787,6 +18834,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:1.52.0":
+  version: 1.52.0
+  resolution: "mime-db@npm:1.52.0"
+  checksum: 10c0/0557a01deebf45ac5f5777fe7740b2a5c309c6d62d40ceab4e23da9f821899ce7a900b7ac8157d4548ddbb7beffe9abc621250e6d182b0397ec7f10c7b91a5aa
+  languageName: node
+  linkType: hard
+
 "mime-db@npm:~1.37.0":
   version: 1.37.0
   resolution: "mime-db@npm:1.37.0"
@@ -18809,6 +18863,15 @@ __metadata:
   dependencies:
     mime-db: "npm:1.49.0"
   checksum: 10c0/26e48e64c91ea9554b851cfc62f6147bb1decfd077cc340c0c2cfefc39d88db9d99876fa7065c577e2225a624d087a09a9d9523e6a00dfe62b6bc96225862082
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^2.1.35":
+  version: 2.1.35
+  resolution: "mime-types@npm:2.1.35"
+  dependencies:
+    mime-db: "npm:1.52.0"
+  checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
   languageName: node
   linkType: hard
 
@@ -20198,7 +20261,7 @@ __metadata:
     apollo-client: "npm:^2.6.8"
     apollo-link-http: "npm:^1.0.20"
     apollo-link-ws: "npm:^1.0.20"
-    axios: "npm:^0.21.2"
+    axios: "patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch"
     babel-loader: "npm:^8.2.1"
     browser-env: "npm:3.x"
     cache-loader: "npm:^4.1.0"


### PR DESCRIPTION
…cation bypass due to prototype pollution of HTTP error handling [openshift-4.12.z]

CVE-2026-42041 is a Prototype Pollution vulnerability in axios that allows authentication bypass via prototype pollution of the validateStatus config property. When Object.prototype.validateStatus is polluted with () => true, all HTTP error responses (401, 403, 500) are silently treated as successful, completely bypassing application authentication and error handling.

Changes:
- Updated axios from 0.21.4 to 0.31.1 in dependencies
- Added axios resolution to ^0.31.1 in resolutions
- Updated yarn.lock to lock axios@npm:0.31.1

Verification:
- yarn lint: ✅ Passed (154 pre-existing warnings, none related to axios)
- yarn test: ✅ Passed (1 pre-existing test failure in environment.spec.tsx unrelated to axios)
- yarn build: ✅ Passed (all assets generated successfully, exit code 0)

The axios 0.31.1 release fixes this vulnerability in the 0.x branch. No breaking changes or axios-related test failures introduced by this update.

Related: OCPBUGS-85030
