### PR TITLE
CONSOLE-5271: Gate lifecycle metadata on server-side OLM lifecycle flag

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -178,6 +178,7 @@ func main() {
 	fNodeOperatingSystems := fs.String("node-operating-systems", "", "List of node operating systems. Example --node-operating-system=linux,windows")
 	fCopiedCSVsDisabled := fs.Bool("copied-csvs-disabled", false, "Flag to indicate if OLM copied CSVs are disabled.")
 	fTechPreview := fs.Bool("tech-preview", false, "Enable console Technology Preview features.")
+	fOLMLifecycle := fs.Bool("olm-lifecycle", false, "Enable OLM operator lifecycle and compatibility features.")
 
 	cfg, err := serverconfig.Parse(fs, os.Args[1:], "BRIDGE")
 	if err != nil {
@@ -357,6 +358,7 @@ func main() {
 		K8sMode:                      *fK8sMode,
 		CopiedCSVsDisabled:           *fCopiedCSVsDisabled,
 		TechPreview:                  *fTechPreview,
+		OLMLifecycle:                 *fOLMLifecycle,
 		Capabilities:                 capabilities,
 	}
 

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -178,7 +178,7 @@ func main() {
 	fNodeOperatingSystems := fs.String("node-operating-systems", "", "List of node operating systems. Example --node-operating-system=linux,windows")
 	fCopiedCSVsDisabled := fs.Bool("copied-csvs-disabled", false, "Flag to indicate if OLM copied CSVs are disabled.")
 	fTechPreview := fs.Bool("tech-preview", false, "Enable console Technology Preview features.")
-	fOLMLifecycle := fs.Bool("olm-lifecycle", false, "Enable OLM operator lifecycle and compatibility features.")
+	fOLMLifecycleMetadata := fs.Bool("olm-lifecycle-metadata", false, "Enable OLM Operator lifecycle and compatibility features.")
 
 	cfg, err := serverconfig.Parse(fs, os.Args[1:], "BRIDGE")
 	if err != nil {
@@ -358,7 +358,7 @@ func main() {
 		K8sMode:                      *fK8sMode,
 		CopiedCSVsDisabled:           *fCopiedCSVsDisabled,
 		TechPreview:                  *fTechPreview,
-		OLMLifecycle:                 *fOLMLifecycle,
+		OLMLifecycleMetadata:         *fOLMLifecycleMetadata,
 		Capabilities:                 capabilities,
 	}
 

--- a/frontend/@types/console/window.d.ts
+++ b/frontend/@types/console/window.d.ts
@@ -64,6 +64,7 @@ declare interface Window {
     hubConsoleURL: string;
     k8sMode: string;
     techPreview: boolean;
+    olmLifecycle: boolean;
     capabilities: {
       name: string;
       visibility: { state: 'Enabled' | 'Disabled' };

--- a/frontend/@types/console/window.d.ts
+++ b/frontend/@types/console/window.d.ts
@@ -64,7 +64,7 @@ declare interface Window {
     hubConsoleURL: string;
     k8sMode: string;
     techPreview: boolean;
-    olmLifecycle: boolean;
+    olmLifecycleMetadata: boolean;
     capabilities: {
       name: string;
       visibility: { state: 'Enabled' | 'Disabled' };

--- a/frontend/packages/operator-lifecycle-manager/src/features.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/features.ts
@@ -2,5 +2,5 @@ import type { FeatureFlagHandler } from '@console/dynamic-plugin-sdk/src/extensi
 import { Flags } from './const';
 
 export const detectLifecycleMetadata: FeatureFlagHandler = (setFeatureFlag) => {
-  setFeatureFlag(Flags.OPERATOR_LIFECYCLE_METADATA, !!window.SERVER_FLAGS.techPreview);
+  setFeatureFlag(Flags.OPERATOR_LIFECYCLE_METADATA, !!window.SERVER_FLAGS.olmLifecycle);
 };

--- a/frontend/packages/operator-lifecycle-manager/src/features.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/features.ts
@@ -2,5 +2,5 @@ import type { FeatureFlagHandler } from '@console/dynamic-plugin-sdk/src/extensi
 import { Flags } from './const';
 
 export const detectLifecycleMetadata: FeatureFlagHandler = (setFeatureFlag) => {
-  setFeatureFlag(Flags.OPERATOR_LIFECYCLE_METADATA, !!window.SERVER_FLAGS.olmLifecycle);
+  setFeatureFlag(Flags.OPERATOR_LIFECYCLE_METADATA, !!window.SERVER_FLAGS.olmLifecycleMetadata);
 };

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -142,7 +142,7 @@ type jsGlobals struct {
 	Telemetry                       serverconfig.MultiKeyValue `json:"telemetry"`
 	ThanosPublicURL                 string                     `json:"thanosPublicURL"`
 	TechPreview                     bool                       `json:"techPreview"`
-	OLMLifecycle                    bool                       `json:"olmLifecycle"`
+	OLMLifecycleMetadata            bool                       `json:"olmLifecycleMetadata"`
 	UserSettingsLocation            string                     `json:"userSettingsLocation"`
 	DevConsoleProxyAvailable        bool                       `json:"devConsoleProxyAvailable"`
 }
@@ -173,7 +173,7 @@ type Server struct {
 	CSRFVerifier                        *csrfverifier.CSRFVerifier
 	CustomLogoFiles                     serverconfig.LogosKeyValue
 	TechPreview                         bool
-	OLMLifecycle                        bool
+	OLMLifecycleMetadata                bool
 	CustomFaviconFiles                  serverconfig.LogosKeyValue
 	CustomProductName                   string
 	DevCatalogCategories                string
@@ -792,7 +792,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		Telemetry:                 s.Telemetry,
 		ThanosPublicURL:           s.ThanosPublicURL.String(),
 		TechPreview:               s.TechPreview,
-		OLMLifecycle:              s.OLMLifecycle,
+		OLMLifecycleMetadata:      s.OLMLifecycleMetadata,
 		UserSettingsLocation:      s.UserSettingsLocation,
 		DevConsoleProxyAvailable:  true,
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -142,6 +142,7 @@ type jsGlobals struct {
 	Telemetry                       serverconfig.MultiKeyValue `json:"telemetry"`
 	ThanosPublicURL                 string                     `json:"thanosPublicURL"`
 	TechPreview                     bool                       `json:"techPreview"`
+	OLMLifecycle                    bool                       `json:"olmLifecycle"`
 	UserSettingsLocation            string                     `json:"userSettingsLocation"`
 	DevConsoleProxyAvailable        bool                       `json:"devConsoleProxyAvailable"`
 }
@@ -172,6 +173,7 @@ type Server struct {
 	CSRFVerifier                        *csrfverifier.CSRFVerifier
 	CustomLogoFiles                     serverconfig.LogosKeyValue
 	TechPreview                         bool
+	OLMLifecycle                        bool
 	CustomFaviconFiles                  serverconfig.LogosKeyValue
 	CustomProductName                   string
 	DevCatalogCategories                string
@@ -790,6 +792,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		Telemetry:                 s.Telemetry,
 		ThanosPublicURL:           s.ThanosPublicURL.String(),
 		TechPreview:               s.TechPreview,
+		OLMLifecycle:              s.OLMLifecycle,
 		UserSettingsLocation:      s.UserSettingsLocation,
 		DevConsoleProxyAvailable:  true,
 	}

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -292,8 +292,8 @@ func addClusterInfo(fs *flag.FlagSet, clusterInfo *ClusterInfo) {
 		fs.Set("tech-preview", "true")
 	}
 
-	if clusterInfo.OLMLifecycleEnabled {
-		fs.Set("olm-lifecycle", "true")
+	if clusterInfo.OLMLifecycleMetadataEnabled {
+		fs.Set("olm-lifecycle-metadata", "true")
 	}
 }
 

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -291,6 +291,10 @@ func addClusterInfo(fs *flag.FlagSet, clusterInfo *ClusterInfo) {
 	if clusterInfo.TechPreviewEnabled {
 		fs.Set("tech-preview", "true")
 	}
+
+	if clusterInfo.OLMLifecycleEnabled {
+		fs.Set("olm-lifecycle", "true")
+	}
 }
 
 func addProviders(fs *flag.FlagSet, providers *Providers) {

--- a/pkg/serverconfig/config_test.go
+++ b/pkg/serverconfig/config_test.go
@@ -292,6 +292,20 @@ func TestSetFlagsFromConfig(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "Should apply OLM lifecycle enabled",
+			config: Config{
+				APIVersion: "console.openshift.io/v1",
+				Kind:       "ConsoleConfig",
+				ClusterInfo: ClusterInfo{
+					OLMLifecycleEnabled: true,
+				},
+			},
+			expectedFlagValues: map[string]string{
+				"olm-lifecycle": "true",
+			},
+			expectedError: nil,
+		},
+		{
 			name: "Should apply CSP configuration",
 			config: Config{
 				APIVersion: "console.openshift.io/v1",
@@ -314,6 +328,7 @@ func TestSetFlagsFromConfig(t *testing.T) {
 			fs.Var(&MultiKeyValue{}, "plugins", "")
 			fs.Var(&MultiKeyValue{}, "telemetry", "")
 			fs.Var(&MultiKeyValue{}, "content-security-policy", "")
+			fs.Bool("olm-lifecycle", false, "")
 
 			actualError := SetFlagsFromConfig(fs, &test.config)
 			actual := make(map[string]string)

--- a/pkg/serverconfig/config_test.go
+++ b/pkg/serverconfig/config_test.go
@@ -292,16 +292,16 @@ func TestSetFlagsFromConfig(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name: "Should apply OLM lifecycle enabled",
+			name: "Applies OLM lifecycle metadata when enabled",
 			config: Config{
 				APIVersion: "console.openshift.io/v1",
 				Kind:       "ConsoleConfig",
 				ClusterInfo: ClusterInfo{
-					OLMLifecycleEnabled: true,
+					OLMLifecycleMetadataEnabled: true,
 				},
 			},
 			expectedFlagValues: map[string]string{
-				"olm-lifecycle": "true",
+				"olm-lifecycle-metadata": "true",
 			},
 			expectedError: nil,
 		},
@@ -328,7 +328,7 @@ func TestSetFlagsFromConfig(t *testing.T) {
 			fs.Var(&MultiKeyValue{}, "plugins", "")
 			fs.Var(&MultiKeyValue{}, "telemetry", "")
 			fs.Var(&MultiKeyValue{}, "content-security-policy", "")
-			fs.Bool("olm-lifecycle", false, "")
+			fs.Bool("olm-lifecycle-metadata", false, "")
 
 			actualError := SetFlagsFromConfig(fs, &test.config)
 			actual := make(map[string]string)

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -72,16 +72,16 @@ type MonitoringInfo struct {
 
 // ClusterInfo holds information the about the cluster such as master public URL and console public URL.
 type ClusterInfo struct {
-	ConsoleBaseAddress   string                `yaml:"consoleBaseAddress,omitempty"`
-	ConsoleBasePath      string                `yaml:"consoleBasePath,omitempty"`
-	MasterPublicURL      string                `yaml:"masterPublicURL,omitempty"`
-	ControlPlaneTopology configv1.TopologyMode `yaml:"controlPlaneTopology,omitempty"`
-	ReleaseVersion       string                `yaml:"releaseVersion,omitempty"`
-	NodeArchitectures    []string              `yaml:"nodeArchitectures,omitempty"`
-	NodeOperatingSystems []string              `yaml:"nodeOperatingSystems,omitempty"`
-	CopiedCSVsDisabled   bool                  `yaml:"copiedCSVsDisabled,omitempty"`
-	TechPreviewEnabled   bool                  `yaml:"techPreviewEnabled,omitempty"`
-	OLMLifecycleEnabled  bool                  `yaml:"olmLifecycleEnabled,omitempty"`
+	ConsoleBaseAddress          string                `yaml:"consoleBaseAddress,omitempty"`
+	ConsoleBasePath             string                `yaml:"consoleBasePath,omitempty"`
+	MasterPublicURL             string                `yaml:"masterPublicURL,omitempty"`
+	ControlPlaneTopology        configv1.TopologyMode `yaml:"controlPlaneTopology,omitempty"`
+	ReleaseVersion              string                `yaml:"releaseVersion,omitempty"`
+	NodeArchitectures           []string              `yaml:"nodeArchitectures,omitempty"`
+	NodeOperatingSystems        []string              `yaml:"nodeOperatingSystems,omitempty"`
+	CopiedCSVsDisabled          bool                  `yaml:"copiedCSVsDisabled,omitempty"`
+	TechPreviewEnabled          bool                  `yaml:"techPreviewEnabled,omitempty"`
+	OLMLifecycleMetadataEnabled bool                  `yaml:"olmLifecycleMetadataEnabled,omitempty"`
 }
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -81,6 +81,7 @@ type ClusterInfo struct {
 	NodeOperatingSystems []string              `yaml:"nodeOperatingSystems,omitempty"`
 	CopiedCSVsDisabled   bool                  `yaml:"copiedCSVsDisabled,omitempty"`
 	TechPreviewEnabled   bool                  `yaml:"techPreviewEnabled,omitempty"`
+	OLMLifecycleEnabled  bool                  `yaml:"olmLifecycleEnabled,omitempty"`
 }
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".


### PR DESCRIPTION
**Analysis / Root cause**:
The operator lifecycle metadata UI (cluster compatibility and support phase columns on the Installed Operators page) was gated on the console's `--tech-preview` server flag (`window.SERVER_FLAGS.techPreview`). This couples the feature to the console's tech-preview mode rather than the cluster-level FeatureGate that controls the OLM lifecycle service itself. The frontend cannot read the `FeatureGate` resource directly because not all users have RBAC for it, so the gating must be done server-side via the console-operator.

**Solution description**:
- Add `--olm-lifecycle` bridge flag and `OLMLifecycleEnabled` config field to `ClusterInfo`
- Thread `olmLifecycle` through `SERVER_FLAGS` to the frontend via `jsGlobals`
- Simplify `detectLifecycleMetadata` to read `window.SERVER_FLAGS.olmLifecycle` instead of `techPreview`
- Remove `FeatureGateModel` (no longer needed — gating is handled server-side)
- Add backend config test for the new flag

**Screenshots / screen recording**:
<!-- No visual changes — feature gating logic only -->

**Test setup:**
Requires the companion console-operator PR (openshift/console-operator#1174) to set `olmLifecycleEnabled` based on the `OLMLifecycleAndCompatibility` cluster FeatureGate.

**Test cases:**
- Verify lifecycle columns (Cluster compatibility, Support phase) appear when `--olm-lifecycle` is set to true
- Verify lifecycle columns are hidden when the flag is false, even if `--tech-preview` is set
- Verify no regressions on the Installed Operators list page

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
Companion PR: openshift/console-operator#1174 (sets `olmLifecycleEnabled` in the ConsoleConfig based on the cluster FeatureGate).
Depends on #16655 and #16551.

**Reviewers and assignees:**
/assign @perdasilva

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `--olm-lifecycle-metadata` CLI flag (default `false`) to control whether Operator Lifecycle Manager lifecycle metadata is exposed to the frontend.
  * Added cluster-level configuration `olmLifecycleMetadataEnabled` to enable this behavior and set the new flag accordingly.
* **UI/Frontend Updates**
  * Updated the frontend to read the lifecycle metadata value from server-provided flags and pass it through to the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->