### PR TITLE
[release-4.16] OCPBUGS-88554: Stabilize legacy OperatorHub Cypress waits

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.cy.ts
@@ -1,5 +1,6 @@
 import { checkErrors, testName } from '../../../integration-tests-cypress/support';
 import { modal } from '../../../integration-tests-cypress/views/modal';
+import { operatorHub } from '../views/operator-hub.view';
 
 describe('Create namespace from install operators', () => {
   before(() => {
@@ -22,6 +23,7 @@ describe('Create namespace from install operators', () => {
     const operatorName = 'Red Hat Integration - 3scale';
     cy.log('test namespace creation from dropdown');
     cy.visit(`/operatorhub/ns/${testName}`);
+    operatorHub.waitForLoaded();
     cy.byTestID('search-operatorhub').type(operatorName);
     cy.byTestID(operatorSelector).click();
     cy.byLegacyTestID('operator-install-btn').click({ force: true });

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.cy.ts
@@ -1,5 +1,6 @@
 import { checkErrors, testName } from '../../../integration-tests-cypress/support';
 import { nav } from '../../../integration-tests-cypress/views/nav';
+import { OPERATOR_HUB_LOAD_TIMEOUT, operatorHub } from '../views/operator-hub.view';
 
 describe('Interacting with OperatorHub', () => {
   before(() => {
@@ -19,11 +20,14 @@ describe('Interacting with OperatorHub', () => {
     cy.log('navigate to OperatorHub');
     nav.sidenav.clickNavLink(['Operators', 'OperatorHub']);
     cy.url().should('include', '/operatorhub/all-namespaces');
+    operatorHub.waitForLoaded();
     cy.log('more than one tile should be present');
     cy.get('.co-catalog-tile').its('length').should('be.gt', 0);
 
     cy.log('enable the Red Hat filter');
-    cy.byTestID('catalogSourceDisplayName-red-hat').click();
+    cy.byTestID('catalogSourceDisplayName-red-hat', { timeout: OPERATOR_HUB_LOAD_TIMEOUT })
+      .should('be.visible')
+      .click();
     cy.log('more than one tile should be present');
     cy.get('.co-catalog-tile').its('length').should('be.gt', 0);
     cy.log('track which tile is first');
@@ -34,17 +38,20 @@ describe('Interacting with OperatorHub', () => {
         const origCatalogTitleTxt = $origCatalogTitle.find('.catalog-tile-pf-title').text();
         cy.log(`first Red Hat filtered tile title text is ${origCatalogTitleTxt}`);
         cy.log('disable the Red Hat filter');
-        cy.byTestID('catalogSourceDisplayName-red-hat').click();
+        cy.byTestID('catalogSourceDisplayName-red-hat', { timeout: OPERATOR_HUB_LOAD_TIMEOUT })
+          .should('be.visible')
+          .click();
         cy.log('enable the Certified filter');
-        cy.byTestID('catalogSourceDisplayName-certified').click();
-        cy.log('more than one tile should be present');
-        cy.get('.co-catalog-tile').its('length').should('be.gt', 0);
-        cy.log('the first tile title text for Certified should not be the same as Red Hat');
-        cy.get('.co-catalog-tile')
-          .first()
-          .find('.catalog-tile-pf-title')
-          .invoke('text')
-          .should('not.equal', origCatalogTitleTxt);
+        cy.byTestID('catalogSourceDisplayName-certified', { timeout: OPERATOR_HUB_LOAD_TIMEOUT })
+          .should('be.visible')
+          .click();
+        cy.log('wait for the Certified results to replace the Red Hat list');
+        cy.get('.co-catalog-tile').should(($tiles) => {
+          expect($tiles.length).to.be.gt(0);
+          expect($tiles.first().find('.catalog-tile-pf-title').text()).not.to.equal(
+            origCatalogTitleTxt,
+          );
+        });
       });
 
     cy.log('filters Operators by name');

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator-hub.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator-hub.view.ts
@@ -1,0 +1,15 @@
+/** OperatorHub can render tiles before the search and filter controls are ready. */
+export const OPERATOR_HUB_LOAD_TIMEOUT = 60000;
+
+export const operatorHub = {
+  waitForLoaded: () => {
+    cy.get('.skeleton-catalog--grid', { timeout: OPERATOR_HUB_LOAD_TIMEOUT }).should('not.exist');
+    cy.byTestID('search-operatorhub', { timeout: OPERATOR_HUB_LOAD_TIMEOUT }).should('be.visible');
+    cy.get('[data-test-group-name="catalogSourceDisplayName"]', {
+      timeout: OPERATOR_HUB_LOAD_TIMEOUT,
+    }).should('be.visible');
+    cy.get('.co-catalog-tile', { timeout: OPERATOR_HUB_LOAD_TIMEOUT })
+      .its('length')
+      .should('be.gt', 0);
+  },
+};


### PR DESCRIPTION
<h2 id="feature-fix">CONSOLE Features and Fixes: </h2>

<h2 id="solution-description">Solution description</h2>
This PR stabilizes the legacy OperatorHub Cypress flows on `release-4.16`.

Why we are fixing this:
- `e2e-gcp-console` on `release-4.16` is being destabilized by flaky OLM OperatorHub tests rather than by the product bug under test.
- Dredge analysis of the recent failed `e2e-gcp-console` jobs showed that on `release-4.16`, `operator-hub.cy.ts` failed in **12/12 failed builds** that were sampled.
- The dominant signature was the legacy filter click timing out on `catalogSourceDisplayName-red-hat` (**9x**), with the remaining **3x** coming from the related `create-namespace.cy.ts` path timing out around `search-operatorhub`.
- On newer branches, the same OperatorHub spec was passing in failed builds, so this is not a general current-branch problem. It is specific to the older `release-4.16` OperatorHub UI/test path.

Why this needs a `release-4.16`-specific fix:
- `release-4.16` still uses the legacy OperatorHub page and selectors like `catalogSourceDisplayName-red-hat` and `search-operatorhub`.
- Newer branches moved to different catalog flows and selectors, so there is no clean newer-branch PR to cherry-pick for this exact flake.

How this PR fixes it:
- Add a small `operatorHub.waitForLoaded()` helper for the legacy OperatorHub page.
- Wait for the loading skeleton to disappear, the search input to be visible, the filter sidebar to be present, and catalog tiles to exist before interacting.
- Use that wait only in the two flaky specs: `operator-hub.cy.ts` and `create-namespace.cy.ts`.
- Add explicit timeout-backed visibility checks for the legacy Red Hat / Certified filter clicks.
- Keep the scope narrow on this older branch and avoid broadening the change through shared install helpers.

<h2 id="reviewers-and-assignees">Reviewers and assignees</h2>
TBD

<h2 id="test-cases">Test cases:</h2>
- Main validation target is the `e2e-gcp-console` lane on `release-4.16`, especially:
  - `Interacting with OperatorHub`
  - `Create namespace from install operators`
- Cross-branch investigation from dredge indicated this specific failure mode is isolated to the legacy `release-4.16` codepath; newer branches were not failing this spec in the sampled failed builds.
- Local Cypress execution is blocked in this environment because `yarn` is not installed.
- Attempted locally:
  - `./test-cypress.sh -p olm -s 'packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.cy.ts' -h true`
  - `./test-cypress.sh -p olm -s 'packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.cy.ts' -h true`

<h2 id="additional-info">Additional info:</h2>
- This is a `release-4.16`-only stabilization for the legacy OperatorHub UI.
- Diff against `release-4.16` is one commit touching three files.
- The intent is to remove CI noise from a known flaky test path so `e2e-gcp-console` can validate actual regressions instead of repeatedly failing on page-load timing.

<h2 id="screenshots">Screen shots / gifs / design review:</h2>
Not applicable; test-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Improved OperatorHub integration test reliability with enhanced synchronization for catalog loading and filter operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->