### PR TITLE
OCPBUGS-94130: Fix CVE-2026-45822 decode-uri-component DoS vulnerability

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -336,7 +336,8 @@
     "minimatch@^10.1.2": "^10.2.1",
     "shell-quote": "1.8.4",
     "protobufjs": "7.5.8",
-    "fast-uri": "3.1.2"
+    "fast-uri": "3.1.2",
+    "decode-uri-component": "0.5.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10075,10 +10075,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decode-uri-component@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "decode-uri-component@npm:0.2.0"
-  checksum: 10c0/dbc3c72e4a740703f76fb3f51e35bb81546aa3e8c7897e015b8bc289813d3044ad6eaa6048fbb43f6b7b34ef005527b7511da50399caa78b91ee39266a341822
+"decode-uri-component@npm:0.5.0":
+  version: 0.5.0
+  resolution: "decode-uri-component@npm:0.5.0"
+  checksum: 10c0/b913bb2ec3a83b4c96d961dcd7808c538f2f69f9a8581ab1bfbbb3d48c90e36779cc4580334198315d4c17f9c32d88ae4467c96582419a70b5f35df2c5a05cb1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Analysis / Root cause

`decode-uri-component` through 0.4.1 is vulnerable to denial of service (CVE-2026-45822, CVSS 7.5). The `decode()` function splits input on `%` and calls `decodeComponents()`, which exhibits super-linear parsing time — 200 `%ab` tokens take ~0.7s, 700 tokens ~6s, 1400 tokens ~33s. An attacker can cause significant CPU consumption and event-loop blocking via crafted input.

The package is a transitive dependency pulled in by two paths:
- `@console/git-service` → `gitlab@10.0.1` → `query-string@6.8.3` → `decode-uri-component@0.2.0`
- `snapdragon@0.8.2` → `source-map-resolve@0.5.3` → `decode-uri-component@0.2.0`

## Solution description

Bump `decode-uri-component` from 0.2.0 to 0.5.0 via yarn resolutions in `frontend/package.json`. Version 0.5.0 ([upstream commit](https://github.com/SamVerschueren/decode-uri-component/commit/fa479da)) rewrites the decoder as a single-pass UTF-8 scanner, eliminating the super-linear parsing behavior entirely.

This follows the existing pattern used for other CVE resolution overrides (`shell-quote`, `protobufjs`, `fast-uri`, etc.).

## Test cases

- [x] `yarn install` completes without errors
- [x] Production build (`webpack --mode=production`) succeeds
- [x] Unit test results identical before and after the change (345/218/1768 — pre-existing failures unrelated to this change)

## Additional info

- Jira: [OCPBUGS-94130](https://redhat.atlassian.net/browse/OCPBUGS-94130)
- CVE: [CVE-2026-45822](https://access.redhat.com/security/cve/CVE-2026-45822)
- Upstream fix: [decode-uri-component v0.5.0](https://github.com/SamVerschueren/decode-uri-component/releases)
- Bugzilla: [BZ#2494807](https://bugzilla.redhat.com/show_bug.cgi?id=2494807)