### PR TITLE
[release-4.22] OCPBUGS-88028: Bump follow-redirects from 1.15.3 to 1.16.0 to fix CVE-2026-40895

### DIFF
--- a/dynamic-demo-plugin/package.json
+++ b/dynamic-demo-plugin/package.json
@@ -78,7 +78,8 @@
     "minimatch@^3.0.4": "^3.1.3",
     "minimatch@^3.1.1": "^3.1.3",
     "minimatch@^9.0.4": "^9.0.6",
-    "immutable": "^3.8.3"
+    "immutable": "^3.8.3",
+    "follow-redirects": "^1.16.0"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -1741,13 +1741,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -329,7 +329,8 @@
     "minimatch@^10.1.2": "^10.2.1",
     "fast-uri": "3.1.2",
     "shell-quote": "1.8.4",
-    "protobufjs": "7.5.8"
+    "protobufjs": "7.5.8",
+    "follow-redirects": "^1.16.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11630,13 +11630,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
-  version: 1.15.3
-  resolution: "follow-redirects@npm:1.15.3"
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/915a2cf22e667bdf47b1a43cc6b7dce14d95039e9bbf9a24d0e739abfbdfa00077dd43c86d4a7a19efefcc7a99af144920a175eedc3888d268af5df67c272ee5
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- **CVE**: CVE-2026-40895 — Information disclosure via custom authentication headers in cross-domain redirects
- **Package**: follow-redirects → 1.16.0 (transitive dependency)
- **Risk Level**: LOW (development-only dependency, not in production)

## Impact
- **Production**: NOT AFFECTED (webpack-dev-server and http-server are devDependencies, not deployed)
- **Development**: Potentially affected (local dev server only)

## Changes
- [x] Added yarn resolution for follow-redirects@^1.16.0 in `frontend/package.json`
- [x] Added yarn resolution for follow-redirects@^1.16.0 in `dynamic-demo-plugin/package.json`
- [x] Updated `frontend/yarn.lock`
- [x] Updated `dynamic-demo-plugin/yarn.lock`

## Test Plan
- [x] `yarn build` succeeds (production build)
- [x] `dynamic-demo-plugin/` installs without errors
