### PR TITLE
[release-4.21] OCPBUGS-88358: Allow VolumeSnapshot restore when parent PVC is deleted

### DIFF
--- a/frontend/packages/console-app/src/components/modals/restore-pvc/restore-pvc-modal.tsx
+++ b/frontend/packages/console-app/src/components/modals/restore-pvc/restore-pvc-modal.tsx
@@ -78,10 +78,16 @@ const RestorePVCModal = ({ close, cancel, resource }: RestorePVCModalProps) => {
   >(PersistentVolumeClaimModel, resource?.spec?.source?.persistentVolumeClaimName, namespace);
 
   const pvcStorageClassName = pvcResource?.spec?.storageClassName;
+  const pvcNotFound = pvcResourceLoaded && !pvcResource;
   const [scResource, scResourceLoaded, scResourceLoadError] = useK8sGet<StorageClassResourceKind>(
     StorageClassModel,
     pvcStorageClassName,
   );
+
+  // Form is ready when either:
+  // - PVC was found and its StorageClass has loaded
+  // - PVC was not found (deleted) — annotations and snapshot status provide sufficient data
+  const formReady = pvcNotFound || (!!pvcStorageClassName && scResourceLoaded);
 
   const [volumeMode, setVolumeMode] = React.useState('');
   const requestedSizeInputChange = ({ value, unit }) => {
@@ -156,13 +162,16 @@ const RestorePVCModal = ({ close, cancel, resource }: RestorePVCModalProps) => {
           />
         </FormGroup>
         <FormGroup fieldId="restore-storage-class" className="co-restore-pvc-modal__input">
-          {!pvcStorageClassName || !scResourceLoaded ? (
+          {!formReady ? (
             <div className="skeleton-text" />
           ) : (
             <StorageClassDropdown
               onChange={handleStorageClass}
-              filter={(scObj: StorageClassResourceKind) =>
-                onlyPvcSCs(scObj, scResourceLoadError, scResource)
+              filter={
+                pvcNotFound
+                  ? undefined
+                  : (scObj: StorageClassResourceKind) =>
+                      onlyPvcSCs(scObj, scResourceLoadError, scResource)
               }
               id="restore-storage-class"
               required
@@ -197,14 +206,16 @@ const RestorePVCModal = ({ close, cancel, resource }: RestorePVCModalProps) => {
           fieldId="pvc-size"
           className="co-restore-pvc-modal__input co-restore-pvc-modal__ocs-size"
         >
-          {!!pvcStorageClassName && scResourceLoaded ? (
+          {formReady ? (
             <RequestSizeInput
               name="requestSize"
               onChange={requestedSizeInputChange}
               defaultRequestSizeUnit={requestedUnit}
               defaultRequestSizeValue={requestedSize}
               dropdownUnits={dropdownUnits}
-              isInputDisabled={scResourceLoadError || isCephProvisioner(scResource?.provisioner)}
+              isInputDisabled={
+                !pvcNotFound && (scResourceLoadError || isCephProvisioner(scResource?.provisioner))
+              }
               required
             />
           ) : (


### PR DESCRIPTION
This is a manual cherry-pick of #16447 to release-4.21.

The automated `/cherry-pick release-4.21` failed due to content conflicts — the file has diverged between main and release-4.21 (PF v6 migration, overlay pattern changes). The fix logic is identical to main; only adapted to the 4.21 code style.

/assign sg00dwin