### PR TITLE
[release-4.13] OCPBUGS-88375 OCPBUGS-88384 OCPBUGS-88442 OCPBUGS-88404 OCPBUGS-88410 OCPBUGS-88391 OCPBUGS-88414: CVE-2026-44495

### DIFF
--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -169,7 +169,7 @@ __metadata:
     "@patternfly/react-core": "npm:4.276.6"
     "@patternfly/react-table": "npm:4.112.39"
     classnames: "npm:2.x"
-    immutable: "npm:^3.8.3"
+    immutable: "npm:3.x"
     lodash: "npm:^4.17.23"
     react: "npm:^17.0.1"
     react-helmet: "npm:^6.1.0"
@@ -2713,10 +2713,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:^3.8.3":
-  version: 3.8.3
-  resolution: "immutable@npm:3.8.3"
-  checksum: 10c0/bafa7b8371b7622bc3d128cd9e6bba3a654b968f09a237929629f43ac26f7e974a5879cd38baad0c26f6f0628753968611bf832add7bf0c44d647bf4306a2988
+"immutable@npm:3.x":
+  version: 3.8.2
+  resolution: "immutable@npm:3.8.2"
+  checksum: 10c0/fb6a2999ad3bda9e51741721e42547076dd492635ee4df9241224055fe953ec843583a700088cc4915f23dc326e5084f4e17f1bbd7388c3e872ef5a242e0ac5e
   languageName: node
   linkType: hard
 

--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -169,7 +169,7 @@ __metadata:
     "@patternfly/react-core": "npm:4.276.6"
     "@patternfly/react-table": "npm:4.112.39"
     classnames: "npm:2.x"
-    immutable: "npm:3.x"
+    immutable: "npm:^3.8.3"
     lodash: "npm:^4.17.23"
     react: "npm:^17.0.1"
     react-helmet: "npm:^6.1.0"
@@ -2713,10 +2713,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:3.x":
-  version: 3.8.2
-  resolution: "immutable@npm:3.8.2"
-  checksum: 10c0/fb6a2999ad3bda9e51741721e42547076dd492635ee4df9241224055fe953ec843583a700088cc4915f23dc326e5084f4e17f1bbd7388c3e872ef5a242e0ac5e
+"immutable@npm:^3.8.3":
+  version: 3.8.3
+  resolution: "immutable@npm:3.8.3"
+  checksum: 10c0/bafa7b8371b7622bc3d128cd9e6bba3a654b968f09a237929629f43ac26f7e974a5879cd38baad0c26f6f0628753968611bf832add7bf0c44d647bf4306a2988
   languageName: node
   linkType: hard
 

--- a/frontend/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch
+++ b/frontend/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch
@@ -1,0 +1,18 @@
+diff --git a/index.d.ts b/index.d.ts
+index 34bc02adf15581be666543f0d77fa845c04d25f9..5e7fb8eb8dcb902fd554428cd6aa533e5dc57db7 100644
+--- a/index.d.ts
++++ b/index.d.ts
+@@ -3,8 +3,12 @@ type HeaderValue = string | string[] | number | boolean;
+ 
+ type AxiosHeaders = Record<string, HeaderValue | Record<Method & CommonHeaders, HeaderValue>>;
+ 
++type LowercaseMethod =
++  | 'get' | 'delete' | 'head' | 'options' | 'post'
++  | 'put' | 'patch' | 'purge' | 'link' | 'unlink';
++
+ type MethodsHeaders = {
+-  [Key in Method as Lowercase<Key>]: AxiosHeaders;
++  [Key in LowercaseMethod]?: AxiosHeaders;
+ };
+ 
+ interface CommonHeaders  {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -355,7 +355,7 @@
     "@types/jest": "21.x",
     "glob-parent": "^5.1.2",
     "postcss": "^8.2.13",
-    "axios@npm:^0.21.1": "patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch"
+    "axios@npm:^0.21.1": "patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch",
     "immutable": "3.8.3"
   },
   "husky": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -159,7 +159,7 @@
     "apollo-client": "^2.6.8",
     "apollo-link-http": "^1.0.20",
     "apollo-link-ws": "^1.0.20",
-    "axios": "^0.21.2",
+    "axios": "^0.31.1",
     "classnames": "2.x",
     "d3": "^5.16.0",
     "file-saver": "1.3.x",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -159,7 +159,7 @@
     "apollo-client": "^2.6.8",
     "apollo-link-http": "^1.0.20",
     "apollo-link-ws": "^1.0.20",
-    "axios": "^0.31.1",
+    "axios": "patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch",
     "classnames": "2.x",
     "d3": "^5.16.0",
     "file-saver": "1.3.x",
@@ -354,7 +354,8 @@
     "ua-parser-js": "^0.7.24",
     "@types/jest": "21.x",
     "glob-parent": "^5.1.2",
-    "postcss": "^8.2.13"
+    "postcss": "^8.2.13",
+    "axios@npm:^0.21.1": "patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch"
   },
   "husky": {
     "hooks": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7083,12 +7083,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.21.1, axios@npm:^0.21.2":
+"axios@npm:^0.21.1":
   version: 0.21.4
   resolution: "axios@npm:0.21.4"
   dependencies:
     follow-redirects: "npm:^1.14.0"
   checksum: 10c0/fbcff55ec68f71f02d3773d467db2fcecdf04e749826c82c2427a232f9eba63242150a05f15af9ef15818352b814257541155de0281f8fb2b7e8a5b79f7f2142
+  languageName: node
+  linkType: hard
+
+"axios@npm:^0.31.1":
+  version: 0.31.1
+  resolution: "axios@npm:0.31.1"
+  dependencies:
+    follow-redirects: "npm:^1.15.4"
+    form-data: "npm:^4.0.4"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/0193483f680a893955d203d26951fc427c407415d273bba5a2450e3d0ed7261a403eb5fe86f28a7e66c42d98597cbf8e17e3a6c324d294bd143a6a68bc10f8ef
   languageName: node
   linkType: hard
 
@@ -9123,7 +9134,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.6, combined-stream@npm:~1.0.5, combined-stream@npm:~1.0.6":
+"combined-stream@npm:^1.0.6, combined-stream@npm:^1.0.8, combined-stream@npm:~1.0.5, combined-stream@npm:~1.0.6":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
   dependencies:
@@ -11926,6 +11937,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-set-tostringtag@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "es-set-tostringtag@npm:2.1.0"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.6"
+    has-tostringtag: "npm:^1.0.2"
+    hasown: "npm:^2.0.2"
+  checksum: 10c0/ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
+  languageName: node
+  linkType: hard
+
 "es-to-primitive@npm:^1.1.1, es-to-primitive@npm:^1.2.0":
   version: 1.2.0
   resolution: "es-to-primitive@npm:1.2.0"
@@ -13438,6 +13461,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"follow-redirects@npm:^1.15.4":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
+  languageName: node
+  linkType: hard
+
 "for-each@npm:^0.3.5":
   version: 0.3.5
   resolution: "for-each@npm:0.3.5"
@@ -13503,6 +13536,19 @@ __metadata:
     combined-stream: "npm:^1.0.6"
     mime-types: "npm:^2.1.12"
   checksum: 10c0/7e8fb913b84a7ac04074781a18d0f94735bbe82815ff35348803331f6480956ff0035db5bcf15826edee09fe01e665cfac664678f1526646a6374ee13f960e56
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.4":
+  version: 4.0.5
+  resolution: "form-data@npm:4.0.5"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.2"
+    mime-types: "npm:^2.1.12"
+  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
   languageName: node
   linkType: hard
 
@@ -13900,7 +13946,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.3.0":
+"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.3.0":
   version: 1.3.1
   resolution: "get-intrinsic@npm:1.3.1"
   dependencies:
@@ -20528,7 +20574,7 @@ __metadata:
     apollo-client: "npm:^2.6.8"
     apollo-link-http: "npm:^1.0.20"
     apollo-link-ws: "npm:^1.0.20"
-    axios: "npm:^0.21.2"
+    axios: "npm:^0.31.1"
     babel-loader: "npm:^8.2.1"
     browser-env: "npm:3.x"
     cache-loader: "npm:^4.1.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7083,16 +7083,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.21.1":
-  version: 0.21.4
-  resolution: "axios@npm:0.21.4"
-  dependencies:
-    follow-redirects: "npm:^1.14.0"
-  checksum: 10c0/fbcff55ec68f71f02d3773d467db2fcecdf04e749826c82c2427a232f9eba63242150a05f15af9ef15818352b814257541155de0281f8fb2b7e8a5b79f7f2142
-  languageName: node
-  linkType: hard
-
-"axios@npm:^0.31.1":
+"axios@npm:0.31.1":
   version: 0.31.1
   resolution: "axios@npm:0.31.1"
   dependencies:
@@ -7100,6 +7091,17 @@ __metadata:
     form-data: "npm:^4.0.4"
     proxy-from-env: "npm:^1.1.0"
   checksum: 10c0/0193483f680a893955d203d26951fc427c407415d273bba5a2450e3d0ed7261a403eb5fe86f28a7e66c42d98597cbf8e17e3a6c324d294bd143a6a68bc10f8ef
+  languageName: node
+  linkType: hard
+
+"axios@patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch":
+  version: 0.31.1
+  resolution: "axios@patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch::version=0.31.1&hash=21a978"
+  dependencies:
+    follow-redirects: "npm:^1.15.4"
+    form-data: "npm:^4.0.4"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/b148742c668c3cbc44c7a65e6aa5214efac23bff529f2f54d4c6c4fa917ea2fbed37ed915165fa3e1d011d94ebe6c1b7263610c28bb1af0de51ce8ad5188dd61
   languageName: node
   linkType: hard
 
@@ -13448,16 +13450,6 @@ __metadata:
   dependencies:
     debug: "npm:^3.2.6"
   checksum: 10c0/7b557ef5d7c7caacf925925f1ddbb92ddead0f08e5f8556abe67a286ef1dbf92d40d6ca80b7a240073c4c6a5c89e28496bd158f678030c909ebeba758c1f658b
-  languageName: node
-  linkType: hard
-
-"follow-redirects@npm:^1.14.0":
-  version: 1.14.3
-  resolution: "follow-redirects@npm:1.14.3"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 10c0/02c94952aa0ce0b0d4fd45cb7af4cce5df37158a1757f9528f9488c3a2ed89b7d630764ba1e09918b98b5d9affbc3e06abc4fce90fb5608a79b10a9a81926e6c
   languageName: node
   linkType: hard
 
@@ -20574,7 +20566,7 @@ __metadata:
     apollo-client: "npm:^2.6.8"
     apollo-link-http: "npm:^1.0.20"
     apollo-link-ws: "npm:^1.0.20"
-    axios: "npm:^0.31.1"
+    axios: "patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch"
     babel-loader: "npm:^8.2.1"
     browser-env: "npm:3.x"
     cache-loader: "npm:^4.1.0"


### PR DESCRIPTION
[release-4.13] OCPBUGS-88375: CVE-2026-44495
https://redhat.atlassian.net/browse/OCPBUGS-88375

The PR **patches axios 0.31.1’s index.d.ts** so it parses under TypeScript 3.8.3 (what release-4.13 uses). 
Console stays on TS 3.8.3. The PR does not patch TypeScript. 
This patch is required as axios version has been updated - without this patch, CI tests consistently fail.

CVE: [OCPBUGS-88375](https://redhat.atlassian.net/browse/OCPBUGS-88375) / CVE-2026-44495 requires axios@0.31.1 ([GHSA-3g43-6gmg-66jw](https://github.com/axios/axios/security/advisories/GHSA-3g43-6gmg-66jw)).

Build issue: release-4.13 uses TypeScript 3.8.3. axios@0.31.1 ships index.d.ts targeting TS 4.1+ ([Key in Method as Lowercase<Key>]), which causes fork-ts-checker-webpack-plugin to fail the frontend build with TS1005 errors in node_modules/axios/index.d.ts (see test-bin / ./build-frontend.sh).

Fix: Yarn patch adjusts only the incompatible type definition. Runtime remains axios@0.31.1; no TypeScript upgrade on the release branch.

These are the steps to create the patch:

**yarn patch axios@npm:0.31.1**

get the directory that is listed e.g./private/var/folders/xh/64_dr2_j14s6q3vdq008bj9r0000gn/T/xfs-8bb6f632/user
in that folder, edit the file index.d.ts
replace
type MethodsHeaders = {
[Key in Method as Lowercase]: AxiosHeaders;
};
with
type LowercaseMethod =
| 'get' | 'delete' | 'head' | 'options' | 'post'
| 'put' | 'patch' | 'purge' | 'link' | 'unlink';

type MethodsHeaders = {
[Key in LowercaseMethod]?: AxiosHeaders;
};

then:
**yarn patch-commit -s /private/var/folders/xh/64_dr2_j14s6q3vdq008bj9r0000gn/T/xfs-8bb6f632/user
yarn install
yarn build**

**git add .yarn/patches/axios-npm-0.31.1-0574a0de7d.patch
git add package.json
git add yarn.lock
git commit -m "OCPBUGS-88375: Patch axios 0.31.1 types for TS 3.8\naxios 0.31.1 ships .d.ts that require TypeScript 4.1+, which\nbreaks the release-4.13 webpack build (TS 3.8.3)."
git push**