### PR TITLE
OCPBUGS-87996: Bump fast-uri to 3.1.2 to fix CVE-2026-6322

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -337,7 +337,8 @@
     "minimatch@^9.0.4": "^9.0.6",
     "minimatch@^10.1.2": "^10.2.1",
     "shell-quote": "1.8.4",
-    "protobufjs": "7.5.8"
+    "protobufjs": "7.5.8",
+    "fast-uri": "3.1.2"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11960,10 +11960,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "fast-uri@npm:3.0.1"
-  checksum: 10c0/3cd46d6006083b14ca61ffe9a05b8eef75ef87e9574b6f68f2e17ecf4daa7aaadeff44e3f0f7a0ef4e0f7e7c20fc07beec49ff14dc72d0b500f00386592f2d10
+"fast-uri@npm:3.1.2":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pin fast-uri to 3.1.2 to address CVE-2026-6322 (URI authority bypass due to improper delimiter handling).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution to ensure compatibility and stability across the frontend environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->