### PR TITLE
NO-ISSUE: Match operator lifecycle versions by major.minor only

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/__tests__/operator-lifecycle-status.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/__tests__/operator-lifecycle-status.spec.tsx
@@ -81,6 +81,10 @@ describe('getClusterCompatibility', () => {
     expect(getClusterCompatibility(lifecycle, '2.0.1', '4.17.0')).toBe('compatible');
     expect(getClusterCompatibility(lifecycle, '2.0.1', '4.14.0')).toBe('incompatible');
   });
+
+  it('returns no data for an invalid operator version', () => {
+    expect(getClusterCompatibility(lifecycle, 'latest', '4.15.0')).toBe('no-data');
+  });
 });
 
 describe('getSupportPhase', () => {
@@ -181,6 +185,12 @@ describe('getSupportPhase', () => {
       versions: [{ name: '1.0' }],
     };
     expect(getSupportPhase(noPhases, '1.0')).toEqual({ status: SupportPhaseStatus.NoData });
+  });
+
+  it('returns no data for an invalid operator version', () => {
+    expect(getSupportPhase(lifecycle, 'latest', new Date('2024-03-15'))).toEqual({
+      status: SupportPhaseStatus.NoData,
+    });
   });
 
   it('matches operator version by minor version when exact match fails', () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-lifecycle-status.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-lifecycle-status.tsx
@@ -54,10 +54,11 @@ const findVersionEntry = (
   if (!operatorVersion) {
     return versions[0];
   }
-  return (
-    versions.find((v) => v.name === operatorVersion) ??
-    versions.find((v) => parseMinorVersion(v.name) === parseMinorVersion(operatorVersion))
-  );
+  const minor = parseMinorVersion(operatorVersion);
+  if (minor === undefined) {
+    return undefined;
+  }
+  return versions.find((v) => parseMinorVersion(v.name) === minor);
 };
 
 export type CompatibilityResult = 'compatible' | 'incompatible' | 'no-data';


### PR DESCRIPTION
**Analysis / Root cause**:
`findVersionEntry` tried an exact version string match before falling back to major.minor matching. The lifecycle data spec ([REQ-VER-01](https://github.com/release-engineering/fbc-update-planner/blob/main/docs/VALIDATION_RULES.md)) requires version names to be strictly `MAJOR.MINOR` format, so the exact-match path was unnecessary — the minor version match always did the real work.

**Solution description**:
Simplified `findVersionEntry` in `operator-lifecycle-status.tsx` to match solely on `major.minor` using `parseMinorVersion()`, removing the redundant exact-match attempt. This aligns the implementation with the lifecycle data spec.

**Screenshots / screen recording**:
N/A — logic-only change with no visual impact.

**Test setup:**
No special setup required.

**Test cases:**
- Existing tests in `operator-lifecycle-status.spec.tsx` continue to pass
- Version matching by minor version (e.g., operator version `1.0.5` matches lifecycle version `1.0`)

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
N/A

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lifecycle status matching now consistently resolves the applicable lifecycle entry using the operator’s minor version.
  * For unparseable operator versions, compatibility now reports “no-data” and the support phase returns “No Data,” preventing misleading results.

* **Tests**
  * Added test coverage for unparseable operator version inputs to validate the expected “no-data” and “No Data” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->