### PR TITLE
[release-4.19] OCPBUGS-90623: Allow VolumeSnapshot restore when parent PVC is deleted

### DIFF
--- a/frontend/packages/console-app/src/components/modals/restore-pvc/restore-pvc-modal.tsx
+++ b/frontend/packages/console-app/src/components/modals/restore-pvc/restore-pvc-modal.tsx
@@ -84,10 +84,16 @@ const RestorePVCModal = withHandlePromise<RestorePVCModalProps>(
     >(PersistentVolumeClaimModel, resource?.spec?.source?.persistentVolumeClaimName, namespace);
 
     const pvcStorageClassName = pvcResource?.spec?.storageClassName;
+    const pvcNotFound = pvcResourceLoaded && !pvcResource;
     const [scResource, scResourceLoaded, scResourceLoadError] = useK8sGet<StorageClassResourceKind>(
       StorageClassModel,
       pvcStorageClassName,
     );
+
+    // Form is ready when either:
+    // - PVC was found and its StorageClass has loaded
+    // - PVC was not found (deleted) — annotations and snapshot status provide sufficient data
+    const formReady = pvcNotFound || (!!pvcStorageClassName && scResourceLoaded);
 
     const [volumeMode, setVolumeMode] = React.useState('');
     const requestedSizeInputChange = ({ value, unit }) => {
@@ -167,13 +173,16 @@ const RestorePVCModal = withHandlePromise<RestorePVCModalProps>(
             />
           </FormGroup>
           <FormGroup fieldId="restore-storage-class" className="co-restore-pvc-modal__input">
-            {!pvcStorageClassName || !scResourceLoaded ? (
+            {!formReady ? (
               <div className="skeleton-text" />
             ) : (
               <StorageClassDropdown
                 onChange={handleStorageClass}
-                filter={(scObj: StorageClassResourceKind) =>
-                  onlyPvcSCs(scObj, scResourceLoadError, scResource)
+                filter={
+                  pvcNotFound
+                    ? undefined
+                    : (scObj: StorageClassResourceKind) =>
+                        onlyPvcSCs(scObj, scResourceLoadError, scResource)
                 }
                 id="restore-storage-class"
                 required
@@ -208,14 +217,17 @@ const RestorePVCModal = withHandlePromise<RestorePVCModalProps>(
             fieldId="pvc-size"
             className="co-restore-pvc-modal__input co-restore-pvc-modal__ocs-size"
           >
-            {!!pvcStorageClassName && scResourceLoaded ? (
+            {formReady ? (
               <RequestSizeInput
                 name="requestSize"
                 onChange={requestedSizeInputChange}
                 defaultRequestSizeUnit={requestedUnit}
                 defaultRequestSizeValue={requestedSize}
                 dropdownUnits={dropdownUnits}
-                isInputDisabled={scResourceLoadError || isCephProvisioner(scResource?.provisioner)}
+                isInputDisabled={
+                  !pvcNotFound &&
+                  (scResourceLoadError || isCephProvisioner(scResource?.provisioner))
+                }
                 required
               />
             ) : (


### PR DESCRIPTION
This is a manual backport of #16447 to release-4.19.

The cherry-pick had merge conflicts because the 4.19 branch still uses the older `withHandlePromise` class-style component pattern (extra indentation, `React.useState`, `className` props on FormGroups), while the main branch had been refactored. I resolved by applying the PR's logic changes (`pvcNotFound`, `formReady`, conditional filter, guarded `isInputDisabled`) while preserving the 4.19 code style.

Assisted by: Claude (Opus 4.6)

```release-note
Allow VolumeSnapshot restore when the parent PVC has been deleted by using snapshot annotations to populate the restore form instead of requiring the parent PVC to exist.
```

**Test Verification (4.19 backport)**

Adapted unit tests from the main branch PR ([#16447](https://github.com/openshift/console/pull/16447)) to work with the 4.19 component structure (withHandlePromise HOC, React.useState, different import paths, no renderWithProviders util). The logic changes are identical to the 4.21 and 4.22 backports — the only differences are structural, matching the older component pattern in 4.19.

**Results:**

All 4 tests pass on the backport branch (with fix)
The "deleted PVC" test correctly fails on release-4.19 without the fix (skeleton loaders render instead of form fields)
3 regression tests pass on both branches, confirming no breakage
Tests:

Renders all form fields when parent PVC exists (regression)
Renders all form fields when parent PVC is deleted ([OCPBUGS-59404](https://issues.redhat.com/browse/OCPBUGS-59404) fix)
Shows skeleton loaders while PVC is still loading
Pre-populates restore name from snapshot name