### PR TITLE
OCPBUGS-98314: bump tar to ^7.5.19 for CVE-2026-59873

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -336,7 +336,8 @@
     "minimatch@^10.1.2": "^10.2.1",
     "shell-quote": "1.8.4",
     "protobufjs": "7.5.8",
-    "fast-uri": "3.1.2"
+    "fast-uri": "3.1.2",
+    "tar": "^7.5.19"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -22475,16 +22475,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.4":
-  version: 7.5.7
-  resolution: "tar@npm:7.5.7"
+"tar@npm:^7.5.19":
+  version: 7.5.19
+  resolution: "tar@npm:7.5.19"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/51f261afc437e1112c3e7919478d6176ea83f7f7727864d8c2cce10f0b03a631d1911644a567348c3063c45abdae39718ba97abb073d22aa3538b9a53ae1e31c
+  checksum: 10c0/7022e8cb04a8ceccc0689f2c731743fa2aab2e3c3f559f7dbc37b65ef7d5913049b427284eded2ec0765c5db5ff72dd7939fe2ae15785ff422cef2116c95d798
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Analysis / Root cause**:

CVE-2026-59873: `node-tar` prior to 7.5.19 does not enforce hard upper bounds on total decompressed data, entry counts, or decompression ratio, allowing a small crafted gzip bomb to exhaust disk space and CPU.

Our `yarn.lock` pinned `tar@7.5.7` via the `node-gyp` build dependency. While this is a build-time only dependency (not shipped in the container image), it triggers security scanner findings against the `ose-console-rhel9` image.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-98314

**Solution description**:

Add a yarn `resolutions` entry for `"tar": "^7.5.19"` in `frontend/package.json` to force the patched version. This follows the established pattern used for other CVE bumps (protobufjs, fast-uri, shell-quote, etc.).

**Screenshots / screen recording**:

N/A — dependency-only change, no UI impact.

**Test setup:**

No special setup required.

**Test cases:**

- `yarn install` completes without errors
- `yarn why tar` shows `7.5.19+`
- Build completes successfully

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**

The `tar` package is only used at build time by `node-gyp` for compiling native addons (fsevents, nan, websocket). It is never included in the production bundle or container image.

**Reviewers and assignees:**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package installation settings to use a constrained version of the `tar` package.
  * Preserved the existing dependency resolution for `fast-uri`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->