### PR TITLE
OCPBUGS-88216: CVE-2026-42338

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -351,7 +351,8 @@
     "ua-parser-js": "^0.7.24",
     "jest": "21.x",
     "glob-parent": "^5.1.2",
-    "postcss": "^8.2.13"
+    "postcss": "^8.2.13",
+    "ip-address": "^10.1.1"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -14107,10 +14107,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.0.1":
-  version: 10.1.0
-  resolution: "ip-address@npm:10.1.0"
-  checksum: 10c0/0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
+"ip-address@npm:^10.1.1":
+  version: 10.2.0
+  resolution: "ip-address@npm:10.2.0"
+  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<h2 id="feature-fix">CONSOLE Features and Fixes:</h2>

- OCPBUGS-88216: CVE-2026-42338

<h2 id="solution-description">Solution description</h2>

Resolve CVE-2026-42338 by adding a yarn resolution for `ip-address` to `^10.1.1`. The transitive dependency (via `socks-proxy-agent` → `socks`) was at 10.1.0 (still vulnerable — fix is in 10.1.1). Updated to 10.2.0.

<h2 id="reviewers-and-assignees">Reviewers and assignees:</h2>

<h2 id="test-cases">Test cases:</h2>

No functional changes — `ip-address` is a transitive dependency not directly used by console source code. Verified the lockfile resolves to 10.2.0.

<h2 id="additional-info">Additional info:</h2>

- **CVE:** [CVE-2026-42338](https://nvd.nist.gov/vuln/detail/CVE-2026-42338)
- **Advisory:** [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g)
- **Fixed in:** ip-address 10.1.1+
- **Risk:** Low — the library is only used internally by `socks` for SOCKS proxy address parsing; console never imports or renders its output as HTML.

<h2 id="screenshots">Screen shots / gifs / design review:</h2>

N/A — no visual changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)