### PR TITLE
CONSOLE-5277: Improve ResourceName data-test uniqueness and fix e2e test patterns

### DIFF
--- a/frontend/e2e/pages/yaml-editor-page.ts
+++ b/frontend/e2e/pages/yaml-editor-page.ts
@@ -15,10 +15,8 @@ export class YamlEditorPage extends BasePage {
   }
 
   async waitForSidebarLoaded(): Promise<void> {
-    try {
+    if ((await this.resourceSidebar.count()) > 0) {
       await expect(this.resourceSidebar).toBeAttached({ timeout: 30_000 });
-    } catch {
-      // Sidebar may not render for all resource types
     }
   }
 

--- a/frontend/e2e/tests/console/crud/environment.spec.ts
+++ b/frontend/e2e/tests/console/crud/environment.spec.ts
@@ -84,7 +84,7 @@ test.describe('Interacting with the environment variable editor', { tag: ['@admi
     });
 
     await test.step('Verify config map variable exists', async () => {
-      await expect(page.getByTestId('resource-name').last()).toHaveText(resourceName);
+      await expect(page.getByTestId(`resource-name-${resourceName}`)).toBeVisible();
       await expect(page.getByTestId('env-prefix')).toHaveValue(prefix);
     });
 
@@ -95,7 +95,8 @@ test.describe('Interacting with the environment variable editor', { tag: ['@admi
     });
 
     await test.step('Verify config map variable removed', async () => {
-      await expect(page.getByTestId('resource-name').last()).toHaveText('container');
+      await expect(page.getByTestId(`resource-name-${resourceName}`)).not.toBeAttached();
+      await expect(page.getByTestId('resource-name-container')).toBeVisible();
       await expect(page.getByTestId('env-prefix')).toHaveValue('');
     });
   });
@@ -115,7 +116,7 @@ test.describe('Interacting with the environment variable editor', { tag: ['@admi
     });
 
     await test.step('Verify secret variable exists', async () => {
-      await expect(page.getByTestId('resource-name').last()).toHaveText(resourceName);
+      await expect(page.getByTestId(`resource-name-${resourceName}`)).toBeVisible();
       await expect(page.getByTestId('env-prefix')).toHaveValue(prefix);
     });
 
@@ -126,7 +127,8 @@ test.describe('Interacting with the environment variable editor', { tag: ['@admi
     });
 
     await test.step('Verify secret variable removed', async () => {
-      await expect(page.getByTestId('resource-name').last()).toHaveText('container');
+      await expect(page.getByTestId(`resource-name-${resourceName}`)).not.toBeAttached();
+      await expect(page.getByTestId('resource-name-container')).toBeVisible();
       await expect(page.getByTestId('env-prefix')).toHaveValue('');
     });
   });

--- a/frontend/public/components/utils/resource-icon.tsx
+++ b/frontend/public/components/utils/resource-icon.tsx
@@ -49,7 +49,7 @@ export type ResourceNameProps = {
 export const ResourceName: FC<ResourceNameProps> = (props) => (
   <span className="co-resource-item">
     <ResourceIcon kind={props.kind} />{' '}
-    <span className="co-resource-item__resource-name" data-test="resource-name">
+    <span className="co-resource-item__resource-name" data-test={`resource-name-${props.name}`}>
       {props.name}
     </span>
   </span>


### PR DESCRIPTION
**Analysis / Root cause**:
Follow-on to #16556. The `ResourceName` component used a static `data-test="resource-name"` attribute, making it impossible to uniquely select a specific resource by name in tests. The `waitForSidebarLoaded` page object method used a try/catch to silently swallow errors instead of a proper conditional check.

**Solution description**:
- **`resource-icon.tsx`**: Changed `data-test="resource-name"` to `data-test={`resource-name-${props.name}`}` so each `ResourceName` instance is uniquely selectable (e.g., `resource-name-my-configmap`).
- **`environment.spec.ts`**: Updated four assertions to use the specific `getByTestId(`resource-name-${name}`)` selector with `toBeVisible()` instead of generic `.last().toHaveText()` chains.
- **`yaml-editor-page.ts`**: Replaced try/catch in `waitForSidebarLoaded` with a conditional `count() > 0` check — if the sidebar element exists, wait for it; otherwise skip cleanly without swallowing exceptions.

**Screenshots / screen recording**:
N/A — no visual changes.

**Test setup:**
Requires an OpenShift cluster with the console running.

**Test cases:**
- [x] `environment.spec.ts` — 3 consecutive green runs (7/7 tests each)
- [x] `resource-crud.spec.ts` — 25/25 tests passing (exercises `waitForSidebarLoaded` across 20 resource types)

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
Follow-on to https://github.com/openshift/console/pull/16556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor reliability for resource types that don’t render a resource sidebar, avoiding intermittent load failures.
  * Updated environment variable editor assertions so “from resource” details after saving and deleting ConfigMap/Secret-sourced values reflect the correct resource-specific UI elements, ensuring consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->