### PR TITLE
OCPBUGS-87100: fix trailing quote in prometheus query

### DIFF
--- a/frontend/packages/console-app/src/queries.ts
+++ b/frontend/packages/console-app/src/queries.ts
@@ -12,7 +12,7 @@ import { PodModel } from '@console/internal/models';
 // to rely on the number of kube-apiserver pods instead of the number of
 // Prometheus targets it has.
 export const API_SERVERS_UP =
-  '(sum(up{job="apiserver",namespace="default"} == 1) / count(kube_pod_labels{label_app="openshift-kube-apiserver",label_apiserver="true",namespace="openshift-kube-apiserver"})) * 100"';
+  '(sum(up{job="apiserver",namespace="default"} == 1) / count(kube_pod_labels{label_app="openshift-kube-apiserver",label_apiserver="true",namespace="openshift-kube-apiserver"})) * 100';
 export const CONTROLLER_MANAGERS_UP =
   '(sum(up{job="kube-controller-manager",namespace="openshift-kube-controller-manager"} == 1) / count(up{job="kube-controller-manager",namespace="openshift-kube-controller-manager"})) * 100';
 export const SCHEDULERS_UP =


### PR DESCRIPTION
<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

JIra Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-87100

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

Per several reports after upgrading cluster to 4.20.23 the dashboard "Control Plane" icon is never appearing green. That might be indicating an issue. 

Per one of the reports there was HTTP 400 captured in the browsernetwork log
<img width="468" height="56" alt="Screenshot 2026-06-04 at 16 16 41" src="https://github.com/user-attachments/assets/1c76c037-f03e-43dc-a6c2-2b67fccb36f0" />

A previous change introduces a trailing `"` quote probably by accident. 
https://github.com/openshift/console/pull/16308/changes#diff-6535e1527287e98a5b1682350eb702d6fa24be9bc798a1b18745a93853883375R15


**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

Fix the `"` to expected `'`.



**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->
<img width="708" height="183" alt="Screenshot 2026-06-04 at 16 14 50" src="https://github.com/user-attachments/assets/d4cbca4c-0467-455a-96c8-28d4b78da60b" />

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Test cases:**
<!-- List possible test cases to validate the changes. -->

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->
