### PR TITLE
NO-ISSUE: Skip OLMv0-specific e2e tests when techPreview is enabled

### DIFF
--- a/frontend/e2e/tests/olm/create-namespace.spec.ts
+++ b/frontend/e2e/tests/olm/create-namespace.spec.ts
@@ -53,6 +53,12 @@ test.describe('Create namespace from install operators', { tag: ['@admin'] }, ()
   });
 
   test('creates namespace from operator install page', async ({ page }) => {
+    // OLMv1 is enabled by default on techPreview clusters, replacing the OLMv0
+    // OperatorHub catalog with an empty Software Catalog. Skip instead of timing out.
+    await page.goto('/');
+    const isTechPreview = await page.evaluate(() => window.SERVER_FLAGS.techPreview);
+    test.skip(isTechPreview, 'OLMv1 is active on techPreview clusters — OLMv0 OperatorHub catalog is unavailable');
+
     await test.step('Navigate to catalog and open operator details', async () => {
       await page.goto('/catalog/ns/default?catalogType=operator');
       await page.getByPlaceholder('Filter by keyword...').fill(operatorName);

--- a/frontend/e2e/tsconfig.json
+++ b/frontend/e2e/tsconfig.json
@@ -8,7 +8,8 @@
     "skipLibCheck": true,
     "noEmit": true,
     "noUnusedLocals": true,
-    "types": ["node"]
+    "typeRoots": ["../@types", "../node_modules/@types"],
+    "types": ["node", "console"]
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules"]

--- a/frontend/packages/dev-console/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/dev-console/integration-tests/support/commands/hooks.ts
@@ -1,6 +1,20 @@
 import { quickStartSidebarPO } from '../pageObjects/quickStarts-po';
 
-before(() => {
+before(function () {
+  // Skip all dev-console tests on techPreview clusters: the Developer perspective is
+  // disabled by default and the htpasswd IDP doesn't exist, so create-user.sh would
+  // need to create it (5-10 min auth-operator cycle) before login can succeed. The
+  // combination causes initAdmin() to time out waiting for the perspective-switcher-toggle.
+  // cy.exec() returns a Cypress Chainable, not a true Promise — it has no .catch() method.
+  // Cypress's command queue manages error handling; this disable is required.
+  // eslint-disable-next-line promise/catch-or-return
+  cy.exec('oc get featuregate cluster -o jsonpath={.spec.featureSet}', {
+    failOnNonZeroExit: false,
+  }).then((result) => {
+    if (result.stdout.trim() === 'TechPreviewNoUpgrade') {
+      this.skip();
+    }
+  });
   cy.exec('../../../../contrib/create-user.sh');
   const bridgePasswordIDP: string = Cypress.expose('BRIDGE_HTPASSWD_IDP') || 'test';
   const bridgePasswordUsername: string = Cypress.expose('BRIDGE_HTPASSWD_USERNAME') || 'test';

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/tests/deprecated-operator-warnings.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/tests/deprecated-operator-warnings.cy.ts
@@ -41,8 +41,16 @@ describe('Deprecated operator warnings', () => {
     );
   };
 
-  before(() => {
+  before(function () {
     cy.login();
+    // cy.window() returns a Cypress Chainable, not a true Promise — it has no .catch() method.
+    // Cypress's command queue manages error handling; this disable is required.
+    // eslint-disable-next-line promise/catch-or-return
+    cy.window().then((win) => {
+      if (win.SERVER_FLAGS?.techPreview) {
+        this.skip();
+      }
+    });
     // Clean up any existing resources from previous failed runs
     cleanupOperatorResources();
     cy.exec(

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-hub.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-hub.cy.ts
@@ -1,8 +1,16 @@
 import { checkErrors, testName } from '@console/cypress-integration-tests/support';
 
 describe('Interacting with Operators', () => {
-  before(() => {
+  before(function () {
     cy.login();
+    // cy.window() returns a Cypress Chainable, not a true Promise — it has no .catch() method.
+    // Cypress's command queue manages error handling; this disable is required.
+    // eslint-disable-next-line promise/catch-or-return
+    cy.window().then((win) => {
+      if (win.SERVER_FLAGS?.techPreview) {
+        this.skip();
+      }
+    });
     cy.createProjectWithCLI(testName);
   });
 

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-install-global.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-install-global.cy.ts
@@ -39,8 +39,16 @@ const cleanupOperatorResources = () => {
 };
 
 describe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
-  before(() => {
+  before(function () {
     cy.login();
+    // cy.window() returns a Cypress Chainable, not a true Promise — it has no .catch() method.
+    // Cypress's command queue manages error handling; this disable is required.
+    // eslint-disable-next-line promise/catch-or-return
+    cy.window().then((win) => {
+      if (win.SERVER_FLAGS?.techPreview) {
+        this.skip();
+      }
+    });
     cleanupOperatorResources();
     operator.install(testOperator.name, testOperator.operatorCardTestID);
   });

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-install-single-namespace.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-install-single-namespace.cy.ts
@@ -41,8 +41,16 @@ const cleanupOperatorResources = (namespace: string) => {
 };
 
 describe(`Installing "${testOperator.name}" operator in test namespace`, () => {
-  before(() => {
+  before(function () {
     cy.login();
+    // cy.window() returns a Cypress Chainable, not a true Promise — it has no .catch() method.
+    // Cypress's command queue manages error handling; this disable is required.
+    // eslint-disable-next-line promise/catch-or-return
+    cy.window().then((win) => {
+      if (win.SERVER_FLAGS?.techPreview) {
+        this.skip();
+      }
+    });
     cy.createProjectWithCLI(testName);
     cleanupOperatorResources(testName);
   });

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-uninstall.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/tests/operator-uninstall.cy.ts
@@ -23,8 +23,16 @@ const alertExists = (titleText: string) => {
 };
 
 describe(`Testing uninstall of ${testOperator.name} Operator`, () => {
-  before(() => {
+  before(function () {
     cy.login();
+    // cy.window() returns a Cypress Chainable, not a true Promise — it has no .catch() method.
+    // Cypress's command queue manages error handling; this disable is required.
+    // eslint-disable-next-line promise/catch-or-return
+    cy.window().then((win) => {
+      if (win.SERVER_FLAGS?.techPreview) {
+        this.skip();
+      }
+    });
     cy.createProjectWithCLI(testName);
     operator.install(
       testOperator.name,


### PR DESCRIPTION
**Analysis / Root cause**:
On techPreview clusters (`TechPreviewNoUpgrade` feature gate), OLMv1 is enabled by default. This replaces the OLMv0 OperatorHub catalog UI with the OLMv1 Software Catalog, which shows "No Catalog items found" instead of operator tiles. All OLMv0-specific selectors (`[data-test="tab operator"]`, `[data-testid="operator-Data Grid"]`, etc.) are absent, causing 40 s timeouts.

Additionally, techPreview clusters disable the Developer perspective by default and have no htpasswd IDP configured. The dev-console test suite's `before()` hook runs `create-user.sh` to create the htpasswd IDP (5-10 min auth-operator cycle), during which `cy.login()` runs against an unready IDP. This leaves Cypress unauthenticated; `initAdmin()` then times out after 40 s waiting for `[data-test-id="perspective-switcher-toggle"]` (absent on the OAuth login page).

Root-caused against a live techPreview cluster (`TechPreviewNoUpgrade` featuregate confirmed via `oc get featuregate cluster`; `SERVER_FLAGS.techPreview: true` confirmed from the console HTML; Developer perspective confirmed disabled in `console.operator.openshift.io/cluster`).

**Solution description**:
- **5 OLM Cypress specs** (`operator-hub`, `deprecated-operator-warnings`, `operator-install-global`, `operator-install-single-namespace`, `operator-uninstall`): add a `SERVER_FLAGS.techPreview` check in each `before()` hook via `cy.window().then()`. If techPreview is detected the suite is skipped immediately before any expensive cluster setup runs.
- **1 Playwright spec** (`olm/create-namespace.spec.ts`): add a `page.evaluate()` + `test.skip()` guard at the top of the test body (after `page.goto('/')` so `SERVER_FLAGS` is populated), matching the pattern already used in `masthead.spec.ts`.
- **dev-console hooks** (`support/commands/hooks.ts`): add a `cy.exec('oc get featuregate ...')` check before `create-user.sh` runs. Uses `oc` (already a dependency of these tests) rather than `window.SERVER_FLAGS` because the browser has not navigated to the console yet at that point in the hook.

**Screenshots / screen recording**:
Screenshots from the failing CI jobs confirm the OLMv1 banner ("Operator Lifecycle Management version 1") and "No Catalog items found" on every affected page.

**Test setup:**
Run against a cluster with `TechPreviewNoUpgrade` feature gate enabled. Affected tests should appear as `skipped` (pending) instead of `failed`.

**Test cases:**
- On a standard (non-techPreview) cluster: all 7 changed locations should still run and pass as before — no behavior change.
- On a techPreview cluster: all 7 locations should be skipped cleanly with a descriptive reason string.

**Browser conformance**: N/A — test infrastructure change only.

**Additional info:**
Failing CI jobs analyzed:
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/81559/rehearse-81559-pull-ci-openshift-console-main-e2e-gcp-console-techpreview/2075585173964984320
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/81559/rehearse-81559-pull-ci-openshift-console-main-e2e-playwright-techpreview/2075585174015315968

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated Dev Console and OLM integration test suites to detect Tech Preview mode and skip unsupported scenarios cleanly.
  - Enhanced Operator Hub, global/single-namespace operator install, and uninstall tests to conditionally bypass execution based on runtime server flags.
  - Improved the OLM namespace creation test to check Tech Preview mode before proceeding, reducing timeout risk.
- **Chores**
  - Updated the e2e TypeScript configuration to include additional ambient types (`node` and `console`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->