### PR TITLE
OCPBUGS-95590: Hide Builds and ImageStreams nav items when Build capability is disabled

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -722,7 +722,7 @@
       "name": "%console-app~Builds%",
       "dataAttributes": { "data-quickstart-id": "qs-nav-builds" }
     },
-    "flags": { "required": ["OPENSHIFT"] }
+    "flags": { "required": ["OPENSHIFT_BUILDCONFIG"] }
   },
   {
     "type": "console.navigation/section",
@@ -1164,7 +1164,8 @@
         "version": "v1",
         "kind": "ImageStream"
       }
-    }
+    },
+    "flags": { "required": ["OPENSHIFT_BUILDCONFIG"] }
   },
   {
     "type": "console.navigation/resource-cluster",


### PR DESCRIPTION
## Fixes
https://issues.redhat.com/browse/CONSOLE-5140

## Analysis / Root cause
On OCP 4.20.x with `baselineCapabilitySet: None` and Build capability not enabled, the admin perspective **Builds** nav section remained visible because:

1. The admin `Builds` section header (`console.navigation/section`) was gated only on `"required": ["OPENSHIFT"]` — always `true` on any OpenShift cluster regardless of Build capability state.
2. The **ImageStreams** nav item inside the Builds section had no flag guard. Since `imagestreams.image.openshift.io` APIs are always present on OpenShift (independent of the Build capability), ImageStreams always appeared — keeping the section non-empty and visible.

As a result, users on clusters with Build capability disabled see a **Builds** section in the admin nav containing only **ImageStreams**, with no BuildConfigs or Builds items (those are already correctly gated by `OPENSHIFT_BUILDCONFIG` / `OPENSHIFT_BUILD` flags).

The Developer perspective **Builds** nav item already has `"required": ["OPENSHIFT_BUILDCONFIG"]` and does not need to be changed.

## Solution Description
- Added `"flags": { "required": ["OPENSHIFT_BUILDCONFIG"] }` to the admin `imagestreams` nav item in `console-app/console-extensions.json`, so it is hidden when `buildconfigs.build.openshift.io` is absent.
- Changed the admin `builds` section flag from `"required": ["OPENSHIFT"]` to `"required": ["OPENSHIFT_BUILDCONFIG"]`, so the entire Builds section header is also hidden when Build capability is disabled.

## Test setup
1. Create a cluster with `baselineCapabilitySet: None` and Build capability **not** enabled
2. Verify `oc api-resources | grep build` shows no `buildconfigs.build.openshift.io`
3. Confirm admin Builds section and ImageStreams nav item are hidden
4. Confirm Developer → Builds nav item is hidden
5. Enable Build capability, re-verify both items reappear correctly