### PR TITLE
OCPBUGS-91728: Fix CVE-2026-12151 undici DoS via unbounded memory growth in WebSocket frames

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -336,7 +336,8 @@
     "minimatch@^10.1.2": "^10.2.1",
     "shell-quote": "1.8.4",
     "protobufjs": "7.5.8",
-    "fast-uri": "3.1.2"
+    "fast-uri": "3.1.2",
+    "undici@^6.19.5": ">=6.27.0 <7.0.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -23300,19 +23300,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:>=6.27.0 <7.0.0":
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
+  languageName: node
+  linkType: hard
+
 "undici@npm:^5.4.0":
   version: 5.28.4
   resolution: "undici@npm:5.28.4"
   dependencies:
     "@fastify/busboy": "npm:^2.0.0"
   checksum: 10c0/08d0f2596553aa0a54ca6e8e9c7f45aef7d042c60918564e3a142d449eda165a80196f6ef19ea2ef2e6446959e293095d8e40af1236f0d67223b06afac5ecad7
-  languageName: node
-  linkType: hard
-
-"undici@npm:^6.19.5":
-  version: 6.21.2
-  resolution: "undici@npm:6.21.2"
-  checksum: 10c0/799bbc02b77dda9b6b12d56d2620a3a4d4cf087908d6a548acc3ce32f21b5c27467f75c2c4b30fab281daf341210be3d685e8fe99854288de541715ae5735027
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Analysis / Root cause

`undici` (HTTP/1.1, HTTP/2, and WebSocket client for Node.js) versions >= 6.17.0 and < 6.26.0 are vulnerable to a denial of service attack (CVE-2026-12151). The undici WebSocket client enforces `maxPayloadSize` on cumulative byte count but not on the number of fragments. A malicious WebSocket server can stream many small or empty continuation frames that pass validation, causing unbounded memory growth and eventual memory exhaustion.

The package is a transitive dependency in the console frontend at version 6.21.2, pulled in by `cheerio`.

## Solution description

Add a scoped yarn resolution for `undici@^6.19.5` to `>=6.27.0 <7.0.0` in `frontend/package.json`. This bumps the 6.x consumer to the patched version (6.27.0) while staying within the same major version to avoid breaking changes. The 5.x consumer (`openapi-typescript`) is not affected by this CVE.

## Screenshots / screen recording

N/A — dependency version bump only, no visual changes.

## Test setup

No special setup required.

## Test cases

- [x] `yarn install` completes without errors
- [x] Development build (`webpack --mode=development`) succeeds (986 assets, 20219 modules)
- [x] All websocket/k8s related unit tests pass (17 suites, 158 tests)
- [x] `undici@5.x` consumer is not affected by the resolution

## Browser conformance

N/A — no runtime behavior changes beyond the security fix.

## Additional info

- Jira: [OCPBUGS-91728](https://redhat.atlassian.net/browse/OCPBUGS-91728)
- CVE: [CVE-2026-12151](https://access.redhat.com/security/cve/CVE-2026-12151)
- Upstream fix: [undici v6.26.0](https://github.com/nodejs/undici/releases/tag/v6.26.0)
- Bugzilla: [BZ#2489980](https://bugzilla.redhat.com/show_bug.cgi?id=2489980)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints to pin a newer compatible version of a networking library.
  * Kept the existing URI-related version constraint unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->