### PR TITLE
OCPBUGS-91965: Add catalog item-type for OLMv1 operator catalog

### DIFF
--- a/frontend/packages/operator-lifecycle-manager-v1/console-extensions.json
+++ b/frontend/packages/operator-lifecycle-manager-v1/console-extensions.json
@@ -33,6 +33,40 @@
     }
   },
   {
+    "type": "console.catalog/item-type",
+    "properties": {
+      "type": "operator",
+      "title": "%olm-v1~Operators%",
+      "catalogDescription": "%olm-v1~Browse for Operators provided by Operator Lifecycle Manager.%",
+      "typeDescription": "%olm-v1~**Operators** are software extensions to OpenShift that make use of custom resources to manage applications and their components. They are managed by Operator Lifecycle Manager.%",
+      "filters": [
+        {
+          "label": "%olm-v1~Source%",
+          "attribute": "source"
+        },
+        {
+          "label": "%olm-v1~Provider%",
+          "attribute": "provider"
+        },
+        {
+          "label": "%olm-v1~Capability level%",
+          "attribute": "capabilities"
+        },
+        {
+          "label": "%olm-v1~Infrastructure features%",
+          "attribute": "infrastructureFeatures"
+        },
+        {
+          "label": "%olm-v1~Valid subscription%",
+          "attribute": "validSubscription"
+        }
+      ]
+    },
+    "flags": {
+      "required": ["CLUSTER_CATALOG_API", "TECH_PREVIEW", "OLMV1_ENABLED"]
+    }
+  },
+  {
     "type": "console.catalog/item-provider",
     "properties": {
       "catalogId": "dev-catalog",

--- a/frontend/packages/operator-lifecycle-manager-v1/locales/en/olm-v1.json
+++ b/frontend/packages/operator-lifecycle-manager-v1/locales/en/olm-v1.json
@@ -1,5 +1,12 @@
 {
   "Operators": "Operators",
+  "Browse for Operators provided by Operator Lifecycle Manager.": "Browse for Operators provided by Operator Lifecycle Manager.",
+  "**Operators** are software extensions to OpenShift that make use of custom resources to manage applications and their components. They are managed by Operator Lifecycle Manager.": "**Operators** are software extensions to OpenShift that make use of custom resources to manage applications and their components. They are managed by Operator Lifecycle Manager.",
+  "Source": "Source",
+  "Provider": "Provider",
+  "Capability level": "Capability level",
+  "Infrastructure features": "Infrastructure features",
+  "Valid subscription": "Valid subscription",
   "OLMv1 Catalog": "OLMv1 Catalog",
   "Enable the OLMv1 catalog experience. OLMv1 is a technology preview feature that provides an updated operator catalog interface.": "Enable the OLMv1 catalog experience. OLMv1 is a technology preview feature that provides an updated operator catalog interface.",
   "Enable OLMv1 catalog": "Enable OLMv1 catalog",


### PR DESCRIPTION
## Analysis / Root cause

On TechPreview / OCP 5.0-ec clusters, operators do not appear in the Software Catalog despite the OLMv1 backend `/api/olm/catalog-items/` returning 133 operators successfully.

The OLMv0 `console.catalog/item-type` for `type: "operator"` uses `$codeRef` comparators in its filters (`filters.sourceComparator`, `filters.providerComparator`, etc.) which fail to resolve when `OLMV1_ENABLED` is active. `useResolvedExtensions` silently excludes extensions with unresolvable `$codeRef` values, so no item-type definition exists for `type: "operator"`.

The OLMv1 package registers a `console.catalog/item-provider` and `console.catalog/categories-provider` for `type: "operator"`, but never registers the `console.catalog/item-type` that defines the type itself (title, description, filters). Without the item-type definition, the CatalogController doesn't know the type exists — no "Operators" filter appears and the fetched items are silently dropped.

## Solution description

Add a `console.catalog/item-type` extension for `type: "operator"` in the OLMv1 package (`operator-lifecycle-manager-v1/console-extensions.json`) with plain filters (no `$codeRef` comparators), gated on `CLUSTER_CATALOG_API`, `TECH_PREVIEW`, and `OLMV1_ENABLED`.

## Screenshots / screen recording

_To be added_

## Test setup

1. Deploy a TechPreview / OCP 5.0-ec cluster with OLMv1 enabled (default)
2. Ensure ClusterCatalogs exist and are healthy

## Test cases

1. Navigate to Software Catalog → verify "Operators" type filter appears in sidebar
2. Click "Operators" → verify operators from ClusterCatalogs are listed
3. Verify Source, Provider, Capability level, Infrastructure features, and Valid subscription filters work
4. Disable OLMv1 in user preferences → verify OLMv0 catalog behavior is unaffected

## Browser conformance

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

## Additional info

- Non-breaking addition — no public API changes
- Jira: [CONSOLE-5365](https://redhat.atlassian.net/browse/CONSOLE-5365)

Reviewers and assignees:

Console Approver:
/assign @TheRealJon 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operators are now discoverable in the catalog with browsable item type.
  * Added catalog filters for operators: Source, Provider, Capability level, Infrastructure features, and Valid subscription.
  * Feature available as a technical preview behind required feature flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->