### PR TITLE
OCPBUGS-65942: Add pod selector columns to Service, ReplicaSet, Job, and ReplicationController lists

### DIFF
--- a/frontend/public/components/job.tsx
+++ b/frontend/public/components/job.tsx
@@ -27,6 +27,7 @@ import { LoadingBox } from './utils/status-box';
 import { PodsComponent, navFactory } from './utils/horizontal-nav';
 import { ResourceLink } from './utils/resource-link';
 import { ResourceSummary } from './utils/details-page';
+import { Selector } from './utils/selector';
 import { SectionHeading } from './utils/headings';
 
 import { Timestamp } from '@console/shared/src/components/datetime/Timestamp';
@@ -60,6 +61,7 @@ const tableColumnInfo = [
   { id: 'name' },
   { id: 'namespace' },
   { id: 'labels' },
+  { id: 'selector' },
   { id: 'completions' },
   { id: 'type' },
   { id: 'created' },
@@ -102,15 +104,18 @@ const getDataViewRows: GetDataViewRows<JobKind> = (data, columns) => {
         cell: <LabelList kind={kind} labels={obj.metadata.labels} />,
       },
       [tableColumnInfo[3].id]: {
-        cell: <Completions obj={obj} completions={completions} />,
+        cell: <Selector selector={obj.spec.selector} namespace={namespace} />,
       },
       [tableColumnInfo[4].id]: {
-        cell: type,
+        cell: <Completions obj={obj} completions={completions} />,
       },
       [tableColumnInfo[5].id]: {
-        cell: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
+        cell: type,
       },
       [tableColumnInfo[6].id]: {
+        cell: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
+      },
+      [tableColumnInfo[7].id]: {
         cell: <LazyActionMenu context={context} />,
         props: actionsCellProps,
       },
@@ -271,37 +276,46 @@ const useJobsColumns = (): {
         },
       },
       {
-        title: t('Completions'),
+        title: t('Pod selector'),
         id: tableColumnInfo[3].id,
-        sort: (data, direction) =>
-          data.sort(sortResourceByValue<JobKind>(direction, sorts.jobCompletionsSucceeded)),
+        sort: 'spec.selector',
         resizableProps: getResizableProps(tableColumnInfo[3].id),
         props: {
           modifier: 'nowrap',
         },
       },
       {
-        title: t('Type'),
+        title: t('Completions'),
         id: tableColumnInfo[4].id,
         sort: (data, direction) =>
-          data.sort(sortResourceByValue<JobKind>(direction, sorts.jobType)),
+          data.sort(sortResourceByValue<JobKind>(direction, sorts.jobCompletionsSucceeded)),
         resizableProps: getResizableProps(tableColumnInfo[4].id),
         props: {
           modifier: 'nowrap',
         },
       },
       {
-        title: t('Created'),
+        title: t('Type'),
         id: tableColumnInfo[5].id,
-        sort: 'metadata.creationTimestamp',
+        sort: (data, direction) =>
+          data.sort(sortResourceByValue<JobKind>(direction, sorts.jobType)),
         resizableProps: getResizableProps(tableColumnInfo[5].id),
         props: {
           modifier: 'nowrap',
         },
       },
       {
-        title: '',
+        title: t('Created'),
         id: tableColumnInfo[6].id,
+        sort: 'metadata.creationTimestamp',
+        resizableProps: getResizableProps(tableColumnInfo[6].id),
+        props: {
+          modifier: 'nowrap',
+        },
+      },
+      {
+        title: '',
+        id: tableColumnInfo[7].id,
         props: {
           ...actionsCellProps,
         },

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -15,6 +15,7 @@ import { AsyncComponent } from './utils/async';
 import { ResourceLink } from './utils/resource-link';
 import { LabelList } from './utils/label-list';
 import { OwnerReferences } from './utils/owner-references';
+import { Selector } from './utils/selector';
 import { LoadingBox } from './utils/status-box';
 import { Timestamp } from '@console/shared/src/components/datetime/Timestamp';
 import { ResourceEventStream } from './events';
@@ -145,6 +146,7 @@ const tableColumnInfo = [
   { id: 'namespace' },
   { id: 'status' },
   { id: 'labels' },
+  { id: 'selector' },
   { id: 'owner' },
   { id: 'created' },
   { id: '' },
@@ -178,12 +180,15 @@ const getDataViewRows = (data, columns) => {
         cell: <LabelList kind={kind} labels={obj.metadata.labels} />,
       },
       [tableColumnInfo[4].id]: {
-        cell: <OwnerReferences resource={obj} />,
+        cell: <Selector selector={obj.spec.selector} namespace={namespace} />,
       },
       [tableColumnInfo[5].id]: {
-        cell: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
+        cell: <OwnerReferences resource={obj} />,
       },
       [tableColumnInfo[6].id]: {
+        cell: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
+      },
+      [tableColumnInfo[7].id]: {
         cell: <LazyActionMenu context={context} />,
         props: actionsCellProps,
       },
@@ -247,26 +252,35 @@ const useReplicaSetsColumns = () => {
         },
       },
       {
-        title: t('Owner'),
+        title: t('Pod selector'),
         id: tableColumnInfo[4].id,
-        sort: 'metadata.ownerReferences[0].name',
+        sort: 'spec.selector',
         resizableProps: getResizableProps(tableColumnInfo[4].id),
         props: {
           modifier: 'nowrap',
         },
       },
       {
-        title: t('Created'),
+        title: t('Owner'),
         id: tableColumnInfo[5].id,
-        sort: 'metadata.creationTimestamp',
+        sort: 'metadata.ownerReferences[0].name',
         resizableProps: getResizableProps(tableColumnInfo[5].id),
         props: {
           modifier: 'nowrap',
         },
       },
       {
-        title: '',
+        title: t('Created'),
         id: tableColumnInfo[6].id,
+        sort: 'metadata.creationTimestamp',
+        resizableProps: getResizableProps(tableColumnInfo[6].id),
+        props: {
+          modifier: 'nowrap',
+        },
+      },
+      {
+        title: '',
+        id: tableColumnInfo[7].id,
         props: {
           ...actionsCellProps,
         },

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -16,6 +16,7 @@ import { SectionHeading } from './utils/headings';
 import { ResourceSummary, ResourcePodCount, RuntimeClass } from './utils/details-page';
 import { AsyncComponent } from './utils/async';
 import { ResourceLink } from './utils/resource-link';
+import { Selector } from './utils/selector';
 import { OwnerReferences } from './utils/owner-references';
 import { LoadingBox } from './utils/status-box';
 import { Timestamp } from '@console/shared/src/components/datetime/Timestamp';
@@ -161,6 +162,7 @@ const tableColumnInfo = [
   { id: 'namespace' },
   { id: 'status' },
   { id: 'phase' },
+  { id: 'selector' },
   { id: 'owner' },
   { id: 'created' },
   { id: '' },
@@ -193,12 +195,15 @@ const getDataViewRows = (data, columns) => {
         cell: <Status status={phase} />,
       },
       [tableColumnInfo[4].id]: {
-        cell: <OwnerReferences resource={obj} />,
+        cell: <Selector selector={obj.spec.selector} namespace={namespace} />,
       },
       [tableColumnInfo[5].id]: {
-        cell: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
+        cell: <OwnerReferences resource={obj} />,
       },
       [tableColumnInfo[6].id]: {
+        cell: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
+      },
+      [tableColumnInfo[7].id]: {
         cell: <LazyActionMenu context={context} />,
         props: actionsCellProps,
       },
@@ -261,26 +266,35 @@ const useReplicationControllersColumns = () => {
         },
       },
       {
-        title: t('Owner'),
+        title: t('Pod selector'),
         id: tableColumnInfo[4].id,
-        sort: 'metadata.ownerReferences[0].name',
+        sort: 'spec.selector',
         resizableProps: getResizableProps(tableColumnInfo[4].id),
         props: {
           modifier: 'nowrap',
         },
       },
       {
-        title: t('Created'),
+        title: t('Owner'),
         id: tableColumnInfo[5].id,
-        sort: 'metadata.creationTimestamp',
+        sort: 'metadata.ownerReferences[0].name',
         resizableProps: getResizableProps(tableColumnInfo[5].id),
         props: {
           modifier: 'nowrap',
         },
       },
       {
-        title: '',
+        title: t('Created'),
         id: tableColumnInfo[6].id,
+        sort: 'metadata.creationTimestamp',
+        resizableProps: getResizableProps(tableColumnInfo[6].id),
+        props: {
+          modifier: 'nowrap',
+        },
+      },
+      {
+        title: '',
+        id: tableColumnInfo[7].id,
         props: {
           ...actionsCellProps,
         },

--- a/frontend/public/components/resource-pages.ts
+++ b/frontend/public/components/resource-pages.ts
@@ -42,6 +42,7 @@ import {
   RoleBindingModel,
   RoleModel,
   SecretModel,
+  ServiceModel,
   ServiceAccountModel,
   ServiceMonitorModel,
   StatefulSetModel,
@@ -382,6 +383,9 @@ const baseListPages = ImmutableMap<ResourceMapKey, ResourceMapValue>()
   )
   .set(referenceForModel(SecretModel), () =>
     import('./secret' /* webpackChunkName: "secret" */).then((m) => m.SecretsPage),
+  )
+  .set(referenceForModel(ServiceModel), () =>
+    import('./service' /* webpackChunkName: "service" */).then((m) => m.ServicesPage),
   )
   .set(referenceForModel(ServiceAccountModel), () =>
     import('./service-account' /* webpackChunkName: "service-account" */).then(

--- a/frontend/public/components/service.tsx
+++ b/frontend/public/components/service.tsx
@@ -1,0 +1,196 @@
+import type { FC } from 'react';
+import { Suspense, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  ConsoleDataView,
+  actionsCellProps,
+  getLabelsColumnWidthStyleProp,
+  getNameCellProps,
+  nameCellProps,
+} from '@console/app/src/components/data-view/ConsoleDataView';
+import type { GetDataViewRows } from '@console/app/src/components/data-view/types';
+import { useColumnWidthSettings } from '@console/app/src/components/data-view/useResizableColumnProps';
+import { getGroupVersionKindForModel } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';
+import { TableColumn } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
+import { LazyActionMenu } from '@console/shared/src/components/actions/LazyActionMenu';
+import { DASH } from '@console/shared/src/constants/ui';
+import { Timestamp } from '@console/shared/src/components/datetime/Timestamp';
+import { K8sResourceKind, referenceFor, referenceForModel } from '../module/k8s';
+import { ServiceModel } from '../models';
+import { ListPage } from './factory/list-page';
+import { LabelList } from './utils/label-list';
+import { ResourceLink } from './utils/resource-link';
+import { Selector } from './utils/selector';
+import { LoadingBox } from './utils/status-box';
+
+const kind = referenceForModel(ServiceModel);
+
+const tableColumnInfo = [
+  { id: 'name' },
+  { id: 'namespace' },
+  { id: 'labels' },
+  { id: 'selector' },
+  { id: 'created' },
+  { id: '' },
+];
+
+const getDataViewRows: GetDataViewRows<K8sResourceKind> = (data, columns) => {
+  return data.map(({ obj }) => {
+    const { name, namespace } = obj.metadata;
+    const context = { [referenceFor(obj)]: obj };
+
+    const rowCells = {
+      [tableColumnInfo[0].id]: {
+        cell: (
+          <ResourceLink
+            groupVersionKind={getGroupVersionKindForModel(ServiceModel)}
+            name={name}
+            namespace={namespace}
+          />
+        ),
+        props: getNameCellProps(name),
+      },
+      [tableColumnInfo[1].id]: {
+        cell: <ResourceLink kind="Namespace" name={namespace} />,
+      },
+      [tableColumnInfo[2].id]: {
+        cell: <LabelList kind={kind} labels={obj.metadata.labels} />,
+      },
+      [tableColumnInfo[3].id]: {
+        cell: <Selector selector={obj.spec.selector} namespace={namespace} />,
+      },
+      [tableColumnInfo[4].id]: {
+        cell: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
+      },
+      [tableColumnInfo[5].id]: {
+        cell: <LazyActionMenu context={context} />,
+        props: actionsCellProps,
+      },
+    };
+
+    return columns.map(({ id }) => {
+      const cell = rowCells[id]?.cell || DASH;
+      return {
+        id,
+        props: rowCells[id]?.props,
+        cell,
+      };
+    });
+  });
+};
+
+const useServiceColumns = (): {
+  columns: TableColumn<K8sResourceKind>[];
+  resetAllColumnWidths: () => void;
+} => {
+  const { t } = useTranslation('public');
+  const { getResizableProps, getWidth, resetAllColumnWidths } = useColumnWidthSettings(
+    ServiceModel,
+  );
+
+  const columns = useMemo(() => {
+    return [
+      {
+        title: t('Name'),
+        id: tableColumnInfo[0].id,
+        sort: 'metadata.name',
+        resizableProps: getResizableProps(tableColumnInfo[0].id),
+        props: {
+          ...nameCellProps,
+          modifier: 'nowrap',
+        },
+      },
+      {
+        title: t('Namespace'),
+        id: tableColumnInfo[1].id,
+        sort: 'metadata.namespace',
+        resizableProps: getResizableProps(tableColumnInfo[1].id),
+        props: {
+          modifier: 'nowrap',
+        },
+      },
+      {
+        title: t('Labels'),
+        id: tableColumnInfo[2].id,
+        sort: 'metadata.labels',
+        resizableProps: getResizableProps(tableColumnInfo[2].id),
+        props: {
+          modifier: 'nowrap',
+          ...getLabelsColumnWidthStyleProp(getWidth(tableColumnInfo[2].id)),
+        },
+      },
+      {
+        title: t('Pod selector'),
+        id: tableColumnInfo[3].id,
+        sort: 'spec.selector',
+        resizableProps: getResizableProps(tableColumnInfo[3].id),
+        props: {
+          modifier: 'nowrap',
+        },
+      },
+      {
+        title: t('Created'),
+        id: tableColumnInfo[4].id,
+        sort: 'metadata.creationTimestamp',
+        resizableProps: getResizableProps(tableColumnInfo[4].id),
+        props: {
+          modifier: 'nowrap',
+        },
+      },
+      {
+        title: '',
+        id: tableColumnInfo[5].id,
+        props: {
+          ...actionsCellProps,
+        },
+      },
+    ];
+  }, [t, getResizableProps, getWidth]);
+
+  return { columns, resetAllColumnWidths };
+};
+
+const ServicesList: FC<ServicesListProps> = ({ data, loaded, ...props }) => {
+  const { columns, resetAllColumnWidths } = useServiceColumns();
+
+  return (
+    <Suspense fallback={<LoadingBox />}>
+      <ConsoleDataView<K8sResourceKind>
+        {...props}
+        label={ServiceModel.labelPlural}
+        data={data}
+        loaded={loaded}
+        columns={columns}
+        getDataViewRows={getDataViewRows}
+        hideColumnManagement={true}
+        isResizable
+        resetAllColumnWidths={resetAllColumnWidths}
+      />
+    </Suspense>
+  );
+};
+
+export const ServicesPage: FC<ServicesPageProps> = (props) => {
+  const { canCreate = true } = props;
+  return (
+    <ListPage
+      {...props}
+      kind={kind}
+      ListComponent={ServicesList}
+      canCreate={canCreate}
+      omitFilterToolbar={true}
+    />
+  );
+};
+
+type ServicesListProps = {
+  data: K8sResourceKind[];
+  loaded: boolean;
+};
+
+type ServicesPageProps = {
+  canCreate?: boolean;
+  showTitle?: boolean;
+  namespace?: string;
+  selector?: any;
+};


### PR DESCRIPTION
**Analysis / Root cause**:
Service, ReplicaSet, Job, and ReplicationController list views did not expose pod selector. This made these resources inconsistent with other workload list views such as Deployment, StatefulSet, DaemonSet, and DeploymentConfig, where users can see and click pod selectors directly from the table.
For Service specifically, the resource was using the generic default list page, so there was no Service-specific table definition where a Pod selector column could be added.

**Solution description**:
Added a Pod selector column to the ReplicaSet, Job, and ReplicationController list views.
Added a dedicated Kubernetes Service list page and registered it in the resource page mapping so Services can display resource-specific columns. The new Service list includes Name, Namespace, Labels, Pod selector, Created, and row actions.
The Pod selector cells reuse the existing `Selector` component, which renders clickable selector links to the Pod search page with the appropriate namespace and label query.

**Screenshots / screen recording**:
<img width="1914" height="940" alt="services" src="https://github.com/user-attachments/assets/8d03f68f-e35e-41e2-85f6-e8b7772442b7" />

**Test setup:**
No special setup required.

**Test cases:**
- Verify the Service list view shows a Pod selector column.
- Verify the ReplicaSet list view shows a Pod selector column.
- Verify the Job list view shows a Pod selector column.
- Verify the ReplicationController list view shows a Pod selector column.
- Verify selectors render as clickable links.
- Verify clicking a selector navigates to `/search/ns/<namespace>?kind=Pod&q=<selector>`.
- Verify resources without a selector show `No selector`.
- Verify existing columns, sorting, row actions, and resource links still work.

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**

**Reviewers and assignees:**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Services list page with columns for name, namespace, labels, pod selector, creation time, and actions.
  * Added Services to resource navigation and page handling.
  * Added Pod selector columns to Jobs, ReplicaSets, and Replication Controllers tables.
  * Pod selectors are now displayed and sortable where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->