### PR TITLE
OCPBUGS-88720: CVE-2026-42338

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -326,7 +326,8 @@
     "minimatch@3.0.5": "^3.1.3",
     "minimatch@^3.1.1": "^3.1.3",
     "minimatch@^9.0.4": "^9.0.6",
-    "minimatch@^10.1.2": "^10.2.1"
+    "minimatch@^10.1.2": "^10.2.1",
+    "ip-address": "^10.1.1"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -13344,13 +13344,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "ip-address@npm:9.0.5"
-  dependencies:
-    jsbn: "npm:1.1.0"
-    sprintf-js: "npm:^1.1.3"
-  checksum: 10c0/331cd07fafcb3b24100613e4b53e1a2b4feab11e671e655d46dc09ee233da5011284d09ca40c4ecbdfe1d0004f462958675c224a804259f2f78d2465a87824bc
+"ip-address@npm:^10.1.1":
+  version: 10.2.0
+  resolution: "ip-address@npm:10.2.0"
+  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
   languageName: node
   linkType: hard
 
@@ -14657,13 +14654,6 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/184a24b4eaacfce40ad9074c64fd42ac83cf74d8c8cd137718d456ced75051229e5061b8633c3366b8aada17945a7a356b337828c19da92b51ae62126575018f
-  languageName: node
-  linkType: hard
-
-"jsbn@npm:1.1.0":
-  version: 1.1.0
-  resolution: "jsbn@npm:1.1.0"
-  checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
   languageName: node
   linkType: hard
 
@@ -20529,7 +20519,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sprintf-js@npm:^1.0.3, sprintf-js@npm:^1.1.3":
+"sprintf-js@npm:^1.0.3":
   version: 1.1.3
   resolution: "sprintf-js@npm:1.1.3"
   checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec


### PR DESCRIPTION
<h2 id="feature-fix">CONSOLE Features and Fixes:</h2>

- OCPBUGS-88720: CVE-2026-42338

<h2 id="solution-description">Solution description</h2>

Resolve CVE-2026-42338 by adding a yarn resolution for `ip-address` to `^10.1.1`. The transitive dependency (via `socks-proxy-agent` → `socks`) was at 9.0.5, which has an XSS vulnerability in `Address6` HTML-emitting methods. Updated to 10.2.0.

<h2 id="reviewers-and-assignees">Reviewers and assignees:</h2>

<h2 id="test-cases">Test cases:</h2>

No functional changes — `ip-address` is a transitive dependency not directly used by console source code. Verified the lockfile resolves to 10.2.0.

<h2 id="additional-info">Additional info:</h2>

- **CVE:** [CVE-2026-42338](https://nvd.nist.gov/vuln/detail/CVE-2026-42338)
- **Advisory:** [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g)
- **Fixed in:** ip-address 10.1.1+
- **Risk:** Low — the library is only used internally by `socks` for SOCKS proxy address parsing; console never imports or renders its output as HTML.

<h2 id="screenshots">Screen shots / gifs / design review:</h2>

N/A — no visual changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)