### PR TITLE
OCPBUGS-88739: Projects cannot be filtered by display name

### DIFF
--- a/frontend/packages/console-app/src/components/data-view/__tests__/useConsoleDataViewFilters.spec.tsx
+++ b/frontend/packages/console-app/src/components/data-view/__tests__/useConsoleDataViewFilters.spec.tsx
@@ -40,6 +40,30 @@ const mockData: K8sResourceCommon[] = [
 
 const initialFilters: ResourceFilters = { name: '', label: '' };
 
+const projectMockData: K8sResourceCommon[] = [
+  {
+    metadata: {
+      name: 'test-proj',
+      annotations: { 'openshift.io/display-name': 'My Test Project' },
+    },
+    kind: 'Project',
+    apiVersion: 'v1',
+  },
+  {
+    metadata: {
+      name: 'other-proj',
+      annotations: { 'openshift.io/display-name': 'Other Project' },
+    },
+    kind: 'Project',
+    apiVersion: 'v1',
+  },
+  {
+    metadata: { name: 'no-display-name' },
+    kind: 'Project',
+    apiVersion: 'v1',
+  },
+];
+
 const createWrapper = (initialEntries: string[] = ['/']): FC<{ children: ReactNode }> => {
   const Wrapper: FC<{ children: ReactNode }> = ({ children }) => (
     <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
@@ -98,6 +122,75 @@ describe('useConsoleDataViewFilters', () => {
 
     expect(result.current.filteredData).toHaveLength(1);
     expect(result.current.filteredData[0].metadata.name).toBe('web-frontend');
+  });
+
+  it('should filter by openshift.io/display-name using fuzzy matching', () => {
+    const { result } = renderHook(
+      () => useConsoleDataViewFilters({ data: projectMockData, initialFilters }),
+      { wrapper: createWrapper(['/?name=My%20Test']) },
+    );
+
+    expect(result.current.filteredData).toHaveLength(1);
+    expect(result.current.filteredData[0].metadata.name).toBe('test-proj');
+  });
+
+  it('should filter by metadata.name when display name differs', () => {
+    const { result } = renderHook(
+      () => useConsoleDataViewFilters({ data: projectMockData, initialFilters }),
+      { wrapper: createWrapper(['/?name=test-proj']) },
+    );
+
+    expect(result.current.filteredData).toHaveLength(1);
+    expect(result.current.filteredData[0].metadata.name).toBe('test-proj');
+  });
+
+  it('should match project by display name case-insensitively in fuzzy mode', () => {
+    // Default fuzzy mode - no mock override
+    const { result } = renderHook(
+      () => useConsoleDataViewFilters({ data: projectMockData, initialFilters }),
+      { wrapper: createWrapper(['/?name=other%20project']) }, // lowercase search
+    );
+
+    // Matches "Other Project" even though we searched "other project"
+    expect(result.current.filteredData).toHaveLength(1);
+    expect(result.current.filteredData[0].metadata.name).toBe('other-proj');
+  });
+
+  it('should not match resources without display-name annotation when searching by display name', () => {
+    const { result } = renderHook(
+      () => useConsoleDataViewFilters({ data: projectMockData, initialFilters }),
+      { wrapper: createWrapper(['/?name=Project']) },
+    );
+
+    // "Project" appears in display names of test-proj and other-proj, but not in "no-display-name"
+    expect(result.current.filteredData).toHaveLength(2);
+    expect(result.current.filteredData.map((d) => d.metadata.name)).toEqual([
+      'test-proj',
+      'other-proj',
+    ]);
+  });
+
+  it('should filter by openshift.io/display-name using exact matching when exact search is enabled', () => {
+    useExactSearch.mockReturnValue([true, true]);
+
+    const { result } = renderHook(
+      () => useConsoleDataViewFilters({ data: projectMockData, initialFilters }),
+      { wrapper: createWrapper(['/?name=My%20Test%20Project']) },
+    );
+
+    expect(result.current.filteredData).toHaveLength(1);
+    expect(result.current.filteredData[0].metadata.name).toBe('test-proj');
+  });
+
+  it('should require case-sensitive match for display-name in exact search mode', () => {
+    useExactSearch.mockReturnValue([true, true]);
+
+    const { result } = renderHook(
+      () => useConsoleDataViewFilters({ data: projectMockData, initialFilters }),
+      { wrapper: createWrapper(['/?name=my%20test']) },
+    );
+
+    expect(result.current.filteredData).toHaveLength(0);
   });
 
   it('should filter by name using exact matching when exact search is enabled', () => {

--- a/frontend/packages/console-app/src/components/data-view/useConsoleDataViewFilters.ts
+++ b/frontend/packages/console-app/src/components/data-view/useConsoleDataViewFilters.ts
@@ -15,6 +15,9 @@ const getK8sResourceMetadata = (obj: K8sResourceCommon): ResourceMetadata => ({
   labels: obj.metadata?.labels,
 });
 
+const getOpenShiftDisplayName = (resource: K8sResourceCommon): string | undefined =>
+  resource.metadata?.annotations?.['openshift.io/display-name'];
+
 export const useConsoleDataViewFilters = <
   TData,
   TFilters extends ResourceFilters = ResourceFilters
@@ -75,12 +78,14 @@ export const useConsoleDataViewFilters = <
     () =>
       data?.filter((resource) => {
         const { name: resourceName, labels } = getObjectMetadata(resource);
+        const displayName = getOpenShiftDisplayName(resource as K8sResourceCommon);
 
-        // Filter by K8s resource name
+        // Filter by K8s resource name or display name
+        const matchFn = isExactSearch ? exactMatch : fuzzyCaseInsensitive;
         const matchesName =
-          !filters.name || isExactSearch
-            ? exactMatch(filters.name, resourceName)
-            : fuzzyCaseInsensitive(filters.name, resourceName);
+          !filters.name ||
+          matchFn(filters.name, resourceName) ||
+          matchFn(filters.name, displayName);
 
         const resourceLabels = mapLabelsToStrings(labels);
         const filterLabelsArray = filters.label?.split(',') ?? [];


### PR DESCRIPTION

 The users are unable to filter projects by display name on the Projects list page ({{/k8s/cluster/projects}}) in the OpenShift 4.21 console. This functionality was available in previous versions. When a user types a project's display name (e.g., "My Test Project") in the filter toolbar, no results are shown even though a project with that display name exists. Only filtering by the actual project name ({{metadata.name}}) works.

**Analysis / Root cause**:
The migration to the new ConsoleDataView component likely lost the display name filtering capability for Projects and Namespaces.

**Solution description**:

  - Extracts display name from "openshift.io/display-name" annotation directly in the filter callback
  - Matches against both metadata.name OR display name

**Screenshots / screen recording**:
**Before:**
<img width="1577" height="738" alt="Screenshot 2026-06-16 at 9 59 04 AM" src="https://github.com/user-attachments/assets/46284451-c4ae-45e5-bb9e-a322d9c516b4" />
<img width="1582" height="777" alt="Screenshot 2026-06-16 at 9 59 11 AM" src="https://github.com/user-attachments/assets/2c1440c0-b640-429c-95e6-8cf42519db4a" />

**After:**
<img width="1554" height="752" alt="Screenshot 2026-06-16 at 10 27 05 AM" src="https://github.com/user-attachments/assets/ab646276-30f2-4cf9-9e0b-17e3b366812f" />

- Added displayName as an optional field to the ResourceMetadata type in internal-types.ts
- Updated getK8sResourceMetadata in useConsoleDataViewFilters.ts to extract the display name from annotations
-  Updated the name matching logic to check both name OR displayName
- Added unit tests to verify display name filtering works correctly for both fuzzy and exact search modes

**Test setup:**
N/A

**Test cases:**
N/A

**Browser conformance**:
N/A

**Additional info:**
N/A

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filtering now matches against display names in addition to resource names, improving resource discoverability
  * Display name filtering supports both fuzzy (case-insensitive) and exact (case-sensitive) search modes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->