### PR TITLE
OCPBUGS-81749: Add SSAR checks to gate OLM actions

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/actions/__tests__/useOperatorActions.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/actions/__tests__/useOperatorActions.spec.ts
@@ -1,0 +1,101 @@
+import { renderHook } from '@testing-library/react';
+import { K8S_VERB_DELETE, K8S_VERB_UPDATE } from '@console/dynamic-plugin-sdk/src/api/constants';
+import { asAccessReview } from '@console/internal/components/utils/rbac';
+import { ClusterServiceVersionModel, SubscriptionModel } from '../../models';
+import useOperatorActions from '../useOperatorActions';
+
+jest.mock('@console/dynamic-plugin-sdk/src/lib-core', () => ({
+  useOverlay: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../../components/modals/uninstall-operator-modal', () => ({
+  useUninstallOperatorModal: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('@console/internal/components/utils/rbac', () => ({
+  asAccessReview: jest.fn((model, resource, verb) => ({
+    group: model.apiGroup,
+    resource: model.plural,
+    verb,
+    namespace: resource?.metadata?.namespace,
+    name: resource?.metadata?.name,
+  })),
+}));
+
+const mockCSV = {
+  apiVersion: 'operators.coreos.com/v1alpha1',
+  kind: 'ClusterServiceVersion',
+  metadata: {
+    name: 'test-csv',
+    namespace: 'test-namespace',
+  },
+};
+
+const mockSubscription = {
+  apiVersion: 'operators.coreos.com/v1alpha1',
+  kind: 'Subscription',
+  metadata: {
+    name: 'test-subscription',
+    namespace: 'test-namespace',
+  },
+  spec: {
+    name: 'test-operator',
+  },
+};
+
+describe('useOperatorActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should include accessReview for Edit Subscription action with UPDATE verb', () => {
+    const { result } = renderHook(() =>
+      useOperatorActions({ resource: mockCSV, subscription: mockSubscription }),
+    );
+
+    const [actions] = result.current;
+    const editAction = actions.find((action) => action.id === 'edit-subscription');
+
+    expect(editAction).toBeDefined();
+    expect(editAction?.accessReview).toBeDefined();
+    expect(asAccessReview).toHaveBeenCalledWith(
+      SubscriptionModel,
+      mockSubscription,
+      K8S_VERB_UPDATE,
+    );
+  });
+
+  it('should include accessReview for Uninstall Operator action with DELETE verb', () => {
+    const { result } = renderHook(() =>
+      useOperatorActions({ resource: mockCSV, subscription: mockSubscription }),
+    );
+
+    const [actions] = result.current;
+    const uninstallAction = actions.find((action) => action.id === 'uninstall-operator');
+
+    expect(uninstallAction).toBeDefined();
+    expect(uninstallAction?.accessReview).toBeDefined();
+    expect(asAccessReview).toHaveBeenCalledWith(
+      SubscriptionModel,
+      mockSubscription,
+      K8S_VERB_DELETE,
+    );
+  });
+
+  it('should return Delete CSV action when subscription is empty', () => {
+    const { result } = renderHook(() =>
+      useOperatorActions({ resource: mockCSV, subscription: {} }),
+    );
+
+    const [actions] = result.current;
+    const deleteAction = actions.find((action) => action.id === 'delete-csv');
+
+    expect(deleteAction).toBeDefined();
+    expect(deleteAction?.accessReview).toBeDefined();
+    expect(asAccessReview).toHaveBeenCalledWith(
+      ClusterServiceVersionModel,
+      mockCSV,
+      K8S_VERB_DELETE,
+    );
+  });
+});

--- a/frontend/packages/operator-lifecycle-manager/src/actions/hooks/__tests__/useSubscriptionActions.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/actions/hooks/__tests__/useSubscriptionActions.spec.ts
@@ -1,0 +1,91 @@
+import { renderHook } from '@testing-library/react';
+import { asAccessReview } from '@console/internal/components/utils';
+import { ClusterServiceVersionModel } from '../../../models';
+import { useSubscriptionActions } from '../useSubscriptionActions';
+
+jest.mock('@console/app/src/actions/hooks/useCommonActions', () => ({
+  useCommonActions: jest.fn(() => [{ Edit: { id: 'edit-resource' } }]),
+}));
+
+jest.mock('@console/shared/src/hooks/useK8sModel', () => ({
+  useK8sModel: jest.fn(() => [
+    {
+      apiGroup: 'operators.coreos.com',
+      apiVersion: 'v1alpha1',
+      kind: 'Subscription',
+      plural: 'subscriptions',
+    },
+  ]),
+}));
+
+jest.mock('../../../components/modals/uninstall-operator-modal', () => ({
+  useUninstallOperatorModal: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('@console/internal/components/utils', () => ({
+  asAccessReview: jest.fn((model, resource, verb) => ({
+    group: model.apiGroup,
+    resource: model.plural,
+    verb,
+    namespace: resource?.metadata?.namespace,
+    name: resource?.metadata?.name,
+  })),
+}));
+
+const mockSubscription = {
+  apiVersion: 'operators.coreos.com/v1alpha1' as const,
+  kind: 'Subscription' as const,
+  metadata: {
+    name: 'test-subscription',
+    namespace: 'test-namespace',
+  },
+  spec: {
+    source: 'test-catalog',
+    name: 'test-operator',
+  },
+  status: {
+    installedCSV: 'test-csv-v1.0.0',
+  },
+};
+
+describe('useSubscriptionActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should include accessReview for View CSV action with get verb', () => {
+    const actions = renderHook(() => useSubscriptionActions(mockSubscription)).result.current;
+
+    const viewCSVAction = actions.find((action) => action.id === 'view-cluster-service-version');
+
+    expect(viewCSVAction).toBeDefined();
+    expect(viewCSVAction?.accessReview).toBeDefined();
+    expect(asAccessReview).toHaveBeenCalledWith(
+      ClusterServiceVersionModel,
+      { metadata: { namespace: 'test-namespace', name: 'test-csv-v1.0.0' } },
+      'get',
+    );
+  });
+
+  it('should not include View CSV action when installedCSV is missing', () => {
+    const subscriptionWithoutCSV = {
+      ...mockSubscription,
+      status: undefined,
+    };
+
+    const actions = renderHook(() => useSubscriptionActions(subscriptionWithoutCSV)).result.current;
+
+    const viewCSVAction = actions.find((action) => action.id === 'view-cluster-service-version');
+
+    expect(viewCSVAction).toBeUndefined();
+  });
+
+  it('should include Remove Subscription action with delete accessReview', () => {
+    const actions = renderHook(() => useSubscriptionActions(mockSubscription)).result.current;
+
+    const removeAction = actions.find((action) => action.id === 'remove-subscription');
+
+    expect(removeAction).toBeDefined();
+    expect(removeAction?.accessReview).toBeDefined();
+  });
+});

--- a/frontend/packages/operator-lifecycle-manager/src/actions/hooks/useSubscriptionActions.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/actions/hooks/useSubscriptionActions.ts
@@ -52,6 +52,11 @@ export const useSubscriptionActions = (
           cta: {
             href: `/k8s/ns/${obj.metadata.namespace}/${ClusterServiceVersionModel.plural}/${installedCSV}`,
           },
+          accessReview: asAccessReview(
+            ClusterServiceVersionModel,
+            { metadata: { namespace: obj.metadata.namespace, name: installedCSV } },
+            'get',
+          ),
         };
       },
     }),

--- a/frontend/packages/operator-lifecycle-manager/src/actions/useOperatorActions.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/actions/useOperatorActions.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { K8S_VERB_DELETE } from '@console/dynamic-plugin-sdk/src/api/constants';
+import { K8S_VERB_DELETE, K8S_VERB_UPDATE } from '@console/dynamic-plugin-sdk/src/api/constants';
 import type { Action } from '@console/dynamic-plugin-sdk/src/extensions/actions';
 import { useOverlay } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { DeleteModalOverlay } from '@console/internal/components/modals/delete-modal';
@@ -44,6 +44,7 @@ const useOperatorActions = ({ resource, subscription }): [Action[], boolean, any
         cta: {
           href: `${resourceObjPath(subscription, referenceFor(subscription))}/yaml`,
         },
+        accessReview: asAccessReview(SubscriptionModel, subscription, K8S_VERB_UPDATE),
       },
       {
         id: 'uninstall-operator',

--- a/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.tsx
@@ -7,7 +7,7 @@ import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useParams, useLocation } from 'react-router';
 import type { K8sResourceKind, WatchK8sResultsObject } from '@console/dynamic-plugin-sdk';
-import { PopoverStatus, StatusIconAndText } from '@console/dynamic-plugin-sdk';
+import { PopoverStatus, StatusIconAndText, useAccessReview } from '@console/dynamic-plugin-sdk';
 import { CreateYAML } from '@console/internal/components/create-yaml';
 import type {
   TableProps,
@@ -405,6 +405,12 @@ const DisabledPopover: FC<DisabledPopoverProps> = ({ operatorHub, sourceName }) 
     [close, operatorHub, sourceName],
   );
   const { t } = useTranslation('olm');
+  const [canPatchOperatorHub] = useAccessReview({
+    group: OperatorHubModel.apiGroup,
+    resource: OperatorHubModel.plural,
+    verb: 'patch',
+    name: operatorHub?.metadata?.name,
+  });
   return (
     <PopoverStatus
       title={t('Disabled')}
@@ -417,9 +423,11 @@ const DisabledPopover: FC<DisabledPopoverProps> = ({ operatorHub, sourceName }) 
           'Operators provided by this source will not appear in Software Catalog and any operators installed from this source will not receive updates until this source is re-enabled.',
         )}
       </p>
-      <Button isInline variant="link" onClick={onClickEnable}>
-        {t('Enable source')}
-      </Button>
+      {canPatchOperatorHub && (
+        <Button isInline variant="link" onClick={onClickEnable}>
+          {t('Enable source')}
+        </Button>
+      )}
     </PopoverStatus>
   );
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/__tests__/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/__tests__/index.spec.tsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react';
+import { useAccessReview } from '@console/dynamic-plugin-sdk';
 import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
 import type { DescriptorDetailsItemProps } from '../..';
 import { DescriptorDetailsItem } from '../..';
@@ -9,6 +10,16 @@ import { SpecCapability, DescriptorType } from '../../types';
 // Mock modal hooks used by PodCount component
 jest.mock('../configure-size', () => ({
   useConfigureSizeModal: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../configure-update-strategy', () => ({
+  useConfigureUpdateStrategyModal: jest.fn(() => jest.fn()),
+}));
+
+// Mock access review hook
+jest.mock('@console/dynamic-plugin-sdk', () => ({
+  ...jest.requireActual('@console/dynamic-plugin-sdk'),
+  useAccessReview: jest.fn(() => [true, false]),
 }));
 
 const OBJ = {
@@ -164,6 +175,78 @@ describe('Spec descriptors', () => {
       renderDescriptor();
 
       expect(screen.getByText(descriptor.displayName)).toBeVisible();
+    });
+  });
+
+  describe('when handling permissions', () => {
+    it('should not render pod count edit button when user lacks update permission', () => {
+      (useAccessReview as jest.Mock).mockReturnValue([false, false]);
+      descriptor = {
+        ...descriptor,
+        path: 'pods',
+        'x-descriptors': [SpecCapability.podCount],
+      };
+      renderDescriptor();
+
+      expect(screen.getByTestId('details-item-value__Some Spec Control')).toBeVisible();
+      expect(screen.getByTestId('details-item-value__Some Spec Control')).toHaveTextContent(
+        `${OBJ.spec.pods} pods`,
+      );
+      expect(
+        screen.queryByTestId('Some Spec Control-details-item__edit-button'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should disable boolean switch when user lacks update permission', () => {
+      (useAccessReview as jest.Mock).mockReturnValue([false, false]);
+      descriptor = {
+        ...descriptor,
+        path: 'boolValue',
+        'x-descriptors': [SpecCapability.booleanSwitch],
+      };
+      const objWithBool = {
+        ...OBJ,
+        spec: { ...OBJ.spec, boolValue: true },
+      };
+      renderDescriptor({ obj: objWithBool });
+
+      const switchElement = screen.getByRole('switch', { name: 'True' });
+      expect(switchElement).toBeDisabled();
+    });
+
+    it('should disable checkbox when user lacks update permission', () => {
+      (useAccessReview as jest.Mock).mockReturnValue([false, false]);
+      descriptor = {
+        ...descriptor,
+        path: 'checkboxValue',
+        displayName: 'Checkbox Test',
+        'x-descriptors': [SpecCapability.checkbox],
+      };
+      const objWithCheckbox = {
+        ...OBJ,
+        spec: { ...OBJ.spec, checkboxValue: true },
+      };
+      renderDescriptor({ obj: objWithCheckbox });
+
+      const checkboxElement = screen.getByRole('checkbox', { name: 'Checkbox Test' });
+      expect(checkboxElement).toBeDisabled();
+    });
+
+    it('should disable update strategy edit button when user lacks update permission', () => {
+      (useAccessReview as jest.Mock).mockReturnValue([false, false]);
+      descriptor = {
+        ...descriptor,
+        path: 'updateStrategy',
+        'x-descriptors': [SpecCapability.updateStrategy],
+      };
+      const objWithStrategy = {
+        ...OBJ,
+        spec: { ...OBJ.spec, updateStrategy: { type: 'RollingUpdate' } },
+      };
+      renderDescriptor({ obj: objWithStrategy });
+
+      expect(screen.getByText('RollingUpdate')).toBeVisible();
+      expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { useAccessReview } from '@console/dynamic-plugin-sdk';
 import type { LabelListProps } from '@console/internal/components/utils';
 import {
   LoadingInline,
@@ -20,9 +21,10 @@ import {
   LabelList,
 } from '@console/internal/components/utils';
 import type { Selector as SelectorType } from '@console/internal/module/k8s';
-import { k8sPatch, k8sUpdate } from '@console/internal/module/k8s';
+import { k8sPatch, k8sUpdate, referenceFor } from '@console/internal/module/k8s';
 import { YellowExclamationTriangleIcon } from '@console/shared/src/components/status/icons';
 import { DASH } from '@console/shared/src/constants/ui';
+import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { DefaultCapability, K8sResourceLinkCapability, SecretCapability } from '../common';
 import type { CapabilityProps, Error } from '../types';
 import { SpecCapability } from '../types';
@@ -50,6 +52,14 @@ const PodCount: FC<SpecCapabilityProps<number>> = ({
     specDescriptor: descriptor,
     specValue: value,
   });
+  const [k8sModel] = useK8sModel(referenceFor(obj));
+  const [canUpdate] = useAccessReview({
+    group: k8sModel?.apiGroup,
+    resource: k8sModel?.plural,
+    namespace: obj?.metadata?.namespace,
+    name: obj?.metadata?.name,
+    verb: 'update',
+  });
 
   return (
     <DetailsItem
@@ -58,6 +68,7 @@ const PodCount: FC<SpecCapabilityProps<number>> = ({
       obj={obj}
       path={fullPath}
       onEdit={launchConfigureSizeModal}
+      canEdit={canUpdate}
     >
       {_.isNil(value) ? '-' : `${value} pods`}
     </DetailsItem>
@@ -170,6 +181,14 @@ const BooleanSwitch: FC<SpecCapabilityProps<boolean>> = ({
   const [checked, setChecked] = useState(Boolean(value));
   const [confirmed, setConfirmed] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
+  const [k8sModel] = useK8sModel(referenceFor(obj));
+  const [canUpdate] = useAccessReview({
+    group: k8sModel?.apiGroup,
+    resource: k8sModel?.plural,
+    namespace: obj?.metadata?.namespace,
+    name: obj?.metadata?.name,
+    verb: 'update',
+  });
 
   const errorCb = (err: Error): void => {
     setConfirmed(false);
@@ -200,6 +219,7 @@ const BooleanSwitch: FC<SpecCapabilityProps<boolean>> = ({
         <Switch
           id={descriptor.path}
           isChecked={checked}
+          isDisabled={!canUpdate}
           onChange={(_event, val) => {
             setChecked(val);
             setConfirmed(false);
@@ -209,7 +229,7 @@ const BooleanSwitch: FC<SpecCapabilityProps<boolean>> = ({
         />
         &nbsp;&nbsp;
         {checked !== Boolean(value) && confirmed && <LoadingInline />}
-        {checked !== Boolean(value) && !confirmed && (
+        {checked !== Boolean(value) && !confirmed && canUpdate && (
           <>
             &nbsp;&nbsp;
             <Button className="pf-m-link--align-left" type="button" variant="link" onClick={update}>
@@ -240,6 +260,14 @@ const CheckboxUIComponent: FC<SpecCapabilityProps<boolean>> = ({
   const { t } = useTranslation('olm');
   const [checked, setChecked] = useState(Boolean(value));
   const [confirmed, setConfirmed] = useState(false);
+  const [k8sModel] = useK8sModel(referenceFor(obj));
+  const [canUpdate] = useAccessReview({
+    group: k8sModel?.apiGroup,
+    resource: k8sModel?.plural,
+    namespace: obj?.metadata?.namespace,
+    name: obj?.metadata?.name,
+    verb: 'update',
+  });
 
   const patchFor = (val: boolean) => [
     { op: 'add', path: `/spec/${getPatchPathFromDescriptor(descriptor)}`, value: val },
@@ -256,6 +284,7 @@ const CheckboxUIComponent: FC<SpecCapabilityProps<boolean>> = ({
           id={descriptor.path}
           style={{ marginLeft: '10px' }}
           isChecked={checked}
+          isDisabled={!canUpdate}
           data-checked-state={checked}
           label={label}
           onChange={(_event, val) => {
@@ -265,7 +294,7 @@ const CheckboxUIComponent: FC<SpecCapabilityProps<boolean>> = ({
         />
         &nbsp;&nbsp;
         {checked !== Boolean(value) && confirmed && <LoadingInline />}
-        {checked !== Boolean(value) && !confirmed && (
+        {checked !== Boolean(value) && !confirmed && canUpdate && (
           <>
             &nbsp;&nbsp;
             <Button className="pf-m-link--align-left" type="button" variant="link" onClick={update}>
@@ -296,6 +325,14 @@ const UpdateStrategy: FC<SpecCapabilityProps> = ({
     specDescriptor: descriptor,
     specValue: value,
   });
+  const [k8sModel] = useK8sModel(referenceFor(obj));
+  const [canUpdate] = useAccessReview({
+    group: k8sModel?.apiGroup,
+    resource: k8sModel?.plural,
+    namespace: obj?.metadata?.namespace,
+    name: obj?.metadata?.name,
+    verb: 'update',
+  });
 
   return (
     <DetailsItem
@@ -303,6 +340,7 @@ const UpdateStrategy: FC<SpecCapabilityProps> = ({
       label={label}
       obj={obj}
       onEdit={launchUpdateStrategyModal}
+      canEdit={canUpdate}
       path={fullPath}
     >
       {value?.type ?? t('None')}

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -21,7 +21,7 @@ import { sortable } from '@patternfly/react-table';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router';
-import { ResourceStatus, StatusIconAndText } from '@console/dynamic-plugin-sdk';
+import { ResourceStatus, StatusIconAndText, useAccessReview } from '@console/dynamic-plugin-sdk';
 import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import type { K8sResourceKind } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { getGroupVersionKindForModel } from '@console/dynamic-plugin-sdk/src/lib-core';
@@ -543,6 +543,13 @@ const SubscriptionUpdates: FC<SubscriptionUpdatesProps> = ({
   const prevInstallPlanApproval = useRef(obj?.spec?.installPlanApproval);
   const prevChannel = useRef(obj?.spec?.channel);
   const [waitingForUpdate, setWaitingForUpdate] = useState(false);
+  const [canUpdateSubscription] = useAccessReview({
+    group: SubscriptionModel.apiGroup,
+    resource: SubscriptionModel.plural,
+    namespace: obj?.metadata?.namespace,
+    name: obj?.metadata?.name,
+    verb: 'update',
+  });
 
   useEffect(() => {
     const stillWaiting =
@@ -610,18 +617,22 @@ const SubscriptionUpdates: FC<SubscriptionUpdatesProps> = ({
             <LoadingInline />
           ) : (
             <>
-              <Button
-                type="button"
-                isInline
-                onClick={channelModal}
-                variant="link"
-                isDisabled={!pkg}
-                data-test="subscription-channel-update-button"
-                icon={<RhUiEditIcon />}
-                iconPosition="end"
-              >
-                {obj.spec.channel || t('No channel')}
-              </Button>
+              {canUpdateSubscription ? (
+                <Button
+                  type="button"
+                  isInline
+                  onClick={channelModal}
+                  variant="link"
+                  isDisabled={!pkg}
+                  data-test="subscription-channel-update-button"
+                  icon={<RhUiEditIcon />}
+                  iconPosition="end"
+                >
+                  {obj.spec.channel || t('olm~No channel')}
+                </Button>
+              ) : (
+                <span>{obj.spec.channel || t('olm~No channel')}</span>
+              )}
               {deprecatedChannel.deprecation && (
                 <DeprecatedOperatorWarningIcon
                   dataTest="deprecated-operator-warning-subscription-update-icon"
@@ -643,16 +654,20 @@ const SubscriptionUpdates: FC<SubscriptionUpdatesProps> = ({
           ) : (
             <>
               <div>
-                <Button
-                  icon={<RhUiEditIcon />}
-                  iconPosition="end"
-                  type="button"
-                  isInline
-                  onClick={approvalModal}
-                  variant="link"
-                >
-                  {obj.spec.installPlanApproval || 'Automatic'}
-                </Button>
+                {canUpdateSubscription ? (
+                  <Button
+                    icon={<RhUiEditIcon />}
+                    iconPosition="end"
+                    type="button"
+                    isInline
+                    onClick={approvalModal}
+                    variant="link"
+                  >
+                    {obj.spec.installPlanApproval || 'Automatic'}
+                  </Button>
+                ) : (
+                  <span>{obj.spec.installPlanApproval || 'Automatic'}</span>
+                )}
               </div>
               {obj.spec.installPlanApproval === InstallPlanApproval.Automatic &&
                 manualSubscriptionsInNamespace?.length > 0 && (

--- a/frontend/public/components/utils/details-item.tsx
+++ b/frontend/public/components/utils/details-item.tsx
@@ -123,6 +123,7 @@ export const DetailsItem: FC<DetailsItemProps> = ({
           'co-editable-label-group': editable && editAsGroup,
         })}
         data-test-selector={`details-item-value__${label}`}
+        data-test={`details-item-value__${label}`}
       >
         {editable && !editAsGroup ? (
           <EditButton testId={label} onClick={onEdit}>


### PR DESCRIPTION
## Summary

Adds permission checks to OLM actions and UI buttons to hide them when users lack required permissions. Server still enforces permissions, but actions now properly gated in UI.

**Fixes:**
- Edit Subscription action - added UPDATE `accessReview`
- View CSV action - added GET `accessReview`
- Enable catalog source button - added `useAccessReview` hook
- Subscription update channel/approval buttons - added `useAccessReview` hook
- Descriptor edit buttons (Boolean, Checkbox, PodCount, UpdateStrategy) - added `useAccessReview` hooks

**Tests:**
- Added unit tests for action `accessReview` checks
- All tests passing ✓

## Test plan

### Automated
- [x] Unit tests for actions: `useOperatorActions.spec.ts`, `useSubscriptionActions.spec.ts`
- [ ] E2E tests (manual verification)

### Manual verification
See `frontend/MANUAL_TEST_INSTRUCTIONS.md` for detailed test procedure.

**Quick test:**
1. Apply test RBAC: `oc apply -f frontend/test-rbac-readonly-user.yaml`
2. Login as "test" user (read-only permissions)
3. Navigate to Operators → Installed Operators
4. Verify edit/delete actions hidden from kebab menus
5. Verify update channel/approval buttons hidden on subscription details
6. Verify descriptor edit buttons hidden/disabled on operand instances

**Expected:** All edit/delete actions hidden for read-only user.
**Expected:** All actions visible for admin user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization checks for operator and subscription management actions.
  * Added permission gating for editing subscription configurations and operator descriptors—UI controls now only display when users have appropriate access.
  * Fixed "Enable source" action visibility to respect patch permissions on operator hubs.

* **Tests**
  * Added comprehensive test coverage for operator actions and subscription actions with permission validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->