### PR TITLE
CONSOLE-5421: Rename "Self-support" to "Unsupported" and stack support phase date

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -389,7 +389,7 @@
   "OpenShift lifecycle ({{version}})": "OpenShift lifecycle ({{version}})",
   "Red Hat product lifecycles": "Red Hat product lifecycles",
   "Lifecycle dates": "Lifecycle dates",
-  "Self-support": "Self-support",
+  "Unsupported": "Unsupported",
   "No PackageManifests Found": "No PackageManifests Found",
   "The CatalogSource author has not added any packages.": "The CatalogSource author has not added any packages.",
   "Catalogs are groups of Operators you can make available on the cluster. Use the <2>Software Catalog</2> to subscribe and grant namespaces access to use installed Operators.": "Catalogs are groups of Operators you can make available on the cluster. Use the <2>Software Catalog</2> to subscribe and grant namespaces access to use installed Operators.",

--- a/frontend/packages/operator-lifecycle-manager/src/components/__tests__/operator-lifecycle-status.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/__tests__/operator-lifecycle-status.spec.tsx
@@ -284,11 +284,11 @@ describe('SupportPhaseBadge', () => {
     expect(screen.getByTestId('support-phase-badge')).toBeInTheDocument();
   });
 
-  it('renders Self-support when phase is self-support', () => {
+  it('renders Unsupported when phase is self-support', () => {
     render(
       <SupportPhaseBadge phase={{ status: SupportPhaseStatus.SelfSupport, allPhases: phases }} />,
     );
-    expect(screen.getByText('Self-support')).toBeInTheDocument();
+    expect(screen.getByText('Unsupported')).toBeInTheDocument();
     expect(screen.getByTestId('support-phase-self-support')).toBeInTheDocument();
   });
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-lifecycle-status.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-lifecycle-status.tsx
@@ -258,7 +258,7 @@ export const SupportPhaseBadge: FC<{ phase: SupportPhaseResult }> = ({ phase }) 
           isInline
         >
           <Label variant="outline" icon={<BlueInfoCircleIcon />} textMaxWidth="100%">
-            {t('Self-support')}
+            {t('Unsupported')}
           </Label>
         </Button>
       </LifecycleDatesPopover>
@@ -277,7 +277,7 @@ export const SupportPhaseBadge: FC<{ phase: SupportPhaseResult }> = ({ phase }) 
     const endDate = formatDate(new Date(parseLocalEndOfDay(phase.currentPhase.endDate)));
 
     return (
-      <span data-test="support-phase-badge">
+      <div data-test="support-phase-badge">
         <LifecycleDatesPopover phases={phase.allPhases}>
           <Button
             variant="link"
@@ -290,9 +290,9 @@ export const SupportPhaseBadge: FC<{ phase: SupportPhaseResult }> = ({ phase }) 
               {phase.currentPhase.name}
             </Label>
           </Button>
-        </LifecycleDatesPopover>{' '}
-        {endDate}
-      </span>
+        </LifecycleDatesPopover>
+        <div>{endDate}</div>
+      </div>
     );
   }
 


### PR DESCRIPTION
**Analysis / Root cause**:
The installed operator "Support phase" column displays "Self-support" for operators past their lifecycle phases. This label needs to be updated to "Unsupported" per [CONSOLE-5421](https://redhat.atlassian.net/browse/CONSOLE-5421). Additionally, the end date in the support phase column should render below the phase name rather than inline next to it.

**Solution description**:
- Renamed the "Self-support" label to "Unsupported" in the `SupportPhaseBadge` component and OLM locale file
- Changed the active support phase badge layout from inline (`<span>` with date next to label) to stacked (`<div>` with date in its own `<div>` below the label)
- Updated the corresponding unit test to assert the new "Unsupported" text

**Screenshots / screen recording**:

<img width="3075" height="755" alt="Screenshot 2026-07-09 at 11 29 04" src="https://github.com/user-attachments/assets/ef3a0e42-3ee7-4706-9f5a-ec064ced73b4" />



**Test setup:**
No special setup required.

**Test cases:**
- Verify that installed operators past all lifecycle phases show "Unsupported" instead of "Self-support"
- Verify that the support phase end date renders below the phase name label
- Unit tests: `yarn test packages/operator-lifecycle-manager/src/components/__tests__/operator-lifecycle-status.spec.tsx`

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
N/A

**Reviewers and assignees:**
<!-- Tag reviewers as needed -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated lifecycle status text to show **“Unsupported”** instead of **“Self-support”** for unsupported components.
  * Improved the lifecycle status display layout so the badge and date information are presented more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->