### PR TITLE
OCPBUGS-59569: Disable create button until CRD is available

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/__tests__/operator-install-page.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/__tests__/operator-install-page.spec.tsx
@@ -1,0 +1,81 @@
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import { testClusterServiceVersion } from '../../../mocks';
+import { CreateInitializationResourceButton } from '../operator-install-page';
+
+const mockDispatch = jest.fn();
+jest.mock('@console/shared/src/hooks/useConsoleDispatch', () => ({
+  useConsoleDispatch: () => mockDispatch,
+}));
+
+const mockGetResourcesAction = { type: 'getResources' };
+const mockGetResources = jest.fn().mockReturnValue(mockGetResourcesAction);
+jest.mock('@console/internal/actions/k8s', () => ({
+  getResources: (...args) => mockGetResources(...args),
+}));
+
+let mockModel: object | undefined;
+let mockInFlight: boolean;
+jest.mock('@console/shared/src/hooks/useK8sModel', () => ({
+  useK8sModel: () => [mockModel, mockInFlight],
+}));
+
+const initializationResource = {
+  apiVersion: 'example.com/v1',
+  kind: 'ExampleResource',
+  metadata: {
+    name: 'example',
+    namespace: 'default',
+  },
+};
+
+const defaultProps = {
+  initializationResource,
+  obj: testClusterServiceVersion,
+};
+
+describe('CreateInitializationResourceButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockModel = undefined;
+    mockInFlight = false;
+  });
+
+  it('returns null when initializationResource is not provided', () => {
+    const { container } = renderWithProviders(
+      <CreateInitializationResourceButton obj={testClusterServiceVersion} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('dispatches getResources when the model is missing', () => {
+    renderWithProviders(<CreateInitializationResourceButton {...defaultProps} />);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(mockGetResourcesAction);
+  });
+
+  it('does not dispatch getResources when the model is available', () => {
+    mockModel = { kind: 'ExampleResource' };
+    renderWithProviders(<CreateInitializationResourceButton {...defaultProps} />);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('disables the button when the model is missing', () => {
+    renderWithProviders(<CreateInitializationResourceButton {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /Create ExampleResource/i })).toBeDisabled();
+  });
+
+  it('disables the button when disabled prop is true', () => {
+    mockModel = { kind: 'ExampleResource' };
+    renderWithProviders(<CreateInitializationResourceButton {...defaultProps} disabled />);
+    expect(screen.getByRole('button', { name: /Create ExampleResource/i })).toBeDisabled();
+  });
+
+  it('enables the button and renders a link when the model is available', () => {
+    mockModel = { kind: 'ExampleResource' };
+    renderWithProviders(<CreateInitializationResourceButton {...defaultProps} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', expect.stringContaining('useInitializationResource'));
+    expect(screen.getByRole('button', { name: /Create ExampleResource/i })).toBeEnabled();
+  });
+});

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react';
+import { useEffect, useState } from 'react';
 import {
   ActionGroup,
   Alert,
@@ -17,6 +18,7 @@ import type { WatchK8sResultsObject } from '@console/dynamic-plugin-sdk';
 import { ResourceStatus, StatusIconAndText } from '@console/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@console/dynamic-plugin-sdk/src/api/core-api';
 import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
+import { getResources } from '@console/internal/actions/k8s';
 import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import {
   LoadingInline,
@@ -34,6 +36,8 @@ import {
   RedExclamationCircleIcon,
   YellowExclamationTriangleIcon,
 } from '@console/shared/src/components/status/icons';
+import { useConsoleDispatch } from '@console/shared/src/hooks/useConsoleDispatch';
+import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import type { RouteParams } from '@console/shared/src/types/route-params';
 import {
   ClusterServiceVersionModel,
@@ -161,18 +165,33 @@ export const CreateInitializationResourceButton: FC<InitializationResourceButton
   obj,
 }) => {
   const { t } = useTranslation('olm');
+  const dispatch = useConsoleDispatch();
+  const reference = initializationResource ? referenceFor(initializationResource) : undefined;
+  const [model, inFlight] = useK8sModel(reference);
+  const [apiRefreshed, setAPIRefreshed] = useState(false);
+
+  // Trigger an API discovery refresh when the CRD model is missing so the
+  // user doesn't have to wait for the next 60-second poll cycle.
+  const modelMissing = !inFlight && !model && !!initializationResource;
+  useEffect(() => {
+    if (!apiRefreshed && modelMissing) {
+      dispatch(getResources());
+      setAPIRefreshed(true);
+    }
+  }, [apiRefreshed, dispatch, modelMissing]);
+
   if (!initializationResource) {
     return null;
   }
 
-  const reference = referenceFor(initializationResource);
   const kind = initializationResource?.kind;
+  const isDisabled = disabled || !model;
   const button = (
-    <Button aria-disabled={disabled} isDisabled={disabled} variant="primary">
+    <Button aria-disabled={isDisabled} isDisabled={isDisabled} variant="primary">
       {t('Create {{item}}', { item: kind })}
     </Button>
   );
-  return disabled ? (
+  return isDisabled ? (
     button
   ) : (
     <Link
@@ -599,7 +618,7 @@ type InitializationLinkProps = {
 };
 type InitializationResourceButtonProps = {
   disabled?: boolean;
-  initializationResource: K8sResourceKind;
+  initializationResource?: K8sResourceKind;
   obj: ClusterServiceVersionKind | InstallPlanKind | SubscriptionKind;
 };
 type ViewOperatorButtonProps = {


### PR DESCRIPTION
**Analysis / Root cause**:
After an operator installs, the install success page immediately shows a "Create <Kind>" button linked to the initialization resource. However, the CRD may not yet be registered on the cluster (API discovery polls every 60 seconds), so clicking the button leads to a 404 error.

**Solution description**:
The `CreateInitializationResourceButton` component now uses `useK8sModel` to check whether the CRD model has been discovered. The button is disabled until the model is available. Additionally, a `useEffect` triggers an immediate API discovery refresh (`getResources()`) when the model is missing, so the user doesn't have to wait for the next 60-second poll cycle. This follows the existing pattern used in `ProvidedAPIsPage`.

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
Install an operator that declares an initialization resource (e.g. Network Observability with FlowCollector).

**Test cases:**
1. Install the operator and verify the "Create" button is disabled immediately after install succeeds
2. Verify the button enables once the CRD is registered on the cluster
3. Verify the button still works correctly when the CRD is already available

**Unit tests:**
Added `operator-install-page.spec.tsx` covering:
- Returns null when no initialization resource is provided
- Dispatches `getResources` when the CRD model is missing
- Does not dispatch when the model is already available
- Button is disabled when the model is missing
- Button is disabled when the `disabled` prop is true
- Button is enabled and wrapped in a link when the model is available

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
https://redhat.atlassian.net/browse/OCPBUGS-59569

**Reviewers and assignees:**
<!-- Tag reviewers -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved initialization resource creation behavior on the operator installation page when the Kubernetes model isn’t available yet, including an automatic refresh and more accurate create button enablement and accessibility state.

* **Tests**
  * Added Jest + React Testing Library coverage for the create initialization resource button to verify rendering, refresh dispatching, button enabled/disabled behavior, and the generated details link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->