### PR TITLE
CONSOLE-5356: Add optional onSubmit parameter to useLabelsModal hook

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
@@ -10,6 +10,10 @@ For current development version of Console, use `4.x.0-prerelease.n` packages.
 For older 1.x plugin SDK packages, refer to "OpenShift Console Versions vs SDK Versions" compatibility
 table in [Console dynamic plugins README](./README.md).
 
+## 4.23.0-prerelease.4 - TBD
+
+- Add optional `onSubmit` parameter to `useLabelsModal` hook for customizing label submission behavior ([CONSOLE-5356], [#16560])
+
 ## 4.23.0-prerelease.3 - 2026-07-07
 
 - Add `@openshift/api-types` as a dependency and replace `K8sResourceCommon` and related types with imports from that package ([CONSOLE-5355], [#16585])
@@ -237,6 +241,7 @@ table in [Console dynamic plugins README](./README.md).
 [CONSOLE-5273]: https://issues.redhat.com/browse/CONSOLE-5273
 [CONSOLE-5315]: https://issues.redhat.com/browse/CONSOLE-5315
 [CONSOLE-5355]: https://issues.redhat.com/browse/CONSOLE-5355
+[CONSOLE-5356]: https://issues.redhat.com/browse/CONSOLE-5356
 [CONSOLE-5361]: https://issues.redhat.com/browse/CONSOLE-5361
 [OCPBUGS-19048]: https://issues.redhat.com/browse/OCPBUGS-19048
 [OCPBUGS-30077]: https://issues.redhat.com/browse/OCPBUGS-30077
@@ -322,6 +327,7 @@ table in [Console dynamic plugins README](./README.md).
 [#16241]: https://github.com/openshift/console/pull/16241
 [#16400]: https://github.com/openshift/console/pull/16400
 [#16491]: https://github.com/openshift/console/pull/16491
+[#16560]: https://github.com/openshift/console/pull/16560
 [#16574]: https://github.com/openshift/console/pull/16574
 [#16581]: https://github.com/openshift/console/pull/16581
 [#16582]: https://github.com/openshift/console/pull/16582

--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -2983,9 +2983,21 @@ A hook that provides a callback to launch a modal for editing Kubernetes resourc
 ### Example
 
 ```tsx
+// Basic usage – default k8sPatchResource behavior
 const PodLabelsButton = ({ pod }) => {
   const { t } = useTranslation();
   const launchLabelsModal = useLabelsModal(pod);
+  return <button onClick={launchLabelsModal}>{t('Edit Pod Labels')}</button>
+}
+
+// Custom onSubmit – receives the resource and edited labels, returns a Promise
+const CustomLabelsButton = ({ pod }) => {
+  const { t } = useTranslation();
+  const onSubmit = React.useCallback(
+    (resource, labels) => updateLabelsOnServer(resource, labels),
+    [],
+  );
+  const launchLabelsModal = useLabelsModal(pod, onSubmit);
   return <button onClick={launchLabelsModal}>{t('Edit Pod Labels')}</button>
 }
 ```
@@ -2997,6 +3009,7 @@ const PodLabelsButton = ({ pod }) => {
 | Parameter Name | Description |
 | -------------- | ----------- |
 | `resource` | The resource to edit labels for, an object of K8sResourceCommon type. |
+| `onSubmit` | Optional callback that completely replaces the default `k8sPatchResource` patch (including pod-selector template-label synchronization). Receives the resource and the full edited labels object. Must return a Promise resolving with the updated resource on success or rejecting on failure. The callback should be wrapped in `useCallback` to avoid unnecessary re-renders. |
 
 
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
@@ -881,12 +881,25 @@ export const useDeleteModal: UseDeleteModal = require('@console/shared/src/hooks
  * A hook that provides a callback to launch a modal for editing Kubernetes resource labels.
  *
  * @param {object} resource - The resource to edit labels for, an object of K8sResourceCommon type.
+ * @param {function} [onSubmit] - Optional callback that completely replaces the default `k8sPatchResource` patch (including pod-selector template-label synchronization). Receives the resource and the full edited labels object. Must return a Promise resolving with the updated resource on success or rejecting on failure. The callback should be wrapped in `useCallback` to avoid unnecessary re-renders.
  * @returns A function which will launch a modal for editing a resource's labels.
  * @example
  * ```tsx
+ * // Basic usage – default k8sPatchResource behavior
  * const PodLabelsButton = ({ pod }) => {
  *   const { t } = useTranslation();
  *   const launchLabelsModal = useLabelsModal(pod);
+ *   return <button onClick={launchLabelsModal}>{t('Edit Pod Labels')}</button>
+ * }
+ *
+ * // Custom onSubmit – receives the resource and edited labels, returns a Promise
+ * const CustomLabelsButton = ({ pod }) => {
+ *   const { t } = useTranslation();
+ *   const onSubmit = React.useCallback(
+ *     (resource, labels) => updateLabelsOnServer(resource, labels),
+ *     [],
+ *   );
+ *   const launchLabelsModal = useLabelsModal(pod, onSubmit);
  *   return <button onClick={launchLabelsModal}>{t('Edit Pod Labels')}</button>
  * }
  * ```

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -935,7 +935,24 @@ export type UseDeleteModal = (
   deleteAllResources?: () => Promise<K8sResourceKind[]>,
 ) => () => void;
 
-export type UseLabelsModal = (resource: K8sResourceCommon) => () => void;
+/**
+ * Callback for custom label submission in the labels modal.
+ *
+ * **Contract:**
+ * - Must return a `Promise` that resolves with the updated resource on success.
+ * - Must return a rejected `Promise` on failure so the modal can display the error.
+ * - Must not throw synchronously; all errors should be expressed as rejected promises.
+ * - Receives the current resource and the full set of edited labels (not a diff).
+ */
+export type LabelsModalOnSubmit = (
+  resource: K8sResourceCommon,
+  labels: { [key: string]: string },
+) => Promise<K8sResourceCommon>;
+
+export type UseLabelsModal = (
+  resource: K8sResourceCommon,
+  onSubmit?: LabelsModalOnSubmit,
+) => () => void;
 
 export type UseValuesForNamespaceContext = () => {
   namespace: string;

--- a/frontend/packages/console-shared/src/hooks/useLabelsModal.tsx
+++ b/frontend/packages/console-shared/src/hooks/useLabelsModal.tsx
@@ -6,13 +6,15 @@ import { getGroupVersionKindForResource } from '@console/dynamic-plugin-sdk/src/
 import { LazyLabelsModalOverlay } from '@console/internal/components/modals';
 import type { LabelsModalProps } from '@console/internal/components/modals/labels-modal';
 
-export const useLabelsModal: UseLabelsModal = (resource) => {
+export const useLabelsModal: UseLabelsModal = (resource, onSubmit) => {
   const launchModal = useOverlay();
   const groupVersionKind = getGroupVersionKindForResource(resource);
   const [kind] = useK8sModel(groupVersionKind);
   return useCallback(
     () =>
-      resource && kind && launchModal<LabelsModalProps>(LazyLabelsModalOverlay, { kind, resource }),
-    [launchModal, kind, resource],
+      resource &&
+      kind &&
+      launchModal<LabelsModalProps>(LazyLabelsModalOverlay, { kind, resource, onSubmit }),
+    [launchModal, kind, resource, onSubmit],
   );
 };

--- a/frontend/public/components/modals/labels-modal.tsx
+++ b/frontend/public/components/modals/labels-modal.tsx
@@ -16,7 +16,10 @@ import {
 import { getGroupVersionKindForModel } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';
 import { K8sModel } from '@console/dynamic-plugin-sdk/src/api/common-types';
 import { k8sPatchResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-resource';
-import { K8sResourceCommon } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
+import {
+  K8sResourceCommon,
+  LabelsModalOnSubmit,
+} from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { OverlayComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/OverlayProvider';
 import { K8sResourceKind } from '../../module/k8s';
 import { usePromiseHandler } from '@console/shared/src/hooks/usePromiseHandler';
@@ -38,6 +41,7 @@ const BaseLabelsModal: FC<BaseLabelsModalProps> = ({
   labelClassName,
   messageKey,
   messageVariables,
+  onSubmit,
   path,
   resource,
 }) => {
@@ -64,32 +68,42 @@ const BaseLabelsModal: FC<BaseLabelsModalProps> = ({
   const submit = useCallback(
     (e): void => {
       e.preventDefault();
-      const data = [
-        {
-          op: createPath ? 'add' : 'replace',
-          path,
-          value: SelectorInput.objectify(labels),
-        },
-      ];
+      const rawValues = SelectorInput.objectify(labels);
+      const labelValues: { [key: string]: string } = Object.fromEntries(
+        Object.entries(rawValues).map(([k, v]) => [k, v ?? '']),
+      );
 
-      // https://kubernetes.io/docs/user-guide/deployments/#selector
-      //   .spec.selector must match .spec.template.metadata.labels, or it will be rejected by the API
-      const updateTemplate =
-        isPodSelector && !_.isEmpty(_.get(resource, TEMPLATE_SELECTOR_PATH.split('/').slice(1)));
+      const promise = onSubmit
+        ? onSubmit(resource, labelValues)
+        : (() => {
+            const data = [
+              {
+                op: createPath ? 'add' : 'replace',
+                path,
+                value: labelValues,
+              },
+            ];
 
-      if (updateTemplate) {
-        data.push({
-          path: TEMPLATE_SELECTOR_PATH,
-          op: 'replace',
-          value: SelectorInput.objectify(labels),
-        });
-      }
-      const promise = k8sPatchResource({ model: kind, resource, data });
+            // https://kubernetes.io/docs/user-guide/deployments/#selector
+            //   .spec.selector must match .spec.template.metadata.labels, or it will be rejected by the API
+            const updateTemplate =
+              isPodSelector &&
+              !_.isEmpty(_.get(resource, TEMPLATE_SELECTOR_PATH.split('/').slice(1)));
+
+            if (updateTemplate) {
+              data.push({
+                path: TEMPLATE_SELECTOR_PATH,
+                op: 'replace',
+                value: labelValues,
+              });
+            }
+            return k8sPatchResource({ model: kind, resource, data });
+          })();
       handlePromise(promise)
         .then(close)
         .catch(() => {});
     },
-    [createPath, path, labels, isPodSelector, resource, kind, handlePromise, close],
+    [createPath, path, labels, isPodSelector, resource, kind, handlePromise, close, onSubmit],
   );
 
   return (
@@ -194,6 +208,7 @@ type BaseLabelsModalProps = {
   labelClassName?: string;
   messageKey?: string;
   messageVariables?: { [key: string]: string };
+  onSubmit?: LabelsModalOnSubmit;
   path: string;
   resource: K8sResourceKind;
 } & ModalComponentProps;


### PR DESCRIPTION
# [RFE-8100](https://redhat.atlassian.net/browse/RFE-8100): Edit Label Modal customization

**Jira ticket:** https://redhat.atlassian.net/browse/RFE-8100


## Analysis / Root cause

CNV and other dynamic plugins maintain their own labels editing modal because `useLabelsModal` always submits via `k8sPatchResource` on `/metadata/labels`. Consumers cannot run custom label-update logic (e.g., multicluster patches) while reusing the standard modal UI.

## Solution description

Add an optional `onSubmit` parameter to the public `useLabelsModal` hook and `LabelsModalOnSubmit` type. When provided, `BaseLabelsModal` calls `onSubmit(resource, labels)` instead of the default patch. The parameter is forwarded from the hook through `LazyLabelsModalOverlay` to the modal. Existing callers without `onSubmit` are unchanged. Updated SDK JSDoc, `CHANGELOG-core.md`, and generated `api.md`.

**Files changed:**

- `frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts`
- `frontend/packages/console-shared/src/hooks/useLabelsModal.tsx`
- `frontend/public/components/modals/labels-modal.tsx`
- `frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts`
- `frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md`
- `frontend/packages/console-dynamic-plugin-sdk/docs/api.md`

## Screenshots / screen recording

N/A — no visual changes to the modal UI.

## Test setup

- Local Console from fork: `yarn dev` in `frontend/`, `./bin/bridge` with `BRIDGE_PLUGINS=kubevirt-plugin=http://localhost:9001/`
- Kubevirt plugin linked to local SDK: `@openshift-console/dynamic-plugin-sdk` → `file:.../dist/core`
- `oc login` to a cluster with resources that support label editing

## Test cases

- [ ] Default behavior: `useLabelsModal(resource)` still patches `/metadata/labels` via `k8sPatchResource`
- [ ] Custom submit: `useLabelsModal(resource, onSubmit)` invokes the callback with resource and labels object on Save
- [ ] Modal closes on successful custom `onSubmit` promise; errors display in modal footer
- [ ] Existing Console callers (details page, `useCommonActions` Edit labels) work unchanged
- [ ] TypeScript: plugin consumers can pass optional `onSubmit` per updated `UseLabelsModal` signature

## Browser conformance

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

## Additional info

Backward-compatible public API extension for [RFE-8100](https://redhat.atlassian.net/browse/RFE-8100). Enables CNV to replace its custom labels modal with Console's `useLabelsModal` while keeping custom patch logic.

**Example usage:**

```tsx
const launchLabelsModal = useLabelsModal(vm, (resource, labels) =>
  customUpdateLabels(resource, labels),
);
```

## Reviewers and assignees

- @logonoff 
- CNV consumer: Gal Kremer (RFE reporter/requester per [RFE-8100](https://redhat.atlassian.net/browse/RFE-8100))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Labels modal and hook now accept an optional onSubmit callback so callers can provide a custom label-submission flow that replaces the default behavior.

* **Documentation**
  * API docs and examples updated to describe the onSubmit callback contract, promise-based return, and recommended usage patterns.

* **Chores**
  * Changelog and type/docs entries added to document the new callback and its expected contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->