### PR TITLE
[release-4.12] OCPBUGS-98415: CVE-2026-59869

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -177,7 +177,7 @@
     "i18next-http-backend": "^1.0.21",
     "immutable": "^3.8.3",
     "js-base64": "^2.5.1",
-    "js-yaml": "^3.13.1",
+    "js-yaml": "^3.15.0",
     "json-schema": "^0.3.0",
     "lodash-es": "^4.17.23",
     "monaco-languageclient": "^0.13.0",
@@ -353,7 +353,8 @@
     "@types/jest": "21.x",
     "glob-parent": "^5.1.2",
     "postcss": "^8.2.13",
-    "immutable": "3.8.3"
+    "immutable": "3.8.3",
+    "js-yaml": "^3.15.0"
   },
   "husky": {
     "hooks": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -17135,39 +17135,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.10.0, js-yaml@npm:^3.9.0":
-  version: 3.14.0
-  resolution: "js-yaml@npm:3.14.0"
+"js-yaml@npm:^3.15.0":
+  version: 3.15.0
+  resolution: "js-yaml@npm:3.15.0"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/9b21ab19f03aae734c83e5c8a3d5e6f80bab5ce0e24bdbb186e531fb0887ff0034affd96ae3eed993c33e33bc606a6b78389207b853df97094393804d6c37184
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^3.13.1":
-  version: 3.13.1
-  resolution: "js-yaml@npm:3.13.1"
-  dependencies:
-    argparse: "npm:^1.0.7"
-    esprima: "npm:^4.0.0"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/6a4f78b998d2eb58964cc5e051c031865bf292dc3c156a8057cf468d9e60a8739f4e8f607a267e97f09eb8d08263b8262df57eddb16b920ec5a04a259c3b4960
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^3.7.0":
-  version: 3.11.0
-  resolution: "js-yaml@npm:3.11.0"
-  dependencies:
-    argparse: "npm:^1.0.7"
-    esprima: "npm:^4.0.0"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/e1654d751ec25558f7680b5bd75f8fbdbc6cfab81615895c85ed5636febba1517d0961a40504e0cd52cabb43d8b26b878a7678bc62b2d040c197ccd3fedc2d5f
+  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
   languageName: node
   linkType: hard
 
@@ -20255,7 +20231,7 @@ __metadata:
     jest-resolve: "npm:^26.4.0"
     jest-transform-graphql: "npm:^2.1.0"
     js-base64: "npm:^2.5.1"
-    js-yaml: "npm:^3.13.1"
+    js-yaml: "npm:^3.15.0"
     json-schema: "npm:^0.3.0"
     lint-staged: "npm:^10.2.2"
     lodash-es: "npm:^4.17.23"


### PR DESCRIPTION
## Summary
- Bump js-yaml from 3.14.0 to 3.15.0 to fix CVE-2026-59869
- CVE-2026-59869: js-yaml quadratic CPU time DoS via chained merge keys (CVSS 7.5)
- Added js-yaml resolution to ensure all transitive instances are also bumped

## Test plan
- [ ] Verify yarn.lock resolves js-yaml to 3.15.0
- [ ] Verify console builds successfully
- [ ] Verify YAML editor functionality works correctly