### PR TITLE
[release-4.22] OCPBUGS-90636: Fix RoleBindings tab error for non-cluster-admin users

### DIFF
--- a/frontend/public/components/RBAC/bindings.tsx
+++ b/frontend/public/components/RBAC/bindings.tsx
@@ -361,6 +361,11 @@ export const RoleBindingsPage: FC<RoleBindingsPageProps> = ({
   }`,
 }) => {
   const { t } = useTranslation();
+  const canListClusterRoleBindings = useAccessReview({
+    group: ClusterRoleBindingModel.apiGroup,
+    resource: ClusterRoleBindingModel.plural,
+    verb: 'list',
+  });
   const watchResources = useMemo(
     () =>
       mock
@@ -372,13 +377,15 @@ export const RoleBindingsPage: FC<RoleBindingsPageProps> = ({
               namespace,
               isList: true,
             },
-            ClusterRoleBinding: {
-              kind: 'ClusterRoleBinding',
-              namespaced: false,
-              isList: true,
-            },
+            ...(canListClusterRoleBindings && {
+              ClusterRoleBinding: {
+                kind: 'ClusterRoleBinding',
+                namespaced: false,
+                isList: true,
+              },
+            }),
           },
-    [mock, namespace],
+    [canListClusterRoleBindings, mock, namespace],
   );
   const resources = useK8sWatchResources(watchResources);
 


### PR DESCRIPTION
## Summary
- Cherry-pick of #16639 to `release-4.22`
- Uses an access review to check whether the user can list ClusterRoleBindings before adding the watch
- When the check fails (non-cluster-admin), the ClusterRoleBinding watch is omitted, preventing the "Restricted access" error on the RoleBindings tab

## Test plan
- [ ] Log in as a non-cluster-admin user, navigate to a project's RoleBindings tab — no error should appear
- [ ] Log in as a cluster-admin user, verify ClusterRoleBindings still appear and the "Cluster-wide RoleBindings" Kind filter works

## After

<img width="3428" height="2006" alt="localhost_9000_k8s_cluster_projects_test_roles_page=1 perPage=50" src="https://github.com/user-attachments/assets/651f47c8-8d7c-4809-943a-4fd8d10b0048" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)