### PR TITLE
OCPBUGS-98449: Replace global Redux timestamp dispatch with local useSyncExternalStore hook

### DIFF
--- a/frontend/packages/console-shared/src/components/datetime/Timestamp.tsx
+++ b/frontend/packages/console-shared/src/components/datetime/Timestamp.tsx
@@ -3,11 +3,11 @@ import { RhUiClockIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { getLastLanguage } from '@console/app/src/components/user-preferences/language/getLastLanguage';
 import type { TimestampProps } from '@console/dynamic-plugin-sdk';
-import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
+import { useTimestampTick } from '../../hooks/useTimestampTick';
 import * as dateTime from '../../utils/datetime';
 
 export const Timestamp = (props: TimestampProps) => {
-  const now = useConsoleSelector<string>(({ UI }) => UI.get('lastTick'));
+  const now = useTimestampTick();
 
   // Workaround for Date&Time values are not showing in supported languages onchange of language selector.
   const lang = getLastLanguage();

--- a/frontend/packages/console-shared/src/components/datetime/__tests__/Timestamp.spec.tsx
+++ b/frontend/packages/console-shared/src/components/datetime/__tests__/Timestamp.spec.tsx
@@ -35,7 +35,7 @@ describe('Timestamp', () => {
     const formattedDate = dateTimeFormatter().format(new Date(timestamp));
     expect(screen.getByText(formattedDate)).toBeDefined();
   });
-  it('should show dash for null timestamp', () => {
+  it('should show dash when timestamp is undefined', () => {
     renderWithProviders(<Timestamp timestamp={undefined} />);
     expect(screen.getByText('-')).toBeDefined();
   });

--- a/frontend/packages/console-shared/src/components/datetime/__tests__/Timestamp.spec.tsx
+++ b/frontend/packages/console-shared/src/components/datetime/__tests__/Timestamp.spec.tsx
@@ -1,5 +1,4 @@
-import { act, screen } from '@testing-library/react';
-import { updateTimestamps } from '@console/internal/actions/ui';
+import { screen } from '@testing-library/react';
 import { dateTimeFormatter } from '@console/internal/components/utils/datetime';
 import { Timestamp } from '@console/shared/src/components/datetime/Timestamp';
 import { ONE_MINUTE } from '@console/shared/src/constants/time';
@@ -17,35 +16,27 @@ describe('Timestamp', () => {
 
   it("should say 'Just now'", () => {
     const timestamp = new Date(NOW).toISOString();
-    const { store } = renderWithProviders(<Timestamp timestamp={timestamp} />);
-    act(() => {
-      store.dispatch(updateTimestamps(NOW));
-    });
+    renderWithProviders(<Timestamp timestamp={timestamp} />);
     expect(screen.getByText('Just now')).toBeDefined();
   });
   it("should say '1 minute ago'", () => {
     const timestamp = new Date(NOW - ONE_MINUTE).toISOString();
-    const { store } = renderWithProviders(<Timestamp timestamp={timestamp} />);
-    act(() => {
-      store.dispatch(updateTimestamps(NOW));
-    });
+    renderWithProviders(<Timestamp timestamp={timestamp} />);
     expect(screen.getByText('1 minute ago')).toBeDefined();
   });
   it("should say '10 minutes ago'", () => {
     const timestamp = new Date(NOW - 10 * ONE_MINUTE).toISOString();
-    const { store } = renderWithProviders(<Timestamp timestamp={timestamp} />);
-    act(() => {
-      store.dispatch(updateTimestamps(NOW));
-    });
+    renderWithProviders(<Timestamp timestamp={timestamp} />);
     expect(screen.getByText('10 minutes ago')).toBeDefined();
   });
   it('should show formatted date', () => {
     const timestamp = new Date(NOW - 11 * ONE_MINUTE).toISOString();
-    const { store } = renderWithProviders(<Timestamp timestamp={timestamp} />);
-    act(() => {
-      store.dispatch(updateTimestamps(NOW));
-    });
+    renderWithProviders(<Timestamp timestamp={timestamp} />);
     const formattedDate = dateTimeFormatter().format(new Date(timestamp));
     expect(screen.getByText(formattedDate)).toBeDefined();
+  });
+  it('should show dash for null timestamp', () => {
+    renderWithProviders(<Timestamp timestamp={undefined} />);
+    expect(screen.getByText('-')).toBeDefined();
   });
 });

--- a/frontend/packages/console-shared/src/hooks/__tests__/useTimestampTick.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useTimestampTick.spec.ts
@@ -1,0 +1,63 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTimestampTick } from '../useTimestampTick';
+
+describe('useTimestampTick', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should return a number representing current time', () => {
+    const { result } = renderHook(() => useTimestampTick());
+    expect(typeof result.current).toBe('number');
+  });
+
+  it('should update after the tick interval', () => {
+    const { result } = renderHook(() => useTimestampTick());
+    const initial = result.current;
+
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    expect(result.current).toBeGreaterThan(initial);
+  });
+
+  it('should not update before the tick interval', () => {
+    const { result } = renderHook(() => useTimestampTick());
+    const initial = result.current;
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(result.current).toBe(initial);
+  });
+
+  it('should clean up interval when unmounted', () => {
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+    const { unmount } = renderHook(() => useTimestampTick());
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+
+  it('should share one interval across multiple consumers', () => {
+    const setIntervalSpy = jest.spyOn(global, 'setInterval');
+    const callsBefore = setIntervalSpy.mock.calls.length;
+
+    const { unmount: unmount1 } = renderHook(() => useTimestampTick());
+    const { unmount: unmount2 } = renderHook(() => useTimestampTick());
+
+    const callsAfter = setIntervalSpy.mock.calls.length;
+    expect(callsAfter - callsBefore).toBe(1);
+
+    unmount1();
+    unmount2();
+    setIntervalSpy.mockRestore();
+  });
+});

--- a/frontend/packages/console-shared/src/hooks/useTimestampTick.ts
+++ b/frontend/packages/console-shared/src/hooks/useTimestampTick.ts
@@ -1,0 +1,35 @@
+import { useSyncExternalStore } from 'react';
+
+const TICK_INTERVAL = 10000;
+
+let tick = Date.now();
+let intervalId: ReturnType<typeof setInterval> | null = null;
+const listeners = new Set<() => void>();
+
+function subscribe(callback: () => void): () => void {
+  listeners.add(callback);
+  if (listeners.size === 1) {
+    tick = Date.now();
+    intervalId = setInterval(() => {
+      tick = Date.now();
+      listeners.forEach((cb) => cb());
+    }, TICK_INTERVAL);
+  }
+  return () => {
+    listeners.delete(callback);
+    if (listeners.size === 0) {
+      if (intervalId !== null) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+    }
+  };
+}
+
+function getSnapshot(): number {
+  return tick;
+}
+
+export function useTimestampTick(): number {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/frontend/packages/console-shared/src/hooks/useTimestampTick.ts
+++ b/frontend/packages/console-shared/src/hooks/useTimestampTick.ts
@@ -6,7 +6,7 @@ let tick = Date.now();
 let intervalId: ReturnType<typeof setInterval> | null = null;
 const listeners = new Set<() => void>();
 
-function subscribe(callback: () => void): () => void {
+const subscribe = (callback: () => void): (() => void) => {
   listeners.add(callback);
   if (listeners.size === 1) {
     tick = Date.now();
@@ -24,12 +24,13 @@ function subscribe(callback: () => void): () => void {
       }
     }
   };
-}
+};
 
-function getSnapshot(): number {
-  return tick;
-}
+const getSnapshot = (): number => tick;
 
-export function useTimestampTick(): number {
-  return useSyncExternalStore(subscribe, getSnapshot);
-}
+/**
+ * Returns the current epoch timestamp (ms) that updates every 10 seconds.
+ * Uses a single shared interval across all consumers — the interval starts on
+ * first mount and stops when the last consumer unmounts.
+ */
+export const useTimestampTick = (): number => useSyncExternalStore(subscribe, getSnapshot);

--- a/frontend/public/actions/common.ts
+++ b/frontend/public/actions/common.ts
@@ -17,7 +17,6 @@ export enum ActionType {
   UpdateOverviewSelectedGroup = 'updateOverviewSelectedGroup',
   UpdateOverviewLabels = 'updateOverviewLabels',
   UpdateOverviewFilterValue = 'updateOverviewFilterValue',
-  UpdateTimestamps = 'updateTimestamps',
   SetPodMetrics = 'setPodMetrics',
   SetNamespaceMetrics = 'setNamespaceMetrics',
   SetNodeMetrics = 'setNodeMetrics',

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -244,8 +244,6 @@ export const updateOverviewMetrics = (metrics: any) =>
   action(ActionType.UpdateOverviewMetrics, { metrics });
 const updateOverviewResources = (resources: OverviewItem[]) =>
   action(ActionType.UpdateOverviewResources, { resources });
-export const updateTimestamps = (lastTick: number) =>
-  action(ActionType.UpdateTimestamps, { lastTick });
 const dismissOverviewDetails = () => action(ActionType.DismissOverviewDetails);
 const updateOverviewSelectedGroup = (group: OverviewSpecialGroup | string) =>
   action(ActionType.UpdateOverviewSelectedGroup, { group });
@@ -301,7 +299,6 @@ const uiActions = {
   setServiceLevel,
   updateOverviewMetrics,
   updateOverviewResources,
-  updateTimestamps,
   dismissOverviewDetails,
   updateOverviewSelectedGroup,
   updateOverviewLabels,

--- a/frontend/public/components/app.tsx
+++ b/frontend/public/components/app.tsx
@@ -431,9 +431,6 @@ store.dispatch<any>(detectFeatures());
 
 initApiDiscovery(store);
 
-// Global timer to ensure all <Timestamp> components update in sync
-setInterval(() => store.dispatch(UIActions.updateTimestamps(Date.now())), 10000);
-
 // Used by GUI tests to check for unhandled exceptions
 window.onerror = (message, source, lineno, colno, error) => {
   // ResizeObserver loop errors are non-actionable and can be ignored

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -130,9 +130,6 @@ export default (state: UIState, action: UIAction): UIState => {
     case ActionType.UpdateOverviewFilterValue: {
       return state.setIn(['overview', 'filterValue'], action.payload.value);
     }
-    case ActionType.UpdateTimestamps:
-      return state.set('lastTick', action.payload.lastTick);
-
     case ActionType.SetPodMetrics:
       return state.setIn(['metrics', 'pod'], action.payload.podMetrics);
 


### PR DESCRIPTION
## Summary

- Replace the global `setInterval` in `app.tsx` that dispatched `UIActions.updateTimestamps(Date.now())` every 10s to the Redux store, causing all ~36 Timestamp components plus every other UI store subscriber to re-render simultaneously
- Introduce a `useTimestampTick` hook using React 18's `useSyncExternalStore` with a shared interval that starts on first Timestamp mount and stops on last unmount
- Remove dead Redux code: `UpdateTimestamps` enum member, `updateTimestamps` action creator, and `lastTick` reducer case (no remaining consumers confirmed via codebase-wide grep)
- SDK compatibility preserved: `Timestamp` component props unchanged, `updateTimestamps` was never part of the public SDK API

## Details

The old approach dispatched a Redux action every 10 seconds, which triggered:
1. An Immutable.js `state.set('lastTick', ...)` in the UI reducer
2. Selector comparisons in **every** component subscribed to the UI store slice — not just Timestamps
3. Simultaneous re-renders of all ~36 Timestamp instances, including off-screen ones

The new `useTimestampTick` hook:
- Uses `useSyncExternalStore` with a cached `tick` value that only changes when the interval fires (stable `getSnapshot`)
- Shares a single `setInterval` across all consumers via a `Set<listener>` pattern
- Starts/stops the interval based on component lifecycle — no wasted cycles when no Timestamps are mounted
- Returns a `number` (epoch ms) directly, avoiding the Immutable.js serialization roundtrip

## Test plan

- [ ] Existing Timestamp tests updated and passing (5 tests)
- [ ] New `useTimestampTick` hook tests passing (5 tests covering: value type, tick update, no early update, cleanup, shared interval)
- [ ] Navigate to Pods list — timestamps update every ~10 seconds
- [ ] Navigate to Events page (many timestamps) — verify updates
- [ ] React DevTools Profiler — confirm Timestamp re-renders are local, not cascading through Redux
- [ ] Verify no console errors or warnings

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp “now” updates so relative times (e.g., “Just now”, “x minutes ago”) stay accurate without relying on a periodic global updater.
* **New Features**
  * Added a shared `useTimestampTick` hook so timestamp views consistently update from a single ticking source.
* **Tests**
  * Updated `Timestamp` tests to render with explicit props and immediately assert output, including `'-'` for missing timestamps.
  * Added tests covering `useTimestampTick` timing, cleanup, and shared interval usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->