### PR TITLE
OCPBUGS-94055: Fix CVE-2026-13676 fast-uri Unicode hostname canonicalization bypass

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -336,7 +336,7 @@
     "minimatch@^10.1.2": "^10.2.1",
     "shell-quote": "1.8.4",
     "protobufjs": "7.5.8",
-    "fast-uri": "3.1.2"
+    "fast-uri": "3.1.3"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -12124,10 +12124,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:3.1.2":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
+"fast-uri@npm:3.1.3":
+  version: 3.1.3
+  resolution: "fast-uri@npm:3.1.3"
+  checksum: 10c0/0ce405815546770ad7e730b8f8fd58db80cefe4533ee99ee1a3263f11d2ccc3b8a0cf10d6cd9ba590e9746eb43b60f2ef2631d0c379a9ebba063ce0d4076b109
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Analysis / Root cause

`fast-uri` versions 2.3.1 through 3.1.2 and 4.0.0 fail to canonicalize Unicode (IDN) hostnames for HTTP-family URLs (CVE-2026-13676). The IDN conversion path calls a helper that does not exist on the global URL constructor, silently leaving the host in its original Unicode form while `normalize()` and `equal()` still return values that differ from a WHATWG-compatible URL parser. Applications that use fast-uri to enforce host-based policy (denylists, loopback filtering, redirect validation, outbound proxy routing) before passing the same URL to Node's `URL` or `fetch` can be bypassed when the two implementations resolve the same input to different hosts.

The package is a transitive dependency pulled in by:
- `ajv@8.17.1` → `fast-uri@3.1.2`

There was already a yarn resolution pinning `fast-uri` at `3.1.2` — the vulnerable version.

## Solution description

Bump `fast-uri` from 3.1.2 to 3.1.3 in the yarn resolutions of `frontend/package.json`. Version 3.1.3 adds proper IDN conversion for HTTP-family URLs, ensuring Unicode hostnames are correctly canonicalized.

This follows the existing pattern used for other CVE resolution overrides (`shell-quote`, `protobufjs`, `decode-uri-component`, etc.).

## Test cases

- [x] `yarn install` completes without errors
- [x] Development build (`webpack --mode=development`) succeeds
- [x] Unit test results identical before and after the change (1 failed suite / 9 failed tests — pre-existing `swagger.spec.ts` failures unrelated to this change)

## Additional info

- Jira: [OCPBUGS-94055](https://redhat.atlassian.net/browse/OCPBUGS-94055)
- CVE: [CVE-2026-13676](https://access.redhat.com/security/cve/CVE-2026-13676)
- Upstream fix: [fast-uri v3.1.3](https://github.com/fastify/fast-uri/releases/tag/v3.1.3)
- Bugzilla: [BZ#2494197](https://bugzilla.redhat.com/show_bug.cgi?id=2494197)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a package resolution for `fast-uri` to a newer patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->