### PR TITLE
OCPBUGS-88715: Bump follow-redirects from 1.15.3 to 1.16.0 to remediate CVE-2026-40895

### DIFF
--- a/dynamic-demo-plugin/package.json
+++ b/dynamic-demo-plugin/package.json
@@ -75,6 +75,7 @@
   },
   "packageManager": "yarn@4.14.1",
   "resolutions": {
+    "follow-redirects": "^1.16.0",
     "minimatch@^3.0.2": "^3.1.3",
     "minimatch@^3.0.4": "^3.1.3",
     "minimatch@^3.1.1": "^3.1.3",

--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -1741,13 +1741,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -324,6 +324,7 @@
   "resolutions": {
     "@types/lodash": "4.14.106",
     "esbuild": "^0.27.3",
+    "follow-redirects": "^1.16.0",
     "glob-parent": "^5.1.2",
     "hosted-git-info": "^3.0.8",
     "immutable": "^3.8.3",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -12256,13 +12256,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
-  version: 1.15.3
-  resolution: "follow-redirects@npm:1.15.3"
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/915a2cf22e667bdf47b1a43cc6b7dce14d95039e9bbf9a24d0e739abfbdfa00077dd43c86d4a7a19efefcc7a99af144920a175eedc3888d268af5df67c272ee5
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- **CVE**: CVE-2026-40895 — Information disclosure via custom authentication headers in cross-domain redirects
- **Package**: follow-redirects 1.15.3 → 1.16.0 (transitive dependency via webpack-dev-server)

## Impact
- **Production**: NOT AFFECTED (webpack-dev-server is a devDependency, not deployed)
- **Development**: Potentially affected (local dev server only)

## Changes
- [x] Added yarn resolution for follow-redirects@^1.16.0
- [x] Updated yarn.lock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution configuration to maintain consistency across the application build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->