### PR TITLE
OCPBUGS-85121: Skip redundant navigate() in setPerspective when target matches current URL

### DIFF
--- a/frontend/packages/console-app/src/components/detect-context/DetectContext.tsx
+++ b/frontend/packages/console-app/src/components/detect-context/DetectContext.tsx
@@ -14,7 +14,7 @@ import {
   PageSidebarBody,
 } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { createPath, useLocation } from 'react-router';
+import { createPath, useLocation, useNavigate } from 'react-router';
 import type { Perspective, ReduxReducer, ContextProvider } from '@console/dynamic-plugin-sdk';
 import {
   PerspectiveContext,
@@ -168,12 +168,21 @@ export const DetectContext: FC<{ children: ReactNode }> = ({ children }) => {
   const perspectiveExtensions = usePerspectives();
   const perspectiveParam = getPerspectiveURLParam(perspectiveExtensions);
   const location = useLocation();
+  const navigate = useNavigate();
 
   useEffect(() => {
-    if (perspectiveParam && perspectiveParam !== activePerspective) {
-      setActivePerspective(perspectiveParam, createPath(location));
+    if (perspectiveParam) {
+      const params = new URLSearchParams(location.search);
+      params.delete('perspective');
+      const search = params.toString();
+      const cleanPath = createPath({ ...location, search: search ? `?${search}` : '' });
+      if (perspectiveParam !== activePerspective) {
+        setActivePerspective(perspectiveParam, cleanPath);
+      } else {
+        navigate(cleanPath, { replace: true });
+      }
     }
-  }, [perspectiveParam, activePerspective, setActivePerspective, location]);
+  }, [perspectiveParam, activePerspective, setActivePerspective, navigate, location]);
 
   useEffect(() => {
     if (reducersResolved) {

--- a/frontend/packages/console-app/src/components/detect-context/__tests__/DetectContext.spec.tsx
+++ b/frontend/packages/console-app/src/components/detect-context/__tests__/DetectContext.spec.tsx
@@ -49,7 +49,8 @@ jest.mock('@console/internal/redux', () => ({
 
 jest.mock('react-router', () => ({
   useLocation: jest.fn(),
-  createPath: jest.fn((loc) => loc.pathname),
+  useNavigate: jest.fn(() => jest.fn()),
+  createPath: jest.fn((loc) => `${loc.pathname}${loc.search || ''}${loc.hash || ''}`),
 }));
 
 const useValuesForPerspectiveContextMock = useValuesForPerspectiveContext as jest.Mock;

--- a/frontend/packages/console-app/src/components/detect-context/useValuesForPerspectiveContext.ts
+++ b/frontend/packages/console-app/src/components/detect-context/useValuesForPerspectiveContext.ts
@@ -36,15 +36,19 @@ export const useValuesForPerspectiveContext = (): [
 
   const setPerspective = useCallback<SetActivePerspective>(
     (newPerspective, next) => {
+      const perspectiveChanged = newPerspective !== perspective;
       setLastPerspective(newPerspective);
       setActivePerspective(newPerspective);
-      // Only navigate if a path is provided to avoid unnecessary navigation
-      if (next && next !== createPath(window.location)) {
-        navigate(next);
+      // Only navigate if perspective changed
+      if (perspectiveChanged) {
+        const targetPath = next || '/';
+        if (targetPath !== createPath(window.location)) {
+          navigate(targetPath);
+        }
       }
       fireTelemetryEvent('Perspective Changed', { perspective: newPerspective });
     },
-    [setLastPerspective, setActivePerspective, navigate, fireTelemetryEvent],
+    [setLastPerspective, setActivePerspective, navigate, fireTelemetryEvent, perspective],
   );
 
   return [isValidPerspective ? perspective : '', setPerspective, loaded];

--- a/frontend/packages/console-app/src/components/detect-context/useValuesForPerspectiveContext.ts
+++ b/frontend/packages/console-app/src/components/detect-context/useValuesForPerspectiveContext.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { createPath, useNavigate } from 'react-router';
 import type { PerspectiveType, UseActivePerspective } from '@console/dynamic-plugin-sdk';
 import {
   usePerspectiveExtension,
@@ -38,8 +38,10 @@ export const useValuesForPerspectiveContext = (): [
     (newPerspective, next) => {
       setLastPerspective(newPerspective);
       setActivePerspective(newPerspective);
-      // Navigate to next or root and let the default page determine where to go to next
-      navigate(next || '/');
+      // Only navigate if a path is provided to avoid unnecessary navigation
+      if (next && next !== createPath(window.location)) {
+        navigate(next);
+      }
       fireTelemetryEvent('Perspective Changed', { perspective: newPerspective });
     },
     [setLastPerspective, setActivePerspective, navigate, fireTelemetryEvent],


### PR DESCRIPTION
Closes https://github.com/openshift/console/issues/16254

**Analysis / Root cause**:

setPerspective() always called navigate() unconditionally, causing redundant page reloads for custom perspective plugins. When the target URL matched the current location, this triggered namespace handler validation loops and visible re-renders. 

This also stripped the ?perspective= param in DetectPerspective to prevent it from persisting and re-triggering the effect.

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

Skip navigate() when the target URL matches the current location

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

Refer to reproduction steps in linked issue

**Test cases:**
<!-- List possible test cases to validate the changes. -->

Ensure reproduction steps in linked issue are no longer reproducible 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved perspective handling by removing the `perspective` query parameter from the URL when present, keeping the address bar clean.
  * Prevented redundant navigation by only updating routes when the perspective value actually changes.
  * Refined route updates to ensure the current view stays consistent without extra page refreshes.
* **Tests**
  * Updated router mocking and URL path/search handling to align with the improved navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->