### PR TITLE
RFE-4925: Fix inconsistent Search page filter default (use Name)

### DIFF
--- a/frontend/public/components/__tests__/search-filter-dropdown.spec.tsx
+++ b/frontend/public/components/__tests__/search-filter-dropdown.spec.tsx
@@ -1,0 +1,27 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import { SearchFilterDropdown } from '@console/internal/components/search-filter-dropdown';
+
+const renderDropdown = () =>
+  renderWithProviders(
+    <SearchFilterDropdown onChange={jest.fn()} nameFilterInput="" labelFilterInput="" />,
+  );
+
+describe('SearchFilterDropdown', () => {
+  it('defaults to filtering by Name to stay consistent with other resource lists', () => {
+    renderDropdown();
+    expect(screen.getByRole('button', { name: /Name/ })).toBeVisible();
+  });
+
+  it('allows the user to switch the filter to Label', async () => {
+    const user = userEvent.setup();
+    renderDropdown();
+
+    await user.click(screen.getByRole('button', { name: /Name/ }));
+    await user.click(screen.getByRole('option', { name: /Label/ }));
+
+    expect(screen.getByRole('button', { name: /Label/ })).toBeVisible();
+  });
+});

--- a/frontend/public/components/search-filter-dropdown.tsx
+++ b/frontend/public/components/search-filter-dropdown.tsx
@@ -27,7 +27,8 @@ export const SearchFilterDropdown: FC<SearchFilterDropdownProps> = ({
   onChange,
 }) => {
   const [isOpen, setOpen] = useState(false);
-  const [selected, setSelected] = useState(searchFilterValues.Label);
+  // Default to filtering by Name to stay consistent with the other resource lists in the console.
+  const [selected, setSelected] = useState(searchFilterValues.Name);
   const { t } = useTranslation('public');
 
   const onToggle = () => setOpen(!isOpen);


### PR DESCRIPTION
<!--
  PR title must be prefixed with a Jira issue, e.g.:
  - CONSOLE-XXXX: Add user preference for default Search filter type
-->

**Analysis / Root cause**:

On the **Search** page, the filter dropdown lets users search resources by **Label** or by **Name**. The selection always defaults to **Label** on every page load, and there is no way to change that default. Users who primarily search by **Name** have to re-select it each time they open the Search page.

This adds a user preference so each user can choose which filter type is preselected on the Search page. The default behavior is unchanged (still **Label**) for users who don't set a preference.

**Solution description**:

- Added a new **General** tab user preference, **"Default search filter"**, with options **Label** (default) and **Name**, stored under the user-settings key `console.searchDefaultFilterType`.
- Added a `useSearchDefaultFilterType` hook (mirroring the existing `useExactSearch` hook) that reads the preference via `useUserPreference`, defaulting to `Label`.
- Updated `SearchFilterDropdown` to read the preference and apply it to the dropdown's initial `selected` state. The default is applied once, **gated on the preference's loaded flag**, via a `useRef` guard so it never overrides a manual selection the user makes in the dropdown and avoids a flash of the wrong default.
- Ran `yarn i18n` to extract the new translatable strings into `packages/console-app/locales/en/console-app.json`.

Changed files:
- `frontend/packages/console-app/console-extensions.json` — new `console.user-preference/item` dropdown extension.
- `frontend/packages/console-app/src/components/user-preferences/search/useSearchDefaultFilterType.ts` — new hook.
- `frontend/public/components/search-filter-dropdown.tsx` — apply preferred default on load.
- `frontend/packages/console-app/locales/en/console-app.json` — extracted i18n keys.
- Tests (see below).

**Screenshots / screen recording**:
<!-- Add before/after screenshots of: (1) User Preferences → General tab showing the new "Default search filter" dropdown, (2) the Search page filter dropdown preselected according to the preference. -->

<img width="1109" height="721" alt="image" src="https://github.com/user-attachments/assets/c37c84e5-3b15-4b5d-8def-a64bf51bba53" />

**Test setup:**

No special setup required.

1. Log in to the console.
2. (Optional) To verify persistence across reloads, ensure user settings are stored (ConfigMap or localStorage fallback).

**Test cases:**

- Default behavior: With no preference set, open **Administration → Search** (or the perspective's Search) — the filter dropdown defaults to **Label**.
- Set preference: Go to **User Preferences → General → Default search filter**, select **Name**. Open the Search page — the filter dropdown is preselected to **Name**.
- Switch back: Set the preference back to **Label**; the Search page dropdown defaults to **Label** again.
- Manual override is preserved: With the preference set to **Name**, open the Search page, then manually switch the dropdown to **Label** — it should not snap back to **Name**.
- Autosave: Changing the preference is autosaved (no explicit save action needed).
- Unit tests:
  - `frontend/packages/console-app/src/components/user-preferences/search/__tests__/useSearchDefaultFilterType.spec.ts`
  - `frontend/public/components/__tests__/search-filter-dropdown.spec.tsx`

  Run with:
  ```bash
  cd frontend && yarn test packages/console-app/src/components/user-preferences/search/__tests__/useSearchDefaultFilterType.spec.ts public/components/__tests__/search-filter-dropdown.spec.tsx
  ```

**Browser conformance**:
- [X] Chrome
- [X] Firefox
- [X] Safari (or Epiphany on Linux)

**Additional info:**

- The stored preference values (`Label` / `Name`) intentionally match the `searchFilterValues` enum so no mapping is required between the preference and the dropdown.
- No public/dynamic-plugin-SDK API changes; this uses the existing `console.user-preference/item` extension point.

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs and PX approvers:
  Console Approver:
  /assign @openshift/team-ux-review

  Docs approver:
  /assign @openshift/team-ux-review

  PX approver:
  /assign @openshift/team-ux-review
-->
Console Approver:
  /assign @openshift/team-ux-review

  Docs approver:
  /assign @openshift/team-ux-review

  PX approver:
  /assign @openshift/team-ux-review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default search filter to start on **Name** instead of **Label**, so the initial toggle and search behavior now match the expected default state.

* **Tests**
  * Added coverage for the search filter dropdown to verify the default selection and confirm users can switch from **Name** to **Label**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->