### PR TITLE
OCPBUGS-86182: Fix ColumnManagementModal not showing NamespaceColumnHelpText

### DIFF
--- a/frontend/public/components/modals/__tests__/column-management-modal.spec.tsx
+++ b/frontend/public/components/modals/__tests__/column-management-modal.spec.tsx
@@ -156,9 +156,35 @@ describe('ColumnManagementModal component', () => {
       expect(screen.getByText('Selected columns will appear in the table.')).toBeVisible();
     });
 
-    it('renders max row info alert', () => {
+    it('renders max row info alert without namespace help text when showNamespaceOverride is true', () => {
       renderColumnManagementModal();
       expect(screen.getByText('You can select up to {{MAX_VIEW_COLS}} columns')).toBeVisible();
+      expect(
+        screen.queryByText('The namespace column is only shown when in "All projects"'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders namespace help text when showNamespaceOverride is false', () => {
+      renderWithProviders(
+        <ColumnManagementModal
+          columnLayout={{
+            columns: columnLayout,
+            id: columnManagementID,
+            selectedColumns: new Set(
+              columnLayout.reduce((acc, column) => {
+                if (column.id && !column.additional) {
+                  acc.push(column.id);
+                }
+                return acc;
+              }, []),
+            ),
+            type: columnManagementType,
+            showNamespaceOverride: false,
+          }}
+          userSettingState={null}
+          setUserSettingState={jest.fn()}
+        />,
+      );
       expect(
         screen.getByText('The namespace column is only shown when in "All projects"'),
       ).toBeVisible();

--- a/frontend/public/components/modals/column-management-modal.tsx
+++ b/frontend/public/components/modals/column-management-modal.tsx
@@ -136,11 +136,11 @@ export const ColumnManagementModal: FC<
                 })}
                 variant="info"
               >
-                {columnLayout?.showNamespaceOverride && <NamespaceColumnHelpText />}
+                {!columnLayout?.showNamespaceOverride && <NamespaceColumnHelpText />}
               </Alert>
             </>
           ) : (
-            columnLayout?.showNamespaceOverride && <NamespaceColumnHelpText />
+            !columnLayout?.showNamespaceOverride && <NamespaceColumnHelpText />
           )}
           <Grid hasGutter>
             <GridItem sm={6}>


### PR DESCRIPTION
**Analysis / Root cause**:
The condition for displaying the `NamespaceColumnHelpText` in the `ColumnManagementModal` was accidentally inverted during the PatternFly 6 modal migration in commit 413f480. `!columnLayout?.showNamespaceOverride` was changed to `columnLayout?.showNamespaceOverride`, causing the help text to only appear when `showNamespaceOverride` is `true` — the opposite of the intended behavior.

**Solution description**:
Restore the `!` negation on both occurrences (lines 139 and 143) so the help text appears when `showNamespaceOverride` is `false`/undefined — i.e., when the namespace column is conditionally hidden outside "All projects". Updated the existing unit test to assert the correct behavior for both `showNamespaceOverride: true` and `false`.

**Screenshots / screen recording**:
<img width="1176" height="742" alt="Screenshot 2026-06-17 at 10 14 51 AM" src="https://github.com/user-attachments/assets/93712aa9-32c9-40f2-9f11-3548538f776b" />
<img width="1177" height="741" alt="Screenshot 2026-06-17 at 10 14 42 AM" src="https://github.com/user-attachments/assets/727198ba-5955-4727-bd1b-1675b28cfa69" />

**Test setup:**
None

**Test cases:**
- Open Workloads > Pods, click "Manage columns" — help text should appear
- Open Compute > Nodes, click "Manage columns" — help text should appear (harmless; no namespace column exists)

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!-- Tag reviewers -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed namespace help text visibility in the column management modal to display correctly based on configuration settings.

* **Tests**
  * Improved test coverage by adding separate assertions for namespace help text rendering under different configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->