### PR TITLE
OCPBUGS-69379: Fix RBAC role rules filter input handling

### DIFF
--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -87,7 +87,7 @@ class Details extends Component {
   constructor(props) {
     super(props);
     this.state = {};
-    this.changeFilter = (val) => this.setState({ ruleFilter: val });
+    this.changeFilter = (_event, val) => this.setState({ ruleFilter: val });
   }
 
   render() {


### PR DESCRIPTION
**Analysis / Root cause**:
The RBAC Role rules filter handled the TextInput `onChange` callback incorrectly. PatternFly TextInput passes the input value as the second argument, but the component stored the first argument in state, which is the change event. As a result, the rules filter did not use the entered filter text correctly.

**Solution description**:
Updated the Role details rules filter handler to read the filter text from the second `onChange` argument.

**Screenshots / screen recording**:
before fix:
https://github.com/user-attachments/assets/0a140b95-781d-4779-bcd1-d0c3f6743847
after fix:
https://github.com/user-attachments/assets/8eb4e15d-2828-4009-9286-d6317df42f41

**Test setup:**
No special setup required.

**Test cases:**
1. Enter a resource name, for example `pods`, in the rules filter input and verify that matching rules remain visible.
2. Enter a verb, for example `get` or `create`, and verify that matching rules remain visible.
3. Enter a non-matching value and verify that the rules table shows no matching rows.
4. Clear the filter input and verify that all rules are shown again.

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
The component is currently implemented in JSX, which made this callback signature mismatch easy to miss. I kept this PR scoped to the bug fix, but I can follow up with a separate TSX migration if maintainers think it would be useful.

**Reviewers and assignees:**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rule filtering so selecting a filter consistently updates the displayed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->