### PR TITLE
[release-4.14] OCPBUGS-98416: CVE-2026-59869

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -183,7 +183,7 @@
     "immutable": "^3.8.3",
     "istextorbinary": "^9.5.0",
     "js-base64": "^2.5.1",
-    "js-yaml": "^3.13.1",
+    "js-yaml": "^3.15.0",
     "json-schema": "^0.3.0",
     "lodash-es": "^4.17.23",
     "monaco-languageclient": "^0.13.0",
@@ -360,7 +360,8 @@
     "glob-parent": "^5.1.2",
     "postcss": "^8.2.13",
     "axios": "^0.31.1",
-    "immutable": "3.8.3"
+    "immutable": "3.8.3",
+    "js-yaml": "^3.15.0"
   },
   "husky": {
     "hooks": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6675,13 +6675,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"argparse@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "argparse@npm:2.0.1"
-  checksum: 10c0/c5640c2d89045371c7cedd6a70212a04e360fd34d6edeae32f6952c63949e3525ea77dbec0289d8213a99bbaeab5abfa860b5c12cf88a2e6cf8106e90dd27a7e
-  languageName: node
-  linkType: hard
-
 "aria-query@npm:^3.0.0":
   version: 3.0.0
   resolution: "aria-query@npm:3.0.0"
@@ -17690,50 +17683,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.0":
-  version: 4.1.0
-  resolution: "js-yaml@npm:4.1.0"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/184a24b4eaacfce40ad9074c64fd42ac83cf74d8c8cd137718d456ced75051229e5061b8633c3366b8aada17945a7a356b337828c19da92b51ae62126575018f
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^3.10.0, js-yaml@npm:^3.9.0":
-  version: 3.14.0
-  resolution: "js-yaml@npm:3.14.0"
+"js-yaml@npm:^3.15.0":
+  version: 3.15.0
+  resolution: "js-yaml@npm:3.15.0"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/9b21ab19f03aae734c83e5c8a3d5e6f80bab5ce0e24bdbb186e531fb0887ff0034affd96ae3eed993c33e33bc606a6b78389207b853df97094393804d6c37184
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^3.13.1":
-  version: 3.13.1
-  resolution: "js-yaml@npm:3.13.1"
-  dependencies:
-    argparse: "npm:^1.0.7"
-    esprima: "npm:^4.0.0"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/6a4f78b998d2eb58964cc5e051c031865bf292dc3c156a8057cf468d9e60a8739f4e8f607a267e97f09eb8d08263b8262df57eddb16b920ec5a04a259c3b4960
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^3.7.0":
-  version: 3.11.0
-  resolution: "js-yaml@npm:3.11.0"
-  dependencies:
-    argparse: "npm:^1.0.7"
-    esprima: "npm:^4.0.0"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/e1654d751ec25558f7680b5bd75f8fbdbc6cfab81615895c85ed5636febba1517d0961a40504e0cd52cabb43d8b26b878a7678bc62b2d040c197ccd3fedc2d5f
+  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
   languageName: node
   linkType: hard
 
@@ -20877,7 +20835,7 @@ __metadata:
     jest-resolve: "npm:^26.4.0"
     jest-transform-graphql: "npm:^2.1.0"
     js-base64: "npm:^2.5.1"
-    js-yaml: "npm:^3.13.1"
+    js-yaml: "npm:^3.15.0"
     json-schema: "npm:^0.3.0"
     lint-staged: "npm:^10.2.2"
     lodash-es: "npm:^4.17.23"


### PR DESCRIPTION
## Summary
- Bump js-yaml from 3.14.0 to 3.15.0 to fix CVE-2026-59869
- CVE-2026-59869: js-yaml quadratic CPU time DoS via chained merge keys (CVSS 7.5)
- Added js-yaml resolution to ensure all transitive instances are also bumped

## Test plan
- [ ] Verify yarn.lock resolves js-yaml to 3.15.0
- [ ] Verify console builds successfully
- [ ] Verify YAML editor functionality works correctly