### PR TITLE
OCPBUGS-83427: Fix Form view injecting multiple providers in ClusterSecretStore spec.provider

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/__tests__/fields.spec.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/__tests__/fields.spec.tsx
@@ -1,0 +1,239 @@
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { JSONSchema7 } from 'json-schema';
+
+// Mock heavy dependencies not needed for unit tests
+jest.mock('@console/internal/components/modals/configure-update-strategy-modal', () => ({
+  ConfigureUpdateStrategy: () => null,
+}));
+jest.mock(
+  '@console/operator-lifecycle-manager/src/components/descriptors/spec/affinity',
+  () => ({ NodeAffinity: () => null, PodAffinity: () => null }),
+);
+jest.mock(
+  '@console/operator-lifecycle-manager/src/components/descriptors/spec/match-expressions',
+  () => ({ MatchExpressions: () => null }),
+);
+jest.mock(
+  '@console/operator-lifecycle-manager/src/components/descriptors/spec/resource-requirements',
+  () => ({ ResourceRequirements: () => null }),
+);
+jest.mock('@console/internal/components/utils/selector-input', () => ({
+  SelectorInput: () => null,
+}));
+jest.mock('@console/internal/components/utils/link', () => ({
+  LinkifyExternal: ({ children }) => children,
+}));
+
+// Minimal ConsoleSelect mock that calls onChange when a new item is selected
+jest.mock('@console/internal/components/utils/console-select', () => ({
+  ConsoleSelect: ({ onChange, selectedKey, items, title, id }) => (
+    <select
+      data-testid={id}
+      aria-label={title}
+      value={selectedKey}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {Object.keys(items).map((key) => (
+        <option key={key} value={key}>
+          {key}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+// Minimal @rjsf/core SchemaField mock — renders each immediate property of an object schema
+// as a simple labelled input so we can verify which sub-form is shown/hidden.
+jest.mock('@rjsf/core/dist/cjs/components/fields/SchemaField', () => {
+  const MockSchemaField = ({ schema, formData, onChange, name }) => {
+    if (schema?.type === 'object' && schema?.properties) {
+      return (
+        <div data-testid={`schema-field-${name}`}>
+          {Object.keys(schema.properties).map((propName) => (
+            <input
+              key={propName}
+              data-testid={`input-${name}-${propName}`}
+              aria-label={`${name}.${propName}`}
+              defaultValue={formData?.[propName] ?? ''}
+              onChange={(e) =>
+                onChange({ ...(formData ?? {}), [propName]: e.target.value })
+              }
+            />
+          ))}
+        </div>
+      );
+    }
+    return (
+      <input
+        data-testid={`schema-field-${name}`}
+        aria-label={name}
+        defaultValue={formData ?? ''}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    );
+  };
+  return MockSchemaField;
+});
+
+jest.mock('@rjsf/core/dist/cjs/utils', () => ({
+  retrieveSchema: (schema) => schema,
+  getUiOptions: () => ({}),
+  getSchemaType: (schema) => schema?.type,
+}));
+
+// Import the default export (fields map) AFTER mocks are set up
+// eslint-disable-next-line import/first
+import fields from '../fields';
+
+const { SchemaField: CustomSchemaField } = fields;
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+const MULTI_PROVIDER_SCHEMA: JSONSchema7 = {
+  type: 'object',
+  maxProperties: 1,
+  properties: {
+    azurekv: {
+      type: 'object',
+      properties: {
+        vaultUrl: { type: 'string' },
+        tenantId: { type: 'string' },
+      },
+    },
+    vault: {
+      type: 'object',
+      properties: {
+        server: { type: 'string' },
+        path: { type: 'string' },
+      },
+    },
+    gcpsm: {
+      type: 'object',
+      properties: {
+        projectID: { type: 'string' },
+      },
+    },
+  },
+};
+
+const makeProps = (schema: JSONSchema7, formData: any = {}, onChange = jest.fn()) => ({
+  schema,
+  formData,
+  onChange,
+  idSchema: { $id: 'root_spec_provider' },
+  uiSchema: {},
+  name: 'provider',
+  required: false,
+  registry: {
+    rootSchema: schema,
+    definitions: {},
+    fields: {},
+    widgets: {},
+    formContext: {},
+  },
+  errorSchema: {},
+  rawErrors: [],
+  disabled: false,
+  readonly: false,
+  autofocus: false,
+});
+
+// -----------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------
+
+describe('SinglePropertyObjectField (via CustomSchemaField)', () => {
+  it('renders a provider dropdown with all property names as options', () => {
+    render(<CustomSchemaField {...makeProps(MULTI_PROVIDER_SCHEMA)} />);
+
+    const select = screen.getByTestId('root_spec_provider_key') as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toEqual(expect.arrayContaining(['azurekv', 'vault', 'gcpsm']));
+  });
+
+  it('defaults to the first key when formData is empty', () => {
+    render(<CustomSchemaField {...makeProps(MULTI_PROVIDER_SCHEMA, {})} />);
+
+    const select = screen.getByTestId('root_spec_provider_key') as HTMLSelectElement;
+    expect(select.value).toBe('azurekv');
+  });
+
+  it('initialises with the key already present in formData', () => {
+    render(
+      <CustomSchemaField
+        {...makeProps(MULTI_PROVIDER_SCHEMA, { vault: { server: 'https://vault.example.com' } })}
+      />,
+    );
+
+    const select = screen.getByTestId('root_spec_provider_key') as HTMLSelectElement;
+    expect(select.value).toBe('vault');
+  });
+
+  it('shows sub-form fields only for the selected provider', () => {
+    render(<CustomSchemaField {...makeProps(MULTI_PROVIDER_SCHEMA, {})} />);
+
+    // azurekv sub-form fields should be visible
+    expect(screen.getByTestId('schema-field-azurekv')).toBeInTheDocument();
+    // vault and gcpsm sub-forms should NOT be rendered
+    expect(screen.queryByTestId('schema-field-vault')).toBeNull();
+    expect(screen.queryByTestId('schema-field-gcpsm')).toBeNull();
+  });
+
+  it('calls onChange with only the new key when the provider selection changes', () => {
+    const onChange = jest.fn();
+    render(<CustomSchemaField {...makeProps(MULTI_PROVIDER_SCHEMA, {}, onChange)} />);
+
+    const select = screen.getByTestId('root_spec_provider_key');
+    fireEvent.change(select, { target: { value: 'vault' } });
+
+    // onChange must have been called with only the vault key
+    expect(onChange).toHaveBeenCalledWith({ vault: {} });
+    // It must NOT include azurekv or gcpsm
+    const [calledWith] = onChange.mock.calls[onChange.mock.calls.length - 1];
+    expect(Object.keys(calledWith)).toEqual(['vault']);
+  });
+
+  it('switches the visible sub-form when a different provider is selected', () => {
+    render(<CustomSchemaField {...makeProps(MULTI_PROVIDER_SCHEMA, {})} />);
+
+    const select = screen.getByTestId('root_spec_provider_key');
+    fireEvent.change(select, { target: { value: 'gcpsm' } });
+
+    expect(screen.getByTestId('schema-field-gcpsm')).toBeInTheDocument();
+    expect(screen.queryByTestId('schema-field-azurekv')).toBeNull();
+    expect(screen.queryByTestId('schema-field-vault')).toBeNull();
+  });
+
+  it('calls onChange with only the selected key when a sub-form field changes', () => {
+    const onChange = jest.fn();
+    render(
+      <CustomSchemaField
+        {...makeProps(MULTI_PROVIDER_SCHEMA, { azurekv: { vaultUrl: 'https://my-vault.vault.azure.net' } }, onChange)}
+      />,
+    );
+
+    const vaultUrlInput = screen.getByTestId('input-azurekv-vaultUrl');
+    fireEvent.change(vaultUrlInput, { target: { value: 'https://updated.vault.azure.net' } });
+
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(Object.keys(lastCall)).toEqual(['azurekv']);
+    expect(lastCall.azurekv.vaultUrl).toBe('https://updated.vault.azure.net');
+  });
+
+  it('does not render SinglePropertyObjectField for a normal object schema without maxProperties: 1', () => {
+    const normalSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        value: { type: 'string' },
+      },
+    };
+    render(<CustomSchemaField {...makeProps(normalSchema, {})} />);
+
+    // The provider dropdown must NOT be rendered for ordinary objects
+    expect(screen.queryByTestId('root_spec_provider_key')).toBeNull();
+  });
+});

--- a/frontend/packages/console-shared/src/components/dynamic-form/fields.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/fields.tsx
@@ -28,7 +28,7 @@ import {
 } from '@console/operator-lifecycle-manager/src/components/descriptors/spec/affinity';
 import { MatchExpressions } from '@console/operator-lifecycle-manager/src/components/descriptors/spec/match-expressions';
 import { ResourceRequirements } from '@console/operator-lifecycle-manager/src/components/descriptors/spec/resource-requirements';
-import { hasNoFields, useSchemaDescription, useSchemaLabel } from './utils';
+import { hasNoFields, isSinglePropertyObject, useSchemaDescription, useSchemaLabel } from './utils';
 
 const Description = ({ id, description }) =>
   description ? (
@@ -336,6 +336,62 @@ const DropdownField: FC<FieldProps> = ({
   );
 };
 
+// Renders a selection UI for JSON Schema objects that use `maxProperties: 1` to express a
+// discriminated union (e.g. ClusterSecretStore spec.provider). A dropdown lets the user pick
+// exactly one active property; only that property's sub-form is shown, and onChange always emits
+// an object with only the selected key — preventing multiple providers from being injected.
+const SinglePropertyObjectField: FC<SchemaFieldProps> = (props) => {
+  const { t } = useTranslation();
+  const { schema, formData = {}, onChange, idSchema, uiSchema, name } = props;
+  const propertyNames = _.keys(schema.properties ?? {});
+
+  // Determine the initially active key: prefer a key already present in formData, otherwise
+  // fall back to the first defined property.
+  const initialKey =
+    propertyNames.find((key) => !_.isUndefined(formData[key])) ?? propertyNames[0];
+  const [selectedKey, setSelectedKey] = useState<string>(initialKey);
+
+  const dropdownItems = _.fromPairs(propertyNames.map((key) => [key, key]));
+
+  const handleKeyChange = (newKey: string) => {
+    setSelectedKey(newKey);
+    // Clear all providers and initialise the newly selected one with an empty object so that its
+    // sub-form renders with schema defaults rather than stale data from a previous selection.
+    onChange({ [newKey]: formData[newKey] ?? {} });
+  };
+
+  const handleSubFormChange = (newSubData: any) => {
+    onChange({ [selectedKey]: newSubData });
+  };
+
+  const selectedPropertySchema = (schema.properties?.[selectedKey] ?? {}) as JSONSchema7;
+  const subIdSchema = { $id: `${idSchema.$id}_${selectedKey}` };
+
+  return (
+    <FieldSet defaultLabel={name} idSchema={idSchema} schema={schema} uiSchema={uiSchema}>
+      <ConsoleSelect
+        id={`${idSchema.$id}_key`}
+        title={t('console-shared~Select {{name}}', { name: name || schema.title })}
+        selectedKey={selectedKey}
+        items={dropdownItems}
+        onChange={handleKeyChange}
+      />
+      {!_.isEmpty(selectedPropertySchema) && (
+        <SchemaField
+          {...props}
+          name={selectedKey}
+          idSchema={subIdSchema}
+          schema={selectedPropertySchema}
+          uiSchema={uiSchema?.[selectedKey] ?? {}}
+          formData={formData?.[selectedKey]}
+          onChange={handleSubFormChange}
+          required={false}
+        />
+      )}
+    </FieldSet>
+  );
+};
+
 const CustomSchemaField: FC<SchemaFieldProps> = (props) => {
   // If the provided schema will not generate any form field elements, return null.
   // To check that, it's required to resolving definition references ($ref) in the
@@ -358,6 +414,13 @@ const CustomSchemaField: FC<SchemaFieldProps> = (props) => {
 
   if (hasNoFields(resolvedSchema, uiSchema)) {
     return null;
+  }
+
+  // Intercept objects that use maxProperties: 1 to express a single-choice discriminated union
+  // (e.g. ClusterSecretStore spec.provider). Render a dedicated selection UI so that only the
+  // chosen property is included in the form data instead of all properties with their defaults.
+  if (isSinglePropertyObject(resolvedSchema)) {
+    return <SinglePropertyObjectField {...props} schema={resolvedSchema} />;
   }
 
   return <SchemaField {...props} />;

--- a/frontend/packages/console-shared/src/components/dynamic-form/utils.spec.ts
+++ b/frontend/packages/console-shared/src/components/dynamic-form/utils.spec.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema7 } from 'json-schema';
 import { JSONSchemaType } from './types';
-import { hasNoFields, prune } from './utils';
+import { hasNoFields, isSinglePropertyObject, prune } from './utils';
 
 const OBJECT: JSONSchema7 = {
   type: JSONSchemaType.object,
@@ -115,6 +115,67 @@ describe('hasNoFields', () => {
 
   it('Returns false for array schema type with properly defined items', () => {
     expect(hasNoFields(ARRAY)).toBeFalsy();
+  });
+});
+
+describe('isSinglePropertyObject', () => {
+  it('Returns true for an object with maxProperties: 1 and multiple defined properties', () => {
+    const schema: JSONSchema7 = {
+      type: JSONSchemaType.object,
+      maxProperties: 1,
+      properties: {
+        providerA: { type: JSONSchemaType.object, properties: { url: { type: JSONSchemaType.string } } },
+        providerB: { type: JSONSchemaType.object, properties: { host: { type: JSONSchemaType.string } } },
+      },
+    };
+    expect(isSinglePropertyObject(schema)).toBeTruthy();
+  });
+
+  it('Returns false when maxProperties is not 1', () => {
+    const schema: JSONSchema7 = {
+      type: JSONSchemaType.object,
+      maxProperties: 2,
+      properties: {
+        a: { type: JSONSchemaType.string },
+        b: { type: JSONSchemaType.string },
+      },
+    };
+    expect(isSinglePropertyObject(schema)).toBeFalsy();
+  });
+
+  it('Returns false when maxProperties is 1 but only one property is defined', () => {
+    const schema: JSONSchema7 = {
+      type: JSONSchemaType.object,
+      maxProperties: 1,
+      properties: {
+        onlyProp: { type: JSONSchemaType.string },
+      },
+    };
+    expect(isSinglePropertyObject(schema)).toBeFalsy();
+  });
+
+  it('Returns false when maxProperties is absent', () => {
+    const schema: JSONSchema7 = {
+      type: JSONSchemaType.object,
+      properties: {
+        a: { type: JSONSchemaType.string },
+        b: { type: JSONSchemaType.string },
+      },
+    };
+    expect(isSinglePropertyObject(schema)).toBeFalsy();
+  });
+
+  it('Returns false for a non-object schema type', () => {
+    const schema: JSONSchema7 = {
+      type: JSONSchemaType.array,
+      maxProperties: 1,
+    } as JSONSchema7;
+    expect(isSinglePropertyObject(schema)).toBeFalsy();
+  });
+
+  it('Returns false for a null/undefined schema', () => {
+    expect(isSinglePropertyObject(null)).toBeFalsy();
+    expect(isSinglePropertyObject(undefined)).toBeFalsy();
   });
 });
 

--- a/frontend/packages/console-shared/src/components/dynamic-form/utils.ts
+++ b/frontend/packages/console-shared/src/components/dynamic-form/utils.ts
@@ -287,3 +287,12 @@ const pruneRecursive = (current: any, sample: any): any => {
 export const prune = (obj: any, sample?: any): any => {
   return pruneRecursive(_.cloneDeep(obj), sample);
 };
+
+// Returns true when a JSON schema object should present a single-choice selection UI:
+// the schema is an object type with maxProperties: 1 and more than one defined property.
+// This pattern is used by operators (e.g. External Secrets Operator ClusterSecretStore
+// spec.provider) to express discriminated union types without using oneOf.
+export const isSinglePropertyObject = (schema: JSONSchema7): boolean =>
+  schema?.type === 'object' &&
+  (schema?.maxProperties as number) === 1 &&
+  _.keys(schema?.properties ?? {}).length > 1;


### PR DESCRIPTION
## Summary

- The External Secrets Operator `ClusterSecretStore` CRD defines `spec.provider` as an object with `maxProperties: 1` (exactly one provider allowed). The Console Form view was rendering **all** provider sub-objects with their CRD schema defaults populated, and `prune()` only strips empty values — so all provider keys survived into the YAML, causing a validation failure: `must have at most 1 items for field 'spec.provider'`.
- Added `isSinglePropertyObject()` helper in `utils.ts` that detects this `maxProperties: 1` + multiple-properties pattern.
- Added `SinglePropertyObjectField` in `fields.tsx`: renders a dropdown to pick exactly one active provider, shows only that provider's sub-form, and calls `onChange` with only `{ [selectedKey]: data }` — preventing sibling providers from being injected.
- Wired the new field into `CustomSchemaField` so it activates automatically for any operator CRD using this pattern.

## Test plan

- [ ] Install Red Hat External Secrets Operator v1.1.0 on OCP 4.18 / 4.20
- [ ] Navigate to Installed Operators → External Secrets Operator → Create ClusterSecretStore (Form view)
- [ ] Select a provider (e.g. AzureKV), fill required fields
- [ ] Switch to YAML view — verify only the selected provider appears under `spec.provider`
- [ ] Click Create — verify resource is created successfully with no `must have at most 1 items` error
- [ ] Run unit tests: `cd frontend && yarn test --testPathPatterns="dynamic-form/(utils|fields)"`

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-83427

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for single-choice selection dropdowns in dynamic forms, enabling users to select one provider from multiple available options with improved state management.

* **Tests**
  * Added comprehensive test coverage for single-choice form field behavior and provider selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->