### PR TITLE
[release-4.16] OCPBUGS-84282: Bump follow-redirects to 1.16.0 to fix CVE-2026-40895

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -351,6 +351,7 @@
     "node": ">=18.x"
   },
   "resolutions": {
+    "follow-redirects": "^1.16.0",
     "@types/react-router": "^5.1.20",
     "@types/react-router-dom": "5.3.x",
     "@types/lodash": "4.14.106",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -12229,7 +12229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.16.0":
+"follow-redirects@npm:^1.16.0":
   version: 1.16.0
   resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:


### PR DESCRIPTION
## Summary
- **CVE**: CVE-2026-40895 — Information disclosure via custom authentication headers in cross-domain redirects
- **Package**: follow-redirects → 1.16.0 (transitive dependency)

## Changes
- [x] Added yarn resolution for follow-redirects@^1.16.0 in `frontend/package.json`
- [x] Updated `frontend/yarn.lock`

## Test Plan
- [x] `yarn build` succeeds 