### PR TITLE
OCPBUGS-88319, CONSOLE-5355: Allow customizing skipImportPrefixes when building Console plugins and begin adoption of API types package

### DIFF
--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -169,6 +169,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openshift-console/dynamic-plugin-sdk@portal:../frontend/packages/console-dynamic-plugin-sdk/dist/core::locator=%40console%2Fdynamic-demo-plugin%40workspace%3A."
   dependencies:
+    "@openshift/api-types": "npm:^1.0.0"
     "@openshift/dynamic-plugin-sdk": "npm:^8.0.0"
     immutable: "npm:^3.8.3"
     lodash: "npm:^4.17.21"
@@ -199,6 +200,13 @@ __metadata:
       optional: true
   languageName: node
   linkType: soft
+
+"@openshift/api-types@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@openshift/api-types@npm:1.0.0"
+  checksum: 10c0/8eb7c324b993145615622f1f809520c6a7be733cc17f3f0718530511da94d269e4ed15a63e9eb4312262bf9895dbc5debe625cec132b9abb005f10df304a6944
+  languageName: node
+  linkType: hard
 
 "@openshift/dynamic-plugin-sdk-webpack@npm:^5.1.1":
   version: 5.1.1

--- a/frontend/e2e/tests/console/cluster-settings/alertmanager/alertmanager.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/alertmanager/alertmanager.spec.ts
@@ -27,7 +27,9 @@ type AlertmanagerRoute = {
 
 test.describe.configure({ mode: 'serial' });
 
-test.describe('Alertmanager', { tag: ['@admin'] }, () => {
+// Skipped due to flakes: OCPBUGS-88451
+// eslint-disable-next-line playwright/no-skipped-test
+test.describe.skip('Alertmanager', { tag: ['@admin'] }, () => {
   let alertmanager: AlertmanagerPage;
   let k8sClient: KubernetesClient;
 

--- a/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/email.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/email.spec.ts
@@ -7,7 +7,9 @@ import KubernetesClient from '../../../../../clients/kubernetes-client';
 
 test.describe.configure({ mode: 'serial' });
 
-test.describe('Alertmanager Email Receiver Form', { tag: ['@admin'] }, () => {
+// Skipped due to flakes: OCPBUGS-88451
+// eslint-disable-next-line playwright/no-skipped-test
+test.describe.skip('Alertmanager Email Receiver Form', { tag: ['@admin'] }, () => {
   let alertmanager: AlertmanagerPage;
   let k8sClient: KubernetesClient;
 

--- a/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/pagerduty.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/pagerduty.spec.ts
@@ -8,7 +8,9 @@ import { resetAlertmanagerConfig } from '../alertmanager-test-utils';
 
 test.describe.configure({ mode: 'serial' });
 
-test.describe('Alertmanager PagerDuty Receiver Form', { tag: ['@admin'] }, () => {
+// Skipped due to flakes: OCPBUGS-88451
+// eslint-disable-next-line playwright/no-skipped-test
+test.describe.skip('Alertmanager PagerDuty Receiver Form', { tag: ['@admin'] }, () => {
   let alertmanager: AlertmanagerPage;
   let k8sClient: KubernetesClient;
 

--- a/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/webhook.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/webhook.spec.ts
@@ -8,7 +8,9 @@ import { resetAlertmanagerConfig } from '../alertmanager-test-utils';
 
 test.describe.configure({ mode: 'serial' });
 
-test.describe('Alertmanager Webhook Receiver Form', { tag: ['@admin'] }, () => {
+// Skipped due to flakes: OCPBUGS-88451
+// eslint-disable-next-line playwright/no-skipped-test
+test.describe.skip('Alertmanager Webhook Receiver Form', { tag: ['@admin'] }, () => {
   let alertmanager: AlertmanagerPage;
   let k8sClient: KubernetesClient;
 

--- a/frontend/e2e/tests/console/cluster-settings/oauth.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/oauth.spec.ts
@@ -3,7 +3,9 @@ import { test } from '../../../fixtures';
 import { OAuthPage } from '../../../pages/oauth-page';
 import type KubernetesClient from '../../../clients/kubernetes-client';
 
-test.describe('OAuth', { tag: ['@admin'] }, () => {
+// Skipped due to flakes: OCPBUGS-88451
+// eslint-disable-next-line playwright/no-skipped-test
+test.describe.skip('OAuth', { tag: ['@admin'] }, () => {
   let client: KubernetesClient;
   let originalOAuthConfig: any;
   const testPrefix = `e2e-${Date.now()}`;

--- a/frontend/e2e/tests/console/cluster-settings/update-modal.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/update-modal.spec.ts
@@ -64,7 +64,9 @@ async function stubMachineConfigPoolWebSocket(page: import('@playwright/test').P
   });
 }
 
-test.describe('Cluster Settings cluster update modal', { tag: ['@admin'] }, () => {
+// Skipped due to flakes: OCPBUGS-88451
+// eslint-disable-next-line playwright/no-skipped-test
+test.describe.skip('Cluster Settings cluster update modal', { tag: ['@admin'] }, () => {
   test('changes based on the cluster', async ({ page }) => {
     const clusterSettings = new ClusterSettingsPage(page);
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -149,6 +149,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
+    "@openshift/api-types": "^1.0.0",
     "@openshift/dynamic-plugin-sdk": "^8.0.0",
     "@openshift/dynamic-plugin-sdk-webpack": "^5.1.1",
     "@patternfly/patternfly": "~6.5.2",

--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
@@ -10,6 +10,10 @@ For current development version of Console, use `4.x.0-prerelease.n` packages.
 For older 1.x plugin SDK packages, refer to "OpenShift Console Versions vs SDK Versions" compatibility
 table in [Console dynamic plugins README](./README.md).
 
+## 4.23.0-prerelease.3 - TBD
+
+- Added `@openshift/api-types` as a dependency and replaced `K8sResourceCommon` and depdendent types with imports from that package ([CONSOLE-5355], [#16585])
+
 ## 4.23.0-prerelease.2 - 2026-05-27
 
 - Updated `@patternfly/react-topology` peer dependency semver range to `~6.5.0` ([OCPBUGS-86488], [#16491])
@@ -226,6 +230,7 @@ table in [Console dynamic plugins README](./README.md).
 [CONSOLE-5093]: https://issues.redhat.com/browse/CONSOLE-5093
 [CONSOLE-5108]: https://issues.redhat.com/browse/CONSOLE-5108
 [CONSOLE-5273]: https://issues.redhat.com/browse/CONSOLE-5273
+[CONSOLE-5355]: https://issues.redhat.com/browse/CONSOLE-5355
 [OCPBUGS-19048]: https://issues.redhat.com/browse/OCPBUGS-19048
 [OCPBUGS-30077]: https://issues.redhat.com/browse/OCPBUGS-30077
 [OCPBUGS-31355]: https://issues.redhat.com/browse/OCPBUGS-31355
@@ -310,3 +315,4 @@ table in [Console dynamic plugins README](./README.md).
 [#16241]: https://github.com/openshift/console/pull/16241
 [#16400]: https://github.com/openshift/console/pull/16400
 [#16491]: https://github.com/openshift/console/pull/16491
+[#16585]: https://github.com/openshift/console/pull/16585

--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-webpack.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-webpack.md
@@ -10,6 +10,10 @@ For current development version of Console, use `4.x.0-prerelease.n` packages.
 For older 1.x plugin SDK packages, refer to "OpenShift Console Versions vs SDK Versions" compatibility
 table in [Console dynamic plugins README](./README.md).
 
+## 4.23.0-prerelease.3 - TBD
+
+- `DynamicModuleImportLoaderOptions` allows extending `skipImportPrefixes`, which suppresses build warnings ([OCPBUGS-88319], [#16585])
+
 ## 4.23.0-prerelease.1 - 2026-05-19
 
 - Fix `resolveDynamicModuleMaps` to skip unavailable packages ([OCPBUGS-84338], [#16340])
@@ -145,6 +149,7 @@ table in [Console dynamic plugins README](./README.md).
 [OCPBUGS-66345]: https://issues.redhat.com/browse/OCPBUGS-66345
 [OCPBUGS-83823]: https://issues.redhat.com/browse/OCPBUGS-83823
 [OCPBUGS-84338]: https://issues.redhat.com/browse/OCPBUGS-84338
+[OCPBUGS-88319]: https://issues.redhat.com/browse/OCPBUGS-88319
 [#13188]: https://github.com/openshift/console/pull/13188
 [#13388]: https://github.com/openshift/console/pull/13388
 [#13521]: https://github.com/openshift/console/pull/13521
@@ -172,3 +177,4 @@ table in [Console dynamic plugins README](./README.md).
 [#16224]: https://github.com/openshift/console/pull/16224
 [#16340]: https://github.com/openshift/console/pull/16340
 [#16376]: https://github.com/openshift/console/pull/16376
+[#16585]: https://github.com/openshift/console/pull/16585

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
@@ -130,7 +130,13 @@ export const getCorePackage: GetPackageDefinition = (
     dependencies: {
       ...parseDeps(
         rootPackage,
-        ['@openshift/dynamic-plugin-sdk', 'immutable', 'reselect', 'typesafe-actions'],
+        [
+          '@openshift/api-types',
+          '@openshift/dynamic-plugin-sdk',
+          'immutable',
+          'reselect',
+          'typesafe-actions',
+        ],
         missingDepCallback,
       ),
       ...parseDepsAs(rootPackage, { 'lodash-es': 'lodash' }, missingDepCallback),

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -7,6 +7,7 @@ import type {
   Dispatch,
   ElementType,
 } from 'react';
+import type { K8sResourceCommon, ObjectMetadata } from '@openshift/api-types';
 import type { QuickStartContextValues } from '@patternfly/quickstarts';
 import type { CodeEditorProps as PfCodeEditorProps } from '@patternfly/react-code-editor';
 import type { AlertVariant, ButtonProps } from '@patternfly/react-core';
@@ -33,69 +34,14 @@ import type {
 import type { Extension, ExtensionTypeGuard } from '../types';
 import type { CustomDataSource } from './dashboard-data-source';
 
-/**
- * ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
- */
-export interface ManagedFieldsEntry {
-  /**
-   * APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
-   */
-  apiVersion?: string;
-  /**
-   * FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"
-   */
-  fieldsType?: string;
-  /**
-   * FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
-   */
-  fieldsV1?: {};
-  /**
-   * Manager is an identifier of the workflow managing these fields.
-   */
-  manager?: string;
-  /**
-   * Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
-   */
-  operation?: string;
-  /**
-   * Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.
-   */
-  subresource?: string;
-  /**
-   * Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.
-   */
-  time?: string;
-}
-
-/**
- * OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
- */
-export interface OwnerReference {
-  /**
-   * API version of the referent.
-   */
-  apiVersion: string;
-  /**
-   * If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
-   */
-  blockOwnerDeletion?: boolean;
-  /**
-   * If true, this reference points to the managing controller.
-   */
-  controller?: boolean;
-  /**
-   * Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-   */
-  kind: string;
-  /**
-   * Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
-   */
-  name: string;
-  /**
-   * UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
-   */
-  uid: string;
-}
+/* eslint-disable no-barrel-files/no-barrel-files */
+export type {
+  ManagedFieldsEntry,
+  OwnerReference,
+  ObjectMetadata,
+  K8sResourceCommon,
+} from '@openshift/api-types';
+/* eslint-enable no-barrel-files/no-barrel-files */
 
 export type ObjectReference = {
   kind?: string;
@@ -106,114 +52,6 @@ export type ObjectReference = {
   resourceVersion?: string;
   fieldPath?: string;
 };
-
-/**
- * ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.
- */
-export interface ObjectMetadata {
-  /**
-   * Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
-   */
-  annotations?: { [k: string]: string };
-  clusterName?: string;
-  /**
-   * CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-   *
-   * Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-   */
-  creationTimestamp?: string;
-  /**
-   * Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
-   */
-  deletionGracePeriodSeconds?: number;
-  /**
-   * DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
-   *
-   * Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-   */
-  deletionTimestamp?: string;
-  /**
-   * Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
-   */
-  finalizers?: string[];
-  /**
-   * GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
-   *
-   * If this field is specified and the generated name exists, the server will return a 409.
-   *
-   * Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
-   */
-  generateName?: string;
-  /**
-   * A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
-   */
-  generation?: number;
-  /**
-   * Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
-   */
-  labels?: { [k: string]: string };
-  /**
-   * ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
-   */
-  managedFields?: ManagedFieldsEntry[];
-  /**
-   * Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
-   */
-  name?: string;
-  /**
-   * Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
-   *
-   * Must be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces
-   */
-  namespace?: string;
-  /**
-   * List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
-   */
-  ownerReferences?: OwnerReference[];
-  /**
-   * An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
-   *
-   * Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-   */
-  resourceVersion?: string;
-  /**
-   * Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
-   *
-   * @deprecated
-   */
-  selfLink?: string;
-  /**
-   * UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
-   *
-   * Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
-   */
-  uid?: string;
-}
-
-// Properties common to (almost) all Kubernetes resources.
-/** Properties common to (almost) all Kubernetes resources. */
-export interface K8sResourceCommon {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object.
-   * Servers should convert recognized schemas to the latest internal value, and
-   * may reject unrecognized values.
-   * More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-   */
-  apiVersion?: string;
-  /**
-   * Kind is a string value representing the REST resource this object represents.
-   * Servers may infer this from the endpoint the client submits requests to.
-   * Cannot be updated.
-   * In CamelCase.
-   * More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-   */
-  kind?: string;
-  /**
-   * metadata is the standard object metadata.
-   * More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-   */
-  metadata?: ObjectMetadata;
-}
 
 export type K8sResourceKind = K8sResourceCommon & {
   spec?: {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
@@ -207,6 +207,15 @@ export const dynamicModuleImportTransformFilter = (moduleRequest: string) => {
   return isCode && (!isVendor || moduleRequest.includes('/node_modules/@openshift-console/'));
 };
 
+export const getDynamicModuleImportSkipPrefixes = (additionalPrefixes: string[] = []) =>
+  _.uniq([
+    '@patternfly/react-core/deprecated',
+    '@patternfly/react-icons/dist/esm/createIcon',
+    '@patternfly/react-core/dist/esm/components/Tooltip/',
+    '@patternfly/react-core/dist/esm/components/Popover/',
+    ...additionalPrefixes,
+  ]);
+
 export type ConsoleRemotePluginOptions = Partial<{
   /**
    * Console dynamic plugin metadata.
@@ -323,6 +332,24 @@ export type ConsoleRemotePluginOptions = Partial<{
      *   _except_ for `@openshift-console/*` packages
      */
     moduleFilter: (moduleRequest: string) => boolean;
+
+    /**
+     * Skip transforming imports whose module specifier matches one of these prefixes.
+     *
+     * This option allows plugins to import parts of vendor packages that are not exposed directly
+     * via package index but have to be imported from a specific path, for example:
+     * ```ts
+     * // Cannot import Tile from '@patternfly/react-core' index
+     * import { Tile } from '@patternfly/react-core/deprecated';
+     * ```
+     *
+     * Import prefixes specified here will be added to the default skip list.
+     *
+     * If not specified, no additional import prefixes will be added to the default skip list.
+     *
+     * @see {@link getDynamicModuleImportSkipPrefixes}
+     */
+    skipImportPrefixes: string[];
   }>;
 }>;
 
@@ -458,6 +485,9 @@ export class ConsoleRemotePlugin implements WebpackPluginInstance {
     new DynamicModuleImportPlugin({
       dynamicModuleMaps: this.dynamicModuleMaps,
       moduleFilter: sharedDynamicModuleSettings.moduleFilter ?? dynamicModuleImportTransformFilter,
+      skipImportPrefixes: getDynamicModuleImportSkipPrefixes(
+        sharedDynamicModuleSettings.skipImportPrefixes,
+      ),
     }).apply(compiler);
 
     // Post-build validations performed before emitting assets

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
@@ -207,15 +207,6 @@ export const dynamicModuleImportTransformFilter = (moduleRequest: string) => {
   return isCode && (!isVendor || moduleRequest.includes('/node_modules/@openshift-console/'));
 };
 
-export const getDynamicModuleImportSkipPrefixes = (additionalPrefixes: string[] = []) =>
-  _.uniq([
-    '@patternfly/react-core/deprecated',
-    '@patternfly/react-icons/dist/esm/createIcon',
-    '@patternfly/react-core/dist/esm/components/Tooltip/',
-    '@patternfly/react-core/dist/esm/components/Popover/',
-    ...additionalPrefixes,
-  ]);
-
 export type ConsoleRemotePluginOptions = Partial<{
   /**
    * Console dynamic plugin metadata.
@@ -485,9 +476,7 @@ export class ConsoleRemotePlugin implements WebpackPluginInstance {
     new DynamicModuleImportPlugin({
       dynamicModuleMaps: this.dynamicModuleMaps,
       moduleFilter: sharedDynamicModuleSettings.moduleFilter ?? dynamicModuleImportTransformFilter,
-      skipImportPrefixes: getDynamicModuleImportSkipPrefixes(
-        sharedDynamicModuleSettings.skipImportPrefixes,
-      ),
+      skipImportPrefixes: sharedDynamicModuleSettings.skipImportPrefixes,
     }).apply(compiler);
 
     // Post-build validations performed before emitting assets

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/DynamicModuleImportPlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/DynamicModuleImportPlugin.ts
@@ -26,6 +26,16 @@ export type DynamicModulePackageSpecs = {
 const isDynamicModuleMap = (obj: unknown): obj is DynamicModuleMap =>
   _.isPlainObject(obj) && Object.values(obj).every((value) => typeof value === 'string');
 
+const defaultDynamicModuleImportSkipPrefixes = [
+  // Imports for PatternFly deprecated APIs
+  '@patternfly/react-core/deprecated',
+  // Imports for PatternFly internal APIs (not exposed via package index)
+  '@patternfly/react-icons/dist/esm/createIcon',
+  '@patternfly/react-core/dist/esm/components/Tooltip/',
+  '@patternfly/react-core/dist/esm/components/Popover/',
+  '@patternfly/react-core/dist/esm/components/OverflowMenu/OverflowMenuContext',
+];
+
 /**
  * Parse or generate dynamic module maps for the provided packages.
  */
@@ -136,7 +146,7 @@ export type DynamicModuleImportPluginOptions = {
   /**
    * Skip transforming imports whose module specifier matches one of these prefixes.
    */
-  skipImportPrefixes: string[];
+  skipImportPrefixes?: string[];
 };
 
 /**
@@ -153,12 +163,15 @@ export class DynamicModuleImportPlugin implements WebpackPluginInstance {
       loader = '@openshift-console/dynamic-plugin-sdk-webpack/lib/webpack/loaders/dynamic-module-import-loader',
       dynamicModuleMaps,
       moduleFilter,
-      skipImportPrefixes,
+      skipImportPrefixes = [],
     } = this.options;
 
     const loaderOptions: DynamicModuleImportLoaderOptions = {
       dynamicModuleMaps,
-      skipImportPrefixes,
+      skipImportPrefixes: _.uniq([
+        ...defaultDynamicModuleImportSkipPrefixes,
+        ...skipImportPrefixes,
+      ]),
     };
 
     compiler.options.module.rules.push({

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/DynamicModuleImportPlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/DynamicModuleImportPlugin.ts
@@ -156,30 +156,15 @@ export class DynamicModuleImportPlugin implements WebpackPluginInstance {
       skipImportPrefixes,
     } = this.options;
 
-    compiler.hooks.thisCompilation.tap(DynamicModuleImportPlugin.name, (compilation) => {
-      const modifiedModules: string[] = [];
+    const loaderOptions: DynamicModuleImportLoaderOptions = {
+      dynamicModuleMaps,
+      skipImportPrefixes,
+    };
 
-      compiler.webpack.NormalModule.getCompilationHooks(compilation).beforeLoaders.tap(
-        DynamicModuleImportPlugin.name,
-        (_loaders, normalModule) => {
-          const { userRequest } = normalModule;
-
-          const moduleRequest = userRequest.substring(
-            userRequest.lastIndexOf('!') === -1 ? 0 : userRequest.lastIndexOf('!') + 1,
-          );
-
-          if (!modifiedModules.includes(moduleRequest) && moduleFilter(moduleRequest)) {
-            const loaderOptions: DynamicModuleImportLoaderOptions = {
-              dynamicModuleMaps,
-              resourceMetadata: { jsx: /\.(jsx|tsx)$/.test(moduleRequest) },
-              skipImportPrefixes,
-            };
-
-            normalModule.loaders.push({ loader, options: loaderOptions } as any);
-            modifiedModules.push(moduleRequest);
-          }
-        },
-      );
+    compiler.options.module.rules.push({
+      test: (resource: string) => moduleFilter(resource),
+      enforce: 'pre',
+      use: [{ loader, options: loaderOptions }],
     });
   }
 }

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/DynamicModuleImportPlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/DynamicModuleImportPlugin.ts
@@ -132,6 +132,11 @@ export type DynamicModuleImportPluginOptions = {
    * Such transformations should only apply to JavaScript or TypeScript code.
    */
   moduleFilter: (moduleRequest: string) => boolean;
+
+  /**
+   * Skip transforming imports whose module specifier matches one of these prefixes.
+   */
+  skipImportPrefixes: string[];
 };
 
 /**
@@ -148,6 +153,7 @@ export class DynamicModuleImportPlugin implements WebpackPluginInstance {
       loader = '@openshift-console/dynamic-plugin-sdk-webpack/lib/webpack/loaders/dynamic-module-import-loader',
       dynamicModuleMaps,
       moduleFilter,
+      skipImportPrefixes,
     } = this.options;
 
     compiler.hooks.thisCompilation.tap(DynamicModuleImportPlugin.name, (compilation) => {
@@ -166,14 +172,7 @@ export class DynamicModuleImportPlugin implements WebpackPluginInstance {
             const loaderOptions: DynamicModuleImportLoaderOptions = {
               dynamicModuleMaps,
               resourceMetadata: { jsx: /\.(jsx|tsx)$/.test(moduleRequest) },
-              skipImportPrefixes: [
-                // Imports for PatternFly deprecated APIs
-                '@patternfly/react-core/deprecated',
-                // Imports for PatternFly internal APIs (not exposed via package index)
-                '@patternfly/react-icons/dist/esm/createIcon',
-                '@patternfly/react-core/dist/esm/components/Tooltip/',
-                '@patternfly/react-core/dist/esm/components/Popover/',
-              ],
+              skipImportPrefixes,
             };
 
             normalModule.loaders.push({ loader, options: loaderOptions } as any);

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/loaders/dynamic-module-import-loader.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/loaders/dynamic-module-import-loader.ts
@@ -4,7 +4,7 @@ import type { DynamicModuleMap } from '../../utils/dynamic-module-parser';
 
 export type DynamicModuleImportLoaderOptions = {
   dynamicModuleMaps: Record<string, DynamicModuleMap>;
-  resourceMetadata: { jsx: boolean };
+  resourceMetadata?: { jsx: boolean };
   skipTypeOnlyImports?: boolean;
   skipImportPrefixes?: string[];
 };
@@ -48,7 +48,7 @@ const getImportInfo = (importDeclaration: ts.ImportDeclaration) => {
 const dynamicModuleImportLoader: DynamicModuleImportLoader = function (source) {
   const {
     dynamicModuleMaps,
-    resourceMetadata,
+    resourceMetadata = { jsx: /\.(jsx|tsx)$/.test(this.resourcePath) },
     skipTypeOnlyImports = true,
     skipImportPrefixes = [],
   } = this.getOptions();

--- a/frontend/packages/shipwright-plugin/src/types.ts
+++ b/frontend/packages/shipwright-plugin/src/types.ts
@@ -18,27 +18,34 @@ import type {
   PersistentVolumeClaimKind,
 } from '@console/internal/module/k8s';
 
-// Add missing latestBuild to Build
+// Add missing latestBuild to Build and ensure K8sResourceCommon compatibility
 export type Build =
-  | (IBuildV1Alpha1 & { latestBuild?: BuildRun })
-  | (IBuildV1Beta1 & { latestBuild?: BuildRun });
+  | (IBuildV1Alpha1 & { latestBuild?: BuildRun } & K8sResourceCommon)
+  | (IBuildV1Beta1 & { latestBuild?: BuildRun } & K8sResourceCommon);
 
 export type BuildSpec = IBuildV1Alpha1['spec'] & IBuildV1Beta1['spec'];
 
 export type BuildStatus = IBuildV1Alpha1['status'] & IBuildV1Beta1['status'];
 
-export type ClusterBuildStrategyKind = IClusterBuildStrategyV1Alpha1 | IClusterBuildStrategyV1Beta1;
+export type ClusterBuildStrategyKind =
+  | (IClusterBuildStrategyV1Alpha1 & K8sResourceCommon)
+  | (IClusterBuildStrategyV1Beta1 & K8sResourceCommon);
 
-export type BuildStrategyKind = IBuildStrategyV1Alpha1 | IBuildStrategyV1Beta1;
+export type BuildStrategyKind =
+  | (IBuildStrategyV1Alpha1 & K8sResourceCommon)
+  | (IBuildStrategyV1Beta1 & K8sResourceCommon);
 
 // Make status.conditions compatible with @console/internal/components/conditions props
+// and ensure K8sResourceCommon compatibility
 export type BuildRun =
-  | (IBuildRunV1Alpha1 & {
-      status?: { conditions?: K8sResourceCondition[]; latestTaskRunRef?: string };
-    })
-  | (IBuildRunV1Beta1 & {
-      status?: { conditions?: K8sResourceCondition[]; taskRunName?: string };
-    });
+  | (IBuildRunV1Alpha1 &
+      K8sResourceCommon & {
+        status?: { conditions?: K8sResourceCondition[]; latestTaskRunRef?: string };
+      })
+  | (IBuildRunV1Beta1 &
+      K8sResourceCommon & {
+        status?: { conditions?: K8sResourceCondition[]; taskRunName?: string };
+      });
 
 // The enum values need to match the dynamic-plugin `Status` `status` prop.
 // A translation (title) is added in the BuildRunStatus component.

--- a/frontend/packages/shipwright-plugin/src/utils.ts
+++ b/frontend/packages/shipwright-plugin/src/utils.ts
@@ -4,7 +4,11 @@ import { useLocation, useParams } from 'react-router';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import type { K8sModel } from '@console/dynamic-plugin-sdk/src/api/common-types';
 import { useFlag } from '@console/dynamic-plugin-sdk/src/lib-core';
-import type { K8sResourceCondition, K8sResourceKind } from '@console/internal/module/k8s';
+import type {
+  K8sResourceCommon,
+  K8sResourceCondition,
+  K8sResourceKind,
+} from '@console/internal/module/k8s';
 import { useTabbedTableBreadcrumbsFor } from '@console/shared/src/hooks/useTabbedTableBreadcrumb';
 import { getBuildRunStatus } from './components/buildrun-status/BuildRunStatus';
 import { BUILDRUN_TO_RESOURCE_MAP_LABEL } from './const';
@@ -102,8 +106,9 @@ export const byCreationTime = (left: K8sResourceKind, right: K8sResourceKind): n
 export const isV1Alpha1Resource = (
   resource: Build | BuildRun,
 ): resource is
-  | IBuildV1Alpha1
-  | (IBuildRunV1Alpha1 & { status?: { conditions?: K8sResourceCondition[] } }) => {
+  | (IBuildV1Alpha1 & K8sResourceCommon)
+  | (IBuildRunV1Alpha1 &
+      K8sResourceCommon & { status?: { conditions?: K8sResourceCondition[] } }) => {
   return resource.apiVersion === 'shipwright.io/v1alpha1';
 };
 

--- a/frontend/packages/vsphere-plugin/src/components/persist.ts
+++ b/frontend/packages/vsphere-plugin/src/components/persist.ts
@@ -1,3 +1,4 @@
+import type { SecretKind } from '@openshift/api-types/dist/kubernetes/latest';
 import { safeLoad, dump } from 'js-yaml';
 import type { ConsoleTFunction } from '@console/dynamic-plugin-sdk';
 import type { K8sModel } from '@console/dynamic-plugin-sdk/src/api/core-api';
@@ -13,7 +14,6 @@ import {
 import type { ConfigMap } from '../resources/configMap';
 import type { Infrastructure } from '../resources/infrastructure';
 import type { KubeControllerManager } from '../resources/kubeControllerManager';
-import type { Secret } from '../resources/secret';
 import type { ConnectionFormFormikValues, PersistOp, ProviderCM } from './types';
 import { encodeBase64, getErrorMessage } from './utils';
 
@@ -43,7 +43,7 @@ const getPersistSecretOp = async (
   };
 
   try {
-    const secret = await k8sGet<Secret>({
+    const secret = await k8sGet<SecretKind>({
       model: secretModel,
       name: VSPHERE_CREDS_SECRET_NAME,
       ns: VSPHERE_CREDS_SECRET_NAMESPACE,
@@ -71,7 +71,7 @@ const getPersistSecretOp = async (
       });
   } catch (e) {
     // Not found, create one
-    const data: Secret = {
+    const data: SecretKind = {
       apiVersion: secretModel.apiVersion,
       kind: secretModel.kind,
       metadata: {

--- a/frontend/packages/vsphere-plugin/src/hooks/use-connection-form.ts
+++ b/frontend/packages/vsphere-plugin/src/hooks/use-connection-form.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import type { SecretKind } from '@openshift/api-types/dist/kubernetes/latest';
 import { useTranslation } from 'react-i18next';
 import type { K8sModel } from '@console/dynamic-plugin-sdk/src/api/core-api';
 import { k8sGet } from '@console/dynamic-plugin-sdk/src/api/core-api';
@@ -6,7 +7,6 @@ import type { ConnectionFormFormikValues } from '../components/types';
 import { decodeBase64, getErrorMessage } from '../components/utils';
 import { VSPHERE_CREDS_SECRET_NAME, VSPHERE_CREDS_SECRET_NAMESPACE } from '../constants';
 import type { Infrastructure } from '../resources/infrastructure';
-import type { Secret } from '../resources/secret';
 import { useConnectionModels } from './use-connection-models';
 
 class LoadError extends Error {
@@ -61,7 +61,7 @@ const initialLoad = async (
   let username = '';
   let password = '';
   try {
-    const secret = await k8sGet<Secret>({
+    const secret = await k8sGet<SecretKind>({
       model: secretModel,
       name: VSPHERE_CREDS_SECRET_NAME,
       ns: VSPHERE_CREDS_SECRET_NAMESPACE,

--- a/frontend/packages/vsphere-plugin/src/resources/secret.ts
+++ b/frontend/packages/vsphere-plugin/src/resources/secret.ts
@@ -1,5 +1,0 @@
-import type { K8sResourceCommon } from '@console/dynamic-plugin-sdk';
-
-export type Secret = K8sResourceCommon & {
-  data?: { [key: string]: string };
-};

--- a/frontend/public/components/__tests__/command-line-tools.spec.tsx
+++ b/frontend/public/components/__tests__/command-line-tools.spec.tsx
@@ -12,6 +12,7 @@ const obj = {
       },
       spec: {
         displayName: 'helm - Helm 3 CLI',
+        description: '',
         links: [],
       },
     },
@@ -22,6 +23,7 @@ const obj = {
       },
       spec: {
         displayName: 'oc - OpenShift Command Line Interface (CLI)',
+        description: '',
         links: [],
       },
     },

--- a/frontend/public/components/command-line-tools.tsx
+++ b/frontend/public/components/command-line-tools.tsx
@@ -16,16 +16,8 @@ import { referenceForModel } from '../module/k8s';
 import { MarkdownView } from '@console/shared/src/components/markdown/MarkdownView';
 import { useCopyCodeModal } from '@console/shared/src/hooks/useCopyCodeModal';
 import { useK8sWatchResource } from './utils/k8s-watch-hook';
-import type { K8sResourceCommon } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
+import type { ConsoleCLIDownloadKind } from '@openshift/api-types/dist/openshift/latest';
 import { LoadingBox } from './utils/status-box';
-
-type CLIDownload = K8sResourceCommon & {
-  spec: {
-    displayName: string;
-    description?: string;
-    links: { href: string; text?: string }[];
-  };
-};
 
 export const CommandLineTools: FC<CommandLineToolsProps> = ({ obj }) => {
   const { t } = useTranslation();
@@ -113,12 +105,12 @@ export const CommandLineToolsPage = () => {
     );
   }
 
-  return <CommandLineTools obj={{ data: cliDownloads as CLIDownload[], loaded, loadError }} />;
+  return <CommandLineTools obj={{ data: cliDownloads as ConsoleCLIDownloadKind[], loaded, loadError }} />;
 };
 
 type CommandLineToolsProps = {
   obj: {
-    data: CLIDownload[];
+    data: ConsoleCLIDownloadKind[];
     loaded: boolean;
     loadError?: unknown;
   };

--- a/frontend/public/components/command-line-tools.tsx
+++ b/frontend/public/components/command-line-tools.tsx
@@ -105,7 +105,9 @@ export const CommandLineToolsPage = () => {
     );
   }
 
-  return <CommandLineTools obj={{ data: cliDownloads as ConsoleCLIDownloadKind[], loaded, loadError }} />;
+  return (
+    <CommandLineTools obj={{ data: cliDownloads as ConsoleCLIDownloadKind[], loaded, loadError }} />
+  );
 };
 
 type CommandLineToolsProps = {

--- a/frontend/public/components/console-notifier.tsx
+++ b/frontend/public/components/console-notifier.tsx
@@ -6,7 +6,7 @@ import { useFlag } from '@console/shared/src/hooks/useFlag';
 import { referenceForModel } from '../module/k8s';
 import { ConsoleNotificationModel } from '../models/index';
 import { useK8sWatchResource } from './utils/k8s-watch-hook';
-import { ConsoleNotificationKind } from '@openshift/api-types/dist/openshift/latest';
+import type { ConsoleNotificationKind } from '@openshift/api-types/dist/openshift/latest';
 
 type ConsoleNotifierProps = {
   location: 'BannerTop' | 'BannerBottom' | 'BannerTopBottom';

--- a/frontend/public/components/console-notifier.tsx
+++ b/frontend/public/components/console-notifier.tsx
@@ -6,20 +6,7 @@ import { useFlag } from '@console/shared/src/hooks/useFlag';
 import { referenceForModel } from '../module/k8s';
 import { ConsoleNotificationModel } from '../models/index';
 import { useK8sWatchResource } from './utils/k8s-watch-hook';
-import type { K8sResourceCommon } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
-
-type ConsoleNotification = K8sResourceCommon & {
-  spec: {
-    location?: 'BannerTop' | 'BannerBottom' | 'BannerTopBottom';
-    backgroundColor?: string;
-    color?: string;
-    text: string;
-    link?: {
-      href: string;
-      text?: string;
-    };
-  };
-};
+import { ConsoleNotificationKind } from '@openshift/api-types/dist/openshift/latest';
 
 type ConsoleNotifierProps = {
   location: 'BannerTop' | 'BannerBottom' | 'BannerTopBottom';
@@ -27,7 +14,7 @@ type ConsoleNotifierProps = {
 
 export const ConsoleNotifier: FC<ConsoleNotifierProps> = ({ location }) => {
   const shouldFetch = useFlag(FLAGS.CONSOLE_NOTIFICATION);
-  const [notifications, loaded, loadError] = useK8sWatchResource<ConsoleNotification[]>(
+  const [notifications, loaded, loadError] = useK8sWatchResource<ConsoleNotificationKind[]>(
     shouldFetch
       ? {
           kind: referenceForModel(ConsoleNotificationModel),

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -16,9 +16,28 @@ import {
   TaintEffect,
 } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { EventInvolvedObject } from './event';
+import type { MachineHealthCheckKind } from '@openshift/api-types/dist/openshift/latest';
 
 export * from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 export * from '@console/dynamic-plugin-sdk/src/api/common-types';
+
+export type {
+  SecretKind,
+  ConfigMapKind,
+  PersistentVolumeKind,
+  EndpointSliceKind,
+  VolumeAttributesClassKind,
+  StorageClassKind as StorageClassResourceKind,
+} from '@openshift/api-types/dist/kubernetes/latest';
+export type {
+  ConsoleLinkKind,
+  ConsolePluginKind,
+  MachineHealthCheckKind,
+  ControlPlaneMachineSetKind,
+} from '@openshift/api-types/dist/openshift/latest';
+export type MachineHealthCondition = NonNullable<
+  NonNullable<MachineHealthCheckKind['spec']>['unhealthyConditions']
+>[number];
 
 export type PartialObjectMetadata = {
   apiVersion: string;
@@ -480,28 +499,6 @@ export type HorizontalPodAutoscalerKind = K8sResourceCommon & {
   };
 };
 
-export type StorageClassResourceKind = {
-  provisioner: string;
-  reclaimPolicy?: string;
-  volumeBindingMode?: string;
-  allowVolumeExpansion?: boolean;
-  parameters?: {
-    [key: string]: string;
-  };
-} & K8sResourceCommon;
-
-export type VolumeAttributesClassKind = {
-  driverName: string;
-  parameters?: {
-    [key: string]: string;
-  };
-} & K8sResourceCommon;
-
-export type ConfigMapKind = {
-  data?: { [key: string]: string };
-  binaryData?: { [key: string]: string };
-} & K8sResourceCommon;
-
 type JobTemplate = {
   metadata: ObjectMetadata;
   spec: {
@@ -751,27 +748,6 @@ export type MachineSetKind = {
   };
 } & K8sResourceCommon;
 
-export type ControlPlaneMachineSetKind = {
-  spec: {
-    replicas: number;
-    selector: Selector;
-    state?: string;
-    strategy?: {
-      type?: string;
-    };
-    template: {
-      machineType: string;
-    };
-  };
-  status: {
-    replicas?: number;
-    readyReplicas?: number;
-    updatedReplicas?: number;
-    unavailableReplicas?: number;
-    conditions?: K8sResourceCondition[];
-  };
-} & K8sResourceCommon;
-
 export type Patch = {
   op: string;
   path: string;
@@ -1016,12 +992,6 @@ export type GroupKind = {
  */
 export type K8sKind = K8sModel;
 
-export type SecretKind = {
-  data?: { [key: string]: string };
-  stringData?: { [key: string]: string };
-  type?: string;
-} & K8sResourceCommon;
-
 export type ListKind<R extends K8sResourceCommon> = K8sResourceCommon & {
   items: R[];
 };
@@ -1046,19 +1016,6 @@ export type EventKind = {
     state?: string;
   };
 } & K8sResourceCommon;
-
-export type MachineHealthCondition = {
-  type: string;
-  status: string;
-  timeout: string;
-};
-
-export type MachineHealthCheckKind = K8sResourceCommon & {
-  spec: {
-    selector: Selector;
-    unhealthyConditions: MachineHealthCondition[];
-  };
-};
 
 export type VolumeSnapshotKind = K8sResourceCommon & {
   status?: VolumeSnapshotStatus & {
@@ -1137,85 +1094,6 @@ export type PersistentVolumeClaimKind = K8sResourceCommon & {
   };
 };
 
-export type PersistentVolumeKind = K8sResourceCommon & {
-  spec: {
-    storageClassName?: string;
-    claimRef?: {
-      namespace: string;
-      name: string;
-    };
-    capacity: { storage: string };
-    storage: string;
-    accessModes: string[];
-    persistentVolumeReclaimPolicy: string;
-    volumeMode?: string;
-    csi?: {
-      driver: string;
-      volumeHandle: string;
-      fsType?: string;
-      readOnly?: boolean;
-      volumeAttributes?: { [key: string]: string };
-      nodeStageSecretRef?: { name: string; namespace: string };
-      nodePublishSecretRef?: { name: string; namespace: string };
-    };
-  };
-  status: {
-    phase: string;
-  };
-};
-
-export type ConsoleLinkKind = K8sResourceCommon & {
-  spec: {
-    applicationMenu?: {
-      imageURL?: string;
-      section: string;
-    };
-    href: string;
-    location: 'ApplicationMenu' | 'HelpMenu' | 'UserMenu' | 'NamespaceDashboard';
-    namespaceDashboard?: {
-      namespaceSelector?: {
-        matchExpressions?: { key?: string; operator?: string; values?: string[] }[];
-        matchLabels?: { [key: string]: string };
-      };
-      namespaces?: string[];
-    };
-    text: string;
-  };
-};
-
-export type ConsolePluginKind = K8sResourceCommon & {
-  spec: {
-    displayName: string;
-    backend: {
-      service: {
-        basePath?: string;
-        name: string;
-        namespace: string;
-        port: number;
-      };
-      type: 'Service';
-    };
-    i18n?: {
-      loadType: 'Preload' | 'Lazy' | '';
-    };
-    proxy?: ConsolePluginProxy[];
-  };
-};
-
-type ConsolePluginProxy = {
-  alias: string;
-  authorization?: 'UserToken' | 'None';
-  caCertificate?: string;
-  endpoint: {
-    service: {
-      name: string;
-      namespace: string;
-      port: string;
-    };
-    type: 'Service';
-  };
-};
-
 export type K8sPodControllerKind = {
   spec?: {
     replicas?: number;
@@ -1272,17 +1150,6 @@ export type ReplicationControllerKind = {
 } & K8sResourceCommon;
 
 export type ReplicaSetKind = {} & ReplicationControllerKind;
-
-type EndpointSlice = {
-  kind?: string;
-  name?: string;
-  namespace?: string;
-  uid?: string;
-};
-
-export type EndpointSliceKind = {
-  endpoints?: EndpointSlice[];
-} & K8sResourceCommon;
 
 type RoleRef = {
   kind: string;

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -17,6 +17,7 @@ import { ExtensionValidatorPlugin } from '@console/dynamic-plugin-sdk/src/webpac
 import {
   dynamicModulePackageSpecs,
   dynamicModuleImportTransformFilter,
+  getDynamicModuleImportSkipPrefixes,
 } from '@console/dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin';
 import {
   DynamicModuleImportPlugin,
@@ -295,6 +296,10 @@ const config: Configuration = {
         '@console/dynamic-plugin-sdk/dist/webpack/lib/webpack/loaders/dynamic-module-import-loader',
       dynamicModuleMaps,
       moduleFilter: dynamicModuleImportTransformFilter,
+      skipImportPrefixes: getDynamicModuleImportSkipPrefixes([
+        // Missing export in @patternfly/react-core/src/components/OverflowMenu/index.ts
+        '@patternfly/react-core/dist/esm/components/OverflowMenu/OverflowMenuContext',
+      ]),
     }),
     new webpack.container.ModuleFederationPlugin({
       shared: getWebpackSharedModules(),

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -17,7 +17,6 @@ import { ExtensionValidatorPlugin } from '@console/dynamic-plugin-sdk/src/webpac
 import {
   dynamicModulePackageSpecs,
   dynamicModuleImportTransformFilter,
-  getDynamicModuleImportSkipPrefixes,
 } from '@console/dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin';
 import {
   DynamicModuleImportPlugin,
@@ -296,10 +295,6 @@ const config: Configuration = {
         '@console/dynamic-plugin-sdk/dist/webpack/lib/webpack/loaders/dynamic-module-import-loader',
       dynamicModuleMaps,
       moduleFilter: dynamicModuleImportTransformFilter,
-      skipImportPrefixes: getDynamicModuleImportSkipPrefixes([
-        // Missing export in @patternfly/react-core/src/components/OverflowMenu/index.ts
-        '@patternfly/react-core/dist/esm/components/OverflowMenu/OverflowMenuContext',
-      ]),
     }),
     new webpack.container.ModuleFederationPlugin({
       shared: getWebpackSharedModules(),

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3437,6 +3437,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openshift/api-types@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@openshift/api-types@npm:1.0.0"
+  checksum: 10c0/8eb7c324b993145615622f1f809520c6a7be733cc17f3f0718530511da94d269e4ed15a63e9eb4312262bf9895dbc5debe625cec132b9abb005f10df304a6944
+  languageName: node
+  linkType: hard
+
 "@openshift/dynamic-plugin-sdk-webpack@npm:^5.1.1":
   version: 5.1.1
   resolution: "@openshift/dynamic-plugin-sdk-webpack@npm:5.1.1"
@@ -18097,6 +18104,7 @@ __metadata:
     "@graphql-codegen/typescript-operations": "npm:^1.15.1"
     "@kubernetes/client-node": "npm:^1.4.0"
     "@monaco-editor/react": "npm:^4.7.0"
+    "@openshift/api-types": "npm:^1.0.0"
     "@openshift/dynamic-plugin-sdk": "npm:^8.0.0"
     "@openshift/dynamic-plugin-sdk-webpack": "npm:^5.1.1"
     "@patternfly/patternfly": "npm:~6.5.2"


### PR DESCRIPTION
### Analysis / Root cause
When building Console with webpack, the following warning is emitted by `DynamicModuleImportPlugin`
```
LOG from @console/dynamic-plugin-sdk/dist/webpack/lib/webpack/loaders/dynamic-module-import-loader ./node_modules/thread-loader/dist/cjs.js!./node_modules/esbuild-loader/dist/index.cjs??ruleSet[1].rules[2].use[1]!./packages/console-shared/src/components/dropdown/ResponsiveActionDropdown.tsx
<w> Non-index and non-dynamic module import @patternfly/react-core/dist/esm/components/OverflowMenu/OverflowMenuContext
```
This is caused by `@patternfly/react-core` package not exposing `OverflowMenuContext` directly via package index
```ts
import { OverflowMenuContext } from '@patternfly/react-core'; // does not work
```
so the relevant import in [`ResponsiveActionDropdown.tsx`](https://github.com/openshift/console/blob/main/frontend/packages/console-shared/src/components/dropdown/ResponsiveActionDropdown.tsx) cannot be transformed into something like
```ts
import { OverflowMenuContext } from '@patternfly/react-core/dist/dynamic/components/OverflowMenu';
```
which means `OverflowMenuContext` code will not be shared with other Console plugins via such `dist/dynamic` module.

To fix this particular issue in Console as well as any similar issues in Console plugins - maintainers of vendor packages that support dynamic modules such as `@patternfly/react-core` should add the relevant export and ensure that `dist/dynamic-modules.json` has relevant entries like
```json
"OverflowMenuContext": "dist/dynamic/components/OverflowMenu",
```

### Solution description
Allow Console and its dynamic plugins to customize `skipImportPrefixes` as a workaround to reduce build warning noise for known issues related to dynamic module import processing.

### Test cases
- [ ] Console webpack build passes
- [ ] Console webpack build log does not include the above mentioned warning about `OverflowMenuContext`


### Reviewers and assignees
/assign @logonoff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to skip specified import prefixes during dynamic-module import processing to reduce unwanted transformations and build warnings.
  * Loader now auto-detects JSX/TSX files by path, enabling appropriate JSX parsing when needed and simplifying module handling.

* **Documentation**
  * Updated changelog for the upcoming 4.23.0-prerelease.3 with these additions and references to related fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->