### PR TITLE
OCPBUGS-87987:[release-4.16] shell-quote: Arbitrary code execution via command injection due to unescaped line terminators

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -364,7 +364,8 @@
     "jest": "21.x",
     "glob-parent": "^5.1.2",
     "postcss": "^8.2.13",
-    "axios": "1.15.0"
+    "axios": "1.15.0",
+    "shell-quote": "^1.8.4"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -22045,10 +22045,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.4.2, shell-quote@npm:^1.6.1":
-  version: 1.7.2
-  resolution: "shell-quote@npm:1.7.2"
-  checksum: 10c0/656aefdcdc394560ca091140a58b95e97f43d5e14bb60ff4a92556ca48841e49af6e837441e887c7890c7a86ae8542960c90e460a86799b68c53271784909edb
+"shell-quote@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
While working on CVE-2026-9277 I have observed shell-quote package has been used as a transitive dependency and in addition to it is using the vulnerable version. So, in order to resolve this issue I have bumped the shell-quote package to the patched version (1.8.4)