### PR TITLE
NO-ISSUE: Return self-support when date is before all lifecycle phases

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/__tests__/operator-lifecycle-status.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/__tests__/operator-lifecycle-status.spec.tsx
@@ -140,17 +140,9 @@ describe('getSupportPhase', () => {
     expect(result).toEqual({ status: SupportPhaseStatus.SelfSupport, allPhases });
   });
 
-  it('returns first phase when date is before all phases', () => {
+  it('returns self-support if the date is before all phases', () => {
     const result = getSupportPhase(lifecycle, '1.0', new Date('2023-06-01'));
-    expect(result).toEqual({
-      status: SupportPhaseStatus.Active,
-      currentPhase: {
-        name: 'Maintenance support',
-        startDate: '2024-01-01',
-        endDate: '2024-06-30',
-      },
-      allPhases,
-    });
+    expect(result).toEqual({ status: SupportPhaseStatus.SelfSupport, allPhases });
   });
 
   it('returns no-data when lifecycle data is undefined', () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-lifecycle-status.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-lifecycle-status.tsx
@@ -138,12 +138,7 @@ export const getSupportPhase = (
     }
   }
 
-  const lastPhase = allPhases[allPhases.length - 1];
-  if (now > parseLocalEndOfDay(lastPhase.endDate)) {
-    return { status: SupportPhaseStatus.SelfSupport, allPhases };
-  }
-
-  return { status: SupportPhaseStatus.Active, currentPhase: allPhases[0], allPhases };
+  return { status: SupportPhaseStatus.SelfSupport, allPhases };
 };
 
 export const ClusterCompatibilityStatus: FC<{ compatible: CompatibilityResult }> = ({


### PR DESCRIPTION
**Analysis / Root cause**:
`getSupportPhase` was returning `Active` with the first phase when the current date was before all lifecycle phases had started. This was misleading — being outside the supported window (whether before or after all phases) should be treated the same way.

**Solution description**:
Changed the fallback in `getSupportPhase` (in `operator-lifecycle-status.tsx`) to return `SelfSupport` instead of `Active` when the current date precedes all phases. Updated the corresponding test case in `operator-lifecycle-status.spec.tsx`.

**Screenshots / screen recording**:
N/A — logic-only change. The UI already renders `SelfSupport` as a "Self-support" badge; this change ensures the badge appears when the date is before all phases (previously it incorrectly showed the first phase name as if it were active).

**Test setup:**
No special setup required.

**Test cases:**
- "returns self-support when date is before all phases" test updated and passing
- All other existing tests continue to pass

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
N/A

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted operator lifecycle status fallback: when a date doesn’t match any defined phase, the status now reports **self-support** (instead of treating the first phase as active).
* **Tests**
  * Updated operator lifecycle status tests to verify the new fallback output, including assertions for the returned status and phase set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->