### PR TITLE
[release-4.18] OCPBUGS-84284: Bump follow-redirects to 1.16.0 to fix CVE-2026-40895

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -339,6 +339,7 @@
     "node": ">=18.x"
   },
   "resolutions": {
+    "follow-redirects": "^1.16.0",
     "@types/react-router": "^5.1.20",
     "@types/react-router-dom": "5.3.x",
     "@types/lodash": "4.14.106",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -12180,13 +12180,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
-  version: 1.15.3
-  resolution: "follow-redirects@npm:1.15.3"
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/915a2cf22e667bdf47b1a43cc6b7dce14d95039e9bbf9a24d0e739abfbdfa00077dd43c86d4a7a19efefcc7a99af144920a175eedc3888d268af5df67c272ee5
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- **CVE**: CVE-2026-40895 — Information disclosure via custom authentication headers in cross-domain redirects
- **Package**: follow-redirects → 1.16.0 (transitive dependency)

## Changes
- [x] Added yarn resolution for follow-redirects@^1.16.0 in `frontend/package.json`
- [x] Updated `frontend/yarn.lock`

## Test Plan
- [x] `yarn build` succeeds 