### PR TITLE
OCPBUGS-87201: Fix RoleBindings tab error for non-cluster-admin users

### DIFF
--- a/frontend/public/components/RBAC/bindings.tsx
+++ b/frontend/public/components/RBAC/bindings.tsx
@@ -361,6 +361,11 @@ export const RoleBindingsPage: FC<RoleBindingsPageProps> = ({
   }`,
 }) => {
   const { t } = useTranslation('public');
+  const canListClusterRoleBindings = useAccessReview({
+    group: ClusterRoleBindingModel.apiGroup,
+    resource: ClusterRoleBindingModel.plural,
+    verb: 'list',
+  });
   const watchResources = useMemo(
     () =>
       mock
@@ -372,13 +377,15 @@ export const RoleBindingsPage: FC<RoleBindingsPageProps> = ({
               namespace,
               isList: true,
             },
-            ClusterRoleBinding: {
-              kind: 'ClusterRoleBinding',
-              namespaced: false,
-              isList: true,
-            },
+            ...(canListClusterRoleBindings && {
+              ClusterRoleBinding: {
+                kind: 'ClusterRoleBinding',
+                namespaced: false,
+                isList: true,
+              },
+            }),
           },
-    [mock, namespace],
+    [canListClusterRoleBindings, mock, namespace],
   );
   const resources = useK8sWatchResources(watchResources);
 


### PR DESCRIPTION
**Analysis / Root cause**:
`RoleBindingsPage` unconditionally watches `ClusterRoleBindings` at cluster scope, even when viewing within a namespace. Non-cluster-admin users lack permissions to list `ClusterRoleBindings` at the cluster scope, causing a "Restricted access" error on the project RoleBindings tab.

**Solution description**:
Use `useAccessReview` to check whether the user has `list` permission on `ClusterRoleBindings`. When the access review fails (non-cluster-admin), the `ClusterRoleBinding` watch is omitted from `watchResources`, preventing the "Restricted access" error. When the access review succeeds (cluster-admin), `ClusterRoleBindings` are fetched regardless of whether a namespace is selected, preserving the "Cluster-wide RoleBindings" Kind filter option on the RoleBindings list page.

**Screenshots / screen recording**:
<img width="3521" height="2005" alt="localhost_9000_k8s_cluster_projects_test_roles_page=1 perPage=50" src="https://github.com/user-attachments/assets/176a6c43-4a69-4637-8f19-e046140138b6" />

**Test setup:**
1. Deploy an OpenShift cluster
2. Create a non-cluster-admin user (e.g., `user1`)
3. Ensure the user is a project admin for at least one namespace

**Test cases:**
1. Log in as non-cluster-admin user → Home → Projects → select project → RoleBindings tab → RoleBindings are displayed without "Restricted access" error
2. Log in as cluster-admin → Home → Projects → select project → RoleBindings tab → both RoleBindings and ClusterRoleBindings are displayed, "Cluster-wide RoleBindings" Kind filter is available
3. Log in as cluster-admin → navigate to the standalone RoleBindings list page (cluster scope) → both RoleBindings and ClusterRoleBindings are displayed
4. Log in as cluster-admin → User details → RoleBindings tab → both binding types are displayed
5. Log in as cluster-admin → Group details → RoleBindings tab → both binding types are displayed

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
https://redhat.atlassian.net/browse/OCPBUGS-87201

**Reviewers and assignees:**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the RBAC role bindings page to respect access when showing binding results: it now avoids loading cluster-wide binding data unless the current user has permission to list cluster role bindings.
  * Improved namespace filtering so role binding results continue to be scoped correctly without triggering unnecessary cluster-wide fetches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->