### PR TITLE
CONSOLE-5306: Surface Playwright report link in Prow Spyglass

### DIFF
--- a/frontend/e2e/reporters/prow-junit-reporter.ts
+++ b/frontend/e2e/reporters/prow-junit-reporter.ts
@@ -221,12 +221,11 @@ class ProwJUnitReporter implements Reporter {
       );
       const html = [
         '<html>',
-        '<head><title>Playwright Report</title></head>',
-        '<body>',
-        `<a target="_blank" href="${reportURL}">Playwright HTML Report</a>`,
+        '<head><title>Playwright Report</title><link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons"></head>',
+        '<body style="font-family: Helvetica, Arial, sans-serif; margin: 0;">',
+        `<div style="font-size: 14px; padding: 8px 24px;"><a target="_blank" href="${reportURL}" style="color: #ff9999">Playwright HTML Report<i class="material-icons" style="font-size: 14px; vertical-align: middle; padding-left: 3px;">open_in_new</i></a></div>`,
         '</body>',
         '</html>',
-        '',
       ].join('\n');
       await fs.promises.writeFile(linkFile, html);
     }

--- a/frontend/e2e/reporters/prow-junit-reporter.ts
+++ b/frontend/e2e/reporters/prow-junit-reporter.ts
@@ -96,6 +96,24 @@ function getTestName(test: TestCase): string {
   return test.titlePath().slice(3).join(' › ');
 }
 
+function deriveStepName(): string | null {
+  const jobName = process.env.JOB_NAME;
+  const repoOwner = process.env.REPO_OWNER;
+  const repoName = process.env.REPO_NAME;
+  const branch = process.env.PULL_BASE_REF;
+
+  if (!jobName || !repoOwner || !repoName || !branch) return null;
+
+  const prefixes = [`pull-ci-`, `periodic-ci-`, `branch-ci-`];
+  for (const prefix of prefixes) {
+    const full = `${prefix}${repoOwner}-${repoName}-${branch}-`;
+    if (jobName.startsWith(full)) {
+      return jobName.slice(full.length);
+    }
+  }
+  return null;
+}
+
 function buildHTMLReportURL(): string | null {
   const buildId = process.env.BUILD_ID;
   const jobName = process.env.JOB_NAME;
@@ -106,12 +124,19 @@ function buildHTMLReportURL(): string | null {
   if (!buildId || !jobName) return null;
 
   const baseURL = 'https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results';
+  let jobPath: string;
 
   if (pullNumber && repoOwner && repoName) {
-    return `${baseURL}/pr-logs/pull/${repoOwner}_${repoName}/${pullNumber}/${jobName}/${buildId}`;
+    jobPath = `${baseURL}/pr-logs/pull/${repoOwner}_${repoName}/${pullNumber}/${jobName}/${buildId}`;
+  } else {
+    jobPath = `${baseURL}/logs/${jobName}/${buildId}`;
   }
 
-  return `${baseURL}/logs/${jobName}/${buildId}`;
+  const stepName = deriveStepName();
+  if (stepName) {
+    return `${jobPath}/artifacts/${stepName}/test/artifacts/playwright-report/index.html`;
+  }
+  return `${jobPath}/artifacts/`;
 }
 
 /**
@@ -187,6 +212,24 @@ class ProwJUnitReporter implements Reporter {
 
     await fs.promises.mkdir(path.dirname(this.outputFile), { recursive: true });
     await fs.promises.writeFile(this.outputFile, xmlContent);
+
+    const reportURL = buildHTMLReportURL();
+    if (reportURL) {
+      const linkFile = path.resolve(
+        path.dirname(this.outputFile),
+        'custom-link-playwright-report.html',
+      );
+      const html = [
+        '<html>',
+        '<head><title>Playwright Report</title></head>',
+        '<body>',
+        `<a target="_blank" href="${reportURL}">Playwright HTML Report</a>`,
+        '</body>',
+        '</html>',
+        '',
+      ].join('\n');
+      await fs.promises.writeFile(linkFile, html);
+    }
 
     this._printSummary(totalTests, failedTests.length, totalSkipped, flakyTests, failedTests, result);
   }
@@ -288,9 +331,13 @@ class ProwJUnitReporter implements Reporter {
 
   private _buildFailedEntry(testName: string, className: string, result: TestResult): XMLEntry {
     const errorInfo = classifyError(result);
-    const stack = stripAnsi(
-      result.error?.stack || result.error?.message || (result.error as { value?: string })?.value || '',
-    );
+    const stack =
+      stripAnsi(
+        result.error?.stack ||
+          result.error?.message ||
+          (result.error as { value?: string })?.value ||
+          '',
+      ) || 'No error details available';
 
     const children: XMLEntry[] = [];
     children.push({
@@ -371,8 +418,7 @@ class ProwJUnitReporter implements Reporter {
     const reportURL = buildHTMLReportURL();
     if (reportURL) {
       console.log(`\nPlaywright HTML Report:`);
-      console.log(`  ${reportURL}/artifacts/*/test/artifacts/playwright-report/index.html`);
-      console.log(`  (Browse to the playwright-report directory in the Artifacts tab if the link doesn't resolve)`);
+      console.log(`  ${reportURL}`);
     }
 
     console.log('='.repeat(70) + '\n');

--- a/frontend/integration-tests/test-playwright-e2e.sh
+++ b/frontend/integration-tests/test-playwright-e2e.sh
@@ -124,6 +124,10 @@ copy_playwright_artifacts_to_dir() {
       cp -a test-results/junit-results.xml "${ARTIFACT_DIR}/junit-playwright.xml" && \
         echo "Copied JUnit report to ${ARTIFACT_DIR}/junit-playwright.xml (Prow report not available)"
     fi
+    if [ -f test-results/custom-link-playwright-report.html ]; then
+      cp -a test-results/custom-link-playwright-report.html "${ARTIFACT_DIR}/custom-link-playwright-report.html" && \
+        echo "Copied Playwright report Spyglass link to ${ARTIFACT_DIR}/custom-link-playwright-report.html"
+    fi
   fi
 
   if [ -d playwright-report ]; then

--- a/frontend/integration-tests/test-playwright-e2e.sh
+++ b/frontend/integration-tests/test-playwright-e2e.sh
@@ -109,13 +109,16 @@ copy_playwright_artifacts_to_dir() {
     mkdir -p "$dest"
     if cp -a test-results/. "$dest/"; then
       copied=true
+      # Remove JUnit XML files from the bulk copy so Prow Spyglass doesn't
+      # parse them as duplicates of the top-level junit-playwright.xml.
+      rm -f "$dest"/*.xml
       echo "Copied Playwright test-results (traces, screenshots, videos) to ${dest}"
     else
       echo "Warning: failed to copy test-results to ${dest}" >&2
     fi
     if [ -f test-results/junit-results.xml ]; then
-      cp -a test-results/junit-results.xml "${ARTIFACT_DIR}/junit-playwright-standard.xml" && \
-        echo "Copied standard JUnit report to ${ARTIFACT_DIR}/junit-playwright-standard.xml"
+      cp -a test-results/junit-results.xml "${ARTIFACT_DIR}/playwright-standard-junit.xml" && \
+        echo "Copied standard JUnit report to ${ARTIFACT_DIR}/playwright-standard-junit.xml"
     fi
     if [ -f test-results/prow-junit-results.xml ]; then
       cp -a test-results/prow-junit-results.xml "${ARTIFACT_DIR}/junit-playwright.xml" && \
@@ -123,10 +126,6 @@ copy_playwright_artifacts_to_dir() {
     elif [ -f test-results/junit-results.xml ]; then
       cp -a test-results/junit-results.xml "${ARTIFACT_DIR}/junit-playwright.xml" && \
         echo "Copied JUnit report to ${ARTIFACT_DIR}/junit-playwright.xml (Prow report not available)"
-    fi
-    if [ -f test-results/custom-link-playwright-report.html ]; then
-      cp -a test-results/custom-link-playwright-report.html "${ARTIFACT_DIR}/custom-link-playwright-report.html" && \
-        echo "Copied Playwright report Spyglass link to ${ARTIFACT_DIR}/custom-link-playwright-report.html"
     fi
   fi
 


### PR DESCRIPTION
**Analysis / Root cause**:
The Playwright HTML report URL printed in CI logs used a wildcard (`*`) for the ci-operator step name, which doesn't resolve in a browser. Additionally, the Spyglass JUnit lens renders `<nil>` for failed tests that have no error details (e.g. tests that never executed due to a prior timeout). Prow Spyglass also showed duplicate Flaky Tests and Failed Tests sections because JUnit XML files in the bulk-copied `playwright-test-results/` subdirectory were being picked up alongside the intended top-level `junit-playwright.xml`.

**Solution description**:
- Derive the ci-operator step name from `JOB_NAME` and `PULL_BASE_REF` to build a direct, resolvable URL to the Playwright HTML report.
- Write a `custom-link-playwright-report.html` artifact that the Spyglass `html` lens renders as a clickable link on the Prow job page.
- Ensure `<failure>` elements always have text content to prevent the Spyglass JUnit lens from rendering `<nil>`.
- Rename the standard JUnit copy from `junit-playwright-standard.xml` to `playwright-standard-junit.xml` so it doesn't match Prow's `junit*.xml` glob.
- Remove `*.xml` files from the bulk `playwright-test-results/` copy to prevent Prow from recursively discovering duplicate JUnit files.
- Style the Spyglass report link with `font-size: 14px` and `color: #ff9999`.

**Screenshots / screen recording**:

https://github.com/user-attachments/assets/17095ae9-faac-4fd3-a651-4f45453d53cc

**Test setup:**
Changes only affect CI reporter output. Verify on the next Prow Playwright job run.

**Test cases:**
- Verify the Playwright HTML Report link appears as a Spyglass panel on the Prow job page
- Verify the link resolves to the correct `playwright-report/index.html`
- Verify failed tests with no error details show "No error details available" instead of `<nil>`
- Verify only a single Flaky Tests / Failed Tests section appears in Spyglass (no duplicates from `playwright-test-results/` subdirectory)

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
N/A

**Reviewers and assignees:**