### PR TITLE
OCPBUGS-90553: Backport inventory card filter link fix to release-4.21

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryItem.tsx
@@ -183,8 +183,7 @@ const StatusLink: React.FC<StatusLinkProps> = ({
   const groupIcon = statusGroupIcons[groupID] || statusGroupIcons[InventoryStatusGroup.NOT_MAPPED];
   const statusItems = encodeURIComponent(statusIDs.join(','));
   const path = basePath || resourcePathFromModel(kind, null, namespace);
-  const to =
-    filterType && statusItems.length > 0 ? `${path}?rowFilter-${filterType}=${statusItems}` : path;
+  const to = filterType && statusItems.length > 0 ? `${path}?${filterType}=${statusItems}` : path;
 
   return <InventoryItemStatus count={count} icon={groupIcon} linkTo={to} />;
 };

--- a/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryItem.tsx
@@ -181,9 +181,13 @@ const StatusLink: React.FC<StatusLinkProps> = ({
   }
 
   const groupIcon = statusGroupIcons[groupID] || statusGroupIcons[InventoryStatusGroup.NOT_MAPPED];
-  const statusItems = encodeURIComponent(statusIDs.join(','));
   const path = basePath || resourcePathFromModel(kind, null, namespace);
-  const to = filterType && statusItems.length > 0 ? `${path}?${filterType}=${statusItems}` : path;
+
+  const queryParams =
+    filterType && statusIDs.length > 0
+      ? statusIDs.map((id) => `${filterType}=${encodeURIComponent(id)}`).join('&')
+      : '';
+  const to = queryParams ? `${path}?${queryParams}` : path;
 
   return <InventoryItemStatus count={count} icon={groupIcon} linkTo={to} />;
 };

--- a/frontend/packages/console-shared/src/components/dashboard/inventory-card/utils.ts
+++ b/frontend/packages/console-shared/src/components/dashboard/inventory-card/utils.ts
@@ -61,12 +61,12 @@ export const getStatusGroups = (resources, mapping, mapper, filterType) => {
 };
 
 export const getPodStatusGroups: StatusGroupMapper = (resources) =>
-  getStatusGroups(resources, POD_PHASE_GROUP_MAPPING, podPhaseFilterReducer, 'pod-status');
+  getStatusGroups(resources, POD_PHASE_GROUP_MAPPING, podPhaseFilterReducer, 'status');
 export const getNodeStatusGroups: StatusGroupMapper = (resources) =>
-  getStatusGroups(resources, NODE_STATUS_GROUP_MAPPING, nodeStatus, 'node-status');
+  getStatusGroups(resources, NODE_STATUS_GROUP_MAPPING, nodeStatus, 'status');
 export const getPVCStatusGroups: StatusGroupMapper = (resources) =>
-  getStatusGroups(resources, PVC_STATUS_GROUP_MAPPING, (pvc) => pvc.status.phase, 'pvc-status');
+  getStatusGroups(resources, PVC_STATUS_GROUP_MAPPING, (pvc) => pvc.status.phase, 'status');
 export const getPVStatusGroups: StatusGroupMapper = (resources) =>
-  getStatusGroups(resources, PV_STATUS_GROUP_MAPPING, (pv) => pv.status.phase, 'pv-status');
+  getStatusGroups(resources, PV_STATUS_GROUP_MAPPING, (pv) => pv.status.phase, 'status');
 export const getVSStatusGroups: StatusGroupMapper = (resources) =>
   getStatusGroups(resources, VS_STATUS_GROUP_MAPPING, snapshotStatus, 'status');

--- a/frontend/packages/integration-tests-cypress/tests/app/resource-log.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/resource-log.cy.ts
@@ -19,7 +19,7 @@ describe('Pod log viewer tab', () => {
 
   it('Open logs from pod details page tab and verify the log buffer sizes', () => {
     cy.visit(
-      `/k8s/ns/openshift-kube-apiserver/core~v1~Pod?name=kube-apiserver-ip-&rowFilter-pod-status=Running&orderBy=asc&sortBy=Owner`,
+      `/k8s/ns/openshift-kube-apiserver/core~v1~Pod?name=kube-apiserver-ip-&status=Running&orderBy=asc&sortBy=Owner`,
     );
     listPage.dvRows.clickFirstLinkInFirstRow();
     detailsPage.isLoaded();

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -505,7 +505,7 @@ export const NodesUpdatesGroup: React.FC<NodesUpdatesGroupProps> = ({
     : machineConfigOperatorLoaded && renderedConfigLoaded && (
         <UpdatesGroup divided={divided}>
           <UpdatesType>
-            <Link to={`/k8s/cluster/nodes?rowFilter-node-role=${nodeRoleFilterValue}`}>
+            <Link to={`/k8s/cluster/nodes?roles=${nodeRoleFilterValue}`}>
               {`${name} ${NodeModel.labelPlural}`}
             </Link>
             {!isMaster && (
@@ -787,10 +787,7 @@ export const ClusterNotUpgradeableAlert: React.FC<ClusterNotUpgradeableAlertProp
           <Flex>
             {notUpgradeableClusterOperatorsPresent && (
               <FlexItem>
-                <ClusterOperatorsLink
-                  onCancel={onCancel}
-                  queryString="?rowFilter-cluster-operator-status=Cannot+update"
-                >
+                <ClusterOperatorsLink onCancel={onCancel} queryString="?status=Cannot+update">
                   {t('public~View ClusterOperators')}
                 </ClusterOperatorsLink>
               </FlexItem>

--- a/frontend/public/components/graphs/health.jsx
+++ b/frontend/public/components/graphs/health.jsx
@@ -63,9 +63,7 @@ const CrashloopingPods = ({ namespace }) => (
     query={`count(increase(kube_pod_container_status_restarts_total${
       namespace ? `{namespace="${namespace}"}` : ''
     }[1h]) > 5 )`}
-    to={`/k8s/${
-      namespace ? `ns/${namespace}` : 'all-namespaces'
-    }/pods?rowFilter-pod-status=CrashLoopBackOff`}
+    to={`/k8s/${namespace ? `ns/${namespace}` : 'all-namespaces'}/pods?status=CrashLoopBackOff`}
   />
 );
 

--- a/frontend/public/components/pod-list.tsx
+++ b/frontend/public/components/pod-list.tsx
@@ -513,7 +513,7 @@ export const PodList: FC<PodListProps> = ({
     () => [
       <DataViewCheckboxFilter
         key="status"
-        filterId="status" // is `rowFilter-pod-status`in <FilterToolbar> as a single param, not multiple
+        filterId="status"
         title={t('public~Status')}
         placeholder={t('public~Filter by status')}
         options={podStatusFilterOptions}


### PR DESCRIPTION
## Solution description

Cherry-pick of the fix for [OCPBUGS-74639](https://issues.redhat.com/browse/OCPBUGS-74639) (PR [#15979](https://github.com/openshift/console/pull/15979)) to `release-4.21`.

Clicking the error pod count badge on the Cluster Overview inventory card navigates to the Pods list page but the filter is not applied. The root cause is a URL parameter mismatch: `StatusLink` was generating `?rowFilter-pod-status=...` but the Pods page (which uses `ConsoleDataView`) expects `?status=...`.

**Changes (from main):**
- Changed `filterType` from `'pod-status'` to `'status'` and removed the `rowFilter-` prefix from URL generation in `StatusLink`
- Updated URL encoding to use multiple separate params (`?status=A&status=B`) instead of a single comma-separated param, matching how PatternFly's `useDataViewFilters` reads array values via `searchParams.getAll(key)`

This fix was already on `main` since Feb 2026 and inherited by release-4.22+, but was never backported to release-4.21.

## Reviewers and assignees

<!-- Tag a reviewer -->

## Test case

1. Navigate to Cluster Overview
2. Locate the Pods inventory card showing error pod counts
3. Click the error count badge
4. Verify the Pods list page opens with the status filter pre-applied (e.g., `CrashLoopBackOff`, `Failed`)
5. Verify the URL contains `?status=CrashLoopBackOff&status=Failed` (not `?rowFilter-pod-status=...`)

## Additional info

OCPBUGS-90553 is a duplicate of OCPBUGS-74639. One conflict resolved during cherry-pick: kept `snapshotStatus` (release-4.21 import name) instead of `volumeSnapshotStatus` (renamed on main).

https://issues.redhat.com/browse/OCPBUGS-90553
https://issues.redhat.com/browse/OCPBUGS-74639 (merged into 4.22)

**After**

<img width="1378" height="1054" alt="OCPBUGS-90553" src="https://github.com/user-attachments/assets/387ecfbb-05f3-4c23-9b4e-f3fd4d548fc8" />
