### PR TITLE
[release-4.21] OCPBUGS-90498: Projects cannot be filtered by display name in the console list view

### DIFF
--- a/frontend/packages/console-app/src/components/data-view/useConsoleDataViewFilters.ts
+++ b/frontend/packages/console-app/src/components/data-view/useConsoleDataViewFilters.ts
@@ -15,6 +15,9 @@ const getK8sResourceMetadata = (obj: K8sResourceCommon): ResourceMetadata => ({
   labels: obj.metadata?.labels,
 });
 
+const getOpenShiftDisplayName = (resource: K8sResourceCommon): string | undefined =>
+  resource.metadata?.annotations?.['openshift.io/display-name'];
+
 export const useConsoleDataViewFilters = <
   TData,
   TFilters extends ResourceFilters = ResourceFilters
@@ -42,12 +45,14 @@ export const useConsoleDataViewFilters = <
     () =>
       data?.filter((resource) => {
         const { name: resourceName, labels } = getObjectMetadata(resource);
+        const displayName = getOpenShiftDisplayName(resource as K8sResourceCommon);
 
-        // Filter by K8s resource name
+        // Filter by K8s resource name or display name
+        const matchFn = isExactSearch ? exactMatch : fuzzyCaseInsensitive;
         const matchesName =
-          !filters.name || isExactSearch
-            ? exactMatch(filters.name, resourceName)
-            : fuzzyCaseInsensitive(filters.name, resourceName);
+          !filters.name ||
+          matchFn(filters.name, resourceName) ||
+          matchFn(filters.name, displayName);
 
         const resourceLabels = mapLabelsToStrings(labels);
         const filterLabelsArray = filters.label?.split(',') ?? [];


### PR DESCRIPTION
## Summary
- Backport of #16632 to release-4.21
- Adds ability to filter OpenShift projects by their `openshift.io/display-name` annotation in the ConsoleDataView component

## Test plan
- [ ] Filter projects by display name in the Projects list
- [ ] Verify fuzzy matching works for display names
- [ ] Verify exact matching works when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)