### PR TITLE
OCPBUGS-69920: use RFC 5737 documentation IP in PV template

### DIFF
--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -196,7 +196,7 @@ spec:
   storageClassName: slow
   nfs:
     path: /tmp
-    server: 172.17.0.2
+    server: 192.0.2.1
 `,
   )
   .setIn(


### PR DESCRIPTION
## Summary

The NFS PersistentVolume YAML template used `172.17.0.2` as an example server address. This IP falls within the Docker bridge network range and is flagged by pen-test tools as internal IP exposure when served via the unauthenticated `/static/` endpoint.

Replaced with `192.0.2.1` from RFC 5737 TEST-NET-1 (`192.0.2.0/24`), the IANA-reserved range specifically designated for documentation and examples. Security scanners recognize this range and will not flag it.

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-69920

## Test plan

- [ ] Verify the PersistentVolume YAML template in the Console editor shows `192.0.2.1` instead of `172.17.0.2`
- [ ] Confirm no other internal IP references remain in bundled static assets

## Screenshots / Screencasts

<!-- Provide screenshots or screencasts showing the change -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated sample configuration templates with revised network settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->