### PR TITLE
[release-4.22] OCPBUGS-90110: Fix ColumnManagementModal not showing NamespaceColumnHelpText

### DIFF
--- a/frontend/public/components/modals/__tests__/column-management-modal.spec.tsx
+++ b/frontend/public/components/modals/__tests__/column-management-modal.spec.tsx
@@ -159,8 +159,34 @@ describe('ColumnManagementModal component', () => {
       expect(screen.getByText('Selected columns will appear in the table.')).toBeVisible();
     });
 
-    it('renders max row info alert', () => {
+    it('renders max row info alert without namespace help text when showNamespaceOverride is true', () => {
       expect(screen.getByText('You can select up to {{MAX_VIEW_COLS}} columns')).toBeVisible();
+      expect(
+        screen.queryByText('The namespace column is only shown when in "All projects"'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders namespace help text when showNamespaceOverride is false', () => {
+      renderWithProviders(
+        <ColumnManagementModal
+          columnLayout={{
+            columns: columnLayout,
+            id: columnManagementID,
+            selectedColumns: new Set(
+              columnLayout.reduce((acc, column) => {
+                if (column.id && !column.additional) {
+                  acc.push(column.id);
+                }
+                return acc;
+              }, []),
+            ),
+            type: columnManagementType,
+            showNamespaceOverride: false,
+          }}
+          userSettingState={null}
+          setUserSettingState={jest.fn()}
+        />,
+      );
       expect(
         screen.getByText('The namespace column is only shown when in "All projects"'),
       ).toBeVisible();

--- a/frontend/public/components/modals/column-management-modal.tsx
+++ b/frontend/public/components/modals/column-management-modal.tsx
@@ -136,11 +136,11 @@ export const ColumnManagementModal: FC<
                 })}
                 variant="info"
               >
-                {columnLayout?.showNamespaceOverride && <NamespaceColumnHelpText />}
+                {!columnLayout?.showNamespaceOverride && <NamespaceColumnHelpText />}
               </Alert>
             </>
           ) : (
-            columnLayout?.showNamespaceOverride && <NamespaceColumnHelpText />
+            !columnLayout?.showNamespaceOverride && <NamespaceColumnHelpText />
           )}
           <Grid hasGutter>
             <GridItem sm={6}>


### PR DESCRIPTION
## Summary
- Cherry-pick of d2f381f419 to release-4.22
- Fixes the `ColumnManagementModal` not showing `NamespaceColumnHelpText` by inverting the `showNamespaceOverride` condition — the help text should display when `showNamespaceOverride` is `false`, not `true`
- Adds test coverage for the namespace help text visibility based on the `showNamespaceOverride` flag

## Test plan
- [ ] Verify the namespace column help text ("The namespace column is only shown when in 'All projects'") appears when `showNamespaceOverride` is `false`
- [ ] Verify the help text does not appear when `showNamespaceOverride` is `true`
- [ ] `yarn test frontend/public/components/modals/__tests__/column-management-modal.spec.tsx` passes