### PR TITLE
Fix for OCPBUGS-94120: CVE-2026-45822

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -363,7 +363,8 @@
     "postcss": "^8.2.13",
     "axios": "^1.16.0",
     "get-intrinsic": "1.3.0",
-    "immutable": "3.8.3"
+    "immutable": "3.8.3",
+    "decode-uri-component": "0.5.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9754,10 +9754,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decode-uri-component@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "decode-uri-component@npm:0.2.0"
-  checksum: 10c0/dbc3c72e4a740703f76fb3f51e35bb81546aa3e8c7897e015b8bc289813d3044ad6eaa6048fbb43f6b7b34ef005527b7511da50399caa78b91ee39266a341822
+"decode-uri-component@npm:0.5.0":
+  version: 0.5.0
+  resolution: "decode-uri-component@npm:0.5.0"
+  checksum: 10c0/b913bb2ec3a83b4c96d961dcd7808c538f2f69f9a8581ab1bfbbb3d48c90e36779cc4580334198315d4c17f9c32d88ae4467c96582419a70b5f35df2c5a05cb1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bump decode-uri-component from 0.2.0 to 0.5.0 via yarn resolutions to fix CVE-2026-45822 (DoS via super-linear parsing)
- Production dependency chain: git-service → gitlab@10.0.1 → query-string@6.8.3 → decode-uri-component@0.2.0