### PR TITLE
NO-JIRA: Downloads: Ensure cleanup of the artifact folder on each startup

### DIFF
--- a/cmd/downloads/config/downloads_config_test.go
+++ b/cmd/downloads/config/downloads_config_test.go
@@ -322,7 +322,9 @@ func TestNewDownloadsServerConfig_CleansOldRandomTempDirs(t *testing.T) {
 		if err := os.MkdirAll(d, 0755); err != nil {
 			t.Fatalf("failed to create old temp dir %s: %v", d, err)
 		}
-		os.WriteFile(filepath.Join(d, leftover), []byte("data"), 0644)
+		if err := os.WriteFile(filepath.Join(d, leftover), []byte("data"), 0644); err != nil {
+			t.Fatalf("failed to write leftover file in %s: %v", d, err)
+		}
 	}
 
 	srcDir := t.TempDir()

--- a/cmd/downloads/config/downloads_config_test.go
+++ b/cmd/downloads/config/downloads_config_test.go
@@ -313,14 +313,16 @@ func TestNewDownloadsServerConfig_CleansOldRandomTempDirs(t *testing.T) {
 	})
 
 	oldDirs := []string{
+		defaultArtifactsDir,
 		"/tmp/artifacts1234test",
 		"/tmp/artifacts5678test",
 	}
+	leftover := "leftover"
 	for _, d := range oldDirs {
 		if err := os.MkdirAll(d, 0755); err != nil {
 			t.Fatalf("failed to create old temp dir %s: %v", d, err)
 		}
-		os.WriteFile(filepath.Join(d, "leftover"), []byte("data"), 0644)
+		os.WriteFile(filepath.Join(d, leftover), []byte("data"), 0644)
 	}
 
 	srcDir := t.TempDir()
@@ -335,6 +337,16 @@ func TestNewDownloadsServerConfig_CleansOldRandomTempDirs(t *testing.T) {
 	}
 
 	for _, d := range oldDirs {
+		if d == defaultArtifactsDir {
+			if _, err := os.Stat(d); err != nil {
+				t.Errorf("failed to stat artifacts dir: %v", err)
+			}
+			f := filepath.Join(d, leftover)
+			if _, err := os.Stat(f); !os.IsNotExist(err) {
+				t.Errorf("leftover %s should have been cleaned up, but still exists", f)
+			}
+			continue
+		}
 		if _, err := os.Stat(d); !os.IsNotExist(err) {
 			t.Errorf("old temp dir %s should have been cleaned up, but still exists", d)
 		}


### PR DESCRIPTION
Downloads: Ensure cleanup of the artifact folder on each startup

Follow up https://github.com/openshift/console-operator/pull/1176

The GoLang implementation uses a fixed folder name `defaultArtifactsDir` to store the files and cleans the folder up [1]. So it should not suffer the issue of accumulating the files over startups.

An existing unit test ensures already the same `defaultArtifactsDir` is used [2].

Another existing unit test checks folders with the prefix `defaultArtifactsDir` are removed. We add the logic in the pull to this unit test to ensure that the files in `defaultArtifactsDir` from previous container are removed too in the new container after startup.

[1]. https://github.com/openshift/console/blob/71f7e03bcfe04f9842f24a8f628660f8f2d4b892/cmd/downloads/config/downloads_config.go#L119-L122

[2]. https://github.com/openshift/console/blob/28f9ca40e41a5b221bcd562194fcc1ff930cc6f4/cmd/downloads/config/downloads_config_test.go#L266-L268

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Test cases:**
<!-- List possible test cases to validate the changes. -->

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved the downloads configuration test to ensure all previously created temporary directories are cleaned up during server config creation, including the default artifacts directory.
  * Added a shared “leftover” sentinel file written into each cleanup target to reliably validate directory removal, with special-case assertions for the default artifacts directory.
  * Expanded cleanup expectations to also remove additional `/tmp/artifacts*test*` artifact-related temporary directories left by the test run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->