### PR TITLE
OCPBUGS-89230: Fix sidebar not toggling at small viewport widths

### DIFF
--- a/frontend/public/components/app.tsx
+++ b/frontend/public/components/app.tsx
@@ -263,6 +263,7 @@ const App: FC = () => {
               id="content"
               // Need to pass mainTabIndex=null to enable keyboard scrolling as default tabIndex is set to -1 by patternfly
               mainTabIndex={null}
+              onPageResize={() => {}}
               masthead={
                 <Masthead
                   isNavOpen={isNavOpen}


### PR DESCRIPTION
**Analysis / Root cause**:

PatternFly's `PageSidebar` component only applies the `pf-m-expanded` CSS class — which is required for sidebar visibility below the xl breakpoint (1200px) — when `isMobile` is `true` in the `Page` context. The `Page` component only tracks viewport width via its internal resize observer when `isManagedSidebar` or `onPageResize` is provided. Console passed neither prop, so `isMobile` was permanently `false` and the sidebar could never receive the `pf-m-expanded` class at small viewports.

At desktop widths (≥ 1200px), a CSS `@media` query sets `translateX: 0` and `opacity: 1` directly on the sidebar, so no modifier class is needed. But below that breakpoint, the base CSS hides the sidebar (`translateX: -100%`, `opacity: 0`), and only `pf-m-expanded` can override it. Without that class, clicking the hamburger button toggled the React state but had no visual effect.

**Solution description**:

Pass `onPageResize={() => {}}` to the `Page` component. This activates the Page's internal resize observer, which correctly sets `isMobile: true` below the xl breakpoint. `PageSidebar` then applies `pf-m-expanded` when `isSidebarOpen` is `true` at small viewports, making the sidebar visible when toggled.

**Screenshots / screen recording**:

https://github.com/user-attachments/assets/ea4af086-16b4-48e0-aae3-c2b062ad9ffd


**Test setup:**
1. Open the console in a browser
2. Resize the browser window below 1200px wide

**Test cases:**
- Resize below 1200px → sidebar should auto-collapse
- Click hamburger button → sidebar should slide in as an overlay
- Click hamburger button again → sidebar should slide out
- Resize back above 1200px → sidebar should auto-expand
- Select a nav item at small viewport → sidebar should close

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**

Jira: https://redhat.atlassian.net/browse/OCPBUGS-89230