### PR TITLE
OCPBUGS-94037: bump react-router to ~7.15.0 for CVE-2026-42342

### DIFF
--- a/dynamic-demo-plugin/package.json
+++ b/dynamic-demo-plugin/package.json
@@ -31,7 +31,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-i18next": "~16.5.8",
-    "react-router": "~7.13.1",
+    "react-router": "~7.15.0",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.5.4",
     "ts-node": "10.9.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -212,7 +212,7 @@
     "react-i18next": "~16.5.8",
     "react-linkify": "^0.2.2",
     "react-redux": "~9.2.0",
-    "react-router": "~7.13.1",
+    "react-router": "~7.15.0",
     "react-svg": "^16.2.0",
     "react-tagsinput": "3.20.x",
     "react-virtualized": "9.x",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -18636,7 +18636,7 @@ __metadata:
     react-linkify: "npm:^0.2.2"
     react-redux: "npm:~9.2.0"
     react-refresh: "npm:^0.10.0"
-    react-router: "npm:~7.13.1"
+    react-router: "npm:~7.15.0"
     react-svg: "npm:^16.2.0"
     react-tagsinput: "npm:3.20.x"
     react-virtualized: "npm:9.x"
@@ -20205,9 +20205,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:~7.13.1":
-  version: 7.13.1
-  resolution: "react-router@npm:7.13.1"
+"react-router@npm:~7.15.0":
+  version: 7.15.1
+  resolution: "react-router@npm:7.15.1"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -20217,7 +20217,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10c0/a64c645cede74251f21483fbfad740b36dc5133522d6f53f12317a873a22865fce659d4c2377d5e19c912f85c7b12b88224a2c70d8f70c082496b569cc4abc31
+  checksum: 10c0/3daff5404c7de1429447e735f1ee7e070d4f11632f589cec70c5171f2357be9cada2162f780bc9061eb153646109ad6e80c2d10a6b27256593f28a66945f4c76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumps `react-router` from ~7.13.1 to ~7.15.0
- Fixes CVE-2026-42342: Denial of Service via unbounded path expansion in `__manifest` endpoint
- CVSS 7.5 (High)

## Details

In React Router Framework Mode (versions 7.0.0 through 7.14.x), crafted requests to the `__manifest` endpoint can consume disproportionate server resources via unbounded path expansion, causing response time degradation and service unavailability.

Patched in react-router 7.15.0.

## Test plan

- [ ] `yarn install` succeeds
- [ ] CI build succeeds
- [ ] Verify console loads and navigates correctly

Fixes: https://issues.redhat.com/browse/OCPBUGS-94037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s routing package to a newer version in both the frontend and demo setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->