### PR TITLE
OCPBUGS-79520: Fix kebab actions on Installed Operators list page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/status/__tests__/csv-status.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/status/__tests__/csv-status.spec.ts
@@ -1,0 +1,145 @@
+import type { ClusterServiceVersionKind, SubscriptionKind } from '../../types';
+import { ClusterServiceVersionPhase, CSVConditionReason } from '../../types';
+import { subscriptionForCSV } from '../csv-status';
+
+describe('subscriptionForCSV', () => {
+  const csvNamespace = 'test-namespace';
+  const csvName = 'test-operator.v1.0.0';
+
+  const createCSV = (
+    name: string,
+    namespace: string,
+    operatorNamespace?: string,
+  ): ClusterServiceVersionKind => ({
+    apiVersion: 'operators.coreos.com/v1alpha1',
+    kind: 'ClusterServiceVersion',
+    metadata: {
+      name,
+      namespace,
+      ...(operatorNamespace && {
+        annotations: { 'olm.operatorNamespace': operatorNamespace },
+      }),
+    },
+    spec: {
+      install: {
+        strategy: 'Deployment',
+        spec: {
+          permissions: [],
+          deployments: [],
+        },
+      },
+    },
+    status: {
+      phase: ClusterServiceVersionPhase.CSVPhaseSucceeded,
+      reason: CSVConditionReason.CSVReasonInstallSuccessful,
+    },
+  });
+
+  const createSubscription = (
+    name: string,
+    namespace: string,
+    installedCSV: string,
+  ): SubscriptionKind => ({
+    apiVersion: 'operators.coreos.com/v1alpha1',
+    kind: 'Subscription',
+    metadata: {
+      name,
+      namespace,
+    },
+    spec: {
+      source: 'test-catalog',
+      name: 'test-package',
+    },
+    status: {
+      installedCSV,
+    },
+  });
+
+  it('should match subscription when operator namespace annotation present', () => {
+    const csv = createCSV(csvName, csvNamespace, csvNamespace);
+    const subscription = createSubscription('test-sub', csvNamespace, csvName);
+    const subscriptions = [subscription];
+
+    const result = subscriptionForCSV(subscriptions, csv);
+
+    expect(result).toBe(subscription);
+  });
+
+  it('should match subscription when operator namespace annotation missing', () => {
+    const csv = createCSV(csvName, csvNamespace);
+    const subscription = createSubscription('test-sub', csvNamespace, csvName);
+    const subscriptions = [subscription];
+
+    const result = subscriptionForCSV(subscriptions, csv);
+
+    expect(result).toBe(subscription);
+  });
+
+  it('should not match subscription with different namespace', () => {
+    const csv = createCSV(csvName, csvNamespace);
+    const subscription = createSubscription('test-sub', 'other-namespace', csvName);
+    const subscriptions = [subscription];
+
+    const result = subscriptionForCSV(subscriptions, csv);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should not match subscription with different installedCSV', () => {
+    const csv = createCSV(csvName, csvNamespace);
+    const subscription = createSubscription('test-sub', csvNamespace, 'other-operator.v1.0.0');
+    const subscriptions = [subscription];
+
+    const result = subscriptionForCSV(subscriptions, csv);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should match subscription when operator namespace annotation differs from CSV namespace', () => {
+    const operatorNs = 'operator-namespace';
+    const csv = createCSV(csvName, csvNamespace, operatorNs);
+    const subscription = createSubscription('test-sub', operatorNs, csvName);
+    const subscriptions = [subscription];
+
+    const result = subscriptionForCSV(subscriptions, csv);
+
+    expect(result).toBe(subscription);
+  });
+
+  it('should return undefined when subscriptions array is empty', () => {
+    const csv = createCSV(csvName, csvNamespace);
+    const subscriptions: SubscriptionKind[] = [];
+
+    const result = subscriptionForCSV(subscriptions, csv);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when subscription status missing installedCSV', () => {
+    const csv = createCSV(csvName, csvNamespace);
+    const subscription = {
+      metadata: {
+        name: 'test-sub',
+        namespace: csvNamespace,
+      },
+      spec: {},
+      status: {},
+    } as SubscriptionKind;
+    const subscriptions = [subscription];
+
+    const result = subscriptionForCSV(subscriptions, csv);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should match subscription when CSV has empty namespace but subscription exists', () => {
+    // Edge case: CSV with empty namespace string
+    const csv = createCSV(csvName, '');
+    const subscription = createSubscription('test-sub', '', csvName);
+    const subscriptions = [subscription];
+
+    const result = subscriptionForCSV(subscriptions, csv);
+
+    expect(result).toBe(subscription);
+  });
+});

--- a/frontend/packages/operator-lifecycle-manager/src/status/csv-status.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/status/csv-status.ts
@@ -26,12 +26,7 @@ export const subscriptionForCSV = (
   return (subscriptions ?? []).find((subscription) => {
     const subscriptionNamespace = subscription.metadata?.namespace || '';
     const installedCSV = subscription.status?.installedCSV || '';
-    return (
-      operatorNamespace &&
-      csvName &&
-      subscriptionNamespace === operatorNamespace &&
-      installedCSV === csvName
-    );
+    return subscriptionNamespace === operatorNamespace && installedCSV === csvName;
   });
 };
 


### PR DESCRIPTION
**Analysis / Root cause**:
The Installed Operators list page was showing incorrect kebab menu actions. Instead of displaying "Edit Subscription" and "Uninstall Operator" for installed operators, it only showed "Delete ClusterServiceVersion". This occurred for operators in both "Installing" and "Succeeded" status.

Root cause: `subscriptionForCSV()` helper function had unnecessary guards (`operatorNamespace &&` and `csvName &&`) that prevented matching when the `olm.operatorNamespace` annotation was missing. When `operatorNamespaceFor(csv)` returned `undefined` and fell back to `csv.metadata.namespace`, the truthy guard still failed, preventing the function from finding the matching subscription even when one existed.

**Solution description**:
Removed the unnecessary `operatorNamespace &&` and `csvName &&` guards from the matching logic in `subscriptionForCSV()`. Kubernetes objects always have name and namespace properties, so these guards were not needed. The function now correctly matches subscriptions whether or not the `olm.operatorNamespace` annotation is present:

- With annotation → uses annotation namespace
- Without annotation → falls back to CSV metadata.namespace
- Both cases now match subscriptions correctly

Added comprehensive test coverage with 8 test cases covering all matching scenarios including edge cases.

**Screenshots / screen recording**:
<!-- Will be added after manual testing -->

**Test setup:**
1. Install an operator from OperatorHub
2. Navigate to Operators → Installed Operators

**Test cases:**
- [ ] Verify kebab menu shows "Edit Subscription" and "Uninstall Operator" for operators in "Succeeded" status
- [ ] Verify kebab menu shows "Edit Subscription" and "Uninstall Operator" for operators in "Installing" status
- [ ] Verify "Delete ClusterServiceVersion" only appears for CSVs without subscriptions (e.g., copied CSVs)
- [ ] Verify unit tests pass: `yarn test packages/operator-lifecycle-manager/src/status/__tests__/csv-status.spec.ts`

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
Related to [CONSOLE-4685](https://redhat.atlassian.net/browse/CONSOLE-4685) which refactored CSV actions. That PR added the fallback logic but kept the guards, which caused this regression.

**Reviewers and assignees:**
/assign @spadgett
/cc @openshift/team-olm

Jira: https://redhat.atlassian.net/browse/OCPBUGS-79520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription matching so operator lifecycle status works correctly even when namespace values are empty or missing.
  * Fixed cases where valid subscriptions were previously ignored due to stricter matching checks.

* **Tests**
  * Added coverage for multiple subscription-to-CSV matching scenarios, including namespace differences, missing installed CSV values, and edge cases with empty namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->