### PR TITLE
[release-4.21] OCPBUGS-99163: fixing severity not showing number of issues

### DIFF
--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/__tests__/index.spec.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/__tests__/index.spec.tsx
@@ -1,0 +1,203 @@
+import { render, screen } from '@testing-library/react';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import { LabelComponent, InsightsPopup } from '../index';
+
+jest.mock('@patternfly/react-charts/victory', () => ({
+  ChartDonut: jest.fn(() => null),
+  ChartLegend: jest.fn(() => null),
+  ChartLabel: jest.fn(() => null),
+}));
+
+jest.mock('@console/internal/components/error', () => ({
+  ErrorState: jest.fn(() => 'ErrorState'),
+}));
+
+jest.mock('@console/shared/src/components/datetime/Timestamp', () => ({
+  Timestamp: jest.fn(() => 'Timestamp'),
+}));
+
+jest.mock('@console/shared/src/components/links/ExternalLink', () => ({
+  ExternalLink: jest.fn(({ text }) => text),
+}));
+
+jest.mock('@console/internal/components/utils', () => ({
+  documentationURLs: { usingInsights: 'usingInsights' },
+  getDocumentationURL: jest.fn(() => 'https://docs.example.com'),
+  isManaged: jest.fn(() => false),
+}));
+
+describe('LabelComponent', () => {
+  it('should generate correct href for a valid clusterID and risk level', () => {
+    render(<LabelComponent clusterID="cluster-abc" datum={{ id: 'critical' }} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute(
+      'href',
+      'https://console.redhat.com/openshift/insights/advisor/clusters/cluster-abc?total_risk=4',
+    );
+  });
+
+  it.each([
+    ['low', 1],
+    ['moderate', 2],
+    ['important', 3],
+    ['critical', 4],
+  ])('should compute totalRisk=%s as %i', (riskId, expectedTotalRisk) => {
+    render(<LabelComponent clusterID="cluster-1" datum={{ id: riskId }} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute(
+      'href',
+      `https://console.redhat.com/openshift/insights/advisor/clusters/cluster-1?total_risk=${expectedTotalRisk}`,
+    );
+  });
+
+  it('should not render a link when clusterID is empty', () => {
+    render(<LabelComponent clusterID="" datum={{ id: 'critical' }} />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('should not render a link when datum is undefined', () => {
+    render(<LabelComponent clusterID="cluster-1" />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('should not render a link when datum.id is an unknown risk level', () => {
+    render(<LabelComponent clusterID="cluster-1" datum={{ id: 'unknown-risk' }} />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('should set target="_blank" and rel="noopener noreferrer"', () => {
+    render(<LabelComponent clusterID="cluster-1" datum={{ id: 'low' }} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('should set tabIndex=0 for keyboard accessibility', () => {
+    render(<LabelComponent clusterID="cluster-1" datum={{ id: 'low' }} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('tabindex', '0');
+  });
+});
+
+const makePrometheusResponse = (
+  results: { metric: Record<string, string>; value: [number, string] }[],
+) => ({
+  status: 'success' as const,
+  data: {
+    resultType: 'vector' as const,
+    result: results,
+  },
+});
+
+const metricsResponse = makePrometheusResponse([
+  { metric: { metric: 'low' }, value: [0, '3'] },
+  { metric: { metric: 'moderate' }, value: [0, '2'] },
+  { metric: { metric: 'important' }, value: [0, '1'] },
+  { metric: { metric: 'critical' }, value: [0, '0'] },
+]);
+
+const operatorAvailable = makePrometheusResponse([
+  { metric: { condition: 'Available' }, value: [0, '1'] },
+]);
+
+const lastGatherResponse = makePrometheusResponse([
+  { metric: {}, value: [0, `${Math.floor(Date.now() / 1000)}`] },
+]);
+
+const k8sCluster = {
+  data: {
+    apiVersion: 'config.openshift.io/v1',
+    kind: 'ClusterVersion',
+    spec: { clusterID: 'test-cluster-id' },
+  },
+  loaded: true,
+  loadError: null,
+} as any;
+
+describe('InsightsPopup', () => {
+  const baseResponses = [
+    { response: metricsResponse, error: null },
+    { response: operatorAvailable, error: null },
+    { response: lastGatherResponse, error: null },
+  ];
+
+  it('should render ErrorState when upload is degraded', () => {
+    const degradedOperator = makePrometheusResponse([
+      { metric: { condition: 'Degraded' }, value: [0, '1'] },
+      { metric: { condition: 'UploadDegraded' }, value: [0, '1'] },
+    ]);
+    const responses = [
+      { response: metricsResponse, error: null },
+      { response: degradedOperator, error: null },
+      { response: lastGatherResponse, error: null },
+    ];
+
+    renderWithProviders(
+      <InsightsPopup responses={responses} k8sResult={k8sCluster} hide={jest.fn()} />,
+    );
+    expect(screen.getByText('ErrorState')).toBeInTheDocument();
+  });
+
+  it('should show "Temporarily unavailable" on metrics error', () => {
+    const responses = [
+      { response: metricsResponse, error: new Error('fail') },
+      { response: operatorAvailable, error: null },
+      { response: lastGatherResponse, error: null },
+    ];
+
+    renderWithProviders(
+      <InsightsPopup responses={responses} k8sResult={k8sCluster} hide={jest.fn()} />,
+    );
+    expect(screen.getByText('Temporarily unavailable.')).toBeInTheDocument();
+  });
+
+  it('should show "Disabled." when operator is disabled', () => {
+    const disabledOperator = makePrometheusResponse([
+      { metric: { condition: 'Disabled' }, value: [0, '1'] },
+    ]);
+    const responses = [
+      { response: metricsResponse, error: null },
+      { response: disabledOperator, error: null },
+      { response: lastGatherResponse, error: null },
+    ];
+
+    renderWithProviders(
+      <InsightsPopup responses={responses} k8sResult={k8sCluster} hide={jest.fn()} />,
+    );
+    expect(screen.getByText('Disabled.')).toBeInTheDocument();
+  });
+
+  it('should show "Waiting for results." when operator status is not yet available', () => {
+    const responses = [
+      { response: metricsResponse, error: null },
+      { response: null, error: null },
+      { response: lastGatherResponse, error: null },
+    ];
+
+    renderWithProviders(
+      <InsightsPopup responses={responses} k8sResult={k8sCluster} hide={jest.fn()} />,
+    );
+    expect(screen.getByText('Waiting for results.')).toBeInTheDocument();
+  });
+
+  it('should render chart area when metrics are available', () => {
+    renderWithProviders(
+      <InsightsPopup responses={baseResponses} k8sResult={k8sCluster} hide={jest.fn()} />,
+    );
+    expect(screen.getByText('Fixable issues')).toBeInTheDocument();
+    expect(
+      screen.getByText('View all recommendations in Red Hat Lightspeed Advisor'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render generic advisor link when clusterID is missing', () => {
+    renderWithProviders(
+      <InsightsPopup
+        responses={baseResponses}
+        k8sResult={{ loaded: true, loadError: null } as any}
+        hide={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('View more in Red Hat Lightspeed Advisor')).toBeInTheDocument();
+  });
+});

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/__tests__/index.spec.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/__tests__/index.spec.tsx
@@ -36,17 +36,39 @@ describe('LabelComponent', () => {
     );
   });
 
-  it.each([
-    ['low', 1],
-    ['moderate', 2],
-    ['important', 3],
-    ['critical', 4],
-  ])('should compute totalRisk=%s as %i', (riskId, expectedTotalRisk) => {
-    render(<LabelComponent clusterID="cluster-1" datum={{ id: riskId }} />);
+  it('should compute totalRisk for low as 1', () => {
+    render(<LabelComponent clusterID="cluster-1" datum={{ id: 'low' }} />);
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute(
       'href',
-      `https://console.redhat.com/openshift/insights/advisor/clusters/cluster-1?total_risk=${expectedTotalRisk}`,
+      'https://console.redhat.com/openshift/insights/advisor/clusters/cluster-1?total_risk=1',
+    );
+  });
+
+  it('should compute totalRisk for moderate as 2', () => {
+    render(<LabelComponent clusterID="cluster-1" datum={{ id: 'moderate' }} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute(
+      'href',
+      'https://console.redhat.com/openshift/insights/advisor/clusters/cluster-1?total_risk=2',
+    );
+  });
+
+  it('should compute totalRisk for important as 3', () => {
+    render(<LabelComponent clusterID="cluster-1" datum={{ id: 'important' }} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute(
+      'href',
+      'https://console.redhat.com/openshift/insights/advisor/clusters/cluster-1?total_risk=3',
+    );
+  });
+
+  it('should compute totalRisk for critical as 4', () => {
+    render(<LabelComponent clusterID="cluster-1" datum={{ id: 'critical' }} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute(
+      'href',
+      'https://console.redhat.com/openshift/insights/advisor/clusters/cluster-1?total_risk=4',
     );
   });
 

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -30,20 +30,28 @@ const DataComponent: React.FC<DataComponentProps> = ({ x, y, datum }) => {
   return <Icon x={x} y={y - 5} fill={legendColorScale[datum.id]} />;
 };
 
-const LabelComponent = ({ clusterID, ...props }) => (
-  <ExternalLink
-    href={`https://console.redhat.com/openshift/insights/advisor/clusters/${clusterID}?total_risk=${
-      riskSorting[props.datum.id] + 1
-    }`}
-  >
-    <ChartLabel
-      {...props}
-      style={{
-        fill: 'var(--pf-t--global--text--color--link--default)',
-      }}
-    />
-  </ExternalLink>
-);
+export const LabelComponent = ({ clusterID, ...props }) => {
+  const riskId = props.datum?.id;
+  const riskIndex = riskId != null ? riskSorting[riskId] : undefined;
+  const totalRisk = Number.isFinite(riskIndex) ? riskIndex + 1 : undefined;
+  const href =
+    clusterID && totalRisk != null
+      ? `https://console.redhat.com/openshift/insights/advisor/clusters/${clusterID}?total_risk=${totalRisk}`
+      : undefined;
+
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" tabIndex={0}>
+      <ChartLabel
+        {...props}
+        style={{
+          ...props.style,
+          fill: 'var(--pf-t--global--text--color--link--default)',
+          cursor: href ? 'pointer' : undefined,
+        }}
+      />
+    </a>
+  );
+};
 
 const SubTitleComponent = (props) => (
   <ChartLabel

--- a/frontend/packages/integration-tests-cypress/tests/dashboards/insights-popup.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/dashboards/insights-popup.cy.ts
@@ -1,0 +1,83 @@
+import { checkErrors } from '../../support';
+
+const INSIGHTS_HEALTH_ITEM = '[data-item-id="Insights-health-item"]';
+const INSIGHTS_BUTTON = '[data-test="Insights"]';
+
+describe('Insights Popup on Cluster Dashboard', () => {
+  before(() => {
+    cy.login();
+    cy.visit('/dashboards');
+    cy.byLegacyTestID('status-card').should('be.visible');
+    // Wait until all health items have finished loading (no skeleton loaders remain)
+    cy.byLegacyTestID('status-card').within(() => {
+      cy.get('.skeleton-health', { timeout: 30000 }).should('not.exist');
+    });
+  });
+
+  afterEach(() => {
+    checkErrors();
+  });
+
+  it('displays the Insights health item in the status card', () => {
+    cy.get(INSIGHTS_HEALTH_ITEM).should('be.visible');
+    cy.get(INSIGHTS_BUTTON).filter('button').should('be.visible');
+  });
+
+  it('opens the Insights popup when clicking the health item', () => {
+    cy.get(INSIGHTS_BUTTON).filter('button').click();
+    cy.get('.pf-v6-c-popover').should('be.visible');
+    cy.get('.pf-v6-c-popover').should('contain.text', 'Red Hat Lightspeed Advisor status');
+  });
+
+  it('shows last refresh timestamp in the popup', () => {
+    cy.get(INSIGHTS_BUTTON).filter('button').click();
+    cy.get('.pf-v6-c-popover').within(() => {
+      cy.contains('Last refresh').should('be.visible');
+    });
+  });
+
+  it('shows the advisor description text', () => {
+    cy.get(INSIGHTS_BUTTON).filter('button').click();
+    cy.get('.pf-v6-c-popover').within(() => {
+      cy.contains('Red Hat Lightspeed Advisor identifies and prioritizes').should('be.visible');
+    });
+  });
+
+  it('renders severity links pointing to the correct Red Hat Insights advisor URL', () => {
+    cy.get(INSIGHTS_BUTTON).filter('button').click();
+    cy.get('.pf-v6-c-popover').within(() => {
+      cy.get('a[href*="console.redhat.com/openshift/insights/advisor"]').should('exist');
+      cy.get('a[href*="console.redhat.com/openshift/insights/advisor"]')
+        .first()
+        .should('have.attr', 'target', '_blank');
+    });
+  });
+
+  it('severity links include total_risk query parameter', () => {
+    cy.get(INSIGHTS_BUTTON).filter('button').click();
+    cy.get('.pf-v6-c-popover').within(() => {
+      cy.get('a[href*="total_risk="]')
+        .should('have.length.greaterThan', 0)
+        .each(($link) => {
+          const href = $link.attr('href');
+          const totalRisk = new URL(href, 'https://placeholder').searchParams.get('total_risk');
+          expect(['1', '2', '3', '4']).to.include(totalRisk);
+        });
+    });
+  });
+
+  it('shows "View all recommendations" or "View more" link', () => {
+    cy.get(INSIGHTS_BUTTON).filter('button').click();
+    cy.get('.pf-v6-c-popover').then(($popover) => {
+      if (
+        $popover.find('a[href*="console.redhat.com/openshift/insights/advisor/clusters/"]').length
+      ) {
+        cy.wrap($popover)
+          .contains('View all recommendations in Red Hat Lightspeed Advisor')
+          .should('be.visible');
+      } else {
+        cy.wrap($popover).contains('View more in Red Hat Lightspeed Advisor').should('be.visible');
+      }
+    });
+  });
+});


### PR DESCRIPTION
Cherry-pick of #15949 into release-4.21. Original PR: https://github.com/openshift/console/pull/15949

Cherry-pick of 4.22 backport: https://github.com/openshift/console/pull/16575

### Changes from original PR

- **Replaced `it.each` with individual test cases** in `InsightsPopup/__tests__/index.spec.tsx`: release-4.21 uses Jest 22.x and `@types/jest` 22.x, which do not support `it.each` (introduced in Jest 23). The parameterized test was expanded into four separate `it` blocks covering the same cases (low=1, moderate=2, important=3, critical=4).