### PR TITLE
[release-4.21] OCPBUGS-95544: Fix RoleBindings tab error for non-cluster-admin users

### DIFF
--- a/frontend/public/components/RBAC/bindings.tsx
+++ b/frontend/public/components/RBAC/bindings.tsx
@@ -345,6 +345,11 @@ export const RoleBindingsPage: React.FCC<RoleBindingsPageProps> = ({
   }`,
 }) => {
   const { t } = useTranslation();
+  const canListClusterRoleBindings = useAccessReview({
+    group: ClusterRoleBindingModel.apiGroup,
+    resource: ClusterRoleBindingModel.plural,
+    verb: 'list',
+  });
   const watchResources = React.useMemo(
     () =>
       mock
@@ -356,13 +361,15 @@ export const RoleBindingsPage: React.FCC<RoleBindingsPageProps> = ({
               namespace,
               isList: true,
             },
-            ClusterRoleBinding: {
-              kind: 'ClusterRoleBinding',
-              namespaced: false,
-              isList: true,
-            },
+            ...(canListClusterRoleBindings && {
+              ClusterRoleBinding: {
+                kind: 'ClusterRoleBinding',
+                namespaced: false,
+                isList: true,
+              },
+            }),
           },
-    [mock, namespace],
+    [canListClusterRoleBindings, mock, namespace],
   );
   const resources = useK8sWatchResources(watchResources);
 


### PR DESCRIPTION
## Summary
- Cherry-pick of 214e15cbbb08 from main to release-4.21
- When viewing the RoleBindings tab on a project details page, the console unconditionally fetched ClusterRoleBindings at cluster scope, causing a "Restricted access" error for users without cluster-admin permissions
- Adds an access review to conditionally omit the ClusterRoleBinding watch for non-cluster-admin users

## Test plan
- [ ] Log in as a non-cluster-admin user, navigate to a project's RoleBindings tab — verify no "Restricted access" error
- [ ] Log in as a cluster-admin user, navigate to the RoleBindings list page — verify "Cluster-wide RoleBindings" Kind filter option still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)