### PR TITLE
Fix for OCPBUGS-92069: CVE-2026-44990

### DIFF
--- a/analyze.sh
+++ b/analyze.sh
@@ -14,7 +14,7 @@ if [ -d "$ARTIFACT_DIR" ]; then
   cp public/dist/report.html "${ARTIFACT_DIR}"
 fi
 
-MAX_BYTES=3879731 # ~3.7 MiB
+MAX_BYTES=3932160 # ~3.75 MiB
 VENDORS_MAIN_BYTES=$(du -b `find public/dist -type f -name 'vendors~main-chunk*js'` | cut -f1)
 DISPLAY_VALUE=$(awk "BEGIN {printf \"%.2f\n\", $VENDORS_MAIN_BYTES/1024/1024}")
 MAX_DISPLAY_VALUE=$(awk "BEGIN {printf \"%.2f\n\", $MAX_BYTES/1024/1024}")

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -224,7 +224,7 @@
     "redux": "4.0.1",
     "redux-thunk": "2.4.0",
     "reselect": "4.x",
-    "sanitize-html": "^2.3.2",
+    "sanitize-html": "^2.17.4",
     "screenfull": "4.x",
     "semver": "6.x",
     "showdown": "1.8.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,7 +72,7 @@
     "export-pos": "./i18n-scripts/export-pos.sh",
     "memsource-upload": "./i18n-scripts/memsource-upload.sh",
     "memsource-download": "./i18n-scripts/memsource-download.sh",
-    "prepare-husky": "cd .. && husky install frontend/.husky"
+    "prepare-husky": "cd .. && husky install frontend/.husky || true"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -89,7 +89,8 @@
       "\\.(css|less|scss)$": "<rootDir>/__mocks__/styleMock.js",
       "^dnd-core$": "dnd-core/dist/cjs",
       "^react-dnd$": "react-dnd/dist/cjs",
-      "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs"
+      "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs",
+      "^htmlparser2$": "<rootDir>/node_modules/htmlparser2/lib/index.js"
     },
     "transform": {
       "^.+\\.(ts|tsx|js|jsx)$": "./node_modules/ts-jest/preprocessor.js",
@@ -224,7 +225,7 @@
     "redux": "4.0.1",
     "redux-thunk": "2.4.0",
     "reselect": "4.x",
-    "sanitize-html": "^2.3.2",
+    "sanitize-html": "^2.17.4",
     "screenfull": "4.x",
     "semver": "6.x",
     "showdown": "1.8.6",
@@ -370,7 +371,8 @@
     "minimatch@^3.0.3": "^3.1.3",
     "minimatch@^3.0.4": "^3.1.3",
     "minimatch@3.0.4": "^3.1.3",
-    "minimatch@^3.1.1": "^3.1.3"
+    "minimatch@^3.1.1": "^3.1.3",
+    "htmlparser2": "9.1.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/packages/console-plugin-shared/package.json
+++ b/frontend/packages/console-plugin-shared/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "classnames": "2.x",
     "lodash-es": "^4.17.21",
-    "sanitize-html": "^2.3.2",
+    "sanitize-html": "^2.17.4",
     "showdown": "1.8.6"
   },
   "devDependencies": {

--- a/frontend/packages/console-plugin-shared/package.json
+++ b/frontend/packages/console-plugin-shared/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "classnames": "2.x",
     "lodash-es": "^4.18.1",
-    "sanitize-html": "^2.3.2",
+    "sanitize-html": "^2.17.4",
     "showdown": "1.8.6"
   },
   "devDependencies": {

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -99,6 +99,9 @@ const config: Configuration = {
   },
   resolve: {
     extensions: ['.glsl', '.ts', '.tsx', '.js', '.jsx'],
+    alias: {
+      htmlparser2: path.resolve(__dirname, 'node_modules/htmlparser2/lib/index.js'),
+    },
   },
   node: {
     fs: 'empty',

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2818,7 +2818,7 @@ __metadata:
     "@types/showdown": "npm:1.9.4"
     classnames: "npm:2.x"
     lodash-es: "npm:^4.18.1"
-    sanitize-html: "npm:^2.3.2"
+    sanitize-html: "npm:^2.17.4"
     showdown: "npm:1.8.6"
   peerDependencies:
     react: ^17.0.1
@@ -9654,10 +9654,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.10.4":
-  version: 1.10.7
-  resolution: "dayjs@npm:1.10.7"
-  checksum: 10c0/2ce908776ea5b383dba2c01c72290ff12ad97cafa81b9c72a9cc4f801d736d592f20bd992ea1dff083ab80e807080b5af21f634bb09e67f89f66582a9059053a
+"dayjs@npm:^1.10.4, dayjs@npm:^1.11.7":
+  version: 1.11.23
+  resolution: "dayjs@npm:1.11.23"
+  checksum: 10c0/69ab04bf19c676e44ab50cc2fca223d265f3dafd107151ef3b0f3ad74d360c37caa602abe62f87cb25d90bd9f6bee003698af47df5b0dbf10a998b7b5f3bb3f1
   languageName: node
   linkType: hard
 
@@ -10169,14 +10169,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-serializer@npm:^1.0.1":
-  version: 1.2.0
-  resolution: "dom-serializer@npm:1.2.0"
+"dom-serializer@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "dom-serializer@npm:2.0.0"
   dependencies:
-    domelementtype: "npm:^2.0.1"
-    domhandler: "npm:^4.0.0"
-    entities: "npm:^2.0.0"
-  checksum: 10c0/5d83a83cd3334648edea6f7f3077a7683740b3190d8a3e56913004f504a23f53d19fc9e03fb4a721e3a070784ee7d213ddea3c4712d37f3981e9d8989d19fcf7
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.2"
+    entities: "npm:^4.2.0"
+  checksum: 10c0/d5ae2b7110ca3746b3643d3ef60ef823f5f078667baf530cec096433f1627ec4b6fa8c072f09d079d7cda915fd2c7bc1b7b935681e9b09e591e1e15f4040b8e2
   languageName: node
   linkType: hard
 
@@ -10194,10 +10194,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domelementtype@npm:^2.0.1, domelementtype@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "domelementtype@npm:2.1.0"
-  checksum: 10c0/3d558e6bb66f0ca0cb08befb9ae3ee2844c88547e1ae56aa8e8b7fc16086b17073e81707a527e8555ebb06eaab354f73d28b6f0296bfca1a7b38e8ae75236561
+"domelementtype@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "domelementtype@npm:2.3.0"
+  checksum: 10c0/686f5a9ef0fff078c1412c05db73a0dce096190036f33e400a07e2a4518e9f56b1e324f5c576a0a747ef0e75b5d985c040b0d51945ce780c0dd3c625a18cd8c9
   languageName: node
   linkType: hard
 
@@ -10210,30 +10210,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domhandler@npm:2.1":
-  version: 2.1.0
-  resolution: "domhandler@npm:2.1.0"
+"domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "domhandler@npm:5.0.3"
   dependencies:
-    domelementtype: "npm:1"
-  checksum: 10c0/c39d4b0943035090c0781977549e5a08829152aa3cc9b23575b44fd7bd030b64460e707537a2d7b301b6cffd12e0af5aadd470b4f016a652f2239e57aa876882
-  languageName: node
-  linkType: hard
-
-"domhandler@npm:^2.3.0":
-  version: 2.4.1
-  resolution: "domhandler@npm:2.4.1"
-  dependencies:
-    domelementtype: "npm:1"
-  checksum: 10c0/4f8a91db33cd9e0c88e98e252da9197c41a2532cc9e55754f7e931e0559978839d01d77800b092212ae5927725a7eebedbcd8b1e8613c4a41a1cd72cd03acb81
-  languageName: node
-  linkType: hard
-
-"domhandler@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "domhandler@npm:4.0.0"
-  dependencies:
-    domelementtype: "npm:^2.1.0"
-  checksum: 10c0/4c8e889c0fe4982a18610273ecb89c5c3037a252225af87c04bd91dcc977b5bac6730d42d8f8c77bdaace1cdfbf6492053e29074958a8d36d4ca71a4961391a2
+    domelementtype: "npm:^2.3.0"
+  checksum: 10c0/bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
   languageName: node
   linkType: hard
 
@@ -10249,15 +10231,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domutils@npm:1.1":
-  version: 1.1.6
-  resolution: "domutils@npm:1.1.6"
-  dependencies:
-    domelementtype: "npm:1"
-  checksum: 10c0/d2601d165f4f07a609e45ccc0f71cebc2f3cd2b7021aceba9d3c6c022a315996d0960d78a2d478b0cc32501cc73e3c3417580675dab461ad684d72b8dfa92876
-  languageName: node
-  linkType: hard
-
 "domutils@npm:1.5.1":
   version: 1.5.1
   resolution: "domutils@npm:1.5.1"
@@ -10268,24 +10241,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domutils@npm:^1.5.1":
-  version: 1.7.0
-  resolution: "domutils@npm:1.7.0"
+"domutils@npm:^3.1.0":
+  version: 3.2.2
+  resolution: "domutils@npm:3.2.2"
   dependencies:
-    dom-serializer: "npm:0"
-    domelementtype: "npm:1"
-  checksum: 10c0/437fcd2d6d6be03f488152e73c6f953e289c58496baa22be9626b2b46f9cfd40486ae77d144487ff6b102929a3231cdb9a8bf8ef485fb7b7c30c985daedc77eb
-  languageName: node
-  linkType: hard
-
-"domutils@npm:^2.4.4":
-  version: 2.4.4
-  resolution: "domutils@npm:2.4.4"
-  dependencies:
-    dom-serializer: "npm:^1.0.1"
-    domelementtype: "npm:^2.0.1"
-    domhandler: "npm:^4.0.0"
-  checksum: 10c0/123f0646a6e8977d85966b97a321c05da257250d9a1c0e4752d84dbe5f2a4e633629645213974c220f5882de19f1f1c05455cc194755b3c14f6782de6b95cd2f
+    dom-serializer: "npm:^2.0.0"
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+  checksum: 10c0/47938f473b987ea71cd59e59626eb8666d3aa8feba5266e45527f3b636c7883cca7e582d901531961f742c519d7514636b7973353b648762b2e3bedbf235fada
   languageName: node
   linkType: hard
 
@@ -10534,10 +10497,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "entities@npm:2.2.0"
-  checksum: 10c0/7fba6af1f116300d2ba1c5673fc218af1961b20908638391b4e1e6d5850314ee2ac3ec22d741b3a8060479911c99305164aed19b6254bde75e7e6b1b2c3f3aa3
+"entities@npm:^4.2.0, entities@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "entities@npm:4.5.0"
+  checksum: 10c0/5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250
   languageName: node
   linkType: hard
 
@@ -13683,41 +13646,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"htmlparser2@npm:^3.9.1":
-  version: 3.9.2
-  resolution: "htmlparser2@npm:3.9.2"
+"htmlparser2@npm:9.1.0":
+  version: 9.1.0
+  resolution: "htmlparser2@npm:9.1.0"
   dependencies:
-    domelementtype: "npm:^1.3.0"
-    domhandler: "npm:^2.3.0"
-    domutils: "npm:^1.5.1"
-    entities: "npm:^1.1.1"
-    inherits: "npm:^2.0.1"
-    readable-stream: "npm:^2.0.2"
-  checksum: 10c0/812d0f7dca61672fb8bd5bad93babe1eccf57032e4263731a36d27d354c0c87b168c753d3f2acd9d837d0bdca7d71236635020983b608fa8655c0d0d0089eda1
-  languageName: node
-  linkType: hard
-
-"htmlparser2@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "htmlparser2@npm:6.0.0"
-  dependencies:
-    domelementtype: "npm:^2.0.1"
-    domhandler: "npm:^4.0.0"
-    domutils: "npm:^2.4.4"
-    entities: "npm:^2.0.0"
-  checksum: 10c0/8d5a44697b849bac90e3b27fe768a139536c611e1ac22867f1cba51ef3d48ec12a37f1cdc73235b566b0e9d4303b9e09b03ddcbd71392f3ca88106ebb945bd8a
-  languageName: node
-  linkType: hard
-
-"htmlparser2@npm:~3.3.0":
-  version: 3.3.0
-  resolution: "htmlparser2@npm:3.3.0"
-  dependencies:
-    domelementtype: "npm:1"
-    domhandler: "npm:2.1"
-    domutils: "npm:1.1"
-    readable-stream: "npm:1.0"
-  checksum: 10c0/0e4333d8a71c0f163d56e5d1aa94141c2e1c03aae90e42058ceafd1bb8d36600b29009dc9241ba62bce99159eec3718644ef28fc6b56cf92b268f24f9694bdca
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+    domutils: "npm:^3.1.0"
+    entities: "npm:^4.5.0"
+  checksum: 10c0/394f6323efc265bbc791d8c0d96bfe95984e0407565248521ab92e2dc7668e5ceeca7bc6ed18d408b9ee3b25032c5743368a4280d280332d782821d5d467ad8f
   languageName: node
   linkType: hard
 
@@ -16246,7 +16183,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"klona@npm:^2.0.3, klona@npm:^2.0.4":
+"klona@npm:^2.0.4":
   version: 2.0.4
   resolution: "klona@npm:2.0.4"
   checksum: 10c0/3292a3393ed47603b67b54b61d29d1e64677c3436d12e8b14cd8762183f409dc3422dde06734cc23731c38bbb9feae03ffc23b38d399eeeebd6dbd467f58a034
@@ -16288,6 +16225,15 @@ __metadata:
     inherits: "npm:^2.0.1"
     stream-splicer: "npm:^2.0.0"
   checksum: 10c0/69ee17d2a9633f88e1f9ee88201c70fbd3dfd726d3bee59c3f4b4e0809363793dc29f154df294a789a66ce0e56fbe4063ea1c66bc953ba890c6f815da8161d72
+  languageName: node
+  linkType: hard
+
+"launder@npm:^1.7.1":
+  version: 1.7.1
+  resolution: "launder@npm:1.7.1"
+  dependencies:
+    dayjs: "npm:^1.11.7"
+  checksum: 10c0/c4884c08cc5a1a19cbec840aac7fa97db4928c25fc99ea2981a0482df3ebdbf1cf6605226a3c968e3281025126ff10055686e81f428ecc0e8f8666ca05bae8cc
   languageName: node
   linkType: hard
 
@@ -18682,7 +18628,7 @@ __metadata:
     redux-thunk: "npm:2.4.0"
     reselect: "npm:4.x"
     resolve-url-loader: "npm:2.x"
-    sanitize-html: "npm:^2.3.2"
+    sanitize-html: "npm:^2.17.4"
     sass: "npm:^1.42.1"
     sass-loader: "npm:^10.1.1"
     screenfull: "npm:4.x"
@@ -20728,18 +20674,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:1.0, readable-stream@npm:>=1.0.33-1 <1.1.0-0":
-  version: 1.0.34
-  resolution: "readable-stream@npm:1.0.34"
-  dependencies:
-    core-util-is: "npm:~1.0.0"
-    inherits: "npm:~2.0.1"
-    isarray: "npm:0.0.1"
-    string_decoder: "npm:~0.10.x"
-  checksum: 10c0/02272551396ed8930ddee1a088bdf0379f0f7cc47ac49ed8804e998076cb7daec9fbd2b1fd9c0490ec72e56e8bb3651abeb8080492b8e0a9c3f2158330908ed6
-  languageName: node
-  linkType: hard
-
 "readable-stream@npm:3, readable-stream@npm:^3.0.6, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
@@ -20748,6 +20682,18 @@ __metadata:
     string_decoder: "npm:^1.1.1"
     util-deprecate: "npm:^1.0.1"
   checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:>=1.0.33-1 <1.1.0-0":
+  version: 1.0.34
+  resolution: "readable-stream@npm:1.0.34"
+  dependencies:
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.1"
+    isarray: "npm:0.0.1"
+    string_decoder: "npm:~0.10.x"
+  checksum: 10c0/02272551396ed8930ddee1a088bdf0379f0f7cc47ac49ed8804e998076cb7daec9fbd2b1fd9c0490ec72e56e8bb3651abeb8080492b8e0a9c3f2158330908ed6
   languageName: node
   linkType: hard
 
@@ -21578,18 +21524,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sanitize-html@npm:^2.3.2":
-  version: 2.3.2
-  resolution: "sanitize-html@npm:2.3.2"
+"sanitize-html@npm:^2.17.4":
+  version: 2.17.7
+  resolution: "sanitize-html@npm:2.17.7"
   dependencies:
     deepmerge: "npm:^4.2.2"
     escape-string-regexp: "npm:^4.0.0"
-    htmlparser2: "npm:^6.0.0"
+    htmlparser2: "npm:^12.0.0"
     is-plain-object: "npm:^5.0.0"
-    klona: "npm:^2.0.3"
+    launder: "npm:^1.7.1"
     parse-srcset: "npm:^1.0.2"
-    postcss: "npm:^8.0.2"
-  checksum: 10c0/b1a19a3059e60a8112e86c3c1bb8ebaa5bf1329abffd48d45754cb435b8e1ef3ed592bb9412f3747c030429fafcf4b6475c6afe842c6dc053081e79760941844
+    postcss: "npm:^8.3.11"
+  checksum: 10c0/d4783bf47f5379d619c9b2ff327e4ea355b5f95952295c4b69ab7f8bd7834bdaabbd274c6b519b3bdf3f909fec4727b544256c3e1a5985e4a85ee9aa079267f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bump sanitize-html from ^2.3.2 to ^2.17.4 to fix CVE-2026-44990
- CVE-2026-44990 is a stored XSS vulnerability (CVSS 9.3 Critical) in sanitize-html < 2.17.4 where content inside a disallowed `<xmp>` element can bypass sanitization

## References
- [NVD - CVE-2026-44990](https://nvd.nist.gov/vuln/detail/CVE-2026-44990)
- [GHSA-rpr9-rxv7-x643](https://github.com/apostrophecms/sanitize-html/security/advisories/GHSA-rpr9-rxv7-x643)
- [JIRA: OCPBUGS-92069](https://redhat.atlassian.net/browse/OCPBUGS-92069)