### PR TITLE
[release-4.20] OCPBUGS-89235: Allow VolumeSnapshot restore when parent PVC is deleted

### DIFF
--- a/frontend/packages/console-app/src/components/modals/restore-pvc/restore-pvc-modal.tsx
+++ b/frontend/packages/console-app/src/components/modals/restore-pvc/restore-pvc-modal.tsx
@@ -82,10 +82,16 @@ const RestorePVCModal = ({ close, cancel, resource }: RestorePVCModalProps) => {
   >(PersistentVolumeClaimModel, resource?.spec?.source?.persistentVolumeClaimName, namespace);
 
   const pvcStorageClassName = pvcResource?.spec?.storageClassName;
+  const pvcNotFound = pvcResourceLoaded && !pvcResource;
   const [scResource, scResourceLoaded, scResourceLoadError] = useK8sGet<StorageClassResourceKind>(
     StorageClassModel,
     pvcStorageClassName,
   );
+
+  // Form is ready when either:
+  // - PVC was found and its StorageClass has loaded
+  // - PVC was not found (deleted) — annotations and snapshot status provide sufficient data
+  const formReady = pvcNotFound || (!!pvcStorageClassName && scResourceLoaded);
 
   const [volumeMode, setVolumeMode] = React.useState('');
   const requestedSizeInputChange = ({ value, unit }) => {
@@ -160,13 +166,16 @@ const RestorePVCModal = ({ close, cancel, resource }: RestorePVCModalProps) => {
           />
         </FormGroup>
         <FormGroup fieldId="restore-storage-class" className="co-restore-pvc-modal__input">
-          {!pvcStorageClassName || !scResourceLoaded ? (
+          {!formReady ? (
             <div className="skeleton-text" />
           ) : (
             <StorageClassDropdown
               onChange={handleStorageClass}
-              filter={(scObj: StorageClassResourceKind) =>
-                onlyPvcSCs(scObj, scResourceLoadError, scResource)
+              filter={
+                pvcNotFound
+                  ? undefined
+                  : (scObj: StorageClassResourceKind) =>
+                      onlyPvcSCs(scObj, scResourceLoadError, scResource)
               }
               id="restore-storage-class"
               required
@@ -201,14 +210,16 @@ const RestorePVCModal = ({ close, cancel, resource }: RestorePVCModalProps) => {
           fieldId="pvc-size"
           className="co-restore-pvc-modal__input co-restore-pvc-modal__ocs-size"
         >
-          {!!pvcStorageClassName && scResourceLoaded ? (
+          {formReady ? (
             <RequestSizeInput
               name="requestSize"
               onChange={requestedSizeInputChange}
               defaultRequestSizeUnit={requestedUnit}
               defaultRequestSizeValue={requestedSize}
               dropdownUnits={dropdownUnits}
-              isInputDisabled={scResourceLoadError || isCephProvisioner(scResource?.provisioner)}
+              isInputDisabled={
+                !pvcNotFound && (scResourceLoadError || isCephProvisioner(scResource?.provisioner))
+              }
               required
             />
           ) : (


### PR DESCRIPTION
## Summary
- Manual cherry-pick of #16447 to release-4.20
- The file has diverged between main and release-4.20 (main uses the new overlay modal pattern while 4.20 uses createModalLauncher). The fix logic is identical to main; only adapted to the 4.20 code style.

Bug: https://issues.redhat.com/browse/OCPBUGS-89235