### PR TITLE
OCPBUGS-97639: bump go-billy to v5.9.0 for CVE-2026-44740

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.7.0 // indirect
+	github.com/go-git/go-billy/v5 v5.9.0 // indirect
 	github.com/go-git/go-git/v5 v5.16.4 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -206,7 +206,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
-	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
+	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxI
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
-github.com/go-git/go-billy/v5 v5.7.0 h1:83lBUJhGWhYp0ngzCMSgllhUSuoHP1iEWYjsPl9nwqM=
-github.com/go-git/go-billy/v5 v5.7.0/go.mod h1:/1IUejTKH8xipsAcdfcSAlUlo2J7lkYV8GTKxAT/L3E=
+github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmmBPA=
+github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.16.4 h1:7ajIEZHZJULcyJebDLo99bGgS0jRrOxzZG4uCk2Yb2Y=
@@ -657,8 +657,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
-golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
-golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
+golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
+golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=

--- a/vendor/github.com/go-git/go-billy/v5/README.md
+++ b/vendor/github.com/go-git/go-billy/v5/README.md
@@ -5,6 +5,10 @@ Billy implements an interface based on the `os` standard library, allowing to de
 
 Billy was born as part of [go-git/go-git](https://github.com/go-git/go-git) project.
 
+## Version support
+
+go-billy v5 is in maintenance mode. Users should upgrade to [go-billy v6](https://pkg.go.dev/github.com/go-git/go-billy/v6) where possible.
+
 ## Installation
 
 ```go

--- a/vendor/github.com/go-git/go-billy/v5/helper/chroot/chroot.go
+++ b/vendor/github.com/go-git/go-billy/v5/helper/chroot/chroot.go
@@ -3,18 +3,24 @@ package chroot
 import (
 	"errors"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/helper/polyfill"
 )
 
 // ChrootHelper is a helper to implement billy.Chroot.
+// It is not a security boundary, callers that need containment should use a
+// filesystem implementation that enforces paths at the OS boundary instead.
 type ChrootHelper struct {
 	underlying billy.Filesystem
 	base       string
 }
+
+const maxFollowedSymlinks = 8 // Aligns with POSIX_SYMLOOP_MAX
 
 // New creates a new filesystem wrapping up the given 'fs'.
 // The created filesystem has its base in the given ChrootHelperectory of the
@@ -34,15 +40,184 @@ func (fs *ChrootHelper) underlyingPath(filename string) (string, error) {
 	return fs.Join(fs.Root(), filename), nil
 }
 
-func isCrossBoundaries(path string) bool {
-	path = filepath.ToSlash(path)
-	path = filepath.Clean(path)
+func (fs *ChrootHelper) followedPath(filename string, followFinal bool, op string) (string, error) {
+	fullpath, err := fs.underlyingPath(filename)
+	if err != nil {
+		return "", err
+	}
 
-	return strings.HasPrefix(path, ".."+string(filepath.Separator))
+	sl, ok := fs.underlying.(billy.Symlink)
+	if !ok {
+		return fullpath, nil
+	}
+
+	rel, err := fs.relativeToRoot(fullpath)
+	if err != nil {
+		return "", err
+	}
+
+	fullpath, err = fs.resolveFollowedPath(rel, followFinal, op, sl)
+	if errors.Is(err, billy.ErrNotSupported) {
+		return fs.underlyingPath(filename)
+	}
+
+	return fullpath, err
+}
+
+func (fs *ChrootHelper) resolveFollowedPath(rel string, followFinal bool, op string, sl billy.Symlink) (string, error) {
+	if rel == "" {
+		return fs.resolveFollowedRoot(followFinal, op, sl)
+	}
+
+	parts := splitRelativePath(rel)
+	resolved := ""
+	followed := 0
+
+	for len(parts) > 0 {
+		part := parts[0]
+		parts = parts[1:]
+
+		currentRel := joinRelativePath(resolved, part)
+		currentPath := fs.Join(fs.Root(), currentRel)
+		if len(parts) == 0 && !followFinal {
+			return currentPath, nil
+		}
+
+		fi, err := sl.Lstat(currentPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fs.Join(fs.Root(), joinRelativePath(append([]string{currentRel}, parts...)...)), nil
+			}
+			return "", err
+		}
+
+		if fi.Mode()&os.ModeSymlink == 0 {
+			resolved = currentRel
+			continue
+		}
+
+		followed++
+		if followed > maxFollowedSymlinks {
+			return "", symlinkLoopError(op, currentPath)
+		}
+
+		target, err := sl.Readlink(currentPath)
+		if err != nil {
+			return "", err
+		}
+
+		targetRel, err := fs.linkTargetRel(currentPath, target)
+		if err != nil {
+			return "", err
+		}
+		if targetRel == currentRel {
+			return "", symlinkLoopError(op, currentPath)
+		}
+
+		parts = append(splitRelativePath(targetRel), parts...)
+		resolved = ""
+	}
+
+	return fs.Join(fs.Root(), resolved), nil
+}
+
+func symlinkLoopError(op, path string) error {
+	return &os.PathError{Op: op, Path: path, Err: syscall.ELOOP}
+}
+
+func (fs *ChrootHelper) resolveFollowedRoot(followFinal bool, op string, sl billy.Symlink) (string, error) {
+	root := fs.Join(fs.Root(), "")
+	if !followFinal {
+		return root, nil
+	}
+
+	fi, err := sl.Lstat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return root, nil
+		}
+		return "", err
+	}
+
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return root, nil
+	}
+
+	target, err := sl.Readlink(root)
+	if err != nil {
+		return "", err
+	}
+
+	targetRel, err := fs.linkTargetRel(root, target)
+	if err != nil {
+		return root, err
+	}
+	if targetRel == "" {
+		return "", symlinkLoopError(op, root)
+	}
+
+	return fs.resolveFollowedPath(targetRel, followFinal, op, sl)
+}
+
+func (fs *ChrootHelper) relativeToRoot(filename string) (string, error) {
+	rel, err := filepath.Rel(filepath.Clean(fs.Root()), filepath.Clean(filename))
+	if err != nil || isCrossBoundaries(rel) {
+		return "", billy.ErrCrossedBoundary
+	}
+
+	if rel == "." {
+		return "", nil
+	}
+	return rel, nil
+}
+
+func (fs *ChrootHelper) linkTargetRel(linkPath, target string) (string, error) {
+	target = filepath.FromSlash(target)
+	if filepath.IsAbs(target) || strings.HasPrefix(target, string(filepath.Separator)) {
+		return fs.relativeToRoot(target)
+	}
+
+	return fs.relativeToRoot(fs.Join(filepath.Dir(linkPath), target))
+}
+
+func splitRelativePath(filename string) []string {
+	filename = filepath.Clean(filename)
+	if filename == "" || filename == "." {
+		return nil
+	}
+
+	return strings.Split(filepath.ToSlash(filename), "/")
+}
+
+func joinRelativePath(elem ...string) string {
+	parts := make([]string, 0, len(elem))
+	for _, part := range elem {
+		if part == "" || part == "." {
+			continue
+		}
+		parts = append(parts, part)
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+	return filepath.Join(parts...)
+}
+
+func isCreateExclusive(flag int) bool {
+	return flag&os.O_CREATE != 0 && flag&os.O_EXCL != 0
+}
+
+func isCrossBoundaries(name string) bool {
+	name = filepath.ToSlash(name)
+	name = strings.TrimLeft(name, "/")
+	name = path.Clean(name)
+
+	return name == ".." || strings.HasPrefix(name, "../")
 }
 
 func (fs *ChrootHelper) Create(filename string) (billy.File, error) {
-	fullpath, err := fs.underlyingPath(filename)
+	fullpath, err := fs.followedPath(filename, true, "create")
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +231,7 @@ func (fs *ChrootHelper) Create(filename string) (billy.File, error) {
 }
 
 func (fs *ChrootHelper) Open(filename string) (billy.File, error) {
-	fullpath, err := fs.underlyingPath(filename)
+	fullpath, err := fs.followedPath(filename, true, "open")
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +245,7 @@ func (fs *ChrootHelper) Open(filename string) (billy.File, error) {
 }
 
 func (fs *ChrootHelper) OpenFile(filename string, flag int, mode os.FileMode) (billy.File, error) {
-	fullpath, err := fs.underlyingPath(filename)
+	fullpath, err := fs.followedPath(filename, !isCreateExclusive(flag), "open")
 	if err != nil {
 		return nil, err
 	}
@@ -84,12 +259,16 @@ func (fs *ChrootHelper) OpenFile(filename string, flag int, mode os.FileMode) (b
 }
 
 func (fs *ChrootHelper) Stat(filename string) (os.FileInfo, error) {
-	fullpath, err := fs.underlyingPath(filename)
+	fullpath, err := fs.followedPath(filename, true, "stat")
 	if err != nil {
 		return nil, err
 	}
 
-	return fs.underlying.Stat(fullpath)
+	fi, err := fs.underlying.Stat(fullpath)
+	if err != nil {
+		return nil, err
+	}
+	return fileInfo{FileInfo: fi, name: filepath.Base(filename)}, nil
 }
 
 func (fs *ChrootHelper) Rename(from, to string) error {
@@ -135,7 +314,7 @@ func (fs *ChrootHelper) TempFile(dir, prefix string) (billy.File, error) {
 }
 
 func (fs *ChrootHelper) ReadDir(path string) ([]os.FileInfo, error) {
-	fullpath, err := fs.underlyingPath(path)
+	fullpath, err := fs.followedPath(path, true, "readdir")
 	if err != nil {
 		return nil, err
 	}
@@ -241,6 +420,11 @@ type file struct {
 	name string
 }
 
+type fileInfo struct {
+	os.FileInfo
+	name string
+}
+
 func newFile(fs billy.Filesystem, f billy.File, filename string) billy.File {
 	filename = fs.Join(fs.Root(), filename)
 	filename, _ = filepath.Rel(fs.Root(), filename)
@@ -253,4 +437,8 @@ func newFile(fs billy.Filesystem, f billy.File, filename string) billy.File {
 
 func (f *file) Name() string {
 	return f.name
+}
+
+func (fi fileInfo) Name() string {
+	return fi.name
 }

--- a/vendor/github.com/go-git/go-billy/v5/helper/polyfill/polyfill.go
+++ b/vendor/github.com/go-git/go-billy/v5/helper/polyfill/polyfill.go
@@ -13,7 +13,7 @@ type Polyfill struct {
 	c capabilities
 }
 
-type capabilities struct{ tempfile, dir, symlink, chroot bool }
+type capabilities struct{ tempfile, dir, symlink, chroot, chmod bool }
 
 // New creates a new filesystem wrapping up 'fs' the intercepts all the calls
 // made and errors if fs doesn't implement any of the billy interfaces.
@@ -28,6 +28,7 @@ func New(fs billy.Basic) billy.Filesystem {
 	_, h.c.dir = h.Basic.(billy.Dir)
 	_, h.c.symlink = h.Basic.(billy.Symlink)
 	_, h.c.chroot = h.Basic.(billy.Chroot)
+	_, h.c.chmod = h.Basic.(billy.Chmod)
 	return h
 }
 
@@ -85,6 +86,14 @@ func (h *Polyfill) Chroot(path string) (billy.Filesystem, error) {
 	}
 
 	return h.Basic.(billy.Chroot).Chroot(path)
+}
+
+func (h *Polyfill) Chmod(path string, mode os.FileMode) error {
+	if !h.c.chmod {
+		return billy.ErrNotSupported
+	}
+
+	return h.Basic.(billy.Chmod).Chmod(path, mode)
 }
 
 func (h *Polyfill) Root() string {

--- a/vendor/github.com/go-git/go-billy/v5/osfs/os.go
+++ b/vendor/github.com/go-git/go-billy/v5/osfs/os.go
@@ -24,6 +24,9 @@ var Default = &ChrootOS{}
 // New returns a new OS filesystem.
 // By default paths are deduplicated, but still enforced
 // under baseDir. For more info refer to WithDeduplicatePath.
+//
+// New returns ChrootOS by default for v5 compatibility. Users should prefer
+// New with WithBoundOS.
 func New(baseDir string, opts ...Option) billy.Filesystem {
 	o := &options{
 		deduplicatePath: true,
@@ -47,6 +50,8 @@ func WithBoundOS() Option {
 }
 
 // WithChrootOS returns the option of using a Chroot filesystem OS.
+//
+// Deprecated: use WithBoundOS instead.
 func WithChrootOS() Option {
 	return func(o *options) {
 		o.Type = ChrootOSFS

--- a/vendor/github.com/go-git/go-billy/v5/osfs/os_bound.go
+++ b/vendor/github.com/go-git/go-billy/v5/osfs/os_bound.go
@@ -20,6 +20,7 @@
 package osfs
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,6 +29,31 @@ import (
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/go-git/go-billy/v5"
 )
+
+var (
+	// ErrBaseDirCannotBeRemoved is returned when removing the BoundOS base dir.
+	ErrBaseDirCannotBeRemoved = errors.New("base dir cannot be removed")
+
+	// ErrBaseDirCannotBeRenamed is returned when renaming the BoundOS base dir.
+	ErrBaseDirCannotBeRenamed = errors.New("base dir cannot be renamed")
+
+	dotPrefixes   = dotPathPrefixes()
+	dotSeparators = dotPathSeparators()
+)
+
+func dotPathPrefixes() []string {
+	if filepath.Separator == '\\' {
+		return []string{"./", ".\\"}
+	}
+	return []string{"./"}
+}
+
+func dotPathSeparators() string {
+	if filepath.Separator == '\\' {
+		return `/\`
+	}
+	return `/`
+}
 
 // BoundOS is a fs implementation based on the OS filesystem which is bound to
 // a base dir.
@@ -54,6 +80,7 @@ func (fs *BoundOS) Create(filename string) (billy.File, error) {
 }
 
 func (fs *BoundOS) OpenFile(filename string, flag int, perm os.FileMode) (billy.File, error) {
+	filename = fs.expandDot(filename)
 	fn, err := fs.abs(filename)
 	if err != nil {
 		return nil, err
@@ -62,6 +89,7 @@ func (fs *BoundOS) OpenFile(filename string, flag int, perm os.FileMode) (billy.
 }
 
 func (fs *BoundOS) ReadDir(path string) ([]os.FileInfo, error) {
+	path = fs.expandDot(path)
 	dir, err := fs.abs(path)
 	if err != nil {
 		return nil, err
@@ -71,6 +99,12 @@ func (fs *BoundOS) ReadDir(path string) ([]os.FileInfo, error) {
 }
 
 func (fs *BoundOS) Rename(from, to string) error {
+	if fs.isBaseDir(from) {
+		return ErrBaseDirCannotBeRenamed
+	}
+	from = fs.expandDot(from)
+	to = fs.expandDot(to)
+
 	f, err := fs.abs(from)
 	if err != nil {
 		return err
@@ -89,6 +123,7 @@ func (fs *BoundOS) Rename(from, to string) error {
 }
 
 func (fs *BoundOS) MkdirAll(path string, perm os.FileMode) error {
+	path = fs.expandDot(path)
 	dir, err := fs.abs(path)
 	if err != nil {
 		return err
@@ -101,6 +136,7 @@ func (fs *BoundOS) Open(filename string) (billy.File, error) {
 }
 
 func (fs *BoundOS) Stat(filename string) (os.FileInfo, error) {
+	filename = fs.expandDot(filename)
 	filename, err := fs.abs(filename)
 	if err != nil {
 		return nil, err
@@ -109,6 +145,11 @@ func (fs *BoundOS) Stat(filename string) (os.FileInfo, error) {
 }
 
 func (fs *BoundOS) Remove(filename string) error {
+	if fs.isBaseDir(filename) {
+		return ErrBaseDirCannotBeRemoved
+	}
+	filename = fs.expandDot(filename)
+
 	fn, err := fs.abs(filename)
 	if err != nil {
 		return err
@@ -122,9 +163,18 @@ func (fs *BoundOS) Remove(filename string) error {
 func (fs *BoundOS) TempFile(dir, prefix string) (billy.File, error) {
 	if dir != "" {
 		var err error
+		dir = fs.expandDot(dir)
 		dir, err = fs.abs(dir)
 		if err != nil {
 			return nil, err
+		}
+
+		_, err = os.Stat(dir)
+		if err != nil && os.IsNotExist(err) {
+			err = os.MkdirAll(dir, defaultDirectoryMode)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -136,6 +186,11 @@ func (fs *BoundOS) Join(elem ...string) string {
 }
 
 func (fs *BoundOS) RemoveAll(path string) error {
+	if fs.isBaseDir(path) {
+		return ErrBaseDirCannotBeRemoved
+	}
+	path = fs.expandDot(path)
+
 	dir, err := fs.abs(path)
 	if err != nil {
 		return err
@@ -144,6 +199,7 @@ func (fs *BoundOS) RemoveAll(path string) error {
 }
 
 func (fs *BoundOS) Symlink(target, link string) error {
+	link = fs.expandDot(link)
 	ln, err := fs.abs(link)
 	if err != nil {
 		return err
@@ -156,6 +212,7 @@ func (fs *BoundOS) Symlink(target, link string) error {
 }
 
 func (fs *BoundOS) Lstat(filename string) (os.FileInfo, error) {
+	filename = fs.expandDot(filename)
 	filename = filepath.Clean(filename)
 	if !filepath.IsAbs(filename) {
 		filename = filepath.Join(fs.baseDir, filename)
@@ -167,6 +224,7 @@ func (fs *BoundOS) Lstat(filename string) (os.FileInfo, error) {
 }
 
 func (fs *BoundOS) Readlink(link string) (string, error) {
+	link = fs.expandDot(link)
 	if !filepath.IsAbs(link) {
 		link = filepath.Clean(filepath.Join(fs.baseDir, link))
 	}
@@ -177,6 +235,7 @@ func (fs *BoundOS) Readlink(link string) (string, error) {
 }
 
 func (fs *BoundOS) Chmod(path string, mode os.FileMode) error {
+	path = fs.expandDot(path)
 	abspath, err := fs.abs(path)
 	if err != nil {
 		return err
@@ -191,7 +250,7 @@ func (fs *BoundOS) Chroot(path string) (billy.Filesystem, error) {
 	if err != nil {
 		return nil, err
 	}
-	return New(joined), nil
+	return New(joined, WithBoundOS()), nil
 }
 
 // Root returns the current base dir of the billy.Filesystem.
@@ -212,6 +271,37 @@ func (fs *BoundOS) createDir(fullpath string) error {
 	return nil
 }
 
+func (fs *BoundOS) expandDot(path string) string {
+	if path == "." {
+		return fs.baseDir
+	}
+	for _, prefix := range dotPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			path = strings.TrimLeft(strings.TrimPrefix(path, prefix), dotSeparators)
+			if path == "" {
+				return fs.baseDir
+			}
+			return path
+		}
+	}
+	return path
+}
+
+func (fs *BoundOS) isBaseDir(path string) bool {
+	if path == "" || filepath.Clean(path) == "." {
+		return true
+	}
+	path = fs.expandDot(path)
+	if filepath.Clean(path) == filepath.Clean(fs.baseDir) {
+		return true
+	}
+	abspath, err := fs.abs(path)
+	if err != nil {
+		return false
+	}
+	return filepath.Clean(abspath) == filepath.Clean(fs.baseDir)
+}
+
 // abs transforms filename to an absolute path, taking into account the base dir.
 // Relative paths won't be allowed to ascend the base dir, so `../file` will become
 // `/working-dir/file`.
@@ -225,7 +315,7 @@ func (fs *BoundOS) abs(filename string) (string, error) {
 
 	path, err := securejoin.SecureJoin(fs.baseDir, filename)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	if fs.deduplicatePath {
@@ -238,24 +328,12 @@ func (fs *BoundOS) abs(filename string) (string, error) {
 	return path, nil
 }
 
-// insideBaseDir checks whether filename is located within
-// the fs.baseDir.
-func (fs *BoundOS) insideBaseDir(filename string) (bool, error) {
-	if filename == fs.baseDir {
-		return true, nil
-	}
-	if !strings.HasPrefix(filename, fs.baseDir+string(filepath.Separator)) {
-		return false, fmt.Errorf("path outside base dir")
-	}
-	return true, nil
-}
-
 // insideBaseDirEval checks whether filename is contained within
 // a dir that is within the fs.baseDir, by first evaluating any symlinks
 // that either filename or fs.baseDir may contain.
 func (fs *BoundOS) insideBaseDirEval(filename string) (bool, error) {
 	// "/" contains all others.
-	if fs.baseDir == "/" {
+	if fs.baseDir == "/" || fs.baseDir == filename {
 		return true, nil
 	}
 	dir, err := filepath.EvalSymlinks(filepath.Dir(filename))

--- a/vendor/github.com/go-git/go-billy/v5/osfs/os_chroot.go
+++ b/vendor/github.com/go-git/go-billy/v5/osfs/os_chroot.go
@@ -14,6 +14,8 @@ import (
 // ChrootOS is a legacy filesystem based on a "soft chroot" of the os filesystem.
 // Although this is still the default os filesystem, consider using BoundOS instead.
 //
+// Deprecated: use New with WithBoundOS instead.
+//
 // Behaviours of note:
 //  1. A "soft chroot" translates the base dir to "/" for the purposes of the
 //     fs abstraction.
@@ -24,6 +26,14 @@ import (
 type ChrootOS struct{}
 
 func newChrootOS(baseDir string) billy.Filesystem {
+	if baseDir != "" {
+		resolved, err := filepath.EvalSymlinks(baseDir)
+		if err != nil {
+			return chroot.New(&ChrootOS{}, baseDir)
+		}
+		baseDir = resolved
+	}
+
 	return chroot.New(&ChrootOS{}, baseDir)
 }
 

--- a/vendor/github.com/go-git/go-billy/v5/util/util.go
+++ b/vendor/github.com/go-git/go-billy/v5/util/util.go
@@ -16,8 +16,6 @@ import (
 // can but returns the first error it encounters. If the path does not exist,
 // RemoveAll returns nil (no error).
 func RemoveAll(fs billy.Basic, path string) error {
-	fs, path = getUnderlyingAndPath(fs, path)
-
 	if r, ok := fs.(removerAll); ok {
 		return r.RemoveAll(path)
 	}
@@ -39,7 +37,7 @@ func removeAll(fs billy.Basic, path string) error {
 	}
 
 	// Otherwise, is this a directory we need to recurse into?
-	dir, serr := fs.Stat(path)
+	dir, serr := lstat(fs, path)
 	if serr != nil {
 		if errors.Is(serr, os.ErrNotExist) {
 			return nil
@@ -48,8 +46,8 @@ func removeAll(fs billy.Basic, path string) error {
 		return serr
 	}
 
-	if !dir.IsDir() {
-		// Not a directory; return the error from Remove.
+	if dir.Mode()&os.ModeSymlink != 0 || !dir.IsDir() {
+		// Not a directory we should recurse into; return the error from Remove.
 		return err
 	}
 
@@ -62,7 +60,7 @@ func removeAll(fs billy.Basic, path string) error {
 	fis, err := dirfs.ReadDir(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			// Race. It was deleted between the Lstat and Open.
+			// Race. It was deleted between the Lstat and ReadDir.
 			// Return nil per RemoveAll's docs.
 			return nil
 		}
@@ -91,7 +89,18 @@ func removeAll(fs billy.Basic, path string) error {
 	}
 
 	return err
+}
 
+func lstat(filesystem billy.Basic, path string) (os.FileInfo, error) {
+	if sl, ok := filesystem.(billy.Symlink); ok {
+		// Avoid following a symlink substituted after the initial Remove fails.
+		fi, err := sl.Lstat(path)
+		if err == nil || !errors.Is(err, billy.ErrNotSupported) {
+			return fi, err
+		}
+	}
+
+	return filesystem.Stat(path)
 }
 
 // WriteFile writes data to a file named by filename in the given filesystem.
@@ -123,8 +132,10 @@ func WriteFile(fs billy.Basic, filename string, data []byte, perm os.FileMode) (
 // We generate random temporary file names so that there's a good
 // chance the file doesn't exist yet - keeps the number of tries in
 // TempFile to a minimum.
-var rand uint32
-var randmu sync.Mutex
+var (
+	rand   uint32
+	randmu sync.Mutex
+)
 
 func reseed() uint32 {
 	return uint32(time.Now().UnixNano() + int64(os.Getpid()))
@@ -218,22 +229,6 @@ func getTempDir(fs billy.Basic) string {
 	}
 
 	return ".tmp"
-}
-
-type underlying interface {
-	Underlying() billy.Basic
-}
-
-func getUnderlyingAndPath(fs billy.Basic, path string) (billy.Basic, string) {
-	u, ok := fs.(underlying)
-	if !ok {
-		return fs, path
-	}
-	if ch, ok := fs.(billy.Chroot); ok {
-		path = fs.Join(ch.Root(), path)
-	}
-
-	return u.Underlying(), path
 }
 
 // ReadFile reads the named file and returns the contents from the given filesystem.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -279,8 +279,8 @@ github.com/go-git/gcfg
 github.com/go-git/gcfg/scanner
 github.com/go-git/gcfg/token
 github.com/go-git/gcfg/types
-# github.com/go-git/go-billy/v5 v5.7.0
-## explicit; go 1.23.0
+# github.com/go-git/go-billy/v5 v5.9.0
+## explicit; go 1.25.0
 github.com/go-git/go-billy/v5
 github.com/go-git/go-billy/v5/helper/chroot
 github.com/go-git/go-billy/v5/helper/polyfill
@@ -929,8 +929,8 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/knownhosts
-# golang.org/x/exp v0.0.0-20260112195511-716be5621a96
-## explicit; go 1.24.0
+# golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
+## explicit; go 1.25.0
 golang.org/x/exp/maps
 golang.org/x/exp/slices
 # golang.org/x/mod v0.36.0


### PR DESCRIPTION
## Summary

- Bumps `github.com/go-git/go-billy/v5` from v5.7.0 to v5.9.0
- Fixes CVE-2026-44740: Denial of Service via crafted input due to insufficient validation in go-billy
- CVSS 6.5 (Medium)

## Details

go-billy prior to v5.9.0 is vulnerable to denial of service through infinite loops, panics, or resource consumption when processing crafted input (bsc#1267332).

## Test plan

- [ ] `go mod verify` passes
- [ ] CI build succeeds
- [ ] No behavioral changes expected (indirect dependency bump)

Fixes: https://issues.redhat.com/browse/OCPBUGS-97639

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied a maintenance update to keep the project aligned with the latest supported tooling and improve overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->