### PR TITLE
OCPBUGS-98489: CVE-2026-59869 bump js-yaml

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -190,7 +190,7 @@
     "immutable": "^3.8.3",
     "istextorbinary": "^9.5.0",
     "js-base64": "^3.7.7",
-    "js-yaml": "^3.13.1",
+    "js-yaml": "^3.15.0",
     "json-schema": "^0.3.0",
     "jsonpath-plus": "^10.3.0",
     "lodash-es": "^4.18.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16073,26 +16073,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.9.0":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
+"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.15.0, js-yaml@npm:^3.9.0":
+  version: 3.15.0
+  resolution: "js-yaml@npm:3.15.0"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
+  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
   languageName: node
   linkType: hard
 
 "js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 
@@ -18597,7 +18597,7 @@ __metadata:
     jest-junit: "npm:^16.0.0"
     jest-resolve: "npm:^30.2.0"
     js-base64: "npm:^3.7.7"
-    js-yaml: "npm:^3.13.1"
+    js-yaml: "npm:^3.15.0"
     json-schema: "npm:^0.3.0"
     jsonpath-plus: "npm:^10.3.0"
     knip: "npm:^6.14.2"


### PR DESCRIPTION
**Analysis / Root cause**:
CVE-2026-59869: js-yaml versions 3.0.0 to before 3.15.0 and 4.0.0 to before 4.3.0 can spend
quadratic CPU time parsing YAML documents with chained merge keys, enabling Denial of Service
via crafted payloads of only tens of kilobytes.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-98489

**Solution description**:
Bump the direct `js-yaml` dependency from `^3.13.1` to `^3.15.0` (patched). The yarn lockfile
naturally resolves v4 consumers to 4.3.0 (also patched), so both v3 and v4 dependents get the
fix with their expected API.

**Screenshots / screen recording**:
N/A — dependency-only change, no UI impact.

**Test setup:**
No special setup required.

**Test cases:**
- `yarn install` completes successfully
- `yarn build` completes successfully
- Verify `yarn.lock` shows js-yaml 3.15.0 for v3 consumers and 4.3.0 for v4 consumers

**Browser conformance**:
N/A — no UI changes.

**Additional info:**
- CVE severity: Major
- Affected component: openshift5/ose-console-rhel9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the YAML parsing library to a newer compatible version.
  * Improved compatibility and stability for YAML processing in frontend tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->