### PR TITLE
OCPBUGS-86280: Guard against null plugin route components

### DIFF
--- a/frontend/packages/console-app/src/hooks/usePluginRoutes.tsx
+++ b/frontend/packages/console-app/src/hooks/usePluginRoutes.tsx
@@ -23,12 +23,17 @@ const LazyRoutePage: FC<LazyRoutePageProps> = ({ extension }) => {
         uid,
         lazy(async () => {
           const Component = await component();
+          if (typeof Component !== 'function') {
+            throw new Error(
+              `Plugin "${pluginName}" route component resolved to ${typeof Component} (extension ${uid})`,
+            );
+          }
           return { default: Component };
         }),
       );
     }
     return lazyComponentCache.get(uid);
-  }, [uid, component]);
+  }, [uid, component, pluginName]);
 
   return (
     <Suspense fallback={<LoadingBox blame={`${pluginName}: ${extension.uid}`} />}>


### PR DESCRIPTION
**Analysis / Root cause**:

When a dynamic plugin's route component fails to load (resolves to null/undefined instead of a React component), `React.lazy()` receives `{ default: null }` and crashes with React error #306: "Element type is invalid. Received a promise that resolves to: null. Lazy element type must resolve to a class or function."

This can happen when a plugin pod is not running, not reachable, or when module federation fails silently after a cluster upgrade.

**Solution description**:

Add a type check in `LazyRoutePage` before passing the resolved component to `React.lazy()`. If the component is not a function, throw an error with the plugin name and extension UID. This error is caught by the existing `ErrorBoundaryPage` in `app-contents.tsx`, showing the standard "Something wrong happened" + "Reload page" UI instead of crashing.

Also fixes a missing `pluginName` in the `useMemo` dependency array.

**Screenshots / screen recording**:

N/A — defensive fix, no visual changes in the happy path.

**Test setup:**

Requires a dynamic plugin whose route component resolves to null. This can be simulated by registering a ConsolePlugin that points to a non-existent or broken plugin service.

**Test cases:**

1. With a working dynamic plugin (e.g. monitoring-plugin): navigate to a plugin-provided page → page loads normally (no regression).
2. With a broken plugin (service down or returning invalid module): navigate to the plugin's route → shows "Something wrong happened" error page instead of React error #306 crash.

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**

- Related Jira: https://redhat.atlassian.net/browse/OCPBUGS-86280
- Analysis: https://gitlab.cee.redhat.com/-/snippets/11562
- The `console.warn` in `coderef-resolver.ts` for null codeRefs is intentional — 43 extension properties have optional codeRefs where null is legitimate. The guard belongs at the consumer level (`usePluginRoutes.tsx`) where `component` is known to be required.

Assisted-by: 🤖 Claude Opus/Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced plugin component validation with improved error messaging to better identify and resolve plugin configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->